### PR TITLE
Explicitly annotating some known ObjC methods.

### DIFF
--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -88,7 +88,7 @@ class AppBarModalPresentationSwiftExamplePresented: UITableViewController {
     return cell!
   }
 
-  func dismissSelf() {
+  @objc func dismissSelf() {
     self.dismiss(animated: true, completion: nil)
   }
 }
@@ -144,7 +144,7 @@ class AppBarModalPresentationSwiftExample: UITableViewController {
     self.navigationController?.setNavigationBarHidden(true, animated: animated)
   }
 
-  func presentModal() {
+  @objc func presentModal() {
     let modalVC = AppBarModalPresentationSwiftExamplePresented()
     self.present(modalVC, animated: true, completion: nil)
   }

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
@@ -65,7 +65,7 @@ class ButtonBarTypicalUseSwiftExample: UIViewController {
     view.backgroundColor = UIColor(white: 0.9, alpha:1.0)
   }
 
-  func didTapActionButton(_ sender: Any) {
+  @objc func didTapActionButton(_ sender: Any) {
     print("Did tap action item: \(sender)")
   }
 

--- a/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
+++ b/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
@@ -85,7 +85,7 @@ class ButtonsDynamicTypeViewController: UIViewController {
       constant: 0.0))
   }
 
-  func tap(_ sender: Any) {
+  @objc func tap(_ sender: Any) {
     print("\(type(of: sender)) was tapped.")
   }
 

--- a/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
+++ b/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
@@ -97,7 +97,7 @@ class ButtonsSimpleExampleSwiftViewController: UIViewController {
       constant: 0.0))
   }
 
-  func tap(_ sender: Any) {
+  @objc func tap(_ sender: Any) {
     print("\(type(of: sender)) was tapped.")
   }
 

--- a/components/Dialogs/examples/DialogsLongAlertViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertViewController.swift
@@ -51,7 +51,7 @@ class DialogsLongAlertViewController: UIViewController {
     ])
   }
 
-  func tap(_ sender: Any) {
+  @objc func tap(_ sender: Any) {
     let messageString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur " +
     "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
     "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +

--- a/components/PageControl/examples/PageControlTypicalUseExample.swift
+++ b/components/PageControl/examples/PageControlTypicalUseExample.swift
@@ -105,7 +105,7 @@ class PageControlSwiftExampleViewController: UIViewController, UIScrollViewDeleg
 
   // MARK: - User events
 
-  func didChangePage(_ sender: MDCPageControl) {
+  @objc func didChangePage(_ sender: MDCPageControl) {
     var offset = scrollView.contentOffset
     offset.x = CGFloat(sender.currentPage) * scrollView.bounds.size.width
     scrollView.setContentOffset(offset, animated: true)

--- a/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
+++ b/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
@@ -48,7 +48,7 @@ class ShadowDragSquareExampleViewController: UIViewController {
     self.blueView.addGestureRecognizer(longPressRecogniser)
   }
 
-  func longPressedInView(_ sender: UILongPressGestureRecognizer) {
+  @objc func longPressedInView(_ sender: UILongPressGestureRecognizer) {
     // Elevation of the view is changed to indicate that it has been pressed or released.
     // view.center is changed to follow the touch events.
     if sender.state == .began {

--- a/components/Tabs/examples/TabBarIconExample.swift
+++ b/components/Tabs/examples/TabBarIconExample.swift
@@ -76,7 +76,7 @@ class TabBarIconSwiftExample: UIViewController {
                               for: .touchUpInside)
   }
 
-  func changeAlignmentDidTouch(sender: UIButton) {
+  @objc func changeAlignmentDidTouch(sender: UIButton) {
     let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
     sheet.addAction(UIAlertAction(title: "Leading", style: .default, handler: { _ in
       self.alignment = .leading
@@ -103,9 +103,9 @@ class TabBarIconSwiftExample: UIViewController {
     starItem.badgeValue = NumberFormatter.localizedString(from:(badgeNumber + 1) as NSNumber,
                                                           number: .none)
   }
+
   // MARK: Action
-  func incrementDidTouch(sender: UIBarButtonItem) {
-    incrementStarBadge()
+  @objc func incrementDidTouch(sender: UIBarButtonItem) { incrementStarBadge()
 
     addStar(centered: false)
   }

--- a/components/TextFields/examples/TextFieldExample.swift
+++ b/components/TextFields/examples/TextFieldExample.swift
@@ -209,11 +209,11 @@ final class TextFieldSwiftExample: UIViewController {
 
   // MARK: - Actions
 
-  func tapDidTouch(sender: Any) {
+  @objc func tapDidTouch(sender: Any) {
     self.view.endEditing(true)
   }
 
-  func buttonDidTouch(sender: Any) {
+  @objc func buttonDidTouch(sender: Any) {
     let alert = UIAlertController(title: "Floating Enabled",
                                   message: nil,
                                   preferredStyle: .actionSheet)
@@ -296,7 +296,7 @@ extension TextFieldSwiftExample {
       object: nil)
   }
 
-  func keyboardWillShow(notif: Notification) {
+  @objc func keyboardWillShow(notif: Notification) {
     guard let frame = notif.userInfo?[UIKeyboardFrameBeginUserInfoKey] as? CGRect else {
       return
     }
@@ -306,7 +306,7 @@ extension TextFieldSwiftExample {
                                            right: 0.0)
   }
 
-  func keyboardWillHide(notif: Notification) {
+  @objc func keyboardWillHide(notif: Notification) {
     scrollView.contentInset = UIEdgeInsets()
   }
 }

--- a/components/TextFields/examples/TextFieldKitchenSinkExample.swift
+++ b/components/TextFields/examples/TextFieldKitchenSinkExample.swift
@@ -370,11 +370,11 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
             textFieldControllerDefaultLeftRightViewFloating]
   }
 
-  func tapDidTouch(sender: Any) {
+  @objc func tapDidTouch(sender: Any) {
     self.view.endEditing(true)
   }
 
-  func errorSwitchDidChange(errorSwitch: UISwitch) {
+  @objc func errorSwitchDidChange(errorSwitch: UISwitch) {
     allInputControllers.forEach { controller in
       if errorSwitch.isOn {
         controller.setErrorText("Uh oh! Try something else.", errorAccessibilityValue: nil)
@@ -384,7 +384,7 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
     }
   }
 
-  func helperSwitchDidChange(helperSwitch: UISwitch) {
+  @objc func helperSwitchDidChange(helperSwitch: UISwitch) {
     allInputControllers.forEach { controller in
       controller.helperText = helperSwitch.isOn ? "This is helper text." : nil
     }
@@ -400,7 +400,7 @@ extension TextFieldKitchenSinkSwiftExample: UITextFieldDelegate {
 }
 
 extension TextFieldKitchenSinkSwiftExample {
-  func contentSizeCategoryDidChange(notif: Notification) {
+  @objc func contentSizeCategoryDidChange(notif: Notification) {
     controlLabel.font = UIFont.preferredFont(forTextStyle: .headline)
     singleLabel.font = UIFont.preferredFont(forTextStyle: .headline)
     errorLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)

--- a/components/TextFields/examples/TextFieldManualLayoutExample.swift
+++ b/components/TextFields/examples/TextFieldManualLayoutExample.swift
@@ -207,11 +207,11 @@ final class TextFieldManualLayoutSwiftExample: UIViewController {
 
   // MARK: - Actions
 
-  func tapDidTouch(sender: Any) {
+  @objc func tapDidTouch(sender: Any) {
     self.view.endEditing(true)
   }
 
-  func buttonDidTouch(sender: Any) {
+  @objc func buttonDidTouch(sender: Any) {
     let alert = UIAlertController(title: "Floating Enabled",
                                   message: nil,
                                   preferredStyle: .actionSheet)
@@ -296,7 +296,7 @@ extension TextFieldManualLayoutSwiftExample {
       object: nil)
   }
 
-  func keyboardWillShow(notif: Notification) {
+  @objc func keyboardWillShow(notif: Notification) {
     guard let frame = notif.userInfo?[UIKeyboardFrameBeginUserInfoKey] as? CGRect else {
       return
     }
@@ -306,7 +306,7 @@ extension TextFieldManualLayoutSwiftExample {
                                            right: 0.0)
   }
 
-  func keyboardWillHide(notif: Notification) {
+  @objc func keyboardWillHide(notif: Notification) {
     scrollView.contentInset = UIEdgeInsets()
   }
 }

--- a/components/TextFields/examples/supplemental/TextFieldKitchenSinkExampleSupplemental.swift
+++ b/components/TextFields/examples/supplemental/TextFieldKitchenSinkExampleSupplemental.swift
@@ -277,7 +277,7 @@ extension TextFieldKitchenSinkSwiftExample {
       object: nil)
   }
 
-  func keyboardWillShow(notif: Notification) {
+  @objc func keyboardWillShow(notif: Notification) {
     guard let frame = notif.userInfo?[UIKeyboardFrameBeginUserInfoKey] as? CGRect else {
       return
     }
@@ -287,7 +287,7 @@ extension TextFieldKitchenSinkSwiftExample {
                                            right: 0.0)
   }
 
-  func keyboardWillHide(notif: Notification) {
+  @objc func keyboardWillHide(notif: Notification) {
     scrollView.contentInset = UIEdgeInsets()
   }
 
@@ -299,7 +299,7 @@ extension TextFieldKitchenSinkSwiftExample {
 
 extension TextFieldKitchenSinkSwiftExample {
   // The 3 'mode' buttons all are similar. The following code is shared by them
-  func buttonDidTouch(button: MDCButton) {
+  @objc func buttonDidTouch(button: MDCButton) {
     var controllersToChange = allInputControllers
     var partialTitle = ""
 


### PR DESCRIPTION
Ease the Swift4 transition by explicitly annotating known ObjC methods. In Swift3 the @objc is implicit.

See: https://help.apple.com/xcode/mac/current/#/deve838b19a1
