### PR TITLE
[KeyboardWatcher] Simplification and cleanup

### DIFF
--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -241,7 +241,7 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
 // Calculates the snap-point for the view to spring to.
 - (CGPoint)targetPoint {
   CGRect bounds = self.bounds;
-  CGFloat keyboardOffset = [MDCKeyboardWatcher sharedKeyboardWatcher].keyboardOffset;
+  CGFloat keyboardOffset = [MDCKeyboardWatcher sharedKeyboardWatcher].visibleKeyboardHeight;
   CGFloat midX = CGRectGetMidX(bounds);
   CGFloat bottomY = CGRectGetMaxY(bounds) - keyboardOffset;
 

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -80,7 +80,7 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
   CGRect presentedViewFrame = CGRectZero;
 
   CGRect containerBounds = self.containerView.bounds;
-  containerBounds.size.height -= [MDCKeyboardWatcher sharedKeyboardWatcher].keyboardOffset;
+  containerBounds.size.height -= [MDCKeyboardWatcher sharedKeyboardWatcher].visibleKeyboardHeight;
 
   presentedViewFrame.size = [self sizeForChildContentContainer:self.presentedViewController
                                        withParentContainerSize:containerBounds.size];

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -191,7 +191,7 @@ static const CGFloat kMaximumHeight = 80.0f;
  change at any time during runtime.
  */
 - (CGFloat)dynamicBottomMargin {
-  CGFloat keyboardHeight = self.watcher.keyboardOffset;
+  CGFloat keyboardHeight = self.watcher.visibleKeyboardHeight;
   CGFloat userHeight = self.bottomOffset;
 
   return MAX(keyboardHeight, userHeight);

--- a/components/private/KeyboardWatcher/src/MDCKeyboardWatcher.h
+++ b/components/private/KeyboardWatcher/src/MDCKeyboardWatcher.h
@@ -45,10 +45,20 @@ OBJC_EXTERN NSString *const MDCKeyboardWatcherKeyboardWillChangeFrameNotificatio
         (NSNotification *)notification;
 
 /**
+ The height of the visible keyboard view.
+
+ Zero if the keyboard is not currently showing or is not docked.
+ */
+@property(nonatomic, readonly) CGFloat visibleKeyboardHeight;
+
+#pragma mark deprecated
+
+/**
  The distance from the top of the keyboard to the bottom of the screen.
 
  Zero if the keyboard is not currently showing or is not docked.
  */
-@property(nonatomic, readonly) CGFloat keyboardOffset;
+@property(nonatomic, readonly) CGFloat keyboardOffset __deprecated_msg("Use visibleKeyboardHeight instead of keyboardOffset")
+;
 
 @end


### PR DESCRIPTION
Removed outdated code supporting iOS 7.
Simplify code.
Rename keyboardOffset to visibleKeyboardHeight.
Deprecate keyboardOffset.

This PR was created from a regenerated upstream/refactorkbwatcher branch.
