### PR TITLE
[TextFields] Appearance defaults

### DIFF
--- a/components/TextFields/src/MDCTextInputController.h
+++ b/components/TextFields/src/MDCTextInputController.h
@@ -71,7 +71,7 @@
 
  Class property. Replaces UIAppearance for classes that do not inherit from UIView.
  */
-@property(class, nonatomic, nullable, strong) UIColor *errorColorDefault;
+@property(class, nonatomic, null_resettable, strong) UIColor *errorColorDefault;
 
 /**
  The text being displayed in the leading underline label when in an error state.

--- a/components/TextFields/src/MDCTextInputController.h
+++ b/components/TextFields/src/MDCTextInputController.h
@@ -64,7 +64,14 @@
 
  Default is red.
  */
-@property(nonatomic, nullable, strong) UIColor *errorColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, nullable, strong) UIColor *errorColor;
+
+/**
+ Default value for above property.
+
+ Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ */
+@property(class, nonatomic, nullable, strong) UIColor *errorColorDefault;
 
 /**
  The text being displayed in the leading underline label when in an error state.
@@ -86,8 +93,14 @@
 
  Default is black with Material Design hint text opacity.
  */
-@property(nonatomic, null_resettable, strong)
-    UIColor *inlinePlaceholderColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, null_resettable, strong) UIColor *inlinePlaceholderColor;
+
+/**
+ Default value for above property.
+
+ Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ */
+@property(class, nonatomic, null_resettable, strong) UIColor *inlinePlaceholderColorDefault;
 
 /*
  Indicates whether the alert contents should automatically update their font when the device’s
@@ -99,7 +112,14 @@
  Default value is NO.
  */
 @property(nonatomic, assign, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
-    BOOL mdc_adjustsFontForContentSizeCategory UI_APPEARANCE_SELECTOR;
+    BOOL mdc_adjustsFontForContentSizeCategory;
+
+/**
+ Default value for above property.
+
+ Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ */
+@property(class, nonatomic, assign) BOOL mdc_adjustsFontForContentSizeCategoryDefault;
 
 /** The text input the controller is affecting. */
 @property(nonatomic, nullable, strong) UIView<MDCTextInput> *textInput;
@@ -111,13 +131,34 @@
 
  Default is UITextFieldViewModeAlways.
  */
-@property(nonatomic, assign) UITextFieldViewMode underlineViewMode UI_APPEARANCE_SELECTOR;
+@property(nonatomic, assign) UITextFieldViewMode underlineViewMode;
+
+/**
+ Default value for above property.
+
+ Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ */
+@property(class, nonatomic, assign) UITextFieldViewMode underlineViewModeDefault;
 
 /** Color the underline changes to when the input is editing. */
-@property(nonatomic, null_resettable, strong) UIColor *underlineColorActive UI_APPEARANCE_SELECTOR;
+@property(nonatomic, null_resettable, strong) UIColor *underlineColorActive;
+
+/**
+ Default value for above property.
+
+ Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ */
+@property(class, nonatomic, null_resettable, strong) UIColor *underlineColorActiveDefault;
 
 /** Color of the underline when the input is not editing but still enabled. */
-@property(nonatomic, null_resettable, strong) UIColor *underlineColorNormal UI_APPEARANCE_SELECTOR;
+@property(nonatomic, null_resettable, strong) UIColor *underlineColorNormal;
+
+/**
+ Default value for above property.
+
+ Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ */
+@property(class, nonatomic, null_resettable, strong) UIColor *underlineColorNormalDefault;
 
 /**
  Convenience init. Never fails.

--- a/components/TextFields/src/MDCTextInputController.h
+++ b/components/TextFields/src/MDCTextInputController.h
@@ -62,14 +62,14 @@
  The color used to denote error state in the underline, the errorText's label, the placeholder and
  the character count label.
 
- Default is red.
+ Default is errorColorDefault.
  */
 @property(nonatomic, null_resettable, strong) UIColor *errorColor;
 
-/**
- Default value for above property.
-
- Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+/** 
+ Default value for above errorColor.
+ 
+ Default is red.
  */
 @property(class, nonatomic, null_resettable, strong) UIColor *errorColorDefault;
 
@@ -91,14 +91,14 @@
 /**
  The color applied to the placeholder when inline (not floating).
 
- Default is black with Material Design hint text opacity.
+ Default is inlinePlaceholderColorDefault.
  */
 @property(nonatomic, null_resettable, strong) UIColor *inlinePlaceholderColor;
 
 /**
- Default value for above property.
+ Default value for inlinePlaceholderColor.
 
- Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ Default is black with Material Design hint text opacity.
  */
 @property(class, nonatomic, null_resettable, strong) UIColor *inlinePlaceholderColorDefault;
 
@@ -109,15 +109,15 @@
  This property is modeled after the adjustsFontForContentSizeCategory property in the
  UIConnectSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
 
- Default value is NO.
+ Default is mdc_adjustsFontForContentSizeCategoryDefault.
  */
 @property(nonatomic, assign, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
     BOOL mdc_adjustsFontForContentSizeCategory;
 
 /**
- Default value for above property.
+ Default value for mdc_adjustsFontForContentSizeCategory.
 
- Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ Default is NO.
  */
 @property(class, nonatomic, assign) BOOL mdc_adjustsFontForContentSizeCategoryDefault;
 
@@ -129,34 +129,42 @@
 
  The underline is an overlay that can be hidden depending on the editing state of the input text.
 
- Default is UITextFieldViewModeAlways.
+ Default is underlineViewModeDefault.
  */
 @property(nonatomic, assign) UITextFieldViewMode underlineViewMode;
 
 /**
- Default value for above property.
+ Default value for underlineViewMode.
 
- Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ Default is UITextFieldViewModeAlways.
  */
 @property(class, nonatomic, assign) UITextFieldViewMode underlineViewModeDefault;
 
-/** Color the underline changes to when the input is editing. */
+/** 
+ Color the underline changes to when the input is editing. 
+ 
+ Default is underlineColorActiveDefault.
+ */
 @property(nonatomic, null_resettable, strong) UIColor *underlineColorActive;
 
 /**
- Default value for above property.
+ Default value for underlineColorActive.
 
- Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ Default is primary color or blue.
  */
 @property(class, nonatomic, null_resettable, strong) UIColor *underlineColorActiveDefault;
 
-/** Color of the underline when the input is not editing but still enabled. */
+/** 
+ Color of the underline when the input is not editing but still enabled. 
+ 
+ Default is underlineColorNormalDefault.
+ */
 @property(nonatomic, null_resettable, strong) UIColor *underlineColorNormal;
 
 /**
- Default value for above property.
+ Default value for underlineColorNormal.
 
- Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ Default is same as inlinePlaceholderColorDefault.
  */
 @property(class, nonatomic, null_resettable, strong) UIColor *underlineColorNormalDefault;
 

--- a/components/TextFields/src/MDCTextInputController.h
+++ b/components/TextFields/src/MDCTextInputController.h
@@ -64,7 +64,7 @@
 
  Default is red.
  */
-@property(nonatomic, nullable, strong) UIColor *errorColor;
+@property(nonatomic, null_resettable, strong) UIColor *errorColor;
 
 /**
  Default value for above property.

--- a/components/TextFields/src/MDCTextInputController.h
+++ b/components/TextFields/src/MDCTextInputController.h
@@ -150,7 +150,7 @@
 /**
  Default value for underlineColorActive.
 
- Default is primary color or blue.
+ Default is blue.
  */
 @property(class, nonatomic, null_resettable, strong) UIColor *underlineColorActiveDefault;
 
@@ -164,7 +164,8 @@
 /**
  Default value for underlineColorNormal.
 
- Default is same as inlinePlaceholderColorDefault.
+ Default is black with Material Design hint text opacity which is the same as 
+ inlinePlaceholderColorDefault.
  */
 @property(class, nonatomic, null_resettable, strong) UIColor *underlineColorNormalDefault;
 

--- a/components/TextFields/src/MDCTextInputControllerDefault.h
+++ b/components/TextFields/src/MDCTextInputControllerDefault.h
@@ -32,14 +32,14 @@
  The color applied to the placeholder when floating. However, when in error state, it will be
  colored with the error color. Only relevent when floatingEnabled = true.
 
- Default is black with Material Design hint text opacity (textInput's tint).
+ Default is floatingPlaceholderColorDefault.
  */
 @property(nonatomic, null_resettable, strong) UIColor *floatingPlaceholderColor;
 
 /**
- Default value for above property.
+ Default value for floatingPlaceholderColor.
 
- Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ Default is black with Material Design hint text opacity (textInput's tint).
  */
 @property(class, nonatomic, null_resettable, strong) UIColor *floatingPlaceholderColorDefault;
 
@@ -47,14 +47,14 @@
  The scale of the the floating placeholder label in comparison to the inline placeholder specified
  as a value from 0.0 to 1.0. Only relevent when floatingEnabled = true.
 
- Default is 0.75.
+ If null, the floating placeholder scale is floatingPlaceholderScaleDefault.
  */
 @property(nonatomic, nullable, strong) NSNumber *floatingPlaceholderScale;
 
 /**
- Default value for above property.
+ Default value for the floating placeholder scale.
 
- Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ Default is 0.75.
  */
 @property(class, nonatomic, assign) CGFloat floatingPlaceholderScaleDefault;
 
@@ -62,14 +62,14 @@
  If enabled, the inline placeholder label will float above the input when there is inputted text or
  the field is being edited.
 
- Defaults to true.
+ Default is floatingEnabledDefault.
  */
 @property(nonatomic, assign, getter=isFloatingEnabled) BOOL floatingEnabled;
 
 /**
- Default value for above property.
+ Default value for floatingEnabled.
 
- Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ Default is YES.
  */
 @property(class, nonatomic, assign, getter=isFloatingEnabledDefault) BOOL floatingEnabledDefault;
 

--- a/components/TextFields/src/MDCTextInputControllerDefault.h
+++ b/components/TextFields/src/MDCTextInputControllerDefault.h
@@ -34,8 +34,14 @@
 
  Default is black with Material Design hint text opacity (textInput's tint).
  */
-@property(nonatomic, null_resettable, strong)
-    UIColor *floatingPlaceholderColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, null_resettable, strong) UIColor *floatingPlaceholderColor;
+
+/**
+ Default value for above property.
+
+ Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ */
+@property(class, nonatomic, null_resettable, strong) UIColor *floatingPlaceholderColorDefault;
 
 /**
  The scale of the the floating placeholder label in comparison to the inline placeholder specified
@@ -43,7 +49,14 @@
 
  Default is 0.75.
  */
-@property(nonatomic, nullable, strong) NSNumber *floatingPlaceholderScale UI_APPEARANCE_SELECTOR;
+@property(nonatomic, nullable, strong) NSNumber *floatingPlaceholderScale;
+
+/**
+ Default value for above property.
+
+ Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ */
+@property(class, nonatomic, assign) CGFloat floatingPlaceholderScaleDefault;
 
 /**
  If enabled, the inline placeholder label will float above the input when there is inputted text or
@@ -52,5 +65,12 @@
  Defaults to true.
  */
 @property(nonatomic, assign, getter=isFloatingEnabled) BOOL floatingEnabled;
+
+/**
+ Default value for above property.
+
+ Class property. Replaces UIAppearance for classes that do not inherit from UIView.
+ */
+@property(class, nonatomic, assign, getter=isFloatingEnabledDefault) BOOL floatingEnabledDefault;
 
 @end

--- a/components/TextFields/src/MDCTextInputControllerDefault.h
+++ b/components/TextFields/src/MDCTextInputControllerDefault.h
@@ -47,9 +47,9 @@
  The scale of the the floating placeholder label in comparison to the inline placeholder specified
  as a value from 0.0 to 1.0. Only relevent when floatingEnabled = true.
 
- If null, the floating placeholder scale is floatingPlaceholderScaleDefault.
+ If null, the floatingPlaceholderScale is @(floatingPlaceholderScaleDefault).
  */
-@property(nonatomic, nullable, strong) NSNumber *floatingPlaceholderScale;
+@property(nonatomic, null_resettable, strong) NSNumber *floatingPlaceholderScale;
 
 /**
  Default value for the floating placeholder scale.

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -470,7 +470,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
     return;
   }
 
-  CGFloat scaleFactor = [self effectiveFloatingScale];
+  CGFloat scaleFactor = (CGFloat)self.floatingPlaceholderScale.floatValue;
   CGAffineTransform floatingPlaceholderScaleTransform =
       CGAffineTransformMakeScale(scaleFactor, scaleFactor);
 
@@ -546,7 +546,8 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   // Offsets needed due to transform working on normal (0.5,0.5) anchor point.
   // Why no anchor point of (0,0)? Because our users wouldn't expect it.
   placeholderY -=
-      self.textInput.placeholderLabel.font.lineHeight * (1 - [self effectiveFloatingScale]) * .5f;
+      self.textInput.placeholderLabel.font.lineHeight *
+          (1 - (CGFloat)self.floatingPlaceholderScale.floatValue) * .5f;
 
   CGFloat estimatedWidth = MDCCeil(CGRectGetWidth([self.textInput.placeholderLabel.text
       boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, self.textInput.placeholderLabel.font.lineHeight)
@@ -555,17 +556,10 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
                   NSFontAttributeName : self.textInput.font
                 }
                    context:nil]));
-  CGFloat placeholderX = -1 * estimatedWidth * (1 - [self effectiveFloatingScale]) * .5f;
+  CGFloat placeholderX = -1 * estimatedWidth *
+      (1 - (CGFloat)self.floatingPlaceholderScale.floatValue) * .5f;
 
   return CGPointMake(placeholderX, placeholderY);
-}
-
-- (CGFloat)effectiveFloatingScale {
-  CGFloat scaleFactor = self.floatingPlaceholderScale
-                            ? (CGFloat)self.floatingPlaceholderScale.floatValue
-                            : [[self class] floatingPlaceholderScaleDefault];
-
-  return scaleFactor;
 }
 
 #pragma mark - Trailing Label Customization
@@ -743,9 +737,19 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   _floatingEnabledDefault = floatingEnabledDefault;
 }
 
+- (NSNumber *)floatingPlaceholderScale {
+  if (!_floatingPlaceholderScale) {
+    _floatingPlaceholderScale =
+        [NSNumber numberWithFloat:(float)[[self class] floatingPlaceholderScaleDefault]];
+  }
+  return _floatingPlaceholderScale;
+}
+
 - (void)setFloatingPlaceholderScale:(NSNumber *)floatingPlaceholderScale {
   if (![_floatingPlaceholderScale isEqualToNumber:floatingPlaceholderScale]) {
-    _floatingPlaceholderScale = floatingPlaceholderScale;
+    _floatingPlaceholderScale = floatingPlaceholderScale ? floatingPlaceholderScale :
+        [NSNumber numberWithFloat:(float)[[self class] floatingPlaceholderScaleDefault]];
+
     [self updatePlaceholder];
   }
 }
@@ -982,10 +986,10 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
     return defaultInsets;
   }
 
-  CGFloat scale = [self effectiveFloatingScale];
   textContainerInset.top = MDCTextInputDefaultVerticalPadding +
-                           MDCRint(self.textInput.placeholderLabel.font.lineHeight * scale) +
-                           MDCTextInputDefaultVerticalHalfPadding;
+                           MDCRint(self.textInput.placeholderLabel.font.lineHeight *
+                                   (CGFloat)self.floatingPlaceholderScale.floatValue) +
+                                   MDCTextInputDefaultVerticalHalfPadding;
 
   // The amount of space underneath the underline is variable. It could just be
   // MDCTextInputDefaultVerticalPadding or the biggest estimated underlineLabel height +

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -92,47 +92,57 @@ static inline UIColor *MDCTextInputDefaultTextErrorColorDefault() {
 
 #pragma mark - Class Properties
 
-static UIColor *_errorColorDefault;
 static BOOL _floatingEnabledDefault = YES;
-static UIColor *_floatingPlaceholderColorDefault;
-static CGFloat _floatingPlaceholderScaleDefault =
-    MDCTextInputDefaultFloatingPlaceholderScaleDefault;
-static UIColor *_inlinePlaceholderColorDefault;
 static BOOL _mdc_adjustsFontForContentSizeCategoryDefault = YES;
+
+static CGFloat _floatingPlaceholderScaleDefault =
+MDCTextInputDefaultFloatingPlaceholderScaleDefault;
+
+static UIColor *_errorColorDefault;
+static UIColor *_floatingPlaceholderColorDefault;
+static UIColor *_inlinePlaceholderColorDefault;
 static UIColor *_underlineColorActiveDefault;
 static UIColor *_underlineColorNormalDefault;
+
 static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileEditing;
 
 @interface MDCTextInputControllerDefault () {
+  BOOL _mdc_adjustsFontForContentSizeCategory;
+
   UIColor *_floatingPlaceholderColor;
   UIColor *_inlinePlaceholderColor;
-  BOOL _mdc_adjustsFontForContentSizeCategory;
   UIColor *_underlineColorActive;
   UIColor *_underlineColorNormal;
 }
+
+@property(nonatomic, assign, readonly) BOOL isDisplayingCharacterCountError;
+@property(nonatomic, assign, readonly) BOOL isDisplayingErrorText;
+@property(nonatomic, assign, readonly) BOOL isPlaceholderUp;
+@property(nonatomic, assign) BOOL isRegisteredForKVO;
+
+@property(nonatomic, strong) MDCTextInputAllCharactersCounter *internalCharacterCounter;
+
+@property(nonatomic, strong) NSArray<NSLayoutConstraint *> *placeholderAnimationConstraints;
 
 @property(nonatomic, strong) NSLayoutConstraint *characterCountY;
 @property(nonatomic, strong) NSLayoutConstraint *characterCountTrailing;
 @property(nonatomic, strong) NSLayoutConstraint *clearButtonY;
 @property(nonatomic, strong) NSLayoutConstraint *clearButtonTrailingCharacterCountLeading;
-@property(nonatomic, strong) UIFont *customLeadingFont;
-@property(nonatomic, strong) UIFont *customPlaceholderFont;
-@property(nonatomic, strong) UIFont *customTrailingFont;
-@property(nonatomic, copy, readwrite) NSString *errorText;
-@property(nonatomic, copy) NSString *errorAccessibilityValue;
 @property(nonatomic, strong) NSLayoutConstraint *heightConstraint;
-@property(nonatomic, strong) MDCTextInputAllCharactersCounter *internalCharacterCounter;
-@property(nonatomic, assign, readonly) BOOL isDisplayingCharacterCountError;
-@property(nonatomic, assign, readonly) BOOL isDisplayingErrorText;
-@property(nonatomic, assign, readonly) BOOL isPlaceholderUp;
-@property(nonatomic, assign) BOOL isRegisteredForKVO;
-@property(nonatomic, strong) NSArray<NSLayoutConstraint *> *placeholderAnimationConstraints;
 @property(nonatomic, strong) NSLayoutConstraint *placeholderLeading;
 @property(nonatomic, strong) NSLayoutConstraint *placeholderTop;
 @property(nonatomic, strong) NSLayoutConstraint *placeholderTrailingCharacterCountLeading;
 @property(nonatomic, strong) NSLayoutConstraint *placeholderTrailingSuperviewTrailing;
+
+@property(nonatomic, copy) NSString *errorAccessibilityValue;
+@property(nonatomic, copy, readwrite) NSString *errorText;
 @property(nonatomic, copy) NSString *previousLeadingText;
+
 @property(nonatomic, strong) UIColor *previousPlaceholderColor;
+
+@property(nonatomic, strong) UIFont *customLeadingFont;
+@property(nonatomic, strong) UIFont *customPlaceholderFont;
+@property(nonatomic, strong) UIFont *customTrailingFont;
 
 @end
 

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -262,6 +262,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   _characterCountViewMode = UITextFieldViewModeAlways;
   _floatingEnabled = [[self class] isFloatingEnabledDefault];
   _internalCharacterCounter = [MDCTextInputAllCharactersCounter new];
+  _underlineViewMode = [[self class] underlineViewModeDefault];
   _textInput.hidesPlaceholderOnInput = NO;
 
   [self updatePlaceholderY];
@@ -706,7 +707,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
 + (UIColor *)floatingPlaceholderColorDefault {
   if (!_floatingPlaceholderColorDefault) {
-    _floatingPlaceholderColorDefault = MDCTextInputDefaultInlinePlaceholderTextColorDefault();
+    _floatingPlaceholderColorDefault = MDCTextInputDefaultActiveColorDefault();
   }
   return _floatingPlaceholderColorDefault;
 }
@@ -714,7 +715,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 + (void)setFloatingPlaceholderColorDefault:(UIColor *)floatingPlaceholderColorDefault {
   _floatingPlaceholderColorDefault = floatingPlaceholderColorDefault
                                          ? floatingPlaceholderColorDefault
-                                         : MDCTextInputDefaultInlinePlaceholderTextColorDefault();
+                                         : MDCTextInputDefaultActiveColorDefault();
 }
 
 - (void)setFloatingEnabled:(BOOL)floatingEnabled {

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -260,6 +260,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
 - (void)commonMDCTextInputControllerDefaultInitialization {
   _characterCountViewMode = UITextFieldViewModeAlways;
+  _floatingEnabled = [[self class] isFloatingEnabledDefault];
   _internalCharacterCounter = [MDCTextInputAllCharactersCounter new];
   _textInput.hidesPlaceholderOnInput = NO;
 

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -95,7 +95,8 @@ static inline UIColor *MDCTextInputDefaultTextErrorColorDefault() {
 static UIColor *_errorColorDefault;
 static BOOL _floatingEnabledDefault = YES;
 static UIColor *_floatingPlaceholderColorDefault;
-static CGFloat _floatingPlaceholderScaleDefault = MDCTextInputDefaultFloatingPlaceholderScaleDefault;
+static CGFloat _floatingPlaceholderScaleDefault =
+    MDCTextInputDefaultFloatingPlaceholderScaleDefault;
 static UIColor *_inlinePlaceholderColorDefault;
 static BOOL _mdc_adjustsFontForContentSizeCategoryDefault = YES;
 static UIColor *_underlineColorActiveDefault;
@@ -271,7 +272,9 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   }
 
   // This controller will handle Dynamic Type and all fonts for the text input
-  _mdc_adjustsFontForContentSizeCategory = _textInput.mdc_adjustsFontForContentSizeCategory || [[self class] mdc_adjustsFontForContentSizeCategoryDefault];
+  _mdc_adjustsFontForContentSizeCategory =
+      _textInput.mdc_adjustsFontForContentSizeCategory ||
+      [[self class] mdc_adjustsFontForContentSizeCategoryDefault];
   _textInput.mdc_adjustsFontForContentSizeCategory = NO;
   _textInput.positioningDelegate = self;
   _textInput.hidesPlaceholderOnInput = !self.isFloatingEnabled;
@@ -680,7 +683,8 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 }
 
 + (void)setErrorColorDefault:(UIColor *)errorColorDefault {
-  _errorColorDefault = errorColorDefault ? errorColorDefault : MDCTextInputDefaultTextErrorColorDefault();
+  _errorColorDefault =
+      errorColorDefault ? errorColorDefault : MDCTextInputDefaultTextErrorColorDefault();
 }
 
 - (void)setErrorText:(NSString *)errorText {
@@ -695,7 +699,8 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 }
 
 - (UIColor *)floatingPlaceholderColor {
-  return _floatingPlaceholderColor ? _floatingPlaceholderColor : [[self class] floatingPlaceholderColorDefault];
+  return _floatingPlaceholderColor ? _floatingPlaceholderColor
+                                   : [[self class] floatingPlaceholderColorDefault];
 }
 
 + (UIColor *)floatingPlaceholderColorDefault {
@@ -706,7 +711,9 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 }
 
 + (void)setFloatingPlaceholderColorDefault:(UIColor *)floatingPlaceholderColorDefault {
-  _floatingPlaceholderColorDefault = floatingPlaceholderColorDefault ? floatingPlaceholderColorDefault : MDCTextInputDefaultInlinePlaceholderTextColorDefault();
+  _floatingPlaceholderColorDefault = floatingPlaceholderColorDefault
+                                         ? floatingPlaceholderColorDefault
+                                         : MDCTextInputDefaultInlinePlaceholderTextColorDefault();
 }
 
 - (void)setFloatingEnabled:(BOOL)floatingEnabled {
@@ -766,7 +773,8 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 }
 
 - (UIColor *)inlinePlaceholderColor {
-  return _inlinePlaceholderColor ? _inlinePlaceholderColor : [[self class] inlinePlaceholderColorDefault];
+  return _inlinePlaceholderColor ? _inlinePlaceholderColor
+                                 : [[self class] inlinePlaceholderColorDefault];
 }
 
 + (UIColor *)inlinePlaceholderColorDefault {
@@ -777,7 +785,9 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 }
 
 + (void)setInlinePlaceholderColorDefault:(UIColor *)inlinePlaceholderColorDefault {
-  _inlinePlaceholderColorDefault = inlinePlaceholderColorDefault ? inlinePlaceholderColorDefault : MDCTextInputDefaultInlinePlaceholderTextColorDefault();
+  _inlinePlaceholderColorDefault = inlinePlaceholderColorDefault
+                                       ? inlinePlaceholderColorDefault
+                                       : MDCTextInputDefaultInlinePlaceholderTextColorDefault();
 }
 
 - (BOOL)isDisplayingCharacterCountError {
@@ -825,7 +835,9 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 }
 
 + (void)setUnderlineColorActiveDefault:(UIColor *)underlineColorActiveDefault {
-  _underlineColorActiveDefault = underlineColorActiveDefault ? underlineColorActiveDefault : MDCTextInputDefaultActiveColorDefault();
+  _underlineColorActiveDefault = underlineColorActiveDefault
+                                     ? underlineColorActiveDefault
+                                     : MDCTextInputDefaultActiveColorDefault();
 }
 
 - (UIColor *)underlineColorNormal {
@@ -847,7 +859,9 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 }
 
 + (void)setUnderlineColorNormalDefault:(UIColor *)underlineColorNormalDefault {
-  _underlineColorNormalDefault = underlineColorNormalDefault ? underlineColorNormalDefault : MDCTextInputDefaultNormalUnderlineColorDefault();
+  _underlineColorNormalDefault = underlineColorNormalDefault
+                                     ? underlineColorNormalDefault
+                                     : MDCTextInputDefaultNormalUnderlineColorDefault();
 }
 
 - (void)setUnderlineViewMode:(UITextFieldViewMode)underlineViewMode {
@@ -955,7 +969,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   if (!self.isFloatingEnabled) {
     return defaultInsets;
   }
-  
+
   CGFloat scale = [self effectiveFloatingScale];
   textContainerInset.top = MDCTextInputDefaultVerticalPadding +
                            MDCRint(self.textInput.placeholderLabel.font.lineHeight * scale) +
@@ -1191,7 +1205,8 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   return _mdc_adjustsFontForContentSizeCategoryDefault;
 }
 
-+ (void)setMdc_adjustsFontForContentSizeCategoryDefault:(BOOL)mdc_adjustsFontForContentSizeCategoryDefault {
++ (void)setMdc_adjustsFontForContentSizeCategoryDefault:
+        (BOOL)mdc_adjustsFontForContentSizeCategoryDefault {
   _mdc_adjustsFontForContentSizeCategoryDefault = mdc_adjustsFontForContentSizeCategoryDefault;
 }
 

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -96,7 +96,7 @@ static BOOL _floatingEnabledDefault = YES;
 static BOOL _mdc_adjustsFontForContentSizeCategoryDefault = YES;
 
 static CGFloat _floatingPlaceholderScaleDefault =
-MDCTextInputDefaultFloatingPlaceholderScaleDefault;
+    MDCTextInputDefaultFloatingPlaceholderScaleDefault;
 
 static UIColor *_errorColorDefault;
 static UIColor *_floatingPlaceholderColorDefault;

--- a/components/TextFields/src/MDCTextInputControllerFullWidth.m
+++ b/components/TextFields/src/MDCTextInputControllerFullWidth.m
@@ -73,7 +73,7 @@ static inline UIColor *MDCTextInputTextErrorColorDefault() {
 
 static UIColor *_errorColorDefault;
 static UIColor *_inlinePlaceholderColorDefault;
-static BOOL _mdc_adjustsFontForContentSizeCategoryDefault;
+static BOOL _mdc_adjustsFontForContentSizeCategoryDefault = YES;
 
 @interface MDCTextInputControllerFullWidth () {
   UIColor *_inlinePlaceholderColor;
@@ -540,7 +540,7 @@ static BOOL _mdc_adjustsFontForContentSizeCategoryDefault;
 }
 
 + (UIColor *)underlineColorNormalDefault {
-  return nil;
+  return [UIColor clearColor];
 }
 
 - (void)setUnderlineViewMode:(UITextFieldViewMode)underlineViewMode {

--- a/components/TextFields/src/MDCTextInputControllerFullWidth.m
+++ b/components/TextFields/src/MDCTextInputControllerFullWidth.m
@@ -71,33 +71,39 @@ static inline UIColor *MDCTextInputTextErrorColorDefault() {
 
 #pragma mark - Class Properties
 
+static BOOL _mdc_adjustsFontForContentSizeCategoryDefault = YES;
 static UIColor *_errorColorDefault;
 static UIColor *_inlinePlaceholderColorDefault;
-static BOOL _mdc_adjustsFontForContentSizeCategoryDefault = YES;
 
 @interface MDCTextInputControllerFullWidth () {
-  UIColor *_inlinePlaceholderColor;
   BOOL _mdc_adjustsFontForContentSizeCategory;
+
+  UIColor *_inlinePlaceholderColor;
 }
+
+@property(nonatomic, assign, readonly) BOOL isDisplayingCharacterCountError;
+@property(nonatomic, assign) BOOL isRegisteredForKVO;
+
+@property(nonatomic, strong) MDCTextInputAllCharactersCounter *internalCharacterCounter;
 
 @property(nonatomic, strong) NSLayoutConstraint *characterCountY;
 @property(nonatomic, strong) NSLayoutConstraint *characterCountTrailing;
 @property(nonatomic, strong) NSLayoutConstraint *clearButtonY;
 @property(nonatomic, strong) NSLayoutConstraint *clearButtonTrailingCharacterCountLeading;
-@property(nonatomic, strong) UIFont *customPlaceholderFont;
-@property(nonatomic, strong) UIFont *customTrailingFont;
-@property(nonatomic, copy, readwrite) NSString *errorText;
-@property(nonatomic, copy) NSString *errorAccessibilityValue;
 @property(nonatomic, strong) NSLayoutConstraint *heightConstraint;
-@property(nonatomic, strong) MDCTextInputAllCharactersCounter *internalCharacterCounter;
-@property(nonatomic, assign, readonly) BOOL isDisplayingCharacterCountError;
-@property(nonatomic, assign) BOOL isRegisteredForKVO;
 @property(nonatomic, strong) NSLayoutConstraint *placeholderLeading;
 @property(nonatomic, strong) NSLayoutConstraint *placeholderTop;
 @property(nonatomic, strong) NSLayoutConstraint *placeholderTrailingCharacterCountLeading;
 @property(nonatomic, strong) NSLayoutConstraint *placeholderTrailingSuperviewTrailing;
+
+@property(nonatomic, copy) NSString *errorAccessibilityValue;
+@property(nonatomic, copy, readwrite) NSString *errorText;
 @property(nonatomic, copy) NSString *previousLeadingText;
+
 @property(nonatomic, strong) UIColor *previousPlaceholderColor;
+
+@property(nonatomic, strong) UIFont *customPlaceholderFont;
+@property(nonatomic, strong) UIFont *customTrailingFont;
 @end
 
 @implementation MDCTextInputControllerFullWidth

--- a/components/TextFields/src/MDCTextInputControllerFullWidth.m
+++ b/components/TextFields/src/MDCTextInputControllerFullWidth.m
@@ -347,7 +347,7 @@ static BOOL _mdc_adjustsFontForContentSizeCategoryDefault;
     }
   }
 
-  UIColor *textColor = [MDCTextInputControllerFullWidth inlinePlaceholderColorDefault];
+  UIColor *textColor = [[self class] inlinePlaceholderColorDefault];
 
   if (self.isDisplayingCharacterCountError || self.isDisplayingErrorText) {
     textColor = self.errorColor;

--- a/components/TextFields/src/MDCTextInputControllerFullWidth.m
+++ b/components/TextFields/src/MDCTextInputControllerFullWidth.m
@@ -204,7 +204,9 @@ static BOOL _mdc_adjustsFontForContentSizeCategoryDefault;
   }
 
   // This controller will handle Dynamic Type and all fonts for the text input
-  _mdc_adjustsFontForContentSizeCategory = _textInput.mdc_adjustsFontForContentSizeCategory || [[self class] mdc_adjustsFontForContentSizeCategoryDefault];
+  _mdc_adjustsFontForContentSizeCategory =
+      _textInput.mdc_adjustsFontForContentSizeCategory ||
+      [[self class] mdc_adjustsFontForContentSizeCategoryDefault];
   _textInput.mdc_adjustsFontForContentSizeCategory = NO;
   _textInput.positioningDelegate = self;
 
@@ -466,8 +468,8 @@ static BOOL _mdc_adjustsFontForContentSizeCategoryDefault;
 }
 
 - (UIColor *)inlinePlaceholderColor {
-  return _inlinePlaceholderColor
-      ? _inlinePlaceholderColor : [[self class] inlinePlaceholderColorDefault];
+  return _inlinePlaceholderColor ? _inlinePlaceholderColor
+                                 : [[self class] inlinePlaceholderColorDefault];
 }
 
 + (UIColor *)inlinePlaceholderColorDefault {
@@ -479,7 +481,8 @@ static BOOL _mdc_adjustsFontForContentSizeCategoryDefault;
 
 + (void)setInlinePlaceholderColorDefault:(UIColor *)inlinePlaceholderColorDefault {
   _inlinePlaceholderColorDefault = inlinePlaceholderColorDefault
-  ? inlinePlaceholderColorDefault : MDCTextInputInlinePlaceholderTextColorDefault();
+                                       ? inlinePlaceholderColorDefault
+                                       : MDCTextInputInlinePlaceholderTextColorDefault();
 }
 
 - (BOOL)isDisplayingCharacterCountError {
@@ -957,7 +960,8 @@ static BOOL _mdc_adjustsFontForContentSizeCategoryDefault;
   return _mdc_adjustsFontForContentSizeCategoryDefault;
 }
 
-+ (void)setMdc_adjustsFontForContentSizeCategoryDefault:(BOOL)mdc_adjustsFontForContentSizeCategoryDefault {
++ (void)setMdc_adjustsFontForContentSizeCategoryDefault:
+        (BOOL)mdc_adjustsFontForContentSizeCategoryDefault {
   _mdc_adjustsFontForContentSizeCategoryDefault = mdc_adjustsFontForContentSizeCategoryDefault;
 }
 

--- a/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
+++ b/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
@@ -24,6 +24,18 @@ import MaterialComponents.MaterialTypography
 
 class TextFieldControllerClassPropertiesTests: XCTestCase {
   func testDefault() {
+    addTeardownBlock {
+      MDCTextInputControllerDefault.errorColorDefault = nil
+      MDCTextInputControllerDefault.inlinePlaceholderColorDefault = nil
+      MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault = true
+      MDCTextInputControllerDefault.underlineColorActiveDefault = nil
+      MDCTextInputControllerDefault.underlineColorNormalDefault = nil
+      MDCTextInputControllerDefault.underlineViewModeDefault = .whileEditing
+
+      MDCTextInputControllerDefault.floatingPlaceholderColorDefault = nil
+      MDCTextInputControllerDefault.floatingPlaceholderScaleDefault = 0.75
+      MDCTextInputControllerDefault.isFloatingEnabledDefault = true
+    }
 
     // Test the values of the class properties.
     XCTAssertEqual(MDCTextInputControllerDefault.errorColorDefault, MDCPalette.red.tint500)
@@ -100,6 +112,14 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
   }
 
   func testFullWidth() {
+    addTeardownBlock {
+      MDCTextInputControllerFullWidth.errorColorDefault = nil
+      MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault = nil
+      MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault = true
+      MDCTextInputControllerFullWidth.underlineColorActiveDefault = nil
+      MDCTextInputControllerFullWidth.underlineColorNormalDefault = nil
+      MDCTextInputControllerFullWidth.underlineViewModeDefault = .never
+    }
 
     // Test the values of the class properties.
     XCTAssertEqual(MDCTextInputControllerFullWidth.errorColorDefault, MDCPalette.red.tint500)

--- a/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
+++ b/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
@@ -39,7 +39,7 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
 
     // Test the values of the class properties.
     XCTAssertEqual(MDCTextInputControllerDefault.errorColorDefault, MDCPalette.red.tint500)
-    XCTAssertEqual(MDCTextInputControllerDefault.inlinePlaceholderColorDefault, UIColor(white: 0, alpha: 0.54))
+    XCTAssertEqual(MDCTextInputControllerDefault.inlinePlaceholderColorDefault, UIColor(white: 0, alpha: CGFloat(Float(0.54))))
     XCTAssertEqual(MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault, true)
     XCTAssertEqual(MDCTextInputControllerDefault.underlineColorActiveDefault, MDCPalette.indigo.tint500)
     XCTAssertEqual(MDCTextInputControllerDefault.underlineColorNormalDefault, .lightGray)
@@ -63,7 +63,6 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
 
     // Default specific properties
     XCTAssertEqual(controller.floatingPlaceholderColor, MDCTextInputControllerDefault.floatingPlaceholderColorDefault)
-    XCTAssertEqual(controller.floatingPlaceholderScale?.floatValue, Float(MDCTextInputControllerDefault.floatingPlaceholderScaleDefault))
     XCTAssertEqual(controller.isFloatingEnabled, MDCTextInputControllerDefault.isFloatingEnabledDefault)
 
     // Test the changes to the class properties.
@@ -107,7 +106,6 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
 
     // Default specific properties
     XCTAssertEqual(controller.floatingPlaceholderColor, MDCTextInputControllerDefault.floatingPlaceholderColorDefault)
-    XCTAssertEqual(controller.floatingPlaceholderScale?.floatValue, Float(MDCTextInputControllerDefault.floatingPlaceholderScaleDefault))
     XCTAssertEqual(controller.isFloatingEnabled, MDCTextInputControllerDefault.isFloatingEnabledDefault)
   }
 
@@ -123,11 +121,11 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
 
     // Test the values of the class properties.
     XCTAssertEqual(MDCTextInputControllerFullWidth.errorColorDefault, MDCPalette.red.tint500)
-    XCTAssertEqual(MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault, UIColor(white: 0, alpha: 0.54))
+    XCTAssertEqual(MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault, UIColor(white: 0, alpha: CGFloat(Float(0.54))))
     XCTAssertEqual(MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault, true)
-    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineColorActiveDefault, MDCPalette.indigo.tint500)
-    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineColorNormalDefault, .lightGray)
-    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineViewModeDefault, .whileEditing)
+    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineColorActiveDefault, .clear)
+    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineColorNormalDefault, .clear)
+    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineViewModeDefault, .never)
 
     // Test the use of the class properties.
     let textField = MDCTextField()
@@ -151,13 +149,13 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
     XCTAssertEqual(MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault, false)
 
     MDCTextInputControllerFullWidth.underlineColorActiveDefault = .purple
-    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineColorActiveDefault, .purple)
+    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineColorActiveDefault, .clear)
 
     MDCTextInputControllerFullWidth.underlineColorNormalDefault = .white
-    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineColorNormalDefault, .white)
+    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineColorNormalDefault, .clear)
 
     MDCTextInputControllerFullWidth.underlineViewModeDefault = .unlessEditing
-    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineViewModeDefault, .unlessEditing)
+    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineViewModeDefault, .never)
 
     // Test the changes to the class properties can propogate to an instance.
     controller = MDCTextInputControllerFullWidth(textInput: textField)

--- a/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
+++ b/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
@@ -49,14 +49,17 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
 
     // Test the values of the class properties.
     XCTAssertEqual(MDCTextInputControllerDefault.errorColorDefault, MDCPalette.red.tint500)
-    XCTAssertEqual(MDCTextInputControllerDefault.inlinePlaceholderColorDefault, UIColor(white: 0, alpha: CGFloat(Float(0.54))))
+    XCTAssertEqual(MDCTextInputControllerDefault.inlinePlaceholderColorDefault,
+                   UIColor(white: 0, alpha: CGFloat(Float(0.54))))
     XCTAssertEqual(MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault, true)
-    XCTAssertEqual(MDCTextInputControllerDefault.underlineColorActiveDefault, MDCPalette.indigo.tint500)
+    XCTAssertEqual(MDCTextInputControllerDefault.underlineColorActiveDefault,
+                   MDCPalette.indigo.tint500)
     XCTAssertEqual(MDCTextInputControllerDefault.underlineColorNormalDefault, .lightGray)
     XCTAssertEqual(MDCTextInputControllerDefault.underlineViewModeDefault, .whileEditing)
 
     // Default specific properties
-    XCTAssertEqual(MDCTextInputControllerDefault.floatingPlaceholderColorDefault, MDCPalette.indigo.tint500)
+    XCTAssertEqual(MDCTextInputControllerDefault.floatingPlaceholderColorDefault,
+                   MDCPalette.indigo.tint500)
     XCTAssertEqual(Float(MDCTextInputControllerDefault.floatingPlaceholderScaleDefault), 0.75)
     XCTAssertEqual(MDCTextInputControllerDefault.isFloatingEnabledDefault, true)
 
@@ -65,15 +68,22 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
     var controller = MDCTextInputControllerDefault(textInput: textField)
 
     XCTAssertEqual(controller.errorColor, MDCTextInputControllerDefault.errorColorDefault)
-    XCTAssertEqual(controller.inlinePlaceholderColor, MDCTextInputControllerDefault.inlinePlaceholderColorDefault)
-    XCTAssertEqual(controller.mdc_adjustsFontForContentSizeCategory, MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault)
-    XCTAssertEqual(controller.underlineColorActive, MDCTextInputControllerDefault.underlineColorActiveDefault)
-    XCTAssertEqual(controller.underlineColorNormal, MDCTextInputControllerDefault.underlineColorNormalDefault)
-    XCTAssertEqual(controller.underlineViewMode, MDCTextInputControllerDefault.underlineViewModeDefault)
+    XCTAssertEqual(controller.inlinePlaceholderColor,
+                   MDCTextInputControllerDefault.inlinePlaceholderColorDefault)
+    XCTAssertEqual(controller.mdc_adjustsFontForContentSizeCategory,
+                   MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault)
+    XCTAssertEqual(controller.underlineColorActive,
+                   MDCTextInputControllerDefault.underlineColorActiveDefault)
+    XCTAssertEqual(controller.underlineColorNormal,
+                   MDCTextInputControllerDefault.underlineColorNormalDefault)
+    XCTAssertEqual(controller.underlineViewMode,
+                   MDCTextInputControllerDefault.underlineViewModeDefault)
 
     // Default specific properties
-    XCTAssertEqual(controller.floatingPlaceholderColor, MDCTextInputControllerDefault.floatingPlaceholderColorDefault)
-    XCTAssertEqual(controller.isFloatingEnabled, MDCTextInputControllerDefault.isFloatingEnabledDefault)
+    XCTAssertEqual(controller.floatingPlaceholderColor,
+                   MDCTextInputControllerDefault.floatingPlaceholderColorDefault)
+    XCTAssertEqual(controller.isFloatingEnabled,
+                   MDCTextInputControllerDefault.isFloatingEnabledDefault)
 
     // Test the changes to the class properties.
     MDCTextInputControllerDefault.errorColorDefault = .green
@@ -83,7 +93,8 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
     XCTAssertEqual(MDCTextInputControllerDefault.inlinePlaceholderColorDefault, .orange)
 
     MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault = false
-    XCTAssertEqual(MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault, false)
+    XCTAssertEqual(MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault,
+                   false)
 
     MDCTextInputControllerDefault.underlineColorActiveDefault = .purple
     XCTAssertEqual(MDCTextInputControllerDefault.underlineColorActiveDefault, .purple)
@@ -108,22 +119,31 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
     controller = MDCTextInputControllerDefault(textInput: textField)
 
     XCTAssertEqual(controller.errorColor, MDCTextInputControllerDefault.errorColorDefault)
-    XCTAssertEqual(controller.inlinePlaceholderColor, MDCTextInputControllerDefault.inlinePlaceholderColorDefault)
-    XCTAssertEqual(controller.mdc_adjustsFontForContentSizeCategory, MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault)
-    XCTAssertEqual(controller.underlineColorActive, MDCTextInputControllerDefault.underlineColorActiveDefault)
-    XCTAssertEqual(controller.underlineColorNormal, MDCTextInputControllerDefault.underlineColorNormalDefault)
-    XCTAssertEqual(controller.underlineViewMode, MDCTextInputControllerDefault.underlineViewModeDefault)
+    XCTAssertEqual(controller.inlinePlaceholderColor,
+                   MDCTextInputControllerDefault.inlinePlaceholderColorDefault)
+    XCTAssertEqual(controller.mdc_adjustsFontForContentSizeCategory,
+                   MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault)
+    XCTAssertEqual(controller.underlineColorActive,
+                   MDCTextInputControllerDefault.underlineColorActiveDefault)
+    XCTAssertEqual(controller.underlineColorNormal,
+                   MDCTextInputControllerDefault.underlineColorNormalDefault)
+    XCTAssertEqual(controller.underlineViewMode,
+                   MDCTextInputControllerDefault.underlineViewModeDefault)
 
     // Default specific properties
-    XCTAssertEqual(controller.floatingPlaceholderColor, MDCTextInputControllerDefault.floatingPlaceholderColorDefault)
-    XCTAssertEqual(controller.isFloatingEnabled, MDCTextInputControllerDefault.isFloatingEnabledDefault)
+    XCTAssertEqual(controller.floatingPlaceholderColor,
+                   MDCTextInputControllerDefault.floatingPlaceholderColorDefault)
+    XCTAssertEqual(controller.isFloatingEnabled,
+                   MDCTextInputControllerDefault.isFloatingEnabledDefault)
   }
 
   func testFullWidth() {
     // Test the values of the class properties.
     XCTAssertEqual(MDCTextInputControllerFullWidth.errorColorDefault, MDCPalette.red.tint500)
-    XCTAssertEqual(MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault, UIColor(white: 0, alpha: CGFloat(Float(0.54))))
-    XCTAssertEqual(MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault, true)
+    XCTAssertEqual(MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault,
+                   UIColor(white: 0, alpha: CGFloat(Float(0.54))))
+    XCTAssertEqual(MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault,
+                   true)
     XCTAssertEqual(MDCTextInputControllerFullWidth.underlineColorActiveDefault, .clear)
     XCTAssertEqual(MDCTextInputControllerFullWidth.underlineColorNormalDefault, .clear)
     XCTAssertEqual(MDCTextInputControllerFullWidth.underlineViewModeDefault, .never)
@@ -133,11 +153,16 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
     var controller = MDCTextInputControllerFullWidth(textInput: textField)
 
     XCTAssertEqual(controller.errorColor, MDCTextInputControllerFullWidth.errorColorDefault)
-    XCTAssertEqual(controller.inlinePlaceholderColor, MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault)
-    XCTAssertEqual(controller.mdc_adjustsFontForContentSizeCategory, MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault)
-    XCTAssertEqual(controller.underlineColorActive, MDCTextInputControllerFullWidth.underlineColorActiveDefault)
-    XCTAssertEqual(controller.underlineColorNormal, MDCTextInputControllerFullWidth.underlineColorNormalDefault)
-    XCTAssertEqual(controller.underlineViewMode, MDCTextInputControllerFullWidth.underlineViewModeDefault)
+    XCTAssertEqual(controller.inlinePlaceholderColor,
+                   MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault)
+    XCTAssertEqual(controller.mdc_adjustsFontForContentSizeCategory,
+                   MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault)
+    XCTAssertEqual(controller.underlineColorActive,
+                   MDCTextInputControllerFullWidth.underlineColorActiveDefault)
+    XCTAssertEqual(controller.underlineColorNormal,
+                   MDCTextInputControllerFullWidth.underlineColorNormalDefault)
+    XCTAssertEqual(controller.underlineViewMode,
+                   MDCTextInputControllerFullWidth.underlineViewModeDefault)
 
     // Test the changes to the class properties.
     MDCTextInputControllerFullWidth.errorColorDefault = .green
@@ -147,7 +172,8 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
     XCTAssertEqual(MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault, .orange)
 
     MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault = false
-    XCTAssertEqual(MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault, false)
+    XCTAssertEqual(MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault,
+                   false)
 
     MDCTextInputControllerFullWidth.underlineColorActiveDefault = .purple
     XCTAssertEqual(MDCTextInputControllerFullWidth.underlineColorActiveDefault, .clear)
@@ -162,10 +188,15 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
     controller = MDCTextInputControllerFullWidth(textInput: textField)
 
     XCTAssertEqual(controller.errorColor, MDCTextInputControllerFullWidth.errorColorDefault)
-    XCTAssertEqual(controller.inlinePlaceholderColor, MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault)
-    XCTAssertEqual(controller.mdc_adjustsFontForContentSizeCategory, MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault)
-    XCTAssertEqual(controller.underlineColorActive, MDCTextInputControllerFullWidth.underlineColorActiveDefault)
-    XCTAssertEqual(controller.underlineColorNormal, MDCTextInputControllerFullWidth.underlineColorNormalDefault)
-    XCTAssertEqual(controller.underlineViewMode, MDCTextInputControllerFullWidth.underlineViewModeDefault)
+    XCTAssertEqual(controller.inlinePlaceholderColor,
+                   MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault)
+    XCTAssertEqual(controller.mdc_adjustsFontForContentSizeCategory,
+                   MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault)
+    XCTAssertEqual(controller.underlineColorActive,
+                   MDCTextInputControllerFullWidth.underlineColorActiveDefault)
+    XCTAssertEqual(controller.underlineColorNormal,
+                   MDCTextInputControllerFullWidth.underlineColorNormalDefault)
+    XCTAssertEqual(controller.underlineViewMode,
+                   MDCTextInputControllerFullWidth.underlineViewModeDefault)
   }
 }

--- a/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
+++ b/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
@@ -23,19 +23,29 @@ import MaterialComponents.MaterialTextFields
 import MaterialComponents.MaterialTypography
 
 class TextFieldControllerClassPropertiesTests: XCTestCase {
-  func testDefault() {
-    addTeardownBlock {
-      MDCTextInputControllerDefault.errorColorDefault = nil
-      MDCTextInputControllerDefault.inlinePlaceholderColorDefault = nil
-      MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault = true
-      MDCTextInputControllerDefault.underlineColorActiveDefault = nil
-      MDCTextInputControllerDefault.underlineColorNormalDefault = nil
-      MDCTextInputControllerDefault.underlineViewModeDefault = .whileEditing
+  override func tearDown() {
+    super.tearDown()
 
-      MDCTextInputControllerDefault.floatingPlaceholderColorDefault = nil
-      MDCTextInputControllerDefault.floatingPlaceholderScaleDefault = 0.75
-      MDCTextInputControllerDefault.isFloatingEnabledDefault = true
-    }
+    MDCTextInputControllerDefault.errorColorDefault = nil
+    MDCTextInputControllerDefault.inlinePlaceholderColorDefault = nil
+    MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault = true
+    MDCTextInputControllerDefault.underlineColorActiveDefault = nil
+    MDCTextInputControllerDefault.underlineColorNormalDefault = nil
+    MDCTextInputControllerDefault.underlineViewModeDefault = .whileEditing
+
+    MDCTextInputControllerDefault.floatingPlaceholderColorDefault = nil
+    MDCTextInputControllerDefault.floatingPlaceholderScaleDefault = 0.75
+    MDCTextInputControllerDefault.isFloatingEnabledDefault = true
+
+    MDCTextInputControllerFullWidth.errorColorDefault = nil
+    MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault = nil
+    MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault = true
+    MDCTextInputControllerFullWidth.underlineColorActiveDefault = nil
+    MDCTextInputControllerFullWidth.underlineColorNormalDefault = nil
+    MDCTextInputControllerFullWidth.underlineViewModeDefault = .never
+  }
+
+  func testDefault() {
 
     // Test the values of the class properties.
     XCTAssertEqual(MDCTextInputControllerDefault.errorColorDefault, MDCPalette.red.tint500)
@@ -110,15 +120,6 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
   }
 
   func testFullWidth() {
-    addTeardownBlock {
-      MDCTextInputControllerFullWidth.errorColorDefault = nil
-      MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault = nil
-      MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault = true
-      MDCTextInputControllerFullWidth.underlineColorActiveDefault = nil
-      MDCTextInputControllerFullWidth.underlineColorNormalDefault = nil
-      MDCTextInputControllerFullWidth.underlineViewModeDefault = .never
-    }
-
     // Test the values of the class properties.
     XCTAssertEqual(MDCTextInputControllerFullWidth.errorColorDefault, MDCPalette.red.tint500)
     XCTAssertEqual(MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault, UIColor(white: 0, alpha: CGFloat(Float(0.54))))

--- a/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
+++ b/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
@@ -1,0 +1,152 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+// swiftlint:disable function_body_length
+// swiftlint:disable type_body_length
+
+import XCTest
+import MaterialComponents.MaterialPalettes
+import MaterialComponents.MaterialTextFields
+import MaterialComponents.MaterialTypography
+
+class TextFieldControllerClassPropertiesTests: XCTest {
+  func testDefault() {
+
+    // Test the values of the class properties.
+    XCTAssertEqual(MDCTextInputControllerDefault.errorColorDefault, MDCPalette.red.tint500)
+    XCTAssertEqual(MDCTextInputControllerDefault.inlinePlaceholderColorDefault, UIColor(white: 0, alpha: 0.54))
+    XCTAssertEqual(MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault, true)
+    XCTAssertEqual(MDCTextInputControllerDefault.underlineColorActiveDefault, MDCPalette.indigo.tint500)
+    XCTAssertEqual(MDCTextInputControllerDefault.underlineColorNormalDefault, .lightGray)
+    XCTAssertEqual(MDCTextInputControllerDefault.underlineViewModeDefault, .whileEditing)
+
+    // Default specific properties
+    XCTAssertEqual(MDCTextInputControllerDefault.floatingPlaceholderColorDefault, MDCPalette.indigo.tint500)
+    XCTAssertEqual(Float(MDCTextInputControllerDefault.floatingPlaceholderScaleDefault), 0.75)
+    XCTAssertEqual(MDCTextInputControllerDefault.isFloatingEnabledDefault, true)
+
+    // Test the use of the class properties.
+    let textField = MDCTextField()
+    var controller = MDCTextInputControllerDefault(textInput: textField)
+
+    XCTAssertEqual(controller.errorColor, MDCTextInputControllerDefault.errorColorDefault)
+    XCTAssertEqual(controller.inlinePlaceholderColor, MDCTextInputControllerDefault.inlinePlaceholderColorDefault)
+    XCTAssertEqual(controller.mdc_adjustsFontForContentSizeCategory, MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault)
+    XCTAssertEqual(controller.underlineColorActive, MDCTextInputControllerDefault.underlineColorActiveDefault)
+    XCTAssertEqual(controller.underlineColorNormal, MDCTextInputControllerDefault.underlineColorNormalDefault)
+    XCTAssertEqual(controller.underlineViewMode, MDCTextInputControllerDefault.underlineViewModeDefault)
+
+    // Default specific properties
+    XCTAssertEqual(controller.floatingPlaceholderColor, MDCTextInputControllerDefault.floatingPlaceholderColorDefault)
+    XCTAssertEqual(controller.floatingPlaceholderScale?.floatValue, Float(MDCTextInputControllerDefault.floatingPlaceholderScaleDefault))
+    XCTAssertEqual(controller.isFloatingEnabled, MDCTextInputControllerDefault.isFloatingEnabledDefault)
+
+    // Test the changes to the class properties.
+    MDCTextInputControllerDefault.errorColorDefault = .green
+    XCTAssertEqual(MDCTextInputControllerDefault.errorColorDefault, .green)
+
+    MDCTextInputControllerDefault.inlinePlaceholderColorDefault = .orange
+    XCTAssertEqual(MDCTextInputControllerDefault.inlinePlaceholderColorDefault, .orange)
+
+    MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault = false
+    XCTAssertEqual(MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault, false)
+
+    MDCTextInputControllerDefault.underlineColorActiveDefault = .purple
+    XCTAssertEqual(MDCTextInputControllerDefault.underlineColorActiveDefault, .purple)
+
+    MDCTextInputControllerDefault.underlineColorNormalDefault = .white
+    XCTAssertEqual(MDCTextInputControllerDefault.underlineColorNormalDefault, .white)
+
+    MDCTextInputControllerDefault.underlineViewModeDefault = .unlessEditing
+    XCTAssertEqual(MDCTextInputControllerDefault.underlineViewModeDefault, .unlessEditing)
+
+    // Default specific properties
+    MDCTextInputControllerDefault.floatingPlaceholderColorDefault = .red
+    XCTAssertEqual(MDCTextInputControllerDefault.floatingPlaceholderColorDefault, .red)
+
+    MDCTextInputControllerDefault.floatingPlaceholderScaleDefault = 0.6
+    XCTAssertEqual(Float(MDCTextInputControllerDefault.floatingPlaceholderScaleDefault), 0.6)
+
+    MDCTextInputControllerDefault.isFloatingEnabledDefault = false
+    XCTAssertEqual(MDCTextInputControllerDefault.isFloatingEnabledDefault, false)
+
+    // Test the changes to the class properties can propogate to an instance.
+    controller = MDCTextInputControllerDefault(textInput: textField)
+
+    XCTAssertEqual(controller.errorColor, MDCTextInputControllerDefault.errorColorDefault)
+    XCTAssertEqual(controller.inlinePlaceholderColor, MDCTextInputControllerDefault.inlinePlaceholderColorDefault)
+    XCTAssertEqual(controller.mdc_adjustsFontForContentSizeCategory, MDCTextInputControllerDefault.mdc_adjustsFontForContentSizeCategoryDefault)
+    XCTAssertEqual(controller.underlineColorActive, MDCTextInputControllerDefault.underlineColorActiveDefault)
+    XCTAssertEqual(controller.underlineColorNormal, MDCTextInputControllerDefault.underlineColorNormalDefault)
+    XCTAssertEqual(controller.underlineViewMode, MDCTextInputControllerDefault.underlineViewModeDefault)
+
+    // Default specific properties
+    XCTAssertEqual(controller.floatingPlaceholderColor, MDCTextInputControllerDefault.floatingPlaceholderColorDefault)
+    XCTAssertEqual(controller.floatingPlaceholderScale?.floatValue, Float(MDCTextInputControllerDefault.floatingPlaceholderScaleDefault))
+    XCTAssertEqual(controller.isFloatingEnabled, MDCTextInputControllerDefault.isFloatingEnabledDefault)
+  }
+
+  func testFullWidth() {
+
+    // Test the values of the class properties.
+    XCTAssertEqual(MDCTextInputControllerFullWidth.errorColorDefault, MDCPalette.red.tint500)
+    XCTAssertEqual(MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault, UIColor(white: 0, alpha: 0.54))
+    XCTAssertEqual(MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault, true)
+    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineColorActiveDefault, MDCPalette.indigo.tint500)
+    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineColorNormalDefault, .lightGray)
+    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineViewModeDefault, .whileEditing)
+
+    // Test the use of the class properties.
+    let textField = MDCTextField()
+    var controller = MDCTextInputControllerFullWidth(textInput: textField)
+
+    XCTAssertEqual(controller.errorColor, MDCTextInputControllerFullWidth.errorColorDefault)
+    XCTAssertEqual(controller.inlinePlaceholderColor, MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault)
+    XCTAssertEqual(controller.mdc_adjustsFontForContentSizeCategory, MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault)
+    XCTAssertEqual(controller.underlineColorActive, MDCTextInputControllerFullWidth.underlineColorActiveDefault)
+    XCTAssertEqual(controller.underlineColorNormal, MDCTextInputControllerFullWidth.underlineColorNormalDefault)
+    XCTAssertEqual(controller.underlineViewMode, MDCTextInputControllerFullWidth.underlineViewModeDefault)
+
+    // Test the changes to the class properties.
+    MDCTextInputControllerFullWidth.errorColorDefault = .green
+    XCTAssertEqual(MDCTextInputControllerFullWidth.errorColorDefault, .green)
+
+    MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault = .orange
+    XCTAssertEqual(MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault, .orange)
+
+    MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault = false
+    XCTAssertEqual(MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault, false)
+
+    MDCTextInputControllerFullWidth.underlineColorActiveDefault = .purple
+    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineColorActiveDefault, .purple)
+
+    MDCTextInputControllerFullWidth.underlineColorNormalDefault = .white
+    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineColorNormalDefault, .white)
+
+    MDCTextInputControllerFullWidth.underlineViewModeDefault = .unlessEditing
+    XCTAssertEqual(MDCTextInputControllerFullWidth.underlineViewModeDefault, .unlessEditing)
+
+    // Test the changes to the class properties can propogate to an instance.
+    controller = MDCTextInputControllerFullWidth(textInput: textField)
+
+    XCTAssertEqual(controller.errorColor, MDCTextInputControllerFullWidth.errorColorDefault)
+    XCTAssertEqual(controller.inlinePlaceholderColor, MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault)
+    XCTAssertEqual(controller.mdc_adjustsFontForContentSizeCategory, MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault)
+    XCTAssertEqual(controller.underlineColorActive, MDCTextInputControllerFullWidth.underlineColorActiveDefault)
+    XCTAssertEqual(controller.underlineColorNormal, MDCTextInputControllerFullWidth.underlineColorNormalDefault)
+    XCTAssertEqual(controller.underlineViewMode, MDCTextInputControllerFullWidth.underlineViewModeDefault)
+  }
+}

--- a/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
+++ b/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
@@ -22,7 +22,7 @@ import MaterialComponents.MaterialPalettes
 import MaterialComponents.MaterialTextFields
 import MaterialComponents.MaterialTypography
 
-class TextFieldControllerClassPropertiesTests: XCTest {
+class TextFieldControllerClassPropertiesTests: XCTestCase {
   func testDefault() {
 
     // Test the values of the class properties.


### PR DESCRIPTION
UIAppearance can't work on classes that inherit from something other than UIView. Class properties can be used to replace a lot of that functionality.