### PR TITLE
[Tests] Fix test failures on iOS 8

### DIFF
--- a/catalog/MDCCatalog.xcodeproj/project.pbxproj
+++ b/catalog/MDCCatalog.xcodeproj/project.pbxproj
@@ -718,7 +718,6 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = MDCInteractionTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.MDCInteractionTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -735,7 +734,6 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = MDCInteractionTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.MDCInteractionTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
This PR fixes an issue where interaction tests would fail immediately when running on iOS 8.0.

The solution was to change the interaction test deployment target from 9.3 back to 8.0. After this change, the tests pass locally on 8.1, 9.3, and 10.2.

Closes #1038.