### PR TITLE
[Typography] Match large font family on iOS 9+

### DIFF
--- a/components/Typography/src/UIFontDescriptor+MaterialTypography.m
+++ b/components/Typography/src/UIFontDescriptor+MaterialTypography.m
@@ -35,9 +35,9 @@
 
   // Store the system font family name to ensure that we load the system font.
   // If we do not explicitly include this UIFontDescriptorFamilyAttribute in the
-  // FontDescriptor the OS will default to Helvetica.
+  // FontDescriptor the OS will default to Helvetica. On iOS 9+, the Font Family
+  // changes from San Francisco to San Francisco Display at point size 20.
   static NSString *smallSystemFontFamilyName;
-  // For font size 20+, iOS returns a different font family. Query it separately.
   static NSString *largeSystemFontFamilyName;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{

--- a/components/Typography/src/UIFontDescriptor+MaterialTypography.m
+++ b/components/Typography/src/UIFontDescriptor+MaterialTypography.m
@@ -36,24 +36,32 @@
   // Store the system font family name to ensure that we load the system font.
   // If we do not explicitly include this UIFontDescriptorFamilyAttribute in the
   // FontDescriptor the OS will default to Helvetica.
-  static NSString *systemFontFamilyName;
+  static NSString *smallSystemFontFamilyName;
+  // For font size 20+, iOS returns a different font family. Query it separately.
+  static NSString *largeSystemFontFamilyName;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    UIFont *systemFont;
+    UIFont *smallSystemFont;
+    UIFont *largeSystemFont;
     if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
-      systemFont = [UIFont systemFontOfSize:12 weight:UIFontWeightRegular];
+      smallSystemFont = [UIFont systemFontOfSize:12 weight:UIFontWeightRegular];
+      largeSystemFont = [UIFont systemFontOfSize:20 weight:UIFontWeightRegular];
     } else {
       // TODO: Remove this fallback once we are 8.2+
-      systemFont = [UIFont systemFontOfSize:12];
+      smallSystemFont = [UIFont systemFontOfSize:12];
+      largeSystemFont = [UIFont systemFontOfSize:20];
     }
-    systemFontFamilyName = [systemFont.familyName copy];
+    smallSystemFontFamilyName = [smallSystemFont.familyName copy];
+    largeSystemFontFamilyName = [largeSystemFont.familyName copy];
   });
 
   NSDictionary *traits = @{ UIFontWeightTrait : @(materialTraits.weight) };
+  NSString *fontFamily =
+      materialTraits.pointSize < 19.5 ? smallSystemFontFamilyName : largeSystemFontFamilyName;
   NSDictionary *attributes = @{
     UIFontDescriptorSizeAttribute : @(materialTraits.pointSize),
     UIFontDescriptorTraitsAttribute : traits,
-    UIFontDescriptorFamilyAttribute : systemFontFamilyName
+    UIFontDescriptorFamilyAttribute : fontFamily
   };
 
   UIFontDescriptor *fontDescriptor = [[UIFontDescriptor alloc] initWithFontAttributes:attributes];

--- a/components/Typography/tests/unit/TypographyTests.m
+++ b/components/Typography/tests/unit/TypographyTests.m
@@ -330,4 +330,32 @@ static const CGFloat kOpacityMedium = 0.87f;
   // Cleanup
   [MDCTypography setFontLoader:[[MDCSystemFontLoader alloc] init]];
 }
+
+- (void)testFontFamilyMatchesSystemFontFamily {
+  // Given
+  NSArray<NSNumber *> *allFontStyles = @[
+                                         @(MDCFontTextStyleBody1),
+                                         @(MDCFontTextStyleBody2),
+                                         @(MDCFontTextStyleCaption),
+                                         @(MDCFontTextStyleHeadline),
+                                         @(MDCFontTextStyleSubheadline),
+                                         @(MDCFontTextStyleTitle),
+                                         @(MDCFontTextStyleDisplay1),
+                                         @(MDCFontTextStyleDisplay2),
+                                         @(MDCFontTextStyleDisplay3),
+                                         @(MDCFontTextStyleDisplay4),
+                                         @(MDCFontTextStyleButton),
+                                         ];
+
+  for (NSNumber *styleObject in allFontStyles) {
+    // When
+    MDCFontTextStyle style = styleObject.integerValue;
+    UIFont *mdcFont = [UIFont mdc_preferredFontForMaterialTextStyle:style];
+    UIFont *systemFont = [UIFont systemFontOfSize:mdcFont.pointSize weight:UIFontWeightRegular];
+
+    // Then
+    XCTAssertEqual(systemFont.familyName, mdcFont.familyName);
+  }
+}
+
 @end

--- a/components/Typography/tests/unit/TypographyTests.m
+++ b/components/Typography/tests/unit/TypographyTests.m
@@ -334,18 +334,18 @@ static const CGFloat kOpacityMedium = 0.87f;
 - (void)testFontFamilyMatchesSystemFontFamily {
   // Given
   NSArray<NSNumber *> *allFontStyles = @[
-                                         @(MDCFontTextStyleBody1),
-                                         @(MDCFontTextStyleBody2),
-                                         @(MDCFontTextStyleCaption),
-                                         @(MDCFontTextStyleHeadline),
-                                         @(MDCFontTextStyleSubheadline),
-                                         @(MDCFontTextStyleTitle),
-                                         @(MDCFontTextStyleDisplay1),
-                                         @(MDCFontTextStyleDisplay2),
-                                         @(MDCFontTextStyleDisplay3),
-                                         @(MDCFontTextStyleDisplay4),
-                                         @(MDCFontTextStyleButton),
-                                         ];
+    @(MDCFontTextStyleBody1),
+    @(MDCFontTextStyleBody2),
+    @(MDCFontTextStyleCaption),
+    @(MDCFontTextStyleHeadline),
+    @(MDCFontTextStyleSubheadline),
+    @(MDCFontTextStyleTitle),
+    @(MDCFontTextStyleDisplay1),
+    @(MDCFontTextStyleDisplay2),
+    @(MDCFontTextStyleDisplay3),
+    @(MDCFontTextStyleDisplay4),
+    @(MDCFontTextStyleButton),
+  ];
 
   for (NSNumber *styleObject in allFontStyles) {
     // When

--- a/components/Typography/tests/unit/TypographyTests.m
+++ b/components/Typography/tests/unit/TypographyTests.m
@@ -334,18 +334,18 @@ static const CGFloat kOpacityMedium = 0.87f;
 - (void)testFontFamilyMatchesSystemFontFamily {
   // Given
   NSArray<NSNumber *> *allFontStyles = @[
-                                         @(MDCFontTextStyleBody1),
-                                         @(MDCFontTextStyleBody2),
-                                         @(MDCFontTextStyleCaption),
-                                         @(MDCFontTextStyleHeadline),
-                                         @(MDCFontTextStyleSubheadline),
-                                         @(MDCFontTextStyleTitle),
-                                         @(MDCFontTextStyleDisplay1),
-                                         @(MDCFontTextStyleDisplay2),
-                                         @(MDCFontTextStyleDisplay3),
-                                         @(MDCFontTextStyleDisplay4),
-                                         @(MDCFontTextStyleButton),
-                                         ];
+    @(MDCFontTextStyleBody1),
+    @(MDCFontTextStyleBody2),
+    @(MDCFontTextStyleCaption),
+    @(MDCFontTextStyleHeadline),
+    @(MDCFontTextStyleSubheadline),
+    @(MDCFontTextStyleTitle),
+    @(MDCFontTextStyleDisplay1),
+    @(MDCFontTextStyleDisplay2),
+    @(MDCFontTextStyleDisplay3),
+    @(MDCFontTextStyleDisplay4),
+    @(MDCFontTextStyleButton),
+  ];
 
   for (NSNumber *styleObject in allFontStyles) {
     // When
@@ -354,7 +354,7 @@ static const CGFloat kOpacityMedium = 0.87f;
     UIFont *systemFont = [UIFont systemFontOfSize:mdcFont.pointSize weight:UIFontWeightRegular];
 
     // Then
-    XCTAssertEqual(systemFont.familyName, mdcFont.familyName);
+    XCTAssertEqualObjects(systemFont.familyName, mdcFont.familyName);
   }
 }
 


### PR DESCRIPTION
This change only affects existing large fonts. Visually display font family has smaller tracking values. However they are still different than default system font would have [1].
Some images to compare for `UIContentSizeCategory`: 
- [UIContentSizeCategoryLarge](https://image.ibb.co/ea1KP5/UIContent_Size_Category_Large.png);
- [UIContentSizeCategoryExtraExtraExtraLarge](https://image.ibb.co/m9NR45/UIContent_Size_Category_Extra_Extra_Extra_Large.png).
Where:
_System_ - `[UIFont systemFontForSize:weight:]`;
_Old_ - state before this change;
_New_ - change results;
_Typography_ - `[MDCTypography *Font]`.

This has no effect on iOS 8, since there is only a single font used everywhere. Checked in _iPhone 5 (8.4)_ simulator.

Partially addresses #1805.

[1] With iOS 11 it should be also possible to load with https://developer.apple.com/documentation/uikit/uifontdescriptor.traitkey and related API.