### PR TITLE
[Typography] Add warning about custom fonts and Dynamic Type

### DIFF
--- a/components/Typography/src/UIFont+MaterialTypography.m
+++ b/components/Typography/src/UIFont+MaterialTypography.m
@@ -13,11 +13,19 @@
 
 #import "UIFont+MaterialTypography.h"
 
+#import "MDCTypography.h"
 #import "UIFontDescriptor+MaterialTypography.h"
 
 @implementation UIFont (MaterialTypography)
 
 + (UIFont *)mdc_preferredFontForMaterialTextStyle:(MDCFontTextStyle)style {
+  // Due to the way iOS handles missing glyphs in fonts, we do not support using a custom font
+  // loader with Dynamic Type.
+  id<MDCTypographyFontLoading>fontLoader = [MDCTypography fontLoader];
+  if (![fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
+    NSLog(@"MaterialTypography : Custom font loaders are not compatible with Dynamic Type.");
+  }
+
   UIFontDescriptor *fontDescriptor =
       [UIFontDescriptor mdc_preferredFontDescriptorForMaterialTextStyle:style];
 


### PR DESCRIPTION
If you attempt to use [UIFont mdc_preferredFontForMaterialTextStyle] with a non standard font loader we will NSLog a warning.
UIFontDescriptor will not generate a log message as one might wish to use those metrics with a custom font.
