### PR TITLE
Make MDCFeatureHighlightView public and prepare color properties for UIAppearance

### DIFF
--- a/components/FeatureHighlight/examples/FeatureHighlightTypicalUseViewController.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightTypicalUseViewController.m
@@ -23,7 +23,11 @@
 - (void)didTapButton:(id)sender {
   MDCFeatureHighlightViewController *vc =
       [[MDCFeatureHighlightViewController alloc] initWithHighlightedView:_button completion:nil];
-  vc.outerHighlightColor = [UIColor colorWithRed:11/255.0 green:232/255.0 blue:94/255.0 alpha:kMDCFeatureHighlightOuterHighlightAlpha];
+  vc.outerHighlightColor =
+      [UIColor colorWithRed:11/255.0
+                      green:232/255.0
+                       blue:94/255.0
+                      alpha:kMDCFeatureHighlightOuterHighlightAlpha];
   vc.titleText = @"Hey a title";
   vc.bodyText = @"This is the description of the feature highlight view controller.";
   [self presentViewController:vc animated:YES completion:nil];

--- a/components/FeatureHighlight/src/MDCFeatureHighlightView.h
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightView.h
@@ -20,8 +20,8 @@ typedef void (^MDCFeatureHighlightInteractionBlock)(BOOL accepted);
 
 @interface MDCFeatureHighlightView : UIView
 
-@property(nonatomic, strong) UIColor *outerHighlightColor;
-@property(nonatomic, strong) UIColor *innerHighlightColor;
+@property(nonatomic, strong) UIColor *outerHighlightColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong) UIColor *innerHighlightColor UI_APPEARANCE_SELECTOR;
 
 @property(nonatomic, assign) CGPoint highlightPoint;
 @property(nonatomic, strong) UIView *displayedView;

--- a/components/FeatureHighlight/src/MDCFeatureHighlightView.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightView.m
@@ -34,6 +34,7 @@ const CGFloat kMDCFeatureHighlightConcentricBound = 88.0f;
 const CGFloat kMDCFeatureHighlightNonconcentricOffset = 20.0f;
 const CGFloat kMDCFeatureHighlightMaxTextHeight = 1000.0f;
 const CGFloat kMDCFeatureHighlightTitleFontSize = 20.0f;
+const CGFloat kMDCFeatureHighlightOuterHighlightAlpha = 0.96f;
 
 // Animation consts
 const CGFloat kMDCFeatureHighlightInnerRadiusFactor = 1.1f;
@@ -97,14 +98,18 @@ const CGFloat kMDCFeatureHighlightPulseRadiusBloomAmount =
         [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(didTapView:)];
     [self addGestureRecognizer:tapRecognizer];
 
-    self.outerHighlightColor = [UIColor blueColor];
-    self.innerHighlightColor = [UIColor whiteColor];
-
     // We want the inner and outer highlights to animate from the same origin so we start them from
     // a concentric position.
     _forceConcentricLayout = YES;
+    [self applyMDCFeatureHighlightViewDefaults];
   }
   return self;
+}
+
+- (void)applyMDCFeatureHighlightViewDefaults {
+  _outerHighlightColor =
+      [[UIColor blueColor] colorWithAlphaComponent:kMDCFeatureHighlightOuterHighlightAlpha];
+  _innerHighlightColor = [UIColor whiteColor];
 }
 
 - (void)layoutAppearing {

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
@@ -78,7 +78,7 @@ typedef void (^MDCFeatureHighlightCompletion)(BOOL accepted);
 - (nonnull instancetype)initWithCoder:(nonnull NSCoder *)aDecoder NS_UNAVAILABLE;
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
-@property(nonatomic, strong, nullable) MDCFeatureHighlightView *featureHighlightView;
+@property(nonatomic, strong, nonnull) MDCFeatureHighlightView *featureHighlightView;
 
 /**
  Sets the text to be displayed as the header of the help text.

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
@@ -78,6 +78,9 @@ typedef void (^MDCFeatureHighlightCompletion)(BOOL accepted);
 - (nonnull instancetype)initWithCoder:(nonnull NSCoder *)aDecoder NS_UNAVAILABLE;
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
+/**
+ The feature highlight view used by the view controller.
+ */
 @property(nonatomic, strong, nonnull) MDCFeatureHighlightView *featureHighlightView;
 
 /**

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
@@ -16,6 +16,8 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MDCFeatureHighlightView.h"
+
 /** The default alpha for the outer highlight circle. */
 extern const CGFloat kMDCFeatureHighlightOuterHighlightAlpha;
 
@@ -75,6 +77,8 @@ typedef void (^MDCFeatureHighlightCompletion)(BOOL accepted);
                                  bundle:(nullable NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 - (nonnull instancetype)initWithCoder:(nonnull NSCoder *)aDecoder NS_UNAVAILABLE;
 - (nonnull instancetype)init NS_UNAVAILABLE;
+
+@property(nonatomic, strong, nullable) MDCFeatureHighlightView *featureHighlightView;
 
 /**
  Sets the text to be displayed as the header of the help text.

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -17,9 +17,6 @@
 #import "MDCFeatureHighlightViewController.h"
 
 #import "private/MDCFeatureHighlightAnimationController.h"
-#import "private/MDCFeatureHighlightView.h"
-
-const CGFloat kMDCFeatureHighlightOuterHighlightAlpha = 0.96f;
 
 static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
 
@@ -29,7 +26,6 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
 @implementation MDCFeatureHighlightViewController {
   MDCFeatureHighlightAnimationController *_animationController;
   MDCFeatureHighlightCompletion _completion;
-  MDCFeatureHighlightView *_featureHighlightView;
   NSTimer *_pulseTimer;
   UIView *_displayedView;
   UIView *_highlightedView;
@@ -52,6 +48,8 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
 
     super.transitioningDelegate = self;
     super.modalPresentationStyle = UIModalPresentationCustom;
+    
+    [self commonMDCFeatureHighlightViewControllerInit];
   }
   return self;
 }
@@ -87,30 +85,31 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
                             completion:completion];
 }
 
-- (void)dealloc {
-  [_pulseTimer invalidate];
-  [_highlightedView removeObserver:self forKeyPath:@"frame"];
-}
-
-- (void)loadView {
+- (void)commonMDCFeatureHighlightViewControllerInit {
   _displayedView.accessibilityTraits = UIAccessibilityTraitButton;
-
+  
   _featureHighlightView = [[MDCFeatureHighlightView alloc] initWithFrame:CGRectZero];
   _featureHighlightView.displayedView = _displayedView;
-  _featureHighlightView.titleLabel.text = self.titleText;
-  _featureHighlightView.bodyLabel.text = self.bodyText;
   _featureHighlightView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  _featureHighlightView.outerHighlightColor = self.outerHighlightColor;
-  _featureHighlightView.innerHighlightColor = self.innerHighlightColor;
 
   __weak __typeof__(self) weakSelf = self;
   _featureHighlightView.interactionBlock = ^(BOOL accepted) {
     __typeof__(self) strongSelf = weakSelf;
     [strongSelf dismiss:accepted];
   };
-
+  
   self.view = _featureHighlightView;
+}
+
+- (void)viewWillLayoutSubviews {
+  _featureHighlightView.titleLabel.text = self.titleText;
+  _featureHighlightView.bodyLabel.text = self.bodyText;
+}
+
+- (void)dealloc {
+  [_pulseTimer invalidate];
+  [_highlightedView removeObserver:self forKeyPath:@"frame"];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -138,17 +137,19 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
 }
 
 - (UIColor *)outerHighlightColor {
-  if (!_outerHighlightColor) {
-    return [[UIColor blueColor] colorWithAlphaComponent:kMDCFeatureHighlightOuterHighlightAlpha];
-  }
-  return _outerHighlightColor;
+  return _featureHighlightView.outerHighlightColor;
+}
+
+- (void)setOuterHighlightColor:(UIColor *)outerHighlightColor {
+  _featureHighlightView.outerHighlightColor = outerHighlightColor;
 }
 
 - (UIColor *)innerHighlightColor {
-  if (!_innerHighlightColor) {
-    return [UIColor whiteColor];
-  }
-  return _innerHighlightColor;
+  return _featureHighlightView.innerHighlightColor;
+}
+
+- (void)setInnerHighlightColor:(UIColor *)innerHighlightColor {
+  _featureHighlightView.innerHighlightColor = innerHighlightColor;
 }
 
 - (void)acceptFeature {

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -98,7 +98,6 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
     __typeof__(self) strongSelf = weakSelf;
     [strongSelf dismiss:accepted];
   };
-  
   self.view = _featureHighlightView;
 }
 

--- a/components/FeatureHighlight/src/MaterialFeatureHighlight.h
+++ b/components/FeatureHighlight/src/MaterialFeatureHighlight.h
@@ -15,3 +15,4 @@
  */
 
 #import "MDCFeatureHighlightViewController.h"
+#import "MDCFeatureHighlightView.h"


### PR DESCRIPTION
Makes MDCFeatureHighlightView publicly accessible and updates color properties so they can be set by a UIAppearance proxy.