### PR TITLE
[AppBar] Fixing modal example bar colors

### DIFF
--- a/components/AppBar/examples/AppBarModalPresentationExample.m
+++ b/components/AppBar/examples/AppBarModalPresentationExample.m
@@ -224,7 +224,7 @@
 
     self.title = @"Modal Presentation";
 
-    UIColor *color = [UIColor colorWithWhite:0.1 alpha:1];
+    UIColor *color = [UIColor colorWithWhite:0.2 alpha:1];
     _appBar.headerViewController.headerView.backgroundColor = color;
     MDCAppBarTextColorAccessibilityMutator *mutator =
         [[MDCAppBarTextColorAccessibilityMutator alloc] init];

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -103,7 +103,7 @@ class AppBarModalPresentationSwiftExample: UITableViewController {
 
     self.addChildViewController(appBar.headerViewController)
 
-    let color = UIColor(white: 0.1, alpha:1)
+    let color = UIColor(white: 0.2, alpha:1)
     appBar.headerViewController.headerView.backgroundColor = color
     let mutator = MDCAppBarTextColorAccessibilityMutator()
     mutator.mutate(appBar)


### PR DESCRIPTION
The "modal" AppBar examples did not have the same header colors as the
rest of the examples and looked a bit odd with the iOS status bar.
