### PR TITLE
[Button] Revert the button tint color change.

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -311,10 +311,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   return CGRectContainsPoint(UIEdgeInsetsInsetRect(self.bounds, _hitAreaInsets), point);
 }
 
-- (void)tintColorDidChange {
-  self.customTitleColor = self.tintColor;
-}
-
 #pragma mark - UIResponder
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {


### PR DESCRIPTION
This PR reverts the changes in https://github.com/material-components/material-components-ios/pull/1134 due to side effects that it causes. See https://github.com/material-components/material-components-ios/issues/1195 and https://github.com/material-components/material-components-ios/issues/1160 for more.

I am reverting this for now until I have time to sit down and implement this correctly and verify that it works as expected in all cases.