### PR TITLE
[TextFields] API Review: Character Counter (additional feature) [DO NOT MERGE]

### DIFF
--- a/components/TextFields/src/MDCTextField.h
+++ b/components/TextFields/src/MDCTextField.h
@@ -1,0 +1,39 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "MDCTextInput.h"
+
+/**
+  Material Design themed single line text input.
+  https://www.google.com/design/spec/components/text-fields.html#text-fields-single-line-text-field
+ */
+@interface MDCTextField : UITextField <MDCTextInput>
+
+/**
+  Color for the "clear the text" button image.
+
+  Color changes are not animated.
+
+  Default is black with 38% opacity.
+ */
+@property(nonatomic, nullable, strong) UIColor *clearButtonColor UI_APPEARANCE_SELECTOR;
+
+/** MDCTextField does not implement borders that conform to UITextBorderStyle. */
+@property(nonatomic) UITextBorderStyle borderStyle NS_UNAVAILABLE;
+
+@end

--- a/components/TextFields/src/MDCTextInput.h
+++ b/components/TextFields/src/MDCTextInput.h
@@ -1,0 +1,79 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights
+ Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+/**
+ The Material Design guideslines have many suggestions for handling text input. The inputs that
+ conform to this protocol have all the API necessary to customize them to those suggestions.
+
+ They are, however, dumb; they do not handle error state nor validation.
+
+ - For handling error states and other Material behaviors use an MDCTextInputBehavior on your inputs
+ - For validation, there are many 3rd party libraries you can use like:
+   - https://github.com/3lvis/Validation
+   - https://github.com/adamwaite/Validator
+ */
+
+@protocol MDCTextInput;
+
+/** Common API for Material Design themed text inputs. */
+@protocol MDCTextInput <NSObject>
+
+/** A Boolean value indicating whether the text field is currently in edit mode. */
+@property(nonatomic, readonly, getter=isEditing) BOOL editing;
+
+/** The text displayed in the text input. */
+@property(nonatomic, nullable, copy) NSString *text;
+
+/** The color of the text in the input. */
+@property(nonatomic, nullable, strong) UIColor *textColor;
+
+/**
+ The label displaying text when no input text has been entered. The Material Design guidelines call
+ this 'Hint text.'
+ */
+@property(nonatomic, nonnull, strong, readonly) UILabel *placeholderLabel;
+
+/**
+ The label on the trailing side under the input.
+
+ This will usually be used for placeholder text to be displayed when no text has been entered. The
+ Material Design guidelines call this 'Helper text.'
+ */
+@property(nonatomic, nonnull, strong, readonly)
+    UILabel *leadingUnderlineLabel NS_SWIFT_NAME(leadingLabel);
+
+/**
+ The label on the trailing side under the input.
+
+ This will usually be for the character count / limit.
+ */
+@property(nonatomic, nonnull, strong, readonly)
+    UILabel *trailingUnderlineLabel NS_SWIFT_NAME(trailingLabel);
+
+/**
+ The color applied to the underline.
+
+ Default is black with Material Design hint text opacity.
+ */
+@property(nonatomic, nullable, strong) UIColor *underlineColor UI_APPEARANCE_SELECTOR;
+
+/** The thickness of the underline. */
+@property(nonatomic, assign) CGFloat underlineWidth UI_APPEARANCE_SELECTOR;
+
+@end

--- a/components/TextFields/src/MDCTextInputBehavior.h
+++ b/components/TextFields/src/MDCTextInputBehavior.h
@@ -17,6 +17,8 @@
 
 #import <UIKit/UIKit.h>
 
+@class MDCTextInputAllCharactersCounter;
+
 @protocol MDCTextInput;
 @protocol MDCTextInputCharacterCounter;
 
@@ -72,13 +74,12 @@ typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
     UI_APPEARANCE_SELECTOR;
 
 /**
- Optional, custom character counter.
+ The character counter. Override to use a custom character counter.
 
- Instead of relying on the default character count which is naive (counts each character regardless
- of context), this object can instead choose to do sophisticated counting (ie: ignoring whitespace,
- ignoring url strings, etc).
+ Default is an internal instance MDCTextInputAllCharactersCounter. Setting this property to null 
+ will reset it to return that instance.
  */
-@property(nonatomic, nullable, weak) IBInspectable id<MDCTextInputCharacterCounter>
+@property(nonatomic, null_resettable, weak) IBInspectable id<MDCTextInputCharacterCounter>
     characterCounter;
 
 /**

--- a/components/TextFields/src/MDCTextInputBehavior.h
+++ b/components/TextFields/src/MDCTextInputBehavior.h
@@ -82,7 +82,8 @@ typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
     characterCounter;
 
 /**
- Controls when the character count will be shown.
+ Controls when the character count will be shown and therefore whether character counting determines
+ error state.
 
  Default is UITextFieldViewModeNever.
  */
@@ -92,6 +93,16 @@ typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
 /**
  The character limit for the text input. A label under the input counts characters entered and
  presents the count / the limit.
+
+ If character count / limit has been hidden by the characterCountViewMode
+ (ie: UITextFieldViewModeNever) changing the value of characterLimit has no effect.
+
+ When using error text: error state is determined by whether error text is set OR (inclusive
+ OR) the character count is over the limit. If the character count goes above its limit, the
+ underline, the character count / limit label and any floating placeholder label all turn to the
+ error color; the text input will be in error state. This happens regardless of whether or not error
+ text is set with setErrorText:errorAccessibilityValue:. Logic:  errorText != nil ||
+ ((character count > characterLimit) && (characterCountViewMode > UITextFieldViewModeNever))
 
  Default is 0.
  */
@@ -155,6 +166,12 @@ typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
  count in the errorColor.
 
  Setting errorAccessibilityValue when errorText == nil has no effect.
+
+ When using character limits: error state is determined by whether error text is set OR (inclusive
+ OR) the character count is over the limit. If the character count goes above its limit, the
+ underline, the character count / limit label and any floating placeholder label all turn to the
+ error color; the text input will be in error state. This happens regardless of whether or not error
+ text is set with this method.
  */
 - (void)setErrorText:(nullable NSString *)errorText
     errorAccessibilityValue:(nullable NSString *)errorAccessibilityValue

--- a/components/TextFields/src/MDCTextInputBehavior.h
+++ b/components/TextFields/src/MDCTextInputBehavior.h
@@ -29,7 +29,7 @@
 typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
   /**
    Default style with an inline placeholder (that disappears when text is entered) and character
-   count / limit below text.
+   count / max below text.
    */
   MDCTextInputPresentationStyleDefault = 0,
 
@@ -92,19 +92,21 @@ typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
     ;
 
 /**
- The character limit for the text input. A label under the input counts characters entered and
- presents the count / the limit.
+ The character count maximum for the text input. A label under the input counts characters entered 
+ and presents the count / the max.
 
- If character count / limit has been hidden by the characterCountViewMode
+ If character count / max has been hidden by the characterCountViewMode
  (ie: UITextFieldViewModeNever) changing the value of characterLimit has no effect.
 
- If the character count goes above its limit, the underline, the character count / limit label and
+ If the character count goes above its max, the underline, the character count / max label and
  any floating placeholder label all turn to the error color; the text input will be in error state.
  Note: setErrorText:errorAccessibilityValue: also sets these MDCTextInput properties.
  
+ There is no support for a minimum character count.
+
  Default is 0.
  */
-@property(nonatomic, assign) IBInspectable NSUInteger characterLimit;
+@property(nonatomic, assign) IBInspectable NSUInteger characterCountMax;
 
 /**
  The color applied to the placeholder when floating. However, when in error state, it will be

--- a/components/TextFields/src/MDCTextInputBehavior.h
+++ b/components/TextFields/src/MDCTextInputBehavior.h
@@ -1,0 +1,163 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights
+ Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@protocol MDCTextInput;
+@protocol MDCTextInputCharacterCounter;
+
+/**
+ Presentation styles for a text input. The style determines specific aspects of the text
+ input, such as sizing, placeholder placement and behavior, layout, etc.
+ */
+typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
+  /**
+   Default style with an inline placeholder (that disappears when text is entered) and character
+   count / limit below text.
+   */
+  MDCTextInputPresentationStyleDefault = 0,
+
+  /**
+   The placeholder text is laid out inline but will float above the field when there is content or
+   the field is being edited. The character count is below text. The Material Design guidelines
+   call this 'Floating inline labels.'
+   https://material.io/guidelines/components/text-fields.html#text-fields-labels
+   */
+  MDCTextInputPresentationStyleFloatingPlaceholder,
+
+  /** The placeholder is laid out inline and the character count is also inline to the right. */
+  MDCTextInputPresentationStyleFullWidth,
+};
+
+/**
+ Material Design themed states for textInputs. The logic for 'automagic' error states changes:
+ underline color, underline text color.
+ https://www.google.com/design/spec/components/text-fields.html#text-fields-single-line-text-field
+ */
+@interface MDCTextInputBehavior : NSObject <NSCoding, NSCopying>
+
+/** The text input the behavior is managing. */
+@property(nonatomic, nullable, weak) UIView<MDCTextInput> *textInput NS_SWIFT_NAME(input);
+
+/**
+ The color used to denote error state in the underline, the errorText's label, the plceholder and
+ the character count label.
+
+ Default is red.
+ */
+@property(nonatomic, nullable, strong) UIColor *errorColor UI_APPEARANCE_SELECTOR;
+
+/**
+ Controls when the underline will be shown.
+
+ The underline is an overlay that can be hidden depending on the editing state of the input text.
+
+ Default is UITextFieldViewModeAlways.
+ */
+@property(nonatomic, assign) UITextFieldViewMode underlineViewMode NS_SWIFT_NAME(underlineMode)
+    UI_APPEARANCE_SELECTOR;
+
+/**
+ Optional, custom character counter.
+
+ Instead of relying on the default character count which is naive (counts each character regardless
+ of context), this object can instead choose to do sophisticated counting (ie: ignoring whitespace,
+ ignoring url strings, etc).
+ */
+@property(nonatomic, nullable, weak) IBInspectable id<MDCTextInputCharacterCounter>
+    characterCounter;
+
+/**
+ Controls when the character count will be shown.
+
+ Default is UITextFieldViewModeNever.
+ */
+@property(nonatomic, assign) UITextFieldViewMode characterCountViewMode NS_SWIFT_NAME(characterMode)
+    ;
+
+/**
+ The character limit for the text input. A label under the input counts characters entered and
+ presents the count / the limit.
+
+ Default is 0.
+ */
+@property(nonatomic, assign) IBInspectable NSUInteger characterLimit;
+
+/**
+ The color applied to the placeholder when floating. However, when in error state, it will be
+ colored with the error color.
+
+ Default is black with Material Design hint text opacity.
+ */
+@property(nonatomic, nullable, strong)
+    UIColor *floatingPlaceholderColor NS_SWIFT_NAME(floatingColor) UI_APPEARANCE_SELECTOR;
+
+/**
+ The scale of the the floating placeholder label in comparison to the inline placeholder specified
+ as a value from 0.0 to 1.0.
+
+ Default is 0.75.
+ */
+@property(nonatomic, assign) CGFloat floatingPlaceholderScale NS_SWIFT_NAME(floatingScale)
+    UI_APPEARANCE_SELECTOR;
+
+/**
+ The color applied to the placeholder when inline (not floating).
+
+ Default is black with Material Design hint text opacity.
+ */
+@property(nonatomic, nullable, strong) UIColor *inlinePlaceholderColor NS_SWIFT_NAME(inlineColor)
+    UI_APPEARANCE_SELECTOR;
+
+/**
+ The presentation style of the text input.
+
+ Default is MDCTextInputPresentationStyleDefault.
+ */
+@property(nonatomic, assign)
+    MDCTextInputPresentationStyle presentationStyle NS_SWIFT_NAME(presentation);
+
+/**
+ Sets the state of the controller by setting the values of properties errorText and
+ errorAccessibilityValue.
+
+ The value of errorText controls the state of the text input.
+
+ @param errorText               The error text to be shown as underline text.
+ @param errorAccessibilityValue Optional override of default underline text accessibility value.
+
+ When errorText != nil, the text input is in an error state:
+ - The error text appears in the underline text with the errorColor as text color.
+ - The input rectangle's underline, placeholder and character is colored with the errorColor.
+
+ When errorText == nil, the text input is not in error state:
+ - The underline text is restored to the color and value it was.
+ - The underline color and width is restored.
+ - The placeholder text is restored to the color it was.
+ - The character count text is restored to the color it was.
+
+ Setting errorText to an empty string (@"") will put the input in error state but the underline text
+ will be empty. It will color (if visible) the underline, the placeholder, and the character
+ count in the errorColor.
+
+ Setting errorAccessibilityValue when errorText == nil has no effect.
+ */
+- (void)setErrorText:(nullable NSString *)errorText
+    errorAccessibilityValue:(nullable NSString *)errorAccessibilityValue
+    NS_SWIFT_NAME(set(errorText:errorAccessibilityValue:));
+
+@end

--- a/components/TextFields/src/MDCTextInputBehavior.h
+++ b/components/TextFields/src/MDCTextInputBehavior.h
@@ -98,13 +98,10 @@ typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
  If character count / limit has been hidden by the characterCountViewMode
  (ie: UITextFieldViewModeNever) changing the value of characterLimit has no effect.
 
- When using error text: error state is determined by whether error text is set OR (inclusive
- OR) the character count is over the limit. If the character count goes above its limit, the
- underline, the character count / limit label and any floating placeholder label all turn to the
- error color; the text input will be in error state. This happens regardless of whether or not error
- text is set with setErrorText:errorAccessibilityValue:. Logic:  errorText != nil ||
- ((character count > characterLimit) && (characterCountViewMode > UITextFieldViewModeNever))
-
+ If the character count goes above its limit, the underline, the character count / limit label and
+ any floating placeholder label all turn to the error color; the text input will be in error state.
+ Note: setErrorText:errorAccessibilityValue: also sets these MDCTextInput properties.
+ 
  Default is 0.
  */
 @property(nonatomic, assign) IBInspectable NSUInteger characterLimit;
@@ -168,11 +165,7 @@ typedef NS_ENUM(NSUInteger, MDCTextInputPresentationStyle) {
 
  Setting errorAccessibilityValue when errorText == nil has no effect.
 
- When using character limits: error state is determined by whether error text is set OR (inclusive
- OR) the character count is over the limit. If the character count goes above its limit, the
- underline, the character count / limit label and any floating placeholder label all turn to the
- error color; the text input will be in error state. This happens regardless of whether or not error
- text is set with this method.
+ Note: The characterLimit property also affects these same MDCTextInput properties.
  */
 - (void)setErrorText:(nullable NSString *)errorText
     errorAccessibilityValue:(nullable NSString *)errorAccessibilityValue

--- a/components/TextFields/src/MDCTextInputCharacterCounter.h
+++ b/components/TextFields/src/MDCTextInputCharacterCounter.h
@@ -38,3 +38,12 @@
 - (NSUInteger)characterCountForTextInput:(UIView<MDCTextInput> *)textInput;
 
 @end
+
+/** 
+ The default character counter.
+ 
+ MDCTextInputAllCharactersCounter is naive (counts each character regardless of context). 
+ */
+@interface MDCTextInputAllCharactersCounter : NSObject <MDCTextInputCharacterCounter>
+
+@end

--- a/components/TextFields/src/MDCTextInputCharacterCounter.h
+++ b/components/TextFields/src/MDCTextInputCharacterCounter.h
@@ -1,0 +1,40 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights
+ Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@protocol MDCTextInput;
+
+/**
+ Protocol for custom character counters.
+
+ Instead of relying on the default character count which is naive (counts each character regardless
+ of context), this object can instead choose to do sophisticated counting (ie: ignoring whitespace,
+ ignoring url strings, etc).
+ */
+@protocol MDCTextInputCharacterCounter <NSObject>
+
+/**
+ Returns the count of characters for the text field.
+
+ @param textField the text field.
+
+ @return count of characters.
+ */
+- (NSUInteger)characterCountForTextInput:(UIView<MDCTextInput> *)textInput;
+
+@end

--- a/components/TextFields/src/MDCTextView.h
+++ b/components/TextFields/src/MDCTextView.h
@@ -1,0 +1,54 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "MDCTextInput.h"
+
+@class MDCTextView;
+
+/** Delegate for MDCTextInput size changes. */
+@protocol MDCTextViewLayoutDelegate <NSObject>
+
+@optional
+/**
+ Notifies the delegate that the textView's content size changed, requiring the size provided for
+ best display.
+
+ If using auto layout, this method is unnecessary; this is a way for views not implementing auto
+ layout to know when to grow and shrink height to accomodate changes in content.
+
+ @param textView  The text view for which the content size changed.
+ @param size      The size required by the text view to fit all of its content.
+ */
+- (void)textView:(MDCTextView* _Nonnull)textView didChangeContentSize:(CGSize)size;
+
+@end
+
+/**
+  Material Design themed text view (multiline text input).
+  https://www.google.com/design/spec/components/text-fields.html#text-fields-multi-line-text-field
+ */
+@interface MDCTextView : UITextView <MDCTextInput>
+
+/**
+ The delegate for changes to preferred content size.
+
+ If using auto layout, it is not necessary to have a layout delegate.
+ */
+@property(nonatomic, nullable, weak) IBInspectable id<MDCTextViewLayoutDelegate> layoutDelegate;
+
+@end

--- a/components/TextFields/src/MaterialTextField.h
+++ b/components/TextFields/src/MaterialTextField.h
@@ -1,0 +1,21 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCTextField.h"
+#import "MDCTextInput.h"
+#import "MDCTextInputBehavior.h"
+#import "MDCTextInputCharacterCounter.h"
+#import "MDCTextView.h"


### PR DESCRIPTION
During porting it was decided the original API had been missing the character counter protocol and property.

See MDCTextInputBehavior.h and MDCTextInputCharacterCounter.h