### PR TITLE
[Collections] Only change selected icon if needed

### DIFF
--- a/components/CollectionCells/src/MDCCollectionViewCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewCell.m
@@ -424,14 +424,19 @@ NSString *const kDeselectedCellAccessibilityHintKey =
 #pragma mark - Selecting
 
 - (void)setSelected:(BOOL)selected {
+  BOOL previousSelectedState = self.selected;
   [super setSelected:selected];
   if (selected) {
-    _editingSelectorImageView.image = [MDCIcons imageFor_ic_check_circle];
-    _editingSelectorImageView.tintColor = self.editingSelectorColor;
+    if (_editingSelectorImageView && previousSelectedState != selected) {
+      _editingSelectorImageView.image = [MDCIcons imageFor_ic_check_circle];
+      _editingSelectorImageView.tintColor = self.editingSelectorColor;
+    }
     self.accessibilityTraits |= UIAccessibilityTraitSelected;
   } else {
-    _editingSelectorImageView.image = [MDCIcons imageFor_ic_radio_button_unchecked];
-    _editingSelectorImageView.tintColor = HEXCOLOR(kCellGrayColor);
+    if (_editingSelectorImageView && previousSelectedState != selected) {
+      _editingSelectorImageView.image = [MDCIcons imageFor_ic_radio_button_unchecked];
+      _editingSelectorImageView.tintColor = HEXCOLOR(kCellGrayColor);
+    }
     self.accessibilityTraits &= ~UIAccessibilityTraitSelected;
   }
   _editingSelectorImageView.image =

--- a/components/CollectionCells/src/MDCCollectionViewCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewCell.m
@@ -430,17 +430,19 @@ NSString *const kDeselectedCellAccessibilityHintKey =
     if (_editingSelectorImageView && previousSelectedState != selected) {
       _editingSelectorImageView.image = [MDCIcons imageFor_ic_check_circle];
       _editingSelectorImageView.tintColor = self.editingSelectorColor;
+      _editingSelectorImageView.image = [_editingSelectorImageView.image
+          imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     }
     self.accessibilityTraits |= UIAccessibilityTraitSelected;
   } else {
     if (_editingSelectorImageView && previousSelectedState != selected) {
       _editingSelectorImageView.image = [MDCIcons imageFor_ic_radio_button_unchecked];
       _editingSelectorImageView.tintColor = HEXCOLOR(kCellGrayColor);
+      _editingSelectorImageView.image = [_editingSelectorImageView.image
+          imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     }
     self.accessibilityTraits &= ~UIAccessibilityTraitSelected;
   }
-  _editingSelectorImageView.image =
-      [_editingSelectorImageView.image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
 }
 
 - (void)setEditingSelectorColor:(UIColor *)editingSelectorColor {


### PR DESCRIPTION
The `-setSelected:` method reassigns the selection icon image every time
a cell is dequeued/reused. Since most cells are unselected most of the
time, this results in a lot of unnecessary UIImage calls.  Only updating
the selected/unselected image if the view exists (it won't until
initially changed to Editing Mode) and if the state has changed.
    
Closes #1708


### Original performance
![screen shot 2017-07-27 at 9 48 25 am](https://user-images.githubusercontent.com/1753199/28673945-f15e1182-72b1-11e7-94f0-3a81256dd042.png)


### Performance with changes
**MDCIcon no longer appears in the trace
![screen shot 2017-07-27 at 9 57 10 am](https://user-images.githubusercontent.com/1753199/28673979-060e817a-72b2-11e7-81f2-194377098984.png)
