### PR TITLE
[Catalog] Fix ButtonsTypicalUse FAB position

### DIFF
--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -117,7 +117,6 @@
   [self.floatingButton addTarget:self
                           action:@selector(didTap:)
                 forControlEvents:UIControlEventTouchUpInside];
-  self.floatingButton.translatesAutoresizingMaskIntoConstraints = NO;
 
   UIImage *plusImage = [UIImage imageNamed:@"Plus"];
   [self.floatingButton setImage:plusImage forState:UIControlStateNormal];


### PR DESCRIPTION
The Floating Action Button still fails to translate its autoresizing
mask into constraints, making the layout break on iOS 9.

Fixes #1757
