### PR TITLE
Update minimum deployment target to iOS 8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 20.1.1
+
+## Component changes
+
+### Snackbar
+
+#### Changes
+
+* [Fix glitchy dismissal animation (#1166)](https://github.com/material-components/material-components-ios/pull/1166) (Sam Morrison)
+* [Update file path for private file. (#1168)](https://github.com/material-components/material-components-ios/commit/1effd8ad0cb879048f00972b366bcdf481e3c2b6) (Louis Romero)
+
 # 20.1.0 
 
 ## API diffs

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -2,7 +2,7 @@ load 'scripts/generated/icons.rb'
 
 Pod::Spec.new do |s|
   s.name         = "MaterialComponents"
-  s.version      = "20.1.0"
+  s.version      = "20.1.1"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
   #
 
   s.subspec "ActivityIndicator" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
 
@@ -45,13 +45,13 @@ Pod::Spec.new do |s|
   end
   
   s.subspec "AnimationTiming" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
   end
 
   s.subspec "AppBar" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}"
 
@@ -70,7 +70,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "Buttons" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
 
@@ -82,7 +82,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "ButtonBar" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
 
@@ -91,7 +91,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "CollectionCells" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
 
@@ -110,13 +110,13 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "CollectionLayoutAttributes" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}"
   end
 
   s.subspec "Collections" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
     ss.resources = ["components/#{ss.base_name}/src/Material#{ss.base_name}.bundle"]
@@ -144,7 +144,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "FeatureHighlight" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
     ss.dependency "MaterialComponents/Typography"
@@ -152,7 +152,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "FlexibleHeader" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
     ss.dependency 'MDFTextAccessibility'
@@ -160,19 +160,19 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "HeaderStackView" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}"
   end
 
   s.subspec "Ink" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
   end
 
   s.subspec "NavigationBar" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}"
 
@@ -182,7 +182,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "OverlayWindow" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
 
@@ -190,20 +190,20 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "PageControl" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
     ss.resources = ["components/#{ss.base_name}/src/Material#{ss.base_name}.bundle"]
   end
 
   s.subspec "Palettes" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
   end
 
   s.subspec "ProgressView" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}"
 
@@ -211,19 +211,19 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "ShadowElevations" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}"
   end
 
   s.subspec "ShadowLayer" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}"
   end
 
   s.subspec "Slider" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
 
@@ -231,7 +231,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "Snackbar" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
 
@@ -245,7 +245,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "Tabs" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
     ss.resources = ["components/#{ss.base_name}/src/Material#{ss.base_name}.bundle"]
@@ -257,7 +257,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "Typography" do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
   end
@@ -270,13 +270,13 @@ Pod::Spec.new do |s|
     registerIcons(pss)
 
     pss.subspec "Application" do |ss|
-      ss.ios.deployment_target = '7.0'
+      ss.ios.deployment_target = '8.0'
       ss.public_header_files = "components/private/#{ss.base_name}/src/*.h"
       ss.source_files = "components/private/#{ss.base_name}/src/*.{h,m}"
     end
 
     pss.subspec "KeyboardWatcher" do |ss|
-      ss.ios.deployment_target = '7.0'
+      ss.ios.deployment_target = '8.0'
       ss.public_header_files = "components/private/#{ss.base_name}/src/*.h"
       ss.source_files = "components/private/#{ss.base_name}/src/*.{h,m}"
 
@@ -284,19 +284,19 @@ Pod::Spec.new do |s|
     end
 
     pss.subspec "Overlay" do |ss|
-      ss.ios.deployment_target = '7.0'
+      ss.ios.deployment_target = '8.0'
       ss.public_header_files = "components/private/#{ss.base_name}/src/*.h"
       ss.source_files = "components/private/#{ss.base_name}/src/*.{h,m}", "components/private/#{ss.base_name}/src/private/*.{h,m}"
     end
 
     pss.subspec "RTL" do |ss|
-      ss.ios.deployment_target = '7.0'
+      ss.ios.deployment_target = '8.0'
       ss.public_header_files = "components/private/#{ss.base_name}/src/*.h"
       ss.source_files = "components/private/#{ss.base_name}/src/*.{h,m}"
     end
 
     pss.subspec "ThumbTrack" do |ss|
-      ss.ios.deployment_target = '7.0'
+      ss.ios.deployment_target = '8.0'
       ss.public_header_files = "components/private/#{ss.base_name}/src/*.h"
       ss.source_files = "components/private/#{ss.base_name}/src/*.{h,m}"
 

--- a/MaterialComponentsCatalog.podspec
+++ b/MaterialComponentsCatalog.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/material-components/material-components-ios"
   s.license      = 'Apache 2.0'
   s.source       = { :git => "https://github.com/material-components/material-components-ios.git", :tag => "v#{s.version}" } 
-  s.platform     = :ios, '7.0'
+  s.platform     = :ios, '8.0'
   s.requires_arc = true
   s.source_files = 'components/*/examples/*.{h,m,swift}', 'components/*/examples/supplemental/*.{h,m,swift}'
   s.resources = ['components/*/examples/resources/*']

--- a/MaterialComponentsCatalog.podspec
+++ b/MaterialComponentsCatalog.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsCatalog"
-  s.version      = "20.1.0"
+  s.version      = "20.1.1"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/MaterialComponentsUnitTests.podspec
+++ b/MaterialComponentsUnitTests.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/material-components/material-components-ios"
   s.license      = 'Apache 2.0'
   s.source       = { :git => "https://github.com/material-components/material-components-ios.git", :tag => "v#{s.version}" }
-  s.platform     = :ios, '7.0'
+  s.platform     = :ios, '8.0'
   s.requires_arc = true
   s.source_files = 'components/*/tests/unit/*.{h,m,swift}', 'components/private/*/tests/unit/*.{h,m,swift}'
   s.framework    = 'XCTest'

--- a/MaterialComponentsUnitTests.podspec
+++ b/MaterialComponentsUnitTests.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsUnitTests"
-  s.version      = "20.1.0"
+  s.version      = "20.1.1"
   s.authors      = "The Material Motion authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/catalog/Podfile.lock
+++ b/catalog/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - CatalogByConvention (2.0.0)
-  - EarlGrey (1.6.0)
+  - EarlGrey (1.6.2)
   - MaterialComponents (20.1.1):
     - MaterialComponents/ActivityIndicator (= 20.1.1)
     - MaterialComponents/AnimationTiming (= 20.1.1)
@@ -157,7 +157,7 @@ PODS:
   - MaterialComponentsUnitTests (20.1.1):
     - MaterialComponents
     - MDFTextAccessibility
-  - MDFTextAccessibility (1.1.3)
+  - MDFTextAccessibility (1.1.4)
 
 DEPENDENCIES:
   - CatalogByConvention
@@ -176,11 +176,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   CatalogByConvention: be55c2263132e4f9f59299ac8a528ee8715b3275
-  EarlGrey: 75b2e9359c57d56c9b7f333e17761c6bff35a9ea
-  MaterialComponents: 26372b7d42f8057bc467a796dea73cf62abc03ed
-  MaterialComponentsCatalog: 59397c868e61e8fe17c86be1602fcd27d83a0e26
-  MaterialComponentsUnitTests: ea9daf504648caa852572fe950fc94fd10aaef03
-  MDFTextAccessibility: f05246cc165f78733bfad535365807ec6fef9601
+  EarlGrey: a20adcac6deeea0dfdb41d8caae41f87c47c3e5a
+  MaterialComponents: f628bce24c4089f905f1c57c08d271af5b6c90bc
+  MaterialComponentsCatalog: 5bbb85074e55d527514040d71bf70a730912272e
+  MaterialComponentsUnitTests: a5f2ad8ad911213b66ad9734b6a995c0bfb5dbfc
+  MDFTextAccessibility: aa897b2675bc614c01a331053af680deea692148
 
 PODFILE CHECKSUM: 0a93a34ae9af89654baaaa3a998126cb7d9e1198
 

--- a/catalog/Podfile.lock
+++ b/catalog/Podfile.lock
@@ -1,7 +1,6 @@
 PODS:
   - CatalogByConvention (2.0.0)
   - EarlGrey (1.6.2)
-<<<<<<< HEAD
   - MaterialComponents (20.1.1):
     - MaterialComponents/ActivityIndicator (= 20.1.1)
     - MaterialComponents/AnimationTiming (= 20.1.1)
@@ -29,35 +28,6 @@ PODS:
     - MaterialComponents/Tabs (= 20.1.1)
     - MaterialComponents/Typography (= 20.1.1)
   - MaterialComponents/ActivityIndicator (20.1.1):
-=======
-  - MaterialComponents (20.1.0):
-    - MaterialComponents/ActivityIndicator (= 20.1.0)
-    - MaterialComponents/AnimationTiming (= 20.1.0)
-    - MaterialComponents/AppBar (= 20.1.0)
-    - MaterialComponents/ButtonBar (= 20.1.0)
-    - MaterialComponents/Buttons (= 20.1.0)
-    - MaterialComponents/CollectionCells (= 20.1.0)
-    - MaterialComponents/CollectionLayoutAttributes (= 20.1.0)
-    - MaterialComponents/Collections (= 20.1.0)
-    - MaterialComponents/Dialogs (= 20.1.0)
-    - MaterialComponents/FeatureHighlight (= 20.1.0)
-    - MaterialComponents/FlexibleHeader (= 20.1.0)
-    - MaterialComponents/HeaderStackView (= 20.1.0)
-    - MaterialComponents/Ink (= 20.1.0)
-    - MaterialComponents/NavigationBar (= 20.1.0)
-    - MaterialComponents/OverlayWindow (= 20.1.0)
-    - MaterialComponents/PageControl (= 20.1.0)
-    - MaterialComponents/Palettes (= 20.1.0)
-    - MaterialComponents/private (= 20.1.0)
-    - MaterialComponents/ProgressView (= 20.1.0)
-    - MaterialComponents/ShadowElevations (= 20.1.0)
-    - MaterialComponents/ShadowLayer (= 20.1.0)
-    - MaterialComponents/Slider (= 20.1.0)
-    - MaterialComponents/Snackbar (= 20.1.0)
-    - MaterialComponents/Tabs (= 20.1.0)
-    - MaterialComponents/Typography (= 20.1.0)
-  - MaterialComponents/ActivityIndicator (20.1.0):
->>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
     - MaterialComponents/private/Application
     - MaterialComponents/private/RTL
   - MaterialComponents/AnimationTiming (20.1.1)
@@ -207,15 +177,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   CatalogByConvention: be55c2263132e4f9f59299ac8a528ee8715b3275
   EarlGrey: a20adcac6deeea0dfdb41d8caae41f87c47c3e5a
-<<<<<<< HEAD
   MaterialComponents: f628bce24c4089f905f1c57c08d271af5b6c90bc
   MaterialComponentsCatalog: 5bbb85074e55d527514040d71bf70a730912272e
   MaterialComponentsUnitTests: a5f2ad8ad911213b66ad9734b6a995c0bfb5dbfc
-=======
-  MaterialComponents: ef50c6355b614732dab43ac72540b57e5c250457
-  MaterialComponentsCatalog: ea9f6ae3943211d34cf1aa55fd8805d0e4458bd1
-  MaterialComponentsUnitTests: 72f89bf32a07e1c90f8cb6106d3e80b40dde5d1d
->>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
   MDFTextAccessibility: aa897b2675bc614c01a331053af680deea692148
 
 PODFILE CHECKSUM: 0a93a34ae9af89654baaaa3a998126cb7d9e1198

--- a/catalog/Podfile.lock
+++ b/catalog/Podfile.lock
@@ -1,6 +1,7 @@
 PODS:
   - CatalogByConvention (2.0.0)
   - EarlGrey (1.6.2)
+<<<<<<< HEAD
   - MaterialComponents (20.1.1):
     - MaterialComponents/ActivityIndicator (= 20.1.1)
     - MaterialComponents/AnimationTiming (= 20.1.1)
@@ -28,6 +29,35 @@ PODS:
     - MaterialComponents/Tabs (= 20.1.1)
     - MaterialComponents/Typography (= 20.1.1)
   - MaterialComponents/ActivityIndicator (20.1.1):
+=======
+  - MaterialComponents (20.1.0):
+    - MaterialComponents/ActivityIndicator (= 20.1.0)
+    - MaterialComponents/AnimationTiming (= 20.1.0)
+    - MaterialComponents/AppBar (= 20.1.0)
+    - MaterialComponents/ButtonBar (= 20.1.0)
+    - MaterialComponents/Buttons (= 20.1.0)
+    - MaterialComponents/CollectionCells (= 20.1.0)
+    - MaterialComponents/CollectionLayoutAttributes (= 20.1.0)
+    - MaterialComponents/Collections (= 20.1.0)
+    - MaterialComponents/Dialogs (= 20.1.0)
+    - MaterialComponents/FeatureHighlight (= 20.1.0)
+    - MaterialComponents/FlexibleHeader (= 20.1.0)
+    - MaterialComponents/HeaderStackView (= 20.1.0)
+    - MaterialComponents/Ink (= 20.1.0)
+    - MaterialComponents/NavigationBar (= 20.1.0)
+    - MaterialComponents/OverlayWindow (= 20.1.0)
+    - MaterialComponents/PageControl (= 20.1.0)
+    - MaterialComponents/Palettes (= 20.1.0)
+    - MaterialComponents/private (= 20.1.0)
+    - MaterialComponents/ProgressView (= 20.1.0)
+    - MaterialComponents/ShadowElevations (= 20.1.0)
+    - MaterialComponents/ShadowLayer (= 20.1.0)
+    - MaterialComponents/Slider (= 20.1.0)
+    - MaterialComponents/Snackbar (= 20.1.0)
+    - MaterialComponents/Tabs (= 20.1.0)
+    - MaterialComponents/Typography (= 20.1.0)
+  - MaterialComponents/ActivityIndicator (20.1.0):
+>>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
     - MaterialComponents/private/Application
     - MaterialComponents/private/RTL
   - MaterialComponents/AnimationTiming (20.1.1)
@@ -177,9 +207,15 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   CatalogByConvention: be55c2263132e4f9f59299ac8a528ee8715b3275
   EarlGrey: a20adcac6deeea0dfdb41d8caae41f87c47c3e5a
+<<<<<<< HEAD
   MaterialComponents: f628bce24c4089f905f1c57c08d271af5b6c90bc
   MaterialComponentsCatalog: 5bbb85074e55d527514040d71bf70a730912272e
   MaterialComponentsUnitTests: a5f2ad8ad911213b66ad9734b6a995c0bfb5dbfc
+=======
+  MaterialComponents: ef50c6355b614732dab43ac72540b57e5c250457
+  MaterialComponentsCatalog: ea9f6ae3943211d34cf1aa55fd8805d0e4458bd1
+  MaterialComponentsUnitTests: 72f89bf32a07e1c90f8cb6106d3e80b40dde5d1d
+>>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
   MDFTextAccessibility: aa897b2675bc614c01a331053af680deea692148
 
 PODFILE CHECKSUM: 0a93a34ae9af89654baaaa3a998126cb7d9e1198

--- a/catalog/Podfile.lock
+++ b/catalog/Podfile.lock
@@ -1,37 +1,37 @@
 PODS:
   - CatalogByConvention (2.0.0)
   - EarlGrey (1.6.0)
-  - MaterialComponents (20.1.0):
-    - MaterialComponents/ActivityIndicator (= 20.1.0)
-    - MaterialComponents/AnimationTiming (= 20.1.0)
-    - MaterialComponents/AppBar (= 20.1.0)
-    - MaterialComponents/ButtonBar (= 20.1.0)
-    - MaterialComponents/Buttons (= 20.1.0)
-    - MaterialComponents/CollectionCells (= 20.1.0)
-    - MaterialComponents/CollectionLayoutAttributes (= 20.1.0)
-    - MaterialComponents/Collections (= 20.1.0)
-    - MaterialComponents/Dialogs (= 20.1.0)
-    - MaterialComponents/FeatureHighlight (= 20.1.0)
-    - MaterialComponents/FlexibleHeader (= 20.1.0)
-    - MaterialComponents/HeaderStackView (= 20.1.0)
-    - MaterialComponents/Ink (= 20.1.0)
-    - MaterialComponents/NavigationBar (= 20.1.0)
-    - MaterialComponents/OverlayWindow (= 20.1.0)
-    - MaterialComponents/PageControl (= 20.1.0)
-    - MaterialComponents/Palettes (= 20.1.0)
-    - MaterialComponents/private (= 20.1.0)
-    - MaterialComponents/ProgressView (= 20.1.0)
-    - MaterialComponents/ShadowElevations (= 20.1.0)
-    - MaterialComponents/ShadowLayer (= 20.1.0)
-    - MaterialComponents/Slider (= 20.1.0)
-    - MaterialComponents/Snackbar (= 20.1.0)
-    - MaterialComponents/Tabs (= 20.1.0)
-    - MaterialComponents/Typography (= 20.1.0)
-  - MaterialComponents/ActivityIndicator (20.1.0):
+  - MaterialComponents (20.1.1):
+    - MaterialComponents/ActivityIndicator (= 20.1.1)
+    - MaterialComponents/AnimationTiming (= 20.1.1)
+    - MaterialComponents/AppBar (= 20.1.1)
+    - MaterialComponents/ButtonBar (= 20.1.1)
+    - MaterialComponents/Buttons (= 20.1.1)
+    - MaterialComponents/CollectionCells (= 20.1.1)
+    - MaterialComponents/CollectionLayoutAttributes (= 20.1.1)
+    - MaterialComponents/Collections (= 20.1.1)
+    - MaterialComponents/Dialogs (= 20.1.1)
+    - MaterialComponents/FeatureHighlight (= 20.1.1)
+    - MaterialComponents/FlexibleHeader (= 20.1.1)
+    - MaterialComponents/HeaderStackView (= 20.1.1)
+    - MaterialComponents/Ink (= 20.1.1)
+    - MaterialComponents/NavigationBar (= 20.1.1)
+    - MaterialComponents/OverlayWindow (= 20.1.1)
+    - MaterialComponents/PageControl (= 20.1.1)
+    - MaterialComponents/Palettes (= 20.1.1)
+    - MaterialComponents/private (= 20.1.1)
+    - MaterialComponents/ProgressView (= 20.1.1)
+    - MaterialComponents/ShadowElevations (= 20.1.1)
+    - MaterialComponents/ShadowLayer (= 20.1.1)
+    - MaterialComponents/Slider (= 20.1.1)
+    - MaterialComponents/Snackbar (= 20.1.1)
+    - MaterialComponents/Tabs (= 20.1.1)
+    - MaterialComponents/Typography (= 20.1.1)
+  - MaterialComponents/ActivityIndicator (20.1.1):
     - MaterialComponents/private/Application
     - MaterialComponents/private/RTL
-  - MaterialComponents/AnimationTiming (20.1.0)
-  - MaterialComponents/AppBar (20.1.0):
+  - MaterialComponents/AnimationTiming (20.1.1)
+  - MaterialComponents/AppBar (20.1.1):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
     - MaterialComponents/NavigationBar
@@ -40,16 +40,16 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ButtonBar (20.1.0):
+  - MaterialComponents/ButtonBar (20.1.1):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/Buttons (20.1.0):
+  - MaterialComponents/Buttons (20.1.1):
     - MaterialComponents/Ink
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/CollectionCells (20.1.0):
+  - MaterialComponents/CollectionCells (20.1.1):
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/private/Icons/ic_check
@@ -60,85 +60,85 @@ PODS:
     - MaterialComponents/private/Icons/ic_reorder
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/CollectionLayoutAttributes (20.1.0)
-  - MaterialComponents/Collections (20.1.0):
+  - MaterialComponents/CollectionLayoutAttributes (20.1.1)
+  - MaterialComponents/Collections (20.1.1):
     - MaterialComponents/CollectionCells
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/Dialogs (20.1.0):
+  - MaterialComponents/Dialogs (20.1.1):
     - MaterialComponents/Buttons
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/RTL
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
-  - MaterialComponents/FeatureHighlight (20.1.0):
+  - MaterialComponents/FeatureHighlight (20.1.1):
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader (20.1.0):
+  - MaterialComponents/FlexibleHeader (20.1.1):
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/HeaderStackView (20.1.0)
-  - MaterialComponents/Ink (20.1.0)
-  - MaterialComponents/NavigationBar (20.1.0):
+  - MaterialComponents/HeaderStackView (20.1.1)
+  - MaterialComponents/Ink (20.1.1)
+  - MaterialComponents/NavigationBar (20.1.1):
     - MaterialComponents/ButtonBar
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/OverlayWindow (20.1.0):
+  - MaterialComponents/OverlayWindow (20.1.1):
     - MaterialComponents/private/Application
-  - MaterialComponents/PageControl (20.1.0)
-  - MaterialComponents/Palettes (20.1.0)
-  - MaterialComponents/private (20.1.0):
-    - MaterialComponents/private/Application (= 20.1.0)
-    - MaterialComponents/private/Icons (= 20.1.0)
-    - MaterialComponents/private/KeyboardWatcher (= 20.1.0)
-    - MaterialComponents/private/Overlay (= 20.1.0)
-    - MaterialComponents/private/RTL (= 20.1.0)
-    - MaterialComponents/private/ThumbTrack (= 20.1.0)
-  - MaterialComponents/private/Application (20.1.0)
-  - MaterialComponents/private/Icons (20.1.0):
-    - MaterialComponents/private/Icons/Base (= 20.1.0)
-    - MaterialComponents/private/Icons/ic_arrow_back (= 20.1.0)
-    - MaterialComponents/private/Icons/ic_check (= 20.1.0)
-    - MaterialComponents/private/Icons/ic_check_circle (= 20.1.0)
-    - MaterialComponents/private/Icons/ic_chevron_right (= 20.1.0)
-    - MaterialComponents/private/Icons/ic_info (= 20.1.0)
-    - MaterialComponents/private/Icons/ic_radio_button_unchecked (= 20.1.0)
-    - MaterialComponents/private/Icons/ic_reorder (= 20.1.0)
-  - MaterialComponents/private/Icons/Base (20.1.0)
-  - MaterialComponents/private/Icons/ic_arrow_back (20.1.0):
+  - MaterialComponents/PageControl (20.1.1)
+  - MaterialComponents/Palettes (20.1.1)
+  - MaterialComponents/private (20.1.1):
+    - MaterialComponents/private/Application (= 20.1.1)
+    - MaterialComponents/private/Icons (= 20.1.1)
+    - MaterialComponents/private/KeyboardWatcher (= 20.1.1)
+    - MaterialComponents/private/Overlay (= 20.1.1)
+    - MaterialComponents/private/RTL (= 20.1.1)
+    - MaterialComponents/private/ThumbTrack (= 20.1.1)
+  - MaterialComponents/private/Application (20.1.1)
+  - MaterialComponents/private/Icons (20.1.1):
+    - MaterialComponents/private/Icons/Base (= 20.1.1)
+    - MaterialComponents/private/Icons/ic_arrow_back (= 20.1.1)
+    - MaterialComponents/private/Icons/ic_check (= 20.1.1)
+    - MaterialComponents/private/Icons/ic_check_circle (= 20.1.1)
+    - MaterialComponents/private/Icons/ic_chevron_right (= 20.1.1)
+    - MaterialComponents/private/Icons/ic_info (= 20.1.1)
+    - MaterialComponents/private/Icons/ic_radio_button_unchecked (= 20.1.1)
+    - MaterialComponents/private/Icons/ic_reorder (= 20.1.1)
+  - MaterialComponents/private/Icons/Base (20.1.1)
+  - MaterialComponents/private/Icons/ic_arrow_back (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check (20.1.0):
+  - MaterialComponents/private/Icons/ic_check (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check_circle (20.1.0):
+  - MaterialComponents/private/Icons/ic_check_circle (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_chevron_right (20.1.0):
+  - MaterialComponents/private/Icons/ic_chevron_right (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_info (20.1.0):
+  - MaterialComponents/private/Icons/ic_info (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_radio_button_unchecked (20.1.0):
+  - MaterialComponents/private/Icons/ic_radio_button_unchecked (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_reorder (20.1.0):
+  - MaterialComponents/private/Icons/ic_reorder (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/KeyboardWatcher (20.1.0):
+  - MaterialComponents/private/KeyboardWatcher (20.1.1):
     - MaterialComponents/private/Application
-  - MaterialComponents/private/Overlay (20.1.0)
-  - MaterialComponents/private/RTL (20.1.0)
-  - MaterialComponents/private/ThumbTrack (20.1.0):
+  - MaterialComponents/private/Overlay (20.1.1)
+  - MaterialComponents/private/RTL (20.1.1)
+  - MaterialComponents/private/ThumbTrack (20.1.1):
     - MaterialComponents/Ink
     - MaterialComponents/private/RTL
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ProgressView (20.1.0):
+  - MaterialComponents/ProgressView (20.1.1):
     - MaterialComponents/private/RTL
-  - MaterialComponents/ShadowElevations (20.1.0)
-  - MaterialComponents/ShadowLayer (20.1.0)
-  - MaterialComponents/Slider (20.1.0):
+  - MaterialComponents/ShadowElevations (20.1.1)
+  - MaterialComponents/ShadowLayer (20.1.1)
+  - MaterialComponents/Slider (20.1.1):
     - MaterialComponents/private/ThumbTrack
-  - MaterialComponents/Snackbar (20.1.0):
+  - MaterialComponents/Snackbar (20.1.1):
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Buttons
     - MaterialComponents/OverlayWindow
@@ -146,15 +146,15 @@ PODS:
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/Overlay
     - MaterialComponents/Typography
-  - MaterialComponents/Tabs (20.1.0):
+  - MaterialComponents/Tabs (20.1.1):
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Ink
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/Typography (20.1.0)
-  - MaterialComponentsCatalog (20.1.0):
+  - MaterialComponents/Typography (20.1.1)
+  - MaterialComponentsCatalog (20.1.1):
     - MaterialComponents
-  - MaterialComponentsUnitTests (20.1.0):
+  - MaterialComponentsUnitTests (20.1.1):
     - MaterialComponents
     - MDFTextAccessibility
   - MDFTextAccessibility (1.1.3)
@@ -177,9 +177,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   CatalogByConvention: be55c2263132e4f9f59299ac8a528ee8715b3275
   EarlGrey: 75b2e9359c57d56c9b7f333e17761c6bff35a9ea
-  MaterialComponents: 17a0c46778351f4b212047f0a8a4a6955797754f
-  MaterialComponentsCatalog: d90590cbd51632b85b06cc6b141b46e4ec7761c4
-  MaterialComponentsUnitTests: a74fc2eaecca8e87ba9fe0acf88375a4a7cd1eed
+  MaterialComponents: 26372b7d42f8057bc467a796dea73cf62abc03ed
+  MaterialComponentsCatalog: 59397c868e61e8fe17c86be1602fcd27d83a0e26
+  MaterialComponentsUnitTests: ea9daf504648caa852572fe950fc94fd10aaef03
   MDFTextAccessibility: f05246cc165f78733bfad535365807ec6fef9601
 
 PODFILE CHECKSUM: 0a93a34ae9af89654baaaa3a998126cb7d9e1198

--- a/demos/Bare/Podfile.lock
+++ b/demos/Bare/Podfile.lock
@@ -150,7 +150,7 @@ PODS:
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
   - MaterialComponents/Typography (20.1.1)
-  - MDFTextAccessibility (1.1.3)
+  - MDFTextAccessibility (1.1.4)
 
 DEPENDENCIES:
   - MaterialComponents (from `../../`)
@@ -160,8 +160,8 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  MaterialComponents: 26372b7d42f8057bc467a796dea73cf62abc03ed
-  MDFTextAccessibility: f05246cc165f78733bfad535365807ec6fef9601
+  MaterialComponents: f628bce24c4089f905f1c57c08d271af5b6c90bc
+  MDFTextAccessibility: aa897b2675bc614c01a331053af680deea692148
 
 PODFILE CHECKSUM: 44e7c616a05bb4ce24db557c3de4bfbe915c2f56
 

--- a/demos/Bare/Podfile.lock
+++ b/demos/Bare/Podfile.lock
@@ -1,4 +1,5 @@
 PODS:
+<<<<<<< HEAD
   - MaterialComponents (20.1.1):
     - MaterialComponents/ActivityIndicator (= 20.1.1)
     - MaterialComponents/AnimationTiming (= 20.1.1)
@@ -26,6 +27,35 @@ PODS:
     - MaterialComponents/Tabs (= 20.1.1)
     - MaterialComponents/Typography (= 20.1.1)
   - MaterialComponents/ActivityIndicator (20.1.1):
+=======
+  - MaterialComponents (20.1.0):
+    - MaterialComponents/ActivityIndicator (= 20.1.0)
+    - MaterialComponents/AnimationTiming (= 20.1.0)
+    - MaterialComponents/AppBar (= 20.1.0)
+    - MaterialComponents/ButtonBar (= 20.1.0)
+    - MaterialComponents/Buttons (= 20.1.0)
+    - MaterialComponents/CollectionCells (= 20.1.0)
+    - MaterialComponents/CollectionLayoutAttributes (= 20.1.0)
+    - MaterialComponents/Collections (= 20.1.0)
+    - MaterialComponents/Dialogs (= 20.1.0)
+    - MaterialComponents/FeatureHighlight (= 20.1.0)
+    - MaterialComponents/FlexibleHeader (= 20.1.0)
+    - MaterialComponents/HeaderStackView (= 20.1.0)
+    - MaterialComponents/Ink (= 20.1.0)
+    - MaterialComponents/NavigationBar (= 20.1.0)
+    - MaterialComponents/OverlayWindow (= 20.1.0)
+    - MaterialComponents/PageControl (= 20.1.0)
+    - MaterialComponents/Palettes (= 20.1.0)
+    - MaterialComponents/private (= 20.1.0)
+    - MaterialComponents/ProgressView (= 20.1.0)
+    - MaterialComponents/ShadowElevations (= 20.1.0)
+    - MaterialComponents/ShadowLayer (= 20.1.0)
+    - MaterialComponents/Slider (= 20.1.0)
+    - MaterialComponents/Snackbar (= 20.1.0)
+    - MaterialComponents/Tabs (= 20.1.0)
+    - MaterialComponents/Typography (= 20.1.0)
+  - MaterialComponents/ActivityIndicator (20.1.0):
+>>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
     - MaterialComponents/private/Application
     - MaterialComponents/private/RTL
   - MaterialComponents/AnimationTiming (20.1.1)
@@ -144,12 +174,20 @@ PODS:
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/Overlay
     - MaterialComponents/Typography
+<<<<<<< HEAD
   - MaterialComponents/Tabs (20.1.1):
+=======
+  - MaterialComponents/Tabs (20.1.0):
+>>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Ink
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
+<<<<<<< HEAD
   - MaterialComponents/Typography (20.1.1)
+=======
+  - MaterialComponents/Typography (20.1.0)
+>>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
   - MDFTextAccessibility (1.1.4)
 
 DEPENDENCIES:
@@ -160,7 +198,11 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
+<<<<<<< HEAD
   MaterialComponents: f628bce24c4089f905f1c57c08d271af5b6c90bc
+=======
+  MaterialComponents: ef50c6355b614732dab43ac72540b57e5c250457
+>>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
   MDFTextAccessibility: aa897b2675bc614c01a331053af680deea692148
 
 PODFILE CHECKSUM: 44e7c616a05bb4ce24db557c3de4bfbe915c2f56

--- a/demos/Bare/Podfile.lock
+++ b/demos/Bare/Podfile.lock
@@ -1,5 +1,4 @@
 PODS:
-<<<<<<< HEAD
   - MaterialComponents (20.1.1):
     - MaterialComponents/ActivityIndicator (= 20.1.1)
     - MaterialComponents/AnimationTiming (= 20.1.1)
@@ -27,35 +26,6 @@ PODS:
     - MaterialComponents/Tabs (= 20.1.1)
     - MaterialComponents/Typography (= 20.1.1)
   - MaterialComponents/ActivityIndicator (20.1.1):
-=======
-  - MaterialComponents (20.1.0):
-    - MaterialComponents/ActivityIndicator (= 20.1.0)
-    - MaterialComponents/AnimationTiming (= 20.1.0)
-    - MaterialComponents/AppBar (= 20.1.0)
-    - MaterialComponents/ButtonBar (= 20.1.0)
-    - MaterialComponents/Buttons (= 20.1.0)
-    - MaterialComponents/CollectionCells (= 20.1.0)
-    - MaterialComponents/CollectionLayoutAttributes (= 20.1.0)
-    - MaterialComponents/Collections (= 20.1.0)
-    - MaterialComponents/Dialogs (= 20.1.0)
-    - MaterialComponents/FeatureHighlight (= 20.1.0)
-    - MaterialComponents/FlexibleHeader (= 20.1.0)
-    - MaterialComponents/HeaderStackView (= 20.1.0)
-    - MaterialComponents/Ink (= 20.1.0)
-    - MaterialComponents/NavigationBar (= 20.1.0)
-    - MaterialComponents/OverlayWindow (= 20.1.0)
-    - MaterialComponents/PageControl (= 20.1.0)
-    - MaterialComponents/Palettes (= 20.1.0)
-    - MaterialComponents/private (= 20.1.0)
-    - MaterialComponents/ProgressView (= 20.1.0)
-    - MaterialComponents/ShadowElevations (= 20.1.0)
-    - MaterialComponents/ShadowLayer (= 20.1.0)
-    - MaterialComponents/Slider (= 20.1.0)
-    - MaterialComponents/Snackbar (= 20.1.0)
-    - MaterialComponents/Tabs (= 20.1.0)
-    - MaterialComponents/Typography (= 20.1.0)
-  - MaterialComponents/ActivityIndicator (20.1.0):
->>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
     - MaterialComponents/private/Application
     - MaterialComponents/private/RTL
   - MaterialComponents/AnimationTiming (20.1.1)
@@ -174,20 +144,12 @@ PODS:
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/Overlay
     - MaterialComponents/Typography
-<<<<<<< HEAD
   - MaterialComponents/Tabs (20.1.1):
-=======
-  - MaterialComponents/Tabs (20.1.0):
->>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Ink
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-<<<<<<< HEAD
   - MaterialComponents/Typography (20.1.1)
-=======
-  - MaterialComponents/Typography (20.1.0)
->>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
   - MDFTextAccessibility (1.1.4)
 
 DEPENDENCIES:
@@ -198,11 +160,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-<<<<<<< HEAD
   MaterialComponents: f628bce24c4089f905f1c57c08d271af5b6c90bc
-=======
-  MaterialComponents: ef50c6355b614732dab43ac72540b57e5c250457
->>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
   MDFTextAccessibility: aa897b2675bc614c01a331053af680deea692148
 
 PODFILE CHECKSUM: 44e7c616a05bb4ce24db557c3de4bfbe915c2f56

--- a/demos/Bare/Podfile.lock
+++ b/demos/Bare/Podfile.lock
@@ -1,34 +1,35 @@
 PODS:
-  - MaterialComponents (20.1.0):
-    - MaterialComponents/ActivityIndicator (= 20.1.0)
-    - MaterialComponents/AnimationTiming (= 20.1.0)
-    - MaterialComponents/AppBar (= 20.1.0)
-    - MaterialComponents/ButtonBar (= 20.1.0)
-    - MaterialComponents/Buttons (= 20.1.0)
-    - MaterialComponents/CollectionCells (= 20.1.0)
-    - MaterialComponents/CollectionLayoutAttributes (= 20.1.0)
-    - MaterialComponents/Collections (= 20.1.0)
-    - MaterialComponents/Dialogs (= 20.1.0)
-    - MaterialComponents/FeatureHighlight (= 20.1.0)
-    - MaterialComponents/FlexibleHeader (= 20.1.0)
-    - MaterialComponents/HeaderStackView (= 20.1.0)
-    - MaterialComponents/Ink (= 20.1.0)
-    - MaterialComponents/NavigationBar (= 20.1.0)
-    - MaterialComponents/OverlayWindow (= 20.1.0)
-    - MaterialComponents/PageControl (= 20.1.0)
-    - MaterialComponents/Palettes (= 20.1.0)
-    - MaterialComponents/private (= 20.1.0)
-    - MaterialComponents/ProgressView (= 20.1.0)
-    - MaterialComponents/ShadowElevations (= 20.1.0)
-    - MaterialComponents/ShadowLayer (= 20.1.0)
-    - MaterialComponents/Slider (= 20.1.0)
-    - MaterialComponents/Snackbar (= 20.1.0)
-    - MaterialComponents/Typography (= 20.1.0)
-  - MaterialComponents/ActivityIndicator (20.1.0):
+  - MaterialComponents (20.1.1):
+    - MaterialComponents/ActivityIndicator (= 20.1.1)
+    - MaterialComponents/AnimationTiming (= 20.1.1)
+    - MaterialComponents/AppBar (= 20.1.1)
+    - MaterialComponents/ButtonBar (= 20.1.1)
+    - MaterialComponents/Buttons (= 20.1.1)
+    - MaterialComponents/CollectionCells (= 20.1.1)
+    - MaterialComponents/CollectionLayoutAttributes (= 20.1.1)
+    - MaterialComponents/Collections (= 20.1.1)
+    - MaterialComponents/Dialogs (= 20.1.1)
+    - MaterialComponents/FeatureHighlight (= 20.1.1)
+    - MaterialComponents/FlexibleHeader (= 20.1.1)
+    - MaterialComponents/HeaderStackView (= 20.1.1)
+    - MaterialComponents/Ink (= 20.1.1)
+    - MaterialComponents/NavigationBar (= 20.1.1)
+    - MaterialComponents/OverlayWindow (= 20.1.1)
+    - MaterialComponents/PageControl (= 20.1.1)
+    - MaterialComponents/Palettes (= 20.1.1)
+    - MaterialComponents/private (= 20.1.1)
+    - MaterialComponents/ProgressView (= 20.1.1)
+    - MaterialComponents/ShadowElevations (= 20.1.1)
+    - MaterialComponents/ShadowLayer (= 20.1.1)
+    - MaterialComponents/Slider (= 20.1.1)
+    - MaterialComponents/Snackbar (= 20.1.1)
+    - MaterialComponents/Tabs (= 20.1.1)
+    - MaterialComponents/Typography (= 20.1.1)
+  - MaterialComponents/ActivityIndicator (20.1.1):
     - MaterialComponents/private/Application
     - MaterialComponents/private/RTL
-  - MaterialComponents/AnimationTiming (20.1.0)
-  - MaterialComponents/AppBar (20.1.0):
+  - MaterialComponents/AnimationTiming (20.1.1)
+  - MaterialComponents/AppBar (20.1.1):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
     - MaterialComponents/NavigationBar
@@ -37,16 +38,16 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ButtonBar (20.1.0):
+  - MaterialComponents/ButtonBar (20.1.1):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/Buttons (20.1.0):
+  - MaterialComponents/Buttons (20.1.1):
     - MaterialComponents/Ink
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/CollectionCells (20.1.0):
+  - MaterialComponents/CollectionCells (20.1.1):
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/private/Icons/ic_check
@@ -57,85 +58,85 @@ PODS:
     - MaterialComponents/private/Icons/ic_reorder
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/CollectionLayoutAttributes (20.1.0)
-  - MaterialComponents/Collections (20.1.0):
+  - MaterialComponents/CollectionLayoutAttributes (20.1.1)
+  - MaterialComponents/Collections (20.1.1):
     - MaterialComponents/CollectionCells
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/Dialogs (20.1.0):
+  - MaterialComponents/Dialogs (20.1.1):
     - MaterialComponents/Buttons
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/RTL
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
-  - MaterialComponents/FeatureHighlight (20.1.0):
+  - MaterialComponents/FeatureHighlight (20.1.1):
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader (20.1.0):
+  - MaterialComponents/FlexibleHeader (20.1.1):
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/HeaderStackView (20.1.0)
-  - MaterialComponents/Ink (20.1.0)
-  - MaterialComponents/NavigationBar (20.1.0):
+  - MaterialComponents/HeaderStackView (20.1.1)
+  - MaterialComponents/Ink (20.1.1)
+  - MaterialComponents/NavigationBar (20.1.1):
     - MaterialComponents/ButtonBar
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/OverlayWindow (20.1.0):
+  - MaterialComponents/OverlayWindow (20.1.1):
     - MaterialComponents/private/Application
-  - MaterialComponents/PageControl (20.1.0)
-  - MaterialComponents/Palettes (20.1.0)
-  - MaterialComponents/private (20.1.0):
-    - MaterialComponents/private/Application (= 20.1.0)
-    - MaterialComponents/private/Icons (= 20.1.0)
-    - MaterialComponents/private/KeyboardWatcher (= 20.1.0)
-    - MaterialComponents/private/Overlay (= 20.1.0)
-    - MaterialComponents/private/RTL (= 20.1.0)
-    - MaterialComponents/private/ThumbTrack (= 20.1.0)
-  - MaterialComponents/private/Application (20.1.0)
-  - MaterialComponents/private/Icons (20.1.0):
-    - MaterialComponents/private/Icons/Base (= 20.1.0)
-    - MaterialComponents/private/Icons/ic_arrow_back (= 20.1.0)
-    - MaterialComponents/private/Icons/ic_check (= 20.1.0)
-    - MaterialComponents/private/Icons/ic_check_circle (= 20.1.0)
-    - MaterialComponents/private/Icons/ic_chevron_right (= 20.1.0)
-    - MaterialComponents/private/Icons/ic_info (= 20.1.0)
-    - MaterialComponents/private/Icons/ic_radio_button_unchecked (= 20.1.0)
-    - MaterialComponents/private/Icons/ic_reorder (= 20.1.0)
-  - MaterialComponents/private/Icons/Base (20.1.0)
-  - MaterialComponents/private/Icons/ic_arrow_back (20.1.0):
+  - MaterialComponents/PageControl (20.1.1)
+  - MaterialComponents/Palettes (20.1.1)
+  - MaterialComponents/private (20.1.1):
+    - MaterialComponents/private/Application (= 20.1.1)
+    - MaterialComponents/private/Icons (= 20.1.1)
+    - MaterialComponents/private/KeyboardWatcher (= 20.1.1)
+    - MaterialComponents/private/Overlay (= 20.1.1)
+    - MaterialComponents/private/RTL (= 20.1.1)
+    - MaterialComponents/private/ThumbTrack (= 20.1.1)
+  - MaterialComponents/private/Application (20.1.1)
+  - MaterialComponents/private/Icons (20.1.1):
+    - MaterialComponents/private/Icons/Base (= 20.1.1)
+    - MaterialComponents/private/Icons/ic_arrow_back (= 20.1.1)
+    - MaterialComponents/private/Icons/ic_check (= 20.1.1)
+    - MaterialComponents/private/Icons/ic_check_circle (= 20.1.1)
+    - MaterialComponents/private/Icons/ic_chevron_right (= 20.1.1)
+    - MaterialComponents/private/Icons/ic_info (= 20.1.1)
+    - MaterialComponents/private/Icons/ic_radio_button_unchecked (= 20.1.1)
+    - MaterialComponents/private/Icons/ic_reorder (= 20.1.1)
+  - MaterialComponents/private/Icons/Base (20.1.1)
+  - MaterialComponents/private/Icons/ic_arrow_back (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check (20.1.0):
+  - MaterialComponents/private/Icons/ic_check (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check_circle (20.1.0):
+  - MaterialComponents/private/Icons/ic_check_circle (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_chevron_right (20.1.0):
+  - MaterialComponents/private/Icons/ic_chevron_right (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_info (20.1.0):
+  - MaterialComponents/private/Icons/ic_info (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_radio_button_unchecked (20.1.0):
+  - MaterialComponents/private/Icons/ic_radio_button_unchecked (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_reorder (20.1.0):
+  - MaterialComponents/private/Icons/ic_reorder (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/KeyboardWatcher (20.1.0):
+  - MaterialComponents/private/KeyboardWatcher (20.1.1):
     - MaterialComponents/private/Application
-  - MaterialComponents/private/Overlay (20.1.0)
-  - MaterialComponents/private/RTL (20.1.0)
-  - MaterialComponents/private/ThumbTrack (20.1.0):
+  - MaterialComponents/private/Overlay (20.1.1)
+  - MaterialComponents/private/RTL (20.1.1)
+  - MaterialComponents/private/ThumbTrack (20.1.1):
     - MaterialComponents/Ink
     - MaterialComponents/private/RTL
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ProgressView (20.1.0):
+  - MaterialComponents/ProgressView (20.1.1):
     - MaterialComponents/private/RTL
-  - MaterialComponents/ShadowElevations (20.1.0)
-  - MaterialComponents/ShadowLayer (20.1.0)
-  - MaterialComponents/Slider (20.1.0):
+  - MaterialComponents/ShadowElevations (20.1.1)
+  - MaterialComponents/ShadowLayer (20.1.1)
+  - MaterialComponents/Slider (20.1.1):
     - MaterialComponents/private/ThumbTrack
-  - MaterialComponents/Snackbar (20.1.0):
+  - MaterialComponents/Snackbar (20.1.1):
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Buttons
     - MaterialComponents/OverlayWindow
@@ -143,7 +144,12 @@ PODS:
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/Overlay
     - MaterialComponents/Typography
-  - MaterialComponents/Typography (20.1.0)
+  - MaterialComponents/Tabs (20.1.1):
+    - MaterialComponents/AnimationTiming
+    - MaterialComponents/Ink
+    - MaterialComponents/private/RTL
+    - MaterialComponents/Typography
+  - MaterialComponents/Typography (20.1.1)
   - MDFTextAccessibility (1.1.3)
 
 DEPENDENCIES:
@@ -154,7 +160,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  MaterialComponents: 17a0c46778351f4b212047f0a8a4a6955797754f
+  MaterialComponents: 26372b7d42f8057bc467a796dea73cf62abc03ed
   MDFTextAccessibility: f05246cc165f78733bfad535365807ec6fef9601
 
 PODFILE CHECKSUM: 44e7c616a05bb4ce24db557c3de4bfbe915c2f56

--- a/demos/Pesto/Podfile.lock
+++ b/demos/Pesto/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - MaterialComponents/AnimationTiming (20.1.0)
-  - MaterialComponents/AppBar (20.1.0):
+  - MaterialComponents/AnimationTiming (20.1.1)
+  - MaterialComponents/AppBar (20.1.1):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
     - MaterialComponents/NavigationBar
@@ -9,16 +9,16 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ButtonBar (20.1.0):
+  - MaterialComponents/ButtonBar (20.1.1):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/Buttons (20.1.0):
+  - MaterialComponents/Buttons (20.1.1):
     - MaterialComponents/Ink
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/CollectionCells (20.1.0):
+  - MaterialComponents/CollectionCells (20.1.1):
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/private/Icons/ic_check
@@ -29,43 +29,43 @@ PODS:
     - MaterialComponents/private/Icons/ic_reorder
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/CollectionLayoutAttributes (20.1.0)
-  - MaterialComponents/Collections (20.1.0):
+  - MaterialComponents/CollectionLayoutAttributes (20.1.1)
+  - MaterialComponents/Collections (20.1.1):
     - MaterialComponents/CollectionCells
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/FlexibleHeader (20.1.0):
+  - MaterialComponents/FlexibleHeader (20.1.1):
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/HeaderStackView (20.1.0)
-  - MaterialComponents/Ink (20.1.0)
-  - MaterialComponents/NavigationBar (20.1.0):
+  - MaterialComponents/HeaderStackView (20.1.1)
+  - MaterialComponents/Ink (20.1.1)
+  - MaterialComponents/NavigationBar (20.1.1):
     - MaterialComponents/ButtonBar
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/private/Application (20.1.0)
-  - MaterialComponents/private/Icons/Base (20.1.0)
-  - MaterialComponents/private/Icons/ic_arrow_back (20.1.0):
+  - MaterialComponents/private/Application (20.1.1)
+  - MaterialComponents/private/Icons/Base (20.1.1)
+  - MaterialComponents/private/Icons/ic_arrow_back (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check (20.1.0):
+  - MaterialComponents/private/Icons/ic_check (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check_circle (20.1.0):
+  - MaterialComponents/private/Icons/ic_check_circle (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_chevron_right (20.1.0):
+  - MaterialComponents/private/Icons/ic_chevron_right (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_info (20.1.0):
+  - MaterialComponents/private/Icons/ic_info (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_radio_button_unchecked (20.1.0):
+  - MaterialComponents/private/Icons/ic_radio_button_unchecked (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_reorder (20.1.0):
+  - MaterialComponents/private/Icons/ic_reorder (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/RTL (20.1.0)
-  - MaterialComponents/ShadowElevations (20.1.0)
-  - MaterialComponents/ShadowLayer (20.1.0)
-  - MaterialComponents/Typography (20.1.0)
+  - MaterialComponents/private/RTL (20.1.1)
+  - MaterialComponents/ShadowElevations (20.1.1)
+  - MaterialComponents/ShadowLayer (20.1.1)
+  - MaterialComponents/Typography (20.1.1)
   - MDFTextAccessibility (1.1.3)
 
 DEPENDENCIES:
@@ -83,7 +83,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  MaterialComponents: 17a0c46778351f4b212047f0a8a4a6955797754f
+  MaterialComponents: 26372b7d42f8057bc467a796dea73cf62abc03ed
   MDFTextAccessibility: f05246cc165f78733bfad535365807ec6fef9601
 
 PODFILE CHECKSUM: 0bae51237ebf30ce3f4ecbcefedc8cf3d7af40cf

--- a/demos/Pesto/Podfile.lock
+++ b/demos/Pesto/Podfile.lock
@@ -66,7 +66,7 @@ PODS:
   - MaterialComponents/ShadowElevations (20.1.1)
   - MaterialComponents/ShadowLayer (20.1.1)
   - MaterialComponents/Typography (20.1.1)
-  - MDFTextAccessibility (1.1.3)
+  - MDFTextAccessibility (1.1.4)
 
 DEPENDENCIES:
   - MaterialComponents/AnimationTiming (from `../../`)
@@ -83,8 +83,8 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  MaterialComponents: 26372b7d42f8057bc467a796dea73cf62abc03ed
-  MDFTextAccessibility: f05246cc165f78733bfad535365807ec6fef9601
+  MaterialComponents: f628bce24c4089f905f1c57c08d271af5b6c90bc
+  MDFTextAccessibility: aa897b2675bc614c01a331053af680deea692148
 
 PODFILE CHECKSUM: 0bae51237ebf30ce3f4ecbcefedc8cf3d7af40cf
 

--- a/demos/Pesto/Podfile.lock
+++ b/demos/Pesto/Podfile.lock
@@ -62,17 +62,10 @@ PODS:
     - MaterialComponents/private/Icons/Base
   - MaterialComponents/private/Icons/ic_reorder (20.1.1):
     - MaterialComponents/private/Icons/Base
-<<<<<<< HEAD
   - MaterialComponents/private/RTL (20.1.1)
   - MaterialComponents/ShadowElevations (20.1.1)
   - MaterialComponents/ShadowLayer (20.1.1)
   - MaterialComponents/Typography (20.1.1)
-=======
-  - MaterialComponents/private/RTL (20.1.0)
-  - MaterialComponents/ShadowElevations (20.1.0)
-  - MaterialComponents/ShadowLayer (20.1.0)
-  - MaterialComponents/Typography (20.1.0)
->>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
   - MDFTextAccessibility (1.1.4)
 
 DEPENDENCIES:
@@ -90,11 +83,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-<<<<<<< HEAD
   MaterialComponents: f628bce24c4089f905f1c57c08d271af5b6c90bc
-=======
-  MaterialComponents: ef50c6355b614732dab43ac72540b57e5c250457
->>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
   MDFTextAccessibility: aa897b2675bc614c01a331053af680deea692148
 
 PODFILE CHECKSUM: 0bae51237ebf30ce3f4ecbcefedc8cf3d7af40cf

--- a/demos/Pesto/Podfile.lock
+++ b/demos/Pesto/Podfile.lock
@@ -62,10 +62,17 @@ PODS:
     - MaterialComponents/private/Icons/Base
   - MaterialComponents/private/Icons/ic_reorder (20.1.1):
     - MaterialComponents/private/Icons/Base
+<<<<<<< HEAD
   - MaterialComponents/private/RTL (20.1.1)
   - MaterialComponents/ShadowElevations (20.1.1)
   - MaterialComponents/ShadowLayer (20.1.1)
   - MaterialComponents/Typography (20.1.1)
+=======
+  - MaterialComponents/private/RTL (20.1.0)
+  - MaterialComponents/ShadowElevations (20.1.0)
+  - MaterialComponents/ShadowLayer (20.1.0)
+  - MaterialComponents/Typography (20.1.0)
+>>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
   - MDFTextAccessibility (1.1.4)
 
 DEPENDENCIES:
@@ -83,7 +90,11 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
+<<<<<<< HEAD
   MaterialComponents: f628bce24c4089f905f1c57c08d271af5b6c90bc
+=======
+  MaterialComponents: ef50c6355b614732dab43ac72540b57e5c250457
+>>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
   MDFTextAccessibility: aa897b2675bc614c01a331053af680deea692148
 
 PODFILE CHECKSUM: 0bae51237ebf30ce3f4ecbcefedc8cf3d7af40cf

--- a/demos/Shrine/Podfile.lock
+++ b/demos/Shrine/Podfile.lock
@@ -31,21 +31,12 @@ PODS:
   - MaterialComponents/private/Icons/Base (20.1.1)
   - MaterialComponents/private/Icons/ic_arrow_back (20.1.1):
     - MaterialComponents/private/Icons/Base
-<<<<<<< HEAD
   - MaterialComponents/private/RTL (20.1.1)
   - MaterialComponents/ShadowElevations (20.1.1)
   - MaterialComponents/ShadowLayer (20.1.1)
   - MaterialComponents/Typography (20.1.1)
   - MDFTextAccessibility (1.1.4)
   - RemoteImageServiceForMDCDemos (20.1.1)
-=======
-  - MaterialComponents/private/RTL (20.1.0)
-  - MaterialComponents/ShadowElevations (20.1.0)
-  - MaterialComponents/ShadowLayer (20.1.0)
-  - MaterialComponents/Typography (20.1.0)
-  - MDFTextAccessibility (1.1.4)
-  - RemoteImageServiceForMDCDemos (20.1.0)
->>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
 
 DEPENDENCIES:
   - MaterialComponents/AppBar (from `../../`)
@@ -59,15 +50,9 @@ EXTERNAL SOURCES:
     :path: "../supplemental"
 
 SPEC CHECKSUMS:
-<<<<<<< HEAD
   MaterialComponents: f628bce24c4089f905f1c57c08d271af5b6c90bc
   MDFTextAccessibility: aa897b2675bc614c01a331053af680deea692148
   RemoteImageServiceForMDCDemos: 487debf834fa4dcee9f04d060769149aa72b9232
-=======
-  MaterialComponents: ef50c6355b614732dab43ac72540b57e5c250457
-  MDFTextAccessibility: aa897b2675bc614c01a331053af680deea692148
-  RemoteImageServiceForMDCDemos: 209bb22d42bbdaebc37ef8c4fcaf637cc07e5b04
->>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
 
 PODFILE CHECKSUM: 5eb94d7fb8deeb6709b7300f5d0e0e1a75902cca
 

--- a/demos/Shrine/Podfile.lock
+++ b/demos/Shrine/Podfile.lock
@@ -31,12 +31,21 @@ PODS:
   - MaterialComponents/private/Icons/Base (20.1.1)
   - MaterialComponents/private/Icons/ic_arrow_back (20.1.1):
     - MaterialComponents/private/Icons/Base
+<<<<<<< HEAD
   - MaterialComponents/private/RTL (20.1.1)
   - MaterialComponents/ShadowElevations (20.1.1)
   - MaterialComponents/ShadowLayer (20.1.1)
   - MaterialComponents/Typography (20.1.1)
   - MDFTextAccessibility (1.1.4)
   - RemoteImageServiceForMDCDemos (20.1.1)
+=======
+  - MaterialComponents/private/RTL (20.1.0)
+  - MaterialComponents/ShadowElevations (20.1.0)
+  - MaterialComponents/ShadowLayer (20.1.0)
+  - MaterialComponents/Typography (20.1.0)
+  - MDFTextAccessibility (1.1.4)
+  - RemoteImageServiceForMDCDemos (20.1.0)
+>>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
 
 DEPENDENCIES:
   - MaterialComponents/AppBar (from `../../`)
@@ -50,9 +59,15 @@ EXTERNAL SOURCES:
     :path: "../supplemental"
 
 SPEC CHECKSUMS:
+<<<<<<< HEAD
   MaterialComponents: f628bce24c4089f905f1c57c08d271af5b6c90bc
   MDFTextAccessibility: aa897b2675bc614c01a331053af680deea692148
   RemoteImageServiceForMDCDemos: 487debf834fa4dcee9f04d060769149aa72b9232
+=======
+  MaterialComponents: ef50c6355b614732dab43ac72540b57e5c250457
+  MDFTextAccessibility: aa897b2675bc614c01a331053af680deea692148
+  RemoteImageServiceForMDCDemos: 209bb22d42bbdaebc37ef8c4fcaf637cc07e5b04
+>>>>>>> 2e2a45668569d94b34e71c8739daf7c27b361b50
 
 PODFILE CHECKSUM: 5eb94d7fb8deeb6709b7300f5d0e0e1a75902cca
 

--- a/demos/Shrine/Podfile.lock
+++ b/demos/Shrine/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - MaterialComponents/AppBar (20.1.0):
+  - MaterialComponents/AppBar (20.1.1):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
     - MaterialComponents/NavigationBar
@@ -8,35 +8,35 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ButtonBar (20.1.0):
+  - MaterialComponents/ButtonBar (20.1.1):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/Buttons (20.1.0):
+  - MaterialComponents/Buttons (20.1.1):
     - MaterialComponents/Ink
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader (20.1.0):
+  - MaterialComponents/FlexibleHeader (20.1.1):
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/HeaderStackView (20.1.0)
-  - MaterialComponents/Ink (20.1.0)
-  - MaterialComponents/NavigationBar (20.1.0):
+  - MaterialComponents/HeaderStackView (20.1.1)
+  - MaterialComponents/Ink (20.1.1)
+  - MaterialComponents/NavigationBar (20.1.1):
     - MaterialComponents/ButtonBar
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/PageControl (20.1.0)
-  - MaterialComponents/private/Application (20.1.0)
-  - MaterialComponents/private/Icons/Base (20.1.0)
-  - MaterialComponents/private/Icons/ic_arrow_back (20.1.0):
+  - MaterialComponents/PageControl (20.1.1)
+  - MaterialComponents/private/Application (20.1.1)
+  - MaterialComponents/private/Icons/Base (20.1.1)
+  - MaterialComponents/private/Icons/ic_arrow_back (20.1.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/RTL (20.1.0)
-  - MaterialComponents/ShadowElevations (20.1.0)
-  - MaterialComponents/ShadowLayer (20.1.0)
-  - MaterialComponents/Typography (20.1.0)
+  - MaterialComponents/private/RTL (20.1.1)
+  - MaterialComponents/ShadowElevations (20.1.1)
+  - MaterialComponents/ShadowLayer (20.1.1)
+  - MaterialComponents/Typography (20.1.1)
   - MDFTextAccessibility (1.1.3)
-  - RemoteImageServiceForMDCDemos (20.1.0)
+  - RemoteImageServiceForMDCDemos (20.1.1)
 
 DEPENDENCIES:
   - MaterialComponents/AppBar (from `../../`)
@@ -50,9 +50,9 @@ EXTERNAL SOURCES:
     :path: "../supplemental"
 
 SPEC CHECKSUMS:
-  MaterialComponents: 17a0c46778351f4b212047f0a8a4a6955797754f
+  MaterialComponents: 26372b7d42f8057bc467a796dea73cf62abc03ed
   MDFTextAccessibility: f05246cc165f78733bfad535365807ec6fef9601
-  RemoteImageServiceForMDCDemos: 209bb22d42bbdaebc37ef8c4fcaf637cc07e5b04
+  RemoteImageServiceForMDCDemos: 487debf834fa4dcee9f04d060769149aa72b9232
 
 PODFILE CHECKSUM: 5eb94d7fb8deeb6709b7300f5d0e0e1a75902cca
 

--- a/demos/Shrine/Podfile.lock
+++ b/demos/Shrine/Podfile.lock
@@ -35,7 +35,7 @@ PODS:
   - MaterialComponents/ShadowElevations (20.1.1)
   - MaterialComponents/ShadowLayer (20.1.1)
   - MaterialComponents/Typography (20.1.1)
-  - MDFTextAccessibility (1.1.3)
+  - MDFTextAccessibility (1.1.4)
   - RemoteImageServiceForMDCDemos (20.1.1)
 
 DEPENDENCIES:
@@ -50,8 +50,8 @@ EXTERNAL SOURCES:
     :path: "../supplemental"
 
 SPEC CHECKSUMS:
-  MaterialComponents: 26372b7d42f8057bc467a796dea73cf62abc03ed
-  MDFTextAccessibility: f05246cc165f78733bfad535365807ec6fef9601
+  MaterialComponents: f628bce24c4089f905f1c57c08d271af5b6c90bc
+  MDFTextAccessibility: aa897b2675bc614c01a331053af680deea692148
   RemoteImageServiceForMDCDemos: 487debf834fa4dcee9f04d060769149aa72b9232
 
 PODFILE CHECKSUM: 5eb94d7fb8deeb6709b7300f5d0e0e1a75902cca

--- a/demos/supplemental/RemoteImageServiceForMDCDemos.podspec
+++ b/demos/supplemental/RemoteImageServiceForMDCDemos.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RemoteImageServiceForMDCDemos"
-  s.version      = "20.1.0"
+  s.version      = "20.1.1"
   s.summary      = "A helper image class for the MDC demos."
   s.description  = "This spec is made for use in the MDC demos. It gets images via url."
   s.homepage     = "https://github.com/material-components/material-components-ios"


### PR DESCRIPTION
Update podspec files to require a minimum of iOS 8.0 as a deployment target.

We will no longer support devices on iOS 7 or earlier.
