### PR TITLE
[MDCPalette] Remove MDC_PALETTE_USE_CLASS_METHODS

### DIFF
--- a/components/Palettes/src/MDCPalettes.h
+++ b/components/Palettes/src/MDCPalettes.h
@@ -75,67 +75,6 @@ CG_EXTERN const MDCPaletteAccent _Nonnull MDCPaletteAccent700Name;
  */
 @interface MDCPalette : NSObject
 
-#ifdef MDC_PALETTE_USE_CLASS_METHODS
-
-/** The red palette. */
-+ (nonnull MDCPalette *)redPalette;
-
-/** The pink palette. */
-+ (nonnull MDCPalette *)pinkPalette;
-
-/** The purple palette. */
-+ (nonnull MDCPalette *)purplePalette;
-
-/** The deep purple palette. */
-+ (nonnull MDCPalette *)deepPurplePalette;
-
-/** The indigo palette. */
-+ (nonnull MDCPalette *)indigoPalette;
-
-/** The blue palette. */
-+ (nonnull MDCPalette *)bluePalette;
-
-/** The light blue palette. */
-+ (nonnull MDCPalette *)lightBluePalette;
-
-/** The cyan palette. */
-+ (nonnull MDCPalette *)cyanPalette;
-
-/** The teal palette. */
-+ (nonnull MDCPalette *)tealPalette;
-
-/** The green palette. */
-+ (nonnull MDCPalette *)greenPalette;
-
-/** The light green palette. */
-+ (nonnull MDCPalette *)lightGreenPalette;
-
-/** The lime palette. */
-+ (nonnull MDCPalette *)limePalette;
-
-/** The yellow palette. */
-+ (nonnull MDCPalette *)yellowPalette;
-
-/** The amber palette. */
-+ (nonnull MDCPalette *)amberPalette;
-
-/** The orange palette. */
-+ (nonnull MDCPalette *)orangePalette;
-
-/** The deep orange palette. */
-+ (nonnull MDCPalette *)deepOrangePalette;
-
-/** The brown palette (no accents). */
-+ (nonnull MDCPalette *)brownPalette;
-
-/** The grey palette (no accents). */
-+ (nonnull MDCPalette *)greyPalette;
-
-/** The blue grey palette (no accents). */
-+ (nonnull MDCPalette *)blueGreyPalette;
-
-# else
-
 /** The red palette. */
 @property(class, readonly, strong, nonnull) MDCPalette *redPalette;
 
@@ -192,8 +131,6 @@ CG_EXTERN const MDCPaletteAccent _Nonnull MDCPaletteAccent700Name;
 
 /** The blue grey palette (no accents). */
 @property(class, readonly, strong, nonnull) MDCPalette *blueGreyPalette;
-
-#endif
 
 /**
  Returns a palette generated from a single target 500 tint color.


### PR DESCRIPTION
Remove the ability to define MDC_PALETTE_USE_CLASS_METHODS to get legacy MDCPalette class methods instead of class properties. 

See `#1436`.