### PR TITLE
[TextFields] API Review [DO NOT MERGE]

### DIFF
--- a/components/TextFields/MDCTextField.h
+++ b/components/TextFields/MDCTextField.h
@@ -31,7 +31,7 @@
 
   Default is black with 38% opacity.
  */
-@property(nonatomic, null_resettable, strong) UIColor *clearButtonColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, nullable, strong) UIColor *clearButtonColor UI_APPEARANCE_SELECTOR;
 
 /** MDCTextField does not implement borders that conform to UITextBorderStyle. */
 @property(nonatomic) UITextBorderStyle borderStyle NS_UNAVAILABLE;

--- a/components/TextFields/MDCTextField.h
+++ b/components/TextFields/MDCTextField.h
@@ -29,9 +29,10 @@
 
   Color changes are not animated.
 
-  Default is Material secondary text color (black with 54% opacity.)
+  Default is black with 38% opacity.
  */
-@property(nonatomic, null_resettable, strong) UIColor *clearButtonColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, null_resettable, strong) UIColor *clearButtonColor NS_SWIFT_NAME(clearColor)
+    UI_APPEARANCE_SELECTOR;
 
 /** MDCTextField does not implement borders that conform to UITextBorderStyle. */
 @property(nullable) UITextBorderStyle borderStyle NS_UNAVAILABLE;

--- a/components/TextFields/MDCTextField.h
+++ b/components/TextFields/MDCTextField.h
@@ -31,8 +31,7 @@
 
   Default is black with 38% opacity.
  */
-@property(nonatomic, null_resettable, strong) UIColor *clearButtonColor NS_SWIFT_NAME(clearColor)
-    UI_APPEARANCE_SELECTOR;
+@property(nonatomic, null_resettable, strong) UIColor *clearButtonColor UI_APPEARANCE_SELECTOR;
 
 /** MDCTextField does not implement borders that conform to UITextBorderStyle. */
 @property(nullable) UITextBorderStyle borderStyle NS_UNAVAILABLE;

--- a/components/TextFields/MDCTextField.h
+++ b/components/TextFields/MDCTextField.h
@@ -1,0 +1,39 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "MDCTextInput.h"
+
+/**
+  Material Design themed single line text input.
+  https://www.google.com/design/spec/components/text-fields.html#text-fields-single-line-text-field
+ */
+@interface MDCTextField : UITextField <MDCTextInput>
+
+/**
+  Color for the "clear the text" button image.
+
+  Color changes are not animated.
+
+  Default is Material secondary text color (black with 54% opacity.)
+ */
+@property(nonatomic, null_resettable, strong) UIColor *clearButtonColor UI_APPEARANCE_SELECTOR;
+
+/** MDCTextField does not implement borders that conform to UITextBorderStyle. */
+@property(nullable) UITextBorderStyle borderStyle NS_UNAVAILABLE;
+
+@end

--- a/components/TextFields/MDCTextField.h
+++ b/components/TextFields/MDCTextField.h
@@ -34,6 +34,6 @@
 @property(nonatomic, null_resettable, strong) UIColor *clearButtonColor UI_APPEARANCE_SELECTOR;
 
 /** MDCTextField does not implement borders that conform to UITextBorderStyle. */
-@property(nullable) UITextBorderStyle borderStyle NS_UNAVAILABLE;
+@property(nonatomic) UITextBorderStyle borderStyle NS_UNAVAILABLE;
 
 @end

--- a/components/TextFields/MDCTextInput.h
+++ b/components/TextFields/MDCTextInput.h
@@ -109,9 +109,6 @@ typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
 /** The text displayed in the text input. */
 @property(nonatomic, nullable, copy) NSString *text;
 
-/** The delegate for the text input. */
-@property(nonatomic, nullable, weak) IBInspectable id<MDCTextInputLayoutDelegate> layoutDelegate;
-
 /**
  The presentation style of the text input.
 

--- a/components/TextFields/MDCTextInput.h
+++ b/components/TextFields/MDCTextInput.h
@@ -17,23 +17,34 @@
 
 #import <UIKit/UIKit.h>
 
+/**
+ The Material Design guideslines have many suggestions for handling text input. The inputs that
+ conform to this protocol have all the API necessary to customize them to those suggestions.
+
+ They are, however, dumb; they do not handle error state nor validation.
+
+ - For handling error states and other Material behaviors use an MDCTextInputBehavior on your inputs
+ - For validation, there are many 3rd party libraries you can use like:
+   - https://github.com/3lvis/Validation
+   - https://github.com/adamwaite/Validator
+ */
+
 @protocol MDCTextInput;
 
 /**
  Presentation styles for a text input. The style determines specific aspects of the text
- input, such as sizing, placeholder placement and behavior, ability to show error state,
- layout, etc.
-
- NOTE: Showing or hiding the character count / limit label is done via setting characterLimit: when
- characterLimit == 0, the label is hidden. When characterLimit > 0, the label is shown.
+ input, such as sizing, placeholder placement and behavior, layout, etc.
  */
 typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
-  /** Default style with an inline placeholder and character count below text. */
+  /**
+   Default style with an inline placeholder (that disappears when text is entered) and character
+   count / limit below text.
+   */
   MDCTextInputPresentationStyleDefault = 0,
 
   /**
    The placeholder text is laid out inline but will float above the field when there is content or
-   the field is being edited. The character count is below text. The Material Design guideslines
+   the field is being edited. The character count is below text. The Material Design guidelines
    call this 'Floating inline labels.'
    https://material.io/guidelines/components/text-fields.html#text-fields-labels
    */
@@ -43,31 +54,18 @@ typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
   MDCTextInputPresentationStyleFullWidth,
 };
 
-/** Delegate for MDCTextInput size changes. */
-@protocol MDCTextInputLayoutDelegate <NSObject>
-
-@optional
-/**
- Notifies the delegate that the textInput's content size changed, requiring the size provided.
-
- @param textInput The text input for which the content size changed.
- @param size      The size required by the text input to fit all of its content.
- */
-- (void)textInput:(_Nonnull id<MDCTextInput>)textInput contentSizeChanged:(CGSize)size;
-
-@end
-
-/** Behavior exhibited by Material Design themed text inputs. */
+/** Common API for Material Design themed text inputs. */
 @protocol MDCTextInput <NSObject>
 
 /** A Boolean value indicating whether the text field is currently in edit mode. */
 @property(nonatomic, readonly, getter=isEditing) BOOL editing;
 
 /**
- The text to be displayed when no text has been entered.
+ The text to be displayed when no text has been entered. The Material Design guidelines call this
+ 'Hint text.'
 
  If presentationStyle == MDCTextInputPresentationStyleFloatingPlaceholder this text will also float
- above the input when text has been entered. The Material Design guidelines call this 'Hint text'.
+ above the input when text has been entered.
  https://material.io/guidelines/components/text-fields.html#text-fields-input
  */
 @property(nonatomic, nullable, copy) IBInspectable NSString *placeholder;
@@ -77,7 +75,8 @@ typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
 
  Default is black with Material Design hint text opacity.
  */
-@property(nonatomic, nullable, strong) UIColor *inlinePlaceholderColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, nullable, strong) UIColor *inlinePlaceholderColor NS_SWIFT_NAME(inlineScale)
+    UI_APPEARANCE_SELECTOR;
 
 /**
  The color applied to the placeholder when floating. However, when in error state, it will be
@@ -85,35 +84,30 @@ typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
 
  Default is black with Material Design hint text opacity.
  */
-@property(nonatomic, nullable, strong) UIColor *floatingPlaceholderColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, nullable, strong)
+    UIColor *floatingPlaceholderColor NS_SWIFT_NAME(floatingColor) UI_APPEARANCE_SELECTOR;
+
+/**
+ The font applied to placeholder labels.
+
+ The UIFont.pointSize is respected for placeholders in an inline mode. However, the pointSize of
+ a placeholder in floating mode is placeholderFont.pointSize * floatingPlaceholderScale.
+
+ Default is system body.
+ */
+@property(nonatomic, nullable, strong) UIFont *placeholderFont UI_APPEARANCE_SELECTOR;
+
+/**
+ The scale of the the floating placeholder label in comparison to the inline placeholder specified
+ as a value from 0.0 to 1.0.
+
+ Default is 0.75.
+ */
+@property(nonatomic, assign) CGFloat floatingPlaceholderScale NS_SWIFT_NAME(floatingScale)
+    UI_APPEARANCE_SELECTOR;
 
 /** The text displayed in the text input. */
 @property(nonatomic, nullable, copy) NSString *text;
-
-/**
- The text displayed under input rectangle, when in error state, that explains the nature of the
- error.
-
- The value of this property controls the state of the text input. When errorText != nil, the text
- input is in an error state:
-  - The error text appears in a label below the input rectangle's underline with the errorColor as
-  text color.
-  - The input rectangle's underline is colored with the errorColor.
- */
-@property(nonatomic, nullable, copy, readonly) IBInspectable NSString *errorText;
-
-/**
- The color used to denote error state in the underline and the errorText's label.
-
- Default is red.
- */
-@property(nonatomic, nullable, copy) UIColor *errorColor UI_APPEARANCE_SELECTOR;
-
-/**
- A localized string that represents the value of the errorText label. Use only when the you need
- to override the default which is the errorText itself.
- */
-@property(nonatomic, nullable, copy, readonly) NSString *errorAccessibilityText;
 
 /** The delegate for the text input. */
 @property(nonatomic, nullable, weak) IBInspectable id<MDCTextInputLayoutDelegate> layoutDelegate;
@@ -127,65 +121,65 @@ typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
     MDCTextInputPresentationStyle presentationStyle NS_SWIFT_NAME(presentation);
 
 /**
- The character limit for the text input.
-
- Displays the character limit text taking into account the MDCTextInputPresentationStyle. A value
- of 0 removes the limit text.
+ The character limit for the text input. A label under the input counts characters entered and
+ presents the count / the limit.
 
  Default is 0.
  */
 @property(nonatomic, assign) IBInspectable NSUInteger characterLimit;
 
 /**
- The color applied to the character count / character limit label. However, when in error state,
- it will be colored with the error color.
+ The color applied to the character count / character limit label.
 
  Default is black with Material Design hint text opacity.
  */
-@property(nonatomic, nullable, strong) UIColor *characterCountColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, nullable, strong) UIColor *characterLimitColor NS_SWIFT_NAME(limitColor)
+    UI_APPEARANCE_SELECTOR;
 
 /**
- The color applied to the underline. However, when in error state, it will be colored with the
- error color.
+ The font applied to the character count / character limit label.
+
+ Default is system caption1.
+ */
+@property(nonatomic, nullable, strong) UIFont *characterLimitFont NS_SWIFT_NAME(limitFont)
+    UI_APPEARANCE_SELECTOR;
+
+/**
+ The color applied to the underline.
 
  Default is black with Material Design hint text opacity.
  */
 @property(nonatomic, nullable, strong) UIColor *underlineColor UI_APPEARANCE_SELECTOR;
 
-/**
- The view mode for the underline.
-
- Default is UITextFieldViewModeAlways.
- */
-@property(nonatomic, assign) UITextFieldViewMode underlineViewMode NS_SWIFT_NAME(underlineMode);
+/** The thickness of the underline. */
+@property(nonatomic, assign) CGFloat underlineWidth UI_APPEARANCE_SELECTOR;
 
 /**
- Set the values of properties: errorText, errorColor, errorAccessibilityValue.
+ The text displayed under input rectangle. The Material Design guidelines call this 'Helper text.'
 
- The value of errorText controls the state of the text input.
-
- @param errorText               The errorText to be shown under the input rectangle's underline.
- @param errorAccessibilityValue Optional override of default errorText accessibility value
- (errorText.text).
-
- When errorText != nil, the text input is in an error state:
- - The error text appears in a label below the input rectangle's underline with the errorColor as
- text color.
- - The input rectangle's underline is colored with the errorColor.
-
- When errorText == nil, the text input is not in error state:
- - There is no error text under the input rectangle.
- - The input rectangle's underline is colored either blue (when isEditing == true) or gray (when
- isEditing == false.)
-
- Setting errorText to an empty string (@"") will put the input in error state but without an
- errorText label. It will just show the input rectangle's underline, the floating placeholder, and
- the character count in the errorColor.
-
- Setting errorAccessibilityValue when errorText == nil has no effect.
+ This is usually error text or further instructions.
  */
-- (void)setErrorText:(nullable NSString *)errorText
-    errorAccessibilityValue:(nullable NSString *)errorAccessibilityValue
-    NS_SWIFT_NAME(set(errorText:errorAccessibilityValue:));
+@property(nonatomic, nullable, copy, readonly) IBInspectable NSString *underlineText;
+
+/**
+ The color of the underlineText label.
+
+ Default is 38% black.
+ */
+@property(nonatomic, nullable, copy) UIColor *underlineTextColor UI_APPEARANCE_SELECTOR;
+
+/**
+ The font applied to the underlineText label.
+
+ Default is system caption1.
+ */
+@property(nonatomic, nullable, strong) UIFont *underlineTextFont UI_APPEARANCE_SELECTOR;
+
+/**
+ A localized string that represents the value of the underline text label. Use only when the you
+ need
+ to override the default which is the underline text itself.
+ */
+@property(nonatomic, nullable, copy, readonly) IBInspectable NSString *underlineAccessibilityText;
 
 @end

--- a/components/TextFields/MDCTextInput.h
+++ b/components/TextFields/MDCTextInput.h
@@ -47,7 +47,7 @@
  The label displaying text when no input text has been entered. The Material Design guidelines call
  this 'Hint text.'
  */
-@property(nonatomic, nonnull, strong) UILabel *placeholderLabel;
+@property(nonatomic, nonnull, strong, readonly) UILabel *placeholderLabel;
 
 /**
  The label on the trailing side under the input.
@@ -55,14 +55,14 @@
  This will usually be used for placeholder text to be displayed when no text has been entered. The
  Material Design guidelines call this 'Helper text.'
  */
-@property(nonatomic, nonnull, strong) UILabel *leadingUnderlineLabel NS_SWIFT_NAME(leadingLabel);
+@property(nonatomic, nonnull, strong, readonly) UILabel *leadingUnderlineLabel NS_SWIFT_NAME(leadingLabel);
 
 /**
  The label on the trailing side under the input.
 
  This will usually be for the character count / limit.
  */
-@property(nonatomic, nonnull, strong) UILabel *trailingUnderlineLabel NS_SWIFT_NAME(trailingLabel);
+@property(nonatomic, nonnull, strong, readonly) UILabel *trailingUnderlineLabel NS_SWIFT_NAME(trailingLabel);
 
 /**
  The color applied to the underline.

--- a/components/TextFields/MDCTextInput.h
+++ b/components/TextFields/MDCTextInput.h
@@ -75,7 +75,7 @@ typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
 
  Default is black with Material Design hint text opacity.
  */
-@property(nonatomic, nullable, strong) UIColor *inlinePlaceholderColor NS_SWIFT_NAME(inlineScale)
+@property(nonatomic, nullable, strong) UIColor *inlinePlaceholderColor NS_SWIFT_NAME(inlineColor)
     UI_APPEARANCE_SELECTOR;
 
 /**

--- a/components/TextFields/MDCTextInput.h
+++ b/components/TextFields/MDCTextInput.h
@@ -40,6 +40,9 @@
 /** The text displayed in the text input. */
 @property(nonatomic, nullable, copy) NSString *text;
 
+/** The color of the text in the input. */
+@property(nonatomic, nullable, strong) UIColor *textColor;
+
 /**
  The label displaying text when no input text has been entered. The Material Design guidelines call
  this 'Hint text.'

--- a/components/TextFields/MDCTextInput.h
+++ b/components/TextFields/MDCTextInput.h
@@ -1,0 +1,191 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights
+ Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@protocol MDCTextInput;
+
+/**
+ Presentation styles for a text input. The style determines specific aspects of the text
+ input, such as sizing, placeholder placement and behavior, ability to show error state,
+ layout, etc.
+
+ NOTE: Showing or hiding the character count / limit label is done via setting characterLimit: when
+ characterLimit == 0, the label is hidden. When characterLimit > 0, the label is shown.
+ */
+typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
+  /** Default style with an inline placeholder and character count below text. */
+  MDCTextInputPresentationStyleDefault = 0,
+
+  /**
+   The placeholder text is laid out inline but will float above the field when there is content or
+   the field is being edited. The character count is below text. The Material Design guideslines
+   call this 'Floating inline labels.'
+   https://material.io/guidelines/components/text-fields.html#text-fields-labels
+   */
+  MDCTextInputPresentationStyleFloatingPlaceholder,
+
+  /** The placeholder is laid out inline and the character count is also inline to the right. */
+  MDCTextInputPresentationStyleFullWidth,
+};
+
+/** Delegate for MDCTextInput size changes. */
+@protocol MDCTextInputLayoutDelegate <NSObject>
+
+@optional
+/**
+ Notifies the delegate that the textInput's content size changed, requiring the size provided.
+
+ @param textInput The text input for which the content size changed.
+ @param size      The size required by the text input to fit all of its content.
+ */
+- (void)textInput:(_Nonnull id<MDCTextInput>)textInput contentSizeChanged:(CGSize)size;
+
+@end
+
+/** Behavior exhibited by Material Design themed text inputs. */
+@protocol MDCTextInput <NSObject>
+
+/** A Boolean value indicating whether the text field is currently in edit mode. */
+@property(nonatomic, readonly, getter=isEditing) BOOL editing;
+
+/**
+ The text to be displayed when no text has been entered.
+
+ If presentationStyle == MDCTextInputPresentationStyleFloatingPlaceholder this text will also float
+ above the input when text has been entered. The Material Design guidelines call this 'Hint text'.
+ https://material.io/guidelines/components/text-fields.html#text-fields-input
+ */
+@property(nonatomic, nullable, copy) IBInspectable NSString *placeholder;
+
+/**
+ The color applied to the placeholder when inline (not floating.)
+
+ Default is black with Material Design hint text opacity.
+ */
+@property(nonatomic, nullable, strong) UIColor *inlinePlaceholderColor UI_APPEARANCE_SELECTOR;
+
+/**
+ The color applied to the placeholder when floating. However, when in error state, it will be
+ colored with the error color.
+
+ Default is black with Material Design hint text opacity.
+ */
+@property(nonatomic, nullable, strong) UIColor *floatingPlaceholderColor UI_APPEARANCE_SELECTOR;
+
+/** The text displayed in the text input. */
+@property(nonatomic, nullable, copy) NSString *text;
+
+/**
+ The text displayed under input rectangle, when in error state, that explains the nature of the
+ error.
+
+ The value of this property controls the state of the text input. When errorText != nil, the text
+ input is in an error state:
+  - The error text appears in a label below the input rectangle's underline with the errorColor as
+  text color.
+  - The input rectangle's underline is colored with the errorColor.
+ */
+@property(nonatomic, nullable, copy, readonly) IBInspectable NSString *errorText;
+
+/**
+ The color used to denote error state in the underline and the errorText's label.
+
+ Default is red.
+ */
+@property(nonatomic, nullable, copy) UIColor *errorColor UI_APPEARANCE_SELECTOR;
+
+/**
+ A localized string that represents the value of the errorText label. Use only when the you need
+ to override the default which is the errorText itself.
+ */
+@property(nonatomic, nullable, copy, readonly) NSString *errorAccessibilityText;
+
+/** The delegate for the text input. */
+@property(nonatomic, nullable, weak) IBInspectable id<MDCTextInputLayoutDelegate> layoutDelegate;
+
+/**
+ The presentation style of the text input.
+
+ Default is MDCTextInputPresentationStyleDefault.
+ */
+@property(nonatomic, assign)
+    MDCTextInputPresentationStyle presentationStyle NS_SWIFT_NAME(presentation);
+
+/**
+ The character limit for the text input.
+
+ Displays the character limit text taking into account the MDCTextInputPresentationStyle. A value
+ of 0 removes the limit text.
+
+ Default is 0.
+ */
+@property(nonatomic, assign) IBInspectable NSUInteger characterLimit;
+
+/**
+ The color applied to the character count / character limit label. However, when in error state,
+ it will be colored with the error color.
+
+ Default is black with Material Design hint text opacity.
+ */
+@property(nonatomic, nullable, strong) UIColor *characterCountColor UI_APPEARANCE_SELECTOR;
+
+/**
+ The color applied to the underline. However, when in error state, it will be colored with the
+ error color.
+
+ Default is black with Material Design hint text opacity.
+ */
+@property(nonatomic, nullable, strong) UIColor *underlineColor UI_APPEARANCE_SELECTOR;
+
+/**
+ The view mode for the underline.
+
+ Default is UITextFieldViewModeAlways.
+ */
+@property(nonatomic, assign) UITextFieldViewMode underlineViewMode NS_SWIFT_NAME(underlineMode);
+
+/**
+ Set the values of properties: errorText, errorColor, errorAccessibilityValue.
+
+ The value of errorText controls the state of the text input.
+
+ @param errorText               The errorText to be shown under the input rectangle's underline.
+ @param errorAccessibilityValue Optional override of default errorText accessibility value
+ (errorText.text).
+
+ When errorText != nil, the text input is in an error state:
+ - The error text appears in a label below the input rectangle's underline with the errorColor as
+ text color.
+ - The input rectangle's underline is colored with the errorColor.
+
+ When errorText == nil, the text input is not in error state:
+ - There is no error text under the input rectangle.
+ - The input rectangle's underline is colored either blue (when isEditing == true) or gray (when
+ isEditing == false.)
+
+ Setting errorText to an empty string (@"") will put the input in error state but without an
+ errorText label. It will just show the input rectangle's underline, the floating placeholder, and
+ the character count in the errorColor.
+
+ Setting errorAccessibilityValue when errorText == nil has no effect.
+ */
+- (void)setErrorText:(nullable NSString *)errorText
+    errorAccessibilityValue:(nullable NSString *)errorAccessibilityValue
+    NS_SWIFT_NAME(set(errorText:errorAccessibilityValue:));
+
+@end

--- a/components/TextFields/MDCTextInput.h
+++ b/components/TextFields/MDCTextInput.h
@@ -31,115 +31,35 @@
 
 @protocol MDCTextInput;
 
-/**
- Presentation styles for a text input. The style determines specific aspects of the text
- input, such as sizing, placeholder placement and behavior, layout, etc.
- */
-typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
-  /**
-   Default style with an inline placeholder (that disappears when text is entered) and character
-   count / limit below text.
-   */
-  MDCTextInputPresentationStyleDefault = 0,
-
-  /**
-   The placeholder text is laid out inline but will float above the field when there is content or
-   the field is being edited. The character count is below text. The Material Design guidelines
-   call this 'Floating inline labels.'
-   https://material.io/guidelines/components/text-fields.html#text-fields-labels
-   */
-  MDCTextInputPresentationStyleFloatingPlaceholder,
-
-  /** The placeholder is laid out inline and the character count is also inline to the right. */
-  MDCTextInputPresentationStyleFullWidth,
-};
-
 /** Common API for Material Design themed text inputs. */
 @protocol MDCTextInput <NSObject>
 
 /** A Boolean value indicating whether the text field is currently in edit mode. */
 @property(nonatomic, readonly, getter=isEditing) BOOL editing;
 
-/**
- The text to be displayed when no text has been entered. The Material Design guidelines call this
- 'Hint text.'
-
- If presentationStyle == MDCTextInputPresentationStyleFloatingPlaceholder this text will also float
- above the input when text has been entered.
- https://material.io/guidelines/components/text-fields.html#text-fields-input
- */
-@property(nonatomic, nullable, copy) IBInspectable NSString *placeholder;
-
-/**
- The color applied to the placeholder when inline (not floating.)
-
- Default is black with Material Design hint text opacity.
- */
-@property(nonatomic, nullable, strong) UIColor *inlinePlaceholderColor NS_SWIFT_NAME(inlineColor)
-    UI_APPEARANCE_SELECTOR;
-
-/**
- The color applied to the placeholder when floating. However, when in error state, it will be
- colored with the error color.
-
- Default is black with Material Design hint text opacity.
- */
-@property(nonatomic, nullable, strong)
-    UIColor *floatingPlaceholderColor NS_SWIFT_NAME(floatingColor) UI_APPEARANCE_SELECTOR;
-
-/**
- The font applied to placeholder labels.
-
- The UIFont.pointSize is respected for placeholders in an inline mode. However, the pointSize of
- a placeholder in floating mode is placeholderFont.pointSize * floatingPlaceholderScale.
-
- Default is system body.
- */
-@property(nonatomic, nullable, strong) UIFont *placeholderFont UI_APPEARANCE_SELECTOR;
-
-/**
- The scale of the the floating placeholder label in comparison to the inline placeholder specified
- as a value from 0.0 to 1.0.
-
- Default is 0.75.
- */
-@property(nonatomic, assign) CGFloat floatingPlaceholderScale NS_SWIFT_NAME(floatingScale)
-    UI_APPEARANCE_SELECTOR;
-
 /** The text displayed in the text input. */
 @property(nonatomic, nullable, copy) NSString *text;
 
 /**
- The presentation style of the text input.
-
- Default is MDCTextInputPresentationStyleDefault.
+ The label displaying text when no input text has been entered. The Material Design guidelines call
+ this 'Hint text.'
  */
-@property(nonatomic, assign)
-    MDCTextInputPresentationStyle presentationStyle NS_SWIFT_NAME(presentation);
+@property(nonatomic, nonnull, strong) UILabel *placeholderLabel;
 
 /**
- The character limit for the text input. A label under the input counts characters entered and
- presents the count / the limit.
+ The label on the trailing side under the input.
 
- Default is 0.
+ This will usually be used for placeholder text to be displayed when no text has been entered. The
+ Material Design guidelines call this 'Helper text.'
  */
-@property(nonatomic, assign) IBInspectable NSUInteger characterLimit;
+@property(nonatomic, nonnull, strong) UILabel *leadingUnderlineLabel NS_SWIFT_NAME(leadingLabel);
 
 /**
- The color applied to the character count / character limit label.
+ The label on the trailing side under the input.
 
- Default is black with Material Design hint text opacity.
+ This will usually be for the character count / limit.
  */
-@property(nonatomic, nullable, strong) UIColor *characterLimitColor NS_SWIFT_NAME(limitColor)
-    UI_APPEARANCE_SELECTOR;
-
-/**
- The font applied to the character count / character limit label.
-
- Default is system caption1.
- */
-@property(nonatomic, nullable, strong) UIFont *characterLimitFont NS_SWIFT_NAME(limitFont)
-    UI_APPEARANCE_SELECTOR;
+@property(nonatomic, nonnull, strong) UILabel *trailingUnderlineLabel NS_SWIFT_NAME(trailingLabel);
 
 /**
  The color applied to the underline.
@@ -150,33 +70,5 @@ typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
 
 /** The thickness of the underline. */
 @property(nonatomic, assign) CGFloat underlineWidth UI_APPEARANCE_SELECTOR;
-
-/**
- The text displayed under input rectangle. The Material Design guidelines call this 'Helper text.'
-
- This is usually error text or further instructions.
- */
-@property(nonatomic, nullable, copy, readonly) IBInspectable NSString *underlineText;
-
-/**
- The color of the underlineText label.
-
- Default is 38% black.
- */
-@property(nonatomic, nullable, copy) UIColor *underlineTextColor UI_APPEARANCE_SELECTOR;
-
-/**
- The font applied to the underlineText label.
-
- Default is system caption1.
- */
-@property(nonatomic, nullable, strong) UIFont *underlineTextFont UI_APPEARANCE_SELECTOR;
-
-/**
- A localized string that represents the value of the underline text label. Use only when the you
- need
- to override the default which is the underline text itself.
- */
-@property(nonatomic, nullable, copy, readonly) IBInspectable NSString *underlineAccessibilityText;
 
 @end

--- a/components/TextFields/MDCTextInputBehavior.h
+++ b/components/TextFields/MDCTextInputBehavior.h
@@ -1,0 +1,104 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights
+ Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@class MDCTextInput;
+
+/**
+ Material Design themed states for textInputs. The logic for 'automagic' error states changes:
+ underline color, underline text color.
+ https://www.google.com/design/spec/components/text-fields.html#text-fields-single-line-text-field
+ */
+@interface MDCTextInputBehavior : NSObject
+
+@property(nonatomic, nonnull, strong) id<MDCTextInput> textInput NS_SWIFT_NAME(input);
+
+/**
+ The text displayed in the underline text that explains the nature of the error.
+
+ The value of this property controls the state of the text input. When errorText != nil, the text
+ input is in an error state:
+ - The error text appears in a label below the input rectangle's underline with the errorColor as
+ text color.
+ - The input rectangle's underline is colored with the errorColor.
+
+ Set this property via setErrorText:errorAccessibilityValue:.
+ */
+@property(nonatomic, nullable, copy, readonly) NSString *errorText;
+
+/**
+ The color used to denote error state in the underline, the errorText's label, the plceholder and
+ the character count label.
+
+ Default is red.
+ */
+@property(nonatomic, nullable, copy) UIColor *errorColor UI_APPEARANCE_SELECTOR;
+
+/**
+ A localized string that represents the value of the errorText label. Use only when the you need
+ to override the default which is the errorText itself.
+ */
+@property(nonatomic, nullable, copy, readonly) NSString *errorAccessibilityText;
+
+/**
+ Controls when the underline will be shown.
+
+ The underline is an overlay that can be hidden depending on the editing state of the input text.
+
+ Default is UITextFieldViewModeAlways.
+ */
+@property(nonatomic, assign) UITextFieldViewMode underlineViewMode NS_SWIFT_NAME(underlineMode);
+
+/**
+ Controls when the character count will be shown.
+
+ Default is UITextFieldViewModeNever.
+ */
+@property(nonatomic, assign) UITextFieldViewMode characterCountViewMode NS_SWIFT_NAME(characterMode)
+    ;
+
+/**
+ Sets the state of the controller by setting the values of properties errorText and
+ errorAccessibilityValue.
+
+ The value of errorText controls the state of the text input.
+
+ @param errorText               The error text to be shown as underline text.
+ @param errorAccessibilityValue Optional override of default underline text accessibility value.
+
+ When errorText != nil, the text input is in an error state:
+ - The error text appears in the underline text with the errorColor as text color.
+ - The input rectangle's underline, placeholder and character is colored with the errorColor.
+
+ When errorText == nil, the text input is not in error state:
+ - The underline text is restored to the color and value it was.
+ - The underline color and width is restored.
+ - The placeholder text is restored to the color it was.
+ - The character count text is restored to the color it was.
+
+ Setting errorText to an empty string (@"") will put the input in error state but the underline text
+ will be empty. It will color (if visible) the underline, the placeholder, and the character
+ count in the errorColor.
+
+ Setting errorAccessibilityValue when errorText == nil has no effect.
+ */
+- (void)setErrorText:(nullable NSString *)errorText
+    errorAccessibilityValue:(nullable NSString *)errorAccessibilityValue
+    NS_SWIFT_NAME(set(errorText:errorAccessibilityValue:));
+
+@end

--- a/components/TextFields/MDCTextInputBehavior.h
+++ b/components/TextFields/MDCTextInputBehavior.h
@@ -26,20 +26,8 @@
  */
 @interface MDCTextInputBehavior : NSObject
 
+/** The text input the behavior is managing. */
 @property(nonatomic, nonnull, strong) id<MDCTextInput> textInput NS_SWIFT_NAME(input);
-
-/**
- The text displayed in the underline text that explains the nature of the error.
-
- The value of this property controls the state of the text input. When errorText != nil, the text
- input is in an error state:
- - The error text appears in a label below the input rectangle's underline with the errorColor as
- text color.
- - The input rectangle's underline is colored with the errorColor.
-
- Set this property via setErrorText:errorAccessibilityValue:.
- */
-@property(nonatomic, nullable, copy, readonly) NSString *errorText;
 
 /**
  The color used to denote error state in the underline, the errorText's label, the plceholder and

--- a/components/TextFields/MDCTextInputBehavior.h
+++ b/components/TextFields/MDCTextInputBehavior.h
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
 @interface MDCTextInputBehavior : NSObject
 
 /** The text input the behavior is managing. */
-@property(nonatomic, nonnull, weak) UIView<MDCTextInput> *textInput NS_SWIFT_NAME(input);
+@property(nonatomic, nullable, weak) UIView<MDCTextInput> *textInput NS_SWIFT_NAME(input);
 
 /**
  The color used to denote error state in the underline, the errorText's label, the plceholder and

--- a/components/TextFields/MDCTextInputBehavior.h
+++ b/components/TextFields/MDCTextInputBehavior.h
@@ -50,7 +50,7 @@
 
  Default is UITextFieldViewModeAlways.
  */
-@property(nonatomic, assign) UITextFieldViewMode underlineViewMode NS_SWIFT_NAME(underlineMode);
+@property(nonatomic, assign) UITextFieldViewMode underlineViewMode NS_SWIFT_NAME(underlineMode) UI_APPEARANCE_SELECTOR;
 
 /**
  Controls when the character count will be shown.

--- a/components/TextFields/MDCTextInputBehavior.h
+++ b/components/TextFields/MDCTextInputBehavior.h
@@ -20,6 +20,29 @@
 @class MDCTextInput;
 
 /**
+ Presentation styles for a text input. The style determines specific aspects of the text
+ input, such as sizing, placeholder placement and behavior, layout, etc.
+ */
+typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
+  /**
+   Default style with an inline placeholder (that disappears when text is entered) and character
+   count / limit below text.
+   */
+  MDCTextInputPresentationStyleDefault = 0,
+
+  /**
+   The placeholder text is laid out inline but will float above the field when there is content or
+   the field is being edited. The character count is below text. The Material Design guidelines
+   call this 'Floating inline labels.'
+   https://material.io/guidelines/components/text-fields.html#text-fields-labels
+   */
+  MDCTextInputPresentationStyleFloatingPlaceholder,
+
+  /** The placeholder is laid out inline and the character count is also inline to the right. */
+  MDCTextInputPresentationStyleFullWidth,
+};
+
+/**
  Material Design themed states for textInputs. The logic for 'automagic' error states changes:
  underline color, underline text color.
  https://www.google.com/design/spec/components/text-fields.html#text-fields-single-line-text-field
@@ -27,7 +50,7 @@
 @interface MDCTextInputBehavior : NSObject
 
 /** The text input the behavior is managing. */
-@property(nonatomic, nonnull, strong) id<MDCTextInput> textInput NS_SWIFT_NAME(input);
+@property(nonatomic, nonnull, weak) UIView<MDCTextInput> *textInput NS_SWIFT_NAME(input);
 
 /**
  The color used to denote error state in the underline, the errorText's label, the plceholder and
@@ -35,13 +58,7 @@
 
  Default is red.
  */
-@property(nonatomic, nullable, copy) UIColor *errorColor UI_APPEARANCE_SELECTOR;
-
-/**
- A localized string that represents the value of the errorText label. Use only when the you need
- to override the default which is the errorText itself.
- */
-@property(nonatomic, nullable, copy, readonly) NSString *errorAccessibilityText;
+@property(nonatomic, nullable, strong) UIColor *errorColor UI_APPEARANCE_SELECTOR;
 
 /**
  Controls when the underline will be shown.
@@ -50,7 +67,8 @@
 
  Default is UITextFieldViewModeAlways.
  */
-@property(nonatomic, assign) UITextFieldViewMode underlineViewMode NS_SWIFT_NAME(underlineMode) UI_APPEARANCE_SELECTOR;
+@property(nonatomic, assign) UITextFieldViewMode underlineViewMode NS_SWIFT_NAME(underlineMode)
+    UI_APPEARANCE_SELECTOR;
 
 /**
  Controls when the character count will be shown.
@@ -59,6 +77,48 @@
  */
 @property(nonatomic, assign) UITextFieldViewMode characterCountViewMode NS_SWIFT_NAME(characterMode)
     ;
+
+/**
+ The character limit for the text input. A label under the input counts characters entered and
+ presents the count / the limit.
+
+ Default is 0.
+ */
+@property(nonatomic, assign) IBInspectable NSUInteger characterLimit;
+
+/**
+ The color applied to the placeholder when floating. However, when in error state, it will be
+ colored with the error color.
+
+ Default is black with Material Design hint text opacity.
+ */
+@property(nonatomic, nullable, strong)
+    UIColor *floatingPlaceholderColor NS_SWIFT_NAME(floatingColor) UI_APPEARANCE_SELECTOR;
+
+/**
+ The scale of the the floating placeholder label in comparison to the inline placeholder specified
+ as a value from 0.0 to 1.0.
+
+ Default is 0.75.
+ */
+@property(nonatomic, assign) CGFloat floatingPlaceholderScale NS_SWIFT_NAME(floatingScale)
+    UI_APPEARANCE_SELECTOR;
+
+/**
+ The color applied to the placeholder when inline (not floating).
+
+ Default is black with Material Design hint text opacity.
+ */
+@property(nonatomic, nullable, strong) UIColor *inlinePlaceholderColor NS_SWIFT_NAME(inlineColor)
+    UI_APPEARANCE_SELECTOR;
+
+/**
+ The presentation style of the text input.
+
+ Default is MDCTextInputPresentationStyleDefault.
+ */
+@property(nonatomic, assign)
+    MDCTextInputPresentationStyle presentationStyle NS_SWIFT_NAME(presentation);
 
 /**
  Sets the state of the controller by setting the values of properties errorText and

--- a/components/TextFields/MDCTextView.h
+++ b/components/TextFields/MDCTextView.h
@@ -42,4 +42,11 @@
  */
 @interface MDCTextView : UITextView <MDCTextInput>
 
+/**
+ The delegate for changes to preferred content size.
+
+ If using auto layout, it is not necessary to have a layout delegate.
+ */
+@property(nonatomic, nullable, weak) IBInspectable id<MDCTextInputLayoutDelegate> layoutDelegate;
+
 @end

--- a/components/TextFields/MDCTextView.h
+++ b/components/TextFields/MDCTextView.h
@@ -18,6 +18,8 @@
 
 #import "MDCTextInput.h"
 
+@class MDCTextView;
+
 /** Delegate for MDCTextInput size changes. */
 @protocol MDCTextViewLayoutDelegate <NSObject>
 
@@ -32,7 +34,7 @@
  @param textView  The text view for which the content size changed.
  @param size      The size required by the text view to fit all of its content.
  */
-- (void)textView:(_Nonnull MDCTextView)textView didChangeContentSize:(CGSize)size;
+- (void)textView:(MDCTextView* _Nonnull)textView didChangeContentSize:(CGSize)size;
 
 @end
 

--- a/components/TextFields/MDCTextView.h
+++ b/components/TextFields/MDCTextView.h
@@ -1,0 +1,27 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "MDCTextInput.h"
+
+/**
+  Material Design themed text view (multiline text input).
+  https://www.google.com/design/spec/components/text-fields.html#text-fields-multi-line-text-field
+ */
+@interface MDCTextView : UITextView <MDCTextInput>
+
+@end

--- a/components/TextFields/MDCTextView.h
+++ b/components/TextFields/MDCTextView.h
@@ -18,6 +18,24 @@
 
 #import "MDCTextInput.h"
 
+/** Delegate for MDCTextInput size changes. */
+@protocol MDCTextViewLayoutDelegate <NSObject>
+
+@optional
+/**
+ Notifies the delegate that the textView's content size changed, requiring the size provided for
+ best display.
+
+ If using auto layout, this method is unnecessary; this is a way for views not implementing auto
+ layout to know when to grow and shrink height to accomodate changes in content.
+
+ @param textView  The text view for which the content size changed.
+ @param size      The size required by the text view to fit all of its content.
+ */
+- (void)textView:(_Nonnull MDCTextView)textView didChangeContentSize:(CGSize)size;
+
+@end
+
 /**
   Material Design themed text view (multiline text input).
   https://www.google.com/design/spec/components/text-fields.html#text-fields-multi-line-text-field

--- a/components/TextFields/MaterialTextField.h
+++ b/components/TextFields/MaterialTextField.h
@@ -1,0 +1,17 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCTextInput.h"


### PR DESCRIPTION
This is based on the internal API review written in 2015. 

The main difference is that validation / error state has been simplified. There is now no separate API for validation; each input merely accepts error text when it needs to be in an error state.

Feel free to add any NS_SWIFT_NAME or NS_SWIFT_REFINED suggestions. None jumped out at this stage.