### PR TITLE
[Feature Highlight] Restore innerHighlightColor setter and fix null_resettable colors

### DIFF
--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -111,12 +111,22 @@ const CGFloat kMDCFeatureHighlightPulseRadiusBloomAmount =
 }
 
 - (void)applyMDCFeatureHighlightViewDefaults {
-  _outerHighlightColor =
-      [[UIColor blueColor] colorWithAlphaComponent:kMDCFeatureHighlightOuterHighlightAlpha];
-  _innerHighlightColor = [UIColor whiteColor];
+  _outerHighlightColor = [self MDCFeatureHighlightDefaultOuterHighlightColor];
+  _innerHighlightColor = [self MDCFeatureHighlightDefaultInnerHighlightColor];
+}
+
+- (UIColor *)MDCFeatureHighlightDefaultOuterHighlightColor {
+  return [[UIColor blueColor] colorWithAlphaComponent:kMDCFeatureHighlightOuterHighlightAlpha];
+}
+
+- (UIColor *)MDCFeatureHighlightDefaultInnerHighlightColor {
+  return [UIColor whiteColor];
 }
 
 - (void)setOuterHighlightColor:(UIColor *)outerHighlightColor {
+  if (!outerHighlightColor) {
+    outerHighlightColor = [self MDCFeatureHighlightDefaultOuterHighlightColor];
+  }
   _outerHighlightColor = outerHighlightColor;
   _outerLayer.fillColor = _outerHighlightColor.CGColor;
 
@@ -142,6 +152,16 @@ const CGFloat kMDCFeatureHighlightPulseRadiusBloomAmount =
                                                          options:options];
   titleAlpha = MAX([MDCTypography titleFontOpacity], titleAlpha);
   _titleLabel.textColor = [_bodyLabel.textColor colorWithAlphaComponent:titleAlpha];
+}
+
+- (void)setInnerHighlightColor:(UIColor *)innerHighlightColor {
+  if (!innerHighlightColor) {
+    innerHighlightColor = [self MDCFeatureHighlightDefaultInnerHighlightColor];
+  }
+  _innerHighlightColor = innerHighlightColor;
+
+  _pulseLayer.fillColor = _innerHighlightColor.CGColor;
+  _innerLayer.fillColor = _innerHighlightColor.CGColor;
 }
 
 - (void)layoutAppearing {


### PR DESCRIPTION
Seems the innerHighlightColor setter was accidentally removed when we made most of MDCFeatureHighlightView private. Closes #1484

This change also makes the MDCFeatureHighlightViewController inner and outer highlight color setters null_resettable. 

Unfortunately null_resettable and UIAppearance proxy are kinda incompatible as we can't pull a value out of the UIAppearance proxy. Going forward we should try to make UIAppearance proxy-able properties be nullable or nonnull.