### PR TITLE
[FlexibleHeader] - Update tests so as not to have 0 in contentSize

### DIFF
--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
@@ -52,7 +52,7 @@
   self.scrollView.frame = self.view.bounds;
   self.scrollView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  self.scrollView.contentSize = CGSizeMake(self.view.bounds.size.width, 2000);
+  self.scrollView.contentSize = CGSizeMake(320, 2000);
   [self.view addSubview:self.scrollView];
   self.fhvc.headerView.trackingScrollView = self.scrollView;
   self.fhvc.view.frame = self.view.bounds;


### PR DESCRIPTION
This closes issue [1040](https://github.com/material-components/material-components-ios/issues/1040)

Changes: Update content size in test so it is not nil width