### PR TITLE
[Snackbar] fix case of UIKit.h in MDCSnackbarManager.h

### DIFF
--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-#import <UIKit/UIKIt.h>
+#import <UIKit/UIKit.h>
 
 @class MDCSnackbarMessage;
 @protocol MDCSnackbarSuspensionToken;


### PR DESCRIPTION
In SDK, it is UIKit.framework/Versions/C/Headers/UIKit.h
Let me make the code use the same case so that it would be compiled on case sensitive filesystem.