### PR TITLE
[Collections] Fix example property attribute

### DIFF
--- a/components/Collections/examples/supplemental/CollectionsSectionInsetsExampleSupplemental.h
+++ b/components/Collections/examples/supplemental/CollectionsSectionInsetsExampleSupplemental.h
@@ -23,6 +23,6 @@ static const NSInteger kSectionItemCount = 3;
 static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 @interface CollectionsSectionInsetsExample : MDCCollectionViewController
-@property(nonatomic, copy) NSMutableArray *content;
-@property(nonatomic, copy) NSMutableDictionary *sectionUsesCustomInsets;
+@property(nonatomic, readonly, copy) NSMutableArray *content;
+@property(nonatomic, readonly, copy) NSMutableDictionary *sectionUsesCustomInsets;
 @end


### PR DESCRIPTION
The static analyzer complained that 2 NSMutableArrays would be copied as
immutable. Fixing their attributes to please the analyzer.
