### PR TITLE
[OverlayWindow] Remove iOS 7 code

### DIFF
--- a/components/OverlayWindow/src/MDCOverlayWindow.m
+++ b/components/OverlayWindow/src/MDCOverlayWindow.m
@@ -95,70 +95,12 @@
   _overlayView.backgroundColor = [UIColor clearColor];
   [self addSubview:_overlayView];
 
-  NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-  [nc addObserver:self
-         selector:@selector(handleRotationNotification:)
-             name:UIApplicationWillChangeStatusBarOrientationNotification
-           object:nil];
-
-  // Set a sane initial position.
-  [self updateOverlayViewForOrientation:[[UIApplication mdc_safeSharedApplication]
-                                            statusBarOrientation]];
-
   // Set a sane hidden state.
   [self updateOverlayHiddenState];
 }
 
 - (void)dealloc {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
-#pragma mark - Rotation
-
-- (void)updateOverlayViewForOrientation:(UIInterfaceOrientation)orientation {
-  // On iOS 8, the window orientation is corrected logically after transforms, so there is
-  // no need to apply this transform correction like we do for iOS 7 and below.
-  BOOL hasFixedCoordinateSpace = NO;
-  UIScreen *screen = [UIScreen mainScreen];
-  hasFixedCoordinateSpace = [screen respondsToSelector:@selector(fixedCoordinateSpace)];
-
-  if (!hasFixedCoordinateSpace) {
-    CGAffineTransform transform = CGAffineTransformIdentity;
-    BOOL swapBounds = NO;
-
-    switch (orientation) {
-      case UIInterfaceOrientationLandscapeLeft:
-        transform = CGAffineTransformMakeRotation((CGFloat)-M_PI_2);
-        swapBounds = YES;
-        break;
-      case UIInterfaceOrientationLandscapeRight:
-        transform = CGAffineTransformMakeRotation((CGFloat)M_PI_2);
-        swapBounds = YES;
-        break;
-      case UIInterfaceOrientationPortraitUpsideDown:
-        transform = CGAffineTransformMakeRotation((CGFloat)M_PI);
-        break;
-      case UIInterfaceOrientationPortrait:
-      default:
-        break;
-    }
-
-    CGRect bounds = self.bounds;
-
-    if (swapBounds) {
-      bounds = CGRectMake(0, 0, bounds.size.height, bounds.size.width);
-    }
-    self.overlayView.bounds = bounds;
-    self.overlayView.transform = transform;
-    [self.overlayView layoutIfNeeded];
-  }
-}
-
-// This method is called within an animation block, so we simply need to update the overlay view.
-- (void)handleRotationNotification:(NSNotification *)notification {
-  UIInterfaceOrientation orientation =
-      [notification.userInfo[UIApplicationStatusBarOrientationUserInfoKey] integerValue];
-  [self updateOverlayViewForOrientation:orientation];
 }
 
 #pragma mark - Window positioning

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -594,15 +594,6 @@ static const CGFloat kMaximumHeight = 80.0f;
   }
 
   self.rotationDuration = duration;
-
-  // On iOS 7, the layout of this overlay view will have already occurred by the time the will
-  // rotation notification is posted. In that event, we need to report rotation here. Opting to
-  // check for version using the UIDevice string methods because we need to perform this check even
-  // if the app was compiled on an iOS 7 SDK and is running on an iOS 8 device.
-  NSString *version = [[UIDevice currentDevice] systemVersion];
-  if ([version compare:@"8.0" options:NSNumericSearch] == NSOrderedAscending) {
-    [self handleRotation];
-  }
 }
 
 - (void)didRotate:(NSNotification *)notification {


### PR DESCRIPTION
iOS 7 is no longer supported, so iOS 7-specific code can be removed.
