### PR TITLE
Release candidate 27.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,10 @@ env:
   - LC_CTYPE=en_US.UTF-8
   - LANG=en_US.UTF-8
   matrix:
-    - DESTINATION="platform=iOS Simulator,name=iPhone 7,OS=10.2" SDK="iphonesimulator10.2"
-    - DESTINATION="platform=iOS Simulator,name=iPhone 5s,OS=8.1" SDK="iphonesimulator8.1"
+    - DESTINATION="platform=iOS Simulator,name=iPhone 7,OS=10.3.1" SDK="iphonesimulator10.3.1"
+    # The iPhone 5 was chosen because it is a 32-bit device.
+    # 8.1 was chosen because it is the earliest iOS offered here.
+    - DESTINATION="platform=iOS Simulator,name=iPhone 5,OS=8.1" SDK="iphonesimulator8.1"
 
 before_install:
   - gem install xcpretty --no-rdoc --no-ri --no-document --quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ env:
     # The iPhone 5 was chosen because it is a 32-bit device.
     # 8.1 was chosen because it is the earliest iOS offered here.
     - DESTINATION="platform=iOS Simulator,name=iPhone 5,OS=8.1" SDK="iphonesimulator8.1"
+    # The iPad Pro 12.9 was chosen because it is the largest resolution we can test on.
+    # 9.3 was chosen to round out the range of iOS versions we are testing on.
+    - DESTINATION="platform=iOS Simulator,name=iPad Pro (12.9-inch),OS=9.3" SDK="iphonesimulator9.3"
 
 before_install:
   - gem install xcpretty --no-rdoc --no-ri --no-document --quiet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,147 @@
 * Removed 'resetElevationForState'.
 * Removed NS_UNAVAILABLE from 'setBackgroundColor'.
 
+## Component changes
+
+### ActivityIndicator
+
+#### Changes
+
+* [[Activity Indicator] Add import to QuartzCore (#1587)](https://github.com/material-components/material-components-ios/commit/97098c6caa3f3acafa5500fe788cf7a842e9135e) (Randall Li)
+
+### AppBar
+
+#### Changes
+
+* [Explicitly annotating some known ObjC methods. (#1617)](https://github.com/material-components/material-components-ios/commit/1e14d4109178956486863dec607996100c91795e) (Martin Petrov)
+
+### BottomSheet
+
+#### Changes
+
+* [[KeyboardWatcher] iOS 8 simplification and cleanup (#1589)](https://github.com/material-components/material-components-ios/commit/87574e57e313cb3e90281b3225031b329e8f91de) (ianegordon)
+
+### ButtonBar
+
+#### Changes
+
+* [Explicitly annotating some known ObjC methods. (#1617)](https://github.com/material-components/material-components-ios/commit/1e14d4109178956486863dec607996100c91795e) (Martin Petrov)
+* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)
+
+### Buttons
+
+#### Changes
+
+* [Elevation clean up (#1574)](https://github.com/material-components/material-components-ios/commit/eec61cf77316c2853f52070931cb8472a1ced48e) (Sam Morrison)
+* [Explicitly annotating some known ObjC methods. (#1617)](https://github.com/material-components/material-components-ios/commit/1e14d4109178956486863dec607996100c91795e) (Martin Petrov)
+* [Ink should ignore content edge insets (#1593)](https://github.com/material-components/material-components-ios/commit/cc57a0791890b07cd268da8f3950cb74b4729825) (Robert Moore)
+* [Remove NS_UNAVAILABLE from setBackgroundColor (#1572)](https://github.com/material-components/material-components-ios/commit/467b843b169d07f8d71ea8d4dc55df7b03ac7900) (Sam Morrison)
+* [Remove trailing spaces from test (#1602)](https://github.com/material-components/material-components-ios/commit/418a5a65fceaadb669a87646c5b17ac53b77e39b) (Sam Morrison)
+* [Sort property/method definitions (#1599)](https://github.com/material-components/material-components-ios/commit/360d504442fe1b5cd80a3923e9c875e6c58d0adf) (Sam Morrison)
+
+### CollectionCells
+
+#### Changes
+
+* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)
+* [Reset cells in prepareForReuse (#1633)](https://github.com/material-components/material-components-ios/commit/25b7c217ca3ed0d082abb4406c400cd8405d63ee) (Robert Moore)
+
+### Collections
+
+#### Changes
+
+* [Do not invalidate layout for all gesture beginning (#1623)](https://github.com/material-components/material-components-ios/commit/0b905c647d3267ca0d3332226fbf806a5c538bb1) (Gauthier Ambard)
+* [Fallback to default cell background color on nil. (#1630)](https://github.com/material-components/material-components-ios/commit/3c92cfe80c6a8b795f52b1baaf6525e0624d433d) (Yurii Samsoniuk)
+* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)
+
+### Dialogs
+
+#### Changes
+
+* [Explicitly annotating some known ObjC methods. (#1617)](https://github.com/material-components/material-components-ios/commit/1e14d4109178956486863dec607996100c91795e) (Martin Petrov)
+* [[Docs] Replaced internal site references with public equivalents. (#1616)](https://github.com/material-components/material-components-ios/commit/0abca36dbbc455c42795efe7e207419b2f1b6e5b) (Adrian Secord)
+* [[KeyboardWatcher] iOS 8 simplification and cleanup (#1589)](https://github.com/material-components/material-components-ios/commit/87574e57e313cb3e90281b3225031b329e8f91de) (ianegordon)
+
+### FeatureHighlight
+
+#### Changes
+
+* [[Docs] Replaced internal site references with public equivalents. (#1616)](https://github.com/material-components/material-components-ios/commit/0abca36dbbc455c42795efe7e207419b2f1b6e5b) (Adrian Secord)
+
+### FlexibleHeader
+
+#### Changes
+
+* [- Updated unit tests (#1619)](https://github.com/material-components/material-components-ios/commit/921241302a7e3f92c8941bf52c6d50f8aaeaf2a2) (Justin Shephard)
+
+### Ink
+
+#### Changes
+
+* [[Docs] Replaced internal site references with public equivalents. (#1616)](https://github.com/material-components/material-components-ios/commit/0abca36dbbc455c42795efe7e207419b2f1b6e5b) (Adrian Secord)
+
+### NavigationBar
+
+#### Changes
+
+* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)
+
+### PageControl
+
+#### Changes
+
+* [Explicitly annotating some known ObjC methods. (#1617)](https://github.com/material-components/material-components-ios/commit/1e14d4109178956486863dec607996100c91795e) (Martin Petrov)
+* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)
+
+### ProgressView
+
+#### Changes
+
+* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)
+
+### ShadowLayer
+
+#### Changes
+
+* [Explicitly annotating some known ObjC methods. (#1617)](https://github.com/material-components/material-components-ios/commit/1e14d4109178956486863dec607996100c91795e) (Martin Petrov)
+* [Support layer copying (#1625)](https://github.com/material-components/material-components-ios/commit/2283e04f02fe15588e95ed7564e53abeef926cba) (Robert Moore)
+
+### Slider
+
+#### Changes
+
+* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)
+
+### Snackbar
+
+#### Changes
+
+* [[KeyboardWatcher] iOS 8 simplification and cleanup (#1589)](https://github.com/material-components/material-components-ios/commit/87574e57e313cb3e90281b3225031b329e8f91de) (ianegordon)
+
+### Tabs
+
+#### Changes
+
+* [Constrain tabs to the view's width (#1615)](https://github.com/material-components/material-components-ios/commit/00ee81453977901ca03ef987d229a20ca51cba06) (Brian Moore)
+* [Explicitly annotating some known ObjC methods. (#1617)](https://github.com/material-components/material-components-ios/commit/1e14d4109178956486863dec607996100c91795e) (Martin Petrov)
+* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)
+* [Restore initial tab selection behavior (#1605)](https://github.com/material-components/material-components-ios/commit/60db284cb2803e873a4a03ba9a57d1a2ab8b6226) (Brian Moore)
+
+### TextFields
+
+#### Changes
+
+* [Explicitly annotating some known ObjC methods. (#1617)](https://github.com/material-components/material-components-ios/commit/1e14d4109178956486863dec607996100c91795e) (Martin Petrov)
+* [Fixes for minor bugs and comment improvements (#1588)](https://github.com/material-components/material-components-ios/commit/6b2cddba39c78b66d1401c6d280632de5857c940) (Will Larche)
+* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)
+* [[TextField] Update demo alert to indicate floating setting. (#1612)](https://github.com/material-components/material-components-ios/commit/7a26712eb96036e416b1937752ac6b164ebac1fc) (Donna McCulloch)
+
+### Typography
+
+#### Changes
+
+* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)
+
 # 26.0.0
 
 ## API diffs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release-candidate TODO: Replace me with version number. 
+
 # 26.0.0
 
 ## API diffs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# release-candidate TODO: Replace me with version number. 
+# 27.0.0
 
 ## API Diffs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # release-candidate TODO: Replace me with version number. 
 
+## API Diffs
+
+### Button
+
+* Removed 'resetElevationForState'.
+* Removed NS_UNAVAILABLE from 'setBackgroundColor'.
+
 # 26.0.0
 
 ## API diffs

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -2,7 +2,7 @@ load 'scripts/generated/icons.rb'
 
 Pod::Spec.new do |s|
   s.name         = "MaterialComponents"
-  s.version      = "26.0.0"
+  s.version      = "27.0.0"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/MaterialComponentsCatalog.podspec
+++ b/MaterialComponentsCatalog.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsCatalog"
-  s.version      = "26.0.0"
+  s.version      = "27.0.0"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/MaterialComponentsEarlGreyTests.podspec
+++ b/MaterialComponentsEarlGreyTests.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsEarlGreyTests"
-  s.version      = "26.0.0"
+  s.version      = "27.0.0"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/MaterialComponentsUnitTests.podspec
+++ b/MaterialComponentsUnitTests.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsUnitTests"
-  s.version      = "26.0.0"
+  s.version      = "27.0.0"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/README.md
+++ b/README.md
@@ -100,15 +100,15 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        let raiseButton = MDCRaisedButton.init();
-        raiseButton.setTitle("Raised Button", forState: .Normal);
-        raiseButton.sizeToFit();
-        raiseButton.addTarget(self, action: #selector(tapped), forControlEvents: .TouchUpInside);
-        self.view.addSubview(raiseButton);
+        let raiseButton = MDCRaisedButton()
+        raiseButton.setTitle("Raised Button", for: .normal)
+        raiseButton.sizeToFit()
+        raiseButton.addTarget(self, action: #selector(tapped), for: .touchUpInside)
+        view.addSubview(raiseButton)
     }
 
-    func tapped(sender: UIButton!){
-        NSLog("Button was tapped!");
+    @objc func tapped(sender: UIButton){
+        print("Button was tapped!")
     }
 
 }

--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -16,6 +16,8 @@
 
 #import "MDCActivityIndicator.h"
 
+#import <QuartzCore/QuartzCore.h>
+
 #import "MaterialRTL.h"
 #import "MaterialApplication.h"
 #import "private/MDCActivityIndicator+Private.h"

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -88,7 +88,7 @@ class AppBarModalPresentationSwiftExamplePresented: UITableViewController {
     return cell!
   }
 
-  func dismissSelf() {
+  @objc func dismissSelf() {
     self.dismiss(animated: true, completion: nil)
   }
 }
@@ -144,7 +144,7 @@ class AppBarModalPresentationSwiftExample: UITableViewController {
     self.navigationController?.setNavigationBarHidden(true, animated: animated)
   }
 
-  func presentModal() {
+  @objc func presentModal() {
     let modalVC = AppBarModalPresentationSwiftExamplePresented()
     self.present(modalVC, animated: true, completion: nil)
   }

--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -241,7 +241,7 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
 // Calculates the snap-point for the view to spring to.
 - (CGPoint)targetPoint {
   CGRect bounds = self.bounds;
-  CGFloat keyboardOffset = [MDCKeyboardWatcher sharedKeyboardWatcher].keyboardOffset;
+  CGFloat keyboardOffset = [MDCKeyboardWatcher sharedKeyboardWatcher].visibleKeyboardHeight;
   CGFloat midX = CGRectGetMidX(bounds);
   CGFloat bottomY = CGRectGetMaxY(bounds) - keyboardOffset;
 

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
@@ -65,7 +65,7 @@ class ButtonBarTypicalUseSwiftExample: UIViewController {
     view.backgroundColor = UIColor(white: 0.9, alpha:1.0)
   }
 
-  func didTapActionButton(_ sender: Any) {
+  @objc func didTapActionButton(_ sender: Any) {
     print("Did tap action item: \(sender)")
   }
 

--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
@@ -82,7 +82,8 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
   [self transferCustomViewOwnershipForBarButtonItem:buttonItem];
 
   // Take the real custom view if it exists instead of sandbag view.
-  UIView *customView = buttonItem.mdc_customView ?: buttonItem.customView;
+  UIView *customView =
+      buttonItem.mdc_customView ? buttonItem.mdc_customView : buttonItem.customView;
   if (customView) {
     return customView;
   }
@@ -213,7 +214,10 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
             withItem:(UIBarButtonItem *)item
           barMetrics:(UIBarMetrics)barMetrics {
   [self updateButton:button withItem:item forState:UIControlStateNormal barMetrics:barMetrics];
-  [self updateButton:button withItem:item forState:UIControlStateHighlighted barMetrics:barMetrics];
+  [self updateButton:button
+            withItem:item
+            forState:UIControlStateHighlighted
+          barMetrics:barMetrics];
   [self updateButton:button withItem:item forState:UIControlStateDisabled barMetrics:barMetrics];
 }
 
@@ -221,7 +225,7 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
             withItem:(UIBarButtonItem *)item
             forState:(UIControlState)state
           barMetrics:(UIBarMetrics)barMetrics {
-  NSString *title = item.title ?: @"";
+  NSString *title = item.title ? item.title : @"";
   if ([UIButton instancesRespondToSelector:@selector(setAttributedTitle:forState:)]) {
     NSMutableDictionary<NSString *, id> *attributes = [NSMutableDictionary dictionary];
 

--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -1,0 +1,54 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+@import UIKit;
+#import "MaterialButtons.h"
+
+@interface ButtonsContentEdgeInsetsExample : UIViewController
+@property(weak, nonatomic) IBOutlet MDCFlatButton *flatButton;
+@property(weak, nonatomic) IBOutlet MDCRaisedButton *raisedButton;
+@property(weak, nonatomic) IBOutlet MDCFloatingButton *floatingActionButton;
+
+@end
+
+@implementation ButtonsContentEdgeInsetsExample
+
+#pragma mark - Catalog by Convention
+
++ (NSArray<NSString *> *)catalogBreadcrumbs {
+  return @[ @"Buttons", @"Buttons (Content Edge Insets)" ];
+}
+
++ (NSString *)catalogStoryboardName {
+  return @"ButtonsContentEdgeInsets";
+}
+
+#pragma mark - UIViewController
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  // Force a darker background color to show the button frame
+  [self.flatButton setBackgroundColor:[UIColor colorWithWhite:0.2 alpha:1.0]
+                             forState:UIControlStateNormal];
+  self.flatButton.inkColor = [UIColor colorWithWhite:1.0 alpha:0.1];
+
+  self.flatButton.contentEdgeInsets = UIEdgeInsetsMake(64, 64, 0, 0);
+  self.raisedButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, 64, 64);
+  self.floatingActionButton.contentEdgeInsets = UIEdgeInsetsMake(0, 128, 0, 0);
+}
+
+@end

--- a/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
+++ b/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
@@ -85,7 +85,7 @@ class ButtonsDynamicTypeViewController: UIViewController {
       constant: 0.0))
   }
 
-  func tap(_ sender: Any) {
+  @objc func tap(_ sender: Any) {
     print("\(type(of: sender)) was tapped.")
   }
 

--- a/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
+++ b/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
@@ -97,7 +97,7 @@ class ButtonsSimpleExampleSwiftViewController: UIViewController {
       constant: 0.0))
   }
 
-  func tap(_ sender: Any) {
+  @objc func tap(_ sender: Any) {
     print("\(type(of: sender)) was tapped.")
   }
 

--- a/components/Buttons/examples/resources/ButtonsContentEdgeInsets.storyboard
+++ b/components/Buttons/examples/resources/ButtonsContentEdgeInsets.storyboard
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Uhh-iX-aVf">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Buttons Content Edge Insets Example-->
+        <scene sceneID="Jts-Jk-8ba">
+            <objects>
+                <viewController id="Uhh-iX-aVf" customClass="ButtonsContentEdgeInsetsExample" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="pu1-Ea-nBj"/>
+                        <viewControllerLayoutGuide type="bottom" id="aOy-6t-l8i"/>
+                    </layoutGuides>
+                    <view key="view" clipsSubviews="YES" contentMode="scaleToFill" id="dDe-BW-Avd">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bvE-5P-0PG" customClass="MDCFlatButton">
+                                <rect key="frame" x="142" y="274.5" width="91" height="34"/>
+                                <color key="tintColor" red="0.19254023644059035" green="0.53181806153905575" blue="0.91669365284974091" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <inset key="contentEdgeInsets" minX="0.0" minY="0.0" maxX="16" maxY="16"/>
+                                <state key="normal" title="Flat Button">
+                                    <color key="titleColor" cocoaTouchSystemColor="lightTextColor"/>
+                                </state>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dqo-nu-adB" customClass="MDCRaisedButton">
+                                <rect key="frame" x="127" y="324.5" width="120" height="18"/>
+                                <inset key="contentEdgeInsets" minX="0.0" minY="0.0" maxX="24" maxY="0.0"/>
+                                <state key="normal" title="Raised Button">
+                                    <color key="titleColor" cocoaTouchSystemColor="lightTextColor"/>
+                                </state>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YCS-6P-hwz" customClass="MDCFloatingButton">
+                                <rect key="frame" x="174" y="358.5" width="26" height="34"/>
+                                <inset key="contentEdgeInsets" minX="16" minY="16" maxX="0.0" maxY="0.0"/>
+                                <state key="normal" title="+"/>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="0.89888392857142863" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="YCS-6P-hwz" firstAttribute="centerX" secondItem="dDe-BW-Avd" secondAttribute="centerX" id="Aeg-aQ-A5S"/>
+                            <constraint firstItem="Dqo-nu-adB" firstAttribute="centerY" secondItem="dDe-BW-Avd" secondAttribute="centerY" id="h3j-9m-Xpr"/>
+                            <constraint firstItem="bvE-5P-0PG" firstAttribute="centerX" secondItem="dDe-BW-Avd" secondAttribute="centerX" id="k35-WX-pnN"/>
+                            <constraint firstItem="Dqo-nu-adB" firstAttribute="centerX" secondItem="dDe-BW-Avd" secondAttribute="centerX" id="wdb-rY-gK0"/>
+                            <constraint firstItem="Dqo-nu-adB" firstAttribute="top" secondItem="bvE-5P-0PG" secondAttribute="bottom" constant="16" id="y2n-KT-Jew"/>
+                            <constraint firstItem="YCS-6P-hwz" firstAttribute="top" secondItem="Dqo-nu-adB" secondAttribute="bottom" constant="16" id="zBf-pL-lyJ"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="flatButton" destination="bvE-5P-0PG" id="8px-6Z-f5o"/>
+                        <outlet property="floatingActionButton" destination="YCS-6P-hwz" id="Mw6-3r-5YL"/>
+                        <outlet property="raisedButton" destination="Dqo-nu-adB" id="rEm-SL-wQr"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Z12-Wq-Srl" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-298" y="87"/>
+        </scene>
+    </scenes>
+    <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+</document>

--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -54,6 +54,9 @@
 - (void)setBackgroundColor:(nullable UIColor *)backgroundColor forState:(UIControlState)state
     UI_APPEARANCE_SELECTOR;
 
+/* Convenience for `setBackgroundColor:backgroundColor forState:UIControlStateNormal`. */
+- (void)setBackgroundColor:(nullable UIColor *)backgroundColor;
+
 /** The ink style of the button. */
 @property(nonatomic, assign) MDCInkStyle inkStyle;
 
@@ -171,9 +174,6 @@
 + (nonnull instancetype)buttonWithType:(UIButtonType)buttonType NS_UNAVAILABLE;
 
 #pragma mark - Deprecated
-
-/** Use setBackgroundColor:forState: instead. */
-- (void)setBackgroundColor:(nullable UIColor *)backgroundColor NS_UNAVAILABLE;
 
 @property(nonatomic)
     BOOL shouldRaiseOnTouch __deprecated_msg("Use MDCFlatButton instead of shouldRaiseOnTouch = NO")

--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -143,13 +143,6 @@
  */
 - (void)setElevation:(CGFloat)elevation forState:(UIControlState)state;
 
-/**
- Resets the elevation for a particular control state back to the button's default behavior.
-
- @param state The control state to reset the elevation.
- */
-- (void)resetElevationForState:(UIControlState)state;
-
 /*
  Indicates whether the button should automatically update its font when the device’s
  UIContentSizeCategory is changed.

--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -35,28 +35,6 @@
  */
 @interface MDCButton : UIButton
 
-/**
- A color used as the button's @c backgroundColor for @c state.
-
- @param state The state.
- @return The background color.
- */
-- (nullable UIColor *)backgroundColorForState:(UIControlState)state;
-
-/**
- A color used as the button's @c backgroundColor.
-
- If left unset or reset to nil for a given state, then a default blue color is used.
-
- @param backgroundColor The background color.
- @param state The state.
- */
-- (void)setBackgroundColor:(nullable UIColor *)backgroundColor forState:(UIControlState)state
-    UI_APPEARANCE_SELECTOR;
-
-/* Convenience for `setBackgroundColor:backgroundColor forState:UIControlStateNormal`. */
-- (void)setBackgroundColor:(nullable UIColor *)backgroundColor;
-
 /** The ink style of the button. */
 @property(nonatomic, assign) MDCInkStyle inkStyle;
 
@@ -119,6 +97,42 @@
  */
 @property(nonatomic, strong, nullable) UIColor *underlyingColorHint;
 
+/*
+ Indicates whether the button should automatically update its font when the device’s
+ UIContentSizeCategory is changed.
+
+ This property is modeled after the adjustsFontForContentSizeCategory property in the
+ UIConnectSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
+
+ If set to YES, this button will base its text font on MDCFontTextStyleButton.
+
+ Defaults value is NO.
+ */
+@property(nonatomic, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
+    BOOL mdc_adjustsFontForContentSizeCategory UI_APPEARANCE_SELECTOR;
+
+/**
+ A color used as the button's @c backgroundColor for @c state.
+
+ @param state The state.
+ @return The background color.
+ */
+- (nullable UIColor *)backgroundColorForState:(UIControlState)state;
+
+/**
+ A color used as the button's @c backgroundColor.
+
+ If left unset or reset to nil for a given state, then a default blue color is used.
+
+ @param backgroundColor The background color.
+ @param state The state.
+ */
+- (void)setBackgroundColor:(nullable UIColor *)backgroundColor forState:(UIControlState)state
+    UI_APPEARANCE_SELECTOR;
+
+/* Convenience for `setBackgroundColor:backgroundColor forState:UIControlStateNormal`. */
+- (void)setBackgroundColor:(nullable UIColor *)backgroundColor;
+
 /** Sets the enabled state with optional animation. */
 - (void)setEnabled:(BOOL)enabled animated:(BOOL)animated;
 
@@ -142,20 +156,6 @@
  @param state The state to set.
  */
 - (void)setElevation:(CGFloat)elevation forState:(UIControlState)state;
-
-/*
- Indicates whether the button should automatically update its font when the device’s
- UIContentSizeCategory is changed.
-
- This property is modeled after the adjustsFontForContentSizeCategory property in the
- UIConnectSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
-
- If set to YES, this button will base its text font on MDCFontTextStyleButton.
-
- Defaults value is NO.
- */
-@property(nonatomic, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
-    BOOL mdc_adjustsFontForContentSizeCategory UI_APPEARANCE_SELECTOR;
 
 #pragma mark - UIButton changes
 

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -303,16 +303,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [super layoutSubviews];
   self.layer.shadowPath = [self boundingPath].CGPath;
   self.layer.cornerRadius = [self cornerRadius];
-
-  // Center the ink view frame taking into account possible insets using contentRectForBounds.
-
-  CGRect contentRect = [self contentRectForBounds:self.bounds];
-  CGPoint contentCenterPoint = CGPointMake(CGRectGetMidX(contentRect), CGRectGetMidY(contentRect));
-  CGPoint boundsCenterPoint = CGPointMake(CGRectGetMidX(self.bounds), CGRectGetMidY(self.bounds));
-
-  CGFloat offsetX = contentCenterPoint.x - boundsCenterPoint.x;
-  CGFloat offsetY = contentCenterPoint.y - boundsCenterPoint.y;
-  _inkView.frame = CGRectMake(offsetX, offsetY, self.bounds.size.width, self.bounds.size.height);
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -493,7 +493,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 #pragma mark - BackgroundColor
 
 - (void)setBackgroundColor:(nullable UIColor *)backgroundColor {
-  // Turns out swift ignores NS_UNAVAILABLE
   [self setBackgroundColor:backgroundColor forState:UIControlStateNormal];
 }
 

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -102,9 +102,12 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   BOOL _mdc_adjustsFontForContentSizeCategory;
 }
 @property(nonatomic, strong) MDCInkView *inkView;
+@property(nonatomic, readonly, strong) MDCShadowLayer *layer;
 @end
 
 @implementation MDCButton
+
+@dynamic layer;
 
 + (Class)layerClass {
   return [MDCShadowLayer class];
@@ -219,12 +222,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [aCoder encodeObject:_accessibilityLabelForState forKey:MDCButtonAccessibilityLabelsKey];
 }
 
-+ (void)initialize {
-  // Default background colors.
-  [[MDCButton appearance] setBackgroundColor:MDCColorFromRGB(MDCButtonDefaultBackgroundColor)
-                                    forState:UIControlStateNormal];
-}
-
 - (void)commonMDCButtonInit {
   _disabledAlpha = MDCButtonDisabledAlpha;
   _shouldRaiseOnTouch = YES;
@@ -232,6 +229,8 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   _userElevations = [NSMutableDictionary dictionary];
   _backgroundColors = [NSMutableDictionary dictionary];
   _accessibilityLabelForState = [NSMutableDictionary dictionary];
+
+  _backgroundColors[@(UIControlStateNormal)] = MDCColorFromRGB(MDCButtonDefaultBackgroundColor);
 
   // Disable default highlight state.
   self.adjustsImageWhenHighlighted = NO;
@@ -244,7 +243,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   // Default content insets
   self.contentEdgeInsets = [self defaultContentEdgeInsets];
 
-  MDCShadowLayer *shadowLayer = [self shadowLayer];
+  MDCShadowLayer *shadowLayer = self.layer;
   shadowLayer.shadowPath = [self boundingPath].CGPath;
   shadowLayer.shadowColor = [UIColor blackColor].CGColor;
   shadowLayer.elevation = [self elevationForState:self.state];
@@ -328,11 +327,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
   CGPoint location = [self locationFromTouches:touches];
   [_inkView startTouchEndedAnimationAtPoint:location completion:nil];
-
-  BOOL inside = CGRectContainsPoint(self.bounds, location);
-  if (inside && _shouldRaiseOnTouch) {
-    [self animateButtonToHeightForState:UIControlStateNormal];
-  }
 }
 
 // Note - in some cases, event may be nil (e.g. view removed from window).
@@ -342,7 +336,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [self evaporateInkToPoint:[self locationFromTouches:touches]];
 }
 
-#pragma mark - UIButton methods
+#pragma mark - UIControl methods
 
 - (void)setEnabled:(BOOL)enabled {
   [self setEnabled:enabled animated:NO];
@@ -350,7 +344,23 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (void)setEnabled:(BOOL)enabled animated:(BOOL)animated {
   [super setEnabled:enabled];
+
   [self updateAlphaAndBackgroundColorAnimated:animated];
+  [self animateButtonToHeightForState:self.state];
+}
+
+- (void)setHighlighted:(BOOL)highlighted {
+  [super setHighlighted:highlighted];
+
+  [self updateAlphaAndBackgroundColorAnimated:NO];
+  [self animateButtonToHeightForState:self.state];
+}
+
+- (void)setSelected:(BOOL)selected {
+  [super setSelected:selected];
+
+  [self updateAlphaAndBackgroundColorAnimated:NO];
+  [self animateButtonToHeightForState:self.state];
 }
 
 #pragma mark - Title Uppercasing
@@ -479,14 +489,14 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 #pragma mark - Shadows
 
-- (MDCShadowLayer *)shadowLayer {
-  return (MDCShadowLayer *)self.layer;
-}
-
 - (void)animateButtonToHeightForState:(UIControlState)state {
+  CGFloat newElevation = [self elevationForState:state];
+  if (self.layer.elevation == newElevation) {
+    return;
+  }
   [CATransaction begin];
   [CATransaction setAnimationDuration:MDCButtonAnimationDuration];
-  [self shadowLayer].elevation = [self elevationForState:state];
+  self.layer.elevation = newElevation;
   [CATransaction commit];
 }
 
@@ -509,12 +519,18 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (CGFloat)elevationForState:(UIControlState)state {
   NSNumber *elevation = _userElevations[@(state)];
-  return elevation ? (CGFloat)[elevation doubleValue] : [self defaultElevationForState:state];
+  if (state != UIControlStateNormal && !elevation) {
+    elevation = _userElevations[@(UIControlStateNormal)];
+  }
+  if (elevation) {
+    return (CGFloat)[elevation doubleValue];
+  }
+  return 0;
 }
 
 - (void)setElevation:(CGFloat)elevation forState:(UIControlState)state {
   _userElevations[@(state)] = @(elevation);
-  [self shadowLayer].elevation = [self elevationForState:self.state];
+  self.layer.elevation = [self elevationForState:self.state];
 
   // The elevation of the normal state controls whether this button is flat or not, and flat buttons
   // have different background color requirements than raised buttons.
@@ -522,11 +538,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   if (state == UIControlStateNormal) {
     [self updateAlphaAndBackgroundColorAnimated:NO];
   }
-}
-
-- (void)resetElevationForState:(UIControlState)state {
-  [_userElevations removeObjectForKey:@(state)];
-  [self shadowLayer].elevation = [self elevationForState:self.state];
 }
 
 #pragma mark - Private methods
@@ -575,9 +586,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (void)handleBeginTouches:(NSSet *)touches {
   [_inkView startTouchBeganAnimationAtPoint:[self locationFromTouches:touches] completion:nil];
-  if (_shouldRaiseOnTouch) {
-    [self animateButtonToHeightForState:UIControlStateSelected];
-  }
 }
 
 - (CGPoint)locationFromTouches:(NSSet *)touches {
@@ -587,9 +595,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (void)evaporateInkToPoint:(CGPoint)toPoint {
   [_inkView startTouchEndedAnimationAtPoint:toPoint completion:nil];
-  if (_shouldRaiseOnTouch) {
-    [self animateButtonToHeightForState:UIControlStateNormal];
-  }
 }
 
 - (UIBezierPath *)boundingPath {
@@ -602,19 +607,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (UIEdgeInsets)defaultContentEdgeInsets {
   return UIEdgeInsetsMake(8, 16, 8, 16);
-}
-
-- (CGFloat)defaultElevationForState:(UIControlState)state {
-  if (state == UIControlStateNormal) {
-    return 0;
-  }
-
-  if ((state & UIControlStateSelected) == UIControlStateSelected) {
-    CGFloat normalElevation = [self elevationForState:UIControlStateNormal];
-    return normalElevation > 0 ? 2 * normalElevation : 1;
-  }
-
-  return [self elevationForState:UIControlStateNormal];
 }
 
 - (BOOL)shouldHaveOpaqueBackground {

--- a/components/Buttons/src/MDCFlatButton.m
+++ b/components/Buttons/src/MDCFlatButton.m
@@ -16,11 +16,22 @@
 
 #import "MDCFlatButton.h"
 
+#import "MaterialShadowElevations.h"
 #import "private/MDCButton+Subclassing.h"
 
 static NSString *const MDCFlatButtonHasOpaqueBackground = @"MDCFlatButtonHasOpaqueBackground";
 
 @implementation MDCFlatButton
+
++ (void)initialize {
+  // Default background colors.
+  [[MDCFlatButton appearance] setBackgroundColor:[UIColor clearColor]
+                                        forState:UIControlStateNormal];
+  [[MDCFlatButton appearance] setElevation:MDCShadowElevationNone
+                                  forState:UIControlStateNormal];
+  [[MDCFlatButton appearance] setElevation:MDCShadowElevationNone
+                                  forState:UIControlStateHighlighted];
+}
 
 - (instancetype)init {
   return [self initWithFrame:CGRectZero];
@@ -45,17 +56,7 @@ static NSString *const MDCFlatButtonHasOpaqueBackground = @"MDCFlatButtonHasOpaq
   return self;
 }
 
-+ (void)initialize {
-  // Default background colors.
-  [[MDCFlatButton appearance] setBackgroundColor:[UIColor clearColor]
-                                    forState:UIControlStateNormal];
-}
-
 - (void)commonMDCFlatButtonInit {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  self.shouldRaiseOnTouch = NO;
-#pragma clang diagnostic pop
   self.inkColor = [UIColor colorWithWhite:0 alpha:0.06f];
 }
 

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -27,6 +27,13 @@ static NSString *const MDCFloatingButtonShapeKey = @"MDCFloatingButtonShapeKey";
   MDCFloatingButtonShape _shape;
 }
 
++ (void)initialize {
+  [[MDCFloatingButton appearance] setElevation:MDCShadowElevationFABResting
+                                      forState:UIControlStateNormal];
+  [[MDCFloatingButton appearance] setElevation:MDCShadowElevationFABPressed
+                                      forState:UIControlStateHighlighted];
+}
+
 + (CGFloat)defaultDimension {
   return MDCFloatingButtonDefaultDimension;
 }
@@ -110,12 +117,6 @@ static NSString *const MDCFloatingButtonShapeKey = @"MDCFloatingButtonShapeKey";
     case MDCFloatingButtonShapeMini:
       return UIEdgeInsetsMake(8, 8, 8, 8);
   }
-}
-
-- (CGFloat)defaultElevationForState:(UIControlState)state {
-  return (((state & UIControlStateSelected) == UIControlStateSelected)
-              ? MDCShadowElevationFABPressed
-              : MDCShadowElevationFABResting);
 }
 
 #pragma mark - Deprecations

--- a/components/Buttons/src/MDCRaisedButton.m
+++ b/components/Buttons/src/MDCRaisedButton.m
@@ -21,12 +21,11 @@
 
 @implementation MDCRaisedButton
 
-#pragma mark - Subclassing
-
-- (CGFloat)defaultElevationForState:(UIControlState)state {
-  return (((state & UIControlStateSelected) == UIControlStateSelected)
-              ? MDCShadowElevationRaisedButtonPressed
-              : MDCShadowElevationRaisedButtonResting);
++ (void)initialize {
+  [[MDCRaisedButton appearance] setElevation:MDCShadowElevationRaisedButtonResting
+                                    forState:UIControlStateNormal];
+  [[MDCRaisedButton appearance] setElevation:MDCShadowElevationRaisedButtonPressed
+                                    forState:UIControlStateHighlighted];
 }
 
 @end

--- a/components/Buttons/src/private/MDCButton+Subclassing.h
+++ b/components/Buttons/src/private/MDCButton+Subclassing.h
@@ -45,7 +45,4 @@
 /** The default content edge insets of the button. They are set at initialization time. */
 - (UIEdgeInsets)defaultContentEdgeInsets;
 
-/** The default elevation for a particular button state (if not set by the calling code). */
-- (CGFloat)defaultElevationForState:(UIControlState)state;
-
 @end

--- a/components/Buttons/tests/unit/ButtonTitleColorAccessibilityMutatorTests.m
+++ b/components/Buttons/tests/unit/ButtonTitleColorAccessibilityMutatorTests.m
@@ -53,10 +53,10 @@ static NSString *controlStateDescription(UIControlState controlState);
         // passed that state. See `UIButton strangeness` in ButtonTests.m
         continue;
       }
-      
+
       // When
       [MDCButtonTitleColorAccessibilityMutator changeTitleColorOfButton:button];
-      
+
       // Then
       XCTAssertNotEqualObjects([button titleColorForState:controlState], color,
                                @"for control state:%@ ", controlStateDescription(controlState));
@@ -80,10 +80,10 @@ static NSString *controlStateDescription(UIControlState controlState);
       // Making the background color the same as the title color.
       [button setBackgroundColor:backgroundColor forState:(UIControlState)controlState];
       [button setTitleColor:titleColor forState:(UIControlState)controlState];
-      
+
       // When
       [MDCButtonTitleColorAccessibilityMutator changeTitleColorOfButton:button];
-      
+
       // Then
       XCTAssertEqualObjects([button titleColorForState:controlState], titleColor,
                             @"for control state:%@ ", controlStateDescription(controlState));
@@ -100,10 +100,10 @@ static NSString *controlStateDescription(UIControlState controlState);
       button.underlyingColorHint = color;
       [button setBackgroundColor:[UIColor clearColor] forState:controlState];
       [button setTitleColor:color forState:(UIControlState)controlState];
-      
+
       // When
       [MDCButtonTitleColorAccessibilityMutator changeTitleColorOfButton:button];
-      
+
       // Then
       XCTAssertNotEqualObjects([button titleColorForState:controlState], color,
                                @"for control state:%@ ", controlStateDescription(controlState));

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -26,6 +26,8 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 // This assumes that UIControlState is actually a set of bitfields and ignores application-specific
 // values.
 static const UIControlState kNumUIControlStates = 2 * UIControlStateSelected - 1;
+static const UIControlState kUIControlStateDisabledHighlighted =
+    UIControlStateHighlighted | UIControlStateDisabled;
 
 static CGFloat randomNumber() {
   return arc4random_uniform(100) / (CGFloat)10;
@@ -61,6 +63,23 @@ static UIColor *randomColor() {
       return [UIColor blueColor];
       break;
   }
+}
+
+static NSString *controlStateDescription(UIControlState controlState) {
+  if (controlState == UIControlStateNormal) {
+    return @"Normal";
+  }
+  NSMutableString *string = [NSMutableString string];
+  if ((UIControlStateHighlighted & controlState) == UIControlStateHighlighted) {
+    [string appendString:@"Highlighted "];
+  }
+  if ((UIControlStateDisabled & controlState) == UIControlStateDisabled) {
+    [string appendString:@"Disabled "];
+  }
+  if ((UIControlStateSelected & controlState) == UIControlStateSelected) {
+    [string appendString:@"Selected "];
+  }
+  return [string copy];
 }
 
 @interface ButtonsTests : XCTestCase
@@ -142,35 +161,7 @@ static UIColor *randomColor() {
   }
 }
 
-- (void)testResetElevationForState {
-  // Given
-  MDCButton *button = [[MDCButton alloc] init];
-
-  for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
-    // And given
-    CGFloat defaultValue = [button elevationForState:controlState];
-
-    // When
-    [button setElevation:randomNumberNotEqualTo(defaultValue) forState:controlState];
-    [button resetElevationForState:controlState];
-
-    // Then
-    XCTAssertEqual([button elevationForState:controlState], defaultValue);
-  }
-}
-
-- (void)testDefaultElevationsForState {
-  // Given
-  MDCButton *button = [[MDCButton alloc] init];
-
-  // Then
-  XCTAssertEqual([button elevationForState:UIControlStateNormal], 0);
-  XCTAssertEqual([button elevationForState:UIControlStateHighlighted], 0);
-  XCTAssertEqual([button elevationForState:UIControlStateDisabled], 0);
-  XCTAssertEqual([button elevationForState:UIControlStateSelected], 1);
-}
-
-- (void)testDefaultElevationRelationships {
+- (void)testElevationNormal {
   // Given
   MDCButton *button = [[MDCButton alloc] init];
   CGFloat normalElevation = randomNumberNotEqualTo(0);
@@ -182,10 +173,10 @@ static UIColor *randomColor() {
   XCTAssertEqual([button elevationForState:UIControlStateNormal], normalElevation);
   XCTAssertEqual([button elevationForState:UIControlStateHighlighted], normalElevation);
   XCTAssertEqual([button elevationForState:UIControlStateDisabled], normalElevation);
-  XCTAssertEqual([button elevationForState:UIControlStateSelected], 2 * normalElevation);
+  XCTAssertEqual([button elevationForState:UIControlStateSelected], normalElevation);
 }
 
-- (void)testDefaultElevationRelationshipsZeroElevation {
+- (void)testElevationNormalZeroElevation {
   // Given
   MDCButton *button = [[MDCButton alloc] init];
 
@@ -194,9 +185,6 @@ static UIColor *randomColor() {
 
   // Then
   XCTAssertEqual([button elevationForState:UIControlStateNormal], 0);
-  XCTAssertEqual([button elevationForState:UIControlStateHighlighted], 0);
-  XCTAssertEqual([button elevationForState:UIControlStateDisabled], 0);
-  XCTAssertEqual([button elevationForState:UIControlStateSelected], 1);
 }
 
 - (void)testBackgroundColorForState {
@@ -215,20 +203,122 @@ static UIColor *randomColor() {
   }
 }
 
-- (void)testCurrentBackgroundColor {
+- (void)testCurrentBackgroundColorNormal {
   // Given
   MDCButton *button = [[MDCButton alloc] init];
+  UIColor *normalColor = [UIColor redColor];
+  [button setBackgroundColor:normalColor forState:UIControlStateNormal];
 
-  for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
-    // And given
-    UIColor *color = randomColor();
+  // Then
+  XCTAssertEqualObjects([button backgroundColor], normalColor);
+}
 
-    // When
-    [button setBackgroundColor:color forState:controlState];
+- (void)testCurrentBackgroundColorHighlighted {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+  UIColor *normalColor = [UIColor redColor];
+  UIColor *color = [UIColor orangeColor];
+  [button setBackgroundColor:normalColor forState:UIControlStateNormal];
+  [button setBackgroundColor:color forState:UIControlStateHighlighted];
 
-    // Then
-    XCTAssertEqualObjects([button backgroundColorForState:controlState], color);
-  }
+  // When
+  button.highlighted = YES;
+
+  // Then
+  XCTAssertEqualObjects([button backgroundColor], color);
+}
+
+- (void)testCurrentBackgroundColorDisabled {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+  UIColor *normalColor = [UIColor redColor];
+  UIColor *color = [UIColor orangeColor];
+  [button setBackgroundColor:normalColor forState:UIControlStateNormal];
+  [button setBackgroundColor:color forState:UIControlStateDisabled];
+
+  // When
+  button.enabled = NO;
+
+  // Then
+  XCTAssertEqualObjects([button backgroundColor], color);
+}
+
+- (void)testCurrentBackgroundColorSelected {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+  UIColor *normalColor = [UIColor redColor];
+  UIColor *color = [UIColor orangeColor];
+  [button setBackgroundColor:normalColor forState:UIControlStateNormal];
+  [button setBackgroundColor:color forState:UIControlStateSelected];
+
+  // When
+  button.selected = YES;
+
+  // Then
+  XCTAssertEqualObjects([button backgroundColor], color);
+}
+
+- (void)testCurrentElevationNormal {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+  CGFloat normalElevation = 10;
+  [button setElevation:normalElevation forState:UIControlStateNormal];
+
+  // Then
+  XCTAssertEqualWithAccuracy([button elevationForState:button.state],
+                             normalElevation,
+                             kEpsilonAccuracy);
+}
+
+- (void)testCurrentElevationHighlighted {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+  CGFloat normalElevation = 10;
+  CGFloat elevation = 40;
+  [button setElevation:normalElevation forState:UIControlStateNormal];
+  [button setElevation:elevation forState:UIControlStateHighlighted];;
+
+  // When
+  button.highlighted = YES;
+
+  // Then
+  XCTAssertEqualWithAccuracy([button elevationForState:button.state],
+                             elevation,
+                             kEpsilonAccuracy);
+}
+
+- (void)testCurrentElevationDisabled {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+  CGFloat normalElevation = 10;
+  CGFloat elevation = 40;
+  [button setElevation:normalElevation forState:UIControlStateNormal];
+  [button setElevation:elevation forState:UIControlStateDisabled];;
+
+  // When
+  button.enabled = NO;
+
+  // Then
+  XCTAssertEqualWithAccuracy([button elevationForState:button.state],
+                             elevation,
+                             kEpsilonAccuracy);
+}
+
+- (void)testCurrentElevationSelected {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+  CGFloat normalElevation = 10;
+  CGFloat elevation = 40;
+  [button setElevation:normalElevation forState:UIControlStateNormal];
+  [button setElevation:elevation forState:UIControlStateSelected];;
+
+  // When
+  button.selected = YES;
+
+  // Then
+  XCTAssertEqualWithAccuracy([button elevationForState:button.state],
+                             elevation,
+                             kEpsilonAccuracy);
 }
 
 - (void)testInkColors {
@@ -256,10 +346,8 @@ static UIColor *randomColor() {
   MDCButton *button = [[MDCButton alloc] init];
   button.inkStyle = arc4random_uniform(2) ? MDCInkStyleBounded : MDCInkStyleUnbounded;
   button.inkMaxRippleRadius = randomNumber();
-  button.disabledAlpha = randomNumber();
   button.uppercaseTitle = arc4random_uniform(2) ? YES : NO;
   button.hitAreaInsets = UIEdgeInsetsMake(10, 10, 10, 10);
-  button.customTitleColor = randomColor();
   button.inkColor = randomColor();
   button.underlyingColorHint = randomColor();
   for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
@@ -277,8 +365,6 @@ static UIColor *randomColor() {
   XCTAssertEqual(button.inkStyle, unarchivedButton.inkStyle);
   XCTAssertEqualWithAccuracy(button.inkMaxRippleRadius, unarchivedButton.inkMaxRippleRadius,
                              kEpsilonAccuracy);
-  XCTAssertEqualWithAccuracy(button.disabledAlpha, unarchivedButton.disabledAlpha,
-                             kEpsilonAccuracy);
   XCTAssertEqualWithAccuracy(button.hitAreaInsets.bottom, unarchivedButton.hitAreaInsets.bottom,
                              kEpsilonAccuracy);
   XCTAssertEqualWithAccuracy(button.hitAreaInsets.top, unarchivedButton.hitAreaInsets.top,
@@ -287,7 +373,6 @@ static UIColor *randomColor() {
                              kEpsilonAccuracy);
   XCTAssertEqualWithAccuracy(button.hitAreaInsets.left, unarchivedButton.hitAreaInsets.left,
                              kEpsilonAccuracy);
-  XCTAssertEqual(button.customTitleColor, unarchivedButton.customTitleColor);
   XCTAssertEqual(button.underlyingColorHint, unarchivedButton.underlyingColorHint);
   for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
     XCTAssertEqualWithAccuracy([button elevationForState:controlState],
@@ -295,6 +380,47 @@ static UIColor *randomColor() {
     XCTAssertEqual([button backgroundColorForState:controlState],
                    [unarchivedButton backgroundColorForState:controlState]);
   }
+}
+
+#pragma mark - UIButton strangeness
+
+- (void)testTitleColorForState {
+  for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
+    if (controlState & kUIControlStateDisabledHighlighted) {
+      // We skip the Disabled Highlighted state because UIButton titleColorForState ignores it.
+      continue;
+    }
+    // Given
+    MDCButton *button = [[MDCButton alloc] init];
+    UIColor *color = [UIColor blueColor];
+
+    // When
+    [button setTitleColor:color forState:controlState];
+
+    // Then
+    XCTAssertEqualObjects([button titleColorForState:controlState], color,
+                          @"for control state:%@ ", controlStateDescription(controlState));
+  }
+}
+- (void)testTitleColorForStateDisabledHighlight {
+  // This is strange that setting the color for a state does not return the value of that state.
+  // It turns out that it returns the value set to the normal state.
+
+  // Given
+  UIControlState controlState = kUIControlStateDisabledHighlighted;
+  MDCButton *button = [[MDCButton alloc] init];
+  UIColor *color = [UIColor blueColor];
+  UIColor *normalColor = [UIColor greenColor];
+  [button setTitleColor:normalColor forState:UIControlStateNormal];
+
+  // When
+  [button setTitleColor:color forState:controlState];
+
+  // Then
+  XCTAssertEqualObjects([button titleColorForState:controlState], normalColor,
+                        @"for control state:%@ ", controlStateDescription(controlState));
+  XCTAssertNotEqualObjects([button titleColorForState:controlState], color,
+                        @"for control state:%@ ", controlStateDescription(controlState));
 }
 
 #pragma mark - UIButton state changes

--- a/components/Buttons/tests/unit/FlatButtonTests.m
+++ b/components/Buttons/tests/unit/FlatButtonTests.m
@@ -1,0 +1,38 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialButtons.h"
+#import "MaterialShadowElevations.h"
+
+@interface FlatButtonsTests : XCTestCase
+@end
+
+@implementation FlatButtonsTests
+
+- (void)testDefaultElevationsForState {
+  // Given
+  MDCFlatButton *button = [MDCFlatButton appearance];
+
+  // Then
+  XCTAssertEqual([button elevationForState:UIControlStateNormal], MDCShadowElevationNone);
+  XCTAssertEqual([button elevationForState:UIControlStateHighlighted], MDCShadowElevationNone);
+  XCTAssertEqual([button elevationForState:UIControlStateDisabled], MDCShadowElevationNone);
+  XCTAssertEqual([button elevationForState:UIControlStateSelected], MDCShadowElevationNone);
+}
+
+@end

--- a/components/Buttons/tests/unit/FloatingButtonTests.m
+++ b/components/Buttons/tests/unit/FloatingButtonTests.m
@@ -1,0 +1,39 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialButtons.h"
+#import "MaterialShadowElevations.h"
+
+@interface FloatingButtonsTests : XCTestCase
+@end
+
+@implementation FloatingButtonsTests
+
+- (void)testDefaultElevationsForState {
+  // Given
+  MDCFloatingButton *button = [MDCFloatingButton appearance];
+
+  // Then
+  XCTAssertEqual([button elevationForState:UIControlStateNormal], MDCShadowElevationFABResting);
+  XCTAssertEqual([button elevationForState:UIControlStateHighlighted],
+                 MDCShadowElevationFABPressed);
+  XCTAssertEqual([button elevationForState:UIControlStateDisabled], MDCShadowElevationNone);
+}
+
+
+@end

--- a/components/Buttons/tests/unit/RaisedButtonTests.m
+++ b/components/Buttons/tests/unit/RaisedButtonTests.m
@@ -1,0 +1,40 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialButtons.h"
+#import "MaterialShadowElevations.h"
+
+@interface RaisedButtonsTests : XCTestCase
+@end
+
+@implementation RaisedButtonsTests
+
+- (void)testDefaultElevationsForState {
+  // Given
+  MDCRaisedButton *button = [MDCRaisedButton appearance];
+
+  // Then
+  XCTAssertEqual([button elevationForState:UIControlStateNormal],
+                 MDCShadowElevationRaisedButtonResting);
+  XCTAssertEqual([button elevationForState:UIControlStateHighlighted],
+                 MDCShadowElevationRaisedButtonPressed);
+  XCTAssertEqual([button elevationForState:UIControlStateDisabled], MDCShadowElevationNone);
+}
+
+
+@end

--- a/components/CollectionCells/src/MDCCollectionViewTextCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewTextCell.m
@@ -20,7 +20,7 @@
 #import "MaterialRTL.h"
 #import "MaterialTypography.h"
 
-#import <tgmath.h>
+#include <tgmath.h>
 
 // Default cell heights.
 const CGFloat MDCCellDefaultOneLineHeight = 48.0f;

--- a/components/CollectionCells/src/MDCCollectionViewTextCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewTextCell.m
@@ -90,6 +90,24 @@ static inline CGRect AlignRectToUpperPixel(CGRect rect) {
   return self;
 }
 
+- (void)resetMDCCollectionViewTextCellLabelProperties {
+  _textLabel.font = kCellDefaultTextFont;
+  _textLabel.textColor = [UIColor colorWithWhite:0 alpha:kCellDefaultTextOpacity];
+  _textLabel.shadowColor = nil;
+  _textLabel.shadowOffset = CGSizeZero;
+  _textLabel.textAlignment = NSTextAlignmentNatural;
+  _textLabel.lineBreakMode = NSLineBreakByTruncatingTail;
+  _textLabel.numberOfLines = 1;
+
+  _detailTextLabel.font = kCellDefaultDetailTextFont;
+  _detailTextLabel.textColor = [UIColor colorWithWhite:0 alpha:kCellDefaultDetailTextFontOpacity];
+  _detailTextLabel.shadowColor = nil;
+  _detailTextLabel.shadowOffset = CGSizeZero;
+  _detailTextLabel.textAlignment = NSTextAlignmentNatural;
+  _detailTextLabel.lineBreakMode = NSLineBreakByTruncatingTail;
+  _detailTextLabel.numberOfLines = 1;
+}
+
 - (void)commonMDCCollectionViewTextCellInit {
   _contentWrapper = [[UIView alloc] initWithFrame:self.contentView.bounds];
   _contentWrapper.autoresizingMask =
@@ -100,26 +118,17 @@ static inline CGRect AlignRectToUpperPixel(CGRect rect) {
 
   // Text label.
   _textLabel = [[UILabel alloc] initWithFrame:CGRectZero];
-  _textLabel.font = kCellDefaultTextFont;
-  _textLabel.textColor = [UIColor colorWithWhite:0 alpha:kCellDefaultTextOpacity];
-  _textLabel.shadowColor = nil;
-  _textLabel.shadowOffset = CGSizeZero;
-  _textLabel.textAlignment = NSTextAlignmentNatural;
-  _textLabel.lineBreakMode = NSLineBreakByTruncatingTail;
   _textLabel.autoresizingMask =
       MDCAutoresizingFlexibleTrailingMargin(self.mdc_effectiveUserInterfaceLayoutDirection);
-  [_contentWrapper addSubview:_textLabel];
 
   // Detail text label.
   _detailTextLabel = [[UILabel alloc] initWithFrame:CGRectZero];
-  _detailTextLabel.font = kCellDefaultDetailTextFont;
-  _detailTextLabel.textColor = [UIColor colorWithWhite:0 alpha:kCellDefaultDetailTextFontOpacity];
-  _detailTextLabel.shadowColor = nil;
-  _detailTextLabel.shadowOffset = CGSizeZero;
-  _detailTextLabel.textAlignment = NSTextAlignmentNatural;
-  _detailTextLabel.lineBreakMode = NSLineBreakByTruncatingTail;
   _detailTextLabel.autoresizingMask =
       MDCAutoresizingFlexibleTrailingMargin(self.mdc_effectiveUserInterfaceLayoutDirection);
+
+  [self resetMDCCollectionViewTextCellLabelProperties];
+
+  [_contentWrapper addSubview:_textLabel];
   [_contentWrapper addSubview:_detailTextLabel];
 
   // Image view.
@@ -132,7 +141,11 @@ static inline CGRect AlignRectToUpperPixel(CGRect rect) {
 #pragma mark - Layout
 
 - (void)prepareForReuse {
-  _imageView.image = nil;
+  self.imageView.image = nil;
+  self.textLabel.text = nil;
+  self.detailTextLabel.text = nil;
+
+  [self resetMDCCollectionViewTextCellLabelProperties];
 
   [super prepareForReuse];
   [self setNeedsLayout];

--- a/components/CollectionCells/tests/unit/CollectionViewTextCellsReuseTests.m
+++ b/components/CollectionCells/tests/unit/CollectionViewTextCellsReuseTests.m
@@ -14,7 +14,8 @@
  limitations under the License.
  */
 
-@import XCTest;
+#import <XCTest/XCTest.h>
+
 #import "MaterialCollectionCells.h"
 
 @interface CollectionViewTextCellsReuseTests : XCTestCase

--- a/components/CollectionCells/tests/unit/CollectionViewTextCellsReuseTests.m
+++ b/components/CollectionCells/tests/unit/CollectionViewTextCellsReuseTests.m
@@ -1,0 +1,107 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing software
+ distributed under the License is distributed on an "AS IS" BASIS
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+@import XCTest;
+#import "MaterialCollectionCells.h"
+
+@interface CollectionViewTextCellsReuseTests : XCTestCase
+@end
+
+@implementation CollectionViewTextCellsReuseTests
+
+- (void)testPrepareForReuse {
+  // Given
+  MDCCollectionViewTextCell *textCell =
+      [[MDCCollectionViewTextCell alloc] initWithFrame:CGRectZero];
+
+  UIFont *textLabelFont = textCell.textLabel.font;
+  UIColor *textLabelTextColor = textCell.textLabel.textColor;
+  CGSize textLabelShadowOffset = textCell.textLabel.shadowOffset;
+  NSTextAlignment textLabelAlignment = textCell.textLabel.textAlignment;
+  NSLineBreakMode textLabelLineBreakMode = textCell.textLabel.lineBreakMode;
+  NSInteger textLabelNumberOfLines = textCell.textLabel.numberOfLines;
+
+  UIFont *detailTextLabelFont = textCell.detailTextLabel.font;
+  UIColor *detailTextLabelTextColor = textCell.detailTextLabel.textColor;
+  CGSize detailTextLabelShadowOffset = textCell.detailTextLabel.shadowOffset;
+  NSTextAlignment detailTextLabelAlignment = textCell.detailTextLabel.textAlignment;
+  NSLineBreakMode detailTextLabelLineBreakMode = textCell.detailTextLabel.lineBreakMode;
+  NSInteger detailTextLabelNumberOfLines = textCell.detailTextLabel.numberOfLines;
+
+  textCell.textLabel.text = @"Text label";
+  textCell.textLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+  textCell.textLabel.textColor = [UIColor redColor];
+  textCell.textLabel.shadowColor = [UIColor blueColor];
+  textCell.textLabel.shadowOffset = CGSizeMake(3, 5);
+  textCell.textLabel.textAlignment = NSTextAlignmentJustified;
+  textCell.textLabel.lineBreakMode = NSLineBreakByClipping;
+  textCell.textLabel.numberOfLines = 7;
+
+  textCell.detailTextLabel.text = @"Detail text label";
+  textCell.detailTextLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+  textCell.detailTextLabel.textColor = [UIColor redColor];
+  textCell.detailTextLabel.shadowColor = [UIColor blueColor];
+  textCell.detailTextLabel.shadowOffset = CGSizeMake(3, 5);
+  textCell.detailTextLabel.textAlignment = NSTextAlignmentJustified;
+  textCell.detailTextLabel.lineBreakMode = NSLineBreakByClipping;
+  textCell.detailTextLabel.numberOfLines = 7;
+
+  textCell.imageView.image = [UIImage imageNamed:@"Plus"];
+
+  // When
+  [textCell prepareForReuse];
+
+  // Then
+  // Main text label
+  XCTAssertNil(textCell.textLabel.text,
+               @"Reusing the cell should remove any text in the textLabel");
+  XCTAssertEqualObjects(textLabelFont, textCell.textLabel.font,
+                        @"Reusing the cell should reset the textLabel font.");
+  XCTAssertEqualObjects(textLabelTextColor, textCell.textLabel.textColor,
+                        @"Reusing the cell should reset the textLabel textColor.");
+  XCTAssertNil(textCell.textLabel.shadowColor,
+               @"Reusing the cell should remove the textLabel shadowColor.");
+  XCTAssert(CGSizeEqualToSize(textLabelShadowOffset, textCell.textLabel.shadowOffset),
+            @"Reusing the cell should reset the textLabel shadowOffset.");
+  XCTAssertEqual(textLabelAlignment, textCell.textLabel.textAlignment,
+                 @"Reusing the cell should reset the textLabel textAlignment.");
+  XCTAssertEqual(textLabelLineBreakMode, textCell.textLabel.lineBreakMode,
+                 @"Reusing the cell should reset the textLabel lineBreakMode.");
+  XCTAssertEqual(textLabelNumberOfLines, textCell.textLabel.numberOfLines,
+                 @"Reusing the cell should reset the textLabel numberOfLines.");
+
+  // Detail text label
+  XCTAssertNil(textCell.detailTextLabel.text,
+               @"Reusing the cell should remove any text in the detailTextLabel");
+  XCTAssertEqualObjects(detailTextLabelFont, textCell.detailTextLabel.font,
+                        @"Reusing the cell should reset the detailTextLabel font.");
+  XCTAssertEqualObjects(detailTextLabelTextColor, textCell.detailTextLabel.textColor,
+                        @"Reusing the cell should reset the detailTextLabel textColor.");
+  XCTAssertNil(textCell.detailTextLabel.shadowColor,
+               @"Reusing the cell should remove the detailTextLabel shadowColor.");
+  XCTAssert(CGSizeEqualToSize(detailTextLabelShadowOffset, textCell.detailTextLabel.shadowOffset),
+            @"Reusing the cell should reset the detailTextLabel shadowOffset.");
+  XCTAssertEqual(detailTextLabelAlignment, textCell.detailTextLabel.textAlignment,
+                 @"Reusing the cell should reset the detailTextLabel textAlignment.");
+  XCTAssertEqual(detailTextLabelLineBreakMode, textCell.detailTextLabel.lineBreakMode,
+                 @"Reusing the cell should reset the detailTextLabel lineBreakMode.");
+  XCTAssertEqual(detailTextLabelNumberOfLines, textCell.detailTextLabel.numberOfLines,
+                 @"Reusing the cell should reset the detailTextLabel numberOfLines.");
+  // Image view
+  XCTAssertNil(textCell.imageView.image, @"Reusing the cell should remove the imageView image.");
+}
+
+@end

--- a/components/Collections/src/MDCCollectionViewController.m
+++ b/components/Collections/src/MDCCollectionViewController.m
@@ -24,7 +24,7 @@
 #import "private/MDCCollectionViewEditor.h"
 #import "private/MDCCollectionViewStyler.h"
 
-#import <tgmath.h>
+#include <tgmath.h>
 
 NSString *const MDCCollectionInfoBarKindHeader = @"MDCCollectionInfoBarKindHeader";
 NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFooter";

--- a/components/Collections/src/MDCCollectionViewFlowLayout.m
+++ b/components/Collections/src/MDCCollectionViewFlowLayout.m
@@ -24,7 +24,7 @@
 #import "private/MDCCollectionInfoBarView.h"
 #import "private/MDCCollectionViewEditor.h"
 
-#import <tgmath.h>
+#include <tgmath.h>
 
 /** The grid background decoration view kind. */
 NSString *const kCollectionGridDecorationView = @"MDCCollectionGridDecorationView";

--- a/components/Collections/src/private/MDCCollectionViewEditor.m
+++ b/components/Collections/src/private/MDCCollectionViewEditor.m
@@ -19,7 +19,7 @@
 #import "MaterialCollections.h"
 #import "MaterialShadowLayer.h"
 
-#import <tgmath.h>
+#include <tgmath.h>
 
 // Distance from center before we start fading the item.
 static const CGFloat kDismissalDistanceBeforeFading = 50.0f;

--- a/components/Collections/src/private/MDCCollectionViewEditor.m
+++ b/components/Collections/src/private/MDCCollectionViewEditor.m
@@ -692,7 +692,11 @@ typedef NS_ENUM(NSInteger, MDCAutoscrollPanningDirection) {
 
 - (void)restorePanningItemIfNecessaryWithMomentumX:(CGFloat)momentumX {
   // If we never had a snapshot, or the snapshot never moved, then skip straight to cleanup.
-  if (_cellSnapshot == nil || CGAffineTransformIsIdentity(_cellSnapshot.transform)) {
+  if (_cellSnapshot == nil) {
+    [self cleanupDismissingInformation];
+    return;
+  }
+  if (CGAffineTransformIsIdentity(_cellSnapshot.transform)) {
     [self restoreEditingItem];
     return;
   }
@@ -748,13 +752,17 @@ typedef NS_ENUM(NSInteger, MDCAutoscrollPanningDirection) {
 }
 
 - (void)restoreEditingItem {
+  [self cleanupDismissingInformation];
+  [_collectionView.collectionViewLayout invalidateLayout];
+}
+
+- (void)cleanupDismissingInformation {
   // Remove snapshot and reset item.
   [_cellSnapshot removeFromSuperview];
   _cellSnapshot = nil;
   _dismissingSection = NSNotFound;
   _dismissingCellIndexPath = nil;
   _reorderingCellIndexPath = nil;
-  [_collectionView.collectionViewLayout invalidateLayout];
 }
 
 // The distance an item must be panned before it is dismissed. Currently half of the bounds width.

--- a/components/Collections/src/private/MDCCollectionViewStyler.m
+++ b/components/Collections/src/private/MDCCollectionViewStyler.m
@@ -528,8 +528,11 @@ NS_INLINE CGRect RectShift(CGRect rect, CGFloat dx, CGFloat dy) {
   // Get cell color.
   UIColor *backgroundColor = _cellBackgroundColor;
   if ([_delegate respondsToSelector:@selector(collectionView:cellBackgroundColorAtIndexPath:)]) {
-    backgroundColor =
+    UIColor *customBackgroundColor =
         [_delegate collectionView:_collectionView cellBackgroundColorAtIndexPath:attr.indexPath];
+    if (customBackgroundColor) {
+      backgroundColor = customBackgroundColor;
+    }
   }
 
   NSPointerArray *cellBackgroundCache = _cellBackgroundCaches[backgroundColor];

--- a/components/Collections/src/private/MDCCollectionViewStyler.m
+++ b/components/Collections/src/private/MDCCollectionViewStyler.m
@@ -19,7 +19,7 @@
 #import "MaterialCollections.h"
 #import "MaterialCollectionLayoutAttributes.h"
 
-#import <tgmath.h>
+#include <tgmath.h>
 
 #define RGBCOLOR(r, g, b) \
   [UIColor colorWithRed:(r) / 255.0f green:(g) / 255.0f blue:(b) / 255.0f alpha:1]

--- a/components/Dialogs/examples/DialogsLongAlertViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertViewController.swift
@@ -51,7 +51,7 @@ class DialogsLongAlertViewController: UIViewController {
     ])
   }
 
-  func tap(_ sender: Any) {
+  @objc func tap(_ sender: Any) {
     let messageString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur " +
     "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
     "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -80,7 +80,7 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
   CGRect presentedViewFrame = CGRectZero;
 
   CGRect containerBounds = self.containerView.bounds;
-  containerBounds.size.height -= [MDCKeyboardWatcher sharedKeyboardWatcher].keyboardOffset;
+  containerBounds.size.height -= [MDCKeyboardWatcher sharedKeyboardWatcher].visibleKeyboardHeight;
 
   presentedViewFrame.size = [self sizeForChildContentContainer:self.presentedViewController
                                        withParentContainerSize:containerBounds.size];

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -98,7 +98,7 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
 - (void)presentationTransitionWillBegin {
   // TODO: Follow the Material spec description of Autonomous surface creation for both
   // presentation and dismissal of the dialog.
-  // https://spec.googleplex.com/quantum/motion/choreography.html#choreography-creation
+  // https://material.io/guidelines/motion/choreography.html#choreography-creation
 
   // Set the dimming view to the container's bounds and fully transparent.
   self.dimmingView.frame = self.containerView.bounds;

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
@@ -32,7 +32,7 @@ typedef void (^MDCFeatureHighlightCompletion)(BOOL accepted);
  MDCFeatureHighlightViewController highlights an element of a UI to introduce features or
  functionality that a user hasn’t tried.
 
- https://material.googleplex.com/growth-communications/feature-discovery.html
+ https://material.io/guidelines/growth-communications/feature-discovery.html
 
  MDCFeatureHighlightViewController should be presented modally and dismissed using either
  |acceptFeature| or |rejectFeature|.

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
@@ -52,7 +52,9 @@
   self.scrollView.frame = self.view.bounds;
   self.scrollView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  self.scrollView.contentSize = CGSizeMake(320, 2000);
+  CGFloat contentHeight = [UIScreen mainScreen].bounds.size.height * 5;
+  CGFloat contentWidth = [UIScreen mainScreen].bounds.size.width;
+  self.scrollView.contentSize = CGSizeMake(contentWidth, contentHeight);
   [self.view addSubview:self.scrollView];
   self.fhvc.headerView.trackingScrollView = self.scrollView;
   self.fhvc.view.frame = self.view.bounds;

--- a/components/Ink/src/private/MDCInkLayer.h
+++ b/components/Ink/src/private/MDCInkLayer.h
@@ -20,8 +20,6 @@
 /**
  A Core Animation layer that draws and animates the ink effect.
 
- Exact behaviour of the ink splash is defined in this sandbox demo: http://go/qinkdemo.
-
  Quick summary of how the ink ripple works:
 
  1. On touch down, blast initiates from the touch point.

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -254,7 +254,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 #pragma mark Accessibility
 
 - (NSArray<__kindof UIView *> *)accessibilityElements {
-  return @[ _leadingButtonBar, self.titleView ?: _titleLabel, _trailingButtonBar ];
+  return @[ _leadingButtonBar, self.titleView ? self.titleView : _titleLabel, _trailingButtonBar ];
 }
 
 - (BOOL)isAccessibilityElement {

--- a/components/PageControl/examples/PageControlTypicalUseExample.swift
+++ b/components/PageControl/examples/PageControlTypicalUseExample.swift
@@ -105,7 +105,7 @@ class PageControlSwiftExampleViewController: UIViewController, UIScrollViewDeleg
 
   // MARK: - User events
 
-  func didChangePage(_ sender: MDCPageControl) {
+  @objc func didChangePage(_ sender: MDCPageControl) {
     var offset = scrollView.contentOffset
     offset.x = CGFloat(sender.currentPage) * scrollView.bounds.size.width
     scrollView.setContentOffset(offset, animated: true)

--- a/components/PageControl/src/MDCPageControl.m
+++ b/components/PageControl/src/MDCPageControl.m
@@ -21,7 +21,7 @@
 #import "private/MaterialPageControlStrings.h"
 #import "private/MaterialPageControlStrings_table.h"
 
-#import <tgmath.h>
+#include <tgmath.h>
 
 // The Bundle for string resources.
 static NSString *const kMaterialPageControlBundle = @"MaterialPageControl.bundle";

--- a/components/ProgressView/src/MDCProgressView.m
+++ b/components/ProgressView/src/MDCProgressView.m
@@ -16,7 +16,7 @@
 
 #import "MDCProgressView.h"
 
-#import <tgmath.h>
+#include <tgmath.h>
 
 #import "MaterialMath.h"
 #import "MaterialRTL.h"

--- a/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
+++ b/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
@@ -48,7 +48,7 @@ class ShadowDragSquareExampleViewController: UIViewController {
     self.blueView.addGestureRecognizer(longPressRecogniser)
   }
 
-  func longPressedInView(_ sender: UILongPressGestureRecognizer) {
+  @objc func longPressedInView(_ sender: UILongPressGestureRecognizer) {
     // Elevation of the view is changed to indicate that it has been pressed or released.
     // view.center is changed to follow the touch events.
     if sender.state == .began {

--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -114,20 +114,38 @@ static NSString *const MDCShadowLayerShadowMaskEnabledKey = @"MDCShadowLayerShad
   return self;
 }
 
+- (instancetype)initWithLayer:(id)layer {
+  if (self = [super initWithLayer:layer]) {
+    if ([layer isKindOfClass:[MDCShadowLayer class]]) {
+      MDCShadowLayer *otherLayer = (MDCShadowLayer *)layer;
+      _elevation = otherLayer.elevation;
+      _shadowMaskEnabled = otherLayer.isShadowMaskEnabled;
+      _bottomShadow = [[CAShapeLayer alloc] initWithLayer:otherLayer.bottomShadow];
+      _topShadow = [[CAShapeLayer alloc] initWithLayer:otherLayer.topShadow];
+      [self commonMDCShadowLayerInit];
+    }
+  }
+  return self;
+}
+
 /**
  commonMDCShadowLayerInit creates additional layers based on the values of _elevation and
  _shadowMaskEnabled.
  */
 - (void)commonMDCShadowLayerInit {
-  _bottomShadow = [CAShapeLayer layer];
-  _bottomShadow.backgroundColor = [UIColor clearColor].CGColor;
-  _bottomShadow.shadowColor = [UIColor blackColor].CGColor;
-  [self addSublayer:_bottomShadow];
+  if (!_bottomShadow) {
+    _bottomShadow = [CAShapeLayer layer];
+    _bottomShadow.backgroundColor = [UIColor clearColor].CGColor;
+    _bottomShadow.shadowColor = [UIColor blackColor].CGColor;
+    [self addSublayer:_bottomShadow];
+  }
 
-  _topShadow = [CAShapeLayer layer];
-  _topShadow.backgroundColor = [UIColor clearColor].CGColor;
-  _topShadow.shadowColor = [UIColor blackColor].CGColor;
-  [self addSublayer:_topShadow];
+  if (!_topShadow) {
+    _topShadow = [CAShapeLayer layer];
+    _topShadow.backgroundColor = [UIColor clearColor].CGColor;
+    _topShadow.shadowColor = [UIColor blackColor].CGColor;
+    [self addSublayer:_topShadow];
+  }
 
   // Setup shadow layer state based off _elevation and _shadowMaskEnabled
   MDCShadowMetrics *shadowMetrics = [MDCShadowMetrics metricsWithElevation:_elevation];
@@ -144,8 +162,6 @@ static NSString *const MDCShadowLayerShadowMaskEnabledKey = @"MDCShadowLayerShad
     _bottomShadow.mask = [self shadowLayerMaskForLayer:_bottomShadow];
   }
 }
-
-// TODO(#993): Implement missing initWithLayer:
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
   [super encodeWithCoder:aCoder];

--- a/components/Slider/src/MDCSlider.m
+++ b/components/Slider/src/MDCSlider.m
@@ -96,7 +96,8 @@ static inline UIColor *MDCColorFromRGB(uint32_t rgbValue) {
 #pragma mark - ThumbTrack passthrough methods
 
 - (void)setTrackBackgroundColor:(UIColor *)trackBackgroundColor {
-  _thumbTrack.trackOffColor = trackBackgroundColor ?: [[self class] defaultTrackOffColor];
+  _thumbTrack.trackOffColor =
+      trackBackgroundColor ? trackBackgroundColor : [[self class] defaultTrackOffColor];
   ;
 }
 
@@ -105,7 +106,7 @@ static inline UIColor *MDCColorFromRGB(uint32_t rgbValue) {
 }
 
 - (void)setColor:(UIColor *)color {
-  _thumbTrack.primaryColor = color ?: [[self class] defaultColor];
+  _thumbTrack.primaryColor = color ? color : [[self class] defaultColor];
 }
 
 - (UIColor *)color {

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -191,7 +191,7 @@ static const CGFloat kMaximumHeight = 80.0f;
  change at any time during runtime.
  */
 - (CGFloat)dynamicBottomMargin {
-  CGFloat keyboardHeight = self.watcher.keyboardOffset;
+  CGFloat keyboardHeight = self.watcher.visibleKeyboardHeight;
   CGFloat userHeight = self.bottomOffset;
 
   return MAX(keyboardHeight, userHeight);

--- a/components/Tabs/examples/TabBarIconExample.swift
+++ b/components/Tabs/examples/TabBarIconExample.swift
@@ -76,7 +76,7 @@ class TabBarIconSwiftExample: UIViewController {
                               for: .touchUpInside)
   }
 
-  func changeAlignmentDidTouch(sender: UIButton) {
+  @objc func changeAlignmentDidTouch(sender: UIButton) {
     let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
     sheet.addAction(UIAlertAction(title: "Leading", style: .default, handler: { _ in
       self.alignment = .leading
@@ -103,9 +103,9 @@ class TabBarIconSwiftExample: UIViewController {
     starItem.badgeValue = NumberFormatter.localizedString(from:(badgeNumber + 1) as NSNumber,
                                                           number: .none)
   }
+
   // MARK: Action
-  func incrementDidTouch(sender: UIBarButtonItem) {
-    incrementStarBadge()
+  @objc func incrementDidTouch(sender: UIBarButtonItem) { incrementStarBadge()
 
     addStar(centered: false)
   }

--- a/components/Tabs/examples/TabBarTextOnlyExample.m
+++ b/components/Tabs/examples/TabBarTextOnlyExample.m
@@ -63,7 +63,9 @@
     [[UITabBarItem alloc] initWithTitle:@"A" image:nil tag:0],
     [[UITabBarItem alloc] initWithTitle:@"Tab Bar" image:nil tag:0],
     [[UITabBarItem alloc] initWithTitle:@"With" image:nil tag:0],
-    [[UITabBarItem alloc] initWithTitle:@"A Variety of Titles of Varying Length" image:nil tag:0],
+    [[UITabBarItem alloc] initWithTitle:@"A Variety of Titles of Varying Length That Might Be Long"
+                                  image:nil
+                                    tag:0],
   ];
 
   // Give change the selected item tint color and the tab bar tint color. For other color properties

--- a/components/Tabs/examples/TabBarTextOnlyExample.m
+++ b/components/Tabs/examples/TabBarTextOnlyExample.m
@@ -29,7 +29,7 @@
 - (id)initWithCollectionViewLayout:(UICollectionViewLayout *)layout {
   self = [super initWithCollectionViewLayout:layout];
   if (self) {
-    [self setupExampleViews:@[@"Change Alignment", @"Toggle Case"]];
+    [self setupExampleViews:@[@"Change Alignment", @"Toggle Case", @"Clear Selection"]];
   }
   return self;
 }
@@ -44,6 +44,10 @@
 
 - (void)toggleCase:(id)sender {
   self.tabBar.displaysUppercaseTitles = !self.tabBar.displaysUppercaseTitles;
+}
+
+- (void)clearSelection:(id)sender {
+  self.tabBar.selectedItem = nil;
 }
 
 #pragma mark - Private
@@ -109,10 +113,22 @@
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
   [super collectionView:collectionView didSelectItemAtIndexPath:indexPath];
-  if (indexPath.row == 0) {
-    [self changeAlignment:collectionView];
-  } else {
-    [self toggleCase:collectionView];
+  switch (indexPath.row) {
+    case 0:
+      [self changeAlignment:collectionView];
+      break;
+
+    case 1:
+      [self toggleCase:collectionView];
+      break;
+
+    case 2:
+      [self clearSelection:collectionView];
+      break;
+
+    default:
+      // Unsupported
+      break;
   }
 }
 

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -41,7 +41,12 @@ IB_DESIGNABLE
 /**
  Items displayed in the tab bar.
 
- If the new items do not contain the currently selected item, the selection will be reset to nil.
+ The bar determines the newly-selected item using the following logic:
+ * Reselect the previously-selected item if it's still present in `items` after the update.
+ * If there was no selection previously or if the old selected item is gone, select the first item.
+   Clients that need empty selection to be preserved across updates to `items` must manually reset
+   selectedItem to nil after the update.
+ 
  Changes to this property are not animated.
  */
 @property(nonatomic, copy, nonnull) NSArray<UITabBarItem *> *items;

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -494,7 +494,7 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 
   style.selectionIndicatorColor = self.tintColor;
   style.inkColor = _inkColor;
-  style.selectedTitleColor = (_selectedItemTintColor ?: self.tintColor);
+  style.selectedTitleColor = (_selectedItemTintColor ? _selectedItemTintColor : self.tintColor);
   style.titleColor = _unselectedItemTintColor;
   style.displaysUppercaseTitles = _displaysUppercaseTitles;
 

--- a/components/Tabs/src/private/MDCItemBar.h
+++ b/components/Tabs/src/private/MDCItemBar.h
@@ -33,10 +33,15 @@
 + (CGFloat)defaultHeightForStyle:(nonnull MDCItemBarStyle *)style;
 
 /**
- Items displayed in bar.
+ Items displayed in the item bar.
 
- If the new items do not contain the currently selected item, the selection will be reset to the
- first item. Changes to this property are not animated. May not be nil.
+ The bar determines the newly-selected item using the following logic:
+ * Reselect the previously-selected item if it's still present in `items` after the update.
+ * If there was no selection previously or if the old selected item is gone, select the first item.
+   Clients that need empty selection to be preserved across updates to `items` must manually reset
+   selectedItem to nil after the update.
+
+ Changes to this property are not animated.
  */
 @property(nonatomic, copy, nonnull) NSArray<UITabBarItem *> *items;
 

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -397,10 +397,13 @@ static void *kItemPropertyContext = &kItemPropertyContext;
     size.width = _collectionView.bounds.size.width / MAX(count, 1);
   }
 
-  // Constrain width if necessary.
+  // Constrain to style-based width if necessary.
   if (_style.maximumItemWidth > 0) {
     size.width = MIN(size.width, _style.maximumItemWidth);
   }
+
+  // Constrain to view width
+  size.width = MIN(size.width, CGRectGetWidth(collectionView.frame));
 
   // Force height to our height.
   size.height = itemHeight;

--- a/components/Tabs/tests/unit/MaterialTabsTests.m
+++ b/components/Tabs/tests/unit/MaterialTabsTests.m
@@ -1,0 +1,90 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialTabs.h"
+
+@interface MaterialTabsTests : XCTestCase
+@end
+
+@implementation MaterialTabsTests {
+  MDCTabBar *_tabBar;
+  UITabBarItem *_itemA;
+  UITabBarItem *_itemB;
+  UITabBarItem *_itemC;
+}
+
+- (void)setUp {
+  _tabBar = [[MDCTabBar alloc] init];
+  _itemA = [[UITabBarItem alloc] initWithTitle:@"A" image:nil tag:0];
+  _itemB = [[UITabBarItem alloc] initWithTitle:@"B" image:nil tag:0];
+  _itemC = [[UITabBarItem alloc] initWithTitle:@"C" image:nil tag:0];
+}
+
+/// Tab bars should by default select the first item in their items array.
+- (void)testSelectsFirstItemByDefault {
+  _tabBar.items = @[ _itemA, _itemB, _itemC ];
+  XCTAssertEqual(_tabBar.selectedItem, _itemA);
+}
+
+/// Tab bars should preserve their selection if possible when changing items.
+- (void)testPreservesSelectedItem {
+  // Set items {A, B} which should select item A
+  _tabBar.items = @[ _itemA, _itemB ];
+
+  // Set items {C, A} which should preserve the selection of A.
+  _tabBar.items = @[ _itemC, _itemA ];
+  XCTAssertEqual(_tabBar.selectedItem, _itemA);
+}
+
+/// Tab bars should select the first item if the old selection is no longer present.
+- (void)testSelectsFirstWhenSelectedItemMissing {
+  // Set items {A, B} which should select item A
+  _tabBar.items = @[ _itemA, _itemB ];
+
+  // Set items not including A, which should select B.
+  _tabBar.items = @[ _itemB, _itemC ];
+  XCTAssertEqual(_tabBar.selectedItem, _itemB);
+}
+
+/// Tab bars should safely accept having their items set to the empty array.
+- (void)testSafelyHandlesEmptyItems {
+  _tabBar.items = @[];
+  XCTAssertNil(_tabBar.selectedItem);
+
+  // Setting the empty array should also be safe coming from a non-empty array.
+  _tabBar.items = @[ _itemA ];
+  _tabBar.items = @[];
+  XCTAssertNil(_tabBar.selectedItem);
+}
+
+// Setting items to the same set of items should change nothing.
+- (void)testItemsUpdateIsIdempotent {
+  // Start with {A, B}, which selects A.
+  _tabBar.items = @[ _itemA, _itemB ];
+  XCTAssertEqual(_tabBar.selectedItem, _itemA);
+
+  // Remove A, which selects B.
+  _tabBar.items = @[ _itemB ];
+  XCTAssertEqual(_tabBar.selectedItem, _itemB);
+
+  // Set same set of items, which should make no difference to the selection.
+  _tabBar.items = @[ _itemB ];
+  XCTAssertEqual(_tabBar.selectedItem, _itemB);
+}
+
+@end

--- a/components/TextFields/examples/TextFieldExample.swift
+++ b/components/TextFields/examples/TextFieldExample.swift
@@ -214,16 +214,20 @@ final class TextFieldSwiftExample: UIViewController {
   }
 
   @objc func buttonDidTouch(sender: Any) {
-    let alert = UIAlertController(title: "Floating Enabled",
+    let isFloatingEnabled = allTextFieldControllers.first?.isFloatingEnabled ?? false
+    let alert = UIAlertController(title: "Floating Labels",
                                   message: nil,
                                   preferredStyle: .actionSheet)
-    let defaultAction = UIAlertAction(title: "Default (Yes)", style: .default) { _ in
+
+    let defaultAction = UIAlertAction(title: "Default (Yes)" + (isFloatingEnabled ? " ✓" : ""),
+                                      style: .default) { _ in
       self.allTextFieldControllers.forEach({ (controller) in
         controller.isFloatingEnabled = true
       })
     }
     alert.addAction(defaultAction)
-    let floatingAction = UIAlertAction(title: "No", style: .default) { _ in
+    let floatingAction = UIAlertAction(title: "No" + (isFloatingEnabled ? "" : " ✓"),
+                                       style: .default) { _ in
       self.allTextFieldControllers.forEach({ (controller) in
         controller.isFloatingEnabled = false
       })

--- a/components/TextFields/examples/TextFieldExample.swift
+++ b/components/TextFields/examples/TextFieldExample.swift
@@ -209,11 +209,11 @@ final class TextFieldSwiftExample: UIViewController {
 
   // MARK: - Actions
 
-  func tapDidTouch(sender: Any) {
+  @objc func tapDidTouch(sender: Any) {
     self.view.endEditing(true)
   }
 
-  func buttonDidTouch(sender: Any) {
+  @objc func buttonDidTouch(sender: Any) {
     let alert = UIAlertController(title: "Floating Enabled",
                                   message: nil,
                                   preferredStyle: .actionSheet)
@@ -296,7 +296,7 @@ extension TextFieldSwiftExample {
       object: nil)
   }
 
-  func keyboardWillShow(notif: Notification) {
+  @objc func keyboardWillShow(notif: Notification) {
     guard let frame = notif.userInfo?[UIKeyboardFrameBeginUserInfoKey] as? CGRect else {
       return
     }
@@ -306,7 +306,7 @@ extension TextFieldSwiftExample {
                                            right: 0.0)
   }
 
-  func keyboardWillHide(notif: Notification) {
+  @objc func keyboardWillHide(notif: Notification) {
     scrollView.contentInset = UIEdgeInsets()
   }
 }

--- a/components/TextFields/examples/TextFieldKitchenSinkExample.swift
+++ b/components/TextFields/examples/TextFieldKitchenSinkExample.swift
@@ -370,11 +370,11 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
             textFieldControllerDefaultLeftRightViewFloating]
   }
 
-  func tapDidTouch(sender: Any) {
+  @objc func tapDidTouch(sender: Any) {
     self.view.endEditing(true)
   }
 
-  func errorSwitchDidChange(errorSwitch: UISwitch) {
+  @objc func errorSwitchDidChange(errorSwitch: UISwitch) {
     allInputControllers.forEach { controller in
       if errorSwitch.isOn {
         controller.setErrorText("Uh oh! Try something else.", errorAccessibilityValue: nil)
@@ -384,7 +384,7 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
     }
   }
 
-  func helperSwitchDidChange(helperSwitch: UISwitch) {
+  @objc func helperSwitchDidChange(helperSwitch: UISwitch) {
     allInputControllers.forEach { controller in
       controller.helperText = helperSwitch.isOn ? "This is helper text." : nil
     }
@@ -400,7 +400,7 @@ extension TextFieldKitchenSinkSwiftExample: UITextFieldDelegate {
 }
 
 extension TextFieldKitchenSinkSwiftExample {
-  func contentSizeCategoryDidChange(notif: Notification) {
+  @objc func contentSizeCategoryDidChange(notif: Notification) {
     controlLabel.font = UIFont.preferredFont(forTextStyle: .headline)
     singleLabel.font = UIFont.preferredFont(forTextStyle: .headline)
     errorLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)

--- a/components/TextFields/examples/TextFieldManualLayoutExample.swift
+++ b/components/TextFields/examples/TextFieldManualLayoutExample.swift
@@ -207,11 +207,11 @@ final class TextFieldManualLayoutSwiftExample: UIViewController {
 
   // MARK: - Actions
 
-  func tapDidTouch(sender: Any) {
+  @objc func tapDidTouch(sender: Any) {
     self.view.endEditing(true)
   }
 
-  func buttonDidTouch(sender: Any) {
+  @objc func buttonDidTouch(sender: Any) {
     let alert = UIAlertController(title: "Floating Enabled",
                                   message: nil,
                                   preferredStyle: .actionSheet)
@@ -296,7 +296,7 @@ extension TextFieldManualLayoutSwiftExample {
       object: nil)
   }
 
-  func keyboardWillShow(notif: Notification) {
+  @objc func keyboardWillShow(notif: Notification) {
     guard let frame = notif.userInfo?[UIKeyboardFrameBeginUserInfoKey] as? CGRect else {
       return
     }
@@ -306,7 +306,7 @@ extension TextFieldManualLayoutSwiftExample {
                                            right: 0.0)
   }
 
-  func keyboardWillHide(notif: Notification) {
+  @objc func keyboardWillHide(notif: Notification) {
     scrollView.contentInset = UIEdgeInsets()
   }
 }

--- a/components/TextFields/examples/supplemental/TextFieldKitchenSinkExampleSupplemental.swift
+++ b/components/TextFields/examples/supplemental/TextFieldKitchenSinkExampleSupplemental.swift
@@ -277,7 +277,7 @@ extension TextFieldKitchenSinkSwiftExample {
       object: nil)
   }
 
-  func keyboardWillShow(notif: Notification) {
+  @objc func keyboardWillShow(notif: Notification) {
     guard let frame = notif.userInfo?[UIKeyboardFrameBeginUserInfoKey] as? CGRect else {
       return
     }
@@ -287,7 +287,7 @@ extension TextFieldKitchenSinkSwiftExample {
                                            right: 0.0)
   }
 
-  func keyboardWillHide(notif: Notification) {
+  @objc func keyboardWillHide(notif: Notification) {
     scrollView.contentInset = UIEdgeInsets()
   }
 
@@ -299,7 +299,7 @@ extension TextFieldKitchenSinkSwiftExample {
 
 extension TextFieldKitchenSinkSwiftExample {
   // The 3 'mode' buttons all are similar. The following code is shared by them
-  func buttonDidTouch(button: MDCButton) {
+  @objc func buttonDidTouch(button: MDCButton) {
     var controllersToChange = allInputControllers
     var partialTitle = ""
 

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -205,6 +205,7 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
   [self.fundament setPlaceholder:placeholder];
 }
 
+// Note: this is also called by the internals of UITextField when editing ends.
 - (void)setText:(NSString *)text {
   [super setText:text];
   [_fundament didSetText];

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -56,8 +56,9 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
     NSString *interfaceBuilderPlaceholder = super.placeholder;
     [self commonMDCTextFieldInitialization];
 
-    _fundament = [aDecoder decodeObjectForKey:MDCTextFieldFundamentKey]
-                     ?: [[MDCTextInputCommonFundament alloc] initWithTextInput:self];
+    MDCTextInputCommonFundament *fundament = [aDecoder decodeObjectForKey:MDCTextFieldFundamentKey];
+    _fundament =
+        fundament ? fundament : [[MDCTextInputCommonFundament alloc] initWithTextInput:self];
 
     if (interfaceBuilderPlaceholder.length) {
       self.placeholder = interfaceBuilderPlaceholder;

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -492,8 +492,11 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
     animationBlock = ^{
       self.textInput.placeholderLabel.transform = CGAffineTransformIdentity;
 
-      self.textInput.placeholderLabel.textColor =
-          self.previousPlaceholderColor ?: self.inlinePlaceholderColor;
+      if (self.previousPlaceholderColor) {
+        self.textInput.placeholderLabel.textColor = self.previousPlaceholderColor;
+      } else {
+        self.textInput.placeholderLabel.textColor = self.inlinePlaceholderColor;
+      }
 
       [NSLayoutConstraint deactivateConstraints:self.placeholderAnimationConstraints];
     };
@@ -665,7 +668,7 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
 }
 
 - (UIColor *)floatingPlaceholderColor {
-  return _floatingPlaceholderColor ?: self.textInput.tintColor;
+  return _floatingPlaceholderColor ? _floatingPlaceholderColor : self.textInput.tintColor;
 }
 
 - (void)setFloatingEnabled:(BOOL)floatingEnabled {
@@ -709,7 +712,8 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
 }
 
 - (UIColor *)inlinePlaceholderColor {
-  return _inlinePlaceholderColor ?: MDCTextInputDefaultInlinePlaceholderTextColor();
+  return _inlinePlaceholderColor ?
+            _inlinePlaceholderColor : MDCTextInputDefaultInlinePlaceholderTextColor();
 }
 
 - (BOOL)isDisplayingCharacterCountError {
@@ -746,7 +750,7 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
 }
 
 - (UIColor *)underlineColorActive {
-  return _underlineColorActive ?: MDCTextInputDefaultActiveUnderlineColor();
+  return _underlineColorActive ? _underlineColorActive : MDCTextInputDefaultActiveUnderlineColor();
 }
 
 - (void)setUnderlineColorNormal:(UIColor *)underlineColorNormal {
@@ -757,7 +761,7 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
 }
 
 - (UIColor *)underlineColorNormal {
-  return _underlineColorNormal ?: MDCTextInputDefaultNormalUnderlineColor();
+  return _underlineColorNormal ? _underlineColorNormal : MDCTextInputDefaultNormalUnderlineColor();
 }
 
 - (void)setUnderlineViewMode:(UITextFieldViewMode)underlineViewMode {
@@ -1018,9 +1022,10 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
   // If error text is unset (nil) we reset to previous values.
   if (!errorText) {
     // If there is a saved state, use it.
-    self.textInput.leadingUnderlineLabel.text =
-        self.previousLeadingText ?: self.textInput.leadingUnderlineLabel.text;
-
+    if (self.previousLeadingText) {
+      self.textInput.leadingUnderlineLabel.text = self.previousLeadingText;
+    }
+    
     // Clear out saved state.
     self.previousLeadingText = nil;
   }
@@ -1044,7 +1049,7 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
 
     NSString *valueString = @"";
 
-    if (self.textInput.text > 0) {
+    if (self.textInput.text.length > 0) {
       valueString = [self.textInput.text copy];
     }
     if (self.textInput.placeholder.length > 0) {
@@ -1053,8 +1058,10 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
     valueString = [valueString stringByAppendingString:@"."];
 
     self.textInput.accessibilityValue = valueString;
+    NSString *leadingUnderlineLabelText = self.textInput.leadingUnderlineLabel.text;
     self.textInput.leadingUnderlineLabel.accessibilityLabel = [NSString
-        stringWithFormat:@"Error: %@.", self.textInput.leadingUnderlineLabel.text ?: @""];
+        stringWithFormat:@"Error: %@.", leadingUnderlineLabelText ?
+                                                               leadingUnderlineLabelText : @""];
   } else {
     self.textInput.accessibilityValue = nil;
     self.textInput.leadingUnderlineLabel.accessibilityLabel = nil;

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -419,7 +419,7 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
 - (void)updatePlaceholderY {
   BOOL isDirectionToUp = NO;
   if (self.floatingEnabled) {
-    isDirectionToUp = self.textInput.text.length > 1 || self.textInput.isEditing;
+    isDirectionToUp = self.textInput.text.length >= 1 || self.textInput.isEditing;
   }
 
   [CATransaction begin];
@@ -927,6 +927,8 @@ static inline UIColor *MDCTextInputDefaultTextErrorColor() {
     [CATransaction setAnimationDuration:0];
     [self updatePlaceholderY];
     [CATransaction commit];
+  } else {
+    [self updateLayout];
   }
 
   // Accessibility

--- a/components/TextFields/src/MDCTextInputControllerFullWidth.m
+++ b/components/TextFields/src/MDCTextInputControllerFullWidth.m
@@ -444,7 +444,8 @@ static inline UIColor *MDCTextInputTextErrorColor() {
 }
 
 - (UIColor *)inlinePlaceholderColor {
-  return _inlinePlaceholderColor ?: MDCTextInputInlinePlaceholderTextColor();
+  return _inlinePlaceholderColor
+            ? _inlinePlaceholderColor : MDCTextInputInlinePlaceholderTextColor();
 }
 
 - (BOOL)isDisplayingCharacterCountError {
@@ -705,7 +706,7 @@ static inline UIColor *MDCTextInputTextErrorColor() {
   // internal implementation of textRect calls [super clearButtonRectForBounds:] in its
   // implementation, our modifications are not picked up. Adjust accordingly.
   // Full width text boxes have their character count on the text input line
-  if (self.textInput.text.length > 0) {
+  if (self.textInput.text.length) {
     switch (textField.clearButtonMode) {
       case UITextFieldViewModeWhileEditing:
         editingRect.size.width -= CGRectGetWidth(self.textInput.clearButton.bounds);
@@ -823,8 +824,9 @@ static inline UIColor *MDCTextInputTextErrorColor() {
   // If error text is unset (nil) we reset to previous values.
   if (!errorText) {
     // If there is a saved state, use it.
-    self.textInput.leadingUnderlineLabel.text =
-        self.previousLeadingText ?: self.textInput.leadingUnderlineLabel.text;
+    if (self.previousLeadingText) {
+      self.textInput.leadingUnderlineLabel.text = self.previousLeadingText;
+    }
 
     // Clear out saved state.
     self.previousLeadingText = nil;
@@ -849,7 +851,7 @@ static inline UIColor *MDCTextInputTextErrorColor() {
 
     NSString *valueString = @"";
 
-    if (self.textInput.text > 0) {
+    if (self.textInput.text.length > 0) {
       valueString = [self.textInput.text copy];
     }
     if (self.textInput.placeholder.length > 0) {
@@ -858,8 +860,10 @@ static inline UIColor *MDCTextInputTextErrorColor() {
     valueString = [valueString stringByAppendingString:@"."];
 
     self.textInput.accessibilityValue = valueString;
+    NSString *leadingUnderlineLabelText = self.textInput.leadingUnderlineLabel.text;
     self.textInput.leadingUnderlineLabel.accessibilityLabel = [NSString
-        stringWithFormat:@"Error: %@.", self.textInput.leadingUnderlineLabel.text ?: @""];
+        stringWithFormat:@"Error: %@.", leadingUnderlineLabelText ?
+                                                               leadingUnderlineLabelText : @""];
   } else {
     self.textInput.accessibilityValue = nil;
     self.textInput.leadingUnderlineLabel.accessibilityLabel = nil;

--- a/components/Typography/src/MDCTypography.m
+++ b/components/Typography/src/MDCTypography.m
@@ -157,8 +157,9 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
   }
   UIFontDescriptor *fontDescriptor =
       [font.fontDescriptor fontDescriptorWithSymbolicTraits:UIFontDescriptorTraitItalic];
-  return [UIFont fontWithDescriptor:fontDescriptor size:0]
-             ?: [UIFont italicSystemFontOfSize:font.pointSize];
+  UIFont *fontFromDescriptor = [UIFont fontWithDescriptor:fontDescriptor size:0];
+  return fontFromDescriptor
+             ? fontFromDescriptor : [UIFont italicSystemFontOfSize:font.pointSize];
 }
 
 + (UIFont *)boldFontFromFont:(UIFont *)font {
@@ -171,8 +172,9 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
     traits = traits | UIFontDescriptorTraitItalic;
   }
   UIFontDescriptor *fontDescriptor = [font.fontDescriptor fontDescriptorWithSymbolicTraits:traits];
-  return [UIFont fontWithDescriptor:fontDescriptor size:0]
-             ?: [UIFont boldSystemFontOfSize:font.pointSize];
+  UIFont *fontFromDescriptor = [UIFont fontWithDescriptor:fontDescriptor size:0];
+  return fontFromDescriptor
+             ? fontFromDescriptor : [UIFont boldSystemFontOfSize:font.pointSize];
 }
 
 #pragma mark - Private

--- a/components/private/KeyboardWatcher/src/MDCKeyboardWatcher.h
+++ b/components/private/KeyboardWatcher/src/MDCKeyboardWatcher.h
@@ -45,10 +45,20 @@ OBJC_EXTERN NSString *const MDCKeyboardWatcherKeyboardWillChangeFrameNotificatio
         (NSNotification *)notification;
 
 /**
+ The height of the visible keyboard view.
+
+ Zero if the keyboard is not currently showing or is not docked.
+ */
+@property(nonatomic, readonly) CGFloat visibleKeyboardHeight;
+
+#pragma mark deprecated
+
+/**
  The distance from the top of the keyboard to the bottom of the screen.
 
  Zero if the keyboard is not currently showing or is not docked.
  */
-@property(nonatomic, readonly) CGFloat keyboardOffset;
+@property(nonatomic, readonly) CGFloat keyboardOffset __deprecated_msg("Use visibleKeyboardHeight instead of keyboardOffset")
+;
 
 @end

--- a/components/private/Overlay/src/MDCOverlayObserver.m
+++ b/components/private/Overlay/src/MDCOverlayObserver.m
@@ -151,7 +151,8 @@ static MDCOverlayObserver *_sOverlayObserver;
     return;
   }
 
-  NSValue *frame = userInfo[MDCOverlayFrameKey] ?: [NSValue valueWithCGRect:CGRectNull];
+  NSValue *frame = userInfo[MDCOverlayFrameKey] ?
+                      userInfo[MDCOverlayFrameKey] : [NSValue valueWithCGRect:CGRectNull];
   NSNumber *duration = userInfo[MDCOverlayTransitionDurationKey];
 
   // Update the overlay frame.

--- a/contributing/clang-format.md
+++ b/contributing/clang-format.md
@@ -9,7 +9,8 @@ format your code whenever you write to disk.
 
 ### Installing clang-format
 
-You can install clang-format via [Brew](http://brew.sh/) by running `scripts/install_clang_format`.
+You can install clang-format via [Brew](http://brew.sh/) by running
+`scripts/install/install_clang_format`.
 
 ### Installing the Xcode plugin
 

--- a/demos/Bare/Podfile.lock
+++ b/demos/Bare/Podfile.lock
@@ -58,6 +58,7 @@ PODS:
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
   - MaterialComponents/BottomSheet (26.0.0):
+    - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/Math
   - MaterialComponents/ButtonBar (26.0.0):
     - MaterialComponents/ButtonBar/ColorThemer (= 26.0.0)
@@ -67,6 +68,7 @@ PODS:
   - MaterialComponents/ButtonBar/ColorThemer (26.0.0):
     - MaterialComponents/ButtonBar/Component
     - MaterialComponents/Buttons
+    - MaterialComponents/NavigationBar/Component
     - MaterialComponents/private/RTL
     - MaterialComponents/Themes
   - MaterialComponents/ButtonBar/Component (26.0.0):
@@ -181,7 +183,7 @@ PODS:
     - MaterialComponents/NavigationBar/Component
     - MaterialComponents/Themes
   - MaterialComponents/NavigationBar/Component (26.0.0):
-    - MaterialComponents/ButtonBar
+    - MaterialComponents/ButtonBar/Component
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
@@ -298,7 +300,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  MaterialComponents: 45604ca1d02b856c5fe862f91b5047ab1e3ee366
+  MaterialComponents: 5ca5a2d73c93a471add1d9b59db0a9b8d948bce3
   MDFTextAccessibility: 94098925e0853551c5a311ce7c1ecefbe297cdb6
 
 PODFILE CHECKSUM: 8c6ad4fe8e5aa667e06c9b43f3f5d4d6430b1322

--- a/demos/Bare/Podfile.lock
+++ b/demos/Bare/Podfile.lock
@@ -1,54 +1,54 @@
 PODS:
-  - MaterialComponents (26.0.0):
-    - MaterialComponents/ActivityIndicator (= 26.0.0)
-    - MaterialComponents/AnimationTiming (= 26.0.0)
-    - MaterialComponents/AppBar (= 26.0.0)
-    - MaterialComponents/BottomSheet (= 26.0.0)
-    - MaterialComponents/ButtonBar (= 26.0.0)
-    - MaterialComponents/Buttons (= 26.0.0)
-    - MaterialComponents/CollectionCells (= 26.0.0)
-    - MaterialComponents/CollectionLayoutAttributes (= 26.0.0)
-    - MaterialComponents/Collections (= 26.0.0)
-    - MaterialComponents/Dialogs (= 26.0.0)
-    - MaterialComponents/FeatureHighlight (= 26.0.0)
-    - MaterialComponents/FlexibleHeader (= 26.0.0)
-    - MaterialComponents/HeaderStackView (= 26.0.0)
-    - MaterialComponents/Ink (= 26.0.0)
-    - MaterialComponents/NavigationBar (= 26.0.0)
-    - MaterialComponents/OverlayWindow (= 26.0.0)
-    - MaterialComponents/PageControl (= 26.0.0)
-    - MaterialComponents/Palettes (= 26.0.0)
-    - MaterialComponents/private (= 26.0.0)
-    - MaterialComponents/ProgressView (= 26.0.0)
-    - MaterialComponents/ShadowElevations (= 26.0.0)
-    - MaterialComponents/ShadowLayer (= 26.0.0)
-    - MaterialComponents/Slider (= 26.0.0)
-    - MaterialComponents/Snackbar (= 26.0.0)
-    - MaterialComponents/Tabs (= 26.0.0)
-    - MaterialComponents/TextFields (= 26.0.0)
-    - MaterialComponents/Themes (= 26.0.0)
-    - MaterialComponents/Typography (= 26.0.0)
-  - MaterialComponents/ActivityIndicator (26.0.0):
-    - MaterialComponents/ActivityIndicator/ColorThemer (= 26.0.0)
-    - MaterialComponents/ActivityIndicator/Component (= 26.0.0)
+  - MaterialComponents (27.0.0):
+    - MaterialComponents/ActivityIndicator (= 27.0.0)
+    - MaterialComponents/AnimationTiming (= 27.0.0)
+    - MaterialComponents/AppBar (= 27.0.0)
+    - MaterialComponents/BottomSheet (= 27.0.0)
+    - MaterialComponents/ButtonBar (= 27.0.0)
+    - MaterialComponents/Buttons (= 27.0.0)
+    - MaterialComponents/CollectionCells (= 27.0.0)
+    - MaterialComponents/CollectionLayoutAttributes (= 27.0.0)
+    - MaterialComponents/Collections (= 27.0.0)
+    - MaterialComponents/Dialogs (= 27.0.0)
+    - MaterialComponents/FeatureHighlight (= 27.0.0)
+    - MaterialComponents/FlexibleHeader (= 27.0.0)
+    - MaterialComponents/HeaderStackView (= 27.0.0)
+    - MaterialComponents/Ink (= 27.0.0)
+    - MaterialComponents/NavigationBar (= 27.0.0)
+    - MaterialComponents/OverlayWindow (= 27.0.0)
+    - MaterialComponents/PageControl (= 27.0.0)
+    - MaterialComponents/Palettes (= 27.0.0)
+    - MaterialComponents/private (= 27.0.0)
+    - MaterialComponents/ProgressView (= 27.0.0)
+    - MaterialComponents/ShadowElevations (= 27.0.0)
+    - MaterialComponents/ShadowLayer (= 27.0.0)
+    - MaterialComponents/Slider (= 27.0.0)
+    - MaterialComponents/Snackbar (= 27.0.0)
+    - MaterialComponents/Tabs (= 27.0.0)
+    - MaterialComponents/TextFields (= 27.0.0)
+    - MaterialComponents/Themes (= 27.0.0)
+    - MaterialComponents/Typography (= 27.0.0)
+  - MaterialComponents/ActivityIndicator (27.0.0):
+    - MaterialComponents/ActivityIndicator/ColorThemer (= 27.0.0)
+    - MaterialComponents/ActivityIndicator/Component (= 27.0.0)
     - MaterialComponents/private/Application
     - MaterialComponents/private/RTL
-  - MaterialComponents/ActivityIndicator/ColorThemer (26.0.0):
+  - MaterialComponents/ActivityIndicator/ColorThemer (27.0.0):
     - MaterialComponents/ActivityIndicator/Component
     - MaterialComponents/private/Application
     - MaterialComponents/private/RTL
     - MaterialComponents/Themes
-  - MaterialComponents/ActivityIndicator/Component (26.0.0):
+  - MaterialComponents/ActivityIndicator/Component (27.0.0):
     - MaterialComponents/private/Application
     - MaterialComponents/private/RTL
-  - MaterialComponents/AnimationTiming (26.0.0)
-  - MaterialComponents/AppBar (26.0.0):
-    - MaterialComponents/AppBar/ColorThemer (= 26.0.0)
-    - MaterialComponents/AppBar/Component (= 26.0.0)
-  - MaterialComponents/AppBar/ColorThemer (26.0.0):
+  - MaterialComponents/AnimationTiming (27.0.0)
+  - MaterialComponents/AppBar (27.0.0):
+    - MaterialComponents/AppBar/ColorThemer (= 27.0.0)
+    - MaterialComponents/AppBar/Component (= 27.0.0)
+  - MaterialComponents/AppBar/ColorThemer (27.0.0):
     - MaterialComponents/AppBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/AppBar/Component (26.0.0):
+  - MaterialComponents/AppBar/Component (27.0.0):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
     - MaterialComponents/NavigationBar
@@ -57,34 +57,34 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/BottomSheet (26.0.0):
+  - MaterialComponents/BottomSheet (27.0.0):
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/Math
-  - MaterialComponents/ButtonBar (26.0.0):
-    - MaterialComponents/ButtonBar/ColorThemer (= 26.0.0)
-    - MaterialComponents/ButtonBar/Component (= 26.0.0)
+  - MaterialComponents/ButtonBar (27.0.0):
+    - MaterialComponents/ButtonBar/ColorThemer (= 27.0.0)
+    - MaterialComponents/ButtonBar/Component (= 27.0.0)
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/ButtonBar/ColorThemer (26.0.0):
+  - MaterialComponents/ButtonBar/ColorThemer (27.0.0):
     - MaterialComponents/ButtonBar/Component
     - MaterialComponents/Buttons
     - MaterialComponents/NavigationBar/Component
     - MaterialComponents/private/RTL
     - MaterialComponents/Themes
-  - MaterialComponents/ButtonBar/Component (26.0.0):
+  - MaterialComponents/ButtonBar/Component (27.0.0):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/Buttons (26.0.0):
-    - MaterialComponents/Buttons/ColorThemer (= 26.0.0)
-    - MaterialComponents/Buttons/Component (= 26.0.0)
-    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 26.0.0)
+  - MaterialComponents/Buttons (27.0.0):
+    - MaterialComponents/Buttons/ColorThemer (= 27.0.0)
+    - MaterialComponents/Buttons/Component (= 27.0.0)
+    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 27.0.0)
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/ColorThemer (26.0.0):
+  - MaterialComponents/Buttons/ColorThemer (27.0.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -93,14 +93,14 @@ PODS:
     - MaterialComponents/Themes
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/Component (26.0.0):
+  - MaterialComponents/Buttons/Component (27.0.0):
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (26.0.0):
+  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (27.0.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -108,7 +108,7 @@ PODS:
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/CollectionCells (26.0.0):
+  - MaterialComponents/CollectionCells (27.0.0):
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/private/Icons/ic_check
@@ -120,149 +120,149 @@ PODS:
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/CollectionLayoutAttributes (26.0.0)
-  - MaterialComponents/Collections (26.0.0):
+  - MaterialComponents/CollectionLayoutAttributes (27.0.0)
+  - MaterialComponents/Collections (27.0.0):
     - MaterialComponents/CollectionCells
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/Dialogs (26.0.0):
-    - MaterialComponents/Dialogs/ColorThemer (= 26.0.0)
-    - MaterialComponents/Dialogs/Component (= 26.0.0)
-  - MaterialComponents/Dialogs/ColorThemer (26.0.0):
+  - MaterialComponents/Dialogs (27.0.0):
+    - MaterialComponents/Dialogs/ColorThemer (= 27.0.0)
+    - MaterialComponents/Dialogs/Component (= 27.0.0)
+  - MaterialComponents/Dialogs/ColorThemer (27.0.0):
     - MaterialComponents/Dialogs/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Dialogs/Component (26.0.0):
+  - MaterialComponents/Dialogs/Component (27.0.0):
     - MaterialComponents/Buttons
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/RTL
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
-  - MaterialComponents/FeatureHighlight (26.0.0):
-    - MaterialComponents/FeatureHighlight/ColorThemer (= 26.0.0)
-    - MaterialComponents/FeatureHighlight/Component (= 26.0.0)
-  - MaterialComponents/FeatureHighlight/ColorThemer (26.0.0):
+  - MaterialComponents/FeatureHighlight (27.0.0):
+    - MaterialComponents/FeatureHighlight/ColorThemer (= 27.0.0)
+    - MaterialComponents/FeatureHighlight/Component (= 27.0.0)
+  - MaterialComponents/FeatureHighlight/ColorThemer (27.0.0):
     - MaterialComponents/FeatureHighlight/Component
     - MaterialComponents/Themes
-  - MaterialComponents/FeatureHighlight/Component (26.0.0):
+  - MaterialComponents/FeatureHighlight/Component (27.0.0):
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader (26.0.0):
-    - MaterialComponents/FlexibleHeader/ColorThemer (= 26.0.0)
-    - MaterialComponents/FlexibleHeader/Component (= 26.0.0)
+  - MaterialComponents/FlexibleHeader (27.0.0):
+    - MaterialComponents/FlexibleHeader/ColorThemer (= 27.0.0)
+    - MaterialComponents/FlexibleHeader/Component (= 27.0.0)
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/ColorThemer (26.0.0):
+  - MaterialComponents/FlexibleHeader/ColorThemer (27.0.0):
     - MaterialComponents/FlexibleHeader/Component
     - MaterialComponents/private/Application
     - MaterialComponents/Themes
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/Component (26.0.0):
+  - MaterialComponents/FlexibleHeader/Component (27.0.0):
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/HeaderStackView (26.0.0):
-    - MaterialComponents/HeaderStackView/ColorThemer (= 26.0.0)
-    - MaterialComponents/HeaderStackView/Component (= 26.0.0)
-  - MaterialComponents/HeaderStackView/ColorThemer (26.0.0):
+  - MaterialComponents/HeaderStackView (27.0.0):
+    - MaterialComponents/HeaderStackView/ColorThemer (= 27.0.0)
+    - MaterialComponents/HeaderStackView/Component (= 27.0.0)
+  - MaterialComponents/HeaderStackView/ColorThemer (27.0.0):
     - MaterialComponents/HeaderStackView/Component
     - MaterialComponents/Themes
-  - MaterialComponents/HeaderStackView/Component (26.0.0)
-  - MaterialComponents/Ink (26.0.0):
-    - MaterialComponents/Ink/ColorThemer (= 26.0.0)
-    - MaterialComponents/Ink/Component (= 26.0.0)
-  - MaterialComponents/Ink/ColorThemer (26.0.0):
+  - MaterialComponents/HeaderStackView/Component (27.0.0)
+  - MaterialComponents/Ink (27.0.0):
+    - MaterialComponents/Ink/ColorThemer (= 27.0.0)
+    - MaterialComponents/Ink/Component (= 27.0.0)
+  - MaterialComponents/Ink/ColorThemer (27.0.0):
     - MaterialComponents/Ink/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Ink/Component (26.0.0)
-  - MaterialComponents/NavigationBar (26.0.0):
-    - MaterialComponents/NavigationBar/ColorThemer (= 26.0.0)
-    - MaterialComponents/NavigationBar/Component (= 26.0.0)
-  - MaterialComponents/NavigationBar/ColorThemer (26.0.0):
+  - MaterialComponents/Ink/Component (27.0.0)
+  - MaterialComponents/NavigationBar (27.0.0):
+    - MaterialComponents/NavigationBar/ColorThemer (= 27.0.0)
+    - MaterialComponents/NavigationBar/Component (= 27.0.0)
+  - MaterialComponents/NavigationBar/ColorThemer (27.0.0):
     - MaterialComponents/NavigationBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/NavigationBar/Component (26.0.0):
+  - MaterialComponents/NavigationBar/Component (27.0.0):
     - MaterialComponents/ButtonBar/Component
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/OverlayWindow (26.0.0):
+  - MaterialComponents/OverlayWindow (27.0.0):
     - MaterialComponents/private/Application
-  - MaterialComponents/PageControl (26.0.0):
-    - MaterialComponents/PageControl/ColorThemer (= 26.0.0)
-    - MaterialComponents/PageControl/Component (= 26.0.0)
-  - MaterialComponents/PageControl/ColorThemer (26.0.0):
+  - MaterialComponents/PageControl (27.0.0):
+    - MaterialComponents/PageControl/ColorThemer (= 27.0.0)
+    - MaterialComponents/PageControl/Component (= 27.0.0)
+  - MaterialComponents/PageControl/ColorThemer (27.0.0):
     - MaterialComponents/PageControl/Component
     - MaterialComponents/Themes
-  - MaterialComponents/PageControl/Component (26.0.0)
-  - MaterialComponents/Palettes (26.0.0)
-  - MaterialComponents/private (26.0.0):
-    - MaterialComponents/private/Application (= 26.0.0)
-    - MaterialComponents/private/Icons (= 26.0.0)
-    - MaterialComponents/private/KeyboardWatcher (= 26.0.0)
-    - MaterialComponents/private/Math (= 26.0.0)
-    - MaterialComponents/private/Overlay (= 26.0.0)
-    - MaterialComponents/private/RTL (= 26.0.0)
-    - MaterialComponents/private/ThumbTrack (= 26.0.0)
-  - MaterialComponents/private/Application (26.0.0)
-  - MaterialComponents/private/Icons (26.0.0):
-    - MaterialComponents/private/Icons/Base (= 26.0.0)
-    - MaterialComponents/private/Icons/ic_arrow_back (= 26.0.0)
-    - MaterialComponents/private/Icons/ic_check (= 26.0.0)
-    - MaterialComponents/private/Icons/ic_check_circle (= 26.0.0)
-    - MaterialComponents/private/Icons/ic_chevron_right (= 26.0.0)
-    - MaterialComponents/private/Icons/ic_info (= 26.0.0)
-    - MaterialComponents/private/Icons/ic_radio_button_unchecked (= 26.0.0)
-    - MaterialComponents/private/Icons/ic_reorder (= 26.0.0)
-  - MaterialComponents/private/Icons/Base (26.0.0)
-  - MaterialComponents/private/Icons/ic_arrow_back (26.0.0):
+  - MaterialComponents/PageControl/Component (27.0.0)
+  - MaterialComponents/Palettes (27.0.0)
+  - MaterialComponents/private (27.0.0):
+    - MaterialComponents/private/Application (= 27.0.0)
+    - MaterialComponents/private/Icons (= 27.0.0)
+    - MaterialComponents/private/KeyboardWatcher (= 27.0.0)
+    - MaterialComponents/private/Math (= 27.0.0)
+    - MaterialComponents/private/Overlay (= 27.0.0)
+    - MaterialComponents/private/RTL (= 27.0.0)
+    - MaterialComponents/private/ThumbTrack (= 27.0.0)
+  - MaterialComponents/private/Application (27.0.0)
+  - MaterialComponents/private/Icons (27.0.0):
+    - MaterialComponents/private/Icons/Base (= 27.0.0)
+    - MaterialComponents/private/Icons/ic_arrow_back (= 27.0.0)
+    - MaterialComponents/private/Icons/ic_check (= 27.0.0)
+    - MaterialComponents/private/Icons/ic_check_circle (= 27.0.0)
+    - MaterialComponents/private/Icons/ic_chevron_right (= 27.0.0)
+    - MaterialComponents/private/Icons/ic_info (= 27.0.0)
+    - MaterialComponents/private/Icons/ic_radio_button_unchecked (= 27.0.0)
+    - MaterialComponents/private/Icons/ic_reorder (= 27.0.0)
+  - MaterialComponents/private/Icons/Base (27.0.0)
+  - MaterialComponents/private/Icons/ic_arrow_back (27.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check (26.0.0):
+  - MaterialComponents/private/Icons/ic_check (27.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check_circle (26.0.0):
+  - MaterialComponents/private/Icons/ic_check_circle (27.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_chevron_right (26.0.0):
+  - MaterialComponents/private/Icons/ic_chevron_right (27.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_info (26.0.0):
+  - MaterialComponents/private/Icons/ic_info (27.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_radio_button_unchecked (26.0.0):
+  - MaterialComponents/private/Icons/ic_radio_button_unchecked (27.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_reorder (26.0.0):
+  - MaterialComponents/private/Icons/ic_reorder (27.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/KeyboardWatcher (26.0.0):
+  - MaterialComponents/private/KeyboardWatcher (27.0.0):
     - MaterialComponents/private/Application
-  - MaterialComponents/private/Math (26.0.0)
-  - MaterialComponents/private/Overlay (26.0.0)
-  - MaterialComponents/private/RTL (26.0.0)
-  - MaterialComponents/private/ThumbTrack (26.0.0):
+  - MaterialComponents/private/Math (27.0.0)
+  - MaterialComponents/private/Overlay (27.0.0)
+  - MaterialComponents/private/RTL (27.0.0)
+  - MaterialComponents/private/ThumbTrack (27.0.0):
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ProgressView (26.0.0):
-    - MaterialComponents/ProgressView/ColorThemer (= 26.0.0)
-    - MaterialComponents/ProgressView/Component (= 26.0.0)
-  - MaterialComponents/ProgressView/ColorThemer (26.0.0):
+  - MaterialComponents/ProgressView (27.0.0):
+    - MaterialComponents/ProgressView/ColorThemer (= 27.0.0)
+    - MaterialComponents/ProgressView/Component (= 27.0.0)
+  - MaterialComponents/ProgressView/ColorThemer (27.0.0):
     - MaterialComponents/ProgressView/Component
     - MaterialComponents/Themes
-  - MaterialComponents/ProgressView/Component (26.0.0):
+  - MaterialComponents/ProgressView/Component (27.0.0):
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
-  - MaterialComponents/ShadowElevations (26.0.0)
-  - MaterialComponents/ShadowLayer (26.0.0)
-  - MaterialComponents/Slider (26.0.0):
-    - MaterialComponents/Slider/ColorThemer (= 26.0.0)
-    - MaterialComponents/Slider/Component (= 26.0.0)
-  - MaterialComponents/Slider/ColorThemer (26.0.0):
+  - MaterialComponents/ShadowElevations (27.0.0)
+  - MaterialComponents/ShadowLayer (27.0.0)
+  - MaterialComponents/Slider (27.0.0):
+    - MaterialComponents/Slider/ColorThemer (= 27.0.0)
+    - MaterialComponents/Slider/Component (= 27.0.0)
+  - MaterialComponents/Slider/ColorThemer (27.0.0):
     - MaterialComponents/Slider/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Slider/Component (26.0.0):
+  - MaterialComponents/Slider/Component (27.0.0):
     - MaterialComponents/private/ThumbTrack
-  - MaterialComponents/Snackbar (26.0.0):
+  - MaterialComponents/Snackbar (27.0.0):
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Buttons
     - MaterialComponents/OverlayWindow
@@ -270,25 +270,25 @@ PODS:
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/Overlay
     - MaterialComponents/Typography
-  - MaterialComponents/Tabs (26.0.0):
-    - MaterialComponents/Tabs/ColorThemer (= 26.0.0)
-    - MaterialComponents/Tabs/Component (= 26.0.0)
-  - MaterialComponents/Tabs/ColorThemer (26.0.0):
+  - MaterialComponents/Tabs (27.0.0):
+    - MaterialComponents/Tabs/ColorThemer (= 27.0.0)
+    - MaterialComponents/Tabs/Component (= 27.0.0)
+  - MaterialComponents/Tabs/ColorThemer (27.0.0):
     - MaterialComponents/Tabs/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Tabs/Component (26.0.0):
+  - MaterialComponents/Tabs/Component (27.0.0):
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Ink
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/TextFields (26.0.0):
+  - MaterialComponents/TextFields (27.0.0):
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Palettes
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/Themes (26.0.0)
-  - MaterialComponents/Typography (26.0.0):
+  - MaterialComponents/Themes (27.0.0)
+  - MaterialComponents/Typography (27.0.0):
     - MaterialComponents/private/Application
   - MDFTextAccessibility (1.2.0)
 
@@ -300,7 +300,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  MaterialComponents: 5ca5a2d73c93a471add1d9b59db0a9b8d948bce3
+  MaterialComponents: 43a68108ffb2018e7019394ceebff34d43218763
   MDFTextAccessibility: 94098925e0853551c5a311ce7c1ecefbe297cdb6
 
 PODFILE CHECKSUM: 8c6ad4fe8e5aa667e06c9b43f3f5d4d6430b1322

--- a/demos/Pesto/Pesto/PestoSettingsViewController.m
+++ b/demos/Pesto/Pesto/PestoSettingsViewController.m
@@ -62,8 +62,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   backButton.image = backImage;
   self.navigationItem.leftBarButtonItem = backButton;
   self.navigationItem.rightBarButtonItem = nil;
-  [self.collectionView registerClass:[MDCCollectionViewTextCell class]
-          forCellWithReuseIdentifier:kReusableIdentifierItem];
 
   // Register cell.
   [self.collectionView registerClass:[MDCCollectionViewTextCell class]

--- a/demos/Pesto/Podfile.lock
+++ b/demos/Pesto/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
-  - MaterialComponents/AnimationTiming (26.0.0)
-  - MaterialComponents/AppBar (26.0.0):
-    - MaterialComponents/AppBar/ColorThemer (= 26.0.0)
-    - MaterialComponents/AppBar/Component (= 26.0.0)
-  - MaterialComponents/AppBar/ColorThemer (26.0.0):
+  - MaterialComponents/AnimationTiming (27.0.0)
+  - MaterialComponents/AppBar (27.0.0):
+    - MaterialComponents/AppBar/ColorThemer (= 27.0.0)
+    - MaterialComponents/AppBar/Component (= 27.0.0)
+  - MaterialComponents/AppBar/ColorThemer (27.0.0):
     - MaterialComponents/AppBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/AppBar/Component (26.0.0):
+  - MaterialComponents/AppBar/Component (27.0.0):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
     - MaterialComponents/NavigationBar
@@ -15,20 +15,20 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ButtonBar/Component (26.0.0):
+  - MaterialComponents/ButtonBar/Component (27.0.0):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/Buttons (26.0.0):
-    - MaterialComponents/Buttons/ColorThemer (= 26.0.0)
-    - MaterialComponents/Buttons/Component (= 26.0.0)
-    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 26.0.0)
+  - MaterialComponents/Buttons (27.0.0):
+    - MaterialComponents/Buttons/ColorThemer (= 27.0.0)
+    - MaterialComponents/Buttons/Component (= 27.0.0)
+    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 27.0.0)
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/ColorThemer (26.0.0):
+  - MaterialComponents/Buttons/ColorThemer (27.0.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -37,14 +37,14 @@ PODS:
     - MaterialComponents/Themes
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/Component (26.0.0):
+  - MaterialComponents/Buttons/Component (27.0.0):
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (26.0.0):
+  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (27.0.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -52,7 +52,7 @@ PODS:
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/CollectionCells (26.0.0):
+  - MaterialComponents/CollectionCells (27.0.0):
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/private/Icons/ic_check
@@ -64,75 +64,75 @@ PODS:
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/CollectionLayoutAttributes (26.0.0)
-  - MaterialComponents/Collections (26.0.0):
+  - MaterialComponents/CollectionLayoutAttributes (27.0.0)
+  - MaterialComponents/Collections (27.0.0):
     - MaterialComponents/CollectionCells
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/FlexibleHeader (26.0.0):
-    - MaterialComponents/FlexibleHeader/ColorThemer (= 26.0.0)
-    - MaterialComponents/FlexibleHeader/Component (= 26.0.0)
+  - MaterialComponents/FlexibleHeader (27.0.0):
+    - MaterialComponents/FlexibleHeader/ColorThemer (= 27.0.0)
+    - MaterialComponents/FlexibleHeader/Component (= 27.0.0)
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/ColorThemer (26.0.0):
+  - MaterialComponents/FlexibleHeader/ColorThemer (27.0.0):
     - MaterialComponents/FlexibleHeader/Component
     - MaterialComponents/private/Application
     - MaterialComponents/Themes
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/Component (26.0.0):
+  - MaterialComponents/FlexibleHeader/Component (27.0.0):
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/HeaderStackView (26.0.0):
-    - MaterialComponents/HeaderStackView/ColorThemer (= 26.0.0)
-    - MaterialComponents/HeaderStackView/Component (= 26.0.0)
-  - MaterialComponents/HeaderStackView/ColorThemer (26.0.0):
+  - MaterialComponents/HeaderStackView (27.0.0):
+    - MaterialComponents/HeaderStackView/ColorThemer (= 27.0.0)
+    - MaterialComponents/HeaderStackView/Component (= 27.0.0)
+  - MaterialComponents/HeaderStackView/ColorThemer (27.0.0):
     - MaterialComponents/HeaderStackView/Component
     - MaterialComponents/Themes
-  - MaterialComponents/HeaderStackView/Component (26.0.0)
-  - MaterialComponents/Ink (26.0.0):
-    - MaterialComponents/Ink/ColorThemer (= 26.0.0)
-    - MaterialComponents/Ink/Component (= 26.0.0)
-  - MaterialComponents/Ink/ColorThemer (26.0.0):
+  - MaterialComponents/HeaderStackView/Component (27.0.0)
+  - MaterialComponents/Ink (27.0.0):
+    - MaterialComponents/Ink/ColorThemer (= 27.0.0)
+    - MaterialComponents/Ink/Component (= 27.0.0)
+  - MaterialComponents/Ink/ColorThemer (27.0.0):
     - MaterialComponents/Ink/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Ink/Component (26.0.0)
-  - MaterialComponents/NavigationBar (26.0.0):
-    - MaterialComponents/NavigationBar/ColorThemer (= 26.0.0)
-    - MaterialComponents/NavigationBar/Component (= 26.0.0)
-  - MaterialComponents/NavigationBar/ColorThemer (26.0.0):
+  - MaterialComponents/Ink/Component (27.0.0)
+  - MaterialComponents/NavigationBar (27.0.0):
+    - MaterialComponents/NavigationBar/ColorThemer (= 27.0.0)
+    - MaterialComponents/NavigationBar/Component (= 27.0.0)
+  - MaterialComponents/NavigationBar/ColorThemer (27.0.0):
     - MaterialComponents/NavigationBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/NavigationBar/Component (26.0.0):
+  - MaterialComponents/NavigationBar/Component (27.0.0):
     - MaterialComponents/ButtonBar/Component
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/private/Application (26.0.0)
-  - MaterialComponents/private/Icons/Base (26.0.0)
-  - MaterialComponents/private/Icons/ic_arrow_back (26.0.0):
+  - MaterialComponents/private/Application (27.0.0)
+  - MaterialComponents/private/Icons/Base (27.0.0)
+  - MaterialComponents/private/Icons/ic_arrow_back (27.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check (26.0.0):
+  - MaterialComponents/private/Icons/ic_check (27.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check_circle (26.0.0):
+  - MaterialComponents/private/Icons/ic_check_circle (27.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_chevron_right (26.0.0):
+  - MaterialComponents/private/Icons/ic_chevron_right (27.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_info (26.0.0):
+  - MaterialComponents/private/Icons/ic_info (27.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_radio_button_unchecked (26.0.0):
+  - MaterialComponents/private/Icons/ic_radio_button_unchecked (27.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_reorder (26.0.0):
+  - MaterialComponents/private/Icons/ic_reorder (27.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Math (26.0.0)
-  - MaterialComponents/private/RTL (26.0.0)
-  - MaterialComponents/ShadowElevations (26.0.0)
-  - MaterialComponents/ShadowLayer (26.0.0)
-  - MaterialComponents/Themes (26.0.0)
-  - MaterialComponents/Typography (26.0.0):
+  - MaterialComponents/private/Math (27.0.0)
+  - MaterialComponents/private/RTL (27.0.0)
+  - MaterialComponents/ShadowElevations (27.0.0)
+  - MaterialComponents/ShadowLayer (27.0.0)
+  - MaterialComponents/Themes (27.0.0)
+  - MaterialComponents/Typography (27.0.0):
     - MaterialComponents/private/Application
   - MDFTextAccessibility (1.2.0)
 
@@ -151,7 +151,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  MaterialComponents: 5ca5a2d73c93a471add1d9b59db0a9b8d948bce3
+  MaterialComponents: 43a68108ffb2018e7019394ceebff34d43218763
   MDFTextAccessibility: 94098925e0853551c5a311ce7c1ecefbe297cdb6
 
 PODFILE CHECKSUM: cdec7a9b5bf338e8f41916eb1ec5588703a9dc16

--- a/demos/Pesto/Podfile.lock
+++ b/demos/Pesto/Podfile.lock
@@ -15,16 +15,6 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ButtonBar (26.0.0):
-    - MaterialComponents/ButtonBar/ColorThemer (= 26.0.0)
-    - MaterialComponents/ButtonBar/Component (= 26.0.0)
-    - MaterialComponents/Buttons
-    - MaterialComponents/private/RTL
-  - MaterialComponents/ButtonBar/ColorThemer (26.0.0):
-    - MaterialComponents/ButtonBar/Component
-    - MaterialComponents/Buttons
-    - MaterialComponents/private/RTL
-    - MaterialComponents/Themes
   - MaterialComponents/ButtonBar/Component (26.0.0):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
@@ -116,7 +106,7 @@ PODS:
     - MaterialComponents/NavigationBar/Component
     - MaterialComponents/Themes
   - MaterialComponents/NavigationBar/Component (26.0.0):
-    - MaterialComponents/ButtonBar
+    - MaterialComponents/ButtonBar/Component
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
@@ -161,7 +151,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  MaterialComponents: 45604ca1d02b856c5fe862f91b5047ab1e3ee366
+  MaterialComponents: 5ca5a2d73c93a471add1d9b59db0a9b8d948bce3
   MDFTextAccessibility: 94098925e0853551c5a311ce7c1ecefbe297cdb6
 
 PODFILE CHECKSUM: cdec7a9b5bf338e8f41916eb1ec5588703a9dc16

--- a/demos/Shrine/Podfile.lock
+++ b/demos/Shrine/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - MaterialComponents/AppBar (26.0.0):
-    - MaterialComponents/AppBar/ColorThemer (= 26.0.0)
-    - MaterialComponents/AppBar/Component (= 26.0.0)
-  - MaterialComponents/AppBar/ColorThemer (26.0.0):
+  - MaterialComponents/AppBar (27.0.0):
+    - MaterialComponents/AppBar/ColorThemer (= 27.0.0)
+    - MaterialComponents/AppBar/Component (= 27.0.0)
+  - MaterialComponents/AppBar/ColorThemer (27.0.0):
     - MaterialComponents/AppBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/AppBar/Component (26.0.0):
+  - MaterialComponents/AppBar/Component (27.0.0):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
     - MaterialComponents/NavigationBar
@@ -14,20 +14,20 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ButtonBar/Component (26.0.0):
+  - MaterialComponents/ButtonBar/Component (27.0.0):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/Buttons (26.0.0):
-    - MaterialComponents/Buttons/ColorThemer (= 26.0.0)
-    - MaterialComponents/Buttons/Component (= 26.0.0)
-    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 26.0.0)
+  - MaterialComponents/Buttons (27.0.0):
+    - MaterialComponents/Buttons/ColorThemer (= 27.0.0)
+    - MaterialComponents/Buttons/Component (= 27.0.0)
+    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 27.0.0)
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/ColorThemer (26.0.0):
+  - MaterialComponents/Buttons/ColorThemer (27.0.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -36,14 +36,14 @@ PODS:
     - MaterialComponents/Themes
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/Component (26.0.0):
+  - MaterialComponents/Buttons/Component (27.0.0):
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (26.0.0):
+  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (27.0.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -51,65 +51,65 @@ PODS:
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader (26.0.0):
-    - MaterialComponents/FlexibleHeader/ColorThemer (= 26.0.0)
-    - MaterialComponents/FlexibleHeader/Component (= 26.0.0)
+  - MaterialComponents/FlexibleHeader (27.0.0):
+    - MaterialComponents/FlexibleHeader/ColorThemer (= 27.0.0)
+    - MaterialComponents/FlexibleHeader/Component (= 27.0.0)
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/ColorThemer (26.0.0):
+  - MaterialComponents/FlexibleHeader/ColorThemer (27.0.0):
     - MaterialComponents/FlexibleHeader/Component
     - MaterialComponents/private/Application
     - MaterialComponents/Themes
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/Component (26.0.0):
+  - MaterialComponents/FlexibleHeader/Component (27.0.0):
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/HeaderStackView (26.0.0):
-    - MaterialComponents/HeaderStackView/ColorThemer (= 26.0.0)
-    - MaterialComponents/HeaderStackView/Component (= 26.0.0)
-  - MaterialComponents/HeaderStackView/ColorThemer (26.0.0):
+  - MaterialComponents/HeaderStackView (27.0.0):
+    - MaterialComponents/HeaderStackView/ColorThemer (= 27.0.0)
+    - MaterialComponents/HeaderStackView/Component (= 27.0.0)
+  - MaterialComponents/HeaderStackView/ColorThemer (27.0.0):
     - MaterialComponents/HeaderStackView/Component
     - MaterialComponents/Themes
-  - MaterialComponents/HeaderStackView/Component (26.0.0)
-  - MaterialComponents/Ink (26.0.0):
-    - MaterialComponents/Ink/ColorThemer (= 26.0.0)
-    - MaterialComponents/Ink/Component (= 26.0.0)
-  - MaterialComponents/Ink/ColorThemer (26.0.0):
+  - MaterialComponents/HeaderStackView/Component (27.0.0)
+  - MaterialComponents/Ink (27.0.0):
+    - MaterialComponents/Ink/ColorThemer (= 27.0.0)
+    - MaterialComponents/Ink/Component (= 27.0.0)
+  - MaterialComponents/Ink/ColorThemer (27.0.0):
     - MaterialComponents/Ink/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Ink/Component (26.0.0)
-  - MaterialComponents/NavigationBar (26.0.0):
-    - MaterialComponents/NavigationBar/ColorThemer (= 26.0.0)
-    - MaterialComponents/NavigationBar/Component (= 26.0.0)
-  - MaterialComponents/NavigationBar/ColorThemer (26.0.0):
+  - MaterialComponents/Ink/Component (27.0.0)
+  - MaterialComponents/NavigationBar (27.0.0):
+    - MaterialComponents/NavigationBar/ColorThemer (= 27.0.0)
+    - MaterialComponents/NavigationBar/Component (= 27.0.0)
+  - MaterialComponents/NavigationBar/ColorThemer (27.0.0):
     - MaterialComponents/NavigationBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/NavigationBar/Component (26.0.0):
+  - MaterialComponents/NavigationBar/Component (27.0.0):
     - MaterialComponents/ButtonBar/Component
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/PageControl (26.0.0):
-    - MaterialComponents/PageControl/ColorThemer (= 26.0.0)
-    - MaterialComponents/PageControl/Component (= 26.0.0)
-  - MaterialComponents/PageControl/ColorThemer (26.0.0):
+  - MaterialComponents/PageControl (27.0.0):
+    - MaterialComponents/PageControl/ColorThemer (= 27.0.0)
+    - MaterialComponents/PageControl/Component (= 27.0.0)
+  - MaterialComponents/PageControl/ColorThemer (27.0.0):
     - MaterialComponents/PageControl/Component
     - MaterialComponents/Themes
-  - MaterialComponents/PageControl/Component (26.0.0)
-  - MaterialComponents/private/Application (26.0.0)
-  - MaterialComponents/private/Icons/Base (26.0.0)
-  - MaterialComponents/private/Icons/ic_arrow_back (26.0.0):
+  - MaterialComponents/PageControl/Component (27.0.0)
+  - MaterialComponents/private/Application (27.0.0)
+  - MaterialComponents/private/Icons/Base (27.0.0)
+  - MaterialComponents/private/Icons/ic_arrow_back (27.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Math (26.0.0)
-  - MaterialComponents/private/RTL (26.0.0)
-  - MaterialComponents/ShadowElevations (26.0.0)
-  - MaterialComponents/ShadowLayer (26.0.0)
-  - MaterialComponents/Themes (26.0.0)
-  - MaterialComponents/Typography (26.0.0):
+  - MaterialComponents/private/Math (27.0.0)
+  - MaterialComponents/private/RTL (27.0.0)
+  - MaterialComponents/ShadowElevations (27.0.0)
+  - MaterialComponents/ShadowLayer (27.0.0)
+  - MaterialComponents/Themes (27.0.0)
+  - MaterialComponents/Typography (27.0.0):
     - MaterialComponents/private/Application
   - MDFTextAccessibility (1.2.0)
-  - RemoteImageServiceForMDCDemos (26.0.0)
+  - RemoteImageServiceForMDCDemos (27.0.0)
 
 DEPENDENCIES:
   - MaterialComponents/AppBar (from `../../`)
@@ -123,9 +123,9 @@ EXTERNAL SOURCES:
     :path: "../supplemental"
 
 SPEC CHECKSUMS:
-  MaterialComponents: 5ca5a2d73c93a471add1d9b59db0a9b8d948bce3
+  MaterialComponents: 43a68108ffb2018e7019394ceebff34d43218763
   MDFTextAccessibility: 94098925e0853551c5a311ce7c1ecefbe297cdb6
-  RemoteImageServiceForMDCDemos: 0b2eed6c2fe8691f530f50ebc7b66838b15d0d3b
+  RemoteImageServiceForMDCDemos: 2a5497b502a8eb8a118b29469e0499264930c06f
 
 PODFILE CHECKSUM: 5eb94d7fb8deeb6709b7300f5d0e0e1a75902cca
 

--- a/demos/Shrine/Podfile.lock
+++ b/demos/Shrine/Podfile.lock
@@ -14,16 +14,6 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ButtonBar (26.0.0):
-    - MaterialComponents/ButtonBar/ColorThemer (= 26.0.0)
-    - MaterialComponents/ButtonBar/Component (= 26.0.0)
-    - MaterialComponents/Buttons
-    - MaterialComponents/private/RTL
-  - MaterialComponents/ButtonBar/ColorThemer (26.0.0):
-    - MaterialComponents/ButtonBar/Component
-    - MaterialComponents/Buttons
-    - MaterialComponents/private/RTL
-    - MaterialComponents/Themes
   - MaterialComponents/ButtonBar/Component (26.0.0):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
@@ -95,7 +85,7 @@ PODS:
     - MaterialComponents/NavigationBar/Component
     - MaterialComponents/Themes
   - MaterialComponents/NavigationBar/Component (26.0.0):
-    - MaterialComponents/ButtonBar
+    - MaterialComponents/ButtonBar/Component
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
@@ -133,7 +123,7 @@ EXTERNAL SOURCES:
     :path: "../supplemental"
 
 SPEC CHECKSUMS:
-  MaterialComponents: 45604ca1d02b856c5fe862f91b5047ab1e3ee366
+  MaterialComponents: 5ca5a2d73c93a471add1d9b59db0a9b8d948bce3
   MDFTextAccessibility: 94098925e0853551c5a311ce7c1ecefbe297cdb6
   RemoteImageServiceForMDCDemos: 0b2eed6c2fe8691f530f50ebc7b66838b15d0d3b
 

--- a/demos/ZShadow/Podfile.lock
+++ b/demos/ZShadow/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - MaterialComponents/ShadowElevations (26.0.0)
-  - MaterialComponents/ShadowLayer (26.0.0)
+  - MaterialComponents/ShadowElevations (27.0.0)
+  - MaterialComponents/ShadowLayer (27.0.0)
 
 DEPENDENCIES:
   - MaterialComponents/ShadowElevations (from `../../`)
@@ -11,7 +11,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  MaterialComponents: 5ca5a2d73c93a471add1d9b59db0a9b8d948bce3
+  MaterialComponents: 43a68108ffb2018e7019394ceebff34d43218763
 
 PODFILE CHECKSUM: 238ed9ba58d5e4a3638e6cea92b00109641989f8
 

--- a/demos/ZShadow/Podfile.lock
+++ b/demos/ZShadow/Podfile.lock
@@ -11,7 +11,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  MaterialComponents: 45604ca1d02b856c5fe862f91b5047ab1e3ee366
+  MaterialComponents: 5ca5a2d73c93a471add1d9b59db0a9b8d948bce3
 
 PODFILE CHECKSUM: 238ed9ba58d5e4a3638e6cea92b00109641989f8
 

--- a/demos/supplemental/RemoteImageServiceForMDCDemos.podspec
+++ b/demos/supplemental/RemoteImageServiceForMDCDemos.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RemoteImageServiceForMDCDemos"
-  s.version      = "26.0.0"
+  s.version      = "27.0.0"
   s.summary      = "A helper image class for the MDC demos."
   s.description  = "This spec is made for use in the MDC demos. It gets images via url."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/scripts/test_all
+++ b/scripts/test_all
@@ -16,8 +16,12 @@
 
 readonly SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly ROOT_DIR="$(dirname $SCRIPTS_DIR)"
-readonly DESTINATION="platform=iOS Simulator,name=iPhone 7,OS=latest"
 readonly COVERAGE_OPTIONS="GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES -enableCodeCoverage YES"
+
+# When run on Travis CI, this variable should be passed in
+if [[ ! $DESTINATION ]]; then
+  DESTINATION="platform=iOS Simulator,name=iPhone 7,OS=latest"
+fi
 
 # Given a path to an Xcode log file in $1, print a guess at what caused the
 # failure.
@@ -36,7 +40,7 @@ else
 fi
 
 all_tests_ok=1
-for workspace_scheme in $WORKSPACE_SCHEMES; do  
+for workspace_scheme in $WORKSPACE_SCHEMES; do
   workspace=$(echo $workspace_scheme | cut -d: -f1)
   scheme=$(echo $workspace_scheme | cut -d: -f2)
 
@@ -60,7 +64,7 @@ for workspace_scheme in $WORKSPACE_SCHEMES; do
   fi
 done
 
-# If any test failed, exit with a failure exit status so continuous integration 
+# If any test failed, exit with a failure exit status so continuous integration
 # tools can react appropriately.
 if [ "$all_tests_ok" -eq 1 ]; then
   exit 0


### PR DESCRIPTION
# 27.0.0

## API Diffs

### Button

* Removed 'resetElevationForState'.
* Removed NS_UNAVAILABLE from 'setBackgroundColor'.

## Component changes

### ActivityIndicator

#### Changes

* [[Activity Indicator] Add import to QuartzCore (#1587)](https://github.com/material-components/material-components-ios/commit/97098c6caa3f3acafa5500fe788cf7a842e9135e) (Randall Li)

### AppBar

#### Changes

* [Explicitly annotating some known ObjC methods. (#1617)](https://github.com/material-components/material-components-ios/commit/1e14d4109178956486863dec607996100c91795e) (Martin Petrov)

### BottomSheet

#### Changes

* [[KeyboardWatcher] iOS 8 simplification and cleanup (#1589)](https://github.com/material-components/material-components-ios/commit/87574e57e313cb3e90281b3225031b329e8f91de) (ianegordon)

### ButtonBar

#### Changes

* [Explicitly annotating some known ObjC methods. (#1617)](https://github.com/material-components/material-components-ios/commit/1e14d4109178956486863dec607996100c91795e) (Martin Petrov)
* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)

### Buttons

#### Changes

* [Elevation clean up (#1574)](https://github.com/material-components/material-components-ios/commit/eec61cf77316c2853f52070931cb8472a1ced48e) (Sam Morrison)
* [Explicitly annotating some known ObjC methods. (#1617)](https://github.com/material-components/material-components-ios/commit/1e14d4109178956486863dec607996100c91795e) (Martin Petrov)
* [Ink should ignore content edge insets (#1593)](https://github.com/material-components/material-components-ios/commit/cc57a0791890b07cd268da8f3950cb74b4729825) (Robert Moore)
* [Remove NS_UNAVAILABLE from setBackgroundColor (#1572)](https://github.com/material-components/material-components-ios/commit/467b843b169d07f8d71ea8d4dc55df7b03ac7900) (Sam Morrison)
* [Remove trailing spaces from test (#1602)](https://github.com/material-components/material-components-ios/commit/418a5a65fceaadb669a87646c5b17ac53b77e39b) (Sam Morrison)
* [Sort property/method definitions (#1599)](https://github.com/material-components/material-components-ios/commit/360d504442fe1b5cd80a3923e9c875e6c58d0adf) (Sam Morrison)

### CollectionCells

#### Changes

* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)
* [Reset cells in prepareForReuse (#1633)](https://github.com/material-components/material-components-ios/commit/25b7c217ca3ed0d082abb4406c400cd8405d63ee) (Robert Moore)

### Collections

#### Changes

* [Do not invalidate layout for all gesture beginning (#1623)](https://github.com/material-components/material-components-ios/commit/0b905c647d3267ca0d3332226fbf806a5c538bb1) (Gauthier Ambard)
* [Fallback to default cell background color on nil. (#1630)](https://github.com/material-components/material-components-ios/commit/3c92cfe80c6a8b795f52b1baaf6525e0624d433d) (Yurii Samsoniuk)
* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)

### Dialogs

#### Changes

* [Explicitly annotating some known ObjC methods. (#1617)](https://github.com/material-components/material-components-ios/commit/1e14d4109178956486863dec607996100c91795e) (Martin Petrov)
* [[Docs] Replaced internal site references with public equivalents. (#1616)](https://github.com/material-components/material-components-ios/commit/0abca36dbbc455c42795efe7e207419b2f1b6e5b) (Adrian Secord)
* [[KeyboardWatcher] iOS 8 simplification and cleanup (#1589)](https://github.com/material-components/material-components-ios/commit/87574e57e313cb3e90281b3225031b329e8f91de) (ianegordon)

### FeatureHighlight

#### Changes

* [[Docs] Replaced internal site references with public equivalents. (#1616)](https://github.com/material-components/material-components-ios/commit/0abca36dbbc455c42795efe7e207419b2f1b6e5b) (Adrian Secord)

### FlexibleHeader

#### Changes

* [- Updated unit tests (#1619)](https://github.com/material-components/material-components-ios/commit/921241302a7e3f92c8941bf52c6d50f8aaeaf2a2) (Justin Shephard)

### Ink

#### Changes

* [[Docs] Replaced internal site references with public equivalents. (#1616)](https://github.com/material-components/material-components-ios/commit/0abca36dbbc455c42795efe7e207419b2f1b6e5b) (Adrian Secord)

### NavigationBar

#### Changes

* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)

### PageControl

#### Changes

* [Explicitly annotating some known ObjC methods. (#1617)](https://github.com/material-components/material-components-ios/commit/1e14d4109178956486863dec607996100c91795e) (Martin Petrov)
* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)

### ProgressView

#### Changes

* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)

### ShadowLayer

#### Changes

* [Explicitly annotating some known ObjC methods. (#1617)](https://github.com/material-components/material-components-ios/commit/1e14d4109178956486863dec607996100c91795e) (Martin Petrov)
* [Support layer copying (#1625)](https://github.com/material-components/material-components-ios/commit/2283e04f02fe15588e95ed7564e53abeef926cba) (Robert Moore)

### Slider

#### Changes

* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)

### Snackbar

#### Changes

* [[KeyboardWatcher] iOS 8 simplification and cleanup (#1589)](https://github.com/material-components/material-components-ios/commit/87574e57e313cb3e90281b3225031b329e8f91de) (ianegordon)

### Tabs

#### Changes

* [Constrain tabs to the view's width (#1615)](https://github.com/material-components/material-components-ios/commit/00ee81453977901ca03ef987d229a20ca51cba06) (Brian Moore)
* [Explicitly annotating some known ObjC methods. (#1617)](https://github.com/material-components/material-components-ios/commit/1e14d4109178956486863dec607996100c91795e) (Martin Petrov)
* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)
* [Restore initial tab selection behavior (#1605)](https://github.com/material-components/material-components-ios/commit/60db284cb2803e873a4a03ba9a57d1a2ab8b6226) (Brian Moore)

### TextFields

#### Changes

* [Explicitly annotating some known ObjC methods. (#1617)](https://github.com/material-components/material-components-ios/commit/1e14d4109178956486863dec607996100c91795e) (Martin Petrov)
* [Fixes for minor bugs and comment improvements (#1588)](https://github.com/material-components/material-components-ios/commit/6b2cddba39c78b66d1401c6d280632de5857c940) (Will Larche)
* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)
* [[TextField] Update demo alert to indicate floating setting. (#1612)](https://github.com/material-components/material-components-ios/commit/7a26712eb96036e416b1937752ac6b164ebac1fc) (Donna McCulloch)

### Typography

#### Changes

* [Remove uses of `typeof` and the `?:` operator (#1601)](https://github.com/material-components/material-components-ios/commit/fa10d655d7f42f9e564636deb6f32573c3975cfe) (Robert Moore)