### PR TITLE
Revert "[Tabs] Disallow tabs that are wider than the screen (#1408)"

### DIFF
--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -399,12 +399,6 @@ static void *kItemPropertyContext = &kItemPropertyContext;
     size.width = MIN(size.width, _style.maximumItemWidth);
   }
 
-  // Constrain tab width to collection content bounds.
-  const UIEdgeInsets sectionInset = _flowLayout.sectionInset;
-  const CGFloat boundsWidth =
-      CGRectGetWidth(collectionView.bounds) - sectionInset.left - sectionInset.right;
-  size.width = MIN(size.width, boundsWidth);
-
   // Force height to our height.
   size.height = itemHeight;
 
@@ -589,12 +583,10 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   }
 
   UIEdgeInsets oldSectionInset = _flowLayout.sectionInset;
-  if (UIEdgeInsetsEqualToEdgeInsets(oldSectionInset, newSectionInset)) {
-    // No inset change - only need to invalidate the layout to pick up new item sizes.
-    UICollectionViewFlowLayoutInvalidationContext *delegateContext =
-        [[UICollectionViewFlowLayoutInvalidationContext alloc] init];
-    delegateContext.invalidateFlowLayoutDelegateMetrics = YES;
-    [_flowLayout invalidateLayoutWithContext:delegateContext];
+  if (UIEdgeInsetsEqualToEdgeInsets(oldSectionInset, newSectionInset) &&
+      _alignment != MDCItemBarAlignmentJustified) {
+    // No change - can bail early, except when the item alignment is "justified". When justified,
+    // the layout metrics need updating due to change in view size or orientation.
     return;
   }
 


### PR DESCRIPTION
This change broke a few clients and should be rolled back.