### PR TITLE
[AppBar] - Added Modal Presentation App Bar Example

### DIFF
--- a/components/AppBar/examples/AppBarModalPresentationExample.m
+++ b/components/AppBar/examples/AppBarModalPresentationExample.m
@@ -1,0 +1,271 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "MaterialAppBar.h"
+
+@interface AppBarModallyPresentedViewController : UITableViewController
+@property(strong, nonatomic) MDCAppBar *appBar;
+@end
+
+@implementation AppBarModallyPresentedViewController
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    self.title = nil;
+
+    // Initialize the App Bar and add the headerViewController as a child.
+    _appBar = [[MDCAppBar alloc] init];
+    [self addChildViewController:_appBar.headerViewController];
+
+    // Optional: Change the App Bar's background color and tint color.
+    UIColor *color = [UIColor colorWithRed:(CGFloat)0x03 / (CGFloat)255
+                                     green:(CGFloat)0xA9 / (CGFloat)255
+                                      blue:(CGFloat)0xF4 / (CGFloat)255
+                                     alpha:1];
+    _appBar.headerViewController.headerView.backgroundColor = color;
+    _appBar.navigationBar.tintColor = [UIColor whiteColor];
+    _appBar.navigationBar.titleTextAttributes =
+    @{NSForegroundColorAttributeName : [UIColor whiteColor]};
+
+    // Set presentation style
+    [self setModalPresentationStyle:UIModalPresentationFormSheet];
+    [self setModalTransitionStyle:UIModalTransitionStyleCoverVertical];
+
+    // Set preferred content size
+    self.preferredContentSize = CGSizeMake(250, 500);
+  }
+  return self;
+}
+
+- (void)viewDidLoad {
+
+  // UITableViewController's tableView.delegate is self by default. We're setting it here for
+  // emphasis.
+  self.tableView.delegate = self;
+
+  self.appBar.headerViewController.headerView.trackingScrollView = self.tableView;
+  [self.appBar addSubviewsToParent];
+
+  self.tableView.layoutMargins = UIEdgeInsetsZero;
+  self.tableView.separatorInset = UIEdgeInsetsZero;
+
+  // Add optional navigation items
+  self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Dismiss"
+                                                                    style:UIBarButtonItemStyleDone
+                                                                          target:nil
+                                                                    action:@selector(dismissSelf)];
+
+  self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Touch"
+                                                                    style:UIBarButtonItemStyleDone
+                                                                              target:nil
+                                                                    action:@selector(touchPressed)];
+}
+
+- (void)touchPressed {}
+
+- (void)dismissSelf {
+  [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+#pragma mark - UIScrollViewDelegate
+
+// The following four methods must be forwarded to the tracking scroll view in order to implement
+// the Flexible Header's behavior.
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
+  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
+    [self.appBar.headerViewController.headerView trackingScrollViewDidScroll];
+  }
+}
+
+- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
+  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
+    [self.appBar.headerViewController.headerView trackingScrollViewDidEndDecelerating];
+  }
+}
+
+- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
+  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
+  if (scrollView == headerView.trackingScrollView) {
+    [headerView trackingScrollViewDidEndDraggingWillDecelerate:decelerate];
+  }
+}
+
+- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
+                     withVelocity:(CGPoint)velocity
+              targetContentOffset:(inout CGPoint *)targetContentOffset {
+  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
+  if (scrollView == headerView.trackingScrollView) {
+    [headerView trackingScrollViewWillEndDraggingWithVelocity:velocity
+                                          targetContentOffset:targetContentOffset];
+  }
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+  return 50;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView
+         cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+  UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:@"cell"];
+  if (!cell) {
+    cell =
+    [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"cell"];
+  }
+  cell.layoutMargins = UIEdgeInsetsZero;
+  return cell;
+}
+
+@end
+
+// The below code class duplicates AppBarTypicalUseExample to present
+//AppBarModallyPresentedViewController
+
+@interface AppBarModalPresentationExample : UITableViewController
+@property(nonatomic, strong) MDCAppBar *appBar;
+@end
+
+@implementation AppBarModalPresentationExample
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  self.tableView.delegate = self;
+
+  self.appBar.headerViewController.headerView.trackingScrollView = self.tableView;
+  [self.appBar addSubviewsToParent];
+
+  self.tableView.layoutMargins = UIEdgeInsetsZero;
+  self.tableView.separatorInset = UIEdgeInsetsZero;
+
+  self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Detail"
+                                                                      style:UIBarButtonItemStyleDone
+                                                                              target:nil
+                                                                    action:@selector(presentModal)];
+}
+
+- (void)presentModal {
+  AppBarModallyPresentedViewController *modalVC =
+      [[AppBarModallyPresentedViewController alloc] init];
+  [self presentViewController:modalVC animated:YES completion:^{}];
+}
+
+#pragma mark - UIScrollViewDelegate
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
+  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
+    [self.appBar.headerViewController.headerView trackingScrollViewDidScroll];
+  }
+}
+
+- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
+  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
+    [self.appBar.headerViewController.headerView trackingScrollViewDidEndDecelerating];
+  }
+}
+
+- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
+  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
+  if (scrollView == headerView.trackingScrollView) {
+    [headerView trackingScrollViewDidEndDraggingWillDecelerate:decelerate];
+  }
+}
+
+- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
+                     withVelocity:(CGPoint)velocity
+              targetContentOffset:(inout CGPoint *)targetContentOffset {
+  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
+  if (scrollView == headerView.trackingScrollView) {
+    [headerView trackingScrollViewWillEndDraggingWithVelocity:velocity
+                                          targetContentOffset:targetContentOffset];
+  }
+}
+
+@end
+
+@implementation AppBarModalPresentationExample (CatalogByConvention)
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"App Bar", @"Modal Presentation" ];
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return YES;
+}
+
+@end
+
+@implementation AppBarModalPresentationExample (TypicalUse)
+
+- (id)init {
+  self = [super init];
+  if (self) {
+    _appBar = [[MDCAppBar alloc] init];
+    _appBar.navigationBar.tintColor = [UIColor whiteColor];
+    _appBar.navigationBar.titleTextAttributes =
+    @{NSForegroundColorAttributeName : [UIColor whiteColor]};
+    [self addChildViewController:_appBar.headerViewController];
+
+    self.title = @"Modal Presentation";
+
+    UIColor *color = [UIColor colorWithRed:(CGFloat)0x03 / (CGFloat)255
+                                     green:(CGFloat)0xA9 / (CGFloat)255
+                                      blue:(CGFloat)0xF4 / (CGFloat)255
+                                     alpha:1];
+    _appBar.headerViewController.headerView.backgroundColor = color;
+  }
+  return self;
+}
+
+- (UIViewController *)childViewControllerForStatusBarHidden {
+  return self.appBar.headerViewController;
+}
+
+- (UIViewController *)childViewControllerForStatusBarStyle {
+  return self.appBar.headerViewController;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+  [super viewWillAppear:animated];
+
+  [self.navigationController setNavigationBarHidden:YES animated:animated];
+}
+
+@end
+
+#pragma mark - Typical application code (not Material-specific)
+
+@implementation AppBarModalPresentationExample (UITableViewDataSource)
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+  return 50;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView
+         cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+  UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:@"cell"];
+  if (!cell) {
+    cell =
+    [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"cell"];
+  }
+  cell.layoutMargins = UIEdgeInsetsZero;
+  return cell;
+}
+
+@end

--- a/components/AppBar/examples/AppBarModalPresentationExample.m
+++ b/components/AppBar/examples/AppBarModalPresentationExample.m
@@ -18,11 +18,11 @@
 
 #import "MaterialAppBar.h"
 
-@interface AppBarModallyPresentedViewController : UITableViewController
+@interface AppBarModalPresentationExamplePresented : UITableViewController
 @property(strong, nonatomic) MDCAppBar *appBar;
 @end
 
-@implementation AppBarModallyPresentedViewController
+@implementation AppBarModalPresentationExamplePresented
 
 - (instancetype)init {
   self = [super init];
@@ -133,7 +133,7 @@
 @end
 
 // The below code class duplicates AppBarTypicalUseExample to present
-// AppBarModallyPresentedViewController
+// AppBarModalPresentationExamplePresented
 
 @interface AppBarModalPresentationExample : UITableViewController
 @property(nonatomic, strong) MDCAppBar *appBar;
@@ -159,8 +159,8 @@
 }
 
 - (void)presentModal {
-  AppBarModallyPresentedViewController *modalVC =
-      [[AppBarModallyPresentedViewController alloc] init];
+  AppBarModalPresentationExamplePresented *modalVC =
+      [[AppBarModalPresentationExamplePresented alloc] init];
   [self presentViewController:modalVC animated:YES completion:^{}];
 }
 

--- a/components/AppBar/examples/AppBarModalPresentationExample.m
+++ b/components/AppBar/examples/AppBarModalPresentationExample.m
@@ -68,16 +68,14 @@
   // Add optional navigation items
   self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Dismiss"
                                                                     style:UIBarButtonItemStyleDone
-                                                                          target:nil
+                                                                          target:self
                                                                     action:@selector(dismissSelf)];
 
   self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Touch"
                                                                     style:UIBarButtonItemStyleDone
                                                                               target:nil
-                                                                    action:@selector(touchPressed)];
+                                                                    action:nil];
 }
-
-- (void)touchPressed {}
 
 - (void)dismissSelf {
   [self dismissViewControllerAnimated:YES completion:nil];
@@ -135,7 +133,7 @@
 @end
 
 // The below code class duplicates AppBarTypicalUseExample to present
-//AppBarModallyPresentedViewController
+// AppBarModallyPresentedViewController
 
 @interface AppBarModalPresentationExample : UITableViewController
 @property(nonatomic, strong) MDCAppBar *appBar;
@@ -156,7 +154,7 @@
 
   self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Detail"
                                                                       style:UIBarButtonItemStyleDone
-                                                                              target:nil
+                                                                              target:self
                                                                     action:@selector(presentModal)];
 }
 

--- a/components/AppBar/examples/AppBarModalPresentationExample.m
+++ b/components/AppBar/examples/AppBarModalPresentationExample.m
@@ -27,7 +27,6 @@
 - (instancetype)init {
   self = [super init];
   if (self) {
-    self.title = nil;
 
     // Initialize the App Bar and add the headerViewController as a child.
     _appBar = [[MDCAppBar alloc] init];
@@ -41,7 +40,7 @@
     _appBar.headerViewController.headerView.backgroundColor = color;
     _appBar.navigationBar.tintColor = [UIColor whiteColor];
     _appBar.navigationBar.titleTextAttributes =
-    @{NSForegroundColorAttributeName : [UIColor whiteColor]};
+        @{NSForegroundColorAttributeName : [UIColor whiteColor]};
 
     // Set presentation style
     [self setModalPresentationStyle:UIModalPresentationFormSheet];

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -1,0 +1,108 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+import MaterialComponents
+
+class AppBarModalPresentationSwiftExample: UITableViewController {
+
+  // Step 1: Create and initialize an App Bar.
+  let appBar = MDCAppBar()
+
+  init() {
+    super.init(nibName: nil, bundle: nil)
+
+    self.title = "Modal Presentation (Swift)"
+
+    self.addChildViewController(appBar.headerViewController)
+
+    let color = UIColor(
+      red: CGFloat(0x03) / CGFloat(255),
+      green: CGFloat(0xA9) / CGFloat(255),
+      blue: CGFloat(0xF4) / CGFloat(255),
+      alpha: 1)
+    appBar.headerViewController.headerView.backgroundColor = color
+    appBar.navigationBar.tintColor = UIColor.white
+    appBar.navigationBar.titleTextAttributes =
+      [ NSForegroundColorAttributeName: UIColor.white ]
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    super.init(coder: aDecoder)
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    appBar.headerViewController.headerView.trackingScrollView = self.tableView
+    self.tableView.delegate = appBar.headerViewController
+
+    appBar.addSubviewsToParent()
+
+    self.tableView.layoutMargins = UIEdgeInsets.zero
+    self.tableView.separatorInset = UIEdgeInsets.zero
+
+    self.navigationItem.rightBarButtonItem =
+      UIBarButtonItem(title: "Detail", style: .done, target: nil, action: nil)
+  }
+
+
+  override var childViewControllerForStatusBarHidden: UIViewController? {
+    return appBar.headerViewController
+  }
+
+  override var childViewControllerForStatusBarStyle: UIViewController? {
+    return appBar.headerViewController
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+
+    self.navigationController?.setNavigationBarHidden(true, animated: animated)
+  }
+}
+
+// MARK: Catalog by convention
+extension AppBarModalPresentationSwiftExample {
+  class func catalogBreadcrumbs() -> [String] {
+    return ["App Bar", "Modal Presentation (Swift)"]
+  }
+  func catalogShouldHideNavigation() -> Bool {
+    return true
+  }
+}
+
+// MARK: - Typical application code (not Material-specific)
+
+// MARK: UITableViewDataSource
+extension AppBarModalPresentationSwiftExample {
+
+  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return 50
+  }
+
+  override func tableView(
+    _ tableView: UITableView,
+    cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    var cell = self.tableView.dequeueReusableCell(withIdentifier: "cell")
+    if cell == nil {
+      cell = UITableViewCell(style: .default, reuseIdentifier: "cell")
+    }
+    cell!.layoutMargins = UIEdgeInsets.zero
+    return cell!
+  }
+  
+}

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -37,6 +37,8 @@ class AppBarModalPresentationSwiftExamplePresented: UITableViewController {
     appBar.navigationBar.tintColor = UIColor.white
     appBar.navigationBar.titleTextAttributes =
       [ NSForegroundColorAttributeName: UIColor.white ]
+    self.modalPresentationStyle = .formSheet
+    self.modalTransitionStyle = .coverVertical
   }
 
   required init?(coder aDecoder: NSCoder) {
@@ -58,7 +60,7 @@ class AppBarModalPresentationSwiftExamplePresented: UITableViewController {
       UIBarButtonItem(title: "Touch", style: .done, target: nil, action: nil)
 
     self.navigationItem.leftBarButtonItem =
-      UIBarButtonItem(title: "Dismiss", style: .done, target: nil, action: nil)
+      UIBarButtonItem(title: "Dismiss", style: .done, target: self, action: #selector(dismissSelf))
   }
 
   override var childViewControllerForStatusBarHidden: UIViewController? {
@@ -88,6 +90,10 @@ class AppBarModalPresentationSwiftExamplePresented: UITableViewController {
     }
     cell!.layoutMargins = UIEdgeInsets.zero
     return cell!
+  }
+
+  func dismissSelf() {
+    self.dismiss(animated: true, completion: nil)
   }
 }
 
@@ -129,7 +135,7 @@ class AppBarModalPresentationSwiftExample: UITableViewController {
     self.tableView.separatorInset = UIEdgeInsets.zero
 
     self.navigationItem.rightBarButtonItem =
-      UIBarButtonItem(title: "Detail", style: .done, target: nil, action: nil)
+      UIBarButtonItem(title: "Detail", style: .done, target: self, action: #selector(presentModal))
   }
 
 
@@ -145,6 +151,11 @@ class AppBarModalPresentationSwiftExample: UITableViewController {
     super.viewWillAppear(animated)
 
     self.navigationController?.setNavigationBarHidden(true, animated: animated)
+  }
+
+  func presentModal() {
+    let modalVC = AppBarModalPresentationSwiftExamplePresented()
+    self.present(modalVC, animated: true, completion: nil)
   }
 }
 

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -17,9 +17,82 @@
 import Foundation
 import MaterialComponents
 
+class AppBarModalPresentationSwiftExamplePresented: UITableViewController {
+
+  let appBar = MDCAppBar()
+
+  init() {
+    super.init(nibName: nil, bundle: nil)
+
+    self.title = "Modal Presentation (Swift)"
+
+    self.addChildViewController(appBar.headerViewController)
+
+    let color = UIColor(
+      red: CGFloat(0x03) / CGFloat(255),
+      green: CGFloat(0xA9) / CGFloat(255),
+      blue: CGFloat(0xF4) / CGFloat(255),
+      alpha: 1)
+    appBar.headerViewController.headerView.backgroundColor = color
+    appBar.navigationBar.tintColor = UIColor.white
+    appBar.navigationBar.titleTextAttributes =
+      [ NSForegroundColorAttributeName: UIColor.white ]
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    super.init(coder: aDecoder)
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    appBar.headerViewController.headerView.trackingScrollView = self.tableView
+    self.tableView.delegate = appBar.headerViewController
+
+    appBar.addSubviewsToParent()
+
+    self.tableView.layoutMargins = UIEdgeInsets.zero
+    self.tableView.separatorInset = UIEdgeInsets.zero
+
+    self.navigationItem.rightBarButtonItem =
+      UIBarButtonItem(title: "Touch", style: .done, target: nil, action: nil)
+
+    self.navigationItem.leftBarButtonItem =
+      UIBarButtonItem(title: "Dismiss", style: .done, target: nil, action: nil)
+  }
+
+  override var childViewControllerForStatusBarHidden: UIViewController? {
+    return appBar.headerViewController
+  }
+
+  override var childViewControllerForStatusBarStyle: UIViewController? {
+    return appBar.headerViewController
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+
+    self.navigationController?.setNavigationBarHidden(true, animated: animated)
+  }
+
+  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return 50
+  }
+
+  override func tableView(
+    _ tableView: UITableView,
+    cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    var cell = self.tableView.dequeueReusableCell(withIdentifier: "cell")
+    if cell == nil {
+      cell = UITableViewCell(style: .default, reuseIdentifier: "cell")
+    }
+    cell!.layoutMargins = UIEdgeInsets.zero
+    return cell!
+  }
+}
+
 class AppBarModalPresentationSwiftExample: UITableViewController {
 
-  // Step 1: Create and initialize an App Bar.
   let appBar = MDCAppBar()
 
   init() {


### PR DESCRIPTION
Changes Made:

- Added example to MDCCatalog to display modal presentation of form sheet while using MDCAppBar

- Added example to MDCCatalog to display modal presentation of form sheet while using MDCAppBar using Swift


This PR will display [issue 1105](https://github.com/material-components/material-components-ios/issues/1105) with which to make proposed fixes indicated in [the design doc](https://docs.google.com/document/d/1OtDBWyOb3G6p8v9vDK6cGf5P82JSH7RUi-MIrtxcajY/edit).