### PR TITLE
[Buttons] Ink should ignore content edge insets

### DIFF
--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -1,0 +1,54 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+@import UIKit;
+#import "MaterialButtons.h"
+
+@interface ButtonsContentEdgeInsetsExample : UIViewController
+@property(weak, nonatomic) IBOutlet MDCFlatButton *flatButton;
+@property(weak, nonatomic) IBOutlet MDCRaisedButton *raisedButton;
+@property(weak, nonatomic) IBOutlet MDCFloatingButton *floatingActionButton;
+
+@end
+
+@implementation ButtonsContentEdgeInsetsExample
+
+#pragma mark - Catalog by Convention
+
++ (NSArray<NSString *> *)catalogBreadcrumbs {
+  return @[ @"Buttons", @"Buttons (Content Edge Insets)" ];
+}
+
++ (NSString *)catalogStoryboardName {
+  return @"ButtonsContentEdgeInsets";
+}
+
+#pragma mark - UIViewController
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  // Force a darker background color to show the button frame
+  [self.flatButton setBackgroundColor:[UIColor colorWithWhite:0.2 alpha:1.0]
+                             forState:UIControlStateNormal];
+  self.flatButton.inkColor = [UIColor colorWithWhite:1.0 alpha:0.1];
+
+  self.flatButton.contentEdgeInsets = UIEdgeInsetsMake(64, 64, 0, 0);
+  self.raisedButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, 64, 64);
+  self.floatingActionButton.contentEdgeInsets = UIEdgeInsetsMake(0, 128, 0, 0);
+}
+
+@end

--- a/components/Buttons/examples/resources/ButtonsContentEdgeInsets.storyboard
+++ b/components/Buttons/examples/resources/ButtonsContentEdgeInsets.storyboard
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Uhh-iX-aVf">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Buttons Content Edge Insets Example-->
+        <scene sceneID="Jts-Jk-8ba">
+            <objects>
+                <viewController id="Uhh-iX-aVf" customClass="ButtonsContentEdgeInsetsExample" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="pu1-Ea-nBj"/>
+                        <viewControllerLayoutGuide type="bottom" id="aOy-6t-l8i"/>
+                    </layoutGuides>
+                    <view key="view" clipsSubviews="YES" contentMode="scaleToFill" id="dDe-BW-Avd">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bvE-5P-0PG" customClass="MDCFlatButton">
+                                <rect key="frame" x="142" y="274.5" width="91" height="34"/>
+                                <color key="tintColor" red="0.19254023644059035" green="0.53181806153905575" blue="0.91669365284974091" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <inset key="contentEdgeInsets" minX="0.0" minY="0.0" maxX="16" maxY="16"/>
+                                <state key="normal" title="Flat Button">
+                                    <color key="titleColor" cocoaTouchSystemColor="lightTextColor"/>
+                                </state>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dqo-nu-adB" customClass="MDCRaisedButton">
+                                <rect key="frame" x="127" y="324.5" width="120" height="18"/>
+                                <inset key="contentEdgeInsets" minX="0.0" minY="0.0" maxX="24" maxY="0.0"/>
+                                <state key="normal" title="Raised Button">
+                                    <color key="titleColor" cocoaTouchSystemColor="lightTextColor"/>
+                                </state>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YCS-6P-hwz" customClass="MDCFloatingButton">
+                                <rect key="frame" x="174" y="358.5" width="26" height="34"/>
+                                <inset key="contentEdgeInsets" minX="16" minY="16" maxX="0.0" maxY="0.0"/>
+                                <state key="normal" title="+"/>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="0.89888392857142863" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="YCS-6P-hwz" firstAttribute="centerX" secondItem="dDe-BW-Avd" secondAttribute="centerX" id="Aeg-aQ-A5S"/>
+                            <constraint firstItem="Dqo-nu-adB" firstAttribute="centerY" secondItem="dDe-BW-Avd" secondAttribute="centerY" id="h3j-9m-Xpr"/>
+                            <constraint firstItem="bvE-5P-0PG" firstAttribute="centerX" secondItem="dDe-BW-Avd" secondAttribute="centerX" id="k35-WX-pnN"/>
+                            <constraint firstItem="Dqo-nu-adB" firstAttribute="centerX" secondItem="dDe-BW-Avd" secondAttribute="centerX" id="wdb-rY-gK0"/>
+                            <constraint firstItem="Dqo-nu-adB" firstAttribute="top" secondItem="bvE-5P-0PG" secondAttribute="bottom" constant="16" id="y2n-KT-Jew"/>
+                            <constraint firstItem="YCS-6P-hwz" firstAttribute="top" secondItem="Dqo-nu-adB" secondAttribute="bottom" constant="16" id="zBf-pL-lyJ"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="flatButton" destination="bvE-5P-0PG" id="8px-6Z-f5o"/>
+                        <outlet property="floatingActionButton" destination="YCS-6P-hwz" id="Mw6-3r-5YL"/>
+                        <outlet property="raisedButton" destination="Dqo-nu-adB" id="rEm-SL-wQr"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Z12-Wq-Srl" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-298" y="87"/>
+        </scene>
+    </scenes>
+    <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+</document>

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -303,16 +303,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [super layoutSubviews];
   self.layer.shadowPath = [self boundingPath].CGPath;
   self.layer.cornerRadius = [self cornerRadius];
-
-  // Center the ink view frame taking into account possible insets using contentRectForBounds.
-
-  CGRect contentRect = [self contentRectForBounds:self.bounds];
-  CGPoint contentCenterPoint = CGPointMake(CGRectGetMidX(contentRect), CGRectGetMidY(contentRect));
-  CGPoint boundsCenterPoint = CGPointMake(CGRectGetMidX(self.bounds), CGRectGetMidY(self.bounds));
-
-  CGFloat offsetX = contentCenterPoint.x - boundsCenterPoint.x;
-  CGFloat offsetY = contentCenterPoint.y - boundsCenterPoint.y;
-  _inkView.frame = CGRectMake(offsetX, offsetY, self.bounds.size.width, self.bounds.size.height);
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {


### PR DESCRIPTION
The `contentEdgeInsets` value of an MDCButton causes the `_inkView` to
realign to match the `contentRect`.  This results in a ripple/highlight
that does not match the position of the button on-screen (doesn't align
with the background).

This commit removes the re-alignment code, so `_inkView` will remain
aligned with the rest of the button's view.

Closes #1591 