### PR TITLE
[Buttons] Unit tests for FAB animations

### DIFF
--- a/components/Buttons/src/MDCFloatingButton+Animation.m
+++ b/components/Buttons/src/MDCFloatingButton+Animation.m
@@ -23,7 +23,8 @@ float UIAnimationDragCoefficient(void);  // Private API for simulator animation 
 static NSString *const kMDCFloatingButtonTransformKey = @"kMDCFloatingButtonTransformKey";
 static NSString *const kMDCFloatingButtonOpacityKey = @"kMDCFloatingButtonOpacityKey";
 
-static const CGFloat kMDCFloatingButtonTransformScale = 0.00001f;
+// By using a power of 2 (2^-12), we can reduce rounding errors during transform multiplication
+static const CGFloat kMDCFloatingButtonTransformScale = (CGFloat)0.000244140625;
 
 static const NSTimeInterval kMDCFloatingButtonEnterDuration = 0.270f;
 static const NSTimeInterval kMDCFloatingButtonExitDuration = 0.180f;

--- a/components/Buttons/tests/unit/FloatingButtonTests.m
+++ b/components/Buttons/tests/unit/FloatingButtonTests.m
@@ -35,5 +35,59 @@
   XCTAssertEqual([button elevationForState:UIControlStateDisabled], MDCShadowElevationNone);
 }
 
+- (void)testCollapseExpandRestoresTransform {
+  // Given
+  MDCFloatingButton *button = [[MDCFloatingButton alloc] init];
+  CGAffineTransform transform = CGAffineTransformRotate(button.transform, M_PI_2);
+  button.transform = transform;
+
+  // When
+  [button collapse:NO completion:nil];
+  [button expand:NO completion:nil];
+
+  // Then
+  XCTAssertTrue(
+      CGAffineTransformEqualToTransform(button.transform, transform),
+      @"Collapse and expand did not restore the original transform.\nExpected: %@\nReceived: %@",
+      NSStringFromCGAffineTransform(transform), NSStringFromCGAffineTransform(button.transform));
+}
+
+- (void)testCollapseExpandAnimatedRestoresTransform {
+  // Given
+  MDCFloatingButton *button = [[MDCFloatingButton alloc] init];
+  CGAffineTransform transform = CGAffineTransformMakeTranslation(10, -77.1);
+  button.transform = transform;
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Collapse animation complete"];
+
+  // When
+  [button collapse:YES
+        completion:^{
+          [expectation fulfill];
+        }];
+
+  // Then
+  // Collapse should take around 200ms in total
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+
+  XCTAssertFalse(CGAffineTransformEqualToTransform(button.transform, transform),
+                 @"Collapse did not modify the original transform.\nOriginal: %@\nReceived: %@",
+                 NSStringFromCGAffineTransform(transform),
+                 NSStringFromCGAffineTransform(button.transform));
+
+  expectation = [self expectationWithDescription:@"Expand animation complete"];
+
+  [button expand:YES
+      completion:^{
+        [expectation fulfill];
+      }];
+
+  // Expand should take around 200ms in total
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+
+  XCTAssertTrue(
+      CGAffineTransformEqualToTransform(button.transform, transform),
+      @"Collapse and expand did not restore the original transform.\nExpected: %@\nReceived: %@",
+      NSStringFromCGAffineTransform(transform), NSStringFromCGAffineTransform(button.transform));
+}
 
 @end

--- a/components/Buttons/tests/unit/FloatingButtonTests.m
+++ b/components/Buttons/tests/unit/FloatingButtonTests.m
@@ -35,6 +35,23 @@
   XCTAssertEqual([button elevationForState:UIControlStateDisabled], MDCShadowElevationNone);
 }
 
+- (void)testCollapseExpandRestoresIdentityTransform {
+  // Given
+  MDCFloatingButton *button = [[MDCFloatingButton alloc] init];
+  CGAffineTransform transform = CGAffineTransformIdentity;
+  button.transform = transform;
+
+  // When
+  [button collapse:NO completion:nil];
+  [button expand:NO completion:nil];
+
+  // Then
+  XCTAssertTrue(
+      CGAffineTransformEqualToTransform(button.transform, transform),
+      @"Collapse and expand did not restore the original transform.\nExpected: %@\nReceived: %@",
+      NSStringFromCGAffineTransform(transform), NSStringFromCGAffineTransform(button.transform));
+}
+
 - (void)testCollapseExpandRestoresTransform {
   // Given
   MDCFloatingButton *button = [[MDCFloatingButton alloc] init];


### PR DESCRIPTION
Adding unit tests to verify that Floating Action Button animations restore the
button's transforms to their original values.

Related to #1755