### PR TITLE
[Dialogs] Alert body text color to match spec

### DIFF
--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -62,6 +62,8 @@ static const CGFloat MDCDialogActionsVerticalPadding = 8.0;
 static const CGFloat MDCDialogActionButtonHeight = 36.0;
 static const CGFloat MDCDialogActionButtonMinimumWidth = 48.0;
 
+static const CGFloat MDCDialogMessageOpacity = 0.38f;
+
 @interface MDCAlertController ()
 
 @property(nonatomic, nonnull, strong) NSMutableArray<UIButton *> *actionButtons;
@@ -218,6 +220,7 @@ static const CGFloat MDCDialogActionButtonMinimumWidth = 48.0;
   self.messageLabel.numberOfLines = 0;
   self.messageLabel.textAlignment = NSTextAlignmentNatural;
   self.messageLabel.font = [MDCTypography body1Font];
+  self.messageLabel.textColor = [UIColor colorWithWhite:0.0 alpha:MDCDialogMessageOpacity];
   [self.contentScrollView addSubview:self.messageLabel];
 
   self.titleLabel.text = self.title;


### PR DESCRIPTION
We were using black for the alert body text.
We are now using black with the proper opacity.

From the Spec
Alert:
https://material.io/guidelines/components/dialogs.html#dialogs-behavior
Color:
https://material.io/guidelines/components/text-fields.html#text-fields-labels
