### PR TITLE
[Buttons] Fix FAB icon scale collapse timing

### DIFF
--- a/components/Buttons/src/MDCFloatingButton+Animation.m
+++ b/components/Buttons/src/MDCFloatingButton+Animation.m
@@ -196,9 +196,8 @@ static const NSTimeInterval kMDCFloatingButtonOpacityExitOffset = 0.150f;
                                                             [MDCFloatingButton collapseTransform])]
                    fromValue:nil
               timingFunction:[[CAMediaTimingFunction alloc]
-                                 initWithControlPoints:0.0f:0.0f:0.2f:1.0f]
-                    fillMode:kCAFillModeForwards
-                    duration:kMDCFloatingButtonExitIconDuration
+                                 initWithControlPoints:0.4f:0.0f:1.0f:1.0f]
+                    fillMode:kCAFillModeForwards duration:kMDCFloatingButtonExitIconDuration
                  beginOffset:kMDCFloatingButtonExitIconOffset];
     [self.imageView.layer addAnimation:iconScaleAnimation forKey:kMDCFloatingButtonTransformKey];
 


### PR DESCRIPTION
The Floating Action Button's collapse animation timing function should
start at 40% and end at 100% (time), rather than starting at 0% and
ending at 20% (time).

**Original animation**
![fab-animate](https://user-images.githubusercontent.com/1753199/29272798-94cfa8a0-80cf-11e7-8444-2d9d18c89a5c.gif)

**Corrected animation**
![fab-animate-fix](https://user-images.githubusercontent.com/1753199/29272805-9b7e5480-80cf-11e7-9ae2-660a892c44de.gif)

Closes #1793 
