### PR TITLE
[Ink] Don't assign compositeRipple frame twice

### DIFF
--- a/components/Ink/src/private/MDCInkLayer.m
+++ b/components/Ink/src/private/MDCInkLayer.m
@@ -484,7 +484,6 @@ static NSString *const kInkLayerBackgroundOpacityAnim = @"backgroundOpacityAnim"
 
 - (void)layoutSublayers {
   [super layoutSublayers];
-  _compositeRipple.frame = self.frame;
   CGFloat radius = MDCInkLayerRadiusBounds(_maxRippleRadius,
                                            MDCInkLayerRectHypotenuse(self.bounds) / 2.f, _bounded);
 


### PR DESCRIPTION
`_compositeRipple.frame` was being assigned InkLayer's frame before
being assigned a second rectangle based on InkLayer's bounds. This can
cause the InkLayer compute its frame within its parent layer/view and is
inefficient.

Closes #1685
