### PR TITLE
[NavigationBar] - Update handling of center-aligned titles

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -467,6 +467,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
                           frame.size.width, frame.size.height);
       }
     }
+    // Intentional Fall Through
     case MDCNavigationBarTitleAlignmentLeading:
       return CGRectMake(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
   }

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -462,10 +462,10 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   switch (alignment) {
       // Center align title if desired unless leading icons will overlap frame
     case MDCNavigationBarTitleAlignmentCenter: {
-      CGFloat xOrigin = CGRectGetMaxX(self.bounds) / 2 - frame.size.width / 2;
+      CGFloat xOrigin = CGRectGetMaxX(self.bounds) / 2 - CGRectGetWidth(frame) / 2;
       if (frame.origin.x <= xOrigin) {
         return CGRectMake(xOrigin, frame.origin.y,
-                          frame.size.width, frame.size.height);
+                          CGRectGetWidth(frame), CGRectGetHeight(frame));
       }
     }
     // Intentional fall through

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -463,14 +463,14 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
       // Center align title if desired unless leading icons will overlap frame
     case MDCNavigationBarTitleAlignmentCenter: {
       CGFloat xOrigin = CGRectGetMaxX(self.bounds) / 2 - CGRectGetWidth(frame) / 2;
-      if (frame.origin.x <= xOrigin) {
-        return CGRectMake(xOrigin, frame.origin.y,
+      if (CGRectGetMinX(frame) <= xOrigin) {
+        return CGRectMake(xOrigin, CGRectGetMinY(frame),
                           CGRectGetWidth(frame), CGRectGetHeight(frame));
       }
     }
     // Intentional fall through
     case MDCNavigationBarTitleAlignmentLeading:
-      return CGRectMake(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
+      return frame;
   }
 }
 

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -461,13 +461,17 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
                              alignment:(MDCNavigationBarTitleAlignment)alignment {
   switch (alignment) {
     case MDCNavigationBarTitleAlignmentCenter: {
+      // Center-Aligned Frame's x-origin
       CGFloat xOrigin = CGRectGetMaxX(self.bounds) / 2 - frame.size.width / 2;
+
+      // Input Frame's x-origin begins with leading alignment to max x-point of leading button bar.
+      // IF: Input x-origin is less than/equal to center-aligned frame's x-origin, then center align
       if (frame.origin.x <= xOrigin) {
         return CGRectMake(xOrigin, frame.origin.y,
                           frame.size.width, frame.size.height);
       }
     }
-    // Intentional Fall Through
+    // Intentional Fall Through. ELSE: switch to leading alignment
     case MDCNavigationBarTitleAlignmentLeading:
       return CGRectMake(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
   }

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -460,18 +460,15 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 - (CGRect)mdc_frameAlignedHorizontally:(CGRect)frame
                              alignment:(MDCNavigationBarTitleAlignment)alignment {
   switch (alignment) {
+      // Center align title if desired unless leading icons will overlap frame
     case MDCNavigationBarTitleAlignmentCenter: {
-      // Center-Aligned Frame's x-origin
       CGFloat xOrigin = CGRectGetMaxX(self.bounds) / 2 - frame.size.width / 2;
-
-      // Input Frame's x-origin begins with leading alignment to max x-point of leading button bar.
-      // IF: Input x-origin is less than/equal to center-aligned frame's x-origin, then center align
       if (frame.origin.x <= xOrigin) {
         return CGRectMake(xOrigin, frame.origin.y,
                           frame.size.width, frame.size.height);
       }
     }
-    // Intentional Fall Through. ELSE: switch to leading alignment
+    // Intentional fall through
     case MDCNavigationBarTitleAlignmentLeading:
       return CGRectMake(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
   }

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -460,10 +460,13 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 - (CGRect)mdc_frameAlignedHorizontally:(CGRect)frame
                              alignment:(MDCNavigationBarTitleAlignment)alignment {
   switch (alignment) {
-    case MDCNavigationBarTitleAlignmentCenter:
-      return CGRectMake(CGRectGetMaxX(self.bounds) / 2 - frame.size.width / 2, frame.origin.y,
-                        frame.size.width, frame.size.height);
-
+    case MDCNavigationBarTitleAlignmentCenter: {
+      CGFloat xOrigin = CGRectGetMaxX(self.bounds) / 2 - frame.size.width / 2;
+      if (frame.origin.x <= xOrigin) {
+        return CGRectMake(xOrigin, frame.origin.y,
+                          frame.size.width, frame.size.height);
+      }
+    }
     case MDCNavigationBarTitleAlignmentLeading:
       return CGRectMake(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
   }


### PR DESCRIPTION
Update handling of center-aligned titles to follow Apple’s implementation of shifting title over if leading buttons encroach.

Rule -

If MDCNavigationBarTitleAlignmentCenter:
- If leading button bar's maximum x coordinate is less than centered titleFrame's x origin, no change (title stays center aligned)
- else, use leading title alignment

This will close Issue #1457 

Apple's UINavigation Bar Alignment Rules:
![screen shot 2017-06-02 at 3 32 25 pm](https://cloud.githubusercontent.com/assets/19916772/26742097/42ca9f0a-47aa-11e7-8dae-d5f9bf09795b.png)

![screen shot 2017-06-02 at 3 32 57 pm](https://cloud.githubusercontent.com/assets/19916772/26742102/49ff6fc6-47aa-11e7-83a8-f5206f2e433a.png)

![screen shot 2017-06-02 at 3 33 21 pm](https://cloud.githubusercontent.com/assets/19916772/26742107/5000a28c-47aa-11e7-98cc-545fce38ec18.png)

![screen shot 2017-06-02 at 3 33 42 pm](https://cloud.githubusercontent.com/assets/19916772/26742111/544e2a62-47aa-11e7-9d32-4bfa9244901e.png)


After Change:
![screen shot 2017-06-02 at 3 27 31 pm](https://cloud.githubusercontent.com/assets/19916772/26742128/65256c10-47aa-11e7-9fdd-d7841de4db6d.png)

![screen shot 2017-06-02 at 3 28 01 pm](https://cloud.githubusercontent.com/assets/19916772/26742130/6adc741e-47aa-11e7-8ad3-b9270553560c.png)

![screen shot 2017-06-02 at 3 28 23 pm](https://cloud.githubusercontent.com/assets/19916772/26742142/751c9058-47aa-11e7-93aa-4c88c53593d0.png)

![screen shot 2017-06-02 at 3 29 06 pm](https://cloud.githubusercontent.com/assets/19916772/26742147/7b0f23d6-47aa-11e7-903c-ba2e4265d93e.png)
