### PR TITLE
[Typography] MDCPreferredFontForStyle now includes the system font family.

### DIFF
--- a/components/Typography/examples/TypographyMaterialStylesViewController.m
+++ b/components/Typography/examples/TypographyMaterialStylesViewController.m
@@ -72,7 +72,10 @@
                   [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleDisplay4]
                   ];
 
-  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(contentSizeCategoryDidChange:) name:UIContentSizeCategoryDidChangeNotification object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(contentSizeCategoryDidChange:)
+                                               name:UIContentSizeCategoryDidChangeNotification
+                                             object:nil];
 
   /*
   UIKIT_EXTERN const CGFloat UIFontWeightUltraLight NS_AVAILABLE_IOS(8_2);
@@ -95,14 +98,16 @@
   NSLog(@"UIFontWeightBold %f", UIFontWeightBold);
   NSLog(@"UIFontWeightHeavy %f", UIFontWeightHeavy);
   NSLog(@"UIFontWeightBlack %f", UIFontWeightBlack);
+
+  UIFont *defaultFont = [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleBody1];
+  NSLog (@"Font Family : %@", defaultFont.familyName);
 }
 
 - (void)contentSizeCategoryDidChange:(NSNotification *)notification {
   NSString *sizeCategory = notification.userInfo[UIContentSizeCategoryNewValueKey];
   NSLog(@"New size category : %@", sizeCategory);
 
-  [self.tableView beginUpdates];
-  [self.tableView endUpdates];
+  [self.tableView reloadData];
 }
 
 #pragma mark - UITableViewDataSource

--- a/components/Typography/examples/TypographyMaterialStylesViewController.m
+++ b/components/Typography/examples/TypographyMaterialStylesViewController.m
@@ -107,6 +107,21 @@
   NSString *sizeCategory = notification.userInfo[UIContentSizeCategoryNewValueKey];
   NSLog(@"New size category : %@", sizeCategory);
 
+  // Update font array to reflect new size category
+  _styleFonts = @[
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleHeadline],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleTitle],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleSubheadline],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleBody2],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleBody1],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleCaption],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleButton],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleDisplay1],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleDisplay2],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleDisplay3],
+                  [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleDisplay4]
+                  ];
+
   [self.tableView reloadData];
 }
 

--- a/components/Typography/src/UIFontDescriptor+MaterialTypography.m
+++ b/components/Typography/src/UIFontDescriptor+MaterialTypography.m
@@ -33,10 +33,27 @@
   MDCFontTraits *materialTraits =
       [MDCFontTraits traitsForTextStyle:style sizeCategory:sizeCategory];
 
+  // Store the system font family name to ensure that we load the system font.
+  // If we do not explicitly include this UIFontDescriptorFamilyAttribute in the
+  // FontDescriptor the OS will default to Helvetica.
+  static NSString *systemFontFamilyName;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    UIFont *systemFont;
+    if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
+      systemFont = [UIFont systemFontOfSize:12 weight:UIFontWeightRegular];
+    } else {
+      // TODO: Remove this fallback once we are 8.2+
+      systemFont = [UIFont systemFontOfSize:12];
+    }
+    systemFontFamilyName = [systemFont.familyName copy];
+  });
+
   NSDictionary *traits = @{ UIFontWeightTrait : @(materialTraits.weight) };
   NSDictionary *attributes = @{
     UIFontDescriptorSizeAttribute : @(materialTraits.pointSize),
-    UIFontDescriptorTraitsAttribute : traits
+    UIFontDescriptorTraitsAttribute : traits,
+    UIFontDescriptorFamilyAttribute : systemFontFamilyName
   };
 
   UIFontDescriptor *fontDescriptor = [[UIFontDescriptor alloc] initWithFontAttributes:attributes];


### PR DESCRIPTION
Originally we were not explicitly setting the font family which resulted in Helvetica.  We now include the system font family as part of the font attributes which results in Helvetica Neue and SF depending on the iOS version.