### PR TITLE
[Scripts] Updated scripts/build_all to take a verbose flag.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
   - pod --version
   - swiftlint
   - scripts/prep_all
-  - travis_wait scripts/build_all
+  - travis_wait scripts/build_all --verbose
   - travis_wait scripts/test_all catalog/MDCCatalog.xcworkspace:MDCUnitTests
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/scripts/build_all
+++ b/scripts/build_all
@@ -25,24 +25,24 @@ function is_expected_failure() {
   grep --quiet "is not configured for Running" "$1" 
 }
 
-# Given a path to an Xcode log file in $1, print a guess at what caused the
-# failure.
-function guess_failure() {
-  if [[ $TRAVIS == "true" ]]; then
-    tail -n 200 "$1"
-  else
-    grep --context=20 "The following build commands failed:" "$1"
-  fi
-}
+# Parse command-line arguments.
+verbose=0
+for i in "$@"; do
+  case $i in
+    -v|--verbose)
+      verbose=1
+      shift
+      ;;
+    *)
+      echo "Unknown option $i, aborting."
+      exit -1
+      ;;
+  esac
+done
+
 
 readonly WORKSPACE_SCHEMES=$("$SCRIPTS_DIR"/xcode/list_all_xcode_schemes)
 readonly SIGNING_OPTIONS="CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO"
-
-if [[ ! -z $1 ]]; then
-  readonly COMMAND="$1"
-else
-  readonly COMMAND=build
-fi
 
 all_builds_ok=1
 for workspace_scheme in $WORKSPACE_SCHEMES; do  
@@ -52,14 +52,22 @@ for workspace_scheme in $WORKSPACE_SCHEMES; do
   echo "xcodebuild $COMMAND $scheme in $workspace."
   log_file=$(dirname "$workspace")/"build_log_for_scheme_${scheme}.txt"
   options="-workspace $workspace -scheme $scheme $SIGNING_OPTIONS"
-  if xcodebuild $options $COMMAND >"$log_file" 2>&1 || \
-     is_expected_failure "$log_file"; then
+
+  # If verbose, pipe the output to standard output (/dev/fd/1).
+  if [ "$verbose" -eq 1 ]; then
+    final_output=/dev/fd/1
+  else
+    final_output=/dev/null
+  fi
+
+  xcodebuild $options build 2>&1 | tee "$log_file" > $final_output
+
+  if [ ${PIPESTATUS[0]} -eq 0 ] || is_expected_failure "$log_file"; then
     rm "$log_file"
   else
     all_builds_ok=0
     echo
     echo "Failed to build $scheme in $workspace:"
-    guess_failure "$log_file"
     echo "Log left in $log_file."
     echo "Continuing with next build..."
     echo


### PR DESCRIPTION
The script used to poop out logs if the build failed, but it often wouldn't poop out enough.

Now `build_all` never poops out logs, while `build_all --verbose` always poops out all logs.

Also removed the unused ability to specify a different `xcodebuild` command apart from `build`.

Tested manually with `[verbose, no verbose] x [build with error, build without error]`.