### PR TITLE
[OverlayWindow] Weakify self in animation blocks

### DIFF
--- a/components/private/Overlay/src/private/MDCOverlayObserverTransition.m
+++ b/components/private/Overlay/src/private/MDCOverlayObserverTransition.m
@@ -75,8 +75,10 @@
                                    completion:(void (^)(BOOL finished))completion {
   if (animations != nil) {
     // Capture the options and animation block, to be executed later when @c runAnimation is called.
+    __weak MDCOverlayObserverTransition *weakSelf = self;
     void (^animationToRun)(void) = ^{
-      [self runAnimationWithOptions:options animations:animations];
+      MDCOverlayObserverTransition *strongSelf = weakSelf;
+      [strongSelf runAnimationWithOptions:options animations:animations];
     };
 
     [self.animationBlocks addObject:[animationToRun copy]];


### PR DESCRIPTION
The MDCOverlayObserverTransition will no longer retain itself in its
|animations| array.  This will allow any objects that had actions
attached to the MDCOverlayObserver to be released as well.

Closes #1821
