### PR TITLE
[Tabs] Restoring ink to the top of the cell

### DIFF
--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -81,8 +81,7 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
 
     // Set up ink controller to splash ink on taps.
     _inkTouchController = [[MDCInkTouchController alloc] initWithView:self];
-    [_inkTouchController addInkView];
-    [self sendSubviewToBack:_inkTouchController.defaultInkView];
+    [_inkTouchController addInkView];   // Ink should always be on top of other views
 
     [self updateInk];
     [self updateColors];


### PR DESCRIPTION
The Ink layer should remain above any other elements within an ItemBarCell. The commit that moved the `inkLayer` below the title and image was merged too quickly without receiving design input and is being reverted.

Reverts commit a68a5531935ad1fae496266732b63482deb481dd

Closes #1480
