### PR TITLE
[Catalog] Fix button typical use layout on iOS 9

### DIFF
--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -51,7 +51,6 @@
   [raisedButton addTarget:self
                    action:@selector(didTap:)
          forControlEvents:UIControlEventTouchUpInside];
-  raisedButton.translatesAutoresizingMaskIntoConstraints = NO;
   [self.view addSubview:raisedButton];
 
   // Disabled raised button
@@ -64,7 +63,6 @@
                            action:@selector(didTap:)
                  forControlEvents:UIControlEventTouchUpInside];
   [disabledRaisedButton setEnabled:NO];
-  disabledRaisedButton.translatesAutoresizingMaskIntoConstraints = NO;
   [self.view addSubview:disabledRaisedButton];
 
   // Flat button
@@ -76,7 +74,6 @@
   [flatButton addTarget:self
                  action:@selector(didTap:)
        forControlEvents:UIControlEventTouchUpInside];
-  flatButton.translatesAutoresizingMaskIntoConstraints = NO;
   [self.view addSubview:flatButton];
 
   // Disabled flat
@@ -89,7 +86,6 @@
                          action:@selector(didTap:)
                forControlEvents:UIControlEventTouchUpInside];
   [disabledFlatButton setEnabled:NO];
-  disabledFlatButton.translatesAutoresizingMaskIntoConstraints = NO;
   [self.view addSubview:disabledFlatButton];
 
   // Custom stroked button
@@ -100,7 +96,6 @@
   [strokedButton addTarget:self
                     action:@selector(didTap:)
           forControlEvents:UIControlEventTouchUpInside];
-  strokedButton.translatesAutoresizingMaskIntoConstraints = NO;
   [self.view addSubview:strokedButton];
 
   // Disabled custom stroked button
@@ -112,7 +107,6 @@
                             action:@selector(didTap:)
                   forControlEvents:UIControlEventTouchUpInside];
   [disabledStrokedButton setEnabled:NO];
-  disabledStrokedButton.translatesAutoresizingMaskIntoConstraints = NO;
   [self.view addSubview:disabledStrokedButton];
 
   // Floating action button

--- a/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
+++ b/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
@@ -53,7 +53,6 @@
   label.font = [MDCTypography captionFont];
   label.alpha = [MDCTypography captionFontOpacity];
   [label sizeToFit];
-  label.translatesAutoresizingMaskIntoConstraints = NO;
   [self.view addSubview:label];
 
   return label;
@@ -74,9 +73,10 @@
   ];
 }
 
-- (void)viewWillLayoutSubviews {
-  CGFloat centerX = CGRectGetMidX(self.view.bounds);
+- (void)viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
 
+  CGFloat centerX = CGRectGetMidX(self.view.bounds);
   [self layoutButtonsInRange:NSMakeRange(0, self.buttons.count) around:centerX];
 
   UIView *lastButton = self.buttons.lastObject;


### PR DESCRIPTION
The manual layout code was disabling automatic constraints generation
and trying to lay-out the view before subviews were laid-out.  The
combination led to broken layout on iOS 9 the first time the view was
loaded.

Resolves #1757
