### PR TITLE
[Feature Highlight] Expose title and body color properties

### DIFF
--- a/components/FeatureHighlight/src/MDCFeatureHighlightView.h
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightView.h
@@ -18,9 +18,9 @@
 
 @interface MDCFeatureHighlightView : UIView
 
-@property(nonatomic, strong) UIColor *innerHighlightColor UI_APPEARANCE_SELECTOR;
-@property(nonatomic, strong) UIColor *outerHighlightColor UI_APPEARANCE_SELECTOR;
-@property(nonatomic, strong) UIColor *titleColor UI_APPEARANCE_SELECTOR;
-@property(nonatomic, strong) UIColor *bodyColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, nullable) UIColor *innerHighlightColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, nullable) UIColor *outerHighlightColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, nullable) UIColor *titleColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, nullable) UIColor *bodyColor UI_APPEARANCE_SELECTOR;
 
 @end

--- a/components/FeatureHighlight/src/MDCFeatureHighlightView.h
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightView.h
@@ -20,5 +20,7 @@
 
 @property(nonatomic, strong) UIColor *innerHighlightColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong) UIColor *outerHighlightColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong) UIColor *titleColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong) UIColor *bodyColor UI_APPEARANCE_SELECTOR;
 
 @end

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
@@ -107,6 +107,22 @@ typedef void (^MDCFeatureHighlightCompletion)(BOOL accepted);
 @property(nonatomic, strong, null_resettable) UIColor *innerHighlightColor;
 
 /**
+ Sets the color to be used for the title text. If nil upon presentation, a color of sufficient
+ contrast to the |outerHighlightColor| will be automatically chosen.
+
+ Defaults to nil.
+ */
+@property(nonatomic, strong, nullable) UIColor *titleColor;
+
+/**
+ Sets the color to be used for the body text. If nil upon presentation, a color of sufficient
+ contrast to the |outerHighlightColor| will be automatically chosen upon presentation.
+
+ Defaults to nil.
+ */
+@property(nonatomic, strong, nullable) UIColor *bodyColor;
+
+/**
  Dismisses the feature highlight using the 'accept' style dismissal animation and triggers the
  completion block with accepted set to YES.
 

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -16,6 +16,8 @@
 
 #import "MDCFeatureHighlightViewController.h"
 
+#import "MaterialTypography.h"
+#import "MDFTextAccessibility.h"
 #import "private/MDCFeatureHighlightAnimationController.h"
 #import "private/MDCFeatureHighlightView+Private.h"
 
@@ -120,6 +122,34 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
   CGPoint point = [_highlightedView.superview convertPoint:_highlightedView.center
                                          toCoordinateSpace:_featureHighlightView];
   _featureHighlightView.highlightPoint = point;
+
+  if (!self.bodyColor) {
+    MDFTextAccessibilityOptions options = MDFTextAccessibilityOptionsPreferLighter;
+    if ([MDFTextAccessibility isLargeForContrastRatios:_featureHighlightView.bodyLabel.font]) {
+      options |= MDFTextAccessibilityOptionsLargeFont;
+    }
+
+    UIColor *outerColor = [self.outerHighlightColor colorWithAlphaComponent:1.0];
+    self.bodyColor =
+        [MDFTextAccessibility textColorOnBackgroundColor:outerColor
+                                         targetTextAlpha:[MDCTypography captionFontOpacity]
+                                                 options:options];
+  }
+
+  if (!self.titleColor) {
+    MDFTextAccessibilityOptions options = MDFTextAccessibilityOptionsPreferLighter;
+    if ([MDFTextAccessibility isLargeForContrastRatios:_featureHighlightView.titleLabel.font]) {
+      options |= MDFTextAccessibilityOptionsLargeFont;
+    }
+    UIColor *outerColor = [self.outerHighlightColor colorWithAlphaComponent:1.0];
+    // Since MDFTextAccessibility can return either a dark value or light value color we want to
+    // guarantee that the title and body have the same value.
+    CGFloat titleAlpha = [MDFTextAccessibility minAlphaOfTextColor:self.bodyColor
+                                                 onBackgroundColor:outerColor
+                                                           options:options];
+    titleAlpha = MAX([MDCTypography titleFontOpacity], titleAlpha);
+    self.titleColor = [self.bodyColor colorWithAlphaComponent:titleAlpha];
+  }
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -152,6 +182,22 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
 
 - (void)setInnerHighlightColor:(UIColor *)innerHighlightColor {
   _featureHighlightView.innerHighlightColor = innerHighlightColor;
+}
+
+- (UIColor *)titleColor {
+  return _featureHighlightView.titleColor;
+}
+
+- (void)setTitleColor:(UIColor *)titleColor {
+  _featureHighlightView.titleColor = titleColor;
+}
+
+- (UIColor *)bodyColor {
+  return _featureHighlightView.bodyColor;
+}
+
+- (void)setBodyColor:(UIColor *)bodyColor {
+  _featureHighlightView.bodyColor = bodyColor;
 }
 
 - (void)acceptFeature {

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -17,7 +17,6 @@
 #import "MDCFeatureHighlightView+Private.h"
 
 #import "MDCFeatureHighlightLayer.h"
-#import "MDFTextAccessibility.h"
 #import "MaterialFeatureHighlightStrings.h"
 #import "MaterialFeatureHighlightStrings_table.h"
 #import "MaterialTypography.h"
@@ -129,29 +128,18 @@ const CGFloat kMDCFeatureHighlightPulseRadiusBloomAmount =
   }
   _outerHighlightColor = outerHighlightColor;
   _outerLayer.fillColor = _outerHighlightColor.CGColor;
+}
 
-  MDFTextAccessibilityOptions options = MDFTextAccessibilityOptionsPreferLighter;
-  if ([MDFTextAccessibility isLargeForContrastRatios:_bodyLabel.font]) {
-    options |= MDFTextAccessibilityOptionsLargeFont;
-  }
+- (void)setTitleColor:(UIColor *)titleColor {
+  _titleColor = titleColor;
 
-  UIColor *outerColor = [_outerHighlightColor colorWithAlphaComponent:1.0];
-  _bodyLabel.textColor =
-      [MDFTextAccessibility textColorOnBackgroundColor:outerColor
-                                       targetTextAlpha:[MDCTypography captionFontOpacity]
-                                               options:options];
+  _titleLabel.textColor = titleColor;
+}
 
-  options = MDFTextAccessibilityOptionsPreferLighter;
-  if ([MDFTextAccessibility isLargeForContrastRatios:_titleLabel.font]) {
-    options |= MDFTextAccessibilityOptionsLargeFont;
-  }
-  // Since MDFTextAccessibility can return either a dark value or light value color we want to
-  // guarantee that the title and body have the same value.
-  CGFloat titleAlpha = [MDFTextAccessibility minAlphaOfTextColor:_bodyLabel.textColor
-                                               onBackgroundColor:outerColor
-                                                         options:options];
-  titleAlpha = MAX([MDCTypography titleFontOpacity], titleAlpha);
-  _titleLabel.textColor = [_bodyLabel.textColor colorWithAlphaComponent:titleAlpha];
+- (void)setBodyColor:(UIColor *)bodyColor {
+  _bodyColor = bodyColor;
+
+  _bodyLabel.textColor = bodyColor;
 }
 
 - (void)setInnerHighlightColor:(UIColor *)innerHighlightColor {

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -59,10 +59,6 @@ const CGFloat kMDCFeatureHighlightPulseRadiusBloomAmount =
   MDCFeatureHighlightLayer *_displayMaskLayer;
 }
 
-@end
-
-@implementation MDCFeatureHighlightView (Private)
-
 - (instancetype)initWithFrame:(CGRect)frame {
   if (self = [super initWithFrame:frame]) {
     self.backgroundColor = [UIColor clearColor];


### PR DESCRIPTION
This PR exposes the title and body color to be user configurable.

In order to make this not introduce changes for current clients of Feature Highlight, if the properties are not set when the Feature Highlight is presented the title and body colors will be automatically chosen as before, using MDFTextAccessibility.

This PR also fixes some warnings (closes #1478).