### PR TITLE
[Docs] Updated link list classes.

### DIFF
--- a/components/ActivityIndicator/README.md
+++ b/components/ActivityIndicator/README.md
@@ -24,7 +24,7 @@ Activity indicators are visual indications of an app loading content. The Activi
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://material.google.com/components/progress-activity.html">Progress & activity</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.google.com/components/progress-activity.html">Progress & activity</a></li>
 </ul>
 
 - - -

--- a/components/AnimationTiming/README.md
+++ b/components/AnimationTiming/README.md
@@ -15,7 +15,7 @@ of an animation so that movement doesn't appear mechanical.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://material.io/guidelines/motion/duration-easing.html">Duration & easing</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/motion/duration-easing.html">Duration & easing</a></li>
 </ul>
 
 ## Installation

--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -25,8 +25,8 @@ navigation experience.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://www.google.com/design/spec/layout/structure.html#structure-app-bar">App Bar Structure</a></li>
-  <li class="icon-spec"><a href="https://www.google.com/design/spec/patterns/scrolling-techniques.html">Scrolling Techniques</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://www.google.com/design/spec/layout/structure.html#structure-app-bar">App Bar Structure</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://www.google.com/design/spec/patterns/scrolling-techniques.html">Scrolling Techniques</a></li>
 </ul>
 
 - - -

--- a/components/Buttons/README.md
+++ b/components/Buttons/README.md
@@ -25,7 +25,7 @@ floating action button.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="http://www.google.com/design/spec/components/buttons.html">Buttons</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="http://www.google.com/design/spec/components/buttons.html">Buttons</a></li>
 </ul>
 
 - - -

--- a/components/CollectionCells/README.md
+++ b/components/CollectionCells/README.md
@@ -17,7 +17,7 @@ Collection view cell classes that adhere to Material Design layout and styling.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://www.google.com/design/spec/components/lists.html#lists-specs">Collection List Specs</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://www.google.com/design/spec/components/lists.html#lists-specs">Collection List Specs</a></li>
 </ul>
 
 - - -

--- a/components/Collections/README.md
+++ b/components/Collections/README.md
@@ -24,7 +24,7 @@ Collection view classes that adhere to Material Design layout and styling.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://www.google.com/design/spec/components/lists.html#lists-specs">Collection List Specs</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://www.google.com/design/spec/components/lists.html#lists-specs">Collection List Specs</a></li>
 </ul>
 
 - - -

--- a/components/Dialogs/README.md
+++ b/components/Dialogs/README.md
@@ -15,7 +15,7 @@ controller that will display a simple modal alert.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://material.google.com/components/dialogs.html">Dialogs</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.google.com/components/dialogs.html">Dialogs</a></li>
 </ul>
 
 ### Dialogs Classes

--- a/components/FeatureHighlight/README.md
+++ b/components/FeatureHighlight/README.md
@@ -23,7 +23,7 @@ The Feature Highlight component is a way to visually highlight a part of the scr
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://material.google.com/growth-communications/feature-discovery.html">Feature Discovery</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.google.com/growth-communications/feature-discovery.html">Feature Discovery</a></li>
 </ul>
 
 - - -

--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -25,7 +25,7 @@ UIScrollViewDelegate events.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://www.google.com/design/spec/patterns/scrolling-techniques.html">Scrolling Techniques</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://www.google.com/design/spec/patterns/scrolling-techniques.html">Scrolling Techniques</a></li>
 </ul>
 
 - - -

--- a/components/HeaderStackView/README.md
+++ b/components/HeaderStackView/README.md
@@ -25,7 +25,7 @@ bar views.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://www.google.com/design/spec/layout/structure.html#structure-app-bar">App Bar</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://www.google.com/design/spec/layout/structure.html#structure-app-bar">App Bar</a></li>
 </ul>
 
 - - -

--- a/components/Ink/README.md
+++ b/components/Ink/README.md
@@ -25,7 +25,7 @@ outward from the user's touch.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://www.google.com/design/spec/animation/responsive-interaction.html#responsive-interaction-radial-action">Radial Action</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://www.google.com/design/spec/animation/responsive-interaction.html#responsive-interaction-radial-action">Radial Action</a></li>
 </ul>
 
 - - -

--- a/components/NavigationBar/README.md
+++ b/components/NavigationBar/README.md
@@ -28,7 +28,7 @@ Consistent with iOS design guidelines, the title in the navigation bar is center
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="http://www.google.com/design/spec/layout/structure.html">Layout Structure</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="http://www.google.com/design/spec/layout/structure.html">Layout Structure</a></li>
 </ul>
 
 - - -

--- a/components/Palettes/README.md
+++ b/components/Palettes/README.md
@@ -14,7 +14,7 @@ The Palettes component provides Material colors organized into similar palettes.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="http://www.google.com/design/spec/style/color.html#color-color-palette">Color palettes</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="http://www.google.com/design/spec/style/color.html#color-color-palette">Color palettes</a></li>
 </ul>
 
 - - -

--- a/components/ProgressView/README.md
+++ b/components/ProgressView/README.md
@@ -27,7 +27,7 @@ few key methods required to achieve the desired animation of the control.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://material.google.com/components/progress-activity.html">Progress & activity</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.google.com/components/progress-activity.html">Progress & activity</a></li>
 </ul>
 
 - - -

--- a/components/README.md
+++ b/components/README.md
@@ -138,7 +138,6 @@ Material Components for iOS are written in Objective-C and support Swift and Int
   Text styles for Material fonts and opacities.
   ](Typography/)
   <!--{: .icon-typography }-->
-<!--{: .icon-list .large-format }-->
 
 - - -
 

--- a/components/ShadowElevations/README.md
+++ b/components/ShadowElevations/README.md
@@ -16,7 +16,7 @@ used Material Design elevations for components.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://www.google.com/design/spec/what-is-material/elevation-shadows.html">Elevation and Shadows</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://www.google.com/design/spec/what-is-material/elevation-shadows.html">Elevation and Shadows</a></li>
 </ul>
 
 - - -

--- a/components/ShadowLayer/README.md
+++ b/components/ShadowLayer/README.md
@@ -27,7 +27,7 @@ elevation.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://www.google.com/design/spec/what-is-material/elevation-shadows.html">Elevation and Shadows</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://www.google.com/design/spec/what-is-material/elevation-shadows.html">Elevation and Shadows</a></li>
 </ul>
 
 ### MDCShadowLayer

--- a/components/Slider/README.md
+++ b/components/Slider/README.md
@@ -25,7 +25,7 @@ or discrete set of values.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://www.google.com/design/spec/components/sliders.html">Sliders</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://www.google.com/design/spec/components/sliders.html">Sliders</a></li>
 </ul>
 
 - - -

--- a/components/Snackbar/README.md
+++ b/components/Snackbar/README.md
@@ -26,7 +26,7 @@ contain a text action, but no icons.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://material.google.com/components/snackbars-toasts.html">Snackbars</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.google.com/components/snackbars-toasts.html">Snackbars</a></li>
 </ul>
 
 - - -

--- a/components/Tabs/README.md
+++ b/components/Tabs/README.md
@@ -24,7 +24,7 @@ Tabs are bars of buttons used to navigate between groups of content.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://material.google.com/components/tabs.html">Tabs</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.google.com/components/tabs.html">Tabs</a></li>
 </ul>
 
 - - -

--- a/components/Typography/README.md
+++ b/components/Typography/README.md
@@ -24,7 +24,7 @@ from the Material Design specifications.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-spec"><a href="https://www.google.com/design/spec/style/typography.html">Typography</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://www.google.com/design/spec/style/typography.html">Typography</a></li>
 </ul>
 
 ## Installation

--- a/contributing/writing_readmes.md
+++ b/contributing/writing_readmes.md
@@ -16,12 +16,12 @@ fill out have been marked with `TODO` statements.
     ## Design & API Documentation
 
     <ul class="icon-list">
-      <li class="icon-spec">
+      <li class="icon-list-item icon-list-item--spec">
         <a href="https://www.google.com/design/spec/<TODO: link to spec>">
           TODO: link to spec
         </a>
       </li>
-      <li class="icon-link">
+      <li class="icon-list-item icon-list-item--link">
         <a href="/components/<ComponentName>/apidocs/Classes/<TODO: API name>.html">
           TODO: API name
         </a>

--- a/howto/README.md
+++ b/howto/README.md
@@ -9,15 +9,11 @@ section: howto
 Material Components for iOS should be immediately useable out of the box with
 Apple's standard development tool chain.
 
-- [Tutorial](tutorial/)
-  <!--{: .icon-guide }-->
-
-- [Build environment](build-env/)
-  <!--{: .icon-guide }-->
-
-- [FAQ](faq/)
-  <!--{: .icon-guide }-->
-<!--{: .icon-list }-->
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--guide"><a href="tutorial/">Tutorial</a></li>
+  <li class="icon-list-item icon-list-item--guide"><a href="build-env/">Build environment</a></li>
+  <li class="icon-list-item icon-list-item--guide"><a href="faq/">FAQ</a></li>
+</ul>
 
 - - -
 

--- a/site-index.md
+++ b/site-index.md
@@ -129,16 +129,19 @@ An easy way to create beautiful apps with modular and customizable UI&nbsp;compo
 
 5.  ## What's next?
 
-    - [Read the Development Guide]({{ site.folder }}/howto/)
-      <!--{: .icon-guide }-->
+    <ul class="icon-list">
+      <li class="icon-list-item icon-list-item--guide">
+        <a href="{{ site.folder }}/howto">Read the Development Guide</a>
+      </li>
+      <li class="icon-list-item icon-list-item--components">
+        <a href="{{ site.folder }}/components">View the Component Documentation</a>
+      </li>
+      <li class="icon-list-item icon-list-item--sample">
+        <a href="{{ site.folder }}/howto/tutorial/#sample-code">Explore our Code Samples</a>
+      </li>
+      <li class="icon-list-item icon-list-item--github">
+        <a href="https://github.com/material-components/material-components-ios/">View the project on GitHub</a>
+      </li>
+    </ul>
 
-    - [View the Component Documentation]({{ site.folder }}/components/)
-      <!--{: .icon-components }-->
-
-    - [Explore our Code Samples]({{ site.folder }}/howto/tutorial/#sample-code)
-      <!--{: .icon-sample }-->
-
-    - [View the project on GitHub](https://github.com/material-components/material-components-ios/)
-      <!--{: .icon-github }-->
-    <!--{: .icon-list }-->
 <!--{: .step-sequence }-->


### PR DESCRIPTION
Link lists now use BEM notation across the board. It's more verbose, but is aligned with the conventions of MDC-web and the docs site.

I've also made the representation of the link lists consistent. All HTML – no more template tags applying classes to markdown.