### PR TITLE
[Typography] Workaround for medium system font on iOS 8

### DIFF
--- a/components/Typography/src/MDCTypography.m
+++ b/components/Typography/src/MDCTypography.m
@@ -237,6 +237,9 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
     return YES;
   }
 
+  // TODO(#): Remove after we drop support for iOS 8
+  // This following value (0.23) is based off what Apple made public in iOS 8.2.
+  // We are re-defining it since we can't assume it exists on iOS 8.1.
   CGFloat MDCFontWeightMedium = (CGFloat)0.23;
 // Based on Apple's SDK-Based Development: Using Weakly Linked Methods, Functions, and Symbols.
 // https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/cross_development/Using/using.html#//apple_ref/doc/uid/20002000-1114537-BABHHJBC
@@ -250,6 +253,15 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
 
   // We treat system font medium as large for accessibility when larger than 14.
   if (font.mdc_weight >= MDCFontWeightMedium) {
+    return YES;
+  }
+
+  // TODO(#): Remove after we drop support for iOS 8
+  // iOS 8 handles medium system font requests by creating a normal weight font of a specific font
+  // face instead of a medium font weight of a general font family.  Therefore we can't assume the
+  // weight is valid on iOS 8.
+  // To workaround we return YES if the font is the specific font use on iOS 8 for Medium weights.
+  if ([font.fontName isEqualToString:@"HelveticaNeue-Medium"]) {
     return YES;
   }
 

--- a/components/Typography/src/MDCTypography.m
+++ b/components/Typography/src/MDCTypography.m
@@ -237,7 +237,7 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
     return YES;
   }
 
-  // TODO(#): Remove after we drop support for iOS 8
+  // TODO(#1296): Remove after we drop support for iOS 8
   // This following value (0.23) is based off what Apple made public in iOS 8.2.
   // We are re-defining it since we can't assume it exists on iOS 8.1.
   CGFloat MDCFontWeightMedium = (CGFloat)0.23;
@@ -256,7 +256,7 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
     return YES;
   }
 
-  // TODO(#): Remove after we drop support for iOS 8
+  // TODO(#1296): Remove after we drop support for iOS 8
   // iOS 8 handles medium system font requests by creating a normal weight font of a specific font
   // face instead of a medium font weight of a general font family.  Therefore we can't assume the
   // weight is valid on iOS 8.

--- a/components/Typography/tests/unit/SystemFontLoaderTests.m
+++ b/components/Typography/tests/unit/SystemFontLoaderTests.m
@@ -97,6 +97,12 @@
   XCTAssertFalse(
       [fontLoader isLargeForContrastRatios:[fontLoader italicFontOfSize:largeIfBoldSize]]);
   XCTAssertTrue([fontLoader isLargeForContrastRatios:[fontLoader italicFontOfSize:largeSize]]);
+
+  // Bold Italic
+  XCTAssertFalse([fontLoader isLargeForContrastRatios:[fontLoader boldItalicFontOfSize:smallSize]]);
+  XCTAssertTrue(
+      [fontLoader isLargeForContrastRatios:[fontLoader boldItalicFontOfSize:largeIfBoldSize]]);
+  XCTAssertTrue([fontLoader isLargeForContrastRatios:[fontLoader boldItalicFontOfSize:largeSize]]);
 }
 
 - (void)testUIFontWeightMediumValue {


### PR DESCRIPTION
Adds a workaround for an iOS 8 medium font weight issue.

Closes #1291 
Closes #1275 