### PR TITLE
[Collections] Use image cache for selection icons

### DIFF
--- a/components/AppBar/src/MDCAppBar.m
+++ b/components/AppBar/src/MDCAppBar.m
@@ -213,7 +213,7 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
   }
   UIBarButtonItem *backBarButtonItem = previousViewControler.navigationItem.backBarButtonItem;
   if (!backBarButtonItem) {
-    UIImage *backButtonImage = [UIImage imageWithContentsOfFile:[MDCIcons pathFor_ic_arrow_back]];
+    UIImage *backButtonImage = [MDCIcons imageFor_ic_arrow_back];
     backButtonImage = [backButtonImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     if (self.navigationBar.mdc_effectiveUserInterfaceLayoutDirection ==
         UIUserInterfaceLayoutDirectionRightToLeft) {

--- a/components/CollectionCells/src/MDCCollectionViewCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewCell.m
@@ -227,7 +227,7 @@ NSString *const kDeselectedCellAccessibilityHintKey =
 
   switch (_accessoryType) {
     case MDCCollectionViewCellAccessoryDisclosureIndicator: {
-      UIImage *image = [UIImage imageWithContentsOfFile:[MDCIcons pathFor_ic_chevron_right]];
+      UIImage *image = [MDCIcons imageFor_ic_chevron_right];
       if (self.mdc_effectiveUserInterfaceLayoutDirection ==
           UIUserInterfaceLayoutDirectionRightToLeft) {
         image = [image mdc_imageFlippedForRightToLeftLayoutDirection];
@@ -236,12 +236,12 @@ NSString *const kDeselectedCellAccessibilityHintKey =
       break;
     }
     case MDCCollectionViewCellAccessoryCheckmark: {
-      UIImage *image = [UIImage imageWithContentsOfFile:[MDCIcons pathFor_ic_check]];
+      UIImage *image = [MDCIcons imageFor_ic_check];
       accessoryImageView.image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
       break;
     }
     case MDCCollectionViewCellAccessoryDetailButton: {
-      UIImage *image = [UIImage imageWithContentsOfFile:[MDCIcons pathFor_ic_info]];
+      UIImage *image = [MDCIcons imageFor_ic_info];
       accessoryImageView.image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
       break;
     }
@@ -363,7 +363,7 @@ NSString *const kDeselectedCellAccessibilityHintKey =
     // Create reorder editing controls.
     if (_attr.shouldShowReorderStateMask) {
       if (!_editingReorderImageView) {
-        UIImage *reorderImage = [UIImage imageWithContentsOfFile:[MDCIcons pathFor_ic_reorder]];
+        UIImage *reorderImage = [MDCIcons imageFor_ic_reorder];
         reorderImage = [reorderImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
         _editingReorderImageView = [[UIImageView alloc] initWithImage:reorderImage];
         _editingReorderImageView.tintColor = HEXCOLOR(kCellGrayColor);
@@ -387,8 +387,7 @@ NSString *const kDeselectedCellAccessibilityHintKey =
     // Create selector editing controls.
     if (_attr.shouldShowSelectorStateMask) {
       if (!_editingSelectorImageView) {
-        UIImage *selectorImage =
-            [UIImage imageWithContentsOfFile:[MDCIcons pathFor_ic_radio_button_unchecked]];
+        UIImage *selectorImage = [MDCIcons imageFor_ic_radio_button_unchecked];
         selectorImage = [selectorImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
         _editingSelectorImageView = [[UIImageView alloc] initWithImage:selectorImage];
         _editingSelectorImageView.tintColor = HEXCOLOR(kCellGrayColor);
@@ -427,13 +426,11 @@ NSString *const kDeselectedCellAccessibilityHintKey =
 - (void)setSelected:(BOOL)selected {
   [super setSelected:selected];
   if (selected) {
-    _editingSelectorImageView.image =
-        [UIImage imageWithContentsOfFile:[MDCIcons pathFor_ic_check_circle]];
+    _editingSelectorImageView.image = [MDCIcons imageFor_ic_check_circle];
     _editingSelectorImageView.tintColor = self.editingSelectorColor;
     self.accessibilityTraits |= UIAccessibilityTraitSelected;
   } else {
-    _editingSelectorImageView.image =
-        [UIImage imageWithContentsOfFile:[MDCIcons pathFor_ic_radio_button_unchecked]];
+    _editingSelectorImageView.image = [MDCIcons imageFor_ic_radio_button_unchecked];
     _editingSelectorImageView.tintColor = HEXCOLOR(kCellGrayColor);
     self.accessibilityTraits &= ~UIAccessibilityTraitSelected;
   }

--- a/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.h
+++ b/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.h
@@ -33,7 +33,6 @@
 
 /*
  Change the style returned by `pathFor_ic_arrow_back`.
-
  @param useNewStyle Use the new iOS style OR Material style for ic_arrow_back.
  */
 + (void)ic_arrow_backUseNewStyle:(BOOL)useNewStyle;

--- a/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.h
+++ b/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.h
@@ -38,4 +38,10 @@
  */
 + (void)ic_arrow_backUseNewStyle:(BOOL)useNewStyle;
 
+/*
+ Returns the bundle for the ic_arrow_back image contained in
+ MaterialIcons_ic_arrow_back.bundle.
+ */
++ (nullable UIImage *)imageFor_ic_arrow_back;
+
 @end

--- a/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.h
+++ b/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.h
@@ -33,13 +33,13 @@
 
 /*
  Change the style returned by `pathFor_ic_arrow_back`.
- 
+
  @param useNewStyle Use the new iOS style OR Material style for ic_arrow_back.
  */
 + (void)ic_arrow_backUseNewStyle:(BOOL)useNewStyle;
 
 /*
- Returns the bundle for the ic_arrow_back image contained in
+ Returns the image for the ic_arrow_back image contained in
  MaterialIcons_ic_arrow_back.bundle.
  */
 + (nullable UIImage *)imageFor_ic_arrow_back;

--- a/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.h
+++ b/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.h
@@ -33,6 +33,7 @@
 
 /*
  Change the style returned by `pathFor_ic_arrow_back`.
+ 
  @param useNewStyle Use the new iOS style OR Material style for ic_arrow_back.
  */
 + (void)ic_arrow_backUseNewStyle:(BOOL)useNewStyle;

--- a/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.m
+++ b/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.m
@@ -19,6 +19,7 @@
 
 #import "MaterialIcons+ic_arrow_back.h"
 
+#import "MDCIcons+BundleLoader.h"
 #import "MaterialIcons.h"
 
 static NSString *const kBundleName = @"MaterialIcons_ic_arrow_back";
@@ -45,6 +46,11 @@ __attribute__((visibility("default"))) char MDCIconsExportToSuppressLibToolWarni
   } else {
     __icArrowBackIconName = kIconName;
   }
+}
+
++ (nullable UIImage *)imageFor_ic_arrow_back {
+  NSBundle *bundle = [self bundleNamed:kBundleName];
+  return [UIImage imageNamed:kIconName inBundle:bundle compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.m
+++ b/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.m
@@ -34,7 +34,7 @@ __attribute__((visibility("default"))) char MDCIconsExportToSuppressLibToolWarni
 @implementation MDCIcons (ic_arrow_back)
 
 + (nonnull NSString *)pathFor_ic_arrow_back {
-  return [self pathForIconName:kIconName withBundleName:kBundleName];
+  return [self pathForIconName:__icArrowBackIconName withBundleName:kBundleName];
 }
 
 // TODO(samnm): Remove this method and __icArrowBackIconName after transitioning all clients to the

--- a/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.m
+++ b/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.m
@@ -19,7 +19,6 @@
 
 #import "MaterialIcons+ic_arrow_back.h"
 
-#import "MDCIcons+BundleLoader.h"
 #import "MaterialIcons.h"
 
 static NSString *const kBundleName = @"MaterialIcons_ic_arrow_back";
@@ -35,7 +34,7 @@ __attribute__((visibility("default"))) char MDCIconsExportToSuppressLibToolWarni
 @implementation MDCIcons (ic_arrow_back)
 
 + (nonnull NSString *)pathFor_ic_arrow_back {
-  return [self pathForIconName:__icArrowBackIconName withBundleName:kBundleName];
+  return [self pathForIconName:kIconName withBundleName:kBundleName];
 }
 
 // TODO(samnm): Remove this method and __icArrowBackIconName after transitioning all clients to the

--- a/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.m
+++ b/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.m
@@ -28,8 +28,8 @@ static NSString *const kNewIconName = @"ic_arrow_back_ios";
 static NSString *__icArrowBackIconName = @"ic_arrow_back_ios";
 
 // Export a nonsense symbol to suppress a libtool warning when this is linked alone in a static lib.
-__attribute__((visibility("default"))) char MDCIconsExportToSuppressLibToolWarning_ic_arrow_back =
-    0;
+__attribute__((visibility("default")))
+    char MDCIconsExportToSuppressLibToolWarning_ic_arrow_back = 0;
 
 @implementation MDCIcons (ic_arrow_back)
 
@@ -49,7 +49,9 @@ __attribute__((visibility("default"))) char MDCIconsExportToSuppressLibToolWarni
 
 + (nullable UIImage *)imageFor_ic_arrow_back {
   NSBundle *bundle = [self bundleNamed:kBundleName];
-  return [UIImage imageNamed:__icArrowBackIconName inBundle:bundle compatibleWithTraitCollection:nil];
+  return [UIImage imageNamed:__icArrowBackIconName
+                    inBundle:bundle
+      compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.m
+++ b/components/private/Icons/icons/ic_arrow_back/src/MaterialIcons+ic_arrow_back.m
@@ -49,7 +49,7 @@ __attribute__((visibility("default"))) char MDCIconsExportToSuppressLibToolWarni
 
 + (nullable UIImage *)imageFor_ic_arrow_back {
   NSBundle *bundle = [self bundleNamed:kBundleName];
-  return [UIImage imageNamed:kIconName inBundle:bundle compatibleWithTraitCollection:nil];
+  return [UIImage imageNamed:__icArrowBackIconName inBundle:bundle compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/components/private/Icons/icons/ic_check/src/MaterialIcons+ic_check.h
+++ b/components/private/Icons/icons/ic_check/src/MaterialIcons+ic_check.h
@@ -30,7 +30,7 @@
 + (nonnull NSString *)pathFor_ic_check;
 
 /*
- Returns the bundle for the ic_check image contained in
+ Returns the image for the ic_check image contained in
  MaterialIcons_ic_check.bundle.
  */
 + (nullable UIImage *)imageFor_ic_check;

--- a/components/private/Icons/icons/ic_check/src/MaterialIcons+ic_check.h
+++ b/components/private/Icons/icons/ic_check/src/MaterialIcons+ic_check.h
@@ -29,4 +29,10 @@
  */
 + (nonnull NSString *)pathFor_ic_check;
 
+/*
+ Returns the bundle for the ic_check image contained in
+ MaterialIcons_ic_check.bundle.
+ */
++ (nullable UIImage *)imageFor_ic_check;
+
 @end

--- a/components/private/Icons/icons/ic_check/src/MaterialIcons+ic_check.m
+++ b/components/private/Icons/icons/ic_check/src/MaterialIcons+ic_check.m
@@ -19,7 +19,7 @@
 
 #import "MaterialIcons+ic_check.h"
 
-#import "MDCIcons+BundleLoader.h"
+#import "MaterialIcons.h"
 
 static NSString *const kBundleName = @"MaterialIcons_ic_check";
 static NSString *const kIconName = @"ic_check";

--- a/components/private/Icons/icons/ic_check/src/MaterialIcons+ic_check.m
+++ b/components/private/Icons/icons/ic_check/src/MaterialIcons+ic_check.m
@@ -35,7 +35,9 @@ __attribute__((visibility("default"))) char MDCIconsExportToSuppressLibToolWarni
 
 + (nullable UIImage *)imageFor_ic_check {
   NSBundle *bundle = [self bundleNamed:kBundleName];
-  return [UIImage imageNamed:kIconName inBundle:bundle compatibleWithTraitCollection:nil];
+  return [UIImage imageNamed:kIconName
+                    inBundle:bundle
+      compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/components/private/Icons/icons/ic_check/src/MaterialIcons+ic_check.m
+++ b/components/private/Icons/icons/ic_check/src/MaterialIcons+ic_check.m
@@ -19,7 +19,7 @@
 
 #import "MaterialIcons+ic_check.h"
 
-#import "MaterialIcons.h"
+#import "MDCIcons+BundleLoader.h"
 
 static NSString *const kBundleName = @"MaterialIcons_ic_check";
 static NSString *const kIconName = @"ic_check";
@@ -31,6 +31,11 @@ __attribute__((visibility("default"))) char MDCIconsExportToSuppressLibToolWarni
 
 + (nonnull NSString *)pathFor_ic_check {
   return [self pathForIconName:kIconName withBundleName:kBundleName];
+}
+
++ (nullable UIImage *)imageFor_ic_check {
+  NSBundle *bundle = [self bundleNamed:kBundleName];
+  return [UIImage imageNamed:kIconName inBundle:bundle compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/components/private/Icons/icons/ic_check_circle/src/MaterialIcons+ic_check_circle.h
+++ b/components/private/Icons/icons/ic_check_circle/src/MaterialIcons+ic_check_circle.h
@@ -30,7 +30,7 @@
 + (nonnull NSString *)pathFor_ic_check_circle;
 
 /*
- Returns the bundle for the ic_check_circle image contained in
+ Returns the image for the ic_check_circle image contained in
  MaterialIcons_ic_check_circle.bundle.
  */
 + (nullable UIImage *)imageFor_ic_check_circle;

--- a/components/private/Icons/icons/ic_check_circle/src/MaterialIcons+ic_check_circle.h
+++ b/components/private/Icons/icons/ic_check_circle/src/MaterialIcons+ic_check_circle.h
@@ -29,4 +29,10 @@
  */
 + (nonnull NSString *)pathFor_ic_check_circle;
 
+/*
+ Returns the bundle for the ic_check_circle image contained in
+ MaterialIcons_ic_check_circle.bundle.
+ */
++ (nullable UIImage *)imageFor_ic_check_circle;
+
 @end

--- a/components/private/Icons/icons/ic_check_circle/src/MaterialIcons+ic_check_circle.m
+++ b/components/private/Icons/icons/ic_check_circle/src/MaterialIcons+ic_check_circle.m
@@ -19,7 +19,7 @@
 
 #import "MaterialIcons+ic_check_circle.h"
 
-#import "MDCIcons+BundleLoader.h"
+#import "MaterialIcons.h"
 
 static NSString *const kBundleName = @"MaterialIcons_ic_check_circle";
 static NSString *const kIconName = @"ic_check_circle";

--- a/components/private/Icons/icons/ic_check_circle/src/MaterialIcons+ic_check_circle.m
+++ b/components/private/Icons/icons/ic_check_circle/src/MaterialIcons+ic_check_circle.m
@@ -25,8 +25,8 @@ static NSString *const kBundleName = @"MaterialIcons_ic_check_circle";
 static NSString *const kIconName = @"ic_check_circle";
 
 // Export a nonsense symbol to suppress a libtool warning when this is linked alone in a static lib.
-__attribute__((visibility("default"))) char MDCIconsExportToSuppressLibToolWarning_ic_check_circle =
-    0;
+__attribute__((visibility("default")))
+    char MDCIconsExportToSuppressLibToolWarning_ic_check_circle = 0;
 
 @implementation MDCIcons (ic_check_circle)
 
@@ -36,7 +36,9 @@ __attribute__((visibility("default"))) char MDCIconsExportToSuppressLibToolWarni
 
 + (nullable UIImage *)imageFor_ic_check_circle {
   NSBundle *bundle = [self bundleNamed:kBundleName];
-  return [UIImage imageNamed:kIconName inBundle:bundle compatibleWithTraitCollection:nil];
+  return [UIImage imageNamed:kIconName
+                    inBundle:bundle
+      compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/components/private/Icons/icons/ic_check_circle/src/MaterialIcons+ic_check_circle.m
+++ b/components/private/Icons/icons/ic_check_circle/src/MaterialIcons+ic_check_circle.m
@@ -19,7 +19,7 @@
 
 #import "MaterialIcons+ic_check_circle.h"
 
-#import "MaterialIcons.h"
+#import "MDCIcons+BundleLoader.h"
 
 static NSString *const kBundleName = @"MaterialIcons_ic_check_circle";
 static NSString *const kIconName = @"ic_check_circle";
@@ -32,6 +32,11 @@ __attribute__((visibility("default"))) char MDCIconsExportToSuppressLibToolWarni
 
 + (nonnull NSString *)pathFor_ic_check_circle {
   return [self pathForIconName:kIconName withBundleName:kBundleName];
+}
+
++ (nullable UIImage *)imageFor_ic_check_circle {
+  NSBundle *bundle = [self bundleNamed:kBundleName];
+  return [UIImage imageNamed:kIconName inBundle:bundle compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/components/private/Icons/icons/ic_chevron_right/src/MaterialIcons+ic_chevron_right.h
+++ b/components/private/Icons/icons/ic_chevron_right/src/MaterialIcons+ic_chevron_right.h
@@ -30,7 +30,7 @@
 + (nonnull NSString *)pathFor_ic_chevron_right;
 
 /*
- Returns the bundle for the ic_chevron_right image contained in
+ Returns the image for the ic_chevron_right image contained in
  MaterialIcons_ic_chevron_right.bundle.
  */
 + (nullable UIImage *)imageFor_ic_chevron_right;

--- a/components/private/Icons/icons/ic_chevron_right/src/MaterialIcons+ic_chevron_right.h
+++ b/components/private/Icons/icons/ic_chevron_right/src/MaterialIcons+ic_chevron_right.h
@@ -29,4 +29,10 @@
  */
 + (nonnull NSString *)pathFor_ic_chevron_right;
 
+/*
+ Returns the bundle for the ic_chevron_right image contained in
+ MaterialIcons_ic_chevron_right.bundle.
+ */
++ (nullable UIImage *)imageFor_ic_chevron_right;
+
 @end

--- a/components/private/Icons/icons/ic_chevron_right/src/MaterialIcons+ic_chevron_right.m
+++ b/components/private/Icons/icons/ic_chevron_right/src/MaterialIcons+ic_chevron_right.m
@@ -19,7 +19,7 @@
 
 #import "MaterialIcons+ic_chevron_right.h"
 
-#import "MDCIcons+BundleLoader.h"
+#import "MaterialIcons.h"
 
 static NSString *const kBundleName = @"MaterialIcons_ic_chevron_right";
 static NSString *const kIconName = @"ic_chevron_right";

--- a/components/private/Icons/icons/ic_chevron_right/src/MaterialIcons+ic_chevron_right.m
+++ b/components/private/Icons/icons/ic_chevron_right/src/MaterialIcons+ic_chevron_right.m
@@ -25,8 +25,8 @@ static NSString *const kBundleName = @"MaterialIcons_ic_chevron_right";
 static NSString *const kIconName = @"ic_chevron_right";
 
 // Export a nonsense symbol to suppress a libtool warning when this is linked alone in a static lib.
-__attribute__((
-    visibility("default"))) char MDCIconsExportToSuppressLibToolWarning_ic_chevron_right = 0;
+__attribute__((visibility("default")))
+    char MDCIconsExportToSuppressLibToolWarning_ic_chevron_right = 0;
 
 @implementation MDCIcons (ic_chevron_right)
 
@@ -36,7 +36,9 @@ __attribute__((
 
 + (nullable UIImage *)imageFor_ic_chevron_right {
   NSBundle *bundle = [self bundleNamed:kBundleName];
-  return [UIImage imageNamed:kIconName inBundle:bundle compatibleWithTraitCollection:nil];
+  return [UIImage imageNamed:kIconName
+                    inBundle:bundle
+      compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/components/private/Icons/icons/ic_chevron_right/src/MaterialIcons+ic_chevron_right.m
+++ b/components/private/Icons/icons/ic_chevron_right/src/MaterialIcons+ic_chevron_right.m
@@ -19,7 +19,7 @@
 
 #import "MaterialIcons+ic_chevron_right.h"
 
-#import "MaterialIcons.h"
+#import "MDCIcons+BundleLoader.h"
 
 static NSString *const kBundleName = @"MaterialIcons_ic_chevron_right";
 static NSString *const kIconName = @"ic_chevron_right";
@@ -32,6 +32,11 @@ __attribute__((
 
 + (nonnull NSString *)pathFor_ic_chevron_right {
   return [self pathForIconName:kIconName withBundleName:kBundleName];
+}
+
++ (nullable UIImage *)imageFor_ic_chevron_right {
+  NSBundle *bundle = [self bundleNamed:kBundleName];
+  return [UIImage imageNamed:kIconName inBundle:bundle compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/components/private/Icons/icons/ic_info/src/MaterialIcons+ic_info.h
+++ b/components/private/Icons/icons/ic_info/src/MaterialIcons+ic_info.h
@@ -30,7 +30,7 @@
 + (nonnull NSString *)pathFor_ic_info;
 
 /*
- Returns the bundle for the ic_info image contained in
+ Returns the image for the ic_info image contained in
  MaterialIcons_ic_info.bundle.
  */
 + (nullable UIImage *)imageFor_ic_info;

--- a/components/private/Icons/icons/ic_info/src/MaterialIcons+ic_info.h
+++ b/components/private/Icons/icons/ic_info/src/MaterialIcons+ic_info.h
@@ -29,4 +29,10 @@
  */
 + (nonnull NSString *)pathFor_ic_info;
 
+/*
+ Returns the bundle for the ic_info image contained in
+ MaterialIcons_ic_info.bundle.
+ */
++ (nullable UIImage *)imageFor_ic_info;
+
 @end

--- a/components/private/Icons/icons/ic_info/src/MaterialIcons+ic_info.m
+++ b/components/private/Icons/icons/ic_info/src/MaterialIcons+ic_info.m
@@ -19,7 +19,7 @@
 
 #import "MaterialIcons+ic_info.h"
 
-#import "MDCIcons+BundleLoader.h"
+#import "MaterialIcons.h"
 
 static NSString *const kBundleName = @"MaterialIcons_ic_info";
 static NSString *const kIconName = @"ic_info";

--- a/components/private/Icons/icons/ic_info/src/MaterialIcons+ic_info.m
+++ b/components/private/Icons/icons/ic_info/src/MaterialIcons+ic_info.m
@@ -35,7 +35,9 @@ __attribute__((visibility("default"))) char MDCIconsExportToSuppressLibToolWarni
 
 + (nullable UIImage *)imageFor_ic_info {
   NSBundle *bundle = [self bundleNamed:kBundleName];
-  return [UIImage imageNamed:kIconName inBundle:bundle compatibleWithTraitCollection:nil];
+  return [UIImage imageNamed:kIconName
+                    inBundle:bundle
+      compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/components/private/Icons/icons/ic_info/src/MaterialIcons+ic_info.m
+++ b/components/private/Icons/icons/ic_info/src/MaterialIcons+ic_info.m
@@ -19,7 +19,7 @@
 
 #import "MaterialIcons+ic_info.h"
 
-#import "MaterialIcons.h"
+#import "MDCIcons+BundleLoader.h"
 
 static NSString *const kBundleName = @"MaterialIcons_ic_info";
 static NSString *const kIconName = @"ic_info";
@@ -31,6 +31,11 @@ __attribute__((visibility("default"))) char MDCIconsExportToSuppressLibToolWarni
 
 + (nonnull NSString *)pathFor_ic_info {
   return [self pathForIconName:kIconName withBundleName:kBundleName];
+}
+
++ (nullable UIImage *)imageFor_ic_info {
+  NSBundle *bundle = [self bundleNamed:kBundleName];
+  return [UIImage imageNamed:kIconName inBundle:bundle compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/components/private/Icons/icons/ic_radio_button_unchecked/src/MaterialIcons+ic_radio_button_unchecked.h
+++ b/components/private/Icons/icons/ic_radio_button_unchecked/src/MaterialIcons+ic_radio_button_unchecked.h
@@ -29,4 +29,10 @@
  */
 + (nonnull NSString *)pathFor_ic_radio_button_unchecked;
 
+/*
+ Returns the bundle for the ic_radio_button_unchecked image contained in
+ MaterialIcons_ic_radio_button_unchecked.bundle.
+ */
++ (nullable UIImage *)imageFor_ic_radio_button_unchecked;
+
 @end

--- a/components/private/Icons/icons/ic_radio_button_unchecked/src/MaterialIcons+ic_radio_button_unchecked.h
+++ b/components/private/Icons/icons/ic_radio_button_unchecked/src/MaterialIcons+ic_radio_button_unchecked.h
@@ -30,7 +30,7 @@
 + (nonnull NSString *)pathFor_ic_radio_button_unchecked;
 
 /*
- Returns the bundle for the ic_radio_button_unchecked image contained in
+ Returns the image for the ic_radio_button_unchecked image contained in
  MaterialIcons_ic_radio_button_unchecked.bundle.
  */
 + (nullable UIImage *)imageFor_ic_radio_button_unchecked;

--- a/components/private/Icons/icons/ic_radio_button_unchecked/src/MaterialIcons+ic_radio_button_unchecked.m
+++ b/components/private/Icons/icons/ic_radio_button_unchecked/src/MaterialIcons+ic_radio_button_unchecked.m
@@ -19,7 +19,7 @@
 
 #import "MaterialIcons+ic_radio_button_unchecked.h"
 
-#import "MDCIcons+BundleLoader.h"
+#import "MaterialIcons.h"
 
 static NSString *const kBundleName = @"MaterialIcons_ic_radio_button_unchecked";
 static NSString *const kIconName = @"ic_radio_button_unchecked";

--- a/components/private/Icons/icons/ic_radio_button_unchecked/src/MaterialIcons+ic_radio_button_unchecked.m
+++ b/components/private/Icons/icons/ic_radio_button_unchecked/src/MaterialIcons+ic_radio_button_unchecked.m
@@ -19,7 +19,7 @@
 
 #import "MaterialIcons+ic_radio_button_unchecked.h"
 
-#import "MaterialIcons.h"
+#import "MDCIcons+BundleLoader.h"
 
 static NSString *const kBundleName = @"MaterialIcons_ic_radio_button_unchecked";
 static NSString *const kIconName = @"ic_radio_button_unchecked";
@@ -32,6 +32,11 @@ __attribute__((visibility(
 
 + (nonnull NSString *)pathFor_ic_radio_button_unchecked {
   return [self pathForIconName:kIconName withBundleName:kBundleName];
+}
+
++ (nullable UIImage *)imageFor_ic_radio_button_unchecked {
+  NSBundle *bundle = [self bundleNamed:kBundleName];
+  return [UIImage imageNamed:kIconName inBundle:bundle compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/components/private/Icons/icons/ic_radio_button_unchecked/src/MaterialIcons+ic_radio_button_unchecked.m
+++ b/components/private/Icons/icons/ic_radio_button_unchecked/src/MaterialIcons+ic_radio_button_unchecked.m
@@ -25,8 +25,8 @@ static NSString *const kBundleName = @"MaterialIcons_ic_radio_button_unchecked";
 static NSString *const kIconName = @"ic_radio_button_unchecked";
 
 // Export a nonsense symbol to suppress a libtool warning when this is linked alone in a static lib.
-__attribute__((visibility(
-    "default"))) char MDCIconsExportToSuppressLibToolWarning_ic_radio_button_unchecked = 0;
+__attribute__((visibility("default")))
+    char MDCIconsExportToSuppressLibToolWarning_ic_radio_button_unchecked = 0;
 
 @implementation MDCIcons (ic_radio_button_unchecked)
 
@@ -36,7 +36,9 @@ __attribute__((visibility(
 
 + (nullable UIImage *)imageFor_ic_radio_button_unchecked {
   NSBundle *bundle = [self bundleNamed:kBundleName];
-  return [UIImage imageNamed:kIconName inBundle:bundle compatibleWithTraitCollection:nil];
+  return [UIImage imageNamed:kIconName
+                    inBundle:bundle
+      compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/components/private/Icons/icons/ic_reorder/src/MaterialIcons+ic_reorder.h
+++ b/components/private/Icons/icons/ic_reorder/src/MaterialIcons+ic_reorder.h
@@ -30,7 +30,7 @@
 + (nonnull NSString *)pathFor_ic_reorder;
 
 /*
- Returns the bundle for the ic_reorder image contained in
+ Returns the image for the ic_reorder image contained in
  MaterialIcons_ic_reorder.bundle.
  */
 + (nullable UIImage *)imageFor_ic_reorder;

--- a/components/private/Icons/icons/ic_reorder/src/MaterialIcons+ic_reorder.h
+++ b/components/private/Icons/icons/ic_reorder/src/MaterialIcons+ic_reorder.h
@@ -29,4 +29,10 @@
  */
 + (nonnull NSString *)pathFor_ic_reorder;
 
+/*
+ Returns the bundle for the ic_reorder image contained in
+ MaterialIcons_ic_reorder.bundle.
+ */
++ (nullable UIImage *)imageFor_ic_reorder;
+
 @end

--- a/components/private/Icons/icons/ic_reorder/src/MaterialIcons+ic_reorder.m
+++ b/components/private/Icons/icons/ic_reorder/src/MaterialIcons+ic_reorder.m
@@ -19,7 +19,7 @@
 
 #import "MaterialIcons+ic_reorder.h"
 
-#import "MDCIcons+BundleLoader.h"
+#import "MaterialIcons.h"
 
 static NSString *const kBundleName = @"MaterialIcons_ic_reorder";
 static NSString *const kIconName = @"ic_reorder";

--- a/components/private/Icons/icons/ic_reorder/src/MaterialIcons+ic_reorder.m
+++ b/components/private/Icons/icons/ic_reorder/src/MaterialIcons+ic_reorder.m
@@ -19,7 +19,7 @@
 
 #import "MaterialIcons+ic_reorder.h"
 
-#import "MaterialIcons.h"
+#import "MDCIcons+BundleLoader.h"
 
 static NSString *const kBundleName = @"MaterialIcons_ic_reorder";
 static NSString *const kIconName = @"ic_reorder";
@@ -31,6 +31,11 @@ __attribute__((visibility("default"))) char MDCIconsExportToSuppressLibToolWarni
 
 + (nonnull NSString *)pathFor_ic_reorder {
   return [self pathForIconName:kIconName withBundleName:kBundleName];
+}
+
++ (nullable UIImage *)imageFor_ic_reorder {
+  NSBundle *bundle = [self bundleNamed:kBundleName];
+  return [UIImage imageNamed:kIconName inBundle:bundle compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/components/private/Icons/icons/ic_reorder/src/MaterialIcons+ic_reorder.m
+++ b/components/private/Icons/icons/ic_reorder/src/MaterialIcons+ic_reorder.m
@@ -35,7 +35,9 @@ __attribute__((visibility("default"))) char MDCIconsExportToSuppressLibToolWarni
 
 + (nullable UIImage *)imageFor_ic_reorder {
   NSBundle *bundle = [self bundleNamed:kBundleName];
-  return [UIImage imageNamed:kIconName inBundle:bundle compatibleWithTraitCollection:nil];
+  return [UIImage imageNamed:kIconName
+                    inBundle:bundle
+      compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/components/private/Icons/src/MDCIcons+BundleLoader.h
+++ b/components/private/Icons/src/MDCIcons+BundleLoader.h
@@ -20,12 +20,15 @@
  The MDCIcons class is designed to be extended by adding individual icon extensions to a project.
 
  Individual icons can be accessed by importing their MaterialIcons+<icon_name>.h header and calling
- [MDCIcons pathFor_<icon_name>] to get the icon's file system path.
+ [MDCIcons pathFor_<icon_name>] to get the icon's file system pathor calling
+ [MDCIcons imageFor_<icon_name>] to get a cached image.
  */
 @interface MDCIcons (BundleLoader)
 
 /** Returns a disk path for an icon contained within a bundle of a given name. */
 + (nonnull NSString *)pathForIconName:(nonnull NSString *)iconName
                        withBundleName:(nonnull NSString *)bundleName;
+
++ (nullable NSBundle *)bundleNamed:(nonnull NSString *)bundleName;
 
 @end

--- a/components/private/Icons/src/MDCIcons+BundleLoader.h
+++ b/components/private/Icons/src/MDCIcons+BundleLoader.h
@@ -20,7 +20,7 @@
  The MDCIcons class is designed to be extended by adding individual icon extensions to a project.
 
  Individual icons can be accessed by importing their MaterialIcons+<icon_name>.h header and calling
- [MDCIcons pathFor_<icon_name>] to get the icon's file system pathor calling
+ [MDCIcons pathFor_<icon_name>] to get the icon's file system path or calling
  [MDCIcons imageFor_<icon_name>] to get a cached image.
  */
 @interface MDCIcons (BundleLoader)

--- a/components/private/Icons/src/MDCIcons.h
+++ b/components/private/Icons/src/MDCIcons.h
@@ -20,7 +20,8 @@
  The MDCIcons class is designed to be extended by adding individual icon extensions to a project.
 
  Individual icons can be accessed by importing their MaterialIcons+<icon_name>.h header and calling
- [MDCIcons pathFor_<icon_name>] to get the icon's file system path.
+ [MDCIcons pathFor_<icon_name>] to get the icon's file system path or calling
+ [MDCIcons imageFor_<icon_name>] to get a cached image.
  */
 @interface MDCIcons : NSObject
 

--- a/components/private/Icons/src/MDCIcons.m
+++ b/components/private/Icons/src/MDCIcons.m
@@ -20,11 +20,17 @@
 
 @implementation MDCIcons
 
-+ (nonnull NSString *)pathForIconName:(nonnull NSString *)iconName
-                       withBundleName:(nonnull NSString *)bundleName {
++ (nullable NSBundle *)bundleNamed:(nonnull NSString *)bundleName {
   NSBundle *baseBundle = [NSBundle bundleForClass:[self class]];
   NSString *bundlePath = [baseBundle pathForResource:bundleName ofType:@"bundle"];
   NSBundle *bundle = [NSBundle bundleWithPath:bundlePath];
+
+  return bundle;
+}
+
++ (nonnull NSString *)pathForIconName:(nonnull NSString *)iconName
+                       withBundleName:(nonnull NSString *)bundleName {
+  NSBundle *bundle = [self bundleNamed:bundleName];
   NSAssert(bundle, @"Missing bundle %@ containing icon %@.", bundleName, iconName);
   return [bundle pathForResource:iconName ofType:@"png"];
 }

--- a/components/private/Icons/src/MaterialIcons.h
+++ b/components/private/Icons/src/MaterialIcons.h
@@ -14,5 +14,5 @@
  limitations under the License.
  */
 
-#import "MDCIcons.h"
 #import "MDCIcons+BundleLoader.h"
+#import "MDCIcons.h"

--- a/components/private/Icons/tests/unit/MDCIconsTests.m
+++ b/components/private/Icons/tests/unit/MDCIconsTests.m
@@ -1,0 +1,76 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+@import XCTest;
+#import "MaterialIcons+ic_arrow_back.h"
+#import "MaterialIcons+ic_check.h"
+#import "MaterialIcons+ic_check_circle.h"
+#import "MaterialIcons+ic_chevron_right.h"
+#import "MaterialIcons+ic_info.h"
+#import "MaterialIcons+ic_radio_button_unchecked.h"
+#import "MaterialIcons+ic_reorder.h"
+
+@interface MDCIconsTests : XCTestCase
+@end
+
+@implementation MDCIconsTests
+
+- (void)testImageForInfo {
+  XCTAssertNotNil([MDCIcons imageFor_ic_info], @"No image was returned for ic_info");
+}
+
+- (void)testImageForCheck {
+  XCTAssertNotNil([MDCIcons imageFor_ic_check], @"No image was returned for ic_check");
+}
+
+- (void)testImageForReorder {
+  XCTAssertNotNil([MDCIcons imageFor_ic_reorder], @"No image was returned for ic_reorder");
+}
+
+- (void)testImageForArrowBackOldStyle {
+  // When
+  [MDCIcons ic_arrow_backUseNewStyle:NO];
+
+  // Then
+  XCTAssertNotNil([MDCIcons imageFor_ic_arrow_back],
+                  @"No image was returned for ic_arrow_back (old style");
+}
+
+- (void)testImageForArrowBackNewStyle {
+  // When
+  [MDCIcons ic_arrow_backUseNewStyle:YES];
+
+  // Then
+  XCTAssertNotNil([MDCIcons imageFor_ic_arrow_back],
+                  @"No image was returned for ic_arrow_back (new style");
+}
+
+- (void)testImageForCheckCircle {
+  XCTAssertNotNil([MDCIcons imageFor_ic_check_circle],
+                  @"No image was returned for ic_check_circle");
+}
+
+- (void)testImageForChevronRight {
+  XCTAssertNotNil([MDCIcons imageFor_ic_chevron_right],
+                  @"No image was returned for ic_chevron_right");
+}
+
+- (void)testImageForRadioButtonUnchecked {
+  XCTAssertNotNil([MDCIcons imageFor_ic_radio_button_unchecked],
+                  @"No image was returned for ic_radio_button_unchecked");
+}
+
+@end

--- a/scripts/sync_icons.sh
+++ b/scripts/sync_icons.sh
@@ -190,6 +190,12 @@ EOL
  */
 + (nonnull NSString *)pathFor_$icon_name;
 
+/*
+ Returns the bundle for the $icon_name image contained in
+ MaterialIcons_$icon_name.bundle.
+ */
++ (nullable UIImage *)imageFor_$icon_name;
+
 @end
 EOL
 
@@ -228,6 +234,12 @@ __attribute__((visibility("default")))
 
 + (nonnull NSString *)pathFor_$icon_name {
   return [self pathForIconName:kIconName withBundleName:kBundleName];
+}
+
++ (nullable UIImage *)imageFor_$icon_name {
+  NSBundle *bundle = [self bundleNamed:kBundleName];
+  return [UIImage imageNamed:kIconName inBundle:bundle
+             compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/scripts/sync_icons.sh
+++ b/scripts/sync_icons.sh
@@ -238,8 +238,9 @@ __attribute__((visibility("default")))
 
 + (nullable UIImage *)imageFor_$icon_name {
   NSBundle *bundle = [self bundleNamed:kBundleName];
-  return [UIImage imageNamed:kIconName inBundle:bundle
-             compatibleWithTraitCollection:nil];
+  return [UIImage imageNamed:kIconName
+                    inBundle:bundle
+      compatibleWithTraitCollection:nil];
 }
 
 @end

--- a/scripts/sync_icons.sh
+++ b/scripts/sync_icons.sh
@@ -191,7 +191,7 @@ EOL
 + (nonnull NSString *)pathFor_$icon_name;
 
 /*
- Returns the bundle for the $icon_name image contained in
+ Returns the image for the $icon_name image contained in
  MaterialIcons_$icon_name.bundle.
  */
 + (nullable UIImage *)imageFor_$icon_name;

--- a/scripts/sync_icons.sh
+++ b/scripts/sync_icons.sh
@@ -221,7 +221,7 @@ EOL
 
 #import "$file.h"
 
-#import "MDCIcons+BundleLoader.h"
+#import "MaterialIcons.h"
 
 static NSString *const kBundleName = @"MaterialIcons_$icon_name";
 static NSString *const kIconName = @"$icon_name";


### PR DESCRIPTION
The selected/unselected state icons are reloaded from disk on every
prepareForReuse call.  Using the cache-backed `-imageNamed` family of
methods in UIImage reduces the overhead required to reload those images.

Closes #1637
