### PR TITLE
[AppBar] - Add missing calls to didMoveToParentViewController:

### DIFF
--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -131,6 +131,7 @@ override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
   super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 
   self.addChildViewController(appBar.headerViewController)
+  appBar.headerViewController.didMove(toParentViewController: self)
 }
 ```
 
@@ -149,6 +150,7 @@ override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     _appBar = [[MDCAppBar alloc] init];
 
     [self addChildViewController:_appBar.headerViewController];
+    [_appBar.headerViewController didMoveToParentViewController:self];
   }
   return self;
 }

--- a/components/AppBar/examples/AppBarDelegateForwardingExample.m
+++ b/components/AppBar/examples/AppBarDelegateForwardingExample.m
@@ -98,6 +98,7 @@
     _appBar.navigationBar.titleTextAttributes =
         @{NSForegroundColorAttributeName : [UIColor whiteColor]};
     [self addChildViewController:_appBar.headerViewController];
+    [_appBar.headerViewController didMoveToParentViewController:self];
 
     self.title = @"Delegate Forwarding";
 

--- a/components/AppBar/examples/AppBarDelegateForwardingExample.swift
+++ b/components/AppBar/examples/AppBarDelegateForwardingExample.swift
@@ -35,6 +35,7 @@ class AppBarDelegateForwardingExample: UITableViewController {
       [ NSForegroundColorAttributeName: UIColor.white ]
 
     self.addChildViewController(appBar.headerViewController)
+    appBar.headerViewController.didMove(toParentViewController: self)
 
     self.title = "Delegate Forwarding"
 

--- a/components/AppBar/examples/AppBarImageryExample.m
+++ b/components/AppBar/examples/AppBarImageryExample.m
@@ -86,6 +86,7 @@
     self.title = @"Imagery";
 
     [self addChildViewController:_appBar.headerViewController];
+    [_appBar.headerViewController didMoveToParentViewController:self];
   }
   return self;
 }

--- a/components/AppBar/examples/AppBarImageryExample.swift
+++ b/components/AppBar/examples/AppBarImageryExample.swift
@@ -69,6 +69,7 @@ class AppBarImagerySwiftExample: UITableViewController {
     self.title = "Imagery (Swift)"
 
     self.addChildViewController(appBar.headerViewController)
+    appBar.headerViewController.didMove(toParentViewController: self)
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
@@ -51,6 +51,7 @@
       @{NSForegroundColorAttributeName : [UIColor whiteColor]};
 
   [self addChildViewController:self.appBar.headerViewController];
+  [_appBar.headerViewController didMoveToParentViewController:self];
   UIColor *headerColor = [UIColor colorWithRed:0.01 green:0.67 blue:0.96 alpha:1.0];
   self.appBar.headerViewController.headerView.backgroundColor = headerColor;
 }

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
@@ -41,6 +41,7 @@ class AppBarInterfaceBuilderSwiftExample: UIViewController, UIScrollViewDelegate
       [ NSForegroundColorAttributeName: UIColor.white ]
 
     addChildViewController(appBar.headerViewController)
+    appBar.headerViewController.didMove(toParentViewController: self)
     let headerColor = UIColor(red: 0.01, green: 0.67, blue: 0.96, alpha: 1.0)
     appBar.headerViewController.headerView.backgroundColor = headerColor
   }

--- a/components/AppBar/examples/AppBarModalPresentationExample.m
+++ b/components/AppBar/examples/AppBarModalPresentationExample.m
@@ -224,6 +224,7 @@
     _appBar.navigationBar.titleTextAttributes =
         @{NSForegroundColorAttributeName : [UIColor whiteColor]};
     [self addChildViewController:_appBar.headerViewController];
+    [_appBar.headerViewController didMoveToParentViewController:self];
 
     self.title = @"Modal Presentation";
 

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -107,6 +107,7 @@ class AppBarModalPresentationSwiftExample: UITableViewController {
     self.title = "Modal Presentation (Swift)"
 
     self.addChildViewController(appBar.headerViewController)
+    appBar.headerViewController.didMove(toParentViewController: self)
 
     let color = UIColor(
       red: CGFloat(0x03) / CGFloat(255),

--- a/components/AppBar/examples/AppBarTypicalUseExample.m
+++ b/components/AppBar/examples/AppBarTypicalUseExample.m
@@ -35,6 +35,7 @@
     // Step 2: Initialize the App Bar and add the headerViewController as a child.
     _appBar = [[MDCAppBar alloc] init];
     [self addChildViewController:_appBar.headerViewController];
+    [_appBar.headerViewController didMoveToParentViewController:self];
 
     // Optional: Change the App Bar's background color and tint color.
     UIColor *color = [UIColor colorWithRed:(CGFloat)0x03 / (CGFloat)255

--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -29,6 +29,7 @@ class AppBarTypicalUseSwiftExample: UITableViewController {
 
     // Step 2: Add the headerViewController as a child.
     self.addChildViewController(appBar.headerViewController)
+    appBar.headerViewController.didMove(toParentViewController: self)
 
     let color = UIColor(
       red: CGFloat(0x03) / CGFloat(255),


### PR DESCRIPTION
As per Apple's [docs](https://developer.apple.com/reference/uikit/uiviewcontroller/1621405-didmovetoparentviewcontroller?language=objc):

> If you are implementing your own container view controller, it must call the didMoveToParentViewController: method of the child view controller after the transition to the new controller is complete or, if there is no transition, immediately after calling the addChildViewController: method.

