### PR TITLE
[MDCPalette] Use class properties

### DIFF
--- a/components/Dialogs/examples/AlertColorThemerTypicalUseViewController.m
+++ b/components/Dialogs/examples/AlertColorThemerTypicalUseViewController.m
@@ -37,19 +37,19 @@
   switch (indexPath.item) {
     case 0: {
       MDCColorScheme *blueScheme = [[MDCColorScheme alloc] init];
-      blueScheme.primaryColor = [MDCPalette bluePalette].tint500;
+      blueScheme.primaryColor = MDCPalette.bluePalette.tint500;
       [MDCAlertColorThemer applyColorScheme:blueScheme];
       break;
     }
     case 1: {
       MDCColorScheme *redScheme = [[MDCColorScheme alloc] init];
-      redScheme.primaryColor = [MDCPalette redPalette].tint500;
+      redScheme.primaryColor = MDCPalette.redPalette.tint500;
       [MDCAlertColorThemer applyColorScheme:redScheme];
       break;
     }
     case 2: {
       MDCColorScheme *greenScheme = [[MDCColorScheme alloc] init];
-      greenScheme.primaryColor = [MDCPalette greenPalette].tint500;
+      greenScheme.primaryColor = MDCPalette.greenPalette.tint500;
       [MDCAlertColorThemer applyColorScheme:greenScheme];
       break;
     }

--- a/components/FeatureHighlight/examples/FeatureHighlightColorThemerTypicalUseViewController.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightColorThemerTypicalUseViewController.m
@@ -36,8 +36,8 @@ static NSString *const kBodyText =
     featureHighlightController.bodyText = kBodyText;
 
     MDCColorScheme *colorScheme = [[MDCColorScheme alloc] init];
-    colorScheme.primaryColor = [MDCPalette bluePalette].tint500;
-    colorScheme.primaryLightColor = [MDCPalette bluePalette].tint100;
+    colorScheme.primaryColor = MDCPalette.bluePalette.tint500;
+    colorScheme.primaryLightColor = MDCPalette.bluePalette.tint100;
 
     [MDCFeatureHighlightColorThemer applyColorScheme:colorScheme
                               toFeatureHighlightView:[MDCFeatureHighlightView appearance]];
@@ -51,8 +51,8 @@ static NSString *const kBodyText =
     featureHighlightController.bodyText = kBodyText;
 
     MDCColorScheme *colorScheme = [[MDCColorScheme alloc] init];
-    colorScheme.primaryColor = [MDCPalette redPalette].tint500;
-    colorScheme.primaryLightColor = [MDCPalette redPalette].tint100;
+    colorScheme.primaryColor = MDCPalette.redPalette.tint500;
+    colorScheme.primaryLightColor = MDCPalette.redPalette.tint100;
 
     [MDCFeatureHighlightColorThemer applyColorScheme:colorScheme
                               toFeatureHighlightView:[MDCFeatureHighlightView appearance]];

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
@@ -104,16 +104,16 @@ static NSString *const reuseIdentifier = @"Cell";
           forCellWithReuseIdentifier:reuseIdentifier];
 
   self.colors = @[
-    [MDCPalette redPalette].tint500,        [MDCPalette pinkPalette].tint500,
-    [MDCPalette purplePalette].tint500,     [MDCPalette deepPurplePalette].tint500,
-    [MDCPalette indigoPalette].tint500,     [MDCPalette bluePalette].tint500,
-    [MDCPalette lightBluePalette].tint500,  [MDCPalette cyanPalette].tint500,
-    [MDCPalette tealPalette].tint500,       [MDCPalette greenPalette].tint500,
-    [MDCPalette lightGreenPalette].tint500, [MDCPalette limePalette].tint500,
-    [MDCPalette yellowPalette].tint500,     [MDCPalette amberPalette].tint500,
-    [MDCPalette orangePalette].tint500,     [MDCPalette deepOrangePalette].tint500,
-    [MDCPalette brownPalette].tint500,      [MDCPalette greyPalette].tint500,
-    [MDCPalette blueGreyPalette].tint500,
+    MDCPalette.redPalette.tint500,        MDCPalette.pinkPalette.tint500,
+    MDCPalette.purplePalette.tint500,     MDCPalette.deepPurplePalette.tint500,
+    MDCPalette.indigoPalette.tint500,     MDCPalette.bluePalette.tint500,
+    MDCPalette.lightBluePalette.tint500,  MDCPalette.cyanPalette.tint500,
+    MDCPalette.tealPalette.tint500,       MDCPalette.greenPalette.tint500,
+    MDCPalette.lightGreenPalette.tint500, MDCPalette.limePalette.tint500,
+    MDCPalette.yellowPalette.tint500,     MDCPalette.amberPalette.tint500,
+    MDCPalette.orangePalette.tint500,     MDCPalette.deepOrangePalette.tint500,
+    MDCPalette.brownPalette.tint500,      MDCPalette.greyPalette.tint500,
+    MDCPalette.blueGreyPalette.tint500,
   ];
 }
 

--- a/components/Palettes/README.md
+++ b/components/Palettes/README.md
@@ -85,12 +85,12 @@ scheme.
 #### Swift
 
 ``` swift
-view.backgroundColor = MDCPalette.green.tint500;
+view.backgroundColor = MDCPalette.green.tint500
 ```
 
 #### Objective-C
 
 ``` objc
-self.view.backgroundColor = [MDCPalette greenPalette].tint500;
+self.view.backgroundColor = MDCPalette.greenPalette.tint500;
 ```
 <!--</div>-->

--- a/components/Palettes/README.md
+++ b/components/Palettes/README.md
@@ -85,7 +85,7 @@ scheme.
 #### Swift
 
 ``` swift
-view.backgroundColor = MDCPalette.green().tint500;
+view.backgroundColor = MDCPalette.green.tint500;
 ```
 
 #### Objective-C

--- a/components/Palettes/examples/PalettesStandardExample.swift
+++ b/components/Palettes/examples/PalettesStandardExample.swift
@@ -20,25 +20,25 @@ class PalettesStandardExampleViewController: PalettesExampleViewController {
   convenience init() {
     self.init(style: .grouped)
     self.palettes = [
-      ("Red", MDCPalette.red()),
-      ("Pink", MDCPalette.pink()),
-      ("Purple", MDCPalette.purple()),
-      ("Deep Purple", MDCPalette.deepPurple()),
-      ("Indigo", MDCPalette.indigo()),
-      ("Blue", MDCPalette.blue()),
-      ("Light Blue", MDCPalette.lightBlue()),
-      ("Cyan", MDCPalette.cyan()),
-      ("Teal", MDCPalette.teal()),
-      ("Green", MDCPalette.green()),
-      ("Light Green", MDCPalette.lightGreen()),
-      ("Lime", MDCPalette.lime()),
-      ("Yellow", MDCPalette.yellow()),
-      ("Amber", MDCPalette.amber()),
-      ("Orange", MDCPalette.orange()),
-      ("Deep Orange", MDCPalette.deepOrange()),
-      ("Brown", MDCPalette.brown()),
-      ("Grey", MDCPalette.grey()),
-      ("Blue Grey", MDCPalette.blueGrey())
+      ("Red", .red),
+      ("Pink", .pink),
+      ("Purple", .purple),
+      ("Deep Purple", .deepPurple),
+      ("Indigo", .indigo),
+      ("Blue", .blue),
+      ("Light Blue", .lightBlue),
+      ("Cyan", .cyan),
+      ("Teal", .teal),
+      ("Green", .green),
+      ("Light Green", .lightGreen),
+      ("Lime", .lime),
+      ("Yellow", .yellow),
+      ("Amber", .amber),
+      ("Orange", .orange),
+      ("Deep Orange", .deepOrange),
+      ("Brown", .brown),
+      ("Grey", .grey),
+      ("Blue Grey", .blueGrey)
     ]
   }
 }

--- a/components/Palettes/src/MDCPalettes.h
+++ b/components/Palettes/src/MDCPalettes.h
@@ -69,6 +69,8 @@ CG_EXTERN const NSString *_Nonnull MDCPaletteAccent700Name;
  */
 @interface MDCPalette : NSObject
 
+#ifdef MDC_PALETTE_USE_CLASS_METHODS
+
 /** The red palette. */
 + (nonnull MDCPalette *)redPalette;
 
@@ -125,6 +127,67 @@ CG_EXTERN const NSString *_Nonnull MDCPaletteAccent700Name;
 
 /** The blue grey palette (no accents). */
 + (nonnull MDCPalette *)blueGreyPalette;
+
+# else
+
+/** The red palette. */
+@property(class, readonly, strong, nonnull) MDCPalette *redPalette;
+
+/** The pink palette. */
+@property(class, readonly, strong, nonnull) MDCPalette *pinkPalette;
+
+/** The purple palette. */
+@property(class, readonly, strong, nonnull) MDCPalette *purplePalette;
+
+/** The deep purple palette. */
+@property(class, readonly, strong, nonnull) MDCPalette *deepPurplePalette;
+
+/** The indigo palette. */
+@property(class, readonly, strong, nonnull) MDCPalette *indigoPalette;
+
+/** The blue palette. */
+@property(class, readonly, strong, nonnull) MDCPalette *bluePalette;
+
+/** The light blue palette. */
+@property(class, readonly, strong, nonnull) MDCPalette *lightBluePalette;
+
+/** The cyan palette. */
+@property(class, readonly, strong, nonnull) MDCPalette *cyanPalette;
+
+/** The teal palette. */
+@property(class, readonly, strong, nonnull) MDCPalette *tealPalette;
+
+/** The green palette. */
+@property(class, readonly, strong, nonnull) MDCPalette *greenPalette;
+
+/** The light green palette. */
+@property(class, readonly, strong, nonnull) MDCPalette *lightGreenPalette;
+
+/** The lime palette. */
+@property(class, readonly, strong, nonnull) MDCPalette *limePalette;
+
+/** The yellow palette. */
+@property(class, readonly, strong, nonnull) MDCPalette *yellowPalette;
+
+/** The amber palette. */
+@property(class, readonly, strong, nonnull) MDCPalette *amberPalette;
+
+/** The orange palette. */
+@property(class, readonly, strong, nonnull) MDCPalette *orangePalette;
+
+/** The deep orange palette. */
+@property(class, readonly, strong, nonnull) MDCPalette *deepOrangePalette;
+
+/** The brown palette (no accents). */
+@property(class, readonly, strong, nonnull) MDCPalette *brownPalette;
+
+/** The grey palette (no accents). */
+@property(class, readonly, strong, nonnull) MDCPalette *greyPalette;
+
+/** The blue grey palette (no accents). */
+@property(class, readonly, strong, nonnull) MDCPalette *blueGreyPalette;
+
+#endif
 
 /**
  Returns a palette generated from a single target 500 tint color.

--- a/components/Palettes/tests/unit/PaletteTests.swift
+++ b/components/Palettes/tests/unit/PaletteTests.swift
@@ -28,23 +28,23 @@ class PaletteTests: XCTestCase {
   }
 
   func testBasics() {
-    let color = MDCPalette.red().tint50
+    let color = MDCPalette.red.tint50
     XCTAssertEqual(color, colorFromRGB(0xFFEBEE))
   }
 
   func testCaching() {
-    let first = MDCPalette.red()
-    let second = MDCPalette.red()
+    let first = MDCPalette.red
+    let second = MDCPalette.red
     XCTAssertTrue(first === second)
   }
 
   func testAccentlessPalette() {
-    let brownPalette = MDCPalette.brown()
+    let brownPalette = MDCPalette.brown
     XCTAssertNil(brownPalette.accent100)
   }
 
   func testGeneratedPalette() {
-    let palette = MDCPalette.init(generatedFrom: UIColor(red: 1, green: 0, blue: 0, alpha: 1))
+    let palette = MDCPalette(generatedFrom: UIColor(red: 1, green: 0, blue: 0, alpha: 1))
     XCTAssertNotNil(palette.tint50)
     XCTAssertNotNil(palette.tint100)
     XCTAssertNotNil(palette.tint200)

--- a/components/ProgressView/examples/ProgressViewExample.m
+++ b/components/ProgressView/examples/ProgressViewExample.m
@@ -53,7 +53,7 @@ static const CGFloat MDCProgressViewAnimationDuration = 1.f;
   _tintedProgressView = [[MDCProgressView alloc] init];
   _tintedProgressView.translatesAutoresizingMaskIntoConstraints = NO;
   [self.view addSubview:_tintedProgressView];
-  _tintedProgressView.progressTintColor = [[MDCPalette redPalette] tint500];
+  _tintedProgressView.progressTintColor = MDCPalette.redPalette.tint500;
   // Reset the track tint color to be based off of the progress tint color.
   _tintedProgressView.trackTintColor = nil;
   // Hide the progress view at setup time.
@@ -62,8 +62,8 @@ static const CGFloat MDCProgressViewAnimationDuration = 1.f;
   _fullyColoredProgressView = [[MDCProgressView alloc] init];
   _fullyColoredProgressView.translatesAutoresizingMaskIntoConstraints = NO;
   [self.view addSubview:_fullyColoredProgressView];
-  _fullyColoredProgressView.progressTintColor = [[MDCPalette greenPalette] tint500];
-  _fullyColoredProgressView.trackTintColor = [[MDCPalette yellowPalette] tint500];
+  _fullyColoredProgressView.progressTintColor = MDCPalette.greenPalette.tint500;
+  _fullyColoredProgressView.trackTintColor = MDCPalette.yellowPalette.tint500;
   // Hide the progress view at setup time.
   _fullyColoredProgressView.hidden = YES;
 

--- a/components/Tabs/examples/TabBarIconExample.swift
+++ b/components/Tabs/examples/TabBarIconExample.swift
@@ -53,7 +53,7 @@ class TabBarIconSwiftExample: UIViewController {
                     UITabBarItem(title: "Stars", image: star, tag:0)]
     tabBar.items[1].badgeValue = "1"
 
-    let blue = MDCPalette.blue().tint500
+    let blue = MDCPalette.blue.tint500
     tabBar.tintColor = blue
     tabBar.inkColor = blue
 

--- a/components/Tabs/examples/TabBarInterfaceBuilderExample.m
+++ b/components/Tabs/examples/TabBarInterfaceBuilderExample.m
@@ -39,8 +39,8 @@
   ];
 
   self.colors = @[
-    [MDCPalette bluePalette].tint500, [MDCPalette pinkPalette].tint500,
-    [MDCPalette redPalette].tint500, [MDCPalette greenPalette].tint500
+    MDCPalette.bluePalette.tint500, MDCPalette.pinkPalette.tint500,
+    MDCPalette.redPalette.tint500, MDCPalette.greenPalette.tint500
   ];
 
   self.view.backgroundColor = self.colors[0];

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
@@ -162,7 +162,7 @@
   self.starPage = [[UIView alloc] initWithFrame:CGRectZero];
   self.starPage.translatesAutoresizingMaskIntoConstraints = NO;
   [self.scrollView addSubview:self.starPage];
-  self.starPage.backgroundColor = [[MDCPalette lightBluePalette] tint200];
+  self.starPage.backgroundColor = MDCPalette.lightBluePalette.tint200;
   [self addStarCentered:YES];
 
   // Layout the views to be equal height and width to each other and self.view, hug the edges of the

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
@@ -55,7 +55,7 @@ extension TabBarIconSwiftExample {
     self.addChildViewController(appBar.headerViewController)
     appBar.headerViewController.headerView.backgroundColor = UIColor.white
     appBar.headerViewController.headerView.minimumHeight = 76 + 72
-    appBar.headerViewController.headerView.tintColor = MDCPalette.blue().tint500
+    appBar.headerViewController.headerView.tintColor = MDCPalette.blue.tint500
 
     appBar.headerStackView.bottomBar = self.tabBar
     appBar.headerStackView.setNeedsLayout()
@@ -110,7 +110,7 @@ extension TabBarIconSwiftExample {
 
     let infoPage = UIView(frame: CGRect())
     infoPage.translatesAutoresizingMaskIntoConstraints = false
-    infoPage.backgroundColor = MDCPalette.lightBlue().tint300
+    infoPage.backgroundColor = MDCPalette.lightBlue.tint300
     scrollView.addSubview(infoPage)
 
     let infoLabel = UILabel(frame: CGRect())
@@ -184,7 +184,7 @@ extension TabBarIconSwiftExample {
   func setupStarPage() -> UIView {
     let starPage = UIView(frame: CGRect())
     starPage.translatesAutoresizingMaskIntoConstraints = false
-    starPage.backgroundColor = MDCPalette.lightBlue().tint200
+    starPage.backgroundColor = MDCPalette.lightBlue.tint200
     self.scrollView.addSubview(starPage)
 
     return starPage


### PR DESCRIPTION
This replaces palette entry class methods with class properties (#1436). This is more consistent with UIKit, following the same pattern as UIColor.

Note that this is a breaking change for Swift users. MDC_PALETTE_USE_CLASS_METHODS may be defined to fall back to the legacy behavior while transitioning.