### PR TITLE
[Typography] Remove unused header that causes circular dependency.

### DIFF
--- a/components/Typography/src/private/UIFont+MaterialTypographyPrivate.h
+++ b/components/Typography/src/private/UIFont+MaterialTypographyPrivate.h
@@ -13,8 +13,6 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MDCFontTextStyle.h"
-
 @interface UIFont (MaterialTypographyPrivate)
 
 /**


### PR DESCRIPTION
(between Typography and Typography/private.)