### PR TITLE
[Snackbar] Notify MDCOverlayObservers of bottom offset changes 

### DIFF
--- a/components/Snackbar/examples/SnackbarOverlayViewExample.m
+++ b/components/Snackbar/examples/SnackbarOverlayViewExample.m
@@ -22,12 +22,13 @@
 
 static const CGFloat kFABBottomOffset = 24.0f;
 static const CGFloat kFABSideOffset = 24.0f;
+static const CGFloat kBottomBarHeight = 44.0f;
 
 @implementation SnackbarOverlayViewExample
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  [self setupExampleViews:@[@"Show Snackbar"]];
+  [self setupExampleViews:@[@"Show Snackbar", @"Toggle bottom bar"]];
   self.title = @"Snackbar Overlay View";
 
   // Make sure we're listening for overlay notifications.
@@ -51,17 +52,50 @@ static const CGFloat kFABSideOffset = 24.0f;
   self.floatingButton.frame = fabFrame;
   self.floatingButton.autoresizingMask =
       (UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin);
+
+  self.bottomBar = [[UIView alloc] initWithFrame:CGRectMake(0,
+                                                            CGRectGetMaxY(self.view.bounds),
+                                                            CGRectGetMaxX(self.view.bounds),
+                                                            kBottomBarHeight)];
+  self.bottomBar.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
+  self.bottomBar.backgroundColor = [UIColor redColor];
+  [self.view addSubview:self.bottomBar];
 }
 
 #pragma mark - Event Handling
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
   [super collectionView:collectionView didSelectItemAtIndexPath:indexPath];
+  if (indexPath.row == 0) {
+    [self showSnackbar];
+  } else {
+    [self toggleBottomBar];
+  }
+  return;
+}
+
+- (void)showSnackbar {
   NSString *text = @"Snackbar Message";
   MDCSnackbarMessage *message = [MDCSnackbarMessage messageWithText:text];
   message.duration = 5.0f;
   [MDCSnackbarManager showMessage:message];
-  return;
+}
+
+- (void)toggleBottomBar {
+  self.isShowingBottomBar = !self.isShowingBottomBar;
+
+  CGFloat bottomOffset = 0;
+  CGFloat translation = kBottomBarHeight;
+
+  if (self.isShowingBottomBar) {
+    translation = -translation;
+    bottomOffset = kBottomBarHeight;
+  }
+
+  [UIView animateWithDuration:0.25 animations:^{
+      self.bottomBar.frame = CGRectOffset(self.bottomBar.frame, 0, translation);
+      [MDCSnackbarManager setBottomOffset:bottomOffset];
+  }];
 }
 
 #pragma mark - Overlay Transitions

--- a/components/Snackbar/examples/SnackbarOverlayViewExample.m
+++ b/components/Snackbar/examples/SnackbarOverlayViewExample.m
@@ -54,8 +54,8 @@ static const CGFloat kBottomBarHeight = 44.0f;
       (UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin);
 
   self.bottomBar = [[UIView alloc] initWithFrame:CGRectMake(0,
-                                                            CGRectGetMaxY(self.view.bounds),
-                                                            CGRectGetMaxX(self.view.bounds),
+                                                            CGRectGetHeight(self.view.bounds),
+                                                            CGRectGetWidth(self.view.bounds),
                                                             kBottomBarHeight)];
   self.bottomBar.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
   self.bottomBar.backgroundColor = [UIColor redColor];

--- a/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.h
+++ b/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.h
@@ -30,6 +30,10 @@
 /** The floating action button shown in the bottom right corner. */
 @property(nonatomic) MDCFloatingButton *floatingButton;
 
+@property(nonatomic) UIView *bottomBar;
+
+@property(nonatomic) BOOL isShowingBottomBar;
+
 @end
 
 @interface SnackbarSimpleExample : SnackbarExample

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -548,8 +548,8 @@ static const CGFloat kMaximumHeight = 80.0f;
     CGRect frame = [self snackbarRectInScreenCoordinates];
     if (CGRectIsNull(frame)) {
       frame = CGRectMake(0,
-                         CGRectGetMaxY(self.frame) - self.bottomOffset,
-                         CGRectGetMaxX(self.frame),
+                         CGRectGetHeight(self.frame) - self.bottomOffset,
+                         CGRectGetWidth(self.frame),
                          self.bottomOffset);
     }
     [self notifyOverlayChangeWithFrame:frame

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -542,6 +542,20 @@ static const CGFloat kMaximumHeight = 80.0f;
 
     self.bottomConstraint.constant = -[self dynamicBottomMargin];
     [self triggerSnackbarLayoutChange];
+
+    // If there is no snackbar the following method returns CGRectNull, but we still need to notify
+    // observers of bottom offset changes.
+    CGRect frame = [self snackbarRectInScreenCoordinates];
+    if (CGRectIsNull(frame)) {
+      frame = CGRectMake(0,
+                         CGRectGetMaxY(self.frame) - self.bottomOffset,
+                         CGRectGetMaxX(self.frame),
+                         self.bottomOffset);
+    }
+    [self notifyOverlayChangeWithFrame:frame
+                              duration:[CATransaction animationDuration]
+                                 curve:UIViewAnimationCurveEaseInOut
+                        timingFunction:nil];
   }
 }
 


### PR DESCRIPTION
Notify MDCOverlayObservers of `MDCSnackbarManager.bottomOffset` changes and update an example to showcase this.

Closes #1643.