### PR TITLE
Until you select an item in MDCTabBar, it should be in the unselected state. Fixed.

### DIFF
--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -186,9 +186,9 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 
     [self reload];
 
-    // Reset selection to a valid item.
+    // Reset selection to the unselected state.
     if (![_items containsObject:_selectedItem]) {
-      self.selectedItem = [_items firstObject];
+      self.selectedItem = nil;
     }
 
     // Start observing new items for changes.


### PR DESCRIPTION
Previously, MDCItemBar, which MDCTabBar uses, couldn't handle being in the unselected state. Now it can. Therefore, there's no need to silently auto-select the first item of the itemBar when items are assigned to it. And since that autoselection happens silently, you can get into an inconsistent state, where the MDCTabBar  does not think anything is selected, but the MDCItemBar shows the first element as selected. This change fixes that.