### PR TITLE
[Collections] Decoration frame is unset when null

### DIFF
--- a/components/Collections/src/MDCCollectionViewFlowLayout.m
+++ b/components/Collections/src/MDCCollectionViewFlowLayout.m
@@ -217,7 +217,10 @@ static const NSInteger kSupplementaryViewZIndex = 99;
       sectionFrame = CGRectUnion(sectionFrame, attribute.frame);
     }
   }
-  decorationAttr.frame = sectionFrame;
+  if (!CGRectIsNull(sectionFrame)) {
+    decorationAttr.frame = sectionFrame;
+  }
+
   decorationAttr.zIndex = -1;
   return decorationAttr;
 }
@@ -398,9 +401,9 @@ static const NSInteger kSupplementaryViewZIndex = 99;
             respondsToSelector:@selector(collectionView:layout:insetForSectionAtIndex:)]) {
       id<UICollectionViewDelegateFlowLayout> flowLayoutDelegate =
           (id<UICollectionViewDelegateFlowLayout>)self.collectionView.delegate;
-        insets = [flowLayoutDelegate collectionView:self.collectionView
-                                             layout:self.collectionView.collectionViewLayout
-                             insetForSectionAtIndex:attr.indexPath.section];
+      insets = [flowLayoutDelegate collectionView:self.collectionView
+                                           layout:self.collectionView.collectionViewLayout
+                           insetForSectionAtIndex:attr.indexPath.section];
     } else {
       insets = [self insetsAtSectionIndex:attr.indexPath.section];
     }


### PR DESCRIPTION
If a section no longer has any cells remaining, the
UICollectionViewLayoutAttributes for that section's decorationView
should not set the frame to CGRectNull.  Instead, the frame should
remain untouched.

Closes #1844
