### PR TITLE
[Everything!] Documentation updates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,15 +59,14 @@ Carthage/Build
 
 # fastlane
 #
-# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the 
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
 # screenshots whenever they are needed.
 
 fastlane/report.xml
 fastlane/screenshots
 
 # material component site
-/gh-pages
-/site-source
+docsite
 
 # Compiled python
 *.pyc

--- a/components/.jekyll_prefix.yaml
+++ b/components/.jekyll_prefix.yaml
@@ -1,5 +1,0 @@
----
-title:  "Material Components Documentation"
-layout: landing
-section: components
----

--- a/components/ActivityIndicator/.jekyll_prefix.yaml
+++ b/components/ActivityIndicator/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Activity Indicator"
-layout: detail
-section: components
-excerpt: "Progress and activity indicators are visual indications of an app loading content."
----

--- a/components/ActivityIndicator/README.md
+++ b/components/ActivityIndicator/README.md
@@ -1,16 +1,29 @@
+<!--docs:
+title:  "Activity Indicator"
+layout: detail
+section: components
+excerpt: "Progress and activity indicators are visual indications of an app loading content."
+-->
+
 # Activity Indicator
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="Activity Indicator"><img src="docs/assets/activity_indicator.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/activity_indicator.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/activity_indicator.png" alt="Activity Indicator" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/activity_indicator.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 Activity indicators are visual indications of an app loading content. The Activity Indicator is a circular indicator that either rotates clockwise or fills to completion clockwise when displaying progress.
-<!--{: .intro :}-->
+<!--{: .article__intro }-->
 
-### Material Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-link"><a href="https://material.google.com/components/progress-activity.html">Progress & activity</a></li>
+  <li class="icon-spec"><a href="https://material.google.com/components/progress-activity.html">Progress & activity</a></li>
 </ul>
 
 - - -

--- a/components/AnimationTiming/.jekyll_prefix.yaml
+++ b/components/AnimationTiming/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Animation Timing"
-layout: detail
-section: components
-excerpt: "Material Design animation timing curves."
----

--- a/components/AnimationTiming/README.md
+++ b/components/AnimationTiming/README.md
@@ -1,3 +1,10 @@
+<!--docs:
+title:  "Animation Timing"
+layout: detail
+section: components
+excerpt: "Material Design animation timing curves."
+-->
+
 # Animation Timing
 
 Animation timing easing curves create smooth and consistent motion. Easing curves allow elements to

--- a/components/AppBar/.jekyll_prefix.yaml
+++ b/components/AppBar/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "App Bar"
-layout: detail
-section: components
-excerpt: "The App Bar is a flexible navigation bar designed to provide a typical Material Design navigation experience."
----

--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -1,18 +1,31 @@
+<!--docs:
+title:  "App Bar"
+layout: detail
+section: components
+excerpt: "The App Bar is a flexible navigation bar designed to provide a typical Material Design navigation experience."
+-->
+
 # App Bar
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="App Bar"><img src="docs/assets/app_bar.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/app_bar.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/app_bar.png" alt="App Bar" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/app_bar.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 The App Bar is a flexible navigation bar designed to provide a typical Material Design
 navigation experience.
-<!--{: .intro :}-->
+<!--{: .article__intro }-->
 
-### Material Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-link"><a href="https://www.google.com/design/spec/layout/structure.html#structure-app-bar">App Bar Structure</a></li>
-  <li class="icon-link"><a href="https://www.google.com/design/spec/patterns/scrolling-techniques.html">Scrolling Techniques</a></li>
+  <li class="icon-spec"><a href="https://www.google.com/design/spec/layout/structure.html#structure-app-bar">App Bar Structure</a></li>
+  <li class="icon-spec"><a href="https://www.google.com/design/spec/patterns/scrolling-techniques.html">Scrolling Techniques</a></li>
 </ul>
 
 - - -

--- a/components/ButtonBar/.jekyll_prefix.yaml
+++ b/components/ButtonBar/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Button Bar"
-layout: detail
-section: components
-excerpt: "The Button Bar component is a view that facilitates the creation and layout of a horizontally-aligned list of buttons."
----

--- a/components/ButtonBar/README.md
+++ b/components/ButtonBar/README.md
@@ -1,11 +1,24 @@
+<!--docs:
+title:  "Button Bar"
+layout: detail
+section: components
+excerpt: "The Button Bar component is a view that facilitates the creation and layout of a horizontally-aligned list of buttons."
+-->
+
 # Button Bar
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="Button Bar"><img src="docs/assets/button_bar.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/button_bar.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/button_bar.png" alt="Button Bar" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/button_bar.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 The Button Bar is a view that represents a list of UIBarButtonItems as horizontally aligned buttons.
-<!--{: .intro }-->
+<!--{: .article__intro }-->
 
 - - -
 

--- a/components/Buttons/.jekyll_prefix.yaml
+++ b/components/Buttons/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Buttons"
-layout: detail
-section: components
-excerpt: "Buttons is a collection of Material Design buttons, including a flat button, a raised button and a floating action button."
----

--- a/components/Buttons/README.md
+++ b/components/Buttons/README.md
@@ -1,18 +1,30 @@
+<!--docs:
+title:  "Buttons"
+layout: detail
+section: components
+excerpt: "Buttons is a collection of Material Design buttons, including a flat button, a raised button and a floating action button."
+-->
+
 # Buttons
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="Buttons"><img src="docs/assets/buttons.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/buttons.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/buttons.png" alt="Buttons" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/buttons.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 Buttons is a collection of Material Design buttons, including a flat button, a raised button and a
 floating action button.
-<!--{: .intro }-->
+<!--{: .article__intro }-->
 
-
-### Material Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-link"><a href="http://www.google.com/design/spec/components/buttons.html">Buttons</a></li>
+  <li class="icon-spec"><a href="http://www.google.com/design/spec/components/buttons.html">Buttons</a></li>
 </ul>
 
 - - -

--- a/components/CollectionCells/.jekyll_prefix.yaml
+++ b/components/CollectionCells/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Collection Cells"
-layout: detail
-section: components
-excerpt: "Collection view cell classes that adhere to Material Design layout and styling."
----

--- a/components/CollectionCells/README.md
+++ b/components/CollectionCells/README.md
@@ -1,15 +1,22 @@
+<!--docs:
+title:  "Collection Cells"
+layout: detail
+section: components
+excerpt: "Collection view cell classes that adhere to Material Design layout and styling."
+-->
+
 # Collection Cells
 
-<a alt="Collection Cells"><img src="docs/assets/collection_cells.png" width="320px"></a>
-<!--{: .ios-screenshot .right }-->
+<img src="docs/assets/collection_cells.png" alt="Collection Cells" width="320">
+<!--{: .article__asset.article__asset--screenshot }-->
 
 Collection view cell classes that adhere to Material Design layout and styling.
-<!--{: .intro :}-->
+<!--{: .article__intro }-->
 
-### Material Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-link"><a href="https://www.google.com/design/spec/components/lists.html#lists-specs">Collection List Specs</a></li>
+  <li class="icon-spec"><a href="https://www.google.com/design/spec/components/lists.html#lists-specs">Collection List Specs</a></li>
 </ul>
 
 - - -

--- a/components/CollectionLayoutAttributes/.jekyll_prefix.yaml
+++ b/components/CollectionLayoutAttributes/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Collection Layout Attributes"
-layout: detail
-section: components
-excerpt: "Allows passing layout attributes to the cells and supplementary views."
----

--- a/components/CollectionLayoutAttributes/README.md
+++ b/components/CollectionLayoutAttributes/README.md
@@ -1,7 +1,14 @@
+<!--docs:
+title:  "Collection Layout Attributes"
+layout: detail
+section: components
+excerpt: "Allows passing layout attributes to the cells and supplementary views."
+-->
+
 # Collection Layout Attributes
 
 Allows passing layout attributes to the cells and supplementary views.
-<!--{: .intro :}-->
+<!--{: .article__intro }-->
 
 - - -
 

--- a/components/Collections/.jekyll_prefix.yaml
+++ b/components/Collections/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Collections"
-layout: detail
-section: components
-excerpt: "Collection view classes that adhere to Material Design layout and styling."
----

--- a/components/Collections/README.md
+++ b/components/Collections/README.md
@@ -1,16 +1,29 @@
+<!--docs:
+title:  "Collections"
+layout: detail
+section: components
+excerpt: "Collection view classes that adhere to Material Design layout and styling."
+-->
+
 # Collections
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="Collections"><img src="docs/assets/collections.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/collections.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/collections.png" alt="Collections" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/collections.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 Collection view classes that adhere to Material Design layout and styling.
-<!--{: .intro :}-->
+<!--{: .article__intro }-->
 
-### Material Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-link"><a href="https://www.google.com/design/spec/components/lists.html#lists-specs">Collection List Specs</a></li>
+  <li class="icon-spec"><a href="https://www.google.com/design/spec/components/lists.html#lists-specs">Collection List Specs</a></li>
 </ul>
 
 - - -

--- a/components/Collections/styling/README.md
+++ b/components/Collections/styling/README.md
@@ -26,7 +26,7 @@ The `styler` allows setting the cell style as Default, Grouped, or Card Style. C
 either set the `styler.cellStyle` property directly, or use the protocol method
 `collectionView:cellStyleForSection:` to style per section.
 
-<!-- <div class="material-code-render" markdown="1"> -->
+<!--<div class="material-code-render" markdown="1">-->
 #### Swift
 ~~~swift
 // Set for entire collection view.
@@ -56,13 +56,13 @@ self.styler.cellStyle = MDCCollectionViewCellStyleCard;
   return MDCCollectionViewCellStyleGrouped;
 }
 ~~~
-<!-- </div> -->
+<!--</div>-->
 
 ### Cell Height
 
 The styling delegate protocol can be used to override the default cell height of `48.0f`.
 
-<!-- <div class="material-code-render" markdown="1"> -->
+<!--<div class="material-code-render" markdown="1">-->
 #### Swift
 ~~~swift
 override func collectionView(collectionView: UICollectionView,
@@ -84,13 +84,13 @@ override func collectionView(collectionView: UICollectionView,
   return 48.0f;
 }
 ~~~
-<!-- </div> -->
+<!--</div>-->
 
 ### Cell Layout
 
 The styler allows setting the cell layout as List, Grid, or Custom.
 
-<!-- <div class="material-code-render" markdown="1"> -->
+<!--<div class="material-code-render" markdown="1">-->
 #### Swift
 ~~~swift
 // Set as list layout.
@@ -112,7 +112,7 @@ self.styler.cellLayoutType = MDCCollectionViewCellLayoutTypeGrid;
 self.styler.gridPadding = 8;
 self.styler.gridColumnCount = 2;
 ~~~
-<!-- </div> -->
+<!--</div>-->
 
 ### Cell Separators
 
@@ -121,7 +121,7 @@ cell customization is also available by using an `MDCCollectionViewCell` cell or
 Learn more by reading the section on [Cell Separators](../CollectionCells/#cell-separators) in the
 [CollectionCells](../CollectionCells/) component.
 
-<!-- <div class="material-code-render" markdown="1"> -->
+<!--<div class="material-code-render" markdown="1">-->
 #### Swift
 ~~~swift
 // Set separator color.
@@ -151,7 +151,7 @@ self.styler.separatorLineHeight = 1.0f;
 // Whether to hide separators.
 self.styler.shouldHideSeparators = NO;
 ~~~
-<!-- </div> -->
+<!--</div>-->
 
 ### Background colors
 
@@ -159,7 +159,7 @@ A background color can be set on the collection view. Also, individual cell back
 set by using the protocol method `collectionView:cellBackgroundColorAtIndexPath:`. The default
 background colors are `#EEEEEE` for the collection view and `#FFFFFF` for the cells.
 
-<!-- <div class="material-code-render" markdown="1"> -->
+<!--<div class="material-code-render" markdown="1">-->
 #### Swift
 ~~~swift
 // Set collection view background color.
@@ -189,4 +189,4 @@ self.collectionView.backgroundColor = [UIColor grayColor];
   return [UIColor redColor];
 }
 ~~~
-<!-- </div> -->
+<!--</div>-->

--- a/components/Dialogs/.jekyll_prefix.yaml
+++ b/components/Dialogs/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Dialogs"
-layout: detail
-section: components
-excerpt: "The Dialogs component implements the Material Design specifications for modal presentations."
----

--- a/components/Dialogs/README.md
+++ b/components/Dialogs/README.md
@@ -1,12 +1,20 @@
+<!--docs:
+title:  "Dialogs"
+layout: detail
+section: components
+excerpt: "The Dialogs component implements the Material Design specifications for modal presentations."
+-->
+
 # Dialogs
 
 Dialogs provides both a presentation controller for displaying a modal dialog and an alert
 controller that will display a simple modal alert.
+<!--{: .article__intro }-->
 
-### Material Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-<li class="icon-link"><a href="https://material.google.com/components/dialogs.html">Dialogs</a></li>
+  <li class="icon-spec"><a href="https://material.google.com/components/dialogs.html">Dialogs</a></li>
 </ul>
 
 ### Dialogs Classes

--- a/components/FeatureHighlight/.jekyll_prefix.yaml
+++ b/components/FeatureHighlight/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Feature Highlight"
-layout: detail
-section: components
-excerpt: "Feature Highlight highlights a part of the screen in order to introduce users to new features and functionality."
----

--- a/components/FeatureHighlight/README.md
+++ b/components/FeatureHighlight/README.md
@@ -1,15 +1,28 @@
+<!--docs:
+title:  "Feature Highlight"
+layout: detail
+section: components
+excerpt: "Feature Highlight highlights a part of the screen in order to introduce users to new features and functionality."
+-->
+
 # Feature Highlight
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="Feature Highlight"><img src="docs/assets/feature_highlight.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/feature_highlight.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/feature_highlight.png" alt="Feature Highlight" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/feature_highlight.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 The Feature Highlight component is a way to visually highlight a part of the screen in order to introduce users to new features and functionality.
 
-### Material Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-<li class="icon-link"><a href="https://material.google.com/growth-communications/feature-discovery.html">Feature Discovery</a></li>
+  <li class="icon-spec"><a href="https://material.google.com/growth-communications/feature-discovery.html">Feature Discovery</a></li>
 </ul>
 
 - - -

--- a/components/FlexibleHeader/.jekyll_prefix.yaml
+++ b/components/FlexibleHeader/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Flexible Header"
-layout: detail
-section: components
-excerpt: "The Flexible Header is a container view whose height and vertical offset react to UIScrollViewDelegate events."
----

--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -1,17 +1,30 @@
+<!--docs:
+title:  "Flexible Header"
+layout: detail
+section: components
+excerpt: "The Flexible Header is a container view whose height and vertical offset react to UIScrollViewDelegate events."
+-->
+
 # Flexible Header
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="Flexible Header"><img src="docs/assets/flexible_header.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/flexible_header.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/flexible_header.png" alt="Flexible Header" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/flexible_header.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 The Flexible Header is a container view whose height and vertical offset react to
 UIScrollViewDelegate events.
-<!--{: .intro }-->
+<!--{: .article__intro }-->
 
-### Material Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-link"><a href="https://www.google.com/design/spec/patterns/scrolling-techniques.html">Scrolling Techniques</a></li>
+  <li class="icon-spec"><a href="https://www.google.com/design/spec/patterns/scrolling-techniques.html">Scrolling Techniques</a></li>
 </ul>
 
 - - -
@@ -374,7 +387,6 @@ headerViewController.layoutDelegate = self;
     flexibleHeaderViewFrameDidChange:(MDCFlexibleHeaderView *)flexibleHeaderView {
   // Called whenever the frame changes.
 }
-
 ~~~
 <!--</div>-->
 
@@ -387,22 +399,22 @@ updateTopLayoutGuide on the flexible header view controller within the paired vi
 viewWillLayoutSubviews method.
 
 <!--<div class="material-code-render" markdown="1">-->
-#### Objective-C
-
-- (void)viewWillLayoutSubviews {
-    [super viewWillLayoutSubviews];
-    [self.headerViewController updateLayoutGuide];
-}
-
-~~~
-
 #### Swift
 
+~~~ swift
 override func viewWillLayoutSubviews() {
     super.viewDidLayoutSubviews()
     headerViewController.updateTopLayoutGuide()
 }
+~~~
 
+#### Objective-C
+
+~~~ objc
+- (void)viewWillLayoutSubviews {
+    [super viewWillLayoutSubviews];
+    [self.headerViewController updateLayoutGuide];
+}
 ~~~
 <!--</div>-->
 

--- a/components/HeaderStackView/.jekyll_prefix.yaml
+++ b/components/HeaderStackView/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Header Stack View"
-layout: detail
-section: components
-excerpt: "The Header Stack View component is a view that coordinates the layout of two vertically stacked bar views."
----

--- a/components/HeaderStackView/README.md
+++ b/components/HeaderStackView/README.md
@@ -1,17 +1,30 @@
+<!--docs:
+title:  "Header Stack View"
+layout: detail
+section: components
+excerpt: "The Header Stack View component is a view that coordinates the layout of two vertically stacked bar views."
+-->
+
 # Header Stack View
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="Header Stack View"><img src="docs/assets/header_stack_view.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/header_stack_view.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/header_stack_view.png" alt="Header Stack View" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/header_stack_view.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 The Header Stack View component is a view that coordinates the layout of two vertically stacked
 bar views.
-<!--{: .intro }-->
+<!--{: .article__intro }-->
 
-### Material Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-link"><a href="https://www.google.com/design/spec/layout/structure.html#structure-app-bar">App Bar</a></li>
+  <li class="icon-spec"><a href="https://www.google.com/design/spec/layout/structure.html#structure-app-bar">App Bar</a></li>
 </ul>
 
 - - -

--- a/components/Ink/.jekyll_prefix.yaml
+++ b/components/Ink/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Ink"
-layout: detail
-section: components
-excerpt: "The Ink component provides a radial action in the form of a visual ripple of ink expanding outward from the user's touch."
----

--- a/components/Ink/README.md
+++ b/components/Ink/README.md
@@ -1,17 +1,30 @@
+<!--docs:
+title:  "Ink"
+layout: detail
+section: components
+excerpt: "The Ink component provides a radial action in the form of a visual ripple of ink expanding outward from the user's touch."
+-->
+
 # Ink
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="Ink"><img src="docs/assets/ink.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/ink.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/ink.png" alt="Ink" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/ink.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 The Ink component provides a radial action in the form of a visual ripple of ink expanding
 outward from the user's touch.
-<!--{: .intro }-->
+<!--{: .article__intro }-->
 
-### Material Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-link"><a href="https://www.google.com/design/spec/animation/responsive-interaction.html#responsive-interaction-radial-action">Radial Action</a></li>
+  <li class="icon-spec"><a href="https://www.google.com/design/spec/animation/responsive-interaction.html#responsive-interaction-radial-action">Radial Action</a></li>
 </ul>
 
 - - -

--- a/components/NavigationBar/.jekyll_prefix.yaml
+++ b/components/NavigationBar/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Navigation Bar"
-layout: detail
-section: components
-excerpt: "The Navigation Bar component is a view composed of a left and right Button Bar and either a title label or a custom title view."
----

--- a/components/NavigationBar/README.md
+++ b/components/NavigationBar/README.md
@@ -1,19 +1,33 @@
+<!--docs:
+title:  "Navigation Bar"
+layout: detail
+section: components
+excerpt: "The Navigation Bar component is a view composed of a left and right Button Bar and either a title label or a custom title view."
+-->
+
 # Navigation Bar
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="Navigation Bar"><img src="docs/assets/navigation_bar.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/navigation_bar.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/navigation_bar.png" alt="Navigation Bar" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/navigation_bar.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 The Navigation Bar component is a view composed of a left and right Button Bar and either a title
 label or a custom title view.
+<!--{: .article__intro }-->
 
 Consistent with iOS design guidelines, the title in the navigation bar is centered by default. However, certain use cases may warrant use of a left aligned title such as: when there is a strong relationship between the title and additional content appearing in the navigation bar, or where centering the title causes ambiguity.
-<!--{: .intro }-->
+<!--{: .article__intro }-->
 
-### Material Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-link"><a href="http://www.google.com/design/spec/layout/structure.html">Layout Structure</a></li>
+  <li class="icon-spec"><a href="http://www.google.com/design/spec/layout/structure.html">Layout Structure</a></li>
 </ul>
 
 - - -

--- a/components/OverlayWindow/.jekyll_prefix.yaml
+++ b/components/OverlayWindow/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "OverlayWindow"
-layout: detail
-section: components
-excerpt: "A window for managing sets of overlay views."
----

--- a/components/OverlayWindow/README.md
+++ b/components/OverlayWindow/README.md
@@ -1,3 +1,10 @@
+<!--docs:
+title:  "OverlayWindow"
+layout: detail
+section: components
+excerpt: "A window for managing sets of overlay views."
+-->
+
 # Overlay Window
 
 Provides a window which can have an arbitrary number of overlay views that will sit above the root

--- a/components/PageControl/.jekyll_prefix.yaml
+++ b/components/PageControl/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Page Control"
-layout: detail
-section: components
-excerpt: "Page Control is a drop-in Material Design replacement for UIPageControl that implements Material Design animation and layout."
----

--- a/components/PageControl/README.md
+++ b/components/PageControl/README.md
@@ -1,14 +1,27 @@
+<!--docs:
+title:  "Page Control"
+layout: detail
+section: components
+excerpt: "Page Control is a drop-in Material Design replacement for UIPageControl that implements Material Design animation and layout."
+-->
+
 # Page Control
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="Page Control"><img src="docs/assets/page_control.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/page_control.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/page_control.png" alt="Page Control" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/page_control.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 This control is designed to be a drop-in replacement for `UIPageControl`, with a user experience
 influenced by Material Design specifications for animation and layout. The API methods are the
 same as a `UIPageControl`, with the addition of a few key methods required to achieve the
 desired animation of the control.
-<!--{: .intro }-->
+<!--{: .article__intro }-->
 
 - - -
 
@@ -53,19 +66,19 @@ final position of the new page.
 
 
 ![screenshot-1](docs/assets/MDCPageControl_screenshot-1.png)
-<!--{: .ios-screenshot .right }-->
+<!--{: .article__asset.article__asset--screenshot }-->
 Page control showing current page in resting state.
 <!--{: .clear-after }-->
 
 
 ![screenshot-2](docs/assets/MDCPageControl_screenshot-2.png)
-<!--{: .ios-screenshot .right }-->
+<!--{: .article__asset.article__asset--screenshot }-->
 Page control showing animated track with current page indicator positioned along the track.
 <!--{: .clear-after }-->
 
 
 ![screenshot-3](docs/assets/MDCPageControl_screenshot-3.png)
-<!--{: .ios-screenshot .right }-->
+<!--{: .article__asset.article__asset--screenshot }-->
 Page control showing new current page.
 <!--{: .clear-after }-->
 

--- a/components/Palettes/.jekyll_prefix.yaml
+++ b/components/Palettes/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Palettes"
-layout: detail
-section: components
-excerpt: "The Palettes component provides Material color palettes."
----

--- a/components/Palettes/README.md
+++ b/components/Palettes/README.md
@@ -1,12 +1,19 @@
+<!--docs:
+title:  "Palettes"
+layout: detail
+section: components
+excerpt: "The Palettes component provides Material color palettes."
+-->
+
 # Palettes
 
 The Palettes component provides Material colors organized into similar palettes.
-<!--{: .intro }-->
+<!--{: .article__intro }-->
 
-### Material Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-link"><a href="http://www.google.com/design/spec/style/color.html#color-color-palette">Color palettes</a></li>
+  <li class="icon-spec"><a href="http://www.google.com/design/spec/style/color.html#color-color-palette">Color palettes</a></li>
 </ul>
 
 - - -

--- a/components/ProgressView/.jekyll_prefix.yaml
+++ b/components/ProgressView/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Progress View"
-layout: detail
-section: components
-excerpt: "Progress View is a determinate and linear progress indicator that implements Material Design animation and layout."
----

--- a/components/ProgressView/README.md
+++ b/components/ProgressView/README.md
@@ -1,19 +1,32 @@
+<!--docs:
+title:  "Progress View"
+layout: detail
+section: components
+excerpt: "Progress View is a determinate and linear progress indicator that implements Material Design animation and layout."
+-->
+
 # Progress View
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="Progress View"><img src="docs/assets/progress_view.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/progress_view.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/progress_view.png" alt="Progress View" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/progress_view.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 This control is designed to be a drop-in replacement for `UIProgressView`, with a user experience
 influenced by [Material Design specifications](https://material.google.com/components/progress-activity.html#)
 for animation and layout. The API methods are the same as a `UIProgressView`, with the addition of a
 few key methods required to achieve the desired animation of the control.
-<!--{: .intro }-->
+<!--{: .article__intro }-->
 
-### Material Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-link"><a href="https://material.google.com/components/progress-activity.html">Progress & activity</a></li>
+  <li class="icon-spec"><a href="https://material.google.com/components/progress-activity.html">Progress & activity</a></li>
 </ul>
 
 - - -

--- a/components/README.md
+++ b/components/README.md
@@ -1,10 +1,15 @@
+<!--docs:
+title:  "Material Components Documentation"
+layout: landing-no-drawer
+section: components
+-->
 
 # Component Documentation
 
 Material Components for iOS (MDC-iOS) help developers execute [Material Design](https://www.material.io). Developed by a core team of engineers and UX designers at Google, these components enable a reliable development workflow to build beautiful and functional iOS apps.
- 
+
 Material Components for iOS are written in Objective-C and support Swift and Interface Builder.
- 
+
 <a name="components"></a>
 <!--{: .jumplink }-->
 

--- a/components/ShadowElevations/.jekyll_prefix.yaml
+++ b/components/ShadowElevations/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Shadow Elevations"
-layout: detail
-section: components
-excerpt: "The Shadow Elevations component provides the most commonly-used Material Design elevations."
----

--- a/components/ShadowElevations/README.md
+++ b/components/ShadowElevations/README.md
@@ -1,15 +1,22 @@
+<!--docs:
+title:  "Shadow Elevations"
+layout: detail
+section: components
+excerpt: "The Shadow Elevations component provides the most commonly-used Material Design elevations."
+-->
+
 # Shadow Elevations
 
 A shadow elevation specifies the degree of shadow intensity to be displayed beneath an object.
 Higher shadow elevations have greater shadow intensities, akin to raising an object above a
 surface resulting in a more prominent, albeit more diffuse, shadow. This component provides commonly
 used Material Design elevations for components.
-<!--{: .intro }-->
+<!--{: .article__intro }-->
 
-### Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-link"><a href="https://www.google.com/design/spec/what-is-material/elevation-shadows.html">Elevation and Shadows</a></li>
+  <li class="icon-spec"><a href="https://www.google.com/design/spec/what-is-material/elevation-shadows.html">Elevation and Shadows</a></li>
 </ul>
 
 - - -

--- a/components/ShadowLayer/.jekyll_prefix.yaml
+++ b/components/ShadowLayer/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Shadow Layer"
-layout: detail
-section: components
-excerpt: "The Shadow Layer component implements the Material Design specifications for elevation and shadows."
----

--- a/components/ShadowLayer/README.md
+++ b/components/ShadowLayer/README.md
@@ -1,15 +1,34 @@
+<!--docs:
+title:  "Shadow Layer"
+layout: detail
+section: components
+excerpt: "The Shadow Layer component implements the Material Design specifications for elevation and shadows."
+-->
+
 # Shadow Layer
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="Shadow Layer"><img src="docs/assets/shadow_layer.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/shadow_layer.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/shadow_layer.png" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/shadow_layer.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 Shadow Layer implements the Material Design specifications for elevation and shadows.
 By simulating the physical properties of paper, elevation and light source, shadows give
 visual depth to components. Shadow Layer provides an elevation property which affects
 a shadow's depth and strength, automatically handling shadow diffusion based on the shadow's
 elevation.
-<!--{: .intro }-->
+<!--{: .article__intro }-->
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-spec"><a href="https://www.google.com/design/spec/what-is-material/elevation-shadows.html">Elevation and Shadows</a></li>
+</ul>
 
 ### MDCShadowLayer
 
@@ -30,12 +49,6 @@ This is enabled by default and the internal portion of the layer is cut out.
 `MDCShadowMetrics` is a series of properties used to set `MDCShadowLayer`. `MDCShadowLayer` consists
 of two distinct layers. The overlay of these two layers generates a single Material Design
 shadow that adheres to defined height and light source principles.
-
-### Design Specifications
-
-<ul class="icon-list">
-  <li class="icon-link"><a href="https://www.google.com/design/spec/what-is-material/elevation-shadows.html">Elevation and Shadows</a></li>
-</ul>
 
 - - -
 
@@ -91,7 +104,7 @@ Example of a custom button based on UIButton with Material Design shadows:
 #### Swift
 ~~~ swift
 class ShadowButton: UIButton {
-  
+
   override class var layerClass: AnyClass {
     return MDCShadowLayer.self
   }

--- a/components/Slider/.jekyll_prefix.yaml
+++ b/components/Slider/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Slider"
-layout: detail
-section: components
-excerpt: "The Slider component provides a Material Design control for selecting a value from a continuous range or discrete set of values."
----

--- a/components/Slider/README.md
+++ b/components/Slider/README.md
@@ -1,17 +1,30 @@
+<!--docs:
+title:  "Slider"
+layout: detail
+section: components
+excerpt: "The Slider component provides a Material Design control for selecting a value from a continuous range or discrete set of values."
+-->
+
 # Slider
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="Slider"><img src="docs/assets/slider.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/slider.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/slider.png" alt="Slider" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/slider.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 The `MDCSlider` object is a Material Design control used to select a value from a continuous range
 or discrete set of values.
-<!--{: .intro }-->
+<!--{: .article__intro }-->
 
-### Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-link"><a href="https://www.google.com/design/spec/components/sliders.html">Sliders</a></li>
+  <li class="icon-spec"><a href="https://www.google.com/design/spec/components/sliders.html">Sliders</a></li>
 </ul>
 
 - - -

--- a/components/Snackbar/.jekyll_prefix.yaml
+++ b/components/Snackbar/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Snackbar"
-layout: detail
-section: components
-excerpt: "Snackbars provide brief feedback about an operation through a message at the bottom of the screen."
----

--- a/components/Snackbar/README.md
+++ b/components/Snackbar/README.md
@@ -1,17 +1,31 @@
+<!--docs:
+title:  "Snackbar"
+layout: detail
+section: components
+excerpt: "Snackbars provide brief feedback about an operation through a message at the bottom of the screen."
+-->
+
 # Snackbar
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="Snackbar"><img src="docs/assets/snackbar.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/snackbar.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/snackbar.png" alt="Snackbar" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/snackbar.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 Snackbars provide brief feedback about an operation through a message at the bottom of the screen.
 Snackbars contain up to two lines of text directly related to the operation performed. They may
 contain a text action, but no icons.
+<!--{: .article__intro }-->
 
-### Material Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-<li class="icon-link"><a href="https://material.google.com/components/snackbars-toasts.html">Snackbars</a></li>
+  <li class="icon-spec"><a href="https://material.google.com/components/snackbars-toasts.html">Snackbars</a></li>
 </ul>
 
 - - -

--- a/components/Tabs/README.md
+++ b/components/Tabs/README.md
@@ -1,24 +1,29 @@
-<!--{% if site.link_to_site == "true" %}-->
-See <a href="https://material-ext.appspot.com/mdc-ios-preview/components/Tabs/">MDC site documentation</a> for richer experience.
-<!--{% else %}See <a href="https://github.com/google/material-components-ios/tree/develop/components/Tabs">GitHub</a> for README documentation.{% endif %}-->
+<!--docs:
+title:  "Tabs"
+layout: detail
+section: components
+excerpt: "TODO(shyndman): Excerpt needed."
+-->
 
 # Tabs
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="Tabs"><img src="docs/assets/tabs.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/tabs.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/tabs.png" alt="Tabs" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/tab_bar.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 Tabs are bars of buttons used to navigate between groups of content.
-<!--{: .intro :}-->
+<!--{: .article__intro }-->
 
-### Material Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-link">
-    <a href="https://material.google.com/components/tabs.html">
-      Tabs
-    </a>
-  </li>
+  <li class="icon-spec"><a href="https://material.google.com/components/tabs.html">Tabs</a></li>
 </ul>
 
 - - -
@@ -80,7 +85,7 @@ import MaterialComponents
 
 ### Delegate
 
-Conform your class to the MDCTabBarDelegate protocol and set it as the tab bar's delegate to handle updating the UI when the user selects a tab. 
+Conform your class to the MDCTabBarDelegate protocol and set it as the tab bar's delegate to handle updating the UI when the user selects a tab.
 
 ### Selected item
 

--- a/components/Typography/.jekyll_prefix.yaml
+++ b/components/Typography/.jekyll_prefix.yaml
@@ -1,6 +1,0 @@
----
-title:  "Typography"
-layout: detail
-section: components
-excerpt: "The Typography component provides methods for displaying text using the type sizes and opacities from the Material Design specifications."
----

--- a/components/Typography/README.md
+++ b/components/Typography/README.md
@@ -1,17 +1,30 @@
+<!--docs:
+title:  "Typography"
+layout: detail
+section: components
+excerpt: "The Typography component provides methods for displaying text using the type sizes and opacities from the Material Design specifications."
+-->
+
 # Typography
 
 <!--{% if site.link_to_site == "true" %}-->
-<a alt="Typography"><img src="docs/assets/typography.png" width="320px"></a>
-<!--{% else %}<div class="ios-animation right" markdown="1"><video src="docs/assets/typography.mp4" autoplay loop></video></div>{% endif %}-->
+<div class="article__asset article__asset--screenshot">
+  <img src="docs/assets/typography.png" alt="Typography" width="320">
+</div>
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <video src="docs/assets/typography.mp4" autoplay loop></video>
+</div>
+{% endif %}-->
 
 The Typography component provides methods for displaying text using the type sizes and opacities
 from the Material Design specifications.
-<!--{: .intro }-->
+<!--{: .article__intro }-->
 
-### Design Specifications
+## Design & API Documentation
 
 <ul class="icon-list">
-<li class="icon-link"><a href="https://www.google.com/design/spec/style/typography.html">Typography</a></li>
+  <li class="icon-spec"><a href="https://www.google.com/design/spec/style/typography.html">Typography</a></li>
 </ul>
 
 ## Installation
@@ -88,12 +101,12 @@ settings in the Material Design specifications.
 ### Font size reference
 ![Material Design Type Size](docs/assets/style_typography_styles_scale.png
                              "Shows the Material Design font sizes")
-<!--{: .illustration }-->
+<!--{: .article__asset.article__asset--illustration }-->
 
 ### Font opacity reference
 ![Material Design Type Opacity](docs/assets/style_typography_styles_contrast.png
                                 "Shows the Material Design font opacities")
-<!--{: .illustration }-->
+<!--{: .article__asset.article__asset--illustration }-->
 
 ## Examples
 
@@ -252,7 +265,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 
 ...
 
-- (BOOL)application:(UIApplication *)application 
+- (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   // Before any UI is called
   [MDCTypography setFontLoader:[[CustomFontLoader alloc] init]];

--- a/contributing/.jekyll_prefix.yaml
+++ b/contributing/.jekyll_prefix.yaml
@@ -1,5 +1,0 @@
----
-title:  "Contributing"
-layout: landing
-section: contributing
----

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -1,10 +1,16 @@
+<!--docs:
+title:  "Contributing"
+layout: landing
+section: contributing
+-->
+
 # General Contributing Guidelines
 
 The Material Components contributing policies and procedures can be found in the main Material Components documentation repository’s [contributing page](https://github.com/material-components/material-components/blob/develop/CONTRIBUTING.md).
 
 ## iOS-specific Additions
 
-The iOS team also abides by the following policy items: 
+The iOS team also abides by the following policy items:
 
 ### Code Conventions
 
@@ -29,7 +35,7 @@ Start the title with `[ComponentName]` to identify which component a change affe
 
 #### Using assignee to indicate who should action on a PR
 
-Since PRs on github permanently stay in the `Changes requested` state it is hard to tell when the author has addressed the concerns. By change the assignee to whomever still needs to action (review or modify/justify) we can more easily keep track of what needs attention in our PR queues. 
+Since PRs on github permanently stay in the `Changes requested` state it is hard to tell when the author has addressed the concerns. By change the assignee to whomever still needs to action (review or modify/justify) we can more easily keep track of what needs attention in our PR queues.
 
 1. For a reviewer this means adding the author as an assignee once the review is finished.
 1. For an author it means adding back the reviewer (and removing themselves) as an assignee.
@@ -45,7 +51,7 @@ Occasionally it is necessary to hotfix the framework. See [hotfixing.md](hotfixi
 
 ## Finding an issue to work on
 
-MDC-iOS uses GitHub to file and track issues. 
+MDC-iOS uses GitHub to file and track issues.
 To find an issue to work on, filter the issues list by the ["is:Help wanted" label](https://github.com/material-components/material-components-ios/labels/is%3AHelp%20wanted).
 
 ## The small print

--- a/contributing/site_content_update.md
+++ b/contributing/site_content_update.md
@@ -1,0 +1,79 @@
+# Site Content Update
+
+## Overview
+Material Components for iOS site consists of 2 parts: [document site](https://material-ext.appspot.com/mdc-ios-preview/) and API reference site of each components (e.g, [AppBar API](https://material-ext.appspot.com/mdc-ios-preview/components/AppBar/apidocs/Classes/MDCAppBarContainerViewController.html), etc...)
+
+This document will walk you through the process for updating the contents on document site and API reference, or adding new sections to the document site. You only need to edit markdown files in most cases, however, if you wish to make further changes to the templates, please read to [Site Development](./site_development.md).
+
+
+## Updating Content
+
+### Document Site and GitHub README.md
+
+#### Syntax
+
+Material Components for iOS uses [Jekyll](https://jekyllrb.com/) to help transform Markdown files into static HTML. This means although it is consistent with GitHub Flavored Markdown for most cases, we do have some style classes and special javascript to handle complicate rendering for the website. Please refer to [Writing READMES](./writing_readmes.md) for the syntax we use.
+
+#### Structure
+
+The document site and GitHub README.md have the exact 1:1 mapping structure, except for the homepage.
+
+- homepage -> site-index.md
+- howto -> howto/README.md
+- howto/[tutorial_name] -> howto/[tutorial_name]/README.md
+- components -> components/README.md
+- components/[component_name] -> components/[component_name]/README.md
+- contributing -> contributing/README.md
+
+#### Add new sections
+
+If you are going to add new sections to the website, you need to modify the configuration file, so that the build system will be aware of the modified structure during build process.
+
+To set it up, run
+
+```
+scripts/build_site.sh --setup
+
+# Modify the navigation data file
+vim site-source/jekyll-site-src/_data/navigation.yaml
+```
+
+In this case, you should change your working directory into `site-source` and run any git commands in that folder.
+
+```
+cd site-source
+# and do git commit & push here...
+```
+
+This relates to how the site is organized. If you are curious about that, you may read the appendix at the end of [Site Development](./site_development.md).
+
+### API Reference
+
+Material Components for iOS uses [jazzy](https://github.com/realm/jazzy) to transform the inline comments in the header files and make it into API reference document. See [their syntax](https://github.com/realm/jazzy#supported-keywords) for updating inline comments in components header files.
+
+## Build and Preview locally
+
+Run the following command and follow the instructions on the command line.
+
+    scripts/build_site.sh
+
+The site should be served at [127.0.0.1:4000](http://127.0.0.1:4000) after build by default.
+
+## Deploy to production
+
+You need to be one of the Material Components for iOS core members in order to deploy the site for the moment. However, we will incorporate the changes to the site for every weekly cut release as well.
+
+If you are able to deploy the site, run
+
+``` bash
+# Run these to install gsutil for the first time
+curl https://sdk.cloud.google.com | bash
+exec -l $SHELL
+#Set up the gsutil authentication information, it doesn't matter which app engine project you choose.
+gcloud init
+
+# Deploy it!
+scripts/build_site.sh --deploy production
+```
+
+Open the [Material Components for iOS](https://material-ext.appspot.com/mdc-ios-preview) site and make sure your modification is there.

--- a/contributing/site_development.md
+++ b/contributing/site_development.md
@@ -1,0 +1,243 @@
+# Site Development
+
+**This document talks about Material Components for iOS site development. If you are trying to
+updating the contents of site, please refer to [Site Content Update](./site_content_update.md)
+instead.**
+
+
+## Overview
+
+Material Components for iOS site consists of 2 parts: [document
+site](https://material-ext.appspot.com/mdc-ios-preview/) and API reference site of each components
+(e.g, [AppBar
+API](https://material-ext.appspot.com/mdc-ios-preview/components/AppBar/apidocs/Classes/MDCAppBarContainerViewController.html),
+etc...)
+
+This document will walk you through how you get the sources, modify and deploy the site. If you are
+curious about how the sources are organized, you may also read the [in depth
+explanation](#appendix-how) at the last of this document.
+
+
+## Get the sources of the site
+
+**If you have ever built the site (no matter run it locally or deploy to the production), you may
+skip this step.**
+
+Make sure you are under **develop** branch and have the latest code pulled. Then run the following
+script.
+
+```scripts/build_site.sh --setup```
+
+The sources of the site will be pulled under a folder called *site-source* under your root folder of
+the repository.
+
+
+## Develop the site
+
+### Develop the document site
+
+Material component for ios uses [jekyll](https://jekyllrb.com/) to help transform the markdowns into
+static HTML.
+
+The sources *site-source/jekyll-site-src* respect the [directory structure
+requirements](https://jekyllrb.com/docs/structure/) of jekyll with a few exceptions. Here is an
+overview of the directory structure for mdc:
+
+- _includes & _layout: the template used by the document site with [liquid
+  tag](https://github.com/Shopify/liquid/wiki)
+
+- _sass: the style of the document site
+
+    - base.scss: the basic style of the default html tags. Most of the styles respect [material
+      design guideline](https://www.google.com/design/spec/)
+
+    - _globals.scss: the variables and responsive grid definitions.
+
+    - _layout: the style defined for document site. You will modify this file for most of the cases.
+
+    - _layout-api: the style defined for API reference site. This is a bit confusing but API
+      reference is actually built in as part of the document site and we want to utilize the syle we
+have for the document site.
+
+    - _icons & _step-sequence & _codemirror-syntax-highlighting: These are the utility class for all
+      icons, step by step guidance and code renderer for example code.
+
+- css: the css that specify which above styles should be included
+
+- _data: the definition of the navigation side bar
+
+- other assets: images, js, thirdparty
+
+Attention should be paid that *components*, *contributing*, *howto* are all copied files and will be
+override at the time when document site is built. So if you are trying to modify the content of
+these files, please read [Site Content Update](/site_content_update.md).
+
+Since the document site uses the feature of jekyll like [Front
+Matter](https://jekyllrb.com/docs/frontmatter/),
+[Configure](https://jekyllrb.com/docs/configuration/), we suggest you to read jekyll's document if
+you are going to develop the site.
+
+
+### Develop the API reference site
+
+Material component for ios uses [jazzy](https://github.com/realm/jazzy) to transform the inline
+comments in the header files and make it into API reference document.
+
+The sources *site-source/apidocs-site-src* contains the theme and assets. When you build the API
+reference, the API reference will be generated and copied to each components folder under
+*jekyll-site-src/components* and later be build as part of the document site. Because of that, if
+you are trying to modify the styling of the site, we suggest you to modify
+*site-source/jekyll-site-src/_scss/_layout-api.scss* instead of css in *theme/assets/css* folder.
+
+
+## Deploy the site
+
+### Serve the site locally
+
+Run the following command and follow the hint in the command line.
+
+    scripts/build_site.sh
+
+The site should be served at [127.0.0.1:4000](http://127.0.0.1:4000) after build by default.
+
+
+### Commit the changes
+
+You should change your working directory into *site-source* and run git command in that folder
+
+```
+cd site-source
+# and do git commit here...
+```
+
+
+We recommend you to read appendix at the last of this document if you want to know how the sources
+are organized.
+
+
+### Deploy the site to production
+
+You need to be one of the Material component core members in order to deploy the site for the
+moment. However, we will incorporate the changes to the site for every weekly cut release as well.
+
+If you are able to deploy the site, run
+
+```
+# Run these to install gsutil for the first time
+curl https://sdk.cloud.google.com | bash
+exec -l $SHELL
+# Set up the gsutil authentication information, it doesn't matter which app engine project you
+# choose.
+gcloud init
+
+# Deploy it!
+scripts/build_site.sh --deploy production
+```
+
+Open [Material Component site](https://material-ext.appspot.com/mdc-ios-preview) and make sure your
+modification is there.
+
+
+## TODO: Modify the site build script
+
+## Appendix - How are the sources organized?
+
+### Overview & Architecture Graph
+
+Material component ios repository is the place where all components and their documents live. Just
+like most of other open source projects, core developers and community members will be actively
+improving the components on master/develop branch. Meanwhile, we also want our website get those
+updates as soon as the changes are pushed and merged, but leave the process as simple as pull out a
+rabbit from the magic hat, without you switching between branches.
+
+The secret sauce we use is "locally nested structure", where contents and templates are separated in
+2 branches (master/develop and site-source) but locally nested one under the other. It is easily to
+understand with the following graph:
+
+![mdc local folder and branch structure](./mdc-local-folder-and-branch-structure.png)
+
+It is pretty clear that the site should be thought as 2 parts: the contents and the templates. In
+our case, the contents are documents of the components.
+
+As shown in the graph, the document lives together with the component it is documenting, so that
+whoever update the component will be able to quickly find the document needed to update and commit
+together with the code. On the other hand, the templates live on another branch called "site-source"
+and they describe what the website should be look like. Since we separate contents and templates
+into branches, it decouples site and components development.
+
+But then how can we let the developers preview their updates to make sure they are not breaking the
+site? The answer lies in the local folder structure. In the repository folder, we cloned another
+repository, put it in a folder called site-source and switch the branch in that folder to
+site-source. Let's actually look at the build process to see what is happening there. But before we
+dive into that, we should also re-emphasize that this folder is gitignored so git won't ever notice
+nor ever commit you local build and previews.
+
+### Build Process
+
+The build process has 2 steps:
+
+- Build the api reference
+- Build the document site
+
+Since the api reference is part of the contents of the document site, so step 1 need to be carried
+out before step 2.
+
+In step 1, we build the api reference from the inline comments of the components using
+[Jazzy](./site_content_update.md#api-reference). The api reference are output to the jekyll folder
+in preparation for step 2.
+
+In step 2, the documents sepcified in ```site-source/jekyll-site-src/_data/navigation.yaml``` are
+copied to the corresponding place and rename to index.md for servering purpose. Jekyll processes
+these files and generates static html into ```site-source/site-build```.
+
+After build, local server might run servering the static html for developer to preview or it will be
+deployed to the production server. We would like to add a git hook, so that when update get merged
+into master branch, the site will be rebuild and pushed at the same time secretly from the
+developer.
+
+
+### Intent behind this
+
+Although the structure seems hard to understand at first glance, it have several benefits once you
+get the gists.
+
+- Benefits of decoupling
+
+  The components developers and site developers' work should not ever interfere with each other. We
+need to ensure in the worst scenario that if one of them need to roll back several commits, the
+other team should not even notice that happened, which obviously cannot be achieved if the contents
+and templates lives in the same branch.
+
+- Single source of truth and clear responsibility
+
+  There is only a single source of the truth for both the contents and templates. While the site
+developer has the authority for styling the site as they like, they probably won't have insights of
+the detailed contents that should be put on the website, component developers vise versa. We barely
+defined the syntax as the protocol for communication, so each party can work on its own thing and
+hold their absolute authority on that.
+
+- Preserve document on github
+
+  Since we only have one set of truth for content and all the other are clearly copies of them, we
+preserve the README.md in the place that github can still find them, so you can read them directly
+on github and even if you are not linked to the internet, you will be able to see all document in
+your local repository
+
+- Benefit of non-blocking
+
+  The component developers should never be blocked by the site developers when updating the content,
+nor should bother the site developers to stop what they are doing and help them with merely an
+content update. In this case, we are not only separating the authority but also make it possible for
+each party to update on their own pace.
+
+- Intuitively find what you need to update
+
+  The site has exactly 1:1 map onto the source that generate the page. For example, if you are
+updating the components/Button/ page, you can find the document right at
+components/Button/README.md, which is also right besides the Button.h and Button.m file
+
+- Simply works
+
+  You actually don't need to understand all the structure if you are not curious. You can write the
+components, update the documents and preview, or you can update the style and see without switch
+branches. You don't need to understand all the nitty-gritty about all these, it simply works.

--- a/contributing/writing_readmes.md
+++ b/contributing/writing_readmes.md
@@ -10,32 +10,27 @@ fill out have been marked with `TODO` statements.
 
     # TODO: ComponentName
 
-    TODO: screenshot.png is made on iPhone 5 simulator
-    ![TODO: ComponentName](docs/assets/screenshot.png)
-    <!--{: .ios-screenshot .right }-->
-
     TODO: Single sentence description of the component.
-    <!--{: .intro :}-->
+    <!--{: .article__intro }-->
 
-    ### Material Design Specifications
+    ## Design & API Documentation
 
     <ul class="icon-list">
-      <li class="icon-link">
+      <li class="icon-spec">
         <a href="https://www.google.com/design/spec/<TODO: link to spec>">
           TODO: link to spec
         </a>
       </li>
-    </ul>
-
-    ### API Documentation
-
-    <ul class="icon-list">
       <li class="icon-link">
         <a href="/components/<ComponentName>/apidocs/Classes/<TODO: API name>.html">
           TODO: API name
         </a>
       </li>
     </ul>
+
+    TODO: screenshot.png is made on iPhone 5 simulator
+    ![TODO: ComponentName](docs/assets/screenshot.png)
+    <!--{: .article__asset.article__asset--screenshot }-->
 
     - - -
 

--- a/howto/.jekyll_prefix.yaml
+++ b/howto/.jekyll_prefix.yaml
@@ -1,5 +1,0 @@
----
-title:  "How to use Material Components"
-layout: landing
-section: howto
----

--- a/howto/README.md
+++ b/howto/README.md
@@ -1,3 +1,9 @@
+<!--docs:
+title:  "How to use Material Components"
+layout: landing
+section: howto
+-->
+
 # How to use Material Components
 
 Material Components for iOS should be immediately useable out of the box with
@@ -23,4 +29,4 @@ Apple's standard development tool chain.
 - [MDC-iOS on Stack Overflow](https://www.stackoverflow.com/questions/tagged/material-components+ios) (external site)
 - [Material.io](https://www.material.io) (external site)
 - [Material Design Guidelines](https://material.google.com) (external site)
-  
+

--- a/howto/build-env/.jekyll_prefix.yaml
+++ b/howto/build-env/.jekyll_prefix.yaml
@@ -1,5 +1,0 @@
----
-title:  "Build environment"
-layout: landing
-section: howto
----

--- a/howto/build-env/README.md
+++ b/howto/build-env/README.md
@@ -1,3 +1,9 @@
+<!--docs:
+title:  "Build environment"
+layout: landing
+section: howto
+-->
+
 # Build environment
 
 Material Components for iOS builds with the standard open-source iOS toolchain:

--- a/howto/faq/.jekyll_prefix.yaml
+++ b/howto/faq/.jekyll_prefix.yaml
@@ -1,5 +1,0 @@
----
-title:  "Frequently Asked Questions"
-layout: landing
-section: howto
----

--- a/howto/faq/README.md
+++ b/howto/faq/README.md
@@ -1,3 +1,9 @@
+<!--docs:
+title:  "Frequently Asked Questions"
+layout: landing
+section: howto
+-->
+
 ## Frequently Asked Questions
 
 ### How do we stay true to our brand while using Material Design?

--- a/howto/tutorial/.jekyll_prefix.yaml
+++ b/howto/tutorial/.jekyll_prefix.yaml
@@ -1,5 +1,0 @@
----
-title:  "Material Components Development Guide"
-layout: landing
-section: howto
----

--- a/howto/tutorial/README.md
+++ b/howto/tutorial/README.md
@@ -1,3 +1,9 @@
+<!--docs:
+title:  "Material Components Development Guide"
+layout: landing
+section: howto
+-->
+
 ## Tutorial
 
 Whether new or legacy, storyboard or code, Swift or Objective C, it's easy to use Material Components in your app.
@@ -129,7 +135,7 @@ Open `Main.storyboard` and delete the default view controller that came with it.
 
 <!--{% if site.link_to_site == "true" %}-->
 [![In the storyboard, replacing the default view controller](docs/assets/Xcode-Storyboard-Replace-Controller.jpg)](docs/assets/Xcode-Storyboard-Replace-Controller.m4v)
-<!--{% else %}<div class="ios-animation large" markdown="1"><video src="docs/assets/Xcode-Storyboard-Replace-Controller.m4v" autoplay loop></video></div>{% endif %}-->
+<!--{% else %}<div class="article__asset large" markdown="1"><video src="docs/assets/Xcode-Storyboard-Replace-Controller.m4v" autoplay loop></video></div>{% endif %}-->
 
 
 Select the prototype cell and set its custom class to `MDCCollectionViewTextCell`,
@@ -138,7 +144,7 @@ then set its reuse identifier to `cell`:
 
 <!--{% if site.link_to_site == "true" %}-->
 [![In the storyboard, changing the cell class and identifier](docs/assets/Xcode-Storyboard-Define-Cell.jpg)](docs/assets/Xcode-Storyboard-Define-Cell.m4v)
-<!--{% else %}<div class="ios-animation large" markdown="1"><video src="docs/assets/Xcode-Storyboard-Define-Cell.m4v" autoplay loop></video></div>{% endif %}-->
+<!--{% else %}<div class="article__asset large" markdown="1"><video src="docs/assets/Xcode-Storyboard-Define-Cell.m4v" autoplay loop></video></div>{% endif %}-->
 
 
 In `viewDidLoad`, configure the collection view’s appearance:
@@ -782,13 +788,14 @@ Use our examples and catalog apps to try out other components and other ways to 
 <!--{% if site.link_to_site == "true" %}-->
 <img src="docs/assets/Pesto.gif">
 <img src="docs/assets/Shrine.gif">
-<!--{% else %}<div class="ios-animation right" markdown="1">
-<img src="docs/assets/Shrine.gif">
+<!--{% else %}
+<div class="article__asset article__asset--screenshot" markdown="1">
+  <img src="docs/assets/Shrine.gif">
 </div>
-
-<div class="ios-animation left" markdown="1">
-<img src="docs/assets/Pesto.gif">
-</div> {% endif %}-->
+<div class="article__asset left" markdown="1">
+  <img src="docs/assets/Pesto.gif">
+</div>
+{% endif %}-->
 
 ---
 

--- a/scripts/build_site.sh
+++ b/scripts/build_site.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright 2015-present the Material Components for iOS authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Validate arguments options
+args=$*
+
+# Checking prerequisites for folders
+# Getting the link for github repository
+GITHUB_REMOTE="git@github.com:material-components/material-components-site-generator.git"
+SITE_SOURCE_BRANCH='master'
+SITE_SOURCE_FOLDER='docsite'
+
+# Switching to the root folder of mdc
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$DIR/.."
+ROOT_DIR="$(pwd)"
+
+# # If site-source doesn't exist, clone the repository into site-source folder
+if [[ -d ./$SITE_SOURCE_FOLDER ]]; then
+  echo "Update site folder..."
+  pushd $SITE_SOURCE_FOLDER
+  git checkout $SITE_SOURCE_BRANCH >> /dev/null 2> /dev/null
+  git pull >> /dev/null 2> /dev/null
+  popd
+else
+  echo "Set up site folder...";
+  git clone $GITHUB_REMOTE $SITE_SOURCE_FOLDER || { echo "Failed to clone."; exit 1; }
+  echo "Please follow the instructions in docsite/README.md, then run build_site.sh to complete the build.";
+  exit 0
+fi
+
+# If it is not for set up, build site
+pushd $SITE_SOURCE_FOLDER
+$ROOT_DIR/$SITE_SOURCE_FOLDER/scripts/build $args ..
+popd

--- a/scripts/check/left_nav
+++ b/scripts/check/left_nav
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+readonly COMPONENT_DIR=$1
+
+readonly SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly ROOT_DIR=$(dirname $(dirname "$SCRIPTS_DIR"))
+readonly NAV_YAML="$ROOT_DIR/site-source/jekyll-site-src/_data/navigation.yaml"
+
+if [ ! -f $NAV_YAML ]; then
+  echo "Error: Could not find the left nav configuration at '$NAV_YAML'."
+  echo "Please run scripts/build_site.sh once to install the site sources."
+  exit -1
+fi
+
+readonly COMPONENT_NAME=$(basename $COMPONENT_DIR)
+
+# Private components should not exist in the left nav.
+if [[ "$COMPONENT_DIR" == *"private/"* ]]; then
+  should_exist=0
+else
+  should_exist=1
+fi
+
+# Search for an entry like "- name: ComponentName", which is the list entry for the
+# component in the left nav.
+GREP_OPTIONS="--quiet"
+grep $GREP_OPTIONS -- "- name: $COMPONENT_NAME" $NAV_YAML
+if [[ "$?" -eq 0 ]]; then 
+  found=1
+else
+  found=0
+fi
+
+if [[ $should_exist -eq 1 ]]; then
+  if [[ $found -eq 0 ]]; then
+    echo "Error: $COMPONENT_NAME not found in left nav config '$NAV_YAML'."
+    exit -1
+  fi
+else
+  if [[ $found -eq 1 ]]; then
+    echo "Error: Private component $COMPONENT_NAME found in left nav config '$NAV_YAML'."
+    exit -1
+  fi
+fi 

--- a/scripts/check/site_icon
+++ b/scripts/check/site_icon
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+readonly COMPONENT_DIR=$1
+readonly COMPONENT_NAME=$(basename $COMPONENT_DIR)
+readonly SCRIPTS_DIR="$(dirname $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd))"
+readonly ROOT_DIR=$(dirname "$SCRIPTS_DIR")
+readonly ICONS_DIR="$ROOT_DIR/site-source/jekyll-site-src/images/custom_icons"
+readonly ICONS_CSS="$ROOT_DIR/site-source/jekyll-site-src/_sass/_icons.scss"
+
+if [ ! -d $ICONS_DIR ]; then
+  echo "Error: Could not find the icons directory at '$ICONS_DIR'."
+  echo "Please run scripts/build_site.sh once to install the site sources."
+  exit -1
+fi
+
+# Private components do not require an icon.
+if [[ $COMPONENT_DIR != *"/private/"* ]]; then
+  # Check for the icon on disk.
+  readonly UNDERSCORE_NAME=$($SCRIPTS_DIR/convert_name -m underscore $COMPONENT_NAME)
+  readonly ICON_NAME="ic_${UNDERSCORE_NAME}_24px.svg"
+  if [ ! -f "$ICONS_DIR/$ICON_NAME" ]; then
+    echo "Error: '$ICONS_DIR' is missing '$ICON_NAME'."
+    exit -1
+  fi
+
+  # Check for a reference to the icon in the _icons.scss.
+  GREP_OPTIONS="--quiet"
+  GREP_PATTERN="background-image:.*images/custom_icons/$ICON_NAME"
+  if ! grep $GREP_OPTIONS -- $GREP_PATTERN $ICONS_CSS; then
+    echo "Error: Could not find entry for $ICON_NAME in '$ICONS_CSS'."
+    exit -1
+  fi
+fi

--- a/site-index.md
+++ b/site-index.md
@@ -1,0 +1,144 @@
+---
+title:  "Material Components for iOS"
+layout: "homepage"
+---
+
+# Material Components for&nbsp;iOS
+<!--{: .title }-->
+
+An easy way to create beautiful apps with modular and customizable UI&nbsp;components.
+<!--{: .subhead }-->
+
+[Get Started](#quickstart)
+[View on GitHub](https://github.com/material-components/material-components-ios)
+<!--{: .button-getstarted }-->
+
+<a name="quickstart"></a>
+<!--{: .jumplink }-->
+
+1.  ## Install CocoaPods
+
+    [CocoaPods](https://cocoapods.org/) is the easiest way to get started.
+    If you're new to CocoaPods, check out their
+    [getting started documentation](https://guides.cocoapods.org/using/getting-started.html).
+
+    To install CocoaPods, run the following commands:
+
+    ~~~ bash
+    sudo gem install cocoapods
+    ~~~
+
+
+2.  ## Create Podfile
+
+    Once you've created an iOS application in Xcode you can start using
+    Material Components for iOS.
+
+    To initialize CocoaPods in your project, run the following commands:
+
+    ~~~ bash
+    cd your-project-directory
+    pod init
+    ~~~
+
+3.  ## Edit Podfile
+
+    Once you've initialized CocoaPods, add the
+    [Material Components for iOS Pod](https://cocoapods.org/pods/MaterialComponentsIOS)
+    to your target in your Podfile:
+
+
+    ~~~ ruby
+    target "MyApp" do
+      ...
+      pod 'MaterialComponents'
+    end
+    ~~~
+
+    If you are using Swift, don’t forget to uncomment the `use_frameworks!` line
+    at the top of your Podfile.
+
+    Then run the command:
+
+    ~~~ bash
+    pod install
+    open your-project.xcworkspace
+    ~~~
+
+    Now you're ready to get started in Xcode.
+
+4.  ## Usage
+
+    Now you’re ready to add a component (e.g. Buttons) to your app!
+    Include the Material Components header for the component you're interested
+    in to your app (detailed below) to get all of the required classes.
+
+    Choose from Objective-C or Swift:
+
+    <!--<div class="material-code-render" markdown="1">-->
+    #### Objective-C
+
+    ~~~ objc
+    #import "MaterialButtons.h"
+
+    @implementation ViewController
+
+    - (void)viewDidLoad {
+      [super viewDidLoad];
+
+      MDCRaisedButton *raisedButton = [MDCRaisedButton new];
+      [raisedButton setTitle:@"Raised Button" forState:UIControlStateNormal];
+      [raisedButton sizeToFit];
+      [raisedButton addTarget:self
+                       action:@selector(tapped:)
+             forControlEvents:UIControlEventTouchUpInside];
+
+      [self.view addSubview:raisedButton];
+    }
+
+    - (void)tapped:(id)sender {
+      NSLog(@"Button was tapped!");
+    }
+
+    @end
+    ~~~
+
+    #### Swift
+
+    ~~~ swift
+    import MaterialComponents.MaterialButtons
+
+    class MDCBuildTestViewController: UIViewController {
+
+        override func viewDidLoad() {
+            super.viewDidLoad()
+            let raiseButton = MDCRaisedButton.init();
+            raiseButton.setTitle("Raised Button", forState: .Normal);
+            raiseButton.sizeToFit();
+            raiseButton.addTarget(self, action: "tapped:", forControlEvents: .TouchUpInside);
+            self.view.addSubview(raiseButton);
+        }
+
+        func tapped(sender: UIButton!){
+            NSLog("Button was tapped!");
+        }
+
+    }
+    ~~~
+    <!--</div>-->
+
+5.  ## What's next?
+
+    - [Read the Development Guide]({{ site.folder }}/howto/)
+      <!--{: .icon-guide }-->
+
+    - [View the Component Documentation]({{ site.folder }}/components/)
+      <!--{: .icon-components }-->
+
+    - [Explore our Code Samples]({{ site.folder }}/howto/tutorial/#sample-code)
+      <!--{: .icon-sample }-->
+
+    - [View the project on GitHub](https://github.com/material-components/material-components-ios/)
+      <!--{: .icon-github }-->
+    <!--{: .icon-list }-->
+<!--{: .step-sequence }-->


### PR DESCRIPTION
There are more changes to come, but it's time we merged back.

Changes:
* Re-introduces the doc site scripts and files that had been deleted previously.
* Updates contributing docs to reflect doc structure changes.
* Applies common header structure across all component documentation.
* Fixes a bunch of liquid syntax bugs.
* Inlines Front Matter metadata in README.md files as HTML comments. Any file prefixed with
```
  <!--docs:
  ...yaml
  -->
```
  Will be converted into Front Matter when generating the site.
* .jekyll_prefix files, which previously stored the data, have been removed.