### PR TITLE
[Pesto] Remove extra reusable cell registration

### DIFF
--- a/demos/Pesto/Pesto/PestoSettingsViewController.m
+++ b/demos/Pesto/Pesto/PestoSettingsViewController.m
@@ -62,8 +62,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   backButton.image = backImage;
   self.navigationItem.leftBarButtonItem = backButton;
   self.navigationItem.rightBarButtonItem = nil;
-  [self.collectionView registerClass:[MDCCollectionViewTextCell class]
-          forCellWithReuseIdentifier:kReusableIdentifierItem];
 
   // Register cell.
   [self.collectionView registerClass:[MDCCollectionViewTextCell class]


### PR DESCRIPTION
MDCCollectionViewTextCell was registered twice. removed so it only have one.
