### PR TITLE
[Catalog] Shared color constants across demos and update Activity Indicator layout.

### DIFF
--- a/MaterialComponentsCatalog.podspec
+++ b/MaterialComponentsCatalog.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/material-components/material-components-ios.git", :tag => "v#{s.version}" }
   s.platform     = :ios, '8.0'
   s.requires_arc = true
-  s.source_files = 'components/*/examples/*.{h,m,swift}', 'components/*/examples/supplemental/*.{h,m,swift}'
+  s.source_files = 'components/*/examples/*.{h,m,swift}', 'components/*/examples/supplemental/*.{h,m,swift}', 'catalog/CBCBase/*.{h,m,swift}'
   s.resources = ['components/*/examples/resources/*']
   s.dependency 'MaterialComponents'
   s.public_header_files = 'components/*/examples/*.h', 'components/*/examples/supplemental/*.h'

--- a/catalog/CBCBase/CatalogStyle.h
+++ b/catalog/CBCBase/CatalogStyle.h
@@ -19,12 +19,19 @@
 /** Shared style that should be used by CatalogByConvention as a base object. */
 @interface CatalogStyle : NSObject
 
+/** Font used in headers: Roboto Mono 16 */
 + (UIFont *)headerFont;
-+ (UIColor *)whiteColor;
-+ (UIColor *)blackColor;
+/** Black (90%) */
++ (UIColor *)primaryColor;
+/** White */
++ (UIColor *)primaryTextColor;
+/** Green (A400) */
++ (UIColor *)secondaryColor;
+/** Page background color */
 + (UIColor *)greyColor;
-+ (UIColor *)greenColor;
+/** NSAttributedText properties for the header. */
 + (NSDictionary *)headerTitleAttributes;
+/** Outputs an array of UIColors with different shades of grey. */
 + (NSArray *)shadesOfGrey:(int)numberOfGreys;
 
 @end

--- a/catalog/CBCBase/CatalogStyle.h
+++ b/catalog/CBCBase/CatalogStyle.h
@@ -17,7 +17,7 @@
 #import <UIKit/UIKit.h>
 
 /** Shared style that should be used by CatalogByConvention as a base object. */
-@interface MDCCatalogStyle : NSObject
+@interface CatalogStyle : NSObject
 
 + (UIFont *)headerFont;
 + (UIColor *)whiteColor;

--- a/catalog/CBCBase/CatalogStyle.m
+++ b/catalog/CBCBase/CatalogStyle.m
@@ -14,9 +14,9 @@
  limitations under the License.
  */
 
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
-@implementation MDCCatalogStyle
+@implementation CatalogStyle
 
 + (UIFont *)headerFont {
   return [UIFont fontWithName:@"RobotoMono-Regular" size:16];

--- a/catalog/CBCBase/CatalogStyle.m
+++ b/catalog/CBCBase/CatalogStyle.m
@@ -39,8 +39,8 @@
 
 + (NSDictionary *)headerTitleAttributes {
   return @{
-      NSForegroundColorAttributeName : [MDCCatalogStyle whiteColor],
-      NSFontAttributeName: [MDCCatalogStyle headerFont]
+      NSForegroundColorAttributeName : [CatalogStyle whiteColor],
+      NSFontAttributeName: [CatalogStyle headerFont]
   };
 }
 

--- a/catalog/CBCBase/CatalogStyle.m
+++ b/catalog/CBCBase/CatalogStyle.m
@@ -21,25 +21,22 @@
 + (UIFont *)headerFont {
   return [UIFont fontWithName:@"RobotoMono-Regular" size:16];
 }
-
-+ (UIColor *)whiteColor {
++ (UIColor *)primaryTextColor {
   return [UIColor colorWithWhite:1 alpha:1];
 }
-
-+ (UIColor *)blackColor {
++ (UIColor *)primaryColor {
   return [UIColor colorWithWhite:0.1f alpha:1];
 }
 + (UIColor *)greyColor {
   return [UIColor colorWithWhite:0.9f alpha:1];
 }
-+ (UIColor *)greenColor {
++ (UIColor *)secondaryColor {
   // Green A400
   return [UIColor colorWithRed:0 green:0xe6/255.0f blue:0x76/255.0f alpha:1];
 }
-
 + (NSDictionary *)headerTitleAttributes {
   return @{
-      NSForegroundColorAttributeName : [CatalogStyle whiteColor],
+      NSForegroundColorAttributeName : [CatalogStyle primaryTextColor],
       NSFontAttributeName: [CatalogStyle headerFont]
   };
 }

--- a/catalog/CBCBase/CatalogStyle.swift
+++ b/catalog/CBCBase/CatalogStyle.swift
@@ -22,8 +22,8 @@ class CatalogStyle {
   static let blackColor = UIColor(white: 0.1, alpha: 1)
   static let greyColor = UIColor(white: 0.9, alpha: 1)
   static let greenColor = UIColor(red: 0, green: 0xe6/255.0, blue: 0x76/255.0, alpha: 1)
-  static let headerTitleAttributes = [
+  static let headerTitleAttributes: [String: Any] = [
     NSForegroundColorAttributeName: CatalogStyle.whiteColor,
-    NSFontAttributeName: CatalogStyle.headerFont
+    NSFontAttributeName: CatalogStyle.headerFont as Any
   ]
 }

--- a/catalog/CBCBase/CatalogStyle.swift
+++ b/catalog/CBCBase/CatalogStyle.swift
@@ -1,12 +1,12 @@
 /*
  Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
- 
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/catalog/CBCBase/CatalogStyle.swift
+++ b/catalog/CBCBase/CatalogStyle.swift
@@ -1,30 +1,29 @@
 /*
  Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
-
+ 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
-
+ 
  http://www.apache.org/licenses/LICENSE-2.0
-
+ 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
- */
+*/
 
-#import <UIKit/UIKit.h>
+import UIKit
 
-/** Shared style that should be used by CatalogByConvention as a base object. */
-@interface MDCCatalogStyle : NSObject
-
-+ (UIFont *)headerFont;
-+ (UIColor *)whiteColor;
-+ (UIColor *)blackColor;
-+ (UIColor *)greyColor;
-+ (UIColor *)greenColor;
-+ (NSDictionary *)headerTitleAttributes;
-+ (NSArray *)shadesOfGrey:(int)numberOfGreys;
-
-@end
+class CatalogStyle {
+  static let headerFont = UIFont(name: "RobotoMono-Regular", size: 16)
+  static let whiteColor = UIColor.white
+  static let blackColor = UIColor(white: 0.1, alpha: 1)
+  static let greyColor = UIColor(white: 0.9, alpha: 1)
+  static let greenColor = UIColor(red: 0, green: 0xe6/255.0, blue: 0x76/255.0, alpha: 1)
+  static let headerTitleAttributes = [
+    NSForegroundColorAttributeName: CatalogStyle.whiteColor,
+    NSFontAttributeName: CatalogStyle.headerFont
+  ]
+}

--- a/catalog/CBCBase/CatalogStyle.swift
+++ b/catalog/CBCBase/CatalogStyle.swift
@@ -17,13 +17,19 @@
 import UIKit
 
 class CatalogStyle {
+  // Font used in all headers.
   static let headerFont = UIFont(name: "RobotoMono-Regular", size: 16)
-  static let whiteColor = UIColor.white
-  static let blackColor = UIColor(white: 0.1, alpha: 1)
+  // Primary color (Black 90%)
+  static let primaryColor = UIColor(white: 0.1, alpha: 1)
+  // Primary text color
+  static let primaryTextColor = UIColor.white
+  // Secondary color (Green A400)
+  static let secondaryColor = UIColor(red: 0, green: 0xe6/255.0, blue: 0x76/255.0, alpha: 1)
+  // Grey background color.
   static let greyColor = UIColor(white: 0.9, alpha: 1)
-  static let greenColor = UIColor(red: 0, green: 0xe6/255.0, blue: 0x76/255.0, alpha: 1)
+  // NSAttributedString attributes for headers. 
   static let headerTitleAttributes: [String: Any] = [
-    NSForegroundColorAttributeName: CatalogStyle.whiteColor,
+    NSForegroundColorAttributeName: CatalogStyle.primaryTextColor,
     NSFontAttributeName: CatalogStyle.headerFont as Any
   ]
 }

--- a/catalog/CBCBase/MDCCatalogStyle.h
+++ b/catalog/CBCBase/MDCCatalogStyle.h
@@ -1,12 +1,12 @@
 /*
  Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
- 
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,12 +16,13 @@
 
 #import <UIKit/UIKit.h>
 
+/** Shared style that should be used by CatalogByConvention as a base object. */
 @interface MDCCatalogStyle : NSObject
 
 + (UIFont *)headerFont;
-+ (UIColor *)mdcBlack;
-+ (UIColor *)mdcGrey;
-+ (UIColor *)mdcGreen;
++ (UIColor *)blackColor;
++ (UIColor *)greyColor;
++ (UIColor *)greenColor;
 + (NSArray *)shadesOfGrey:(int)numberOfGreys;
 
 @end

--- a/catalog/CBCBase/MDCCatalogStyle.m
+++ b/catalog/CBCBase/MDCCatalogStyle.m
@@ -19,8 +19,13 @@
 @implementation MDCCatalogStyle
 
 + (UIFont *)headerFont {
-  return [UIFont fontWithName:@"RobotoMono-Regular" size:14];
+  return [UIFont fontWithName:@"RobotoMono-Regular" size:16];
 }
+
++ (UIColor *)whiteColor {
+  return [UIColor colorWithWhite:1 alpha:1];
+}
+
 + (UIColor *)blackColor {
   return [UIColor colorWithWhite:0.1f alpha:1];
 }
@@ -30,6 +35,13 @@
 + (UIColor *)greenColor {
   // Green A400
   return [UIColor colorWithRed:0 green:0xe6/255.0f blue:0x76/255.0f alpha:1];
+}
+
++ (NSDictionary *)headerTitleAttributes {
+  return @{
+      NSForegroundColorAttributeName : [MDCCatalogStyle whiteColor],
+      NSFontAttributeName: [MDCCatalogStyle headerFont]
+  };
 }
 
 + (NSArray *)shadesOfGrey:(int)numberOfGreys {

--- a/catalog/CBCBase/MDCCatalogStyle.m
+++ b/catalog/CBCBase/MDCCatalogStyle.m
@@ -1,12 +1,12 @@
 /*
  Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
- 
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,13 +21,13 @@
 + (UIFont *)headerFont {
   return [UIFont fontWithName:@"RobotoMono-Regular" size:14];
 }
-+ (UIColor *)mdcBlack {
++ (UIColor *)blackColor {
   return [UIColor colorWithWhite:0.1f alpha:1];
 }
-+ (UIColor *)mdcGrey {
++ (UIColor *)greyColor {
   return [UIColor colorWithWhite:0.9f alpha:1];
 }
-+ (UIColor *)mdcGreen {
++ (UIColor *)greenColor {
   // Green A400
   return [UIColor colorWithRed:0 green:0xe6/255.0f blue:0x76/255.0f alpha:1];
 }

--- a/catalog/MDCCatalog.xcodeproj/project.pbxproj
+++ b/catalog/MDCCatalog.xcodeproj/project.pbxproj
@@ -20,7 +20,6 @@
 		64307B3F1DF74FEF004AE4AC /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 64307B3D1DF74FEF004AE4AC /* MainInterface.storyboard */; };
 		64307B431DF74FEF004AE4AC /* MDCActionExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 64307B381DF74FEF004AE4AC /* MDCActionExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		64307B4A1DF76198004AE4AC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 64307B491DF76198004AE4AC /* Assets.xcassets */; };
-		64BD963B1EBC9EF600284D1C /* MDCCatalogStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = 64BD963A1EBC9EF600284D1C /* MDCCatalogStyle.m */; };
 		664524B71C6BA62A001ADBF8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664524B61C6BA62A001ADBF8 /* AppDelegate.swift */; };
 		664524B91C6BA62A001ADBF8 /* MDCNodeListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664524B81C6BA62A001ADBF8 /* MDCNodeListViewController.swift */; };
 		664524BE1C6BA62A001ADBF8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 664524BD1C6BA62A001ADBF8 /* Assets.xcassets */; };
@@ -136,8 +135,6 @@
 		64307B3E1DF74FEF004AE4AC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
 		64307B401DF74FEF004AE4AC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		64307B491DF76198004AE4AC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		64BD96391EBC9EF600284D1C /* MDCCatalogStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDCCatalogStyle.h; sourceTree = "<group>"; };
-		64BD963A1EBC9EF600284D1C /* MDCCatalogStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDCCatalogStyle.m; sourceTree = "<group>"; };
 		664524B31C6BA62A001ADBF8 /* MDCCatalog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MDCCatalog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		664524B61C6BA62A001ADBF8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		664524B81C6BA62A001ADBF8 /* MDCNodeListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDCNodeListViewController.swift; sourceTree = "<group>"; };
@@ -263,8 +260,6 @@
 				66519B061CCA980600E5423E /* MDCInkTouchController+Injection.m */,
 				664524B81C6BA62A001ADBF8 /* MDCNodeListViewController.swift */,
 				665A34DE1C6BDAE700962055 /* Resources */,
-				64BD96391EBC9EF600284D1C /* MDCCatalogStyle.h */,
-				64BD963A1EBC9EF600284D1C /* MDCCatalogStyle.m */,
 			);
 			path = MDCCatalog;
 			sourceTree = "<group>";
@@ -631,7 +626,6 @@
 				6681FDFD1CC586660013A0C7 /* MDCCatalogTileView.swift in Sources */,
 				0B4A5E6D1CC9307A00D2AC5D /* MDCCatalogWindow.swift in Sources */,
 				664524B91C6BA62A001ADBF8 /* MDCNodeListViewController.swift in Sources */,
-				64BD963B1EBC9EF600284D1C /* MDCCatalogStyle.m in Sources */,
 				0BE1D27E1DD276D000F8544B /* MDCCatalogTiles.m in Sources */,
 				66519B071CCA980600E5423E /* MDCInkTouchController+Injection.m in Sources */,
 				664524B71C6BA62A001ADBF8 /* AppDelegate.swift in Sources */,

--- a/catalog/MDCCatalog/MDCCatalogStyle.m
+++ b/catalog/MDCCatalog/MDCCatalogStyle.m
@@ -28,8 +28,8 @@
   return [UIColor colorWithWhite:0.9f alpha:1];
 }
 + (UIColor *)mdcGreen {
-  // #B2FF59 ? TODO
-  return [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:1];
+  // Green A400
+  return [UIColor colorWithRed:0 green:0xe6/255.0f blue:0x76/255.0f alpha:1];
 }
 
 + (NSArray *)shadesOfGrey:(int)numberOfGreys {

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -350,6 +350,7 @@ extension MDCNodeListViewController {
       } else {
         let appBarFont = UIFont(name: "RobotoMono-Regular", size: 16)
         let container = MDCAppBarContainerViewController(contentViewController: contentVC)
+
         container.appBar.navigationBar.titleAlignment = .center
         container.appBar.navigationBar.tintColor = UIColor.white
         container.appBar.navigationBar.titleTextAttributes =

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -350,7 +350,6 @@ extension MDCNodeListViewController {
       } else {
         let appBarFont = UIFont(name: "RobotoMono-Regular", size: 16)
         let container = MDCAppBarContainerViewController(contentViewController: contentVC)
-
         container.appBar.navigationBar.titleAlignment = .center
         container.appBar.navigationBar.tintColor = UIColor.white
         container.appBar.navigationBar.titleTextAttributes =

--- a/components/ActivityIndicator/examples/ActivityIndicatorExample.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorExample.m
@@ -17,7 +17,7 @@
 #import <UIKit/UIKit.h>
 
 #import "ActivityIndicatorExampleSupplemental.h"
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 #import "MaterialActivityIndicator.h"
 
 @interface ActivityIndicatorExample ()
@@ -45,7 +45,7 @@
   CGRect defaultRect = CGRectMake(0, 0, 32, 32);
   self.activityIndicator1 = [[MDCActivityIndicator alloc] initWithFrame:defaultRect];
   self.activityIndicator1.delegate = self;
-  self.activityIndicator1.cycleColors =  @[[MDCCatalogStyle blackColor]];
+  self.activityIndicator1.cycleColors =  @[[CatalogStyle blackColor]];
   self.activityIndicator1.progress = 0.6f;
   self.activityIndicator1.indicatorMode = MDCActivityIndicatorModeDeterminate;
   [self.activityIndicator1 sizeToFit];
@@ -54,7 +54,7 @@
   // Initialize indeterminate indicator.
   self.activityIndicator2 = [[MDCActivityIndicator alloc] initWithFrame:defaultRect];
   self.activityIndicator2.delegate = self;
-  self.activityIndicator2.cycleColors =  @[[MDCCatalogStyle blackColor]];
+  self.activityIndicator2.cycleColors =  @[[CatalogStyle blackColor]];
   self.activityIndicator2.indicatorMode = MDCActivityIndicatorModeIndeterminate;
   [self.activityIndicator2 sizeToFit];
   [self.activityIndicator2 startAnimating];
@@ -63,7 +63,7 @@
   self.activityIndicator3 = [[MDCActivityIndicator alloc] initWithFrame:defaultRect];
   self.activityIndicator3.delegate = self;
   self.activityIndicator3.cycleColors =
-      @[[MDCCatalogStyle blackColor], [MDCCatalogStyle greenColor]];
+      @[[CatalogStyle blackColor], [CatalogStyle greenColor]];
   self.activityIndicator3.indicatorMode = MDCActivityIndicatorModeIndeterminate;
   [self.activityIndicator3 sizeToFit];
   [self.activityIndicator3 startAnimating];

--- a/components/ActivityIndicator/examples/ActivityIndicatorExample.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorExample.m
@@ -19,8 +19,11 @@
 #import "ActivityIndicatorExampleSupplemental.h"
 #import "MaterialActivityIndicator.h"
 
-@interface ActivityIndicatorExample ()
+#define MDC_CATALOG_BLACK [UIColor colorWithWhite:0.1f alpha:1]
+#define MDC_CATALOG_GREY  [UIColor colorWithWhite:0.9f alpha:1]
+#define MDC_CATALOG_GREEN [UIColor colorWithRed:0 green:0xe6/255.0f blue:0x76/255.0f alpha:1]
 
+@interface ActivityIndicatorExample ()
 @end
 
 @implementation ActivityIndicatorExample
@@ -29,24 +32,6 @@
   self = [super init];
   if (self) {
     self.title = @"Activity Indicator";
-    self.view.backgroundColor = [UIColor whiteColor];
-
-    CGRect activityIndicator =
-        CGRectMake(0, 0, kActivityIndicatorRadius * 2, kActivityIndicatorRadius * 2);
-    _activityIndicator = [[MDCActivityIndicator alloc] initWithFrame:activityIndicator];
-    _activityIndicator.delegate = self;
-    _activityIndicator.radius = kActivityIndicatorRadius;
-    _activityIndicator.strokeWidth = 8.f;
-    _activityIndicator.cycleColors = @[[UIColor colorWithWhite:0.1 alpha:1.0]];
-
-    _activityIndicator.autoresizingMask =
-        (UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin |
-         UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin);
-    [self.view addSubview:_activityIndicator];
-
-    _activityIndicator.indicatorMode = MDCActivityIndicatorModeDeterminate;
-    _activityIndicator.progress = kActivityInitialProgress;
-    [_activityIndicator startAnimating];
   }
   return self;
 }
@@ -57,6 +42,34 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+  self.view.backgroundColor = [UIColor whiteColor];
+
+  // Initialize single color progress indicator
+  CGRect defaultRect = CGRectMake(0, 0, 32, 32);
+  self.activityIndicator1 = [[MDCActivityIndicator alloc] initWithFrame:defaultRect];
+  self.activityIndicator1.delegate = self;
+  self.activityIndicator1.cycleColors =  @[MDC_CATALOG_BLACK];
+  self.activityIndicator1.progress = 0.6f;
+  self.activityIndicator1.indicatorMode = MDCActivityIndicatorModeDeterminate;
+  [self.activityIndicator1 sizeToFit];
+  [self.activityIndicator1 startAnimating];
+
+  // Initialize indeterminate indicator.
+  self.activityIndicator2 = [[MDCActivityIndicator alloc] initWithFrame:defaultRect];
+  self.activityIndicator2.delegate = self;
+  self.activityIndicator2.cycleColors =  @[MDC_CATALOG_BLACK];
+  self.activityIndicator2.indicatorMode = MDCActivityIndicatorModeIndeterminate;
+  [self.activityIndicator2 sizeToFit];
+  [self.activityIndicator2 startAnimating];
+
+  // Initiatlize multiple color indicator
+  self.activityIndicator3 = [[MDCActivityIndicator alloc] initWithFrame:defaultRect];
+  self.activityIndicator3.delegate = self;
+  self.activityIndicator3.cycleColors =  @[MDC_CATALOG_BLACK, MDC_CATALOG_GREEN];
+  self.activityIndicator3.indicatorMode = MDCActivityIndicatorModeIndeterminate;
+  [self.activityIndicator3 sizeToFit];
+  [self.activityIndicator3 startAnimating];
+
   [self setupExampleViews];
 }
 

--- a/components/ActivityIndicator/examples/ActivityIndicatorExample.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorExample.m
@@ -17,11 +17,8 @@
 #import <UIKit/UIKit.h>
 
 #import "ActivityIndicatorExampleSupplemental.h"
+#import "MDCCatalogStyle.h"
 #import "MaterialActivityIndicator.h"
-
-#define MDC_CATALOG_BLACK [UIColor colorWithWhite:0.1f alpha:1]
-#define MDC_CATALOG_GREY  [UIColor colorWithWhite:0.9f alpha:1]
-#define MDC_CATALOG_GREEN [UIColor colorWithRed:0 green:0xe6/255.0f blue:0x76/255.0f alpha:1]
 
 @interface ActivityIndicatorExample ()
 @end
@@ -48,7 +45,7 @@
   CGRect defaultRect = CGRectMake(0, 0, 32, 32);
   self.activityIndicator1 = [[MDCActivityIndicator alloc] initWithFrame:defaultRect];
   self.activityIndicator1.delegate = self;
-  self.activityIndicator1.cycleColors =  @[MDC_CATALOG_BLACK];
+  self.activityIndicator1.cycleColors =  @[[MDCCatalogStyle blackColor]];
   self.activityIndicator1.progress = 0.6f;
   self.activityIndicator1.indicatorMode = MDCActivityIndicatorModeDeterminate;
   [self.activityIndicator1 sizeToFit];
@@ -57,7 +54,7 @@
   // Initialize indeterminate indicator.
   self.activityIndicator2 = [[MDCActivityIndicator alloc] initWithFrame:defaultRect];
   self.activityIndicator2.delegate = self;
-  self.activityIndicator2.cycleColors =  @[MDC_CATALOG_BLACK];
+  self.activityIndicator2.cycleColors =  @[[MDCCatalogStyle blackColor]];
   self.activityIndicator2.indicatorMode = MDCActivityIndicatorModeIndeterminate;
   [self.activityIndicator2 sizeToFit];
   [self.activityIndicator2 startAnimating];
@@ -65,7 +62,8 @@
   // Initiatlize multiple color indicator
   self.activityIndicator3 = [[MDCActivityIndicator alloc] initWithFrame:defaultRect];
   self.activityIndicator3.delegate = self;
-  self.activityIndicator3.cycleColors =  @[MDC_CATALOG_BLACK, MDC_CATALOG_GREEN];
+  self.activityIndicator3.cycleColors =
+      @[[MDCCatalogStyle blackColor], [MDCCatalogStyle greenColor]];
   self.activityIndicator3.indicatorMode = MDCActivityIndicatorModeIndeterminate;
   [self.activityIndicator3 sizeToFit];
   [self.activityIndicator3 startAnimating];

--- a/components/ActivityIndicator/examples/ActivityIndicatorExample.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorExample.m
@@ -45,7 +45,7 @@
   CGRect defaultRect = CGRectMake(0, 0, 32, 32);
   self.activityIndicator1 = [[MDCActivityIndicator alloc] initWithFrame:defaultRect];
   self.activityIndicator1.delegate = self;
-  self.activityIndicator1.cycleColors =  @[[CatalogStyle blackColor]];
+  self.activityIndicator1.cycleColors =  @[[CatalogStyle primaryColor]];
   self.activityIndicator1.progress = 0.6f;
   self.activityIndicator1.indicatorMode = MDCActivityIndicatorModeDeterminate;
   [self.activityIndicator1 sizeToFit];
@@ -54,7 +54,7 @@
   // Initialize indeterminate indicator.
   self.activityIndicator2 = [[MDCActivityIndicator alloc] initWithFrame:defaultRect];
   self.activityIndicator2.delegate = self;
-  self.activityIndicator2.cycleColors =  @[[CatalogStyle blackColor]];
+  self.activityIndicator2.cycleColors =  @[[CatalogStyle primaryColor]];
   self.activityIndicator2.indicatorMode = MDCActivityIndicatorModeIndeterminate;
   [self.activityIndicator2 sizeToFit];
   [self.activityIndicator2 startAnimating];
@@ -63,7 +63,7 @@
   self.activityIndicator3 = [[MDCActivityIndicator alloc] initWithFrame:defaultRect];
   self.activityIndicator3.delegate = self;
   self.activityIndicator3.cycleColors =
-      @[[CatalogStyle blackColor], [CatalogStyle greenColor]];
+      @[[CatalogStyle primaryColor], [CatalogStyle secondaryColor]];
   self.activityIndicator3.indicatorMode = MDCActivityIndicatorModeIndeterminate;
   [self.activityIndicator3 sizeToFit];
   [self.activityIndicator3 startAnimating];

--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.h
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.h
@@ -22,6 +22,7 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialActivityIndicator.h"
+#import "MaterialCollections.h"
 
 static const CGFloat kActivityIndicatorRadius = 72.f;
 static const CGFloat kActivityInitialProgress = 0.6f;
@@ -29,16 +30,15 @@ static const CGFloat kActivityInitialProgress = 0.6f;
 @class ActivityIndicatorExample;
 @class MDCActivityIndicator;
 
-@interface ActivityIndicatorExample : UIViewController <MDCActivityIndicatorDelegate>
+@interface ActivityIndicatorExample : MDCCollectionViewController <MDCActivityIndicatorDelegate>
 
-@property(nonatomic, strong) MDCActivityIndicator *activityIndicator;
-@property(nonatomic, strong) UILabel *determinateSwitchLabel;
-@property(nonatomic, strong) UILabel *onSwitchLabel;
-@property(nonatomic, strong) UILabel *progressLabel;
-@property(nonatomic, strong) UILabel *progressPercentLabel;
+@property(nonatomic, strong) MDCActivityIndicator *activityIndicator1;
+@property(nonatomic, strong) MDCActivityIndicator *activityIndicator2;
+@property(nonatomic, strong) MDCActivityIndicator *activityIndicator3;
+@property(nonatomic, strong) UIView *indicators;
+
 @property(nonatomic, strong) UISlider *slider;
 @property(nonatomic, strong) UISwitch *onSwitch;
-@property(nonatomic, strong) UISwitch *determinateSwitch;
 
 @end
 

--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
@@ -71,7 +71,7 @@ static NSString * const kCell = @"Cell";
 
 
   self.onSwitch = [[UISwitch alloc] init];
-  self.onSwitch.onTintColor = [CatalogStyle blackColor];
+  self.onSwitch.onTintColor = [CatalogStyle primaryColor];
   [self.onSwitch setOn:YES];
   [self.onSwitch addTarget:self
                     action:@selector(didChangeOnSwitch:)
@@ -79,7 +79,7 @@ static NSString * const kCell = @"Cell";
 
   CGRect sliderFrame = CGRectMake(0, 0, 160, 27);
   self.slider = [[UISlider alloc] initWithFrame:sliderFrame];
-  self.slider.tintColor = [CatalogStyle blackColor];
+  self.slider.tintColor = [CatalogStyle primaryColor];
   self.slider.value = kActivityInitialProgress;
   [self.slider addTarget:self
                   action:@selector(didChangeSliderValue:)

--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
@@ -24,6 +24,13 @@
 #import "ActivityIndicatorExampleSupplemental.h"
 #import "MaterialTypography.h"
 
+#define MDC_CATALOG_BLACK [UIColor colorWithWhite:0.1f alpha:1]
+#define MDC_CATALOG_GREY  [UIColor colorWithWhite:0.9f alpha:1]
+#define MDC_CATALOG_GREEN [UIColor colorWithRed:0 green:0xe6/255.0f blue:0x76/255.0f alpha:1]
+
+static NSString * const kCell = @"Cell";
+
+
 @implementation ActivityIndicatorExample (CatalogByConvention)
 
 + (NSArray *)catalogBreadcrumbs {
@@ -45,116 +52,101 @@
 
 - (void)setupExampleViews {
 
+  [self.collectionView registerClass:[MDCCollectionViewTextCell class] forCellWithReuseIdentifier:kCell];
+
+  // Set up container view of three activity indicators.
+  UIView *indicators = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 160)];
+  indicators.backgroundColor = MDC_CATALOG_GREY;
+
+  [indicators addSubview:self.activityIndicator1];
+  [indicators addSubview:self.activityIndicator2];
+  [indicators addSubview:self.activityIndicator3];
+
+  self.activityIndicator1.center =
+      CGPointMake(indicators.bounds.size.width / 3, indicators.bounds.size.height / 2);
+  self.activityIndicator2.center =
+      CGPointMake(indicators.bounds.size.width / 2, indicators.bounds.size.height / 2);
+  self.activityIndicator3.center =
+      CGPointMake(2 * indicators.bounds.size.width / 3, indicators.bounds.size.height / 2);
+
+  self.indicators = indicators;
+
+
   self.onSwitch = [[UISwitch alloc] init];
-  self.onSwitch.onTintColor = [UIColor colorWithWhite:0.1 alpha:1.0];
-  
+  self.onSwitch.onTintColor = MDC_CATALOG_BLACK;
   [self.onSwitch setOn:YES];
   [self.onSwitch addTarget:self
                     action:@selector(didChangeOnSwitch:)
           forControlEvents:UIControlEventValueChanged];
-  [self.view addSubview:self.onSwitch];
 
-  self.onSwitchLabel = [[UILabel alloc] init];
-  self.onSwitchLabel.text = @"Indicator Active";
-  self.onSwitchLabel.font = [MDCTypography captionFont];
-  self.onSwitchLabel.alpha = [MDCTypography captionFontOpacity];
-  [self.onSwitchLabel sizeToFit];
-  [self.view addSubview:self.onSwitchLabel];
-
-  self.determinateSwitch = [[UISwitch alloc] init];
-  self.determinateSwitch.onTintColor = [UIColor colorWithWhite:0.1 alpha:1.0];
-  [self.determinateSwitch setOn:YES];
-  [self.determinateSwitch addTarget:self
-                             action:@selector(didChangeDeterminateSwitch:)
-                   forControlEvents:UIControlEventValueChanged];
-  [self.view addSubview:self.determinateSwitch];
-
-  self.determinateSwitchLabel = [[UILabel alloc] init];
-  self.determinateSwitchLabel.text = @"Determinate Mode";
-  self.determinateSwitchLabel.font = [MDCTypography captionFont];
-  self.determinateSwitchLabel.alpha = [MDCTypography captionFontOpacity];
-  [self.determinateSwitchLabel sizeToFit];
-  [self.view addSubview:self.determinateSwitchLabel];
-
-  CGRect sliderFrame = CGRectMake(0, 0, 240, 27);
+  CGRect sliderFrame = CGRectMake(0, 0, 160, 27);
   self.slider = [[UISlider alloc] initWithFrame:sliderFrame];
-  self.slider.tintColor = [UIColor colorWithWhite:0.1 alpha:1.0];
+  self.slider.tintColor = MDC_CATALOG_BLACK;
   self.slider.value = kActivityInitialProgress;
   [self.slider addTarget:self
                   action:@selector(didChangeSliderValue:)
         forControlEvents:UIControlEventValueChanged];
-  [self.view addSubview:self.slider];
-
-  self.progressLabel = [[UILabel alloc] init];
-  self.progressLabel.text = @"Progress";
-  self.progressLabel.font = [MDCTypography captionFont];
-  self.progressLabel.alpha = [MDCTypography captionFontOpacity];
-  [self.progressLabel sizeToFit];
-  [self.view addSubview:self.progressLabel];
-
-  self.progressPercentLabel = [[UILabel alloc] init];
-  self.progressPercentLabel.text =
-      [NSString stringWithFormat:@"%.00f%%", kActivityInitialProgress * 100];
-  self.progressPercentLabel.font = [MDCTypography captionFont];
-  self.progressPercentLabel.alpha = [MDCTypography captionFontOpacity];
-  self.progressPercentLabel.frame = CGRectMake(0, 0, 100, 16);
-  self.progressPercentLabel.textAlignment = NSTextAlignmentCenter;
-  [self.view addSubview:self.progressPercentLabel];
-}
-
-- (void)viewWillLayoutSubviews {
-  [super viewWillLayoutSubviews];
-
-  CGFloat navHeight = self.navigationController.navigationBar.frame.size.height;
-  if (self.view.frame.size.height > self.view.frame.size.width) {
-    self.activityIndicator.center =
-        CGPointMake(CGRectGetMidX(self.view.frame), CGRectGetMidY(self.view.frame) - navHeight * 2);
-    self.slider.center = CGPointMake(CGRectGetMidX(self.view.frame), 80);
-    self.progressLabel.center = CGPointMake(CGRectGetMidX(self.view.frame), 110);
-    self.onSwitch.center =
-        CGPointMake(CGRectGetMidX(self.view.frame) - 50, self.view.frame.size.height - 140);
-    self.onSwitchLabel.center =
-        CGPointMake(CGRectGetMidX(self.view.frame) + 32, self.view.frame.size.height - 140);
-    self.determinateSwitch.center =
-        CGPointMake(CGRectGetMidX(self.view.frame) - 50, self.view.frame.size.height - 90);
-    self.determinateSwitchLabel.center =
-        CGPointMake(CGRectGetMidX(self.view.frame) + 38, self.view.frame.size.height - 90);
-  } else {
-    self.activityIndicator.center =
-        CGPointMake(CGRectGetMidX(self.view.frame) - 150, CGRectGetMidY(self.view.frame) - 100);
-    self.slider.center = CGPointMake(CGRectGetMidX(self.view.frame) + 150, 20);
-    self.progressLabel.center = CGPointMake(CGRectGetMidX(self.view.frame) + 150, 50);
-    self.onSwitch.center =
-        CGPointMake(CGRectGetMidX(self.view.frame) + 90, self.view.frame.size.height - 140);
-    self.onSwitchLabel.center =
-        CGPointMake(CGRectGetMidX(self.view.frame) + 172, self.view.frame.size.height - 140);
-    self.determinateSwitch.center =
-        CGPointMake(CGRectGetMidX(self.view.frame) + 90, self.view.frame.size.height - 90);
-    self.determinateSwitchLabel.center =
-        CGPointMake(CGRectGetMidX(self.view.frame) + 178, self.view.frame.size.height - 90);
-  }
-  self.progressPercentLabel.center = self.activityIndicator.center;
-}
-
-- (void)didChangeDeterminateSwitch:(UISwitch *)determinateSwitch {
-  if (determinateSwitch.on) {
-    self.activityIndicator.indicatorMode = MDCActivityIndicatorModeDeterminate;
-  } else {
-    self.activityIndicator.indicatorMode = MDCActivityIndicatorModeIndeterminate;
-  }
 }
 
 - (void)didChangeOnSwitch:(UISwitch *)onSwitch {
   if (onSwitch.on) {
-    [self.activityIndicator startAnimating];
+    [self.activityIndicator1 startAnimating];
+    [self.activityIndicator2 startAnimating];
+    [self.activityIndicator3 startAnimating];
   } else {
-    [self.activityIndicator stopAnimating];
+    [self.activityIndicator1 stopAnimating];
+    [self.activityIndicator2 stopAnimating];
+    [self.activityIndicator3 stopAnimating];
   }
 }
 
 - (void)didChangeSliderValue:(UISlider *)slider {
-  self.activityIndicator.progress = slider.value;
-  self.progressPercentLabel.text = [NSString stringWithFormat:@"%.00f%%", slider.value * 100];
+  self.activityIndicator1.progress = slider.value;
+  MDCCollectionViewTextCell *cell =
+      (MDCCollectionViewTextCell *)[self.collectionView cellForItemAtIndexPath:
+                                        [NSIndexPath indexPathForRow:1 inSection:0]];
+  cell.textLabel.text = [NSString stringWithFormat:@"%.00f%%", slider.value * 100];
+  [cell setNeedsDisplay];
 }
+
+#pragma mark - 
+
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView
+     numberOfItemsInSection:(NSInteger)section {
+  return 3;
+}
+
+- (CGFloat)collectionView:(UICollectionView *)collectionView
+    cellHeightAtIndexPath:(NSIndexPath *)indexPath {
+  if (indexPath.row == 0) return 160;
+  return 56;
+}
+
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
+                  cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+  MDCCollectionViewTextCell *cell =
+      [collectionView dequeueReusableCellWithReuseIdentifier:kCell forIndexPath:indexPath];
+  cell.textLabel.text = @"";
+  switch (indexPath.row) {
+    case 0:
+      cell.accessoryView = nil;
+      cell.textLabel.text = nil;
+      [cell addSubview:self.indicators];
+      break;
+    case 1:
+      cell.accessoryView = self.slider;
+      cell.textLabel.text = @"Progress";
+      break;
+    case 2:
+      cell.accessoryView = self.onSwitch;
+      cell.textLabel.text = @"Show Indicator";
+      break;
+    default:
+      break;
+  }
+  return cell;
+}
+
 
 @end

--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
@@ -24,9 +24,7 @@
 #import "ActivityIndicatorExampleSupplemental.h"
 #import "MaterialTypography.h"
 
-#define MDC_CATALOG_BLACK [UIColor colorWithWhite:0.1f alpha:1]
-#define MDC_CATALOG_GREY  [UIColor colorWithWhite:0.9f alpha:1]
-#define MDC_CATALOG_GREEN [UIColor colorWithRed:0 green:0xe6/255.0f blue:0x76/255.0f alpha:1]
+#import "CatalogStyle.h"
 
 static NSString * const kCell = @"Cell";
 
@@ -56,7 +54,7 @@ static NSString * const kCell = @"Cell";
 
   // Set up container view of three activity indicators.
   UIView *indicators = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 160)];
-  indicators.backgroundColor = MDC_CATALOG_GREY;
+  indicators.backgroundColor = [CatalogStyle greyColor];
 
   [indicators addSubview:self.activityIndicator1];
   [indicators addSubview:self.activityIndicator2];
@@ -73,7 +71,7 @@ static NSString * const kCell = @"Cell";
 
 
   self.onSwitch = [[UISwitch alloc] init];
-  self.onSwitch.onTintColor = MDC_CATALOG_BLACK;
+  self.onSwitch.onTintColor = [CatalogStyle blackColor];
   [self.onSwitch setOn:YES];
   [self.onSwitch addTarget:self
                     action:@selector(didChangeOnSwitch:)
@@ -81,7 +79,7 @@ static NSString * const kCell = @"Cell";
 
   CGRect sliderFrame = CGRectMake(0, 0, 160, 27);
   self.slider = [[UISlider alloc] initWithFrame:sliderFrame];
-  self.slider.tintColor = MDC_CATALOG_BLACK;
+  self.slider.tintColor = [CatalogStyle blackColor];
   self.slider.value = kActivityInitialProgress;
   [self.slider addTarget:self
                   action:@selector(didChangeSliderValue:)

--- a/components/AppBar/examples/AppBarDelegateForwardingExample.m
+++ b/components/AppBar/examples/AppBarDelegateForwardingExample.m
@@ -17,6 +17,7 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialAppBar.h"
+#import "MDCCatalogStyle.h"
 
 // This example builds upon AppBarTypicalUseExample.
 
@@ -94,15 +95,15 @@
   self = [super init];
   if (self) {
     _appBar = [[MDCAppBar alloc] init];
-    _appBar.navigationBar.tintColor = [UIColor whiteColor];
+    _appBar.navigationBar.tintColor = [MDCCatalogStyle whiteColor];
     _appBar.navigationBar.titleTextAttributes =
-        @{NSForegroundColorAttributeName : [UIColor whiteColor]};
+        @{NSForegroundColorAttributeName : [MDCCatalogStyle whiteColor],
+          NSFontAttributeName: [MDCCatalogStyle headerFont]};
     [self addChildViewController:_appBar.headerViewController];
 
     self.title = @"Delegate Forwarding";
 
-    UIColor *color = [UIColor colorWithWhite:0.1 alpha:1];
-    _appBar.headerViewController.headerView.backgroundColor = color;
+    _appBar.headerViewController.headerView.backgroundColor = [MDCCatalogStyle blackColor];
   }
   return self;
 }

--- a/components/AppBar/examples/AppBarDelegateForwardingExample.m
+++ b/components/AppBar/examples/AppBarDelegateForwardingExample.m
@@ -95,15 +95,16 @@
   self = [super init];
   if (self) {
     _appBar = [[MDCAppBar alloc] init];
-    _appBar.navigationBar.tintColor = [CatalogStyle whiteColor];
-    _appBar.navigationBar.titleTextAttributes =
-        @{NSForegroundColorAttributeName : [CatalogStyle whiteColor],
-          NSFontAttributeName: [CatalogStyle headerFont]};
+    _appBar.navigationBar.tintColor = [CatalogStyle primaryTextColor];
+    _appBar.navigationBar.titleTextAttributes = @{
+        NSForegroundColorAttributeName : [CatalogStyle primaryTextColor],
+        NSFontAttributeName: [CatalogStyle headerFont]
+    };
     [self addChildViewController:_appBar.headerViewController];
 
     self.title = @"Delegate Forwarding";
 
-    _appBar.headerViewController.headerView.backgroundColor = [CatalogStyle blackColor];
+    _appBar.headerViewController.headerView.backgroundColor = [CatalogStyle primaryColor];
   }
   return self;
 }

--- a/components/AppBar/examples/AppBarDelegateForwardingExample.m
+++ b/components/AppBar/examples/AppBarDelegateForwardingExample.m
@@ -17,7 +17,7 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialAppBar.h"
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
 // This example builds upon AppBarTypicalUseExample.
 
@@ -95,15 +95,15 @@
   self = [super init];
   if (self) {
     _appBar = [[MDCAppBar alloc] init];
-    _appBar.navigationBar.tintColor = [MDCCatalogStyle whiteColor];
+    _appBar.navigationBar.tintColor = [CatalogStyle whiteColor];
     _appBar.navigationBar.titleTextAttributes =
-        @{NSForegroundColorAttributeName : [MDCCatalogStyle whiteColor],
-          NSFontAttributeName: [MDCCatalogStyle headerFont]};
+        @{NSForegroundColorAttributeName : [CatalogStyle whiteColor],
+          NSFontAttributeName: [CatalogStyle headerFont]};
     [self addChildViewController:_appBar.headerViewController];
 
     self.title = @"Delegate Forwarding";
 
-    _appBar.headerViewController.headerView.backgroundColor = [MDCCatalogStyle blackColor];
+    _appBar.headerViewController.headerView.backgroundColor = [CatalogStyle blackColor];
   }
   return self;
 }

--- a/components/AppBar/examples/AppBarDelegateForwardingExample.swift
+++ b/components/AppBar/examples/AppBarDelegateForwardingExample.swift
@@ -30,17 +30,15 @@ class AppBarDelegateForwardingExample: UITableViewController {
   override init(style: UITableViewStyle) {
     super.init(style: style)
 
-    self.appBar.navigationBar.tintColor = UIColor.white
-    appBar.navigationBar.titleTextAttributes =
-      [ NSForegroundColorAttributeName: UIColor.white ]
+    self.appBar.navigationBar.tintColor = CatalogStyle.whiteColor
+    appBar.navigationBar.titleTextAttributes = CatalogStyle.headerTitleAttributes
 
     self.addChildViewController(appBar.headerViewController)
 
     self.title = "Delegate Forwarding"
 
-    let color = UIColor(white: 0.1, alpha:1)
-    appBar.headerViewController.headerView.backgroundColor = color
-    appBar.navigationBar.tintColor = UIColor.white
+    appBar.headerViewController.headerView.backgroundColor = CatalogStyle.blackColor
+    appBar.navigationBar.tintColor = CatalogStyle.whiteColor
   }
 
   override func viewDidLoad() {

--- a/components/AppBar/examples/AppBarDelegateForwardingExample.swift
+++ b/components/AppBar/examples/AppBarDelegateForwardingExample.swift
@@ -30,15 +30,17 @@ class AppBarDelegateForwardingExample: UITableViewController {
   override init(style: UITableViewStyle) {
     super.init(style: style)
 
-    self.appBar.navigationBar.tintColor = CatalogStyle.whiteColor
-    appBar.navigationBar.titleTextAttributes = CatalogStyle.headerTitleAttributes
-
+    self.appBar.navigationBar.tintColor = CatalogStyle.primaryTextColor
+    appBar.navigationBar.titleTextAttributes =
+      [ NSForegroundColorAttributeName: CatalogStyle.primaryTextColor,
+        NSFontAttributeName: CatalogStyle.headerFont! ]
+    
     self.addChildViewController(appBar.headerViewController)
 
     self.title = "Delegate Forwarding"
 
-    appBar.headerViewController.headerView.backgroundColor = CatalogStyle.blackColor
-    appBar.navigationBar.tintColor = CatalogStyle.whiteColor
+    appBar.headerViewController.headerView.backgroundColor = CatalogStyle.primaryColor
+    appBar.navigationBar.tintColor = CatalogStyle.primaryTextColor
   }
 
   override func viewDidLoad() {

--- a/components/AppBar/examples/AppBarImageryExample.m
+++ b/components/AppBar/examples/AppBarImageryExample.m
@@ -46,11 +46,11 @@
 
   // We want navigation bar + status bar tint color to be white, so we set tint color here and
   // implement -preferredStatusBarStyle.
-  self.appBar.headerViewController.headerView.tintColor = [CatalogStyle whiteColor];
-  self.appBar.navigationBar.titleTextAttributes =
-      @{NSForegroundColorAttributeName : [CatalogStyle whiteColor],
-        NSFontAttributeName: [CatalogStyle headerFont]};
-
+  self.appBar.headerViewController.headerView.tintColor = [CatalogStyle primaryTextColor];
+  self.appBar.navigationBar.titleTextAttributes = @{
+      NSForegroundColorAttributeName : [CatalogStyle primaryTextColor],
+      NSFontAttributeName: [CatalogStyle headerFont]
+  };
   // Allow the header to show more of the image.
   self.appBar.headerViewController.headerView.maximumHeight = 200;
 

--- a/components/AppBar/examples/AppBarImageryExample.m
+++ b/components/AppBar/examples/AppBarImageryExample.m
@@ -17,6 +17,7 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialAppBar.h"
+#import "MDCCatalogStyle.h"
 
 @interface AppBarImageryExample : UITableViewController
 @property(nonatomic, strong) MDCAppBar *appBar;
@@ -45,9 +46,10 @@
 
   // We want navigation bar + status bar tint color to be white, so we set tint color here and
   // implement -preferredStatusBarStyle.
-  self.appBar.headerViewController.headerView.tintColor = [UIColor whiteColor];
+  self.appBar.headerViewController.headerView.tintColor = [MDCCatalogStyle whiteColor];
   self.appBar.navigationBar.titleTextAttributes =
-      @{NSForegroundColorAttributeName : [UIColor whiteColor]};
+      @{NSForegroundColorAttributeName : [MDCCatalogStyle whiteColor],
+        NSFontAttributeName: [MDCCatalogStyle headerFont]};
 
   // Allow the header to show more of the image.
   self.appBar.headerViewController.headerView.maximumHeight = 200;

--- a/components/AppBar/examples/AppBarImageryExample.m
+++ b/components/AppBar/examples/AppBarImageryExample.m
@@ -17,7 +17,7 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialAppBar.h"
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
 @interface AppBarImageryExample : UITableViewController
 @property(nonatomic, strong) MDCAppBar *appBar;
@@ -46,10 +46,10 @@
 
   // We want navigation bar + status bar tint color to be white, so we set tint color here and
   // implement -preferredStatusBarStyle.
-  self.appBar.headerViewController.headerView.tintColor = [MDCCatalogStyle whiteColor];
+  self.appBar.headerViewController.headerView.tintColor = [CatalogStyle whiteColor];
   self.appBar.navigationBar.titleTextAttributes =
-      @{NSForegroundColorAttributeName : [MDCCatalogStyle whiteColor],
-        NSFontAttributeName: [MDCCatalogStyle headerFont]};
+      @{NSForegroundColorAttributeName : [CatalogStyle whiteColor],
+        NSFontAttributeName: [CatalogStyle headerFont]};
 
   // Allow the header to show more of the image.
   self.appBar.headerViewController.headerView.maximumHeight = 200;

--- a/components/AppBar/examples/AppBarImageryExample.swift
+++ b/components/AppBar/examples/AppBarImageryExample.swift
@@ -43,9 +43,10 @@ class AppBarImagerySwiftExample: UITableViewController {
 
     // We want navigation bar + status bar tint color to be white, so we set tint color here and
     // implement -preferredStatusBarStyle.
-    headerView.tintColor = UIColor.white
+    headerView.tintColor = CatalogStyle.whiteColor
     appBar.navigationBar.titleTextAttributes =
-      [ NSForegroundColorAttributeName: UIColor.white ]
+      [ NSForegroundColorAttributeName: CatalogStyle.whiteColor,
+        NSFontAttributeName: CatalogStyle.headerFont! ]
 
     // Allow the header to show more of the image.
     headerView.maximumHeight = 200

--- a/components/AppBar/examples/AppBarImageryExample.swift
+++ b/components/AppBar/examples/AppBarImageryExample.swift
@@ -43,9 +43,9 @@ class AppBarImagerySwiftExample: UITableViewController {
 
     // We want navigation bar + status bar tint color to be white, so we set tint color here and
     // implement -preferredStatusBarStyle.
-    headerView.tintColor = CatalogStyle.whiteColor
+    headerView.tintColor = CatalogStyle.primaryTextColor
     appBar.navigationBar.titleTextAttributes =
-      [ NSForegroundColorAttributeName: CatalogStyle.whiteColor,
+      [ NSForegroundColorAttributeName: CatalogStyle.primaryTextColor,
         NSFontAttributeName: CatalogStyle.headerFont! ]
 
     // Allow the header to show more of the image.

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
@@ -17,7 +17,7 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialAppBar.h"
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
 @interface AppBarInterfaceBuilderExample : UIViewController <UIScrollViewDelegate>
 
@@ -47,13 +47,13 @@
 }
 
 - (void)commonAppBarInterfaceBuilderExampleSetup {
-  self.appBar.navigationBar.tintColor = [MDCCatalogStyle whiteColor];
+  self.appBar.navigationBar.tintColor = [CatalogStyle whiteColor];
   self.appBar.navigationBar.titleTextAttributes =
-      @{NSForegroundColorAttributeName : [MDCCatalogStyle whiteColor],
-        NSFontAttributeName: [MDCCatalogStyle headerFont]};
+      @{NSForegroundColorAttributeName : [CatalogStyle whiteColor],
+        NSFontAttributeName: [CatalogStyle headerFont]};
 
   [self addChildViewController:self.appBar.headerViewController];
-  self.appBar.headerViewController.headerView.backgroundColor = [MDCCatalogStyle blackColor];
+  self.appBar.headerViewController.headerView.backgroundColor = [CatalogStyle blackColor];
 }
 
 - (void)viewDidLoad {

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
@@ -47,13 +47,13 @@
 }
 
 - (void)commonAppBarInterfaceBuilderExampleSetup {
-  self.appBar.navigationBar.tintColor = [CatalogStyle whiteColor];
+  self.appBar.navigationBar.tintColor = [CatalogStyle primaryTextColor];
   self.appBar.navigationBar.titleTextAttributes =
-      @{NSForegroundColorAttributeName : [CatalogStyle whiteColor],
+      @{NSForegroundColorAttributeName : [CatalogStyle primaryTextColor],
         NSFontAttributeName: [CatalogStyle headerFont]};
 
   [self addChildViewController:self.appBar.headerViewController];
-  self.appBar.headerViewController.headerView.backgroundColor = [CatalogStyle blackColor];
+  self.appBar.headerViewController.headerView.backgroundColor = [CatalogStyle primaryColor];
 }
 
 - (void)viewDidLoad {

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
@@ -17,6 +17,7 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialAppBar.h"
+#import "MDCCatalogStyle.h"
 
 @interface AppBarInterfaceBuilderExample : UIViewController <UIScrollViewDelegate>
 
@@ -46,13 +47,13 @@
 }
 
 - (void)commonAppBarInterfaceBuilderExampleSetup {
-  self.appBar.navigationBar.tintColor = [UIColor whiteColor];
+  self.appBar.navigationBar.tintColor = [MDCCatalogStyle whiteColor];
   self.appBar.navigationBar.titleTextAttributes =
-      @{NSForegroundColorAttributeName : [UIColor whiteColor]};
+      @{NSForegroundColorAttributeName : [MDCCatalogStyle whiteColor],
+        NSFontAttributeName: [MDCCatalogStyle headerFont]};
 
   [self addChildViewController:self.appBar.headerViewController];
-  UIColor *headerColor = [UIColor colorWithWhite:0.1 alpha:1];
-  self.appBar.headerViewController.headerView.backgroundColor = headerColor;
+  self.appBar.headerViewController.headerView.backgroundColor = [MDCCatalogStyle blackColor];
 }
 
 - (void)viewDidLoad {

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
@@ -36,13 +36,13 @@ class AppBarInterfaceBuilderSwiftExample: UIViewController, UIScrollViewDelegate
   }
 
   func commonAppBarInterfaceBuilderSwiftExampleSetup() {
-    appBar.navigationBar.tintColor = UIColor.white
+    appBar.navigationBar.tintColor = CatalogStyle.primaryTextColor
     appBar.navigationBar.titleTextAttributes =
-      [ NSForegroundColorAttributeName: UIColor.white ]
+      [ NSForegroundColorAttributeName: CatalogStyle.primaryTextColor,
+        NSFontAttributeName: CatalogStyle.headerFont! ]
 
     addChildViewController(appBar.headerViewController)
-    let color = UIColor(white: 0.1, alpha:1)
-    appBar.headerViewController.headerView.backgroundColor = color
+    appBar.headerViewController.headerView.backgroundColor = CatalogStyle.primaryColor
   }
 
   override func viewDidLoad() {

--- a/components/AppBar/examples/AppBarModalPresentationExample.m
+++ b/components/AppBar/examples/AppBarModalPresentationExample.m
@@ -34,10 +34,12 @@
     [self addChildViewController:_appBar.headerViewController];
 
     // Optional: Change the App Bar's background color and tint color.
-    _appBar.headerViewController.headerView.backgroundColor = [CatalogStyle blackColor];
-    _appBar.navigationBar.tintColor = [UIColor whiteColor];
-    _appBar.navigationBar.titleTextAttributes =
-        @{NSForegroundColorAttributeName : [UIColor whiteColor]};
+    _appBar.headerViewController.headerView.backgroundColor = [CatalogStyle primaryColor];
+    _appBar.navigationBar.tintColor = [CatalogStyle primaryTextColor];
+    _appBar.navigationBar.titleTextAttributes = @{
+        NSForegroundColorAttributeName : [CatalogStyle primaryTextColor],
+        NSFontAttributeName: [CatalogStyle headerFont]
+    };
 
     // Set presentation style
     [self setModalPresentationStyle:UIModalPresentationFormSheet];
@@ -225,7 +227,7 @@
 
     self.title = @"Modal Presentation";
 
-    UIColor *color = [CatalogStyle blackColor];
+    UIColor *color = [CatalogStyle primaryColor];
     _appBar.headerViewController.headerView.backgroundColor = color;
   }
   return self;

--- a/components/AppBar/examples/AppBarModalPresentationExample.m
+++ b/components/AppBar/examples/AppBarModalPresentationExample.m
@@ -18,6 +18,8 @@
 
 #import "MaterialAppBar.h"
 
+#import "CatalogStyle.h"
+
 @interface AppBarModalPresentationExamplePresented : UITableViewController
 @property(strong, nonatomic) MDCAppBar *appBar;
 @end
@@ -32,8 +34,7 @@
     [self addChildViewController:_appBar.headerViewController];
 
     // Optional: Change the App Bar's background color and tint color.
-    UIColor *color = [UIColor colorWithWhite:0.1 alpha:1];
-    _appBar.headerViewController.headerView.backgroundColor = color;
+    _appBar.headerViewController.headerView.backgroundColor = [CatalogStyle blackColor];
     _appBar.navigationBar.tintColor = [UIColor whiteColor];
     _appBar.navigationBar.titleTextAttributes =
         @{NSForegroundColorAttributeName : [UIColor whiteColor]};
@@ -224,7 +225,7 @@
 
     self.title = @"Modal Presentation";
 
-    UIColor *color = [UIColor colorWithWhite:0.1 alpha:1];
+    UIColor *color = [CatalogStyle blackColor];
     _appBar.headerViewController.headerView.backgroundColor = color;
   }
   return self;

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -104,11 +104,11 @@ class AppBarModalPresentationSwiftExample: UITableViewController {
 
     self.addChildViewController(appBar.headerViewController)
 
-    let color = UIColor(white: 0.1, alpha:1)
-    appBar.headerViewController.headerView.backgroundColor = color
-    appBar.navigationBar.tintColor = UIColor.white
+    appBar.headerViewController.headerView.backgroundColor = CatalogStyle.primaryColor
+    appBar.navigationBar.tintColor = CatalogStyle.primaryTextColor
     appBar.navigationBar.titleTextAttributes =
-      [ NSForegroundColorAttributeName: UIColor.white ]
+      [ NSForegroundColorAttributeName: CatalogStyle.primaryTextColor,
+        NSFontAttributeName: CatalogStyle.headerFont! ]
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/components/AppBar/examples/AppBarTypicalUseExample.m
+++ b/components/AppBar/examples/AppBarTypicalUseExample.m
@@ -17,6 +17,7 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialAppBar.h"
+#import "MDCCatalogStyle.h"
 
 @interface AppBarTypicalUseExample : UITableViewController
 
@@ -37,11 +38,11 @@
     [self addChildViewController:_appBar.headerViewController];
 
     // Optional: Change the App Bar's background color and tint color.
-    UIColor *color = [UIColor colorWithWhite:0.1 alpha:1];
-    _appBar.headerViewController.headerView.backgroundColor = color;
-    _appBar.navigationBar.tintColor = [UIColor whiteColor];
+    _appBar.headerViewController.headerView.backgroundColor = [MDCCatalogStyle blackColor];
+    _appBar.navigationBar.tintColor = [MDCCatalogStyle whiteColor];
     _appBar.navigationBar.titleTextAttributes =
-        @{NSForegroundColorAttributeName : [UIColor whiteColor]};
+        @{NSForegroundColorAttributeName : [MDCCatalogStyle whiteColor],
+          NSFontAttributeName: [MDCCatalogStyle headerFont]};
   }
   return self;
 }

--- a/components/AppBar/examples/AppBarTypicalUseExample.m
+++ b/components/AppBar/examples/AppBarTypicalUseExample.m
@@ -17,7 +17,7 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialAppBar.h"
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
 @interface AppBarTypicalUseExample : UITableViewController
 
@@ -38,11 +38,11 @@
     [self addChildViewController:_appBar.headerViewController];
 
     // Optional: Change the App Bar's background color and tint color.
-    _appBar.headerViewController.headerView.backgroundColor = [MDCCatalogStyle blackColor];
-    _appBar.navigationBar.tintColor = [MDCCatalogStyle whiteColor];
+    _appBar.headerViewController.headerView.backgroundColor = [CatalogStyle blackColor];
+    _appBar.navigationBar.tintColor = [CatalogStyle whiteColor];
     _appBar.navigationBar.titleTextAttributes =
-        @{NSForegroundColorAttributeName : [MDCCatalogStyle whiteColor],
-          NSFontAttributeName: [MDCCatalogStyle headerFont]};
+        @{NSForegroundColorAttributeName : [CatalogStyle whiteColor],
+          NSFontAttributeName: [CatalogStyle headerFont]};
   }
   return self;
 }

--- a/components/AppBar/examples/AppBarTypicalUseExample.m
+++ b/components/AppBar/examples/AppBarTypicalUseExample.m
@@ -38,11 +38,12 @@
     [self addChildViewController:_appBar.headerViewController];
 
     // Optional: Change the App Bar's background color and tint color.
-    _appBar.headerViewController.headerView.backgroundColor = [CatalogStyle blackColor];
-    _appBar.navigationBar.tintColor = [CatalogStyle whiteColor];
-    _appBar.navigationBar.titleTextAttributes =
-        @{NSForegroundColorAttributeName : [CatalogStyle whiteColor],
-          NSFontAttributeName: [CatalogStyle headerFont]};
+    _appBar.headerViewController.headerView.backgroundColor = [CatalogStyle primaryColor];
+    _appBar.navigationBar.tintColor = [CatalogStyle primaryTextColor];
+    _appBar.navigationBar.titleTextAttributes = @{
+        NSForegroundColorAttributeName : [CatalogStyle primaryTextColor],
+        NSFontAttributeName: [CatalogStyle headerFont]
+    };
   }
   return self;
 }

--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -30,11 +30,11 @@ class AppBarTypicalUseSwiftExample: UITableViewController {
     // Step 2: Add the headerViewController as a child.
     self.addChildViewController(appBar.headerViewController)
 
-    let color = UIColor(white: 0.1, alpha:1)
-    appBar.headerViewController.headerView.backgroundColor = color
-    appBar.navigationBar.tintColor = UIColor.white
+    appBar.headerViewController.headerView.backgroundColor = CatalogStyle.blackColor
+    appBar.navigationBar.tintColor = CatalogStyle.whiteColor
     appBar.navigationBar.titleTextAttributes =
-      [ NSForegroundColorAttributeName: UIColor.white ]
+      [ NSForegroundColorAttributeName: CatalogStyle.whiteColor,
+        NSFontAttributeName: CatalogStyle.headerFont ]
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -34,7 +34,7 @@ class AppBarTypicalUseSwiftExample: UITableViewController {
     appBar.navigationBar.tintColor = CatalogStyle.whiteColor
     appBar.navigationBar.titleTextAttributes =
       [ NSForegroundColorAttributeName: CatalogStyle.whiteColor,
-        NSFontAttributeName: CatalogStyle.headerFont ]
+        NSFontAttributeName: CatalogStyle.headerFont! ]
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -30,10 +30,10 @@ class AppBarTypicalUseSwiftExample: UITableViewController {
     // Step 2: Add the headerViewController as a child.
     self.addChildViewController(appBar.headerViewController)
 
-    appBar.headerViewController.headerView.backgroundColor = CatalogStyle.blackColor
-    appBar.navigationBar.tintColor = CatalogStyle.whiteColor
+    appBar.headerViewController.headerView.backgroundColor = CatalogStyle.primaryColor
+    appBar.navigationBar.tintColor = CatalogStyle.primaryTextColor
     appBar.navigationBar.titleTextAttributes =
-      [ NSForegroundColorAttributeName: CatalogStyle.whiteColor,
+      [ NSForegroundColorAttributeName: CatalogStyle.primaryTextColor,
         NSFontAttributeName: CatalogStyle.headerFont! ]
   }
 

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
@@ -92,11 +92,11 @@ extension ButtonBarTypicalUseSwiftExample {
 
 extension ButtonBarTypicalUseSwiftExample {
   func buttonBarBackgroundColor() -> UIColor {
-    return UIColor(white: 0.1, alpha: 1.0)
+    return UIColor(white: 0.8, alpha: 1.0)
   }
 
   func itemTitleTextAttributes () -> [String: Any] {
-    let textColor = UIColor(white: 1, alpha: 0.8)
+    let textColor = UIColor(white: 0, alpha: 0.8)
     return [NSForegroundColorAttributeName: textColor]
   }
 }

--- a/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
+++ b/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
@@ -27,8 +27,8 @@ class ButtonsDynamicTypeViewController: UIViewController {
     super.viewDidLoad()
 
     view.backgroundColor = CatalogStyle.greyColor
-    let titleColor = CatalogStyle.whiteColor
-    let backgroundColor = CatalogStyle.blackColor
+    let titleColor = CatalogStyle.primaryTextColor
+    let backgroundColor = CatalogStyle.primaryColor
 
     let flatButtonStatic = MDCRaisedButton()
     flatButtonStatic.setTitleColor(titleColor, for: .normal)

--- a/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
+++ b/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
@@ -26,9 +26,9 @@ class ButtonsDynamicTypeViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor = UIColor(white: 0.9, alpha:1.0)
-    let titleColor = UIColor.white
-    let backgroundColor = UIColor(white: 0.1, alpha: 1.0)
+    view.backgroundColor = CatalogStyle.greyColor
+    let titleColor = CatalogStyle.whiteColor
+    let backgroundColor = CatalogStyle.blackColor
 
     let flatButtonStatic = MDCRaisedButton()
     flatButtonStatic.setTitleColor(titleColor, for: .normal)

--- a/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
+++ b/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
@@ -29,7 +29,7 @@ class ButtonsSimpleExampleSwiftViewController: UIViewController {
     super.viewDidLoad()
 
     view.backgroundColor = CatalogStyle.greyColor
-    let backgroundColor = CatalogStyle.blackColor
+    let backgroundColor = CatalogStyle.primaryColor
 
     let raisedButton = MDCRaisedButton()
     raisedButton.setBackgroundColor(backgroundColor, for: .normal)

--- a/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
+++ b/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
@@ -28,9 +28,8 @@ class ButtonsSimpleExampleSwiftViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor = UIColor(white: 0.9, alpha: 1.0);
-    //let titleColor = UIColor.white
-    let backgroundColor = UIColor(white: 0.1, alpha: 1.0)
+    view.backgroundColor = CatalogStyle.greyColor
+    let backgroundColor = CatalogStyle.blackColor
 
     let raisedButton = MDCRaisedButton()
     raisedButton.setBackgroundColor(backgroundColor, for: .normal)

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -113,8 +113,8 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
                          constant: 0)
     ])
 
-    let titleColor = CatalogStyle.whiteColor
-    let backgroundColor = CatalogStyle.blackColor
+    let titleColor = CatalogStyle.primaryTextColor
+    let backgroundColor = CatalogStyle.primaryColor
 
     raisedButton.setTitle("Programmatic", for: .normal)
     raisedButton.setTitleColor(titleColor, for: .normal)

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -113,8 +113,8 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
                          constant: 0)
     ])
 
-    let titleColor = UIColor.white
-    let backgroundColor = UIColor(white: 0.1, alpha: 1.0)
+    let titleColor = CatalogStyle.whiteColor
+    let backgroundColor = CatalogStyle.blackColor
 
     raisedButton.setTitle("Programmatic", for: .normal)
     raisedButton.setTitleColor(titleColor, for: .normal)

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -19,6 +19,8 @@
 #import "MaterialButtons.h"
 #import "MaterialTypography.h"
 
+#import "MDCCatalogStyle.h"
+
 @interface ButtonsTypicalUseViewController ()
 
 @end
@@ -27,9 +29,9 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  self.view.backgroundColor = [UIColor colorWithWhite:0.9 alpha:1.0];
-  UIColor *buttonBackground = [UIColor colorWithWhite:0.1 alpha:1.0];
-  UIColor *titleColor = [UIColor whiteColor];
+  self.view.backgroundColor = [MDCCatalogStyle greyColor];
+  UIColor *buttonBackground = [MDCCatalogStyle blackColor];
+  UIColor *titleColor = [MDCCatalogStyle whiteColor];
 
   // Raised button
 

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -19,7 +19,7 @@
 #import "MaterialButtons.h"
 #import "MaterialTypography.h"
 
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
 @interface ButtonsTypicalUseViewController ()
 
@@ -29,9 +29,9 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  self.view.backgroundColor = [MDCCatalogStyle greyColor];
-  UIColor *buttonBackground = [MDCCatalogStyle blackColor];
-  UIColor *titleColor = [MDCCatalogStyle whiteColor];
+  self.view.backgroundColor = [CatalogStyle greyColor];
+  UIColor *buttonBackground = [CatalogStyle blackColor];
+  UIColor *titleColor = [CatalogStyle whiteColor];
 
   // Raised button
 

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -30,8 +30,8 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
   self.view.backgroundColor = [CatalogStyle greyColor];
-  UIColor *buttonBackground = [CatalogStyle blackColor];
-  UIColor *titleColor = [CatalogStyle whiteColor];
+  UIColor *buttonBackground = [CatalogStyle primaryColor];
+  UIColor *titleColor = [CatalogStyle primaryTextColor];
 
   // Raised button
 
@@ -50,7 +50,7 @@
 
   MDCRaisedButton *disabledRaisedButton = [[MDCRaisedButton alloc] init];
   [disabledRaisedButton setTitleColor:titleColor forState:UIControlStateNormal];
-  [disabledRaisedButton setBackgroundColor:buttonBackground forState:UIControlStateNormal];
+  [disabledRaisedButton setBackgroundColor:[CatalogStyle greyColor] forState:UIControlStateNormal];
   [disabledRaisedButton setTitle:@"Button" forState:UIControlStateNormal];
   [disabledRaisedButton sizeToFit];
   [disabledRaisedButton addTarget:self

--- a/components/CollectionCells/examples/CollectionCellsLayoutExample.m
+++ b/components/CollectionCells/examples/CollectionCellsLayoutExample.m
@@ -17,6 +17,8 @@
 #import "CollectionCellsLayoutExample.h"
 
 #import "MaterialTypography.h"
+#import "MDCCatalogStyle.h"
+
 
 @interface SimpleModel : NSObject
 @property(nonatomic, strong, nullable) NSString *text;
@@ -67,10 +69,6 @@ static NSString *const kExampleText =
 static NSString *const kExampleDetailText =
     @"Pellentesque non quam ornare, porta urna sed, malesuada felis. Praesent at gravida felis, "
      "non facilisis enim. Proin dapibus laoreet lorem, in viverra leo dapibus a.";
-
-#define RGBCOLOR(r, g, b) \
-  [UIColor colorWithRed:(r) / 255.0f green:(g) / 255.0f blue:(b) / 255.0f alpha:1]
-#define HEXCOLOR(hex) RGBCOLOR((((hex) >> 16) & 0xFF), (((hex) >> 8) & 0xFF), ((hex)&0xFF))
 
 @implementation CollectionCellsLayoutExample {
   NSMutableArray *_content;
@@ -160,7 +158,7 @@ static NSString *const kExampleDetailText =
   }
   if (model.circle) {
     cell.imageView.image =
-        [self imageWithSize:CGSizeMake(40, 40) color:HEXCOLOR(0x80CBC4) cornerRadius:20];
+        [self imageWithSize:CGSizeMake(40, 40) color:[MDCCatalogStyle greenColor] cornerRadius:20];
   }
 
   return cell;

--- a/components/CollectionCells/examples/CollectionCellsLayoutExample.m
+++ b/components/CollectionCells/examples/CollectionCellsLayoutExample.m
@@ -17,7 +17,7 @@
 #import "CollectionCellsLayoutExample.h"
 
 #import "MaterialTypography.h"
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
 
 @interface SimpleModel : NSObject
@@ -158,7 +158,7 @@ static NSString *const kExampleDetailText =
   }
   if (model.circle) {
     cell.imageView.image =
-        [self imageWithSize:CGSizeMake(40, 40) color:[MDCCatalogStyle greenColor] cornerRadius:20];
+        [self imageWithSize:CGSizeMake(40, 40) color:[CatalogStyle greenColor] cornerRadius:20];
   }
 
   return cell;

--- a/components/CollectionCells/examples/CollectionCellsLayoutExample.m
+++ b/components/CollectionCells/examples/CollectionCellsLayoutExample.m
@@ -158,7 +158,7 @@ static NSString *const kExampleDetailText =
   }
   if (model.circle) {
     cell.imageView.image =
-        [self imageWithSize:CGSizeMake(40, 40) color:[CatalogStyle greenColor] cornerRadius:20];
+        [self imageWithSize:CGSizeMake(40, 40) color:[CatalogStyle secondaryColor] cornerRadius:20];
   }
 
   return cell;

--- a/components/Dialogs/examples/DialogsAlertViewController.m
+++ b/components/Dialogs/examples/DialogsAlertViewController.m
@@ -53,7 +53,7 @@
 
 - (IBAction)didTapShowAlert:(id)sender {
   [[MDCButton appearanceWhenContainedIn:[MDCAlertController class], nil]
-      setCustomTitleColor:[CatalogStyle blackColor]];
+      setCustomTitleColor:[CatalogStyle primaryColor]];
 
   NSString *titleString = @"Using Material alert controller?";
   NSString *messageString = @"Be careful with modal alerts as they can be annoying if over-used.";

--- a/components/Dialogs/examples/DialogsAlertViewController.m
+++ b/components/Dialogs/examples/DialogsAlertViewController.m
@@ -19,6 +19,8 @@
 #import "MaterialButtons.h"
 #import "MaterialDialogs.h"
 
+#import "CatalogStyle.h"
+
 @implementation DialogsAlertViewController
 
 
@@ -51,7 +53,7 @@
 
 - (IBAction)didTapShowAlert:(id)sender {
   [[MDCButton appearanceWhenContainedIn:[MDCAlertController class], nil]
-      setCustomTitleColor:[UIColor colorWithWhite:0.1 alpha:1.0]];
+      setCustomTitleColor:[CatalogStyle blackColor]];
 
   NSString *titleString = @"Using Material alert controller?";
   NSString *messageString = @"Be careful with modal alerts as they can be annoying if over-used.";

--- a/components/Dialogs/examples/DialogsLongAlertViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertViewController.swift
@@ -27,7 +27,7 @@ class DialogsLongAlertViewController: UIViewController {
     view.backgroundColor = UIColor.white
 
     flatButton.setTitle("PRESENT ALERT", for: UIControlState())
-    flatButton.setTitleColor(UIColor(white: 0.1, alpha:1), for: UIControlState())
+    flatButton.setTitleColor(CatalogStyle.blackColor, for: UIControlState())
     flatButton.sizeToFit()
     flatButton.translatesAutoresizingMaskIntoConstraints = false
     flatButton.addTarget(self, action: #selector(tap), for: .touchUpInside)
@@ -77,7 +77,7 @@ class DialogsLongAlertViewController: UIViewController {
 // MARK: Catalog by convention
 extension DialogsLongAlertViewController {
   class func catalogBreadcrumbs() -> [String] {
-    return [ "Dialogs", "Swift Alert Demo"]
+    return [ "Dialogs", "Swift Alert Example"]
   }
   class func catalogDescription() -> String {
     return "Swift Alert Example"

--- a/components/Dialogs/examples/DialogsLongAlertViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertViewController.swift
@@ -27,7 +27,7 @@ class DialogsLongAlertViewController: UIViewController {
     view.backgroundColor = UIColor.white
 
     flatButton.setTitle("PRESENT ALERT", for: UIControlState())
-    flatButton.setTitleColor(CatalogStyle.blackColor, for: UIControlState())
+    flatButton.setTitleColor(CatalogStyle.primaryColor, for: UIControlState())
     flatButton.sizeToFit()
     flatButton.translatesAutoresizingMaskIntoConstraints = false
     flatButton.addTarget(self, action: #selector(tap), for: .touchUpInside)

--- a/components/Dialogs/examples/supplemental/DialogsAlertViewControllerSupplemental.h
+++ b/components/Dialogs/examples/supplemental/DialogsAlertViewControllerSupplemental.h
@@ -25,5 +25,8 @@
 
 @interface DialogsAlertViewController : MDCCollectionViewController
 @property(nonatomic, strong, nullable) NSArray *modes;
+@end
+
+@interface DialogsAlertViewController (Supplemental)
 - (void)loadCollectionView:(nullable NSArray *)modes;
 @end

--- a/components/Dialogs/examples/supplemental/DialogsAlertViewControllerSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsAlertViewControllerSupplemental.m
@@ -56,15 +56,16 @@ static NSString * const kReusableIdentifierItem = @"cell";
 @implementation DialogsAlertViewController (CatalogByConvention)
 
 + (NSArray *)catalogBreadcrumbs {
-  return @[ @"Dialogs", @"AlertController" ];
+  return @[ @"Dialogs", @"Alerts" ];
 }
 
 + (NSString *)catalogDescription {
-  return @"Demonstrate Material spec'd alert controllers.";
+  return @"The dialog component can be used to display simple alert style dialogs and "
+         @" fully custom content inside a container.";
 }
 
 + (BOOL)catalogIsPrimaryDemo {
-  return NO;
+  return YES;
 }
 
 @end

--- a/components/Dialogs/examples/supplemental/DialogsKeyboardViewControllerSupplemental.h
+++ b/components/Dialogs/examples/supplemental/DialogsKeyboardViewControllerSupplemental.h
@@ -24,5 +24,8 @@
 @import MaterialComponents.MaterialCollections;
 
 @interface DialogsKeyboardViewController : MDCCollectionViewController
+@end
+
+@interface DialogsKeyboardViewController (Supplemental)
 - (void)loadCollectionView;
 @end

--- a/components/Dialogs/examples/supplemental/DialogsKeyboardViewControllerSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsKeyboardViewControllerSupplemental.m
@@ -54,7 +54,7 @@ static NSString * const kReusableIdentifierItem = @"cell";
 @implementation DialogsKeyboardViewController (CatalogByConvention)
 
 + (NSArray *)catalogBreadcrumbs {
-  return @[ @"Dialogs", @"Dialog with an Input Field" ];
+  return @[ @"Dialogs", @"Text Field Dialog" ];
 }
 
 + (NSString *)catalogDescription {

--- a/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
@@ -88,8 +88,8 @@ static NSString * const kReusableIdentifierItem = @"cell";
 
   _dismissButton = [[MDCFlatButton alloc] init];
   [_dismissButton setTitle:@"Dismiss" forState:UIControlStateNormal];
-  [_dismissButton setBackgroundColor:[CatalogStyle blackColor] forState:UIControlStateNormal];
-  [_dismissButton setTitleColor:[CatalogStyle whiteColor] forState:UIControlStateNormal];
+  [_dismissButton setBackgroundColor:[CatalogStyle primaryColor] forState:UIControlStateNormal];
+  [_dismissButton setTitleColor:[CatalogStyle primaryTextColor] forState:UIControlStateNormal];
   
   _dismissButton.autoresizingMask =
       UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |

--- a/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
@@ -26,6 +26,7 @@
 #import "MaterialDialogs.h"
 #import "MaterialTypography.h"
 #import "MaterialCollections.h"
+#import "MDCCatalogStyle.h"
 
 #pragma mark - DialogsTypicalUseViewController
 
@@ -58,16 +59,16 @@ static NSString * const kReusableIdentifierItem = @"cell";
 @implementation DialogsTypicalUseViewController (CatalogByConvention)
 
 + (NSArray *)catalogBreadcrumbs {
-  return @[ @"Dialogs", @"Dialogs" ];
+  return @[ @"Dialogs", @"Containers" ];
 }
 
 + (NSString *)catalogDescription {
-  return @"Dialogs includes a presentation controller that displays your modal interfaces in a"
+  return @"Dialogs includes a presentation controller that can display a custom interfaces in a"
           " Material spec defined context.";
 }
 
 + (BOOL)catalogIsPrimaryDemo {
-  return YES;
+  return NO;
 }
 
 @end
@@ -87,7 +88,9 @@ static NSString * const kReusableIdentifierItem = @"cell";
 
   _dismissButton = [[MDCFlatButton alloc] init];
   [_dismissButton setTitle:@"Dismiss" forState:UIControlStateNormal];
-  [_dismissButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
+  [_dismissButton setBackgroundColor:[MDCCatalogStyle blackColor] forState:UIControlStateNormal];
+  [_dismissButton setTitleColor:[MDCCatalogStyle whiteColor] forState:UIControlStateNormal];
+  
   _dismissButton.autoresizingMask =
       UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |
       UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin;

--- a/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
@@ -26,7 +26,7 @@
 #import "MaterialDialogs.h"
 #import "MaterialTypography.h"
 #import "MaterialCollections.h"
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
 #pragma mark - DialogsTypicalUseViewController
 
@@ -88,8 +88,8 @@ static NSString * const kReusableIdentifierItem = @"cell";
 
   _dismissButton = [[MDCFlatButton alloc] init];
   [_dismissButton setTitle:@"Dismiss" forState:UIControlStateNormal];
-  [_dismissButton setBackgroundColor:[MDCCatalogStyle blackColor] forState:UIControlStateNormal];
-  [_dismissButton setTitleColor:[MDCCatalogStyle whiteColor] forState:UIControlStateNormal];
+  [_dismissButton setBackgroundColor:[CatalogStyle blackColor] forState:UIControlStateNormal];
+  [_dismissButton setTitleColor:[CatalogStyle whiteColor] forState:UIControlStateNormal];
   
   _dismissButton.autoresizingMask =
       UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |

--- a/components/FeatureHighlight/examples/FeatureHighlightTypicalUseViewController.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightTypicalUseViewController.m
@@ -24,7 +24,7 @@
 - (void)didTapButton:(id)sender {
   MDCFeatureHighlightViewController *vc =
       [[MDCFeatureHighlightViewController alloc] initWithHighlightedView:_button completion:nil];
-  vc.outerHighlightColor = [[CatalogStyle greenColor] colorWithAlphaComponent: kMDCFeatureHighlightOuterHighlightAlpha];
+  vc.outerHighlightColor = [[CatalogStyle greenColor] colorWithAlphaComponent:kMDCFeatureHighlightOuterHighlightAlpha];
   vc.titleText = @"Hey a title";
   vc.bodyText = @"This is the description of the feature highlight view controller.";
   [self presentViewController:vc animated:YES completion:nil];

--- a/components/FeatureHighlight/examples/FeatureHighlightTypicalUseViewController.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightTypicalUseViewController.m
@@ -24,7 +24,7 @@
 - (void)didTapButton:(id)sender {
   MDCFeatureHighlightViewController *vc =
       [[MDCFeatureHighlightViewController alloc] initWithHighlightedView:_button completion:nil];
-  vc.outerHighlightColor = [[CatalogStyle greenColor] colorWithAlphaComponent:kMDCFeatureHighlightOuterHighlightAlpha];
+  vc.outerHighlightColor = [[CatalogStyle secondaryColor] colorWithAlphaComponent:kMDCFeatureHighlightOuterHighlightAlpha];
   vc.titleText = @"Hey a title";
   vc.bodyText = @"This is the description of the feature highlight view controller.";
   [self presentViewController:vc animated:YES completion:nil];

--- a/components/FeatureHighlight/examples/FeatureHighlightTypicalUseViewController.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightTypicalUseViewController.m
@@ -17,17 +17,14 @@
 #import "FeatureHighlightExampleSupplemental.h"
 
 #import "MaterialFeatureHighlight.h"
+#import "CatalogStyle.h"
 
 @implementation FeatureHighlightTypicalUseViewController
 
 - (void)didTapButton:(id)sender {
   MDCFeatureHighlightViewController *vc =
       [[MDCFeatureHighlightViewController alloc] initWithHighlightedView:_button completion:nil];
-  vc.outerHighlightColor =
-      [UIColor colorWithRed:11/255.0
-                      green:232/255.0
-                       blue:94/255.0
-                      alpha:kMDCFeatureHighlightOuterHighlightAlpha];
+  vc.outerHighlightColor = [[CatalogStyle greenColor] colorWithAlphaComponent: kMDCFeatureHighlightOuterHighlightAlpha];
   vc.titleText = @"Hey a title";
   vc.bodyText = @"This is the description of the feature highlight view controller.";
   [self presentViewController:vc animated:YES completion:nil];

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
@@ -20,6 +20,8 @@
 #import "MaterialPalettes.h"
 #import "MaterialTypography.h"
 
+#import "CatalogStyle.h"
+
 static NSString *const reuseIdentifier = @"Cell";
 
 @implementation FeatureHighlightTypicalUseViewController (CatalogByConvention)
@@ -50,7 +52,7 @@ static NSString *const reuseIdentifier = @"Cell";
   [self.view addSubview:self.infoLabel];
 
   self.button = [[MDCRaisedButton alloc] init];
-  [self.button setBackgroundColor:[UIColor colorWithWhite:0.1 alpha:1]];
+  [self.button setBackgroundColor:[CatalogStyle blackColor]];
   [self.button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
   [self.button setTitle:@"Action" forState:UIControlStateNormal];
   [self.button sizeToFit];

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
@@ -52,7 +52,7 @@ static NSString *const reuseIdentifier = @"Cell";
   [self.view addSubview:self.infoLabel];
 
   self.button = [[MDCRaisedButton alloc] init];
-  [self.button setBackgroundColor:[CatalogStyle blackColor]];
+  [self.button setBackgroundColor:[CatalogStyle primaryColor]];
   [self.button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
   [self.button setTitle:@"Action" forState:UIControlStateNormal];
   [self.button sizeToFit];

--- a/components/FlexibleHeader/examples/FlexibleHeaderFABExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderFABExample.m
@@ -21,7 +21,7 @@
 #import "MaterialButtons.h"
 #import "MaterialFlexibleHeader.h"
 
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
 static const CGFloat kFlexibleHeaderMinHeight = 200.f;
 
@@ -74,7 +74,7 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [MDCCatalogStyle blackColor];
+  self.fhvc.headerView.backgroundColor = [CatalogStyle blackColor];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -85,7 +85,7 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
   [self.navigationController setNavigationBarHidden:YES animated:animated];
 
   self.floatingButton = [[MDCFloatingButton alloc] init];
-  [self.floatingButton setBackgroundColor:[MDCCatalogStyle greenColor]
+  [self.floatingButton setBackgroundColor:[CatalogStyle greenColor]
                                  forState:UIControlStateNormal];
   [self.floatingButton sizeToFit];
   self.floatingButton.center = CGPointMake(

--- a/components/FlexibleHeader/examples/FlexibleHeaderFABExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderFABExample.m
@@ -21,6 +21,8 @@
 #import "MaterialButtons.h"
 #import "MaterialFlexibleHeader.h"
 
+#import "MDCCatalogStyle.h"
+
 static const CGFloat kFlexibleHeaderMinHeight = 200.f;
 
 @interface FlexibleHeaderFABExample () <UIScrollViewDelegate>
@@ -64,21 +66,15 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+  [self loadCollectionView];
 
-  self.scrollView = [[UIScrollView alloc] initWithFrame:self.view.bounds];
-  self.scrollView.backgroundColor = [UIColor whiteColor];
-  self.scrollView.autoresizingMask =
-      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  [self.view addSubview:self.scrollView];
-
-  self.scrollView.delegate = self;
-  self.fhvc.headerView.trackingScrollView = self.scrollView;
+  self.fhvc.headerView.trackingScrollView = self.collectionView;
 
   self.fhvc.view.frame = self.view.bounds;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1.0];
+  self.fhvc.headerView.backgroundColor = [MDCCatalogStyle blackColor];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -89,7 +85,7 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
   [self.navigationController setNavigationBarHidden:YES animated:animated];
 
   self.floatingButton = [[MDCFloatingButton alloc] init];
-  [self.floatingButton setBackgroundColor:[UIColor colorWithRed:11/255.0 green:232/255.0 blue:94/255.0 alpha:1]
+  [self.floatingButton setBackgroundColor:[MDCCatalogStyle greenColor]
                                  forState:UIControlStateNormal];
   [self.floatingButton sizeToFit];
   self.floatingButton.center = CGPointMake(

--- a/components/FlexibleHeader/examples/FlexibleHeaderFABExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderFABExample.m
@@ -74,7 +74,7 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [CatalogStyle blackColor];
+  self.fhvc.headerView.backgroundColor = [CatalogStyle primaryColor];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -85,7 +85,7 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
   [self.navigationController setNavigationBarHidden:YES animated:animated];
 
   self.floatingButton = [[MDCFloatingButton alloc] init];
-  [self.floatingButton setBackgroundColor:[CatalogStyle greenColor]
+  [self.floatingButton setBackgroundColor:[CatalogStyle secondaryColor]
                                  forState:UIControlStateNormal];
   [self.floatingButton sizeToFit];
   self.floatingButton.center = CGPointMake(

--- a/components/FlexibleHeader/examples/FlexibleHeaderHorizontalPagingExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderHorizontalPagingExample.m
@@ -149,7 +149,7 @@ static const NSUInteger kNumberOfPages = 10;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [CatalogStyle blackColor];
+  self.fhvc.headerView.backgroundColor = [CatalogStyle primaryColor];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {

--- a/components/FlexibleHeader/examples/FlexibleHeaderHorizontalPagingExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderHorizontalPagingExample.m
@@ -18,12 +18,7 @@
 
 #import "MaterialFlexibleHeader.h"
 
-static UIColor *HexColor(uint32_t hex) {
-  return [UIColor colorWithRed:(CGFloat)((uint8_t)(hex >> 16)) / (CGFloat)255
-                         green:(CGFloat)((uint8_t)(hex >> 8)) / (CGFloat)255
-                          blue:(CGFloat)((uint8_t)hex) / (CGFloat)255
-                         alpha:1];
-}
+#import "MDCCatalogStyle.h"
 
 static const NSUInteger kNumberOfPages = 10;
 
@@ -46,7 +41,7 @@ static const NSUInteger kNumberOfPages = 10;
   _pagingScrollView.scrollsToTop = NO;
   self.title = @"Swipe Right From Left Edge to Go Back";
 
-  NSArray *pageColors = @[ HexColor(0x55C4F5), HexColor(0x8BC34A), HexColor(0xFFC107) ];
+  NSArray *pageColors = [MDCCatalogStyle shadesOfGrey:3];
 
   NSMutableArray *pageScrollViews = [NSMutableArray array];
   for (NSUInteger ix = 0; ix < kNumberOfPages; ++ix) {
@@ -154,7 +149,7 @@ static const NSUInteger kNumberOfPages = 10;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1.0];
+  self.fhvc.headerView.backgroundColor = [MDCCatalogStyle blackColor];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {

--- a/components/FlexibleHeader/examples/FlexibleHeaderHorizontalPagingExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderHorizontalPagingExample.m
@@ -18,7 +18,7 @@
 
 #import "MaterialFlexibleHeader.h"
 
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
 static const NSUInteger kNumberOfPages = 10;
 
@@ -41,7 +41,7 @@ static const NSUInteger kNumberOfPages = 10;
   _pagingScrollView.scrollsToTop = NO;
   self.title = @"Swipe Right From Left Edge to Go Back";
 
-  NSArray *pageColors = [MDCCatalogStyle shadesOfGrey:3];
+  NSArray *pageColors = [CatalogStyle shadesOfGrey:3];
 
   NSMutableArray *pageScrollViews = [NSMutableArray array];
   for (NSUInteger ix = 0; ix < kNumberOfPages; ++ix) {
@@ -149,7 +149,7 @@ static const NSUInteger kNumberOfPages = 10;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [MDCCatalogStyle blackColor];
+  self.fhvc.headerView.backgroundColor = [CatalogStyle blackColor];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {

--- a/components/FlexibleHeader/examples/FlexibleHeaderPageControlExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderPageControlExample.m
@@ -22,7 +22,7 @@
 #import "MaterialFlexibleHeader.h"
 #import "MaterialPageControl.h"
 
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
 static const CGFloat kFlexibleHeaderMinHeight = 200.f;
 
@@ -84,7 +84,7 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [MDCCatalogStyle blackColor];
+  self.fhvc.headerView.backgroundColor = [CatalogStyle blackColor];
 
   CGFloat boundsWidth = CGRectGetWidth(self.fhvc.headerView.bounds);
   CGFloat boundsHeight = CGRectGetHeight(self.fhvc.headerView.bounds);

--- a/components/FlexibleHeader/examples/FlexibleHeaderPageControlExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderPageControlExample.m
@@ -22,15 +22,10 @@
 #import "MaterialFlexibleHeader.h"
 #import "MaterialPageControl.h"
 
+#import "MDCCatalogStyle.h"
+
 static const CGFloat kFlexibleHeaderMinHeight = 200.f;
 
-// Creates a UIColor from a 24-bit RGB color encoded as an integer.
-static inline UIColor *ColorFromRGB(uint32_t rgbValue) {
-  return [UIColor colorWithRed:((CGFloat)((rgbValue & 0xFF0000) >> 16)) / 255
-                         green:((CGFloat)((rgbValue & 0x00FF00) >> 8)) / 255
-                          blue:((CGFloat)((rgbValue & 0x0000FF) >> 0)) / 255
-                         alpha:1];
-}
 
 @interface FlexibleHeaderPageControlExample () <UIScrollViewDelegate>
 
@@ -89,7 +84,7 @@ static inline UIColor *ColorFromRGB(uint32_t rgbValue) {
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1];
+  self.fhvc.headerView.backgroundColor = [MDCCatalogStyle blackColor];
 
   CGFloat boundsWidth = CGRectGetWidth(self.fhvc.headerView.bounds);
   CGFloat boundsHeight = CGRectGetHeight(self.fhvc.headerView.bounds);

--- a/components/FlexibleHeader/examples/FlexibleHeaderPageControlExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderPageControlExample.m
@@ -84,7 +84,7 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [CatalogStyle blackColor];
+  self.fhvc.headerView.backgroundColor = [CatalogStyle primaryColor];
 
   CGFloat boundsWidth = CGRectGetWidth(self.fhvc.headerView.bounds);
   CGFloat boundsHeight = CGRectGetHeight(self.fhvc.headerView.bounds);

--- a/components/FlexibleHeader/examples/FlexibleHeaderTopLayoutGuideExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderTopLayoutGuideExample.m
@@ -78,7 +78,7 @@
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [CatalogStyle blackColor];
+  self.fhvc.headerView.backgroundColor = [CatalogStyle primaryColor];
   self.fhvc.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar;
 
   [self setupScrollViewContent];
@@ -87,7 +87,7 @@
 
   // Create UIView Object
   UIView *constrainedView = [[UIView alloc] init];
-  constrainedView.backgroundColor = [CatalogStyle greenColor];
+  constrainedView.backgroundColor = [CatalogStyle secondaryColor];
   constrainedView.translatesAutoresizingMaskIntoConstraints = NO;
   self.constrainedView = constrainedView;
   [self.view addSubview:self.constrainedView];

--- a/components/FlexibleHeader/examples/FlexibleHeaderTopLayoutGuideExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderTopLayoutGuideExample.m
@@ -20,7 +20,7 @@
 
 #import "MaterialFlexibleHeader.h"
 
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
 @interface FlexibleHeaderTopLayoutGuideExample () <MDCFlexibleHeaderViewLayoutDelegate,
                                                    UIScrollViewDelegate>
@@ -78,7 +78,7 @@
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [MDCCatalogStyle blackColor];
+  self.fhvc.headerView.backgroundColor = [CatalogStyle blackColor];
   self.fhvc.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar;
 
   [self setupScrollViewContent];
@@ -87,7 +87,7 @@
 
   // Create UIView Object
   UIView *constrainedView = [[UIView alloc] init];
-  constrainedView.backgroundColor = [MDCCatalogStyle greenColor];
+  constrainedView.backgroundColor = [CatalogStyle greenColor];
   constrainedView.translatesAutoresizingMaskIntoConstraints = NO;
   self.constrainedView = constrainedView;
   [self.view addSubview:self.constrainedView];

--- a/components/FlexibleHeader/examples/FlexibleHeaderTopLayoutGuideExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderTopLayoutGuideExample.m
@@ -20,6 +20,8 @@
 
 #import "MaterialFlexibleHeader.h"
 
+#import "MDCCatalogStyle.h"
+
 @interface FlexibleHeaderTopLayoutGuideExample () <MDCFlexibleHeaderViewLayoutDelegate,
                                                    UIScrollViewDelegate>
 
@@ -76,7 +78,7 @@
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1.0];
+  self.fhvc.headerView.backgroundColor = [MDCCatalogStyle blackColor];
   self.fhvc.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar;
 
   [self setupScrollViewContent];
@@ -85,8 +87,7 @@
 
   // Create UIView Object
   UIView *constrainedView = [[UIView alloc] init];
-  constrainedView.backgroundColor =
-      [UIColor colorWithRed:11/255.0 green:232/255.0 blue:94/255.0 alpha:1];
+  constrainedView.backgroundColor = [MDCCatalogStyle greenColor];
   constrainedView.translatesAutoresizingMaskIntoConstraints = NO;
   self.constrainedView = constrainedView;
   [self.view addSubview:self.constrainedView];

--- a/components/FlexibleHeader/examples/FlexibleHeaderTypicalUseExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderTypicalUseExample.m
@@ -78,7 +78,7 @@
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [CatalogStyle blackColor];
+  self.fhvc.headerView.backgroundColor = [CatalogStyle primaryColor];
 
   [self setupExampleViews];
 }

--- a/components/FlexibleHeader/examples/FlexibleHeaderTypicalUseExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderTypicalUseExample.m
@@ -20,6 +20,8 @@
 
 #import "FlexibleHeaderTypicalUseSupplemental.h"
 
+#import "CatalogStyle.h"
+
 @interface FlexibleHeaderTypicalUseViewController ()
 
 @property(nonatomic) MDCFlexibleHeaderViewController *fhvc;
@@ -76,7 +78,7 @@
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1.0];
+  self.fhvc.headerView.backgroundColor = [CatalogStyle blackColor];
 
   [self setupExampleViews];
 }

--- a/components/FlexibleHeader/examples/FlexibleHeaderUINavigationBarExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderUINavigationBarExample.m
@@ -123,7 +123,7 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [CatalogStyle blackColor];
+  self.fhvc.headerView.backgroundColor = [CatalogStyle primaryColor];
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/components/FlexibleHeader/examples/FlexibleHeaderUINavigationBarExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderUINavigationBarExample.m
@@ -21,6 +21,8 @@
 #import "MaterialButtons.h"
 #import "MaterialFlexibleHeader.h"
 
+#import "CatalogStyle.h"
+
 static const CGFloat kFlexibleHeaderMinHeight = 200.f;
 
 @interface FlexibleHeaderUINavigationBarExample () <UIScrollViewDelegate>
@@ -121,7 +123,7 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1.0];
+  self.fhvc.headerView.backgroundColor = [CatalogStyle blackColor];
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/components/FlexibleHeader/examples/FlexibleHeaderWrappedExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderWrappedExample.m
@@ -20,6 +20,8 @@
 
 #import "MaterialFlexibleHeader.h"
 
+#import "CatalogStyle.h"
+
 @interface FlexibleHeaderWrappedExample () <UIScrollViewDelegate>
 
 @property(nonatomic) MDCFlexibleHeaderViewController *fhvc;
@@ -81,7 +83,7 @@
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1];
+  self.fhvc.headerView.backgroundColor = [CatalogStyle blackColor];
 
   [self.scrollView setScrollEnabled:YES];
   [self.scrollView addSubview:self.wrappedViewController.view];

--- a/components/FlexibleHeader/examples/FlexibleHeaderWrappedExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderWrappedExample.m
@@ -83,7 +83,7 @@
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [CatalogStyle blackColor];
+  self.fhvc.headerView.backgroundColor = [CatalogStyle primaryColor];
 
   [self.scrollView setScrollEnabled:YES];
   [self.scrollView addSubview:self.wrappedViewController.view];

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
@@ -24,6 +24,8 @@
 #import "FlexibleHeaderConfiguratorControlItem.h"
 #import "MaterialFlexibleHeader.h"
 
+#import "CatalogStyle.h"
+
 static const UITableViewStyle kStyle = UITableViewStyleGrouped;
 
 @implementation FlexibleHeaderConfiguratorExample (CatalogByConvention)
@@ -76,7 +78,7 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1.0];
+  self.fhvc.headerView.backgroundColor = [CatalogStyle blackColor];
 
   UILabel *titleLabel = [[UILabel alloc] init];
   CGRect frame = self.fhvc.headerView.bounds;

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
@@ -78,7 +78,7 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [CatalogStyle blackColor];
+  self.fhvc.headerView.backgroundColor = [CatalogStyle primaryColor];
 
   UILabel *titleLabel = [[UILabel alloc] init];
   CGRect frame = self.fhvc.headerView.bounds;

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderFABSupplemental.h
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderFABSupplemental.h
@@ -21,12 +21,11 @@
 
 #import <UIKit/UIKit.h>
 
-@interface FlexibleHeaderFABExample : UIViewController
+#import "MaterialCollections.h"
 
-@property(nonatomic, strong, nullable) UIScrollView *scrollView;
-
+@interface FlexibleHeaderFABExample : MDCCollectionViewController
 @end
 
 @interface FlexibleHeaderFABExample (Supplemental)
-
+- (void)loadCollectionView;
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderFABSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderFABSupplemental.m
@@ -23,15 +23,27 @@
 
 #import "MaterialFlexibleHeader.h"
 
+static NSString * const kCell = @"cell";
+
 @implementation FlexibleHeaderFABExample (CatalogByConvention)
 
 + (NSArray *)catalogBreadcrumbs {
-  return @[ @"Flexible Header", @"Floating Action Button" ];
+  return @[ @"Flexible Header", @"Flexible Header with FAB" ];
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
 }
+
++ (NSString *)catalogDescription {
+  return @"The Flexible Header is a container view whose height and vertical offset react to"
+  " UIScrollViewDelegate events.";
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return YES;
+}
+
 
 @end
 
@@ -43,8 +55,48 @@
 
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
-
-  self.scrollView.contentSize = self.view.bounds.size;
 }
+
+- (void)loadCollectionView {
+  [self.collectionView registerClass:[MDCCollectionViewTextCell class]
+          forCellWithReuseIdentifier:kCell];
+}
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView
+     numberOfItemsInSection:(NSInteger)section {
+  return 10;
+}
+
+- (CGFloat)collectionView:(UICollectionView *)collectionView
+    cellHeightAtIndexPath:(NSIndexPath *)indexPath {
+  if (indexPath.row == 0) return 160;
+  return 56;
+}
+
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
+                  cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+  MDCCollectionViewTextCell *cell =
+      [collectionView dequeueReusableCellWithReuseIdentifier:kCell forIndexPath:indexPath];
+  cell.textLabel.text = @"";
+  switch (indexPath.row) {
+    case 0:
+      break;
+    case 1:
+      cell.textLabel.text = @"Scroll down to shrink header.";
+      break;
+    case 2:
+      cell.textLabel.text = @"Scroll up to reveal header.";
+      break;
+    case 3:
+      cell.textLabel.text = @"Left-side swipe to go back.";
+      break;
+    default:
+      break;
+  }
+  return cell;
+}
+
+
+
 
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTypicalUseSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTypicalUseSupplemental.m
@@ -39,7 +39,7 @@
 }
 
 + (BOOL)catalogIsPrimaryDemo {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.m
+++ b/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.m
@@ -57,7 +57,7 @@
   self.navBar = [[MDCNavigationBar alloc] initWithFrame:CGRectZero];
   self.navBar.titleTextAttributes = [self itemTitleTextAttributes];
 
-  [self.navBar setBackgroundColor:[CatalogStyle blackColor]];
+  [self.navBar setBackgroundColor:[CatalogStyle primaryColor]];
 
   UIBarButtonItem *moreButton =
       [[UIBarButtonItem alloc] initWithTitle:@"Reveal"

--- a/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.m
+++ b/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.m
@@ -24,6 +24,8 @@
 #import "MaterialHeaderStackView.h"
 #import "MaterialNavigationBar.h"
 
+#import "MDCCatalogStyle.h"
+
 @interface ExampleInstructionsViewHeaderStackViewTypicalUse : UIView
 
 @end
@@ -55,7 +57,7 @@
   self.navBar = [[MDCNavigationBar alloc] initWithFrame:CGRectZero];
   self.navBar.titleTextAttributes = [self itemTitleTextAttributes];
 
-  [self.navBar setBackgroundColor:[UIColor colorWithWhite:0.1 alpha:1.0]];
+  [self.navBar setBackgroundColor:[MDCCatalogStyle blackColor]];
 
   UIBarButtonItem *moreButton =
       [[UIBarButtonItem alloc] initWithTitle:@"Reveal"

--- a/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.m
+++ b/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.m
@@ -24,7 +24,7 @@
 #import "MaterialHeaderStackView.h"
 #import "MaterialNavigationBar.h"
 
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
 @interface ExampleInstructionsViewHeaderStackViewTypicalUse : UIView
 
@@ -57,7 +57,7 @@
   self.navBar = [[MDCNavigationBar alloc] initWithFrame:CGRectZero];
   self.navBar.titleTextAttributes = [self itemTitleTextAttributes];
 
-  [self.navBar setBackgroundColor:[MDCCatalogStyle blackColor]];
+  [self.navBar setBackgroundColor:[CatalogStyle blackColor]];
 
   UIBarButtonItem *moreButton =
       [[UIBarButtonItem alloc] initWithTitle:@"Reveal"

--- a/components/Ink/examples/InkTypicalUse.m
+++ b/components/Ink/examples/InkTypicalUse.m
@@ -20,7 +20,7 @@
 
 #import "InkTypicalUseSupplemental.h"
 
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
 @interface InkTypicalUseViewController () <MDCInkTouchControllerDelegate>
 
@@ -59,7 +59,7 @@
   inkTouchController.delegate = self;
   [inkTouchController addInkView];
 
-  UIColor *greenColor = [[MDCCatalogStyle greenColor] colorWithAlphaComponent:0.2f];
+  UIColor *greenColor = [[CatalogStyle greenColor] colorWithAlphaComponent:0.2f];
   inkTouchController.defaultInkView.inkColor = greenColor;
   inkTouchController.defaultInkView.inkStyle = MDCInkStyleUnbounded;
   [_inkTouchControllers addObject:inkTouchController];

--- a/components/Ink/examples/InkTypicalUse.m
+++ b/components/Ink/examples/InkTypicalUse.m
@@ -20,6 +20,8 @@
 
 #import "InkTypicalUseSupplemental.h"
 
+#import "MDCCatalogStyle.h"
+
 @interface InkTypicalUseViewController () <MDCInkTouchControllerDelegate>
 
 @property(nonatomic, strong) NSMutableArray *inkTouchControllers;  // MDCInkTouchControllers.
@@ -57,8 +59,8 @@
   inkTouchController.delegate = self;
   [inkTouchController addInkView];
 
-  UIColor *blueColor = [UIColor colorWithRed:11/255.0 green:232/255.0 blue:94/255.0 alpha:0.2];
-  inkTouchController.defaultInkView.inkColor = blueColor;
+  UIColor *greenColor = [[MDCCatalogStyle greenColor] colorWithAlphaComponent:0.2f];
+  inkTouchController.defaultInkView.inkColor = greenColor;
   inkTouchController.defaultInkView.inkStyle = MDCInkStyleUnbounded;
   [_inkTouchControllers addObject:inkTouchController];
   [self.view addSubview:self.unboundedShape];

--- a/components/Ink/examples/InkTypicalUse.m
+++ b/components/Ink/examples/InkTypicalUse.m
@@ -59,7 +59,7 @@
   inkTouchController.delegate = self;
   [inkTouchController addInkView];
 
-  UIColor *greenColor = [[CatalogStyle greenColor] colorWithAlphaComponent:0.2f];
+  UIColor *greenColor = [[CatalogStyle secondaryColor] colorWithAlphaComponent:0.2f];
   inkTouchController.defaultInkView.inkColor = greenColor;
   inkTouchController.defaultInkView.inkStyle = MDCInkStyleUnbounded;
   [_inkTouchControllers addObject:inkTouchController];

--- a/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
+++ b/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
@@ -25,6 +25,8 @@
 
 #import "MaterialTypography.h"
 
+#import "MDCCatalogStyle.h"
+
 // A set of UILabels in an variety of shapes to tap on.
 
 @interface ExampleShapes ()
@@ -97,7 +99,7 @@
 @implementation InkTypicalUseViewController (Supplemental)
 
 - (void)setupExampleViews {
-  self.view.backgroundColor = [UIColor colorWithWhite:0.95 alpha:1];
+  self.view.backgroundColor = [MDCCatalogStyle greyColor];
 
   CGRect boundedTitleLabelFrame =
       CGRectMake(0, self.boundedShapes.frame.size.height, self.boundedShapes.frame.size.width, 24);

--- a/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
+++ b/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
@@ -25,7 +25,7 @@
 
 #import "MaterialTypography.h"
 
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
 // A set of UILabels in an variety of shapes to tap on.
 
@@ -99,7 +99,7 @@
 @implementation InkTypicalUseViewController (Supplemental)
 
 - (void)setupExampleViews {
-  self.view.backgroundColor = [MDCCatalogStyle greyColor];
+  self.view.backgroundColor = [CatalogStyle greyColor];
 
   CGRect boundedTitleLabelFrame =
       CGRectMake(0, self.boundedShapes.frame.size.height, self.boundedShapes.frame.size.width, 24);

--- a/components/NavigationBar/examples/NavigationBarTypicalUseExample.m
+++ b/components/NavigationBar/examples/NavigationBarTypicalUseExample.m
@@ -37,7 +37,7 @@
   self.navBar = [[MDCNavigationBar alloc] initWithFrame:CGRectZero];
   self.navBar.titleTextAttributes = [CatalogStyle headerTitleAttributes];
   [self.navBar observeNavigationItem:self.navigationItem];
-  [self.navBar setBackgroundColor:[CatalogStyle blackColor]];
+  [self.navBar setBackgroundColor:[CatalogStyle primaryColor]];
   MDCNavigationBarTextColorAccessibilityMutator *mutator =
       [[MDCNavigationBarTextColorAccessibilityMutator alloc] init];
   [mutator mutate:self.navBar];

--- a/components/NavigationBar/examples/NavigationBarTypicalUseExample.m
+++ b/components/NavigationBar/examples/NavigationBarTypicalUseExample.m
@@ -20,6 +20,8 @@
 
 #import "NavigationBarTypicalUseExampleSupplemental.h"
 
+#import "MDCCatalogStyle.h"
+
 @interface NavigationBarTypicalUseExample ()
 
 @end
@@ -33,9 +35,9 @@
   self.title = @"Navigation Bar";
 
   self.navBar = [[MDCNavigationBar alloc] initWithFrame:CGRectZero];
-  self.navBar.titleTextAttributes = @{NSForegroundColorAttributeName : [UIColor whiteColor]};
+  self.navBar.titleTextAttributes = [MDCCatalogStyle headerTitleAttributes];
   [self.navBar observeNavigationItem:self.navigationItem];
-  [self.navBar setBackgroundColor:[UIColor colorWithWhite:0.1 alpha:1.0]];
+  [self.navBar setBackgroundColor:[MDCCatalogStyle blackColor]];
   MDCNavigationBarTextColorAccessibilityMutator *mutator =
       [[MDCNavigationBarTextColorAccessibilityMutator alloc] init];
   [mutator mutate:self.navBar];

--- a/components/NavigationBar/examples/NavigationBarTypicalUseExample.m
+++ b/components/NavigationBar/examples/NavigationBarTypicalUseExample.m
@@ -20,7 +20,7 @@
 
 #import "NavigationBarTypicalUseExampleSupplemental.h"
 
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
 @interface NavigationBarTypicalUseExample ()
 
@@ -35,9 +35,9 @@
   self.title = @"Navigation Bar";
 
   self.navBar = [[MDCNavigationBar alloc] initWithFrame:CGRectZero];
-  self.navBar.titleTextAttributes = [MDCCatalogStyle headerTitleAttributes];
+  self.navBar.titleTextAttributes = [CatalogStyle headerTitleAttributes];
   [self.navBar observeNavigationItem:self.navigationItem];
-  [self.navBar setBackgroundColor:[MDCCatalogStyle blackColor]];
+  [self.navBar setBackgroundColor:[CatalogStyle blackColor]];
   MDCNavigationBarTextColorAccessibilityMutator *mutator =
       [[MDCNavigationBarTextColorAccessibilityMutator alloc] init];
   [mutator mutate:self.navBar];

--- a/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
+++ b/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
@@ -47,7 +47,7 @@
   self.navBar = [[MDCNavigationBar alloc] initWithFrame:CGRectZero];
   [self.navBar observeNavigationItem:self.navigationItem];
   self.navBar.titleTextAttributes = [CatalogStyle headerTitleAttributes];
-  [self.navBar setBackgroundColor:[CatalogStyle blackColor]];
+  [self.navBar setBackgroundColor:[CatalogStyle primaryColor]];
   MDCNavigationBarTextColorAccessibilityMutator *mutator =
       [[MDCNavigationBarTextColorAccessibilityMutator alloc] init];
   [mutator mutate:self.navBar];

--- a/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
+++ b/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
@@ -20,6 +20,8 @@
 
 #import "NavigationBarTypicalUseExampleSupplemental.h"
 
+#import "MDCCatalogStyle.h"
+
 @interface NavigationBarWithBarItemsExample : NavigationBarTypicalUseExample
 @end
 
@@ -44,8 +46,8 @@
 
   self.navBar = [[MDCNavigationBar alloc] initWithFrame:CGRectZero];
   [self.navBar observeNavigationItem:self.navigationItem];
-
-  [self.navBar setBackgroundColor:[UIColor colorWithWhite:0.1 alpha:1.0]];
+  self.navBar.titleTextAttributes = [MDCCatalogStyle headerTitleAttributes];
+  [self.navBar setBackgroundColor:[MDCCatalogStyle blackColor]];
   MDCNavigationBarTextColorAccessibilityMutator *mutator =
       [[MDCNavigationBarTextColorAccessibilityMutator alloc] init];
   [mutator mutate:self.navBar];

--- a/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
+++ b/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
@@ -20,7 +20,7 @@
 
 #import "NavigationBarTypicalUseExampleSupplemental.h"
 
-#import "MDCCatalogStyle.h"
+#import "CatalogStyle.h"
 
 @interface NavigationBarWithBarItemsExample : NavigationBarTypicalUseExample
 @end
@@ -46,8 +46,8 @@
 
   self.navBar = [[MDCNavigationBar alloc] initWithFrame:CGRectZero];
   [self.navBar observeNavigationItem:self.navigationItem];
-  self.navBar.titleTextAttributes = [MDCCatalogStyle headerTitleAttributes];
-  [self.navBar setBackgroundColor:[MDCCatalogStyle blackColor]];
+  self.navBar.titleTextAttributes = [CatalogStyle headerTitleAttributes];
+  [self.navBar setBackgroundColor:[CatalogStyle blackColor]];
   MDCNavigationBarTextColorAccessibilityMutator *mutator =
       [[MDCNavigationBarTextColorAccessibilityMutator alloc] init];
   [mutator mutate:self.navBar];

--- a/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.m
+++ b/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.m
@@ -55,7 +55,7 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27.0f;
     self.backgroundColor = [UIColor whiteColor];
 
     _elevationLabel = [[UILabel alloc] initWithFrame:CGRectMake(24, 24, frame.size.width - 48, 64)];
-    _elevationLabel.textColor = [CatalogStyle blackColor];
+    _elevationLabel.textColor = [CatalogStyle primaryColor];
     _elevationLabel.font = [MDCTypography body2Font];
     _elevationLabel.textAlignment = NSTextAlignmentLeft;
     _elevationLabel.text = @"MDCShadowElevationFABPressed";
@@ -77,7 +77,7 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27.0f;
     CGRect sliderRect = CGRectMake(margin, 140.f, frame.size.width - margin * 2,
                                    kShadowElevationsSliderFrameHeight);
     MDCSlider *sliderControl = [[MDCSlider alloc] initWithFrame:sliderRect];
-    sliderControl.color = [CatalogStyle greenColor];
+    sliderControl.color = [CatalogStyle secondaryColor];
     sliderControl.value = kShadowElevationsDefault / kShadowElevationsMax;
     sliderControl.autoresizingMask =
         (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin |

--- a/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.m
+++ b/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.m
@@ -19,6 +19,9 @@
 #import "MaterialShadowElevations.h"
 #import "MaterialShadowLayer.h"
 #import "MaterialSlider.h"
+#import "MaterialTypography.h"
+
+#import "CatalogStyle.h"
 
 static const CGFloat kShadowElevationsDefault = 8.f;
 static const CGFloat kShadowElevationsMax = 24.f;
@@ -51,8 +54,10 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27.0f;
   if (self) {
     self.backgroundColor = [UIColor whiteColor];
 
-    _elevationLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 20, frame.size.width, 100)];
-    _elevationLabel.textAlignment = NSTextAlignmentCenter;
+    _elevationLabel = [[UILabel alloc] initWithFrame:CGRectMake(24, 24, frame.size.width - 48, 64)];
+    _elevationLabel.textColor = [CatalogStyle blackColor];
+    _elevationLabel.font = [MDCTypography body2Font];
+    _elevationLabel.textAlignment = NSTextAlignmentLeft;
     _elevationLabel.text = @"MDCShadowElevationFABPressed";
     [self addSubview:_elevationLabel];
 
@@ -72,6 +77,7 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27.0f;
     CGRect sliderRect = CGRectMake(margin, 140.f, frame.size.width - margin * 2,
                                    kShadowElevationsSliderFrameHeight);
     MDCSlider *sliderControl = [[MDCSlider alloc] initWithFrame:sliderRect];
+    sliderControl.color = [CatalogStyle greenColor];
     sliderControl.value = kShadowElevationsDefault / kShadowElevationsMax;
     sliderControl.autoresizingMask =
         (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin |

--- a/components/Tabs/examples/TabBarIconExample.m
+++ b/components/Tabs/examples/TabBarIconExample.m
@@ -74,11 +74,11 @@
   // Give the second item a badge
   [tabBar.items[1] setBadgeValue:@"1"];
 
-  tabBar.barTintColor = [CatalogStyle blackColor];
-  tabBar.tintColor = [CatalogStyle greenColor];
-  tabBar.inkColor = [[CatalogStyle whiteColor] colorWithAlphaComponent:0.1];
-  tabBar.selectedItemTintColor = [[CatalogStyle whiteColor] colorWithAlphaComponent:.87f];
-  tabBar.unselectedItemTintColor = [[CatalogStyle whiteColor] colorWithAlphaComponent:.38f];
+  tabBar.barTintColor = [CatalogStyle primaryColor];
+  tabBar.tintColor = [CatalogStyle secondaryColor];
+  tabBar.inkColor = [[CatalogStyle primaryTextColor] colorWithAlphaComponent:0.1];
+  tabBar.selectedItemTintColor = [[CatalogStyle primaryTextColor] colorWithAlphaComponent:.87f];
+  tabBar.unselectedItemTintColor = [[CatalogStyle primaryTextColor] colorWithAlphaComponent:.38f];
   tabBar.itemAppearance = MDCTabBarItemAppearanceTitledImages;
 
   self.tabBar = tabBar;

--- a/components/Tabs/examples/TabBarIconExample.m
+++ b/components/Tabs/examples/TabBarIconExample.m
@@ -16,6 +16,8 @@
 
 #import "TabBarIconExampleSupplemental.h"
 
+#import "CatalogStyle.h"
+
 @import MaterialComponents.MaterialAppBar;
 @import MaterialComponents.MaterialPalettes;
 @import MaterialComponents.MaterialTabs;
@@ -57,7 +59,7 @@
 - (void)loadTabBar {
   MDCTabBar *tabBar = [MDCTabBar new];
   tabBar.delegate = self;
-  tabBar.alignment = MDCTabBarAlignmentCenterSelected;
+  tabBar.alignment = MDCTabBarAlignmentCenter;
 
   NSBundle *bundle = [NSBundle bundleForClass:[self class]];
   UIImage *infoImage =
@@ -72,13 +74,11 @@
   // Give the second item a badge
   [tabBar.items[1] setBadgeValue:@"1"];
 
-  UIColor *green =  [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:1];
-
-  tabBar.barTintColor = [UIColor colorWithWhite:0.1f alpha:1.0];
-  tabBar.tintColor = green;
-  tabBar.inkColor = [[UIColor whiteColor] colorWithAlphaComponent:0.1];
-  tabBar.selectedItemTintColor = [[UIColor whiteColor] colorWithAlphaComponent:.87f];
-  tabBar.unselectedItemTintColor = [[UIColor whiteColor] colorWithAlphaComponent:.38f];
+  tabBar.barTintColor = [CatalogStyle blackColor];
+  tabBar.tintColor = [CatalogStyle greenColor];
+  tabBar.inkColor = [[CatalogStyle whiteColor] colorWithAlphaComponent:0.1];
+  tabBar.selectedItemTintColor = [[CatalogStyle whiteColor] colorWithAlphaComponent:.87f];
+  tabBar.unselectedItemTintColor = [[CatalogStyle whiteColor] colorWithAlphaComponent:.38f];
   tabBar.itemAppearance = MDCTabBarItemAppearanceTitledImages;
 
   self.tabBar = tabBar;

--- a/components/Tabs/examples/TabBarIconExample.swift
+++ b/components/Tabs/examples/TabBarIconExample.swift
@@ -53,13 +53,13 @@ class TabBarIconSwiftExample: UIViewController {
                     UITabBarItem(title: "Stars", image: star, tag:0)]
     tabBar.items[1].badgeValue = "1"
 
-    tabBar.tintColor =  CatalogStyle.greenColor
+    tabBar.tintColor =  CatalogStyle.secondaryColor
     tabBar.inkColor = UIColor.white.withAlphaComponent(0.2)
 
-    tabBar.barTintColor = CatalogStyle.blackColor
+    tabBar.barTintColor = CatalogStyle.primaryColor
     tabBar.itemAppearance = .titledImages
-    tabBar.selectedItemTintColor = CatalogStyle.whiteColor.withAlphaComponent(0.87)
-    tabBar.unselectedItemTintColor = CatalogStyle.whiteColor.withAlphaComponent(0.38)
+    tabBar.selectedItemTintColor = CatalogStyle.primaryTextColor.withAlphaComponent(0.87)
+    tabBar.unselectedItemTintColor = CatalogStyle.primaryTextColor.withAlphaComponent(0.38)
 
     return tabBar
   }()

--- a/components/Tabs/examples/TabBarIconExample.swift
+++ b/components/Tabs/examples/TabBarIconExample.swift
@@ -43,7 +43,7 @@ class TabBarIconSwiftExample: UIViewController {
   lazy var tabBar: MDCTabBar = {
     let tabBar = MDCTabBar()
     tabBar.delegate = self
-    tabBar.alignment = .centerSelected
+    tabBar.alignment = .center
 
     let bundle = Bundle(for: type(of: self))
     let info = UIImage.init(named: "TabBarDemo_ic_info", in: bundle, compatibleWith:nil)
@@ -53,14 +53,13 @@ class TabBarIconSwiftExample: UIViewController {
                     UITabBarItem(title: "Stars", image: star, tag:0)]
     tabBar.items[1].badgeValue = "1"
 
-    let blue = MDCPalette.blue().tint500
-    tabBar.tintColor = blue
-    tabBar.inkColor = blue
+    tabBar.tintColor =  CatalogStyle.greenColor
+    tabBar.inkColor = UIColor.white.withAlphaComponent(0.2)
 
-    tabBar.barTintColor = UIColor.white
+    tabBar.barTintColor = CatalogStyle.blackColor
     tabBar.itemAppearance = .titledImages
-    tabBar.selectedItemTintColor = UIColor.black.withAlphaComponent(0.87)
-    tabBar.unselectedItemTintColor = UIColor.black.withAlphaComponent(0.38)
+    tabBar.selectedItemTintColor = CatalogStyle.whiteColor.withAlphaComponent(0.87)
+    tabBar.unselectedItemTintColor = CatalogStyle.whiteColor.withAlphaComponent(0.38)
 
     return tabBar
   }()

--- a/components/Tabs/examples/TabBarTextOnlyExample.m
+++ b/components/Tabs/examples/TabBarTextOnlyExample.m
@@ -65,8 +65,8 @@
   // Give it a white appearance to show dark text and customize the unselected title color.
   self.tabBar.selectedItemTintColor = [UIColor whiteColor];
   self.tabBar.unselectedItemTintColor = [UIColor grayColor];
-  self.tabBar.tintColor = [CatalogStyle greenColor];
-  self.tabBar.barTintColor = [CatalogStyle blackColor];
+  self.tabBar.tintColor = [CatalogStyle secondaryColor];
+  self.tabBar.barTintColor = [CatalogStyle primaryColor];
   self.tabBar.inkColor = [UIColor colorWithWhite:1 alpha:0.1];
 
   self.tabBar.autoresizingMask =

--- a/components/Tabs/examples/TabBarTextOnlyExample.m
+++ b/components/Tabs/examples/TabBarTextOnlyExample.m
@@ -22,7 +22,7 @@
 #import "MaterialTabs.h"
 
 #import "TabBarTextOnlyExampleSupplemental.h"
-
+#import "CatalogStyle.h"
 
 @implementation TabBarTextOnlyExample
 
@@ -65,8 +65,8 @@
   // Give it a white appearance to show dark text and customize the unselected title color.
   self.tabBar.selectedItemTintColor = [UIColor whiteColor];
   self.tabBar.unselectedItemTintColor = [UIColor grayColor];
-  self.tabBar.tintColor = [UIColor colorWithRed:11/255.0 green:232/255.0 blue:94/255.0 alpha:1];
-  self.tabBar.barTintColor = [UIColor colorWithWhite:0.1 alpha:1];
+  self.tabBar.tintColor = [CatalogStyle greenColor];
+  self.tabBar.barTintColor = [CatalogStyle blackColor];
   self.tabBar.inkColor = [UIColor colorWithWhite:1 alpha:0.1];
 
   self.tabBar.autoresizingMask =

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
@@ -74,8 +74,8 @@
   self.appBar = [[MDCAppBar alloc] init];
   [self addChildViewController:self.appBar.headerViewController];
 
-  self.appBar.headerViewController.headerView.tintColor = [CatalogStyle whiteColor];
-  self.appBar.headerViewController.headerView.backgroundColor = [CatalogStyle blackColor];
+  self.appBar.headerViewController.headerView.tintColor = [CatalogStyle primaryTextColor];
+  self.appBar.headerViewController.headerView.backgroundColor = [CatalogStyle primaryColor];
   self.appBar.headerViewController.headerView.minimumHeight = 76 + 72;
 
   self.appBar.navigationBar.titleTextAttributes = [CatalogStyle headerTitleAttributes];
@@ -129,7 +129,7 @@
 
   UILabel *infoLabel = [[UILabel alloc] initWithFrame:CGRectZero];
   infoLabel.translatesAutoresizingMaskIntoConstraints = NO;
-  infoLabel.textColor = [CatalogStyle blackColor];
+  infoLabel.textColor = [CatalogStyle primaryColor];
   infoLabel.numberOfLines = 0;
   infoLabel.text =
       @"Tabs enable content organization at a high level, such as switching between views";

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
@@ -20,6 +20,8 @@
 
 #import "TabBarIconExampleSupplemental.h"
 
+#import "CatalogStyle.h"
+
 @import MaterialComponents.MaterialAppBar;
 @import MaterialComponents.MaterialButtons;
 @import MaterialComponents.MaterialPalettes;
@@ -72,18 +74,18 @@
   self.appBar = [[MDCAppBar alloc] init];
   [self addChildViewController:self.appBar.headerViewController];
 
-  self.appBar.headerViewController.headerView.tintColor = [UIColor whiteColor];
-  self.appBar.headerViewController.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1.0];
+  self.appBar.headerViewController.headerView.tintColor = [CatalogStyle whiteColor];
+  self.appBar.headerViewController.headerView.backgroundColor = [CatalogStyle blackColor];
   self.appBar.headerViewController.headerView.minimumHeight = 76 + 72;
 
-  self.appBar.navigationBar.titleTextAttributes = @{
-    NSForegroundColorAttributeName: [UIColor whiteColor],
-    NSFontAttributeName: [UIFont fontWithName:@"RobotoMono-Regular" size:14] };
+  self.appBar.navigationBar.titleTextAttributes = [CatalogStyle headerTitleAttributes];
   
   [self.appBar addSubviewsToParent];
 
+  UIImage *addImage =
+      [[UIImage imageNamed:@"Plus"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   UIBarButtonItem *badgeIncrementItem =
-      [[UIBarButtonItem alloc] initWithTitle:@"Add"
+      [[UIBarButtonItem alloc] initWithImage:addImage
                                        style:UIBarButtonItemStylePlain
                                       target:self
                                       action:@selector(incrementDidTouch:)];
@@ -123,11 +125,11 @@
   UIView *infoPage = [[UIView alloc] initWithFrame:CGRectZero];
   infoPage.translatesAutoresizingMaskIntoConstraints = NO;
   [self.scrollView addSubview:infoPage];
-  infoPage.backgroundColor = [UIColor whiteColor];
+  infoPage.backgroundColor = [CatalogStyle greyColor];
 
   UILabel *infoLabel = [[UILabel alloc] initWithFrame:CGRectZero];
   infoLabel.translatesAutoresizingMaskIntoConstraints = NO;
-  infoLabel.textColor = [UIColor colorWithRed:0.459 green:0.459 blue:0.459 alpha:0.87f];
+  infoLabel.textColor = [CatalogStyle blackColor];
   infoLabel.numberOfLines = 0;
   infoLabel.text =
       @"Tabs enable content organization at a high level, such as switching between views";
@@ -162,7 +164,7 @@
   self.starPage = [[UIView alloc] initWithFrame:CGRectZero];
   self.starPage.translatesAutoresizingMaskIntoConstraints = NO;
   [self.scrollView addSubview:self.starPage];
-  self.starPage.backgroundColor = [[MDCPalette lightBluePalette] tint200];
+  self.starPage.backgroundColor = [UIColor whiteColor];
   [self addStarCentered:YES];
 
   // Layout the views to be equal height and width to each other and self.view, hug the edges of the
@@ -259,7 +261,7 @@
 }
 
 + (BOOL)catalogIsPrimaryDemo {
-  return YES;
+  return NO;
 }
 
 + (NSString *)catalogDescription {

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
@@ -27,6 +27,7 @@ extension TabBarIconSwiftExample {
 
     alignmentButton.setTitle("Change Alignment", for: .normal)
     alignmentButton.setTitleColor(.white, for: .normal)
+    alignmentButton.backgroundColor = CatalogStyle.blackColor
 
     self.view.addSubview(alignmentButton)
     alignmentButton.translatesAutoresizingMaskIntoConstraints = false
@@ -53,9 +54,12 @@ extension TabBarIconSwiftExample {
     let appBar = MDCAppBar()
 
     self.addChildViewController(appBar.headerViewController)
-    appBar.headerViewController.headerView.backgroundColor = UIColor.white
+    appBar.headerViewController.headerView.backgroundColor = CatalogStyle.blackColor
     appBar.headerViewController.headerView.minimumHeight = 76 + 72
-    appBar.headerViewController.headerView.tintColor = MDCPalette.blue().tint500
+    appBar.headerViewController.headerView.tintColor = CatalogStyle.whiteColor
+    
+    appBar.navigationBar.titleTextAttributes = CatalogStyle.headerTitleAttributes
+
 
     appBar.headerStackView.bottomBar = self.tabBar
     appBar.headerStackView.setNeedsLayout()
@@ -67,7 +71,8 @@ extension TabBarIconSwiftExample {
 
     appBar.addSubviewsToParent()
 
-    let badgeIncrementItem = UIBarButtonItem(title: "Add",
+    let addImage = UIImage(named: "Plus")?.withRenderingMode(.alwaysTemplate)
+    let badgeIncrementItem = UIBarButtonItem(image: addImage,
                                              style: .plain,
                                              target: self,
                                              action:#selector(incrementDidTouch(sender: )))
@@ -86,7 +91,7 @@ extension TabBarIconSwiftExample {
     scrollView.isScrollEnabled = false
     self.view.addSubview(scrollView)
 
-    scrollView.backgroundColor = UIColor.red
+    scrollView.backgroundColor = UIColor.white
 
     let views = ["scrollView": scrollView, "header": self.appBar.headerStackView]
     NSLayoutConstraint.activate(NSLayoutConstraint.constraints(withVisualFormat: "V:[header][scrollView]|",
@@ -110,12 +115,12 @@ extension TabBarIconSwiftExample {
 
     let infoPage = UIView(frame: CGRect())
     infoPage.translatesAutoresizingMaskIntoConstraints = false
-    infoPage.backgroundColor = MDCPalette.lightBlue().tint300
+    infoPage.backgroundColor = CatalogStyle.greyColor
     scrollView.addSubview(infoPage)
 
     let infoLabel = UILabel(frame: CGRect())
     infoLabel.translatesAutoresizingMaskIntoConstraints = false
-    infoLabel.textColor = UIColor.white
+    infoLabel.textColor = UIColor.black
     infoLabel.numberOfLines = 0
     infoLabel.text = "Tabs enable content organization at a high level,"
         + " such as switching between views"
@@ -184,7 +189,7 @@ extension TabBarIconSwiftExample {
   func setupStarPage() -> UIView {
     let starPage = UIView(frame: CGRect())
     starPage.translatesAutoresizingMaskIntoConstraints = false
-    starPage.backgroundColor = MDCPalette.lightBlue().tint200
+    starPage.backgroundColor = CatalogStyle.whiteColor
     self.scrollView.addSubview(starPage)
 
     return starPage

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
@@ -27,7 +27,7 @@ extension TabBarIconSwiftExample {
 
     alignmentButton.setTitle("Change Alignment", for: .normal)
     alignmentButton.setTitleColor(.white, for: .normal)
-    alignmentButton.backgroundColor = CatalogStyle.blackColor
+    alignmentButton.backgroundColor = CatalogStyle.primaryColor
 
     self.view.addSubview(alignmentButton)
     alignmentButton.translatesAutoresizingMaskIntoConstraints = false
@@ -54,9 +54,9 @@ extension TabBarIconSwiftExample {
     let appBar = MDCAppBar()
 
     self.addChildViewController(appBar.headerViewController)
-    appBar.headerViewController.headerView.backgroundColor = CatalogStyle.blackColor
+    appBar.headerViewController.headerView.backgroundColor = CatalogStyle.primaryColor
     appBar.headerViewController.headerView.minimumHeight = 76 + 72
-    appBar.headerViewController.headerView.tintColor = CatalogStyle.whiteColor
+    appBar.headerViewController.headerView.tintColor = CatalogStyle.primaryTextColor
     
     appBar.navigationBar.titleTextAttributes = CatalogStyle.headerTitleAttributes
 
@@ -189,7 +189,7 @@ extension TabBarIconSwiftExample {
   func setupStarPage() -> UIView {
     let starPage = UIView(frame: CGRect())
     starPage.translatesAutoresizingMaskIntoConstraints = false
-    starPage.backgroundColor = CatalogStyle.whiteColor
+    starPage.backgroundColor = CatalogStyle.primaryTextColor
     self.scrollView.addSubview(starPage)
 
     return starPage

--- a/components/Tabs/examples/supplemental/TabBarTextOnlyExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarTextOnlyExampleSupplemental.m
@@ -24,6 +24,7 @@
 #import "MaterialTabs.h"
 
 #import "TabBarTextOnlyExampleSupplemental.h"
+#import "CatalogStyle.h"
 
 static CGFloat const kStatusBarHeight = 20;
 static CGFloat const kAppBarMinHeight = 56;
@@ -52,17 +53,15 @@ static NSString * const kReusableIdentifierItem = @"Cell";
   self.appBar.headerViewController.headerView.shiftBehavior =
       MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar;
 
-  self.appBar.navigationBar.tintColor = [UIColor whiteColor];
-  self.appBar.headerViewController.headerView.tintColor = [UIColor whiteColor];
-  self.appBar.headerViewController.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1.0];
+  self.appBar.navigationBar.tintColor = [CatalogStyle whiteColor];
+  self.appBar.headerViewController.headerView.tintColor = [CatalogStyle whiteColor];
+  self.appBar.headerViewController.headerView.backgroundColor = [CatalogStyle blackColor];
   self.appBar.headerViewController.headerView.minimumHeight =
       kStatusBarHeight + kTabBarHeight;
   self.appBar.headerViewController.headerView.maximumHeight =
       kStatusBarHeight + kAppBarMinHeight + kTabBarHeight;
   
-  self.appBar.navigationBar.titleTextAttributes = @{
-      NSForegroundColorAttributeName: [UIColor whiteColor],
-      NSFontAttributeName: [UIFont fontWithName:@"RobotoMono-Regular" size:14] };
+  self.appBar.navigationBar.titleTextAttributes = [CatalogStyle headerTitleAttributes];
   [self.appBar addSubviewsToParent];
   
   

--- a/components/Tabs/examples/supplemental/TabBarTextOnlyExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarTextOnlyExampleSupplemental.m
@@ -53,9 +53,9 @@ static NSString * const kReusableIdentifierItem = @"Cell";
   self.appBar.headerViewController.headerView.shiftBehavior =
       MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar;
 
-  self.appBar.navigationBar.tintColor = [CatalogStyle whiteColor];
-  self.appBar.headerViewController.headerView.tintColor = [CatalogStyle whiteColor];
-  self.appBar.headerViewController.headerView.backgroundColor = [CatalogStyle blackColor];
+  self.appBar.navigationBar.tintColor = [CatalogStyle primaryTextColor];
+  self.appBar.headerViewController.headerView.tintColor = [CatalogStyle primaryTextColor];
+  self.appBar.headerViewController.headerView.backgroundColor = [CatalogStyle primaryColor];
   self.appBar.headerViewController.headerView.minimumHeight =
       kStatusBarHeight + kTabBarHeight;
   self.appBar.headerViewController.headerView.maximumHeight =

--- a/components/Typography/examples/TypographyFontListExample.swift
+++ b/components/Typography/examples/TypographyFontListExample.swift
@@ -81,8 +81,7 @@ class TypographyFontListExampleViewController: UITableViewController {
   }
 
   let strings = [
-    "Material Design Components",
-    "A quick brown fox jumped over the lazy dog.",
+    "Material Components",
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
     "abcdefghijklmnopqrstuvwxyz",
     "1234567890",

--- a/components/Typography/examples/TypographyMaterialStylesViewController.m
+++ b/components/Typography/examples/TypographyMaterialStylesViewController.m
@@ -33,8 +33,7 @@
   self.tableView.estimatedRowHeight = 50.0;
 
   _strings = @[
-               @"Material Design Components",
-               @"A quick brown fox jumped over the lazy dog.",
+               @"Material Components",
                @"ABCDEFGHIJKLMNOPQRSTUVWXYZ",
                @"abcdefghijklmnopqrstuvwxyz",
                @"1234567890",

--- a/components/Typography/examples/TypographySimpleExampleViewController.m
+++ b/components/Typography/examples/TypographySimpleExampleViewController.m
@@ -40,7 +40,7 @@
 }
 
 + (NSArray *)catalogBreadcrumbs {
-  return @[ @"Typography and Fonts", @"Read Me Demo" ];
+  return @[ @"Typography and Fonts", @"Simple Usage" ];
 }
 
 @end


### PR DESCRIPTION
 * Renamed MDCCatalogStyle to CatalogStyle (to avoid conflict with the framework prefix).
 * Moved CatalogStyle from Catalog target to the CbyC MaterialComponentsCatalog target through Podfile changes so that it is visible to the examples.
 * Made all demos use the CatalogStyle constants for colors and fonts.
 * Renamed black/white/green to primary/primaryText/secondary so that we can change them easily in the future.

 * Updated ActivityIndicator demo layout to look more standard.
 * Updated FlexibleHeader examples to adopt the right font.
 * Fixed Disabled Button color to workaround conflict with grey on grey.
 * Fixed multiple view controllers designated as primary for Dialogs section.
 * Made primary example in Flexible header the example with a FAB because it looks great.
 * Fixed multiple view controller designated as primary for Tab Bar.
 * Removed one example from Typography to shorten it a little.