### PR TITLE
Add Masked Transition component.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -250,6 +250,16 @@ Pod::Spec.new do |s|
     end
   end
 
+  s.subspec "MaskedTransition" do |ss|
+    ss.ios.deployment_target = '8.0'
+    ss.public_header_files = "components/#{ss.base_name}/src/*.h"
+    ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
+
+    ss.dependency "Transitioning", "~> 1.1"
+    ss.dependency "MotionAnimator", "~> 1.0"
+    ss.dependency "MotionInterchange", "~> 1.0"
+  end
+
   s.subspec "NavigationBar" do |ss|
     ss.subspec "Component" do |sss|
       sss.ios.deployment_target = '8.0'

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -255,7 +255,7 @@ Pod::Spec.new do |s|
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"
     ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
 
-    ss.dependency "Transitioning", "~> 1.1"
+    ss.dependency "MotionTransitioning", "~> 3.0"
     ss.dependency "MotionAnimator", "~> 1.0"
     ss.dependency "MotionInterchange", "~> 1.0"
   end

--- a/components/MaskedTransition/README.md
+++ b/components/MaskedTransition/README.md
@@ -47,9 +47,10 @@ pod install
 
 ## Overview
 
-A masked transition is a UIViewController transition using the
-[Transitioning](https://github.com/material-motion/transitioning-objc) library. It assumes that you
-are transitioning from a circular source view.
+A masked transition is a UIViewController transition that can be used to present a contextual
+expansion from a circular source view. This transition follows the motion timing defined by the
+section on [Radial transformations](https://material.io/guidelines/motion/transforming-material.html#transforming-material-radial-transformation)
+in the Material Design guidelines.
 
 - - -
 

--- a/components/MaskedTransition/README.md
+++ b/components/MaskedTransition/README.md
@@ -1,0 +1,130 @@
+<!--docs:
+title: "Masked Transitions"
+layout: detail
+section: components
+excerpt: "A masked transition reveals content from a source view using a view controller transition."
+iconId: maskedTransition
+path: /catalog/masked-transitions/
+api_doc_root: true
+-->
+
+# Masked Transitions
+
+A masked transition reveals content from a source view using a view controller transition.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/motion/transforming-material.html#transforming-material-radial-transformation">Material Design guidelines: Radial Transformations</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/masked-transitions/api-docs/Classes/MDCMaskedTransition.html">API: MDCMaskedTransition</a></li>
+</ul>
+
+- - -
+
+## Installation
+
+### Requirements
+
+- Xcode 7.0 or higher.
+- iOS SDK version 7.0 or higher.
+
+### Installation with CocoaPods
+
+To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:
+
+```
+pod 'MaterialComponents/MaskedTransition'
+```
+<!--{: .code-renderer.code-renderer--install }-->
+
+Then, run the following command:
+
+``` bash
+pod install
+```
+
+- - -
+
+## Overview
+
+A masked transition is a UIViewController transition using the
+[Transitioning](https://github.com/material-motion/transitioning-objc) library. It assumes that you
+are transitioning from a circular source view.
+
+- - -
+
+## Usage
+
+### Importing
+
+Before using Masked Transition, you'll need to import it:
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+``` swift
+import MaterialComponents.MaterialMaskedTransition
+```
+
+#### Objective-C
+
+``` objc
+#import "MaterialMaskedTransition.h"
+```
+<!--</div>-->
+
+### Using MDCMaskedTransition to present a view controller
+
+Create an instance of MDCMaskedTransition and assign it to the view controller's
+`mdm_transitionController.transition` property prior to presenting the view controller:
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+``` swift
+vc.transitionController.transition = MDCMaskedTransition(sourceView: button)
+present(vc, animated: true)
+```
+
+#### Objective-C
+
+``` objc
+vc.mdm_transitionController.transition = [[MDCMaskedTransition alloc] initWithSourceView:button];
+[self presentViewController:vc animated:YES completion:nil];
+```
+<!--</div>-->
+
+### Customizing the presented frame
+
+You can customize the presented frame of the view controller by assigning a
+`calculateFrameOfPresentedView` block on the transition instance. For example, to present a modal
+dialog centered in the screen you can use the following examples:
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+``` swift
+let transition = MDCMaskedTransition(sourceView: button)
+transition.calculateFrameOfPresentedView = { info in
+  let size = CGSize(width: 200, height: 200)
+  return CGRect(x: (info.containerView!.bounds.width - size.width) / 2,
+                y: (info.containerView!.bounds.height - size.height) / 2,
+                width: size.width,
+                height: size.height)
+}
+vc.transitionController.transition = transition
+present(vc, animated: true)
+```
+
+#### Objective-C
+
+``` objc
+MDCMaskedTransition *transition = [[MDCMaskedTransition alloc] initWithSourceView:button];
+transition.calculateFrameOfPresentedView = ^(UIPresentationController *info) {
+  CGSize size = CGSizeMake(200, 200);
+  return CGRectMake((info.containerView.bounds.size.width - size.width) / 2,
+                    (info.containerView.bounds.size.height - size.height) / 2,
+                    size.width,
+                    size.height);
+};
+vc.mdm_transitionController.transition = transition;
+[self presentViewController:vc animated:YES completion:nil];
+```
+<!--</div>-->

--- a/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
+++ b/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
@@ -1,0 +1,162 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+import MaterialComponents
+
+open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
+
+  struct TargetInfo {
+    let name: String
+    let viewControllerType: UIViewController.Type
+    let calculateFrame: ((UIPresentationController) -> CGRect)?
+  }
+  var targets: [TargetInfo] = []
+
+  var tableView: UITableView!
+  override open func viewDidLoad() {
+    super.viewDidLoad()
+
+    tableView = UITableView(frame: view.bounds, style: .plain)
+    tableView.dataSource = self
+    tableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+    view.addSubview(tableView)
+
+    let rightFab = UIButton(type: .custom)
+    rightFab.frame = .init(x: view.bounds.maxX - 100, y: view.bounds.maxY - 100, width: 64, height: 64)
+    rightFab.setTitle("+", for: .normal)
+    rightFab.titleLabel?.font = UIFont.systemFont(ofSize: 28)
+    rightFab.layer.cornerRadius = rightFab.bounds.width / 2
+    rightFab.backgroundColor = .orange
+    rightFab.addTarget(self, action: #selector(didTapFab), for: .touchUpInside)
+    rightFab.autoresizingMask = [.flexibleTopMargin, .flexibleLeftMargin]
+    view.addSubview(rightFab)
+
+    let leftFab = UIButton(type: .custom)
+    leftFab.frame = .init(x: 100 - 64, y: view.bounds.maxY - 100, width: 64, height: 64)
+    leftFab.setTitle("+", for: .normal)
+    leftFab.titleLabel?.font = UIFont.systemFont(ofSize: 28)
+    leftFab.layer.cornerRadius = leftFab.bounds.width / 2
+    leftFab.backgroundColor = .blue
+    leftFab.addTarget(self, action: #selector(didTapFab), for: .touchUpInside)
+    leftFab.autoresizingMask = [.flexibleTopMargin, .flexibleRightMargin]
+    view.addSubview(leftFab)
+
+    targets.append(.init(name: "Bottom sheet", viewControllerType: ModalViewController.self, calculateFrame: { info in
+      let size = CGSize(width: info.containerView!.bounds.width, height: 300)
+      return CGRect(x: info.containerView!.bounds.minX,
+                    y: info.containerView!.bounds.height - size.height,
+                    width: size.width,
+                    height: size.height)
+    }))
+
+    targets.append(.init(name: "Centered card", viewControllerType: ModalViewController.self, calculateFrame: { info in
+      let size = CGSize(width: 200, height: 200)
+      return CGRect(x: (info.containerView!.bounds.width - size.width) / 2,
+                    y: (info.containerView!.bounds.height - size.height) / 2,
+                    width: size.width,
+                    height: size.height)
+    }))
+
+    targets.append(.init(name: "Full screen", viewControllerType: ModalViewController.self, calculateFrame: nil))
+
+    targets.append(.init(name: "Left card", viewControllerType: ModalViewController.self, calculateFrame: { info in
+      return CGRect(x: leftFab.frame.minX - 16, y: leftFab.frame.minY - 200, width: 200, height: 264)
+    }))
+
+    targets.append(.init(name: "Right card", viewControllerType: ModalViewController.self, calculateFrame: { info in
+      return CGRect(x: rightFab.frame.maxX - 200, y: rightFab.frame.minY - 200, width: 200, height: 264)
+    }))
+
+    targets.append(.init(name: "Toolbar", viewControllerType: ToolbarViewController.self, calculateFrame: { info in
+      guard let containerView = info.containerView else {
+        return .zero
+      }
+      return CGRect(x: 0, y: containerView.bounds.height - 100, width: containerView.bounds.width, height: 100)
+    }))
+
+    tableView.selectRow(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .none)
+  }
+
+  func didTapFab(fab: UIView) {
+    let target = targets[tableView.indexPathForSelectedRow!.row]
+    let vc = target.viewControllerType.init()
+
+    let transition = MDCMaskedTransition(sourceView: fab)
+    transition.calculateFrameOfPresentedView = target.calculateFrame
+    vc.transitionController.transition = transition
+
+    showDetailViewController(vc, sender: self)
+  }
+
+}
+
+extension MaskedTransitionTypicalUseSwiftExample: UITableViewDataSource {
+  public func numberOfSections(in tableView: UITableView) -> Int {
+    return 1
+  }
+  public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return targets.count
+  }
+  public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+    cell.textLabel?.text = targets[indexPath.row].name
+    return cell
+  }
+}
+
+private class ToolbarViewController: UIViewController {
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    let toolbar = UIToolbar(frame: view.bounds)
+    toolbar.isTranslucent = false
+    toolbar.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    toolbar.items = [.init(barButtonSystemItem: .camera, target: self, action: #selector(didTap))]
+    view.addSubview(toolbar)
+  }
+
+  func didTap() {
+    dismiss(animated: true)
+  }
+}
+
+private class ModalViewController: UIViewController {
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    view.backgroundColor = .white
+
+    view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTap)))
+
+    let label = UILabel(frame: view.bounds)
+    label.numberOfLines = 0
+    label.lineBreakMode = .byWordWrapping
+    label.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. In aliquam dolor eget orci condimentum, eu blandit metus dictum. Suspendisse vitae metus pellentesque, sagittis massa vel, sodales velit. Aliquam placerat nibh et posuere interdum. Etiam fermentum purus vel turpis lobortis auctor. Curabitur auctor maximus purus, ac iaculis mi. In ac hendrerit sapien, eget porttitor risus. Integer placerat cursus viverra. Proin mollis nulla vitae nisi posuere, eu rutrum mauris condimentum. Nullam in faucibus nulla, non tincidunt lectus. Maecenas mollis massa purus, in viverra elit molestie eu. Nunc volutpat magna eget mi vestibulum pharetra. Suspendisse nulla ligula, laoreet non ante quis, vehicula facilisis libero. Morbi faucibus, sapien a convallis sodales, leo quam scelerisque leo, ut tincidunt diam velit laoreet nulla. Proin at quam vel nibh varius ultrices porta id diam. Pellentesque pretium consequat neque volutpat tristique. Sed placerat a purus ut molestie. Nullam laoreet venenatis urna non pulvinar. Proin a vestibulum nulla, eu placerat est. Morbi molestie aliquam justo, ut aliquet neque tristique consectetur. In hac habitasse platea dictumst. Fusce vehicula justo in euismod elementum. Ut vel malesuada est. Aliquam mattis, ex vel viverra eleifend, mauris nibh faucibus nibh, in fringilla sem purus vitae elit. Donec sed dapibus orci, ut vulputate sapien. Integer eu magna efficitur est pellentesque tempor. Sed ac imperdiet ex. Maecenas congue quis lacus vel dictum. Phasellus dictum mi at sollicitudin euismod. Mauris laoreet, eros vitae euismod commodo, libero ligula pretium massa, in scelerisque eros dui eu metus. Fusce elementum mauris velit, eu tempor nulla congue ut. In at tellus id quam feugiat semper eget ut felis. Nulla quis varius quam. Nullam tincidunt laoreet risus, ut aliquet nisl gravida id. Nulla iaculis mauris velit, vitae feugiat nunc scelerisque ac. Vivamus eget ligula porta, pulvinar ex vitae, sollicitudin erat. Maecenas semper ornare suscipit. Ut et neque condimentum lectus pulvinar maximus in sit amet odio. Aliquam congue purus erat, eu rutrum risus placerat a."
+    label.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    view.addSubview(label)
+  }
+
+  override var preferredStatusBarStyle: UIStatusBarStyle {
+    return .lightContent
+  }
+
+  func didTap() {
+    dismiss(animated: true)
+  }
+}

--- a/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
+++ b/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
@@ -92,18 +92,6 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
     tableView.selectRow(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .none)
   }
 
-  open override func viewWillDisappear(_ animated: Bool) {
-    super.viewWillDisappear(animated)
-
-    print("Will disappear")
-  }
-
-  open override func viewDidDisappear(_ animated: Bool) {
-    super.viewDidDisappear(animated)
-
-    print("Did disappear")
-  }
-
   func didTapFab(fab: UIView) {
     let target = targets[tableView.indexPathForSelectedRow!.row]
     let vc = target.viewControllerType.init()

--- a/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
+++ b/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
@@ -23,6 +23,7 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
     let name: String
     let viewControllerType: UIViewController.Type
     let calculateFrame: ((UIPresentationController) -> CGRect)?
+    let autoresizingMask: UIViewAutoresizing
   }
   var targets: [TargetInfo] = []
 
@@ -62,7 +63,7 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
                     y: info.containerView!.bounds.height - size.height,
                     width: size.width,
                     height: size.height)
-    }))
+    }, autoresizingMask: [.flexibleWidth, .flexibleTopMargin]))
 
     targets.append(.init(name: "Centered card", viewControllerType: ModalViewController.self, calculateFrame: { info in
       let size = CGSize(width: 200, height: 200)
@@ -70,24 +71,25 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
                     y: (info.containerView!.bounds.height - size.height) / 2,
                     width: size.width,
                     height: size.height)
-    }))
+    }, autoresizingMask: [.flexibleLeftMargin, .flexibleTopMargin,
+                          .flexibleRightMargin, .flexibleBottomMargin]))
 
-    targets.append(.init(name: "Full screen", viewControllerType: ModalViewController.self, calculateFrame: nil))
+    targets.append(.init(name: "Full screen", viewControllerType: ModalViewController.self, calculateFrame: nil, autoresizingMask: [.flexibleWidth, .flexibleHeight]))
 
     targets.append(.init(name: "Left card", viewControllerType: ModalViewController.self, calculateFrame: { info in
       return CGRect(x: leftFab.frame.minX - 16, y: leftFab.frame.minY - 200, width: 200, height: 264)
-    }))
+    }, autoresizingMask: [.flexibleTopMargin, .flexibleRightMargin, .flexibleBottomMargin]))
 
     targets.append(.init(name: "Right card", viewControllerType: ModalViewController.self, calculateFrame: { info in
       return CGRect(x: rightFab.frame.maxX - 200, y: rightFab.frame.minY - 200, width: 200, height: 264)
-    }))
+    }, autoresizingMask: [.flexibleTopMargin, .flexibleLeftMargin, .flexibleBottomMargin]))
 
     targets.append(.init(name: "Toolbar", viewControllerType: ToolbarViewController.self, calculateFrame: { info in
       guard let containerView = info.containerView else {
         return .zero
       }
       return CGRect(x: 0, y: containerView.bounds.height - 100, width: containerView.bounds.width, height: 100)
-    }))
+    }, autoresizingMask: [.flexibleTopMargin, .flexibleWidth]))
 
     tableView.selectRow(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .none)
   }
@@ -98,6 +100,7 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
 
     let transition = MDCMaskedTransition(sourceView: fab)
     transition.calculateFrameOfPresentedView = target.calculateFrame
+    vc.view.autoresizingMask = target.autoresizingMask
     vc.transitionController.transition = transition
 
     showDetailViewController(vc, sender: self)

--- a/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
+++ b/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
@@ -92,6 +92,18 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
     tableView.selectRow(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .none)
   }
 
+  open override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+
+    print("Will disappear")
+  }
+
+  open override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+
+    print("Did disappear")
+  }
+
   func didTapFab(fab: UIView) {
     let target = targets[tableView.indexPathForSelectedRow!.row]
     let vc = target.viewControllerType.init()

--- a/components/MaskedTransition/examples/supplemental/MaskedTransitionTypicalUseSupplemental.swift
+++ b/components/MaskedTransition/examples/supplemental/MaskedTransitionTypicalUseSupplemental.swift
@@ -1,0 +1,39 @@
+/*Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+/* IMPORTANT:
+ This file contains supplemental code used to populate the examples with dummy data and/or
+ instructions. It is not necessary to import this file to use Material Components for iOS.
+ */
+
+import Foundation
+import MaterialComponents
+
+extension MaskedTransitionTypicalUseSwiftExample {
+
+  // (CatalogByConvention)
+
+  class func catalogBreadcrumbs() -> [String] {
+    return [ "Masked Transition", "Masked Transition (Swift)" ]
+  }
+
+  class func catalogDescription() -> String {
+    return ""
+  }
+
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+
+}

--- a/components/MaskedTransition/src/MDCMaskedTransition.h
+++ b/components/MaskedTransition/src/MDCMaskedTransition.h
@@ -1,0 +1,48 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import <Transitioning/Transitioning.h>
+
+/**
+ A masked transition will animate between two view controllers using an expanding mask effect.
+
+ It is presently assumed that the mask will be a circular mask and that the source view is a view
+ with equal width and height and a corner radius equal to half the view's width.
+ */
+@interface MDCMaskedTransition: NSObject <MDMTransition>
+
+/**
+ Initializes the transition with the view from which the mask should emanate.
+
+ @param sourceView The view from which the mask should emanate. The view is assumed to be in the
+                   presenting view controller's view hierarchy.
+ */
+- (nonnull instancetype)initWithSourceView:(nonnull UIView *)sourceView
+    NS_DESIGNATED_INITIALIZER;
+
+/**
+ An optional block that may be used to calculate the frame of the presented view controller's view.
+
+ If provided, the block will be invoked immediately before the transition is initiated and the
+ returned rect will be assigned to the presented view controller's frame.
+ */
+@property(nonatomic, copy, nullable) CGRect (^calculateFrameOfPresentedView)(UIPresentationController * _Nonnull);
+
+- (nonnull instancetype)init NS_UNAVAILABLE;
+
+@end

--- a/components/MaskedTransition/src/MDCMaskedTransition.h
+++ b/components/MaskedTransition/src/MDCMaskedTransition.h
@@ -16,7 +16,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import <Transitioning/Transitioning.h>
+#import <MotionTransitioning/MotionTransitioning.h>
 
 /**
  A masked transition will animate between two view controllers using an expanding mask effect.

--- a/components/MaskedTransition/src/MDCMaskedTransition.m
+++ b/components/MaskedTransition/src/MDCMaskedTransition.m
@@ -1,0 +1,286 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCMaskedTransition.h"
+
+#import <MotionAnimator/MotionAnimator.h>
+
+#import "MDCMaskedPresentationController.h"
+#import "MDCMaskedTransitionMotionForContext.h"
+#import "MDCMaskedTransitionMotionSpec.h"
+
+// Math utilities
+
+static CGPoint centerOfFrame(CGRect frame) {
+  return CGPointMake(CGRectGetMidX(frame), CGRectGetMidY(frame));
+}
+
+static CGPoint anchorPointFromPosition(CGPoint position, CGRect bounds) {
+  return CGPointMake(position.x / bounds.size.width, position.y / bounds.size.height);
+}
+
+static CGRect frameCenteredAround(CGPoint position, CGSize size) {
+  return CGRectMake(position.x - size.width / 2,
+                    position.y - size.height / 2,
+                    size.width,
+                    size.height);
+}
+
+static CGFloat lengthOfVector(CGVector vector) {
+  return (CGFloat)sqrt(vector.dx * vector.dx + vector.dy * vector.dy);
+}
+
+@interface MDCMaskedTransition () <MDMTransitionWithPresentation, MDMTransitionWithFallback>
+@end
+
+@implementation MDCMaskedTransition {
+  UIView *_sourceView;
+  MDCMaskedPresentationController *_presentationController;
+  BOOL _shouldSlideWhenCollapsed;
+}
+
+- (instancetype)initWithSourceView:(UIView *)sourceView {
+  self = [super init];
+  if (self) {
+    _sourceView = sourceView;
+  }
+  return self;
+}
+
+- (id<MDMTransition>)fallbackTransitionWithContext:(id<MDMTransitionContext>)context {
+  return _shouldSlideWhenCollapsed ? nil : self;
+}
+
+#pragma mark - MDMTransitionWithPresentation
+
+- (UIModalPresentationStyle)defaultModalPresentationStyle {
+  return UIModalPresentationCustom;
+}
+
+- (UIPresentationController *)presentationControllerForPresentedViewController:(UIViewController *)presented
+                                                      presentingViewController:(UIViewController *)presenting
+                                                          sourceViewController:(UIViewController *)source {
+  _presentationController =
+      [[MDCMaskedPresentationController alloc] initWithPresentedViewController:presented
+                                                      presentingViewController:presenting
+                                                 calculateFrameOfPresentedView:_calculateFrameOfPresentedView];
+  return _presentationController;
+}
+
+- (void)startWithContext:(NSObject<MDMTransitionContext> *)context {
+  MDCMaskedTransitionMotionSpec spec = motionForContext(context);
+  if (context.direction == MDMTransitionDirectionForward) {
+    _shouldSlideWhenCollapsed = spec.shouldSlideWhenCollapsed;
+  }
+
+  MDMMotionAnimator *animator = [[MDMMotionAnimator alloc] init];
+  animator.shouldReverseValues = context.direction == MDMTransitionDirectionBackward;
+
+  // # Caching original state
+
+  // We're going to reparent the fore view, so keep this information for later.
+  UIView *originalSuperview = context.foreViewController.view.superview;
+  const CGRect originalFrame = context.foreViewController.view.frame;
+  UIView *originalSourceSuperview = _sourceView.superview;
+  const CGRect originalSourceFrame = _sourceView.frame;
+  UIColor *originalSourceBackgroundColor = _sourceView.backgroundColor;
+
+  // # Scrim and presentation controller configuration
+
+  UIView *scrimView;
+  if (!_presentationController) {
+    scrimView = createScrimView(context);
+
+  } else {
+    scrimView = _presentationController.scrimView;
+  }
+
+  // The presentation controller, if available, will decide when to make the source view visible
+  // again.
+  _presentationController.sourceView = _sourceView;
+
+  // # Reparent the fore view into a masked view
+
+  UIView *maskedView = [[UIView alloc] initWithFrame:context.foreViewController.view.frame];
+  {
+    CGRect reparentedFrame = context.foreViewController.view.frame;
+    reparentedFrame.origin = CGPointZero;
+    context.foreViewController.view.frame = reparentedFrame;
+
+    maskedView.layer.cornerRadius = context.foreViewController.view.layer.cornerRadius;
+    maskedView.clipsToBounds = context.foreViewController.view.clipsToBounds;
+  }
+  [context.containerView addSubview:maskedView];
+
+  // # Flood fill view
+
+  UIView *floodFillView = [[UIView alloc] initWithFrame:context.foreViewController.view.bounds];
+  floodFillView.backgroundColor = _sourceView.backgroundColor;
+
+  // TODO(featherless): Profile whether it's more performant to fade the flood fill out or to
+  // fade the fore view in (what we're currently doing).
+  [maskedView addSubview:floodFillView];
+  [maskedView addSubview:context.foreViewController.view];
+
+  // # Frame calculations
+
+  // All frames are assumed to be relative to the container view unless named otherwise.
+
+  const CGRect initialSourceFrame = [_sourceView convertRect:_sourceView.bounds
+                                                      toView:context.containerView];
+  const CGRect finalMaskedFrame = originalFrame;
+  CGRect initialMaskedFrame;
+  CGPoint corner;
+  const CGPoint initialSourceCenter = centerOfFrame(initialSourceFrame);
+  if (spec.isCentered) {
+    initialMaskedFrame = frameCenteredAround(initialSourceCenter, originalFrame.size);
+    // Bottom right
+    corner = CGPointMake(CGRectGetMaxX(initialMaskedFrame), CGRectGetMaxY(initialMaskedFrame));
+
+  } else {
+    initialMaskedFrame = CGRectMake(context.containerView.bounds.origin.x,
+                                    initialSourceFrame.origin.y - 20,
+                                    originalFrame.size.width,
+                                    originalFrame.size.height);
+    if (CGRectGetMidX(initialSourceFrame) < CGRectGetMidX(initialMaskedFrame)) {
+      // Middle-right
+      corner = CGPointMake(CGRectGetMaxX(initialMaskedFrame), CGRectGetMidY(initialMaskedFrame));
+    } else {
+      // Middle-left
+      corner = CGPointMake(CGRectGetMinX(initialMaskedFrame), CGRectGetMidY(initialMaskedFrame));
+    }
+  }
+
+  maskedView.frame = initialMaskedFrame;
+  const CGRect initialSourceFrameInMask = [maskedView convertRect:initialSourceFrame
+                                                         fromView:context.containerView];
+
+  // # Scale calculations
+
+  const CGFloat initialRadius = _sourceView.bounds.size.width / 2;
+  const CGFloat finalRadius = lengthOfVector(CGVectorMake(initialSourceCenter.x - corner.x,
+                                                          initialSourceCenter.y - corner.y));
+  const CGFloat finalScale = finalRadius / initialRadius;
+
+  // # Preparing the mask
+
+  CAShapeLayer *shapeLayer = [[CAShapeLayer alloc] init];
+  {
+    // Ensures that we transform from the center of the source view's frame.
+    shapeLayer.anchorPoint = anchorPointFromPosition(centerOfFrame(initialSourceFrameInMask),
+                                                     maskedView.layer.bounds);
+    shapeLayer.frame = maskedView.layer.bounds;
+    shapeLayer.path = [[UIBezierPath bezierPathWithOvalInRect:initialSourceFrameInMask] CGPath];
+  }
+  maskedView.layer.mask = shapeLayer;
+
+  _sourceView.frame = initialSourceFrameInMask;
+  _sourceView.backgroundColor = nil;
+  [maskedView addSubview:_sourceView];
+
+  // # Begin adding animations.
+
+  [CATransaction begin];
+  [CATransaction setCompletionBlock:^{
+    context.foreViewController.view.frame = originalFrame;
+    [originalSuperview addSubview:context.foreViewController.view];
+
+    _sourceView.frame = originalSourceFrame;
+    _sourceView.backgroundColor = originalSourceBackgroundColor;
+    [originalSourceSuperview addSubview:_sourceView];
+
+    [maskedView removeFromSuperview];
+
+    // No presentation controller means we need to undo any changes we made to the view hierarchy.
+    if (!_presentationController) {
+      [scrimView removeFromSuperview];
+    }
+
+    [context transitionDidEnd]; // Hand off back to UIKit
+  }];
+
+  MDCMaskedTransitionMotionTiming motion = (context.direction == MDMTransitionDirectionForward) ? spec.expansion : spec.collapse;
+
+  [animator animateWithTiming:motion.iconFade
+                      toLayer:_sourceView.layer
+                   withValues:@[ @1, @0 ]
+                      keyPath:@"opacity"];
+
+  [animator animateWithTiming:motion.contentFade
+                      toLayer:context.foreViewController.view.layer
+                   withValues:@[ @0, @1 ]
+                      keyPath:@"opacity"];
+
+  // TODO: Support shadow + elevation changes. May need companion transition for this?
+
+  // Color transformation
+  {
+    UIColor *initialColor = floodFillView.backgroundColor;
+    if (!initialColor) {
+      initialColor = [UIColor clearColor];
+    }
+    UIColor *finalColor = context.foreViewController.view.backgroundColor;
+    if (!finalColor) {
+      finalColor = [UIColor whiteColor];
+    }
+    [animator animateWithTiming:motion.floodBackgroundColor
+                        toLayer:floodFillView.layer
+                     withValues:@[ initialColor, finalColor ]
+                        keyPath:@"backgroundColor"];
+  }
+
+  // Mask transformation
+  {
+    void (^completion)() = nil;
+    if (context.direction == MDMTransitionDirectionForward) {
+      completion = ^{
+        // Upon completion of the animation we want all of the content to be visible, so we jump
+        // to a full bounds mask.
+        shapeLayer.transform = CATransform3DIdentity;
+        shapeLayer.path = [[UIBezierPath bezierPathWithRect:context.foreViewController.view.bounds]
+                           CGPath];
+      };
+    }
+    [animator animateWithTiming:motion.maskTransformation
+                        toLayer:shapeLayer
+                     withValues:@[ @1, @(finalScale) ]
+                        keyPath:@"transform.scale.xy"
+                     completion:completion];
+  }
+
+  [animator animateWithTiming:motion.horizontalMovement
+                      toLayer:maskedView.layer
+                   withValues:@[ @(CGRectGetMidX(initialMaskedFrame)),
+                                 @(CGRectGetMidX(finalMaskedFrame)) ]
+                      keyPath:@"position.x"];
+
+  [animator animateWithTiming:motion.verticalMovement
+                      toLayer:maskedView.layer
+                   withValues:@[ @(CGRectGetMidY(initialMaskedFrame)),
+                                 @(CGRectGetMidY(finalMaskedFrame)) ]
+                      keyPath:@"position.y"];
+
+  if (!_presentationController) {
+    [animator animateWithTiming:motion.scrimFade
+                        toLayer:scrimView.layer
+                     withValues:@[ @0, @1 ]
+                        keyPath:@"opacity"];
+  }
+
+  [CATransaction commit];
+}
+
+@end

--- a/components/MaskedTransition/src/MDCMaskedTransition.m
+++ b/components/MaskedTransition/src/MDCMaskedTransition.m
@@ -40,7 +40,7 @@ static inline CGRect FrameCenteredAround(CGPoint position, CGSize size) {
 }
 
 static inline CGFloat LengthOfVector(CGVector vector) {
-  return (CGFloat)sqrt(vector.dx * vector.dx + vector.dy * vector.dy);
+  return (CGFloat)hypot(vector.dx, vector.dy);
 }
 
 @interface MDCMaskedTransition () <MDMTransitionWithPresentation, MDMTransitionWithFallback>

--- a/components/MaskedTransition/src/MDCMaskedTransition.m
+++ b/components/MaskedTransition/src/MDCMaskedTransition.m
@@ -97,14 +97,6 @@ static inline CGFloat LengthOfVector(CGVector vector) {
   const CGRect originalSourceFrame = _sourceView.frame;
   UIColor *originalSourceBackgroundColor = _sourceView.backgroundColor;
 
-  UIView *scrimView;
-  if (!_presentationController) {
-    scrimView = CreateScrimView(context);
-
-  } else {
-    scrimView = _presentationController.scrimView;
-  }
-
   // The presentation controller, if available, will decide when to make the source view visible
   // again.
   _presentationController.sourceView = _sourceView;
@@ -189,11 +181,6 @@ static inline CGFloat LengthOfVector(CGVector vector) {
 
     [maskedView removeFromSuperview];
 
-    // No presentation controller means we need to undo any changes we made to the view hierarchy.
-    if (!_presentationController) {
-      [scrimView removeFromSuperview];
-    }
-
     [context transitionDidEnd]; // Hand off back to UIKit
   }];
 
@@ -255,13 +242,6 @@ static inline CGFloat LengthOfVector(CGVector vector) {
                    withValues:@[ @(CGRectGetMidY(initialMaskedFrame)),
                                  @(CGRectGetMidY(finalMaskedFrame)) ]
                       keyPath:@"position.y"];
-
-  if (!_presentationController) {
-    [animator animateWithTiming:motion.scrimFade
-                        toLayer:scrimView.layer
-                     withValues:@[ @0, @1 ]
-                        keyPath:@"opacity"];
-  }
 
   [CATransaction commit];
 }

--- a/components/MaskedTransition/src/MDCMaskedTransition.m
+++ b/components/MaskedTransition/src/MDCMaskedTransition.m
@@ -48,7 +48,6 @@ static inline CGFloat LengthOfVector(CGVector vector) {
 
 @implementation MDCMaskedTransition {
   UIView *_sourceView;
-  MDCMaskedPresentationController *_presentationController;
   BOOL _shouldSlideWhenCollapsed;
 }
 
@@ -73,11 +72,12 @@ static inline CGFloat LengthOfVector(CGVector vector) {
 - (UIPresentationController *)presentationControllerForPresentedViewController:(UIViewController *)presented
                                                       presentingViewController:(UIViewController *)presenting
                                                           sourceViewController:(UIViewController *)source {
-  _presentationController =
+  MDCMaskedPresentationController *presentationController =
       [[MDCMaskedPresentationController alloc] initWithPresentedViewController:presented
                                                       presentingViewController:presenting
                                                  calculateFrameOfPresentedView:_calculateFrameOfPresentedView];
-  return _presentationController;
+  presentationController.sourceView = _sourceView;
+  return presentationController;
 }
 
 - (void)startWithContext:(NSObject<MDMTransitionContext> *)context {
@@ -96,10 +96,6 @@ static inline CGFloat LengthOfVector(CGVector vector) {
   UIView *originalSourceSuperview = _sourceView.superview;
   const CGRect originalSourceFrame = _sourceView.frame;
   UIColor *originalSourceBackgroundColor = _sourceView.backgroundColor;
-
-  // The presentation controller, if available, will decide when to make the source view visible
-  // again.
-  _presentationController.sourceView = _sourceView;
 
   // Reparent the fore view into a masked view.
   UIView *maskedView = [[UIView alloc] initWithFrame:context.foreViewController.view.frame];

--- a/components/MaskedTransition/src/MDCMaskedTransition.m
+++ b/components/MaskedTransition/src/MDCMaskedTransition.m
@@ -29,7 +29,7 @@ static inline CGPoint CenterOfFrame(CGRect frame) {
 }
 
 static inline CGPoint AnchorPointFromPosition(CGPoint position, CGRect bounds) {
-  return CGPointMake(position.x / bounds.size.width, position.y / bounds.size.height);
+  return CGPointMake(position.x / CGRectGetWidth(bounds), position.y / CGRectGetHeight(bounds));
 }
 
 static inline CGRect FrameCenteredAround(CGPoint position, CGSize size) {
@@ -134,10 +134,10 @@ static inline CGFloat LengthOfVector(CGVector vector) {
     corner = CGPointMake(CGRectGetMaxX(initialMaskedFrame), CGRectGetMaxY(initialMaskedFrame));
 
   } else {
-    initialMaskedFrame = CGRectMake(context.containerView.bounds.origin.x,
-                                    initialSourceFrame.origin.y - 20,
-                                    originalFrame.size.width,
-                                    originalFrame.size.height);
+    initialMaskedFrame = CGRectMake(CGRectGetMinX(context.containerView.bounds),
+                                    CGRectGetMinY(initialSourceFrame) - 20,
+                                    CGRectGetWidth(originalFrame),
+                                    CGRectGetHeight(originalFrame));
     if (CGRectGetMidX(initialSourceFrame) < CGRectGetMidX(initialMaskedFrame)) {
       // Middle-right
       corner = CGPointMake(CGRectGetMaxX(initialMaskedFrame), CGRectGetMidY(initialMaskedFrame));
@@ -151,7 +151,7 @@ static inline CGFloat LengthOfVector(CGVector vector) {
   const CGRect initialSourceFrameInMask = [maskedView convertRect:initialSourceFrame
                                                          fromView:context.containerView];
 
-  const CGFloat initialRadius = _sourceView.bounds.size.width / 2;
+  const CGFloat initialRadius = CGRectGetWidth(_sourceView.bounds) / 2;
   const CGFloat finalRadius = LengthOfVector(CGVectorMake(initialSourceCenter.x - corner.x,
                                                           initialSourceCenter.y - corner.y));
   const CGFloat finalScale = finalRadius / initialRadius;

--- a/components/MaskedTransition/src/MaterialMaskedTransition.h
+++ b/components/MaskedTransition/src/MaterialMaskedTransition.h
@@ -1,0 +1,17 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCMaskedTransition.h"

--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.h
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.h
@@ -18,7 +18,7 @@
 
 @protocol MDMTransitionContext;
 
-FOUNDATION_EXPORT UIView *createScrimView(id<MDMTransitionContext> context);
+FOUNDATION_EXPORT UIView *CreateScrimView(id<MDMTransitionContext> context);
 
 @interface MDCMaskedPresentationController : UIPresentationController
 

--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.h
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.h
@@ -1,0 +1,37 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+@protocol MDMTransitionContext;
+
+FOUNDATION_EXPORT UIView *createScrimView(id<MDMTransitionContext> context);
+
+@interface MDCMaskedPresentationController : UIPresentationController
+
+- (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController
+                       presentingViewController:(UIViewController *)presentingViewController
+                  calculateFrameOfPresentedView:(CGRect (^)(UIPresentationController *))calculateFrameOfPresentedView
+NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController
+                       presentingViewController:(UIViewController *)presentingViewController
+NS_UNAVAILABLE;
+
+@property(nonatomic, strong) UIView *sourceView;
+@property(nonatomic, strong) UIView *scrimView;
+
+@end

--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.h
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.h
@@ -18,8 +18,6 @@
 
 @protocol MDMTransitionContext;
 
-FOUNDATION_EXPORT UIView *CreateScrimView(id<MDMTransitionContext> context);
-
 @interface MDCMaskedPresentationController : UIPresentationController
 
 - (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController

--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
@@ -21,7 +21,7 @@
 
 #import "MDCMaskedTransitionMotionForContext.h"
 
-UIView *createScrimView(id<MDMTransitionContext> context) {
+UIView *CreateScrimView(id<MDMTransitionContext> context) {
   UIView *scrimView = [[UIView alloc] initWithFrame:context.containerView.bounds];
   scrimView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.3];
   [context.containerView addSubview:scrimView];
@@ -92,7 +92,7 @@ UIView *createScrimView(id<MDMTransitionContext> context) {
   MDCMaskedTransitionMotionTiming motion = (context.direction == MDMTransitionDirectionForward) ? spec.expansion : spec.collapse;
 
   if (!self.scrimView) {
-    self.scrimView = createScrimView(context);
+    self.scrimView = CreateScrimView(context);
   }
 
   [animator animateWithTiming:motion.scrimFade

--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
@@ -41,7 +41,7 @@ UIView *CreateScrimView(id<MDMTransitionContext> context) {
   self = [super initWithPresentedViewController:presentedViewController
                        presentingViewController:presentingViewController];
   if (self) {
-    _calculateFrameOfPresentedView = calculateFrameOfPresentedView;
+    _calculateFrameOfPresentedView = [calculateFrameOfPresentedView copy];
   }
   return self;
 }

--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
@@ -1,0 +1,104 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCMaskedPresentationController.h"
+
+#import <Transitioning/Transitioning.h>
+#import <MotionAnimator/MotionAnimator.h>
+
+#import "MDCMaskedTransitionMotionForContext.h"
+
+UIView *createScrimView(id<MDMTransitionContext> context) {
+  UIView *scrimView = [[UIView alloc] initWithFrame:context.containerView.bounds];
+  scrimView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.3];
+  [context.containerView addSubview:scrimView];
+  return scrimView;
+}
+
+@interface MDCMaskedPresentationController () <MDMTransition>
+@end
+
+@implementation MDCMaskedPresentationController {
+  CGRect (^_calculateFrameOfPresentedView)(UIPresentationController *);
+}
+
+- (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController
+                       presentingViewController:(UIViewController *)presentingViewController
+                  calculateFrameOfPresentedView:(CGRect (^)(UIPresentationController *))calculateFrameOfPresentedView {
+  self = [super initWithPresentedViewController:presentedViewController
+                       presentingViewController:presentingViewController];
+  if (self) {
+    _calculateFrameOfPresentedView = calculateFrameOfPresentedView;
+  }
+  return self;
+}
+
+- (CGRect)frameOfPresentedViewInContainerView {
+  if (_calculateFrameOfPresentedView) {
+    return _calculateFrameOfPresentedView(self);
+  } else {
+    return self.containerView.bounds;
+  }
+}
+
+- (BOOL)shouldRemovePresentersView {
+  BOOL definitelyFullscreen = _calculateFrameOfPresentedView == nil;
+  return definitelyFullscreen;
+}
+
+- (void)dismissalTransitionWillBegin {
+  if (!self.presentedViewController.mdm_transitionController.activeTransition) {
+    [self.presentedViewController.transitionCoordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+      self.scrimView.alpha = 0;
+    } completion:nil];
+
+    self.sourceView.alpha = 1;
+  }
+}
+
+- (void)dismissalTransitionDidEnd:(BOOL)completed {
+  if (completed) {
+    [self.scrimView removeFromSuperview];
+    self.scrimView = nil;
+
+    self.sourceView.alpha = 1;
+    self.sourceView = nil;
+
+  } else {
+    self.scrimView.alpha = 1;
+    self.sourceView.alpha = 0;
+  }
+}
+
+- (void)startWithContext:(NSObject<MDMTransitionContext> *)context {
+  MDCMaskedTransitionMotionSpec spec = motionForContext(context);
+
+  MDMMotionAnimator *animator = [[MDMMotionAnimator alloc] init];
+  animator.shouldReverseValues = context.direction == MDMTransitionDirectionBackward;
+
+  MDCMaskedTransitionMotionTiming motion = (context.direction == MDMTransitionDirectionForward) ? spec.expansion : spec.collapse;
+
+  if (!self.scrimView) {
+    self.scrimView = createScrimView(context);
+  }
+
+  [animator animateWithTiming:motion.scrimFade
+                      toLayer:self.scrimView.layer
+                   withValues:@[ @0, @1 ]
+                      keyPath:@"opacity"];
+}
+
+@end

--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
@@ -21,13 +21,6 @@
 
 #import "MDCMaskedTransitionMotionForContext.h"
 
-UIView *CreateScrimView(id<MDMTransitionContext> context) {
-  UIView *scrimView = [[UIView alloc] initWithFrame:context.containerView.bounds];
-  scrimView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.3];
-  [context.containerView addSubview:scrimView];
-  return scrimView;
-}
-
 @interface MDCMaskedPresentationController () <MDMTransition>
 @end
 
@@ -55,7 +48,14 @@ UIView *CreateScrimView(id<MDMTransitionContext> context) {
 }
 
 - (BOOL)shouldRemovePresentersView {
+  // We don't have access to the container view when this method is called, so we can only guess as
+  // to whether we'll be presenting full screen by checking for the presence of a frame calculation
+  // block.
   BOOL definitelyFullscreen = _calculateFrameOfPresentedView == nil;
+
+  // Returning true here will cause UIKit to invoke viewWillDisappear and viewDidDisappear on the
+  // presenting view controller, and the presenting view controller's view will be removed on
+  // completion of the transition.
   return definitelyFullscreen;
 }
 
@@ -92,7 +92,9 @@ UIView *CreateScrimView(id<MDMTransitionContext> context) {
   MDCMaskedTransitionMotionTiming motion = (context.direction == MDMTransitionDirectionForward) ? spec.expansion : spec.collapse;
 
   if (!self.scrimView) {
-    self.scrimView = CreateScrimView(context);
+    self.scrimView = [[UIView alloc] initWithFrame:context.containerView.bounds];
+    self.scrimView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.3];
+    [context.containerView addSubview:self.scrimView];
   }
 
   [animator animateWithTiming:motion.scrimFade

--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
@@ -16,7 +16,7 @@
 
 #import "MDCMaskedPresentationController.h"
 
-#import <Transitioning/Transitioning.h>
+#import <MotionTransitioning/MotionTransitioning.h>
 #import <MotionAnimator/MotionAnimator.h>
 
 #import "MDCMaskedTransitionMotionForContext.h"
@@ -93,6 +93,8 @@
 
   if (!self.scrimView) {
     self.scrimView = [[UIView alloc] initWithFrame:context.containerView.bounds];
+    self.scrimView.autoresizingMask = (UIViewAutoresizingFlexibleWidth
+                                       | UIViewAutoresizingFlexibleHeight);
     self.scrimView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.3];
     [context.containerView addSubview:self.scrimView];
   }

--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
@@ -95,7 +95,7 @@
     self.scrimView = [[UIView alloc] initWithFrame:context.containerView.bounds];
     self.scrimView.autoresizingMask = (UIViewAutoresizingFlexibleWidth
                                        | UIViewAutoresizingFlexibleHeight);
-    self.scrimView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.3];
+    self.scrimView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.3f];
     [context.containerView addSubview:self.scrimView];
   }
 

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.h
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.h
@@ -1,0 +1,22 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Transitioning/Transitioning.h>
+
+#import "MDCMaskedTransitionMotionSpec.h"
+
+FOUNDATION_EXPORT MDCMaskedTransitionMotionSpec motionForContext(NSObject<MDMTransitionContext> *context);

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.h
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.h
@@ -15,7 +15,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <Transitioning/Transitioning.h>
+#import <MotionTransitioning/MotionTransitioning.h>
 
 #import "MDCMaskedTransitionMotionSpec.h"
 

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.m
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.m
@@ -1,0 +1,42 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCMaskedTransitionMotionForContext.h"
+
+MDCMaskedTransitionMotionSpec motionForContext(NSObject<MDMTransitionContext> *context) {
+  const CGRect foreBounds = context.foreViewController.view.bounds;
+  const CGRect foreFrame = context.foreViewController.view.frame;
+  const CGRect containerBounds = context.containerView.bounds;
+
+  if (CGRectEqualToRect(context.foreViewController.view.frame, containerBounds)) {
+    return fullscreen;
+
+  } else if (foreBounds.size.width == containerBounds.size.width
+             && CGRectGetMaxY(foreFrame) == CGRectGetMaxY(containerBounds)) {
+    if (foreFrame.size.height > 100) {
+      return bottomSheet;
+
+    } else {
+      return toolbar;
+    }
+
+  } else if (foreBounds.size.width < containerBounds.size.width
+             && CGRectGetMidY(foreFrame) >= CGRectGetMidY(containerBounds)) {
+    return bottomCard;
+  }
+
+  return fullscreen;
+}

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.m
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.m
@@ -33,8 +33,7 @@ MDCMaskedTransitionMotionSpec motionForContext(NSObject<MDMTransitionContext> *c
       return toolbar;
     }
 
-  } else if (foreBounds.size.width < containerBounds.size.width
-             && CGRectGetMidY(foreFrame) >= CGRectGetMidY(containerBounds)) {
+  } else if (foreBounds.size.width < containerBounds.size.width) {
     return bottomCard;
   }
 

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionSpec.h
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionSpec.h
@@ -1,0 +1,42 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <MotionInterchange/MotionInterchange.h>
+
+struct MDCMaskedTransitionMotionTiming {
+  MDMMotionTiming iconFade;
+  MDMMotionTiming contentFade;
+  MDMMotionTiming floodBackgroundColor;
+  MDMMotionTiming maskTransformation;
+  MDMMotionTiming horizontalMovement;
+  MDMMotionTiming verticalMovement;
+  MDMMotionTiming scrimFade;
+};
+typedef struct MDCMaskedTransitionMotionTiming MDCMaskedTransitionMotionTiming;
+
+struct MDCMaskedTransitionMotionSpec {
+  MDCMaskedTransitionMotionTiming expansion;
+  MDCMaskedTransitionMotionTiming collapse;
+  BOOL shouldSlideWhenCollapsed;
+  BOOL isCentered;
+};
+typedef struct MDCMaskedTransitionMotionSpec MDCMaskedTransitionMotionSpec;
+
+FOUNDATION_EXPORT struct MDCMaskedTransitionMotionSpec fullscreen;
+FOUNDATION_EXPORT struct MDCMaskedTransitionMotionSpec bottomSheet;
+FOUNDATION_EXPORT struct MDCMaskedTransitionMotionSpec bottomCard;
+FOUNDATION_EXPORT struct MDCMaskedTransitionMotionSpec toolbar;

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionSpec.m
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionSpec.m
@@ -1,0 +1,175 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCMaskedTransitionMotionSpec.h"
+
+#define MDMEightyForty _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f)
+#define MDMFortyOut _MDMBezier(0.4f, 0.0f, 1.0f, 1.0f)
+#define MDMEightyIn _MDMBezier(0.0f, 0.0f, 0.2f, 1.0f)
+
+struct MDCMaskedTransitionMotionSpec fullscreen = {
+  .expansion = {
+    .iconFade = {
+      .delay = 0.000, .duration = 0.075, .curve = MDMEightyForty,
+    },
+    .contentFade = {
+      .delay = 0.150, .duration = 0.225, .curve = MDMEightyForty,
+    },
+    .floodBackgroundColor = {
+      .delay = 0.000, .duration = 0.075, .curve = MDMEightyForty,
+    },
+    .maskTransformation = {
+      .delay = 0.000, .duration = 0.105, .curve = MDMFortyOut,
+    },
+    .horizontalMovement = {.curve = { .type = MDMMotionCurveTypeInstant }},
+    .verticalMovement = {
+      .delay = 0.045, .duration = 0.330, .curve = MDMEightyForty,
+    },
+    .scrimFade = {
+      .delay = 0.000, .duration = 0.150, .curve = MDMEightyForty,
+    }
+  },
+  .shouldSlideWhenCollapsed = true,
+  .isCentered = false
+};
+
+struct MDCMaskedTransitionMotionSpec bottomSheet = {
+  .expansion = {
+    .iconFade = {
+      .delay = 0.000, .duration = 0.075, .curve = MDMEightyForty, // No spec
+    },
+    .contentFade = { // No spec for this
+      .delay = 0.100, .duration = 0.200, .curve = MDMEightyForty,
+    },
+    .floodBackgroundColor = {
+      .delay = 0.000, .duration = 0.075, .curve = MDMEightyForty,
+    },
+    .maskTransformation = {
+      .delay = 0.000, .duration = 0.105, .curve = MDMFortyOut,
+    },
+    .horizontalMovement = {.curve = { .type = MDMMotionCurveTypeInstant }},
+    .verticalMovement = {
+      .delay = 0.045, .duration = 0.330, .curve = MDMEightyForty,
+    },
+    .scrimFade = {
+      .delay = 0.000, .duration = 0.150, .curve = MDMEightyForty,
+    }
+  },
+  .shouldSlideWhenCollapsed = true,
+  .isCentered = false
+};
+
+struct MDCMaskedTransitionMotionSpec bottomCard = {
+  .expansion = {
+    .iconFade = {
+      .delay = 0.000, .duration = 0.120, .curve = MDMEightyForty,
+    },
+    .contentFade = {
+      .delay = 0.150, .duration = 0.150, .curve = MDMEightyForty,
+    },
+    .floodBackgroundColor = {
+      .delay = 0.075, .duration = 0.075, .curve = MDMEightyForty,
+    },
+    .maskTransformation = {
+      .delay = 0.045, .duration = 0.225, .curve = MDMFortyOut,
+    },
+    .horizontalMovement = {
+      .delay = 0.000, .duration = 0.150, .curve = MDMEightyForty,
+    },
+    .verticalMovement = {
+      .delay = 0.000, .duration = 0.345, .curve = MDMEightyForty,
+    },
+    .scrimFade = {
+      .delay = 0.075, .duration = 0.150, .curve = MDMEightyForty,
+    }
+  },
+  .collapse = {
+    .iconFade = {
+      .delay = 0.150, .duration = 0.150, .curve = MDMEightyForty,
+    },
+    .contentFade = {
+      .delay = 0.000, .duration = 0.075, .curve = MDMFortyOut,
+    },
+    .floodBackgroundColor = {
+      .delay = 0.060, .duration = 0.150, .curve = MDMEightyForty,
+    },
+    .maskTransformation = {
+      .delay = 0.000, .duration = 0.180, .curve = MDMEightyIn,
+    },
+    .horizontalMovement = {
+      .delay = 0.045, .duration = 0.255, .curve = MDMEightyForty,
+    },
+    .verticalMovement = {
+      .delay = 0.000, .duration = 0.255, .curve = MDMEightyForty,
+    },
+    .scrimFade = {
+      .delay = 0.000, .duration = 0.150, .curve = MDMEightyForty,
+    }
+  },
+  .shouldSlideWhenCollapsed = false,
+  .isCentered = true
+};
+
+struct MDCMaskedTransitionMotionSpec toolbar = {
+  .expansion = {
+    .iconFade = {
+      .delay = 0.000, .duration = 0.120, .curve = MDMEightyForty,
+    },
+    .contentFade = {
+      .delay = 0.150, .duration = 0.150, .curve = MDMEightyForty,
+    },
+    .floodBackgroundColor = {
+      .delay = 0.075, .duration = 0.075, .curve = MDMEightyForty,
+    },
+    .maskTransformation = {
+      .delay = 0.045, .duration = 0.225, .curve = MDMFortyOut,
+    },
+    .horizontalMovement = {
+      .delay = 0.000, .duration = 0.300, .curve = MDMEightyForty,
+    },
+    .verticalMovement = {
+      .delay = 0.000, .duration = 0.120, .curve = MDMEightyForty,
+    },
+    .scrimFade = {
+      .delay = 0.075, .duration = 0.150, .curve = MDMEightyForty,
+    }
+  },
+  .collapse = {
+    .iconFade = {
+      .delay = 0.150, .duration = 0.150, .curve = MDMEightyForty,
+    },
+    .contentFade = {
+      .delay = 0.000, .duration = 0.075, .curve = MDMFortyOut,
+    },
+    .floodBackgroundColor = {
+      .delay = 0.060, .duration = 0.150, .curve = MDMEightyForty,
+    },
+    .maskTransformation = {
+      .delay = 0.000, .duration = 0.180, .curve = MDMEightyIn,
+    },
+    .horizontalMovement = {
+      .delay = 0.105, .duration = 0.195, .curve = MDMEightyForty,
+    },
+    .verticalMovement = {
+      .delay = 0.000, .duration = 0.255, .curve = MDMEightyForty,
+    },
+    .scrimFade = {
+      .delay = 0.000, .duration = 0.150, .curve = MDMEightyForty,
+    }
+  },
+  .shouldSlideWhenCollapsed = false,
+  .isCentered = true
+};

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionSpec.m
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionSpec.m
@@ -16,30 +16,30 @@
 
 #import "MDCMaskedTransitionMotionSpec.h"
 
-#define MDMEightyForty _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f)
-#define MDMFortyOut _MDMBezier(0.4f, 0.0f, 1.0f, 1.0f)
-#define MDMEightyIn _MDMBezier(0.0f, 0.0f, 0.2f, 1.0f)
+#define EaseInEaseOut _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f)
+#define EaseIn _MDMBezier(0.4f, 0.0f, 1.0f, 1.0f)
+#define EaseOut _MDMBezier(0.0f, 0.0f, 0.2f, 1.0f)
 
 struct MDCMaskedTransitionMotionSpec fullscreen = {
   .expansion = {
     .iconFade = {
-      .delay = 0.000, .duration = 0.075, .curve = MDMEightyForty,
+      .delay = 0.000, .duration = 0.075, .curve = EaseInEaseOut,
     },
     .contentFade = {
-      .delay = 0.150, .duration = 0.225, .curve = MDMEightyForty,
+      .delay = 0.150, .duration = 0.225, .curve = EaseInEaseOut,
     },
     .floodBackgroundColor = {
-      .delay = 0.000, .duration = 0.075, .curve = MDMEightyForty,
+      .delay = 0.000, .duration = 0.075, .curve = EaseInEaseOut,
     },
     .maskTransformation = {
-      .delay = 0.000, .duration = 0.105, .curve = MDMFortyOut,
+      .delay = 0.000, .duration = 0.105, .curve = EaseIn,
     },
     .horizontalMovement = {.curve = { .type = MDMMotionCurveTypeInstant }},
     .verticalMovement = {
-      .delay = 0.045, .duration = 0.330, .curve = MDMEightyForty,
+      .delay = 0.045, .duration = 0.330, .curve = EaseInEaseOut,
     },
     .scrimFade = {
-      .delay = 0.000, .duration = 0.150, .curve = MDMEightyForty,
+      .delay = 0.000, .duration = 0.150, .curve = EaseInEaseOut,
     }
   },
   .shouldSlideWhenCollapsed = true,
@@ -49,23 +49,23 @@ struct MDCMaskedTransitionMotionSpec fullscreen = {
 struct MDCMaskedTransitionMotionSpec bottomSheet = {
   .expansion = {
     .iconFade = {
-      .delay = 0.000, .duration = 0.075, .curve = MDMEightyForty, // No spec
+      .delay = 0.000, .duration = 0.075, .curve = EaseInEaseOut, // No spec
     },
     .contentFade = { // No spec for this
-      .delay = 0.100, .duration = 0.200, .curve = MDMEightyForty,
+      .delay = 0.100, .duration = 0.200, .curve = EaseInEaseOut,
     },
     .floodBackgroundColor = {
-      .delay = 0.000, .duration = 0.075, .curve = MDMEightyForty,
+      .delay = 0.000, .duration = 0.075, .curve = EaseInEaseOut,
     },
     .maskTransformation = {
-      .delay = 0.000, .duration = 0.105, .curve = MDMFortyOut,
+      .delay = 0.000, .duration = 0.105, .curve = EaseIn,
     },
     .horizontalMovement = {.curve = { .type = MDMMotionCurveTypeInstant }},
     .verticalMovement = {
-      .delay = 0.045, .duration = 0.330, .curve = MDMEightyForty,
+      .delay = 0.045, .duration = 0.330, .curve = EaseInEaseOut,
     },
     .scrimFade = {
-      .delay = 0.000, .duration = 0.150, .curve = MDMEightyForty,
+      .delay = 0.000, .duration = 0.150, .curve = EaseInEaseOut,
     }
   },
   .shouldSlideWhenCollapsed = true,
@@ -75,48 +75,48 @@ struct MDCMaskedTransitionMotionSpec bottomSheet = {
 struct MDCMaskedTransitionMotionSpec bottomCard = {
   .expansion = {
     .iconFade = {
-      .delay = 0.000, .duration = 0.120, .curve = MDMEightyForty,
+      .delay = 0.000, .duration = 0.120, .curve = EaseInEaseOut,
     },
     .contentFade = {
-      .delay = 0.150, .duration = 0.150, .curve = MDMEightyForty,
+      .delay = 0.150, .duration = 0.150, .curve = EaseInEaseOut,
     },
     .floodBackgroundColor = {
-      .delay = 0.075, .duration = 0.075, .curve = MDMEightyForty,
+      .delay = 0.075, .duration = 0.075, .curve = EaseInEaseOut,
     },
     .maskTransformation = {
-      .delay = 0.045, .duration = 0.225, .curve = MDMFortyOut,
+      .delay = 0.045, .duration = 0.225, .curve = EaseIn,
     },
     .horizontalMovement = {
-      .delay = 0.000, .duration = 0.150, .curve = MDMEightyForty,
+      .delay = 0.000, .duration = 0.150, .curve = EaseInEaseOut,
     },
     .verticalMovement = {
-      .delay = 0.000, .duration = 0.345, .curve = MDMEightyForty,
+      .delay = 0.000, .duration = 0.345, .curve = EaseInEaseOut,
     },
     .scrimFade = {
-      .delay = 0.075, .duration = 0.150, .curve = MDMEightyForty,
+      .delay = 0.075, .duration = 0.150, .curve = EaseInEaseOut,
     }
   },
   .collapse = {
     .iconFade = {
-      .delay = 0.150, .duration = 0.150, .curve = MDMEightyForty,
+      .delay = 0.150, .duration = 0.150, .curve = EaseInEaseOut,
     },
     .contentFade = {
-      .delay = 0.000, .duration = 0.075, .curve = MDMFortyOut,
+      .delay = 0.000, .duration = 0.075, .curve = EaseIn,
     },
     .floodBackgroundColor = {
-      .delay = 0.060, .duration = 0.150, .curve = MDMEightyForty,
+      .delay = 0.060, .duration = 0.150, .curve = EaseInEaseOut,
     },
     .maskTransformation = {
-      .delay = 0.000, .duration = 0.180, .curve = MDMEightyIn,
+      .delay = 0.000, .duration = 0.180, .curve = EaseOut,
     },
     .horizontalMovement = {
-      .delay = 0.045, .duration = 0.255, .curve = MDMEightyForty,
+      .delay = 0.045, .duration = 0.255, .curve = EaseInEaseOut,
     },
     .verticalMovement = {
-      .delay = 0.000, .duration = 0.255, .curve = MDMEightyForty,
+      .delay = 0.000, .duration = 0.255, .curve = EaseInEaseOut,
     },
     .scrimFade = {
-      .delay = 0.000, .duration = 0.150, .curve = MDMEightyForty,
+      .delay = 0.000, .duration = 0.150, .curve = EaseInEaseOut,
     }
   },
   .shouldSlideWhenCollapsed = false,
@@ -126,48 +126,48 @@ struct MDCMaskedTransitionMotionSpec bottomCard = {
 struct MDCMaskedTransitionMotionSpec toolbar = {
   .expansion = {
     .iconFade = {
-      .delay = 0.000, .duration = 0.120, .curve = MDMEightyForty,
+      .delay = 0.000, .duration = 0.120, .curve = EaseInEaseOut,
     },
     .contentFade = {
-      .delay = 0.150, .duration = 0.150, .curve = MDMEightyForty,
+      .delay = 0.150, .duration = 0.150, .curve = EaseInEaseOut,
     },
     .floodBackgroundColor = {
-      .delay = 0.075, .duration = 0.075, .curve = MDMEightyForty,
+      .delay = 0.075, .duration = 0.075, .curve = EaseInEaseOut,
     },
     .maskTransformation = {
-      .delay = 0.045, .duration = 0.225, .curve = MDMFortyOut,
+      .delay = 0.045, .duration = 0.225, .curve = EaseIn,
     },
     .horizontalMovement = {
-      .delay = 0.000, .duration = 0.300, .curve = MDMEightyForty,
+      .delay = 0.000, .duration = 0.300, .curve = EaseInEaseOut,
     },
     .verticalMovement = {
-      .delay = 0.000, .duration = 0.120, .curve = MDMEightyForty,
+      .delay = 0.000, .duration = 0.120, .curve = EaseInEaseOut,
     },
     .scrimFade = {
-      .delay = 0.075, .duration = 0.150, .curve = MDMEightyForty,
+      .delay = 0.075, .duration = 0.150, .curve = EaseInEaseOut,
     }
   },
   .collapse = {
     .iconFade = {
-      .delay = 0.150, .duration = 0.150, .curve = MDMEightyForty,
+      .delay = 0.150, .duration = 0.150, .curve = EaseInEaseOut,
     },
     .contentFade = {
-      .delay = 0.000, .duration = 0.075, .curve = MDMFortyOut,
+      .delay = 0.000, .duration = 0.075, .curve = EaseIn,
     },
     .floodBackgroundColor = {
-      .delay = 0.060, .duration = 0.150, .curve = MDMEightyForty,
+      .delay = 0.060, .duration = 0.150, .curve = EaseInEaseOut,
     },
     .maskTransformation = {
-      .delay = 0.000, .duration = 0.180, .curve = MDMEightyIn,
+      .delay = 0.000, .duration = 0.180, .curve = EaseOut,
     },
     .horizontalMovement = {
-      .delay = 0.105, .duration = 0.195, .curve = MDMEightyForty,
+      .delay = 0.105, .duration = 0.195, .curve = EaseInEaseOut,
     },
     .verticalMovement = {
-      .delay = 0.000, .duration = 0.255, .curve = MDMEightyForty,
+      .delay = 0.000, .duration = 0.255, .curve = EaseInEaseOut,
     },
     .scrimFade = {
-      .delay = 0.000, .duration = 0.150, .curve = MDMEightyForty,
+      .delay = 0.000, .duration = 0.150, .curve = EaseInEaseOut,
     }
   },
   .shouldSlideWhenCollapsed = false,


### PR DESCRIPTION
This component makes it possible to present a view controller from a source view, such as a floating action button, using a masked reveal transition.

This component depends on Material Motion's [Transitioning](https://github.com/material-motion/transitioning-objc), [MotionInterchange](https://github.com/material-motion/motion-interchange-objc), and [MotionAnimator](https://github.com/material-motion/motion-animator-objc) libraries.

The component itself is a Transition instance and can be used like this:

    vc.transitionController.transition = MDCMaskedTransition(sourceView: fab)
    present(vc, animated: true)

The component's motion is defined in its motion spec and was extracted directly from the Material motion spec.

The transition supports the following contexts:

- Fullscreen
- Bottom sheet
- Floating card
- Bottom toolbar