### PR TITLE
[Fonts] Cache system fonts

### DIFF
--- a/components/Typography/src/MDCTypography.m
+++ b/components/Typography/src/MDCTypography.m
@@ -188,8 +188,9 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
 
 @interface MDCSystemFontLoader ()
 
-/**
- Basic cache to keep track of recently-used fonts.
+/*
+ In collectionView scrolling tests, manually caching UIFonts performs around 4.5 times better 
+ (e.g. 230 ms vs. 1,080 ms in one test) than calling [UIFont systemFontForSize:weight:] every time.
  */
 @property(nonatomic, strong) NSCache *fontCache;
 

--- a/components/Typography/src/MDCTypography.m
+++ b/components/Typography/src/MDCTypography.m
@@ -215,7 +215,7 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
 }
 
 - (UIFont *)lightFontOfSize:(CGFloat)fontSize {
-  NSString *cacheKey = [NSString stringWithFormat:@"light-%06f", fontSize];
+  NSString *cacheKey = [NSString stringWithFormat:@"%@-%06f", NSStringFromSelector(_cmd), fontSize];
   UIFont *font = [self.fontCache objectForKey:cacheKey];
   if (font) {
     return font;
@@ -234,7 +234,7 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
 }
 
 - (UIFont *)regularFontOfSize:(CGFloat)fontSize {
-  NSString *cacheKey = [NSString stringWithFormat:@"regular-%06f", fontSize];
+  NSString *cacheKey = [NSString stringWithFormat:@"%@-%06f", NSStringFromSelector(_cmd), fontSize];
   UIFont *font = [self.fontCache objectForKey:cacheKey];
   if (font) {
     return font;
@@ -252,7 +252,7 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
 }
 
 - (UIFont *)mediumFontOfSize:(CGFloat)fontSize {
-  NSString *cacheKey = [NSString stringWithFormat:@"medium-%06f", fontSize];
+  NSString *cacheKey = [NSString stringWithFormat:@"%@-%06f", NSStringFromSelector(_cmd), fontSize];
   UIFont *font = [self.fontCache objectForKey:cacheKey];
   if (font) {
     return font;
@@ -270,7 +270,7 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
 }
 
 - (UIFont *)boldFontOfSize:(CGFloat)fontSize {
-  NSString *cacheKey = [NSString stringWithFormat:@"bold-%06f", fontSize];
+  NSString *cacheKey = [NSString stringWithFormat:@"%@-%06f", NSStringFromSelector(_cmd), fontSize];
   UIFont *font = [self.fontCache objectForKey:cacheKey];
   if (font) {
     return font;
@@ -288,7 +288,7 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
 }
 
 - (UIFont *)italicFontOfSize:(CGFloat)fontSize {
-  NSString *cacheKey = [NSString stringWithFormat:@"italic-%06f", fontSize];
+  NSString *cacheKey = [NSString stringWithFormat:@"%@-%06f", NSStringFromSelector(_cmd), fontSize];
   UIFont *font = [self.fontCache objectForKey:cacheKey];
   if (font) {
     return font;
@@ -302,7 +302,7 @@ const CGFloat MDCTypographySecondaryOpacity = 0.54f;
 }
 
 - (UIFont *)boldItalicFontOfSize:(CGFloat)fontSize {
-  NSString *cacheKey = [NSString stringWithFormat:@"boldItalic-%06f", fontSize];
+  NSString *cacheKey = [NSString stringWithFormat:@"%@-%06f", NSStringFromSelector(_cmd), fontSize];
   UIFont *font = [self.fontCache objectForKey:cacheKey];
   if (font) {
     return font;


### PR DESCRIPTION
`[UIFont systemFontForSize:weight]` performs some kind of internal
caching (it returns the same pointers) but the performance is relatively
poor compared to an actual NSCache. Introducing a cache in the
MDCSystemFontLoader and clearing the cache whenever the Content Category
size changes (dynamic type notifications) even though we're not
currently using those fonts.

Performance is improved when scrolling MDCCollectionViewTextCells, which
retrieve the fonts in `prepareForReuse`.

## Original performance
![uifont-28 0 0](https://user-images.githubusercontent.com/1753199/28579987-37004c14-712c-11e7-8e36-fa1a16b401cc.png)

## Cached fonts
![uifont-28 0 0-cache](https://user-images.githubusercontent.com/1753199/28579990-3c7fb026-712c-11e7-8576-49e6d65a0794.png)
