### PR TITLE
[NavigationBar] - Fixed title's center align issue on RTL

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -466,12 +466,18 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 - (CGRect)mdc_frameAlignedHorizontally:(CGRect)frame
                              alignment:(MDCNavigationBarTitleAlignment)alignment {
   switch (alignment) {
-      // Center align title if desired unless leading icons will overlap frame
+    // Center align title if desired unless leading icons will overlap frame
     case MDCNavigationBarTitleAlignmentCenter: {
       CGFloat xOrigin = CGRectGetMaxX(self.bounds) / 2 - CGRectGetWidth(frame) / 2;
-      if (CGRectGetMinX(frame) <= xOrigin) {
-        return CGRectMake(xOrigin, CGRectGetMinY(frame),
-                          CGRectGetWidth(frame), CGRectGetHeight(frame));
+      CGFloat minX = CGRectGetMinX(frame);
+      // If RTL, we must use distance from maxX to bounds instead
+      if (self.mdc_effectiveUserInterfaceLayoutDirection ==
+          UIUserInterfaceLayoutDirectionRightToLeft) {
+        minX = CGRectGetMaxX(self.bounds) - CGRectGetMaxX(frame);
+      }
+      if (minX <= xOrigin) {
+        return CGRectMake(xOrigin, CGRectGetMinY(frame), CGRectGetWidth(frame),
+                          CGRectGetHeight(frame));
       }
     }
     // Intentional fall through


### PR DESCRIPTION
NavigationBar - Fixes center align issue on MDCNavigationBar for RTL.

Updated x-value used to determine whether it crosses the midpoint threshold on RTL from minX value of titleFrame to the difference between nav bar maxX and titleFrame maxX

Closes [Issue 1645](https://github.com/material-components/material-components-ios/issues/1645)
