### PR TITLE
[Collections] Allow selection of cells with hidden ink

### DIFF
--- a/components/Collections/src/MDCCollectionViewController.h
+++ b/components/Collections/src/MDCCollectionViewController.h
@@ -49,9 +49,6 @@
  as well as ink during the highlight/unhighlight states.
  */
 
-- (BOOL)collectionView:(nonnull UICollectionView *)collectionView
-    shouldHighlightItemAtIndexPath:(nonnull NSIndexPath *)indexPath NS_REQUIRES_SUPER;
-
 - (void)collectionView:(nonnull UICollectionView *)collectionView
     didHighlightItemAtIndexPath:(nonnull NSIndexPath *)indexPath NS_REQUIRES_SUPER;
 

--- a/components/Collections/src/MDCCollectionViewController.h
+++ b/components/Collections/src/MDCCollectionViewController.h
@@ -49,6 +49,9 @@
  as well as ink during the highlight/unhighlight states.
  */
 
+- (BOOL)collectionView:(nonnull UICollectionView *)collectionView
+    shouldHighlightItemAtIndexPath:(nonnull NSIndexPath *)indexPath NS_REQUIRES_SUPER;
+
 - (void)collectionView:(nonnull UICollectionView *)collectionView
     didHighlightItemAtIndexPath:(nonnull NSIndexPath *)indexPath NS_REQUIRES_SUPER;
 

--- a/components/Collections/src/MDCCollectionViewController.m
+++ b/components/Collections/src/MDCCollectionViewController.m
@@ -398,6 +398,11 @@ NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFoote
 
 #pragma mark - <UICollectionViewDelegate>
 
+- (BOOL)collectionView:(UICollectionView *)collectionView
+    shouldHighlightItemAtIndexPath:(NSIndexPath *)indexPath {
+  return YES;
+}
+
 - (void)collectionView:(UICollectionView *)collectionView
     didHighlightItemAtIndexPath:(NSIndexPath *)indexPath {
   if ([_styler.delegate respondsToSelector:@selector(collectionView:hidesInkViewAtIndexPath:)]

--- a/components/Collections/src/MDCCollectionViewController.m
+++ b/components/Collections/src/MDCCollectionViewController.m
@@ -398,16 +398,12 @@ NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFoote
 
 #pragma mark - <UICollectionViewDelegate>
 
-- (BOOL)collectionView:(UICollectionView *)collectionView
-    shouldHighlightItemAtIndexPath:(NSIndexPath *)indexPath {
-  if ([_styler.delegate respondsToSelector:@selector(collectionView:hidesInkViewAtIndexPath:)]) {
-    return ![_styler.delegate collectionView:collectionView hidesInkViewAtIndexPath:indexPath];
-  }
-  return YES;
-}
-
 - (void)collectionView:(UICollectionView *)collectionView
     didHighlightItemAtIndexPath:(NSIndexPath *)indexPath {
+  if ([_styler.delegate respondsToSelector:@selector(collectionView:hidesInkViewAtIndexPath:)]
+      && [_styler.delegate collectionView:collectionView hidesInkViewAtIndexPath:indexPath]) {
+    return;
+  }
   UICollectionViewCell *cell = [collectionView cellForItemAtIndexPath:indexPath];
   CGPoint location = [collectionView convertPoint:_inkTouchLocation toView:cell];
 


### PR DESCRIPTION
MDCCollectionViewController does not receive messages for
`-collectionView:didSelectItemAtIndexPath:` if it responds `NO` to
`-collectionView:shouldHighlightCellAtIndexPath:`. It seems by allowing
highlight, but not performing a highlight animation on the cell, the delegate
will receive *didSelect* messages for cells with hidden ink.

Closes #1446
