### PR TITLE
[Bottom sheet] API review (do not merge)

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -16,25 +16,43 @@
 
 #import <UIKit/UIKit.h>
 
+@class MDCBottomSheetPresentationController;
+
+/**
+ Delegate for MDCBottomSheetPresentationController.
+ */
+@protocol MDCBottomSheetPresentationControllerDelegate <UIAdaptivePresentationControllerDelegate>
+@optional
+
+/**
+ Called before the bottom sheet is presented.
+
+ @param bottomSheet The MDCBottomSheetPresentationController being presented.
+ */
+- (void)prepareForBottomSheetPresentation:
+    (nonnull MDCBottomSheetPresentationController *)bottomSheet;
+
+/**
+ Called after dimissing the bottom sheet to let clients know it is no longer onscreen. The bottom
+ sheet controller calls this method only in response to user actions such as tapping the background
+ or draging the sheet offscreen. This method is not called if the bottom sheet is dismissed
+ programmatically.
+
+ @param bottomSheet The MDCBottomSheetPresentationController that was dismissed.
+ */
+- (void)bottomSheetPresentationControllerDidDismiss:
+    (nonnull MDCBottomSheetPresentationController *)bottomSheet;
+
+@end
+
 /**
  A UIPresentationController for presenting a modal view controller as a bottom sheet.
- 
- @note If your presented view controller has a UIScrollView as the root view (or you are presenting
- a UICollectionViewController or UIWebViewController) MDCBottomSheetPresentationController will 
- observe the contentSize of the scroll view in order to react to changes in the content size.
- @note MDCBottomSheetPresentationController can dismiss the presented view controller if the user
- taps outside the bottom sheet or pulls it offscreen.
  */
 @interface MDCBottomSheetPresentationController : UIPresentationController
 
 /**
- Controls the height that the sheet should be when it appears. If NO, it defaults to half the height
- of the screen. If YES, and the @c -preferredContentSize is non-zero on the content view controller,
- it defaults to the preferredContentSize.
-
- @note The height used will never be any taller than the screen of the device.
- The default value is NO.
+ Delegate to tell the presenter when to dismiss.
  */
-@property(nonatomic) BOOL usePreferredHeight;
+@property(nonatomic, weak, nullable) id<MDCBottomSheetPresentationControllerDelegate> delegate;
 
 @end

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -19,6 +19,9 @@
 /**
  A UIPresentationController for presenting a modal view controller as a bottom sheet.
  
+ @note If your presented view controller has a UIScrollView as the root view (or you are presenting
+ a UICollectionViewController or UIWebViewController) MDCBottomSheetPresentationController will 
+ observe the contentSize of the scroll view in order to react to changes in the content size.
  @note MDCBottomSheetPresentationController can dismiss the presented view controller if the user
  taps outside the bottom sheet or pulls it offscreen.
  */

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -1,0 +1,66 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@class MDCBottomSheetPresentationController;
+
+/**
+ Delegate for MDCBottomSheetPresentationController.
+ */
+@protocol MDCBottomSheetPresentationControllerDelegate <UIAdaptivePresentationControllerDelegate>
+
+/**
+ Called when the user taps the background or drags the bottom sheet off screen.
+ @param controller The MDCBottomSheetPresentationController that was dismissed.
+ */
+- (void)bottomSheetPresentationControllerDidCancel:
+    (nonnull MDCBottomSheetPresentationController *)controller;
+
+@end
+
+/**
+ A UIPresentationController for presenting a modal view controller as a bottom sheet.
+ */
+@interface MDCBottomSheetPresentationController : UIPresentationController
+
+/**
+ Delegate to tell the presenter when to dismiss.
+ */
+@property(nonatomic, weak, nullable) id<MDCBottomSheetPresentationControllerDelegate> delegate;
+
+/**
+ If YES the bottom sheet presentation controller will dismiss the presented view controller when the
+ user taps the dimming view or pulls the bottom sheet off the screen.
+ If NO the bottom sheet will never automatically dismiss the presented view controller.
+
+ @note If NO clients should dismiss the presented view controller inside the delegate callback
+   |bottomSheetPresentationControllerDidCancel|.
+ The default value is YES.
+ */
+@property(nonatomic, assign) BOOL automaticallyDismissBottomSheet;
+
+/**
+ Controls the height that the sheet should be when it appears. If NO, it defaults to half the height
+ of the screen. If YES, and the @c -preferredContentSize is non-zero on the content view controller,
+ it defaults to the preferredContentSize.
+
+ @note The height used will never be any taller than the screen of the device.
+ The default value is NO.
+ */
+@property(nonatomic) BOOL usePreferredHeight;
+
+@end

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -18,6 +18,9 @@
 
 /**
  A UIPresentationController for presenting a modal view controller as a bottom sheet.
+ 
+ @note MDCBottomSheetPresentationController can dismiss the presented view controller if the user
+ taps on the dimming view or pulls the bottom sheet offscreen.
  */
 @interface MDCBottomSheetPresentationController : UIPresentationController
 

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -16,42 +16,10 @@
 
 #import <UIKit/UIKit.h>
 
-@class MDCBottomSheetPresentationController;
-
-/**
- Delegate for MDCBottomSheetPresentationController.
- */
-@protocol MDCBottomSheetPresentationControllerDelegate <UIAdaptivePresentationControllerDelegate>
-
-/**
- Called when the user taps the background or drags the bottom sheet off screen.
- @param controller The MDCBottomSheetPresentationController that was dismissed.
- */
-- (void)bottomSheetPresentationControllerDidCancel:
-    (nonnull MDCBottomSheetPresentationController *)controller;
-
-@end
-
 /**
  A UIPresentationController for presenting a modal view controller as a bottom sheet.
  */
 @interface MDCBottomSheetPresentationController : UIPresentationController
-
-/**
- Delegate to tell the presenter when to dismiss.
- */
-@property(nonatomic, weak, nullable) id<MDCBottomSheetPresentationControllerDelegate> delegate;
-
-/**
- If YES the bottom sheet presentation controller will dismiss the presented view controller when the
- user taps the dimming view or pulls the bottom sheet off the screen.
- If NO the bottom sheet will never automatically dismiss the presented view controller.
-
- @note If NO clients should dismiss the presented view controller inside the delegate callback
-   |bottomSheetPresentationControllerDidCancel|.
- The default value is YES.
- */
-@property(nonatomic, assign) BOOL automaticallyDismissBottomSheet;
 
 /**
  Controls the height that the sheet should be when it appears. If NO, it defaults to half the height

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -20,7 +20,7 @@
  A UIPresentationController for presenting a modal view controller as a bottom sheet.
  
  @note MDCBottomSheetPresentationController can dismiss the presented view controller if the user
- taps on the dimming view or pulls the bottom sheet offscreen.
+ taps outside the bottom sheet or pulls it offscreen.
  */
 @interface MDCBottomSheetPresentationController : UIPresentationController
 

--- a/components/BottomSheet/src/MaterialBottomSheet.h
+++ b/components/BottomSheet/src/MaterialBottomSheet.h
@@ -1,0 +1,17 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCBottomSheetPresentationController.h"


### PR DESCRIPTION
A very minimal API review.

Historically our internal implementation of `usePreferredHeight` has defaulted to NO but in this modern day and age it might be more reasonable to default to YES.

Example:
```
- (void)didTapButton:(id)sender {
  UIViewController *viewController = [[UIViewController alloc] init];
  viewController.transitioningDelegate = self;
  viewController.modalPresentationStyle = UIModalPresentationCustom;
  [self presentViewController:viewController animated:YES completion:nil];
}

- (UIPresentationController *)
    presentationControllerForPresentedViewController:(UIViewController *)presented
                            presentingViewController:(UIViewController *)presenting
                                sourceViewController:(UIViewController *)source {
  return [[MDCBottomSheetPresentationController alloc] initWithPresentedViewController:presented 
                                                              presentingViewController:presenting];
}
```