### PR TITLE
[AppBar] Header stack view in AppBarController

### DIFF
--- a/components/AppBar/src/MDCAppBar.m
+++ b/components/AppBar/src/MDCAppBar.m
@@ -151,7 +151,7 @@ static const CGFloat kStatusBarHeight = 20;
   // Underlying issue is you need view loaded before accessing. Below change will accomplish that
   // by calling for view.bounds initializing the stack view
   if (!_headerStackView) {
-    _headerStackView = [[MDCHeaderStackView alloc] initWithFrame:self.view.bounds];
+    _headerStackView = [[MDCHeaderStackView alloc] initWithFrame:CGRectZero];
   }
   return _headerStackView;
 }


### PR DESCRIPTION
Since the header stack view is going to be laid out with auto layout, it should be inited with a CGRectZero. Doing it with self.view.bounds creates a tiny loop since the view is not loaded yet.

### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [ ] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [ ] Link to GitHub issues it solves. ```closes #1234```
- [ ] Sign the CLA bot. You can do this once the pull request is submitted.

[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
pull request.
