### PR TITLE
[Typography] Made MDCTypographyFontLoading protocol method isLargeForContrastRatios: non-optional

### DIFF
--- a/components/Typography/src/MDCTypography.h
+++ b/components/Typography/src/MDCTypography.h
@@ -36,14 +36,6 @@
 /** Asks the receiver to return a font with a medium weight. */
 - (nonnull UIFont *)mediumFontOfSize:(CGFloat)fontSize;
 
-@optional
-
-/** Asks the receiver to return a font with a bold weight. */
-- (nonnull UIFont *)boldFontOfSize:(CGFloat)fontSize;
-
-/** Asks the receiver to return an italic font. */
-- (nonnull UIFont *)italicFontOfSize:(CGFloat)fontSize;
-
 /**
  Asks the receiver to determine if a particular font would be considered "large" for the purposes of
  calculating contrast ratios.
@@ -56,6 +48,14 @@
  @return YES if the font is non-nil and is considered "large".
  */
 - (BOOL)isLargeForContrastRatios:(nonnull UIFont *)font;
+
+@optional
+
+/** Asks the receiver to return a font with a bold weight. */
+- (nonnull UIFont *)boldFontOfSize:(CGFloat)fontSize;
+
+/** Asks the receiver to return an italic font. */
+- (nonnull UIFont *)italicFontOfSize:(CGFloat)fontSize;
 
 @end
 


### PR DESCRIPTION
We need a way for Typography to tell its client components if a font is large or not. 

I was initially thinking that Typography had a class method that would call the optional fontloader method. And if it was not implemented then use MDFTextAccessiblity. But I did not like the extra dependency to Typography. https://github.com/material-components/material-components-ios/issues/1250 By making it non-optional client components of Typography can just call it directly.

I didn't consider the hammer of always returning false which still seems incorrect to me. If someone passes in a 50pt font then it should be true. Or we could copy MDFTextAccessiblity logic?