### PR TITLE
[NavigationBar] Hide UINavigationBar in example

### DIFF
--- a/components/NavigationBar/examples/NavigationBarTypicalUseExample.m
+++ b/components/NavigationBar/examples/NavigationBarTypicalUseExample.m
@@ -69,7 +69,7 @@
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];
 
-  [self.navigationController setNavigationBarHidden:NO animated:animated];
+  [self.navigationController setNavigationBarHidden:YES animated:animated];
 }
 
 @end


### PR DESCRIPTION
UINavigationBar was accidentally exposed during a recent change to the
example.
