### PR TITLE
[Buttons] Deprecate customTitleColor and remove auto-accessibility from setTitleColor

### DIFF
--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -180,7 +180,7 @@ static NSString *const MDCButtonBarButtonLayoutPositionKey = @"MDCButtonBarButto
   for (UIView *viewObj in _buttonViews) {
     if ([viewObj isKindOfClass:[MDCButton class]]) {
       MDCButton *buttonView = (MDCButton *)viewObj;
-      buttonView.customTitleColor = self.tintColor;
+      [buttonView setTitleColor:self.tintColor forState:UIControlStateNormal];
     }
   }
 }

--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
@@ -121,7 +121,7 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
 
   button.tag = buttonItem.tag;
 
-  button.customTitleColor = self.buttonTitleColor;
+  [button setTitleColor:self.buttonTitleColor forState:UIControlStateNormal];
   [button setUnderlyingColorHint:self.buttonUnderlyingColor];
 
   [self updateButton:button withItem:buttonItem barMetrics:UIBarMetricsDefault];

--- a/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
+++ b/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
@@ -42,7 +42,7 @@ class ButtonsSimpleExampleSwiftViewController: UIViewController {
     view.addSubview(raisedButton)
 
     let flatButton = MDCFlatButton()
-    flatButton.customTitleColor = .gray
+    flatButton.setTitleColor(.gray, for: .normal)
     flatButton.setTitle("Touch me", for: UIControlState())
     flatButton.sizeToFit()
     flatButton.translatesAutoresizingMaskIntoConstraints = false

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -124,7 +124,7 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
     raisedButton.addTarget(self, action: #selector(tap), for: .touchUpInside)
     innerContainerView.addSubview(raisedButton)
 
-    flatButton.customTitleColor = UIColor.gray
+    flatButton.setTitleColor(.gray, for: .normal)
     flatButton.setTitle("Programmatic", for: .normal)
     flatButton.sizeToFit()
     flatButton.translatesAutoresizingMaskIntoConstraints = false

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -60,7 +60,7 @@
 
   MDCFlatButton *flatButton = [[MDCFlatButton alloc] init];
   [flatButton setTitle:@"Button" forState:UIControlStateNormal];
-  [flatButton setCustomTitleColor:[UIColor grayColor]];
+  [flatButton setTitleColor:[UIColor grayColor] forState:UIControlStateNormal];
   [flatButton sizeToFit];
   [flatButton addTarget:self
                  action:@selector(didTap:)
@@ -72,7 +72,7 @@
 
   MDCFlatButton *disabledFlatButton = [[MDCFlatButton alloc] init];
   [disabledFlatButton setTitle:@"Button" forState:UIControlStateNormal];
-  [disabledFlatButton setCustomTitleColor:[UIColor grayColor]];
+  [disabledFlatButton setTitleColor:[UIColor grayColor] forState:UIControlStateNormal];
   [disabledFlatButton sizeToFit];
   [disabledFlatButton addTarget:self
                          action:@selector(didTap:)

--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -159,12 +159,7 @@
 #pragma mark - Deprecated
 
 /**
- A custom title color for the non-disabled states. The default is nil, which means that the button
- chooses its title color automatically based on @c underlyingColor, whether the button is opaque,
- its current background color, etc.
-
- Setting this to a non-nil color overrides that logic, and the caller is responsible for ensuring
- that the title color/background color combination meets the accessibility requirements.
+ This property sets/gets the title color for UIControlStateNormal.
  */
 @property(nonatomic, strong, nullable) UIColor *customTitleColor UI_APPEARANCE_SELECTOR
     __deprecated_msg("Use setTitleColor:forState: instead");

--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -140,8 +140,6 @@
 /**
  Sets the elevation for a particular control state.
 
- Use resetElevationForState: to reset the button's behavior to the default for a particular state.
-
  @param elevation The elevation to set.
  @param state The state to set.
  */

--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -48,16 +48,6 @@
 @property(nonatomic, assign) CGFloat inkMaxRippleRadius;
 
 /**
- A custom title color for the non-disabled states. The default is nil, which means that the button
- chooses its title color automatically based on @c underlyingColor, whether the button is opaque,
- its current background color, etc.
-
- Setting this to a non-nil color overrides that logic, and the caller is responsible for ensuring
- that the title color/background color combination meets the accessibility requirements.
- */
-@property(nonatomic, strong, nullable) UIColor *customTitleColor UI_APPEARANCE_SELECTOR;
-
-/**
  The alpha value that will be applied when the button is disabled. Most clients can leave this as
  the default value to get a semi-transparent button automatically.
  */
@@ -167,6 +157,17 @@
 + (nonnull instancetype)buttonWithType:(UIButtonType)buttonType NS_UNAVAILABLE;
 
 #pragma mark - Deprecated
+
+/**
+ A custom title color for the non-disabled states. The default is nil, which means that the button
+ chooses its title color automatically based on @c underlyingColor, whether the button is opaque,
+ its current background color, etc.
+
+ Setting this to a non-nil color overrides that logic, and the caller is responsible for ensuring
+ that the title color/background color combination meets the accessibility requirements.
+ */
+@property(nonatomic, strong, nullable) UIColor *customTitleColor UI_APPEARANCE_SELECTOR
+    __deprecated_msg("Use setTitleColor:forState: instead");
 
 @property(nonatomic)
     BOOL shouldRaiseOnTouch __deprecated_msg("Use MDCFlatButton instead of shouldRaiseOnTouch = NO")

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -52,10 +52,10 @@ static NSString *const MDCButtonAccessibilityLabelsKey = @"MDCButtonAccessibilit
 static const NSTimeInterval MDCButtonAnimationDuration = 0.2;
 
 // https://material.io/guidelines/components/buttons.html#buttons-main-buttons
-static const CGFloat MDCButtonDisabledAlpha = 0.1f;
+static const CGFloat MDCButtonDisabledAlpha = 0.12f;
 
 // Blue 500 from https://material.io/guidelines/style/color.html#color-color-palette .
-static const uint32_t MDCButtonDefaultBackgroundColor = 0x2196F3;
+static const uint32_t MDCButtonDefaultBackgroundColor = 0x191919;
 
 // Creates a UIColor from a 24-bit RGB color encoded as an integer.
 static inline UIColor *MDCColorFromRGB(uint32_t rgbValue) {

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -130,19 +130,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   if (self) {
     [self commonMDCButtonInit];
 
-    // TODO(randallli): Add backward compatibility to background colors
-    //    if ([aDecoder containsValueForKey:MDCButtonEnabledBackgroundColorKey]) {
-    //      self.enabledBackgroundColor =
-    //          [aDecoder decodeObjectForKey:MDCButtonEnabledBackgroundColorKey];
-    //    }
-    //    if ([aDecoder containsValueForKey:MDCButtonDisabledBackgroundColorLightKey]) {
-    //      self.disabledBackgroundColorLight =
-    //          [aDecoder decodeObjectForKey:MDCButtonDisabledBackgroundColorLightKey];
-    //    }
-    //    if ([aDecoder containsValueForKey:MDCButtonDisabledBackgroundColorDarkKey]) {
-    //      self.disabledBackgroundColorDark =
-    //          [aDecoder decodeObjectForKey:MDCButtonDisabledBackgroundColorDarkKey];
-    //    }
     if ([aDecoder containsValueForKey:MDCButtonInkViewInkStyleKey]) {
       self.inkView.inkStyle = [aDecoder decodeIntegerForKey:MDCButtonInkViewInkStyleKey];
     }

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -287,11 +287,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
                                                 object:nil];
 }
 
-- (void)setCustomTitleColor:(UIColor *)customTitleColor {
-  _customTitleColor = customTitleColor;
-  [self updateTitleColor];
-}
-
 - (void)setUnderlyingColorHint:(UIColor *)underlyingColorHint {
   _underlyingColorHint = underlyingColorHint;
   [self updateAlphaAndBackgroundColorAnimated:NO];
@@ -634,16 +629,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 }
 
 - (void)updateBackgroundColor {
-  //  UIColor *color = nil;
-  //  if ([self shouldHaveOpaqueBackground]) {
-  //    if (self.enabled) {
-  ////      color = self.enabledBackgroundColor;
-  //    } else {
-  //      color = [self isDarkColor:_underlyingColorHint] ? _disabledBackgroundColorLight
-  //                                                  : _disabledBackgroundColorDark;
-  //    }
-  //  }
-  [self updateTitleColor];
   [self updateDisabledTitleColor];
   super.backgroundColor = self.currentBackgroundColor;
 }
@@ -655,25 +640,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   BOOL darkBackground = [self isDarkColor:[self underlyingColorHint]];
   [self setTitleColor:darkBackground ? [UIColor whiteColor] : [UIColor blackColor]
              forState:UIControlStateDisabled];
-}
-
-- (void)updateTitleColor {
-  if (_customTitleColor) {
-    [self setTitleColor:_customTitleColor forState:UIControlStateNormal];
-    return;
-  }
-
-  if (![self isTransparentColor:[self effectiveBackgroundColor]]) {
-    MDFTextAccessibilityOptions options = 0;
-    if ([MDFTextAccessibility isLargeForContrastRatios:self.titleLabel.font]) {
-      options = MDFTextAccessibilityOptionsLargeFont;
-    }
-    UIColor *color =
-        [MDFTextAccessibility textColorOnBackgroundColor:[self effectiveBackgroundColor]
-                                         targetTextAlpha:[MDCTypography buttonFontOpacity]
-                                                 options:options];
-    [self setTitleColor:color forState:UIControlStateNormal];
-  }
 }
 
 - (BOOL)mdc_adjustsFontForContentSizeCategory {
@@ -703,6 +669,14 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 }
 
 #pragma mark - Deprecations
+
+- (void)setCustomTitleColor:(UIColor *)customTitleColor {
+  [self setTitleColor:customTitleColor forState:UIControlStateNormal];
+}
+
+- (UIColor *)customTitleColor {
+  return [self titleColorForState:UIControlStateNormal];
+}
 
 - (BOOL)shouldCapitalizeTitle {
   return [self isUppercaseTitle];

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -171,13 +171,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
       self.underlyingColorHint = [aDecoder decodeObjectForKey:MDCButtonUnderlyingColorHintKey];
     }
 
-    if ([aDecoder containsValueForKey:MDCButtonCustomTitleColorKey]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      self.customTitleColor = [aDecoder decodeObjectForKey:MDCButtonCustomTitleColorKey];
-#pragma clang diagnostic pop
-    }
-
     if ([aDecoder containsValueForKey:MDCButtonDisableAlphaKey]) {
       self.disabledAlpha = (CGFloat)[aDecoder decodeDoubleForKey:MDCButtonDisableAlphaKey];
     }
@@ -216,12 +209,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
     [aCoder encodeObject:_underlyingColorHint forKey:MDCButtonUnderlyingColorHintKey];
   }
   [aCoder encodeDouble:self.disabledAlpha forKey:MDCButtonDisableAlphaKey];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  if (self.customTitleColor) {
-    [aCoder encodeObject:self.customTitleColor forKey:MDCButtonCustomTitleColorKey];
-  }
-#pragma clang diagnostic pop
   [aCoder encodeUIEdgeInsets:self.hitAreaInsets forKey:MDCButtonAreaInsetKey];
   [aCoder encodeObject:_userElevations forKey:MDCButtonUserElevationsKey];
   [aCoder encodeObject:_backgroundColors forKey:MDCButtonBackgroundColorsKey];

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -172,7 +172,10 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
     }
 
     if ([aDecoder containsValueForKey:MDCButtonCustomTitleColorKey]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
       self.customTitleColor = [aDecoder decodeObjectForKey:MDCButtonCustomTitleColorKey];
+#pragma clang diagnostic pop
     }
 
     if ([aDecoder containsValueForKey:MDCButtonDisableAlphaKey]) {
@@ -213,9 +216,12 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
     [aCoder encodeObject:_underlyingColorHint forKey:MDCButtonUnderlyingColorHintKey];
   }
   [aCoder encodeDouble:self.disabledAlpha forKey:MDCButtonDisableAlphaKey];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   if (self.customTitleColor) {
     [aCoder encodeObject:self.customTitleColor forKey:MDCButtonCustomTitleColorKey];
   }
+#pragma clang diagnostic pop
   [aCoder encodeUIEdgeInsets:self.hitAreaInsets forKey:MDCButtonAreaInsetKey];
   [aCoder encodeObject:_userElevations forKey:MDCButtonUserElevationsKey];
   [aCoder encodeObject:_backgroundColors forKey:MDCButtonBackgroundColorsKey];

--- a/components/Buttons/src/MDCFlatButton.m
+++ b/components/Buttons/src/MDCFlatButton.m
@@ -31,6 +31,8 @@ static NSString *const MDCFlatButtonHasOpaqueBackground = @"MDCFlatButtonHasOpaq
                                   forState:UIControlStateNormal];
   [[MDCFlatButton appearance] setElevation:MDCShadowElevationNone
                                   forState:UIControlStateHighlighted];
+  [[MDCFlatButton appearance] setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+  [[MDCFlatButton appearance] setTitleColor:[UIColor blackColor] forState:UIControlStateDisabled];
 }
 
 - (instancetype)init {

--- a/components/Buttons/src/MDCRaisedButton.m
+++ b/components/Buttons/src/MDCRaisedButton.m
@@ -26,6 +26,8 @@
                                     forState:UIControlStateNormal];
   [[MDCRaisedButton appearance] setElevation:MDCShadowElevationRaisedButtonPressed
                                     forState:UIControlStateHighlighted];
+  [[MDCRaisedButton appearance] setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+  [[MDCRaisedButton appearance] setTitleColor:[UIColor blackColor] forState:UIControlStateDisabled];
 }
 
 @end

--- a/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
+++ b/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
@@ -22,10 +22,10 @@
 + (void)applyColorScheme:(NSObject<MDCColorScheme> *)colorScheme {
   #if defined(__IPHONE_9_0) && __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_9_0
   [[MDCButton appearanceWhenContainedInInstancesOfClasses:@[[MDCAlertController class]]]
-      setCustomTitleColor:colorScheme.primaryColor];
+      setTitleColor:colorScheme.primaryColor forState:UIControlStateNormal];
   #else
   [[MDCButton appearanceWhenContainedIn:[MDCAlertController class], nil]
-      setCustomTitleColor:colorScheme.primaryColor];
+      setTitleColor:colorScheme.primaryColor forState:UIControlStateNormal];
   #endif
 }
 

--- a/components/TextFields/examples/supplemental/TextFieldKitchenSinkExampleSupplemental.swift
+++ b/components/TextFields/examples/supplemental/TextFieldKitchenSinkExampleSupplemental.swift
@@ -49,7 +49,7 @@ extension TextFieldKitchenSinkSwiftExample {
 
   func setupButton() -> MDCButton {
     let button = MDCButton()
-    button.customTitleColor = .white
+    button.setTitleColor(.white, for: .normal)
     return button
   }
 


### PR DESCRIPTION
This deprecates customTitleColor on MDCButton and removes the automatic title color accessibility  magic from setTitleColor:forState:.

Currently setTitleColor:forState will highjack the title color if it isn't of sufficient contrast with the button background color. This PR undoes this behavior. If you were dependent on this feature please refer to MDCButtonTitleColorAccessibilityMutator. 