### PR TITLE
Release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 23.4.1
+
+Fixed podspec
+
+## Component changes
+
+### Buttons
+
+#### Changes
+
+* [Revert "Fix case-sensitive imports from private to Private. Causing compilation failures in Xcode 8.3.2 about non-portable path."](https://github.com/material-components/material-components-ios/commit/9cae7fca7bcd490a921c5ca1aacbd585cd61a021) (randallli)
+
+### Typography
+
+#### Changes
+
+* [Revert "Fix case-sensitive imports from private to Private. Causing compilation failures in Xcode 8.3.2 about non-portable path."](https://github.com/material-components/material-components-ios/commit/9cae7fca7bcd490a921c5ca1aacbd585cd61a021) (randallli)
+
 # 23.4.0
 
 ## API diffs

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -273,7 +273,6 @@ Pod::Spec.new do |s|
     ss.ios.deployment_target = '8.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
-    ss.resources = ["components/#{ss.base_name}/src/Material#{ss.base_name}.bundle"]
 
     ss.dependency "MaterialComponents/FeatureHighlight"
     ss.dependency "MaterialComponents/Dialogs"

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -2,7 +2,7 @@ load 'scripts/generated/icons.rb'
 
 Pod::Spec.new do |s|
   s.name         = "MaterialComponents"
-  s.version      = "23.4.0"
+  s.version      = "23.4.1"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/MaterialComponentsCatalog.podspec
+++ b/MaterialComponentsCatalog.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsCatalog"
-  s.version      = "23.4.0"
+  s.version      = "23.4.1"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/MaterialComponentsUnitTests.podspec
+++ b/MaterialComponentsUnitTests.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsUnitTests"
-  s.version      = "23.4.0"
+  s.version      = "23.4.1"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -22,7 +22,7 @@
 #import "MaterialShadowElevations.h"
 #import "MaterialShadowLayer.h"
 #import "MaterialTypography.h"
-#import "Private/MDCButton+Subclassing.h"
+#import "private/MDCButton+Subclassing.h"
 
 // TODO(ajsecord): Animate title color when animating between enabled/disabled states.
 // Non-trivial: http://corecocoa.wordpress.com/2011/10/04/animatable-text-color-of-uilabel/

--- a/components/Buttons/src/MDCFlatButton.m
+++ b/components/Buttons/src/MDCFlatButton.m
@@ -16,7 +16,7 @@
 
 #import "MDCFlatButton.h"
 
-#import "Private/MDCButton+Subclassing.h"
+#import "private/MDCButton+Subclassing.h"
 
 static NSString *const MDCFlatButtonHasOpaqueBackground = @"MDCFlatButtonHasOpaqueBackground";
 

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -17,7 +17,7 @@
 #import "MDCFloatingButton.h"
 
 #import "MaterialShadowElevations.h"
-#import "Private/MDCButton+Subclassing.h"
+#import "private/MDCButton+Subclassing.h"
 
 static const CGFloat MDCFloatingButtonDefaultDimension = 56.0f;
 static const CGFloat MDCFloatingButtonMiniDimension = 40.0f;

--- a/components/Buttons/src/MDCRaisedButton.m
+++ b/components/Buttons/src/MDCRaisedButton.m
@@ -17,7 +17,7 @@
 #import "MDCRaisedButton.h"
 
 #import "MaterialShadowElevations.h"
-#import "Private/MDCButton+Subclassing.h"
+#import "private/MDCButton+Subclassing.h"
 
 @implementation MDCRaisedButton
 

--- a/components/Typography/src/MDCTypography.m
+++ b/components/Typography/src/MDCTypography.m
@@ -15,7 +15,7 @@
  */
 
 #import "MDCTypography.h"
-#import "Private/UIFont+MaterialTypographyPrivate.h"
+#import "private/UIFont+MaterialTypographyPrivate.h"
 
 static id<MDCTypographyFontLoading> gFontLoader = nil;
 const CGFloat MDCTypographyStandardOpacity = 0.87f;

--- a/components/Typography/src/UIFontDescriptor+MaterialTypography.m
+++ b/components/Typography/src/UIFontDescriptor+MaterialTypography.m
@@ -15,7 +15,7 @@
 
 #import "UIApplication+AppExtensions.h"
 
-#import "Private/MDCFontTraits.h"
+#import "private/MDCFontTraits.h"
 
 @implementation UIFontDescriptor (MaterialTypography)
 

--- a/demos/Bare/Podfile.lock
+++ b/demos/Bare/Podfile.lock
@@ -1,36 +1,36 @@
 PODS:
-  - MaterialComponents (23.4.0):
-    - MaterialComponents/ActivityIndicator (= 23.4.0)
-    - MaterialComponents/AnimationTiming (= 23.4.0)
-    - MaterialComponents/AppBar (= 23.4.0)
-    - MaterialComponents/ButtonBar (= 23.4.0)
-    - MaterialComponents/Buttons (= 23.4.0)
-    - MaterialComponents/CollectionCells (= 23.4.0)
-    - MaterialComponents/CollectionLayoutAttributes (= 23.4.0)
-    - MaterialComponents/Collections (= 23.4.0)
-    - MaterialComponents/Dialogs (= 23.4.0)
-    - MaterialComponents/FeatureHighlight (= 23.4.0)
-    - MaterialComponents/FlexibleHeader (= 23.4.0)
-    - MaterialComponents/HeaderStackView (= 23.4.0)
-    - MaterialComponents/Ink (= 23.4.0)
-    - MaterialComponents/NavigationBar (= 23.4.0)
-    - MaterialComponents/OverlayWindow (= 23.4.0)
-    - MaterialComponents/PageControl (= 23.4.0)
-    - MaterialComponents/Palettes (= 23.4.0)
-    - MaterialComponents/private (= 23.4.0)
-    - MaterialComponents/ProgressView (= 23.4.0)
-    - MaterialComponents/ShadowElevations (= 23.4.0)
-    - MaterialComponents/ShadowLayer (= 23.4.0)
-    - MaterialComponents/Slider (= 23.4.0)
-    - MaterialComponents/Snackbar (= 23.4.0)
-    - MaterialComponents/Tabs (= 23.4.0)
-    - MaterialComponents/Themes (= 23.4.0)
-    - MaterialComponents/Typography (= 23.4.0)
-  - MaterialComponents/ActivityIndicator (23.4.0):
+  - MaterialComponents (23.4.1):
+    - MaterialComponents/ActivityIndicator (= 23.4.1)
+    - MaterialComponents/AnimationTiming (= 23.4.1)
+    - MaterialComponents/AppBar (= 23.4.1)
+    - MaterialComponents/ButtonBar (= 23.4.1)
+    - MaterialComponents/Buttons (= 23.4.1)
+    - MaterialComponents/CollectionCells (= 23.4.1)
+    - MaterialComponents/CollectionLayoutAttributes (= 23.4.1)
+    - MaterialComponents/Collections (= 23.4.1)
+    - MaterialComponents/Dialogs (= 23.4.1)
+    - MaterialComponents/FeatureHighlight (= 23.4.1)
+    - MaterialComponents/FlexibleHeader (= 23.4.1)
+    - MaterialComponents/HeaderStackView (= 23.4.1)
+    - MaterialComponents/Ink (= 23.4.1)
+    - MaterialComponents/NavigationBar (= 23.4.1)
+    - MaterialComponents/OverlayWindow (= 23.4.1)
+    - MaterialComponents/PageControl (= 23.4.1)
+    - MaterialComponents/Palettes (= 23.4.1)
+    - MaterialComponents/private (= 23.4.1)
+    - MaterialComponents/ProgressView (= 23.4.1)
+    - MaterialComponents/ShadowElevations (= 23.4.1)
+    - MaterialComponents/ShadowLayer (= 23.4.1)
+    - MaterialComponents/Slider (= 23.4.1)
+    - MaterialComponents/Snackbar (= 23.4.1)
+    - MaterialComponents/Tabs (= 23.4.1)
+    - MaterialComponents/Themes (= 23.4.1)
+    - MaterialComponents/Typography (= 23.4.1)
+  - MaterialComponents/ActivityIndicator (23.4.1):
     - MaterialComponents/private/Application
     - MaterialComponents/private/RTL
-  - MaterialComponents/AnimationTiming (23.4.0)
-  - MaterialComponents/AppBar (23.4.0):
+  - MaterialComponents/AnimationTiming (23.4.1)
+  - MaterialComponents/AppBar (23.4.1):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
     - MaterialComponents/NavigationBar
@@ -39,17 +39,17 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ButtonBar (23.4.0):
+  - MaterialComponents/ButtonBar (23.4.1):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/Buttons (23.4.0):
+  - MaterialComponents/Buttons (23.4.1):
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/CollectionCells (23.4.0):
+  - MaterialComponents/CollectionCells (23.4.1):
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/private/Icons/ic_check
@@ -61,91 +61,91 @@ PODS:
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/CollectionLayoutAttributes (23.4.0)
-  - MaterialComponents/Collections (23.4.0):
+  - MaterialComponents/CollectionLayoutAttributes (23.4.1)
+  - MaterialComponents/Collections (23.4.1):
     - MaterialComponents/CollectionCells
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/Dialogs (23.4.0):
+  - MaterialComponents/Dialogs (23.4.1):
     - MaterialComponents/Buttons
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/RTL
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
-  - MaterialComponents/FeatureHighlight (23.4.0):
+  - MaterialComponents/FeatureHighlight (23.4.1):
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader (23.4.0):
+  - MaterialComponents/FlexibleHeader (23.4.1):
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/HeaderStackView (23.4.0)
-  - MaterialComponents/Ink (23.4.0)
-  - MaterialComponents/NavigationBar (23.4.0):
+  - MaterialComponents/HeaderStackView (23.4.1)
+  - MaterialComponents/Ink (23.4.1)
+  - MaterialComponents/NavigationBar (23.4.1):
     - MaterialComponents/ButtonBar
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/OverlayWindow (23.4.0):
+  - MaterialComponents/OverlayWindow (23.4.1):
     - MaterialComponents/private/Application
-  - MaterialComponents/PageControl (23.4.0)
-  - MaterialComponents/Palettes (23.4.0)
-  - MaterialComponents/private (23.4.0):
-    - MaterialComponents/private/Application (= 23.4.0)
-    - MaterialComponents/private/Icons (= 23.4.0)
-    - MaterialComponents/private/KeyboardWatcher (= 23.4.0)
-    - MaterialComponents/private/Math (= 23.4.0)
-    - MaterialComponents/private/Overlay (= 23.4.0)
-    - MaterialComponents/private/RTL (= 23.4.0)
-    - MaterialComponents/private/ThumbTrack (= 23.4.0)
-  - MaterialComponents/private/Application (23.4.0)
-  - MaterialComponents/private/Icons (23.4.0):
-    - MaterialComponents/private/Icons/Base (= 23.4.0)
-    - MaterialComponents/private/Icons/ic_arrow_back (= 23.4.0)
-    - MaterialComponents/private/Icons/ic_check (= 23.4.0)
-    - MaterialComponents/private/Icons/ic_check_circle (= 23.4.0)
-    - MaterialComponents/private/Icons/ic_chevron_right (= 23.4.0)
-    - MaterialComponents/private/Icons/ic_info (= 23.4.0)
-    - MaterialComponents/private/Icons/ic_radio_button_unchecked (= 23.4.0)
-    - MaterialComponents/private/Icons/ic_reorder (= 23.4.0)
-  - MaterialComponents/private/Icons/Base (23.4.0)
-  - MaterialComponents/private/Icons/ic_arrow_back (23.4.0):
+  - MaterialComponents/PageControl (23.4.1)
+  - MaterialComponents/Palettes (23.4.1)
+  - MaterialComponents/private (23.4.1):
+    - MaterialComponents/private/Application (= 23.4.1)
+    - MaterialComponents/private/Icons (= 23.4.1)
+    - MaterialComponents/private/KeyboardWatcher (= 23.4.1)
+    - MaterialComponents/private/Math (= 23.4.1)
+    - MaterialComponents/private/Overlay (= 23.4.1)
+    - MaterialComponents/private/RTL (= 23.4.1)
+    - MaterialComponents/private/ThumbTrack (= 23.4.1)
+  - MaterialComponents/private/Application (23.4.1)
+  - MaterialComponents/private/Icons (23.4.1):
+    - MaterialComponents/private/Icons/Base (= 23.4.1)
+    - MaterialComponents/private/Icons/ic_arrow_back (= 23.4.1)
+    - MaterialComponents/private/Icons/ic_check (= 23.4.1)
+    - MaterialComponents/private/Icons/ic_check_circle (= 23.4.1)
+    - MaterialComponents/private/Icons/ic_chevron_right (= 23.4.1)
+    - MaterialComponents/private/Icons/ic_info (= 23.4.1)
+    - MaterialComponents/private/Icons/ic_radio_button_unchecked (= 23.4.1)
+    - MaterialComponents/private/Icons/ic_reorder (= 23.4.1)
+  - MaterialComponents/private/Icons/Base (23.4.1)
+  - MaterialComponents/private/Icons/ic_arrow_back (23.4.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check (23.4.0):
+  - MaterialComponents/private/Icons/ic_check (23.4.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check_circle (23.4.0):
+  - MaterialComponents/private/Icons/ic_check_circle (23.4.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_chevron_right (23.4.0):
+  - MaterialComponents/private/Icons/ic_chevron_right (23.4.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_info (23.4.0):
+  - MaterialComponents/private/Icons/ic_info (23.4.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_radio_button_unchecked (23.4.0):
+  - MaterialComponents/private/Icons/ic_radio_button_unchecked (23.4.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_reorder (23.4.0):
+  - MaterialComponents/private/Icons/ic_reorder (23.4.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/KeyboardWatcher (23.4.0):
+  - MaterialComponents/private/KeyboardWatcher (23.4.1):
     - MaterialComponents/private/Application
-  - MaterialComponents/private/Math (23.4.0)
-  - MaterialComponents/private/Overlay (23.4.0)
-  - MaterialComponents/private/RTL (23.4.0)
-  - MaterialComponents/private/ThumbTrack (23.4.0):
+  - MaterialComponents/private/Math (23.4.1)
+  - MaterialComponents/private/Overlay (23.4.1)
+  - MaterialComponents/private/RTL (23.4.1)
+  - MaterialComponents/private/ThumbTrack (23.4.1):
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ProgressView (23.4.0):
+  - MaterialComponents/ProgressView (23.4.1):
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
-  - MaterialComponents/ShadowElevations (23.4.0)
-  - MaterialComponents/ShadowLayer (23.4.0)
-  - MaterialComponents/Slider (23.4.0):
+  - MaterialComponents/ShadowElevations (23.4.1)
+  - MaterialComponents/ShadowLayer (23.4.1)
+  - MaterialComponents/Slider (23.4.1):
     - MaterialComponents/private/ThumbTrack
-  - MaterialComponents/Snackbar (23.4.0):
+  - MaterialComponents/Snackbar (23.4.1):
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Buttons
     - MaterialComponents/OverlayWindow
@@ -153,14 +153,15 @@ PODS:
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/Overlay
     - MaterialComponents/Typography
-  - MaterialComponents/Tabs (23.4.0):
+  - MaterialComponents/Tabs (23.4.1):
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Ink
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/Themes (23.4.0):
+  - MaterialComponents/Themes (23.4.1):
+    - MaterialComponents/Dialogs
     - MaterialComponents/FeatureHighlight
-  - MaterialComponents/Typography (23.4.0):
+  - MaterialComponents/Typography (23.4.1):
     - MaterialComponents/private/Application
   - MDFTextAccessibility (1.2.0)
 
@@ -172,7 +173,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  MaterialComponents: d4103d89f5803ce7ab712c1e2fcf8a21bc85d3d3
+  MaterialComponents: baaab2cdd2d4a4f75eb40beae6df360e5fedd3a2
   MDFTextAccessibility: 94098925e0853551c5a311ce7c1ecefbe297cdb6
 
 PODFILE CHECKSUM: 8c6ad4fe8e5aa667e06c9b43f3f5d4d6430b1322

--- a/demos/Pesto/Podfile.lock
+++ b/demos/Pesto/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - MaterialComponents/AnimationTiming (23.4.0)
-  - MaterialComponents/AppBar (23.4.0):
+  - MaterialComponents/AnimationTiming (23.4.1)
+  - MaterialComponents/AppBar (23.4.1):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
     - MaterialComponents/NavigationBar
@@ -9,17 +9,17 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ButtonBar (23.4.0):
+  - MaterialComponents/ButtonBar (23.4.1):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/Buttons (23.4.0):
+  - MaterialComponents/Buttons (23.4.1):
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/CollectionCells (23.4.0):
+  - MaterialComponents/CollectionCells (23.4.1):
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/private/Icons/ic_check
@@ -31,46 +31,46 @@ PODS:
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/CollectionLayoutAttributes (23.4.0)
-  - MaterialComponents/Collections (23.4.0):
+  - MaterialComponents/CollectionLayoutAttributes (23.4.1)
+  - MaterialComponents/Collections (23.4.1):
     - MaterialComponents/CollectionCells
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/FlexibleHeader (23.4.0):
+  - MaterialComponents/FlexibleHeader (23.4.1):
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/HeaderStackView (23.4.0)
-  - MaterialComponents/Ink (23.4.0)
-  - MaterialComponents/NavigationBar (23.4.0):
+  - MaterialComponents/HeaderStackView (23.4.1)
+  - MaterialComponents/Ink (23.4.1)
+  - MaterialComponents/NavigationBar (23.4.1):
     - MaterialComponents/ButtonBar
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/private/Application (23.4.0)
-  - MaterialComponents/private/Icons/Base (23.4.0)
-  - MaterialComponents/private/Icons/ic_arrow_back (23.4.0):
+  - MaterialComponents/private/Application (23.4.1)
+  - MaterialComponents/private/Icons/Base (23.4.1)
+  - MaterialComponents/private/Icons/ic_arrow_back (23.4.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check (23.4.0):
+  - MaterialComponents/private/Icons/ic_check (23.4.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check_circle (23.4.0):
+  - MaterialComponents/private/Icons/ic_check_circle (23.4.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_chevron_right (23.4.0):
+  - MaterialComponents/private/Icons/ic_chevron_right (23.4.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_info (23.4.0):
+  - MaterialComponents/private/Icons/ic_info (23.4.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_radio_button_unchecked (23.4.0):
+  - MaterialComponents/private/Icons/ic_radio_button_unchecked (23.4.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_reorder (23.4.0):
+  - MaterialComponents/private/Icons/ic_reorder (23.4.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Math (23.4.0)
-  - MaterialComponents/private/RTL (23.4.0)
-  - MaterialComponents/ShadowElevations (23.4.0)
-  - MaterialComponents/ShadowLayer (23.4.0)
-  - MaterialComponents/Typography (23.4.0):
+  - MaterialComponents/private/Math (23.4.1)
+  - MaterialComponents/private/RTL (23.4.1)
+  - MaterialComponents/ShadowElevations (23.4.1)
+  - MaterialComponents/ShadowLayer (23.4.1)
+  - MaterialComponents/Typography (23.4.1):
     - MaterialComponents/private/Application
   - MDFTextAccessibility (1.2.0)
 
@@ -89,7 +89,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  MaterialComponents: d4103d89f5803ce7ab712c1e2fcf8a21bc85d3d3
+  MaterialComponents: baaab2cdd2d4a4f75eb40beae6df360e5fedd3a2
   MDFTextAccessibility: 94098925e0853551c5a311ce7c1ecefbe297cdb6
 
 PODFILE CHECKSUM: 0bae51237ebf30ce3f4ecbcefedc8cf3d7af40cf

--- a/demos/Shrine/Podfile.lock
+++ b/demos/Shrine/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - MaterialComponents/AppBar (23.4.0):
+  - MaterialComponents/AppBar (23.4.1):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
     - MaterialComponents/NavigationBar
@@ -8,40 +8,40 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ButtonBar (23.4.0):
+  - MaterialComponents/ButtonBar (23.4.1):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/Buttons (23.4.0):
+  - MaterialComponents/Buttons (23.4.1):
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader (23.4.0):
+  - MaterialComponents/FlexibleHeader (23.4.1):
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/HeaderStackView (23.4.0)
-  - MaterialComponents/Ink (23.4.0)
-  - MaterialComponents/NavigationBar (23.4.0):
+  - MaterialComponents/HeaderStackView (23.4.1)
+  - MaterialComponents/Ink (23.4.1)
+  - MaterialComponents/NavigationBar (23.4.1):
     - MaterialComponents/ButtonBar
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/PageControl (23.4.0)
-  - MaterialComponents/private/Application (23.4.0)
-  - MaterialComponents/private/Icons/Base (23.4.0)
-  - MaterialComponents/private/Icons/ic_arrow_back (23.4.0):
+  - MaterialComponents/PageControl (23.4.1)
+  - MaterialComponents/private/Application (23.4.1)
+  - MaterialComponents/private/Icons/Base (23.4.1)
+  - MaterialComponents/private/Icons/ic_arrow_back (23.4.1):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Math (23.4.0)
-  - MaterialComponents/private/RTL (23.4.0)
-  - MaterialComponents/ShadowElevations (23.4.0)
-  - MaterialComponents/ShadowLayer (23.4.0)
-  - MaterialComponents/Typography (23.4.0):
+  - MaterialComponents/private/Math (23.4.1)
+  - MaterialComponents/private/RTL (23.4.1)
+  - MaterialComponents/ShadowElevations (23.4.1)
+  - MaterialComponents/ShadowLayer (23.4.1)
+  - MaterialComponents/Typography (23.4.1):
     - MaterialComponents/private/Application
   - MDFTextAccessibility (1.2.0)
-  - RemoteImageServiceForMDCDemos (23.4.0)
+  - RemoteImageServiceForMDCDemos (23.4.1)
 
 DEPENDENCIES:
   - MaterialComponents/AppBar (from `../../`)
@@ -55,9 +55,9 @@ EXTERNAL SOURCES:
     :path: "../supplemental"
 
 SPEC CHECKSUMS:
-  MaterialComponents: d4103d89f5803ce7ab712c1e2fcf8a21bc85d3d3
+  MaterialComponents: baaab2cdd2d4a4f75eb40beae6df360e5fedd3a2
   MDFTextAccessibility: 94098925e0853551c5a311ce7c1ecefbe297cdb6
-  RemoteImageServiceForMDCDemos: 1b995c81846415f84eeca6f8d120e36c73c9fee9
+  RemoteImageServiceForMDCDemos: 7fc2f80ec0c07108a689ac3882cc892d0841c575
 
 PODFILE CHECKSUM: 5eb94d7fb8deeb6709b7300f5d0e0e1a75902cca
 

--- a/demos/ZShadow/Podfile.lock
+++ b/demos/ZShadow/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - MaterialComponents/ShadowElevations (23.4.0)
-  - MaterialComponents/ShadowLayer (23.4.0)
+  - MaterialComponents/ShadowElevations (23.4.1)
+  - MaterialComponents/ShadowLayer (23.4.1)
 
 DEPENDENCIES:
   - MaterialComponents/ShadowElevations (from `../../`)
@@ -11,7 +11,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  MaterialComponents: d4103d89f5803ce7ab712c1e2fcf8a21bc85d3d3
+  MaterialComponents: baaab2cdd2d4a4f75eb40beae6df360e5fedd3a2
 
 PODFILE CHECKSUM: 238ed9ba58d5e4a3638e6cea92b00109641989f8
 

--- a/demos/supplemental/RemoteImageServiceForMDCDemos.podspec
+++ b/demos/supplemental/RemoteImageServiceForMDCDemos.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RemoteImageServiceForMDCDemos"
-  s.version      = "23.4.0"
+  s.version      = "23.4.1"
   s.summary      = "A helper image class for the MDC demos."
   s.description  = "This spec is made for use in the MDC demos. It gets images via url."
   s.homepage     = "https://github.com/material-components/material-components-ios"


### PR DESCRIPTION
# 23.4.1

Fixed podspec

## Component changes

### Buttons

#### Changes

* [Revert "Fix case-sensitive imports from private to Private. Causing compilation failures in Xcode 8.3.2 about non-portable path."](https://github.com/material-components/material-components-ios/commit/9cae7fca7bcd490a921c5ca1aacbd585cd61a021) (randallli)

### Typography

#### Changes

* [Revert "Fix case-sensitive imports from private to Private. Causing compilation failures in Xcode 8.3.2 about non-portable path."](https://github.com/material-components/material-components-ios/commit/9cae7fca7bcd490a921c5ca1aacbd585cd61a021) (randallli)
