### PR TITLE
[TextFields] Tests for default priorities of constraints.

### DIFF
--- a/components/TextFields/tests/unit/TextFieldTests.swift
+++ b/components/TextFields/tests/unit/TextFieldTests.swift
@@ -29,6 +29,8 @@ class TextFieldTests: XCTestCase {
     XCTAssertEqual(textField.attributedText?.string, string)
   }
 
+  // All the constraints created internally by the MDCTextField need to have a rather low priority 
+  // so they can be overridden by a controller from the outside.
   func testConstraintPriorities() {
     let textField = MDCTextField()
 

--- a/components/TextFields/tests/unit/TextFieldTests.swift
+++ b/components/TextFields/tests/unit/TextFieldTests.swift
@@ -29,6 +29,14 @@ class TextFieldTests: XCTestCase {
     XCTAssertEqual(textField.attributedText?.string, string)
   }
 
+  func testConstraintPriorities() {
+    let textField = MDCTextField()
+
+    for constraint in textField.constraints {
+      XCTAssertLessThanOrEqual(constraint.priority, UILayoutPriorityDefaultLow + 10, String(describing: constraint))
+    }
+  }
+
   func testCopyingTextField() {
     let textField = MDCTextField()
 


### PR DESCRIPTION
All the constraints created internally by the element need to have a rather low priority so they can be overridden by a controller if necessary.