### PR TITLE
[Ink] Ink reset passes animation value to ripples

### DIFF
--- a/components/Ink/src/private/MDCInkLayer+Testing.h
+++ b/components/Ink/src/private/MDCInkLayer+Testing.h
@@ -1,0 +1,28 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCInkLayer.h"
+
+@interface MDCInkLayerRipple : CAShapeLayer
+@end
+
+@interface MDCInkLayerForegroundRipple : MDCInkLayerRipple
+- (void)exit:(BOOL)animated;
+@end
+
+@interface MDCInkLayerBackgroundRipple : MDCInkLayerRipple
+- (void)exit:(BOOL)animated;
+@end

--- a/components/Ink/src/private/MDCInkLayer.m
+++ b/components/Ink/src/private/MDCInkLayer.m
@@ -15,6 +15,7 @@
  */
 
 #import "MDCInkLayer.h"
+#import "MDCInkLayer+Testing.h"
 
 #import <UIKit/UIKit.h>
 
@@ -87,7 +88,12 @@ typedef NS_ENUM(NSInteger, MDCInkRippleState) {
 
 @end
 
-@interface MDCInkLayerRipple : CAShapeLayer
+#if defined(__IPHONE_10_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0)
+@interface MDCInkLayerRipple () <CAAnimationDelegate>
+@end
+#endif
+
+@interface MDCInkLayerRipple ()
 
 @property(nonatomic, assign, getter=isAnimationCleared) BOOL animationCleared;
 @property(nonatomic, weak) id<MDCInkLayerRippleDelegate> animationDelegate;
@@ -98,13 +104,7 @@ typedef NS_ENUM(NSInteger, MDCInkRippleState) {
 @property(nonatomic, assign) CGRect targetFrame;
 @property(nonatomic, assign) MDCInkRippleState rippleState;
 @property(nonatomic, strong) UIColor *color;
-
 @end
-
-#if defined(__IPHONE_10_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0)
-@interface MDCInkLayerRipple () <CAAnimationDelegate>
-@end
-#endif
 
 @implementation MDCInkLayerRipple
 
@@ -197,14 +197,12 @@ static NSString *const kInkLayerForegroundOpacityAnim = @"foregroundOpacityAnim"
 static NSString *const kInkLayerForegroundPositionAnim = @"foregroundPositionAnim";
 static NSString *const kInkLayerForegroundScaleAnim = @"foregroundScaleAnim";
 
-@interface MDCInkLayerForegroundRipple : MDCInkLayerRipple
-
+@interface MDCInkLayerForegroundRipple ()
 @property(nonatomic, assign) BOOL useCustomInkCenter;
 @property(nonatomic, assign) CGPoint customInkCenter;
 @property(nonatomic, strong) CAKeyframeAnimation *foregroundOpacityAnim;
 @property(nonatomic, strong) CAKeyframeAnimation *foregroundPositionAnim;
 @property(nonatomic, strong) CAKeyframeAnimation *foregroundScaleAnim;
-
 @end
 
 @implementation MDCInkLayerForegroundRipple
@@ -379,10 +377,8 @@ static CGFloat const kInkLayerBackgroundBaseOpacityExitDuration = 0.48f;
 static CGFloat const kInkLayerBackgroundFastEnterDuration = 0.12f;
 static NSString *const kInkLayerBackgroundOpacityAnim = @"backgroundOpacityAnim";
 
-@interface MDCInkLayerBackgroundRipple : MDCInkLayerRipple
-
+@interface MDCInkLayerBackgroundRipple ()
 @property(nonatomic, strong) CAKeyframeAnimation *backgroundOpacityAnim;
-
 @end
 
 @implementation MDCInkLayerBackgroundRipple
@@ -452,7 +448,9 @@ static NSString *const kInkLayerBackgroundOpacityAnim = @"backgroundOpacityAnim"
  @param point Evaporate the ink towards the point.
  @param completionBlock Block called after the completion of the animation.
  */
-- (void)resetBottomInk:(BOOL)animated toPoint:(CGPoint)point completion:(void (^)(void))completionBlock;
+- (void)resetBottomInk:(BOOL)animated
+               toPoint:(CGPoint)point
+            completion:(void (^)(void))completionBlock;
 
 @property(nonatomic, strong) CAShapeLayer *compositeRipple;
 @property(nonatomic, strong) NSMutableArray<MDCInkLayerForegroundRipple *> *foregroundRipples;
@@ -493,11 +491,11 @@ static NSString *const kInkLayerBackgroundOpacityAnim = @"backgroundOpacityAnim"
 }
 
 - (void)resetAllInk:(BOOL)animated {
-  if (self.foregroundRipples.count > 0) {
-    [self.foregroundRipples makeObjectsPerformSelector:@selector(exit:)];
+  for (MDCInkLayerForegroundRipple *foregroundRipple in self.foregroundRipples) {
+    [foregroundRipple exit:animated];
   }
-  if (self.backgroundRipples.count > 0) {
-    [self.backgroundRipples makeObjectsPerformSelector:@selector(exit:)];
+  for (MDCInkLayerBackgroundRipple *backgroundRipple in self.backgroundRipples) {
+    [backgroundRipple exit:animated];
   }
 }
 

--- a/components/Ink/tests/unit/MDCInkLayerTests.m
+++ b/components/Ink/tests/unit/MDCInkLayerTests.m
@@ -1,0 +1,102 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+@import XCTest;
+#import "MDCInkLayer+Testing.h"
+
+#pragma mark - Property exposure
+
+@interface MDCInkLayer (UnitTests)
+
+@property(nonatomic, strong) NSMutableArray<MDCInkLayerForegroundRipple *> *foregroundRipples;
+@property(nonatomic, strong) NSMutableArray<MDCInkLayerBackgroundRipple *> *backgroundRipples;
+
+@end
+
+#pragma mark - Subclasses for testing
+
+@interface MDCFakeForegroundRipple : MDCInkLayerForegroundRipple
+
+@property(nonatomic, assign) BOOL exitAnimationParameter;
+
+@end
+
+@implementation MDCFakeForegroundRipple
+
+- (void)exit:(BOOL)animated {
+  self.exitAnimationParameter = animated;
+}
+
+@end
+
+@interface MDCFakeBackgroundRipple : MDCInkLayerBackgroundRipple
+
+@property(nonatomic, assign) BOOL exitAnimationParameter;
+
+@end
+
+@implementation MDCFakeBackgroundRipple
+
+- (void)exit:(BOOL)animated {
+  self.exitAnimationParameter = animated;
+}
+
+@end
+
+#pragma mark - Tests
+
+@interface MDCInkLayerTests : XCTestCase
+@end
+
+@implementation MDCInkLayerTests
+
+- (void)testResetRipplesWithoutAnimation {
+  // Given
+  MDCInkLayer *inkLayer = [[MDCInkLayer alloc] init];
+  MDCFakeForegroundRipple *fakeForegroundRipple = [[MDCFakeForegroundRipple alloc] init];
+  MDCFakeBackgroundRipple *fakeBackgroundRipple = [[MDCFakeBackgroundRipple alloc] init];
+
+  // When
+  [inkLayer.foregroundRipples addObject:fakeForegroundRipple];
+  [inkLayer.backgroundRipples addObject:fakeBackgroundRipple];
+  [inkLayer resetAllInk:NO];
+
+  // Then
+  XCTAssertFalse(fakeForegroundRipple.exitAnimationParameter,
+                 @"When calling without animation, the ripple should receive a 'NO' argument");
+  XCTAssertFalse(fakeBackgroundRipple.exitAnimationParameter,
+                 @"When calling without animation, the ripple should receive a 'NO' argument");
+}
+
+- (void)testResetRipplesWithAnimation {
+  // Given
+  MDCInkLayer *inkLayer = [[MDCInkLayer alloc] init];
+  MDCFakeForegroundRipple *fakeForegroundRipple = [[MDCFakeForegroundRipple alloc] init];
+  MDCFakeBackgroundRipple *fakeBackgroundRipple = [[MDCFakeBackgroundRipple alloc] init];
+
+  // When
+  [inkLayer.foregroundRipples addObject:fakeForegroundRipple];
+  [inkLayer.backgroundRipples addObject:fakeBackgroundRipple];
+  [inkLayer resetAllInk:YES];
+
+  // Then
+  XCTAssertTrue(fakeForegroundRipple.exitAnimationParameter,
+                @"When calling without animation, the ripple should receive a 'NO' argument");
+  XCTAssertTrue(fakeBackgroundRipple.exitAnimationParameter,
+                @"When calling without animation, the ripple should receive a 'NO' argument");
+}
+
+@end


### PR DESCRIPTION
When the MDCInkLayer resets ink, it will now pass the `animated` parameter to the ripple sublayers. This fixes a bug where resetting the ink without animation would cause animations to be executed.

Closes #1651
