### PR TITLE
[Scripts] SwiftLint integration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,6 @@
+excluded:
+  - third_party
+
 disabled_rules:
   - closure_parameter_position
   - colon

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,6 @@
 excluded:
+  - Carthage
+  - Pods
   - third_party
 
 disabled_rules:
@@ -20,5 +22,4 @@ disabled_rules:
   - type_body_length
   - type_name
   - unused_closure_parameter
-
-variable_name: warning
+  - variable_name

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,14 +1,21 @@
 disabled_rules:
-  - conditional_binding_cascade
+  - closure_parameter_position
+  - colon
+  - control_statement # Enable eventually
   - cyclomatic_complexity
   - file_length
+  - force_cast
+  - force_try
   - function_body_length
+  - function_parameter_count
+  - legacy_constructor # Enable eventually
   - line_length
   - statement_position
+  - syntactic_sugar
   - todo
   - trailing_whitespace
+  - type_body_length
   - type_name
-  - force_try
-  - force_cast
+  - unused_closure_parameter
 
 variable_name: warning

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,14 @@
+disabled_rules:
+  - conditional_binding_cascade
+  - cyclomatic_complexity
+  - file_length
+  - function_body_length
+  - line_length
+  - statement_position
+  - todo
+  - trailing_whitespace
+  - type_name
+  - force_try
+  - force_cast
+
+variable_name: warning

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,22 +4,7 @@ excluded:
   - third_party
 
 disabled_rules:
-  - closure_parameter_position
-  - colon
-  - control_statement # Enable eventually
   - cyclomatic_complexity
-  - file_length
-  - force_cast
-  - force_try
-  - function_body_length
-  - function_parameter_count
-  - legacy_constructor # Enable eventually
-  - line_length
-  - statement_position
-  - syntactic_sugar
-  - todo
-  - trailing_whitespace
-  - type_body_length
-  - type_name
-  - unused_closure_parameter
-  - variable_name
+
+force_cast: warning
+force_try: warning

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - DESTINATION="platform=iOS Simulator,name=iPhone 7,OS=10.2" SDK="iphonesimulator10.2"
 before_install:
   - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
+  - brew update && brew install swiftlint
 # The travis_wait prefix ensures that the build doesn't error out because too much time went past
 # without any output being produced.
 script:
@@ -22,6 +23,7 @@ script:
   - xcodebuild -version
   - xcodebuild -showsdks
   - pod --version
+  - swiftlint
   - scripts/prep_all
   - travis_wait scripts/build_all
   - travis_wait scripts/test_all

--- a/catalog/.swiftlint.yml
+++ b/catalog/.swiftlint.yml
@@ -1,0 +1,1 @@
+../.swiftlint.yml

--- a/catalog/MDCCatalog.xcodeproj/project.pbxproj
+++ b/catalog/MDCCatalog.xcodeproj/project.pbxproj
@@ -507,7 +507,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ..\n${SRCROOT}/../scripts/lint.sh";
+			shellScript = "${SRCROOT}/../scripts/lint.sh";
 		};
 		72ACDAA295D1F2087113246F /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/catalog/MDCCatalog.xcodeproj/project.pbxproj
+++ b/catalog/MDCCatalog.xcodeproj/project.pbxproj
@@ -353,6 +353,7 @@
 				664524AF1C6BA62A001ADBF8 /* Sources */,
 				664524B01C6BA62A001ADBF8 /* Frameworks */,
 				664524B11C6BA62A001ADBF8 /* Resources */,
+				5951872D1E1DA83700AC2110 /* SwiftLint */,
 				72ACDAA295D1F2087113246F /* [CP] Embed Pods Frameworks */,
 				8164F6F5D8C80F373A698031 /* [CP] Copy Pods Resources */,
 				64307B471DF74FEF004AE4AC /* Embed App Extensions */,
@@ -493,6 +494,20 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MDCInteractionTests/Pods-MDCInteractionTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		5951872D1E1DA83700AC2110 /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cd ..\n${SRCROOT}/../scripts/lint.sh";
 		};
 		72ACDAA295D1F2087113246F /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -87,7 +87,7 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
     titleLabel.textColor = UIColor(white: 0.46, alpha: 1)
     titleLabel.font = MDCTypography.titleFont()
     titleLabel.sizeToFit()
-    if (inset + titleLabel.frame.size.width > containerView.frame.size.width) {
+    if inset + titleLabel.frame.size.width > containerView.frame.size.width {
       titleLabel.font = MDCTypography.body2Font()
     }
 
@@ -216,7 +216,7 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: IndexPath) -> CGSize {
     let pad = CGFloat(1)
     var cellWidth = (self.view.frame.size.width - 3 * pad) / 2
-    if (self.view.frame.size.width > self.view.frame.size.height) {
+    if self.view.frame.size.width > self.view.frame.size.height {
       cellWidth = (self.view.frame.size.width - 4 * pad) / 3
     }
     return CGSize(width: cellWidth, height: cellWidth * 0.825)

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -63,7 +63,7 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
       forCellWithReuseIdentifier: "MDCCatalogCollectionViewCell")
     self.collectionView?.backgroundColor = UIColor(white: 0.9, alpha: 1)
 
-    MDCIcons.ic_arrow_backUseNewStyle(true);
+    MDCIcons.ic_arrow_backUseNewStyle(true)
   }
 
   convenience init(node: CBCNode) {

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -43,8 +43,8 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
     self.node = node
 
     let layout = UICollectionViewFlowLayout()
-    let sectionInset:CGFloat = spacing
-    layout.sectionInset = UIEdgeInsetsMake(sectionInset, sectionInset, sectionInset, sectionInset)
+    let sectionInset: CGFloat = spacing
+    layout.sectionInset = UIEdgeInsets(top: sectionInset, left: sectionInset, bottom: sectionInset, right: sectionInset)
     layout.minimumInteritemSpacing = spacing
     layout.minimumLineSpacing = spacing
 

--- a/catalog/MDCCatalog/MDCCatalogTileView.swift
+++ b/catalog/MDCCatalog/MDCCatalogTileView.swift
@@ -19,7 +19,7 @@ import UIKit
 class MDCCatalogTileView: UIView {
 
   fileprivate var componentNameString = "Misc"
-  var componentName:String {
+  var componentName: String {
     get {
       return componentNameString
     }

--- a/catalog/MDCCatalog/MDCCatalogWindow.swift
+++ b/catalog/MDCCatalog/MDCCatalogWindow.swift
@@ -34,7 +34,7 @@ class MDCCatalogWindow: MDCOverlayWindow {
       for touch in touches {
         switch touch.phase {
         case .began:
-          if (enabled) {
+          if enabled {
             beginDisplayingTouch(touch)
           }
           continue
@@ -44,7 +44,7 @@ class MDCCatalogWindow: MDCOverlayWindow {
         case .stationary:
           continue
         case .ended:
-          if (touch.tapCount == 3) {
+          if touch.tapCount == 3 {
             enabled = !enabled
           }
           fallthrough

--- a/catalog/MDCCatalog/MDCCatalogWindow.swift
+++ b/catalog/MDCCatalog/MDCCatalogWindow.swift
@@ -77,7 +77,7 @@ class MDCCatalogWindow: MDCOverlayWindow {
                                animations: {
                                  view?.alpha = 0
                                },
-                               completion: { finished in
+                               completion: { _ in
                                 view?.removeFromSuperview()
                                })
   }

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -216,9 +216,9 @@ class MDCNodeListViewController: CBCNodeListViewController {
       textView.alpha = MDCTypography.captionFontOpacity()
 
       if (UIApplication.shared.userInterfaceLayoutDirection == .leftToRight) {
-          textView.contentInset = UIEdgeInsetsMake(-8, -5, -8, 5)
+          textView.contentInset = UIEdgeInsets(top: -8, left: -5, bottom: -8, right: 5)
       } else {
-          textView.contentInset = UIEdgeInsetsMake(-8, 5, -8, -5)
+          textView.contentInset = UIEdgeInsets(top: -8, left: 5, bottom: -8, right: -5)
       }
 
       textView.isEditable = false
@@ -240,12 +240,12 @@ class MDCNodeListViewController: CBCNodeListViewController {
         let horizontalConstraints =
             NSLayoutConstraint.constraints(withVisualFormat: "H:|-(20)-[textView]-(20)-|",
                                                            options: [], metrics: nil,
-                                                           views: ["textView" : textView])
+                                                           views: ["textView": textView])
         let verticalConstraints =
             NSLayoutConstraint.constraints(withVisualFormat: "V:|-(40)-[textView(==h)]",
                                                            options: [],
-                                                           metrics: ["h" : textViewHeight],
-                                                           views: ["textView" : textView])
+                                                           metrics: ["h": textViewHeight],
+                                                           views: ["textView": textView])
         sectionView.addConstraints(horizontalConstraints)
         sectionView.addConstraints(verticalConstraints)
       }
@@ -330,7 +330,7 @@ class MDCNodeListViewController: CBCNodeListViewController {
 
         let textColor = UIColor(white: 0, alpha: 0.8)
         UIBarButtonItem.appearance().setTitleTextAttributes(
-          [NSForegroundColorAttributeName:textColor],
+          [NSForegroundColorAttributeName: textColor],
           for: UIControlState())
 
         var contentFrame = container.contentViewController.view.frame

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -143,7 +143,7 @@ class MDCNodeListViewController: CBCNodeListViewController {
   // MARK: UITableViewDataSource
 
   override func numberOfSections(in tableView: UITableView) -> Int {
-    if (node.children.count == 1) {
+    if node.children.count == 1 {
       return 1
     }
     return sectionNames.count
@@ -209,13 +209,13 @@ class MDCNodeListViewController: CBCNodeListViewController {
       multiplier: 1.0,
       constant: additionalExamplesSectionHeight).isActive = true
 
-    if (section == 0) {
+    if section == 0 {
       let textView = UITextView()
       textView.text = componentDescription
       textView.font = MDCTypography.captionFont()
       textView.alpha = MDCTypography.captionFontOpacity()
 
-      if (UIApplication.shared.userInterfaceLayoutDirection == .leftToRight) {
+      if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
           textView.contentInset = UIEdgeInsets(top: -8, left: -5, bottom: -8, right: 5)
       } else {
           textView.contentInset = UIEdgeInsets(top: -8, left: 5, bottom: -8, right: -5)
@@ -256,14 +256,14 @@ class MDCNodeListViewController: CBCNodeListViewController {
 
   override func tableView(_ tableView: UITableView,
     heightForHeaderInSection section: Int) -> CGFloat {
-      if (section == Section.description.rawValue) {
+      if section == Section.description.rawValue {
         return descriptionSectionHeight
       }
       return additionalExamplesSectionHeight
   }
 
   override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    if (section == Section.description.rawValue) {
+    if section == Section.description.rawValue {
       return 1
     }
     return node.children.count - 1
@@ -272,13 +272,13 @@ class MDCNodeListViewController: CBCNodeListViewController {
   override func tableView(_ tableView: UITableView,
     cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     var cell = tableView.dequeueReusableCell(withIdentifier: "NodeViewTableViewDemoCell")
-    if ((cell == nil)) {
+    if cell == nil {
       cell = NodeViewTableViewDemoCell.init(style: .subtitle,
         reuseIdentifier: "NodeViewTableViewDemoCell")
     }
 
     var subtitleText: String?
-    if (indexPath.section == Section.description.rawValue) {
+    if indexPath.section == Section.description.rawValue {
       subtitleText = node.children[indexPath.row].exampleViewControllerName()
       cell!.textLabel!.text = "Demo"
       cell!.textLabel!.textColor = UIColor(red: 0.01, green: 0.66, blue: 0.96, alpha: 1)
@@ -307,7 +307,7 @@ class MDCNodeListViewController: CBCNodeListViewController {
 
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     var node = self.node.children[0]
-    if (indexPath.section == Section.additionalExamples.rawValue) {
+    if indexPath.section == Section.additionalExamples.rawValue {
       node = self.node.children[indexPath.row + 1]
     }
 

--- a/components/AppBar/examples/AppBarDelegateForwardingExample.swift
+++ b/components/AppBar/examples/AppBarDelegateForwardingExample.swift
@@ -32,7 +32,7 @@ class AppBarDelegateForwardingExample: UITableViewController {
 
     self.appBar.navigationBar.tintColor = UIColor.white
     appBar.navigationBar.titleTextAttributes =
-      [ NSForegroundColorAttributeName : UIColor.white ]
+      [ NSForegroundColorAttributeName: UIColor.white ]
 
     self.addChildViewController(appBar.headerViewController)
 
@@ -124,11 +124,11 @@ extension AppBarDelegateForwardingExample {
 }
 
 extension AppBarDelegateForwardingExample {
-  override var childViewControllerForStatusBarHidden : UIViewController? {
+  override var childViewControllerForStatusBarHidden: UIViewController? {
     return appBar.headerViewController
   }
 
-  override var childViewControllerForStatusBarStyle : UIViewController? {
+  override var childViewControllerForStatusBarStyle: UIViewController? {
     return appBar.headerViewController
   }
 

--- a/components/AppBar/examples/AppBarImageryExample.swift
+++ b/components/AppBar/examples/AppBarImageryExample.swift
@@ -45,7 +45,7 @@ class AppBarImagerySwiftExample: UITableViewController {
     // implement -preferredStatusBarStyle.
     headerView.tintColor = UIColor.white
     appBar.navigationBar.titleTextAttributes =
-      [ NSForegroundColorAttributeName : UIColor.white ]
+      [ NSForegroundColorAttributeName: UIColor.white ]
 
     // Allow the header to show more of the image.
     headerView.maximumHeight = 200
@@ -56,7 +56,7 @@ class AppBarImagerySwiftExample: UITableViewController {
     appBar.addSubviewsToParent()
   }
 
-  override var preferredStatusBarStyle : UIStatusBarStyle {
+  override var preferredStatusBarStyle: UIStatusBarStyle {
     // Ensure that our status bar is white.
     return .lightContent
   }

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
@@ -45,7 +45,6 @@ class AppBarInterfaceBuilderSwiftExample: UIViewController, UIScrollViewDelegate
     appBar.headerViewController.headerView.backgroundColor = headerColor
   }
 
-
   override func viewDidLoad() {
     super.viewDidLoad()
 

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
@@ -38,7 +38,7 @@ class AppBarInterfaceBuilderSwiftExample: UIViewController, UIScrollViewDelegate
   func commonAppBarInterfaceBuilderSwiftExampleSetup() {
     appBar.navigationBar.tintColor = UIColor.white
     appBar.navigationBar.titleTextAttributes =
-      [ NSForegroundColorAttributeName : UIColor.white ]
+      [ NSForegroundColorAttributeName: UIColor.white ]
 
     addChildViewController(appBar.headerViewController)
     let headerColor = UIColor(red: 0.01, green: 0.67, blue: 0.96, alpha: 1.0)
@@ -55,7 +55,7 @@ class AppBarInterfaceBuilderSwiftExample: UIViewController, UIScrollViewDelegate
     appBar.addSubviewsToParent()
   }
 
-  override var preferredStatusBarStyle : UIStatusBarStyle {
+  override var preferredStatusBarStyle: UIStatusBarStyle {
     // Ensure that our status bar is white.
     return .lightContent
   }

--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -38,7 +38,7 @@ class AppBarTypicalUseSwiftExample: UITableViewController {
     appBar.headerViewController.headerView.backgroundColor = color
     appBar.navigationBar.tintColor = UIColor.white
     appBar.navigationBar.titleTextAttributes =
-      [ NSForegroundColorAttributeName : UIColor.white ]
+      [ NSForegroundColorAttributeName: UIColor.white ]
   }
 
   required init?(coder aDecoder: NSCoder) {
@@ -61,20 +61,20 @@ class AppBarTypicalUseSwiftExample: UITableViewController {
 
     self.tableView.layoutMargins = UIEdgeInsets.zero
     self.tableView.separatorInset = UIEdgeInsets.zero
-    
+
     self.navigationItem.rightBarButtonItem =
       UIBarButtonItem(title: "Right", style: .done, target: nil, action: nil)
   }
 
   // Optional step: If you allow the header view to hide the status bar you must implement this
   //                method and return the headerViewController.
-  override var childViewControllerForStatusBarHidden : UIViewController? {
+  override var childViewControllerForStatusBarHidden: UIViewController? {
     return appBar.headerViewController
   }
 
   // Optional step: The Header View Controller does basic inspection of the header view's background
   //                color to identify whether the status bar should be light or dark-themed.
-  override var childViewControllerForStatusBarStyle : UIViewController? {
+  override var childViewControllerForStatusBarStyle: UIViewController? {
     return appBar.headerViewController
   }
 

--- a/components/AppBar/tests/unit/AppBarEncodingTests.swift
+++ b/components/AppBar/tests/unit/AppBarEncodingTests.swift
@@ -32,7 +32,7 @@ class AppBarEncodingTests: XCTestCase {
     appBar.navigationBar.backgroundColor = UIColor.black
     appBar.navigationBar.tintColor = UIColor.white
     appBar.navigationBar.title = "Title"
-    appBar.navigationBar.titleTextAttributes = [ NSForegroundColorAttributeName : UIColor.white ]
+    appBar.navigationBar.titleTextAttributes = [ NSForegroundColorAttributeName: UIColor.white ]
     appBar.navigationBar.titleAlignment = .leading
 
     // When

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
@@ -97,6 +97,6 @@ extension ButtonBarTypicalUseSwiftExample {
 
   func itemTitleTextAttributes () -> [String:AnyObject] {
     let textColor = UIColor(white: 0, alpha: 0.8)
-    return [NSForegroundColorAttributeName:textColor]
+    return [NSForegroundColorAttributeName: textColor]
   }
 }

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
@@ -54,8 +54,8 @@ class ButtonBarTypicalUseSwiftExample: UIViewController {
 
     // MDCButtonBar's sizeThatFits gives a "best-fit" size of the provided items.
     let size = buttonBar.sizeThatFits(self.view.bounds.size)
-    let x = (self.view.bounds.size.width - size.width) / 2;
-    let y = self.view.bounds.size.height / 2 - size.height;
+    let x = (self.view.bounds.size.width - size.width) / 2
+    let y = self.view.bounds.size.height / 2 - size.height
     buttonBar.frame = CGRect(x: x, y: y, width: size.width, height: size.height)
     buttonBar.autoresizingMask =
       [.flexibleTopMargin, .flexibleBottomMargin, .flexibleLeftMargin, .flexibleRightMargin]

--- a/components/ButtonBar/tests/unit/ButtonBarIssue370Tests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarIssue370Tests.swift
@@ -24,9 +24,9 @@ import MaterialComponents
 class ButtonBarIssue370Tests: XCTestCase {
 
   var buttonBar: MDCButtonBar!
-  let globalAttributes = [NSForegroundColorAttributeName:UIColor.blue]
-  let directAttributes = [NSForegroundColorAttributeName:UIColor.blue]
-  let fontAttributes = [NSFontAttributeName:UIFont.systemFont(ofSize: 12)]
+  let globalAttributes = [NSForegroundColorAttributeName: UIColor.blue]
+  let directAttributes = [NSForegroundColorAttributeName: UIColor.blue]
+  let fontAttributes = [NSFontAttributeName: UIFont.systemFont(ofSize: 12)]
 
   override func setUp() {
     buttonBar = MDCButtonBar()

--- a/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
+++ b/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
@@ -48,8 +48,8 @@ class ButtonsSimpleExampleSwiftViewController: UIViewController {
     floatingButton.translatesAutoresizingMaskIntoConstraints = false
     floatingButton.addTarget(self, action: #selector(tap), for: .touchUpInside)
 
-    let plusShapeLayer = ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton);
-    floatingButton.layer.addSublayer(plusShapeLayer);
+    let plusShapeLayer = ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton)
+    floatingButton.layer.addSublayer(plusShapeLayer)
 
     self.view.addSubview(floatingButton)
 

--- a/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
+++ b/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
@@ -18,7 +18,7 @@ import Foundation
 import MaterialComponents
 
 class ButtonsSimpleExampleSwiftViewController: UIViewController {
-  
+
   let floatingButtonPlusDimension = CGFloat(24)
 
   override func viewDidLoad() {

--- a/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.swift
+++ b/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.swift
@@ -34,7 +34,7 @@ class ButtonsTypicalUseSupplemental: NSObject {
     bezierPath.addLine(to: CGPoint(x: 19, y: 11))
     bezierPath.addLine(to: CGPoint(x: 19, y: 13))
     bezierPath.close()
-    return bezierPath;
+    return bezierPath
   }
 
   static func createPlusShapeLayer(_ floatingButton: MDCFloatingButton) -> CAShapeLayer {
@@ -44,7 +44,7 @@ class ButtonsTypicalUseSupplemental: NSObject {
     plusShape.position =
       CGPoint(x: (floatingButton.frame.size.width - floatingButtonPlusDimension) / 2,
                   y: (floatingButton.frame.size.height - floatingButtonPlusDimension) / 2)
-    return plusShape;
+    return plusShape
   }
 
 }

--- a/components/Dialogs/examples/DialogsLongAlertViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertViewController.swift
@@ -24,10 +24,10 @@ class DialogsLongAlertViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor = UIColor.white;
+    view.backgroundColor = UIColor.white
 
     flatButton.setTitle("PRESENT ALERT", for: UIControlState())
-    flatButton.setTitleColor(UIColor.blue, for: UIControlState());
+    flatButton.setTitleColor(UIColor.blue, for: UIControlState())
     flatButton.sizeToFit()
     flatButton.translatesAutoresizingMaskIntoConstraints = false
     flatButton.addTarget(self, action: #selector(tap), for: .touchUpInside)
@@ -49,7 +49,7 @@ class DialogsLongAlertViewController: UIViewController {
     "vel turpis maximus, accumsan dui quis, cursus turpis. Nunc a tincidunt nunc, ut tempus " +
     "libero. Morbi ut orci laoreet, luctus neque nec, rhoncus enim. Cras dui erat, blandit ac " +
     "malesuada vitae, fringilla ac ante. Nullam dui diam, condimentum vitae mi et, dictum " +
-    "euismod libero. Aliquam commodo urna vitae massa convallis aliquet.";
+    "euismod libero. Aliquam commodo urna vitae massa convallis aliquet."
 
     let materialAlertController = MDCAlertController(title: nil, message: messageString)
 

--- a/components/Dialogs/examples/DialogsLongAlertViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertViewController.swift
@@ -53,7 +53,7 @@ class DialogsLongAlertViewController: UIViewController {
 
     let materialAlertController = MDCAlertController(title: nil, message: messageString)
 
-    let action = MDCAlertAction(title:"OK") { (action) in print("OK") }
+    let action = MDCAlertAction(title:"OK") { (_) in print("OK") }
 
     materialAlertController.addAction(action)
 

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTypicalUseSupplemental.swift
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTypicalUseSupplemental.swift
@@ -42,5 +42,5 @@ extension FlexibleHeaderTypicalUseViewControllerSwift {
   func catalogShouldHideNavigation() -> Bool {
     return true
   }
-  
+
 }

--- a/components/HeaderStackView/examples/HeaderStackViewTypicalUse.swift
+++ b/components/HeaderStackView/examples/HeaderStackViewTypicalUse.swift
@@ -40,8 +40,8 @@ open class HeaderStackViewTypicalUseSwiftExample: HeaderStackViewTypicalUse {
     super.viewWillAppear(animated)
     navigationController?.setNavigationBarHidden(true, animated: animated)
   }
-  
-  override open var prefersStatusBarHidden : Bool {
+
+  override open var prefersStatusBarHidden: Bool {
     return true
   }
 }

--- a/components/HeaderStackView/examples/HeaderStackViewTypicalUse.swift
+++ b/components/HeaderStackView/examples/HeaderStackViewTypicalUse.swift
@@ -24,13 +24,13 @@ open class HeaderStackViewTypicalUseSwiftExample: HeaderStackViewTypicalUse {
     super.viewDidLoad()
     self.setupExampleViews()
 
-    stackView = MDCHeaderStackView.init();
-    stackView!.autoresizingMask = .flexibleWidth;
-    stackView!.topBar = topView;
-    stackView!.bottomBar = navBar;
+    stackView = MDCHeaderStackView.init()
+    stackView!.autoresizingMask = .flexibleWidth
+    stackView!.topBar = topView
+    stackView!.bottomBar = navBar
 
-    let frame = self.view.bounds;
-    stackView!.frame = frame;
+    let frame = self.view.bounds
+    stackView!.frame = frame
     stackView!.sizeToFit()
 
     view.addSubview(stackView!)

--- a/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.swift
+++ b/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.swift
@@ -40,5 +40,5 @@ extension HeaderStackViewTypicalUseSwiftExample {
   func catalogShouldHideNavigation() -> Bool {
     return true
   }
-  
+
 }

--- a/components/NavigationBar/examples/NavigationBarTypicalUseExample.swift
+++ b/components/NavigationBar/examples/NavigationBarTypicalUseExample.swift
@@ -30,7 +30,7 @@ open class NavigationBarTypicalUseSwiftExample: NavigationBarTypicalUseExample {
     navBar!.observe(navigationItem)
     navBar!.tintColor = .white
     navBar!.titleTextAttributes =
-      [ NSForegroundColorAttributeName : UIColor.white ]
+      [ NSForegroundColorAttributeName: UIColor.white ]
 
     // Light blue 500
     navBar!.backgroundColor = UIColor.init(red: 0.012, green: 0.663, blue: 0.957, alpha: 1)
@@ -39,7 +39,7 @@ open class NavigationBarTypicalUseSwiftExample: NavigationBarTypicalUseExample {
 
     navBar!.translatesAutoresizingMaskIntoConstraints = false
 
-    let viewBindings = ["navBar" : navBar!]
+    let viewBindings = ["navBar": navBar!]
 
     var constraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|[navBar]|",
       options: [], metrics: nil, views: viewBindings)
@@ -55,7 +55,7 @@ open class NavigationBarTypicalUseSwiftExample: NavigationBarTypicalUseExample {
     navigationController?.setNavigationBarHidden(true, animated: animated)
   }
 
-  override open var prefersStatusBarHidden : Bool {
+  override open var prefersStatusBarHidden: Bool {
     return true
   }
 }

--- a/components/PageControl/examples/PageControlTypicalUseExample.swift
+++ b/components/PageControl/examples/PageControlTypicalUseExample.swift
@@ -34,26 +34,26 @@ class PageControlSwiftExampleViewController: UIViewController, UIScrollViewDeleg
       type(of: self).ColorFromRGB(0x1EAAF1),
       type(of: self).ColorFromRGB(0x55C4f5),
       type(of: self).ColorFromRGB(0x35B7F3),
-      type(of: self).ColorFromRGB(0x1EAAF1),
-    ];
+      type(of: self).ColorFromRGB(0x1EAAF1)
+    ]
 
     scrollView.frame = self.view.bounds
     scrollView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     scrollView.delegate = self
     scrollView.isPagingEnabled = true
     scrollView.contentSize = CGSize(width: view.bounds.width * CGFloat(pageColors.count), height: view.bounds.height)
-    scrollView.showsHorizontalScrollIndicator = false;
+    scrollView.showsHorizontalScrollIndicator = false
     view.addSubview(scrollView)
 
     // Add pages to scrollView.
     for (i, pageColor) in pageColors.enumerated() {
-      let pageFrame:CGRect = self.view.bounds.offsetBy(dx: CGFloat(i) * view.bounds.width, dy: 0);
+      let pageFrame:CGRect = self.view.bounds.offsetBy(dx: CGFloat(i) * view.bounds.width, dy: 0)
       let page = UILabel.init(frame:pageFrame)
       page.text = String(format: "Page %zd", i + 1)
       page.font = page.font.withSize(50)
       page.textColor = UIColor.init(white: 0, alpha: 0.8)
-      page.backgroundColor = pageColor;
-      page.textAlignment = NSTextAlignment.center;
+      page.backgroundColor = pageColor
+      page.textAlignment = NSTextAlignment.center
       page.autoresizingMask = [.flexibleTopMargin, .flexibleBottomMargin]
       scrollView.addSubview(page)
       pages.add(page)
@@ -62,9 +62,9 @@ class PageControlSwiftExampleViewController: UIViewController, UIScrollViewDeleg
     pageControl.numberOfPages = pageColors.count
 
     let pageControlSize = pageControl.sizeThatFits(view.bounds.size)
-    pageControl.frame = CGRect(x: 0, y: view.bounds.height - pageControlSize.height, width: view.bounds.width, height: pageControlSize.height);
+    pageControl.frame = CGRect(x: 0, y: view.bounds.height - pageControlSize.height, width: view.bounds.width, height: pageControlSize.height)
     pageControl.addTarget(self, action: #selector(didChangePage), for: .valueChanged)
-    pageControl.autoresizingMask = [.flexibleTopMargin, .flexibleWidth];
+    pageControl.autoresizingMask = [.flexibleTopMargin, .flexibleWidth]
     view.addSubview(pageControl)
   }
 
@@ -72,16 +72,16 @@ class PageControlSwiftExampleViewController: UIViewController, UIScrollViewDeleg
 
   override func viewWillLayoutSubviews() {
     super.viewWillLayoutSubviews()
-    let pageBeforeFrameChange = pageControl.currentPage;
+    let pageBeforeFrameChange = pageControl.currentPage
     for (i, page) in pages.enumerated() {
       let pageLabel:UILabel = page as! UILabel
-      pageLabel.frame = view.bounds.offsetBy(dx: CGFloat(i) * view.bounds.width, dy: 0);
+      pageLabel.frame = view.bounds.offsetBy(dx: CGFloat(i) * view.bounds.width, dy: 0)
     }
-    scrollView.contentSize = CGSize(width: view.bounds.width * CGFloat(pages.count), height: view.bounds.height);
-    var offset = scrollView.contentOffset;
-    offset.x = CGFloat(pageBeforeFrameChange) * view.bounds.width;
+    scrollView.contentSize = CGSize(width: view.bounds.width * CGFloat(pages.count), height: view.bounds.height)
+    var offset = scrollView.contentOffset
+    offset.x = CGFloat(pageBeforeFrameChange) * view.bounds.width
     // This non-anmiated change of offset ensures we keep the same page
-    scrollView.contentOffset = offset;
+    scrollView.contentOffset = offset
   }
 
   // MARK: - UIScrollViewDelegate
@@ -100,9 +100,9 @@ class PageControlSwiftExampleViewController: UIViewController, UIScrollViewDeleg
 
   // MARK: - User events
 
-  func didChangePage(_ sender: MDCPageControl){
+  func didChangePage(_ sender: MDCPageControl) {
     var offset = scrollView.contentOffset
-    offset.x = CGFloat(sender.currentPage) * scrollView.bounds.size.width;
+    offset.x = CGFloat(sender.currentPage) * scrollView.bounds.size.width
     scrollView.setContentOffset(offset, animated: true)
   }
 

--- a/components/PageControl/examples/PageControlTypicalUseExample.swift
+++ b/components/PageControl/examples/PageControlTypicalUseExample.swift
@@ -47,7 +47,7 @@ class PageControlSwiftExampleViewController: UIViewController, UIScrollViewDeleg
 
     // Add pages to scrollView.
     for (i, pageColor) in pageColors.enumerated() {
-      let pageFrame:CGRect = self.view.bounds.offsetBy(dx: CGFloat(i) * view.bounds.width, dy: 0)
+      let pageFrame: CGRect = self.view.bounds.offsetBy(dx: CGFloat(i) * view.bounds.width, dy: 0)
       let page = UILabel.init(frame:pageFrame)
       page.text = String(format: "Page %zd", i + 1)
       page.font = page.font.withSize(50)
@@ -74,7 +74,7 @@ class PageControlSwiftExampleViewController: UIViewController, UIScrollViewDeleg
     super.viewWillLayoutSubviews()
     let pageBeforeFrameChange = pageControl.currentPage
     for (i, page) in pages.enumerated() {
-      let pageLabel:UILabel = page as! UILabel
+      let pageLabel: UILabel = page as! UILabel
       pageLabel.frame = view.bounds.offsetBy(dx: CGFloat(i) * view.bounds.width, dy: 0)
     }
     scrollView.contentSize = CGSize(width: view.bounds.width * CGFloat(pages.count), height: view.bounds.height)

--- a/components/Palettes/examples/PalettesExpandedExample.swift
+++ b/components/Palettes/examples/PalettesExpandedExample.swift
@@ -17,7 +17,7 @@ limitations under the License.
 import MaterialComponents
 
 private func randomFloat() -> CGFloat {
-  return CGFloat(arc4random()) / CGFloat(UInt32.max);
+  return CGFloat(arc4random()) / CGFloat(UInt32.max)
 }
 
 private func generateRandomPalettes(_ count: Int) -> [(name: String, palette: MDCPalette)] {

--- a/components/Palettes/examples/PalettesStandardExample.swift
+++ b/components/Palettes/examples/PalettesStandardExample.swift
@@ -38,7 +38,7 @@ class PalettesStandardExampleViewController: PalettesExampleViewController {
       ("Deep Orange", MDCPalette.deepOrange()),
       ("Brown", MDCPalette.brown()),
       ("Grey", MDCPalette.grey()),
-      ("Blue Grey", MDCPalette.blueGrey()),
+      ("Blue Grey", MDCPalette.blueGrey())
     ]
   }
 }

--- a/components/Palettes/examples/supplemental/PalettesExampleViewController.swift
+++ b/components/Palettes/examples/supplemental/PalettesExampleViewController.swift
@@ -23,7 +23,7 @@ func ExampleTonesForPalette(_ palette: MDCPalette) -> [ExampleTone] {
     (MDCPaletteTint100Name, palette.tint100),
     (MDCPaletteTint300Name, palette.tint300),
     (MDCPaletteTint500Name, palette.tint500),
-    (MDCPaletteTint700Name, palette.tint700),
+    (MDCPaletteTint700Name, palette.tint700)
     ]
 
   if let accent = palette.accent400 {

--- a/components/Palettes/examples/supplemental/PalettesExampleViewController.swift
+++ b/components/Palettes/examples/supplemental/PalettesExampleViewController.swift
@@ -19,7 +19,7 @@ import MaterialComponents
 typealias ExampleTone = (name: String, tone: UIColor)
 
 func ExampleTonesForPalette(_ palette: MDCPalette) -> [ExampleTone] {
-  var tones : [ExampleTone] = [
+  var tones: [ExampleTone] = [
     (MDCPaletteTint100Name, palette.tint100),
     (MDCPaletteTint300Name, palette.tint300),
     (MDCPaletteTint500Name, palette.tint500),

--- a/components/Palettes/tests/unit/PaletteTests.swift
+++ b/components/Palettes/tests/unit/PaletteTests.swift
@@ -24,7 +24,7 @@ class PaletteTests: XCTestCase {
       red:CGFloat((rgbValue & 0xFF0000) >> 16) / 255,
       green:CGFloat((rgbValue & 0x00FF00) >> 8) / 255,
       blue:CGFloat((rgbValue & 0x0000FF) >> 0) / 255,
-      alpha:1);
+      alpha:1)
   }
 
   func testBasics() {

--- a/components/Palettes/tests/unit/PaletteTests.swift
+++ b/components/Palettes/tests/unit/PaletteTests.swift
@@ -63,22 +63,22 @@ class PaletteTests: XCTestCase {
 
   func testCustomPalette() {
     let tints = [
-      MDCPaletteTint50Name : UIColor(white: 0, alpha: 1),
-      MDCPaletteTint100Name : UIColor(white: 0.1, alpha: 1),
-      MDCPaletteTint200Name : UIColor(white: 0.2, alpha: 1),
-      MDCPaletteTint300Name : UIColor(white: 0.3, alpha: 1),
-      MDCPaletteTint400Name : UIColor(white: 0.4, alpha: 1),
-      MDCPaletteTint500Name : UIColor(white: 0.5, alpha: 1),
-      MDCPaletteTint600Name : UIColor(white: 0.6, alpha: 1),
-      MDCPaletteTint700Name : UIColor(white: 0.7, alpha: 1),
-      MDCPaletteTint800Name : UIColor(white: 0.8, alpha: 1),
-      MDCPaletteTint900Name : UIColor(white: 0.9, alpha: 1)
+      MDCPaletteTint50Name: UIColor(white: 0, alpha: 1),
+      MDCPaletteTint100Name: UIColor(white: 0.1, alpha: 1),
+      MDCPaletteTint200Name: UIColor(white: 0.2, alpha: 1),
+      MDCPaletteTint300Name: UIColor(white: 0.3, alpha: 1),
+      MDCPaletteTint400Name: UIColor(white: 0.4, alpha: 1),
+      MDCPaletteTint500Name: UIColor(white: 0.5, alpha: 1),
+      MDCPaletteTint600Name: UIColor(white: 0.6, alpha: 1),
+      MDCPaletteTint700Name: UIColor(white: 0.7, alpha: 1),
+      MDCPaletteTint800Name: UIColor(white: 0.8, alpha: 1),
+      MDCPaletteTint900Name: UIColor(white: 0.9, alpha: 1)
     ]
     let accents = [
-      MDCPaletteAccent100Name : UIColor(white: 1, alpha: 0),
-      MDCPaletteAccent200Name : UIColor(white: 1, alpha: 0.25),
-      MDCPaletteAccent400Name : UIColor(white: 1, alpha: 0.75),
-      MDCPaletteAccent700Name : UIColor(white: 1, alpha: 1)
+      MDCPaletteAccent100Name: UIColor(white: 1, alpha: 0),
+      MDCPaletteAccent200Name: UIColor(white: 1, alpha: 0.25),
+      MDCPaletteAccent400Name: UIColor(white: 1, alpha: 0.75),
+      MDCPaletteAccent700Name: UIColor(white: 1, alpha: 1)
     ]
     let palette = MDCPalette(tints: tints, accents: accents)
     XCTAssertEqual(palette.tint50, tints[MDCPaletteTint50Name])

--- a/components/ShadowLayer/examples/ExampleShadowedView.swift
+++ b/components/ShadowLayer/examples/ExampleShadowedView.swift
@@ -20,7 +20,7 @@ import MaterialComponents.MaterialShadowLayer
 
 class ExampleShadowedView: UIView {
 
-  override class var layerClass : AnyClass {
+  override class var layerClass: AnyClass {
     return MDCShadowLayer.self
   }
 

--- a/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
+++ b/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
@@ -48,7 +48,7 @@ class ShadowDragSquareExampleViewController: UIViewController {
     self.blueView.addGestureRecognizer(longPressRecogniser)
   }
 
-  func longPressedInView(_ sender:UILongPressGestureRecognizer) {
+  func longPressedInView(_ sender: UILongPressGestureRecognizer) {
     // Elevation of the view is changed to indicate that it has been pressed or released.
     // view.center is changed to follow the touch events.
     if (sender.state == .began) {

--- a/components/private/RTL/tests/unit/RTLTests.swift
+++ b/components/private/RTL/tests/unit/RTLTests.swift
@@ -70,14 +70,14 @@ class RTLTests: XCTestCase {
   class func testImage() -> UIImage {
     let rect = CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0)
     UIGraphicsBeginImageContext(rect.size)
-    let context = UIGraphicsGetCurrentContext();
+    let context = UIGraphicsGetCurrentContext()
 
-    context!.setFillColor(UIColor.blue.cgColor);
-    context!.fill(rect);
+    context!.setFillColor(UIColor.blue.cgColor)
+    context!.fill(rect)
 
-    let image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
+    let image = UIGraphicsGetImageFromCurrentImageContext()
+    UIGraphicsEndImageContext()
 
-    return image!;
+    return image!
   }
 }

--- a/demos/Shrine/.swiftlint.yml
+++ b/demos/Shrine/.swiftlint.yml
@@ -1,0 +1,1 @@
+../../.swiftlint.yml

--- a/demos/Shrine/Shrine.xcodeproj/project.pbxproj
+++ b/demos/Shrine/Shrine.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 				DE5D2A401C81068100C9C650 /* Sources */,
 				DE5D2A411C81068100C9C650 /* Frameworks */,
 				DE5D2A421C81068100C9C650 /* Resources */,
+				595187321E1DB4E300AC2110 /* SwiftLint */,
 				D1F846F8DE8314F37D7BCFC1 /* [CP] Embed Pods Frameworks */,
 				E79A83FFB3D723D88B7FB762 /* [CP] Copy Pods Resources */,
 			);
@@ -196,6 +197,20 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		595187321E1DB4E300AC2110 /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "${SRCROOT}/../../scripts/lint.sh";
+		};
 		BD04A4A94E7A074ACE45ED21 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/demos/Shrine/Shrine/AppDelegate.swift
+++ b/demos/Shrine/Shrine/AppDelegate.swift
@@ -25,10 +25,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 
     let flexHeadVC = ShrineFlexibleHeaderContainerViewController()
-    self.window?.rootViewController = flexHeadVC;
-    self.window?.makeKeyAndVisible();
+    self.window?.rootViewController = flexHeadVC
+    self.window?.makeKeyAndVisible()
 
-    MDCIcons.ic_arrow_backUseNewStyle(true);
+    MDCIcons.ic_arrow_backUseNewStyle(true)
 
     return true
   }

--- a/demos/Shrine/Shrine/ShrineCollectionViewCell.swift
+++ b/demos/Shrine/Shrine/ShrineCollectionViewCell.swift
@@ -36,7 +36,7 @@ class ShrineCollectionViewCell: UICollectionViewCell {
     cellContent.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     cellContent.clipsToBounds = true
 
-    imageView.contentMode = .scaleAspectFill;
+    imageView.contentMode = .scaleAspectFill
     imageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     cellContent.addSubview(imageView)
 

--- a/demos/Shrine/Shrine/ShrineCollectionViewCell.swift
+++ b/demos/Shrine/Shrine/ShrineCollectionViewCell.swift
@@ -64,7 +64,7 @@ class ShrineCollectionViewCell: UICollectionViewCell {
     super.init(coder: coder)!
   }
 
-  override func apply(_ layoutAttributes : UICollectionViewLayoutAttributes) {
+  override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
     super.apply(layoutAttributes)
   }
 
@@ -72,12 +72,12 @@ class ShrineCollectionViewCell: UICollectionViewCell {
     super.layoutSubviews()
     self.addSubview(cellContent)
 
-    let imagePad:CGFloat = 40
+    let imagePad: CGFloat = 40
     imageView.frame = CGRect(x: imagePad,
       y: imagePad,
       width: self.frame.size.width - imagePad * 2,
       height: self.frame.size.height - 10 - imagePad * 2)
-    let avatarDim:CGFloat = 24
+    let avatarDim: CGFloat = 24
     avatar.frame = CGRect(x: 10,
       y: self.frame.size.height - avatarDim - 10,
       width: avatarDim,
@@ -99,22 +99,22 @@ class ShrineCollectionViewCell: UICollectionViewCell {
     avatar.image = nil
   }
 
-  func populateCell(_ title : String, imageName : String, avatar : String, shopTitle : String,
-    price : String) {
+  func populateCell(_ title: String, imageName: String, avatar: String, shopTitle: String,
+    price: String) {
     labelAvatar.text = shopTitle
     labelPrice.text = price
     let urlString = ShrineData.baseURL + imageName
     let url = URL(string: urlString)
-    remoteImageService.fetchImageAndThumbnail(from: url) { (image:UIImage?,
-      thumbnailImage:UIImage?) -> Void in
+    remoteImageService.fetchImageAndThumbnail(from: url) { (image: UIImage?,
+      thumbnailImage: UIImage?) -> Void in
       DispatchQueue.main.sync(execute: {
         self.imageView.image = thumbnailImage
       })
     }
     let avatarURLString = ShrineData.baseURL + avatar
     let avatarURL = URL(string: avatarURLString)
-    remoteImageService.fetchImageAndThumbnail(from: avatarURL) { (image:UIImage?,
-      thumbnailImage:UIImage?) -> Void in
+    remoteImageService.fetchImageAndThumbnail(from: avatarURL) { (image: UIImage?,
+      thumbnailImage: UIImage?) -> Void in
       DispatchQueue.main.sync(execute: {
         self.avatar.image = thumbnailImage
       })

--- a/demos/Shrine/Shrine/ShrineCollectionViewController.swift
+++ b/demos/Shrine/Shrine/ShrineCollectionViewController.swift
@@ -47,7 +47,7 @@ class ShrineCollectionViewController: UICollectionViewController {
   override func collectionView(_ collectionView: UICollectionView,
                                cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "ShrineCollectionViewCell", for: indexPath) as! ShrineCollectionViewCell
-    let itemNum:NSInteger = (indexPath as NSIndexPath).row;
+    let itemNum:NSInteger = (indexPath as NSIndexPath).row
 
     let title = self.shrineData.titles[itemNum] as! String
     let imageName = self.shrineData.imageNames[itemNum] as! String
@@ -62,14 +62,14 @@ class ShrineCollectionViewController: UICollectionViewController {
   func collectionView(_ collectionView: UICollectionView,
     layout collectionViewLayout: UICollectionViewLayout,
     sizeForItemAtIndexPath indexPath: IndexPath) -> CGSize {
-      let cellWidth = floor((self.view.frame.size.width - (2 * 5)) / 2) - (2 * 5);
+      let cellWidth = floor((self.view.frame.size.width - (2 * 5)) / 2) - (2 * 5)
       let cellHeight = cellWidth * 1.2
-      return CGSize(width: cellWidth, height: cellHeight);
+      return CGSize(width: cellWidth, height: cellHeight)
   }
 
   override func collectionView(_ collectionView: UICollectionView,
                                didSelectItemAt indexPath: IndexPath) {
-    let itemNum:NSInteger = (indexPath as NSIndexPath).row;
+    let itemNum:NSInteger = (indexPath as NSIndexPath).row
 
     let detailVC = ShrineDetailViewController()
     detailVC.productTitle = self.shrineData.titles[itemNum] as! String
@@ -80,8 +80,8 @@ class ShrineCollectionViewController: UICollectionViewController {
   }
 
   override func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    headerViewController.scrollViewDidScroll(scrollView);
-    let scrollOffsetY = scrollView.contentOffset.y;
+    headerViewController.scrollViewDidScroll(scrollView)
+    let scrollOffsetY = scrollView.contentOffset.y
     let duration = 0.5
     if (scrollOffsetY > -240) {
       UIView.animate(withDuration: duration, animations: {
@@ -104,11 +104,11 @@ class ShrineCollectionViewController: UICollectionViewController {
     let headerView = headerViewController.headerView
     let bounds = UIScreen.main.bounds
     if (bounds.size.width < bounds.size.height) {
-      headerView.maximumHeight = 440;
-      headerView.minimumHeight = 72;
+      headerView.maximumHeight = 440
+      headerView.minimumHeight = 72
     } else {
-      headerView.maximumHeight = 72;
-      headerView.minimumHeight = 72;
+      headerView.maximumHeight = 72
+      headerView.minimumHeight = 72
     }
   }
 
@@ -125,8 +125,8 @@ class ShrineCollectionViewController: UICollectionViewController {
   func setupHeaderView() {
     let headerView = headerViewController.headerView
     headerView.trackingScrollView = collectionView
-    headerView.maximumHeight = 440;
-    headerView.minimumHeight = 72;
+    headerView.maximumHeight = 440
+    headerView.minimumHeight = 72
     headerView.backgroundColor = UIColor.white
     headerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 

--- a/demos/Shrine/Shrine/ShrineCollectionViewController.swift
+++ b/demos/Shrine/Shrine/ShrineCollectionViewController.swift
@@ -19,8 +19,8 @@ import MaterialComponents.MaterialFlexibleHeader
 
 class ShrineCollectionViewController: UICollectionViewController {
 
-  var headerViewController:MDCFlexibleHeaderViewController!
-  fileprivate let shrineData:ShrineData
+  var headerViewController: MDCFlexibleHeaderViewController!
+  fileprivate let shrineData: ShrineData
   fileprivate var headerContentView = ShrineHeaderContentView(frame: CGRect.zero)
 
   override init(collectionViewLayout layout: UICollectionViewLayout) {
@@ -47,7 +47,7 @@ class ShrineCollectionViewController: UICollectionViewController {
   override func collectionView(_ collectionView: UICollectionView,
                                cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "ShrineCollectionViewCell", for: indexPath) as! ShrineCollectionViewCell
-    let itemNum:NSInteger = (indexPath as NSIndexPath).row
+    let itemNum: NSInteger = (indexPath as NSIndexPath).row
 
     let title = self.shrineData.titles[itemNum] as! String
     let imageName = self.shrineData.imageNames[itemNum] as! String
@@ -69,7 +69,7 @@ class ShrineCollectionViewController: UICollectionViewController {
 
   override func collectionView(_ collectionView: UICollectionView,
                                didSelectItemAt indexPath: IndexPath) {
-    let itemNum:NSInteger = (indexPath as NSIndexPath).row
+    let itemNum: NSInteger = (indexPath as NSIndexPath).row
 
     let detailVC = ShrineDetailViewController()
     detailVC.productTitle = self.shrineData.titles[itemNum] as! String
@@ -112,7 +112,7 @@ class ShrineCollectionViewController: UICollectionViewController {
     }
   }
 
-  override func willAnimateRotation(to toInterfaceOrientation:UIInterfaceOrientation, duration: TimeInterval) {
+  override func willAnimateRotation(to toInterfaceOrientation: UIInterfaceOrientation, duration: TimeInterval) {
     sizeHeaderView()
     collectionView?.collectionViewLayout.invalidateLayout()
   }

--- a/demos/Shrine/Shrine/ShrineData.swift
+++ b/demos/Shrine/Shrine/ShrineData.swift
@@ -49,7 +49,7 @@ class ShrineData {
       let price = product["price"] as! String
       prices.add(price)
     }
-    
+
     let shops = json["shops"] as! NSArray
     for shp in shops {
       let shop = shp as! NSDictionary

--- a/demos/Shrine/Shrine/ShrineDetailViewController.swift
+++ b/demos/Shrine/Shrine/ShrineDetailViewController.swift
@@ -36,16 +36,16 @@ class ShrineDetailView: UIScrollView {
     let minContentHeight = CGFloat(640)
     self.contentSize = CGSize(width: self.frame.width, height: minContentHeight)
 
-    let labelPadding:CGFloat = 50
+    let labelPadding: CGFloat = 50
     imageView.frame = CGRect(x: labelPadding, y: labelPadding,
       width: self.frame.size.width - 2 * labelPadding, height: 220)
     imageView.contentMode = UIViewContentMode.scaleAspectFit
     imageView.autoresizingMask = .flexibleHeight
     self.addSubview(imageView)
-    let urlString:String = ShrineData.baseURL + imageName
+    let urlString: String = ShrineData.baseURL + imageName
     let url = URL(string: urlString)
-    remoteImageService.fetchImageAndThumbnail(from: url) { (image:UIImage?,
-      thumbnailImage:UIImage?) -> Void in
+    remoteImageService.fetchImageAndThumbnail(from: url) { (image: UIImage?,
+      _) -> Void in
       DispatchQueue.main.async(execute: {
         self.imageView.image = image
         self.imageView.setNeedsDisplay()
@@ -92,7 +92,7 @@ class ShrineDetailView: UIScrollView {
 
 class ShrineDetailViewController: UIViewController {
 
-  let fabPadding:CGFloat = 25
+  let fabPadding: CGFloat = 25
   var productTitle = ""
   var desc = ""
   var imageName = "popsicle.png"

--- a/demos/Shrine/Shrine/ShrineDetailViewController.swift
+++ b/demos/Shrine/Shrine/ShrineDetailViewController.swift
@@ -64,7 +64,7 @@ class ShrineDetailView: UIScrollView {
       value:paragraphStyle,
       range:NSMakeRange(0, attrString.length))
     label.attributedText = attrString
-    label.sizeToFit();
+    label.sizeToFit()
     label.frame = CGRect(x: labelPadding,
       y: 280, width: label.frame.size.width, height: label.frame.size.height)
     label.autoresizingMask = [.flexibleWidth, .flexibleHeight]

--- a/demos/Shrine/Shrine/ShrineFlexibleHeaderContainerViewController.swift
+++ b/demos/Shrine/Shrine/ShrineFlexibleHeaderContainerViewController.swift
@@ -20,14 +20,14 @@ import MaterialComponents.MaterialFlexibleHeader
 class ShrineFlexibleHeaderContainerViewController: MDCFlexibleHeaderContainerViewController {
 
   init() {
-    let layout = UICollectionViewFlowLayout();
+    let layout = UICollectionViewFlowLayout()
     let sectionInset:CGFloat = 10.0
     layout.sectionInset = UIEdgeInsetsMake(sectionInset, sectionInset, sectionInset, sectionInset)
     let collectionVC = ShrineCollectionViewController(collectionViewLayout: layout)
     super.init(contentViewController: collectionVC)
 
-    collectionVC.headerViewController = self.headerViewController;
-    collectionVC.setupHeaderView();
+    collectionVC.headerViewController = self.headerViewController
+    collectionVC.setupHeaderView()
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/demos/Shrine/Shrine/ShrineFlexibleHeaderContainerViewController.swift
+++ b/demos/Shrine/Shrine/ShrineFlexibleHeaderContainerViewController.swift
@@ -21,8 +21,8 @@ class ShrineFlexibleHeaderContainerViewController: MDCFlexibleHeaderContainerVie
 
   init() {
     let layout = UICollectionViewFlowLayout()
-    let sectionInset:CGFloat = 10.0
-    layout.sectionInset = UIEdgeInsetsMake(sectionInset, sectionInset, sectionInset, sectionInset)
+    let sectionInset: CGFloat = 10.0
+    layout.sectionInset = UIEdgeInsets(top: sectionInset, left: sectionInset, bottom: sectionInset, right: sectionInset)
     let collectionVC = ShrineCollectionViewController(collectionViewLayout: layout)
     super.init(contentViewController: collectionVC)
 

--- a/demos/Shrine/Shrine/ShrineHeaderContentView.swift
+++ b/demos/Shrine/Shrine/ShrineHeaderContentView.swift
@@ -98,8 +98,8 @@ class ShrineHeaderContentView: UIView, UIScrollViewDelegate {
     imageView.autoresizingMask = .flexibleHeight
     (page as AnyObject).addSubview(imageView)
     let url = URL(string: ShrineData.baseURL + imageName)
-    remoteImageService.fetchImageAndThumbnail(from: url) { (image:UIImage?,
-      thumbnailImage:UIImage?) -> Void in
+    remoteImageService.fetchImageAndThumbnail(from: url) { (image: UIImage?,
+      _) -> Void in
       DispatchQueue.main.async(execute: {
         imageView.image = image
         imageView.setNeedsDisplay()
@@ -158,7 +158,7 @@ class ShrineHeaderContentView: UIView, UIScrollViewDelegate {
     let pageControlSize = pageControl.sizeThatFits(self.bounds.size)
     pageControl.frame = CGRect(x: 0, y: boundsHeight - pageControlSize.height, width: boundsWidth,
       height: pageControlSize.height)
-    let scrollWidth:CGFloat = boundsWidth * CGFloat(pages.count)
+    let scrollWidth: CGFloat = boundsWidth * CGFloat(pages.count)
     scrollView.frame = CGRect(x: 0, y: 0, width: boundsWidth, height: boundsHeight)
     scrollView.contentSize = CGSize(width: scrollWidth, height: boundsHeight)
 

--- a/demos/Shrine/Shrine/ShrineHeaderContentView.swift
+++ b/demos/Shrine/Shrine/ShrineHeaderContentView.swift
@@ -101,7 +101,7 @@ class ShrineHeaderContentView: UIView, UIScrollViewDelegate {
     remoteImageService.fetchImageAndThumbnail(from: url) { (image:UIImage?,
       thumbnailImage:UIImage?) -> Void in
       DispatchQueue.main.async(execute: {
-        imageView.image = image;
+        imageView.image = image
         imageView.setNeedsDisplay()
       })
     }
@@ -111,7 +111,7 @@ class ShrineHeaderContentView: UIView, UIScrollViewDelegate {
     label.lineBreakMode = .byWordWrapping
     label.numberOfLines = 2
     label.attributedText = attributedString(description, lineHeightMultiple: 0.8)
-    label.sizeToFit();
+    label.sizeToFit()
     (page as AnyObject).addSubview(label)
 
     labelDesc.lineBreakMode = .byWordWrapping

--- a/demos/Shrine/Shrine/ShrineInkOverlay.swift
+++ b/demos/Shrine/Shrine/ShrineInkOverlay.swift
@@ -19,7 +19,7 @@ import MaterialComponents.MaterialInk
 
 class ShrineInkOverlay: UIView, MDCInkTouchControllerDelegate {
 
-  fileprivate var inkTouchController:MDCInkTouchController?
+  fileprivate var inkTouchController: MDCInkTouchController?
 
   override init(frame: CGRect) {
     super.init(frame: frame)

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,5 @@
+if which swiftlint >/dev/null; then
+  swiftlint
+else
+  echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
+fi


### PR DESCRIPTION
This PR integrates [SwiftLint](https://github.com/realm/SwiftLint) into the project. It fixes basic style warnings in the catalog and components.

I have disabled a number of rules for now since there are an overwhelming number of violations otherwise, but I think we should gradually enable some of these rules and fix the warnings. I haven't done that here in the interest of keeping this PR small.

The `.swiftlint.yml` file exists in the root directory and has been symlinked to `catalog`. Originally the script was running `swiftlint` from the root directory, but then you see warnings from the other projects in the warnings navigator, which can be distracting.

Related to #857.

---

#### To Do:

* [x] Integrate SwiftLint into Shrine and fix the warnings
* [x] Do an audit of the disabled rules