### PR TITLE
[Buttons] Call designated initializer in init methods

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -111,11 +111,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 }
 
 - (instancetype)init {
-  self = [super init];
-  if (self) {
-    [self commonMDCButtonInit];
-  }
-  return self;
+  return [self initWithFrame:CGRectZero];
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {

--- a/components/Buttons/src/MDCFlatButton.m
+++ b/components/Buttons/src/MDCFlatButton.m
@@ -23,11 +23,7 @@ static NSString *const MDCFlatButtonHasOpaqueBackground = @"MDCFlatButtonHasOpaq
 @implementation MDCFlatButton
 
 - (instancetype)init {
-  self = [super init];
-  if (self) {
-    [self commonMDCFlatButtonInit];
-  }
-  return self;
+  return [self initWithFrame:CGRectZero];
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {


### PR DESCRIPTION
"If an object declares one or more initialization methods, you should decide which method is the designated initializer. This is often the method that offers the most options for initialization (such as the method with the most arguments), and is called by other methods you write for convenience. You should also typically override init to call your designated initializer with suitable default values."

https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/EncapsulatingData/EncapsulatingData.html