### PR TITLE
[Button] Adhere to tintColor changes

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -311,6 +311,10 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   return CGRectContainsPoint(UIEdgeInsetsInsetRect(self.bounds, _hitAreaInsets), point);
 }
 
+- (void)tintColorDidChange {
+  self.customTitleColor = self.tintColor;
+}
+
 #pragma mark - UIResponder
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {


### PR DESCRIPTION
This PR updates `MDCButton` to support `tintColor` correctly.

Closes #602.

---

The result after adding `MDCButton.appearance().tintColor = .red` to the catalog as a test:

![simulator screen shot 5 01 2017 12 48 49 pm](https://cloud.githubusercontent.com/assets/183774/21663482/6057623a-d345-11e6-9519-08d22cb8ed5f.png)
