### PR TITLE
[Collections] Add StylingDelegate methods to control separator display

### DIFF
--- a/components/Collections/examples/CollectionsCellSeparatorExample.m
+++ b/components/Collections/examples/CollectionsCellSeparatorExample.m
@@ -35,6 +35,11 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   [self.collectionView registerClass:[MDCCollectionViewTextCell class]
           forCellWithReuseIdentifier:kReusableIdentifierItem];
 
+  // Register header.
+  [self.collectionView registerClass:[MDCCollectionViewTextCell class]
+          forSupplementaryViewOfKind:UICollectionElementKindSectionHeader
+                 withReuseIdentifier:UICollectionElementKindSectionHeader];
+
   // Populate content.
   _content = [NSMutableArray array];
   for (NSInteger i = 0; i < kSectionCount; i++) {
@@ -78,6 +83,46 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   }
 
   return cell;
+}
+
+- (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView
+           viewForSupplementaryElementOfKind:(NSString *)kind
+                                 atIndexPath:(NSIndexPath *)indexPath {
+  MDCCollectionViewTextCell *supplementaryView =
+      [collectionView dequeueReusableSupplementaryViewOfKind:kind
+                                         withReuseIdentifier:kind
+                                                forIndexPath:indexPath];
+
+  if ([kind isEqualToString:UICollectionElementKindSectionHeader]) {
+    if (indexPath.section == 3) {
+      supplementaryView.textLabel.text = @"Header with separator";
+    } else if (indexPath.section == 4) {
+      supplementaryView.textLabel.text = @"Header without separator";
+    }
+  }
+
+  return supplementaryView;
+}
+
+- (CGSize)collectionView:(UICollectionView *)collectionView
+                             layout:(UICollectionViewLayout *)collectionViewLayout
+    referenceSizeForHeaderInSection:(NSInteger)section {
+  if (section == 3 || section == 4) {
+    return CGSizeMake(collectionView.bounds.size.width, MDCCellDefaultOneLineHeight);
+  }
+  return CGSizeZero;
+}
+
+#pragma mark - <MDCCollectionViewStylingDelegate>
+
+- (BOOL)collectionView:(UICollectionView *)collectionView
+    shouldHideItemSeparatorAtIndexPath:(NSIndexPath *)indexPath {
+  return indexPath.section == 3;
+}
+
+- (BOOL)collectionView:(UICollectionView *)collectionView
+    shouldHideHeaderSeparatorForSection:(NSInteger)section {
+  return section == 4;
 }
 
 @end

--- a/components/Collections/src/MDCCollectionViewFlowLayout.m
+++ b/components/Collections/src/MDCCollectionViewFlowLayout.m
@@ -374,7 +374,7 @@ static const NSInteger kSupplementaryViewZIndex = 99;
   attr.separatorColor = self.styler.separatorColor;
   attr.separatorInset = self.styler.separatorInset;
   attr.separatorLineHeight = self.styler.separatorLineHeight;
-  attr.shouldHideSeparators = self.styler.shouldHideSeparators;
+  attr.shouldHideSeparators = [self.styler shouldHideSeparatorForCellLayoutAttributes:attr];
 
   // Set inlay and hidden state if necessary.
   [self inlayAttributeIfNecessary:attr];
@@ -397,7 +397,7 @@ static const NSInteger kSupplementaryViewZIndex = 99;
       if ([attr.representedElementKind isEqualToString:UICollectionElementKindSectionHeader]) {
         insetFrame.origin.y += insets.top;
       } else if ([attr.representedElementKind
-                  isEqualToString:UICollectionElementKindSectionFooter]) {
+                     isEqualToString:UICollectionElementKindSectionFooter]) {
         insetFrame.origin.y -= insets.bottom;
       }
       attr.frame = insetFrame;
@@ -531,8 +531,8 @@ static const NSInteger kSupplementaryViewZIndex = 99;
           (id<MDCCollectionViewEditingDelegate>)self.collectionView.dataSource;
 
       // Check if delegate can select during editing.
-      if ([editingDelegate respondsToSelector:@selector(collectionView:
-                                                  canSelectItemDuringEditingAtIndexPath:)]) {
+      if ([editingDelegate respondsToSelector:@selector
+                           (collectionView:canSelectItemDuringEditingAtIndexPath:)]) {
         attr.shouldShowSelectorStateMask = [editingDelegate collectionView:self.collectionView
                                      canSelectItemDuringEditingAtIndexPath:attr.indexPath];
       }

--- a/components/Collections/src/MDCCollectionViewStyling.h
+++ b/components/Collections/src/MDCCollectionViewStyling.h
@@ -142,6 +142,16 @@ typedef NS_ENUM(NSUInteger, MDCCollectionViewCellLayoutType) {
 /* Whether to hide the cell separators. Defaults to NO. */
 @property(nonatomic) BOOL shouldHideSeparators;
 
+/**
+ Returns whether the separator should be hidden for the cell with this layout attributes, determined
+ by the cell position and type.
+
+ @param attr The cell's layout attributes.
+ @return Whether the separtor should be hidden.
+ */
+- (BOOL)shouldHideSeparatorForCellLayoutAttributes:
+        (nonnull MDCCollectionViewLayoutAttributes *)attr;
+
 #pragma mark - Item Inlaying
 
 /**

--- a/components/Collections/src/MDCCollectionViewStyling.h
+++ b/components/Collections/src/MDCCollectionViewStyling.h
@@ -145,6 +145,8 @@ typedef NS_ENUM(NSUInteger, MDCCollectionViewCellLayoutType) {
 /**
  Returns whether the separator should be hidden for the cell with this layout attributes, determined
  by the cell position and type.
+ This method may override the shouldHideSeparators property depending on which delegate methods are
+ implemented.
 
  @param attr The cell's layout attributes.
  @return Whether the separtor should be hidden.

--- a/components/Collections/src/MDCCollectionViewStylingDelegate.h
+++ b/components/Collections/src/MDCCollectionViewStylingDelegate.h
@@ -90,6 +90,38 @@
 - (BOOL)collectionView:(nonnull UICollectionView *)collectionView
     shouldHideFooterBackgroundForSection:(NSInteger)section;
 
+#pragma mark - Separator
+
+/**
+ Asks the delegate whether the specified item should hide its separator.
+
+ @param collectionView The collection view.
+ @param indexPath The item's index path.
+ @return If the item separator should be hidden at the specified index path.
+ */
+- (BOOL)collectionView:(nonnull UICollectionView *)collectionView
+    shouldHideItemSeparatorAtIndexPath:(nonnull NSIndexPath *)indexPath;
+
+/**
+ Asks the delegate whether the specified header should hide its separator.
+
+ @param collectionView The collection view.
+ @param section The collection view section.
+ @return If the header separator should be hidden at the specified section.
+ */
+- (BOOL)collectionView:(nonnull UICollectionView *)collectionView
+    shouldHideHeaderSeparatorForSection:(NSInteger)section;
+
+/**
+ Asks the delegate whether the specified footer should hide its separator.
+
+ @param collectionView The collection view.
+ @param section The collection view section.
+ @return If the footer separator should be hidden at the specified section.
+ */
+- (BOOL)collectionView:(nonnull UICollectionView *)collectionView
+    shouldHideFooterSeparatorForSection:(NSInteger)section;
+
 #pragma mark - Item inlaying
 
 /**

--- a/components/Collections/src/private/MDCCollectionViewStyler.m
+++ b/components/Collections/src/private/MDCCollectionViewStyler.m
@@ -248,29 +248,34 @@ NS_INLINE CGRect RectShift(CGRect rect, CGFloat dx, CGFloat dy) {
 
 - (BOOL)shouldHideSeparatorForCellLayoutAttributes:(MDCCollectionViewLayoutAttributes *)attr {
   BOOL shouldHideSeparator = self.shouldHideSeparators;
-  if (!self.delegate)
+  if (!self.delegate) {
     return shouldHideSeparator;
+  }
 
   NSIndexPath *indexPath = attr.indexPath;
+  BOOL isCell = attr.representedElementCategory == UICollectionElementCategoryCell;
   BOOL isSectionHeader =
       [attr.representedElementKind isEqualToString:UICollectionElementKindSectionHeader];
   BOOL isSectionFooter =
       [attr.representedElementKind isEqualToString:UICollectionElementKindSectionFooter];
-  BOOL isCell = attr.representedElementCategory == UICollectionElementCategoryCell;
-  if (isSectionHeader && [self.delegate respondsToSelector:@selector
-                                        (collectionView:shouldHideHeaderSeparatorForSection:)]) {
-    shouldHideSeparator = [self.delegate collectionView:_collectionView
-                    shouldHideHeaderSeparatorForSection:indexPath.section];
-  }
-  if (isSectionFooter && [self.delegate respondsToSelector:@selector
-                                        (collectionView:shouldHideFooterSeparatorForSection:)]) {
-    shouldHideSeparator = [self.delegate collectionView:_collectionView
-                    shouldHideFooterSeparatorForSection:indexPath.section];
-  }
-  if (isCell && [self.delegate respondsToSelector:@selector
-                               (collectionView:shouldHideItemSeparatorAtIndexPath:)]) {
-    shouldHideSeparator =
-        [self.delegate collectionView:_collectionView shouldHideItemSeparatorAtIndexPath:indexPath];
+  if (isCell) {
+    if ([self.delegate
+            respondsToSelector:@selector(collectionView:shouldHideItemSeparatorAtIndexPath:)]) {
+      shouldHideSeparator = [self.delegate collectionView:_collectionView
+                       shouldHideItemSeparatorAtIndexPath:indexPath];
+    }
+  } else if (isSectionHeader) {
+    if ([self.delegate
+            respondsToSelector:@selector(collectionView:shouldHideHeaderSeparatorForSection:)]) {
+      shouldHideSeparator = [self.delegate collectionView:_collectionView
+                      shouldHideHeaderSeparatorForSection:indexPath.section];
+    }
+  } else if (isSectionFooter) {
+    if ([self.delegate
+            respondsToSelector:@selector(collectionView:shouldHideFooterSeparatorForSection:)]) {
+      shouldHideSeparator = [self.delegate collectionView:_collectionView
+                      shouldHideFooterSeparatorForSection:indexPath.section];
+    }
   }
   return shouldHideSeparator;
 }

--- a/components/Collections/src/private/MDCCollectionViewStyler.m
+++ b/components/Collections/src/private/MDCCollectionViewStyler.m
@@ -16,8 +16,8 @@
 
 #import "MDCCollectionViewStyler.h"
 
-#import "MaterialCollections.h"
 #import "MaterialCollectionLayoutAttributes.h"
+#import "MaterialCollections.h"
 
 #import <tgmath.h>
 
@@ -244,6 +244,35 @@ NS_INLINE CGRect RectShift(CGRect rect, CGFloat dx, CGFloat dy) {
   [_cellBackgroundCaches removeAllObjects];
   [self invalidateLayoutForStyleChange];
   _cellStyle = cellStyle;
+}
+
+- (BOOL)shouldHideSeparatorForCellLayoutAttributes:(MDCCollectionViewLayoutAttributes *)attr {
+  BOOL shouldHideSeparator = self.shouldHideSeparators;
+  if (!self.delegate)
+    return shouldHideSeparator;
+
+  NSIndexPath *indexPath = attr.indexPath;
+  BOOL isSectionHeader =
+      [attr.representedElementKind isEqualToString:UICollectionElementKindSectionHeader];
+  BOOL isSectionFooter =
+      [attr.representedElementKind isEqualToString:UICollectionElementKindSectionFooter];
+  BOOL isCell = attr.representedElementCategory == UICollectionElementCategoryCell;
+  if (isSectionHeader && [self.delegate respondsToSelector:@selector
+                                        (collectionView:shouldHideHeaderSeparatorForSection:)]) {
+    shouldHideSeparator = [self.delegate collectionView:_collectionView
+                    shouldHideHeaderSeparatorForSection:indexPath.section];
+  }
+  if (isSectionFooter && [self.delegate respondsToSelector:@selector
+                                        (collectionView:shouldHideFooterSeparatorForSection:)]) {
+    shouldHideSeparator = [self.delegate collectionView:_collectionView
+                    shouldHideFooterSeparatorForSection:indexPath.section];
+  }
+  if (isCell && [self.delegate respondsToSelector:@selector
+                               (collectionView:shouldHideItemSeparatorAtIndexPath:)]) {
+    shouldHideSeparator =
+        [self.delegate collectionView:_collectionView shouldHideItemSeparatorAtIndexPath:indexPath];
+  }
+  return shouldHideSeparator;
 }
 
 #pragma mark - Public

--- a/components/Collections/tests/unit/CollectionsStylerTests.m
+++ b/components/Collections/tests/unit/CollectionsStylerTests.m
@@ -110,8 +110,11 @@ static MDCCollectionViewLayoutAttributes* footer1() {
   styler.shouldHideSeparators = YES;
 
   // Then
+  XCTAssertTrue([styler shouldHideSeparatorForCellLayoutAttributes:cell00()]);
   XCTAssertTrue([styler shouldHideSeparatorForCellLayoutAttributes:cell01()]);
   XCTAssertTrue([styler shouldHideSeparatorForCellLayoutAttributes:header0()]);
+  XCTAssertTrue([styler shouldHideSeparatorForCellLayoutAttributes:header1()]);
+  XCTAssertTrue([styler shouldHideSeparatorForCellLayoutAttributes:footer0()]);
   XCTAssertTrue([styler shouldHideSeparatorForCellLayoutAttributes:footer1()]);
 }
 
@@ -128,9 +131,12 @@ static MDCCollectionViewLayoutAttributes* footer1() {
   styler.shouldHideSeparators = NO;
 
   // Then
+  XCTAssertFalse([styler shouldHideSeparatorForCellLayoutAttributes:cell00()]);
   XCTAssertFalse([styler shouldHideSeparatorForCellLayoutAttributes:cell01()]);
   XCTAssertFalse([styler shouldHideSeparatorForCellLayoutAttributes:header0()]);
+  XCTAssertFalse([styler shouldHideSeparatorForCellLayoutAttributes:header1()]);
   XCTAssertFalse([styler shouldHideSeparatorForCellLayoutAttributes:footer0()]);
+  XCTAssertFalse([styler shouldHideSeparatorForCellLayoutAttributes:footer1()]);
 }
 
 @end

--- a/components/Collections/tests/unit/CollectionsStylerTests.m
+++ b/components/Collections/tests/unit/CollectionsStylerTests.m
@@ -1,0 +1,136 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing software
+ distributed under the License is distributed on an "AS IS" BASIS
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MDCCollectionViewStyler.h"
+#import "MaterialCollectionLayoutAttributes.h"
+#import "MaterialCollections.h"
+
+static MDCCollectionViewLayoutAttributes* cell00() {
+  return [MDCCollectionViewLayoutAttributes
+      layoutAttributesForCellWithIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
+}
+static MDCCollectionViewLayoutAttributes* cell01() {
+  return [MDCCollectionViewLayoutAttributes
+      layoutAttributesForCellWithIndexPath:[NSIndexPath indexPathForItem:1 inSection:0]];
+}
+static MDCCollectionViewLayoutAttributes* header0() {
+  return [MDCCollectionViewLayoutAttributes
+      layoutAttributesForSupplementaryViewOfKind:UICollectionElementKindSectionHeader
+                                   withIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
+}
+static MDCCollectionViewLayoutAttributes* header1() {
+  return [MDCCollectionViewLayoutAttributes
+      layoutAttributesForSupplementaryViewOfKind:UICollectionElementKindSectionHeader
+                                   withIndexPath:[NSIndexPath indexPathForItem:1 inSection:1]];
+}
+static MDCCollectionViewLayoutAttributes* footer0() {
+  return [MDCCollectionViewLayoutAttributes
+      layoutAttributesForSupplementaryViewOfKind:UICollectionElementKindSectionFooter
+                                   withIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
+}
+static MDCCollectionViewLayoutAttributes* footer1() {
+  return [MDCCollectionViewLayoutAttributes
+      layoutAttributesForSupplementaryViewOfKind:UICollectionElementKindSectionFooter
+                                   withIndexPath:[NSIndexPath indexPathForItem:1 inSection:1]];
+}
+
+// Implementation of a MDCCollectionViewStylingDelegate for testing purpose.
+@interface CollectionsStylerTestsDelegate : NSObject <MDCCollectionViewStylingDelegate>
+
+@end
+
+@implementation CollectionsStylerTestsDelegate
+
+- (BOOL)collectionView:(UICollectionView*)collectionView
+    shouldHideItemSeparatorAtIndexPath:(NSIndexPath*)indexPath {
+  return indexPath.section == 0 && indexPath.item == 1;
+}
+
+- (BOOL)collectionView:(UICollectionView*)collectionView
+    shouldHideHeaderSeparatorForSection:(NSInteger)section {
+  return section == 1;
+}
+
+- (BOOL)collectionView:(UICollectionView*)collectionView
+    shouldHideFooterSeparatorForSection:(NSInteger)section {
+  return section == 0;
+}
+
+@end
+
+@interface CollectionsStylerTests : XCTestCase
+@end
+
+@implementation CollectionsStylerTests
+
+- (void)testHideSeparatorWithDelegate {
+  // Given
+  UICollectionView* collectionView =
+      [[UICollectionView alloc] initWithFrame:CGRectZero
+                         collectionViewLayout:[[UICollectionViewFlowLayout alloc] init]];
+  CollectionsStylerTestsDelegate* delegate = [[CollectionsStylerTestsDelegate alloc] init];
+  MDCCollectionViewStyler* styler =
+      [[MDCCollectionViewStyler alloc] initWithCollectionView:collectionView];
+  styler.delegate = delegate;
+
+  // Then
+  XCTAssertFalse([styler shouldHideSeparatorForCellLayoutAttributes:cell00()]);
+  XCTAssertTrue([styler shouldHideSeparatorForCellLayoutAttributes:cell01()]);
+  XCTAssertFalse([styler shouldHideSeparatorForCellLayoutAttributes:header0()]);
+  XCTAssertTrue([styler shouldHideSeparatorForCellLayoutAttributes:header1()]);
+  XCTAssertTrue([styler shouldHideSeparatorForCellLayoutAttributes:footer0()]);
+  XCTAssertFalse([styler shouldHideSeparatorForCellLayoutAttributes:footer1()]);
+}
+
+- (void)testHideSeparatorWithoutDelegate {
+  // Given
+  UICollectionView* collectionView =
+      [[UICollectionView alloc] initWithFrame:CGRectZero
+                         collectionViewLayout:[[UICollectionViewFlowLayout alloc] init]];
+  MDCCollectionViewStyler* styler =
+      [[MDCCollectionViewStyler alloc] initWithCollectionView:collectionView];
+  styler.delegate = nil;
+
+  // When
+  styler.shouldHideSeparators = YES;
+
+  // Then
+  XCTAssertTrue([styler shouldHideSeparatorForCellLayoutAttributes:cell01()]);
+  XCTAssertTrue([styler shouldHideSeparatorForCellLayoutAttributes:header0()]);
+  XCTAssertTrue([styler shouldHideSeparatorForCellLayoutAttributes:footer1()]);
+}
+
+- (void)testShowSeparatorWithoutDelegate {
+  // Given
+  UICollectionView* collectionView =
+      [[UICollectionView alloc] initWithFrame:CGRectZero
+                         collectionViewLayout:[[UICollectionViewFlowLayout alloc] init]];
+  MDCCollectionViewStyler* styler =
+      [[MDCCollectionViewStyler alloc] initWithCollectionView:collectionView];
+  styler.delegate = nil;
+
+  // When
+  styler.shouldHideSeparators = NO;
+
+  // Then
+  XCTAssertFalse([styler shouldHideSeparatorForCellLayoutAttributes:cell01()]);
+  XCTAssertFalse([styler shouldHideSeparatorForCellLayoutAttributes:header0()]);
+  XCTAssertFalse([styler shouldHideSeparatorForCellLayoutAttributes:footer0()]);
+}
+
+@end


### PR DESCRIPTION
Adds methods to MDCCollectionViewStylingDelegate, allowing the delegate to control the display of the separator on cells, header and footer.

Closes #1406 