### PR TITLE
[Snackbar] Resuming messages when tokens are deallocated

### DIFF
--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -572,4 +572,8 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
   return self;
 }
 
+- (void)dealloc {
+  [MDCSnackbarManager resumeMessagesWithToken:self];
+}
+
 @end

--- a/components/Snackbar/tests/unit/SnackbarManagerSwiftTests.swift
+++ b/components/Snackbar/tests/unit/SnackbarManagerSwiftTests.swift
@@ -1,0 +1,43 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents
+
+class SnackbarManagerSwiftTests: XCTestCase {
+
+  func testMessagesResumedWhenTokenIsDeallocated() {
+    let expectation = self.expectation(description: "completion")
+
+    guard let suspendedMessage = MDCSnackbarMessage(text: "") else { XCTAssert(false); return }
+    suspendedMessage.duration = 0.05
+    suspendedMessage.completionHandler = { (userInitiated) -> Void  in
+      expectation.fulfill()
+    }
+
+    // Encourage the runtime to deallocate the token immediately
+    autoreleasepool {
+      var token = MDCSnackbarManager.suspendAllMessages()
+      MDCSnackbarManager.show(suspendedMessage)
+      token = nil
+      XCTAssertNil(token, "Ensuring that the compiler knows we're reading this variable")
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+}
+

--- a/components/Snackbar/tests/unit/SnackbarManagerSwiftTests.swift
+++ b/components/Snackbar/tests/unit/SnackbarManagerSwiftTests.swift
@@ -36,7 +36,7 @@ class SnackbarManagerSwiftTests: XCTestCase {
       XCTAssertNil(token, "Ensuring that the compiler knows we're reading this variable")
     }
 
-    self.wait(for: [expectation], timeout: 1.0)
+    self.waitForExpectations(timeout: 1.0, handler: nil)
   }
 
 }

--- a/components/Snackbar/tests/unit/SnackbarManagerSwiftTests.swift
+++ b/components/Snackbar/tests/unit/SnackbarManagerSwiftTests.swift
@@ -20,6 +20,7 @@ import MaterialComponents
 class SnackbarManagerSwiftTests: XCTestCase {
 
   func testMessagesResumedWhenTokenIsDeallocated() {
+    // Given
     let expectation = self.expectation(description: "completion")
 
     guard let suspendedMessage = MDCSnackbarMessage(text: "") else { XCTAssert(false); return }
@@ -33,9 +34,12 @@ class SnackbarManagerSwiftTests: XCTestCase {
       var token = MDCSnackbarManager.suspendAllMessages()
       MDCSnackbarManager.show(suspendedMessage)
       token = nil
+
+    // When
       XCTAssertNil(token, "Ensuring that the compiler knows we're reading this variable")
     }
 
+    // Then
     self.waitForExpectations(timeout: 1.0, handler: nil)
   }
 

--- a/components/Snackbar/tests/unit/SnackbarManagerTests.m
+++ b/components/Snackbar/tests/unit/SnackbarManagerTests.m
@@ -42,7 +42,7 @@
   }
 
   // Then
-  [self waitForExpectations:@[expectation] timeout:1];
+  [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
 @end

--- a/components/Snackbar/tests/unit/SnackbarManagerTests.m
+++ b/components/Snackbar/tests/unit/SnackbarManagerTests.m
@@ -1,0 +1,43 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+@import XCTest;
+#import "MaterialSnackBar.h"
+
+@interface SnackbarManagerTests : XCTestCase
+
+@end
+
+@implementation SnackbarManagerTests
+
+- (void)testMessagesResumedWhenTokenIsDeallocated {
+  MDCSnackbarMessage *suspendedMessage = [MDCSnackbarMessage messageWithText:@"foo1"];
+  suspendedMessage.duration = 0.05;
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completed"];
+  suspendedMessage.completionHandler = ^(BOOL userInitiated) {
+    [expectation fulfill];
+  };
+
+  // Encourage the runtime to deallocate the token immediately
+  @autoreleasepool {
+    id<MDCSnackbarSuspensionToken> token = [MDCSnackbarManager suspendAllMessages];
+    [MDCSnackbarManager showMessage:suspendedMessage];
+    token = nil;
+  }
+  [self waitForExpectations:@[expectation] timeout:1];
+}
+
+@end

--- a/components/Snackbar/tests/unit/SnackbarManagerTests.m
+++ b/components/Snackbar/tests/unit/SnackbarManagerTests.m
@@ -24,6 +24,7 @@
 @implementation SnackbarManagerTests
 
 - (void)testMessagesResumedWhenTokenIsDeallocated {
+  // Given
   MDCSnackbarMessage *suspendedMessage = [MDCSnackbarMessage messageWithText:@"foo1"];
   suspendedMessage.duration = 0.05;
   XCTestExpectation *expectation = [self expectationWithDescription:@"completed"];
@@ -35,8 +36,12 @@
   @autoreleasepool {
     id<MDCSnackbarSuspensionToken> token = [MDCSnackbarManager suspendAllMessages];
     [MDCSnackbarManager showMessage:suspendedMessage];
+
+  // When
     token = nil;
   }
+
+  // Then
   [self waitForExpectations:@[expectation] timeout:1];
 }
 


### PR DESCRIPTION
Updating MDCSnackbarSuspensionToken's dealloc behavior to resume any related message categories.

The SnackbarManager documentation states that when the last token is deallocated, any suspended
messages will be resumed.  This behavior was broken and the messages would remain suspended
indefinitely.

Closes #710 