### PR TITLE
Add uploading of testing code coverage results to codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,5 @@ script:
   - scripts/release/manage_pods.py install
   - scripts/build_all
   - scripts/test_all
+after_success:
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This won't do anything yet, but once we start emitting code coverage files it will.

Related to #1113