### PR TITLE
[Tabs] Fix maximum width logic for centered tabs

### DIFF
--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -399,8 +399,10 @@ static void *kItemPropertyContext = &kItemPropertyContext;
     size.width = MIN(size.width, _style.maximumItemWidth);
   }
 
-  // Constrain tab width to collection bounds.
-  const CGFloat boundsWidth = CGRectGetWidth(collectionView.bounds);
+  // Constrain tab width to collection content bounds.
+  const UIEdgeInsets sectionInset = _flowLayout.sectionInset;
+  const CGFloat boundsWidth =
+      CGRectGetWidth(collectionView.bounds) - sectionInset.left - sectionInset.right;
   size.width = MIN(size.width, boundsWidth);
 
   // Force height to our height.
@@ -584,14 +586,6 @@ static void *kItemPropertyContext = &kItemPropertyContext;
     case MDCItemBarAlignmentCenterSelected:
       newSectionInset = [self centerSelectedInsets];
       break;
-  }
-
-  UIEdgeInsets oldSectionInset = _flowLayout.sectionInset;
-  if (UIEdgeInsetsEqualToEdgeInsets(oldSectionInset, newSectionInset) &&
-      _alignment != MDCItemBarAlignmentJustified) {
-    // No change - can bail early, except when the item alignment is "justified". When justified,
-    // the layout metrics need updating due to change in view size or orientation.
-    return;
   }
 
   // Rather than just updating the sectionInset on the existing flowLayout, a new layout object

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -399,6 +399,10 @@ static void *kItemPropertyContext = &kItemPropertyContext;
     size.width = MIN(size.width, _style.maximumItemWidth);
   }
 
+  // Constrain tab width to collection bounds.
+  const CGFloat boundsWidth = CGRectGetWidth(collectionView.bounds);
+  size.width = MIN(size.width, boundsWidth);
+
   // Force height to our height.
   size.height = itemHeight;
 

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -588,6 +588,16 @@ static void *kItemPropertyContext = &kItemPropertyContext;
       break;
   }
 
+  UIEdgeInsets oldSectionInset = _tabFlowLayout.sectionInset;
+  if (UIEdgeInsetsEqualToEdgeInsets(oldSectionInset, newSectionInset)) {
+    // No inset change - only need to invalidate the layout to pick up new item sizes.
+    UICollectionViewFlowLayoutInvalidationContext *delegateContext =
+        [[UICollectionViewFlowLayoutInvalidationContext alloc] init];
+    delegateContext.invalidateFlowLayoutDelegateMetrics = YES;
+    [_tabFlowLayout invalidateLayoutWithContext:delegateContext];
+    return;
+  }
+
   // Rather than just updating the sectionInset on the existing flowLayout, a new layout object
   // is created. This gives more control over whether the change is animated or not - as there is
   // no control when updating flow layout sectionInset (it's always animated).

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -588,13 +588,13 @@ static void *kItemPropertyContext = &kItemPropertyContext;
       break;
   }
 
-  UIEdgeInsets oldSectionInset = _tabFlowLayout.sectionInset;
+  UIEdgeInsets oldSectionInset = _flowLayout.sectionInset;
   if (UIEdgeInsetsEqualToEdgeInsets(oldSectionInset, newSectionInset)) {
     // No inset change - only need to invalidate the layout to pick up new item sizes.
     UICollectionViewFlowLayoutInvalidationContext *delegateContext =
         [[UICollectionViewFlowLayoutInvalidationContext alloc] init];
     delegateContext.invalidateFlowLayoutDelegateMetrics = YES;
-    [_tabFlowLayout invalidateLayoutWithContext:delegateContext];
+    [_flowLayout invalidateLayoutWithContext:delegateContext];
     return;
   }
 

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -400,9 +400,8 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   }
 
   // Constrain tab width to collection content bounds.
-  const UIEdgeInsets sectionInset = _flowLayout.sectionInset;
   const CGFloat boundsWidth =
-      CGRectGetWidth(collectionView.bounds) - sectionInset.left - sectionInset.right;
+      CGRectGetWidth(UIEdgeInsetsInsetRect(collectionView.bounds, _flowLayout.sectionInset));
   size.width = MIN(size.width, boundsWidth);
 
   // Force height to our height.

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -383,8 +383,9 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   CGSize size = CGSizeMake(CGFLOAT_MAX, itemHeight);
 
   // Size cell to fit content.
+  UIUserInterfaceSizeClass sizeClass = [self horizontalSizeClass];
   size = [MDCItemBarCell sizeThatFits:size
-                  horizontalSizeClass:[self horizontalSizeClass]
+                  horizontalSizeClass:sizeClass
                                  item:item
                                 style:_style];
 
@@ -399,9 +400,12 @@ static void *kItemPropertyContext = &kItemPropertyContext;
     size.width = MIN(size.width, _style.maximumItemWidth);
   }
 
-  // Constrain tab width to collection content bounds.
+  // Constrain tab width to bounds, insetting to fit comfortably at the edges of the scroll bounds.
+  const BOOL isRegular = (sizeClass == UIUserInterfaceSizeClassRegular);
+  const CGFloat inset = isRegular ? kRegularInset : kCompactInset;
+  const UIEdgeInsets boundsInsets = UIEdgeInsetsMake(0.0f, inset, 0.0f, inset);
   const CGFloat boundsWidth =
-      CGRectGetWidth(UIEdgeInsetsInsetRect(collectionView.bounds, _flowLayout.sectionInset));
+      CGRectGetWidth(UIEdgeInsetsInsetRect(collectionView.bounds, boundsInsets));
   size.width = MIN(size.width, boundsWidth);
 
   // Force height to our height.


### PR DESCRIPTION
The previous change didn't work well for small centered tabs, which have a large section inset to achieve their centeredness. This change makes the max width just have a small fixed size class-based inset.