### PR TITLE
[docs] Associated icons with components

### DIFF
--- a/components/ActivityIndicator/README.md
+++ b/components/ActivityIndicator/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Activity Indicator"
+title: "Activity Indicator"
 layout: detail
 section: components
 excerpt: "Progress and activity indicators are visual indications of an app loading content."

--- a/components/ActivityIndicator/README.md
+++ b/components/ActivityIndicator/README.md
@@ -3,6 +3,7 @@ title:  "Activity Indicator"
 layout: detail
 section: components
 excerpt: "Progress and activity indicators are visual indications of an app loading content."
+iconId: progress_activity
 -->
 
 # Activity Indicator

--- a/components/AnimationTiming/README.md
+++ b/components/AnimationTiming/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Animation Timing"
+title: "Animation Timing"
 layout: detail
 section: components
 excerpt: "Material Design animation timing curves."

--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -3,6 +3,7 @@ title:  "App Bar"
 layout: detail
 section: components
 excerpt: "The App Bar is a flexible navigation bar designed to provide a typical Material Design navigation experience."
+iconId: toolbar
 -->
 
 # App Bar

--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "App Bar"
+title: "App Bar"
 layout: detail
 section: components
 excerpt: "The App Bar is a flexible navigation bar designed to provide a typical Material Design navigation experience."

--- a/components/ButtonBar/README.md
+++ b/components/ButtonBar/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Button Bar"
+title: "Button Bar"
 layout: detail
 section: components
 excerpt: "The Button Bar component is a view that facilitates the creation and layout of a horizontally-aligned list of buttons."

--- a/components/ButtonBar/README.md
+++ b/components/ButtonBar/README.md
@@ -3,6 +3,7 @@ title:  "Button Bar"
 layout: detail
 section: components
 excerpt: "The Button Bar component is a view that facilitates the creation and layout of a horizontally-aligned list of buttons."
+iconId: button
 -->
 
 # Button Bar

--- a/components/Buttons/README.md
+++ b/components/Buttons/README.md
@@ -3,6 +3,7 @@ title:  "Buttons"
 layout: detail
 section: components
 excerpt: "Buttons is a collection of Material Design buttons, including a flat button, a raised button and a floating action button."
+iconId: button
 -->
 
 # Buttons

--- a/components/Buttons/README.md
+++ b/components/Buttons/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Buttons"
+title: "Buttons"
 layout: detail
 section: components
 excerpt: "Buttons is a collection of Material Design buttons, including a flat button, a raised button and a floating action button."

--- a/components/CollectionCells/README.md
+++ b/components/CollectionCells/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Collection Cells"
+title: "Collection Cells"
 layout: detail
 section: components
 excerpt: "Collection view cell classes that adhere to Material Design layout and styling."

--- a/components/CollectionCells/README.md
+++ b/components/CollectionCells/README.md
@@ -3,6 +3,7 @@ title:  "Collection Cells"
 layout: detail
 section: components
 excerpt: "Collection view cell classes that adhere to Material Design layout and styling."
+iconId: list
 -->
 
 # Collection Cells

--- a/components/CollectionLayoutAttributes/README.md
+++ b/components/CollectionLayoutAttributes/README.md
@@ -3,6 +3,7 @@ title:  "Collection Layout Attributes"
 layout: detail
 section: components
 excerpt: "Allows passing layout attributes to the cells and supplementary views."
+iconId: list
 -->
 
 # Collection Layout Attributes

--- a/components/CollectionLayoutAttributes/README.md
+++ b/components/CollectionLayoutAttributes/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Collection Layout Attributes"
+title: "Collection Layout Attributes"
 layout: detail
 section: components
 excerpt: "Allows passing layout attributes to the cells and supplementary views."

--- a/components/Collections/README.md
+++ b/components/Collections/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Collections"
+title: "Collections"
 layout: detail
 section: components
 excerpt: "Collection view classes that adhere to Material Design layout and styling."

--- a/components/Collections/README.md
+++ b/components/Collections/README.md
@@ -3,6 +3,7 @@ title:  "Collections"
 layout: detail
 section: components
 excerpt: "Collection view classes that adhere to Material Design layout and styling."
+iconId: list
 -->
 
 # Collections

--- a/components/Collections/editing/README.md
+++ b/components/Collections/editing/README.md
@@ -2,6 +2,7 @@
 title:  "Editing the collection view"
 layout: detail
 section: components
+iconId: list
 ---
 # Editing the collection view
 
@@ -53,19 +54,19 @@ override func collectionView(collectionView: UICollectionView,
 ~~~
 <!--</div>-->
 
-> Important: When enabling editing, if your custom view controller incorporates section headers or 
-> footers you must include the below code at the top of your implementation of the 
+> Important: When enabling editing, if your custom view controller incorporates section headers or
+> footers you must include the below code at the top of your implementation of the
 > **collectionView:viewForSupplementaryElementOfKind:atIndexPath:** method as shown below.
 > <!--<div class="material-code-render" markdown="1">-->
 > #### Objective-C
 > ~~~ objc
-> - (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView 
->            viewForSupplementaryElementOfKind:(NSString *)kind 
+> - (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView
+>            viewForSupplementaryElementOfKind:(NSString *)kind
 >                                  atIndexPath:(NSIndexPath *)indexPath
 > {
 >
->   id supplementaryView = [super collectionView:collectionView 
->              viewForSupplementaryElementOfKind:kind 
+>   id supplementaryView = [super collectionView:collectionView
+>              viewForSupplementaryElementOfKind:kind
 >                                    atIndexPath:indexPath];
 >   if (supplementaryView) {
 >     return supplementaryView;
@@ -73,16 +74,16 @@ override func collectionView(collectionView: UICollectionView,
 >
 >   // Custom Section Header Code
 > ~~~
-> 
+>
 > #### Swift
-> ~~~ swift 
-> override func collectionView(_ collectionView: UICollectionView, 
->        viewForSupplementaryElementOfKind kind: String, 
+> ~~~ swift
+> override func collectionView(_ collectionView: UICollectionView,
+>        viewForSupplementaryElementOfKind kind: String,
 >                                  at indexPath: IndexPath) -> UICollectionReusableView
 > {
 >
->   var supplementaryView = super.collectionView(collectionView, 
->                             viewForSupplementaryElementOfKind: kind, 
+>   var supplementaryView = super.collectionView(collectionView,
+>                             viewForSupplementaryElementOfKind: kind,
 >                                                            at: indexPath)
 >   if supplementaryView != nil {
 >     return supplementaryView

--- a/components/Collections/editing/README.md
+++ b/components/Collections/editing/README.md
@@ -1,5 +1,5 @@
 ---
-title:  "Editing the collection view"
+title: "Editing the collection view"
 layout: detail
 section: components
 iconId: list

--- a/components/Collections/styling/README.md
+++ b/components/Collections/styling/README.md
@@ -2,6 +2,7 @@
 title:  "Styling the collection view"
 layout: detail
 section: components
+iconId: list
 ---
 # Styling the collection view
 

--- a/components/Collections/styling/README.md
+++ b/components/Collections/styling/README.md
@@ -1,5 +1,5 @@
 ---
-title:  "Styling the collection view"
+title: "Styling the collection view"
 layout: detail
 section: components
 iconId: list

--- a/components/Dialogs/README.md
+++ b/components/Dialogs/README.md
@@ -3,6 +3,7 @@ title:  "Dialogs"
 layout: detail
 section: components
 excerpt: "The Dialogs component implements the Material Design specifications for modal presentations."
+iconId: dialog
 -->
 
 # Dialogs

--- a/components/Dialogs/README.md
+++ b/components/Dialogs/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Dialogs"
+title: "Dialogs"
 layout: detail
 section: components
 excerpt: "The Dialogs component implements the Material Design specifications for modal presentations."

--- a/components/FeatureHighlight/README.md
+++ b/components/FeatureHighlight/README.md
@@ -3,6 +3,7 @@ title:  "Feature Highlight"
 layout: detail
 section: components
 excerpt: "Feature Highlight highlights a part of the screen in order to introduce users to new features and functionality."
+iconId: feature_highlight
 -->
 
 # Feature Highlight

--- a/components/FeatureHighlight/README.md
+++ b/components/FeatureHighlight/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Feature Highlight"
+title: "Feature Highlight"
 layout: detail
 section: components
 excerpt: "Feature Highlight highlights a part of the screen in order to introduce users to new features and functionality."

--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Flexible Header"
+title: "Flexible Header"
 layout: detail
 section: components
 excerpt: "The Flexible Header is a container view whose height and vertical offset react to UIScrollViewDelegate events."

--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -3,6 +3,7 @@ title:  "Flexible Header"
 layout: detail
 section: components
 excerpt: "The Flexible Header is a container view whose height and vertical offset react to UIScrollViewDelegate events."
+iconId: header
 -->
 
 # Flexible Header

--- a/components/HeaderStackView/README.md
+++ b/components/HeaderStackView/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Header Stack View"
+title: "Header Stack View"
 layout: detail
 section: components
 excerpt: "The Header Stack View component is a view that coordinates the layout of two vertically stacked bar views."

--- a/components/HeaderStackView/README.md
+++ b/components/HeaderStackView/README.md
@@ -3,6 +3,7 @@ title:  "Header Stack View"
 layout: detail
 section: components
 excerpt: "The Header Stack View component is a view that coordinates the layout of two vertically stacked bar views."
+iconId: header
 -->
 
 # Header Stack View

--- a/components/Ink/README.md
+++ b/components/Ink/README.md
@@ -3,6 +3,7 @@ title:  "Ink"
 layout: detail
 section: components
 excerpt: "The Ink component provides a radial action in the form of a visual ripple of ink expanding outward from the user's touch."
+iconId: ripple
 -->
 
 # Ink

--- a/components/Ink/README.md
+++ b/components/Ink/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Ink"
+title: "Ink"
 layout: detail
 section: components
 excerpt: "The Ink component provides a radial action in the form of a visual ripple of ink expanding outward from the user's touch."

--- a/components/NavigationBar/README.md
+++ b/components/NavigationBar/README.md
@@ -3,6 +3,7 @@ title:  "Navigation Bar"
 layout: detail
 section: components
 excerpt: "The Navigation Bar component is a view composed of a left and right Button Bar and either a title label or a custom title view."
+iconId: toolbar
 -->
 
 # Navigation Bar

--- a/components/NavigationBar/README.md
+++ b/components/NavigationBar/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Navigation Bar"
+title: "Navigation Bar"
 layout: detail
 section: components
 excerpt: "The Navigation Bar component is a view composed of a left and right Button Bar and either a title label or a custom title view."

--- a/components/OverlayWindow/README.md
+++ b/components/OverlayWindow/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "OverlayWindow"
+title: "OverlayWindow"
 layout: detail
 section: components
 excerpt: "A window for managing sets of overlay views."

--- a/components/OverlayWindow/README.md
+++ b/components/OverlayWindow/README.md
@@ -3,6 +3,7 @@ title:  "OverlayWindow"
 layout: detail
 section: components
 excerpt: "A window for managing sets of overlay views."
+iconId: tooltip
 -->
 
 # Overlay Window

--- a/components/PageControl/README.md
+++ b/components/PageControl/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Page Control"
+title: "Page Control"
 layout: detail
 section: components
 excerpt: "Page Control is a drop-in Material Design replacement for UIPageControl that implements Material Design animation and layout."

--- a/components/Palettes/README.md
+++ b/components/Palettes/README.md
@@ -3,6 +3,7 @@ title:  "Palettes"
 layout: detail
 section: components
 excerpt: "The Palettes component provides Material color palettes."
+iconId: color
 -->
 
 # Palettes

--- a/components/Palettes/README.md
+++ b/components/Palettes/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Palettes"
+title: "Palettes"
 layout: detail
 section: components
 excerpt: "The Palettes component provides Material color palettes."

--- a/components/ProgressView/README.md
+++ b/components/ProgressView/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Progress View"
+title: "Progress View"
 layout: detail
 section: components
 excerpt: "Progress View is a determinate and linear progress indicator that implements Material Design animation and layout."

--- a/components/ProgressView/README.md
+++ b/components/ProgressView/README.md
@@ -3,6 +3,7 @@ title:  "Progress View"
 layout: detail
 section: components
 excerpt: "Progress View is a determinate and linear progress indicator that implements Material Design animation and layout."
+iconId: progress_activity
 -->
 
 # Progress View

--- a/components/README.md
+++ b/components/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Material Components Documentation"
+title: "Material Components Documentation"
 layout: landing-no-drawer
 section: components
 -->

--- a/components/ShadowElevations/README.md
+++ b/components/ShadowElevations/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Shadow Elevations"
+title: "Shadow Elevations"
 layout: detail
 section: components
 excerpt: "The Shadow Elevations component provides the most commonly-used Material Design elevations."

--- a/components/ShadowLayer/README.md
+++ b/components/ShadowLayer/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Shadow Layer"
+title: "Shadow Layer"
 layout: detail
 section: components
 excerpt: "The Shadow Layer component implements the Material Design specifications for elevation and shadows."

--- a/components/Slider/README.md
+++ b/components/Slider/README.md
@@ -3,6 +3,7 @@ title:  "Slider"
 layout: detail
 section: components
 excerpt: "The Slider component provides a Material Design control for selecting a value from a continuous range or discrete set of values."
+iconId: slider
 -->
 
 # Slider

--- a/components/Slider/README.md
+++ b/components/Slider/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Slider"
+title: "Slider"
 layout: detail
 section: components
 excerpt: "The Slider component provides a Material Design control for selecting a value from a continuous range or discrete set of values."

--- a/components/Snackbar/README.md
+++ b/components/Snackbar/README.md
@@ -3,6 +3,7 @@ title:  "Snackbar"
 layout: detail
 section: components
 excerpt: "Snackbars provide brief feedback about an operation through a message at the bottom of the screen."
+iconId: toast
 -->
 
 # Snackbar

--- a/components/Snackbar/README.md
+++ b/components/Snackbar/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Snackbar"
+title: "Snackbar"
 layout: detail
 section: components
 excerpt: "Snackbars provide brief feedback about an operation through a message at the bottom of the screen."

--- a/components/Tabs/README.md
+++ b/components/Tabs/README.md
@@ -3,6 +3,7 @@ title:  "Tabs"
 layout: detail
 section: components
 excerpt: "TODO(shyndman): Excerpt needed."
+iconId: tabs
 -->
 
 # Tabs

--- a/components/Tabs/README.md
+++ b/components/Tabs/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Tabs"
+title: "Tabs"
 layout: detail
 section: components
 excerpt: "TODO(shyndman): Excerpt needed."

--- a/components/Typography/README.md
+++ b/components/Typography/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Typography"
+title: "Typography"
 layout: detail
 section: components
 excerpt: "The Typography component provides methods for displaying text using the type sizes and opacities from the Material Design specifications."

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Contributing"
+title: "Contributing"
 layout: landing
 section: contributing
 -->

--- a/howto/README.md
+++ b/howto/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "How to use Material Components"
+title: "How to use Material Components"
 layout: landing
 section: howto
 -->

--- a/howto/build-env/README.md
+++ b/howto/build-env/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Build environment"
+title: "Build environment"
 layout: landing
 section: howto
 -->

--- a/howto/faq/README.md
+++ b/howto/faq/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Frequently Asked Questions"
+title: "Frequently Asked Questions"
 layout: landing
 section: howto
 -->

--- a/howto/tutorial/README.md
+++ b/howto/tutorial/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title:  "Material Components Development Guide"
+title: "Material Components Development Guide"
 layout: landing
 section: howto
 -->

--- a/site-index.md
+++ b/site-index.md
@@ -1,5 +1,5 @@
 ---
-title:  "Material Components for iOS"
+title: "Material Components for iOS"
 layout: "homepage"
 ---
 


### PR DESCRIPTION
Took a first pass at associating the components with [these icons](https://github.com/material-components/material-components-site-generator/tree/master/jekyll-site-src/images/component_icons). Some didn't have a good match, and have been left without an iconId field in their metadata. The doc site will display a generic component icon in these cases.

Also took the opportunity to remove a set of unnecessary spaces that've been staring at me for days. :)