### PR TITLE
[Collections] Dynamic height for more than 3 lines.

### DIFF
--- a/components/CollectionCells/examples/CollectionCellsLayoutExample.m
+++ b/components/CollectionCells/examples/CollectionCellsLayoutExample.m
@@ -105,6 +105,14 @@ static NSString *const kExampleDetailText =
                                         textLineArray:@[ @(3), @(0) ]
                                             checkMark:NO
                                                circle:NO]];
+  [_content addObject:[SimpleModel modelWithTextArray:@[ kExampleText, @"Detail text" ]
+                                        textLineArray:@[ @(3), @(1) ]
+                                              checkMark:NO
+                                                 circle:NO]];
+  [_content addObject:[SimpleModel modelWithTextArray:@[ kExampleText, @"Detail text" ]
+                                        textLineArray:@[ @(4), @(1) ]
+                                              checkMark:NO
+                                                 circle:NO]];
   [_content addObject:[SimpleModel modelWithTextArray:@[ @"", @"Detail text" ]
                                         textLineArray:@[ @(0), @(1) ]
                                             checkMark:NO
@@ -171,15 +179,7 @@ static NSString *const kExampleDetailText =
 - (CGFloat)collectionView:(UICollectionView *)collectionView
     cellHeightAtIndexPath:(NSIndexPath *)indexPath {
   SimpleModel *model = _content[indexPath.item];
-  NSInteger numberOfLines = model.textLines + model.detailTextLines;
-  if (numberOfLines == 1) {
-    return MDCCellDefaultOneLineHeight;
-  } else if (numberOfLines == 2) {
-    return MDCCellDefaultTwoLineHeight;
-  } else if (numberOfLines == 3) {
-    return MDCCellDefaultThreeLineHeight;
-  }
-  return MDCCellDefaultOneLineHeight;
+  return [MDCCollectionViewTextCell cellHeightFromNumberOfTextLines: model.textLines andDescriptionLines: model.detailTextLines];
 }
 
 #pragma mark - <MDCCollectionViewEditingDelegate>

--- a/components/CollectionCells/examples/CollectionCellsLayoutExample.m
+++ b/components/CollectionCells/examples/CollectionCellsLayoutExample.m
@@ -179,7 +179,7 @@ static NSString *const kExampleDetailText =
 - (CGFloat)collectionView:(UICollectionView *)collectionView
     cellHeightAtIndexPath:(NSIndexPath *)indexPath {
   SimpleModel *model = _content[indexPath.item];
-  return [MDCCollectionViewTextCell cellHeightFromNumberOfTextLines: model.textLines andDescriptionLines: model.detailTextLines];
+  return [MDCCollectionViewTextCell cellHeightFromNumberOfTextLines: model.textLines andDetailLines: model.detailTextLines];
 }
 
 #pragma mark - <MDCCollectionViewEditingDelegate>

--- a/components/CollectionCells/src/MDCCollectionViewTextCell.h
+++ b/components/CollectionCells/src/MDCCollectionViewTextCell.h
@@ -45,7 +45,7 @@ extern const CGFloat MDCCellDefaultThreeLineHeight;
  @param textLines   The number of lines of text to show.
  @param descriptionLines   The number of lines of description text to show.
  */
-+ (CGFloat)cellHeightFromNumberOfTextLines: (int)textLines andDescriptionLines: (int)descriptionLines;
++ (CGFloat)cellHeightFromNumberOfTextLines: (int)textLines andDetailLines: (int)detailLines;
 
 /**
  A text label. Typically this will be the first line of text in the cell.

--- a/components/CollectionCells/src/MDCCollectionViewTextCell.h
+++ b/components/CollectionCells/src/MDCCollectionViewTextCell.h
@@ -36,6 +36,16 @@ extern const CGFloat MDCCellDefaultThreeLineHeight;
  @see http://www.google.com/design/spec/components/lists.html#lists-specs
  */
 @interface MDCCollectionViewTextCell : MDCCollectionViewCell
+    
+
+/**
+ Simple helper method for getting the right cell height based on total lines of text that you
+ want to show into the MDCCollectionViewTextCell.
+ 
+ @param textLines   The number of lines of text to show.
+ @param descriptionLines   The number of lines of description text to show.
+ */
++ (CGFloat)cellHeightFromNumberOfTextLines: (int)textLines andDescriptionLines: (int)descriptionLines;
 
 /**
  A text label. Typically this will be the first line of text in the cell.

--- a/components/CollectionCells/src/MDCCollectionViewTextCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewTextCell.m
@@ -88,6 +88,19 @@ static inline CGRect AlignRectToUpperPixel(CGRect rect) {
 @implementation MDCCollectionViewTextCell {
   UIView *_contentWrapper;
 }
+    
++ (CGFloat)cellHeightFromNumberOfTextLines: (int)textLines andDescriptionLines: (int)descriptionLines {
+  int totalNumberOfLines = textLines + descriptionLines;
+  if (totalNumberOfLines == 1) {
+    return MDCCellDefaultOneLineHeight;
+  } else if (totalNumberOfLines == 2) {
+    return MDCCellDefaultTwoLineHeight;
+  } else if (totalNumberOfLines == 3) {
+    return MDCCellDefaultThreeLineHeight;
+  } else {
+    return kCellThreeLinePaddingTop + kCellThreeLinePaddingBottom + (kCellDefaultTextFont.lineHeight * textLines) + (kCellDefaultDetailTextFont.lineHeight * descriptionLines);
+  }
+}
 
 - (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];
@@ -208,7 +221,7 @@ static inline CGRect AlignRectToUpperPixel(CGRect rect) {
       detailFrame.origin.y = (boundsHeight / 2) - (detailFrame.size.height / 2);
     }
 
-  } else if ([self numberOfAllVisibleTextLines] == 3) {
+  } else if ([self numberOfAllVisibleTextLines] >= 3) {
     if (!CGRectIsEmpty(textFrame) && !CGRectIsEmpty(detailFrame)) {
       // Alignment for three lines.
       textFrame.origin.y =

--- a/components/CollectionCells/src/MDCCollectionViewTextCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewTextCell.m
@@ -89,8 +89,8 @@ static inline CGRect AlignRectToUpperPixel(CGRect rect) {
   UIView *_contentWrapper;
 }
     
-+ (CGFloat)cellHeightFromNumberOfTextLines: (int)textLines andDescriptionLines: (int)descriptionLines {
-  int totalNumberOfLines = textLines + descriptionLines;
++ (CGFloat)cellHeightFromNumberOfTextLines: (int)textLines andDetailLines: (int)detailLines {
+  int totalNumberOfLines = textLines + detailLines;
   if (totalNumberOfLines == 1) {
     return MDCCellDefaultOneLineHeight;
   } else if (totalNumberOfLines == 2) {
@@ -98,7 +98,7 @@ static inline CGRect AlignRectToUpperPixel(CGRect rect) {
   } else if (totalNumberOfLines == 3) {
     return MDCCellDefaultThreeLineHeight;
   } else {
-    return kCellThreeLinePaddingTop + kCellThreeLinePaddingBottom + (kCellDefaultTextFont.lineHeight * textLines) + (kCellDefaultDetailTextFont.lineHeight * descriptionLines);
+    return kCellThreeLinePaddingTop + kCellThreeLinePaddingBottom + (kCellDefaultTextFont.lineHeight * textLines) + (kCellDefaultDetailTextFont.lineHeight * detailLines);
   }
 }
 


### PR DESCRIPTION
Added helper method for calculating height of the cell based on
number of text and detail lines with support for more than
three lines of text.