### PR TITLE
[ButtonBar] Refactor ButtonBarBuilder for testing

### DIFF
--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
@@ -103,23 +103,8 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
   button.disabledAlpha = kDisabledButtonAlpha;
 
   button.exclusiveTouch = YES;
-  if (buttonItem.title != nil) {
-    [button setTitle:buttonItem.title forState:UIControlStateNormal];
-  }
-  if (buttonItem.image != nil) {
-    [button setImage:buttonItem.image forState:UIControlStateNormal];
-  }
-  if (buttonItem.tintColor != nil) {
-    button.tintColor = buttonItem.tintColor;
-  }
 
-  if (buttonItem.title) {
-    button.inkStyle = MDCInkStyleBounded;
-  } else {
-    button.inkStyle = MDCInkStyleUnbounded;
-  }
-
-  button.tag = buttonItem.tag;
+  [MDCAppBarButtonBarBuilder configureButton:button fromButtonItem:buttonItem];
 
   [button setTitleColor:self.buttonTitleColor forState:UIControlStateNormal];
   [button setUnderlyingColorHint:self.buttonUnderlyingColor];
@@ -210,14 +195,36 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
 
 #pragma mark - Private
 
++ (void)configureButton:(MDCButton *)destinationButton
+         fromButtonItem:(UIBarButtonItem *)sourceButtonItem {
+  if (sourceButtonItem == nil || destinationButton == nil) {
+    return;
+  }
+
+  if (sourceButtonItem.title != nil) {
+    [destinationButton setTitle:sourceButtonItem.title forState:UIControlStateNormal];
+  }
+  if (sourceButtonItem.image != nil) {
+    [destinationButton setImage:sourceButtonItem.image forState:UIControlStateNormal];
+  }
+  if (sourceButtonItem.tintColor != nil) {
+    destinationButton.tintColor = sourceButtonItem.tintColor;
+  }
+
+  if (sourceButtonItem.title) {
+    destinationButton.inkStyle = MDCInkStyleBounded;
+  } else {
+    destinationButton.inkStyle = MDCInkStyleUnbounded;
+  }
+
+  destinationButton.tag = sourceButtonItem.tag;
+}
+
 - (void)updateButton:(UIButton *)button
             withItem:(UIBarButtonItem *)item
           barMetrics:(UIBarMetrics)barMetrics {
   [self updateButton:button withItem:item forState:UIControlStateNormal barMetrics:barMetrics];
-  [self updateButton:button
-            withItem:item
-            forState:UIControlStateHighlighted
-          barMetrics:barMetrics];
+  [self updateButton:button withItem:item forState:UIControlStateHighlighted barMetrics:barMetrics];
   [self updateButton:button withItem:item forState:UIControlStateDisabled barMetrics:barMetrics];
 }
 

--- a/components/ButtonBar/tests/unit/ButtonBarBuilderTests.m
+++ b/components/ButtonBar/tests/unit/ButtonBarBuilderTests.m
@@ -1,0 +1,139 @@
+//
+//  ButtonBarBuilderTests.m
+//  Pods
+//
+//  Created by Rob Moore on 8/14/17.
+//
+//
+
+#import <XCTest/XCTest.h>
+#import "MDCAppBarButtonBarBuilder.h"
+#import "MaterialButtonBar.h"
+#import "MaterialButtons.h"
+
+@interface MDCAppBarButtonBarBuilder (UnitTests)
++ (void)configureButton:(MDCButton *)destinationButton
+         fromButtonItem:(UIBarButtonItem *)sourceButtonItem;
+@end
+
+@interface ButtonBarBuilderTests : XCTestCase
+
+@end
+
+@implementation ButtonBarBuilderTests
+
+- (void)testConfigureButtonFromNilItem {
+  // Given
+  MDCButton *destinationButton = [[MDCButton alloc] initWithFrame:CGRectZero];
+  NSString *defaultTitle = [destinationButton titleForState:UIControlStateNormal];
+  UIColor *defaultTintColor = destinationButton.tintColor;
+  UIImage *defaultImage = [destinationButton imageForState:UIControlStateNormal];
+  MDCInkStyle defaultInkStyle = destinationButton.inkStyle;
+  NSInteger defaultTag = destinationButton.tag;
+
+  // When
+  [MDCAppBarButtonBarBuilder configureButton:destinationButton fromButtonItem:nil];
+
+  // Then
+  XCTAssertEqualObjects([destinationButton titleForState:UIControlStateNormal], defaultTitle);
+  XCTAssertEqualObjects([destinationButton imageForState:UIControlStateNormal], defaultImage);
+  XCTAssertEqualObjects(destinationButton.tintColor, defaultTintColor);
+  XCTAssertEqual(destinationButton.inkStyle, defaultInkStyle);
+  XCTAssertEqual(destinationButton.tag, defaultTag);
+}
+
+- (void)testConfigureButtonFromButtonItemWithTitle {
+  // Given
+  UIBarButtonItem *itemWithTitle = [[UIBarButtonItem alloc] initWithTitle:@"Title"
+                                                                    style:UIBarButtonItemStylePlain
+                                                                   target:nil
+                                                                   action:nil];
+  itemWithTitle.tag = 0x02468ace;
+  itemWithTitle.tintColor = [UIColor colorWithRed:0.5 green:0.25 blue:0.75 alpha:0.125];
+  MDCButton *destinationButton = [[MDCButton alloc] initWithFrame:CGRectZero];
+
+  // When
+  [MDCAppBarButtonBarBuilder configureButton:destinationButton fromButtonItem:itemWithTitle];
+
+  // Then
+  NSString *expectedTitle = destinationButton.isUppercaseTitle
+                                ? [itemWithTitle.title uppercaseString]
+                                : itemWithTitle.title;
+  XCTAssertEqualObjects(
+      [destinationButton titleForState:UIControlStateNormal], expectedTitle,
+      @"The MDC button should have a normal state title equal to the UIBarButtonItem's title.");
+  XCTAssertEqualObjects(destinationButton.tintColor, itemWithTitle.tintColor,
+                        @"The MDC button should have the same tint as the UIBarButtonItem");
+  XCTAssertNil([destinationButton imageForState:UIControlStateNormal],
+               @"The MDC button should not receive a normal state image if the UIBarButtonItem did "
+               @"not have one.");
+  XCTAssertEqual(destinationButton.inkStyle, MDCInkStyleBounded,
+                 @"MDC buttons with text should use bounded ink when used within a button bar.");
+  XCTAssertEqual(destinationButton.tag, itemWithTitle.tag,
+                 @"The MDC button should have the same tag as the UIBarButtonItem.");
+}
+
+- (void)testConfigureButtonFromButtonItemWithImage {
+  // Given
+  UIBarButtonItem *itemWithImage = [[UIBarButtonItem alloc] initWithImage:[[UIImage alloc] init]
+                                                                    style:UIBarButtonItemStylePlain
+                                                                   target:nil
+                                                                   action:nil];
+  itemWithImage.tag = 0x13579bdf;
+  itemWithImage.tintColor = [UIColor colorWithRed:0.75 green:0.5 blue:0.125 alpha:0.25];
+  MDCButton *destinationButton = [[MDCButton alloc] initWithFrame:CGRectZero];
+
+  // When
+  [MDCAppBarButtonBarBuilder configureButton:destinationButton fromButtonItem:itemWithImage];
+
+  // Then
+  XCTAssertNil(
+      [destinationButton titleForState:UIControlStateNormal],
+      @"The MDC button should have no title in the normal state if the UIBarButtonItem had none.");
+  XCTAssertEqualObjects(destinationButton.tintColor, itemWithImage.tintColor,
+                        @"The MDC button should have the same tint as the UIBarButtonItem");
+  XCTAssertEqualObjects(
+      [destinationButton imageForState:UIControlStateNormal], itemWithImage.image,
+      @"The MDC button should have a normal state image equal to the UIBarButtonItem's image.");
+  XCTAssertEqual(
+      destinationButton.inkStyle, MDCInkStyleUnbounded,
+      @"MDC buttons with only an image should use unbounded ink when used within a button bar.");
+  XCTAssertEqual(destinationButton.tag, itemWithImage.tag,
+                 @"The MDC button should have the same tag as the UIBarButtonItem.");
+}
+
+- (void)testConfigureButtonFromButtonItemWithTitleAndImage {
+  // Given
+  UIBarButtonItem *itemWithTitleAndImage =
+      [[UIBarButtonItem alloc] initWithImage:[[UIImage alloc] init]
+                                       style:UIBarButtonItemStylePlain
+                                      target:nil
+                                      action:nil];
+  itemWithTitleAndImage.title = @"Title";
+  itemWithTitleAndImage.tag = 0x13579bdf;
+  itemWithTitleAndImage.tintColor = [UIColor colorWithRed:0.25 green:0.75 blue:0.625 alpha:0.5];
+  MDCButton *destinationButton = [[MDCButton alloc] initWithFrame:CGRectZero];
+
+  // When
+  [MDCAppBarButtonBarBuilder configureButton:destinationButton
+                              fromButtonItem:itemWithTitleAndImage];
+
+  // Then
+  NSString *expectedTitle = destinationButton.isUppercaseTitle
+                                ? [itemWithTitleAndImage.title uppercaseString]
+                                : itemWithTitleAndImage.title;
+  XCTAssertEqualObjects(
+      [destinationButton titleForState:UIControlStateNormal], expectedTitle,
+      @"The MDC button should have a normal state title equal to the UIBarButtonItem's title.");
+  XCTAssertEqualObjects(destinationButton.tintColor, itemWithTitleAndImage.tintColor,
+                        @"The MDC button should have the same tint as the UIBarButtonItem");
+  XCTAssertEqualObjects(
+      [destinationButton imageForState:UIControlStateNormal], itemWithTitleAndImage.image,
+      @"The MDC button should have a normal state image equal to the UIBarButtonItem's image.");
+  XCTAssertEqual(destinationButton.inkStyle, MDCInkStyleBounded,
+                 @"MDC buttons with a title should use bounded ink when used within a button bar.");
+  XCTAssertEqual(destinationButton.tag, itemWithTitleAndImage.tag,
+                 @"The MDC button should have the same tag as the UIBarButtonItem.");
+}
+
+@end

--- a/components/ButtonBar/tests/unit/ButtonBarBuilderTests.m
+++ b/components/ButtonBar/tests/unit/ButtonBarBuilderTests.m
@@ -1,10 +1,18 @@
-//
-//  ButtonBarBuilderTests.m
-//  Pods
-//
-//  Created by Rob Moore on 8/14/17.
-//
-//
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
 
 #import <XCTest/XCTest.h>
 #import "MDCAppBarButtonBarBuilder.h"


### PR DESCRIPTION
Pulling out part of the ButtonBarBuilder logic to start making it more
testable.  Extracting the initial configuration of MDCButton from a
UIBarButtonItem into a class method and adding unit tests.
