### PR TITLE
[Docs] Adds API documentation roots and tidies up here and there.

### DIFF
--- a/.mdc-docsite.yml
+++ b/.mdc-docsite.yml
@@ -8,3 +8,4 @@ site_description: >
   Material Components for iOS is a set of user interface components that help iOS app developers build apps with material design.
 repo_url: https://github.com/material-components/material-components-ios/
 repo_stable_branch: stable
+api_doc_generator: jazzy

--- a/components/ActivityIndicator/README.md
+++ b/components/ActivityIndicator/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "Progress and activity indicators are visual indications of an app loading content."
 iconId: progress_activity
 path: /catalog/progress-indicators/activity-indicators/
+api_doc_root: true
 -->
 
 # Activity Indicators

--- a/components/ActivityIndicator/README.md
+++ b/components/ActivityIndicator/README.md
@@ -19,7 +19,7 @@ Activity indicators are visual indications of an app loading content. The Activi
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/progress-activity.html">Progress & activity</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/progress-activity.html">Material Design guidelines: Progress & activity</a></li>
 </ul>
 
 - - -

--- a/components/ActivityIndicator/README.md
+++ b/components/ActivityIndicator/README.md
@@ -20,6 +20,9 @@ Activity indicators are visual indications of an app loading content. The Activi
 
 <ul class="icon-list">
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/progress-activity.html">Material Design guidelines: Progress & activity</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/progress-indicators/activity-indicators/api-docs/Classes/MDCActivityIndicator.html">API: MDCActivityIndicator</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/progress-indicators/activity-indicators/api-docs/Enums/MDCActivityIndicatorMode.html">API: MDCActivityIndicatorMode</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/progress-indicators/activity-indicators/api-docs/Protocols/MDCActivityIndicatorDelegate.html">API: MDCActivityIndicatorDelegate</a></li>
 </ul>
 
 - - -

--- a/components/AnimationTiming/README.md
+++ b/components/AnimationTiming/README.md
@@ -21,7 +21,7 @@ of an animation so that movement doesn't appear mechanical.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/motion/duration-easing.html">Duration & easing</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/motion/duration-easing.html">Material Design guidelines: Duration & easing</a></li>
 </ul>
 
 ## Installation

--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "The App Bar is a flexible navigation bar designed to provide a typical Material Design navigation experience."
 iconId: toolbar
 path: /catalog/app-bars/
+api_doc_root: true
 -->
 
 # App Bars

--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -20,8 +20,8 @@ navigation experience.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/layout/structure.html#structure-app-bar">App Bar Structure</a></li>
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/patterns/scrolling-techniques.html">Scrolling Techniques</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/layout/structure.html#structure-app-bar">Material Design guidelines: App Bar Structure</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/patterns/scrolling-techniques.html">Material Design guidelines: Scrolling Techniques</a></li>
 </ul>
 
 - - -

--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -22,6 +22,8 @@ navigation experience.
 <ul class="icon-list">
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/layout/structure.html#structure-app-bar">Material Design guidelines: App Bar Structure</a></li>
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/patterns/scrolling-techniques.html">Material Design guidelines: Scrolling Techniques</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/app-bars/api-docs/Classes/MDCAppBar.html">API: MDCAppBar</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/app-bars/api-docs/Classes/MDCAppBarContainerViewController.html">API: MDCAppBarContainerViewController</a></li>
 </ul>
 
 - - -

--- a/components/ButtonBar/README.md
+++ b/components/ButtonBar/README.md
@@ -16,6 +16,13 @@ api_doc_root: true
 
 The Button Bar is a view that represents a list of UIBarButtonItems as horizontally aligned buttons.
 
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/button-bars/api-docs/Classes/MDCButtonBar.html">API: MDCButtonBar</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/button-bars/api-docs/Protocols/MDCButtonBarDelegate.html">API: MDCButtonBarDelegate</a></li>
+</ul>
+
 - - -
 
 ## Installation

--- a/components/ButtonBar/README.md
+++ b/components/ButtonBar/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "The Button Bar component is a view that facilitates the creation and layout of a horizontally-aligned list of buttons."
 iconId: button
 path: /catalog/button-bars/
+api_doc_root: true
 -->
 
 # Button Bars

--- a/components/Buttons/README.md
+++ b/components/Buttons/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "Buttons is a collection of Material Design buttons, including a flat button, a raised button and a floating action button."
 iconId: button
 path: /catalog/buttons/
+api_doc_root: true
 -->
 
 # Buttons

--- a/components/Buttons/README.md
+++ b/components/Buttons/README.md
@@ -21,6 +21,9 @@ floating action button.
 
 <ul class="icon-list">
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/buttons.html">Material Design guidelines: Buttons</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/buttons/api-docs/Classes/MDCButton.html">API: MDCButton</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/buttons/api-docs/Classes/MDCFlatButton.html">API: MDCFlatButton</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/buttons/api-docs/Classes/MDCFloatingButton.html">API: MDCFloatingButton</a></li>
 </ul>
 
 - - -

--- a/components/Buttons/README.md
+++ b/components/Buttons/README.md
@@ -20,7 +20,7 @@ floating action button.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/buttons.html">Buttons</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/buttons.html">Material Design guidelines: Buttons</a></li>
 </ul>
 
 - - -

--- a/components/CollectionCells/README.md
+++ b/components/CollectionCells/README.md
@@ -19,7 +19,7 @@ Collection view cell classes that adhere to Material Design layout and styling.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/lists.html#lists-specs">Collection List Specs</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/lists.html#lists-specs">Material Design guidelines: Collection List Specs</a></li>
 </ul>
 
 - - -

--- a/components/CollectionCells/README.md
+++ b/components/CollectionCells/README.md
@@ -20,6 +20,8 @@ Collection view cell classes that adhere to Material Design layout and styling.
 
 <ul class="icon-list">
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/lists.html#lists-specs">Material Design guidelines: Collection List Specs</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/collections/collection-cells/api-docs/Classes/MDCCollectionViewCell.html">API: MDCCollectionViewCell</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/collections/collection-cells/api-docs/Classes/MDCCollectionViewTextCell.html">API: MDCCollectionViewTextCell</a></li>
 </ul>
 
 - - -

--- a/components/CollectionCells/README.md
+++ b/components/CollectionCells/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "Collection view cell classes that adhere to Material Design layout and styling."
 iconId: list
 path: /catalog/collections/collection-cells/
+api_doc_root: true
 -->
 
 # Collection Cells

--- a/components/CollectionLayoutAttributes/README.md
+++ b/components/CollectionLayoutAttributes/README.md
@@ -12,6 +12,12 @@ api_doc_root: true
 
 Allows passing layout attributes to the cells and supplementary views.
 
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/collections/collection-layout-attributes/api-docs/Classes/MDCCollectionViewLayoutAttributes.html">API: MDCCollectionViewLayoutAttributes</a></li>
+</ul>
+
 - - -
 
 ## Installation

--- a/components/CollectionLayoutAttributes/README.md
+++ b/components/CollectionLayoutAttributes/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "Allows passing layout attributes to the cells and supplementary views."
 iconId: list
 path: /catalog/collections/collection-layout-attributes/
+api_doc_root: true
 -->
 
 # Collection Layout Attributes

--- a/components/Collections/README.md
+++ b/components/Collections/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "Collection view classes that adhere to Material Design layout and styling."
 iconId: list
 path: /catalog/collections/
+api_doc_root: true
 -->
 
 # Collections

--- a/components/Collections/README.md
+++ b/components/Collections/README.md
@@ -20,6 +20,11 @@ Collection view classes that adhere to Material Design layout and styling.
 
 <ul class="icon-list">
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/lists.html#lists-specs">Material Design guidelines: Collection List Specs</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/collections/api-docs/Classes/MDCCollectionViewController.html">API: MDCCollectionViewController</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/collections/api-docs/Protocols/MDCCollectionViewEditing.html">API: MDCCollectionViewEditing</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/collections/api-docs/Protocols/MDCCollectionViewEditingDelegate.html">API: MDCCollectionViewEditingDelegate</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/collections/api-docs/Protocols/MDCCollectionViewStyling.html">API: MDCCollectionViewStyling</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/collections/api-docs/Protocols/MDCCollectionViewStylingDelegate.html">API: MDCCollectionViewStylingDelegate</a></li>
 </ul>
 
 - - -

--- a/components/Collections/README.md
+++ b/components/Collections/README.md
@@ -19,7 +19,7 @@ Collection view classes that adhere to Material Design layout and styling.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/lists.html#lists-specs">Collection List Specs</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/lists.html#lists-specs">Material Design guidelines: Collection List Specs</a></li>
 </ul>
 
 - - -

--- a/components/Dialogs/README.md
+++ b/components/Dialogs/README.md
@@ -19,7 +19,7 @@ controller that will display a simple modal alert.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/dialogs.html">Dialogs</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/dialogs.html">Material Design guidelines: Dialogs</a></li>
 </ul>
 
 ### Dialogs Classes

--- a/components/FeatureHighlight/README.md
+++ b/components/FeatureHighlight/README.md
@@ -18,7 +18,7 @@ The Feature Highlight component is a way to visually highlight a part of the scr
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/growth-communications/feature-discovery.html">Feature Discovery</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/growth-communications/feature-discovery.html">Material Design guidelines: Feature Discovery</a></li>
 </ul>
 
 - - -

--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -20,7 +20,7 @@ UIScrollViewDelegate events.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/patterns/scrolling-techniques.html">Scrolling Techniques</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/patterns/scrolling-techniques.html">Material Design guidelines: Scrolling Techniques</a></li>
 </ul>
 
 - - -

--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "The Flexible Header is a container view whose height and vertical offset react to UIScrollViewDelegate events."
 iconId: header
 path: /catalog/flexible-headers/
+api_doc_root: true
 -->
 
 # Flexible Header

--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -21,6 +21,11 @@ UIScrollViewDelegate events.
 
 <ul class="icon-list">
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/patterns/scrolling-techniques.html">Material Design guidelines: Scrolling Techniques</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/flexible-headers/api-docs/Classes/MDCFlexibleHeaderContainerViewController.html">API: MDCFlexibleHeaderContainerViewController</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/flexible-headers/api-docs/Classes/MDCFlexibleHeaderView.html">API: MDCFlexibleHeaderView</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/flexible-headers/api-docs/Classes/MDCFlexibleHeaderViewController.html">API: MDCFlexibleHeaderViewController</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/flexible-headers/api-docs/Protocols/MDCFlexibleHeaderViewDelegate.html">API: MDCFlexibleHeaderViewDelegate</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/flexible-headers/api-docs/Protocols/MDCFlexibleHeaderViewLayoutDelegate.html">API: MDCFlexibleHeaderViewLayoutDelegate</a></li>
 </ul>
 
 - - -

--- a/components/HeaderStackView/README.md
+++ b/components/HeaderStackView/README.md
@@ -21,6 +21,7 @@ bar views.
 
 <ul class="icon-list">
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/layout/structure.html#structure-app-bar">Material Design guidelines: App Bar</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/flexible-headers/header-stack-views/api-docs/Classes/MDCHeaderStackView.html">API: MDCHeaderStackView</a></li>
 </ul>
 
 - - -

--- a/components/HeaderStackView/README.md
+++ b/components/HeaderStackView/README.md
@@ -20,7 +20,7 @@ bar views.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/layout/structure.html#structure-app-bar">App Bar</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/layout/structure.html#structure-app-bar">Material Design guidelines: App Bar</a></li>
 </ul>
 
 - - -

--- a/components/HeaderStackView/README.md
+++ b/components/HeaderStackView/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "The Header Stack View component is a view that coordinates the layout of two vertically stacked bar views."
 iconId: header
 path: /catalog/flexible-headers/header-stack-views/
+api_doc_root: true
 -->
 
 # Header Stack Views

--- a/components/Ink/README.md
+++ b/components/Ink/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "The Ink component provides a radial action in the form of a visual ripple of ink expanding outward from the user's touch."
 iconId: ripple
 path: /catalog/ink/
+api_doc_root: true
 -->
 
 # Ink

--- a/components/Ink/README.md
+++ b/components/Ink/README.md
@@ -21,6 +21,9 @@ outward from the user's touch.
 
 <ul class="icon-list">
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/animation/responsive-interaction.html#responsive-interaction-radial-action">Material Design guidelines: Radial Action</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/ink/api-docs/Classes/MDCInkGestureRecognizer.html">API: MDCInkGestureRecognizer</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/ink/api-docs/Classes/MDCInkTouchController.html">API: MDCInkTouchController</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/ink/api-docs/Classes/MDCInkView.html">API: MDCInkView</a></li>
 </ul>
 
 - - -

--- a/components/Ink/README.md
+++ b/components/Ink/README.md
@@ -20,7 +20,7 @@ outward from the user's touch.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/animation/responsive-interaction.html#responsive-interaction-radial-action">Radial Action</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/animation/responsive-interaction.html#responsive-interaction-radial-action">Material Design guidelines: Radial Action</a></li>
 </ul>
 
 - - -

--- a/components/NavigationBar/README.md
+++ b/components/NavigationBar/README.md
@@ -22,7 +22,7 @@ Consistent with iOS design guidelines, the title in the navigation bar is center
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/layout/structure.html">Layout Structure</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/layout/structure.html">Material Design guidelines: Layout Structure</a></li>
 </ul>
 
 - - -

--- a/components/NavigationBar/README.md
+++ b/components/NavigationBar/README.md
@@ -22,7 +22,8 @@ Consistent with iOS design guidelines, the title in the navigation bar is center
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/layout/structure.html">Material Design guidelines: Layout Structure</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/components/ios/catalog/flexible-headers/navigation-bars/api-docs/Classes/MDCNavigationBar.html">API: MDCNavigationBar</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/flexible-headers/navigation-bars/api-docs/Protocols/MDCUINavigationItemObservables.html">API: MDCUINavigationItemObservables</a></li>
 </ul>
 
 - - -

--- a/components/NavigationBar/README.md
+++ b/components/NavigationBar/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "The Navigation Bar component is a view composed of a left and right Button Bar and either a title label or a custom title view."
 iconId: toolbar
 path: /catalog/flexible-headers/navigation-bars/
+api_doc_root: true
 -->
 
 # Navigation Bar

--- a/components/PageControl/README.md
+++ b/components/PageControl/README.md
@@ -18,6 +18,12 @@ influenced by Material Design specifications for animation and layout. The API m
 same as a `UIPageControl`, with the addition of a few key methods required to achieve the
 desired animation of the control.
 
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/page-controls/api-docs/Classes/MDCPageControl.html">API: MDCPageControl</a></li>
+</ul>
+
 - - -
 
 ## Installation

--- a/components/PageControl/README.md
+++ b/components/PageControl/README.md
@@ -4,6 +4,7 @@ layout: detail
 section: components
 excerpt: "Page Control is a drop-in Material Design replacement for UIPageControl that implements Material Design animation and layout."
 path: /catalog/page-controls/
+api_doc_root: true
 -->
 
 # Page Control

--- a/components/Palettes/README.md
+++ b/components/Palettes/README.md
@@ -19,7 +19,7 @@ The Palettes component provides Material colors organized into similar palettes.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/style/color.html#color-color-palette">Color palettes</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/style/color.html#color-color-palette">Material Design guidelines: Color palettes</a></li>
 </ul>
 
 - - -

--- a/components/Palettes/README.md
+++ b/components/Palettes/README.md
@@ -20,6 +20,7 @@ The Palettes component provides Material colors organized into similar palettes.
 
 <ul class="icon-list">
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/style/color.html#color-color-palette">Material Design guidelines: Color palettes</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/palette/api-docs/Classes/MDCPalette.html">API: MDCPalette</a></li>
 </ul>
 
 - - -

--- a/components/Palettes/README.md
+++ b/components/Palettes/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "The Palettes component provides Material color palettes."
 iconId: color
 path: /catalog/palette/
+api_doc_root: true
 -->
 
 # Palettes

--- a/components/ProgressView/README.md
+++ b/components/ProgressView/README.md
@@ -22,7 +22,7 @@ few key methods required to achieve the desired animation of the control.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/progress-activity.html">Progress & activity</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/progress-activity.html">Material Design guidelines: Progress & activity</a></li>
 </ul>
 
 - - -

--- a/components/ProgressView/README.md
+++ b/components/ProgressView/README.md
@@ -23,6 +23,7 @@ few key methods required to achieve the desired animation of the control.
 
 <ul class="icon-list">
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/progress-activity.html">Material Design guidelines: Progress & activity</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/progress-indicators/progress-views/api-docs/Classes/MDCProgressView.html">API: MDCProgressView</a></li>
 </ul>
 
 - - -

--- a/components/ProgressView/README.md
+++ b/components/ProgressView/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "Progress View is a determinate and linear progress indicator that implements Material Design animation and layout."
 iconId: progress_linear
 path: /catalog/progress-indicators/progress-views/
+api_doc_root: true
 -->
 
 # Progress View

--- a/components/ShadowElevations/README.md
+++ b/components/ShadowElevations/README.md
@@ -23,6 +23,7 @@ used Material Design elevations for components.
 
 <ul class="icon-list">
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/what-is-material/elevation-shadows.html">Material Design guidelines: Elevation & Shadows</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/shadows/shadow-elevations/api-docs/Constants.html">API: Constants</a></li>
 </ul>
 
 - - -

--- a/components/ShadowElevations/README.md
+++ b/components/ShadowElevations/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "The Shadow Elevations component provides the most commonly-used Material Design elevations."
 iconId: shadow
 path: /catalog/shadows/shadow-elevations/
+api_doc_root: true
 -->
 
 # Shadow Elevations

--- a/components/ShadowElevations/README.md
+++ b/components/ShadowElevations/README.md
@@ -22,7 +22,7 @@ used Material Design elevations for components.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/what-is-material/elevation-shadows.html">Elevation and Shadows</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/what-is-material/elevation-shadows.html">Material Design guidelines: Elevation & Shadows</a></li>
 </ul>
 
 - - -

--- a/components/ShadowLayer/README.md
+++ b/components/ShadowLayer/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "The Shadow Layer component implements the Material Design specifications for elevation and shadows."
 iconId: shadow
 path: /catalog/shadows/shadow-layers/
+api_doc_root: true
 -->
 
 # Shadow Layer

--- a/components/ShadowLayer/README.md
+++ b/components/ShadowLayer/README.md
@@ -23,7 +23,7 @@ elevation.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/what-is-material/elevation-shadows.html">Elevation and Shadows</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/what-is-material/elevation-shadows.html">Material Design guidelines: Elevation & Shadows</a></li>
 </ul>
 
 ### MDCShadowLayer

--- a/components/ShadowLayer/README.md
+++ b/components/ShadowLayer/README.md
@@ -24,6 +24,8 @@ elevation.
 
 <ul class="icon-list">
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/what-is-material/elevation-shadows.html">Material Design guidelines: Elevation & Shadows</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/shadows/shadow-layers/api-docs/Classes/MDCShadowLayer.html">API: MDCShadowLayer</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/shadows/shadow-layers/api-docs/Classes/MDCShadowMetrics.html">API: MDCShadowMetrics</a></li>
 </ul>
 
 ### MDCShadowLayer

--- a/components/Slider/README.md
+++ b/components/Slider/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "The Slider component provides a Material Design control for selecting a value from a continuous range or discrete set of values."
 iconId: slider
 path: /catalog/sliders/
+api_doc_root: true
 -->
 
 # Slider

--- a/components/Slider/README.md
+++ b/components/Slider/README.md
@@ -21,6 +21,7 @@ or discrete set of values.
 
 <ul class="icon-list">
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/sliders.html">Material Design guidelines: Sliders</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/sliders/api-docs/Classes/MDCSlider.html">API: MDCSlider</a></li>
 </ul>
 
 - - -

--- a/components/Slider/README.md
+++ b/components/Slider/README.md
@@ -20,7 +20,7 @@ or discrete set of values.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/sliders.html">Sliders</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/sliders.html">Material Design guidelines: Sliders</a></li>
 </ul>
 
 - - -

--- a/components/Snackbar/README.md
+++ b/components/Snackbar/README.md
@@ -20,7 +20,7 @@ contain a text action, but no icons.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/snackbars-toasts.html">Snackbars</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/snackbars-toasts.html">Material Design guidelines: Snackbars</a></li>
 </ul>
 
 - - -

--- a/components/Tabs/README.md
+++ b/components/Tabs/README.md
@@ -18,7 +18,7 @@ Tabs are bars of buttons used to navigate between groups of content.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/tabs.html">Tabs</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/tabs.html">Material Design guidelines: Tabs</a></li>
 </ul>
 
 - - -

--- a/components/Typography/README.md
+++ b/components/Typography/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "The Typography component provides methods for displaying text using the type sizes and opacities from the Material Design specifications."
 iconId: typography
 path: /catalog/typography/
+api_doc_root: true
 -->
 
 # Typography

--- a/components/Typography/README.md
+++ b/components/Typography/README.md
@@ -21,6 +21,8 @@ from the Material Design specifications.
 
 <ul class="icon-list">
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/style/typography.html">Material Design guidelines: Typography</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/typography/api-docs/Classes/MDCTypography.html">API: MDCTypography</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/typography/api-docs/Protocols/MDCTypographyFontLoading.html">API: MDCTypographyFontLoading</a></li>
 </ul>
 
 ## Installation

--- a/components/Typography/README.md
+++ b/components/Typography/README.md
@@ -20,7 +20,7 @@ from the Material Design specifications.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/style/typography.html">Typography</a></li>
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/style/typography.html">Material Design guidelines: Typography</a></li>
 </ul>
 
 ## Installation


### PR DESCRIPTION
* Configures the repo to use Jazzy as its documentation generator
* Marks the individual API documentation roots (where Jazzy is run)
* Adds a common prefix to all Material Design guidelines links