### PR TITLE
Release candidate 29.0.0 (hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 29.0.0
+
+* Reverts changes to the title color of MDCFlatButton and MDCRaisedButton.
+
 # 28.0.0
 
 ## API Diffs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# 29.0.0
-
-* Reverts changes to the title color of MDCFlatButton and MDCRaisedButton.
-
 # 28.0.0
 
 ## API Diffs

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -2,7 +2,7 @@ load 'scripts/generated/icons.rb'
 
 Pod::Spec.new do |s|
   s.name         = "MaterialComponents"
-  s.version      = "28.0.0"
+  s.version      = "29.0.0"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/MaterialComponentsCatalog.podspec
+++ b/MaterialComponentsCatalog.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsCatalog"
-  s.version      = "28.0.0"
+  s.version      = "29.0.0"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/MaterialComponentsEarlGreyTests.podspec
+++ b/MaterialComponentsEarlGreyTests.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsEarlGreyTests"
-  s.version      = "28.0.0"
+  s.version      = "29.0.0"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/MaterialComponentsUnitTests.podspec
+++ b/MaterialComponentsUnitTests.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsUnitTests"
-  s.version      = "28.0.0"
+  s.version      = "29.0.0"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/components/Buttons/src/MDCFlatButton.m
+++ b/components/Buttons/src/MDCFlatButton.m
@@ -31,8 +31,6 @@ static NSString *const MDCFlatButtonHasOpaqueBackground = @"MDCFlatButtonHasOpaq
                                   forState:UIControlStateNormal];
   [[MDCFlatButton appearance] setElevation:MDCShadowElevationNone
                                   forState:UIControlStateHighlighted];
-  [[MDCFlatButton appearance] setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
-  [[MDCFlatButton appearance] setTitleColor:[UIColor blackColor] forState:UIControlStateDisabled];
 }
 
 - (instancetype)init {

--- a/components/Buttons/src/MDCRaisedButton.m
+++ b/components/Buttons/src/MDCRaisedButton.m
@@ -26,8 +26,6 @@
                                     forState:UIControlStateNormal];
   [[MDCRaisedButton appearance] setElevation:MDCShadowElevationRaisedButtonPressed
                                     forState:UIControlStateHighlighted];
-  [[MDCRaisedButton appearance] setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
-  [[MDCRaisedButton appearance] setTitleColor:[UIColor blackColor] forState:UIControlStateDisabled];
 }
 
 @end

--- a/demos/Bare/Podfile.lock
+++ b/demos/Bare/Podfile.lock
@@ -1,54 +1,54 @@
 PODS:
-  - MaterialComponents (28.0.0):
-    - MaterialComponents/ActivityIndicator (= 28.0.0)
-    - MaterialComponents/AnimationTiming (= 28.0.0)
-    - MaterialComponents/AppBar (= 28.0.0)
-    - MaterialComponents/BottomSheet (= 28.0.0)
-    - MaterialComponents/ButtonBar (= 28.0.0)
-    - MaterialComponents/Buttons (= 28.0.0)
-    - MaterialComponents/CollectionCells (= 28.0.0)
-    - MaterialComponents/CollectionLayoutAttributes (= 28.0.0)
-    - MaterialComponents/Collections (= 28.0.0)
-    - MaterialComponents/Dialogs (= 28.0.0)
-    - MaterialComponents/FeatureHighlight (= 28.0.0)
-    - MaterialComponents/FlexibleHeader (= 28.0.0)
-    - MaterialComponents/HeaderStackView (= 28.0.0)
-    - MaterialComponents/Ink (= 28.0.0)
-    - MaterialComponents/NavigationBar (= 28.0.0)
-    - MaterialComponents/OverlayWindow (= 28.0.0)
-    - MaterialComponents/PageControl (= 28.0.0)
-    - MaterialComponents/Palettes (= 28.0.0)
-    - MaterialComponents/private (= 28.0.0)
-    - MaterialComponents/ProgressView (= 28.0.0)
-    - MaterialComponents/ShadowElevations (= 28.0.0)
-    - MaterialComponents/ShadowLayer (= 28.0.0)
-    - MaterialComponents/Slider (= 28.0.0)
-    - MaterialComponents/Snackbar (= 28.0.0)
-    - MaterialComponents/Tabs (= 28.0.0)
-    - MaterialComponents/TextFields (= 28.0.0)
-    - MaterialComponents/Themes (= 28.0.0)
-    - MaterialComponents/Typography (= 28.0.0)
-  - MaterialComponents/ActivityIndicator (28.0.0):
-    - MaterialComponents/ActivityIndicator/ColorThemer (= 28.0.0)
-    - MaterialComponents/ActivityIndicator/Component (= 28.0.0)
+  - MaterialComponents (29.0.0):
+    - MaterialComponents/ActivityIndicator (= 29.0.0)
+    - MaterialComponents/AnimationTiming (= 29.0.0)
+    - MaterialComponents/AppBar (= 29.0.0)
+    - MaterialComponents/BottomSheet (= 29.0.0)
+    - MaterialComponents/ButtonBar (= 29.0.0)
+    - MaterialComponents/Buttons (= 29.0.0)
+    - MaterialComponents/CollectionCells (= 29.0.0)
+    - MaterialComponents/CollectionLayoutAttributes (= 29.0.0)
+    - MaterialComponents/Collections (= 29.0.0)
+    - MaterialComponents/Dialogs (= 29.0.0)
+    - MaterialComponents/FeatureHighlight (= 29.0.0)
+    - MaterialComponents/FlexibleHeader (= 29.0.0)
+    - MaterialComponents/HeaderStackView (= 29.0.0)
+    - MaterialComponents/Ink (= 29.0.0)
+    - MaterialComponents/NavigationBar (= 29.0.0)
+    - MaterialComponents/OverlayWindow (= 29.0.0)
+    - MaterialComponents/PageControl (= 29.0.0)
+    - MaterialComponents/Palettes (= 29.0.0)
+    - MaterialComponents/private (= 29.0.0)
+    - MaterialComponents/ProgressView (= 29.0.0)
+    - MaterialComponents/ShadowElevations (= 29.0.0)
+    - MaterialComponents/ShadowLayer (= 29.0.0)
+    - MaterialComponents/Slider (= 29.0.0)
+    - MaterialComponents/Snackbar (= 29.0.0)
+    - MaterialComponents/Tabs (= 29.0.0)
+    - MaterialComponents/TextFields (= 29.0.0)
+    - MaterialComponents/Themes (= 29.0.0)
+    - MaterialComponents/Typography (= 29.0.0)
+  - MaterialComponents/ActivityIndicator (29.0.0):
+    - MaterialComponents/ActivityIndicator/ColorThemer (= 29.0.0)
+    - MaterialComponents/ActivityIndicator/Component (= 29.0.0)
     - MaterialComponents/private/Application
     - MaterialComponents/private/RTL
-  - MaterialComponents/ActivityIndicator/ColorThemer (28.0.0):
+  - MaterialComponents/ActivityIndicator/ColorThemer (29.0.0):
     - MaterialComponents/ActivityIndicator/Component
     - MaterialComponents/private/Application
     - MaterialComponents/private/RTL
     - MaterialComponents/Themes
-  - MaterialComponents/ActivityIndicator/Component (28.0.0):
+  - MaterialComponents/ActivityIndicator/Component (29.0.0):
     - MaterialComponents/private/Application
     - MaterialComponents/private/RTL
-  - MaterialComponents/AnimationTiming (28.0.0)
-  - MaterialComponents/AppBar (28.0.0):
-    - MaterialComponents/AppBar/ColorThemer (= 28.0.0)
-    - MaterialComponents/AppBar/Component (= 28.0.0)
-  - MaterialComponents/AppBar/ColorThemer (28.0.0):
+  - MaterialComponents/AnimationTiming (29.0.0)
+  - MaterialComponents/AppBar (29.0.0):
+    - MaterialComponents/AppBar/ColorThemer (= 29.0.0)
+    - MaterialComponents/AppBar/Component (= 29.0.0)
+  - MaterialComponents/AppBar/ColorThemer (29.0.0):
     - MaterialComponents/AppBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/AppBar/Component (28.0.0):
+  - MaterialComponents/AppBar/Component (29.0.0):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
     - MaterialComponents/NavigationBar
@@ -57,34 +57,34 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/BottomSheet (28.0.0):
+  - MaterialComponents/BottomSheet (29.0.0):
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/Math
-  - MaterialComponents/ButtonBar (28.0.0):
-    - MaterialComponents/ButtonBar/ColorThemer (= 28.0.0)
-    - MaterialComponents/ButtonBar/Component (= 28.0.0)
+  - MaterialComponents/ButtonBar (29.0.0):
+    - MaterialComponents/ButtonBar/ColorThemer (= 29.0.0)
+    - MaterialComponents/ButtonBar/Component (= 29.0.0)
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/ButtonBar/ColorThemer (28.0.0):
+  - MaterialComponents/ButtonBar/ColorThemer (29.0.0):
     - MaterialComponents/ButtonBar/Component
     - MaterialComponents/Buttons
     - MaterialComponents/NavigationBar/Component
     - MaterialComponents/private/RTL
     - MaterialComponents/Themes
-  - MaterialComponents/ButtonBar/Component (28.0.0):
+  - MaterialComponents/ButtonBar/Component (29.0.0):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/Buttons (28.0.0):
-    - MaterialComponents/Buttons/ColorThemer (= 28.0.0)
-    - MaterialComponents/Buttons/Component (= 28.0.0)
-    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 28.0.0)
+  - MaterialComponents/Buttons (29.0.0):
+    - MaterialComponents/Buttons/ColorThemer (= 29.0.0)
+    - MaterialComponents/Buttons/Component (= 29.0.0)
+    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 29.0.0)
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/ColorThemer (28.0.0):
+  - MaterialComponents/Buttons/ColorThemer (29.0.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -93,14 +93,14 @@ PODS:
     - MaterialComponents/Themes
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/Component (28.0.0):
+  - MaterialComponents/Buttons/Component (29.0.0):
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (28.0.0):
+  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (29.0.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -108,7 +108,7 @@ PODS:
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/CollectionCells (28.0.0):
+  - MaterialComponents/CollectionCells (29.0.0):
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/private/Icons/ic_check
@@ -120,150 +120,150 @@ PODS:
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/CollectionLayoutAttributes (28.0.0)
-  - MaterialComponents/Collections (28.0.0):
+  - MaterialComponents/CollectionLayoutAttributes (29.0.0)
+  - MaterialComponents/Collections (29.0.0):
     - MaterialComponents/CollectionCells
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/Dialogs (28.0.0):
-    - MaterialComponents/Dialogs/ColorThemer (= 28.0.0)
-    - MaterialComponents/Dialogs/Component (= 28.0.0)
-  - MaterialComponents/Dialogs/ColorThemer (28.0.0):
+  - MaterialComponents/Dialogs (29.0.0):
+    - MaterialComponents/Dialogs/ColorThemer (= 29.0.0)
+    - MaterialComponents/Dialogs/Component (= 29.0.0)
+  - MaterialComponents/Dialogs/ColorThemer (29.0.0):
     - MaterialComponents/Dialogs/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Dialogs/Component (28.0.0):
+  - MaterialComponents/Dialogs/Component (29.0.0):
     - MaterialComponents/Buttons
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/RTL
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
-  - MaterialComponents/FeatureHighlight (28.0.0):
-    - MaterialComponents/FeatureHighlight/ColorThemer (= 28.0.0)
-    - MaterialComponents/FeatureHighlight/Component (= 28.0.0)
-  - MaterialComponents/FeatureHighlight/ColorThemer (28.0.0):
+  - MaterialComponents/FeatureHighlight (29.0.0):
+    - MaterialComponents/FeatureHighlight/ColorThemer (= 29.0.0)
+    - MaterialComponents/FeatureHighlight/Component (= 29.0.0)
+  - MaterialComponents/FeatureHighlight/ColorThemer (29.0.0):
     - MaterialComponents/FeatureHighlight/Component
     - MaterialComponents/Themes
-  - MaterialComponents/FeatureHighlight/Component (28.0.0):
+  - MaterialComponents/FeatureHighlight/Component (29.0.0):
     - MaterialComponents/private/Math
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader (28.0.0):
-    - MaterialComponents/FlexibleHeader/ColorThemer (= 28.0.0)
-    - MaterialComponents/FlexibleHeader/Component (= 28.0.0)
+  - MaterialComponents/FlexibleHeader (29.0.0):
+    - MaterialComponents/FlexibleHeader/ColorThemer (= 29.0.0)
+    - MaterialComponents/FlexibleHeader/Component (= 29.0.0)
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/ColorThemer (28.0.0):
+  - MaterialComponents/FlexibleHeader/ColorThemer (29.0.0):
     - MaterialComponents/FlexibleHeader/Component
     - MaterialComponents/private/Application
     - MaterialComponents/Themes
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/Component (28.0.0):
+  - MaterialComponents/FlexibleHeader/Component (29.0.0):
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/HeaderStackView (28.0.0):
-    - MaterialComponents/HeaderStackView/ColorThemer (= 28.0.0)
-    - MaterialComponents/HeaderStackView/Component (= 28.0.0)
-  - MaterialComponents/HeaderStackView/ColorThemer (28.0.0):
+  - MaterialComponents/HeaderStackView (29.0.0):
+    - MaterialComponents/HeaderStackView/ColorThemer (= 29.0.0)
+    - MaterialComponents/HeaderStackView/Component (= 29.0.0)
+  - MaterialComponents/HeaderStackView/ColorThemer (29.0.0):
     - MaterialComponents/HeaderStackView/Component
     - MaterialComponents/Themes
-  - MaterialComponents/HeaderStackView/Component (28.0.0)
-  - MaterialComponents/Ink (28.0.0):
-    - MaterialComponents/Ink/ColorThemer (= 28.0.0)
-    - MaterialComponents/Ink/Component (= 28.0.0)
-  - MaterialComponents/Ink/ColorThemer (28.0.0):
+  - MaterialComponents/HeaderStackView/Component (29.0.0)
+  - MaterialComponents/Ink (29.0.0):
+    - MaterialComponents/Ink/ColorThemer (= 29.0.0)
+    - MaterialComponents/Ink/Component (= 29.0.0)
+  - MaterialComponents/Ink/ColorThemer (29.0.0):
     - MaterialComponents/Ink/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Ink/Component (28.0.0)
-  - MaterialComponents/NavigationBar (28.0.0):
-    - MaterialComponents/NavigationBar/ColorThemer (= 28.0.0)
-    - MaterialComponents/NavigationBar/Component (= 28.0.0)
-  - MaterialComponents/NavigationBar/ColorThemer (28.0.0):
+  - MaterialComponents/Ink/Component (29.0.0)
+  - MaterialComponents/NavigationBar (29.0.0):
+    - MaterialComponents/NavigationBar/ColorThemer (= 29.0.0)
+    - MaterialComponents/NavigationBar/Component (= 29.0.0)
+  - MaterialComponents/NavigationBar/ColorThemer (29.0.0):
     - MaterialComponents/NavigationBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/NavigationBar/Component (28.0.0):
+  - MaterialComponents/NavigationBar/Component (29.0.0):
     - MaterialComponents/ButtonBar/Component
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/OverlayWindow (28.0.0):
+  - MaterialComponents/OverlayWindow (29.0.0):
     - MaterialComponents/private/Application
-  - MaterialComponents/PageControl (28.0.0):
-    - MaterialComponents/PageControl/ColorThemer (= 28.0.0)
-    - MaterialComponents/PageControl/Component (= 28.0.0)
-  - MaterialComponents/PageControl/ColorThemer (28.0.0):
+  - MaterialComponents/PageControl (29.0.0):
+    - MaterialComponents/PageControl/ColorThemer (= 29.0.0)
+    - MaterialComponents/PageControl/Component (= 29.0.0)
+  - MaterialComponents/PageControl/ColorThemer (29.0.0):
     - MaterialComponents/PageControl/Component
     - MaterialComponents/Themes
-  - MaterialComponents/PageControl/Component (28.0.0)
-  - MaterialComponents/Palettes (28.0.0)
-  - MaterialComponents/private (28.0.0):
-    - MaterialComponents/private/Application (= 28.0.0)
-    - MaterialComponents/private/Icons (= 28.0.0)
-    - MaterialComponents/private/KeyboardWatcher (= 28.0.0)
-    - MaterialComponents/private/Math (= 28.0.0)
-    - MaterialComponents/private/Overlay (= 28.0.0)
-    - MaterialComponents/private/RTL (= 28.0.0)
-    - MaterialComponents/private/ThumbTrack (= 28.0.0)
-  - MaterialComponents/private/Application (28.0.0)
-  - MaterialComponents/private/Icons (28.0.0):
-    - MaterialComponents/private/Icons/Base (= 28.0.0)
-    - MaterialComponents/private/Icons/ic_arrow_back (= 28.0.0)
-    - MaterialComponents/private/Icons/ic_check (= 28.0.0)
-    - MaterialComponents/private/Icons/ic_check_circle (= 28.0.0)
-    - MaterialComponents/private/Icons/ic_chevron_right (= 28.0.0)
-    - MaterialComponents/private/Icons/ic_info (= 28.0.0)
-    - MaterialComponents/private/Icons/ic_radio_button_unchecked (= 28.0.0)
-    - MaterialComponents/private/Icons/ic_reorder (= 28.0.0)
-  - MaterialComponents/private/Icons/Base (28.0.0)
-  - MaterialComponents/private/Icons/ic_arrow_back (28.0.0):
+  - MaterialComponents/PageControl/Component (29.0.0)
+  - MaterialComponents/Palettes (29.0.0)
+  - MaterialComponents/private (29.0.0):
+    - MaterialComponents/private/Application (= 29.0.0)
+    - MaterialComponents/private/Icons (= 29.0.0)
+    - MaterialComponents/private/KeyboardWatcher (= 29.0.0)
+    - MaterialComponents/private/Math (= 29.0.0)
+    - MaterialComponents/private/Overlay (= 29.0.0)
+    - MaterialComponents/private/RTL (= 29.0.0)
+    - MaterialComponents/private/ThumbTrack (= 29.0.0)
+  - MaterialComponents/private/Application (29.0.0)
+  - MaterialComponents/private/Icons (29.0.0):
+    - MaterialComponents/private/Icons/Base (= 29.0.0)
+    - MaterialComponents/private/Icons/ic_arrow_back (= 29.0.0)
+    - MaterialComponents/private/Icons/ic_check (= 29.0.0)
+    - MaterialComponents/private/Icons/ic_check_circle (= 29.0.0)
+    - MaterialComponents/private/Icons/ic_chevron_right (= 29.0.0)
+    - MaterialComponents/private/Icons/ic_info (= 29.0.0)
+    - MaterialComponents/private/Icons/ic_radio_button_unchecked (= 29.0.0)
+    - MaterialComponents/private/Icons/ic_reorder (= 29.0.0)
+  - MaterialComponents/private/Icons/Base (29.0.0)
+  - MaterialComponents/private/Icons/ic_arrow_back (29.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check (28.0.0):
+  - MaterialComponents/private/Icons/ic_check (29.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check_circle (28.0.0):
+  - MaterialComponents/private/Icons/ic_check_circle (29.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_chevron_right (28.0.0):
+  - MaterialComponents/private/Icons/ic_chevron_right (29.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_info (28.0.0):
+  - MaterialComponents/private/Icons/ic_info (29.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_radio_button_unchecked (28.0.0):
+  - MaterialComponents/private/Icons/ic_radio_button_unchecked (29.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_reorder (28.0.0):
+  - MaterialComponents/private/Icons/ic_reorder (29.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/KeyboardWatcher (28.0.0):
+  - MaterialComponents/private/KeyboardWatcher (29.0.0):
     - MaterialComponents/private/Application
-  - MaterialComponents/private/Math (28.0.0)
-  - MaterialComponents/private/Overlay (28.0.0)
-  - MaterialComponents/private/RTL (28.0.0)
-  - MaterialComponents/private/ThumbTrack (28.0.0):
+  - MaterialComponents/private/Math (29.0.0)
+  - MaterialComponents/private/Overlay (29.0.0)
+  - MaterialComponents/private/RTL (29.0.0)
+  - MaterialComponents/private/ThumbTrack (29.0.0):
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ProgressView (28.0.0):
-    - MaterialComponents/ProgressView/ColorThemer (= 28.0.0)
-    - MaterialComponents/ProgressView/Component (= 28.0.0)
-  - MaterialComponents/ProgressView/ColorThemer (28.0.0):
+  - MaterialComponents/ProgressView (29.0.0):
+    - MaterialComponents/ProgressView/ColorThemer (= 29.0.0)
+    - MaterialComponents/ProgressView/Component (= 29.0.0)
+  - MaterialComponents/ProgressView/ColorThemer (29.0.0):
     - MaterialComponents/ProgressView/Component
     - MaterialComponents/Themes
-  - MaterialComponents/ProgressView/Component (28.0.0):
+  - MaterialComponents/ProgressView/Component (29.0.0):
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
-  - MaterialComponents/ShadowElevations (28.0.0)
-  - MaterialComponents/ShadowLayer (28.0.0)
-  - MaterialComponents/Slider (28.0.0):
-    - MaterialComponents/Slider/ColorThemer (= 28.0.0)
-    - MaterialComponents/Slider/Component (= 28.0.0)
-  - MaterialComponents/Slider/ColorThemer (28.0.0):
+  - MaterialComponents/ShadowElevations (29.0.0)
+  - MaterialComponents/ShadowLayer (29.0.0)
+  - MaterialComponents/Slider (29.0.0):
+    - MaterialComponents/Slider/ColorThemer (= 29.0.0)
+    - MaterialComponents/Slider/Component (= 29.0.0)
+  - MaterialComponents/Slider/ColorThemer (29.0.0):
     - MaterialComponents/Slider/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Slider/Component (28.0.0):
+  - MaterialComponents/Slider/Component (29.0.0):
     - MaterialComponents/private/ThumbTrack
-  - MaterialComponents/Snackbar (28.0.0):
+  - MaterialComponents/Snackbar (29.0.0):
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Buttons
     - MaterialComponents/OverlayWindow
@@ -271,25 +271,25 @@ PODS:
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/Overlay
     - MaterialComponents/Typography
-  - MaterialComponents/Tabs (28.0.0):
-    - MaterialComponents/Tabs/ColorThemer (= 28.0.0)
-    - MaterialComponents/Tabs/Component (= 28.0.0)
-  - MaterialComponents/Tabs/ColorThemer (28.0.0):
+  - MaterialComponents/Tabs (29.0.0):
+    - MaterialComponents/Tabs/ColorThemer (= 29.0.0)
+    - MaterialComponents/Tabs/Component (= 29.0.0)
+  - MaterialComponents/Tabs/ColorThemer (29.0.0):
     - MaterialComponents/Tabs/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Tabs/Component (28.0.0):
+  - MaterialComponents/Tabs/Component (29.0.0):
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Ink
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/TextFields (28.0.0):
+  - MaterialComponents/TextFields (29.0.0):
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Palettes
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/Themes (28.0.0)
-  - MaterialComponents/Typography (28.0.0):
+  - MaterialComponents/Themes (29.0.0)
+  - MaterialComponents/Typography (29.0.0):
     - MaterialComponents/private/Application
   - MDFTextAccessibility (1.2.0)
 
@@ -298,10 +298,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   MaterialComponents:
-    :path: "../../"
+    :path: ../../
 
 SPEC CHECKSUMS:
-  MaterialComponents: 8307865c3150da217dabdcf1ad921a7fd6663dd8
+  MaterialComponents: d0ae7d9b517a72608caaa609682fe2de41921ba0
   MDFTextAccessibility: 94098925e0853551c5a311ce7c1ecefbe297cdb6
 
 PODFILE CHECKSUM: 8c6ad4fe8e5aa667e06c9b43f3f5d4d6430b1322

--- a/demos/Bare/Podfile.lock
+++ b/demos/Bare/Podfile.lock
@@ -298,7 +298,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   MaterialComponents:
-    :path: ../../
+    :path: "../../"
 
 SPEC CHECKSUMS:
   MaterialComponents: 8307865c3150da217dabdcf1ad921a7fd6663dd8

--- a/demos/Bare/Podfile.lock
+++ b/demos/Bare/Podfile.lock
@@ -298,7 +298,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   MaterialComponents:
-    :path: "../../"
+    :path: ../../
 
 SPEC CHECKSUMS:
   MaterialComponents: 8307865c3150da217dabdcf1ad921a7fd6663dd8

--- a/demos/Pesto/Podfile.lock
+++ b/demos/Pesto/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
-  - MaterialComponents/AnimationTiming (28.0.0)
-  - MaterialComponents/AppBar (28.0.0):
-    - MaterialComponents/AppBar/ColorThemer (= 28.0.0)
-    - MaterialComponents/AppBar/Component (= 28.0.0)
-  - MaterialComponents/AppBar/ColorThemer (28.0.0):
+  - MaterialComponents/AnimationTiming (29.0.0)
+  - MaterialComponents/AppBar (29.0.0):
+    - MaterialComponents/AppBar/ColorThemer (= 29.0.0)
+    - MaterialComponents/AppBar/Component (= 29.0.0)
+  - MaterialComponents/AppBar/ColorThemer (29.0.0):
     - MaterialComponents/AppBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/AppBar/Component (28.0.0):
+  - MaterialComponents/AppBar/Component (29.0.0):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
     - MaterialComponents/NavigationBar
@@ -15,20 +15,20 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ButtonBar/Component (28.0.0):
+  - MaterialComponents/ButtonBar/Component (29.0.0):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/Buttons (28.0.0):
-    - MaterialComponents/Buttons/ColorThemer (= 28.0.0)
-    - MaterialComponents/Buttons/Component (= 28.0.0)
-    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 28.0.0)
+  - MaterialComponents/Buttons (29.0.0):
+    - MaterialComponents/Buttons/ColorThemer (= 29.0.0)
+    - MaterialComponents/Buttons/Component (= 29.0.0)
+    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 29.0.0)
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/ColorThemer (28.0.0):
+  - MaterialComponents/Buttons/ColorThemer (29.0.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -37,14 +37,14 @@ PODS:
     - MaterialComponents/Themes
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/Component (28.0.0):
+  - MaterialComponents/Buttons/Component (29.0.0):
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (28.0.0):
+  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (29.0.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -52,7 +52,7 @@ PODS:
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/CollectionCells (28.0.0):
+  - MaterialComponents/CollectionCells (29.0.0):
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/private/Icons/ic_check
@@ -64,75 +64,75 @@ PODS:
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/CollectionLayoutAttributes (28.0.0)
-  - MaterialComponents/Collections (28.0.0):
+  - MaterialComponents/CollectionLayoutAttributes (29.0.0)
+  - MaterialComponents/Collections (29.0.0):
     - MaterialComponents/CollectionCells
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/FlexibleHeader (28.0.0):
-    - MaterialComponents/FlexibleHeader/ColorThemer (= 28.0.0)
-    - MaterialComponents/FlexibleHeader/Component (= 28.0.0)
+  - MaterialComponents/FlexibleHeader (29.0.0):
+    - MaterialComponents/FlexibleHeader/ColorThemer (= 29.0.0)
+    - MaterialComponents/FlexibleHeader/Component (= 29.0.0)
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/ColorThemer (28.0.0):
+  - MaterialComponents/FlexibleHeader/ColorThemer (29.0.0):
     - MaterialComponents/FlexibleHeader/Component
     - MaterialComponents/private/Application
     - MaterialComponents/Themes
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/Component (28.0.0):
+  - MaterialComponents/FlexibleHeader/Component (29.0.0):
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/HeaderStackView (28.0.0):
-    - MaterialComponents/HeaderStackView/ColorThemer (= 28.0.0)
-    - MaterialComponents/HeaderStackView/Component (= 28.0.0)
-  - MaterialComponents/HeaderStackView/ColorThemer (28.0.0):
+  - MaterialComponents/HeaderStackView (29.0.0):
+    - MaterialComponents/HeaderStackView/ColorThemer (= 29.0.0)
+    - MaterialComponents/HeaderStackView/Component (= 29.0.0)
+  - MaterialComponents/HeaderStackView/ColorThemer (29.0.0):
     - MaterialComponents/HeaderStackView/Component
     - MaterialComponents/Themes
-  - MaterialComponents/HeaderStackView/Component (28.0.0)
-  - MaterialComponents/Ink (28.0.0):
-    - MaterialComponents/Ink/ColorThemer (= 28.0.0)
-    - MaterialComponents/Ink/Component (= 28.0.0)
-  - MaterialComponents/Ink/ColorThemer (28.0.0):
+  - MaterialComponents/HeaderStackView/Component (29.0.0)
+  - MaterialComponents/Ink (29.0.0):
+    - MaterialComponents/Ink/ColorThemer (= 29.0.0)
+    - MaterialComponents/Ink/Component (= 29.0.0)
+  - MaterialComponents/Ink/ColorThemer (29.0.0):
     - MaterialComponents/Ink/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Ink/Component (28.0.0)
-  - MaterialComponents/NavigationBar (28.0.0):
-    - MaterialComponents/NavigationBar/ColorThemer (= 28.0.0)
-    - MaterialComponents/NavigationBar/Component (= 28.0.0)
-  - MaterialComponents/NavigationBar/ColorThemer (28.0.0):
+  - MaterialComponents/Ink/Component (29.0.0)
+  - MaterialComponents/NavigationBar (29.0.0):
+    - MaterialComponents/NavigationBar/ColorThemer (= 29.0.0)
+    - MaterialComponents/NavigationBar/Component (= 29.0.0)
+  - MaterialComponents/NavigationBar/ColorThemer (29.0.0):
     - MaterialComponents/NavigationBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/NavigationBar/Component (28.0.0):
+  - MaterialComponents/NavigationBar/Component (29.0.0):
     - MaterialComponents/ButtonBar/Component
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/private/Application (28.0.0)
-  - MaterialComponents/private/Icons/Base (28.0.0)
-  - MaterialComponents/private/Icons/ic_arrow_back (28.0.0):
+  - MaterialComponents/private/Application (29.0.0)
+  - MaterialComponents/private/Icons/Base (29.0.0)
+  - MaterialComponents/private/Icons/ic_arrow_back (29.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check (28.0.0):
+  - MaterialComponents/private/Icons/ic_check (29.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check_circle (28.0.0):
+  - MaterialComponents/private/Icons/ic_check_circle (29.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_chevron_right (28.0.0):
+  - MaterialComponents/private/Icons/ic_chevron_right (29.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_info (28.0.0):
+  - MaterialComponents/private/Icons/ic_info (29.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_radio_button_unchecked (28.0.0):
+  - MaterialComponents/private/Icons/ic_radio_button_unchecked (29.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_reorder (28.0.0):
+  - MaterialComponents/private/Icons/ic_reorder (29.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Math (28.0.0)
-  - MaterialComponents/private/RTL (28.0.0)
-  - MaterialComponents/ShadowElevations (28.0.0)
-  - MaterialComponents/ShadowLayer (28.0.0)
-  - MaterialComponents/Themes (28.0.0)
-  - MaterialComponents/Typography (28.0.0):
+  - MaterialComponents/private/Math (29.0.0)
+  - MaterialComponents/private/RTL (29.0.0)
+  - MaterialComponents/ShadowElevations (29.0.0)
+  - MaterialComponents/ShadowLayer (29.0.0)
+  - MaterialComponents/Themes (29.0.0)
+  - MaterialComponents/Typography (29.0.0):
     - MaterialComponents/private/Application
   - MDFTextAccessibility (1.2.0)
 
@@ -148,10 +148,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   MaterialComponents:
-    :path: "../../"
+    :path: ../../
 
 SPEC CHECKSUMS:
-  MaterialComponents: 8307865c3150da217dabdcf1ad921a7fd6663dd8
+  MaterialComponents: d0ae7d9b517a72608caaa609682fe2de41921ba0
   MDFTextAccessibility: 94098925e0853551c5a311ce7c1ecefbe297cdb6
 
 PODFILE CHECKSUM: cdec7a9b5bf338e8f41916eb1ec5588703a9dc16

--- a/demos/Pesto/Podfile.lock
+++ b/demos/Pesto/Podfile.lock
@@ -148,7 +148,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   MaterialComponents:
-    :path: "../../"
+    :path: ../../
 
 SPEC CHECKSUMS:
   MaterialComponents: 8307865c3150da217dabdcf1ad921a7fd6663dd8

--- a/demos/Pesto/Podfile.lock
+++ b/demos/Pesto/Podfile.lock
@@ -148,7 +148,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   MaterialComponents:
-    :path: ../../
+    :path: "../../"
 
 SPEC CHECKSUMS:
   MaterialComponents: 8307865c3150da217dabdcf1ad921a7fd6663dd8

--- a/demos/Shrine/Podfile.lock
+++ b/demos/Shrine/Podfile.lock
@@ -118,9 +118,9 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   MaterialComponents:
-    :path: "../../"
+    :path: ../../
   RemoteImageServiceForMDCDemos:
-    :path: "../supplemental"
+    :path: ../supplemental
 
 SPEC CHECKSUMS:
   MaterialComponents: 8307865c3150da217dabdcf1ad921a7fd6663dd8

--- a/demos/Shrine/Podfile.lock
+++ b/demos/Shrine/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - MaterialComponents/AppBar (28.0.0):
-    - MaterialComponents/AppBar/ColorThemer (= 28.0.0)
-    - MaterialComponents/AppBar/Component (= 28.0.0)
-  - MaterialComponents/AppBar/ColorThemer (28.0.0):
+  - MaterialComponents/AppBar (29.0.0):
+    - MaterialComponents/AppBar/ColorThemer (= 29.0.0)
+    - MaterialComponents/AppBar/Component (= 29.0.0)
+  - MaterialComponents/AppBar/ColorThemer (29.0.0):
     - MaterialComponents/AppBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/AppBar/Component (28.0.0):
+  - MaterialComponents/AppBar/Component (29.0.0):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
     - MaterialComponents/NavigationBar
@@ -14,20 +14,20 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ButtonBar/Component (28.0.0):
+  - MaterialComponents/ButtonBar/Component (29.0.0):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/Buttons (28.0.0):
-    - MaterialComponents/Buttons/ColorThemer (= 28.0.0)
-    - MaterialComponents/Buttons/Component (= 28.0.0)
-    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 28.0.0)
+  - MaterialComponents/Buttons (29.0.0):
+    - MaterialComponents/Buttons/ColorThemer (= 29.0.0)
+    - MaterialComponents/Buttons/Component (= 29.0.0)
+    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 29.0.0)
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/ColorThemer (28.0.0):
+  - MaterialComponents/Buttons/ColorThemer (29.0.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -36,14 +36,14 @@ PODS:
     - MaterialComponents/Themes
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/Component (28.0.0):
+  - MaterialComponents/Buttons/Component (29.0.0):
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (28.0.0):
+  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (29.0.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -51,65 +51,65 @@ PODS:
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader (28.0.0):
-    - MaterialComponents/FlexibleHeader/ColorThemer (= 28.0.0)
-    - MaterialComponents/FlexibleHeader/Component (= 28.0.0)
+  - MaterialComponents/FlexibleHeader (29.0.0):
+    - MaterialComponents/FlexibleHeader/ColorThemer (= 29.0.0)
+    - MaterialComponents/FlexibleHeader/Component (= 29.0.0)
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/ColorThemer (28.0.0):
+  - MaterialComponents/FlexibleHeader/ColorThemer (29.0.0):
     - MaterialComponents/FlexibleHeader/Component
     - MaterialComponents/private/Application
     - MaterialComponents/Themes
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/Component (28.0.0):
+  - MaterialComponents/FlexibleHeader/Component (29.0.0):
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/HeaderStackView (28.0.0):
-    - MaterialComponents/HeaderStackView/ColorThemer (= 28.0.0)
-    - MaterialComponents/HeaderStackView/Component (= 28.0.0)
-  - MaterialComponents/HeaderStackView/ColorThemer (28.0.0):
+  - MaterialComponents/HeaderStackView (29.0.0):
+    - MaterialComponents/HeaderStackView/ColorThemer (= 29.0.0)
+    - MaterialComponents/HeaderStackView/Component (= 29.0.0)
+  - MaterialComponents/HeaderStackView/ColorThemer (29.0.0):
     - MaterialComponents/HeaderStackView/Component
     - MaterialComponents/Themes
-  - MaterialComponents/HeaderStackView/Component (28.0.0)
-  - MaterialComponents/Ink (28.0.0):
-    - MaterialComponents/Ink/ColorThemer (= 28.0.0)
-    - MaterialComponents/Ink/Component (= 28.0.0)
-  - MaterialComponents/Ink/ColorThemer (28.0.0):
+  - MaterialComponents/HeaderStackView/Component (29.0.0)
+  - MaterialComponents/Ink (29.0.0):
+    - MaterialComponents/Ink/ColorThemer (= 29.0.0)
+    - MaterialComponents/Ink/Component (= 29.0.0)
+  - MaterialComponents/Ink/ColorThemer (29.0.0):
     - MaterialComponents/Ink/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Ink/Component (28.0.0)
-  - MaterialComponents/NavigationBar (28.0.0):
-    - MaterialComponents/NavigationBar/ColorThemer (= 28.0.0)
-    - MaterialComponents/NavigationBar/Component (= 28.0.0)
-  - MaterialComponents/NavigationBar/ColorThemer (28.0.0):
+  - MaterialComponents/Ink/Component (29.0.0)
+  - MaterialComponents/NavigationBar (29.0.0):
+    - MaterialComponents/NavigationBar/ColorThemer (= 29.0.0)
+    - MaterialComponents/NavigationBar/Component (= 29.0.0)
+  - MaterialComponents/NavigationBar/ColorThemer (29.0.0):
     - MaterialComponents/NavigationBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/NavigationBar/Component (28.0.0):
+  - MaterialComponents/NavigationBar/Component (29.0.0):
     - MaterialComponents/ButtonBar/Component
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/PageControl (28.0.0):
-    - MaterialComponents/PageControl/ColorThemer (= 28.0.0)
-    - MaterialComponents/PageControl/Component (= 28.0.0)
-  - MaterialComponents/PageControl/ColorThemer (28.0.0):
+  - MaterialComponents/PageControl (29.0.0):
+    - MaterialComponents/PageControl/ColorThemer (= 29.0.0)
+    - MaterialComponents/PageControl/Component (= 29.0.0)
+  - MaterialComponents/PageControl/ColorThemer (29.0.0):
     - MaterialComponents/PageControl/Component
     - MaterialComponents/Themes
-  - MaterialComponents/PageControl/Component (28.0.0)
-  - MaterialComponents/private/Application (28.0.0)
-  - MaterialComponents/private/Icons/Base (28.0.0)
-  - MaterialComponents/private/Icons/ic_arrow_back (28.0.0):
+  - MaterialComponents/PageControl/Component (29.0.0)
+  - MaterialComponents/private/Application (29.0.0)
+  - MaterialComponents/private/Icons/Base (29.0.0)
+  - MaterialComponents/private/Icons/ic_arrow_back (29.0.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Math (28.0.0)
-  - MaterialComponents/private/RTL (28.0.0)
-  - MaterialComponents/ShadowElevations (28.0.0)
-  - MaterialComponents/ShadowLayer (28.0.0)
-  - MaterialComponents/Themes (28.0.0)
-  - MaterialComponents/Typography (28.0.0):
+  - MaterialComponents/private/Math (29.0.0)
+  - MaterialComponents/private/RTL (29.0.0)
+  - MaterialComponents/ShadowElevations (29.0.0)
+  - MaterialComponents/ShadowLayer (29.0.0)
+  - MaterialComponents/Themes (29.0.0)
+  - MaterialComponents/Typography (29.0.0):
     - MaterialComponents/private/Application
   - MDFTextAccessibility (1.2.0)
-  - RemoteImageServiceForMDCDemos (28.0.0)
+  - RemoteImageServiceForMDCDemos (29.0.0)
 
 DEPENDENCIES:
   - MaterialComponents/AppBar (from `../../`)
@@ -118,14 +118,14 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   MaterialComponents:
-    :path: "../../"
+    :path: ../../
   RemoteImageServiceForMDCDemos:
-    :path: "../supplemental"
+    :path: ../supplemental
 
 SPEC CHECKSUMS:
-  MaterialComponents: 8307865c3150da217dabdcf1ad921a7fd6663dd8
+  MaterialComponents: d0ae7d9b517a72608caaa609682fe2de41921ba0
   MDFTextAccessibility: 94098925e0853551c5a311ce7c1ecefbe297cdb6
-  RemoteImageServiceForMDCDemos: a83c4631a4504220c98f476ab36cd33a30a92746
+  RemoteImageServiceForMDCDemos: 56d5543fb64c2a9fcb8e6dcffc0b91c9ff626455
 
 PODFILE CHECKSUM: 5eb94d7fb8deeb6709b7300f5d0e0e1a75902cca
 

--- a/demos/Shrine/Podfile.lock
+++ b/demos/Shrine/Podfile.lock
@@ -118,9 +118,9 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   MaterialComponents:
-    :path: ../../
+    :path: "../../"
   RemoteImageServiceForMDCDemos:
-    :path: ../supplemental
+    :path: "../supplemental"
 
 SPEC CHECKSUMS:
   MaterialComponents: 8307865c3150da217dabdcf1ad921a7fd6663dd8

--- a/demos/ZShadow/Podfile.lock
+++ b/demos/ZShadow/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - MaterialComponents/ShadowElevations (28.0.0)
-  - MaterialComponents/ShadowLayer (28.0.0)
+  - MaterialComponents/ShadowElevations (29.0.0)
+  - MaterialComponents/ShadowLayer (29.0.0)
 
 DEPENDENCIES:
   - MaterialComponents/ShadowElevations (from `../../`)
@@ -8,10 +8,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   MaterialComponents:
-    :path: "../../"
+    :path: ../../
 
 SPEC CHECKSUMS:
-  MaterialComponents: 8307865c3150da217dabdcf1ad921a7fd6663dd8
+  MaterialComponents: d0ae7d9b517a72608caaa609682fe2de41921ba0
 
 PODFILE CHECKSUM: 238ed9ba58d5e4a3638e6cea92b00109641989f8
 

--- a/demos/supplemental/RemoteImageServiceForMDCDemos.podspec
+++ b/demos/supplemental/RemoteImageServiceForMDCDemos.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RemoteImageServiceForMDCDemos"
-  s.version      = "28.0.0"
+  s.version      = "29.0.0"
   s.summary      = "A helper image class for the MDC demos."
   s.description  = "This spec is made for use in the MDC demos. It gets images via url."
   s.homepage     = "https://github.com/material-components/material-components-ios"


### PR DESCRIPTION
Hotfix release to undo changes to the [title colors of MDCFlatButton and MDCRaisedButton](https://github.com/material-components/material-components-ios/commit/4c84b99f2b65fdd4208d385c26133d4e4bd153d6).