### PR TITLE
[Tabs] Disallow tabs that are wider than the screen

### DIFF
--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -399,8 +399,10 @@ static void *kItemPropertyContext = &kItemPropertyContext;
     size.width = MIN(size.width, _style.maximumItemWidth);
   }
 
-  // Constrain tab width to collection bounds.
-  const CGFloat boundsWidth = CGRectGetWidth(collectionView.bounds);
+  // Constrain tab width to collection content bounds.
+  const UIEdgeInsets sectionInset = _flowLayout.sectionInset;
+  const CGFloat boundsWidth =
+      CGRectGetWidth(collectionView.bounds) - sectionInset.left - sectionInset.right;
   size.width = MIN(size.width, boundsWidth);
 
   // Force height to our height.
@@ -584,14 +586,6 @@ static void *kItemPropertyContext = &kItemPropertyContext;
     case MDCItemBarAlignmentCenterSelected:
       newSectionInset = [self centerSelectedInsets];
       break;
-  }
-
-  UIEdgeInsets oldSectionInset = _flowLayout.sectionInset;
-  if (UIEdgeInsetsEqualToEdgeInsets(oldSectionInset, newSectionInset) &&
-      _alignment != MDCItemBarAlignmentJustified) {
-    // No change - can bail early, except when the item alignment is "justified". When justified,
-    // the layout metrics need updating due to change in view size or orientation.
-    return;
   }
 
   // Rather than just updating the sectionInset on the existing flowLayout, a new layout object

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -399,6 +399,10 @@ static void *kItemPropertyContext = &kItemPropertyContext;
     size.width = MIN(size.width, _style.maximumItemWidth);
   }
 
+  // Constrain tab width to collection bounds.
+  const CGFloat boundsWidth = CGRectGetWidth(collectionView.bounds);
+  size.width = MIN(size.width, boundsWidth);
+
   // Force height to our height.
   size.height = itemHeight;
 

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -588,6 +588,16 @@ static void *kItemPropertyContext = &kItemPropertyContext;
       break;
   }
 
+  UIEdgeInsets oldSectionInset = _tabFlowLayout.sectionInset;
+  if (UIEdgeInsetsEqualToEdgeInsets(oldSectionInset, newSectionInset)) {
+    // No inset change - only need to invalidate the layout to pick up new item sizes.
+    UICollectionViewFlowLayoutInvalidationContext *delegateContext =
+        [[UICollectionViewFlowLayoutInvalidationContext alloc] init];
+    delegateContext.invalidateFlowLayoutDelegateMetrics = YES;
+    [_tabFlowLayout invalidateLayoutWithContext:delegateContext];
+    return;
+  }
+
   // Rather than just updating the sectionInset on the existing flowLayout, a new layout object
   // is created. This gives more control over whether the change is animated or not - as there is
   // no control when updating flow layout sectionInset (it's always animated).

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -588,13 +588,13 @@ static void *kItemPropertyContext = &kItemPropertyContext;
       break;
   }
 
-  UIEdgeInsets oldSectionInset = _tabFlowLayout.sectionInset;
+  UIEdgeInsets oldSectionInset = _flowLayout.sectionInset;
   if (UIEdgeInsetsEqualToEdgeInsets(oldSectionInset, newSectionInset)) {
     // No inset change - only need to invalidate the layout to pick up new item sizes.
     UICollectionViewFlowLayoutInvalidationContext *delegateContext =
         [[UICollectionViewFlowLayoutInvalidationContext alloc] init];
     delegateContext.invalidateFlowLayoutDelegateMetrics = YES;
-    [_tabFlowLayout invalidateLayoutWithContext:delegateContext];
+    [_flowLayout invalidateLayoutWithContext:delegateContext];
     return;
   }
 


### PR DESCRIPTION
Previously the tab bar allowed tabs to be any width, including wider than the screen. Too-wide tabs never worked correctly and looked pretty bad. This imposes a maximum width on all tabs at the content width of the collection view.