### PR TITLE
[Collections] Fix header info view z-index

### DIFF
--- a/components/Collections/src/private/MDCCollectionInfoBarView.m
+++ b/components/Collections/src/private/MDCCollectionInfoBarView.m
@@ -104,6 +104,11 @@ static inline UIColor *ColorFromRGB(uint32_t rgbValue) {
                                             CGRectGetHeight(self.backgroundView.bounds) + 1);
 }
 
+- (void)applyLayoutAttributes:(UICollectionViewLayoutAttributes *)layoutAttributes {
+  [super applyLayoutAttributes:layoutAttributes];
+  self.layer.zPosition = layoutAttributes.zIndex;
+}
+
 - (void)setTintColor:(UIColor *)tintColor {
   _tintColor = tintColor;
   _backgroundView.backgroundColor = _tintColor;

--- a/components/Collections/tests/unit/MDCCollectionInfoBarViewTests.m
+++ b/components/Collections/tests/unit/MDCCollectionInfoBarViewTests.m
@@ -1,0 +1,58 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import "MDCCollectionInfoBarView.h"
+
+@interface MDCCollectionInfoBarViewTests : XCTestCase
+
+@end
+
+@implementation MDCCollectionInfoBarViewTests
+
+- (void)testAppliesZIndexForKindHeader {
+  // Given
+  UICollectionViewLayoutAttributes *layoutAttributes = [UICollectionViewLayoutAttributes
+      layoutAttributesForSupplementaryViewOfKind:MDCCollectionInfoBarKindHeader
+                                   withIndexPath:[NSIndexPath indexPathWithIndex:0]];
+  MDCCollectionInfoBarView *infoBarView =
+      [[MDCCollectionInfoBarView alloc] initWithFrame:CGRectZero];
+  layoutAttributes.zIndex = 5;
+
+  // When
+  [infoBarView applyLayoutAttributes:layoutAttributes];
+
+  // Then
+  XCTAssertEqual(infoBarView.layer.zPosition, layoutAttributes.zIndex);
+}
+
+- (void)testAppliesZIndexForKindFooter {
+  // Given
+  UICollectionViewLayoutAttributes *layoutAttributes = [UICollectionViewLayoutAttributes
+      layoutAttributesForSupplementaryViewOfKind:MDCCollectionInfoBarKindFooter
+                                   withIndexPath:[NSIndexPath indexPathWithIndex:0]];
+  MDCCollectionInfoBarView *infoBarView =
+      [[MDCCollectionInfoBarView alloc] initWithFrame:CGRectZero];
+  layoutAttributes.zIndex = 5;
+
+  // When
+  [infoBarView applyLayoutAttributes:layoutAttributes];
+
+  // Then
+  XCTAssertEqual(infoBarView.layer.zPosition, layoutAttributes.zIndex);
+}
+
+@end


### PR DESCRIPTION
The Info Bar view wasn't correctly applying the z-index value from the
LayoutAttributes.  This resulted in the header appearing behind the
collectionView cells on iOS 11.

Closes #1786
