### PR TITLE
[EarlGrey] Specified minimum version for EarlGrey

### DIFF
--- a/catalog/Podfile
+++ b/catalog/Podfile
@@ -40,7 +40,7 @@ target TEST_TARGET do
   platform :ios, '8.0'
   project PROJECT_NAME
   inherit! :search_paths
-  pod 'EarlGrey'
+  pod 'EarlGrey', '>= 1.9.3'
   pod 'MaterialComponentsEarlGreyTests', :path => '../'
 
   use_frameworks!


### PR DESCRIPTION
so that `pod install` will result in a buildable project

If we dont do this then `pod update` is required.