### PR TITLE
[demos/Bare] Fix runtime initialization error 

### DIFF
--- a/demos/Bare/Bare/AppDelegate.h
+++ b/demos/Bare/Bare/AppDelegate.h
@@ -18,4 +18,6 @@
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
+@property (strong, nonatomic) UIWindow *window;
+
 @end


### PR DESCRIPTION
* The app delegate must implement the window property if it wants to use a main storyboard file.
* src: http://stackoverflow.com/a/32157899/3670829

# Error:
![glass_and_iphone_5s_ _ios_10_1__14b72_](https://cloud.githubusercontent.com/assets/884725/22623505/4ff8fffe-eb44-11e6-82ec-08d1d5e47c01.jpg)

# Result
![glass_and_iphone_5s_ _ios_10_1__14b72_](https://cloud.githubusercontent.com/assets/884725/22623506/64b5b77a-eb44-11e6-9b48-d435900a468e.jpg)

