### PR TITLE
[CollectionCells] Add accessibility hint in edit mode

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   #    ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
   #
   #    # Only if you have a resource bundle
-  #    ss.resources = ["components/#{ss.base_name}/Material#{ss.base_name}.bundle"]
+  #    ss.resources = ["components/#{ss.base_name}/src/Material#{ss.base_name}.bundle"]
   #
   #  end
   #
@@ -95,6 +95,7 @@ Pod::Spec.new do |s|
     ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
+    ss.resources = ["components/#{ss.base_name}/src/Material#{ss.base_name}.bundle"]
 
     ss.framework = "CoreGraphics", "QuartzCore"
 

--- a/components/CollectionCells/src/MDCCollectionViewCell.h
+++ b/components/CollectionCells/src/MDCCollectionViewCell.h
@@ -33,6 +33,12 @@ typedef NS_ENUM(NSUInteger, MDCCollectionViewCellAccessoryType) {
   MDCCollectionViewCellAccessoryDetailButton
 };
 
+// String key for accessibility hint of selected cells.
+FOUNDATION_EXPORT NSString * _Nonnull const kSelectedCellAccessibilityHintKey;
+
+// String key for accessibility hint of deselected cells.
+FOUNDATION_EXPORT NSString * _Nonnull const kDeselectedCellAccessibilityHintKey;
+
 /**
  The MDCCollectionViewCell class provides an implementation of UICollectionViewCell that
  supports Material Design layout and styling.

--- a/components/CollectionCells/src/MDCCollectionViewCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewCell.m
@@ -38,6 +38,20 @@ static const UIEdgeInsets kAccessoryInsetDefault = {0, 16.0f, 0, 16.0f};
 static const uint32_t kCellGrayColor = 0x626262;
 static const uint32_t kCellRedColor = 0xF44336;
 
+// File name of the bundle (without the '.bundle' extension) containing resources.
+static NSString *const kResourceBundleName = @"MaterialCollectionCells";
+
+// String table name containing localized strings.
+static NSString *const kStringTableName = @"MaterialCollectionCells";
+
+// String key for accessibility hint of selected cells.
+static NSString *const kSelectedCellAccessibilityHintKey =
+    @"MaterialCollectionCellsAccessibilitySelectedHint";
+
+// String key for accessibility hint of deselected cells.
+static NSString *const kDeselectedCellAccessibilityHintKey =
+    @"MaterialCollectionCellsAccessibilityDeselectedHint";
+
 // To be used as accessory view when an accessory type is set. It has no particular functionalities
 // other than being a private class defined here, to check if an accessory view was set via an
 // accessory type, or if the user of MDCCollectionViewCell set a custom accessory view.
@@ -478,7 +492,24 @@ static const uint32_t kCellRedColor = 0xF44336;
   return accessibilityTraits;
 }
 
+- (NSString *)accessibilityHint {
+  if (_attr.shouldShowSelectorStateMask) {
+    NSString* localizedHintKey =
+        self.selected ? kSelectedCellAccessibilityHintKey : kDeselectedCellAccessibilityHintKey;
+    return [[self class] localizedStringWithKey:localizedHintKey];
+  }
+  return nil;
+}
+
 #pragma mark - Private
+
++ (NSString *)localizedStringWithKey:(NSString *)key {
+  NSBundle *containingBundle = [NSBundle bundleForClass:self];
+  NSURL *resourceBundleURL =
+      [containingBundle URLForResource:kResourceBundleName withExtension:@"bundle"];
+  NSBundle *resourceBundle = [NSBundle bundleWithURL:resourceBundleURL];
+  return [resourceBundle localizedStringForKey:key value:nil table:kStringTableName];
+}
 
 - (CGRect)contentViewFrame {
   CGFloat leadingPadding =

--- a/components/CollectionCells/src/MDCCollectionViewCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewCell.m
@@ -44,12 +44,10 @@ static NSString *const kResourceBundleName = @"MaterialCollectionCells";
 // String table name containing localized strings.
 static NSString *const kStringTableName = @"MaterialCollectionCells";
 
-// String key for accessibility hint of selected cells.
-static NSString *const kSelectedCellAccessibilityHintKey =
+NSString *const kSelectedCellAccessibilityHintKey =
     @"MaterialCollectionCellsAccessibilitySelectedHint";
 
-// String key for accessibility hint of deselected cells.
-static NSString *const kDeselectedCellAccessibilityHintKey =
+NSString *const kDeselectedCellAccessibilityHintKey =
     @"MaterialCollectionCellsAccessibilityDeselectedHint";
 
 // To be used as accessory view when an accessory type is set. It has no particular functionalities

--- a/components/CollectionCells/src/MaterialCollectionCells.bundle/Resources/en.lproj/MaterialCollectionCells.strings
+++ b/components/CollectionCells/src/MaterialCollectionCells.bundle/Resources/en.lproj/MaterialCollectionCells.strings
@@ -1,0 +1,5 @@
+/* Accessibility hint for selected cells in edit mode. */
+"MaterialCollectionCellsAccessibilitySelectedHint" = "Double tap to deselect.";
+
+/* Accessibility hint for deselected cells in edit mode. */
+"MaterialCollectionCellsAccessibilityDeselectedHint" = "Double tap to select.";

--- a/components/CollectionCells/tests/unit/CollectionCellsIssue1257Tests.m
+++ b/components/CollectionCells/tests/unit/CollectionCellsIssue1257Tests.m
@@ -1,0 +1,69 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing software
+ distributed under the License is distributed on an "AS IS" BASIS
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MDCCollectionViewCell.h"
+#import "MDCCollectionViewLayoutAttributes.h"
+
+// Expose internal helper method.
+@interface MDCCollectionViewCell (Private)
++ (NSString *)localizedStringWithKey:(NSString *)key;
+@end
+
+// Tests confirming that the accessibility hint for (de)selectable cells is correctly set up.
+//
+// Based on issue https://github.com/material-components/material-components-ios/issues/1257
+@interface CollectionCellsIssue1257Tests : XCTestCase
+@property(nonatomic, strong) MDCCollectionViewCell *cell;
+@property(nonatomic, strong) MDCCollectionViewLayoutAttributes *layoutAttributes;
+@end
+
+@implementation CollectionCellsIssue1257Tests
+
+- (void)setUp {
+  [super setUp];
+  self.cell = [[MDCCollectionViewCell alloc] init];
+  self.layoutAttributes = [[MDCCollectionViewLayoutAttributes alloc] init];
+}
+
+- (void)testSelectableSelected {
+  self.layoutAttributes.shouldShowSelectorStateMask = YES;
+  [self.cell applyLayoutAttributes:self.layoutAttributes];
+  self.cell.selected = YES;
+
+  XCTAssertEqual(self.cell.accessibilityHint,
+                 [MDCCollectionViewCell localizedStringWithKey:kSelectedCellAccessibilityHintKey]);
+}
+
+- (void)testSelectableDeselected {
+  self.layoutAttributes.shouldShowSelectorStateMask = YES;
+  [self.cell applyLayoutAttributes:self.layoutAttributes];
+  self.cell.selected = NO;
+
+  XCTAssertEqual(
+      self.cell.accessibilityHint,
+      [MDCCollectionViewCell localizedStringWithKey:kDeselectedCellAccessibilityHintKey]);
+}
+
+- (void)testUnselectable {
+  self.layoutAttributes.shouldShowSelectorStateMask = NO;
+  [self.cell applyLayoutAttributes:self.layoutAttributes];
+
+  XCTAssertEqual(self.cell.accessibilityHint, nil);
+}
+
+@end


### PR DESCRIPTION
When editing, selectable/deselectable cells now give an accessibility
hint: "Double tap to select.". This helps users to know what they can do
while in edit mode.

Related: #1257