### PR TITLE
Remove redundant RTL frame adjustment

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -302,9 +302,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   CGRect alignedFrame = [self mdc_frameAlignedVertically:titleFrame
                                             withinBounds:textFrame
                                                alignment:titleVerticalAlignment];
-  alignedFrame = [self mdc_frameAlignedHorizontally:alignedFrame alignment:self.titleAlignment];
-  _titleLabel.frame = MDCRectFlippedForRTL(alignedFrame, self.bounds.size.width,
-                                           self.mdc_effectiveUserInterfaceLayoutDirection);
+  _titleLabel.frame = [self mdc_frameAlignedHorizontally:alignedFrame alignment:self.titleAlignment];
   self.titleView.frame = textFrame;
 
   // Button and title label alignment


### PR DESCRIPTION
Addresses bug where navigation bar title is not aligned correctly in RTL languages since MDCRectFlippedForRTL is called twice (for both vertical and horizontal alignment). MDCRectFlippedForRTL should only be called once.

Fixes issue: https://github.com/material-components/material-components-ios/issues/1099