### PR TITLE
[Themers] Support alert dialog color themer in iOS 8

### DIFF
--- a/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
+++ b/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
@@ -20,8 +20,13 @@
 @implementation MDCAlertColorThemer
 
 + (void)applyColorScheme:(NSObject<MDCColorScheme> *)colorScheme {
+  #if defined(__IPHONE_9_0) && __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_9_0
   [[MDCButton appearanceWhenContainedInInstancesOfClasses:@[[MDCAlertController class]]]
       setCustomTitleColor:colorScheme.primaryColor];
+  #else
+  [[MDCButton appearanceWhenContainedIn:[MDCAlertController class], nil]
+      setCustomTitleColor:colorScheme.primaryColor];
+  #endif
 }
 
 @end


### PR DESCRIPTION
Fixes issue in iOS 8 where new iOS 9 method is used. Use deprecated method when iOS 8 is used.