### PR TITLE
[Collections] Rewrite color helpers are functions

### DIFF
--- a/components/CollectionCells/src/MDCCollectionViewCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewCell.m
@@ -25,9 +25,12 @@
 #import "MaterialIcons+ic_reorder.h"
 #import "MaterialRTL.h"
 
-#define RGBCOLOR(r, g, b) \
-  [UIColor colorWithRed:(r) / 255.0f green:(g) / 255.0f blue:(b) / 255.0f alpha:1]
-#define HEXCOLOR(hex) RGBCOLOR((((hex) >> 16) & 0xFF), (((hex) >> 8) & 0xFF), ((hex)&0xFF))
+static inline UIColor *RGBColor(NSInteger red, NSInteger green, NSInteger blue) {
+  return [UIColor colorWithRed:(red / 255.0f) green:(green / 255.0f) blue:(blue / 255.0f) alpha:1];
+}
+static inline UIColor *HexColor(NSInteger hex) {
+  return RGBColor((hex >> 16) & 0xFF, (hex >> 8) & 0xFF, hex & 0xFF);
+}
 
 static CGFloat kEditingControlAppearanceOffset = 16.0f;
 
@@ -95,7 +98,7 @@ NSString *const kDeselectedCellAccessibilityHintKey =
   // Accessory defaults.
   _accessoryType = MDCCollectionViewCellAccessoryNone;
   _accessoryInset = kAccessoryInsetDefault;
-  _editingSelectorColor = HEXCOLOR(kCellRedColor);
+  _editingSelectorColor = HexColor(kCellRedColor);
 }
 
 #pragma mark - Layout
@@ -366,7 +369,7 @@ NSString *const kDeselectedCellAccessibilityHintKey =
         UIImage *reorderImage = [MDCIcons imageFor_ic_reorder];
         reorderImage = [reorderImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
         _editingReorderImageView = [[UIImageView alloc] initWithImage:reorderImage];
-        _editingReorderImageView.tintColor = HEXCOLOR(kCellGrayColor);
+        _editingReorderImageView.tintColor = HexColor(kCellGrayColor);
         _editingReorderImageView.autoresizingMask =
             MDCAutoresizingFlexibleTrailingMargin(self.mdc_effectiveUserInterfaceLayoutDirection);
         [self addSubview:_editingReorderImageView];
@@ -390,7 +393,7 @@ NSString *const kDeselectedCellAccessibilityHintKey =
         UIImage *selectorImage = [MDCIcons imageFor_ic_radio_button_unchecked];
         selectorImage = [selectorImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
         _editingSelectorImageView = [[UIImageView alloc] initWithImage:selectorImage];
-        _editingSelectorImageView.tintColor = HEXCOLOR(kCellGrayColor);
+        _editingSelectorImageView.tintColor = HexColor(kCellGrayColor);
         _editingSelectorImageView.autoresizingMask =
             MDCAutoresizingFlexibleLeadingMargin(self.mdc_effectiveUserInterfaceLayoutDirection);
         [self addSubview:_editingSelectorImageView];
@@ -437,7 +440,7 @@ NSString *const kDeselectedCellAccessibilityHintKey =
   } else {
     if (_editingSelectorImageView && previousSelectedState != selected) {
       _editingSelectorImageView.image = [MDCIcons imageFor_ic_radio_button_unchecked];
-      _editingSelectorImageView.tintColor = HEXCOLOR(kCellGrayColor);
+      _editingSelectorImageView.tintColor = HexColor(kCellGrayColor);
       _editingSelectorImageView.image = [_editingSelectorImageView.image
           imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     }
@@ -447,7 +450,7 @@ NSString *const kDeselectedCellAccessibilityHintKey =
 
 - (void)setEditingSelectorColor:(UIColor *)editingSelectorColor {
   if (editingSelectorColor == nil) {
-    editingSelectorColor = HEXCOLOR(kCellRedColor);
+    editingSelectorColor = HexColor(kCellRedColor);
   }
   _editingSelectorColor = editingSelectorColor;
 }

--- a/components/Collections/src/private/MDCCollectionViewStyler.m
+++ b/components/Collections/src/private/MDCCollectionViewStyler.m
@@ -21,8 +21,9 @@
 
 #include <tgmath.h>
 
-#define RGBCOLOR(r, g, b) \
-  [UIColor colorWithRed:(r) / 255.0f green:(g) / 255.0f blue:(b) / 255.0f alpha:1]
+static inline UIColor *RGBColor(NSInteger red, NSInteger green, NSInteger blue) {
+  return [UIColor colorWithRed:(red / 255.0f) green:(green / 255.0f) blue:(blue / 255.0f) alpha:1];
+}
 
 typedef NS_OPTIONS(NSUInteger, BackgroundCacheKey) {
   BackgroundCacheKeyFlat = 0,
@@ -125,11 +126,11 @@ NS_INLINE CGRect RectShift(CGRect rect, CGFloat dx, CGFloat dy) {
     // Cell default style properties.
     _cellBackgroundColor = [UIColor whiteColor];
     _cellStyle = MDCCollectionViewCellStyleDefault;
-    _collectionView.backgroundColor = RGBCOLOR(0xEE, 0xEE, 0xEE);
+    _collectionView.backgroundColor = RGBColor(0xEE, 0xEE, 0xEE);
     _inlaidIndexPathSet = [NSMutableSet set];
 
     // Cell separator defaults.
-    _separatorColor = RGBCOLOR(224, 224, 224);
+    _separatorColor = RGBColor(224, 224, 224);
     _separatorInset = UIEdgeInsetsZero;
     _separatorLineHeight =
         kCollectionViewCellSeparatorDefaultHeightInPixels / [[UIScreen mainScreen] scale];


### PR DESCRIPTION
One convenience macro was being used to transform integer red/green/blue
values into CGFloat for UIColor.  Another was transforming an integer
value into 8-bit red/green/blue components. Both are being changed to
static inline functions.

References #1682
