### PR TITLE
[FlexibleHeader] - Updated unit tests

### DIFF
--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
@@ -52,7 +52,8 @@
   self.scrollView.frame = self.view.bounds;
   self.scrollView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  self.scrollView.contentSize = CGSizeMake(320, 2000);
+  CGFloat contentHeight = [UIScreen mainScreen].bounds.size.height * 5;
+  self.scrollView.contentSize = CGSizeMake(320, contentHeight);
   [self.view addSubview:self.scrollView];
   self.fhvc.headerView.trackingScrollView = self.scrollView;
   self.fhvc.view.frame = self.view.bounds;

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
@@ -53,7 +53,8 @@
   self.scrollView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   CGFloat contentHeight = [UIScreen mainScreen].bounds.size.height * 5;
-  self.scrollView.contentSize = CGSizeMake(320, contentHeight);
+  CGFloat contentWidth = [UIScreen mainScreen].bounds.size.width;
+  self.scrollView.contentSize = CGSizeMake(contentWidth, contentHeight);
   [self.view addSubview:self.scrollView];
   self.fhvc.headerView.trackingScrollView = self.scrollView;
   self.fhvc.view.frame = self.view.bounds;


### PR DESCRIPTION
Fix unit tests compatibility for iPad
- Update content heights of scrollView in unit test setup to provide sufficient content height for tests to be run on iPads

Closes [Issue 1618](https://github.com/material-components/material-components-ios/issues/1618)