### PR TITLE
[Snackbar] Fixing snackbar/overlay during rotation

### DIFF
--- a/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
+++ b/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#import "MDCSnackbarMessageView.h"
+
 @class MDCSnackbarMessage;
 @class MDCSnackbarMessageAction;
 

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -18,12 +18,12 @@
 
 #import "MDCSnackbarOverlayView.h"
 
-#import "MaterialSnackbar.h"
 #import "MDCSnackbarMessageViewInternal.h"
 #import "MaterialAnimationTiming.h"
+#import "MaterialApplication.h"
 #import "MaterialKeyboardWatcher.h"
 #import "MaterialOverlay.h"
-#import "MaterialApplication.h"
+#import "MaterialSnackbar.h"
 
 NSString *const MDCSnackbarOverlayIdentifier = @"MDCSnackbar";
 
@@ -341,16 +341,8 @@ static const CGFloat kMaximumHeight = 80.0f;
     return CGRectNull;
   }
 
-  UIScreen *screen = window.screen;
-  if ([screen respondsToSelector:@selector(fixedCoordinateSpace)]) {
-    return [self.snackbarView convertRect:self.snackbarView.bounds
-                        toCoordinateSpace:screen.fixedCoordinateSpace];
-  }
-
-  CGRect snackbarWindowFrame =
-      [window convertRect:self.snackbarView.bounds fromView:self.snackbarView];
-  CGRect snackbarScreenFrame = [window convertRect:snackbarWindowFrame toWindow:nil];
-  return snackbarScreenFrame;
+  return [self.snackbarView convertRect:self.snackbarView.bounds
+                      toCoordinateSpace:window.screen.coordinateSpace];
 }
 
 #pragma mark - Presentation/Dismissal
@@ -547,10 +539,8 @@ static const CGFloat kMaximumHeight = 80.0f;
     // observers of bottom offset changes.
     CGRect frame = [self snackbarRectInScreenCoordinates];
     if (CGRectIsNull(frame)) {
-      frame = CGRectMake(0,
-                         CGRectGetHeight(self.frame) - self.bottomOffset,
-                         CGRectGetWidth(self.frame),
-                         self.bottomOffset);
+      frame = CGRectMake(0, CGRectGetHeight(self.frame) - self.bottomOffset,
+                         CGRectGetWidth(self.frame), self.bottomOffset);
     }
     [self notifyOverlayChangeWithFrame:frame
                               duration:[CATransaction animationDuration]
@@ -574,6 +564,7 @@ static const CGFloat kMaximumHeight = 80.0f;
   [super layoutSubviews];
 
   if (!self.manualLayoutChange && self.rotationDuration > 0) {
+    [self.containingView layoutIfNeeded];
     [self handleRotation];
   }
 }

--- a/components/private/Overlay/src/MDCOverlayTransitioning.h
+++ b/components/private/Overlay/src/MDCOverlayTransitioning.h
@@ -31,13 +31,6 @@
  */
 @property(nonatomic, readonly) CGRect frame;
 
-/**
- Returns the frame of the overlay, in @c targetView's coordinate space.
-
- The result may go outside of the bounds of @c targetView.
- */
-- (CGRect)overlayFrameInView:(UIView *)targetView;
-
 @end
 
 /**

--- a/components/private/Overlay/src/private/MDCOverlayObserverOverlay.h
+++ b/components/private/Overlay/src/private/MDCOverlayObserverOverlay.h
@@ -31,6 +31,6 @@
 /**
  The frame of the overlay, in screen coordinates.
  */
-@property(nonatomic) CGRect frame;
+@property(nonatomic, assign) CGRect frame;
 
 @end

--- a/components/private/Overlay/src/private/MDCOverlayObserverOverlay.m
+++ b/components/private/Overlay/src/private/MDCOverlayObserverOverlay.m
@@ -15,12 +15,7 @@
  */
 
 #import "MDCOverlayObserverOverlay.h"
-#import "MDCOverlayUtilities.h"
 
 @implementation MDCOverlayObserverOverlay
-
-- (CGRect)overlayFrameInView:(UIView *)targetView {
-  return MDCOverlayConvertRectToView(self.frame, targetView);
-}
 
 @end

--- a/components/private/Overlay/src/private/MDCOverlayUtilities.m
+++ b/components/private/Overlay/src/private/MDCOverlayUtilities.m
@@ -18,17 +18,8 @@
 
 CGRect MDCOverlayConvertRectToView(CGRect screenRect, UIView *target) {
   if (target != nil && !CGRectIsNull(screenRect)) {
-    // Overlay rectangles are in screen fixed coordinates in iOS 8. If available, we'll use that
-    // API to do the conversion.
     UIScreen *screen = [UIScreen mainScreen];
-    if ([screen respondsToSelector:@selector(fixedCoordinateSpace)]) {
-      return [target convertRect:screenRect fromCoordinateSpace:screen.fixedCoordinateSpace];
-    }
-
-    // If we can't use coordinate spaces (iOS 8 only), then convert the rectangle from screen
-    // coordinates to our own view. On iOS 7 and below, the window is the same size as the screen's
-    // bounds, so we can safely convert from window coordinates here and get the same outcome.
-    return [target convertRect:screenRect fromView:nil];
+    return [target convertRect:screenRect fromCoordinateSpace:screen.coordinateSpace];
   }
   return CGRectNull;
 }


### PR DESCRIPTION
The MDCSnackbarOverlayView was not correctly laying-out its containingView
during rotation. Forcing the containingView to layout during the overlay
view's layoutSubviews method has corrected the position of the Snackbar for
notification recipients. It was also using the fixedCoordinateSpace of
UIScreen, which is incorrect as it does not account for rotation.

Updating the Snackbar Overlay View example to include an animated FAB to
demonstrate an incompatibility with autoresizing masks.

Continues to work for floating and split keyboards.
![simulator screen shot aug 17 2017 10 30 53 pm](https://user-images.githubusercontent.com/1753199/29441812-c9a5637a-839b-11e7-8b66-cb1fb41ac93c.png)
![simulator screen shot aug 17 2017 10 30 59 pm](https://user-images.githubusercontent.com/1753199/29441814-cc193ea6-839b-11e7-9275-7de1c8d020a5.png)

![simulator screen shot aug 17 2017 10 28 17 pm](https://user-images.githubusercontent.com/1753199/29441754-70044e3a-839b-11e7-999c-aa7d15fa118f.png)
![simulator screen shot aug 17 2017 10 27 23 pm](https://user-images.githubusercontent.com/1753199/29441756-73197bcc-839b-11e7-92f7-dda916339268.png)


Closes #1701
