### PR TITLE
[Feature highlight] Dynamically size inner highlight

### DIFF
--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
@@ -50,7 +50,7 @@ static NSString *const reuseIdentifier = @"Cell";
   [self.view addSubview:self.infoLabel];
 
   self.button = [[MDCRaisedButton alloc] init];
-  [self.button setTitle:@"GO really far!" forState:UIControlStateNormal];
+  [self.button setTitle:@"GO!" forState:UIControlStateNormal];
   [self.button sizeToFit];
   [self.button addTarget:self
                   action:@selector(didTapButton:)

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
@@ -50,7 +50,7 @@ static NSString *const reuseIdentifier = @"Cell";
   [self.view addSubview:self.infoLabel];
 
   self.button = [[MDCRaisedButton alloc] init];
-  [self.button setTitle:@"GO!" forState:UIControlStateNormal];
+  [self.button setTitle:@"GO really far!" forState:UIControlStateNormal];
   [self.button sizeToFit];
   [self.button addTarget:self
                   action:@selector(didTapButton:)

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
@@ -39,6 +39,9 @@ typedef void (^MDCFeatureHighlightCompletion)(BOOL accepted);
 
  While MDCFeatureHighlightViewController supports changing state while presented, it is not
  recommended as the design spec does not specify any patterns for that behavior.
+ 
+ @note Due to a bug in the iOS simulator it is possible that the feature highlight will not render
+ correctly in the simulator. If you're encountering issues make sure to test on device.
  */
 @interface MDCFeatureHighlightViewController : UIViewController
 

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView.m
@@ -35,6 +35,10 @@ const CGFloat kMDCFeatureHighlightInnerRadiusFactor = 1.1f;
 const CGFloat kMDCFeatureHighlightOuterRadiusFactor = 1.125f;
 const CGFloat kMDCFeatureHighlightPulseRadiusFactor = 2.0f;
 const CGFloat kMDCFeatureHighlightPulseStartAlpha = 0.54f;
+const CGFloat kMDCFeatureHighlightInnerRadiusBloomAmount =
+    (kMDCFeatureHighlightInnerRadiusFactor - 1) * kMDCFeatureHighlightMinimumInnerRadius;
+const CGFloat kMDCFeatureHighlightPulseRadiusBloomAmount =
+    (kMDCFeatureHighlightPulseRadiusFactor - 1) * kMDCFeatureHighlightMinimumInnerRadius;
 
 @implementation MDCFeatureHighlightView {
   BOOL _forceConcentricLayout;
@@ -199,11 +203,13 @@ const CGFloat kMDCFeatureHighlightPulseStartAlpha = 0.54f;
   [CATransaction setAnimationDuration:1.0f];
   [CATransaction setAnimationTimingFunction:[CAMediaTimingFunction
                                                 functionWithName:kCAMediaTimingFunctionEaseOut]];
+  CGFloat innerBloomRadius = radius + kMDCFeatureHighlightInnerRadiusBloomAmount;
+  CGFloat pulseBloomRadius = radius + kMDCFeatureHighlightPulseRadiusBloomAmount;
   NSArray *innerKeyframes =
-      @[ @(radius), @(radius * kMDCFeatureHighlightInnerRadiusFactor), @(radius) ];
+      @[ @(radius), @(innerBloomRadius), @(radius) ];
   [_innerLayer animateRadiusOverKeyframes:innerKeyframes keyTimes:keyTimes center:_highlightPoint];
   NSArray *pulseKeyframes =
-      @[ @(radius), @(radius), @(radius * kMDCFeatureHighlightPulseRadiusFactor) ];
+      @[ @(radius), @(radius), @(pulseBloomRadius) ];
   [_pulseLayer animateRadiusOverKeyframes:pulseKeyframes keyTimes:keyTimes center:_highlightPoint];
   [_pulseLayer animateFillColorOverKeyframes:@[ pulseColorStart, pulseColorStart, pulseColorEnd ]
                                     keyTimes:keyTimes];

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView.m
@@ -20,7 +20,7 @@
 #import "MDFTextAccessibility.h"
 #import "MaterialTypography.h"
 
-const CGFloat kMDCFeatureHighlightInnerRadius = 44.0f;
+const CGFloat kMDCFeatureHighlightMinimumInnerRadius = 44.0f;
 const CGFloat kMDCFeatureHighlightInnerPadding = 20.0f;
 const CGFloat kMDCFeatureHighlightTextPadding = 40.0f;
 const CGFloat kMDCFeatureHighlightTextMaxWidth = 300.0f;
@@ -40,6 +40,7 @@ const CGFloat kMDCFeatureHighlightPulseStartAlpha = 0.54f;
   UIView *_highlightView;
   CGPoint _highlightPoint;
   CGPoint _highlightCenter;
+  CGFloat _innerRadius;
   CGPoint _outerCenter;
   CGFloat _outerRadius;
   MDCFeatureHighlightLayer *_outerLayer;
@@ -87,6 +88,8 @@ const CGFloat kMDCFeatureHighlightPulseStartAlpha = 0.54f;
 
     self.outerHighlightColor = [UIColor blueColor];
     self.innerHighlightColor = [UIColor whiteColor];
+
+    _innerRadius = kMDCFeatureHighlightMinimumInnerRadius;
 
     // We want the inner and outer highlights to animate from the same origin so we start them from
     // a concentric position.
@@ -168,10 +171,10 @@ const CGFloat kMDCFeatureHighlightPulseStartAlpha = 0.54f;
                                                 functionWithName:kCAMediaTimingFunctionEaseOut]];
   [CATransaction setAnimationDuration:duration];
   [_displayMaskLayer setCenter:displayMaskCenter
-                        radius:kMDCFeatureHighlightInnerRadius
+                        radius:_innerRadius
                       animated:YES];
   [_innerLayer setFillColor:[_innerHighlightColor colorWithAlphaComponent:1].CGColor animated:YES];
-  [_innerLayer setCenter:_highlightPoint radius:kMDCFeatureHighlightInnerRadius animated:YES];
+  [_innerLayer setCenter:_highlightPoint radius:_innerRadius animated:YES];
   [_outerLayer setFillColor:_outerHighlightColor.CGColor animated:YES];
   [_outerLayer setCenter:_highlightCenter radius:_outerRadius animated:YES];
   [CATransaction commit];
@@ -186,7 +189,7 @@ const CGFloat kMDCFeatureHighlightPulseStartAlpha = 0.54f;
           [_innerHighlightColor colorWithAlphaComponent:kMDCFeatureHighlightPulseStartAlpha]
               .CGColor;
   id pulseColorEnd = (__bridge id)[_innerHighlightColor colorWithAlphaComponent:0].CGColor;
-  CGFloat radius = kMDCFeatureHighlightInnerRadius;
+  CGFloat radius = _innerRadius;
 
   [CATransaction begin];
   [CATransaction setAnimationDuration:1.0f];
@@ -263,9 +266,9 @@ const CGFloat kMDCFeatureHighlightPulseStartAlpha = 0.54f;
     _highlightCenter = _highlightPoint;
   } else {
     if (topHalf) {
-      _highlightCenter.y = _highlightPoint.y + kMDCFeatureHighlightInnerRadius + textHeight / 2;
+      _highlightCenter.y = _highlightPoint.y + _innerRadius + textHeight / 2;
     } else {
-      _highlightCenter.y = _highlightPoint.y - kMDCFeatureHighlightInnerRadius - textHeight / 2;
+      _highlightCenter.y = _highlightPoint.y - _innerRadius - textHeight / 2;
     }
     if (leftHalf) {
       _highlightCenter.x = _highlightPoint.x + kMDCFeatureHighlightNonconcentricOffset;
@@ -290,11 +293,9 @@ const CGFloat kMDCFeatureHighlightPulseStartAlpha = 0.54f;
   CGPoint titlePos = CGPointMake(0, 0);
   titlePos.x = MIN(MAX(_highlightCenter.x - textWidth / 2, leftTextBound), rightTextBound);
   if (topHalf) {
-    titlePos.y =
-        _highlightPoint.y + kMDCFeatureHighlightInnerPadding + kMDCFeatureHighlightInnerRadius;
+    titlePos.y = _highlightPoint.y + kMDCFeatureHighlightInnerPadding + _innerRadius;
   } else {
-    titlePos.y = _highlightPoint.y - kMDCFeatureHighlightInnerPadding -
-                 kMDCFeatureHighlightInnerRadius - textHeight;
+    titlePos.y = _highlightPoint.y - kMDCFeatureHighlightInnerPadding - _innerRadius - textHeight;
   }
 
   CGRect titleFrame = (CGRect){titlePos, titleSize};
@@ -315,7 +316,7 @@ const CGFloat kMDCFeatureHighlightPulseStartAlpha = 0.54f;
   CGPoint pos = [tapGestureRecognizer locationInView:self];
   CGFloat dist =
       (float)(sqrt(pow(pos.x - _highlightPoint.x, 2) + pow(pos.y - _highlightPoint.y, 2)));
-  BOOL accepted = dist <= kMDCFeatureHighlightInnerRadius;
+  BOOL accepted = dist <= _innerRadius;
 
   if (self.interactionBlock) {
     self.interactionBlock(accepted);


### PR DESCRIPTION
This does not have an upper limit so it does let people create absurd looking highlights. We should eventually support highlights without the white inner highlight for cases where the content is particularly large. Closes #860.

Before:
![fhbefore](https://cloud.githubusercontent.com/assets/1251373/21827835/5b494352-d75b-11e6-873e-206a6cb56fa9.png)

After:
![fhafter](https://cloud.githubusercontent.com/assets/1251373/21827838/5ecdaff4-d75b-11e6-99fe-c7614aeef0af.png)