### PR TITLE
Corrected release instructions.

### DIFF
--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -292,6 +292,7 @@ and delete the release branch:
 
 ## Publish to Cocoapods
 
+    git checkout stable
     pod trunk push MaterialComponents.podspec
 
 ## Reply to the original release email message


### PR DESCRIPTION
We should to be on the stable branch when we publish the Cocoapods.