### PR TITLE
[Scripts] Modified scripts/test_all to use latest simulator available.

### DIFF
--- a/scripts/test_all
+++ b/scripts/test_all
@@ -16,9 +16,7 @@
 
 readonly SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly ROOT_DIR="$(dirname $SCRIPTS_DIR)"
-# Note that the following is using 10.1 until Travis CI fixes 
-# https://github.com/travis-ci/travis-ci/issues/7031
-readonly DESTINATION="platform=iOS Simulator,name=iPhone 7,OS=10.1"
+readonly DESTINATION="platform=iOS Simulator,name=iPhone 7,OS=latest"
 readonly COVERAGE_OPTIONS="GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES -enableCodeCoverage YES"
 
 # Given a path to an Xcode log file in $1, print a guess at what caused the


### PR DESCRIPTION
We had originally pinned the version to avoid duplicate simulators that [Travis CI had accidentally installed](https://github.com/travis-ci/travis-ci/issues/7031).