### PR TITLE
Remove uses of `typeof` and the `?:` operator

### DIFF
--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
@@ -82,7 +82,8 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
   [self transferCustomViewOwnershipForBarButtonItem:buttonItem];
 
   // Take the real custom view if it exists instead of sandbag view.
-  UIView *customView = buttonItem.mdc_customView ?: buttonItem.customView;
+  UIView *customView =
+      buttonItem.mdc_customView ? buttonItem.mdc_customView : buttonItem.customView;
   if (customView) {
     return customView;
   }
@@ -213,7 +214,10 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
             withItem:(UIBarButtonItem *)item
           barMetrics:(UIBarMetrics)barMetrics {
   [self updateButton:button withItem:item forState:UIControlStateNormal barMetrics:barMetrics];
-  [self updateButton:button withItem:item forState:UIControlStateHighlighted barMetrics:barMetrics];
+  [self updateButton:button
+            withItem:item
+            forState:UIControlStateHighlighted
+          barMetrics:barMetrics];
   [self updateButton:button withItem:item forState:UIControlStateDisabled barMetrics:barMetrics];
 }
 
@@ -221,7 +225,7 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
             withItem:(UIBarButtonItem *)item
             forState:(UIControlState)state
           barMetrics:(UIBarMetrics)barMetrics {
-  NSString *title = item.title ?: @"";
+  NSString *title = item.title ? item.title : @"";
   if ([UIButton instancesRespondToSelector:@selector(setAttributedTitle:forState:)]) {
     NSMutableDictionary<NSString *, id> *attributes = [NSMutableDictionary dictionary];
 

--- a/components/CollectionCells/src/MDCCollectionViewTextCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewTextCell.m
@@ -20,7 +20,7 @@
 #import "MaterialRTL.h"
 #import "MaterialTypography.h"
 
-#import <tgmath.h>
+#include <tgmath.h>
 
 // Default cell heights.
 const CGFloat MDCCellDefaultOneLineHeight = 48.0f;

--- a/components/Collections/src/MDCCollectionViewController.m
+++ b/components/Collections/src/MDCCollectionViewController.m
@@ -24,7 +24,7 @@
 #import "private/MDCCollectionViewEditor.h"
 #import "private/MDCCollectionViewStyler.h"
 
-#import <tgmath.h>
+#include <tgmath.h>
 
 NSString *const MDCCollectionInfoBarKindHeader = @"MDCCollectionInfoBarKindHeader";
 NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFooter";

--- a/components/Collections/src/MDCCollectionViewFlowLayout.m
+++ b/components/Collections/src/MDCCollectionViewFlowLayout.m
@@ -24,7 +24,7 @@
 #import "private/MDCCollectionInfoBarView.h"
 #import "private/MDCCollectionViewEditor.h"
 
-#import <tgmath.h>
+#include <tgmath.h>
 
 /** The grid background decoration view kind. */
 NSString *const kCollectionGridDecorationView = @"MDCCollectionGridDecorationView";

--- a/components/Collections/src/private/MDCCollectionViewEditor.m
+++ b/components/Collections/src/private/MDCCollectionViewEditor.m
@@ -19,7 +19,7 @@
 #import "MaterialCollections.h"
 #import "MaterialShadowLayer.h"
 
-#import <tgmath.h>
+#include <tgmath.h>
 
 // Distance from center before we start fading the item.
 static const CGFloat kDismissalDistanceBeforeFading = 50.0f;

--- a/components/Collections/src/private/MDCCollectionViewStyler.m
+++ b/components/Collections/src/private/MDCCollectionViewStyler.m
@@ -19,7 +19,7 @@
 #import "MaterialCollections.h"
 #import "MaterialCollectionLayoutAttributes.h"
 
-#import <tgmath.h>
+#include <tgmath.h>
 
 #define RGBCOLOR(r, g, b) \
   [UIColor colorWithRed:(r) / 255.0f green:(g) / 255.0f blue:(b) / 255.0f alpha:1]

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -254,7 +254,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 #pragma mark Accessibility
 
 - (NSArray<__kindof UIView *> *)accessibilityElements {
-  return @[ _leadingButtonBar, self.titleView ?: _titleLabel, _trailingButtonBar ];
+  return @[ _leadingButtonBar, self.titleView ? self.titleView : _titleLabel, _trailingButtonBar ];
 }
 
 - (BOOL)isAccessibilityElement {

--- a/components/PageControl/src/MDCPageControl.m
+++ b/components/PageControl/src/MDCPageControl.m
@@ -21,7 +21,7 @@
 #import "private/MaterialPageControlStrings.h"
 #import "private/MaterialPageControlStrings_table.h"
 
-#import <tgmath.h>
+#include <tgmath.h>
 
 // The Bundle for string resources.
 static NSString *const kMaterialPageControlBundle = @"MaterialPageControl.bundle";

--- a/components/ProgressView/src/MDCProgressView.m
+++ b/components/ProgressView/src/MDCProgressView.m
@@ -16,7 +16,7 @@
 
 #import "MDCProgressView.h"
 
-#import <tgmath.h>
+#include <tgmath.h>
 
 #import "MaterialMath.h"
 #import "MaterialRTL.h"

--- a/components/Slider/src/MDCSlider.m
+++ b/components/Slider/src/MDCSlider.m
@@ -96,7 +96,8 @@ static inline UIColor *MDCColorFromRGB(uint32_t rgbValue) {
 #pragma mark - ThumbTrack passthrough methods
 
 - (void)setTrackBackgroundColor:(UIColor *)trackBackgroundColor {
-  _thumbTrack.trackOffColor = trackBackgroundColor ?: [[self class] defaultTrackOffColor];
+  _thumbTrack.trackOffColor =
+      trackBackgroundColor ? trackBackgroundColor : [[self class] defaultTrackOffColor];
   ;
 }
 
@@ -105,7 +106,7 @@ static inline UIColor *MDCColorFromRGB(uint32_t rgbValue) {
 }
 
 - (void)setColor:(UIColor *)color {
-  _thumbTrack.primaryColor = color ?: [[self class] defaultColor];
+  _thumbTrack.primaryColor = color ? color : [[self class] defaultColor];
 }
 
 - (UIColor *)color {

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -494,7 +494,7 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 
   style.selectionIndicatorColor = self.tintColor;
   style.inkColor = _inkColor;
-  style.selectedTitleColor = (_selectedItemTintColor ?: self.tintColor);
+  style.selectedTitleColor = (_selectedItemTintColor ? _selectedItemTintColor : self.tintColor);
   style.titleColor = _unselectedItemTintColor;
   style.displaysUppercaseTitles = _displaysUppercaseTitles;
 

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -56,8 +56,9 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
     NSString *interfaceBuilderPlaceholder = super.placeholder;
     [self commonMDCTextFieldInitialization];
 
-    _fundament = [aDecoder decodeObjectForKey:MDCTextFieldFundamentKey]
-                     ?: [[MDCTextInputCommonFundament alloc] initWithTextInput:self];
+    MDCTextInputCommonFundament *fundament = [aDecoder decodeObjectForKey:MDCTextFieldFundamentKey];
+    _fundament =
+        fundament ? fundament : [[MDCTextInputCommonFundament alloc] initWithTextInput:self];
 
     if (interfaceBuilderPlaceholder.length) {
       self.placeholder = interfaceBuilderPlaceholder;

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -492,8 +492,11 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
     animationBlock = ^{
       self.textInput.placeholderLabel.transform = CGAffineTransformIdentity;
 
-      self.textInput.placeholderLabel.textColor =
-          self.previousPlaceholderColor ?: self.inlinePlaceholderColor;
+      if (self.previousPlaceholderColor) {
+        self.textInput.placeholderLabel.textColor = self.previousPlaceholderColor;
+      } else {
+        self.textInput.placeholderLabel.textColor = self.inlinePlaceholderColor;
+      }
 
       [NSLayoutConstraint deactivateConstraints:self.placeholderAnimationConstraints];
     };
@@ -665,7 +668,7 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
 }
 
 - (UIColor *)floatingPlaceholderColor {
-  return _floatingPlaceholderColor ?: self.textInput.tintColor;
+  return _floatingPlaceholderColor ? _floatingPlaceholderColor : self.textInput.tintColor;
 }
 
 - (void)setFloatingEnabled:(BOOL)floatingEnabled {
@@ -709,7 +712,8 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
 }
 
 - (UIColor *)inlinePlaceholderColor {
-  return _inlinePlaceholderColor ?: MDCTextInputDefaultInlinePlaceholderTextColor();
+  return _inlinePlaceholderColor ?
+            _inlinePlaceholderColor : MDCTextInputDefaultInlinePlaceholderTextColor();
 }
 
 - (BOOL)isDisplayingCharacterCountError {
@@ -746,7 +750,7 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
 }
 
 - (UIColor *)underlineColorActive {
-  return _underlineColorActive ?: MDCTextInputDefaultActiveUnderlineColor();
+  return _underlineColorActive ? _underlineColorActive : MDCTextInputDefaultActiveUnderlineColor();
 }
 
 - (void)setUnderlineColorNormal:(UIColor *)underlineColorNormal {
@@ -757,7 +761,7 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
 }
 
 - (UIColor *)underlineColorNormal {
-  return _underlineColorNormal ?: MDCTextInputDefaultNormalUnderlineColor();
+  return _underlineColorNormal ? _underlineColorNormal : MDCTextInputDefaultNormalUnderlineColor();
 }
 
 - (void)setUnderlineViewMode:(UITextFieldViewMode)underlineViewMode {
@@ -1018,9 +1022,10 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
   // If error text is unset (nil) we reset to previous values.
   if (!errorText) {
     // If there is a saved state, use it.
-    self.textInput.leadingUnderlineLabel.text =
-        self.previousLeadingText ?: self.textInput.leadingUnderlineLabel.text;
-
+    if (self.previousLeadingText) {
+      self.textInput.leadingUnderlineLabel.text = self.previousLeadingText;
+    }
+    
     // Clear out saved state.
     self.previousLeadingText = nil;
   }
@@ -1044,7 +1049,7 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
 
     NSString *valueString = @"";
 
-    if (self.textInput.text > 0) {
+    if (self.textInput.text.length > 0) {
       valueString = [self.textInput.text copy];
     }
     if (self.textInput.placeholder.length > 0) {
@@ -1053,8 +1058,10 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
     valueString = [valueString stringByAppendingString:@"."];
 
     self.textInput.accessibilityValue = valueString;
+    NSString *leadingUnderlineLabelText = self.textInput.leadingUnderlineLabel.text;
     self.textInput.leadingUnderlineLabel.accessibilityLabel = [NSString
-        stringWithFormat:@"Error: %@.", self.textInput.leadingUnderlineLabel.text ?: @""];
+        stringWithFormat:@"Error: %@.", leadingUnderlineLabelText ?
+                                                               leadingUnderlineLabelText : @""];
   } else {
     self.textInput.accessibilityValue = nil;
     self.textInput.leadingUnderlineLabel.accessibilityLabel = nil;

--- a/components/TextFields/src/MDCTextInputControllerFullWidth.m
+++ b/components/TextFields/src/MDCTextInputControllerFullWidth.m
@@ -444,7 +444,8 @@ static inline UIColor *MDCTextInputTextErrorColor() {
 }
 
 - (UIColor *)inlinePlaceholderColor {
-  return _inlinePlaceholderColor ?: MDCTextInputInlinePlaceholderTextColor();
+  return _inlinePlaceholderColor
+            ? _inlinePlaceholderColor : MDCTextInputInlinePlaceholderTextColor();
 }
 
 - (BOOL)isDisplayingCharacterCountError {
@@ -705,7 +706,7 @@ static inline UIColor *MDCTextInputTextErrorColor() {
   // internal implementation of textRect calls [super clearButtonRectForBounds:] in its
   // implementation, our modifications are not picked up. Adjust accordingly.
   // Full width text boxes have their character count on the text input line
-  if (self.textInput.text.length > 0) {
+  if (self.textInput.text.length) {
     switch (textField.clearButtonMode) {
       case UITextFieldViewModeWhileEditing:
         editingRect.size.width -= CGRectGetWidth(self.textInput.clearButton.bounds);
@@ -823,8 +824,9 @@ static inline UIColor *MDCTextInputTextErrorColor() {
   // If error text is unset (nil) we reset to previous values.
   if (!errorText) {
     // If there is a saved state, use it.
-    self.textInput.leadingUnderlineLabel.text =
-        self.previousLeadingText ?: self.textInput.leadingUnderlineLabel.text;
+    if (self.previousLeadingText) {
+      self.textInput.leadingUnderlineLabel.text = self.previousLeadingText;
+    }
 
     // Clear out saved state.
     self.previousLeadingText = nil;
@@ -849,7 +851,7 @@ static inline UIColor *MDCTextInputTextErrorColor() {
 
     NSString *valueString = @"";
 
-    if (self.textInput.text > 0) {
+    if (self.textInput.text.length > 0) {
       valueString = [self.textInput.text copy];
     }
     if (self.textInput.placeholder.length > 0) {
@@ -858,8 +860,10 @@ static inline UIColor *MDCTextInputTextErrorColor() {
     valueString = [valueString stringByAppendingString:@"."];
 
     self.textInput.accessibilityValue = valueString;
+    NSString *leadingUnderlineLabelText = self.textInput.leadingUnderlineLabel.text;
     self.textInput.leadingUnderlineLabel.accessibilityLabel = [NSString
-        stringWithFormat:@"Error: %@.", self.textInput.leadingUnderlineLabel.text ?: @""];
+        stringWithFormat:@"Error: %@.", leadingUnderlineLabelText ?
+                                                               leadingUnderlineLabelText : @""];
   } else {
     self.textInput.accessibilityValue = nil;
     self.textInput.leadingUnderlineLabel.accessibilityLabel = nil;

--- a/components/Typography/src/MDCTypography.m
+++ b/components/Typography/src/MDCTypography.m
@@ -157,8 +157,9 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
   }
   UIFontDescriptor *fontDescriptor =
       [font.fontDescriptor fontDescriptorWithSymbolicTraits:UIFontDescriptorTraitItalic];
-  return [UIFont fontWithDescriptor:fontDescriptor size:0]
-             ?: [UIFont italicSystemFontOfSize:font.pointSize];
+  UIFont *fontFromDescriptor = [UIFont fontWithDescriptor:fontDescriptor size:0];
+  return fontFromDescriptor
+             ? fontFromDescriptor : [UIFont italicSystemFontOfSize:font.pointSize];
 }
 
 + (UIFont *)boldFontFromFont:(UIFont *)font {
@@ -171,8 +172,9 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
     traits = traits | UIFontDescriptorTraitItalic;
   }
   UIFontDescriptor *fontDescriptor = [font.fontDescriptor fontDescriptorWithSymbolicTraits:traits];
-  return [UIFont fontWithDescriptor:fontDescriptor size:0]
-             ?: [UIFont boldSystemFontOfSize:font.pointSize];
+  UIFont *fontFromDescriptor = [UIFont fontWithDescriptor:fontDescriptor size:0];
+  return fontFromDescriptor
+             ? fontFromDescriptor : [UIFont boldSystemFontOfSize:font.pointSize];
 }
 
 #pragma mark - Private

--- a/components/private/Overlay/src/MDCOverlayObserver.m
+++ b/components/private/Overlay/src/MDCOverlayObserver.m
@@ -151,7 +151,8 @@ static MDCOverlayObserver *_sOverlayObserver;
     return;
   }
 
-  NSValue *frame = userInfo[MDCOverlayFrameKey] ?: [NSValue valueWithCGRect:CGRectNull];
+  NSValue *frame = userInfo[MDCOverlayFrameKey] ?
+                      userInfo[MDCOverlayFrameKey] : [NSValue valueWithCGRect:CGRectNull];
   NSNumber *duration = userInfo[MDCOverlayTransitionDurationKey];
 
   // Update the overlay frame.


### PR DESCRIPTION
Make the code base more portable by replacing some GNU extension code
with C99-compatible versions.

* Replace shortcut `?:` operator with explicit middle (*true*) terms
* Remove pointer inequality checks in conditionals
* (Cleanup) Change to `#include` for `<tgmath.h>` based on style guide

Closes #846