### PR TITLE
[Button] Add Dynamic Type support

### DIFF
--- a/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
+++ b/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
@@ -1,0 +1,88 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import UIKit
+import MaterialComponents
+
+class ButtonsDynamicTypeViewController: UIViewController {
+
+  class func catalogBreadcrumbs() -> [String] {
+    return ["Buttons", "Buttons (DynamicType)"]
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    view.backgroundColor = .white
+
+    let flatButtonStatic = MDCFlatButton()
+    flatButtonStatic.backgroundColor = .blue
+    flatButtonStatic.setTitle("Static", for: UIControlState())
+    flatButtonStatic.sizeToFit()
+    flatButtonStatic.translatesAutoresizingMaskIntoConstraints = false
+    flatButtonStatic.addTarget(self, action: #selector(tap), for: .touchUpInside)
+    view.addSubview(flatButtonStatic)
+
+    let flatButtonDynamic = MDCFlatButton()
+    flatButtonDynamic.backgroundColor = .blue
+    flatButtonDynamic.setTitle("Dynamic", for: UIControlState())
+    flatButtonDynamic.sizeToFit()
+    flatButtonDynamic.translatesAutoresizingMaskIntoConstraints = false
+    flatButtonDynamic.addTarget(self, action: #selector(tap), for: .touchUpInside)
+    flatButtonDynamic.mdc_adjustsFontForContentSizeCategory = true
+    view.addSubview(flatButtonDynamic)
+
+    let views = [
+      "flatStatic": flatButtonStatic,
+      "flatDynamic": flatButtonDynamic,
+    ]
+
+    centerView(view: flatButtonDynamic, onView: self.view)
+
+    view.addConstraints(
+      NSLayoutConstraint.constraints(withVisualFormat: "V:[flatStatic]-40-[flatDynamic]",
+                                     options: .alignAllCenterX,
+                                     metrics: nil,
+                                     views: views))
+  }
+
+  // MARK: Private
+
+  func centerView(view: UIView, onView: UIView) {
+    onView.addConstraint(NSLayoutConstraint(
+      item: view,
+      attribute: .centerX,
+      relatedBy: .equal,
+      toItem: onView,
+      attribute: .centerX,
+      multiplier: 1.0,
+      constant: 0.0))
+
+    onView.addConstraint(NSLayoutConstraint(
+      item: view,
+      attribute: .centerY,
+      relatedBy: .equal,
+      toItem: onView,
+      attribute: .centerY,
+      multiplier: 1.0,
+      constant: 0.0))
+  }
+  
+  func tap(_ sender: Any) {
+    print("\(type(of: sender)) was tapped.")
+  }
+
+}

--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -154,6 +154,8 @@
  UIConnectSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
 
  If set to YES, this button will base its text font on MDCFontTextStyleButton.
+ 
+ Defaults value is NO.
  */
 @property (nonatomic, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
     BOOL mdc_adjustsFontForContentSizeCategory UI_APPEARANCE_SELECTOR;

--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -150,6 +150,9 @@
  Indicates whether the button should automatically update its font when the device’s
  UIContentSizeCategory is changed.
  
+ This property is modeled after the adjustsFontForContentSizeCategory property in the
+ UIConnectSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
+
  If set to YES, this button will base its text font on MDCFontTextStyleButton.
  */
 @property (nonatomic, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)

--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -146,6 +146,15 @@
  */
 - (void)resetElevationForState:(UIControlState)state;
 
+/*
+ Indicates whether the button should automatically update its font when the device’s
+ UIContentSizeCategory is changed.
+ 
+ If set to YES, this button will base its text font on MDCFontTextStyleButton.
+ */
+@property (nonatomic, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
+    BOOL mdc_adjustsFontForContentSizeCategory UI_APPEARANCE_SELECTOR;
+
 #pragma mark - UIButton changes
 
 /**

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -102,6 +102,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   // Cached accessibility settings.
   NSMutableDictionary<NSNumber *, NSString *> *_accessibilityLabelForState;
   NSString *_accessibilityLabelExplicitValue;
+
   BOOL _mdc_adjustsFontForContentSizeCategory;
 }
 @property(nonatomic, strong) MDCInkView *inkView;

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -102,6 +102,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   // Cached accessibility settings.
   NSMutableDictionary<NSNumber *, NSString *> *_accessibilityLabelForState;
   NSString *_accessibilityLabelExplicitValue;
+  BOOL _mdc_adjustsFontForContentSizeCategory;
 }
 @property(nonatomic, strong) MDCInkView *inkView;
 @end
@@ -272,6 +273,10 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (void)dealloc {
   [self removeTarget:self action:NULL forControlEvents:UIControlEventAllEvents];
+
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:UIContentSizeCategoryDidChangeNotification
+                                                object:nil];
 }
 
 - (void)setCustomTitleColor:(UIColor *)customTitleColor {
@@ -674,6 +679,31 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
                                                  options:options];
     [self setTitleColor:color forState:UIControlStateNormal];
   }
+}
+
+- (BOOL)mdc_adjustsFontForContentSizeCategory {
+  return _mdc_adjustsFontForContentSizeCategory;
+}
+
+- (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {
+  _mdc_adjustsFontForContentSizeCategory = adjusts;
+  if (_mdc_adjustsFontForContentSizeCategory) {
+    UIFont *font = [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleButton];
+    self.titleLabel.font = font;
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(contentSizeCategoryDidChange:)
+                                                 name:UIContentSizeCategoryDidChangeNotification
+                                               object:nil];
+  } else {
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:UIContentSizeCategoryDidChangeNotification
+                                                  object:nil];
+  }
+}
+
+- (void)contentSizeCategoryDidChange:(NSNotification *)notification {
+  UIFont *font = [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleButton];
+  self.titleLabel.font = font;
 }
 
 #pragma mark - Deprecations

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -417,7 +417,6 @@ static UIColor *randomColor() {
 
   // Then
   XCTAssertTrue(button.mdc_adjustsFontForContentSizeCategory);
-
   UIFont *buttonFont = button.titleLabel.font;
   UIFont *preferredFont = [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleButton];
   XCTAssertEqualWithAccuracy(buttonFont.pointSize,

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -411,15 +411,14 @@ static UIColor *randomColor() {
 - (void)testAdjustsFontProperty {
   // Given
   MDCButton *button = [[MDCButton alloc] init];
+  UIFont *preferredFont = [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleButton];
 
   // When
   button.mdc_adjustsFontForContentSizeCategory = YES;
 
   // Then
   XCTAssertTrue(button.mdc_adjustsFontForContentSizeCategory);
-  UIFont *buttonFont = button.titleLabel.font;
-  UIFont *preferredFont = [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleButton];
-  XCTAssertEqualWithAccuracy(buttonFont.pointSize,
+  XCTAssertEqualWithAccuracy(button.titleLabel.font.pointSize,
                              preferredFont.pointSize,
                              kEpsilonAccuracy,
                              @"Font size should be equal to MDCFontTextStyleButton's.");

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -15,8 +15,10 @@
  */
 
 #import <XCTest/XCTest.h>
-#import "MDCShadowElevations.h"
+
 #import "MaterialButtons.h"
+#import "MaterialShadowElevations.h"
+#import "MaterialTypography.h"
 
 static const CGFloat kEpsilonAccuracy = 0.001f;
 // A value greater than the largest value created by combining normal values of UIControlState.
@@ -396,6 +398,32 @@ static UIColor *randomColor() {
   // Then
   XCTAssertFalse(button.selected);
   XCTAssertFalse(button.state & UIControlStateSelected);
+}
+
+- (void)testDefaultAdjustsFontProperty {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+
+  // Then
+  XCTAssertFalse(button.mdc_adjustsFontForContentSizeCategory);
+}
+
+- (void)testAdjustsFontProperty {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+
+  // When
+  button.mdc_adjustsFontForContentSizeCategory = YES;
+
+  // Then
+  XCTAssertTrue(button.mdc_adjustsFontForContentSizeCategory);
+
+  UIFont *buttonFont = button.titleLabel.font;
+  UIFont *preferredFont = [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleButton];
+  XCTAssertEqualWithAccuracy(buttonFont.pointSize,
+                             preferredFont.pointSize,
+                             0.001,
+                             @"Font size should be equal to MDCFontTextStyleButton's.");
 }
 
 @end

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -422,7 +422,7 @@ static UIColor *randomColor() {
   UIFont *preferredFont = [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleButton];
   XCTAssertEqualWithAccuracy(buttonFont.pointSize,
                              preferredFont.pointSize,
-                             0.001,
+                             kEpsilonAccuracy,
                              @"Font size should be equal to MDCFontTextStyleButton's.");
 }
 


### PR DESCRIPTION
This adds automatic font adjustment / Dynamic Type support to MDCButton.

The main functionality is exposed through the mdc_adjustsFontForContentSizeCategory property.

This property is modeled after the adjustsFontForContentSizeCategory property in the UIConnectSizeCategoryAdjusting protocol added by Apple in iOS 10.0.

