### PR TITLE
[Snackbar] Render messages correctly for RTL

### DIFF
--- a/components/Snackbar/src/private/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/private/MDCSnackbarMessageView.m
@@ -293,10 +293,7 @@ static const CGFloat kButtonInkRadius = 64.0f;
     [messageString addAttributes:attributes range:NSMakeRange(0, messageString.length)];
 
     _label.backgroundColor = [UIColor clearColor];
-    _label.textAlignment = NSTextAlignmentLeft;
-
-    // TODO: Add support for RTL languages so @c _label renders correctly.
-
+    _label.textAlignment = NSTextAlignmentNatural;
     _label.attributedText = messageString;
     _label.numberOfLines = 0;
     [_label setTranslatesAutoresizingMaskIntoConstraints:NO];


### PR DESCRIPTION
Closes #1058

Before:
![rtl-before](https://cloud.githubusercontent.com/assets/1251373/21694540/d2373ab6-d353-11e6-9075-536c794d3879.png)

After:
![rtl-after](https://cloud.githubusercontent.com/assets/1251373/21694542/d495eec4-d353-11e6-9fd7-53c69f36685a.png)