### PR TITLE
[TextFields] Reorganizing and internal clean up

### DIFF
--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -123,6 +123,20 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
                       object:self];
 }
 
+#pragma mark - Layout
+
+- (UIEdgeInsets)textInsets {
+  UIEdgeInsets textInsets = UIEdgeInsetsZero;
+
+  textInsets.top = MDCTextInputFullPadding;
+  textInsets.bottom = MDCTextInputFullPadding;
+
+  if ([self.positioningDelegate respondsToSelector:@selector(textInsets:)]) {
+    return [self.positioningDelegate textInsets:textInsets];
+  }
+  return textInsets;
+}
+
 #pragma mark - Properties Implementation
 
 - (UIButton *)clearButton {
@@ -298,14 +312,14 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
 #pragma mark - UITextField Overrides
 
 // This method doesn't have a positioning delegate mirror per se. But it uses the
-// textContainerInsets' value that the positioning delegate can return to inset this text rect.
+// textInsets' value that the positioning delegate can return to inset this text rect.
 - (CGRect)textRectForBounds:(CGRect)bounds {
   CGRect textRect = bounds;
 
   // Standard textRect calculation
-  UIEdgeInsets textContainerInset = [_fundament textContainerInset];
-  textRect.origin.x += textContainerInset.left;
-  textRect.size.width -= textContainerInset.left + textContainerInset.right;
+  UIEdgeInsets textInsets = self.textInsets;
+  textRect.origin.x += textInsets.left;
+  textRect.size.width -= textInsets.left + textInsets.right;
 
   // Adjustments for .leftView, .rightView
   // When in RTL mode, the .rightView is presented using the leftViewRectForBounds frame and the
@@ -435,7 +449,7 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
 }
 
 - (CGFloat)centerYForOverlayViews:(CGFloat)heightOfView {
-  CGFloat centerY = [_fundament textContainerInset].top +
+  CGFloat centerY = self.textInsets.top +
                     (self.placeholderLabel.font.lineHeight / 2.f) - (heightOfView / 2.f);
   return centerY;
 }

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -174,10 +174,7 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
 }
 
 - (BOOL)needsUpdateUnderlinePosition {
-  NSInteger currentConstant = (NSInteger)(self.underlineY.constant * 1000);
-  NSInteger idealConstant = (NSInteger)([self underlineYConstant] * 1000);
-
-  return currentConstant != idealConstant;
+  return MDCCGFloatEqual(self.underlineY.constant, [self underlineYConstant]);
 }
 
 - (void)updateUnderlinePosition {

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -37,12 +37,11 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
 
 @property(nonatomic, strong) MDCTextInputCommonFundament *fundament;
 
-/** 
- 
- This constraint controls the default center Y of the underline view. 
+/**
+ Constraint for center Y of the underline view.
 
- Default is from the top of the text field with constant of height of input's font line-height +
- half padding.
+ Default constant: self.top + font line height + MDCTextInputHalfPadding. 
+ eg: ~4 pts below the input rect.
  */
 @property(nonatomic, strong) NSLayoutConstraint *underlineY;
 

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -41,7 +41,7 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
  
  This constraint controls the default center Y of the underline view. 
 
- Default is from the top of the text field with constant of height of input's font line-height + 
+ Default is from the top of the text field with constant of height of input's font line-height +
  half padding.
  */
 @property(nonatomic, strong) NSLayoutConstraint *underlineY;
@@ -157,7 +157,6 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
   underlineTrailing.priority = UILayoutPriorityDefaultLow;
   underlineTrailing.active = YES;
 
-  CGFloat estimatedTextHeight = MDCCeil(self.font.lineHeight * 2.f) / 2.f;
   _underlineY =
   [NSLayoutConstraint constraintWithItem:self.underline
                                attribute:NSLayoutAttributeCenterY
@@ -165,16 +164,14 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
                                   toItem:self
                                attribute:NSLayoutAttributeTop
                               multiplier:1
-                                constant:[self textInsets].top + estimatedTextHeight +
+                                constant:[self textInsets].top + [self estimatedTextHeight] +
    MDCTextInputHalfPadding];
   _underlineY.priority = UILayoutPriorityDefaultLow;
   _underlineY.active = YES;
 }
 
 - (CGFloat)underlineYConstant {
-  CGFloat estimatedTextHeight = MDCCeil(self.font.lineHeight * 2.f) / 2.f;
-
-  return [self textInsets].top + estimatedTextHeight + MDCTextInputHalfPadding;
+  return [self textInsets].top + [self estimatedTextHeight] + MDCTextInputHalfPadding;
 }
 
 - (BOOL)needsUpdateUnderlinePosition {
@@ -198,6 +195,12 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
     return [self.positioningDelegate textInsets:textInsets];
   }
   return textInsets;
+}
+
+- (CGFloat)estimatedTextHeight {
+  CGFloat estimatedTextHeight = MDCCeil(self.font.lineHeight * 2.f) / 2.f;
+
+  return estimatedTextHeight;
 }
 
 #pragma mark - Properties Implementation
@@ -531,9 +534,7 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
   CGSize boundingSize = CGSizeZero;
   boundingSize.width = UIViewNoIntrinsicMetric;
 
-  CGFloat estimatedTextHeight = MDCCeil(self.font.lineHeight * 2.f) / 2.f;
-
-  CGFloat height = MDCTextInputFullPadding + estimatedTextHeight + MDCTextInputHalfPadding * 2.f;
+  CGFloat height = MDCTextInputFullPadding + [self estimatedTextHeight] + MDCTextInputHalfPadding * 2.f;
 
   CGFloat underlineLabelsHeight =
       MAX(MDCCeil(self.leadingUnderlineLabel.font.lineHeight * 2.f) / 2.f,

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -368,7 +368,7 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
       (CGRectGetHeight(bounds) / 2.f) - MDCRint(MAX(self.font.lineHeight,
                                                     self.placeholderLabel.font.lineHeight) /
                                                 2.f);  // Text field or placeholder
-  actualY = textContainerInset.top - actualY;
+  actualY = textInsets.top - actualY;
   textRect.origin.y = actualY;
 
   if (self.mdc_effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -37,6 +37,13 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
 
 @property(nonatomic, strong) MDCTextInputCommonFundament *fundament;
 
+/** 
+ 
+ This constraint controls the default center Y of the underline view. 
+
+ Default is from the top of the text field with constant of height of input's font line-height + 
+ half padding.
+ */
 @property(nonatomic, strong) NSLayoutConstraint *underlineY;
 
 @end

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -175,7 +175,10 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
 }
 
 - (BOOL)needsUpdateUnderlinePosition {
-  return self.underlineY.constant != [self underlineYConstant];
+  NSInteger currentConstant = (NSInteger)(self.underlineY.constant * 1000);
+  NSInteger idealConstant = (NSInteger)([self underlineYConstant] * 1000);
+
+  return currentConstant != idealConstant;
 }
 
 - (void)updateUnderlinePosition {

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -157,14 +157,14 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
   underlineTrailing.active = YES;
 
   _underlineY =
-  [NSLayoutConstraint constraintWithItem:self.underline
-                               attribute:NSLayoutAttributeCenterY
-                               relatedBy:NSLayoutRelationEqual
-                                  toItem:self
-                               attribute:NSLayoutAttributeTop
-                              multiplier:1
-                                constant:[self textInsets].top + [self estimatedTextHeight] +
-   MDCTextInputHalfPadding];
+      [NSLayoutConstraint constraintWithItem:self.underline
+                                   attribute:NSLayoutAttributeCenterY
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:self
+                                   attribute:NSLayoutAttributeTop
+                                  multiplier:1
+                                    constant:[self textInsets].top + [self estimatedTextHeight] +
+      MDCTextInputHalfPadding];
   _underlineY.priority = UILayoutPriorityDefaultLow;
   _underlineY.active = YES;
 }

--- a/components/TextFields/src/MDCTextFieldPositioningDelegate.h
+++ b/components/TextFields/src/MDCTextFieldPositioningDelegate.h
@@ -34,7 +34,7 @@
  @param defaultInsets The value of text container insets that the MDCTextInput has calculated by
  default.
  */
-- (UIEdgeInsets)textContainerInset:(UIEdgeInsets)defaultInsets;
+- (UIEdgeInsets)textInsets:(UIEdgeInsets)defaultInsets;
 
 /**
  The area that inputted text should be displayed while isEditing = true.

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -929,7 +929,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   self.placeholderTrailingCharacterCountLeading.active = NO;
   self.placeholderTrailingSuperviewTrailing.active = NO;
 
-  UIEdgeInsets insets = [self textContainerInset:UIEdgeInsetsZero];
+  UIEdgeInsets insets = [self textInsets:UIEdgeInsetsZero];
 
   if (self.isFloatingEnabled) {
     self.heightConstraint.constant =
@@ -959,7 +959,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
 // clang-format off
 /**
- textContainerInset: is the source of truth for vertical layout. It's used to figure out the proper
+ textInsets: is the source of truth for vertical layout. It's used to figure out the proper
  height and also where to place the placeholder / text field.
  
  NOTE: It's applied before the textRect is flipped for RTL. So all calculations are done here à la
@@ -976,17 +976,17 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
  MAX(underlineLabelsOffset,MDCTextInputDefaultVerticalHalfPadding)           // Padding and/or labels
  */
 // clang-format on
-- (UIEdgeInsets)textContainerInset:(UIEdgeInsets)defaultInsets {
+- (UIEdgeInsets)textInsets:(UIEdgeInsets)defaultInsets {
   // NOTE: UITextFields have a centerY based layout. But you can change EITHER the height or the Y.
   // Not both. Don't know why. So, we have to leave the text rect as big as the bounds and move it
   // to a Y that works. In other words, no bottom inset will make a difference here for UITextFields
-  UIEdgeInsets textContainerInset = defaultInsets;
+  UIEdgeInsets textInsets = defaultInsets;
 
   if (!self.isFloatingEnabled) {
     return defaultInsets;
   }
 
-  textContainerInset.top = MDCTextInputDefaultVerticalPadding +
+  textInsets.top = MDCTextInputDefaultVerticalPadding +
                            MDCRint(self.textInput.placeholderLabel.font.lineHeight *
                                    (CGFloat)self.floatingPlaceholderScale.floatValue) +
                                    MDCTextInputDefaultVerticalHalfPadding;
@@ -1007,9 +1007,9 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   CGFloat underlineOffset = MDCTextInputDefaultVerticalHalfPadding + underlineLabelsOffset;
 
   // .bottom = underlineOffset + the half padding above the line but below the text field
-  textContainerInset.bottom = underlineOffset + MDCTextInputDefaultVerticalHalfPadding;
+  textInsets.bottom = underlineOffset + MDCTextInputDefaultVerticalHalfPadding;
 
-  return textContainerInset;
+  return textInsets;
 }
 
 - (CGSize)sizeThatFits:(CGSize)size defaultSize:(CGSize)defaultSize {

--- a/components/TextFields/src/MDCTextInputControllerFullWidth.m
+++ b/components/TextFields/src/MDCTextInputControllerFullWidth.m
@@ -714,7 +714,7 @@ static UIColor *_inlinePlaceholderColorDefault;
 
 // clang-format off
 /**
- textContainerInset: is the source of truth for vertical layout. It's used to figure out the proper
+ textInsets: is the source of truth for vertical layout. It's used to figure out the proper
  height and also where to place the placeholder / text field.
 
  NOTE: It's applied before the textRect is flipped for RTL. So all calculations are done here à la
@@ -731,21 +731,21 @@ static UIColor *_inlinePlaceholderColorDefault;
  MAX(underlineLabelsOffset,MDCTextInputVerticalHalfPadding)           // Padding and/or labels
  */
 // clang-format on
-- (UIEdgeInsets)textContainerInset:(UIEdgeInsets)defaultInsets {
+- (UIEdgeInsets)textInsets:(UIEdgeInsets)defaultInsets {
   // NOTE: UITextFields have a centerY based layout. But you can change EITHER the height or the Y.
   // Not both. Don't know why. So, we have to leave the text rect as big as the bounds and move it
   // to a Y that works. In other words, no bottom inset will make a difference here for UITextFields
-  UIEdgeInsets textContainerInset = UIEdgeInsetsZero;
+  UIEdgeInsets textInsets = UIEdgeInsetsZero;
 
-  textContainerInset.top = MDCTextInputFullWidthVerticalPadding;
-  textContainerInset.bottom = MDCTextInputFullWidthVerticalPadding;
-  textContainerInset.left = MDCTextInputFullWidthHorizontalPadding;
-  textContainerInset.right = MDCTextInputFullWidthHorizontalPadding;
+  textInsets.top = MDCTextInputFullWidthVerticalPadding;
+  textInsets.bottom = MDCTextInputFullWidthVerticalPadding;
+  textInsets.left = MDCTextInputFullWidthHorizontalPadding;
+  textInsets.right = MDCTextInputFullWidthHorizontalPadding;
 
   // The trailing label gets in the way. If it has a frame, it's used. But if not, an
   // estimate is made of the size the text will be.
   if (CGRectGetWidth(self.textInput.trailingUnderlineLabel.frame) > 1.f) {
-    textContainerInset.right +=
+    textInsets.right +=
         MDCCeil(CGRectGetWidth(self.textInput.trailingUnderlineLabel.frame));
   } else if (self.characterCountMax) {
     CGRect charCountRect = [[self characterCountText]
@@ -755,10 +755,10 @@ static UIColor *_inlinePlaceholderColorDefault;
                     NSFontAttributeName : self.textInput.trailingUnderlineLabel.font
                   }
                      context:nil];
-    textContainerInset.right += MDCCeil(CGRectGetWidth(charCountRect));
+    textInsets.right += MDCCeil(CGRectGetWidth(charCountRect));
   }
 
-  return textContainerInset;
+  return textInsets;
 }
 
 - (CGRect)editingRectForBounds:(CGRect)bounds defaultRect:(CGRect)defaultRect {
@@ -778,7 +778,7 @@ static UIColor *_inlinePlaceholderColorDefault;
       case UITextFieldViewModeWhileEditing:
         editingRect.size.width -= CGRectGetWidth(self.textInput.clearButton.bounds);
       case UITextFieldViewModeUnlessEditing:
-        // The 'defaultRect' is based on the textContainerInsets so we need to compensate for
+        // The 'defaultRect' is based on the textInsets so we need to compensate for
         // the button NOT being there.
         editingRect.size.width += CGRectGetWidth(self.textInput.clearButton.bounds);
         editingRect.size.width -= MDCTextInputFullWidthHorizontalInnerPadding;

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -713,18 +713,6 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   }
 }
 
-- (UIEdgeInsets)textContainerInset {
-  UIEdgeInsets textContainerInset = UIEdgeInsetsZero;
-
-  textContainerInset.top = MDCTextInputFullPadding;
-  textContainerInset.bottom = MDCTextInputFullPadding;
-
-  if ([self.textInput.positioningDelegate respondsToSelector:@selector(textContainerInset:)]) {
-    return [self.textInput.positioningDelegate textContainerInset:textContainerInset];
-  }
-  return textContainerInset;
-}
-
 - (void)setTextInput:(UIView<MDCTextInput> *)textInput {
   _textInput = textInput;
 
@@ -806,20 +794,28 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 }
 
 - (void)updatePlaceholderPosition {
-  self.placeholderTop.constant = [self textContainerInset].top;
+  if ([_textInput isKindOfClass:[MDCTextField class]]) {
+    MDCTextField *textField = (MDCTextField *)_textInput;
+    self.placeholderTop.constant = textField.textInsets.top;
+  }
 
   [self updatePlaceholderToOverlayViewsPosition];
   [self.textInput invalidateIntrinsicContentSize];
 }
 
 - (NSArray<NSLayoutConstraint *> *)placeholderDefaultConstaints {
+  UIEdgeInsets insets = UIEdgeInsetsZero;
+  if ([_textInput isKindOfClass:[MDCTextField class]]) {
+    insets = ((MDCTextField *)_textInput).textInsets;
+  }
+
   self.placeholderTop = [NSLayoutConstraint constraintWithItem:_placeholderLabel
                                                      attribute:NSLayoutAttributeTop
                                                      relatedBy:NSLayoutRelationEqual
                                                         toItem:_relativeSuperview
                                                      attribute:NSLayoutAttributeTop
                                                     multiplier:1
-                                                      constant:[self textContainerInset].top];
+                                                      constant:insets.top];
   [self.placeholderTop setPriority:UILayoutPriorityDefaultLow];
 
   // This can be affected by .leftView and .rightView.
@@ -830,7 +826,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                                             toItem:_relativeSuperview
                                                          attribute:NSLayoutAttributeLeading
                                                         multiplier:1
-                                                          constant:[self textContainerInset].left];
+                                                          constant:insets.left];
   [self.placeholderLeading setPriority:UILayoutPriorityDefaultLow];
 
   NSLayoutConstraint *placeholderTrailing =
@@ -840,7 +836,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                       toItem:_relativeSuperview
                                    attribute:NSLayoutAttributeTrailing
                                   multiplier:1
-                                    constant:[self textContainerInset].right];
+                                    constant:insets.right];
   placeholderTrailing.priority = UILayoutPriorityDefaultLow;
 
   return @[ self.placeholderTop, self.placeholderLeading, placeholderTrailing ];


### PR DESCRIPTION
In preparation for multiple text input classes, non-shared logic has been moved into text field and out of the fundament and text insets have been renamed.