### PR TITLE
Adds api_doc_root to TextFields/README.md.

### DIFF
--- a/components/TextFields/README.md
+++ b/components/TextFields/README.md
@@ -5,6 +5,7 @@ section: components
 excerpt: "Text fields allow users to input text into your app."
 iconId: textfields
 path: /catalog/textfields/
+api_doc_root: true
 -->
 
 # Text Fields


### PR DESCRIPTION
This indicates to the site generator that Jazzy should be invoked on this directory.

This will require a followup PR to add links to the API docs in the link list.