### PR TITLE
[Collections] Delegate method for cards' style margins

### DIFF
--- a/components/Collections/src/MDCCollectionViewController.m
+++ b/components/Collections/src/MDCCollectionViewController.m
@@ -224,7 +224,8 @@ NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFoote
 
 - (UIEdgeInsets)insetsAtSectionIndex:(NSInteger)section {
   // Determine insets based on cell style.
-  CGFloat inset = (CGFloat)floor(MDCCollectionViewCellStyleCardSectionInset);
+  CGFloat verticalInset = (CGFloat)floor(MDCCollectionViewCellStyleCardSectionInset);
+  CGFloat horizontalInset = (CGFloat)floor([_styler cellStyleCardSectionHorizontalMargin]);
   UIEdgeInsets insets = UIEdgeInsetsZero;
   NSInteger numberOfSections = self.collectionView.numberOfSections;
   BOOL isTop = (section == 0);
@@ -234,13 +235,13 @@ NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFoote
   BOOL isGroupedStyle = cellStyle == MDCCollectionViewCellStyleGrouped;
   // Set left/right insets.
   if (isCardStyle) {
-    insets.left = inset;
-    insets.right = inset;
+    insets.left = horizontalInset;
+    insets.right = horizontalInset;
   }
   // Set top/bottom insets.
   if (isCardStyle || isGroupedStyle) {
-    insets.top = (CGFloat)floor((isTop) ? inset : inset / 2.0f);
-    insets.bottom = (CGFloat)floor((isBottom) ? inset : inset / 2.0f);
+    insets.top = (CGFloat)floor((isTop) ? verticalInset : verticalInset / 2.0f);
+    insets.bottom = (CGFloat)floor((isBottom) ? verticalInset : verticalInset / 2.0f);
   }
   return insets;
 }

--- a/components/Collections/src/MDCCollectionViewFlowLayout.m
+++ b/components/Collections/src/MDCCollectionViewFlowLayout.m
@@ -408,7 +408,8 @@ static const NSInteger kSupplementaryViewZIndex = 99;
 
 - (UIEdgeInsets)insetsAtSectionIndex:(NSInteger)section {
   // Determine insets based on cell style.
-  CGFloat inset = (CGFloat)floor(MDCCollectionViewCellStyleCardSectionInset);
+  CGFloat verticalInset = (CGFloat)floor(MDCCollectionViewCellStyleCardSectionInset);
+  CGFloat horizontalInset = (CGFloat)floor([self.styler cellStyleCardSectionHorizontalMargin]);
   UIEdgeInsets insets = UIEdgeInsetsZero;
   NSInteger numberOfSections = self.collectionView.numberOfSections;
   BOOL isTop = (section == 0);
@@ -418,13 +419,13 @@ static const NSInteger kSupplementaryViewZIndex = 99;
   BOOL isGroupedStyle = cellStyle == MDCCollectionViewCellStyleGrouped;
   // Set left/right insets.
   if (isCardStyle) {
-    insets.left = inset;
-    insets.right = inset;
+    insets.left = horizontalInset;
+    insets.right = horizontalInset;
   }
   // Set top/bottom insets.
   if (isCardStyle || isGroupedStyle) {
-    insets.top = (CGFloat)floor((isTop) ? inset : inset / 2.0f);
-    insets.bottom = (CGFloat)floor((isBottom) ? inset : inset / 2.0f);
+    insets.top = (CGFloat)floor((isTop) ? verticalInset : verticalInset / 2.0f);
+    insets.bottom = (CGFloat)floor((isBottom) ? verticalInset : verticalInset / 2.0f);
   }
   return insets;
 }

--- a/components/Collections/src/MDCCollectionViewStyling.h
+++ b/components/Collections/src/MDCCollectionViewStyling.h
@@ -92,6 +92,13 @@ typedef NS_ENUM(NSUInteger, MDCCollectionViewCellLayoutType) {
 @property(nonatomic, assign) MDCCollectionViewCellStyle cellStyle;
 
 /**
+ The left and right margin for a section with a Cards style.
+
+ @return The margin of the sections.
+ */
+-(CGFloat)cellStyleCardSectionHorizontalMargin;
+
+/**
  Updates the cell style with/without animation.
 
  @param animated YES the transition will be animated; otherwise, NO.

--- a/components/Collections/src/MDCCollectionViewStylingDelegate.h
+++ b/components/Collections/src/MDCCollectionViewStylingDelegate.h
@@ -40,6 +40,14 @@
     cellHeightAtIndexPath:(nonnull NSIndexPath *)indexPath;
 
 /**
+ The left and right margin for a section with a Cards style.
+
+ @return The margin of the sections.
+ */
+-(CGFloat)collectionViewCellStyleCardSectionMargin:(nonnull UICollectionView *)collectionView;
+
+
+/**
  Asks the delegate for the cell style at the specified collection view section index. All
  remaining sections to have their cells styled per the styler @c cellStyle property.
 

--- a/components/Collections/src/private/MDCCollectionViewStyler.m
+++ b/components/Collections/src/private/MDCCollectionViewStyler.m
@@ -294,6 +294,15 @@ NS_INLINE CGRect RectShift(CGRect rect, CGFloat dx, CGFloat dy) {
   return insets;
 }
 
+-(CGFloat)cellStyleCardSectionHorizontalMargin {
+  CGFloat margin = MDCCollectionViewCellStyleCardSectionInset;
+  if (self.delegate &&
+      [self.delegate respondsToSelector:@selector(collectionViewCellStyleCardSectionMargin:)]) {
+    margin = [self.delegate collectionViewCellStyleCardSectionMargin:_collectionView];
+  }
+  return margin;
+}
+
 - (void)setCellStyle:(MDCCollectionViewCellStyle)cellStyle animated:(BOOL)animated {
   _cellStyle = cellStyle;
   [self updateLayoutAnimated:animated];


### PR DESCRIPTION
When the card style is used, the margins for the cards are set to 8pt.
On large devices, it would be better if the margin can be dynamically set.
This commit adds a delegate method to the MDCCollectionViewEditingDelegate
to provide this value.

Closes #1507 