### PR TITLE
[FlexibleHeader] Make default shadow layer background match the view

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -407,6 +407,13 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   }
 }
 
+- (void)setBackgroundColor:(UIColor *)backgroundColor {
+  [super setBackgroundColor:backgroundColor];
+
+  // Update default shadow to match
+  _defaultShadowLayer.backgroundColor = self.backgroundColor.CGColor;
+}
+
 #pragma mark - Private (fhv_ prefix)
 
 - (void)fhv_removeInsetsFromScrollView:(UIScrollView *)scrollView {


### PR DESCRIPTION
Previously the behavior was incorrect - _defaultShadowLayer had its background set to the view's background color on init, but that color was not updated if the header's background color was subsequently changed. This caused unexpected behavior if shadowLayer was set to nil to restore "default" behavior.
