### PR TITLE
[Typography] Initial Material Text Style API

### DIFF
--- a/catalog/Podfile.lock
+++ b/catalog/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - CatalogByConvention (2.0.0)
-  - EarlGrey (1.6.2)
+  - EarlGrey (1.7.0)
   - MaterialComponents (20.1.1):
     - MaterialComponents/ActivityIndicator (= 20.1.1)
     - MaterialComponents/AnimationTiming (= 20.1.1)
@@ -176,7 +176,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   CatalogByConvention: be55c2263132e4f9f59299ac8a528ee8715b3275
-  EarlGrey: a20adcac6deeea0dfdb41d8caae41f87c47c3e5a
+  EarlGrey: 5cd1dd38c52e5cec70a819ed0fd8f95da240cf9f
   MaterialComponents: f628bce24c4089f905f1c57c08d271af5b6c90bc
   MaterialComponentsCatalog: 5bbb85074e55d527514040d71bf70a730912272e
   MaterialComponentsUnitTests: a5f2ad8ad911213b66ad9734b6a995c0bfb5dbfc

--- a/components/Typography/examples/TypographyMaterialStylesViewController.h
+++ b/components/Typography/examples/TypographyMaterialStylesViewController.h
@@ -14,16 +14,7 @@
  limitations under the License.
  */
 
-/**
- The Typography component provides methods for getting sized fonts and opacities following Material
- style guidelines.
+#import <UIKit/UIKit.h>
 
- This header is the umbrella header for the component and should be imported by consumers of the
- Typography component. Please do not directly import other headers. This will allow the componet to
- expand or contract the header file space without consumer modifications.
- */
-
-#import "MDCTypography.h"
-#import "MDCFontTextStyle.h"
-#import "UIFont+MaterialTypography.h"
-#import "UIFontDescriptor+MaterialTypography.h"
+@interface TypographyMaterialStyleViewController : UITableViewController
+@end

--- a/components/Typography/examples/TypographyMaterialStylesViewController.m
+++ b/components/Typography/examples/TypographyMaterialStylesViewController.m
@@ -1,0 +1,166 @@
+/*
+ Copyright 2015-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "TypographyMaterialStylesViewController.h"
+
+#import "MaterialTypography.h"
+
+@implementation TypographyMaterialStyleViewController {
+  NSArray <NSString *> *_strings;
+  NSArray <NSString *> *_styleNames;
+  NSArray <UIFont *> *_styleFonts;
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+
+  self.tableView.rowHeight = UITableViewAutomaticDimension;
+  self.tableView.estimatedRowHeight = 50.0;
+
+  _strings = @[
+               @"Material Design Components",
+               @"A quick brown fox jumped over the lazy dog.",
+               @"ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+               @"abcdefghijklmnopqrstuvwxyz",
+               @"1234567890",
+               @"!@#$%^&*()-=_+[]\\;',./<>?:\""
+               ];
+
+  _styleNames = @[
+                  // Common UI fonts.
+                  @"Headline Font",
+                  @"Title Font",
+                  @"Subhead Font",
+                  @"Body 2 Font",
+                  @"Body 1 Font",
+                  @"Caption Font",
+                  @"Button Font",
+
+                  // Display fonts (extra large fonts)
+                  @"Display 1 Font",
+                  @"Display 2 Font",
+                  @"Display 3 Font",
+                  @"Display 4 Font"
+                  ];
+
+  _styleFonts = @[
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleHeadline],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleTitle],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleSubheadline],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleBody2],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleBody1],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleCaption],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleButton],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleDisplay1],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleDisplay2],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleDisplay3],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleDisplay4]
+                  ];
+
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(contentSizeCategoryDidChange:) name:UIContentSizeCategoryDidChangeNotification object:nil];
+
+  /*
+  UIKIT_EXTERN const CGFloat UIFontWeightUltraLight NS_AVAILABLE_IOS(8_2);
+  UIKIT_EXTERN const CGFloat UIFontWeightThin NS_AVAILABLE_IOS(8_2);
+  UIKIT_EXTERN const CGFloat UIFontWeightLight NS_AVAILABLE_IOS(8_2);
+  UIKIT_EXTERN const CGFloat UIFontWeightRegular NS_AVAILABLE_IOS(8_2);
+  UIKIT_EXTERN const CGFloat UIFontWeightMedium NS_AVAILABLE_IOS(8_2);
+  UIKIT_EXTERN const CGFloat UIFontWeightSemibold NS_AVAILABLE_IOS(8_2);
+  UIKIT_EXTERN const CGFloat UIFontWeightBold NS_AVAILABLE_IOS(8_2);
+  UIKIT_EXTERN const CGFloat UIFontWeightHeavy NS_AVAILABLE_IOS(8_2);
+  UIKIT_EXTERN const CGFloat UIFontWeightBlack NS_AVAILABLE_IOS(8_2);
+*/
+
+  NSLog(@"UIFontWeightUltraLight %f", UIFontWeightUltraLight);
+  NSLog(@"UIFontWeightThin %f", UIFontWeightThin);
+  NSLog(@"UIFontWeightLight %f", UIFontWeightLight);
+  NSLog(@"UIFontWeightRegular %f", UIFontWeightRegular);
+  NSLog(@"UIFontWeightMedium %f", UIFontWeightMedium);
+  NSLog(@"UIFontWeightSemibold %f", UIFontWeightSemibold);
+  NSLog(@"UIFontWeightBold %f", UIFontWeightBold);
+  NSLog(@"UIFontWeightHeavy %f", UIFontWeightHeavy);
+  NSLog(@"UIFontWeightBlack %f", UIFontWeightBlack);
+}
+
+- (void)contentSizeCategoryDidChange:(NSNotification *)notification {
+  NSString *sizeCategory = notification.userInfo[UIContentSizeCategoryNewValueKey];
+  NSLog(@"New size category : %@", sizeCategory);
+
+  [self.tableView beginUpdates];
+  [self.tableView endUpdates];
+
+  //TODO Wierdness on iOS 8
+//  [self.tableView reloadData];
+}
+
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  NSLog(@"traitCollectionDidChange:");
+  UITraitCollection *currentTraitCollection = self.traitCollection;
+
+  // contentSize change doesn't arrive until iOS 10
+
+  //  [self.tableView beginUpdates];
+  //  [self.tableView endUpdates];
+
+//  [self.tableView reloadData];
+}
+
+#pragma mark - UITableViewDataSource
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Typography and Fonts", @"Material Font Styles" ];
+}
+
+#pragma mark - UITableViewDelegate
+
+#pragma mark - UITableViewDataSource
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+  return _strings.count;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+  return _styleFonts.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+  UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:@"cell"];
+  if (cell == nil) {
+    cell =
+        [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"cell"];
+  }
+  cell.textLabel.text = _strings[indexPath.section];
+  cell.textLabel.font = _styleFonts[indexPath.row];
+  cell.textLabel.numberOfLines = 0;
+  cell.textLabel.lineBreakMode = NSLineBreakByWordWrapping;
+
+  UIFont *currentFont = _styleFonts[indexPath.row];
+
+  if (cell.textLabel.font.pointSize > 100 && indexPath.section == 0) {
+    cell.textLabel.text = @"MDC";
+  }
+
+  cell.detailTextLabel.text = _styleNames[indexPath.row];
+  cell.detailTextLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleCaption1];
+
+  cell.selectionStyle = UITableViewCellSelectionStyleNone;
+
+  return cell;
+}
+@end

--- a/components/Typography/src/MDCFontTextStyle.h
+++ b/components/Typography/src/MDCFontTextStyle.h
@@ -1,0 +1,34 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/*
+ Material font text styles
+ These styles are defined in:
+ https://material.io/guidelines/style/typography.html
+ This enumeration is a set of semantic descriptions intended to describe the fonts returned by
+ + [UIFont mdc_preferredFontForMaterialTextStyle:]
+ + [UIFontDescriptor mdc_preferredFontDescriptorForMaterialTextStyle:]
+ */
+typedef NS_ENUM(NSInteger, MDCFontTextStyle) {
+  MDCFontTextStyleBody1,
+  MDCFontTextStyleBody2,
+  MDCFontTextStyleCaption,
+  MDCFontTextStyleHeadline,
+  MDCFontTextStyleSubheadline,
+  MDCFontTextStyleTitle,
+  MDCFontTextStyleDisplay1,
+  MDCFontTextStyleDisplay2,
+  MDCFontTextStyleDisplay3,
+  MDCFontTextStyleDisplay4,
+  MDCFontTextStyleButton,
+};

--- a/components/Typography/src/MDCFontTextStyle.h
+++ b/components/Typography/src/MDCFontTextStyle.h
@@ -11,8 +11,9 @@
  limitations under the License.
  */
 
-/*
+/**
  Material font text styles
+ 
  These styles are defined in:
  https://material.io/guidelines/style/typography.html
  This enumeration is a set of semantic descriptions intended to describe the fonts returned by

--- a/components/Typography/src/MaterialTypography.h
+++ b/components/Typography/src/MaterialTypography.h
@@ -23,7 +23,7 @@
  expand or contract the header file space without consumer modifications.
  */
 
-#import "MDCTypography.h"
 #import "MDCFontTextStyle.h"
+#import "MDCTypography.h"
 #import "UIFont+MaterialTypography.h"
 #import "UIFontDescriptor+MaterialTypography.h"

--- a/components/Typography/src/UIFont+MaterialTypography.h
+++ b/components/Typography/src/UIFont+MaterialTypography.h
@@ -1,0 +1,28 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "MDCFontTextStyle.h"
+
+@interface UIFont (MaterialTypography)
+
+/*
+ Returns an instance of the font associated with the Material text style and scaled based on the
+ content size category.
+
+ @style The Material font text style for which to return a font.
+ */
++ (nonnull UIFont *)mdc_preferredFontForMaterialTextStyle:(MDCFontTextStyle)style;
+
+@end

--- a/components/Typography/src/UIFont+MaterialTypography.h
+++ b/components/Typography/src/UIFont+MaterialTypography.h
@@ -17,11 +17,12 @@
 
 @interface UIFont (MaterialTypography)
 
-/*
+/**
  Returns an instance of the font associated with the Material text style and scaled based on the
  content size category.
 
- @style The Material font text style for which to return a font.
+ @param style The Material font text style for which to return a font.
+ @return The font associated with the specified style.
  */
 + (nonnull UIFont *)mdc_preferredFontForMaterialTextStyle:(MDCFontTextStyle)style;
 

--- a/components/Typography/src/UIFont+MaterialTypography.m
+++ b/components/Typography/src/UIFont+MaterialTypography.m
@@ -1,12 +1,9 @@
 /*
- Copyright 2015-present the Material Components for iOS authors. All Rights Reserved.
-
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
-
  http://www.apache.org/licenses/LICENSE-2.0
-
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,16 +11,20 @@
  limitations under the License.
  */
 
-/**
- The Typography component provides methods for getting sized fonts and opacities following Material
- style guidelines.
-
- This header is the umbrella header for the component and should be imported by consumers of the
- Typography component. Please do not directly import other headers. This will allow the componet to
- expand or contract the header file space without consumer modifications.
- */
-
-#import "MDCTypography.h"
-#import "MDCFontTextStyle.h"
 #import "UIFont+MaterialTypography.h"
+
 #import "UIFontDescriptor+MaterialTypography.h"
+
+@implementation UIFont (MaterialTypography)
+
++ (UIFont *)mdc_preferredFontForMaterialTextStyle:(MDCFontTextStyle)style {
+  UIFontDescriptor *fontDescriptor =
+      [UIFontDescriptor mdc_preferredFontDescriptorForMaterialTextStyle:style];
+
+  // Size is included in the fontDescriptor, so we pass in 0.0 in the parameter
+  UIFont *font = [UIFont fontWithDescriptor:fontDescriptor size:0.0];
+
+  return font;
+}
+
+@end

--- a/components/Typography/src/UIFont+MaterialTypography.m
+++ b/components/Typography/src/UIFont+MaterialTypography.m
@@ -21,7 +21,7 @@
   UIFontDescriptor *fontDescriptor =
       [UIFontDescriptor mdc_preferredFontDescriptorForMaterialTextStyle:style];
 
-  // Size is included in the fontDescriptor, so we pass in 0.0 in the parameter
+  // Size is included in the fontDescriptor, so we pass in 0.0 in the parameter.
   UIFont *font = [UIFont fontWithDescriptor:fontDescriptor size:0.0];
 
   return font;

--- a/components/Typography/src/UIFontDescriptor+MaterialTypography.h
+++ b/components/Typography/src/UIFontDescriptor+MaterialTypography.h
@@ -20,10 +20,10 @@
 /*
  Returns an instance of the font descriptor associated with the Material text style and scaled
  based on the content size category.
- 
+
  @style The Material font text style for which to return a font descriptor.
  */
-+ (nonnull UIFontDescriptor *)
-    mdc_preferredFontDescriptorForMaterialTextStyle:(MDCFontTextStyle)style;
++ (nonnull UIFontDescriptor *)mdc_preferredFontDescriptorForMaterialTextStyle:
+        (MDCFontTextStyle)style;
 
 @end

--- a/components/Typography/src/UIFontDescriptor+MaterialTypography.h
+++ b/components/Typography/src/UIFontDescriptor+MaterialTypography.h
@@ -20,6 +20,7 @@
 /*
  Returns an instance of the font descriptor associated with the Material text style and scaled
  based on the content size category.
+ 
  @style The Material font text style for which to return a font descriptor.
  */
 + (nonnull UIFontDescriptor *)

--- a/components/Typography/src/UIFontDescriptor+MaterialTypography.h
+++ b/components/Typography/src/UIFontDescriptor+MaterialTypography.h
@@ -1,0 +1,28 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "MDCFontTextStyle.h"
+
+@interface UIFontDescriptor (MaterialTypography)
+
+/*
+ Returns an instance of the font descriptor associated with the Material text style and scaled
+ based on the content size category.
+ @style The Material font text style for which to return a font descriptor.
+ */
++ (nonnull UIFontDescriptor *)
+    mdc_preferredFontDescriptorForMaterialTextStyle:(MDCFontTextStyle)style;
+
+@end

--- a/components/Typography/src/UIFontDescriptor+MaterialTypography.h
+++ b/components/Typography/src/UIFontDescriptor+MaterialTypography.h
@@ -17,11 +17,12 @@
 
 @interface UIFontDescriptor (MaterialTypography)
 
-/*
+/**
  Returns an instance of the font descriptor associated with the Material text style and scaled
  based on the content size category.
 
- @style The Material font text style for which to return a font descriptor.
+ @param style The Material font text style for which to return a font descriptor.
+ @return The font descriptor associated with the specified style.
  */
 + (nonnull UIFontDescriptor *)mdc_preferredFontDescriptorForMaterialTextStyle:
         (MDCFontTextStyle)style;

--- a/components/Typography/src/UIFontDescriptor+MaterialTypography.m
+++ b/components/Typography/src/UIFontDescriptor+MaterialTypography.m
@@ -19,9 +19,8 @@
 
 @implementation UIFontDescriptor (MaterialTypography)
 
-+ (nonnull UIFontDescriptor *)
-    mdc_preferredFontDescriptorForMaterialTextStyle:(MDCFontTextStyle)style {
-
++ (nonnull UIFontDescriptor *)mdc_preferredFontDescriptorForMaterialTextStyle:
+        (MDCFontTextStyle)style {
   // The default size category is Large
   NSString *sizeCategory = UIContentSizeCategoryLarge;
 
@@ -33,8 +32,10 @@
   MDCFontTraits *fontTraits = [MDCFontTraits traitsForTextStyle:style sizeCategory:sizeCategory];
 
   NSDictionary *traits = @{ UIFontWeightTrait : @(fontTraits.weight) };
-  NSDictionary *attributes = @{ UIFontDescriptorSizeAttribute : @(fontTraits.pointSize),
-                                UIFontDescriptorTraitsAttribute : traits };
+  NSDictionary *attributes = @{
+    UIFontDescriptorSizeAttribute : @(fontTraits.pointSize),
+    UIFontDescriptorTraitsAttribute : traits
+  };
 
   UIFontDescriptor *fontDescriptor = [[UIFontDescriptor alloc] initWithFontAttributes:attributes];
 

--- a/components/Typography/src/UIFontDescriptor+MaterialTypography.m
+++ b/components/Typography/src/UIFontDescriptor+MaterialTypography.m
@@ -1,0 +1,45 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "UIFontDescriptor+MaterialTypography.h"
+
+#import "UIApplication+AppExtensions.h"
+
+#import "private/MDCFontTraits.h"
+
+@implementation UIFontDescriptor (MaterialTypography)
+
++ (nonnull UIFontDescriptor *)
+    mdc_preferredFontDescriptorForMaterialTextStyle:(MDCFontTextStyle)style {
+
+  // The default size category is Large
+  NSString *sizeCategory = UIContentSizeCategoryLarge;
+
+  // If we are within an application, queary the preferredContentSizeCategory
+  if ([UIApplication mdc_safeSharedApplication]) {
+    sizeCategory = [UIApplication mdc_safeSharedApplication].preferredContentSizeCategory;
+    NSLog(@"UIFontDescriptor : PreferredContentSizeCategory : %@", sizeCategory);  //KM
+  }
+
+  MDCFontTraits *fontTraits = [MDCFontTraits traitsForTextStyle:style sizeCategory:sizeCategory];
+
+  NSDictionary *traits = @{ UIFontWeightTrait : @(fontTraits.weight) };
+  NSDictionary *attributes = @{ UIFontDescriptorSizeAttribute : @(fontTraits.pointSize),
+                                UIFontDescriptorTraitsAttribute : traits };
+
+  UIFontDescriptor *fontDescriptor = [[UIFontDescriptor alloc] initWithFontAttributes:attributes];
+
+  return fontDescriptor;
+}
+
+@end

--- a/components/Typography/src/UIFontDescriptor+MaterialTypography.m
+++ b/components/Typography/src/UIFontDescriptor+MaterialTypography.m
@@ -28,7 +28,6 @@
   // If we are within an application, queary the preferredContentSizeCategory
   if ([UIApplication mdc_safeSharedApplication]) {
     sizeCategory = [UIApplication mdc_safeSharedApplication].preferredContentSizeCategory;
-    NSLog(@"UIFontDescriptor : PreferredContentSizeCategory : %@", sizeCategory);  //KM
   }
 
   MDCFontTraits *fontTraits = [MDCFontTraits traitsForTextStyle:style sizeCategory:sizeCategory];

--- a/components/Typography/src/UIFontDescriptor+MaterialTypography.m
+++ b/components/Typography/src/UIFontDescriptor+MaterialTypography.m
@@ -21,19 +21,21 @@
 
 + (nonnull UIFontDescriptor *)mdc_preferredFontDescriptorForMaterialTextStyle:
         (MDCFontTextStyle)style {
-  // The default size category is Large
+  // iOS' default UIContentSizeCategory is Large.
   NSString *sizeCategory = UIContentSizeCategoryLarge;
 
-  // If we are within an application, queary the preferredContentSizeCategory
+  // If we are within an application, query the preferredContentSizeCategory.
   if ([UIApplication mdc_safeSharedApplication]) {
     sizeCategory = [UIApplication mdc_safeSharedApplication].preferredContentSizeCategory;
   }
 
-  MDCFontTraits *fontTraits = [MDCFontTraits traitsForTextStyle:style sizeCategory:sizeCategory];
+  // TODO(#1179): We should include our leading and tracking metrics when creating this descriptor.
+  MDCFontTraits *materialTraits =
+      [MDCFontTraits traitsForTextStyle:style sizeCategory:sizeCategory];
 
-  NSDictionary *traits = @{ UIFontWeightTrait : @(fontTraits.weight) };
+  NSDictionary *traits = @{ UIFontWeightTrait : @(materialTraits.weight) };
   NSDictionary *attributes = @{
-    UIFontDescriptorSizeAttribute : @(fontTraits.pointSize),
+    UIFontDescriptorSizeAttribute : @(materialTraits.pointSize),
     UIFontDescriptorTraitsAttribute : traits
   };
 

--- a/components/Typography/src/private/MDCFontTraits.h
+++ b/components/Typography/src/private/MDCFontTraits.h
@@ -21,12 +21,11 @@
 
 @interface MDCFontTraits : NSObject
 
-@property (nonatomic, readonly) CGFloat pointSize;
-@property (nonatomic, readonly) CGFloat weight;
-@property (nonatomic, readonly) CGFloat leading;
-@property (nonatomic, readonly) CGFloat tracking;
+@property(nonatomic, readonly) CGFloat pointSize;
+@property(nonatomic, readonly) CGFloat weight;
+@property(nonatomic, readonly) CGFloat leading;
+@property(nonatomic, readonly) CGFloat tracking;
 
 + (MDCFontTraits *)traitsForTextStyle:(MDCFontTextStyle)style sizeCategory:(NSString *)sizeCategory;
-
 
 @end

--- a/components/Typography/src/private/MDCFontTraits.h
+++ b/components/Typography/src/private/MDCFontTraits.h
@@ -26,8 +26,6 @@
 @property (nonatomic, readonly) CGFloat leading;
 @property (nonatomic, readonly) CGFloat tracking;
 
-- (instancetype)initWithPointSize:(CGFloat)pointSize weight:(CGFloat)weight leading:(CGFloat)leading tracking:(CGFloat)tracking;
-
 + (MDCFontTraits *)traitsForTextStyle:(MDCFontTextStyle)style sizeCategory:(NSString *)sizeCategory;
 
 

--- a/components/Typography/src/private/MDCFontTraits.h
+++ b/components/Typography/src/private/MDCFontTraits.h
@@ -1,0 +1,34 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "MDCFontTextStyle.h"
+
+/*
+ This class is based off Apple recommendation in WWDC 2016 - Typography session
+ */
+
+@interface MDCFontTraits : NSObject
+
+@property (nonatomic, readonly) CGFloat pointSize;
+@property (nonatomic, readonly) CGFloat weight;
+@property (nonatomic, readonly) CGFloat leading;
+@property (nonatomic, readonly) CGFloat tracking;
+
+- (instancetype)initWithPointSize:(CGFloat)pointSize weight:(CGFloat)weight leading:(CGFloat)leading tracking:(CGFloat)tracking;
+
++ (MDCFontTraits *)traitsForTextStyle:(MDCFontTextStyle)style sizeCategory:(NSString *)sizeCategory;
+
+
+@end

--- a/components/Typography/src/private/MDCFontTraits.h
+++ b/components/Typography/src/private/MDCFontTraits.h
@@ -15,17 +15,45 @@
 
 #import "MDCFontTextStyle.h"
 
-/*
- This class is based off Apple recommendation in WWDC 2016 - Typography session
- */
+/**
+ Provides a means of storing defining font metrics based on size categories.
 
+ This class is based off Apple recommendation in WWDC 2016 - 803 - Typography and Fonts @ 17:33.
+ */
 @interface MDCFontTraits : NSObject
 
+/**
+ The size to which the font is scaled. 
+ 
+ This value, in points, must be greater than 0.0.
+ */
 @property(nonatomic, readonly) CGFloat pointSize;
+
+/**
+ The weight of the font, specified as a font weight constant. 
+ 
+ For a list of possible values, see "Font Weights” in UIFontDescriptor. Avoid passing an arbitrary
+ floating-point number for weight, because a font might not include a variant for every weight.
+ */
 @property(nonatomic, readonly) CGFloat weight;
+
+/**
+ The leading value represents additional space between lines of text and is measured in points.
+ */
 @property(nonatomic, readonly) CGFloat leading;
+
+/**
+ The tracking value represents additional horizontal space between glyphs and is measured in points.
+ */
 @property(nonatomic, readonly) CGFloat tracking;
 
-+ (MDCFontTraits *)traitsForTextStyle:(MDCFontTextStyle)style sizeCategory:(NSString *)sizeCategory;
+/**
+ @param style MDCFontStyle of font traits being requested.
+ @param sizeCategory UIContentSizeCategory of the font traits being requested.
+
+ @return Font traits that can be used to initialize a UIFont or UIFontDescriptor.
+ */
++ (nonnull MDCFontTraits *)traitsForTextStyle:(MDCFontTextStyle)style
+                                 sizeCategory:(nonnull NSString *)sizeCategory;
 
 @end

--- a/components/Typography/src/private/MDCFontTraits.m
+++ b/components/Typography/src/private/MDCFontTraits.m
@@ -1,0 +1,225 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCFontTraits.h"
+
+/*
+ MDCFontTextStyleBody1,
+ MDCFontTextStyleBody2,
+ MDCFontTextStyleCaption,
+ MDCFontTextStyleHeadline,
+ MDCFontTextStyleSubheadline,
+ MDCFontTextStyleTitle,
+ MDCFontTextStyleDisplay1,
+ MDCFontTextStyleDisplay2,
+ MDCFontTextStyleDisplay3,
+ MDCFontTextStyleDisplay4,
+ MDCFontTextStyleButton,
+ */
+
+static NSDictionary <NSString *, MDCFontTraits *> *_body1Traits;
+static NSDictionary <NSString *, MDCFontTraits *> *_body2Traits;
+static NSDictionary <NSString *, MDCFontTraits *> *_buttonTraits;
+static NSDictionary <NSString *, MDCFontTraits *> *_captionTraits;
+static NSDictionary <NSString *, MDCFontTraits *> *_display1Traits;
+static NSDictionary <NSString *, MDCFontTraits *> *_display2Traits;
+static NSDictionary <NSString *, MDCFontTraits *> *_display3Traits;
+static NSDictionary <NSString *, MDCFontTraits *> *_display4Traits;
+static NSDictionary <NSString *, MDCFontTraits *> *_headlineTraits;
+static NSDictionary <NSString *, MDCFontTraits *> *_subheadlineTraits;
+static NSDictionary <NSString *, MDCFontTraits *> *_titleTraits;
+
+static NSDictionary <NSNumber *, NSDictionary *> *_styleTable;
+
+
+@interface MDCFontTraits (MaterialTypographyPrivate)
+
+- (instancetype)initWithPointSize:(CGFloat)pointSize weight:(CGFloat)weight leading:(CGFloat)leading tracking:(CGFloat)tracking;
+
+@end
+
+@implementation MDCFontTraits
+
++ (void)initialize {
+  _body1Traits = @{
+                   UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:11 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+                   UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:12 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:13 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:14 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:16 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:18 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:20 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryAccessibilityMedium: [[MDCFontTraits alloc] initWithPointSize:25 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryAccessibilityLarge: [[MDCFontTraits alloc] initWithPointSize:30 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryAccessibilityExtraLarge: [[MDCFontTraits alloc] initWithPointSize:37 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryAccessibilityExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:44 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryAccessibilityExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:52 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+                   };
+
+  _body2Traits = @{
+                   UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:11 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+                   UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:12 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:13 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:14 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:16 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:18 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:20 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryAccessibilityMedium: [[MDCFontTraits alloc] initWithPointSize:25 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryAccessibilityLarge: [[MDCFontTraits alloc] initWithPointSize:30 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryAccessibilityExtraLarge: [[MDCFontTraits alloc] initWithPointSize:37 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryAccessibilityExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:44 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+                   UIContentSizeCategoryAccessibilityExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:52 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+                   };
+
+  _buttonTraits = @ {
+  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:11 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:12 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:13 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:14 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:16 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:18 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:20 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+  };
+
+  _captionTraits = @ {
+  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:11 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:11 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:11 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:12 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:14 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:16 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:18 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  };
+
+  _display1Traits = @ {
+  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:28 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:30 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:32 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:34 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:36 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:38 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:40 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  };
+
+  _display2Traits = @ {
+  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:39 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:41 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:43 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:45 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:47 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:49 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:51 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  };
+
+  _display3Traits = @ {
+  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:50 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:52 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:54 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:56 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:58 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:60 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:62 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  };
+
+  _display4Traits = @ {
+  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:100 weight:UIFontWeightLight leading:0.0 tracking:0.0],
+  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:104 weight:UIFontWeightLight leading:0.0 tracking:0.0],
+  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:108 weight:UIFontWeightLight leading:0.0 tracking:0.0],
+  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:112 weight:UIFontWeightLight leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:116 weight:UIFontWeightLight leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:120 weight:UIFontWeightLight leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:124 weight:UIFontWeightLight leading:0.0 tracking:0.0],
+  };
+
+  _headlineTraits = @ {
+  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:21 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:22 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:23 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:24 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:26 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:28 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:30 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  };
+
+  _subheadlineTraits = @ {
+  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:13 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:14 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:15 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:16 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:18 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:20 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:22 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  };
+
+  _titleTraits = @ {
+  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:17 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:18 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:19 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:20 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:22 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:24 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:26 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+  };
+
+  _styleTable = @{
+                  @(MDCFontTextStyleBody1) : _body1Traits,
+                  @(MDCFontTextStyleBody2) : _body2Traits,
+                  @(MDCFontTextStyleButton) : _buttonTraits,
+                  @(MDCFontTextStyleCaption) : _captionTraits,
+                  @(MDCFontTextStyleDisplay1) : _display1Traits,
+                  @(MDCFontTextStyleDisplay2) : _display2Traits,
+                  @(MDCFontTextStyleDisplay3) : _display3Traits,
+                  @(MDCFontTextStyleDisplay4) : _display4Traits,
+                  @(MDCFontTextStyleHeadline) : _headlineTraits,
+                  @(MDCFontTextStyleSubheadline) : _subheadlineTraits,
+                  @(MDCFontTextStyleTitle) : _titleTraits
+                  };
+}
+
+- (instancetype)initWithPointSize:(CGFloat)pointSize
+                           weight:(CGFloat)weight
+                          leading:(CGFloat)leading
+                         tracking:(CGFloat)tracking {
+  self = [super init];
+  if (self) {
+    _pointSize = pointSize;
+    _weight = weight;
+    _leading = leading;
+    _tracking = tracking;
+  }
+
+  return self;
+}
+
+
++ (MDCFontTraits *)traitsForTextStyle:(MDCFontTextStyle)style
+                         sizeCategory:(NSString *)sizeCategory {
+  NSDictionary *traitsTable = _styleTable[@(style)];
+
+  MDCFontTraits *traits;
+  if (traitsTable) {
+    if (sizeCategory) {
+      traits = traitsTable[sizeCategory];
+    }
+
+    if (traits == nil) {
+      traits = traitsTable[UIContentSizeCategoryExtraExtraExtraLarge];
+    }
+  }
+
+  // Asert traits
+
+  return traits;
+}
+
+@end

--- a/components/Typography/src/private/MDCFontTraits.m
+++ b/components/Typography/src/private/MDCFontTraits.m
@@ -476,12 +476,15 @@ static NSDictionary<NSNumber *, NSDictionary *> *_styleTable;
       traits = traitsTable[sizeCategory];
     }
 
+    // If you have queried the table for a sizeCategory that doesn't exist, we will return the
+    // traits for XXXL.  This handles the case where the values are requested for one of the
+    // accessibility size categories beyond XXXL such as
+    // UIContentSizeCategoryAccessibilityExtraLarge.  Accessbility size categories are only
+    // defined for the Body Font Style.
     if (traits == nil) {
       traits = traitsTable[UIContentSizeCategoryExtraExtraExtraLarge];
     }
   }
-
-  // Asert traits
 
   return traits;
 }

--- a/components/Typography/src/private/MDCFontTraits.m
+++ b/components/Typography/src/private/MDCFontTraits.m
@@ -13,20 +13,6 @@
 
 #import "MDCFontTraits.h"
 
-/*
- MDCFontTextStyleBody1,
- MDCFontTextStyleBody2,
- MDCFontTextStyleCaption,
- MDCFontTextStyleHeadline,
- MDCFontTextStyleSubheadline,
- MDCFontTextStyleTitle,
- MDCFontTextStyleDisplay1,
- MDCFontTextStyleDisplay2,
- MDCFontTextStyleDisplay3,
- MDCFontTextStyleDisplay4,
- MDCFontTextStyleButton,
- */
-
 static NSDictionary <NSString *, MDCFontTraits *> *_body1Traits;
 static NSDictionary <NSString *, MDCFontTraits *> *_body2Traits;
 static NSDictionary <NSString *, MDCFontTraits *> *_buttonTraits;
@@ -44,6 +30,8 @@ static NSDictionary <NSNumber *, NSDictionary *> *_styleTable;
 
 @interface MDCFontTraits (MaterialTypographyPrivate)
 
++ (instancetype)traitsWithPointSize:(CGFloat)pointSize weight:(CGFloat)weight leading:(CGFloat)leading tracking:(CGFloat)tracking;
+
 - (instancetype)initWithPointSize:(CGFloat)pointSize weight:(CGFloat)weight leading:(CGFloat)leading tracking:(CGFloat)tracking;
 
 @end
@@ -52,19 +40,32 @@ static NSDictionary <NSNumber *, NSDictionary *> *_styleTable;
 
 + (void)initialize {
   _body1Traits = @{
-                   UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:11 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-                   UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:12 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:13 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:14 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:16 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:18 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:20 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryAccessibilityMedium: [[MDCFontTraits alloc] initWithPointSize:25 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryAccessibilityLarge: [[MDCFontTraits alloc] initWithPointSize:30 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryAccessibilityExtraLarge: [[MDCFontTraits alloc] initWithPointSize:37 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryAccessibilityExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:44 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryAccessibilityExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:52 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-                   };
+    UIContentSizeCategoryExtraSmall:
+        [MDCFontTraits traitsWithPointSize:11 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+    UIContentSizeCategorySmall:
+        [MDCFontTraits traitsWithPointSize:12 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+    UIContentSizeCategoryMedium:
+        [MDCFontTraits traitsWithPointSize:13 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+    UIContentSizeCategoryLarge:
+        [MDCFontTraits traitsWithPointSize:14 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+    UIContentSizeCategoryExtraLarge:
+        [MDCFontTraits traitsWithPointSize:16 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+    UIContentSizeCategoryExtraExtraLarge:
+        [MDCFontTraits traitsWithPointSize:18 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+    UIContentSizeCategoryExtraExtraExtraLarge:
+        [MDCFontTraits traitsWithPointSize:20 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+    UIContentSizeCategoryAccessibilityMedium:
+        [MDCFontTraits traitsWithPointSize:25 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+    UIContentSizeCategoryAccessibilityLarge:
+        [MDCFontTraits traitsWithPointSize:30 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+    UIContentSizeCategoryAccessibilityExtraLarge:
+        [MDCFontTraits traitsWithPointSize:37 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+    UIContentSizeCategoryAccessibilityExtraExtraLarge:
+        [MDCFontTraits traitsWithPointSize:44 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+    UIContentSizeCategoryAccessibilityExtraExtraExtraLarge:
+        [MDCFontTraits traitsWithPointSize:52 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  };
+
 
   _body2Traits = @{
                    UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:11 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
@@ -184,6 +185,16 @@ static NSDictionary <NSNumber *, NSDictionary *> *_styleTable;
                   @(MDCFontTextStyleSubheadline) : _subheadlineTraits,
                   @(MDCFontTextStyleTitle) : _titleTraits
                   };
+}
+
++ (instancetype)traitsWithPointSize:(CGFloat)pointSize
+                             weight:(CGFloat)weight
+                            leading:(CGFloat)leading
+                           tracking:(CGFloat)tracking {
+  return [[MDCFontTraits alloc] initWithPointSize:pointSize
+                                           weight:weight
+                                          leading:leading
+                                         tracking:tracking];
 }
 
 - (instancetype)initWithPointSize:(CGFloat)pointSize

--- a/components/Typography/src/private/MDCFontTraits.m
+++ b/components/Typography/src/private/MDCFontTraits.m
@@ -13,26 +13,31 @@
 
 #import "MDCFontTraits.h"
 
-static NSDictionary <NSString *, MDCFontTraits *> *_body1Traits;
-static NSDictionary <NSString *, MDCFontTraits *> *_body2Traits;
-static NSDictionary <NSString *, MDCFontTraits *> *_buttonTraits;
-static NSDictionary <NSString *, MDCFontTraits *> *_captionTraits;
-static NSDictionary <NSString *, MDCFontTraits *> *_display1Traits;
-static NSDictionary <NSString *, MDCFontTraits *> *_display2Traits;
-static NSDictionary <NSString *, MDCFontTraits *> *_display3Traits;
-static NSDictionary <NSString *, MDCFontTraits *> *_display4Traits;
-static NSDictionary <NSString *, MDCFontTraits *> *_headlineTraits;
-static NSDictionary <NSString *, MDCFontTraits *> *_subheadlineTraits;
-static NSDictionary <NSString *, MDCFontTraits *> *_titleTraits;
+static NSDictionary<NSString *, MDCFontTraits *> *_body1Traits;
+static NSDictionary<NSString *, MDCFontTraits *> *_body2Traits;
+static NSDictionary<NSString *, MDCFontTraits *> *_buttonTraits;
+static NSDictionary<NSString *, MDCFontTraits *> *_captionTraits;
+static NSDictionary<NSString *, MDCFontTraits *> *_display1Traits;
+static NSDictionary<NSString *, MDCFontTraits *> *_display2Traits;
+static NSDictionary<NSString *, MDCFontTraits *> *_display3Traits;
+static NSDictionary<NSString *, MDCFontTraits *> *_display4Traits;
+static NSDictionary<NSString *, MDCFontTraits *> *_headlineTraits;
+static NSDictionary<NSString *, MDCFontTraits *> *_subheadlineTraits;
+static NSDictionary<NSString *, MDCFontTraits *> *_titleTraits;
 
-static NSDictionary <NSNumber *, NSDictionary *> *_styleTable;
-
+static NSDictionary<NSNumber *, NSDictionary *> *_styleTable;
 
 @interface MDCFontTraits (MaterialTypographyPrivate)
 
-+ (instancetype)traitsWithPointSize:(CGFloat)pointSize weight:(CGFloat)weight leading:(CGFloat)leading tracking:(CGFloat)tracking;
++ (instancetype)traitsWithPointSize:(CGFloat)pointSize
+                             weight:(CGFloat)weight
+                            leading:(CGFloat)leading
+                           tracking:(CGFloat)tracking;
 
-- (instancetype)initWithPointSize:(CGFloat)pointSize weight:(CGFloat)weight leading:(CGFloat)leading tracking:(CGFloat)tracking;
+- (instancetype)initWithPointSize:(CGFloat)pointSize
+                           weight:(CGFloat)weight
+                          leading:(CGFloat)leading
+                         tracking:(CGFloat)tracking;
 
 @end
 
@@ -40,151 +45,400 @@ static NSDictionary <NSNumber *, NSDictionary *> *_styleTable;
 
 + (void)initialize {
   _body1Traits = @{
-    UIContentSizeCategoryExtraSmall:
+    UIContentSizeCategoryExtraSmall :
         [MDCFontTraits traitsWithPointSize:11 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-    UIContentSizeCategorySmall:
+    UIContentSizeCategorySmall :
         [MDCFontTraits traitsWithPointSize:12 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-    UIContentSizeCategoryMedium:
+    UIContentSizeCategoryMedium :
         [MDCFontTraits traitsWithPointSize:13 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-    UIContentSizeCategoryLarge:
+    UIContentSizeCategoryLarge :
         [MDCFontTraits traitsWithPointSize:14 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-    UIContentSizeCategoryExtraLarge:
+    UIContentSizeCategoryExtraLarge :
         [MDCFontTraits traitsWithPointSize:16 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-    UIContentSizeCategoryExtraExtraLarge:
+    UIContentSizeCategoryExtraExtraLarge :
         [MDCFontTraits traitsWithPointSize:18 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-    UIContentSizeCategoryExtraExtraExtraLarge:
+    UIContentSizeCategoryExtraExtraExtraLarge :
         [MDCFontTraits traitsWithPointSize:20 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-    UIContentSizeCategoryAccessibilityMedium:
+    UIContentSizeCategoryAccessibilityMedium :
         [MDCFontTraits traitsWithPointSize:25 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-    UIContentSizeCategoryAccessibilityLarge:
+    UIContentSizeCategoryAccessibilityLarge :
         [MDCFontTraits traitsWithPointSize:30 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-    UIContentSizeCategoryAccessibilityExtraLarge:
+    UIContentSizeCategoryAccessibilityExtraLarge :
         [MDCFontTraits traitsWithPointSize:37 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-    UIContentSizeCategoryAccessibilityExtraExtraLarge:
+    UIContentSizeCategoryAccessibilityExtraExtraLarge :
         [MDCFontTraits traitsWithPointSize:44 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-    UIContentSizeCategoryAccessibilityExtraExtraExtraLarge:
+    UIContentSizeCategoryAccessibilityExtraExtraExtraLarge :
         [MDCFontTraits traitsWithPointSize:52 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
   };
 
-
   _body2Traits = @{
-                   UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:11 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-                   UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:12 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:13 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:14 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:16 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:18 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:20 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryAccessibilityMedium: [[MDCFontTraits alloc] initWithPointSize:25 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryAccessibilityLarge: [[MDCFontTraits alloc] initWithPointSize:30 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryAccessibilityExtraLarge: [[MDCFontTraits alloc] initWithPointSize:37 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryAccessibilityExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:44 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-                   UIContentSizeCategoryAccessibilityExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:52 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-                   };
-
-  _buttonTraits = @ {
-  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:11 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:12 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:13 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:14 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:16 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:18 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:20 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+    UIContentSizeCategoryExtraSmall : [[MDCFontTraits alloc] initWithPointSize:11
+                                                                        weight:UIFontWeightMedium
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategorySmall : [[MDCFontTraits alloc] initWithPointSize:12
+                                                                   weight:UIFontWeightMedium
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryMedium : [[MDCFontTraits alloc] initWithPointSize:13
+                                                                    weight:UIFontWeightMedium
+                                                                   leading:0.0
+                                                                  tracking:0.0],
+    UIContentSizeCategoryLarge : [[MDCFontTraits alloc] initWithPointSize:14
+                                                                   weight:UIFontWeightMedium
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryExtraLarge : [[MDCFontTraits alloc] initWithPointSize:16
+                                                                        weight:UIFontWeightMedium
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategoryExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:18
+                                          weight:UIFontWeightMedium
+                                         leading:0.0
+                                        tracking:0.0],
+    UIContentSizeCategoryExtraExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:20
+                                          weight:UIFontWeightMedium
+                                         leading:0.0
+                                        tracking:0.0],
+    UIContentSizeCategoryAccessibilityMedium :
+        [[MDCFontTraits alloc] initWithPointSize:25
+                                          weight:UIFontWeightMedium
+                                         leading:0.0
+                                        tracking:0.0],
+    UIContentSizeCategoryAccessibilityLarge :
+        [[MDCFontTraits alloc] initWithPointSize:30
+                                          weight:UIFontWeightMedium
+                                         leading:0.0
+                                        tracking:0.0],
+    UIContentSizeCategoryAccessibilityExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:37
+                                          weight:UIFontWeightMedium
+                                         leading:0.0
+                                        tracking:0.0],
+    UIContentSizeCategoryAccessibilityExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:44
+                                          weight:UIFontWeightMedium
+                                         leading:0.0
+                                        tracking:0.0],
+    UIContentSizeCategoryAccessibilityExtraExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:52
+                                          weight:UIFontWeightMedium
+                                         leading:0.0
+                                        tracking:0.0],
   };
 
-  _captionTraits = @ {
-  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:11 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:11 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:11 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:12 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:14 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:16 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:18 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  _buttonTraits = @{
+    UIContentSizeCategoryExtraSmall : [[MDCFontTraits alloc] initWithPointSize:11
+                                                                        weight:UIFontWeightMedium
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategorySmall : [[MDCFontTraits alloc] initWithPointSize:12
+                                                                   weight:UIFontWeightMedium
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryMedium : [[MDCFontTraits alloc] initWithPointSize:13
+                                                                    weight:UIFontWeightMedium
+                                                                   leading:0.0
+                                                                  tracking:0.0],
+    UIContentSizeCategoryLarge : [[MDCFontTraits alloc] initWithPointSize:14
+                                                                   weight:UIFontWeightMedium
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryExtraLarge : [[MDCFontTraits alloc] initWithPointSize:16
+                                                                        weight:UIFontWeightMedium
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategoryExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:18
+                                          weight:UIFontWeightMedium
+                                         leading:0.0
+                                        tracking:0.0],
+    UIContentSizeCategoryExtraExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:20
+                                          weight:UIFontWeightMedium
+                                         leading:0.0
+                                        tracking:0.0],
   };
 
-  _display1Traits = @ {
-  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:28 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:30 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:32 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:34 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:36 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:38 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:40 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  _captionTraits = @{
+    UIContentSizeCategoryExtraSmall : [[MDCFontTraits alloc] initWithPointSize:11
+                                                                        weight:UIFontWeightRegular
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategorySmall : [[MDCFontTraits alloc] initWithPointSize:11
+                                                                   weight:UIFontWeightRegular
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryMedium : [[MDCFontTraits alloc] initWithPointSize:11
+                                                                    weight:UIFontWeightRegular
+                                                                   leading:0.0
+                                                                  tracking:0.0],
+    UIContentSizeCategoryLarge : [[MDCFontTraits alloc] initWithPointSize:12
+                                                                   weight:UIFontWeightRegular
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryExtraLarge : [[MDCFontTraits alloc] initWithPointSize:14
+                                                                        weight:UIFontWeightRegular
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategoryExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:16
+                                          weight:UIFontWeightRegular
+                                         leading:0.0
+                                        tracking:0.0],
+    UIContentSizeCategoryExtraExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:18
+                                          weight:UIFontWeightRegular
+                                         leading:0.0
+                                        tracking:0.0],
   };
 
-  _display2Traits = @ {
-  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:39 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:41 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:43 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:45 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:47 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:49 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:51 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  _display1Traits = @{
+    UIContentSizeCategoryExtraSmall : [[MDCFontTraits alloc] initWithPointSize:28
+                                                                        weight:UIFontWeightRegular
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategorySmall : [[MDCFontTraits alloc] initWithPointSize:30
+                                                                   weight:UIFontWeightRegular
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryMedium : [[MDCFontTraits alloc] initWithPointSize:32
+                                                                    weight:UIFontWeightRegular
+                                                                   leading:0.0
+                                                                  tracking:0.0],
+    UIContentSizeCategoryLarge : [[MDCFontTraits alloc] initWithPointSize:34
+                                                                   weight:UIFontWeightRegular
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryExtraLarge : [[MDCFontTraits alloc] initWithPointSize:36
+                                                                        weight:UIFontWeightRegular
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategoryExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:38
+                                          weight:UIFontWeightRegular
+                                         leading:0.0
+                                        tracking:0.0],
+    UIContentSizeCategoryExtraExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:40
+                                          weight:UIFontWeightRegular
+                                         leading:0.0
+                                        tracking:0.0],
   };
 
-  _display3Traits = @ {
-  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:50 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:52 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:54 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:56 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:58 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:60 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:62 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  _display2Traits = @{
+    UIContentSizeCategoryExtraSmall : [[MDCFontTraits alloc] initWithPointSize:39
+                                                                        weight:UIFontWeightRegular
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategorySmall : [[MDCFontTraits alloc] initWithPointSize:41
+                                                                   weight:UIFontWeightRegular
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryMedium : [[MDCFontTraits alloc] initWithPointSize:43
+                                                                    weight:UIFontWeightRegular
+                                                                   leading:0.0
+                                                                  tracking:0.0],
+    UIContentSizeCategoryLarge : [[MDCFontTraits alloc] initWithPointSize:45
+                                                                   weight:UIFontWeightRegular
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryExtraLarge : [[MDCFontTraits alloc] initWithPointSize:47
+                                                                        weight:UIFontWeightRegular
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategoryExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:49
+                                          weight:UIFontWeightRegular
+                                         leading:0.0
+                                        tracking:0.0],
+    UIContentSizeCategoryExtraExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:51
+                                          weight:UIFontWeightRegular
+                                         leading:0.0
+                                        tracking:0.0],
   };
 
-  _display4Traits = @ {
-  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:100 weight:UIFontWeightLight leading:0.0 tracking:0.0],
-  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:104 weight:UIFontWeightLight leading:0.0 tracking:0.0],
-  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:108 weight:UIFontWeightLight leading:0.0 tracking:0.0],
-  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:112 weight:UIFontWeightLight leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:116 weight:UIFontWeightLight leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:120 weight:UIFontWeightLight leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:124 weight:UIFontWeightLight leading:0.0 tracking:0.0],
+  _display3Traits = @{
+    UIContentSizeCategoryExtraSmall : [[MDCFontTraits alloc] initWithPointSize:50
+                                                                        weight:UIFontWeightRegular
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategorySmall : [[MDCFontTraits alloc] initWithPointSize:52
+                                                                   weight:UIFontWeightRegular
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryMedium : [[MDCFontTraits alloc] initWithPointSize:54
+                                                                    weight:UIFontWeightRegular
+                                                                   leading:0.0
+                                                                  tracking:0.0],
+    UIContentSizeCategoryLarge : [[MDCFontTraits alloc] initWithPointSize:56
+                                                                   weight:UIFontWeightRegular
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryExtraLarge : [[MDCFontTraits alloc] initWithPointSize:58
+                                                                        weight:UIFontWeightRegular
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategoryExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:60
+                                          weight:UIFontWeightRegular
+                                         leading:0.0
+                                        tracking:0.0],
+    UIContentSizeCategoryExtraExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:62
+                                          weight:UIFontWeightRegular
+                                         leading:0.0
+                                        tracking:0.0],
   };
 
-  _headlineTraits = @ {
-  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:21 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:22 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:23 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:24 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:26 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:28 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:30 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  _display4Traits = @{
+    UIContentSizeCategoryExtraSmall : [[MDCFontTraits alloc] initWithPointSize:100
+                                                                        weight:UIFontWeightLight
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategorySmall : [[MDCFontTraits alloc] initWithPointSize:104
+                                                                   weight:UIFontWeightLight
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryMedium : [[MDCFontTraits alloc] initWithPointSize:108
+                                                                    weight:UIFontWeightLight
+                                                                   leading:0.0
+                                                                  tracking:0.0],
+    UIContentSizeCategoryLarge : [[MDCFontTraits alloc] initWithPointSize:112
+                                                                   weight:UIFontWeightLight
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryExtraLarge : [[MDCFontTraits alloc] initWithPointSize:116
+                                                                        weight:UIFontWeightLight
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategoryExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:120
+                                          weight:UIFontWeightLight
+                                         leading:0.0
+                                        tracking:0.0],
+    UIContentSizeCategoryExtraExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:124
+                                          weight:UIFontWeightLight
+                                         leading:0.0
+                                        tracking:0.0],
   };
 
-  _subheadlineTraits = @ {
-  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:13 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:14 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:15 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:16 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:18 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:20 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:22 weight:UIFontWeightRegular leading:0.0 tracking:0.0],
+  _headlineTraits = @{
+    UIContentSizeCategoryExtraSmall : [[MDCFontTraits alloc] initWithPointSize:21
+                                                                        weight:UIFontWeightRegular
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategorySmall : [[MDCFontTraits alloc] initWithPointSize:22
+                                                                   weight:UIFontWeightRegular
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryMedium : [[MDCFontTraits alloc] initWithPointSize:23
+                                                                    weight:UIFontWeightRegular
+                                                                   leading:0.0
+                                                                  tracking:0.0],
+    UIContentSizeCategoryLarge : [[MDCFontTraits alloc] initWithPointSize:24
+                                                                   weight:UIFontWeightRegular
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryExtraLarge : [[MDCFontTraits alloc] initWithPointSize:26
+                                                                        weight:UIFontWeightRegular
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategoryExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:28
+                                          weight:UIFontWeightRegular
+                                         leading:0.0
+                                        tracking:0.0],
+    UIContentSizeCategoryExtraExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:30
+                                          weight:UIFontWeightRegular
+                                         leading:0.0
+                                        tracking:0.0],
   };
 
-  _titleTraits = @ {
-  UIContentSizeCategoryExtraSmall: [[MDCFontTraits alloc] initWithPointSize:17 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-  UIContentSizeCategorySmall: [[MDCFontTraits alloc] initWithPointSize:18 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-  UIContentSizeCategoryMedium: [[MDCFontTraits alloc] initWithPointSize:19 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-  UIContentSizeCategoryLarge: [[MDCFontTraits alloc] initWithPointSize:20 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraLarge: [[MDCFontTraits alloc] initWithPointSize:22 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:24 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
-  UIContentSizeCategoryExtraExtraExtraLarge: [[MDCFontTraits alloc] initWithPointSize:26 weight:UIFontWeightMedium leading:0.0 tracking:0.0],
+  _subheadlineTraits = @{
+    UIContentSizeCategoryExtraSmall : [[MDCFontTraits alloc] initWithPointSize:13
+                                                                        weight:UIFontWeightRegular
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategorySmall : [[MDCFontTraits alloc] initWithPointSize:14
+                                                                   weight:UIFontWeightRegular
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryMedium : [[MDCFontTraits alloc] initWithPointSize:15
+                                                                    weight:UIFontWeightRegular
+                                                                   leading:0.0
+                                                                  tracking:0.0],
+    UIContentSizeCategoryLarge : [[MDCFontTraits alloc] initWithPointSize:16
+                                                                   weight:UIFontWeightRegular
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryExtraLarge : [[MDCFontTraits alloc] initWithPointSize:18
+                                                                        weight:UIFontWeightRegular
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategoryExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:20
+                                          weight:UIFontWeightRegular
+                                         leading:0.0
+                                        tracking:0.0],
+    UIContentSizeCategoryExtraExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:22
+                                          weight:UIFontWeightRegular
+                                         leading:0.0
+                                        tracking:0.0],
+  };
+
+  _titleTraits = @{
+    UIContentSizeCategoryExtraSmall : [[MDCFontTraits alloc] initWithPointSize:17
+                                                                        weight:UIFontWeightMedium
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategorySmall : [[MDCFontTraits alloc] initWithPointSize:18
+                                                                   weight:UIFontWeightMedium
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryMedium : [[MDCFontTraits alloc] initWithPointSize:19
+                                                                    weight:UIFontWeightMedium
+                                                                   leading:0.0
+                                                                  tracking:0.0],
+    UIContentSizeCategoryLarge : [[MDCFontTraits alloc] initWithPointSize:20
+                                                                   weight:UIFontWeightMedium
+                                                                  leading:0.0
+                                                                 tracking:0.0],
+    UIContentSizeCategoryExtraLarge : [[MDCFontTraits alloc] initWithPointSize:22
+                                                                        weight:UIFontWeightMedium
+                                                                       leading:0.0
+                                                                      tracking:0.0],
+    UIContentSizeCategoryExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:24
+                                          weight:UIFontWeightMedium
+                                         leading:0.0
+                                        tracking:0.0],
+    UIContentSizeCategoryExtraExtraExtraLarge :
+        [[MDCFontTraits alloc] initWithPointSize:26
+                                          weight:UIFontWeightMedium
+                                         leading:0.0
+                                        tracking:0.0],
   };
 
   _styleTable = @{
-                  @(MDCFontTextStyleBody1) : _body1Traits,
-                  @(MDCFontTextStyleBody2) : _body2Traits,
-                  @(MDCFontTextStyleButton) : _buttonTraits,
-                  @(MDCFontTextStyleCaption) : _captionTraits,
-                  @(MDCFontTextStyleDisplay1) : _display1Traits,
-                  @(MDCFontTextStyleDisplay2) : _display2Traits,
-                  @(MDCFontTextStyleDisplay3) : _display3Traits,
-                  @(MDCFontTextStyleDisplay4) : _display4Traits,
-                  @(MDCFontTextStyleHeadline) : _headlineTraits,
-                  @(MDCFontTextStyleSubheadline) : _subheadlineTraits,
-                  @(MDCFontTextStyleTitle) : _titleTraits
-                  };
+    @(MDCFontTextStyleBody1) : _body1Traits,
+    @(MDCFontTextStyleBody2) : _body2Traits,
+    @(MDCFontTextStyleButton) : _buttonTraits,
+    @(MDCFontTextStyleCaption) : _captionTraits,
+    @(MDCFontTextStyleDisplay1) : _display1Traits,
+    @(MDCFontTextStyleDisplay2) : _display2Traits,
+    @(MDCFontTextStyleDisplay3) : _display3Traits,
+    @(MDCFontTextStyleDisplay4) : _display4Traits,
+    @(MDCFontTextStyleHeadline) : _headlineTraits,
+    @(MDCFontTextStyleSubheadline) : _subheadlineTraits,
+    @(MDCFontTextStyleTitle) : _titleTraits
+  };
 }
 
 + (instancetype)traitsWithPointSize:(CGFloat)pointSize
@@ -211,7 +465,6 @@ static NSDictionary <NSNumber *, NSDictionary *> *_styleTable;
 
   return self;
 }
-
 
 + (MDCFontTraits *)traitsForTextStyle:(MDCFontTextStyle)style
                          sizeCategory:(NSString *)sizeCategory {

--- a/components/Typography/src/private/UIFont+MaterialTypographyPrivate.h
+++ b/components/Typography/src/private/UIFont+MaterialTypographyPrivate.h
@@ -19,7 +19,7 @@
 
 /*
  Returns the weigtht of the font.
- 
+
  @return A value between -1.0 (very thin) to 1.0 (very thick).  Regular weight is 0.0.
  */
 - (CGFloat)mdc_weight;

--- a/components/Typography/src/private/UIFont+MaterialTypographyPrivate.h
+++ b/components/Typography/src/private/UIFont+MaterialTypographyPrivate.h
@@ -18,7 +18,9 @@
 @interface UIFont (MaterialTypographyPrivate)
 
 /*
- Returns an weigth of the font.
+ Returns the weigtht of the font.
+ 
+ @return A value between -1.0 (very thin) to 1.0 (very thick).  Regular weight is 0.0.
  */
 - (CGFloat)mdc_weight;
 

--- a/components/Typography/src/private/UIFont+MaterialTypographyPrivate.h
+++ b/components/Typography/src/private/UIFont+MaterialTypographyPrivate.h
@@ -1,0 +1,30 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "MDCFontTextStyle.h"
+
+@interface UIFont (MaterialTypographyPrivate)
+
+/*
+ Returns an weigth of the font.
+ */
+- (CGFloat)mdc_weight;
+
+/*
+ Returns an extended description of the font including name, pointsize and weight
+ */
+- (nonnull NSString *)mdc_extendedDescription;
+
+@end

--- a/components/Typography/src/private/UIFont+MaterialTypographyPrivate.h
+++ b/components/Typography/src/private/UIFont+MaterialTypographyPrivate.h
@@ -17,15 +17,17 @@
 
 @interface UIFont (MaterialTypographyPrivate)
 
-/*
- Returns the weigtht of the font.
+/**
+ Returns the weight of the font.
 
- @return A value between -1.0 (very thin) to 1.0 (very thick).  Regular weight is 0.0.
+ @return A value between -1.0 (very thin) to 1.0 (very thick).  
+ 
+ Regular weight is 0.0.
  */
 - (CGFloat)mdc_weight;
 
-/*
- Returns an extended description of the font including name, pointsize and weight
+/**
+ Returns an extended description of the font including name, pointsize and weight.
  */
 - (nonnull NSString *)mdc_extendedDescription;
 

--- a/components/Typography/src/private/UIFont+MaterialTypographyPrivate.m
+++ b/components/Typography/src/private/UIFont+MaterialTypographyPrivate.m
@@ -17,7 +17,7 @@
 
 + (NSString *)mdc_fontWeightDescription:(CGFloat)weight {
   NSLog(@"Weight %.3f", weight);
-  // NS_AVAILABLE_IOS(8_2)
+  // The UIFontWeight enumeration was added in iOS 8.2
 #if defined(UIFontWeightUltraLight)
   if (weight == UIFontWeightUltraLight) {
     return @"UltraLight";
@@ -48,8 +48,8 @@
 }
 
 - (CGFloat)mdc_weight {
-  //FIXME
-  CGFloat weight = -999.9;
+  // The default font weight is 0.0 / Regular.
+  CGFloat weight = 0.0;
 
   NSDictionary *fontTraits = [self.fontDescriptor objectForKey:UIFontDescriptorTraitsAttribute];
   if (fontTraits) {
@@ -73,7 +73,7 @@
   NSMutableString *extendedDescription = [[NSMutableString alloc] init];
   [extendedDescription appendFormat:@"%@ : ", self.fontName];
   [extendedDescription appendFormat:@"%@ : ", self.familyName];
-  [extendedDescription appendFormat:@"%.1f - ", self.pointSize];
+  [extendedDescription appendFormat:@"%.1f pt : ", self.pointSize];
   [extendedDescription appendFormat:@"%@", [self mdc_weightString]];
 
   return extendedDescription;

--- a/components/Typography/src/private/UIFont+MaterialTypographyPrivate.m
+++ b/components/Typography/src/private/UIFont+MaterialTypographyPrivate.m
@@ -50,7 +50,7 @@
 }
 
 - (CGFloat)mdc_weight {
-  // The default font weight is 0.0 / Regular.
+  // The default font weight is UIFontWeightRegular, which is 0.0.
   CGFloat weight = 0.0;
 
   NSDictionary *fontTraits = [self.fontDescriptor objectForKey:UIFontDescriptorTraitsAttribute];

--- a/components/Typography/src/private/UIFont+MaterialTypographyPrivate.m
+++ b/components/Typography/src/private/UIFont+MaterialTypographyPrivate.m
@@ -1,0 +1,82 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "UIFont+MaterialTypographyPrivate.h"
+
+@implementation UIFont (MaterialTypographyPrivate)
+
++ (NSString *)mdc_fontWeightDescription:(CGFloat)weight {
+  NSLog(@"Weight %.3f", weight);
+  // NS_AVAILABLE_IOS(8_2)
+#if defined(UIFontWeightUltraLight)
+  if (weight == UIFontWeightUltraLight) {
+    return @"UltraLight";
+  } else if (weight == UIFontWeightThin) {
+    return @"Thin";
+  } else if (weight == UIFontWeightLight) {
+    return @"Light";
+  } else if (weight == UIFontWeightRegular) {
+    return @"Regular";
+  } else if (weight == UIFontWeightMedium) {
+    return @"Medium";
+  } else if (weight == UIFontWeightSemibold) {
+    return @"Semibold";
+  } else if (weight == UIFontWeightBold) {
+    return @"Bold";
+  } else if (weight == UIFontWeightHeavy) {
+    return @"Heavy";
+  } else if (weight == UIFontWeightBlack) {
+    return @"Black";
+  } else {
+    NSString *description = [NSString stringWithFormat:@"(%.3f)", weight];
+    return description;
+  }
+#else
+  NSString *description = [NSString stringWithFormat:@"(%.3f)", weight];
+  return description;
+#endif
+}
+
+- (CGFloat)mdc_weight {
+  //FIXME
+  CGFloat weight = -999.9;
+
+  NSDictionary *fontTraits = [self.fontDescriptor objectForKey:UIFontDescriptorTraitsAttribute];
+  if (fontTraits) {
+    NSNumber *weightNumber = fontTraits[UIFontWeightTrait];
+    if (weightNumber) {
+      weight = [weightNumber floatValue];
+    }
+  }
+
+  return weight;
+}
+
+- (NSString *)mdc_weightString {
+  CGFloat weight = [self mdc_weight];
+  NSString *weightString = [UIFont mdc_fontWeightDescription:weight];
+
+  return weightString;
+}
+
+- (NSString *)mdc_extendedDescription {
+  NSMutableString *extendedDescription = [[NSMutableString alloc] init];
+  [extendedDescription appendFormat:@"%@ : ", self.fontName];
+  [extendedDescription appendFormat:@"%@ : ", self.familyName];
+  [extendedDescription appendFormat:@"%.1f - ", self.pointSize];
+  [extendedDescription appendFormat:@"%@", [self mdc_weightString]];
+
+  return extendedDescription;
+}
+
+@end

--- a/components/Typography/src/private/UIFont+MaterialTypographyPrivate.m
+++ b/components/Typography/src/private/UIFont+MaterialTypographyPrivate.m
@@ -15,10 +15,12 @@
 
 @implementation UIFont (MaterialTypographyPrivate)
 
+/*
+ Returns a string indicating the weight of the font.  These weights were added in iOS 8.2.
+ */
 + (NSString *)mdc_fontWeightDescription:(CGFloat)weight {
-  NSLog(@"Weight %.3f", weight);
-  // The UIFontWeight enumeration was added in iOS 8.2
-#if defined(UIFontWeightUltraLight)
+// The UIFontWeight enumeration was added in iOS 8.2
+#if defined(__IPHONE_8_2)
   if (weight == UIFontWeightUltraLight) {
     return @"UltraLight";
   } else if (weight == UIFontWeightThin) {


### PR DESCRIPTION
This adds the interface and implementation for MDCFontTextStyle.

This API was originally reviewed in #1170.