### PR TITLE
[Collections] Limit the drag needed to dismiss an item

### DIFF
--- a/components/Collections/examples/CollectionsGridExample.m
+++ b/components/Collections/examples/CollectionsGridExample.m
@@ -132,4 +132,23 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   [self dismissViewControllerAnimated:YES completion:nil];
 }
 
+#pragma mark - <MDCCollectionViewEditingDelegate>
+
+- (BOOL)collectionViewAllowsSwipeToDismissItem:(UICollectionView *)collectionView {
+  return YES;
+}
+
+- (BOOL)collectionView:(UICollectionView *)collectionView
+    canSwipeToDismissItemAtIndexPath:(NSIndexPath *)indexPath {
+  return YES;
+}
+
+- (void)collectionView:(UICollectionView *)collectionView
+    willDeleteItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths {
+  // Remove these swiped index paths from our data.
+  for (NSIndexPath *indexPath in indexPaths) {
+    [_content[indexPath.section] removeObjectAtIndex:indexPath.item];
+  }
+}
+
 @end

--- a/components/Collections/src/private/MDCCollectionViewEditor.m
+++ b/components/Collections/src/private/MDCCollectionViewEditor.m
@@ -768,7 +768,7 @@ typedef NS_ENUM(NSInteger, MDCAutoscrollPanningDirection) {
 // The distance an item must be panned before it is dismissed. Currently half of the bounds width.
 - (CGFloat)distanceThresholdForDismissal {
   if (_cellSnapshot) {
-    return _cellSnapshot.bounds.size.width / 2;
+    return CGRectGetWidth(_cellSnapshot.bounds) / 2;
   } else {
     return _collectionView.bounds.size.width / 2;
   }

--- a/components/Collections/src/private/MDCCollectionViewEditor.m
+++ b/components/Collections/src/private/MDCCollectionViewEditor.m
@@ -767,7 +767,11 @@ typedef NS_ENUM(NSInteger, MDCAutoscrollPanningDirection) {
 
 // The distance an item must be panned before it is dismissed. Currently half of the bounds width.
 - (CGFloat)distanceThresholdForDismissal {
-  return _collectionView.bounds.size.width / 2;
+  if (_cellSnapshot) {
+    return _cellSnapshot.bounds.size.width / 2;
+  } else {
+    return _collectionView.bounds.size.width / 2;
+  }
 }
 
 - (CGFloat)dismissalAlphaForTranslationX:(CGFloat)translationX {

--- a/components/Collections/src/private/MDCCollectionViewEditor.m
+++ b/components/Collections/src/private/MDCCollectionViewEditor.m
@@ -770,7 +770,7 @@ typedef NS_ENUM(NSInteger, MDCAutoscrollPanningDirection) {
   if (_cellSnapshot) {
     return CGRectGetWidth(_cellSnapshot.bounds) / 2;
   } else {
-    return _collectionView.bounds.size.width / 2;
+    return CGRectGetWidth(_collectionView.bounds) / 2;
   }
 }
 


### PR DESCRIPTION
When using the swipe-to-dimiss gesture on large screens, the distance on which the user has to move the item can be big.
This commit limits the distance by using the width of the item instead of the width of the collection.

Closes #1780