### PR TITLE
[Typography] added boldFontFromFont: and italicFontFormFont:

### DIFF
--- a/components/Typography/src/MDCTypography.h
+++ b/components/Typography/src/MDCTypography.h
@@ -47,6 +47,11 @@
 /** Asks the receiver to return a font with an italic bold weight. FontSize must be larger tha 0. */
 - (nonnull UIFont *)boldItalicFontOfSize:(CGFloat)fontSize;
 
+/** Returns a bold version of the specified font. */
+- (nonnull UIFont *)boldFontFromFont:(nonnull UIFont *)font;
+
+/** Returns an italic version of the specified font. */
+- (nonnull UIFont *)italicFontFromFont:(nonnull UIFont *)font;
 /**
  Asks the receiver to determine if a particular font would be considered "large" for the purposes of
  calculating contrast ratios.
@@ -148,6 +153,13 @@
 
 /** Returns the recommended opacity of black text for the button font. */
 + (CGFloat)buttonFontOpacity;
+
+/** Returns a bold version of the specified font. */
++ (nonnull UIFont *)boldFontFromFont:(nonnull UIFont *)font;
+
+/** Returns an italic version of the specified font. */
++ (nonnull UIFont *)italicFontFromFont:(nonnull UIFont *)font;
+
 
 /**
  Asks the receiver to determine if a particular font would be considered "large" for the purposes of

--- a/components/Typography/src/MDCTypography.m
+++ b/components/Typography/src/MDCTypography.m
@@ -148,6 +148,31 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
   BOOL isBold =
       (fontDescriptor.symbolicTraits & UIFontDescriptorTraitBold) == UIFontDescriptorTraitBold;
   return font.pointSize >= 18 || (isBold && font.pointSize >= 14);
+  
+}
+
++ (UIFont *)italicFontFromFont:(UIFont *)font {
+  SEL selector = @selector(italicFontFromFont:);
+  if ([self.fontLoader respondsToSelector:selector]) {
+    return [self.fontLoader italicFontFromFont:font];
+  }
+  UIFontDescriptor * fontDescriptor = [font.fontDescriptor
+                              fontDescriptorWithSymbolicTraits: UIFontDescriptorTraitItalic];
+  return [UIFont fontWithDescriptor:fontDescriptor size:0];
+}
+
++ (UIFont *)boldFontFromFont:(UIFont *)font {
+  SEL selector = @selector(boldFontFromFont:);
+  if ([self.fontLoader respondsToSelector:selector]) {
+    return [self.fontLoader boldFontFromFont:font];
+  }
+  UIFontDescriptorSymbolicTraits traits = UIFontDescriptorTraitBold;
+  if (font.mdc_slant != 0) {
+    traits = traits | UIFontDescriptorTraitItalic;
+  }
+  UIFontDescriptor * fontDescriptor =
+      [font.fontDescriptor fontDescriptorWithSymbolicTraits: traits];
+  return [UIFont fontWithDescriptor:fontDescriptor size:0];
 }
 
 #pragma mark - Private
@@ -183,9 +208,10 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
 
 - (UIFont *)boldFontOfSize:(CGFloat)fontSize {
   if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
-    return [UIFont systemFontOfSize:fontSize weight:UIFontWeightBold];
+    return [UIFont systemFontOfSize:fontSize weight:UIFontWeightSemibold];
   }
   return [UIFont boldSystemFontOfSize:fontSize];
+  
 }
 
 - (UIFont *)italicFontOfSize:(CGFloat)fontSize {

--- a/components/Typography/src/private/UIFont+MaterialTypographyPrivate.h
+++ b/components/Typography/src/private/UIFont+MaterialTypographyPrivate.h
@@ -25,6 +25,15 @@
 - (CGFloat)mdc_weight;
 
 /**
+ Returns the slant of the font.
+ 
+ @return more than 0 when italic and 0 when not italic.
+ 
+ Regular slant is 0.0.
+ */
+- (CGFloat)mdc_slant;
+
+/**
  Returns an extended description of the font including name, pointsize and weight.
  */
 - (nonnull NSString *)mdc_extendedDescription;

--- a/components/Typography/src/private/UIFont+MaterialTypographyPrivate.m
+++ b/components/Typography/src/private/UIFont+MaterialTypographyPrivate.m
@@ -64,6 +64,20 @@
   return weight;
 }
 
+- (CGFloat)mdc_slant {
+  CGFloat slant = 0.0;
+  
+  NSDictionary *fontTraits = [self.fontDescriptor objectForKey:UIFontDescriptorTraitsAttribute];
+  if (fontTraits) {
+    NSNumber *slantNumber = fontTraits[UIFontSlantTrait];
+    if (slantNumber) {
+      slant = [slantNumber floatValue];
+    }
+  }
+  
+  return slant;
+}
+
 - (NSString *)mdc_weightString {
   CGFloat weight = [self mdc_weight];
   NSString *weightString = [UIFont mdc_fontWeightDescription:weight];

--- a/components/Typography/tests/unit/SystemFontLoaderTests.m
+++ b/components/Typography/tests/unit/SystemFontLoaderTests.m
@@ -37,7 +37,7 @@
     XCTAssertEqual([fontLoader mediumFontOfSize:size],
                    [UIFont systemFontOfSize:size weight: UIFontWeightMedium]);
     XCTAssertEqual([fontLoader boldFontOfSize:size],
-                   [UIFont systemFontOfSize:size weight: UIFontWeightBold]);
+                   [UIFont systemFontOfSize:size weight: UIFontWeightSemibold]);
   } else {
     // Fallback on earlier versions
     XCTAssertEqual([fontLoader lightFontOfSize:size], [UIFont fontWithName:@"HelveticaNeue-Light" size:size]);

--- a/components/Typography/tests/unit/TypographyTests.m
+++ b/components/Typography/tests/unit/TypographyTests.m
@@ -242,4 +242,42 @@ static const CGFloat kOpacityMedium = 0.87f;
   XCTAssertEqualWithAccuracy(font.pointSize, 14, kEpsilon, @"The font size of button must be 14.");
 }
 
+- (void)testItalicFontFromFont {
+  // Given
+  CGFloat size = 8;
+  MDCSystemFontLoader *fontLoader=[[MDCSystemFontLoader alloc] init];
+  UIFont *normalFont = [UIFont systemFontOfSize:size];
+  UIFont *italicFont = [UIFont italicSystemFontOfSize:size];
+  UIFont *mediumFont = [fontLoader mediumFontOfSize:size];
+  UIFontDescriptor *fontDescriptor =
+      [mediumFont.fontDescriptor fontDescriptorWithSymbolicTraits: UIFontDescriptorTraitItalic];
+  UIFont *italicMediumFont = [UIFont fontWithDescriptor:fontDescriptor size:0];
+  
+  // Then
+  XCTAssertEqualObjects([MDCTypography italicFontFromFont:mediumFont], italicMediumFont);
+  XCTAssertEqualObjects([MDCTypography italicFontFromFont:normalFont], italicFont);
+}
+
+- (void)testBoldFontFromFont {
+  // Given
+  CGFloat size = 8;
+  MDCSystemFontLoader *fontLoader=[[MDCSystemFontLoader alloc] init];
+  UIFont *normalFont = [UIFont systemFontOfSize:size];
+  UIFont *boldFont = [UIFont boldSystemFontOfSize:size];
+  UIFont *italicFont = [UIFont italicSystemFontOfSize:size];
+  UIFontDescriptor *fontDescriptor = [[UIFont systemFontOfSize:size].fontDescriptor
+      fontDescriptorWithSymbolicTraits:UIFontDescriptorTraitItalic | UIFontDescriptorTraitBold];
+  UIFont *italicBoldFont = [UIFont fontWithDescriptor:fontDescriptor size:0];
+  UIFont *fontLoaderRegularFont = [fontLoader regularFontOfSize:size];
+  UIFont *fontLoaderBoldFont = [fontLoader boldFontOfSize:size];
+
+  
+  // Then
+  XCTAssertEqualObjects([MDCTypography boldFontFromFont:italicFont], italicBoldFont);
+  XCTAssertEqualObjects([MDCTypography boldFontFromFont:normalFont], boldFont);
+  // For some reason the fonts are not equal, the names are the same though.
+  XCTAssertEqualObjects([MDCTypography boldFontFromFont:fontLoaderRegularFont].fontName,
+      fontLoaderBoldFont.fontName);
+}
+
 @end


### PR DESCRIPTION
Turns out that there is no italic-bold san francisco font. Only a simibold italic san francisco font. Also [UIFont boldSystemFontOfSize:] returns the semibold one so we are switching to that for request for "bold"

started off as cl/150391112