### PR TITLE
[NavigationBar] Vertically center navigationBar title within its default height for UIControlContentVerticalAlignmentTop

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -314,7 +314,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   CGRect titleFrame = CGRectMake(textFrame.origin.x, 0, titleSize.width, titleSize.height);
   titleFrame = MDCRectFlippedForRTL(titleFrame, self.bounds.size.width,
                                     self.mdc_effectiveUserInterfaceLayoutDirection);
-  UIControlContentVerticalAlignment titleVerticalAlignment = UIControlContentVerticalAlignmentCenter;
+  UIControlContentVerticalAlignment titleVerticalAlignment = UIControlContentVerticalAlignmentTop;
   CGRect alignedFrame = [self mdc_frameAlignedVertically:titleFrame
                                             withinBounds:textFrame
                                                alignment:titleVerticalAlignment];
@@ -448,7 +448,10 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
     }
 
     case UIControlContentVerticalAlignmentTop: {
-      return CGRectMake(frame.origin.x, bounds.origin.y, frame.size.width, frame.size.height);
+      CGFloat navigationBarCenteredY =
+          MDCFloor(([self intrinsicContentSize].height - frame.size.height) / 2);
+      return CGRectMake(frame.origin.x, navigationBarCenteredY, frame.size.width,
+                        frame.size.height);
     }
 
     case UIControlContentVerticalAlignmentFill: {

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -314,7 +314,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   CGRect titleFrame = CGRectMake(textFrame.origin.x, 0, titleSize.width, titleSize.height);
   titleFrame = MDCRectFlippedForRTL(titleFrame, self.bounds.size.width,
                                     self.mdc_effectiveUserInterfaceLayoutDirection);
-  UIControlContentVerticalAlignment titleVerticalAlignment = UIControlContentVerticalAlignmentTop;
+  UIControlContentVerticalAlignment titleVerticalAlignment = UIControlContentVerticalAlignmentCenter;
   CGRect alignedFrame = [self mdc_frameAlignedVertically:titleFrame
                                             withinBounds:textFrame
                                                alignment:titleVerticalAlignment];

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -448,6 +448,8 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
     }
 
     case UIControlContentVerticalAlignmentTop: {
+      // The title frame is vertically centered with the back button but will stick to the top of
+      // the header regardless of the header's height.
       CGFloat navigationBarCenteredY =
           MDCFloor(([self intrinsicContentSize].height - frame.size.height) / 2);
       navigationBarCenteredY = MAX(0, navigationBarCenteredY);

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -450,6 +450,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
     case UIControlContentVerticalAlignmentTop: {
       CGFloat navigationBarCenteredY =
           MDCFloor(([self intrinsicContentSize].height - frame.size.height) / 2);
+      navigationBarCenteredY = MAX(0, navigationBarCenteredY);
       return CGRectMake(frame.origin.x, navigationBarCenteredY, frame.size.width,
                         frame.size.height);
     }


### PR DESCRIPTION
Since MDCNavigationBar is now using the iOS back button style, it doesn't look right to top align the title label. Update this -layoutSubviews implementation to use UIControlContentVerticalAlignmentCenter instead.

Doing an inspection shows that the title label is not currently center aligned with the back button.

### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [x] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [x] Link to GitHub issues it solves. ```closes #1596```
- [ ] Sign the CLA bot. You can do this once the pull request is submitted.

[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
pull request.
