### PR TITLE
[Typography] Added isLargeForContrastRatio to protocol

### DIFF
--- a/components/Typography/src/MDCTypography.h
+++ b/components/Typography/src/MDCTypography.h
@@ -43,7 +43,18 @@
 - (nonnull UIFont *)italicFontOfSize:(CGFloat)fontSize;
 
 @optional
-/** Asks the receiver to decide if a font is large for accessibilty purposes. */
+
+/**
+ Asks the receiver to determine if a particular font would be considered "large" for the purposes of
+ calculating contrast ratios.
+
+ Large fonts are defined as greater than 18pt normal or 14pt bold. If the passed font is nil, then
+ this method returns NO.
+ For more see: https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html
+
+ @param font The font to examine, or nil.
+ @return YES if the font is non-nil and is considered "large".
+ */
 - (BOOL)isLargeForContrastRatios:(nonnull UIFont *)font;
 
 @end

--- a/components/Typography/src/MDCTypography.h
+++ b/components/Typography/src/MDCTypography.h
@@ -146,6 +146,7 @@
 /** Returns the recommended opacity of black text for the button font. */
 + (CGFloat)buttonFontOpacity;
 
++ (BOOL)isLargeForContrastRatios:(nonnull UIFont *)font;
 @end
 
 /**

--- a/components/Typography/src/MDCTypography.h
+++ b/components/Typography/src/MDCTypography.h
@@ -42,6 +42,10 @@
 /** Asks the receiver to return an italic font. */
 - (nonnull UIFont *)italicFontOfSize:(CGFloat)fontSize;
 
+@optional
+/** Asks the receiver to decide if a font is large for accessibilty purposes. */
+- (BOOL)isLargeForContrastRatios:(nonnull UIFont *)font;
+
 @end
 
 /**

--- a/components/Typography/src/MDCTypography.h
+++ b/components/Typography/src/MDCTypography.h
@@ -36,13 +36,13 @@
 /** Asks the receiver to return a font with a medium weight. */
 - (nonnull UIFont *)mediumFontOfSize:(CGFloat)fontSize;
 
+@optional
+
 /** Asks the receiver to return a font with a bold weight. */
 - (nonnull UIFont *)boldFontOfSize:(CGFloat)fontSize;
 
 /** Asks the receiver to return an italic font. */
 - (nonnull UIFont *)italicFontOfSize:(CGFloat)fontSize;
-
-@optional
 
 /**
  Asks the receiver to determine if a particular font would be considered "large" for the purposes of

--- a/components/Typography/src/MDCTypography.h
+++ b/components/Typography/src/MDCTypography.h
@@ -146,7 +146,6 @@
 /** Returns the recommended opacity of black text for the button font. */
 + (CGFloat)buttonFontOpacity;
 
-+ (BOOL)isLargeForContrastRatios:(nonnull UIFont *)font;
 @end
 
 /**

--- a/components/Typography/src/MDCTypography.m
+++ b/components/Typography/src/MDCTypography.m
@@ -136,26 +136,6 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
   return MDCTypographyStandardOpacity;
 }
 
-+ (BOOL)isLargeForContrastRatios:(UIFont *)font {
-  if (font.pointSize >= 18) {
-    return YES;
-  }
-  if (font.pointSize < 14) {
-    return NO;
-  }
-
-  UIFontDescriptor *fontDescriptor = font.fontDescriptor;
-  if ((fontDescriptor.symbolicTraits & UIFontDescriptorTraitBold) == UIFontDescriptorTraitBold) {
-    return YES;
-  }
-
-  // We treat medium as large for MDC accesibility when larger than 14
-  if (UIFontWeightMedium <= [font mdc_weight]) {
-    return YES;
-  }
-  return NO;
-}
-
 #pragma mark - Private
 
 + (id<MDCTypographyFontLoading>)defaultFontLoader {

--- a/components/Typography/src/MDCTypography.m
+++ b/components/Typography/src/MDCTypography.m
@@ -191,7 +191,7 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
     return YES;
   }
 
-  // We treat medium as large for MDC accesibility when larger than 14
+  // We treat medium as large for MDC accessibility when larger than 14.
   if ([font.fontName rangeOfString:@"medium" options:NSCaseInsensitiveSearch].location != NSNotFound) {
     return YES;
   }

--- a/components/Typography/src/MDCTypography.m
+++ b/components/Typography/src/MDCTypography.m
@@ -177,4 +177,25 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
   return [UIFont italicSystemFontOfSize:fontSize];
 }
 
+- (BOOL)isLargeForContrastRatios:(UIFont *)font {
+  if (font.pointSize >= 18) {
+    return YES;
+  }
+  if (font.pointSize < 14) {
+    return NO;
+  }
+
+  UIFontDescriptor *fontDescriptor = font.fontDescriptor;
+  if ((fontDescriptor.symbolicTraits & UIFontDescriptorTraitBold) == UIFontDescriptorTraitBold) {
+    return YES;
+  }
+
+  // We treat medium as large for MDC accesibility when larger than 14
+  if ([font.fontName rangeOfString:@"medium" options:NSCaseInsensitiveSearch].location != NSNotFound) {
+    return YES;
+  }
+
+  return NO;
+}
+
 @end

--- a/components/Typography/src/MDCTypography.m
+++ b/components/Typography/src/MDCTypography.m
@@ -15,6 +15,7 @@
  */
 
 #import "MDCTypography.h"
+#import "UIFont+MaterialTypographyPrivate.h"
 
 static id<MDCTypographyFontLoading> gFontLoader = nil;
 const CGFloat MDCTypographyStandardOpacity = 0.87f;
@@ -133,6 +134,26 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
 
 + (CGFloat)buttonFontOpacity {
   return MDCTypographyStandardOpacity;
+}
+
++ (BOOL)isLargeForContrastRatios:(UIFont *)font {
+  if (font.pointSize >= 18) {
+    return YES;
+  }
+  if (font.pointSize < 14) {
+    return NO;
+  }
+
+  UIFontDescriptor *fontDescriptor = font.fontDescriptor;
+  if ((fontDescriptor.symbolicTraits & UIFontDescriptorTraitBold) == UIFontDescriptorTraitBold) {
+    return YES;
+  }
+
+  // We treat medium as large for MDC accesibility when larger than 14
+  if (UIFontWeightMedium <= [font mdc_weight]) {
+    return YES;
+  }
+  return NO;
 }
 
 #pragma mark - Private

--- a/components/Typography/src/MDCTypography.m
+++ b/components/Typography/src/MDCTypography.m
@@ -191,8 +191,19 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
     return YES;
   }
 
-  // We treat medium as large for MDC accessibility when larger than 14.
-  if ([font.fontName rangeOfString:@"medium" options:NSCaseInsensitiveSearch].location != NSNotFound) {
+  CGFloat MDCFontWeightMedium = (CGFloat)0.23;
+  // Based on Apple's SDK-Based Development: Using Weakly Linked Methods, Functions, and Symbols.
+  // https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/cross_development/Using/using.html#//apple_ref/doc/uid/20002000-1114537-BABHHJBC
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-pointer-compare"
+#pragma clang diagnostic ignored "-Wunreachable-code"
+  if (&UIFontWeightMedium != NULL) {
+    MDCFontWeightMedium = UIFontWeightMedium;
+  }
+#pragma clang diagnostic pop
+
+  // We treat system font medium as large for accessibility when larger than 14.
+  if (font.mdc_weight >= MDCFontWeightMedium) {
     return YES;
   }
 

--- a/components/Typography/tests/unit/SystemFontLoaderTests.m
+++ b/components/Typography/tests/unit/SystemFontLoaderTests.m
@@ -23,7 +23,7 @@
 
 @implementation SystemFontLoaderTests
 
-- (void)testExample {
+- (void)testWeights {
   // Given
   CGFloat size = 10.0;
   MDCSystemFontLoader *fontLoader = [[MDCSystemFontLoader alloc] init];
@@ -47,6 +47,46 @@
   }
   XCTAssertEqual([fontLoader italicFontOfSize:size], [UIFont italicSystemFontOfSize:size]);
 
+}
+
+- (void)testIsLargeForContrastRatio {
+  // Given
+  CGFloat smallSize = 10.0f;
+  CGFloat largeIfBoldSize = 15.0f;
+  CGFloat largeSize = 18.0f;
+  MDCSystemFontLoader *fontLoader = [[MDCSystemFontLoader alloc] init];
+
+  // Then
+  XCTAssertFalse([fontLoader isLargeForContrastRatios:[UIFont systemFontOfSize:smallSize]]);
+  XCTAssertFalse([fontLoader isLargeForContrastRatios:[UIFont boldSystemFontOfSize:smallSize]]);
+  XCTAssertTrue([fontLoader isLargeForContrastRatios:[UIFont boldSystemFontOfSize:largeIfBoldSize]]);
+  XCTAssertTrue([fontLoader isLargeForContrastRatios:[UIFont systemFontOfSize:largeSize]]);
+
+  // Light
+  XCTAssertFalse([fontLoader isLargeForContrastRatios:[fontLoader lightFontOfSize:smallSize]]);
+  XCTAssertFalse([fontLoader isLargeForContrastRatios:[fontLoader lightFontOfSize:largeIfBoldSize]]);
+  XCTAssertTrue([fontLoader isLargeForContrastRatios:[fontLoader lightFontOfSize:largeSize]]);
+
+  // Regular
+  XCTAssertFalse([fontLoader isLargeForContrastRatios:[fontLoader regularFontOfSize:smallSize]]);
+  XCTAssertFalse([fontLoader isLargeForContrastRatios:[fontLoader regularFontOfSize:largeIfBoldSize]]);
+  XCTAssertTrue([fontLoader isLargeForContrastRatios:[fontLoader regularFontOfSize:largeSize]]);
+
+  // Medium
+  XCTAssertFalse([fontLoader isLargeForContrastRatios:[fontLoader mediumFontOfSize:smallSize]]);
+  // We treat medium as large for MDC accesibility.
+  XCTAssertTrue([fontLoader isLargeForContrastRatios:[fontLoader mediumFontOfSize:largeIfBoldSize]]);
+  XCTAssertTrue([fontLoader isLargeForContrastRatios:[fontLoader mediumFontOfSize:largeSize]]);
+
+  // Bold
+  XCTAssertFalse([fontLoader isLargeForContrastRatios:[fontLoader boldFontOfSize:smallSize]]);
+  XCTAssertTrue([fontLoader isLargeForContrastRatios:[fontLoader boldFontOfSize:largeIfBoldSize]]);
+  XCTAssertTrue([fontLoader isLargeForContrastRatios:[fontLoader boldFontOfSize:largeSize]]);
+
+  // Italic
+  XCTAssertFalse([fontLoader isLargeForContrastRatios:[fontLoader italicFontOfSize:smallSize]]);
+  XCTAssertFalse([fontLoader isLargeForContrastRatios:[fontLoader italicFontOfSize:largeIfBoldSize]]);
+  XCTAssertTrue([fontLoader isLargeForContrastRatios:[fontLoader italicFontOfSize:largeSize]]);
 }
 
 @end

--- a/components/Typography/tests/unit/SystemFontLoaderTests.m
+++ b/components/Typography/tests/unit/SystemFontLoaderTests.m
@@ -96,4 +96,12 @@
   XCTAssertTrue([fontLoader isLargeForContrastRatios:[fontLoader italicFontOfSize:largeSize]]);
 }
 
+- (void)testUIFontWeightMediumValue {
+  // Given
+  CGFloat MDCFontWeightMedium = (CGFloat)0.23;
+  // Ensure that our placehold value for UIFontWeightMedium matches the real value.
+  // We are defining it for < iOS 8.2 in MDCTypography.m
+  XCTAssertEqualWithAccuracy(UIFontWeightMedium, MDCFontWeightMedium, FLT_EPSILON);
+}
+
 @end

--- a/components/Typography/tests/unit/SystemFontLoaderTests.m
+++ b/components/Typography/tests/unit/SystemFontLoaderTests.m
@@ -57,25 +57,31 @@
   MDCSystemFontLoader *fontLoader = [[MDCSystemFontLoader alloc] init];
 
   // Then
+  XCTAssertFalse([fontLoader isLargeForContrastRatios:nil]);
+
   XCTAssertFalse([fontLoader isLargeForContrastRatios:[UIFont systemFontOfSize:smallSize]]);
   XCTAssertFalse([fontLoader isLargeForContrastRatios:[UIFont boldSystemFontOfSize:smallSize]]);
-  XCTAssertTrue([fontLoader isLargeForContrastRatios:[UIFont boldSystemFontOfSize:largeIfBoldSize]]);
+  XCTAssertTrue(
+      [fontLoader isLargeForContrastRatios:[UIFont boldSystemFontOfSize:largeIfBoldSize]]);
   XCTAssertTrue([fontLoader isLargeForContrastRatios:[UIFont systemFontOfSize:largeSize]]);
 
   // Light
   XCTAssertFalse([fontLoader isLargeForContrastRatios:[fontLoader lightFontOfSize:smallSize]]);
-  XCTAssertFalse([fontLoader isLargeForContrastRatios:[fontLoader lightFontOfSize:largeIfBoldSize]]);
+  XCTAssertFalse(
+      [fontLoader isLargeForContrastRatios:[fontLoader lightFontOfSize:largeIfBoldSize]]);
   XCTAssertTrue([fontLoader isLargeForContrastRatios:[fontLoader lightFontOfSize:largeSize]]);
 
   // Regular
   XCTAssertFalse([fontLoader isLargeForContrastRatios:[fontLoader regularFontOfSize:smallSize]]);
-  XCTAssertFalse([fontLoader isLargeForContrastRatios:[fontLoader regularFontOfSize:largeIfBoldSize]]);
+  XCTAssertFalse(
+      [fontLoader isLargeForContrastRatios:[fontLoader regularFontOfSize:largeIfBoldSize]]);
   XCTAssertTrue([fontLoader isLargeForContrastRatios:[fontLoader regularFontOfSize:largeSize]]);
 
   // Medium
   XCTAssertFalse([fontLoader isLargeForContrastRatios:[fontLoader mediumFontOfSize:smallSize]]);
   // We treat medium as large for MDC accesibility.
-  XCTAssertTrue([fontLoader isLargeForContrastRatios:[fontLoader mediumFontOfSize:largeIfBoldSize]]);
+  XCTAssertTrue(
+      [fontLoader isLargeForContrastRatios:[fontLoader mediumFontOfSize:largeIfBoldSize]]);
   XCTAssertTrue([fontLoader isLargeForContrastRatios:[fontLoader mediumFontOfSize:largeSize]]);
 
   // Bold
@@ -85,7 +91,8 @@
 
   // Italic
   XCTAssertFalse([fontLoader isLargeForContrastRatios:[fontLoader italicFontOfSize:smallSize]]);
-  XCTAssertFalse([fontLoader isLargeForContrastRatios:[fontLoader italicFontOfSize:largeIfBoldSize]]);
+  XCTAssertFalse(
+      [fontLoader isLargeForContrastRatios:[fontLoader italicFontOfSize:largeIfBoldSize]]);
   XCTAssertTrue([fontLoader isLargeForContrastRatios:[fontLoader italicFontOfSize:largeSize]]);
 }
 


### PR DESCRIPTION
So that we can make the font tell us if it is has large fonts.

MDC wants to treat medium fonts as large when larger that 14pts.
Other than looking at the font names there is no way to get the weight of a UIFont. Therefore it has to be the responsibility of the fontloader to determine if a font is large because it knows the names of the fonts.