### PR TITLE
[Collections, TextFields] Fix static analyzer warnings

### DIFF
--- a/components/Collections/examples/supplemental/CollectionsSectionInsetsExampleSupplemental.h
+++ b/components/Collections/examples/supplemental/CollectionsSectionInsetsExampleSupplemental.h
@@ -23,6 +23,6 @@ static const NSInteger kSectionItemCount = 3;
 static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 @interface CollectionsSectionInsetsExample : MDCCollectionViewController
-@property(nonatomic, copy) NSMutableArray *content;
-@property(nonatomic, copy) NSMutableDictionary *sectionUsesCustomInsets;
+@property(nonatomic, readonly, copy) NSMutableArray *content;
+@property(nonatomic, readonly, copy) NSMutableDictionary *sectionUsesCustomInsets;
 @end

--- a/components/Collections/src/MDCCollectionViewFlowLayout.m
+++ b/components/Collections/src/MDCCollectionViewFlowLayout.m
@@ -394,7 +394,7 @@ static const NSInteger kSupplementaryViewZIndex = 99;
   // view rows.
   CGRect insetFrame = attr.frame;
   if (!CGRectIsEmpty(insetFrame)) {
-    UIEdgeInsets insets = self.sectionInset;
+    UIEdgeInsets insets;
 
     // Retrieve the insets from the Flow Layout delegate to maintain consistency with the CVC
     if ([self.collectionView.delegate

--- a/components/TextFields/src/MDCMultilineTextField.m
+++ b/components/TextFields/src/MDCMultilineTextField.m
@@ -434,9 +434,16 @@ static NSString *const MDCMultilineTextFieldTrailingViewModeKey =
                                                              constant:0];
   }
   self.trailingViewCenterY.active = YES;
-  
+
   if (!self.textViewTrailingTrailingViewLeading) {
-    self.textViewTrailingTrailingViewLeading = [NSLayoutConstraint constraintWithItem:self.textView attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationEqual toItem:self.trailingView attribute:NSLayoutAttributeLeading multiplier:1 constant:self.textViewTrailing.constant];
+    self.textViewTrailingTrailingViewLeading =
+        [NSLayoutConstraint constraintWithItem:self.textView
+                                     attribute:NSLayoutAttributeTrailing
+                                     relatedBy:NSLayoutRelationEqual
+                                        toItem:self.trailingView
+                                     attribute:NSLayoutAttributeLeading
+                                    multiplier:1
+                                      constant:self.textViewTrailing.constant];
   }
   self.textViewTrailingTrailingViewLeading.active = !MDCCGFloatEqual([self trailingViewAlpha], 0.f);
 }
@@ -448,7 +455,7 @@ static NSString *const MDCMultilineTextFieldTrailingViewModeKey =
 - (CGFloat)trailingViewAlpha {
   // The trailing view has the same behavior as .rightView in UITextField: It has visual precedence
   // over the clear button.
-  CGFloat trailingViewAlpha = self.trailingView.alpha;
+  CGFloat trailingViewAlpha;
   switch (self.trailingViewMode) {
     case UITextFieldViewModeAlways:
       trailingViewAlpha = 1.f;


### PR DESCRIPTION
Two instances of values being assigned without being read (they were
always being reassigned), and one example of confusing property
attributes (a copied NSMutableArray). There should be no functional
change in the code, but now the static analyzer has no warnings.
