### PR TITLE
[Collections] Added custom Storyboard cell to the Storyboard example.

### DIFF
--- a/components/Collections/examples/CollectionsStoryboardExample.m
+++ b/components/Collections/examples/CollectionsStoryboardExample.m
@@ -18,7 +18,11 @@
 
 static const NSInteger kSectionCount = 10;
 static const NSInteger kSectionItemCount = 5;
-static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
+static NSString *const kReusableIdentifierItem = @"customCell";
+
+@interface CollectionStoryboardExampleCell: UICollectionViewCell
+@property(nonatomic, weak) IBOutlet UILabel *label;
+@end
 
 @implementation CollectionsStoryboardExample {
   NSMutableArray *_content;
@@ -35,10 +39,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 - (void)viewDidLoad {
   [super viewDidLoad];
   self.title = @"Storyboard Demo";
-
-  // Register cell class.
-  [self.collectionView registerClass:[MDCCollectionViewTextCell class]
-          forCellWithReuseIdentifier:kReusableIdentifierItem];
 
   // Populate content.
   _content = [NSMutableArray array];
@@ -68,11 +68,15 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
                   cellForItemAtIndexPath:(NSIndexPath *)indexPath {
-  MDCCollectionViewTextCell *cell =
+  CollectionStoryboardExampleCell *cell =
       [collectionView dequeueReusableCellWithReuseIdentifier:kReusableIdentifierItem
                                                 forIndexPath:indexPath];
-  cell.textLabel.text = _content[indexPath.section][indexPath.item];
+  cell.label.text = _content[indexPath.section][indexPath.item];
+
   return cell;
 }
 
+@end
+
+@implementation CollectionStoryboardExampleCell
 @end

--- a/components/Collections/examples/resources/CollectionsStoryboardExample.storyboard
+++ b/components/Collections/examples/resources/CollectionsStoryboardExample.storyboard
@@ -1,16 +1,20 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BMn-rM-e2q">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BMn-rM-e2q">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--CollectionsStoryboardExample-->
         <scene sceneID="nRw-zU-Xbw">
             <objects>
                 <collectionViewController title="CollectionsStoryboardExample" id="BMn-rM-e2q" customClass="CollectionsStoryboardExample" sceneMemberID="viewController">
-                    <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="H2V-rH-0Z8">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                    <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" dataMode="prototypes" id="H2V-rH-0Z8">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="eqs-fm-Qll">
                             <size key="itemSize" width="50" height="50"/>
@@ -19,23 +23,26 @@
                             <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         </collectionViewFlowLayout>
                         <cells>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="firstCell" id="ya3-i3-i11">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="customCell" id="ya3-i3-i11" userLabel="customCell" customClass="CollectionStoryboardExampleCell">
                                 <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                     <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                     <autoresizingMask key="autoresizingMask"/>
-                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QSw-4r-pfz">
+                                            <rect key="frame" x="4" y="15" width="42" height="21"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                            <fontDescription key="fontDescription" type="italicSystem" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
                                 </view>
-                            </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="secondCell" id="ACF-5M-rsG">
-                                <rect key="frame" x="61" y="0.0" width="50" height="50"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                                    <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                </view>
+                                <color key="backgroundColor" red="0.8633875639571934" green="0.93266503655327992" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <connections>
+                                    <outlet property="label" destination="QSw-4r-pfz" id="yUG-kP-cZg"/>
+                                </connections>
                             </collectionViewCell>
                         </cells>
                         <connections>


### PR DESCRIPTION
Added an example for [this StackOverflow question](http://stackoverflow.com/questions/41382383/is-it-possible-to-set-mdccollectionviewcell-from-interface-builder). It uses a custom cell with italic text and a light blue background created in a Storyboard.

![screen shot 2017-01-10 at 5 51 57 pm](https://cloud.githubusercontent.com/assets/742162/21828276/a4c5c2e2-d75d-11e6-9abf-594cdf705901.png)
