### PR TITLE
[FeatureHighlight] Fix gesture recognizers

### DIFF
--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightDismissGestureRecognizer.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightDismissGestureRecognizer.m
@@ -86,7 +86,11 @@
   [super touchesEnded:touches withEvent:event];
 
   if (_hasTouch) {
-    self.state = UIGestureRecognizerStateEnded;
+    if (MDCCGFloatEqual(_progress, 1.0)) {
+      self.state = UIGestureRecognizerStateCancelled;
+    } else {
+      self.state = UIGestureRecognizerStateEnded;
+    }
   }
 }
 

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightDismissGestureRecognizer.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightDismissGestureRecognizer.m
@@ -86,11 +86,7 @@
   [super touchesEnded:touches withEvent:event];
 
   if (_hasTouch) {
-    if (MDCCGFloatEqual(_progress, 1.0)) {
-      self.state = UIGestureRecognizerStateCancelled;
-    } else {
-      self.state = UIGestureRecognizerStateEnded;
-    }
+    self.state = UIGestureRecognizerStateEnded;
   }
 }
 

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.h
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.h
@@ -33,7 +33,7 @@ typedef void (^MDCFeatureHighlightInteractionBlock)(BOOL accepted);
 
 @end
 
-@interface MDCFeatureHighlightView (Private)
+@interface MDCFeatureHighlightView (Private) <UIGestureRecognizerDelegate>
 
 - (void)layoutAppearing;
 - (void)layoutDisappearing;

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -127,6 +127,7 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
 
     UITapGestureRecognizer *tapRecognizer =
         [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(didTapView:)];
+    tapRecognizer.delegate = self;
     [self addGestureRecognizer:tapRecognizer];
 
     MDCFeatureHighlightDismissGestureRecognizer *panRecognizer =
@@ -522,6 +523,14 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   NSString *localizedString = NSLocalizedStringFromTableInBundle(
       key, kMaterialFeatureHighlightStringsTableName, [self bundle], @"Double-tap to dismiss.");
   return localizedString;
+}
+
+#pragma mark - UIGestureRecognizerDelegate (Tap)
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+    shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  return YES;
 }
 
 #pragma mark - Resource bundle


### PR DESCRIPTION
The most recent feature highlight fix broke part of the tap-to-dismiss #1735. This PR fixes it correctly.

Core change:
* Allow both gesture recognizers to act simultaneously.