### PR TITLE
Ensure the MDCFlexibleHeaderView adheres to UIAppearance proxy if set

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -310,7 +310,10 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
       (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
   [super addSubview:_contentView];
 
-  self.backgroundColor = [UIColor lightGrayColor];
+  if (![MDCFlexibleHeaderView appearance].backgroundColor) {
+    self.backgroundColor = [UIColor lightGrayColor];
+  }
+
   _defaultShadowLayer.backgroundColor = self.backgroundColor.CGColor;
 
   self.layer.shadowColor = [[UIColor blackColor] CGColor];


### PR DESCRIPTION
Currently if set the UIAppearance proxy for MDCFlexibleHeaderView, it doesn't set the background color accordingly as the common init method always sets it's background color.
