### PR TITLE
[Buttons] Reset Ink when moved to new superview

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -283,6 +283,13 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   return CGRectContainsPoint(UIEdgeInsetsInsetRect(self.bounds, _hitAreaInsets), point);
 }
 
+- (void)willMoveToSuperview:(UIView *)newSuperview {
+  [super willMoveToSuperview:newSuperview];
+  if (newSuperview) {
+    [self.inkView cancelAllAnimationsAnimated:NO];
+  }
+}
+
 #pragma mark - UIResponder
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -285,11 +285,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (void)willMoveToSuperview:(UIView *)newSuperview {
   [super willMoveToSuperview:newSuperview];
-  if (newSuperview) {
-    [self.inkView cancelAllAnimationsAnimated:YES];
-  } else {
-    [self.inkView cancelAllAnimationsAnimated:NO];
-  }
+  [self.inkView cancelAllAnimationsAnimated:NO];
 }
 
 #pragma mark - UIResponder

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -285,7 +285,9 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (void)willMoveToSuperview:(UIView *)newSuperview {
   [super willMoveToSuperview:newSuperview];
-  if (newSuperview == nil) {
+  if (newSuperview) {
+    [self.inkView cancelAllAnimationsAnimated:YES];
+  } else {
     [self.inkView cancelAllAnimationsAnimated:NO];
   }
 }

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -285,7 +285,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (void)willMoveToSuperview:(UIView *)newSuperview {
   [super willMoveToSuperview:newSuperview];
-  if (newSuperview) {
+  if (newSuperview == nil) {
     [self.inkView cancelAllAnimationsAnimated:NO];
   }
 }

--- a/components/Ink/src/private/MDCInkLayer.m
+++ b/components/Ink/src/private/MDCInkLayer.m
@@ -168,7 +168,6 @@ typedef NS_ENUM(NSInteger, MDCInkRippleState) {
 
 - (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)finished {
   if (!self.isAnimationCleared) {
-    [self removeFromSuperlayer];
     [self.animationDelegate animationDidStop:anim shapeLayer:self finished:finished];
   }
 }
@@ -588,6 +587,8 @@ static NSString *const kInkLayerBackgroundOpacityAnim = @"backgroundOpacityAnim"
 - (void)animationDidStop:(CAAnimation *)anim
               shapeLayer:(CAShapeLayer *)shapeLayer
                 finished:(BOOL)finished {
+  // Even when the ripple is "exited" without animation, we need to remove it from compositeRipple
+  [shapeLayer removeFromSuperlayer];
   [shapeLayer removeAllAnimations];
 
   if ([shapeLayer isMemberOfClass:[MDCInkLayerForegroundRipple class]]) {

--- a/components/Ink/src/private/MDCInkLayer.m
+++ b/components/Ink/src/private/MDCInkLayer.m
@@ -271,6 +271,8 @@ static NSString *const kInkLayerForegroundScaleAnim = @"foregroundScaleAnim";
     __weak MDCInkLayerForegroundRipple *weakSelf = self;
     [CATransaction setCompletionBlock:^(void) {
       MDCInkLayerForegroundRipple *strongSelf = weakSelf;
+      [strongSelf removeFromSuperlayer];
+
       if ([strongSelf.animationDelegate
               respondsToSelector:@selector(animationDidStop:shapeLayer:finished:)]) {
         [strongSelf.animationDelegate animationDidStop:nil shapeLayer:strongSelf finished:YES];
@@ -398,6 +400,8 @@ static NSString *const kInkLayerBackgroundOpacityAnim = @"backgroundOpacityAnim"
     __weak MDCInkLayerBackgroundRipple *weakSelf = self;
     [CATransaction setCompletionBlock:^(void) {
       MDCInkLayerBackgroundRipple *strongSelf = weakSelf;
+      [strongSelf removeFromSuperlayer];
+
       if ([strongSelf.animationDelegate
               respondsToSelector:@selector(animationDidStop:shapeLayer:finished:)]) {
         [strongSelf.animationDelegate animationDidStop:nil shapeLayer:strongSelf finished:YES];


### PR DESCRIPTION
MDCButton will now reset all Ink effects before it is added to a new
superview. This prevents retaining Ripple objects indefinitely if the
button is moved between superviews while a touch is held down.

Closes #1655