### PR TITLE
[NavigationBar] Improve centering when barButtonItems are asymmetric

### DIFF
--- a/components/NavigationBar/examples/NavigationBarLayoutExample.m
+++ b/components/NavigationBar/examples/NavigationBarLayoutExample.m
@@ -1,0 +1,191 @@
+//
+//  NavigationBarLayoutExample.m
+//  Pods
+//
+//  Created by Rob Moore on 7/28/17.
+//
+//
+
+#import "MaterialIcons+ic_arrow_back.h"
+#import "MaterialNavigationBar.h"
+#import "MaterialTextFields.h"
+#import "UIImage+MaterialRTL.h"
+#import "UIView+MaterialRTL.h"
+
+@interface NavigationBarLayoutExample : UIViewController <UITextFieldDelegate>
+
+@property(nonatomic, strong) MDCNavigationBar *navigationBar;
+@property(nonatomic, strong) MDCTextInputControllerDefault *leadingItemController;
+@property(nonatomic, strong) MDCTextField *leadingItemField;
+@property(nonatomic, strong) MDCTextInputControllerDefault *trailingItemController;
+@property(nonatomic, strong) MDCTextField *trailingItemField;
+@property(nonatomic, strong) MDCTextInputControllerDefault *titleController;
+@property(nonatomic, strong) MDCTextField *titleField;
+@property(nonatomic, weak) UIBarButtonItem *trailingBarButtonItem;
+@property(nonatomic, weak) UIBarButtonItem *leadingBarButtonItem;
+
+@end
+@implementation NavigationBarLayoutExample
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  self.title = @"Title";
+  self.view.backgroundColor = UIColor.whiteColor;
+
+  self.navigationBar = [[MDCNavigationBar alloc] initWithFrame:CGRectZero];
+  self.navigationBar.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.navigationBar observeNavigationItem:self.navigationItem];
+  self.navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName : UIColor.whiteColor};
+  [self.view addSubview:self.navigationBar];
+
+  self.navigationItem.hidesBackButton = NO;
+
+  UIBarButtonItem *backButtonItem = [[UIBarButtonItem alloc]
+      initWithImage:[[[MDCIcons imageFor_ic_arrow_back]
+                        mdc_imageFlippedForRightToLeftLayoutDirection]
+                        imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]
+              style:UIBarButtonItemStylePlain
+             target:self
+             action:@selector(didTapBackButton)];
+  backButtonItem.tintColor = UIColor.whiteColor;
+
+  UIBarButtonItem *leadingButtonItem =
+      [[UIBarButtonItem alloc] initWithTitle:@"L"
+                                       style:UIBarButtonItemStylePlain
+                                      target:nil
+                                      action:nil];
+  UIBarButtonItem *trailingButtonItem =
+      [[UIBarButtonItem alloc] initWithTitle:@"T"
+                                       style:UIBarButtonItemStylePlain
+                                      target:nil
+                                      action:nil];
+
+  self.navigationBar.tintColor = UIColor.whiteColor;
+  self.leadingBarButtonItem = leadingButtonItem;
+  self.trailingBarButtonItem = trailingButtonItem;
+  self.navigationItem.hidesBackButton = NO;
+  self.navigationItem.leftBarButtonItems = @[ leadingButtonItem ];
+  self.navigationItem.rightBarButtonItem = trailingButtonItem;
+
+  self.leadingItemField = [[MDCTextField alloc] initWithFrame:CGRectZero];
+  self.leadingItemField.translatesAutoresizingMaskIntoConstraints = NO;
+  self.leadingItemField.delegate = self;
+  self.leadingItemField.text = @"L";
+
+  self.leadingItemController =
+      [[MDCTextInputControllerDefault alloc] initWithTextInput:self.leadingItemField];
+
+  self.trailingItemField = [[MDCTextField alloc] initWithFrame:CGRectZero];
+  self.trailingItemField.translatesAutoresizingMaskIntoConstraints = NO;
+  self.trailingItemField.delegate = self;
+  self.trailingItemField.text = @"T";
+  self.trailingItemController =
+      [[MDCTextInputControllerDefault alloc] initWithTextInput:self.trailingItemField];
+
+  self.titleField = [[MDCTextField alloc] initWithFrame:CGRectZero];
+  self.titleField.translatesAutoresizingMaskIntoConstraints = NO;
+  self.titleField.delegate = self;
+  self.titleField.text = self.title;
+  self.titleController = [[MDCTextInputControllerDefault alloc] initWithTextInput:self.titleField];
+
+  [self.view addSubview:self.leadingItemField];
+  [self.view addSubview:self.trailingItemField];
+  [self.view addSubview:self.titleField];
+
+  NSDictionary *viewsBindings = NSDictionaryOfVariableBindings(_navigationBar, _leadingItemField,
+                                                               _titleField, _trailingItemField);
+  [NSLayoutConstraint
+      activateConstraints:[NSLayoutConstraint
+                              constraintsWithVisualFormat:@"V:|[_navigationBar]-[_leadingItemField]"
+                                                          @"-[_titleField]-[_trailingItemField]"
+                                                  options:0
+                                                  metrics:nil
+                                                    views:viewsBindings]];
+  [NSLayoutConstraint
+      activateConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_navigationBar]|"
+                                                                  options:0
+                                                                  metrics:nil
+                                                                    views:viewsBindings]];
+  [NSLayoutConstraint
+      activateConstraints:[NSLayoutConstraint
+                              constraintsWithVisualFormat:@"H:|-16-[_leadingItemField]-16-|"
+                                                  options:0
+                                                  metrics:nil
+                                                    views:viewsBindings]];
+  [NSLayoutConstraint
+      activateConstraints:[NSLayoutConstraint
+                              constraintsWithVisualFormat:@"H:|-16-[_titleField]-16-|"
+                                                  options:0
+                                                  metrics:nil
+                                                    views:viewsBindings]];
+  [NSLayoutConstraint
+      activateConstraints:[NSLayoutConstraint
+                              constraintsWithVisualFormat:@"H:|-16-[_trailingItemField]-16-|"
+                                                  options:0
+                                                  metrics:nil
+                                                    views:viewsBindings]];
+}
+
+- (BOOL)prefersStatusBarHidden {
+  return YES;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+  [super viewWillAppear:animated];
+
+  [self.navigationController setNavigationBarHidden:YES animated:animated];
+}
+
+- (void)didTapBackButton {
+  [self.navigationController popViewControllerAnimated:YES];
+}
+
+#pragma mark - <UITextFieldDelegate>
+
+- (BOOL)textField:(UITextField *)textField
+    shouldChangeCharactersInRange:(NSRange)range
+                replacementString:(NSString *)string {
+  NSString *finishedString =
+      [textField.text stringByReplacingCharactersInRange:range withString:string];
+
+  // MDCNavigationBar doesn't handle BarButtonItems with no image and zero-length strings
+  if (finishedString.length == 0) {
+    finishedString = @" ";
+  }
+  if (textField == self.leadingItemField) {
+    NSMutableArray<UIBarButtonItem *> *leadingItems =
+        [self.navigationItem.leftBarButtonItems mutableCopy];
+    [leadingItems removeLastObject];
+    [leadingItems addObject:[[UIBarButtonItem alloc] initWithTitle:finishedString
+                                                             style:UIBarButtonItemStylePlain
+                                                            target:nil
+                                                            action:nil]];
+    self.navigationItem.leftBarButtonItems = leadingItems;
+  } else if (textField == self.trailingItemField) {
+    // We need to allocate and reassign because MDCNavigationBar does not adjust its layout
+    // when the existing items change their title
+    self.navigationItem.rightBarButtonItem =
+        [[UIBarButtonItem alloc] initWithTitle:finishedString
+                                         style:UIBarButtonItemStylePlain
+                                        target:nil
+                                        action:nil];
+  } else if (textField == self.titleField) {
+    self.title = finishedString;
+  }
+  return YES;
+}
+
+@end
+
+@implementation NavigationBarLayoutExample (CatalogByConvention)
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Navigation Bar", @"Navigation Bar Item Layout" ];
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return YES;
+}
+
+@end

--- a/components/NavigationBar/examples/NavigationBarTypicalUseExample.m
+++ b/components/NavigationBar/examples/NavigationBarTypicalUseExample.m
@@ -69,7 +69,7 @@
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];
 
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
+  [self.navigationController setNavigationBarHidden:NO animated:animated];
 }
 
 @end

--- a/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
+++ b/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
@@ -20,9 +20,6 @@
 
 #import "NavigationBarTypicalUseExampleSupplemental.h"
 
-@interface NavigationBarWithBarItemsExample : NavigationBarTypicalUseExample
-@end
-
 @implementation NavigationBarWithBarItemsExample
 
 - (void)viewDidLoad {

--- a/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.h
+++ b/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.h
@@ -34,3 +34,6 @@ limitations under the License.
 - (void)setupExampleViews;
 
 @end
+
+@interface NavigationBarWithBarItemsExample : NavigationBarTypicalUseExample
+@end

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -486,17 +486,20 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
         titleRightInset = textInsets.left;
       }
 
+      // Determine how much space is available to the left/right of the navigation bar's midpoint
       CGFloat midX = CGRectGetMidX(self.bounds);
       CGFloat leftMidSpaceX = midX - CGRectGetMaxX(leftButtonBar.frame) - titleLeftInset;
       CGFloat rightMidSpaceX = CGRectGetMinX(rightButtonBar.frame) - midX - titleRightInset;
       CGFloat halfFrameWidth = CGRectGetWidth(frame) / 2;
+
+      // Place the title in the exact center if we have enough left/right space
       if (leftMidSpaceX >= halfFrameWidth && rightMidSpaceX >= halfFrameWidth) {
         CGFloat xOrigin = CGRectGetMaxX(self.bounds) / 2 - CGRectGetWidth(frame) / 2;
         return CGRectMake(xOrigin, CGRectGetMinY(frame), CGRectGetWidth(frame),
                           CGRectGetHeight(frame));
       }
 
-      // Attempt to get as close to center as possible
+      // Place the title as close to the center, shifting it slightly in to the side with more space
       if (leftMidSpaceX >= halfFrameWidth) {
         CGFloat frameMaxX = CGRectGetMinX(rightButtonBar.frame) - titleRightInset;
         return CGRectMake(frameMaxX - frame.size.width, frame.origin.y, frame.size.width,

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -466,18 +466,45 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 - (CGRect)mdc_frameAlignedHorizontally:(CGRect)frame
                              alignment:(MDCNavigationBarTitleAlignment)alignment {
   switch (alignment) {
-    // Center align title if desired unless leading icons will overlap frame
+    // Center align title
     case MDCNavigationBarTitleAlignmentCenter: {
-      CGFloat xOrigin = CGRectGetMaxX(self.bounds) / 2 - CGRectGetWidth(frame) / 2;
-      CGFloat minX = CGRectGetMinX(frame);
-      // If RTL, we must use distance from maxX to bounds instead
-      if (self.mdc_effectiveUserInterfaceLayoutDirection ==
-          UIUserInterfaceLayoutDirectionRightToLeft) {
-        minX = CGRectGetMaxX(self.bounds) - CGRectGetMaxX(frame);
+      BOOL isRTL = [self mdc_effectiveUserInterfaceLayoutDirection] ==
+                   UIUserInterfaceLayoutDirectionRightToLeft;
+
+      MDCButtonBar *leftButtonBar = self.leadingButtonBar;
+      MDCButtonBar *rightButtonBar = self.trailingButtonBar;
+      UIEdgeInsets textInsets =
+          [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad ? kTextPadInsets
+                                                                                   : kTextInsets;
+      CGFloat titleLeftInset = textInsets.left;
+      CGFloat titleRightInset = textInsets.right;
+
+      if (isRTL) {
+        leftButtonBar = self.trailingButtonBar;
+        rightButtonBar = self.leadingButtonBar;
+        titleLeftInset = textInsets.right;
+        titleRightInset = textInsets.left;
       }
-      if (minX <= xOrigin) {
+
+      CGFloat midX = CGRectGetMidX(self.bounds);
+      CGFloat leftMidSpaceX = midX - CGRectGetMaxX(leftButtonBar.frame) - titleLeftInset;
+      CGFloat rightMidSpaceX = CGRectGetMinX(rightButtonBar.frame) - midX - titleRightInset;
+      CGFloat halfFrameWidth = CGRectGetWidth(frame) / 2;
+      if (leftMidSpaceX >= halfFrameWidth && rightMidSpaceX >= halfFrameWidth) {
+        CGFloat xOrigin = CGRectGetMaxX(self.bounds) / 2 - CGRectGetWidth(frame) / 2;
         return CGRectMake(xOrigin, CGRectGetMinY(frame), CGRectGetWidth(frame),
                           CGRectGetHeight(frame));
+      }
+
+      // Attempt to get as close to center as possible
+      if (leftMidSpaceX >= halfFrameWidth) {
+        CGFloat frameMaxX = CGRectGetMinX(rightButtonBar.frame) - titleRightInset;
+        return CGRectMake(frameMaxX - frame.size.width, frame.origin.y, frame.size.width,
+                          frame.size.height);
+      }
+      if (rightMidSpaceX >= halfFrameWidth) {
+        CGFloat frameOriginX = CGRectGetMaxX(leftButtonBar.frame) + titleLeftInset;
+        return CGRectMake(frameOriginX, frame.origin.y, frame.size.width, frame.size.height);
       }
     }
     // Intentional fall through


### PR DESCRIPTION
Adjusting the NavigationBar layout computation to determine if there is sufficient space in the center of the navigation bar before adjusting the Title frame.

**Original RTL Behavior**
![navbar-center-orig](https://user-images.githubusercontent.com/1753199/28929505-15325dfc-783e-11e7-8dde-e8fe54e8594b.gif)


**Updated RTL Behavior**
![navbar-center-final](https://user-images.githubusercontent.com/1753199/28929076-1c35f88a-783d-11e7-8927-84d51cd0adc8.gif)


Closes #1662, #1650 