### PR TITLE
[Buttons] Elevation clean up

### DIFF
--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -140,13 +140,6 @@
  */
 - (void)setElevation:(CGFloat)elevation forState:(UIControlState)state;
 
-/**
- Resets the elevation for a particular control state back to the button's default behavior.
-
- @param state The control state to reset the elevation.
- */
-- (void)resetElevationForState:(UIControlState)state;
-
 /*
  Indicates whether the button should automatically update its font when the device’s
  UIContentSizeCategory is changed.

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -109,17 +109,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 @dynamic layer;
 
-+ (void)initialize {
-  // Default background colors.
-  [[MDCButton appearance] setBackgroundColor:MDCColorFromRGB(MDCButtonDefaultBackgroundColor)
-                                    forState:UIControlStateNormal];
-
-  [[MDCButton appearance] setElevation:MDCShadowElevationRaisedButtonResting
-                              forState:UIControlStateNormal];
-  [[MDCButton appearance] setElevation:MDCShadowElevationRaisedButtonPressed
-                              forState:UIControlStateHighlighted];
-}
-
 + (Class)layerClass {
   return [MDCShadowLayer class];
 }
@@ -240,6 +229,10 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   _userElevations = [NSMutableDictionary dictionary];
   _backgroundColors = [NSMutableDictionary dictionary];
   _accessibilityLabelForState = [NSMutableDictionary dictionary];
+
+  _backgroundColors[@(UIControlStateNormal)] = MDCColorFromRGB(MDCButtonDefaultBackgroundColor);
+  _userElevations[@(UIControlStateNormal)] = @(MDCShadowElevationRaisedButtonResting);
+  _userElevations[@(UIControlStateHighlighted)] = @(MDCShadowElevationRaisedButtonPressed);
 
   // Disable default highlight state.
   self.adjustsImageWhenHighlighted = NO;

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -231,8 +231,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   _accessibilityLabelForState = [NSMutableDictionary dictionary];
 
   _backgroundColors[@(UIControlStateNormal)] = MDCColorFromRGB(MDCButtonDefaultBackgroundColor);
-  _userElevations[@(UIControlStateNormal)] = @(MDCShadowElevationRaisedButtonResting);
-  _userElevations[@(UIControlStateHighlighted)] = @(MDCShadowElevationRaisedButtonPressed);
 
   // Disable default highlight state.
   self.adjustsImageWhenHighlighted = NO;

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -525,11 +525,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   }
 }
 
-- (void)resetElevationForState:(UIControlState)state {
-  [_userElevations removeObjectForKey:@(state)];
-  [self shadowLayer].elevation = [self elevationForState:self.state];
-}
-
 #pragma mark - Private methods
 
 - (UIColor *)currentBackgroundColor {

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -102,9 +102,12 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   BOOL _mdc_adjustsFontForContentSizeCategory;
 }
 @property(nonatomic, strong) MDCInkView *inkView;
+@property(nonatomic, readonly, strong) MDCShadowLayer *layer;
 @end
 
 @implementation MDCButton
+
+@dynamic layer;
 
 + (void)initialize {
   // Default background colors.
@@ -249,7 +252,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   // Default content insets
   self.contentEdgeInsets = [self defaultContentEdgeInsets];
 
-  MDCShadowLayer *shadowLayer = [self shadowLayer];
+  MDCShadowLayer *shadowLayer = self.layer;
   shadowLayer.shadowPath = [self boundingPath].CGPath;
   shadowLayer.shadowColor = [UIColor blackColor].CGColor;
   shadowLayer.elevation = [self elevationForState:self.state];
@@ -495,14 +498,14 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 #pragma mark - Shadows
 
-- (MDCShadowLayer *)shadowLayer {
-  return (MDCShadowLayer *)self.layer;
-}
-
 - (void)animateButtonToHeightForState:(UIControlState)state {
+  CGFloat newElevation = [self elevationForState:state];
+  if (self.layer.elevation == newElevation) {
+    return;
+  }
   [CATransaction begin];
   [CATransaction setAnimationDuration:MDCButtonAnimationDuration];
-  [self shadowLayer].elevation = [self elevationForState:state];
+  self.layer.elevation = newElevation;
   [CATransaction commit];
 }
 
@@ -537,7 +540,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (void)setElevation:(CGFloat)elevation forState:(UIControlState)state {
   _userElevations[@(state)] = @(elevation);
-  [self shadowLayer].elevation = [self elevationForState:self.state];
+  self.layer.elevation = [self elevationForState:self.state];
 
   // The elevation of the normal state controls whether this button is flat or not, and flat buttons
   // have different background color requirements than raised buttons.

--- a/components/Buttons/src/MDCFlatButton.m
+++ b/components/Buttons/src/MDCFlatButton.m
@@ -57,10 +57,6 @@ static NSString *const MDCFlatButtonHasOpaqueBackground = @"MDCFlatButtonHasOpaq
 }
 
 - (void)commonMDCFlatButtonInit {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  self.shouldRaiseOnTouch = NO;
-#pragma clang diagnostic pop
   self.inkColor = [UIColor colorWithWhite:0 alpha:0.06f];
 }
 

--- a/components/Buttons/src/MDCFlatButton.m
+++ b/components/Buttons/src/MDCFlatButton.m
@@ -16,11 +16,22 @@
 
 #import "MDCFlatButton.h"
 
+#import "MaterialShadowElevations.h"
 #import "private/MDCButton+Subclassing.h"
 
 static NSString *const MDCFlatButtonHasOpaqueBackground = @"MDCFlatButtonHasOpaqueBackground";
 
 @implementation MDCFlatButton
+
++ (void)initialize {
+  // Default background colors.
+  [[MDCFlatButton appearance] setBackgroundColor:[UIColor clearColor]
+                                        forState:UIControlStateNormal];
+  [[MDCFlatButton appearance] setElevation:MDCShadowElevationNone
+                                  forState:UIControlStateNormal];
+  [[MDCFlatButton appearance] setElevation:MDCShadowElevationNone
+                                  forState:UIControlStateHighlighted];
+}
 
 - (instancetype)init {
   return [self initWithFrame:CGRectZero];
@@ -43,12 +54,6 @@ static NSString *const MDCFlatButtonHasOpaqueBackground = @"MDCFlatButtonHasOpaq
     [self commonMDCFlatButtonInit];
   }
   return self;
-}
-
-+ (void)initialize {
-  // Default background colors.
-  [[MDCFlatButton appearance] setBackgroundColor:[UIColor clearColor]
-                                    forState:UIControlStateNormal];
 }
 
 - (void)commonMDCFlatButtonInit {

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -27,6 +27,13 @@ static NSString *const MDCFloatingButtonShapeKey = @"MDCFloatingButtonShapeKey";
   MDCFloatingButtonShape _shape;
 }
 
++ (void)initialize {
+  [[MDCFloatingButton appearance] setElevation:MDCShadowElevationFABResting
+                                      forState:UIControlStateNormal];
+  [[MDCFloatingButton appearance] setElevation:MDCShadowElevationFABPressed
+                                      forState:UIControlStateHighlighted];
+}
+
 + (CGFloat)defaultDimension {
   return MDCFloatingButtonDefaultDimension;
 }
@@ -110,12 +117,6 @@ static NSString *const MDCFloatingButtonShapeKey = @"MDCFloatingButtonShapeKey";
     case MDCFloatingButtonShapeMini:
       return UIEdgeInsetsMake(8, 8, 8, 8);
   }
-}
-
-- (CGFloat)defaultElevationForState:(UIControlState)state {
-  return (((state & UIControlStateSelected) == UIControlStateSelected)
-              ? MDCShadowElevationFABPressed
-              : MDCShadowElevationFABResting);
 }
 
 #pragma mark - Deprecations

--- a/components/Buttons/src/MDCRaisedButton.m
+++ b/components/Buttons/src/MDCRaisedButton.m
@@ -21,12 +21,11 @@
 
 @implementation MDCRaisedButton
 
-#pragma mark - Subclassing
-
-- (CGFloat)defaultElevationForState:(UIControlState)state {
-  return (((state & UIControlStateSelected) == UIControlStateSelected)
-              ? MDCShadowElevationRaisedButtonPressed
-              : MDCShadowElevationRaisedButtonResting);
++ (void)initialize {
+  [[MDCRaisedButton appearance] setElevation:MDCShadowElevationRaisedButtonResting
+                                    forState:UIControlStateNormal];
+  [[MDCRaisedButton appearance] setElevation:MDCShadowElevationRaisedButtonPressed
+                                    forState:UIControlStateHighlighted];
 }
 
 @end

--- a/components/Buttons/src/private/MDCButton+Subclassing.h
+++ b/components/Buttons/src/private/MDCButton+Subclassing.h
@@ -45,7 +45,4 @@
 /** The default content edge insets of the button. They are set at initialization time. */
 - (UIEdgeInsets)defaultContentEdgeInsets;
 
-/** The default elevation for a particular button state (if not set by the calling code). */
-- (CGFloat)defaultElevationForState:(UIControlState)state;
-
 @end

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -65,6 +65,23 @@ static UIColor *randomColor() {
   }
 }
 
+static NSString *controlStateDescription(UIControlState controlState) {
+  if (controlState == UIControlStateNormal) {
+    return @"Normal";
+  }
+  NSMutableString *string = [NSMutableString string];
+  if ((UIControlStateHighlighted & controlState) == UIControlStateHighlighted) {
+    [string appendString:@"Highlighted "];
+  }
+  if ((UIControlStateDisabled & controlState) == UIControlStateDisabled) {
+    [string appendString:@"Disabled "];
+  }
+  if ((UIControlStateSelected & controlState) == UIControlStateSelected) {
+    [string appendString:@"Selected "];
+  }
+  return [string copy];
+}
+
 @interface ButtonsTests : XCTestCase
 @end
 
@@ -382,7 +399,7 @@ static UIColor *randomColor() {
 
     // Then
     XCTAssertEqualObjects([button titleColorForState:controlState], color,
-                          @"for control state:%@ ", [self controlState:controlState]);
+                          @"for control state:%@ ", controlStateDescription(controlState));
   }
 }
 - (void)testTitleColorForStateDisabledHighlight {
@@ -401,9 +418,9 @@ static UIColor *randomColor() {
 
   // Then
   XCTAssertEqualObjects([button titleColorForState:controlState], normalColor,
-                        @"for control state:%@ ", [self controlState:controlState]);
+                        @"for control state:%@ ", controlStateDescription(controlState));
   XCTAssertNotEqualObjects([button titleColorForState:controlState], color,
-                        @"for control state:%@ ", [self controlState:controlState]);
+                        @"for control state:%@ ", controlStateDescription(controlState));
 }
 
 #pragma mark - UIButton state changes
@@ -530,25 +547,6 @@ static UIColor *randomColor() {
   XCTAssertEqualWithAccuracy(button.titleLabel.font.pointSize, preferredFont.pointSize,
                              kEpsilonAccuracy,
                              @"Font size should be equal to MDCFontTextStyleButton's.");
-}
-
-#pragma mark utilities
-
-- (NSString*)controlState:(UIControlState)controlState {
-  NSMutableString *string = [NSMutableString string];
-  if (UIControlStateNormal) {
-    return @".Normal";
-  }
-  if (controlState & UIControlStateHighlighted) {
-    [string appendString:@"Highlighted "];
-  }
-  if (controlState & UIControlStateDisabled) {
-    [string appendString:@"Disabled "];
-  }
-  if (controlState & UIControlStateSelected) {
-    [string appendString:@"Selected "];
-  }
-  return [string copy];
 }
 
 @end

--- a/components/Buttons/tests/unit/FlatButtonTests.m
+++ b/components/Buttons/tests/unit/FlatButtonTests.m
@@ -1,0 +1,38 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialButtons.h"
+#import "MaterialShadowElevations.h"
+
+@interface FlatButtonsTests : XCTestCase
+@end
+
+@implementation FlatButtonsTests
+
+- (void)testDefaultElevationsForState {
+  // Given
+  MDCFlatButton *button = [MDCFlatButton appearance];
+
+  // Then
+  XCTAssertEqual([button elevationForState:UIControlStateNormal], MDCShadowElevationNone);
+  XCTAssertEqual([button elevationForState:UIControlStateHighlighted], MDCShadowElevationNone);
+  XCTAssertEqual([button elevationForState:UIControlStateDisabled], MDCShadowElevationNone);
+  XCTAssertEqual([button elevationForState:UIControlStateSelected], MDCShadowElevationNone);
+}
+
+@end

--- a/components/Buttons/tests/unit/FloatingButtonTests.m
+++ b/components/Buttons/tests/unit/FloatingButtonTests.m
@@ -1,0 +1,39 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialButtons.h"
+#import "MaterialShadowElevations.h"
+
+@interface FloatingButtonsTests : XCTestCase
+@end
+
+@implementation FloatingButtonsTests
+
+- (void)testDefaultElevationsForState {
+  // Given
+  MDCFloatingButton *button = [MDCFloatingButton appearance];
+
+  // Then
+  XCTAssertEqual([button elevationForState:UIControlStateNormal], MDCShadowElevationFABResting);
+  XCTAssertEqual([button elevationForState:UIControlStateHighlighted],
+                 MDCShadowElevationFABPressed);
+  XCTAssertEqual([button elevationForState:UIControlStateDisabled], MDCShadowElevationNone);
+}
+
+
+@end

--- a/components/Buttons/tests/unit/RaisedButtonTests.m
+++ b/components/Buttons/tests/unit/RaisedButtonTests.m
@@ -1,0 +1,40 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialButtons.h"
+#import "MaterialShadowElevations.h"
+
+@interface RaisedButtonsTests : XCTestCase
+@end
+
+@implementation RaisedButtonsTests
+
+- (void)testDefaultElevationsForState {
+  // Given
+  MDCRaisedButton *button = [MDCRaisedButton appearance];
+
+  // Then
+  XCTAssertEqual([button elevationForState:UIControlStateNormal],
+                 MDCShadowElevationRaisedButtonResting);
+  XCTAssertEqual([button elevationForState:UIControlStateHighlighted],
+                 MDCShadowElevationRaisedButtonPressed);
+  XCTAssertEqual([button elevationForState:UIControlStateDisabled], MDCShadowElevationNone);
+}
+
+
+@end


### PR DESCRIPTION
This PR pulls in the elevation-related changes from #1555.

Changes:
* Removes [MDCButton resetElevationForState]
* Changes MDCButton to correctly treat UIControlStateHighlighted as the pressed state
* Moves MDCButton (and subclasses) elevation initialization to UIAppearance calls in +initialize
* Changes elevation assignment from touchesBegan/Moved/Ended to state observation
* Removes defaultElevationForState from MDCButton+Subclassing.h
* MDCFlatButton no longer depends on shouldRaiseOnTouch