### PR TITLE
[Math] Align frames to pixel boundaries

### DIFF
--- a/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
+++ b/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
@@ -23,6 +23,7 @@
 
 #import "ButtonsTypicalUseSupplemental.h"
 #import "MaterialButtons.h"
+#import "MaterialMath.h"
 #import "MaterialTypography.h"
 
 #pragma mark - ButtonsTypicalUseViewController
@@ -130,7 +131,7 @@
     UILabel *label = self.labels[i];
 
     button.frame = CGRectOffset(button.frame, 0, verticalCenterY);
-    label.frame = CGRectOffset(label.frame, 0, verticalCenterY);
+    label.frame = MDCRectIntegral(CGRectOffset(label.frame, 0, verticalCenterY));
   }
 }
 

--- a/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
+++ b/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
@@ -131,7 +131,8 @@
     UILabel *label = self.labels[i];
 
     button.frame = CGRectOffset(button.frame, 0, verticalCenterY);
-    label.frame = MDCRectIntegral(CGRectOffset(label.frame, 0, verticalCenterY));
+    label.frame = MDCRectAlignToScale(CGRectOffset(label.frame, 0, verticalCenterY),
+                                      [[UIScreen mainScreen] scale]);
   }
 }
 

--- a/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
+++ b/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
@@ -132,7 +132,7 @@
 
     button.frame = CGRectOffset(button.frame, 0, verticalCenterY);
     label.frame = MDCRectAlignToScale(CGRectOffset(label.frame, 0, verticalCenterY),
-                                      [[UIScreen mainScreen] scale]);
+                                      [UIScreen mainScreen].scale);
   }
 }
 

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -299,7 +299,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   } else {
     _inkView.frame = self.bounds;
   }
-  self.titleLabel.frame = MDCRectAlignToScale(self.titleLabel.frame, [[UIScreen mainScreen] scale]);
+  self.titleLabel.frame = MDCRectAlignToScale(self.titleLabel.frame, [UIScreen mainScreen].scale);
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -299,7 +299,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   } else {
     _inkView.frame = self.bounds;
   }
-  self.titleLabel.frame = MDCRectIntegral(self.titleLabel.frame);
+  self.titleLabel.frame = MDCRectAlignToScale(self.titleLabel.frame, [[UIScreen mainScreen] scale]);
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -299,6 +299,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   } else {
     _inkView.frame = self.bounds;
   }
+  self.titleLabel.frame = MDCRectIntegral(self.titleLabel.frame);
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
@@ -75,8 +75,8 @@ static NSString *const reuseIdentifier = @"Cell";
   self.button.frame = frame;
 
   CGSize labelSize = [self.infoLabel sizeThatFits:self.view.frame.size];
-  self.infoLabel.frame = MDCRectIntegral(CGRectMake(
-      self.view.frame.size.width / 2 - labelSize.width / 2, 20, labelSize.width, labelSize.height));
+  self.infoLabel.frame = MDCRectAlignToScale(
+                CGRectMake(self.view.frame.size.width / 2 - labelSize.width / 2, 20, labelSize.width, labelSize.height), [[UIScreen mainScreen] scale]);
 }
 
 - (void)didTapBackground:(UITapGestureRecognizer *)recognizer {

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
@@ -17,6 +17,7 @@
 #import "FeatureHighlightExampleSupplemental.h"
 
 #import "MaterialButtons.h"
+#import "MaterialMath.h"
 #import "MaterialPalettes.h"
 #import "MaterialTypography.h"
 
@@ -74,8 +75,8 @@ static NSString *const reuseIdentifier = @"Cell";
   self.button.frame = frame;
 
   CGSize labelSize = [self.infoLabel sizeThatFits:self.view.frame.size];
-  self.infoLabel.frame = CGRectMake(self.view.frame.size.width / 2 - labelSize.width / 2, 20,
-                                    labelSize.width, labelSize.height);
+  self.infoLabel.frame = MDCRectIntegral(CGRectMake(
+      self.view.frame.size.width / 2 - labelSize.width / 2, 20, labelSize.width, labelSize.height));
 }
 
 - (void)didTapBackground:(UITapGestureRecognizer *)recognizer {

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
@@ -75,8 +75,10 @@ static NSString *const reuseIdentifier = @"Cell";
   self.button.frame = frame;
 
   CGSize labelSize = [self.infoLabel sizeThatFits:self.view.frame.size];
-  self.infoLabel.frame = MDCRectAlignToScale(
-                CGRectMake(self.view.frame.size.width / 2 - labelSize.width / 2, 20, labelSize.width, labelSize.height), [[UIScreen mainScreen] scale]);
+  self.infoLabel.frame =
+      MDCRectAlignToScale(CGRectMake(self.view.frame.size.width / 2 - labelSize.width / 2, 20,
+                                     labelSize.width, labelSize.height),
+                          [UIScreen mainScreen].scale);
 }
 
 - (void)didTapBackground:(UITapGestureRecognizer *)recognizer {

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -286,7 +286,7 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
 
   CGFloat leftTextBound = kMDCFeatureHighlightTextPadding;
   CGFloat rightTextBound = self.frame.size.width - MAX(titleSize.width, detailSize.width) -
-                           kMDCFeatureHighlightTextPadding;
+      kMDCFeatureHighlightTextPadding;
   CGPoint titlePos = CGPointMake(0, 0);
   titlePos.x = MIN(MAX(_highlightCenter.x - textWidth / 2, leftTextBound), rightTextBound);
   if (topHalf) {

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -16,8 +16,8 @@
 
 #import "MDCFeatureHighlightView+Private.h"
 
-#import "MDCFeatureHighlightLayer.h"
 #import "MDCFeatureHighlightDismissGestureRecognizer.h"
+#import "MDCFeatureHighlightLayer.h"
 #import "MDFTextAccessibility.h"
 
 #import "MaterialFeatureHighlightStrings.h"
@@ -131,7 +131,8 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
 
     MDCFeatureHighlightDismissGestureRecognizer *panRecognizer =
         [[MDCFeatureHighlightDismissGestureRecognizer alloc]
-             initWithTarget:self action:@selector(didGestureDismiss:)];
+            initWithTarget:self
+                    action:@selector(didGestureDismiss:)];
     [self addGestureRecognizer:panRecognizer];
 
     // We want the inner and outer highlights to animate from the same origin so we start them from
@@ -285,7 +286,7 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
 
   CGFloat leftTextBound = kMDCFeatureHighlightTextPadding;
   CGFloat rightTextBound = self.frame.size.width - MAX(titleSize.width, detailSize.width) -
-      kMDCFeatureHighlightTextPadding;
+                           kMDCFeatureHighlightTextPadding;
   CGPoint titlePos = CGPointMake(0, 0);
   titlePos.x = MIN(MAX(_highlightCenter.x - textWidth / 2, leftTextBound), rightTextBound);
   if (topHalf) {
@@ -294,7 +295,8 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
     titlePos.y = _highlightPoint.y - kMDCFeatureHighlightInnerPadding - _innerRadius - textHeight;
   }
 
-  CGRect titleFrame = MDCRectAlignToScale((CGRect){titlePos, titleSize}, [[UIScreen mainScreen] scale]);
+  CGRect titleFrame =
+      MDCRectAlignToScale((CGRect){titlePos, titleSize}, [UIScreen mainScreen].scale);
   _titleLabel.frame = titleFrame;
 
   CGRect detailFrame = (CGRect){CGPointMake(titlePos.x, CGRectGetMaxY(titleFrame)), detailSize};
@@ -370,7 +372,7 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   [self updateOuterHighlight];
 
   // Square progress to ease-in the translation
-  CGFloat translationProgress = (1 - progress*progress);
+  CGFloat translationProgress = (1 - progress * progress);
   CGPoint pointOffset = CGPointMake((_highlightPoint.x - _highlightCenter.x) * translationProgress,
                                     (_highlightPoint.y - _highlightCenter.y) * translationProgress);
   CGPoint center = CGPointAddedToPoint(_highlightCenter, pointOffset);
@@ -379,26 +381,29 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
 
   if (_isLayedOutAppearing) {
     if (progress < kMDCFeatureHighlightGestureDisappearThresh) {
-      [UIView animateWithDuration:kMDCFeatureHighlightGestureAnimationDuration animations:^{
-        [self layoutDisappearing];
-      }];
+      [UIView animateWithDuration:kMDCFeatureHighlightGestureAnimationDuration
+                       animations:^{
+                         [self layoutDisappearing];
+                       }];
     }
   } else if (progress > kMDCFeatureHighlightGestureAppearThresh) {
-    [UIView animateWithDuration:kMDCFeatureHighlightGestureAnimationDuration animations:^{
-      [self layoutAppearing];
-    }];
+    [UIView animateWithDuration:kMDCFeatureHighlightGestureAnimationDuration
+                     animations:^{
+                       [self layoutAppearing];
+                     }];
   }
 }
 
 - (void)animateDismissalCancelled {
-  [UIView animateWithDuration:kMDCFeatureHighlightGestureAnimationDuration animations:^{
-    [self layoutAppearing];
-  }];
+  [UIView animateWithDuration:kMDCFeatureHighlightGestureAnimationDuration
+                   animations:^{
+                     [self layoutAppearing];
+                   }];
 
   _outerRadiusScale = 1;
   [CATransaction begin];
   [CATransaction setAnimationTimingFunction:[CAMediaTimingFunction
-                                             functionWithName:kCAMediaTimingFunctionEaseOut]];
+                                                functionWithName:kCAMediaTimingFunctionEaseOut]];
   [CATransaction setAnimationDuration:kMDCFeatureHighlightDismissAnimationDuration];
   [_outerLayer setRadius:_outerRadius * _outerRadiusScale animated:YES];
   [_outerLayer setPosition:_highlightCenter animated:YES];
@@ -420,7 +425,7 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
 
   [CATransaction begin];
   [CATransaction setAnimationTimingFunction:[CAMediaTimingFunction
-                                             functionWithName:kCAMediaTimingFunctionEaseOut]];
+                                                functionWithName:kCAMediaTimingFunctionEaseOut]];
   [CATransaction setAnimationDuration:duration];
   [_displayMaskLayer setRadius:_innerRadius animated:YES];
   [_innerLayer setFillColor:[_innerHighlightColor colorWithAlphaComponent:1].CGColor animated:YES];
@@ -436,15 +441,16 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
 - (void)animatePulse {
   NSArray *keyTimes = @[ @0, @0.5, @1 ];
   id pulseColorStart =
-      (__bridge id)[_innerHighlightColor
-                    colorWithAlphaComponent:kMDCFeatureHighlightPulseStartAlpha].CGColor;
+      (__bridge id)
+          [_innerHighlightColor colorWithAlphaComponent:kMDCFeatureHighlightPulseStartAlpha]
+              .CGColor;
   id pulseColorEnd = (__bridge id)[_innerHighlightColor colorWithAlphaComponent:0].CGColor;
   CGFloat radius = _innerRadius;
 
   [CATransaction begin];
   [CATransaction setAnimationDuration:1.0f];
   [CATransaction setAnimationTimingFunction:[CAMediaTimingFunction
-                                             functionWithName:kCAMediaTimingFunctionEaseOut]];
+                                                functionWithName:kCAMediaTimingFunctionEaseOut]];
   CGFloat innerBloomRadius = radius + kMDCFeatureHighlightInnerRadiusBloomAmount;
   CGFloat pulseBloomRadius = radius + kMDCFeatureHighlightPulseRadiusBloomAmount;
   NSArray *innerKeyframes = @[ @(radius), @(innerBloomRadius), @(radius) ];
@@ -462,7 +468,7 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
 
   [CATransaction begin];
   [CATransaction setAnimationTimingFunction:[CAMediaTimingFunction
-                                             functionWithName:kCAMediaTimingFunctionEaseOut]];
+                                                functionWithName:kCAMediaTimingFunctionEaseOut]];
   [CATransaction setAnimationDuration:duration];
   [_displayMaskLayer setPosition:displayMaskCenter animated:YES];
   [_displayMaskLayer setRadius:0.0 animated:YES];
@@ -482,7 +488,7 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
 
   [CATransaction begin];
   [CATransaction setAnimationTimingFunction:[CAMediaTimingFunction
-                                             functionWithName:kCAMediaTimingFunctionEaseOut]];
+                                                functionWithName:kCAMediaTimingFunctionEaseOut]];
   [CATransaction setAnimationDuration:duration];
   [_displayMaskLayer setPosition:displayMaskCenter animated:YES];
   [_displayMaskLayer setRadius:0 animated:YES];
@@ -513,11 +519,8 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
 + (NSString *)dismissAccessibilityHint {
   NSString *key =
       kMaterialFeatureHighlightStringTable[kStr_MaterialFeatureHighlightDismissAccessibilityHint];
-  NSString *localizedString =
-      NSLocalizedStringFromTableInBundle(key,
-                                         kMaterialFeatureHighlightStringsTableName,
-                                         [self bundle],
-                                         @"Double-tap to dismiss.");
+  NSString *localizedString = NSLocalizedStringFromTableInBundle(
+      key, kMaterialFeatureHighlightStringsTableName, [self bundle], @"Double-tap to dismiss.");
   return localizedString;
 }
 
@@ -538,7 +541,7 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   // not be in the main .app bundle, but rather in a nested framework, so figure out where we live
   // and use that as the search location.
   NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-  NSString *resourcePath = [(nil == bundle ? [NSBundle mainBundle] : bundle)resourcePath];
+  NSString *resourcePath = [(nil == bundle ? [NSBundle mainBundle] : bundle) resourcePath];
   return [resourcePath stringByAppendingPathComponent:bundleName];
 }
 

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -294,7 +294,7 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
     titlePos.y = _highlightPoint.y - kMDCFeatureHighlightInnerPadding - _innerRadius - textHeight;
   }
 
-  CGRect titleFrame = MDCRectIntegral((CGRect){titlePos, titleSize});
+  CGRect titleFrame = MDCRectAlignToScale((CGRect){titlePos, titleSize}, [[UIScreen mainScreen] scale]);
   _titleLabel.frame = titleFrame;
 
   CGRect detailFrame = (CGRect){CGPointMake(titlePos.x, CGRectGetMaxY(titleFrame)), detailSize};

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -294,7 +294,7 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
     titlePos.y = _highlightPoint.y - kMDCFeatureHighlightInnerPadding - _innerRadius - textHeight;
   }
 
-  CGRect titleFrame = (CGRect){titlePos, titleSize};
+  CGRect titleFrame = MDCRectIntegral((CGRect){titlePos, titleSize});
   _titleLabel.frame = titleFrame;
 
   CGRect detailFrame = (CGRect){CGPointMake(titlePos.x, CGRectGetMaxY(titleFrame)), detailSize};

--- a/components/Slider/examples/SliderCompareExampleViewController.m
+++ b/components/Slider/examples/SliderCompareExampleViewController.m
@@ -17,6 +17,7 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialSlider.h"
+#import "MaterialMath.h"
 
 @interface SliderCompareExampleViewController : UIViewController
 
@@ -42,6 +43,7 @@
   [label sizeToFit];
   [self.view addSubview:label];
   label.center = CGPointMake(slider.center.x, slider.center.y + 2 * label.frame.size.height);
+  label.frame = MDCRectIntegral(label.frame);
 
   // Vanilla  UISlider for comparison.
   UISlider *uiSlider = [[UISlider alloc] initWithFrame:CGRectMake(0, 0, 100, 27)];
@@ -58,6 +60,7 @@
   [self.view addSubview:uiSliderLabel];
   uiSliderLabel.center =
       CGPointMake(uiSlider.center.x, uiSlider.center.y + 2 * uiSliderLabel.frame.size.height);
+  uiSliderLabel.frame = MDCRectIntegral(uiSliderLabel.frame);
 }
 
 - (void)didChangeMDCSliderValue:(MDCSlider *)slider {

--- a/components/Slider/examples/SliderCompareExampleViewController.m
+++ b/components/Slider/examples/SliderCompareExampleViewController.m
@@ -43,7 +43,7 @@
   [label sizeToFit];
   [self.view addSubview:label];
   label.center = CGPointMake(slider.center.x, slider.center.y + 2 * label.frame.size.height);
-  label.frame = MDCRectIntegral(label.frame);
+  label.frame = MDCRectAlignToScale(label.frame, [[UIScreen mainScreen] scale]);
 
   // Vanilla  UISlider for comparison.
   UISlider *uiSlider = [[UISlider alloc] initWithFrame:CGRectMake(0, 0, 100, 27)];
@@ -60,7 +60,7 @@
   [self.view addSubview:uiSliderLabel];
   uiSliderLabel.center =
       CGPointMake(uiSlider.center.x, uiSlider.center.y + 2 * uiSliderLabel.frame.size.height);
-  uiSliderLabel.frame = MDCRectIntegral(uiSliderLabel.frame);
+  uiSliderLabel.frame = MDCRectAlignToScale(uiSliderLabel.frame, [[UIScreen mainScreen] scale]);
 }
 
 - (void)didChangeMDCSliderValue:(MDCSlider *)slider {

--- a/components/Slider/examples/SliderCompareExampleViewController.m
+++ b/components/Slider/examples/SliderCompareExampleViewController.m
@@ -16,8 +16,8 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialSlider.h"
 #import "MaterialMath.h"
+#import "MaterialSlider.h"
 
 @interface SliderCompareExampleViewController : UIViewController
 

--- a/components/Slider/examples/SliderCompareExampleViewController.m
+++ b/components/Slider/examples/SliderCompareExampleViewController.m
@@ -43,7 +43,7 @@
   [label sizeToFit];
   [self.view addSubview:label];
   label.center = CGPointMake(slider.center.x, slider.center.y + 2 * label.frame.size.height);
-  label.frame = MDCRectAlignToScale(label.frame, [[UIScreen mainScreen] scale]);
+  label.frame = MDCRectAlignToScale(label.frame, [UIScreen mainScreen].scale);
 
   // Vanilla  UISlider for comparison.
   UISlider *uiSlider = [[UISlider alloc] initWithFrame:CGRectMake(0, 0, 100, 27)];
@@ -60,7 +60,7 @@
   [self.view addSubview:uiSliderLabel];
   uiSliderLabel.center =
       CGPointMake(uiSlider.center.x, uiSlider.center.y + 2 * uiSliderLabel.frame.size.height);
-  uiSliderLabel.frame = MDCRectAlignToScale(uiSliderLabel.frame, [[UIScreen mainScreen] scale]);
+  uiSliderLabel.frame = MDCRectAlignToScale(uiSliderLabel.frame, [UIScreen mainScreen].scale);
 }
 
 - (void)didChangeMDCSliderValue:(MDCSlider *)slider {

--- a/components/private/Math/src/MDCMath.h
+++ b/components/private/Math/src/MDCMath.h
@@ -95,6 +95,12 @@ static inline CGFloat MDCSqrt(CGFloat value) {
 #endif
 }
 
+/**
+ Expand `rect' to the smallest rect containing it with integral origin and
+ size.
+ 
+ @see CGRectIntegral
+ */
 static inline CGRect MDCRectIntegral(CGRect rect) {
   CGFloat scale = [[UIScreen mainScreen] scale];
   if (MDCCGFloatEqual(scale, 1)) {

--- a/components/private/Math/src/MDCMath.h
+++ b/components/private/Math/src/MDCMath.h
@@ -100,13 +100,15 @@ static inline CGFloat MDCSqrt(CGFloat value) {
  
  @see CGRectIntegral
  */
-static inline CGRect MDCRectIntegral(CGRect rect) {
-  CGFloat scale = [[UIScreen mainScreen] scale];
+static inline CGRect MDCRectAlignToScale(CGRect rect, CGFloat scale) {
   if (MDCCGFloatEqual(scale, 1)) {
     return CGRectIntegral(rect);
   }
-  return CGRectMake(MDCFloor(rect.origin.x * scale) / scale,
-                    MDCFloor(rect.origin.y * scale) / scale,
-                    MDCCeil(rect.size.width * scale) / scale,
-                    MDCCeil(rect.size.height * scale) / scale);
+  CGPoint newOrigin = CGPointMake(MDCFloor(rect.origin.x * scale) / scale,
+                                  MDCFloor(rect.origin.y * scale) / scale);
+  CGSize adjustWidthHeight = CGSizeMake(rect.origin.x - newOrigin.x,
+                                         rect.origin.y - newOrigin.y);
+  return CGRectMake(newOrigin.x, newOrigin.y,
+                    MDCCeil((rect.size.width + adjustWidthHeight.width) * scale) / scale,
+                    MDCCeil((rect.size.height + adjustWidthHeight.height) * scale) / scale);
 }

--- a/components/private/Math/src/MDCMath.h
+++ b/components/private/Math/src/MDCMath.h
@@ -94,3 +94,14 @@ static inline CGFloat MDCSqrt(CGFloat value) {
   return sqrtf(value);
 #endif
 }
+
+static inline CGRect MDCRectIntegral(CGRect rect) {
+  CGFloat scale = [[UIScreen mainScreen] scale];
+  if (MDCCGFloatEqual(scale, 1)) {
+    return CGRectIntegral(rect);
+  }
+  return CGRectMake(MDCFloor(rect.origin.x * scale) / scale,
+                    MDCFloor(rect.origin.y * scale) / scale,
+                    MDCCeil(rect.size.width * scale) / scale,
+                    MDCCeil(rect.size.height * scale) / scale);
+}

--- a/components/private/Math/src/MDCMath.h
+++ b/components/private/Math/src/MDCMath.h
@@ -97,17 +97,16 @@ static inline CGFloat MDCSqrt(CGFloat value) {
 
 /**
  Expand `rect' to the smallest rect containing it with pixel-aligned origin and size.
- 
+
  @see CGRectIntegral
  */
 static inline CGRect MDCRectAlignToScale(CGRect rect, CGFloat scale) {
   if (MDCCGFloatEqual(scale, 1)) {
     return CGRectIntegral(rect);
   }
-  CGPoint newOrigin = CGPointMake(MDCFloor(rect.origin.x * scale) / scale,
-                                  MDCFloor(rect.origin.y * scale) / scale);
-  CGSize adjustWidthHeight = CGSizeMake(rect.origin.x - newOrigin.x,
-                                         rect.origin.y - newOrigin.y);
+  CGPoint newOrigin =
+      CGPointMake(MDCFloor(rect.origin.x * scale) / scale, MDCFloor(rect.origin.y * scale) / scale);
+  CGSize adjustWidthHeight = CGSizeMake(rect.origin.x - newOrigin.x, rect.origin.y - newOrigin.y);
   return CGRectMake(newOrigin.x, newOrigin.y,
                     MDCCeil((rect.size.width + adjustWidthHeight.width) * scale) / scale,
                     MDCCeil((rect.size.height + adjustWidthHeight.height) * scale) / scale);

--- a/components/private/Math/src/MDCMath.h
+++ b/components/private/Math/src/MDCMath.h
@@ -96,7 +96,7 @@ static inline CGFloat MDCSqrt(CGFloat value) {
 }
 
 /**
- Expand `rect' to the smallest rect containing it with pixel-aligned origin and size.
+ Expand `rect' to the smallest standardized rect containing it with pixel-aligned origin and size.
 
  @see CGRectIntegral
  */
@@ -104,10 +104,13 @@ static inline CGRect MDCRectAlignToScale(CGRect rect, CGFloat scale) {
   if (MDCCGFloatEqual(scale, 1)) {
     return CGRectIntegral(rect);
   }
-  CGPoint newOrigin =
-      CGPointMake(MDCFloor(rect.origin.x * scale) / scale, MDCFloor(rect.origin.y * scale) / scale);
-  CGSize adjustWidthHeight = CGSizeMake(rect.origin.x - newOrigin.x, rect.origin.y - newOrigin.y);
+
+  CGPoint originalMinimumPoint = CGPointMake(CGRectGetMinX(rect), CGRectGetMinY(rect));
+  CGPoint newOrigin = CGPointMake(MDCFloor(originalMinimumPoint.x * scale) / scale,
+                                  MDCFloor(originalMinimumPoint.y * scale) / scale);
+  CGSize adjustWidthHeight =
+      CGSizeMake(originalMinimumPoint.x - newOrigin.x, originalMinimumPoint.y - newOrigin.y);
   return CGRectMake(newOrigin.x, newOrigin.y,
-                    MDCCeil((rect.size.width + adjustWidthHeight.width) * scale) / scale,
-                    MDCCeil((rect.size.height + adjustWidthHeight.height) * scale) / scale);
+                    MDCCeil((CGRectGetWidth(rect) + adjustWidthHeight.width) * scale) / scale,
+                    MDCCeil((CGRectGetHeight(rect) + adjustWidthHeight.height) * scale) / scale);
 }

--- a/components/private/Math/src/MDCMath.h
+++ b/components/private/Math/src/MDCMath.h
@@ -96,8 +96,7 @@ static inline CGFloat MDCSqrt(CGFloat value) {
 }
 
 /**
- Expand `rect' to the smallest rect containing it with integral origin and
- size.
+ Expand `rect' to the smallest rect containing it with pixel-aligned origin and size.
  
  @see CGRectIntegral
  */

--- a/components/private/Math/tests/unit/MDCMathTests.m
+++ b/components/private/Math/tests/unit/MDCMathTests.m
@@ -28,7 +28,7 @@
   CGRect misalignedRect = CGRectMake(0.45, 0.78, 1.01, 5.98);
   CGRect alignedScale1Rect = CGRectMake(0, 0, 2, 7);
   CGRect alignedScale2Rect = CGRectMake(0, 0.5, 1.5, 6.5);
-  CGRect alignedScale3Rect = CGRectMake(1.0/3.0, 2.0/3.0, 4.0/3.0, 19.0/3.0);
+  CGRect alignedScale3Rect = CGRectMake(1.0 / 3.0, 2.0 / 3.0, 4.0 / 3.0, 19.0 / 3.0);
 
   // Then
   XCTAssertTrue(CGRectEqualToRect(alignedScale1Rect, MDCRectAlignToScale(misalignedRect, 1)));
@@ -41,7 +41,7 @@
   CGRect misalignedRect = CGRectMake(-5.01, -0.399, 8.35, 2.65);
   CGRect alignedScale1Rect = CGRectMake(-6, -1, 10, 4);
   CGRect alignedScale2Rect = CGRectMake(-5.5, -0.5, 9, 3);
-  CGRect alignedScale3Rect = CGRectMake(-16.0/3.0, -2.0/3.0, 9, 3);
+  CGRect alignedScale3Rect = CGRectMake(-16.0 / 3.0, -2.0 / 3.0, 9, 3);
 
   // Then
   XCTAssertTrue(CGRectEqualToRect(alignedScale1Rect, MDCRectAlignToScale(misalignedRect, 1)));

--- a/components/private/Math/tests/unit/MDCMathTests.m
+++ b/components/private/Math/tests/unit/MDCMathTests.m
@@ -1,0 +1,52 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import "MDCMath.h"
+
+@interface MDCMathTests : XCTestCase
+
+@end
+
+@implementation MDCMathTests
+
+- (void)testMDCRectAlignScale {
+  // Given
+  CGRect misalignedRect = CGRectMake(0.45, 0.78, 1.01, 5.98);
+  CGRect alignedScale1Rect = CGRectMake(0, 0, 2, 7);
+  CGRect alignedScale2Rect = CGRectMake(0, 0.5, 1.5, 6.5);
+  CGRect alignedScale3Rect = CGRectMake(1.0/3.0, 2.0/3.0, 4.0/3.0, 19.0/3.0);
+
+  // Then
+  XCTAssertTrue(CGRectEqualToRect(alignedScale1Rect, MDCRectAlignToScale(misalignedRect, 1)));
+  XCTAssertTrue(CGRectEqualToRect(alignedScale2Rect, MDCRectAlignToScale(misalignedRect, 2)));
+  XCTAssertTrue(CGRectEqualToRect(alignedScale3Rect, MDCRectAlignToScale(misalignedRect, 3)));
+}
+
+- (void)testMDCRectAlignScaleNegativeRectangle {
+  // Given
+  CGRect misalignedRect = CGRectMake(-5.01, -0.399, 8.35, 2.65);
+  CGRect alignedScale1Rect = CGRectMake(-6, -1, 10, 4);
+  CGRect alignedScale2Rect = CGRectMake(-5.5, -0.5, 9, 3);
+  CGRect alignedScale3Rect = CGRectMake(-16.0/3.0, -2.0/3.0, 9, 3);
+
+  // Then
+  XCTAssertTrue(CGRectEqualToRect(alignedScale1Rect, MDCRectAlignToScale(misalignedRect, 1)));
+  XCTAssertTrue(CGRectEqualToRect(alignedScale2Rect, MDCRectAlignToScale(misalignedRect, 2)));
+  XCTAssertTrue(CGRectEqualToRect(alignedScale3Rect, MDCRectAlignToScale(misalignedRect, 3)));
+}
+
+@end

--- a/components/private/Math/tests/unit/MDCMathTests.m
+++ b/components/private/Math/tests/unit/MDCMathTests.m
@@ -23,6 +23,9 @@
 
 @implementation MDCMathTests
 
+/**
+ Basic test for alignment.
+ */
 - (void)testMDCRectAlignScale {
   // Given
   CGRect misalignedRect = CGRectMake(0.45, 0.78, 1.01, 5.98);
@@ -31,11 +34,22 @@
   CGRect alignedScale3Rect = CGRectMake(1.0 / 3.0, 2.0 / 3.0, 4.0 / 3.0, 19.0 / 3.0);
 
   // Then
-  XCTAssertTrue(CGRectEqualToRect(alignedScale1Rect, MDCRectAlignToScale(misalignedRect, 1)));
-  XCTAssertTrue(CGRectEqualToRect(alignedScale2Rect, MDCRectAlignToScale(misalignedRect, 2)));
-  XCTAssertTrue(CGRectEqualToRect(alignedScale3Rect, MDCRectAlignToScale(misalignedRect, 3)));
+  CGRect outputScale1Rect = MDCRectAlignToScale(misalignedRect, 1);
+  XCTAssertTrue(CGRectEqualToRect(alignedScale1Rect, outputScale1Rect));
+  XCTAssertTrue(CGRectContainsRect(outputScale1Rect, misalignedRect));
+
+  CGRect outputScale2Rect = MDCRectAlignToScale(misalignedRect, 2);
+  XCTAssertTrue(CGRectEqualToRect(alignedScale2Rect, outputScale2Rect));
+  XCTAssertTrue(CGRectContainsRect(outputScale2Rect, misalignedRect));
+
+  CGRect outputScale3Rect = MDCRectAlignToScale(misalignedRect, 3);
+  XCTAssertTrue(CGRectEqualToRect(alignedScale3Rect, outputScale3Rect));
+  XCTAssertTrue(CGRectContainsRect(outputScale3Rect, misalignedRect));
 }
 
+/**
+ Basic test of rectangle alignment when the origin has negative values.
+ */
 - (void)testMDCRectAlignScaleNegativeRectangle {
   // Given
   CGRect misalignedRect = CGRectMake(-5.01, -0.399, 8.35, 2.65);
@@ -44,9 +58,65 @@
   CGRect alignedScale3Rect = CGRectMake(-16.0 / 3.0, -2.0 / 3.0, 9, 3);
 
   // Then
-  XCTAssertTrue(CGRectEqualToRect(alignedScale1Rect, MDCRectAlignToScale(misalignedRect, 1)));
-  XCTAssertTrue(CGRectEqualToRect(alignedScale2Rect, MDCRectAlignToScale(misalignedRect, 2)));
-  XCTAssertTrue(CGRectEqualToRect(alignedScale3Rect, MDCRectAlignToScale(misalignedRect, 3)));
+  CGRect outputScale1Rect = MDCRectAlignToScale(misalignedRect, 1);
+  XCTAssertTrue(CGRectEqualToRect(alignedScale1Rect, outputScale1Rect));
+  XCTAssertTrue(CGRectContainsRect(outputScale1Rect, misalignedRect));
+
+  CGRect outputScale2Rect = MDCRectAlignToScale(misalignedRect, 2);
+  XCTAssertTrue(CGRectEqualToRect(alignedScale2Rect, outputScale2Rect));
+  XCTAssertTrue(CGRectContainsRect(outputScale2Rect, misalignedRect));
+
+  CGRect outputScale3Rect = MDCRectAlignToScale(misalignedRect, 3);
+  XCTAssertTrue(CGRectEqualToRect(alignedScale3Rect, outputScale3Rect));
+  XCTAssertTrue(CGRectContainsRect(outputScale3Rect, misalignedRect));
+}
+
+/**
+ Test of a non-standardized rectangle (height/width are negative)
+ */
+- (void)testMDCRectAlignScaleNonStandardRectangle {
+  // Given
+  CGRect misalignedRect = CGRectMake(17.9, -4.44, -10.10, -15.85);
+  // Standardized: (7.80, -20.29), (10.10, 15.85)
+  CGRect alignedScale1Rect = CGRectMake(7, -21, 11, 17);
+  CGRect alignedScale2Rect = CGRectMake(7.5, -20.5, 10.5, 16.5);
+  CGRect alignedScale3Rect = CGRectMake(23.0 / 3.0, -61.0 / 3.0, 31.0 / 3.0, 16);
+
+  // Then
+  CGRect outputScale1Rect = MDCRectAlignToScale(misalignedRect, 1);
+  XCTAssertTrue(CGRectEqualToRect(alignedScale1Rect, outputScale1Rect));
+  XCTAssertTrue(CGRectContainsRect(outputScale1Rect, misalignedRect));
+
+  CGRect outputScale2Rect = MDCRectAlignToScale(misalignedRect, 2);
+  XCTAssertTrue(CGRectEqualToRect(alignedScale2Rect, outputScale2Rect));
+  XCTAssertTrue(CGRectContainsRect(outputScale2Rect, misalignedRect));
+
+  CGRect outputScale3Rect = MDCRectAlignToScale(misalignedRect, 3);
+  XCTAssertTrue(CGRectEqualToRect(alignedScale3Rect, outputScale3Rect));
+  XCTAssertTrue(CGRectContainsRect(outputScale3Rect, misalignedRect));
+}
+
+/**
+ Test that an already-aligned rectangle will not be changed.
+ */
+- (void)testMDCRectAlignScaleAlreadyAligned {
+  // Given
+  CGRect alignedScale1Rect = CGRectMake(10, 15, 5, 10);
+  CGRect alignedScale2Rect = CGRectMake(10.5, 15.5, 5.5, 10.5);
+  CGRect alignedScale3Rect = CGRectMake(31.0 / 3.0, 47.0 / 3.0, 16.0 / 3.0, 32.0 / 3.0);
+
+  // Then
+  CGRect outputScale1Rect = MDCRectAlignToScale(alignedScale1Rect, 1);
+  XCTAssertTrue(CGRectEqualToRect(alignedScale1Rect, outputScale1Rect));
+  XCTAssertTrue(CGRectContainsRect(outputScale1Rect, alignedScale1Rect));
+
+  CGRect outputScale2Rect = MDCRectAlignToScale(alignedScale2Rect, 2);
+  XCTAssertTrue(CGRectEqualToRect(alignedScale2Rect, outputScale2Rect));
+  XCTAssertTrue(CGRectContainsRect(outputScale2Rect, alignedScale2Rect));
+
+  CGRect outputScale3Rect = MDCRectAlignToScale(alignedScale3Rect, 3);
+  XCTAssertTrue(CGRectEqualToRect(alignedScale3Rect, outputScale3Rect));
+  XCTAssertTrue(CGRectContainsRect(outputScale3Rect, alignedScale3Rect));
 }
 
 @end

--- a/components/private/ThumbTrack/src/MDCThumbTrack.m
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.m
@@ -621,7 +621,7 @@ static inline CGFloat DistanceFromPointToPoint(CGPoint point1, CGPoint point2) {
     if ([_delegate respondsToSelector:@selector(thumbTrack:stringForValue:)]) {
       _valueLabel.text = [_delegate thumbTrack:self stringForValue:_value];
       if (CGRectGetWidth(_valueLabel.frame) > 1) {
-        _valueLabel.frame = MDCRectIntegral(_valueLabel.frame);
+        _valueLabel.frame = MDCRectAlignToScale(_valueLabel.frame, [[UIScreen mainScreen] scale]);
       }
     }
   }

--- a/components/private/ThumbTrack/src/MDCThumbTrack.m
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.m
@@ -621,7 +621,7 @@ static inline CGFloat DistanceFromPointToPoint(CGPoint point1, CGPoint point2) {
     if ([_delegate respondsToSelector:@selector(thumbTrack:stringForValue:)]) {
       _valueLabel.text = [_delegate thumbTrack:self stringForValue:_value];
       if (CGRectGetWidth(_valueLabel.frame) > 1) {
-        _valueLabel.frame = MDCRectAlignToScale(_valueLabel.frame, [[UIScreen mainScreen] scale]);
+        _valueLabel.frame = MDCRectAlignToScale(_valueLabel.frame, [UIScreen mainScreen].scale);
       }
     }
   }

--- a/components/private/ThumbTrack/src/MDCThumbTrack.m
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.m
@@ -620,6 +620,9 @@ static inline CGFloat DistanceFromPointToPoint(CGPoint point1, CGPoint point2) {
     _valueLabel.textColor = [UIColor whiteColor];
     if ([_delegate respondsToSelector:@selector(thumbTrack:stringForValue:)]) {
       _valueLabel.text = [_delegate thumbTrack:self stringForValue:_value];
+      if (CGRectGetWidth(_valueLabel.frame) > 1) {
+        _valueLabel.frame = MDCRectIntegral(_valueLabel.frame);
+      }
     }
   }
 


### PR DESCRIPTION
Adding a new function to realign a CGRect (frame) to pixel boundaries
based on the screen scale. After a review of the catalog, I'm updating
the areas where I found misaligned frames.

|Component|Before|After|
|------------|-------|-----|
|Slider | ![slider-blur](https://user-images.githubusercontent.com/1753199/28936350-75aa9bba-7855-11e7-82af-4cecd0f5fbfc.png)|![slider-pixel](https://user-images.githubusercontent.com/1753199/28936358-791350c6-7855-11e7-84eb-513fcbd92fab.png)
|Feature Highlight|![feature-blur](https://user-images.githubusercontent.com/1753199/28936373-8c1b592a-7855-11e7-9895-dddbe5e5faf9.png)|![feature-pixel](https://user-images.githubusercontent.com/1753199/28936380-90aa3146-7855-11e7-891b-39388284dafe.png)
|Navigation Bar (Buttons)|![navbar_blur](https://user-images.githubusercontent.com/1753199/28936395-9e4212d8-7855-11e7-8166-e6721300c4f1.png)|![navbar_pixel](https://user-images.githubusercontent.com/1753199/28936406-a830ee2c-7855-11e7-9285-a948d1045b35.png)





Closes #1723
