### PR TITLE
[Buttons] Undo MDCFlatButton title color changes

### DIFF
--- a/components/Buttons/src/MDCFlatButton.m
+++ b/components/Buttons/src/MDCFlatButton.m
@@ -31,8 +31,6 @@ static NSString *const MDCFlatButtonHasOpaqueBackground = @"MDCFlatButtonHasOpaq
                                   forState:UIControlStateNormal];
   [[MDCFlatButton appearance] setElevation:MDCShadowElevationNone
                                   forState:UIControlStateHighlighted];
-  [[MDCFlatButton appearance] setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
-  [[MDCFlatButton appearance] setTitleColor:[UIColor blackColor] forState:UIControlStateDisabled];
 }
 
 - (instancetype)init {


### PR DESCRIPTION
It seems defaulting MDCFlatButton to a white title color is a bad idea.