### PR TITLE
[Tabs] Bottom navigation support

### DIFF
--- a/components/Tabs/README.md
+++ b/components/Tabs/README.md
@@ -96,6 +96,11 @@ By default, the tab bar is configured to display items with white text and icons
 
 Configure where items are placed in the tab bar by setting the `alignment` property.
 
+### Bottom navigation
+
+Implement `positionForBar:` and return `UIBarPositionBottom` to configure the tab bar as a bottom
+navigation bar. The bar will automatically update with styling appropriate for bottom navigation.
+
 - - -
 
 ## Example

--- a/components/Tabs/README.md
+++ b/components/Tabs/README.md
@@ -99,7 +99,7 @@ Configure where items are placed in the tab bar by setting the `alignment` prope
 ### Bottom navigation
 
 Implement `positionForBar:` and return `UIBarPositionBottom` to configure the tab bar as a bottom
-navigation bar. The bar will automatically update with styling appropriate for bottom navigation.
+navigation bar. The bar will automatically update with the appropriate styling.
 
 - - -
 

--- a/components/Tabs/examples/BottomNavigationBarExample.m
+++ b/components/Tabs/examples/BottomNavigationBarExample.m
@@ -1,0 +1,105 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights
+ Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+@import MaterialComponents.MaterialTabs;
+
+@interface BottomNavigationBarExample : UIViewController<MDCTabBarDelegate>
+@end
+
+@implementation BottomNavigationBarExample {
+  MDCTabBar *_bottomNavigationBar;
+
+  NSArray<UIColor *> *_colors;
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  _bottomNavigationBar = [[MDCTabBar alloc] initWithFrame:CGRectZero];
+  _bottomNavigationBar.autoresizingMask =
+      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
+  _bottomNavigationBar.delegate = self;
+
+  _bottomNavigationBar.barTintColor = [UIColor whiteColor];
+  _bottomNavigationBar.selectedItemTintColor = nil;
+  _bottomNavigationBar.unselectedItemTintColor = [UIColor colorWithWhite:0 alpha:0.50];
+  _bottomNavigationBar.tintColor = [UIColor colorWithRed:0 green:0.5 blue:0 alpha:1];
+  _bottomNavigationBar.inkColor = [UIColor colorWithRed:0 green:0.5 blue:0 alpha:0.15];
+
+  NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+  UIImage *infoImage =
+      [UIImage imageNamed:@"TabBarDemo_ic_info" inBundle:bundle compatibleWithTraitCollection:nil];
+  UIImage *starImage =
+      [UIImage imageNamed:@"TabBarDemo_ic_star" inBundle:bundle compatibleWithTraitCollection:nil];
+  _bottomNavigationBar.items = @[
+    [[UITabBarItem alloc] initWithTitle:@"Red" image:infoImage tag:0],
+    [[UITabBarItem alloc] initWithTitle:@"Blue" image:starImage tag:0]
+  ];
+
+  _colors = @[[UIColor colorWithRed:0.5 green:0 blue:0 alpha:1],
+              [UIColor colorWithRed:0 green:0 blue:0.5 alpha:1]];
+
+  CGRect bounds = self.view.bounds;
+
+  // Place bar at bottom of view
+  CGRect barFrame = CGRectZero;
+  barFrame.size = [_bottomNavigationBar sizeThatFits:self.view.bounds.size];
+  barFrame.origin.y = CGRectGetMaxY(bounds) - barFrame.size.height;
+  _bottomNavigationBar.frame = barFrame;
+
+  [self.view addSubview:_bottomNavigationBar];
+
+  [self updateDisplay];
+}
+
+#pragma mark - MDCTabBarDelegate
+
+- (void)tabBar:(MDCTabBar *)tabBar didSelectItem:(UITabBarItem *)item {
+  [self updateDisplay];
+}
+
+#pragma mark - UIBarPositioningDelegate
+
+- (UIBarPosition)positionForBar:(id<UIBarPositioning>)bar {
+  return UIBarPositionBottom;
+}
+
+#pragma mark - Private
+
+- (void)updateDisplay {
+  UITabBarItem *selectedItem = _bottomNavigationBar.selectedItem;
+  if (!selectedItem) {
+    return;
+  }
+
+  NSUInteger selectedIndex = [_bottomNavigationBar.items indexOfObject:selectedItem];
+  if (selectedIndex == NSNotFound) {
+    return;
+  }
+
+  self.view.backgroundColor = _colors[selectedIndex];
+}
+
+@end
+
+@implementation BottomNavigationBarExample (CatalogByConvention)
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Tab Bar", @"Bottom Navigation" ];
+}
+
+@end

--- a/components/Tabs/examples/BottomNavigationBarExample.m
+++ b/components/Tabs/examples/BottomNavigationBarExample.m
@@ -17,7 +17,7 @@
 
 @import MaterialComponents.MaterialTabs;
 
-@interface BottomNavigationBarExample : UIViewController<MDCTabBarDelegate>
+@interface BottomNavigationBarExample : UIViewController <MDCTabBarDelegate>
 @end
 
 @implementation BottomNavigationBarExample {
@@ -50,8 +50,10 @@
     [[UITabBarItem alloc] initWithTitle:@"Blue" image:starImage tag:0]
   ];
 
-  _colors = @[[UIColor colorWithRed:0.5 green:0 blue:0 alpha:1],
-              [UIColor colorWithRed:0 green:0 blue:0.5 alpha:1]];
+  _colors = @[
+    [UIColor colorWithRed:0.5 green:0 blue:0 alpha:1],
+    [UIColor colorWithRed:0 green:0 blue:0.5 alpha:1]
+  ];
 
   CGRect bounds = self.view.bounds;
 

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -35,10 +35,6 @@
 IB_DESIGNABLE
 @interface MDCTabBar : UIView <UIBarPositioning>
 
-/** The default height for the tab bar given a position and item appearance. */
-+ (CGFloat)defaultHeightForPosition:(UIBarPosition)position
-                     itemAppearance:(MDCTabBarItemAppearance)appearance;
-
 /** The default height for the tab bar in the top position, given an item appearance. */
 + (CGFloat)defaultHeightForItemAppearance:(MDCTabBarItemAppearance)appearance;
 
@@ -106,7 +102,7 @@ IB_DESIGNABLE
 
  The default value is based on the position and is recommended for most applications.
  */
-@property(nonatomic) BOOL displaysUppercaseTitles;
+@property(nonatomic) IBInspectable BOOL displaysUppercaseTitles;
 
 /**
  Select an item with optional animation. Setting to nil will clear the selection.
@@ -140,7 +136,7 @@ IB_DESIGNABLE
 
 /**
  Delegate protocol for MDCTabBar. Clients may implement this protocol to receive notifications of
- selection changes in the tab bar or to change the bar's position-based appearance.
+ selection changes in the tab bar or to determine the bar's position.
  */
 @protocol MDCTabBarDelegate <UIBarPositioningDelegate>
 

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -33,9 +33,13 @@
  @see https://material.io/guidelines/components/tabs.html
  */
 IB_DESIGNABLE
-@interface MDCTabBar : UIView
+@interface MDCTabBar : UIView <UIBarPositioning>
 
-/** Return the desired height for the tab bar given an item appearance. */
+/** The default height for the tab bar given a position and item appearance. */
++ (CGFloat)defaultHeightForPosition:(UIBarPosition)position
+                     itemAppearance:(MDCTabBarItemAppearance)appearance;
+
+/** The default height for the tab bar in the top position, given an item appearance. */
 + (CGFloat)defaultHeightForItemAppearance:(MDCTabBarItemAppearance)appearance;
 
 /**
@@ -84,12 +88,15 @@ IB_DESIGNABLE
 /**
  Horizontal alignment of tabs within the tab bar. Changes are not animated. Default alignment is
  MDCTabBarAlignmentLeading.
+
+ The default value is based on the position and is recommended for most applications.
  */
 @property(nonatomic) MDCTabBarAlignment alignment;
 
 /**
- Appearance of tabs within the tab bar. Changes are not animated. Default appearance is
- MDCTabBarItemAppearanceTitles.
+ Appearance of tabs within the tab bar. Changes are not animated.
+
+ The default value is based on the position and is recommended for most applications.
  */
 @property(nonatomic) MDCTabBarItemAppearance itemAppearance;
 
@@ -97,7 +104,7 @@ IB_DESIGNABLE
  Indicates if all tab titles should be uppercased for display. If NO, item titles will be
  displayed verbatim.
 
- Default is YES and is recommended whenever possible.
+ The default value is based on the position and is recommended for most applications.
  */
 @property(nonatomic) BOOL displaysUppercaseTitles;
 
@@ -133,9 +140,9 @@ IB_DESIGNABLE
 
 /**
  Delegate protocol for MDCTabBar. Clients may implement this protocol to receive notifications of
- selection changes in the tab bar.
+ selection changes in the tab bar or to change the bar's position-based appearance.
  */
-@protocol MDCTabBarDelegate <NSObject>
+@protocol MDCTabBarDelegate <UIBarPositioningDelegate>
 
 @optional
 

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -40,13 +40,13 @@ static const CGFloat kTitleOnlyBarHeight = 48;
 static const CGFloat kTitledImageBarHeight = 72;
 
 /// Height for bottom navigation bars, in points.
-const CGFloat kBottomNavigationBarHeight = 56;
+static const CGFloat kBottomNavigationBarHeight = 56;
 
 /// Maximum width for individual items in bottom navigation bars, in points.
-const CGFloat kBottomNavigationMaximumItemWidth = 168;
+static const CGFloat kBottomNavigationMaximumItemWidth = 168;
 
 /// Title-image padding for bottom navigation bars, in points.
-const CGFloat kBottomNavigationTitleImagePadding = 3;
+static const CGFloat kBottomNavigationTitleImagePadding = 3;
 
 static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignment alignment) {
   switch (alignment) {
@@ -141,25 +141,6 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 
 + (CGFloat)defaultHeightForItemAppearance:(MDCTabBarItemAppearance)appearance {
   return [self defaultHeightForPosition:UIBarPositionAny itemAppearance:appearance];
-}
-
-+ (CGFloat)defaultHeightForPosition:(UIBarPosition)position
-                     itemAppearance:(MDCTabBarItemAppearance)appearance {
-  if ([self isTopTabsForPosition:position]) {
-    switch (appearance) {
-      case MDCTabBarItemAppearanceTitledImages:
-        return kTitledImageBarHeight;
-
-      case MDCTabBarItemAppearanceTitles:
-        return kTitleOnlyBarHeight;
-
-      case MDCTabBarItemAppearanceImages:
-        return kImageOnlyBarHeight;
-    }
-  } else {
-    // Bottom navigation has a fixed height.
-    return kBottomNavigationBarHeight;
-  }
 }
 
 - (void)setDelegate:(id<MDCTabBarDelegate>)delegate {
@@ -288,6 +269,25 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 }
 
 #pragma mark - Private
+
++ (CGFloat)defaultHeightForPosition:(UIBarPosition)position
+                     itemAppearance:(MDCTabBarItemAppearance)appearance {
+  if ([self isTopTabsForPosition:position]) {
+    switch (appearance) {
+      case MDCTabBarItemAppearanceTitledImages:
+        return kTitledImageBarHeight;
+
+      case MDCTabBarItemAppearanceTitles:
+        return kTitleOnlyBarHeight;
+
+      case MDCTabBarItemAppearanceImages:
+        return kImageOnlyBarHeight;
+    }
+  } else {
+    // Bottom navigation has a fixed height.
+    return kBottomNavigationBarHeight;
+  }
+}
 
 + (MDCItemBarStyle *)defaultStyleForPosition:(UIBarPosition)position
                               itemAppearance:(MDCTabBarItemAppearance)appearance {

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -479,8 +479,7 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 - (void)updateItemBarStyle {
   MDCItemBarStyle *style;
 
-  style = [[self class] defaultStyleForPosition:_barPosition
-                                 itemAppearance:_itemAppearance];
+  style = [[self class] defaultStyleForPosition:_barPosition itemAppearance:_itemAppearance];
 
   style.selectionIndicatorColor = self.tintColor;
   style.inkColor = _inkColor;


### PR DESCRIPTION
This PR adds bottom navigation support to MDCTabBar by extending the UIBarPositioningDelegate protocol. Delegates which implement `positionForBar:` and return UIBarPositionBottom will cause the tab bar to be rendered as a bottom navigation bar.