### PR TITLE
[Tabs] Restore initial tab selection behavior

### DIFF
--- a/components/Tabs/examples/TabBarTextOnlyExample.m
+++ b/components/Tabs/examples/TabBarTextOnlyExample.m
@@ -29,7 +29,7 @@
 - (id)initWithCollectionViewLayout:(UICollectionViewLayout *)layout {
   self = [super initWithCollectionViewLayout:layout];
   if (self) {
-    [self setupExampleViews:@[@"Change Alignment", @"Toggle Case"]];
+    [self setupExampleViews:@[@"Change Alignment", @"Toggle Case", @"Clear Selection"]];
   }
   return self;
 }
@@ -44,6 +44,10 @@
 
 - (void)toggleCase:(id)sender {
   self.tabBar.displaysUppercaseTitles = !self.tabBar.displaysUppercaseTitles;
+}
+
+- (void)clearSelection:(id)sender {
+  self.tabBar.selectedItem = nil;
 }
 
 #pragma mark - Private
@@ -109,10 +113,22 @@
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
   [super collectionView:collectionView didSelectItemAtIndexPath:indexPath];
-  if (indexPath.row == 0) {
-    [self changeAlignment:collectionView];
-  } else {
-    [self toggleCase:collectionView];
+  switch (indexPath.row) {
+    case 0:
+      [self changeAlignment:collectionView];
+      break;
+
+    case 1:
+      [self toggleCase:collectionView];
+      break;
+
+    case 2:
+      [self clearSelection:collectionView];
+      break;
+
+    default:
+      // Unsupported
+      break;
   }
 }
 

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -43,9 +43,9 @@ IB_DESIGNABLE
 
  The bar determines the newly-selected item using the following logic:
  * Reselect the previously-selected item if it's still present in `items` after the update.
- * Select the first item in `items` if `selectedItem` is nil and has never been explicitly set. This
-   enables simple setup in the common case of creating a tab bar and setting its `items`.
- * Preserve empty selection if `selectedItem` is nil and has been explicitly set at some point.
+ * If there was no selection previously or if the old selected item is gone, select the first item.
+   Clients that need empty selection to be preserved across updates to `items` must manually reset
+   selectedItem to nil after the update.
  
  Changes to this property are not animated.
  */

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -41,7 +41,12 @@ IB_DESIGNABLE
 /**
  Items displayed in the tab bar.
 
- If the new items do not contain the currently selected item, the selection will be reset to nil.
+ The bar determines the newly-selected item using the following logic:
+ * Reselect the previously-selected item if it's still present in `items` after the update.
+ * Select the first item in `items` if `selectedItem` is nil and has never been explicitly set. This
+   enables simple setup in the common case of creating a tab bar and setting its `items`.
+ * Preserve empty selection if `selectedItem` is nil and has been explicitly set at some point.
+ 
  Changes to this property are not animated.
  */
 @property(nonatomic, copy, nonnull) NSArray<UITabBarItem *> *items;

--- a/components/Tabs/src/private/MDCItemBar.h
+++ b/components/Tabs/src/private/MDCItemBar.h
@@ -37,9 +37,9 @@
 
  The bar determines the newly-selected item using the following logic:
  * Reselect the previously-selected item if it's still present in `items` after the update.
- * Select the first item in `items` if `selectedItem` is nil and has never been explicitly set. This
- enables simple setup in the common case of creating a tab bar and setting its `items`.
- * Preserve empty selection if `selectedItem` is nil and has been explicitly set at some point.
+ * If there was no selection previously or if the old selected item is gone, select the first item.
+   Clients that need empty selection to be preserved across updates to `items` must manually reset
+   selectedItem to nil after the update.
 
  Changes to this property are not animated.
  */

--- a/components/Tabs/src/private/MDCItemBar.h
+++ b/components/Tabs/src/private/MDCItemBar.h
@@ -33,10 +33,15 @@
 + (CGFloat)defaultHeightForStyle:(nonnull MDCItemBarStyle *)style;
 
 /**
- Items displayed in bar.
+ Items displayed in the item bar.
 
- If the new items do not contain the currently selected item, the selection will be reset to the
- first item. Changes to this property are not animated. May not be nil.
+ The bar determines the newly-selected item using the following logic:
+ * Reselect the previously-selected item if it's still present in `items` after the update.
+ * Select the first item in `items` if `selectedItem` is nil and has never been explicitly set. This
+ enables simple setup in the common case of creating a tab bar and setting its `items`.
+ * Preserve empty selection if `selectedItem` is nil and has been explicitly set at some point.
+
+ Changes to this property are not animated.
  */
 @property(nonatomic, copy, nonnull) NSArray<UITabBarItem *> *items;
 

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -198,35 +198,20 @@ static void *kItemPropertyContext = &kItemPropertyContext;
       }
     }
 
-    // Update selected item.
-    if ((newSelectedItem != _selectedItem) && ![newSelectedItem isEqual:_selectedItem]) {
-      // Update _selectedItem directly to avoid clearing _shouldPreserveEmptySelectionOnItemsChange.
-      _selectedItem = newSelectedItem;
-      [self selectedItemDidChange];
-    }
+    // Update _selectedItem directly to avoid clearing _shouldPreserveEmptySelectionOnItemsChange.
+    _selectedItem = newSelectedItem;
+    [self updateLastSelectedIndexPath];
 
     // Update collection with new items
     [self reload];
 
+    // Select tab for current item.
+    [self selectItemAtIndex:(_lastSelectedIndexPath ? _lastSelectedIndexPath.item : NSNotFound)
+                   animated:NO];
+
     // Start observing new items for changes.
     [self startObservingItems];
   }
-}
-
-- (void)selectedItemDidChange {
-  // Update the index path for the selected item.
-  NSIndexPath *selectedItemIndexPath = nil;
-  if (_selectedItem) {
-    NSUInteger index = [_items indexOfObject:_selectedItem];
-    if (NSNotFound != index) {
-      // Valid index
-      selectedItemIndexPath = [NSIndexPath indexPathForItem:index inSection:0];
-    }
-  }
-  _lastSelectedIndexPath = selectedItemIndexPath;
-
-  // Update UI to select the item.
-  [self selectItemAtIndex:NSNotFound animated:NO];
 }
 
 - (void)setAlignment:(MDCItemBarAlignment)alignment {
@@ -260,7 +245,9 @@ static void *kItemPropertyContext = &kItemPropertyContext;
       }
     }
     _selectedItem = selectedItem;
-    [self selectedItemDidChange];
+    [self updateLastSelectedIndexPath];
+    [self selectItemAtIndex:(_lastSelectedIndexPath ? _lastSelectedIndexPath.item : NSNotFound)
+                   animated:NO];
   }
 }
 
@@ -491,6 +478,19 @@ static void *kItemPropertyContext = &kItemPropertyContext;
       [item removeObserver:self forKeyPath:key context:kItemPropertyContext];
     }
   }
+}
+
+- (void)updateLastSelectedIndexPath {
+  // Update the index path for the selected item.
+  NSIndexPath *selectedItemIndexPath = nil;
+  if (_selectedItem) {
+    NSUInteger index = [_items indexOfObject:_selectedItem];
+    if (NSNotFound != index) {
+      // Valid index
+      selectedItemIndexPath = [NSIndexPath indexPathForItem:index inSection:0];
+    }
+  }
+  _lastSelectedIndexPath = selectedItemIndexPath;
 }
 
 - (UIUserInterfaceSizeClass)horizontalSizeClass {

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -79,12 +79,6 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 
   /// Current style properties.
   MDCItemBarStyle *_style;
-
-  /// Internal state tracking what should happen to `selectedItem` when the `items` array changes.
-  /// By default this is NO which causes empty selections to not be preserved: Instead, the bar
-  /// selects the first item in the new items array on updates. When YES, a nil selection remains
-  /// nil after updating `items`. It's set to YES when `selectedItem` is explicitly set by clients.
-  BOOL _shouldPreserveEmptySelectionOnItemsChange;
 }
 
 + (CGFloat)defaultHeightForStyle:(nonnull MDCItemBarStyle *)style {
@@ -184,21 +178,15 @@ static void *kItemPropertyContext = &kItemPropertyContext;
         // Preserve selection.
         newSelectedItem = _selectedItem;
       } else {
-        // Previously-selected item gone - clear selection.
-        newSelectedItem = nil;
-      }
-    } else {
-      // No previously selected item.
-      if (_shouldPreserveEmptySelectionOnItemsChange) {
-        // Preserve the empty selection.
-        newSelectedItem = nil;
-      } else {
-        // Select first item. (Default behavior)
+        // Previously-selected item gone - select first.
         newSelectedItem = _items.firstObject;
       }
+    } else {
+      // No previously selected item, select first item.
+      newSelectedItem = _items.firstObject;
     }
 
-    // Update _selectedItem directly to avoid clearing _shouldPreserveEmptySelectionOnItemsChange.
+    // Update _selectedItem directly so we can update _lastSelectedIndexPath before reloading.
     _selectedItem = newSelectedItem;
     [self updateLastSelectedIndexPath];
 
@@ -231,9 +219,6 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 }
 
 - (void)setSelectedItem:(nullable UITabBarItem *)selectedItem animated:(BOOL)animated {
-  // Selected item was explicitly set - must preserve empty selection now.
-  _shouldPreserveEmptySelectionOnItemsChange = YES;
-
   if (_selectedItem != selectedItem) {
     NSUInteger itemIndex = NSNotFound;
     if (selectedItem) {

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -80,6 +80,10 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   /// Current style properties.
   MDCItemBarStyle *_style;
 
+  /// Internal state tracking what should happen to `selectedItem` when the `items` array changes.
+  /// By default this is NO which causes empty selections to not be preserved: Instead, the bar
+  /// selects the first item in the new items array on updates. When YES, a nil selection remains
+  /// nil after updating `items`. It's set to YES when `selectedItem` is explicitly set by clients.
   BOOL _shouldPreserveEmptySelectionOnItemsChange;
 }
 
@@ -173,7 +177,7 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 
     _items = [items copy];
 
-    // Determine newly selected item.
+    // Determine new selected item.
     UITabBarItem *newSelectedItem = nil;
     if (_selectedItem) {
       if ([_items containsObject:_selectedItem]) {
@@ -184,12 +188,12 @@ static void *kItemPropertyContext = &kItemPropertyContext;
         newSelectedItem = nil;
       }
     } else {
-      // No previously selected item
+      // No previously selected item.
       if (_shouldPreserveEmptySelectionOnItemsChange) {
-        // Preserve empty selection.
+        // Preserve the empty selection.
         newSelectedItem = nil;
       } else {
-        // Default state: Select first item.
+        // Select first item. (Default behavior)
         newSelectedItem = _items.firstObject;
       }
     }

--- a/components/Tabs/tests/unit/MaterialTabsTests.m
+++ b/components/Tabs/tests/unit/MaterialTabsTests.m
@@ -1,0 +1,109 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialTabs.h"
+
+@interface MaterialTabsTests : XCTestCase
+@end
+
+@implementation MaterialTabsTests {
+  MDCTabBar *_tabBar;
+  UITabBarItem *_itemA;
+  UITabBarItem *_itemB;
+  UITabBarItem *_itemC;
+}
+
+- (void)setUp {
+  _tabBar = [[MDCTabBar alloc] init];
+  _itemA = [[UITabBarItem alloc] initWithTitle:@"A" image:nil tag:0];
+  _itemB = [[UITabBarItem alloc] initWithTitle:@"B" image:nil tag:0];
+  _itemC = [[UITabBarItem alloc] initWithTitle:@"C" image:nil tag:0];
+}
+
+/// Tab bars should by default select the first item in their items array.
+- (void)testSelectsFirstItemByDefault {
+  _tabBar.items = @[_itemA, _itemB, _itemC];
+  XCTAssertEqual(_tabBar.selectedItem, _itemA);
+}
+
+/// Tab bars should preserve their selection if possible when changing items.
+- (void)testPreservesDefaultSelectedItem {
+  // Set items {A, B} which should select item A
+  _tabBar.items = @[_itemA, _itemB];
+
+  // Set items {C, A} which should preserve the selection of A.
+  _tabBar.items = @[_itemC, _itemA];
+  XCTAssertEqual(_tabBar.selectedItem, _itemA);
+}
+
+/// Tab bars should preserve their explicitly-set selection if possible when changing items.
+- (void)testPreservesNondefaultSelectedItem {
+  // Set items {A, B} and explicitly select B.
+  _tabBar.items = @[_itemA, _itemB];
+  _tabBar.selectedItem = _itemB;
+
+  // Set items {B, C} which should preserve the selection of B.
+  _tabBar.items = @[_itemB, _itemC];
+  XCTAssertEqual(_tabBar.selectedItem, _itemB);
+}
+
+/// Tab bars should clear the default selection if that item is no longer present.
+- (void)testDeselectsWhenDefaultSelectedItemMissing {
+  // Set items {A, B} which should select item A
+  _tabBar.items = @[_itemA, _itemB];
+
+  // Set items not including A, which should clear the selection.
+  _tabBar.items = @[_itemB, _itemC];
+  XCTAssertNil(_tabBar.selectedItem);
+}
+
+/// Tab bars should clear the explicit selection if that item is no longer present.
+- (void)testDeselectsWhenNondefaultSelectedItemMissing {
+  // Set items {A, B} and select B
+  _tabBar.items = @[_itemA, _itemB];
+  _tabBar.selectedItem = _itemB;
+
+  // Set items not including B, which should clear the selection.
+  _tabBar.items = @[_itemA, _itemC];
+  XCTAssertNil(_tabBar.selectedItem);
+}
+
+/// Tab bars should safely accept having their items set to the empty array.
+- (void)testSafelyHandlesEmptyItems {
+  _tabBar.items = @[];
+  XCTAssertNil(_tabBar.selectedItem);
+
+  // Setting the empty array should also be safe coming from a non-empty array.
+  _tabBar.items = @[_itemA];
+  _tabBar.items = @[];
+  XCTAssertNil(_tabBar.selectedItem);
+}
+
+/// If the selection is cleared, future updates should preserve the empty selection.
+- (void)testPerservesEmptySelection {
+  // Initial state: Items but explicitly cleared selection.
+  _tabBar.items = @[_itemA, _itemB];
+  _tabBar.selectedItem = nil;
+  XCTAssertNil(_tabBar.selectedItem);
+
+  // Update with new items, verify that empty selection is preserved.
+  _tabBar.items = @[_itemB, _itemC];
+  XCTAssertNil(_tabBar.selectedItem);
+}
+
+@end

--- a/components/Tabs/tests/unit/MaterialTabsTests.m
+++ b/components/Tabs/tests/unit/MaterialTabsTests.m
@@ -37,49 +37,49 @@
 
 /// Tab bars should by default select the first item in their items array.
 - (void)testSelectsFirstItemByDefault {
-  _tabBar.items = @[_itemA, _itemB, _itemC];
+  _tabBar.items = @[ _itemA, _itemB, _itemC ];
   XCTAssertEqual(_tabBar.selectedItem, _itemA);
 }
 
 /// Tab bars should preserve their selection if possible when changing items.
 - (void)testPreservesDefaultSelectedItem {
   // Set items {A, B} which should select item A
-  _tabBar.items = @[_itemA, _itemB];
+  _tabBar.items = @[ _itemA, _itemB ];
 
   // Set items {C, A} which should preserve the selection of A.
-  _tabBar.items = @[_itemC, _itemA];
+  _tabBar.items = @[ _itemC, _itemA ];
   XCTAssertEqual(_tabBar.selectedItem, _itemA);
 }
 
 /// Tab bars should preserve their explicitly-set selection if possible when changing items.
 - (void)testPreservesNondefaultSelectedItem {
   // Set items {A, B} and explicitly select B.
-  _tabBar.items = @[_itemA, _itemB];
+  _tabBar.items = @[ _itemA, _itemB ];
   _tabBar.selectedItem = _itemB;
 
   // Set items {B, C} which should preserve the selection of B.
-  _tabBar.items = @[_itemB, _itemC];
+  _tabBar.items = @[ _itemB, _itemC ];
   XCTAssertEqual(_tabBar.selectedItem, _itemB);
 }
 
 /// Tab bars should clear the default selection if that item is no longer present.
 - (void)testDeselectsWhenDefaultSelectedItemMissing {
   // Set items {A, B} which should select item A
-  _tabBar.items = @[_itemA, _itemB];
+  _tabBar.items = @[ _itemA, _itemB ];
 
   // Set items not including A, which should clear the selection.
-  _tabBar.items = @[_itemB, _itemC];
+  _tabBar.items = @[ _itemB, _itemC ];
   XCTAssertNil(_tabBar.selectedItem);
 }
 
 /// Tab bars should clear the explicit selection if that item is no longer present.
 - (void)testDeselectsWhenNondefaultSelectedItemMissing {
   // Set items {A, B} and select B
-  _tabBar.items = @[_itemA, _itemB];
+  _tabBar.items = @[ _itemA, _itemB ];
   _tabBar.selectedItem = _itemB;
 
   // Set items not including B, which should clear the selection.
-  _tabBar.items = @[_itemA, _itemC];
+  _tabBar.items = @[ _itemA, _itemC ];
   XCTAssertNil(_tabBar.selectedItem);
 }
 
@@ -89,7 +89,7 @@
   XCTAssertNil(_tabBar.selectedItem);
 
   // Setting the empty array should also be safe coming from a non-empty array.
-  _tabBar.items = @[_itemA];
+  _tabBar.items = @[ _itemA ];
   _tabBar.items = @[];
   XCTAssertNil(_tabBar.selectedItem);
 }
@@ -97,12 +97,12 @@
 /// If the selection is cleared, future updates should preserve the empty selection.
 - (void)testPerservesEmptySelection {
   // Initial state: Items but explicitly cleared selection.
-  _tabBar.items = @[_itemA, _itemB];
+  _tabBar.items = @[ _itemA, _itemB ];
   _tabBar.selectedItem = nil;
   XCTAssertNil(_tabBar.selectedItem);
 
   // Update with new items, verify that empty selection is preserved.
-  _tabBar.items = @[_itemB, _itemC];
+  _tabBar.items = @[ _itemB, _itemC ];
   XCTAssertNil(_tabBar.selectedItem);
 }
 

--- a/components/Tabs/tests/unit/MaterialTabsTests.m
+++ b/components/Tabs/tests/unit/MaterialTabsTests.m
@@ -42,7 +42,7 @@
 }
 
 /// Tab bars should preserve their selection if possible when changing items.
-- (void)testPreservesDefaultSelectedItem {
+- (void)testPreservesSelectedItem {
   // Set items {A, B} which should select item A
   _tabBar.items = @[ _itemA, _itemB ];
 
@@ -51,36 +51,14 @@
   XCTAssertEqual(_tabBar.selectedItem, _itemA);
 }
 
-/// Tab bars should preserve their explicitly-set selection if possible when changing items.
-- (void)testPreservesNondefaultSelectedItem {
-  // Set items {A, B} and explicitly select B.
-  _tabBar.items = @[ _itemA, _itemB ];
-  _tabBar.selectedItem = _itemB;
-
-  // Set items {B, C} which should preserve the selection of B.
-  _tabBar.items = @[ _itemB, _itemC ];
-  XCTAssertEqual(_tabBar.selectedItem, _itemB);
-}
-
-/// Tab bars should clear the default selection if that item is no longer present.
-- (void)testDeselectsWhenDefaultSelectedItemMissing {
+/// Tab bars should select the first item if the old selection is no longer present.
+- (void)testSelectsFirstWhenSelectedItemMissing {
   // Set items {A, B} which should select item A
   _tabBar.items = @[ _itemA, _itemB ];
 
-  // Set items not including A, which should clear the selection.
+  // Set items not including A, which should select B.
   _tabBar.items = @[ _itemB, _itemC ];
-  XCTAssertNil(_tabBar.selectedItem);
-}
-
-/// Tab bars should clear the explicit selection if that item is no longer present.
-- (void)testDeselectsWhenNondefaultSelectedItemMissing {
-  // Set items {A, B} and select B
-  _tabBar.items = @[ _itemA, _itemB ];
-  _tabBar.selectedItem = _itemB;
-
-  // Set items not including B, which should clear the selection.
-  _tabBar.items = @[ _itemA, _itemC ];
-  XCTAssertNil(_tabBar.selectedItem);
+  XCTAssertEqual(_tabBar.selectedItem, _itemB);
 }
 
 /// Tab bars should safely accept having their items set to the empty array.
@@ -94,16 +72,19 @@
   XCTAssertNil(_tabBar.selectedItem);
 }
 
-/// If the selection is cleared, future updates should preserve the empty selection.
-- (void)testPerservesEmptySelection {
-  // Initial state: Items but explicitly cleared selection.
+// Setting items to the same set of items should change nothing.
+- (void)testItemsUpdateIsIdempotent {
+  // Start with {A, B}, which selects A.
   _tabBar.items = @[ _itemA, _itemB ];
-  _tabBar.selectedItem = nil;
-  XCTAssertNil(_tabBar.selectedItem);
+  XCTAssertEqual(_tabBar.selectedItem, _itemA);
 
-  // Update with new items, verify that empty selection is preserved.
-  _tabBar.items = @[ _itemB, _itemC ];
-  XCTAssertNil(_tabBar.selectedItem);
+  // Remove A, which selects B.
+  _tabBar.items = @[ _itemB ];
+  XCTAssertEqual(_tabBar.selectedItem, _itemB);
+
+  // Set same set of items, which should make no difference to the selection.
+  _tabBar.items = @[ _itemB ];
+  XCTAssertEqual(_tabBar.selectedItem, _itemB);
 }
 
 @end


### PR DESCRIPTION
Recent changes to the tab bar unintentionally changed the initial selection behavior of MDCTabBar such that creating a tab bar and setting its items array no longer automatically selected the first item. This broke all of our examples and made the API more onerous to use for the 99% case.

This change preserves the ability to set an empty selection while fixing the common case and keeping the API simple. To help solidify this behavior it adds some unit tests and new capabilities to the example.