### PR TITLE
[Icons] Cache NSBundles based on names

### DIFF
--- a/components/private/Icons/src/MDCIcons.m
+++ b/components/private/Icons/src/MDCIcons.m
@@ -21,10 +21,19 @@
 @implementation MDCIcons
 
 + (nullable NSBundle *)bundleNamed:(nonnull NSString *)bundleName {
-  NSBundle *baseBundle = [NSBundle bundleForClass:[self class]];
-  NSString *bundlePath = [baseBundle pathForResource:bundleName ofType:@"bundle"];
-  NSBundle *bundle = [NSBundle bundleWithPath:bundlePath];
-
+  static NSCache *bundleCache;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    bundleCache = [[NSCache alloc] init];
+  });
+  
+  NSBundle *bundle = [bundleCache objectForKey:bundleName];
+  if (!bundle) {
+    NSBundle *baseBundle = [NSBundle bundleForClass:[self class]];
+    NSString *bundlePath = [baseBundle pathForResource:bundleName ofType:@"bundle"];
+    bundle = [NSBundle bundleWithPath:bundlePath];
+    [bundleCache setObject:bundle forKey:bundleName];
+  }
   return bundle;
 }
 


### PR DESCRIPTION
NSBundles are looked-up for each icon we try to load. Instead of
performing a file path search each time, we can cache the bundles to
make icon loading faster.

## Original code
![bundle-28 0 0](https://user-images.githubusercontent.com/1753199/28580492-a2e237e8-712d-11e7-8fae-97fdc2b8a3da.png)

## Cached bundles
![bundle-28 0 0-cache](https://user-images.githubusercontent.com/1753199/28580498-a7f1c1a4-712d-11e7-84da-a332230535d3.png)

