### PR TITLE
[TextFields] Renaming legacy tests and examples.

### DIFF
--- a/components/TextFields/examples/MultilineTextFieldLegacyExample.m
+++ b/components/TextFields/examples/MultilineTextFieldLegacyExample.m
@@ -1,0 +1,222 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MaterialTextFields.h"
+
+@interface MultilineTextFieldLegacyExample : UIViewController <UITextViewDelegate>
+
+// Be sure to keep your controllers in memory somewhere like a property:
+@property(nonatomic, strong) MDCTextInputControllerLegacyDefault *textFieldControllerDefaultCharMax;
+@property(nonatomic, strong) MDCTextInputControllerLegacyDefault *textFieldControllerFloating;
+@property(nonatomic, strong) MDCTextInputControllerFullWidth *textFieldControllerFullWidth;
+@property(nonatomic, strong) UIScrollView *scrollView;
+
+@end
+
+@implementation MultilineTextFieldLegacyExample
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  self.view.backgroundColor = [UIColor colorWithWhite:0.97 alpha:1.0];
+
+  self.title = @"Legacy Multiline Text Fields";
+
+  self.scrollView = [[UIScrollView alloc] initWithFrame:CGRectZero];
+  [self.view addSubview:self.scrollView];
+  self.scrollView.translatesAutoresizingMaskIntoConstraints = NO;
+
+  UIEdgeInsets margins = UIEdgeInsetsMake(0, 16, 0, 16);
+  self.scrollView.layoutMargins = margins;
+
+  [NSLayoutConstraint
+      activateConstraints:[NSLayoutConstraint
+                              constraintsWithVisualFormat:@"V:|[scrollView]|"
+                                                  options:0
+                                                  metrics:nil
+                                                    views:@{
+                                                      @"scrollView" : self.scrollView
+                                                    }]];
+  [NSLayoutConstraint
+      activateConstraints:[NSLayoutConstraint
+                              constraintsWithVisualFormat:@"H:|[scrollView]|"
+                                                  options:0
+                                                  metrics:nil
+                                                    views:@{
+                                                      @"scrollView" : self.scrollView
+                                                    }]];
+
+  MDCMultilineTextField *multilineTextFieldUnstyled = [[MDCMultilineTextField alloc] init];
+  [self.scrollView addSubview:multilineTextFieldUnstyled];
+  multilineTextFieldUnstyled.translatesAutoresizingMaskIntoConstraints = NO;
+
+  multilineTextFieldUnstyled.placeholder = @"No Controller (unstyled)";
+  multilineTextFieldUnstyled.textView.delegate = self;
+  multilineTextFieldUnstyled.leadingUnderlineLabel.text = @"Leading";
+  multilineTextFieldUnstyled.trailingUnderlineLabel.text = @"Trailing";
+
+  MDCMultilineTextField *multilineTextFieldUnstyledBox = [[MDCMultilineTextField alloc] init];
+  [self.scrollView addSubview:multilineTextFieldUnstyledBox];
+  multilineTextFieldUnstyledBox.translatesAutoresizingMaskIntoConstraints = NO;
+
+  multilineTextFieldUnstyledBox.placeholder = @"No Controller (unstyled) minimum of 3 lines";
+  multilineTextFieldUnstyledBox.textView.delegate = self;
+  multilineTextFieldUnstyledBox.leadingUnderlineLabel.text = @"Leading";
+  multilineTextFieldUnstyledBox.trailingUnderlineLabel.text = @"Trailing";
+  multilineTextFieldUnstyledBox.minimumLines = 3;
+  multilineTextFieldUnstyledBox.expandsOnOverflow = NO;
+
+  MDCMultilineTextField *multilineTextFieldFloating = [[MDCMultilineTextField alloc] init];
+  [self.scrollView addSubview:multilineTextFieldFloating];
+  multilineTextFieldFloating.translatesAutoresizingMaskIntoConstraints = NO;
+
+  multilineTextFieldFloating.placeholder = @"Floating Controller";
+  multilineTextFieldFloating.textView.delegate = self;
+
+  self.textFieldControllerFloating =
+      [[MDCTextInputControllerLegacyDefault alloc] initWithTextInput:multilineTextFieldFloating];
+
+  MDCMultilineTextField *multilineTextFieldCharMaxDefault = [[MDCMultilineTextField alloc] init];
+  [self.scrollView addSubview:multilineTextFieldCharMaxDefault];
+  multilineTextFieldCharMaxDefault.translatesAutoresizingMaskIntoConstraints = NO;
+
+  multilineTextFieldCharMaxDefault.placeholder = @"Inline Placeholder Only";
+  multilineTextFieldCharMaxDefault.textView.delegate = self;
+
+  self.textFieldControllerDefaultCharMax =
+      [[MDCTextInputControllerLegacyDefault alloc] initWithTextInput:multilineTextFieldCharMaxDefault];
+  self.textFieldControllerDefaultCharMax.characterCountMax = 30;
+  self.textFieldControllerDefaultCharMax.floatingEnabled = NO;
+
+  MDCMultilineTextField *multilineTextFieldCharMaxFullWidth = [[MDCMultilineTextField alloc] init];
+  [self.scrollView addSubview:multilineTextFieldCharMaxFullWidth];
+  multilineTextFieldCharMaxFullWidth.translatesAutoresizingMaskIntoConstraints = NO;
+
+  multilineTextFieldCharMaxFullWidth.placeholder = @"Full Width Controller";
+  multilineTextFieldCharMaxFullWidth.textView.delegate = self;
+
+  self.textFieldControllerFullWidth = [[MDCTextInputControllerFullWidth alloc]
+      initWithTextInput:multilineTextFieldCharMaxFullWidth];
+  self.textFieldControllerFullWidth.characterCountMax = 140;
+
+  [NSLayoutConstraint
+      activateConstraints:[NSLayoutConstraint
+                              constraintsWithVisualFormat:
+                                  @"V:|-20-[unstyled]-[box]-[floating]-[charMax]-[fullWidth]-|"
+                                                  options:0
+                                                  metrics:nil
+                                                    views:@{
+                                                      @"unstyled" : multilineTextFieldUnstyled,
+                                                      @"box" : multilineTextFieldUnstyledBox,
+                                                      @"charMax" : multilineTextFieldCharMaxDefault,
+                                                      @"floating" : multilineTextFieldFloating,
+                                                      @"fullWidth" :
+                                                          multilineTextFieldCharMaxFullWidth
+                                                    }]];
+  [NSLayoutConstraint
+      activateConstraints:[NSLayoutConstraint
+                              constraintsWithVisualFormat:@"H:|-[unstyled]-|"
+                                                  options:0
+                                                  metrics:nil
+                                                    views:@{
+                                                      @"unstyled" : multilineTextFieldUnstyled
+                                                    }]];
+  [NSLayoutConstraint
+      activateConstraints:[NSLayoutConstraint
+                              constraintsWithVisualFormat:@"H:|-[box]-|"
+                                                  options:0
+                                                  metrics:nil
+                                                    views:@{
+                                                      @"box" : multilineTextFieldUnstyledBox
+                                                    }]];
+  [NSLayoutConstraint
+      activateConstraints:[NSLayoutConstraint
+                              constraintsWithVisualFormat:@"H:|-[floating]-|"
+                                                  options:0
+                                                  metrics:nil
+                                                    views:@{
+                                                      @"floating" : multilineTextFieldFloating
+                                                    }]];
+  [NSLayoutConstraint
+      activateConstraints:[NSLayoutConstraint
+                              constraintsWithVisualFormat:@"H:|-[charMax]-|"
+                                                  options:0
+                                                  metrics:nil
+                                                    views:@{
+                                                      @"charMax" : multilineTextFieldCharMaxDefault
+                                                    }]];
+
+  [NSLayoutConstraint constraintWithItem:multilineTextFieldCharMaxFullWidth
+                               attribute:NSLayoutAttributeLeading
+                               relatedBy:NSLayoutRelationEqual
+                                  toItem:self.view
+                               attribute:NSLayoutAttributeLeading
+                              multiplier:1
+                                constant:0]
+      .active = YES;
+  [NSLayoutConstraint constraintWithItem:multilineTextFieldCharMaxFullWidth
+                               attribute:NSLayoutAttributeTrailing
+                               relatedBy:NSLayoutRelationEqual
+                                  toItem:self.view
+                               attribute:NSLayoutAttributeTrailing
+                              multiplier:1
+                                constant:0]
+      .active = YES;
+  [NSLayoutConstraint
+      activateConstraints:[NSLayoutConstraint
+                              constraintsWithVisualFormat:@"H:|[fullWidth]|"
+                                                  options:0
+                                                  metrics:nil
+                                                    views:@{
+                                                      @"fullWidth" :
+                                                          multilineTextFieldCharMaxFullWidth
+                                                    }]];
+
+  UITapGestureRecognizer *tapRecognizer =
+      [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapDidTouch)];
+  [self.view addGestureRecognizer:tapRecognizer];
+
+  [[NSNotificationCenter defaultCenter]
+      addObserverForName:UIKeyboardWillShowNotification
+                  object:nil
+                   queue:[NSOperationQueue mainQueue]
+              usingBlock:^(NSNotification *_Nonnull note) {
+                CGRect frame =
+                    [[note.userInfo valueForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
+                self.scrollView.contentInset = UIEdgeInsetsMake(0, 0, CGRectGetHeight(frame), 0);
+              }];
+}
+
+- (void)tapDidTouch {
+  [self.view endEditing:YES];
+}
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Text Field", @"[Legacy] Multiline (Objective C)" ];
+}
+
++ (NSString *)catalogDescription {
+  return @"Simple legacy MDCMultilineTextField example.";
+}
+
+@end
+
+@implementation MultilineTextFieldLegacyExample (UITextViewDelegate)
+
+- (void)textViewDidChange:(UITextView *)textView {
+  NSLog(@"%@", textView.text);
+}
+
+@end

--- a/components/TextFields/examples/TextFieldInterfaceBuilderLegacyExample.m
+++ b/components/TextFields/examples/TextFieldInterfaceBuilderLegacyExample.m
@@ -1,0 +1,60 @@
+//
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import "TextFieldInterfaceBuilderLegacyExampleSupplemental.h"
+
+@import MaterialComponents.MaterialTextFields;
+
+@interface TextFieldInterfaceBuilderLegacyExample () <UITextFieldDelegate>
+
+@property(weak, nonatomic) IBOutlet MDCTextField *firstTextField;
+@property(nonatomic, strong) MDCTextInputControllerLegacyDefault *firstController;
+@property(weak, nonatomic) IBOutlet MDCTextField *lastTextField;
+@property(nonatomic, strong) MDCTextInputControllerLegacyDefault *lastController;
+@property(weak, nonatomic) IBOutlet MDCTextField *address1TextField;
+@property(nonatomic, strong) MDCTextInputControllerLegacyDefault *address1Controller;
+@property(weak, nonatomic) IBOutlet MDCTextField *address2TextField;
+@property(nonatomic, strong) MDCTextInputControllerLegacyDefault *address2Controller;
+
+@end
+
+@implementation TextFieldInterfaceBuilderLegacyExample
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  self.title = @"MDCTextFields";
+
+  [self setupExampleViews];
+
+  self.firstController =
+      [[MDCTextInputControllerLegacyDefault alloc] initWithTextInput:self.firstTextField];
+  self.lastController =
+      [[MDCTextInputControllerLegacyDefault alloc] initWithTextInput:self.lastTextField];
+  self.address1Controller =
+      [[MDCTextInputControllerLegacyDefault alloc] initWithTextInput:self.address1TextField];
+  self.address2Controller =
+      [[MDCTextInputControllerLegacyDefault alloc] initWithTextInput:self.address2TextField];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+  [super viewWillAppear:animated];
+  self.address2TextField.text = @"Apt 3F";
+}
+
+@end

--- a/components/TextFields/examples/TextFieldKitchenSinkLegacyExample.swift
+++ b/components/TextFields/examples/TextFieldKitchenSinkLegacyExample.swift
@@ -1,0 +1,568 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+// swiftlint:disable file_length
+// swiftlint:disable type_body_length
+// swiftlint:disable function_body_length
+
+import UIKit
+
+import MaterialComponents.MaterialTextFields
+import MaterialComponents.MaterialAppBar
+import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialTypography
+
+final class TextFieldKitchenSinkLegacySwiftExample: UIViewController {
+
+  let scrollView = UIScrollView()
+
+  let controlLabel: UILabel = {
+    let controlLabel = UILabel()
+    controlLabel.translatesAutoresizingMaskIntoConstraints = false
+    controlLabel.text = "Options"
+    controlLabel.font = UIFont.preferredFont(forTextStyle: .headline)
+    controlLabel.textColor = UIColor(white: 0, alpha: MDCTypography.headlineFontOpacity())
+    return controlLabel
+  }()
+
+  let singleLabel: UILabel = {
+    let singleLabel = UILabel()
+    singleLabel.translatesAutoresizingMaskIntoConstraints = false
+    singleLabel.text = "Single Line Text Fields"
+    singleLabel.font = UIFont.preferredFont(forTextStyle: .headline)
+    singleLabel.textColor = UIColor(white: 0, alpha: MDCTypography.headlineFontOpacity())
+    singleLabel.numberOfLines = 0
+    return singleLabel
+  }()
+
+  let multiLabel: UILabel = {
+    let multiLabel = UILabel()
+    multiLabel.translatesAutoresizingMaskIntoConstraints = false
+    multiLabel.text = "Multiline Text Fields"
+    multiLabel.font = UIFont.preferredFont(forTextStyle: .headline)
+    multiLabel.textColor = UIColor(white: 0, alpha: MDCTypography.headlineFontOpacity())
+    multiLabel.numberOfLines = 0
+    return multiLabel
+  }()
+
+  let errorLabel: UILabel = {
+    let errorLabel = UILabel()
+    errorLabel.translatesAutoresizingMaskIntoConstraints = false
+    errorLabel.text = "In Error:"
+    errorLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
+    errorLabel.textColor = UIColor(white: 0, alpha: MDCTypography.subheadFontOpacity())
+    errorLabel.numberOfLines = 0
+    return errorLabel
+  }()
+
+  let helperLabel: UILabel = {
+    let helperLabel = UILabel()
+    helperLabel.translatesAutoresizingMaskIntoConstraints = false
+    helperLabel.text = "Show Helper Text:"
+    helperLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
+    helperLabel.textColor = UIColor(white: 0, alpha: MDCTypography.subheadFontOpacity())
+    helperLabel.numberOfLines = 0
+    return helperLabel
+  }()
+
+  var allInputControllers = [MDCTextInputController]()
+  var allTextFieldControllers = [MDCTextInputController]()
+  var allMultilineTextFieldControllers = [MDCTextInputController]()
+  var controllersWithCharacterCount = [MDCTextInputController]()
+  var controllersFullWidth = [MDCTextInputControllerFullWidth]()
+
+  let unstyledTextField = MDCTextField()
+  let unstyledMultilineTextField = MDCMultilineTextField()
+
+  lazy var characterModeButton: MDCButton = self.setupButton()
+  lazy var clearModeButton: MDCButton = self.setupButton()
+  lazy var underlineButton: MDCButton = self.setupButton()
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    setupExampleViews()
+  }
+
+  func setupDefaultTextFields() -> [MDCTextInputControllerLegacyDefault] {
+    let textFieldDefault = MDCTextField()
+    scrollView.addSubview(textFieldDefault)
+    textFieldDefault.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldDefault.delegate = self
+    textFieldDefault.clearButtonMode = .whileEditing
+    textFieldDefault.backgroundColor = .white
+
+    let textFieldControllerDefault = MDCTextInputControllerLegacyDefault(textInput: textFieldDefault)
+
+    textFieldControllerDefault.isFloatingEnabled = false
+
+    let textFieldDefaultPlaceholder = MDCTextField()
+    scrollView.addSubview(textFieldDefaultPlaceholder)
+    textFieldDefaultPlaceholder.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldDefaultPlaceholder.placeholder = "This is a text field w/ inline placeholder"
+    textFieldDefaultPlaceholder.delegate = self
+
+    textFieldDefaultPlaceholder.clearButtonMode = .whileEditing
+
+    let textFieldControllerDefaultPlaceholder =
+      MDCTextInputControllerLegacyDefault(textInput: textFieldDefaultPlaceholder)
+
+    textFieldControllerDefaultPlaceholder.isFloatingEnabled = false
+
+    let textFieldDefaultCharMax = MDCTextField()
+    scrollView.addSubview(textFieldDefaultCharMax)
+    textFieldDefaultCharMax.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldDefaultCharMax.placeholder = "This is a text field w/ character count"
+    textFieldDefaultCharMax.delegate = self
+    textFieldDefaultCharMax.clearButtonMode = .whileEditing
+
+    let textFieldControllerDefaultCharMax =
+      MDCTextInputControllerLegacyDefault(textInput: textFieldDefaultCharMax)
+    textFieldControllerDefaultCharMax.characterCountMax = 50
+    textFieldControllerDefaultCharMax.isFloatingEnabled = false
+
+    controllersWithCharacterCount.append(textFieldControllerDefaultCharMax)
+
+    return [textFieldControllerDefault, textFieldControllerDefaultPlaceholder,
+            textFieldControllerDefaultCharMax]
+  }
+
+  func setupFullWidthTextFields() -> [MDCTextInputControllerFullWidth] {
+    let textFieldFullWidth = MDCTextField()
+    scrollView.addSubview(textFieldFullWidth)
+    textFieldFullWidth.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldFullWidth.delegate = self
+    textFieldFullWidth.clearButtonMode = .whileEditing
+    textFieldFullWidth.backgroundColor = .white
+
+    let textFieldControllerFullWidth =
+      MDCTextInputControllerFullWidth(textInput: textFieldFullWidth)
+
+    let textFieldFullWidthPlaceholder = MDCTextField()
+    scrollView.addSubview(textFieldFullWidthPlaceholder)
+    textFieldFullWidthPlaceholder.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldFullWidthPlaceholder.placeholder = "This is a full width text field"
+    textFieldFullWidthPlaceholder.delegate = self
+    textFieldFullWidthPlaceholder.clearButtonMode = .whileEditing
+
+    let textFieldControllerFullWidthPlaceholder =
+      MDCTextInputControllerFullWidth(textInput: textFieldFullWidthPlaceholder)
+
+    let textFieldFullWidthCharMax = MDCTextField()
+    scrollView.addSubview(textFieldFullWidthCharMax)
+    textFieldFullWidthCharMax.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldFullWidthCharMax.placeholder =
+      "This is a full width text field with character count and a very long placeholder"
+    textFieldFullWidthCharMax.delegate = self
+    textFieldFullWidthCharMax.clearButtonMode = .whileEditing
+
+    let textFieldControllerFullWidthCharMax =
+      MDCTextInputControllerFullWidth(textInput: textFieldFullWidthCharMax)
+    textFieldControllerFullWidthCharMax.characterCountMax = 50
+
+    controllersWithCharacterCount.append(textFieldControllerFullWidthCharMax)
+
+    return [textFieldControllerFullWidth, textFieldControllerFullWidthPlaceholder,
+            textFieldControllerFullWidthCharMax]
+  }
+
+  func setupFloatingTextFields() -> [MDCTextInputControllerLegacyDefault] {
+    let textFieldFloating = MDCTextField()
+    scrollView.addSubview(textFieldFloating)
+    textFieldFloating.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldFloating.placeholder = "This is a text field w/ floating placeholder"
+    textFieldFloating.delegate = self
+    textFieldFloating.clearButtonMode = .whileEditing
+
+    let textFieldControllerFloating = MDCTextInputControllerLegacyDefault(textInput: textFieldFloating)
+
+    let textFieldFloatingCharMax = MDCTextField()
+    scrollView.addSubview(textFieldFloatingCharMax)
+    textFieldFloatingCharMax.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldFloatingCharMax.placeholder = "This is floating with character count"
+    textFieldFloatingCharMax.delegate = self
+    textFieldFloatingCharMax.clearButtonMode = .whileEditing
+
+    let textFieldControllerFloatingCharMax =
+      MDCTextInputControllerLegacyDefault(textInput: textFieldFloatingCharMax)
+    textFieldControllerFloatingCharMax.characterCountMax = 50
+
+    controllersWithCharacterCount.append(textFieldControllerFloatingCharMax)
+
+    return [textFieldControllerFloating, textFieldControllerFloatingCharMax]
+  }
+
+  func setupSpecialTextFields() -> [MDCTextInputControllerLegacyDefault] {
+    let textFieldDisabled = MDCTextField()
+    scrollView.addSubview(textFieldDisabled)
+    textFieldDisabled.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldDisabled.placeholder = "This is a disabled text field"
+    textFieldDisabled.delegate = self
+    textFieldDisabled.isEnabled = false
+
+    let textFieldControllerDefaultDisabled =
+      MDCTextInputControllerLegacyDefault(textInput: textFieldDisabled)
+    textFieldControllerDefaultDisabled.isFloatingEnabled = false
+
+    let textFieldCustomFont = MDCTextField()
+    scrollView.addSubview(textFieldCustomFont)
+    textFieldCustomFont.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldCustomFont.font = UIFont.preferredFont(forTextStyle: .headline)
+    textFieldCustomFont.placeholder = "This is a custom font"
+    textFieldCustomFont.delegate = self
+    textFieldCustomFont.clearButtonMode = .whileEditing
+
+    let textFieldControllerDefaultCustomFont =
+      MDCTextInputControllerLegacyDefault(textInput: textFieldCustomFont)
+    textFieldCustomFont.placeholderLabel.font = UIFont.preferredFont(forTextStyle: .headline)
+    textFieldControllerDefaultCustomFont.isFloatingEnabled = false
+
+    let textFieldCustomFontFloating = MDCTextField()
+    scrollView.addSubview(textFieldCustomFontFloating)
+    textFieldCustomFontFloating.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldCustomFontFloating.font = UIFont.preferredFont(forTextStyle: .headline)
+    textFieldCustomFontFloating.placeholder = "This is a custom font with the works"
+    textFieldCustomFontFloating.delegate = self
+    textFieldCustomFontFloating.clearButtonMode = .whileEditing
+
+    let textFieldControllerDefaultCustomFontFloating =
+      MDCTextInputControllerLegacyDefault(textInput: textFieldCustomFontFloating)
+    textFieldControllerDefaultCustomFontFloating.characterCountMax = 40
+    textFieldControllerDefaultCustomFontFloating.helperText = "Custom Font"
+    textFieldControllerDefaultCustomFontFloating.activeColor = .green
+    textFieldControllerDefaultCustomFontFloating.normalColor = .purple
+    textFieldCustomFontFloating.leadingUnderlineLabel.font =
+      UIFont.preferredFont(forTextStyle: .headline)
+    textFieldCustomFontFloating.placeholderLabel.font =
+      UIFont.preferredFont(forTextStyle: .headline)
+    textFieldCustomFontFloating.trailingUnderlineLabel.font =
+      UIFont.preferredFont(forTextStyle: .subheadline)
+    textFieldCustomFontFloating.clearButtonColor = MDCPalette.red.accent400
+
+    let bundle = Bundle(for: TextFieldKitchenSinkSwiftExample.self)
+    let leftViewImagePath = bundle.path(forResource: "ic_search", ofType: "png")!
+    let leftViewImage = UIImage(contentsOfFile: leftViewImagePath)!
+
+    let textFieldLeftView = MDCTextField()
+    textFieldLeftView.leftViewMode = .always
+    textFieldLeftView.leftView = UIImageView(image:leftViewImage)
+
+    scrollView.addSubview(textFieldLeftView)
+    textFieldLeftView.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldLeftView.placeholder = "This has a left view"
+    textFieldLeftView.delegate = self
+    textFieldLeftView.clearButtonMode = .whileEditing
+
+    let textFieldControllerDefaultLeftView =
+      MDCTextInputControllerLegacyDefault(textInput: textFieldLeftView)
+    textFieldControllerDefaultLeftView.isFloatingEnabled = false
+
+    let textFieldLeftViewFloating = MDCTextField()
+    textFieldLeftViewFloating.leftViewMode = .always
+    textFieldLeftViewFloating.leftView = UIImageView(image:leftViewImage)
+
+    scrollView.addSubview(textFieldLeftViewFloating)
+    textFieldLeftViewFloating.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldLeftViewFloating.placeholder = "This has a left view and floats"
+    textFieldLeftViewFloating.delegate = self
+    textFieldLeftViewFloating.clearButtonMode = .whileEditing
+
+    let textFieldControllerDefaultLeftViewFloating =
+      MDCTextInputControllerLegacyDefault(textInput: textFieldLeftViewFloating)
+
+    let rightViewImagePath = bundle.path(forResource: "ic_done", ofType: "png")!
+    let rightViewImage = UIImage(contentsOfFile: rightViewImagePath)!
+
+    let textFieldRightView = MDCTextField()
+    textFieldRightView.rightViewMode = .always
+    textFieldRightView.rightView = UIImageView(image:rightViewImage)
+
+    scrollView.addSubview(textFieldRightView)
+    textFieldRightView.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldRightView.placeholder = "This has a right view"
+    textFieldRightView.delegate = self
+    textFieldRightView.clearButtonMode = .whileEditing
+
+    let textFieldControllerDefaultRightView =
+      MDCTextInputControllerLegacyDefault(textInput: textFieldRightView)
+    textFieldControllerDefaultRightView.isFloatingEnabled = false
+
+    let textFieldRightViewFloating = MDCTextField()
+    textFieldRightViewFloating.rightViewMode = .always
+    textFieldRightViewFloating.rightView = UIImageView(image:rightViewImage)
+
+    scrollView.addSubview(textFieldRightViewFloating)
+    textFieldRightViewFloating.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldRightViewFloating.placeholder = "This has a right view and floats"
+    textFieldRightViewFloating.delegate = self
+    textFieldRightViewFloating.clearButtonMode = .whileEditing
+
+    let textFieldControllerDefaultRightViewFloating =
+      MDCTextInputControllerLegacyDefault(textInput: textFieldRightViewFloating)
+
+    let textFieldLeftRightView = MDCTextField()
+    textFieldLeftRightView.leftViewMode = .whileEditing
+    textFieldLeftRightView.leftView = UIImageView(image: leftViewImage)
+    textFieldLeftRightView.rightViewMode = .unlessEditing
+    textFieldLeftRightView.rightView = UIImageView(image:rightViewImage)
+
+    scrollView.addSubview(textFieldLeftRightView)
+    textFieldLeftRightView.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldLeftRightView.placeholder =
+      "This has left & right views and a very long placeholder that should be truncated"
+    textFieldLeftRightView.delegate = self
+    textFieldLeftRightView.clearButtonMode = .whileEditing
+
+    let textFieldControllerDefaultLeftRightView =
+      MDCTextInputControllerLegacyDefault(textInput: textFieldLeftRightView)
+    textFieldControllerDefaultLeftRightView.isFloatingEnabled = false
+
+    let textFieldLeftRightViewFloating = MDCTextField()
+    textFieldLeftRightViewFloating.leftViewMode = .always
+    textFieldLeftRightViewFloating.leftView = UIImageView(image: leftViewImage)
+    textFieldLeftRightViewFloating.rightViewMode = .whileEditing
+    textFieldLeftRightViewFloating.rightView = UIImageView(image:rightViewImage)
+
+    scrollView.addSubview(textFieldLeftRightViewFloating)
+    textFieldLeftRightViewFloating.translatesAutoresizingMaskIntoConstraints = false
+
+    textFieldLeftRightViewFloating.placeholder =
+      "This has left & right views and floats and a very long placeholder that should be truncated"
+    textFieldLeftRightViewFloating.delegate = self
+    textFieldLeftRightViewFloating.clearButtonMode = .whileEditing
+
+    let textFieldControllerDefaultLeftRightViewFloating =
+      MDCTextInputControllerLegacyDefault(textInput: textFieldLeftRightViewFloating)
+
+    scrollView.addSubview(unstyledTextField)
+    unstyledTextField.translatesAutoresizingMaskIntoConstraints = false
+
+    unstyledTextField.placeholder = "This is an unstyled text field (no controller)"
+    unstyledTextField.leadingUnderlineLabel.text = "Leading label"
+    unstyledTextField.trailingUnderlineLabel.text = "Trailing label"
+    unstyledTextField.delegate = self
+    unstyledTextField.clearButtonMode = .whileEditing
+    unstyledTextField.leftView = UIImageView(image: leftViewImage)
+    unstyledTextField.leftViewMode = .always
+    unstyledTextField.rightView = UIImageView(image: rightViewImage)
+    unstyledTextField.rightViewMode = .always
+
+    return [textFieldControllerDefaultDisabled,
+            textFieldControllerDefaultCustomFont, textFieldControllerDefaultCustomFontFloating,
+            textFieldControllerDefaultLeftView, textFieldControllerDefaultLeftViewFloating,
+            textFieldControllerDefaultRightView, textFieldControllerDefaultRightViewFloating,
+            textFieldControllerDefaultLeftRightView,
+            textFieldControllerDefaultLeftRightViewFloating]
+  }
+
+  // MARK: - Multiline
+  func setupDefaultMultilineTextFields() -> [MDCTextInputControllerLegacyDefault] {
+    let multilineTextFieldDefault = MDCMultilineTextField()
+    scrollView.addSubview(multilineTextFieldDefault)
+    multilineTextFieldDefault.translatesAutoresizingMaskIntoConstraints = false
+
+    multilineTextFieldDefault.textView?.delegate = self
+
+    let multilineTextFieldControllerDefault =
+        MDCTextInputControllerLegacyDefault(textInput: multilineTextFieldDefault)
+    multilineTextFieldControllerDefault.isFloatingEnabled = false
+
+    let multilineTextFieldDefaultPlaceholder = MDCMultilineTextField()
+    scrollView.addSubview(multilineTextFieldDefaultPlaceholder)
+    multilineTextFieldDefaultPlaceholder.translatesAutoresizingMaskIntoConstraints = false
+
+    multilineTextFieldDefaultPlaceholder.placeholder =
+        "This is a multiline text field with placeholder"
+    multilineTextFieldDefaultPlaceholder.textView?.delegate = self
+
+    let multilineTextFieldControllerDefaultPlaceholder =
+      MDCTextInputControllerLegacyDefault(textInput: multilineTextFieldDefaultPlaceholder)
+    multilineTextFieldControllerDefaultPlaceholder.isFloatingEnabled = false
+
+    let multilineTextFieldDefaultCharMax = MDCMultilineTextField()
+    scrollView.addSubview(multilineTextFieldDefaultCharMax)
+    multilineTextFieldDefaultCharMax.translatesAutoresizingMaskIntoConstraints = false
+
+    multilineTextFieldDefaultCharMax.placeholder = "This is a multiline text field with placeholder"
+    multilineTextFieldDefaultCharMax.textView?.delegate = self
+
+    let multilineTextFieldControllerDefaultCharMax =
+          MDCTextInputControllerLegacyDefault(textInput: multilineTextFieldDefaultCharMax)
+    multilineTextFieldControllerDefaultCharMax.characterCountMax = 140
+    multilineTextFieldControllerDefaultCharMax.isFloatingEnabled = false
+
+    controllersWithCharacterCount.append(multilineTextFieldControllerDefaultCharMax)
+
+    return [multilineTextFieldControllerDefault, multilineTextFieldControllerDefaultPlaceholder,
+            multilineTextFieldControllerDefaultCharMax]
+  }
+
+  func setupFullWidthMultilineTextFields() -> [MDCTextInputControllerFullWidth] {
+    let multilineTextFieldFullWidth = MDCMultilineTextField()
+    scrollView.addSubview(multilineTextFieldFullWidth)
+    multilineTextFieldFullWidth.translatesAutoresizingMaskIntoConstraints = false
+
+    multilineTextFieldFullWidth.placeholder = "This is a full width multiline text field"
+    multilineTextFieldFullWidth.textView?.delegate = self
+
+    let multilineTextFieldControllerFullWidth =
+          MDCTextInputControllerFullWidth(textInput: multilineTextFieldFullWidth)
+
+    let multilineTextFieldFullWidthCharMax = MDCMultilineTextField()
+    scrollView.addSubview(multilineTextFieldFullWidthCharMax)
+    multilineTextFieldFullWidthCharMax.translatesAutoresizingMaskIntoConstraints = false
+
+    multilineTextFieldFullWidthCharMax.placeholder =
+        "This is a full width multiline text field with character count"
+    multilineTextFieldFullWidthCharMax.textView?.delegate = self
+
+    let multilineTextFieldControllerFullWidthCharMax =
+          MDCTextInputControllerFullWidth(textInput: multilineTextFieldFullWidthCharMax)
+
+    controllersWithCharacterCount.append(multilineTextFieldControllerFullWidthCharMax)
+    multilineTextFieldControllerFullWidthCharMax.characterCountMax = 140
+
+    return [multilineTextFieldControllerFullWidth, multilineTextFieldControllerFullWidthCharMax]
+  }
+
+  func setupFloatingMultilineTextFields() -> [MDCTextInputControllerLegacyDefault] {
+    let multilineTextFieldFloating = MDCMultilineTextField()
+    scrollView.addSubview(multilineTextFieldFloating)
+    multilineTextFieldFloating.translatesAutoresizingMaskIntoConstraints = false
+
+    multilineTextFieldFloating.textView?.delegate = self
+    multilineTextFieldFloating.placeholder =
+        "This is a multiline text field with a floating placeholder"
+
+    let multilineTextFieldControllerFloating =
+          MDCTextInputControllerLegacyDefault(textInput: multilineTextFieldFloating)
+
+    let multilineTextFieldFloatingCharMax = MDCMultilineTextField()
+    scrollView.addSubview(multilineTextFieldFloatingCharMax)
+    multilineTextFieldFloatingCharMax.translatesAutoresizingMaskIntoConstraints = false
+
+    multilineTextFieldFloatingCharMax.textView?.delegate = self
+    multilineTextFieldFloatingCharMax.placeholder =
+        "This is a multiline text field with a floating placeholder and character count"
+
+    let multilineTextFieldControllerFloatingCharMax =
+          MDCTextInputControllerLegacyDefault(textInput: multilineTextFieldFloatingCharMax)
+
+    controllersWithCharacterCount.append(multilineTextFieldControllerFloatingCharMax)
+
+    return [multilineTextFieldControllerFloating, multilineTextFieldControllerFloatingCharMax]
+  }
+
+  func setupSpecialMultilineTextFields() -> [MDCTextInputController] {
+    let bundle = Bundle(for: TextFieldKitchenSinkSwiftExample.self)
+    let rightViewImagePath = bundle.path(forResource: "ic_done", ofType: "png")!
+    let rightViewImage = UIImage(contentsOfFile: rightViewImagePath)!
+
+    let multilineTextFieldTrailingView = MDCMultilineTextField()
+    multilineTextFieldTrailingView.trailingViewMode = .always
+    multilineTextFieldTrailingView.trailingView = UIImageView(image:rightViewImage)
+
+    scrollView.addSubview(multilineTextFieldTrailingView)
+    multilineTextFieldTrailingView.translatesAutoresizingMaskIntoConstraints = false
+
+    multilineTextFieldTrailingView.placeholder = "This has a trailing view"
+    multilineTextFieldTrailingView.textView?.delegate = self
+    multilineTextFieldTrailingView.clearButtonMode = .whileEditing
+
+    let multilineTextFieldControllerDefaultTrailingView =
+        MDCTextInputControllerLegacyDefault(textInput: multilineTextFieldTrailingView)
+    multilineTextFieldControllerDefaultTrailingView.isFloatingEnabled = false
+
+    let multilineTextFieldCustomFont = MDCMultilineTextField()
+    scrollView.addSubview(multilineTextFieldCustomFont)
+    multilineTextFieldCustomFont.translatesAutoresizingMaskIntoConstraints = false
+
+    multilineTextFieldCustomFont.placeholder = "This has a custom font"
+
+    let multilineTextFieldControllerDefaultCustomFont =
+        MDCTextInputControllerLegacyDefault(textInput: multilineTextFieldCustomFont)
+
+    scrollView.addSubview(unstyledMultilineTextField)
+    unstyledMultilineTextField.translatesAutoresizingMaskIntoConstraints = false
+
+    unstyledMultilineTextField.placeholder =
+        "This multiline text field has no controller (unstyled)"
+    unstyledMultilineTextField.leadingUnderlineLabel.text = "Leading label"
+    unstyledMultilineTextField.trailingUnderlineLabel.text = "Trailing label"
+    unstyledMultilineTextField.textView?.delegate = self
+
+    return [multilineTextFieldControllerDefaultTrailingView,
+            multilineTextFieldControllerDefaultCustomFont]
+  }
+
+  @objc func tapDidTouch(sender: Any) {
+    self.view.endEditing(true)
+  }
+
+  @objc func errorSwitchDidChange(errorSwitch: UISwitch) {
+    allInputControllers.forEach { controller in
+      if errorSwitch.isOn {
+        controller.setErrorText("Uh oh! Try something else.", errorAccessibilityValue: nil)
+      } else {
+        controller.setErrorText(nil, errorAccessibilityValue: nil)
+      }
+    }
+  }
+
+  @objc func helperSwitchDidChange(helperSwitch: UISwitch) {
+    allInputControllers.forEach { controller in
+      controller.helperText = helperSwitch.isOn ? "This is helper text." : nil
+    }
+  }
+
+}
+
+extension TextFieldKitchenSinkLegacySwiftExample: UITextFieldDelegate {
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    textField.resignFirstResponder()
+    return false
+  }
+}
+
+extension TextFieldKitchenSinkLegacySwiftExample: UITextViewDelegate {
+  func textViewDidChange(_ textView: UITextView) {
+    print(textView.text)
+  }
+}
+
+extension TextFieldKitchenSinkLegacySwiftExample {
+  @objc func contentSizeCategoryDidChange(notif: Notification) {
+    controlLabel.font = UIFont.preferredFont(forTextStyle: .headline)
+    singleLabel.font = UIFont.preferredFont(forTextStyle: .headline)
+    errorLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
+    helperLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
+  }
+}

--- a/components/TextFields/examples/TextFieldLegacyExample.swift
+++ b/components/TextFields/examples/TextFieldLegacyExample.swift
@@ -1,0 +1,354 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+// swiftlint:disable function_body_length
+
+import MaterialComponents.MaterialTextFields
+
+final class TextFieldLegacySwiftExample: UIViewController {
+
+  let scrollView = UIScrollView()
+
+  let name: MDCTextField = {
+    let name = MDCTextField()
+    name.placeholder = "Name"
+    name.translatesAutoresizingMaskIntoConstraints = false
+    name.autocapitalizationType = .words
+    return name
+  }()
+
+  let address: MDCTextField = {
+    let address = MDCTextField()
+    address.placeholder = "Address"
+    address.translatesAutoresizingMaskIntoConstraints = false
+    address.autocapitalizationType = .words
+    return address
+  }()
+
+  let city: MDCTextField = {
+    let city = MDCTextField()
+    city.placeholder = "City"
+    city.translatesAutoresizingMaskIntoConstraints = false
+    city.autocapitalizationType = .words
+    return city
+  }()
+  let cityController: MDCTextInputControllerLegacyDefault
+
+  let state: MDCTextField = {
+    let state = MDCTextField()
+    state.placeholder = "State"
+    state.translatesAutoresizingMaskIntoConstraints = false
+    state.autocapitalizationType = .allCharacters
+    return state
+  }()
+
+  let zip: MDCTextField = {
+    let zip = MDCTextField()
+    zip.placeholder = "Zip code"
+    zip.translatesAutoresizingMaskIntoConstraints = false
+    return zip
+  }()
+  let zipController: MDCTextInputControllerLegacyDefault
+
+  let phone: MDCTextField = {
+    let phone = MDCTextField()
+    phone.placeholder = "Phone number"
+    phone.translatesAutoresizingMaskIntoConstraints = false
+    return phone
+  }()
+
+  let message: MDCMultilineTextField = {
+    let message = MDCMultilineTextField()
+    message.placeholder = "Message"
+    message.translatesAutoresizingMaskIntoConstraints = false
+    return message
+  }()
+
+  var allTextFieldControllers = [MDCTextInputControllerLegacyDefault]()
+
+  override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    cityController = MDCTextInputControllerLegacyDefault(textInput: city)
+    zipController = MDCTextInputControllerLegacyDefault(textInput: zip)
+    super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = UIColor(white:0.97, alpha: 1.0)
+
+    title = "Material Text Fields"
+
+    setupScrollView()
+    setupTextFields()
+
+    registerKeyboardNotifications()
+    addGestureRecognizer()
+
+    let styleButton = UIBarButtonItem(title: "Style",
+                                      style: .plain,
+                                      target: self,
+                                      action: #selector(buttonDidTouch(sender: )))
+    self.navigationItem.rightBarButtonItem = styleButton
+  }
+
+  func setupTextFields() {
+    scrollView.addSubview(name)
+    let nameController = MDCTextInputControllerLegacyDefault(textInput: name)
+    name.delegate = self
+    allTextFieldControllers.append(nameController)
+
+    scrollView.addSubview(address)
+    let addressController = MDCTextInputControllerLegacyDefault(textInput: address)
+    address.delegate = self
+    allTextFieldControllers.append(addressController)
+
+    scrollView.addSubview(city)
+    city.delegate = self
+    allTextFieldControllers.append(cityController)
+
+    // In iOS 9+, you could accomplish this with a UILayoutGuide.
+    // TODO: (larche) add iOS version specific implementations
+    let stateZip = UIView()
+    stateZip.translatesAutoresizingMaskIntoConstraints = false
+    scrollView.addSubview(stateZip)
+
+    stateZip.addSubview(state)
+    let stateController = MDCTextInputControllerLegacyDefault(textInput: state)
+    state.delegate = self
+    allTextFieldControllers.append(stateController)
+
+    stateZip.addSubview(zip)
+    zip.delegate = self
+    allTextFieldControllers.append(zipController)
+
+    scrollView.addSubview(phone)
+    let phoneController = MDCTextInputControllerLegacyDefault(textInput: phone)
+    phone.delegate = self
+    allTextFieldControllers.append(phoneController)
+
+    scrollView.addSubview(message)
+    let messageController = MDCTextInputControllerLegacyDefault(textInput: message)
+    message.textView?.delegate = self
+    allTextFieldControllers.append(messageController)
+
+    var tag = 0
+    for controller in allTextFieldControllers {
+      guard let textField = controller.textInput as? MDCTextField else { continue }
+      textField.tag = tag
+      tag += 1
+    }
+
+    let views = [ "name": name,
+                  "address": address,
+                  "city": city,
+                  "stateZip": stateZip,
+                  "phone": phone,
+                  "message": message ]
+    var constraints = NSLayoutConstraint.constraints(withVisualFormat:
+      "V:|-20-[name]-[address]-[city]-[stateZip]-[phone]-[message]-|",
+                                                     options: [.alignAllLeading, .alignAllTrailing],
+                                                     metrics: nil,
+                                                     views: views)
+
+    constraints += [NSLayoutConstraint(item: name,
+                                       attribute: .leading,
+                                       relatedBy: .equal,
+                                       toItem: view,
+                                       attribute: .leadingMargin,
+                                       multiplier: 1,
+                                       constant: 0)]
+    constraints += [NSLayoutConstraint(item: name,
+                                       attribute: .trailing,
+                                       relatedBy: .equal,
+                                       toItem: view,
+                                       attribute: .trailingMargin,
+                                       multiplier: 1,
+                                       constant: 0)]
+    constraints += NSLayoutConstraint.constraints(withVisualFormat: "H:[name]|",
+                                                  options: [],
+                                                  metrics: nil,
+                                                  views: views)
+
+    let stateZipViews = [ "state": state, "zip": zip ]
+    constraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|[state(80)]-[zip]|",
+                                                  options: [.alignAllTop],
+                                                  metrics: nil,
+                                                  views: stateZipViews)
+    constraints += NSLayoutConstraint.constraints(withVisualFormat: "V:|[state]|",
+                                                  options: [],
+                                                  metrics: nil,
+                                                  views: stateZipViews)
+
+    NSLayoutConstraint.activate(constraints)
+  }
+
+  func setupScrollView() {
+    view.addSubview(scrollView)
+    scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate(NSLayoutConstraint.constraints(
+      withVisualFormat: "V:|[scrollView]|",
+      options: [],
+      metrics: nil,
+      views: ["scrollView": scrollView]))
+    NSLayoutConstraint.activate(NSLayoutConstraint.constraints(withVisualFormat: "H:|[scrollView]|",
+                                                               options: [],
+                                                               metrics: nil,
+                                                               views: ["scrollView": scrollView]))
+    let marginOffset: CGFloat = 16
+    let margins = UIEdgeInsets(top: 0, left: marginOffset, bottom: 0, right: marginOffset)
+
+    scrollView.layoutMargins = margins
+  }
+
+  func addGestureRecognizer() {
+    let tapRecognizer = UITapGestureRecognizer(target: self,
+                                               action: #selector(tapDidTouch(sender: )))
+    self.scrollView.addGestureRecognizer(tapRecognizer)
+  }
+
+  // MARK: - Actions
+
+  @objc func tapDidTouch(sender: Any) {
+    self.view.endEditing(true)
+  }
+
+  @objc func buttonDidTouch(sender: Any) {
+    let isFloatingEnabled = allTextFieldControllers.first?.isFloatingEnabled ?? false
+    let alert = UIAlertController(title: "Floating Labels",
+                                  message: nil,
+                                  preferredStyle: .actionSheet)
+
+    let defaultAction = UIAlertAction(title: "Default (Yes)" + (isFloatingEnabled ? " ✓" : ""),
+                                      style: .default) { _ in
+      self.allTextFieldControllers.forEach({ (controller) in
+        controller.isFloatingEnabled = true
+      })
+    }
+    alert.addAction(defaultAction)
+    let floatingAction = UIAlertAction(title: "No" + (isFloatingEnabled ? "" : " ✓"),
+                                       style: .default) { _ in
+      self.allTextFieldControllers.forEach({ (controller) in
+        controller.isFloatingEnabled = false
+      })
+    }
+    alert.addAction(floatingAction)
+    present(alert, animated: true, completion: nil)
+  }
+}
+
+extension TextFieldLegacySwiftExample: UITextFieldDelegate {
+  func textField(_ textField: UITextField,
+                 shouldChangeCharactersIn range: NSRange,
+                 replacementString string: String) -> Bool {
+    guard let rawText = textField.text else {
+      return true
+    }
+
+    let fullString = NSString(string: rawText).replacingCharacters(in: range, with: string)
+
+    if textField == zip {
+      if let range = fullString.rangeOfCharacter(from: CharacterSet.letters),
+        fullString[range].characters.count > 0 {
+        zipController.setErrorText("Error: Zip can only contain numbers",
+                                   errorAccessibilityValue: nil)
+      } else if fullString.characters.count > 5 {
+        zipController.setErrorText("Error: Zip can only contain five digits",
+                                   errorAccessibilityValue: nil)
+      } else {
+        zipController.setErrorText(nil, errorAccessibilityValue: nil)
+      }
+    } else if textField == city {
+      if let range = fullString.rangeOfCharacter(from: CharacterSet.decimalDigits),
+        fullString[range].characters.count > 0 {
+        cityController.setErrorText("Error: City can only contain letters",
+                                    errorAccessibilityValue: nil)
+      } else {
+        cityController.setErrorText(nil, errorAccessibilityValue: nil)
+      }
+    }
+    return true
+  }
+
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    let index = textField.tag
+    if index + 1 < allTextFieldControllers.count,
+      let nextField = allTextFieldControllers[index + 1].textInput as? MDCTextField {
+      nextField.becomeFirstResponder()
+    } else {
+      textField.resignFirstResponder()
+    }
+
+    return false
+  }
+}
+
+extension TextFieldLegacySwiftExample: UITextViewDelegate {
+  func textViewDidEndEditing(_ textView: UITextView) {
+    print(textView.text)
+  }
+}
+
+// MARK: - Keyboard Handling
+
+extension TextFieldLegacySwiftExample {
+  func registerKeyboardNotifications() {
+    let notificationCenter = NotificationCenter.default
+    notificationCenter.addObserver(
+      self,
+      selector: #selector(keyboardWillShow(notif:)),
+      name: .UIKeyboardWillShow,
+      object: nil)
+    notificationCenter.addObserver(
+      self,
+      selector: #selector(keyboardWillHide(notif:)),
+      name: .UIKeyboardWillHide,
+      object: nil)
+  }
+
+  @objc func keyboardWillShow(notif: Notification) {
+    guard let frame = notif.userInfo?[UIKeyboardFrameBeginUserInfoKey] as? CGRect else {
+      return
+    }
+    scrollView.contentInset = UIEdgeInsets(top: 0.0,
+                                           left: 0.0,
+                                           bottom: frame.height,
+                                           right: 0.0)
+  }
+
+  @objc func keyboardWillHide(notif: Notification) {
+    scrollView.contentInset = UIEdgeInsets()
+  }
+}
+
+// MARK: - Status Bar Style
+
+extension TextFieldLegacySwiftExample {
+  override var preferredStatusBarStyle: UIStatusBarStyle {
+    return .lightContent
+  }
+}
+
+extension TextFieldLegacySwiftExample {
+  class func catalogBreadcrumbs() -> [String] {
+    return ["Text Field", "[Legacy] Typical Use"]
+  }
+
+}

--- a/components/TextFields/examples/TextFieldManualLayoutLegacyExample.m
+++ b/components/TextFields/examples/TextFieldManualLayoutLegacyExample.m
@@ -1,0 +1,157 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MaterialTextFields.h"
+
+@interface TextFieldManualLayoutLegacyExample : UIViewController <UITextFieldDelegate>
+
+@property(nonatomic) MDCTextInputControllerLegacyDefault *nameController;
+@property(nonatomic) MDCTextInputControllerLegacyDefault *phoneController;
+
+@end
+
+@implementation TextFieldManualLayoutLegacyExample
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  self.view.backgroundColor = [UIColor whiteColor];
+  MDCTextField *textFieldName = [[MDCTextField alloc] init];
+  [self.view addSubview:textFieldName];
+
+  textFieldName.placeholder = @"Full Name";
+  textFieldName.delegate = self;
+  textFieldName.clearButtonMode = UITextFieldViewModeUnlessEditing;
+
+  self.nameController = [[MDCTextInputControllerLegacyDefault alloc] initWithTextInput:textFieldName];
+
+  textFieldName.frame = CGRectMake(10, 40, CGRectGetWidth(self.view.bounds) - 20, 0);
+
+  MDCTextField *textFieldPhone = [[MDCTextField alloc] init];
+  [self.view addSubview:textFieldPhone];
+
+  textFieldPhone.placeholder = @"Phone Number";
+  textFieldPhone.delegate = self;
+  textFieldPhone.clearButtonMode = UITextFieldViewModeUnlessEditing;
+
+  self.phoneController = [[MDCTextInputControllerLegacyDefault alloc] initWithTextInput:textFieldPhone];
+
+  textFieldPhone.frame = CGRectMake(10, CGRectGetMaxY(self.nameController.textInput.frame) + 20,
+                                    CGRectGetWidth(self.view.bounds) - 20, 0);
+
+  self.phoneController.helperText = @"XXX-XXX-XXXX";
+}
+
+- (void)viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
+
+  [self.nameController.textInput sizeToFit];
+  [self.phoneController.textInput sizeToFit];
+  self.phoneController.textInput.frame = CGRectMake(
+      10, CGRectGetMaxY(self.nameController.textInput.frame) + 20,
+      CGRectGetWidth(self.view.bounds) - 20, CGRectGetHeight(self.phoneController.textInput.frame));
+}
+
+#pragma mark - UITextFieldDelegate
+
+- (BOOL)textFieldShouldReturn:(UITextField *)textField {
+  [textField resignFirstResponder];
+
+  if (textField == (UITextField *)self.phoneController.textInput &&
+      ![self isValidPhoneNumber:textField.text partially:NO]) {
+    [self.phoneController setErrorText:@"Invalid Phone Number" errorAccessibilityValue:nil];
+  }
+
+  return NO;
+}
+
+- (BOOL)textField:(UITextField *)textField
+    shouldChangeCharactersInRange:(NSRange)range
+                replacementString:(NSString *)string {
+  NSString *finishedString =
+      [textField.text stringByReplacingCharactersInRange:range withString:string];
+
+  if (textField == (UITextField *)self.nameController.textInput) {
+    if ([finishedString rangeOfCharacterFromSet:[NSCharacterSet decimalDigitCharacterSet]].length &&
+        ![self.nameController.errorText isEqualToString:@"You cannot enter numbers"]) {
+      // The entered text contains numbers and we have not set an error
+      [self.nameController setErrorText:@"You cannot enter numbers" errorAccessibilityValue:nil];
+
+      // Since we are doing manual layout, we need to react to the expansion of the input that will
+      // come from setting an error.
+      [self.view setNeedsLayout];
+    } else if (self.nameController.errorText != nil) {
+      // There should be no error but error text is being shown.
+      [self.nameController setErrorText:nil errorAccessibilityValue:nil];
+
+      // Since we are doing manual layout, we need to react to the contraction of the input that
+      // will come from setting an error.
+      [self.view setNeedsLayout];
+    }
+  }
+
+  if (textField == (UITextField *)self.phoneController.textInput) {
+    if (![self isValidPhoneNumber:finishedString partially:YES] &&
+        ![self.phoneController.errorText isEqualToString:@"Invalid phone number"]) {
+      // The entered text is not valid and we have not set an error
+      [self.phoneController setErrorText:@"Invalid phone number" errorAccessibilityValue:nil];
+
+      // The text field has helper text that already expanded the frame so we don't need to call
+      // setNeedsLayout.
+    } else if (self.phoneController.errorText != nil) {
+      [self.phoneController setErrorText:nil errorAccessibilityValue:nil];
+
+      // The text field has helper text and cannot contract the frame so we don't need to call
+      // setNeedsLayout.
+    }
+  }
+
+  return YES;
+}
+
+#pragma mark - Phone Number Validation
+
+- (BOOL)isValidPhoneNumber:(NSString *)inputString partially:(BOOL)isPartialCheck {
+  // In real life there would be much more robust validation that takes locale into account, checks
+  // against invalid phone numbers (like those that begin with 0), and perhaps even auto-inserts the
+  // hyphens so the user doesn't have to.
+
+  if (inputString.length == 0) {
+    return YES;
+  }
+
+  NSCharacterSet *characterSet = [NSCharacterSet characterSetWithCharactersInString:@"0123456789-"];
+  characterSet = [characterSet invertedSet];
+
+  BOOL isValid = ![inputString rangeOfCharacterFromSet:characterSet].length;
+
+  if (!isPartialCheck) {
+    isValid = isValid && inputString.length == 12;
+  } else {
+    isValid = isValid && inputString.length <= 12;
+  }
+  return isValid;
+}
+
+@end
+
+@implementation TextFieldManualLayoutLegacyExample (CatalogByConvention)
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Text Field", @"[Legacy] Manual Layout (Objective C)" ];
+}
+
+@end

--- a/components/TextFields/examples/TextFieldManualLayoutLegacyExample.swift
+++ b/components/TextFields/examples/TextFieldManualLayoutLegacyExample.swift
@@ -1,0 +1,326 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+// swiftlint:disable function_body_length
+
+import MaterialComponents.MaterialTextFields
+
+final class TextFieldManualLayoutLegacySwiftExample: UIViewController {
+
+  private enum LayoutConstants {
+    static let largeMargin: CGFloat = 16
+    static let smallMargin: CGFloat = 8
+
+    static let floatingHeight: CGFloat = 84
+    static let defaultHeight: CGFloat = 62
+
+    static let stateWidth: CGFloat = 80
+  }
+
+  let scrollView = UIScrollView()
+
+  let name: MDCTextField = {
+    let name = MDCTextField()
+    name.placeholder = "Name"
+    return name
+  }()
+
+  let address: MDCTextField = {
+    let address = MDCTextField()
+    address.placeholder = "Address"
+    return address
+  }()
+
+  let city: MDCTextField = {
+    let city = MDCTextField()
+    city.placeholder = "City"
+    return city
+  }()
+  let cityController: MDCTextInputControllerLegacyDefault
+
+  let state: MDCTextField = {
+    let state = MDCTextField()
+    state.placeholder = "State"
+    return state
+  }()
+
+  let zip: MDCTextField = {
+    let zip = MDCTextField()
+    zip.placeholder = "Zip code"
+    return zip
+  }()
+  let zipController: MDCTextInputControllerLegacyDefault
+
+  let phone: MDCTextField = {
+    let phone = MDCTextField()
+    phone.placeholder = "Phone number"
+    return phone
+  }()
+
+  let stateZip = UIView()
+
+  var allTextFieldControllers = [MDCTextInputControllerLegacyDefault]()
+
+  override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    cityController = MDCTextInputControllerLegacyDefault(textInput: city)
+    zipController = MDCTextInputControllerLegacyDefault(textInput: zip)
+    super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = UIColor(white:0.97, alpha: 1.0)
+
+    title = "Manual Text Fields"
+
+    setupScrollView()
+    setupTextFields()
+
+    updateLayout()
+
+    registerKeyboardNotifications()
+    addGestureRecognizer()
+
+    let styleButton = UIBarButtonItem(title: "Style",
+                                      style: .plain,
+                                      target: self,
+                                      action: #selector(buttonDidTouch(sender: )))
+    self.navigationItem.rightBarButtonItem = styleButton
+  }
+
+  func setupTextFields() {
+    scrollView.addSubview(name)
+    let nameController = MDCTextInputControllerLegacyDefault(textInput: name)
+    name.delegate = self
+    allTextFieldControllers.append(nameController)
+
+    scrollView.addSubview(address)
+    let addressController = MDCTextInputControllerLegacyDefault(textInput: address)
+    address.delegate = self
+    allTextFieldControllers.append(addressController)
+
+    scrollView.addSubview(city)
+    city.delegate = self
+    allTextFieldControllers.append(cityController)
+
+    scrollView.addSubview(stateZip)
+
+    stateZip.addSubview(state)
+    let stateController = MDCTextInputControllerLegacyDefault(textInput: state)
+    state.delegate = self
+    allTextFieldControllers.append(stateController)
+
+    stateZip.addSubview(zip)
+    zip.delegate = self
+    allTextFieldControllers.append(zipController)
+
+    scrollView.addSubview(phone)
+    let phoneController = MDCTextInputControllerLegacyDefault(textInput: phone)
+    phone.delegate = self
+    allTextFieldControllers.append(phoneController)
+
+    var tag = 0
+    for controller in allTextFieldControllers {
+      guard let textField = controller.textInput as? MDCTextField else { continue }
+      textField.tag = tag
+      tag += 1
+    }
+
+  }
+
+  func setupScrollView() {
+    view.addSubview(scrollView)
+    scrollView.frame = view.bounds
+
+    scrollView.contentSize =
+      CGSize(width: scrollView.bounds.width - 2 * LayoutConstants.largeMargin,
+             height: 372.0)
+  }
+
+  func addGestureRecognizer() {
+    let tapRecognizer = UITapGestureRecognizer(target: self,
+                                               action: #selector(tapDidTouch(sender: )))
+    self.scrollView.addGestureRecognizer(tapRecognizer)
+  }
+
+  func updateLayout() {
+    let commonWidth = view.bounds.width - 2 * LayoutConstants.largeMargin
+    var height = LayoutConstants.floatingHeight
+    if let controller = allTextFieldControllers.first {
+      height = controller.isFloatingEnabled ?
+        LayoutConstants.floatingHeight : LayoutConstants.defaultHeight
+    }
+
+    name.frame = CGRect(x: LayoutConstants.largeMargin,
+                        y: LayoutConstants.smallMargin,
+                        width: commonWidth,
+                        height: height)
+
+    address.frame = CGRect(x: LayoutConstants.largeMargin,
+                           y: name.frame.minY + height + LayoutConstants.smallMargin,
+                           width: commonWidth,
+                           height: height)
+
+    city.frame = CGRect(x: LayoutConstants.largeMargin,
+                        y: address.frame.minY + height + LayoutConstants.smallMargin,
+                        width: commonWidth,
+                        height: height)
+
+    stateZip.frame = CGRect(x: LayoutConstants.largeMargin,
+                            y: city.frame.minY + height + LayoutConstants.smallMargin,
+                            width: commonWidth,
+                            height: height)
+
+    state.frame = CGRect(x: 0,
+                         y: 0,
+                         width: LayoutConstants.stateWidth,
+                         height: height)
+
+    zip.frame = CGRect(x: LayoutConstants.stateWidth + LayoutConstants.smallMargin,
+                       y: 0,
+                       width: stateZip.bounds.width - LayoutConstants.stateWidth -
+                        LayoutConstants.smallMargin,
+                       height: height)
+
+    phone.frame = CGRect(x: LayoutConstants.largeMargin,
+                         y: stateZip.frame.minY + height + LayoutConstants.smallMargin,
+                         width: commonWidth,
+                         height: height)
+  }
+
+  // MARK: - Actions
+
+  @objc func tapDidTouch(sender: Any) {
+    self.view.endEditing(true)
+  }
+
+  @objc func buttonDidTouch(sender: Any) {
+    let alert = UIAlertController(title: "Floating Enabled",
+                                  message: nil,
+                                  preferredStyle: .actionSheet)
+    let defaultAction = UIAlertAction(title: "Default (Yes)", style: .default) { _ in
+      self.allTextFieldControllers.forEach({ (controller) in
+        controller.isFloatingEnabled = true
+      })
+      self.updateLayout()
+    }
+    alert.addAction(defaultAction)
+    let floatingAction = UIAlertAction(title: "No", style: .default) { _ in
+      self.allTextFieldControllers.forEach({ (controller) in
+        controller.isFloatingEnabled = false
+      })
+      self.updateLayout()
+    }
+    alert.addAction(floatingAction)
+    present(alert, animated: true, completion: nil)
+  }
+}
+
+extension TextFieldManualLayoutLegacySwiftExample: UITextFieldDelegate {
+  func textField(_ textField: UITextField,
+                 shouldChangeCharactersIn range: NSRange,
+                 replacementString string: String) -> Bool {
+    guard let rawText = textField.text else {
+      return true
+    }
+
+    let fullString = NSString(string: rawText).replacingCharacters(in: range, with: string)
+
+    if textField == zip {
+      if let range = fullString.rangeOfCharacter(from: CharacterSet.letters),
+        fullString[range].characters.count > 0 {
+        zipController.setErrorText("Error: Zip can only contain numbers",
+                                   errorAccessibilityValue: nil)
+      } else if fullString.characters.count > 5 {
+        zipController.setErrorText("Error: Zip can only contain five digits",
+                                   errorAccessibilityValue: nil)
+      } else {
+        zipController.setErrorText(nil, errorAccessibilityValue: nil)
+      }
+    } else if textField == city {
+      if let range = fullString.rangeOfCharacter(from: CharacterSet.decimalDigits),
+        fullString[range].characters.count > 0 {
+        cityController.setErrorText("Error: City can only contain letters",
+                                    errorAccessibilityValue: nil)
+      } else {
+        cityController.setErrorText(nil, errorAccessibilityValue: nil)
+      }
+    }
+    return true
+  }
+
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    let index = textField.tag
+    if index + 1 < allTextFieldControllers.count,
+      let nextField = allTextFieldControllers[index + 1].textInput as? MDCTextField {
+      nextField.becomeFirstResponder()
+    } else {
+      textField.resignFirstResponder()
+    }
+
+    return false
+  }
+}
+
+// MARK: - Keyboard Handling
+
+extension TextFieldManualLayoutLegacySwiftExample {
+  func registerKeyboardNotifications() {
+    let notificationCenter = NotificationCenter.default
+    notificationCenter.addObserver(
+      self,
+      selector: #selector(keyboardWillShow(notif:)),
+      name: .UIKeyboardWillShow,
+      object: nil)
+    notificationCenter.addObserver(
+      self,
+      selector: #selector(keyboardWillHide(notif:)),
+      name: .UIKeyboardWillHide,
+      object: nil)
+  }
+
+  @objc func keyboardWillShow(notif: Notification) {
+    guard let frame = notif.userInfo?[UIKeyboardFrameBeginUserInfoKey] as? CGRect else {
+      return
+    }
+    scrollView.contentInset = UIEdgeInsets(top: 0.0,
+                                           left: 0.0,
+                                           bottom: frame.height,
+                                           right: 0.0)
+  }
+
+  @objc func keyboardWillHide(notif: Notification) {
+    scrollView.contentInset = UIEdgeInsets()
+  }
+}
+
+// MARK: - Status Bar Style
+
+extension TextFieldManualLayoutLegacySwiftExample {
+  override var preferredStatusBarStyle: UIStatusBarStyle {
+    return .lightContent
+  }
+}
+
+extension TextFieldManualLayoutLegacySwiftExample {
+  class func catalogBreadcrumbs() -> [String] {
+    return ["Text Field", "[Legacy] Manual Layout"]
+  }
+}

--- a/components/TextFields/examples/supplemental/TextFieldInterfaceBuilderLegacyExampleSupplemental.h
+++ b/components/TextFields/examples/supplemental/TextFieldInterfaceBuilderLegacyExampleSupplemental.h
@@ -1,0 +1,27 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+@import UIKit;
+
+@interface TextFieldInterfaceBuilderLegacyExample : UIViewController
+
+@end
+
+@interface TextFieldInterfaceBuilderLegacyExample (Supplemental)
+
+- (void)setupExampleViews;
+
+@end

--- a/components/TextFields/examples/supplemental/TextFieldInterfaceBuilderLegacyExampleSupplemental.m
+++ b/components/TextFields/examples/supplemental/TextFieldInterfaceBuilderLegacyExampleSupplemental.m
@@ -1,0 +1,37 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "TextFieldInterfaceBuilderLegacyExampleSupplemental.h"
+
+@implementation TextFieldInterfaceBuilderLegacyExample (Supplemental)
+
+- (void)setupExampleViews {
+  self.title = @"Material Text Fields";
+}
+
+@end
+
+@implementation TextFieldInterfaceBuilderLegacyExample (CatalogByConvention)
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Text Field", @"[Legacy] Storyboard (Objective C)" ];
+}
+
++ (NSString *)catalogStoryboardName {
+  return @"TextFieldInterfaceBuilderExample";
+}
+
+@end

--- a/components/TextFields/examples/supplemental/TextFieldKitchenSinkLegacyExampleSupplemental.swift
+++ b/components/TextFields/examples/supplemental/TextFieldKitchenSinkLegacyExampleSupplemental.swift
@@ -1,0 +1,397 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+// swiftlint:disable file_length
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable function_body_length
+
+import UIKit
+
+extension TextFieldKitchenSinkLegacySwiftExample {
+
+  func setupExampleViews() {
+    view.backgroundColor = UIColor(white:0.97, alpha: 1.0)
+
+    title = "Material Text Fields"
+
+    let textFieldControllersFullWidth = setupFullWidthTextFields()
+
+    allTextFieldControllers = [setupDefaultTextFields(),
+                               textFieldControllersFullWidth,
+                               setupFloatingTextFields(),
+                               setupSpecialTextFields()].flatMap { $0 as! [MDCTextInputController] }
+
+    let multilineTextFieldControllersFullWidth = setupFullWidthMultilineTextFields()
+
+    allMultilineTextFieldControllers = [setupDefaultMultilineTextFields(),
+                              multilineTextFieldControllersFullWidth,
+                              setupFloatingMultilineTextFields(),
+                              setupSpecialMultilineTextFields()].flatMap { $0 as! [MDCTextInputController] }
+
+    controllersFullWidth = textFieldControllersFullWidth + multilineTextFieldControllersFullWidth
+
+    allInputControllers = allTextFieldControllers + allMultilineTextFieldControllers
+
+    setupScrollView()
+
+    NotificationCenter.default.addObserver(self,
+                                           selector: #selector(TextFieldKitchenSinkSwiftExample.contentSizeCategoryDidChange(notif:)),
+                                           name:.UIContentSizeCategoryDidChange,
+                                           object: nil)
+  }
+
+  func setupButton() -> MDCButton {
+    let button = MDCButton()
+    button.setTitleColor(.white, for: .normal)
+    return button
+  }
+
+  func setupControls() -> [UIView] {
+    let container = UIView()
+    container.translatesAutoresizingMaskIntoConstraints = false
+    scrollView.addSubview(container)
+
+    container.addSubview(errorLabel)
+
+    let errorSwitch = UISwitch()
+    errorSwitch.translatesAutoresizingMaskIntoConstraints = false
+    errorSwitch.addTarget(self,
+                          action: #selector(TextFieldKitchenSinkSwiftExample.errorSwitchDidChange(errorSwitch:)),
+                          for: .touchUpInside)
+    container.addSubview(errorSwitch)
+    errorSwitch.accessibilityLabel = "Show errors"
+
+    container.addSubview(helperLabel)
+
+    let helperSwitch = UISwitch()
+    helperSwitch.translatesAutoresizingMaskIntoConstraints = false
+    helperSwitch.addTarget(self,
+                           action: #selector(TextFieldKitchenSinkSwiftExample.helperSwitchDidChange(helperSwitch:)),
+                           for: .touchUpInside)
+    container.addSubview(helperSwitch)
+    helperSwitch.accessibilityLabel = "Helper text"
+
+    let views = ["errorLabel": errorLabel, "errorSwitch": errorSwitch,
+                 "helperLabel": helperLabel, "helperSwitch": helperSwitch]
+    NSLayoutConstraint.activate(NSLayoutConstraint.constraints(withVisualFormat:
+      "H:|-[errorLabel]-[errorSwitch]|", options: [.alignAllCenterY], metrics: nil, views: views))
+    NSLayoutConstraint.activate(NSLayoutConstraint.constraints(withVisualFormat:
+      "H:|-[helperLabel]-[helperSwitch]|", options: [.alignAllCenterY], metrics: nil, views: views))
+    NSLayoutConstraint.activate(NSLayoutConstraint.constraints(withVisualFormat:
+      "V:|-[errorSwitch]-[helperSwitch]|", options: [], metrics: nil, views: views))
+
+    characterModeButton.translatesAutoresizingMaskIntoConstraints = false
+    characterModeButton.addTarget(self,
+                                  action: #selector(buttonDidTouch(button:)),
+                                  for: .touchUpInside)
+    characterModeButton.setTitle("Character Count Mode: Always", for: .normal)
+    characterModeButton.setTitleColor(.white, for: .normal)
+    characterModeButton.mdc_adjustsFontForContentSizeCategory = true
+    scrollView.addSubview(characterModeButton)
+
+    clearModeButton.translatesAutoresizingMaskIntoConstraints = false
+    clearModeButton.addTarget(self,
+                              action: #selector(buttonDidTouch(button:)),
+                              for: .touchUpInside)
+    clearModeButton.setTitle("Clear Button Mode: While Editing", for: .normal)
+    clearModeButton.setTitleColor(.white, for: .normal)
+    clearModeButton.mdc_adjustsFontForContentSizeCategory = true
+    scrollView.addSubview(clearModeButton)
+
+    underlineButton.translatesAutoresizingMaskIntoConstraints = false
+    underlineButton.addTarget(self,
+                              action: #selector(buttonDidTouch(button:)),
+                              for: .touchUpInside)
+
+    underlineButton.setTitle("Underline Mode: While Editing", for: .normal)
+    underlineButton.setTitleColor(.white, for: .normal)
+    underlineButton.mdc_adjustsFontForContentSizeCategory = true
+    scrollView.addSubview(underlineButton)
+
+    return [container, characterModeButton, underlineButton, clearModeButton]
+  }
+
+  func setupSectionLabels() {
+    scrollView.addSubview(controlLabel)
+    scrollView.addSubview(singleLabel)
+    scrollView.addSubview(multiLabel)
+
+    NSLayoutConstraint(item: singleLabel,
+                       attribute: .leading,
+                       relatedBy: .equal,
+                       toItem: view,
+                       attribute: .leadingMargin,
+                       multiplier: 1,
+                       constant: 0).isActive = true
+
+    NSLayoutConstraint(item: singleLabel,
+                       attribute: .trailing,
+                       relatedBy: .equal,
+                       toItem: view,
+                       attribute: .trailingMargin,
+                       multiplier: 1,
+                       constant: 0).isActive = true
+  }
+
+  func setupScrollView() {
+    view.addSubview(scrollView)
+    scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate(NSLayoutConstraint.constraints(
+      withVisualFormat: "V:|[scrollView]|",
+      options: [],
+      metrics: nil,
+      views: ["scrollView": scrollView]))
+    NSLayoutConstraint.activate(NSLayoutConstraint.constraints(withVisualFormat: "H:|[scrollView]|",
+                                                               options: [],
+                                                               metrics: nil,
+                                                               views: ["scrollView": scrollView]))
+    let marginOffset: CGFloat = 16
+    let margins = UIEdgeInsets(top: 0, left: marginOffset, bottom: 0, right: marginOffset)
+
+    scrollView.layoutMargins = margins
+
+    setupSectionLabels()
+
+    let prefix = "view"
+    let concatenatingClosure = {
+      (accumulator, object: AnyObject) in
+      accumulator + "[" + self.unique(from: object, with: prefix) +
+        "]" + "-"
+    }
+
+    let allControls = setupControls()
+    let controlsString = allControls.reduce("", concatenatingClosure)
+
+    var controls = [String: UIView]()
+    allControls.forEach { control in
+      controls[unique(from: control, with: prefix)] =
+      control
+    }
+
+    let allTextFields = allTextFieldControllers.flatMap { $0.textInput }
+    let textFieldsString = allTextFields.reduce("", concatenatingClosure)
+
+    var textFields = [String: UIView]()
+    allTextFields.forEach { textInput in
+      textFields[unique(from: textInput, with: prefix)] = textInput
+    }
+
+    let allTextViews = allMultilineTextFieldControllers.flatMap { $0.textInput }
+    let textViewsString = allTextViews.reduce("", concatenatingClosure)
+
+    var textViews = [String: UIView]()
+    allTextViews.forEach { input in
+      textViews[unique(from: input, with: prefix)] = input
+    }
+
+    let visualString = "V:|-20-[singleLabel]-" +
+      textFieldsString + "[unstyledTextField]-20-[multiLabel]-" + textViewsString +
+      "[unstyledTextView]-10-[controlLabel]-" + controlsString + "20-|"
+
+    let labels: [String: UIView] = ["controlLabel": controlLabel,
+                                    "singleLabel": singleLabel,
+                                    "multiLabel": multiLabel,
+                                    "unstyledTextField": unstyledTextField,
+                                    "unstyledTextView": unstyledMultilineTextField]
+
+    var views = [String: UIView]()
+
+    let dictionaries = [labels, textFields, controls, textViews]
+
+    dictionaries.forEach { dictionary in
+      dictionary.forEach { (key, value) in
+        views[key] = value
+
+        // We have a scrollview and we're adding some elements that are subclassed from scrollviews.
+        // So constraints need to be in relation to something that doesn't have a content size.
+        // We'll use the view controller's view.
+        let leading = NSLayoutConstraint(item: value,
+                                         attribute: .leading,
+                                         relatedBy: .equal,
+                                         toItem: view,
+                                         attribute: .leadingMargin,
+                                         multiplier: 1.0,
+                                         constant: 0.0)
+        leading.priority = 750.0
+        leading.isActive = true
+
+        let trailing = NSLayoutConstraint(item: value,
+                                          attribute: .trailing,
+                                          relatedBy: .equal,
+                                          toItem: view,
+                                          attribute: .trailing,
+                                          multiplier: 1.0,
+                                          constant: 0.0)
+        trailing.priority = 750.0
+        trailing.isActive = true
+      }
+    }
+
+    NSLayoutConstraint.activate(NSLayoutConstraint.constraints(withVisualFormat: visualString,
+                                                               options: [.alignAllCenterX],
+                                                               metrics: nil,
+                                                               views: views))
+
+    controllersFullWidth.flatMap { $0.textInput }.forEach { textInput in
+      NSLayoutConstraint(item: textInput,
+                         attribute: .leading,
+                         relatedBy: .equal,
+                         toItem: view,
+                         attribute: .leading,
+                         multiplier: 1.0,
+                         constant: 0).isActive = true
+      NSLayoutConstraint(item: textInput,
+                         attribute: .trailing,
+                         relatedBy: .equal,
+                         toItem: view,
+                         attribute: .trailing,
+                         multiplier: 1.0,
+                         constant: 0).isActive = true
+
+      // This constraint is necessary for the scrollview to have a content width.
+      NSLayoutConstraint(item: textInput,
+                         attribute: .trailing,
+                         relatedBy: .equal,
+                         toItem: scrollView,
+                         attribute: .trailing,
+                         multiplier: 1.0,
+                         constant: 0).isActive = true
+    }
+    registerKeyboardNotifications()
+    addGestureRecognizer()
+  }
+
+  func addGestureRecognizer() {
+    let tapRecognizer = UITapGestureRecognizer(target: self,
+                                               action: #selector(tapDidTouch(sender: )))
+    self.scrollView.addGestureRecognizer(tapRecognizer)
+  }
+
+  func registerKeyboardNotifications() {
+    let notificationCenter = NotificationCenter.default
+    notificationCenter.addObserver(
+      self,
+      selector: #selector(TextFieldKitchenSinkSwiftExample.keyboardWillShow(notif:)),
+      name: .UIKeyboardWillShow,
+      object: nil)
+    notificationCenter.addObserver(
+      self,
+      selector: #selector(TextFieldKitchenSinkSwiftExample.keyboardWillHide(notif:)),
+      name: .UIKeyboardWillHide,
+      object: nil)
+  }
+
+  @objc func keyboardWillShow(notif: Notification) {
+    guard let frame = notif.userInfo?[UIKeyboardFrameBeginUserInfoKey] as? CGRect else {
+      return
+    }
+    scrollView.contentInset = UIEdgeInsets(top: 0.0,
+                                           left: 0.0,
+                                           bottom: frame.height,
+                                           right: 0.0)
+  }
+
+  @objc func keyboardWillHide(notif: Notification) {
+    scrollView.contentInset = UIEdgeInsets()
+  }
+
+  func unique(from input: AnyObject, with prefix: String) -> String {
+    return prefix + String(describing: Unmanaged.passUnretained(input).toOpaque())
+  }
+
+}
+
+extension TextFieldKitchenSinkLegacySwiftExample {
+  // The 3 'mode' buttons all are similar. The following code is shared by them
+  @objc func buttonDidTouch(button: MDCButton) {
+    var controllersToChange = allInputControllers
+    var partialTitle = ""
+
+    if button == characterModeButton {
+      partialTitle = "Character Count Mode"
+      controllersToChange = controllersWithCharacterCount
+    } else if button == clearModeButton {
+      partialTitle = "Clear Button Mode"
+      controllersToChange = allTextFieldControllers
+    } else {
+      partialTitle = "Underline View Mode"
+    }
+
+    let closure: (UITextFieldViewMode, String) -> Void = { mode, title in
+      controllersToChange.forEach { controller in
+        if button == self.characterModeButton {
+          controller.characterCountViewMode = mode
+        } else if button == self.clearModeButton {
+          if let input = controller.textInput as? MDCTextField {
+            input.clearButtonMode = mode
+          }
+        } else {
+          controller.underlineViewMode = mode
+        }
+
+        button.setTitle(title + ": " + self.modeName(mode: mode), for: .normal)
+      }
+    }
+
+    let alert = UIAlertController(title: partialTitle,
+                                  message: nil,
+                                  preferredStyle: .alert)
+    presentAlert(alert: alert, partialTitle: partialTitle, closure: closure)
+  }
+
+  func presentAlert (alert: UIAlertController,
+                     partialTitle: String,
+                     closure: @escaping (_ mode: UITextFieldViewMode, _ title: String) -> Void) -> Void {
+
+    for rawMode in 0...3 {
+      let mode = UITextFieldViewMode(rawValue: rawMode)!
+      alert.addAction(UIAlertAction(title: modeName(mode: mode),
+                                    style: .default,
+                                    handler: { _ in
+                                      closure(mode, partialTitle)
+      }))
+    }
+
+    present(alert, animated: true, completion: nil)
+  }
+
+  func modeName(mode: UITextFieldViewMode) -> String {
+    switch mode {
+    case .always:
+      return "Always"
+    case .whileEditing:
+      return "While Editing"
+    case .unlessEditing:
+      return "Unless Editing"
+    case .never:
+      return "Never"
+    }
+  }
+}
+
+extension TextFieldKitchenSinkLegacySwiftExample {
+  override var preferredStatusBarStyle: UIStatusBarStyle {
+    return .lightContent
+  }
+}
+
+extension TextFieldKitchenSinkLegacySwiftExample {
+  class func catalogBreadcrumbs() -> [String] {
+    return ["Text Field", "[Legacy] Kitchen Sink"]
+  }
+}

--- a/components/TextFields/tests/unit/MultilineTextFieldLegacyTests.swift
+++ b/components/TextFields/tests/unit/MultilineTextFieldLegacyTests.swift
@@ -1,0 +1,56 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+// swiftlint:disable function_body_length
+// swiftlint:disable type_body_length
+
+import XCTest
+import MaterialComponents.MaterialTextFields
+
+class MultilineTextFieldLegacyTests: XCTestCase {
+
+  func testSerializationLegacy() {
+    let textField = MDCMultilineTextField()
+    textField.translatesAutoresizingMaskIntoConstraints = false
+    textField.text = "Lorem ipsum dolor sit amet, consectetuer adipiscing"
+
+    let controller = MDCTextInputControllerLegacyDefault(textInput: textField)
+    XCTAssertNotNil(controller.textInput)
+
+    let leadingText = "Serialized Helper Test"
+    controller.helperText = leadingText
+    controller.characterCountMax = 40
+
+    let serializedInput = NSKeyedArchiver.archivedData(withRootObject: textField)
+    XCTAssertNotNil(serializedInput)
+
+    let unserializedInput =
+      NSKeyedUnarchiver.unarchiveObject(with: serializedInput) as? MDCMultilineTextField
+    XCTAssertNotNil(unserializedInput)
+
+    XCTAssertEqual(textField.translatesAutoresizingMaskIntoConstraints,
+                   unserializedInput?.translatesAutoresizingMaskIntoConstraints)
+    XCTAssertEqual(textField.text,
+                   unserializedInput?.text)
+
+    XCTAssertEqual(textField.leadingUnderlineLabel.text,
+                   unserializedInput?.leadingUnderlineLabel.text)
+
+    XCTAssertEqual(textField.trailingUnderlineLabel.text, "51 / 40")
+    XCTAssertEqual(textField.trailingUnderlineLabel.text,
+                   unserializedInput?.trailingUnderlineLabel.text)
+  }
+}

--- a/components/TextFields/tests/unit/TextFieldControllerClassPropertiesLegacyTests.swift
+++ b/components/TextFields/tests/unit/TextFieldControllerClassPropertiesLegacyTests.swift
@@ -1,0 +1,139 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+// swiftlint:disable function_body_length
+// swiftlint:disable type_body_length
+
+import XCTest
+import MaterialComponents.MaterialPalettes
+import MaterialComponents.MaterialTextFields
+import MaterialComponents.MaterialTypography
+
+class TextFieldControllerClassPropertiesLegacyTests: XCTestCase {
+  override func tearDown() {
+    super.tearDown()
+
+    MDCTextInputControllerLegacyDefault.errorColorDefault = nil
+    MDCTextInputControllerLegacyDefault.inlinePlaceholderColorDefault = nil
+    MDCTextInputControllerLegacyDefault.mdc_adjustsFontForContentSizeCategoryDefault = true
+    MDCTextInputControllerLegacyDefault.activeColorDefault = nil
+    MDCTextInputControllerLegacyDefault.normalColorDefault = nil
+    MDCTextInputControllerLegacyDefault.underlineViewModeDefault = .whileEditing
+
+    MDCTextInputControllerLegacyDefault.floatingPlaceholderColorDefault = nil
+    MDCTextInputControllerLegacyDefault.floatingPlaceholderScaleDefault = 0.75
+    MDCTextInputControllerLegacyDefault.isFloatingEnabledDefault = true
+
+    MDCTextInputControllerFullWidth.errorColorDefault = nil
+    MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault = nil
+    MDCTextInputControllerFullWidth.mdc_adjustsFontForContentSizeCategoryDefault = true
+    MDCTextInputControllerFullWidth.activeColorDefault = nil
+    MDCTextInputControllerFullWidth.normalColorDefault = nil
+    MDCTextInputControllerFullWidth.underlineViewModeDefault = .never
+  }
+
+  func testLegacyDefault() {
+
+    // Test the values of the class properties.
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.errorColorDefault, MDCPalette.red.accent400)
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.inlinePlaceholderColorDefault,
+                   UIColor(white: 0, alpha: CGFloat(Float(0.54))))
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.mdc_adjustsFontForContentSizeCategoryDefault, true)
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.activeColorDefault,
+                   MDCPalette.blue.accent700)
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.normalColorDefault, .lightGray)
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.underlineViewModeDefault, .whileEditing)
+
+    // Default specific properties
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.floatingPlaceholderColorDefault,
+                   MDCPalette.blue.accent700)
+    XCTAssertEqual(Float(MDCTextInputControllerLegacyDefault.floatingPlaceholderScaleDefault), 0.75)
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.isFloatingEnabledDefault, true)
+
+    // Test the use of the class properties.
+    let textField = MDCTextField()
+    var controller = MDCTextInputControllerLegacyDefault(textInput: textField)
+
+    XCTAssertEqual(controller.errorColor, MDCTextInputControllerLegacyDefault.errorColorDefault)
+    XCTAssertEqual(controller.inlinePlaceholderColor,
+                   MDCTextInputControllerLegacyDefault.inlinePlaceholderColorDefault)
+    XCTAssertEqual(controller.mdc_adjustsFontForContentSizeCategory,
+                   MDCTextInputControllerLegacyDefault.mdc_adjustsFontForContentSizeCategoryDefault)
+    XCTAssertEqual(controller.activeColor,
+                   MDCTextInputControllerLegacyDefault.activeColorDefault)
+    XCTAssertEqual(controller.normalColor,
+                   MDCTextInputControllerLegacyDefault.normalColorDefault)
+    XCTAssertEqual(controller.underlineViewMode,
+                   MDCTextInputControllerLegacyDefault.underlineViewModeDefault)
+
+    // Default specific properties
+    XCTAssertEqual(controller.floatingPlaceholderColor,
+                   MDCTextInputControllerLegacyDefault.floatingPlaceholderColorDefault)
+    XCTAssertEqual(controller.isFloatingEnabled,
+                   MDCTextInputControllerLegacyDefault.isFloatingEnabledDefault)
+
+    // Test the changes to the class properties.
+    MDCTextInputControllerLegacyDefault.errorColorDefault = .green
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.errorColorDefault, .green)
+
+    MDCTextInputControllerLegacyDefault.inlinePlaceholderColorDefault = .orange
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.inlinePlaceholderColorDefault, .orange)
+
+    MDCTextInputControllerLegacyDefault.mdc_adjustsFontForContentSizeCategoryDefault = false
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.mdc_adjustsFontForContentSizeCategoryDefault,
+                   false)
+
+    MDCTextInputControllerLegacyDefault.activeColorDefault = .purple
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.activeColorDefault, .purple)
+
+    MDCTextInputControllerLegacyDefault.normalColorDefault = .white
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.normalColorDefault, .white)
+
+    MDCTextInputControllerLegacyDefault.underlineViewModeDefault = .unlessEditing
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.underlineViewModeDefault, .unlessEditing)
+
+    // Default specific properties
+    MDCTextInputControllerLegacyDefault.floatingPlaceholderColorDefault = .red
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.floatingPlaceholderColorDefault, .red)
+
+    MDCTextInputControllerLegacyDefault.floatingPlaceholderScaleDefault = 0.6
+    XCTAssertEqual(Float(MDCTextInputControllerLegacyDefault.floatingPlaceholderScaleDefault), 0.6)
+
+    MDCTextInputControllerLegacyDefault.isFloatingEnabledDefault = false
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.isFloatingEnabledDefault, false)
+
+    // Test the changes to the class properties can propogate to an instance.
+    controller = MDCTextInputControllerLegacyDefault(textInput: textField)
+
+    XCTAssertEqual(controller.errorColor, MDCTextInputControllerLegacyDefault.errorColorDefault)
+    XCTAssertEqual(controller.inlinePlaceholderColor,
+                   MDCTextInputControllerLegacyDefault.inlinePlaceholderColorDefault)
+    XCTAssertEqual(controller.mdc_adjustsFontForContentSizeCategory,
+                   MDCTextInputControllerLegacyDefault.mdc_adjustsFontForContentSizeCategoryDefault)
+    XCTAssertEqual(controller.activeColor,
+                   MDCTextInputControllerLegacyDefault.activeColorDefault)
+    XCTAssertEqual(controller.normalColor,
+                   MDCTextInputControllerLegacyDefault.normalColorDefault)
+    XCTAssertEqual(controller.underlineViewMode,
+                   MDCTextInputControllerLegacyDefault.underlineViewModeDefault)
+
+    // Default specific properties
+    XCTAssertEqual(controller.floatingPlaceholderColor,
+                   MDCTextInputControllerLegacyDefault.floatingPlaceholderColorDefault)
+    XCTAssertEqual(controller.isFloatingEnabled,
+                   MDCTextInputControllerLegacyDefault.isFloatingEnabledDefault)
+  }
+}

--- a/components/TextFields/tests/unit/TextFieldControllerLegacyTests.swift
+++ b/components/TextFields/tests/unit/TextFieldControllerLegacyTests.swift
@@ -1,0 +1,225 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+// swiftlint:disable function_body_length
+// swiftlint:disable type_body_length
+
+import XCTest
+import MaterialComponents.MaterialTextFields
+
+class TextFieldControllerLegacyDefaultTests: XCTestCase {
+  func testCopyingLegacyDefault() {
+    let textField = MDCTextField()
+
+    let controller = MDCTextInputControllerLegacyDefault(textInput: textField)
+    controller.characterCountMax = 49
+    controller.characterCountViewMode = .always
+    controller.isFloatingEnabled = false
+    controller.floatingPlaceholderColor = .purple
+    controller.floatingPlaceholderScale = 0.1
+    controller.helperText = "Helper"
+    controller.inlinePlaceholderColor = .green
+    controller.activeColor = .blue
+    controller.normalColor = .white
+    controller.underlineViewMode = .always
+
+    if let controllerCopy = controller.copy() as? MDCTextInputControllerLegacyDefault {
+      XCTAssertEqual(controller.characterCountMax, controllerCopy.characterCountMax)
+      XCTAssertEqual(controller.characterCountViewMode, controllerCopy.characterCountViewMode)
+      XCTAssertEqual(controller.isFloatingEnabled, controllerCopy.isFloatingEnabled)
+      XCTAssertEqual(controller.floatingPlaceholderColor, controllerCopy.floatingPlaceholderColor)
+      XCTAssertEqual(controller.floatingPlaceholderScale, controllerCopy.floatingPlaceholderScale)
+      XCTAssertEqual(controller.helperText, controllerCopy.helperText)
+      XCTAssertEqual(controller.inlinePlaceholderColor, controllerCopy.inlinePlaceholderColor)
+      XCTAssertEqual(controller.activeColor, controllerCopy.activeColor)
+      XCTAssertEqual(controller.normalColor, controllerCopy.normalColor)
+      XCTAssertEqual(controller.underlineViewMode, controllerCopy.underlineViewMode)
+    } else {
+      XCTFail("No copy or copy is wrong class")
+    }
+  }
+
+  func testDynamicTypeLegacyDefault() {
+    let textField = MDCTextField()
+
+    XCTAssertFalse(textField.mdc_adjustsFontForContentSizeCategory)
+    textField.mdc_adjustsFontForContentSizeCategory = true
+    XCTAssertTrue(textField.mdc_adjustsFontForContentSizeCategory)
+
+    let controller = MDCTextInputControllerLegacyDefault(textInput: textField)
+    XCTAssertNotNil(controller.textInput)
+
+    controller.mdc_adjustsFontForContentSizeCategory = true
+    XCTAssertTrue(controller.mdc_adjustsFontForContentSizeCategory)
+
+    // The controller takes over listening for dynamic type size changes.
+    XCTAssertFalse(textField.mdc_adjustsFontForContentSizeCategory)
+  }
+
+  func testCharacterMaxLegacyDefault() {
+    let textField = MDCTextField()
+    let controller = MDCTextInputControllerLegacyDefault(textInput: textField)
+
+    let altLeading = "Alternative Helper Test"
+    controller.helperText = altLeading
+
+    controller.characterCountMax = 50
+
+    // By setting the folowing text with is 51 characters when the max is set to 50 characters, it 
+    // should trigger an error state.
+    textField.text = "Lorem ipsum dolor sit amet, consectetuer adipiscing"
+
+    XCTAssertTrue("51 / 50".isEqual(textField.trailingUnderlineLabel.text))
+    XCTAssertEqual(MDCPalette.red.accent400, textField.underline?.color)
+    XCTAssertEqual(MDCPalette.red.accent400, textField.trailingUnderlineLabel.textColor)
+  }
+
+  func testErrorsLegacyDefault() {
+    let textField = MDCTextField()
+    let controller = MDCTextInputControllerLegacyDefault(textInput: textField)
+
+    // Helper text is shown on the leading underline label. Make sure the color and content are as 
+    // expected.
+    let altLeading = "Alternative Helper Test"
+    controller.helperText = altLeading
+    textField.leadingUnderlineLabel.textColor = .green
+    XCTAssertEqual(.green, textField.leadingUnderlineLabel.textColor)
+    XCTAssertEqual(altLeading, textField.leadingUnderlineLabel.text)
+    XCTAssertNil(controller.errorText)
+
+    // Setting error text should change the color and content of the leading underline label
+    let error = "Error Test"
+    controller.setErrorText(error, errorAccessibilityValue: nil)
+    XCTAssertNotEqual(altLeading, textField.leadingUnderlineLabel.text)
+    XCTAssertEqual(error, textField.leadingUnderlineLabel.text)
+    XCTAssertEqual(error, controller.errorText)
+
+    let newError = "Different Error Test"
+    let altErrorAccessibilityValue = "Not the default"
+    controller.setErrorText(newError, errorAccessibilityValue: altErrorAccessibilityValue)
+    XCTAssertEqual(newError, controller.errorText)
+    XCTAssertEqual(newError, textField.leadingUnderlineLabel.text)
+    XCTAssertNotEqual(error, controller.errorText)
+    XCTAssertNotEqual(error, textField.leadingUnderlineLabel.text)
+
+    // Setting an error should change the leading label's text color.
+    XCTAssertNotEqual(.green, textField.leadingUnderlineLabel.textColor)
+
+    // Setting error color should change the color of the underline, leading, and trailing colors.
+    controller.errorColor = .blue
+    XCTAssertEqual(.blue, controller.errorColor)
+
+    XCTAssertNotEqual(MDCPalette.red.accent400, textField.leadingUnderlineLabel.textColor)
+    XCTAssertNotEqual(MDCPalette.red.accent400, textField.trailingUnderlineLabel.textColor)
+    XCTAssertNotEqual(MDCPalette.red.accent400, textField.underline?.color)
+
+    XCTAssertEqual(.blue, textField.leadingUnderlineLabel.textColor)
+    XCTAssertEqual(.blue, textField.trailingUnderlineLabel.textColor)
+    XCTAssertEqual(.blue, textField.underline?.color)
+
+    // If the controller is also in a character max error state, the leading label should still be 
+    // showing the text from the error that was set.
+    controller.setErrorText(error, errorAccessibilityValue: nil)
+    controller.characterCountMax = 50
+    textField.text = "Lorem ipsum dolor sit amet, consectetuer adipiscing"
+    XCTAssertEqual(error, textField.leadingUnderlineLabel.text)
+
+    // Removing the error should set the leading text back to its previous text.
+    controller.setErrorText(nil, errorAccessibilityValue: nil)
+    XCTAssertNotEqual(error, textField.leadingUnderlineLabel.text)
+    XCTAssertEqual(altLeading, textField.leadingUnderlineLabel.text)
+
+    // Test error text being reset but character max still exceded.
+    XCTAssertEqual(.blue, textField.leadingUnderlineLabel.textColor)
+    XCTAssertEqual(.blue, textField.trailingUnderlineLabel.textColor)
+    XCTAssertEqual(.blue, textField.underline?.color)
+
+    // Removing the text should remove the error state from character max and therefore remove 
+    // anything from showing the error color.
+    textField.text = nil
+    XCTAssertNotEqual(.blue, textField.leadingUnderlineLabel.textColor)
+    XCTAssertNotEqual(.blue, textField.trailingUnderlineLabel.textColor)
+    XCTAssertNotEqual(.blue, textField.underline?.color)
+  }
+
+  func testPresentationLegacyDefault() {
+    let textField = MDCTextField()
+    let controller = MDCTextInputControllerLegacyDefault(textInput: textField)
+
+    XCTAssertEqual(controller.isFloatingEnabled, true)
+    controller.isFloatingEnabled = false
+    XCTAssertEqual(controller.isFloatingEnabled, false)
+
+    controller.isFloatingEnabled = true
+    textField.sizeToFit()
+    XCTAssertEqual(textField.frame.height, 70)
+
+    controller.helperText = "Helper"
+    textField.sizeToFit()
+    XCTAssertEqual(textField.frame.height, 84.5)
+
+    controller.characterCountViewMode = .never
+    XCTAssertEqual(.clear, textField.trailingUnderlineLabel.textColor)
+    controller.characterCountViewMode = .always
+    XCTAssertNotEqual(.clear, textField.trailingUnderlineLabel.textColor)
+
+    controller.underlineViewMode = .never
+    XCTAssertEqual(.lightGray, textField.underline?.color)
+    controller.underlineViewMode = .always
+    XCTAssertEqual(MDCPalette.blue.accent700, textField.underline?.color)
+  }
+
+  func testSerializationLegacyDefault() {
+    let textField = MDCTextField()
+
+    let controller = MDCTextInputControllerLegacyDefault(textInput: textField)
+    controller.characterCountMax = 25
+    controller.characterCountViewMode = .always
+    controller.isFloatingEnabled = false
+    controller.floatingPlaceholderColor = .purple
+    controller.floatingPlaceholderScale = 0.1
+    controller.helperText = "Helper"
+    controller.inlinePlaceholderColor = .green
+    controller.activeColor = .blue
+    controller.normalColor = .white
+    controller.underlineViewMode = .always
+
+    let serializedController = NSKeyedArchiver.archivedData(withRootObject: controller)
+    XCTAssertNotNil(serializedController)
+
+    let unserializedController =
+      NSKeyedUnarchiver.unarchiveObject(with: serializedController) as?
+      MDCTextInputControllerLegacyDefault
+    XCTAssertNotNil(unserializedController)
+
+    unserializedController?.textInput = textField
+    XCTAssertEqual(controller.characterCountMax, unserializedController?.characterCountMax)
+    XCTAssertEqual(controller.characterCountViewMode,
+                   unserializedController?.characterCountViewMode)
+    XCTAssertEqual(controller.isFloatingEnabled, unserializedController?.isFloatingEnabled)
+    XCTAssertEqual(controller.floatingPlaceholderColor,
+                   unserializedController?.floatingPlaceholderColor)
+    XCTAssertEqual(controller.floatingPlaceholderScale,
+                   unserializedController?.floatingPlaceholderScale)
+    XCTAssertEqual(controller.helperText, unserializedController?.helperText)
+    XCTAssertEqual(controller.inlinePlaceholderColor,
+                   unserializedController?.inlinePlaceholderColor)
+    XCTAssertEqual(controller.activeColor, unserializedController?.activeColor)
+    XCTAssertEqual(controller.normalColor, unserializedController?.normalColor)
+    XCTAssertEqual(controller.underlineViewMode, unserializedController?.underlineViewMode)
+  }
+
+}

--- a/components/TextFields/tests/unit/TextFieldLegacyTests.swift
+++ b/components/TextFields/tests/unit/TextFieldLegacyTests.swift
@@ -1,0 +1,80 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents.MaterialTextFields
+
+class TextFieldLegacyTests: XCTestCase {
+  func testSerializationTextFieldLegacy() {
+    let textField = MDCTextField()
+
+    let leadingView = UILabel()
+    leadingView.text = "$"
+
+    textField.leadingView = leadingView
+    textField.leadingViewMode = .unlessEditing
+
+    let trailingView = UILabel()
+    trailingView.text = ".com"
+
+    textField.trailingView = trailingView
+    textField.trailingViewMode = .unlessEditing
+
+    textField.translatesAutoresizingMaskIntoConstraints = false
+    textField.text = "Lorem ipsum dolor sit amet, consectetuer adipiscing"
+
+    let controller = MDCTextInputControllerLegacyDefault(textInput: textField)
+    XCTAssertNotNil(controller.textInput)
+
+    let leadingText = "Serialized Helper Test"
+    controller.helperText = leadingText
+    controller.characterCountMax = 40
+
+    let serializedInput = NSKeyedArchiver.archivedData(withRootObject: textField)
+    XCTAssertNotNil(serializedInput)
+
+    let unserializedInput =
+      NSKeyedUnarchiver.unarchiveObject(with: serializedInput) as? MDCTextField
+    XCTAssertNotNil(unserializedInput)
+
+    XCTAssertEqual(textField.translatesAutoresizingMaskIntoConstraints,
+                   unserializedInput?.translatesAutoresizingMaskIntoConstraints)
+    XCTAssertEqual(textField.text,
+                   unserializedInput?.text)
+
+    XCTAssertEqual(textField.leadingUnderlineLabel.text,
+                   unserializedInput?.leadingUnderlineLabel.text)
+
+    XCTAssertEqual(textField.trailingUnderlineLabel.text, "51 / 40")
+    XCTAssertEqual(textField.trailingUnderlineLabel.text,
+                   unserializedInput?.trailingUnderlineLabel.text)
+
+    if let leadingViewUnserialized = unserializedInput?.leadingView as? UILabel {
+      XCTAssertEqual(leadingViewUnserialized.text, leadingView.text)
+    } else {
+      XCTFail("No leading view or it isn't a UILabel")
+    }
+    XCTAssertEqual(unserializedInput?.leadingViewMode, .unlessEditing)
+
+    if let trailingViewUnserialized = unserializedInput?.trailingView as? UILabel {
+      XCTAssertEqual(trailingViewUnserialized.text, trailingView.text)
+    } else {
+      XCTFail("No trailing view or it isn't a UILabel")
+    }
+    XCTAssertEqual(unserializedInput?.trailingViewMode, .unlessEditing)
+  }
+
+}


### PR DESCRIPTION
Only renaming files, marking an example as not primary anymore, and changing titles to reflex legacy.

No new functionality.

Dependent on #1814 , #1812 , #1815, #1816 .