### PR TITLE
[PageControl] Send UIControlEventChanges Event on setCurrentPage

### DIFF
--- a/components/PageControl/src/MDCPageControl.m
+++ b/components/PageControl/src/MDCPageControl.m
@@ -175,6 +175,7 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
                                                    // more to ensure
                                                    // no hidden indicators remain.
                                                    [self revealIndicatorsReversed:shouldReverse];
+                                                   [self sendActionsForControlEvents:UIControlEventValueChanged];
                                                  }];
                        [self revealIndicatorsReversed:shouldReverse];
                      });
@@ -193,6 +194,7 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
     [CATransaction setDisableActions:YES];
     [_indicators[previousPage] setHidden:NO];
     [CATransaction commit];
+    [self sendActionsForControlEvents:UIControlEventValueChanged];
   }
 }
 


### PR DESCRIPTION
Call sendActions:UIControlerEventValueChanged when setCurrentPage is called.

Originally part of #1728 by @Eccelor.
