### PR TITLE
[ActivityIndicator] Default cycleColors property for empty arrays #1508

### DIFF
--- a/components/ActivityIndicator/src/MDCActivityIndicator.h
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.h
@@ -97,8 +97,8 @@ IB_DESIGNABLE
 
 /**
  The array of colors that are cycled through when animating the spinner. Populated with default
- colors of blue, red, yellow and green on initialization. An empty array results in a blue spinner
- with no color cycling.
+ colors of blue, red, yellow and green on initialization. Passing an empty array will cause the
+ default values to be returned.
  */
 @property(nonatomic, copy, nonnull) NSArray<UIColor *> *cycleColors UI_APPEARANCE_SELECTOR;
 

--- a/components/ActivityIndicator/src/MDCActivityIndicator.h
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.h
@@ -96,9 +96,11 @@ IB_DESIGNABLE
 @property(nonatomic, assign) IBInspectable float progress;
 
 /**
- The array of colors that are cycled through when animating the spinner. Populated with default
- colors of blue, red, yellow and green on initialization. Passing an empty array will cause the
- default values to be returned.
+ The array of colors that are cycled through when animating the spinner. Populated with a set of
+ default colors. 
+ 
+ @note If an empty array is provided to this property's setter, then the provided array will be 
+ discarded and an array consisting of the default color values will be assigned instead.
  */
 @property(nonatomic, copy, nonnull) NSArray<UIColor *> *cycleColors UI_APPEARANCE_SELECTOR;
 

--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -113,7 +113,10 @@ static const CGFloat kSingleCycleRotation =
 }
 
 + (void)initialize {
-  [MDCActivityIndicator appearance].cycleColors = [MDCActivityIndicator defaultCycleColors];
+  // Ensure we do not set the UIAppearance proxy if subclasses are initialized
+  if (self == [MDCActivityIndicator class]) {
+    [MDCActivityIndicator appearance].cycleColors = [MDCActivityIndicator defaultCycleColors];
+  }
 }
 
 - (void)dealloc {

--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -89,7 +89,6 @@ static const CGFloat kSingleCycleRotation =
   BOOL _cycleInProgress;
   CGFloat _currentProgress;
   CGFloat _lastProgress;
-  NSArray<UIColor *> *_cycleColors;
 }
 
 #pragma mark - Init
@@ -106,6 +105,8 @@ static const CGFloat kSingleCycleRotation =
   self = [super initWithCoder:coder];
   if (self) {
     [self commonMDCActivityIndicatorInit];
+    // TODO: Overwrite cycleColors if the value is present in the coder
+    // https://github.com/material-components/material-components-ios/issues/1530
   }
   return self;
 }
@@ -134,19 +135,6 @@ static const CGFloat kSingleCycleRotation =
   }];
 }
 
-+ (NSArray<UIColor *> *)defaultCycleColors {
-  static NSArray<UIColor *> *s_defaultCycleColors;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    s_defaultCycleColors =
-        @[ [[UIColor alloc] initWithRed:0.129f green:0.588f blue:0.953f alpha:1],
-           [[UIColor alloc] initWithRed:0.957f green:0.263f blue:0.212f alpha:1],
-           [[UIColor alloc] initWithRed:1.0f green:0.922f blue:0.231f alpha:1],
-           [[UIColor alloc] initWithRed:0.298f green:0.686f blue:0.314f alpha:1] ];
-  });
-  return s_defaultCycleColors;
-}
-
 - (void)commonMDCActivityIndicatorInit {
   // Register notifications for foreground and background if needed.
   [self registerForegroundAndBackgroundNotificationObserversIfNeeded];
@@ -164,6 +152,7 @@ static const CGFloat kSingleCycleRotation =
 
   // Colors.
   _currentColorCount = 0;
+  _cycleColors = [MDCActivityIndicator defaultCycleColors];
 
   // Track layer.
   _trackLayer = [CAShapeLayer layer];
@@ -395,36 +384,12 @@ static const CGFloat kSingleCycleRotation =
   if (cycleColors.count) {
     _cycleColors = [cycleColors copy];
   } else {
-    // Use NSNull to track "explicit" nil versus implicit nil (uninitialized value)
-    _cycleColors = (NSArray<UIColor *> *)[NSNull null];
+    _cycleColors = [MDCActivityIndicator defaultCycleColors];
   }
 
   if (self.cycleColors.count) {
     [self setStrokeColor:self.cycleColors[0]];
   }
-}
-
-/*
- The custom getter is needed for two main reasons:
-   - As a nonnull property proxied by UIAppearance, it can return nil before the ActivityIndicator 
-     is added to the view hierarchy. Setting the ivar would make it hard to distinguish between
-     the property being set externally versus the implicit default value.
-   - If the user explicitly sets the value with an empty array, we treat that as a special case of
-     reverting back to the default values. NSNull also makes it easier to distinguish between
-     implicit and explicit nil values during (de)serialization.
- */
-- (NSArray<UIColor *> *)cycleColors {
-  NSArray<UIColor *> *cycleColors = _cycleColors;
-  // Use NSNull to track "explicit" nil versus implicit nil (uninitialized value)
-  if (cycleColors == (NSArray<UIColor *> *)[NSNull null]) {
-    return [MDCActivityIndicator defaultCycleColors];
-  }
-  if (cycleColors) {
-    return cycleColors;
-  }
-
-  NSArray<UIColor *> *proxyColors = [MDCActivityIndicator appearance].cycleColors;
-  return proxyColors.count ? proxyColors : [MDCActivityIndicator defaultCycleColors];
 }
 
 - (void)updateStrokePath {
@@ -816,6 +781,19 @@ static const CGFloat kSingleCycleRotation =
 
 + (CGFloat)defaultHeight {
   return kSpinnerRadius * 2.f;
+}
+
++ (NSArray<UIColor *> *)defaultCycleColors {
+  static NSArray<UIColor *> *s_defaultCycleColors;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    s_defaultCycleColors =
+    @[ [[UIColor alloc] initWithRed:0.129f green:0.588f blue:0.953f alpha:1],
+       [[UIColor alloc] initWithRed:0.957f green:0.263f blue:0.212f alpha:1],
+       [[UIColor alloc] initWithRed:1.0f green:0.922f blue:0.231f alpha:1],
+       [[UIColor alloc] initWithRed:0.298f green:0.686f blue:0.314f alpha:1] ];
+  });
+  return s_defaultCycleColors;
 }
 
 - (void)applyPropertiesWithoutAnimation:(void (^)(void))setPropBlock {

--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -46,10 +46,11 @@ static const CGFloat kSingleCycleRotation =
 @property(nonatomic, assign, readonly) CGFloat minStrokeDifference;
 
 /**
- The current color count for the spinner. Subclasses can change this value to start the spinner at
- a different color.
+ The index of the current stroke color in the @c cycleColors array.
+
+ @note Subclasses can change this value to start the spinner at a different color.
  */
-@property(nonatomic, assign) NSUInteger currentColorCount;
+@property(nonatomic, assign) NSUInteger cycleColorsIndex;
 
 /**
  The current cycle count.
@@ -151,7 +152,7 @@ static const CGFloat kSingleCycleRotation =
   _strokeWidth = 2.0f;
 
   // Colors.
-  _currentColorCount = 0;
+  _cycleColorsIndex = 0;
   _cycleColors = [MDCActivityIndicator defaultCycleColors];
 
   // Track layer.
@@ -234,7 +235,7 @@ static const CGFloat kSingleCycleRotation =
 }
 
 - (void)resetStrokeColor {
-  _currentColorCount = 0;
+  _cycleColorsIndex = 0;
 
   [self updateStrokeColor];
 }
@@ -406,12 +407,10 @@ static const CGFloat kSingleCycleRotation =
 }
 
 - (void)updateStrokeColor {
-  NSArray<UIColor *> *cycleColors = self.cycleColors;
-  NSUInteger currentColorCount = _currentColorCount;
-  if (cycleColors.count > 0 && cycleColors.count > currentColorCount) {
-    [self setStrokeColor:cycleColors[currentColorCount]];
+  if (self.cycleColors.count > 0 && self.cycleColors.count > self.cycleColorsIndex) {
+    [self setStrokeColor:self.cycleColors[self.cycleColorsIndex]];
   } else {
-    NSAssert(NO, @"nonnull cycleColors property incorrectly returned nil.");
+    NSAssert(NO, @"cycleColorsIndex is outside the bounds of cycleColors.");
     [self setStrokeColor:[[MDCActivityIndicator defaultCycleColors] firstObject]];
   }
 }
@@ -693,9 +692,8 @@ static const CGFloat kSingleCycleRotation =
     return;
   }
   if (state == MDCActivityIndicatorStateIndeterminate) {
-    NSUInteger cycleColorsCount = self.cycleColors.count;
-    if (cycleColorsCount > 0) {
-      _currentColorCount = (_currentColorCount + 1) % cycleColorsCount;
+    if (self.cycleColors.count > 0) {
+      self.cycleColorsIndex = (self.cycleColorsIndex + 1) % self.cycleColors.count;
       [self updateStrokeColor];
     }
     _cycleCount = (_cycleCount + 1) % kMDCActivityIndicatorTotalDetentCount;

--- a/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.m
+++ b/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.m
@@ -71,7 +71,7 @@ static CGFloat randomNumber() {
 
   // Then
   XCTAssertGreaterThan(indicator.cycleColors.count, 0,
-                        @"The default value for |cycleCount| should be a non-empty array.");
+                        @"The default value for |cycleColors| should be a non-empty array.");
 }
 
 - (void)testSetCycleColorsEmptyReturnsDefault {
@@ -83,21 +83,8 @@ static CGFloat randomNumber() {
 
   // Then
   XCTAssertGreaterThan(indicator.cycleColors.count, 0,
-                        @"Assigning an empty array for |cycleCount| should result in a default"
+                        @"Assigning an empty array for |cycleColors| should result in a default"
                         " value being used instead.");
-}
-
-- (void)testSetAppearanceProxyCycleColorEmptyReturnsDefault {
-  // Given
-  MDCActivityIndicator *indicator = [[MDCActivityIndicator alloc] init];
-
-  // When
-  [MDCActivityIndicator appearance].cycleColors = @[];
-
-  // Then
-  XCTAssertGreaterThan(indicator.cycleColors.count, 0,
-                       @"Assigning an empty array for |cycleCount| to both the instance and the"
-                       " UIAppearance proxy should result in a default value being used instead.");
 }
 
 - (void)testSetCycleColorNonEmpty {

--- a/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.m
+++ b/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.m
@@ -65,4 +65,53 @@ static CGFloat randomNumber() {
   XCTAssertEqual(indicator.radius, random);
 }
 
+- (void)testDefaultColorCycle {
+  // Given
+  MDCActivityIndicator *indicator = [[MDCActivityIndicator alloc] init];
+
+  // Then
+  XCTAssertGreaterThan(indicator.cycleColors.count, 0,
+                        @"The default value for |cycleCount| should be a non-empty array.");
+}
+
+- (void)testSetCycleColorsEmptyReturnsDefault {
+  // Given
+  MDCActivityIndicator *indicator = [[MDCActivityIndicator alloc] init];
+
+  // When
+  indicator.cycleColors = @[];
+
+  // Then
+  XCTAssertGreaterThan(indicator.cycleColors.count, 0,
+                        @"Assigning an empty array for |cycleCount| should result in a default"
+                        " value being used instead.");
+}
+
+- (void)testSetAppearanceProxyCycleColorEmptyReturnsDefault {
+  // Given
+  MDCActivityIndicator *indicator = [[MDCActivityIndicator alloc] init];
+
+  // When
+  [MDCActivityIndicator appearance].cycleColors = @[];
+
+  // Then
+  XCTAssertGreaterThan(indicator.cycleColors.count, 0,
+                       @"Assigning an empty array for |cycleCount| to both the instance and the"
+                       " UIAppearance proxy should result in a default value being used instead.");
+}
+
+- (void)testSetCycleColorNonEmpty {
+  // Given
+  MDCActivityIndicator *indicator = [[MDCActivityIndicator alloc] init];
+  NSArray <UIColor *> *cycleColors = @[[UIColor redColor], [UIColor whiteColor]];
+
+  // When
+  indicator.cycleColors = cycleColors;
+
+  // Then
+  XCTAssertEqualObjects(indicator.cycleColors, cycleColors,
+                        @"With a non-empty array, the |cycleColors| property should override the"
+                        " default value.");
+}
+
 @end

--- a/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.swift
+++ b/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.swift
@@ -1,0 +1,40 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents
+
+class ActivityIndicatorTests: XCTestCase {
+
+  func testCycleColorDefaultValue() {
+    let indicator = MDCActivityIndicator()
+
+    XCTAssertGreaterThan(indicator.cycleColors.count, 0,
+                         "The default value for |cycleColors| should be a non-empty array.")
+
+  }
+
+  func testCycleColorEmptyArraySupport() {
+    let indicator = MDCActivityIndicator()
+
+    indicator.cycleColors = []
+
+    XCTAssertGreaterThan(indicator.cycleColors.count, 0,
+                         "Assigning an empty array for |cycleColors| should result in a default " +
+                         "value being used instead.")
+  }
+
+}


### PR DESCRIPTION
The `cycleColors` property currently handles empty array assignments by assigning an array with a
single blue color.  This change will modify that behavior to revert back to the original "default"
array.

* Adding unit tests to confirm the default behavior in different scenarios.
