### PR TITLE
[Scripts] Only lint catalog, components, and demos

### DIFF
--- a/scripts/lint_all
+++ b/scripts/lint_all
@@ -16,9 +16,12 @@
 
 readonly SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly ROOT_DIR="$SCRIPTS_DIR/.."
+readonly LINT_DIRS=("catalog" "components" "demos")
 
 if which swiftlint >/dev/null; then
-  swiftlint lint --path "$ROOT_DIR" --quiet
+  for lintdir in ${LINT_DIRS[@]}; do
+    swiftlint lint --path "$ROOT_DIR/$lintdir" --quiet
+  done 
 else
   echo "warning: run scripts/install_contributor_tools to enable SwiftLint warnings."
 fi


### PR DESCRIPTION
The lint_all script should stick to the MDC-iOS code and not the docs,
scripts, etc. that are included in the repository.  Specifically, we are
only linting the Components, Catalog, and Demos that we ship.

Closes #1578
