### PR TITLE
Fix Swift example in the FlexibleHeader docs

### DIFF
--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -614,7 +614,7 @@ controller.
 #### Swift
 ``` swift
 override var childViewControllerForStatusBarStyle: UIViewController? {
-   return self.headerViewController
+  return headerViewController
 }
 ```
 

--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -613,8 +613,8 @@ controller.
 <!--<div class="material-code-render" markdown="1">-->
 #### Swift
 ``` swift
-override func childViewControllerForStatusBarStyle() -> UIViewController? {
-  return headerViewController
+override var childViewControllerForStatusBarStyle: UIViewController? {
+   return self.headerViewController
 }
 ```
 


### PR DESCRIPTION
The existing example doesn't work in the latest Swift. Updating the example in the docs to reflect this.