### PR TITLE
[Snackbar] Fix glitchy dismissal animation

### DIFF
--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -55,11 +55,6 @@ static const CGFloat kMaximumHeight = 80.0f;
 @property(nonatomic) MDCSnackbarMessageView *snackbarView;
 
 /**
- Storage for a completion block that is waiting for a CAAnimation to finish.
- */
-@property(nonatomic, copy) void (^pendingCompletionBlock)(void);
-
-/**
  The object which will notify us of changes in the keyboard position.
  */
 @property(nonatomic) MDCKeyboardWatcher *watcher;
@@ -87,6 +82,16 @@ static const CGFloat kMaximumHeight = 80.0f;
  If we received a rotation event, this is the duration that should be used.
  */
 @property(nonatomic) NSTimeInterval rotationDuration;
+
+/**
+ The constraint used to pin the bottom of the snackbar to the bottom of the screen.
+ */
+@property(nonatomic) NSLayoutConstraint *snackbarOnscreenConstraint;
+
+/**
+ The constraint used to pin the top of the snackbar to the bottom of the screen.
+ */
+@property(nonatomic) NSLayoutConstraint *snackbarOffscreenConstraint;
 
 @end
 
@@ -272,13 +277,26 @@ static const CGFloat kMaximumHeight = 80.0f;
       }
 
       // Always pin the snackbar to the bottom of the container.
-      [container addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
-                                                            attribute:NSLayoutAttributeBottom
-                                                            relatedBy:NSLayoutRelationEqual
-                                                               toItem:container
-                                                            attribute:NSLayoutAttributeBottom
-                                                           multiplier:1.0
-                                                             constant:-bottomMargin]];
+      _snackbarOnscreenConstraint = [NSLayoutConstraint constraintWithItem:snackbarView
+                                                                 attribute:NSLayoutAttributeBottom
+                                                                 relatedBy:NSLayoutRelationEqual
+                                                                    toItem:container
+                                                                 attribute:NSLayoutAttributeBottom
+                                                                multiplier:1.0
+                                                                  constant:-bottomMargin];
+      _snackbarOnscreenConstraint.active = NO; // snackbar starts off-screen.
+      _snackbarOnscreenConstraint.priority = UILayoutPriorityDefaultHigh;
+      [container addConstraint:_snackbarOnscreenConstraint];
+
+      _snackbarOffscreenConstraint = [NSLayoutConstraint constraintWithItem:snackbarView
+                                                                  attribute:NSLayoutAttributeTop
+                                                                  relatedBy:NSLayoutRelationEqual
+                                                                     toItem:container
+                                                                  attribute:NSLayoutAttributeBottom
+                                                                 multiplier:1.0
+                                                                   constant:-bottomMargin];
+      _snackbarOffscreenConstraint.active = YES;
+      [container addConstraint:_snackbarOffscreenConstraint];
 
       // Always limit the height of the snackbar.
       [container
@@ -408,40 +426,45 @@ static const CGFloat kMaximumHeight = 80.0f;
 #pragma mark - Slide Animation
 
 - (void)slideMessageView:(MDCSnackbarMessageView *)snackbarView
-                   fromY:(CGFloat)fromY
-                     toY:(CGFloat)toY
+                onscreen:(BOOL)onscreen
       fromContentOpacity:(CGFloat)fromContentOpacity
         toContentOpacity:(CGFloat)toContentOpacity
        notificationFrame:(CGRect)notificationFrame
               completion:(void (^)(void))completion {
-  // Save off @c completion for when the CAAnimation completes.
-  self.pendingCompletionBlock = completion;
+  // Prepare to move the snackbar.
+  _snackbarOnscreenConstraint.active = onscreen;
+  _snackbarOffscreenConstraint.active = !onscreen;
+  [_containingView setNeedsUpdateConstraints];
 
-  [CATransaction begin];
-
-  // Move the snackbar.
-  CABasicAnimation *translationAnimation =
-      [CABasicAnimation animationWithKeyPath:@"transform.translation.y"];
-  translationAnimation.duration = MDCSnackbarTransitionDuration;
-  translationAnimation.fromValue = @(fromY);
-  translationAnimation.toValue = @(toY);
-  translationAnimation.delegate = self;
-  translationAnimation.timingFunction =
+  CAMediaTimingFunction *timingFunction =
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionEaseInOut];
+  [CATransaction begin];
+  [CATransaction setAnimationTimingFunction:timingFunction];
 
-  [snackbarView.layer addAnimation:translationAnimation forKey:@"translation"];
+  // We use UIView animation inside a CATransaction in order to use the custom animation curve.
+  [UIView animateWithDuration:MDCSnackbarTransitionDuration
+                        delay:0
+                      options:UIViewAnimationOptionCurveEaseInOut
+                   animations:^{
+                     // Trigger snackbar animation.
+                     [_containingView layoutIfNeeded];
+                   } completion:^(BOOL finished) {
+                     if (completion) {
+                       completion();
+                     }
+                   }];
 
   [snackbarView animateContentOpacityFrom:fromContentOpacity
                                        to:toContentOpacity
-                                 duration:translationAnimation.duration
-                           timingFunction:translationAnimation.timingFunction];
+                                 duration:MDCSnackbarTransitionDuration
+                           timingFunction:timingFunction];
   [CATransaction commit];
 
   // Notify the overlay system.
   [self notifyOverlayChangeWithFrame:[self snackbarRectInScreenCoordinates]
                             duration:MDCSnackbarTransitionDuration
                                curve:0
-                      timingFunction:translationAnimation.timingFunction];
+                      timingFunction:timingFunction];
 }
 
 - (void)slideInMessageView:(MDCSnackbarMessageView *)snackbarView
@@ -450,8 +473,7 @@ static const CGFloat kMaximumHeight = 80.0f;
   [self triggerSnackbarLayoutChange];
 
   [self slideMessageView:snackbarView
-                   fromY:snackbarView.bounds.size.height + [self staticBottomMargin]
-                     toY:0.0f
+                onscreen:YES
       fromContentOpacity:0
         toContentOpacity:1
        notificationFrame:[self snackbarRectInScreenCoordinates]
@@ -464,23 +486,11 @@ static const CGFloat kMaximumHeight = 80.0f;
   [self triggerSnackbarLayoutChange];
 
   [self slideMessageView:snackbarView
-                   fromY:0.0f
-                     toY:snackbarView.bounds.size.height + [self staticBottomMargin]
+                onscreen:NO
       fromContentOpacity:1
         toContentOpacity:0
        notificationFrame:CGRectNull
               completion:completion];
-}
-
-#pragma mark - CAAnimationDelegate
-
-- (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag {
-  void (^block)(void) = self.pendingCompletionBlock;
-  self.pendingCompletionBlock = nil;
-
-  if (block) {
-    block();
-  }
 }
 
 #pragma mark - Keyboard Notifications

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -429,7 +429,6 @@ static const CGFloat kMaximumHeight = 80.0f;
                 onscreen:(BOOL)onscreen
       fromContentOpacity:(CGFloat)fromContentOpacity
         toContentOpacity:(CGFloat)toContentOpacity
-       notificationFrame:(CGRect)notificationFrame
               completion:(void (^)(void))completion {
   // Prepare to move the snackbar.
   _snackbarOnscreenConstraint.active = onscreen;
@@ -476,7 +475,6 @@ static const CGFloat kMaximumHeight = 80.0f;
                 onscreen:YES
       fromContentOpacity:0
         toContentOpacity:1
-       notificationFrame:[self snackbarRectInScreenCoordinates]
               completion:completion];
 }
 
@@ -489,7 +487,6 @@ static const CGFloat kMaximumHeight = 80.0f;
                 onscreen:NO
       fromContentOpacity:1
         toContentOpacity:0
-       notificationFrame:CGRectNull
               completion:completion];
 }
 

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -438,8 +438,8 @@ static const CGFloat kMaximumHeight = 80.0f;
   [CATransaction commit];
 
   // Notify the overlay system.
-  [self notifyOverlayChangeWithFrame:notificationFrame
-                            duration:translationAnimation.duration
+  [self notifyOverlayChangeWithFrame:[self snackbarRectInScreenCoordinates]
+                            duration:MDCSnackbarTransitionDuration
                                curve:0
                       timingFunction:translationAnimation.timingFunction];
 }


### PR DESCRIPTION
Fixes the glitchy snackbar dismissal animation. Tested with rotation and MDCOverlayObserver on device.

This very slightly changes the behavior of MDCOverlayObserver by returning an offscreen rect instead of CGRectNull when the snackbar disappears.

Closes #1018