### PR TITLE
[Collections] Making Disclosure indicator tinted

### DIFF
--- a/components/CollectionCells/src/MDCCollectionViewCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewCell.m
@@ -232,7 +232,7 @@ NSString *const kDeselectedCellAccessibilityHintKey =
           UIUserInterfaceLayoutDirectionRightToLeft) {
         image = [image mdc_imageFlippedForRightToLeftLayoutDirection];
       }
-      accessoryImageView.image = image;
+      accessoryImageView.image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
       break;
     }
     case MDCCollectionViewCellAccessoryCheckmark: {


### PR DESCRIPTION
Collection cell accessory views set to "Disclosure Indicator" will now
use template mode and will utilize the tinting of the cell/collection
view.

**Original**
![disclosure-before](https://user-images.githubusercontent.com/1753199/29041799-3fe25998-7b82-11e7-93aa-27482db4a2ad.png)

**This Change**
![disclosure-after](https://user-images.githubusercontent.com/1753199/29041803-442ccfce-7b82-11e7-918f-807bd14640d3.png)


Closes #1575
