### PR TITLE
[Collections] Reuse label frames in applyMetrics

### DIFF
--- a/components/CollectionCells/src/MDCCollectionViewTextCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewTextCell.m
@@ -188,12 +188,13 @@ static inline CGRect AlignRectToUpperPixel(CGRect rect) {
   detailFrame.origin.x = 0;
 
   // Adjust the labels Y origin.
-  if ([self numberOfAllVisibleTextLines] == 1) {
+  NSInteger numberOfAllVisibleTextLines = [self numberOfAllVisibleTextLinesForLabelSize:textFrame.size detailSize:detailFrame.size];
+  if (numberOfAllVisibleTextLines == 1) {
     // Alignment for single line.
     textFrame.origin.y = (boundsHeight / 2) - (textFrame.size.height / 2);
     detailFrame.origin.y = (boundsHeight / 2) - (detailFrame.size.height / 2);
 
-  } else if ([self numberOfAllVisibleTextLines] == 2) {
+  } else if (numberOfAllVisibleTextLines == 2) {
     if (!CGRectIsEmpty(textFrame) && !CGRectIsEmpty(detailFrame)) {
       // Alignment for two lines.
       textFrame.origin.y =
@@ -206,7 +207,7 @@ static inline CGRect AlignRectToUpperPixel(CGRect rect) {
       detailFrame.origin.y = (boundsHeight / 2) - (detailFrame.size.height / 2);
     }
 
-  } else if ([self numberOfAllVisibleTextLines] == 3) {
+  } else if (numberOfAllVisibleTextLines == 3) {
     if (!CGRectIsEmpty(textFrame) && !CGRectIsEmpty(detailFrame)) {
       // Alignment for three lines.
       textFrame.origin.y =
@@ -231,12 +232,12 @@ static inline CGRect AlignRectToUpperPixel(CGRect rect) {
                                           self.mdc_effectiveUserInterfaceLayoutDirection);
 }
 
-- (NSInteger)numberOfAllVisibleTextLines {
-  return [self numberOfLinesForLabel:_textLabel] + [self numberOfLinesForLabel:_detailTextLabel];
+- (NSInteger)numberOfAllVisibleTextLinesForLabelSize:(CGSize)labelSize detailSize:(CGSize)detailSize {
+  return [self numberOfLinesForLabel:_textLabel withSize:labelSize] + [self numberOfLinesForLabel:_detailTextLabel withSize:detailSize];
 }
 
-- (NSInteger)numberOfLinesForLabel:(UILabel *)label {
-  CGSize size = [self frameSizeForLabel:label];
+- (NSInteger)numberOfLinesForLabel:(UILabel *)label withSize:(CGSize)aSize {
+  CGSize size = CGSizeEqualToSize(CGSizeZero, aSize) ? [self frameSizeForLabel:label] : aSize;
   return (NSInteger)floor(size.height / label.font.lineHeight);
 }
 

--- a/components/CollectionCells/src/MDCCollectionViewTextCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewTextCell.m
@@ -188,7 +188,8 @@ static inline CGRect AlignRectToUpperPixel(CGRect rect) {
   detailFrame.origin.x = 0;
 
   // Adjust the labels Y origin.
-  NSInteger numberOfAllVisibleTextLines = [self numberOfAllVisibleTextLinesForLabelSize:textFrame.size detailSize:detailFrame.size];
+  NSInteger numberOfAllVisibleTextLines =
+      [self visibleTextLinesForTitleLabelOfSize:textFrame.size detailLabelOfSize:detailFrame.size];
   if (numberOfAllVisibleTextLines == 1) {
     // Alignment for single line.
     textFrame.origin.y = (boundsHeight / 2) - (textFrame.size.height / 2);
@@ -232,8 +233,10 @@ static inline CGRect AlignRectToUpperPixel(CGRect rect) {
                                           self.mdc_effectiveUserInterfaceLayoutDirection);
 }
 
-- (NSInteger)numberOfAllVisibleTextLinesForLabelSize:(CGSize)labelSize detailSize:(CGSize)detailSize {
-  return [self numberOfLinesForLabel:_textLabel withSize:labelSize] + [self numberOfLinesForLabel:_detailTextLabel withSize:detailSize];
+- (NSInteger)visibleTextLinesForTitleLabelOfSize:(CGSize)labelSize
+                               detailLabelOfSize:(CGSize)detailSize {
+  return [self numberOfLinesForLabel:_textLabel withSize:labelSize] +
+         [self numberOfLinesForLabel:_detailTextLabel withSize:detailSize];
 }
 
 - (NSInteger)numberOfLinesForLabel:(UILabel *)label withSize:(CGSize)aSize {


### PR DESCRIPTION
`applyMetrics` currently computes the UILabel frames both to determine
the size of the frames and again to determine their origin. Reusing the
frames results in a lower CPU utilization while rendering the cells.

### Original code
![frame-28 0 0](https://user-images.githubusercontent.com/1753199/28577770-afa84808-7125-11e7-8b1c-d9fb978dede9.png)

### Reused frames
![frame-28 0 0-reuse](https://user-images.githubusercontent.com/1753199/28577787-b8f225fa-7125-11e7-8a9a-91100f7cbdef.png)

Closes #1699 