### PR TITLE
[AnimationTiming] Add nullability annotations

### DIFF
--- a/components/AnimationTiming/src/CAMediaTimingFunction+MDCAnimationTiming.h
+++ b/components/AnimationTiming/src/CAMediaTimingFunction+MDCAnimationTiming.h
@@ -65,6 +65,6 @@ typedef NS_ENUM(NSUInteger, MDCAnimationTimingFunction) {
 
  @param type A Material Design media timing function.
  */
-+ (CAMediaTimingFunction *)mdc_functionWithType:(MDCAnimationTimingFunction)type;
++ (nullable CAMediaTimingFunction *)mdc_functionWithType:(MDCAnimationTimingFunction)type;
 
 @end

--- a/components/AnimationTiming/src/UIView+MDCTimingFunction.h
+++ b/components/AnimationTiming/src/UIView+MDCTimingFunction.h
@@ -29,11 +29,11 @@
  @param animations Animations to which the timing function will apply.
  @param completion A completion block fired after the animations complete.
  */
-+ (void)mdc_animateWithTimingFunction:(CAMediaTimingFunction *)timingFunction
++ (void)mdc_animateWithTimingFunction:(nullable CAMediaTimingFunction *)timingFunction
                              duration:(NSTimeInterval)duration
                                 delay:(NSTimeInterval)delay
                               options:(UIViewAnimationOptions)options
-                           animations:(void (^)(void))animations
-                           completion:(void (^)(BOOL finished))completion;
+                           animations:(void (^ __nonnull)(void))animations
+                           completion:(void (^ __nullable)(BOOL finished))completion;
 
 @end


### PR DESCRIPTION
These are a best guess based on implementation and comparable UIKit APIs.

Note: This has the potential cause small breakages or warnings for code which relied on the previous unannotated API. These cases should generally be straightforward to resolve.