### PR TITLE
[Collections] - Fix static analyzer warnings

### DIFF
--- a/components/Collections/src/MDCCollectionViewController.m
+++ b/components/Collections/src/MDCCollectionViewController.m
@@ -365,11 +365,19 @@
 
 - (void)collectionView:(UICollectionView *)collectionView
     didUnhighlightItemAtIndexPath:(NSIndexPath *)indexPath {
-  // Start cell ink evaporate animation.
-  MDCInkView *inkView =
-      [self inkTouchController:_inkTouchController inkViewAtTouchLocation:_inkTouchLocation];
+
   UICollectionViewCell *cell = [collectionView cellForItemAtIndexPath:indexPath];
   CGPoint location = [collectionView convertPoint:_inkTouchLocation toView:cell];
+
+  // Start cell ink evaporate animation.
+  MDCInkView *inkView;
+  if ([cell respondsToSelector:@selector(inkView)]) {
+    inkView =
+        [self inkTouchController:_inkTouchController inkViewAtTouchLocation:_inkTouchLocation];
+  } else {
+    return;
+  }
+
   self.currentlyActiveInk = NO;
   [inkView startTouchEndedAnimationAtPoint:location completion:nil];
 }

--- a/components/Collections/src/MDCCollectionViewController.m
+++ b/components/Collections/src/MDCCollectionViewController.m
@@ -278,14 +278,7 @@
             inkViewAtTouchLocation:(CGPoint)location {
   NSIndexPath *indexPath = [self.collectionView indexPathForItemAtPoint:location];
   UICollectionViewCell *cell = [self.collectionView cellForItemAtIndexPath:indexPath];
-  MDCInkView *ink = nil;
-  if ([cell isKindOfClass:[MDCCollectionViewCell class]]) {
-    MDCCollectionViewCell *inkCell = (MDCCollectionViewCell *)cell;
-    if ([inkCell respondsToSelector:@selector(inkView)]) {
-      // Set cell ink.
-      ink = [cell performSelector:@selector(inkView)];
-    }
-  }
+  MDCInkView *ink = [cell performSelector:@selector(inkView)];
 
   if ([_styler.delegate
           respondsToSelector:@selector(collectionView:inkTouchController:inkViewAtIndexPath:)]) {
@@ -345,11 +338,18 @@
 
 - (void)collectionView:(UICollectionView *)collectionView
     didHighlightItemAtIndexPath:(NSIndexPath *)indexPath {
-  // Start cell ink show animation.
-  MDCInkView *inkView =
-      [self inkTouchController:_inkTouchController inkViewAtTouchLocation:_inkTouchLocation];
+
   UICollectionViewCell *cell = [collectionView cellForItemAtIndexPath:indexPath];
   CGPoint location = [collectionView convertPoint:_inkTouchLocation toView:cell];
+
+  // Start cell ink show animation.
+  MDCInkView *inkView;
+  if ([cell respondsToSelector:@selector(inkView)]) {
+    inkView =
+        [self inkTouchController:_inkTouchController inkViewAtTouchLocation:_inkTouchLocation];
+  } else {
+    return;
+  }
 
   // Update ink color if necessary.
   if ([_styler.delegate respondsToSelector:@selector(collectionView:inkColorAtIndexPath:)]) {

--- a/components/Collections/src/MDCCollectionViewController.m
+++ b/components/Collections/src/MDCCollectionViewController.m
@@ -278,13 +278,20 @@
             inkViewAtTouchLocation:(CGPoint)location {
   NSIndexPath *indexPath = [self.collectionView indexPathForItemAtPoint:location];
   UICollectionViewCell *cell = [self.collectionView cellForItemAtIndexPath:indexPath];
-  MDCInkView *ink = [cell performSelector:@selector(inkView)];
+  MDCInkView *ink = nil;
 
   if ([_styler.delegate
-          respondsToSelector:@selector(collectionView:inkTouchController:inkViewAtIndexPath:)]) {
+       respondsToSelector:@selector(collectionView:inkTouchController:inkViewAtIndexPath:)]) {
     return [_styler.delegate collectionView:self.collectionView
                          inkTouchController:inkTouchController
                          inkViewAtIndexPath:indexPath];
+  }
+  if ([cell isKindOfClass:[MDCCollectionViewCell class]]) {
+    MDCCollectionViewCell *inkCell = (MDCCollectionViewCell *)cell;
+    if ([inkCell respondsToSelector:@selector(inkView)]) {
+      // Set cell ink.
+      ink = [cell performSelector:@selector(inkView)];
+    }
   }
 
   return ink;
@@ -345,8 +352,7 @@
   // Start cell ink show animation.
   MDCInkView *inkView;
   if ([cell respondsToSelector:@selector(inkView)]) {
-    inkView =
-        [self inkTouchController:_inkTouchController inkViewAtTouchLocation:_inkTouchLocation];
+    inkView = [cell performSelector:@selector(inkView)];
   } else {
     return;
   }
@@ -372,8 +378,7 @@
   // Start cell ink evaporate animation.
   MDCInkView *inkView;
   if ([cell respondsToSelector:@selector(inkView)]) {
-    inkView =
-        [self inkTouchController:_inkTouchController inkViewAtTouchLocation:_inkTouchLocation];
+    inkView = [cell performSelector:@selector(inkView)];
   } else {
     return;
   }

--- a/components/Collections/src/MDCCollectionViewStyling.h
+++ b/components/Collections/src/MDCCollectionViewStyling.h
@@ -125,7 +125,7 @@ typedef NS_ENUM(NSUInteger, MDCCollectionViewCellLayoutType) {
  @param attr The cell's layout attributes.
  @return Image as determined by cell style and section ordinal position.
  */
-- (nonnull UIImage *)backgroundImageForCellLayoutAttributes:
+- (nullable UIImage *)backgroundImageForCellLayoutAttributes:
         (nonnull MDCCollectionViewLayoutAttributes *)attr;
 
 #pragma mark - Cell Separator

--- a/components/Ink/src/MDCInkTouchController.h
+++ b/components/Ink/src/MDCInkTouchController.h
@@ -149,7 +149,7 @@
  @param location The touch location in the coords of @c inkTouchController.view.
  @return An ink view to use at the touch location.
  */
-- (nonnull MDCInkView *)inkTouchController:(nonnull MDCInkTouchController *)inkTouchController
+- (nullable MDCInkView *)inkTouchController:(nonnull MDCInkTouchController *)inkTouchController
                     inkViewAtTouchLocation:(CGPoint)location;
 
 /**


### PR DESCRIPTION
Closes issue [1227](https://github.com/material-components/material-components-ios/issues/1227)

Fix Static Analyzer Warnings

Changes:
- Within MDCCollectionViewController, move fail safes which check for inkView within cell out of InkTouchController delegate methods to UITableViewDelegate methods
- Changed nullability qualifier on MDCCollectionViewStyling from nonnull return type for method backgroundImageForCellLayoutAttributes: to nullable as there are a number of conditionals which return nil
