### PR TITLE
Explicitly indicate the simulator in test_all script

### DIFF
--- a/scripts/test_all
+++ b/scripts/test_all
@@ -16,9 +16,10 @@
 
 readonly SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly ROOT_DIR="$(dirname $SCRIPTS_DIR)"
-# Note that the following is using 10.1 until Travis CI fixes 
+# Note that the following is using an explicit id until Travis CI fixes
 # https://github.com/travis-ci/travis-ci/issues/7031
-readonly DESTINATION="platform=iOS Simulator,name=iPhone 7,OS=10.1"
+# id=8996B396-3F44-4DD4-A56D-E4DE74ECF678 -> platform=iOS Simulator,name=iPhone 7,OS=10.2
+readonly DESTINATION="id=8996B396-3F44-4DD4-A56D-E4DE74ECF678"
 readonly COVERAGE_OPTIONS="GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES -enableCodeCoverage YES"
 
 # Given a path to an Xcode log file in $1, print a guess at what caused the


### PR DESCRIPTION
This fixes a problem on travis-ci and locally when using scripts/test_all.

Travis currently requires an explicit id.
https://github.com/travis-ci/travis-ci/issues/7031

We now target an Xcode 8.2 simulator.
