### PR TITLE
[CollectionLayoutAttributes] Fix comparison

### DIFF
--- a/components/CollectionLayoutAttributes/src/MDCCollectionViewLayoutAttributes.m
+++ b/components/CollectionLayoutAttributes/src/MDCCollectionViewLayoutAttributes.m
@@ -49,18 +49,30 @@
 
   // Compare custom properties that affect layout.
   MDCCollectionViewLayoutAttributes *otherAttrs = (MDCCollectionViewLayoutAttributes *)object;
+  BOOL backgroundImageIdentity = NO;
+  if (self.backgroundImage && otherAttrs.backgroundImage) {
+    backgroundImageIdentity = [self.backgroundImage isEqual:otherAttrs.backgroundImage];
+  } else if (!self.backgroundImage && !otherAttrs.backgroundImage) {
+    backgroundImageIdentity = YES;
+  }
+
+  BOOL separatorColorIdentity = NO;
+  if (self.separatorColor && otherAttrs.separatorColor) {
+    separatorColorIdentity = [self.separatorColor isEqual:otherAttrs.separatorColor];
+  } else if (!self.separatorColor && !otherAttrs.separatorColor) {
+    separatorColorIdentity = YES;
+  }
+
   if ((otherAttrs.editing != self.editing) ||
       (otherAttrs.shouldShowReorderStateMask != self.shouldShowReorderStateMask) ||
       (otherAttrs.shouldShowSelectorStateMask != self.shouldShowSelectorStateMask) ||
       (otherAttrs.shouldShowGridBackground != self.shouldShowGridBackground) ||
       (otherAttrs.sectionOrdinalPosition != self.sectionOrdinalPosition) ||
-      ![MDCCollectionViewLayoutAttributes is:otherAttrs.backgroundImage
-                                     equalTo:self.backgroundImage] ||
+      !backgroundImageIdentity ||
       (!UIEdgeInsetsEqualToEdgeInsets(otherAttrs.backgroundImageViewInsets,
                                       self.backgroundImageViewInsets)) ||
       (otherAttrs.isGridLayout != self.isGridLayout) ||
-      ![MDCCollectionViewLayoutAttributes is:otherAttrs.separatorColor
-                                     equalTo:self.separatorColor] ||
+      !separatorColorIdentity ||
       (!UIEdgeInsetsEqualToEdgeInsets(otherAttrs.separatorInset, self.separatorInset)) ||
       (otherAttrs.separatorLineHeight != self.separatorLineHeight) ||
       (otherAttrs.shouldHideSeparators != self.shouldHideSeparators) ||
@@ -77,11 +89,6 @@
          (NSUInteger)self.sectionOrdinalPosition ^ (NSUInteger)self.backgroundImage ^
          (NSUInteger)self.isGridLayout ^ (NSUInteger)self.separatorColor ^
          (NSUInteger)self.separatorLineHeight ^ (NSUInteger)self.shouldHideSeparators;
-}
-
-+ (BOOL)is:(id)object1 equalTo:(id)object2 {
-  // Test for equality, including when both objects are nil.
-  return (!object1 && !object2) || [object1 isEqual:object2];
 }
 
 @end

--- a/components/CollectionLayoutAttributes/src/MDCCollectionViewLayoutAttributes.m
+++ b/components/CollectionLayoutAttributes/src/MDCCollectionViewLayoutAttributes.m
@@ -54,11 +54,13 @@
       (otherAttrs.shouldShowSelectorStateMask != self.shouldShowSelectorStateMask) ||
       (otherAttrs.shouldShowGridBackground != self.shouldShowGridBackground) ||
       (otherAttrs.sectionOrdinalPosition != self.sectionOrdinalPosition) ||
-      ![otherAttrs.backgroundImage isEqual:self.backgroundImage] ||
+      ![MDCCollectionViewLayoutAttributes is:otherAttrs.backgroundImage
+                                     equalTo:self.backgroundImage] ||
       (!UIEdgeInsetsEqualToEdgeInsets(otherAttrs.backgroundImageViewInsets,
                                       self.backgroundImageViewInsets)) ||
       (otherAttrs.isGridLayout != self.isGridLayout) ||
-      ![otherAttrs.separatorColor isEqual:self.separatorColor] ||
+      ![MDCCollectionViewLayoutAttributes is:otherAttrs.separatorColor
+                                     equalTo:self.separatorColor] ||
       (!UIEdgeInsetsEqualToEdgeInsets(otherAttrs.separatorInset, self.separatorInset)) ||
       (otherAttrs.separatorLineHeight != self.separatorLineHeight) ||
       (otherAttrs.shouldHideSeparators != self.shouldHideSeparators) ||
@@ -75,6 +77,11 @@
          (NSUInteger)self.sectionOrdinalPosition ^ (NSUInteger)self.backgroundImage ^
          (NSUInteger)self.isGridLayout ^ (NSUInteger)self.separatorColor ^
          (NSUInteger)self.separatorLineHeight ^ (NSUInteger)self.shouldHideSeparators;
+}
+
++ (BOOL)is:(id)object1 equalTo:(id)object2 {
+  // Test for equality, including when both objects are nil.
+  return (!object1 && !object2) || [object1 isEqual:object2];
 }
 
 @end

--- a/components/CollectionLayoutAttributes/tests/unit/CollectionLayoutAttributesTests.m
+++ b/components/CollectionLayoutAttributes/tests/unit/CollectionLayoutAttributesTests.m
@@ -82,4 +82,14 @@
   XCTAssertEqual(_attributes.hash, copy.hash);
 }
 
+- (void)testEqualNilObject {
+  // When
+  _attributes.backgroundImage = nil;
+  _attributes.separatorColor = nil;
+  MDCCollectionViewLayoutAttributes *copy = [_attributes copy];
+  
+  // Then
+  XCTAssertEqualObjects(_attributes, copy);
+}
+
 @end


### PR DESCRIPTION
Fix the comparison operator of MDCCollectionViewLayoutAttributes.
The MDCCollectionViewLayoutAttributes isEqual: method used a isEqual: on
objects that can be nil. This returns nil even if the two objects are nil.

closes #1264