### PR TITLE
[Tabs] Constrain tabs to the view's width

### DIFF
--- a/components/Tabs/examples/TabBarTextOnlyExample.m
+++ b/components/Tabs/examples/TabBarTextOnlyExample.m
@@ -59,7 +59,9 @@
     [[UITabBarItem alloc] initWithTitle:@"A" image:nil tag:0],
     [[UITabBarItem alloc] initWithTitle:@"Tab Bar" image:nil tag:0],
     [[UITabBarItem alloc] initWithTitle:@"With" image:nil tag:0],
-    [[UITabBarItem alloc] initWithTitle:@"A Variety of Titles of Varying Length" image:nil tag:0],
+    [[UITabBarItem alloc] initWithTitle:@"A Variety of Titles of Varying Length That Might Be Long"
+                                  image:nil
+                                    tag:0],
   ];
 
   // Give change the selected item tint color and the tab bar tint color. For other color properties

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -408,10 +408,13 @@ static void *kItemPropertyContext = &kItemPropertyContext;
     size.width = _collectionView.bounds.size.width / MAX(count, 1);
   }
 
-  // Constrain width if necessary.
+  // Constrain to style-based width if necessary.
   if (_style.maximumItemWidth > 0) {
     size.width = MIN(size.width, _style.maximumItemWidth);
   }
+
+  // Constrain to view width
+  size.width = MIN(size.width, CGRectGetWidth(collectionView.frame));
 
   // Force height to our height.
   size.height = itemHeight;


### PR DESCRIPTION
This limits the width of all individual tabs to the width of the view. It isn't perfect - small insets will mean that there is still some scrolling "slop" for single-tabbed situations - but it solves the most common case of broken tab bar layouts.