### PR TITLE
[Ink] Add nonnull to the MDCInkTouchController initializer

### DIFF
--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -71,7 +71,7 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    inkController = MDCInkTouchController(view: self.collectionView!)!
+    inkController = MDCInkTouchController(view: self.collectionView!)
     inkController!.addInkView()
     inkController!.delaysInkSpread = true
     inkController!.delegate = self

--- a/components/Ink/src/MDCInkTouchController.h
+++ b/components/Ink/src/MDCInkTouchController.h
@@ -81,7 +81,7 @@
 
  @param view View that responds to touch events for ink.
  */
-- (nullable instancetype)initWithView:(nonnull UIView *)view NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)initWithView:(nonnull UIView *)view NS_DESIGNATED_INITIALIZER;
 
 /**
  When called the @c defaultInkView is added to the @c view.

--- a/demos/Shrine/Shrine/ShrineInkOverlay.swift
+++ b/demos/Shrine/Shrine/ShrineInkOverlay.swift
@@ -24,7 +24,7 @@ class ShrineInkOverlay: UIView, MDCInkTouchControllerDelegate {
   override init(frame: CGRect) {
     super.init(frame: frame)
     let cyan = UIColor(red: 22 / 255, green: 240 / 255, blue: 240 / 255, alpha: 0.2)
-    self.inkTouchController = MDCInkTouchController(view:self)!
+    self.inkTouchController = MDCInkTouchController(view:self)
     self.inkTouchController!.defaultInkView.inkColor = cyan
     self.inkTouchController!.addInkView()
     self.inkTouchController!.delegate = self


### PR DESCRIPTION
This PR changes the `MDCInkTouchController` initializer from `nullable` to `nonnull`. The catalog needed a trivial update to work with this change, but otherwise this should be fine.

Closes #430.