### PR TITLE
[Palette] Swift enums for MDCPaletteTint/Accent.

### DIFF
--- a/components/Palettes/examples/supplemental/PalettesExampleViewController.swift
+++ b/components/Palettes/examples/supplemental/PalettesExampleViewController.swift
@@ -20,14 +20,14 @@ typealias ExampleTone = (name: String, tone: UIColor)
 
 func ExampleTonesForPalette(_ palette: MDCPalette) -> [ExampleTone] {
   var tones: [ExampleTone] = [
-    (MDCPaletteTint100Name, palette.tint100),
-    (MDCPaletteTint300Name, palette.tint300),
-    (MDCPaletteTint500Name, palette.tint500),
-    (MDCPaletteTint700Name, palette.tint700)
+    (MDCPaletteTint.tint100Name.rawValue, palette.tint100),
+    (MDCPaletteTint.tint300Name.rawValue, palette.tint300),
+    (MDCPaletteTint.tint500Name.rawValue, palette.tint500),
+    (MDCPaletteTint.tint700Name.rawValue, palette.tint700)
     ]
 
   if let accent = palette.accent400 {
-    tones.append((MDCPaletteAccent400Name, accent))
+    tones.append((MDCPaletteAccent.accent400Name.rawValue, accent))
   }
 
   return tones

--- a/components/Palettes/src/MDCPalettes.h
+++ b/components/Palettes/src/MDCPalettes.h
@@ -16,47 +16,53 @@
 
 #import <UIKit/UIKit.h>
 
+/** Tint color name. */
+typedef NSString *MDCPaletteTint NS_EXTENSIBLE_STRING_ENUM;
+
 /** The name of the tint 50 color when creating a custom palette. */
-CG_EXTERN const NSString *_Nonnull MDCPaletteTint50Name;
+CG_EXTERN const MDCPaletteTint _Nonnull MDCPaletteTint50Name;
 
 /** The name of the tint 100 color when creating a custom palette. */
-CG_EXTERN const NSString *_Nonnull MDCPaletteTint100Name;
+CG_EXTERN const MDCPaletteTint _Nonnull MDCPaletteTint100Name;
 
 /** The name of the tint 200 color when creating a custom palette. */
-CG_EXTERN const NSString *_Nonnull MDCPaletteTint200Name;
+CG_EXTERN const MDCPaletteTint _Nonnull MDCPaletteTint200Name;
 
 /** The name of the tint 300 color when creating a custom palette. */
-CG_EXTERN const NSString *_Nonnull MDCPaletteTint300Name;
+CG_EXTERN const MDCPaletteTint _Nonnull MDCPaletteTint300Name;
 
 /** The name of the tint 400 color when creating a custom palette. */
-CG_EXTERN const NSString *_Nonnull MDCPaletteTint400Name;
+CG_EXTERN const MDCPaletteTint _Nonnull MDCPaletteTint400Name;
 
 /** The name of the tint 500 color when creating a custom palette. */
-CG_EXTERN const NSString *_Nonnull MDCPaletteTint500Name;
+CG_EXTERN const MDCPaletteTint _Nonnull MDCPaletteTint500Name;
 
 /** The name of the tint 600 color when creating a custom palette. */
-CG_EXTERN const NSString *_Nonnull MDCPaletteTint600Name;
+CG_EXTERN const MDCPaletteTint _Nonnull MDCPaletteTint600Name;
 
 /** The name of the tint 700 color when creating a custom palette. */
-CG_EXTERN const NSString *_Nonnull MDCPaletteTint700Name;
+CG_EXTERN const MDCPaletteTint _Nonnull MDCPaletteTint700Name;
 
 /** The name of the tint 800 color when creating a custom palette. */
-CG_EXTERN const NSString *_Nonnull MDCPaletteTint800Name;
+CG_EXTERN const MDCPaletteTint _Nonnull MDCPaletteTint800Name;
 
 /** The name of the tint 900 color when creating a custom palette. */
-CG_EXTERN const NSString *_Nonnull MDCPaletteTint900Name;
+CG_EXTERN const MDCPaletteTint _Nonnull MDCPaletteTint900Name;
+
+/** Accent color name. */
+typedef NSString *MDCPaletteAccent NS_EXTENSIBLE_STRING_ENUM;
 
 /** The name of the accent 100 color when creating a custom palette. */
-CG_EXTERN const NSString *_Nonnull MDCPaletteAccent100Name;
+CG_EXTERN const MDCPaletteAccent _Nonnull MDCPaletteAccent100Name;
 
 /** The name of the accent 200 color when creating a custom palette. */
-CG_EXTERN const NSString *_Nonnull MDCPaletteAccent200Name;
+CG_EXTERN const MDCPaletteAccent _Nonnull MDCPaletteAccent200Name;
 
 /** The name of the accent 400 color when creating a custom palette. */
-CG_EXTERN const NSString *_Nonnull MDCPaletteAccent400Name;
+CG_EXTERN const MDCPaletteAccent _Nonnull MDCPaletteAccent400Name;
 
 /** The name of the accent 700 color when creating a custom palette. */
-CG_EXTERN const NSString *_Nonnull MDCPaletteAccent700Name;
+CG_EXTERN const MDCPaletteAccent _Nonnull MDCPaletteAccent700Name;
 
 /**
  A palette of Material colors.
@@ -148,9 +154,9 @@ CG_EXTERN const NSString *_Nonnull MDCPaletteAccent700Name;
  @param accents An optional dictionary mapping MDCPaletteAccent.*Name keys to UIColors.
  @return An palette containing the custom colors.
  */
-+ (nonnull instancetype)paletteWithTints:(nonnull NSDictionary<const NSString *, UIColor *> *)tints
++ (nonnull instancetype)paletteWithTints:(nonnull NSDictionary<MDCPaletteTint, UIColor *> *)tints
                                  accents:
-                                     (nullable NSDictionary<const NSString *, UIColor *> *)accents;
+                                     (nullable NSDictionary<MDCPaletteAccent, UIColor *> *)accents;
 
 /**
  Returns an initialized palette object with a custom set of tints and accents.
@@ -164,8 +170,8 @@ CG_EXTERN const NSString *_Nonnull MDCPaletteAccent700Name;
  @param accents An optional dictionary mapping MDCPaletteAccent.*Name keys to UIColors.
  @return An initialized MDCPalette object containing the custom colors.
  */
-- (nonnull instancetype)initWithTints:(nonnull NSDictionary<const NSString *, UIColor *> *)tints
-                              accents:(nullable NSDictionary<const NSString *, UIColor *> *)accents;
+- (nonnull instancetype)initWithTints:(nonnull NSDictionary<MDCPaletteTint, UIColor *> *)tints
+                              accents:(nullable NSDictionary<MDCPaletteAccent, UIColor *> *)accents;
 
 /** The 50 tint color, the lightest tint of the palette. */
 @property(nonatomic, nonnull, readonly) UIColor *tint50;

--- a/components/Palettes/src/MDCPalettes.m
+++ b/components/Palettes/src/MDCPalettes.m
@@ -18,20 +18,22 @@
 #import "private/MDCPaletteExpansions.h"
 #import "private/MDCPaletteNames.h"
 
-const NSString *MDCPaletteTint50Name = MDC_PALETTE_TINT_50_INTERNAL_NAME;
-const NSString *MDCPaletteTint100Name = MDC_PALETTE_TINT_100_INTERNAL_NAME;
-const NSString *MDCPaletteTint200Name = MDC_PALETTE_TINT_200_INTERNAL_NAME;
-const NSString *MDCPaletteTint300Name = MDC_PALETTE_TINT_300_INTERNAL_NAME;
-const NSString *MDCPaletteTint400Name = MDC_PALETTE_TINT_400_INTERNAL_NAME;
-const NSString *MDCPaletteTint500Name = MDC_PALETTE_TINT_500_INTERNAL_NAME;
-const NSString *MDCPaletteTint600Name = MDC_PALETTE_TINT_600_INTERNAL_NAME;
-const NSString *MDCPaletteTint700Name = MDC_PALETTE_TINT_700_INTERNAL_NAME;
-const NSString *MDCPaletteTint800Name = MDC_PALETTE_TINT_800_INTERNAL_NAME;
-const NSString *MDCPaletteTint900Name = MDC_PALETTE_TINT_900_INTERNAL_NAME;
-const NSString *MDCPaletteAccent100Name = MDC_PALETTE_ACCENT_100_INTERNAL_NAME;
-const NSString *MDCPaletteAccent200Name = MDC_PALETTE_ACCENT_200_INTERNAL_NAME;
-const NSString *MDCPaletteAccent400Name = MDC_PALETTE_ACCENT_400_INTERNAL_NAME;
-const NSString *MDCPaletteAccent700Name = MDC_PALETTE_ACCENT_700_INTERNAL_NAME;
+
+const MDCPaletteTint MDCPaletteTint50Name = MDC_PALETTE_TINT_50_INTERNAL_NAME;
+const MDCPaletteTint MDCPaletteTint100Name = MDC_PALETTE_TINT_100_INTERNAL_NAME;
+const MDCPaletteTint MDCPaletteTint200Name = MDC_PALETTE_TINT_200_INTERNAL_NAME;
+const MDCPaletteTint MDCPaletteTint300Name = MDC_PALETTE_TINT_300_INTERNAL_NAME;
+const MDCPaletteTint MDCPaletteTint400Name = MDC_PALETTE_TINT_400_INTERNAL_NAME;
+const MDCPaletteTint MDCPaletteTint500Name = MDC_PALETTE_TINT_500_INTERNAL_NAME;
+const MDCPaletteTint MDCPaletteTint600Name = MDC_PALETTE_TINT_600_INTERNAL_NAME;
+const MDCPaletteTint MDCPaletteTint700Name = MDC_PALETTE_TINT_700_INTERNAL_NAME;
+const MDCPaletteTint MDCPaletteTint800Name = MDC_PALETTE_TINT_800_INTERNAL_NAME;
+const MDCPaletteTint MDCPaletteTint900Name = MDC_PALETTE_TINT_900_INTERNAL_NAME;
+
+const MDCPaletteAccent MDCPaletteAccent100Name = MDC_PALETTE_ACCENT_100_INTERNAL_NAME;
+const MDCPaletteAccent MDCPaletteAccent200Name = MDC_PALETTE_ACCENT_200_INTERNAL_NAME;
+const MDCPaletteAccent MDCPaletteAccent400Name = MDC_PALETTE_ACCENT_400_INTERNAL_NAME;
+const MDCPaletteAccent MDCPaletteAccent700Name = MDC_PALETTE_ACCENT_700_INTERNAL_NAME;
 
 // Creates a UIColor from a 24-bit RGB color encoded as an integer.
 static inline UIColor *ColorFromRGB(uint32_t rgbValue) {
@@ -42,8 +44,8 @@ static inline UIColor *ColorFromRGB(uint32_t rgbValue) {
 }
 
 @interface MDCPalette () {
-  NSDictionary<const NSString *, UIColor *> *_tints;
-  NSDictionary<const NSString *, UIColor *> *_accents;
+  NSDictionary<MDCPaletteTint, UIColor *> *_tints;
+  NSDictionary<MDCPaletteAccent, UIColor *> *_accents;
 }
 
 @end
@@ -538,43 +540,43 @@ static inline UIColor *ColorFromRGB(uint32_t rgbValue) {
   ];
 
   NSMutableDictionary *tints = [[NSMutableDictionary alloc] init];
-  for (NSString *name in tintNames) {
+  for (MDCPaletteTint name in tintNames) {
     [tints setObject:MDCPaletteTintFromTargetColor(target500Color, name) forKey:name];
   }
 
   NSArray *accentNames = @[
-    MDCPaletteAccent100Name, MDCPaletteAccent200Name, MDCPaletteAccent400Name,
-    MDCPaletteAccent700Name
+      MDCPaletteAccent100Name, MDCPaletteAccent200Name, MDCPaletteAccent400Name,
+      MDCPaletteAccent700Name
   ];
   NSMutableDictionary *accents = [[NSMutableDictionary alloc] init];
-  for (NSString *name in accentNames) {
+  for (MDCPaletteAccent name in accentNames) {
     [accents setObject:MDCPaletteAccentFromTargetColor(target500Color, name) forKey:name];
   }
 
   return [self paletteWithTints:tints accents:accents];
 }
 
-+ (instancetype)paletteWithTints:(NSDictionary<NSString *, UIColor *> *)tints
-                         accents:(NSDictionary<NSString *, UIColor *> *)accents {
++ (instancetype)paletteWithTints:(NSDictionary<MDCPaletteTint, UIColor *> *)tints
+                         accents:(NSDictionary<MDCPaletteAccent, UIColor *> *)accents {
   return [[self alloc] initWithTints:tints accents:accents];
 }
 
-- (instancetype)initWithTints:(NSDictionary<const NSString *, UIColor *> *)tints
-                      accents:(NSDictionary<const NSString *, UIColor *> *)accents {
+- (instancetype)initWithTints:(NSDictionary<MDCPaletteTint, UIColor *> *)tints
+                      accents:(NSDictionary<MDCPaletteAccent, UIColor *> *)accents {
   self = [super init];
   if (self) {
     _accents = accents ? [accents copy] : @{};
 
     // Check if all the accent colors are present.
-    NSDictionary<const NSString *, UIColor *> *allTints = tints;
-    NSMutableSet<const NSString *> *requiredTintKeys =
+    NSDictionary<MDCPaletteTint, UIColor *> *allTints = tints;
+    NSMutableSet<MDCPaletteAccent> *requiredTintKeys =
         [NSMutableSet setWithSet:[[self class] requiredTintKeys]];
     [requiredTintKeys minusSet:[NSSet setWithArray:[tints allKeys]]];
     if ([requiredTintKeys count] != 0) {
       NSAssert(NO, @"Missing accent colors for the following keys: %@.", requiredTintKeys);
-      NSMutableDictionary<const NSString *, UIColor *> *replacementTints =
+      NSMutableDictionary<MDCPaletteTint, UIColor *> *replacementTints =
           [NSMutableDictionary dictionaryWithDictionary:_accents];
-      for (NSString *tintKey in requiredTintKeys) {
+      for (MDCPaletteTint tintKey in requiredTintKeys) {
         [replacementTints setObject:[UIColor clearColor] forKey:tintKey];
       }
       allTints = replacementTints;
@@ -643,7 +645,7 @@ static inline UIColor *ColorFromRGB(uint32_t rgbValue) {
 
 #pragma mark - Private methods
 
-+ (nonnull NSSet<const NSString *> *)requiredTintKeys {
++ (nonnull NSSet<MDCPaletteTint> *)requiredTintKeys {
   return [NSSet setWithArray:@[
     MDCPaletteTint50Name, MDCPaletteTint100Name, MDCPaletteTint200Name, MDCPaletteTint300Name,
     MDCPaletteTint400Name, MDCPaletteTint500Name, MDCPaletteTint600Name, MDCPaletteTint700Name,

--- a/components/Palettes/src/MDCPalettes.m
+++ b/components/Palettes/src/MDCPalettes.m
@@ -18,7 +18,6 @@
 #import "private/MDCPaletteExpansions.h"
 #import "private/MDCPaletteNames.h"
 
-
 const MDCPaletteTint MDCPaletteTint50Name = MDC_PALETTE_TINT_50_INTERNAL_NAME;
 const MDCPaletteTint MDCPaletteTint100Name = MDC_PALETTE_TINT_100_INTERNAL_NAME;
 const MDCPaletteTint MDCPaletteTint200Name = MDC_PALETTE_TINT_200_INTERNAL_NAME;
@@ -545,8 +544,8 @@ static inline UIColor *ColorFromRGB(uint32_t rgbValue) {
   }
 
   NSArray *accentNames = @[
-      MDCPaletteAccent100Name, MDCPaletteAccent200Name, MDCPaletteAccent400Name,
-      MDCPaletteAccent700Name
+    MDCPaletteAccent100Name, MDCPaletteAccent200Name, MDCPaletteAccent400Name,
+    MDCPaletteAccent700Name
   ];
   NSMutableDictionary *accents = [[NSMutableDictionary alloc] init];
   for (MDCPaletteAccent name in accentNames) {

--- a/components/Palettes/tests/unit/PaletteTests.swift
+++ b/components/Palettes/tests/unit/PaletteTests.swift
@@ -62,38 +62,38 @@ class PaletteTests: XCTestCase {
   }
 
   func testCustomPalette() {
-    let tints = [
-      MDCPaletteTint50Name: UIColor(white: 0, alpha: 1),
-      MDCPaletteTint100Name: UIColor(white: 0.1, alpha: 1),
-      MDCPaletteTint200Name: UIColor(white: 0.2, alpha: 1),
-      MDCPaletteTint300Name: UIColor(white: 0.3, alpha: 1),
-      MDCPaletteTint400Name: UIColor(white: 0.4, alpha: 1),
-      MDCPaletteTint500Name: UIColor(white: 0.5, alpha: 1),
-      MDCPaletteTint600Name: UIColor(white: 0.6, alpha: 1),
-      MDCPaletteTint700Name: UIColor(white: 0.7, alpha: 1),
-      MDCPaletteTint800Name: UIColor(white: 0.8, alpha: 1),
-      MDCPaletteTint900Name: UIColor(white: 0.9, alpha: 1)
+    let tints: [MDCPaletteTint: UIColor] = [
+      .tint50Name: UIColor(white: 0, alpha: 1),
+      .tint100Name: UIColor(white: 0.1, alpha: 1),
+      .tint200Name: UIColor(white: 0.2, alpha: 1),
+      .tint300Name: UIColor(white: 0.3, alpha: 1),
+      .tint400Name: UIColor(white: 0.4, alpha: 1),
+      .tint500Name: UIColor(white: 0.5, alpha: 1),
+      .tint600Name: UIColor(white: 0.6, alpha: 1),
+      .tint700Name: UIColor(white: 0.7, alpha: 1),
+      .tint800Name: UIColor(white: 0.8, alpha: 1),
+      .tint900Name: UIColor(white: 0.9, alpha: 1)
     ]
-    let accents = [
-      MDCPaletteAccent100Name: UIColor(white: 1, alpha: 0),
-      MDCPaletteAccent200Name: UIColor(white: 1, alpha: 0.25),
-      MDCPaletteAccent400Name: UIColor(white: 1, alpha: 0.75),
-      MDCPaletteAccent700Name: UIColor(white: 1, alpha: 1)
+    let accents: [MDCPaletteAccent: UIColor] = [
+      .accent100Name: UIColor(white: 1, alpha: 0),
+      .accent200Name: UIColor(white: 1, alpha: 0.25),
+      .accent400Name: UIColor(white: 1, alpha: 0.75),
+      .accent700Name: UIColor(white: 1, alpha: 1)
     ]
     let palette = MDCPalette(tints: tints, accents: accents)
-    XCTAssertEqual(palette.tint50, tints[MDCPaletteTint50Name])
-    XCTAssertEqual(palette.tint100, tints[MDCPaletteTint100Name])
-    XCTAssertEqual(palette.tint200, tints[MDCPaletteTint200Name])
-    XCTAssertEqual(palette.tint300, tints[MDCPaletteTint300Name])
-    XCTAssertEqual(palette.tint400, tints[MDCPaletteTint400Name])
-    XCTAssertEqual(palette.tint500, tints[MDCPaletteTint500Name])
-    XCTAssertEqual(palette.tint600, tints[MDCPaletteTint600Name])
-    XCTAssertEqual(palette.tint700, tints[MDCPaletteTint700Name])
-    XCTAssertEqual(palette.tint800, tints[MDCPaletteTint800Name])
-    XCTAssertEqual(palette.tint900, tints[MDCPaletteTint900Name])
-    XCTAssertEqual(palette.accent100, accents[MDCPaletteAccent100Name])
-    XCTAssertEqual(palette.accent200, accents[MDCPaletteAccent200Name])
-    XCTAssertEqual(palette.accent400, accents[MDCPaletteAccent400Name])
-    XCTAssertEqual(palette.accent700, accents[MDCPaletteAccent700Name])
+    XCTAssertEqual(palette.tint50, tints[.tint50Name])
+    XCTAssertEqual(palette.tint100, tints[.tint100Name])
+    XCTAssertEqual(palette.tint200, tints[.tint200Name])
+    XCTAssertEqual(palette.tint300, tints[.tint300Name])
+    XCTAssertEqual(palette.tint400, tints[.tint400Name])
+    XCTAssertEqual(palette.tint500, tints[.tint500Name])
+    XCTAssertEqual(palette.tint600, tints[.tint600Name])
+    XCTAssertEqual(palette.tint700, tints[.tint700Name])
+    XCTAssertEqual(palette.tint800, tints[.tint800Name])
+    XCTAssertEqual(palette.tint900, tints[.tint900Name])
+    XCTAssertEqual(palette.accent100, accents[.accent100Name])
+    XCTAssertEqual(palette.accent200, accents[.accent200Name])
+    XCTAssertEqual(palette.accent400, accents[.accent400Name])
+    XCTAssertEqual(palette.accent700, accents[.accent700Name])
   }
 }


### PR DESCRIPTION
Note that this is a breaking change for Swift users. It changes
MDCPalette accent and names from stringly typed to strongly typed,
creating a new MDCPaletteTint and MDCPaletteAccent enum.