### PR TITLE
[Scripts] Stop installing contributor tools for CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ env:
 
 before_install:
   - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
-  - scripts/install_contributor_tools
 
 # The travis_wait prefix ensures that the build doesn't error out because too much time went past
 # without any output being produced.


### PR DESCRIPTION
The Travis-CI .yaml script currently installs all of our "contributor
tools" before building.  These tools are not needed for continuous
integration builds, which target unit tests and code coverage.
