### PR TITLE
[Switch] Removed documentation link to deprecated/removed Switch component

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -118,11 +118,6 @@ Material Components for iOS are written in Objective-C and support Swift and Int
   ](Snackbar/)
   <!--{: .icon-snackbar }-->
 
-- [**Switch**
-  A Material on/off switch with an interface similar to UISwitch.
-  ](Switch/)
-  <!--{: .icon-switch }-->
-
 - [**Tabs**
   A material tab bar for switching between grouped content.
   ](Tabs/)


### PR DESCRIPTION
The MDCSwitch component has been removed, so this link in the docs is no longer needed.

### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [x] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [x] Link to GitHub issues it solves. ```closes #1234```
- [x] Sign the CLA bot. You can do this once the pull request is submitted.

[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
pull request.
