### PR TITLE
[Dialogs] Fix example class warnings

### DIFF
--- a/components/Dialogs/examples/supplemental/DialogsAlertViewControllerSupplemental.h
+++ b/components/Dialogs/examples/supplemental/DialogsAlertViewControllerSupplemental.h
@@ -25,5 +25,8 @@
 
 @interface DialogsAlertViewController : MDCCollectionViewController
 @property(nonatomic, strong, nullable) NSArray *modes;
+@end
+
+@interface DialogsAlertViewController (Supplemental)
 - (void)loadCollectionView:(nullable NSArray *)modes;
 @end

--- a/components/Dialogs/examples/supplemental/DialogsAlertViewControllerSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsAlertViewControllerSupplemental.m
@@ -26,9 +26,7 @@
 #import "MaterialDialogs.h"
 #import "MaterialTypography.h"
 
-
-static NSString * const kReusableIdentifierItem = @"cell";
-
+static NSString *const kReusableIdentifierItem = @"cell";
 
 @implementation DialogsAlertViewController (Supplemental)
 
@@ -38,15 +36,16 @@ static NSString * const kReusableIdentifierItem = @"cell";
   self.modes = modes;
 }
 
-- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+- (NSInteger)collectionView:(UICollectionView *)collectionView
+     numberOfItemsInSection:(NSInteger)section {
   return self.modes.count;
 }
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
                   cellForItemAtIndexPath:(NSIndexPath *)indexPath {
   MDCCollectionViewTextCell *cell =
-  [collectionView dequeueReusableCellWithReuseIdentifier:kReusableIdentifierItem
-                                            forIndexPath:indexPath];
+      [collectionView dequeueReusableCellWithReuseIdentifier:kReusableIdentifierItem
+                                                forIndexPath:indexPath];
   cell.textLabel.text = self.modes[indexPath.row];
   return cell;
 }

--- a/components/Dialogs/examples/supplemental/DialogsKeyboardViewControllerSupplemental.h
+++ b/components/Dialogs/examples/supplemental/DialogsKeyboardViewControllerSupplemental.h
@@ -24,5 +24,8 @@
 @import MaterialComponents.MaterialCollections;
 
 @interface DialogsKeyboardViewController : MDCCollectionViewController
+@end
+
+@interface DialogsKeyboardViewController (Supplemental)
 - (void)loadCollectionView;
 @end


### PR DESCRIPTION
A couple of methods were defined in the main class interface but
implemented in the category. They should be defined in the category and
implemented there as well.
