### PR TITLE
[Buttons] Make uppercaseTitle nondestructive

### DIFF
--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -54,10 +54,10 @@
 @property(nonatomic) CGFloat disabledAlpha;
 
 /**
- If true, converts the button title to uppercase. Changing this property to NO will not update the
+ If true, converts the button title to uppercase. Changing this property to NO will update the
  current title string.
 
- Default is YES and is recommended whenever possible.
+ Default is YES.
  */
 @property(nonatomic, getter=isUppercaseTitle) BOOL uppercaseTitle UI_APPEARANCE_SELECTOR;
 

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -259,7 +259,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
   // Uppercase all titles
   if (_uppercaseTitle) {
-    [self uppercaseAllTitles];
+    [self updateTitleCase];
   }
 }
 
@@ -372,24 +372,20 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (void)setUppercaseTitle:(BOOL)uppercaseTitle {
   _uppercaseTitle = uppercaseTitle;
-  if (_uppercaseTitle) {
-    [self uppercaseAllTitles];
-  }
+
+  [self updateTitleCase];
 }
 
-- (void)uppercaseAllTitles {
-  // This ensures existing titles will get uppercased.
-  UIControlState allControlStates = UIControlStateNormal | UIControlStateHighlighted |
-                                    UIControlStateDisabled | UIControlStateSelected;
-  for (UIControlState state = 0; state <= allControlStates; ++state) {
-    NSString *title = [self titleForState:state];
-    if (title) {
-      [self setTitle:[title uppercaseStringWithLocale:[NSLocale currentLocale]] forState:state];
-    }
-
-    NSAttributedString *attributedTitle = [self attributedTitleForState:state];
-    if (attributedTitle) {
-      [self setAttributedTitle:uppercaseAttributedString(attributedTitle) forState:state];
+- (void)updateTitleCase {
+  // This calls setTitle or setAttributedTitle for every title value we have stored. In each
+  // respective setter the title is upcased if _uppercaseTitle is YES.
+  for (NSNumber *key in _nontransformedTitles.keyEnumerator) {
+    UIControlState state = key.unsignedIntegerValue;
+    NSString *title = _nontransformedTitles[key];
+    if ([title isKindOfClass:[NSAttributedString class]]) {
+      [self setAttributedTitle:(NSAttributedString *)title forState:state];
+    } else {
+      [self setTitle:title forState:state];
     }
   }
 }

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -47,7 +47,8 @@ static NSString *const MDCButtonAreaInsetKey = @"MDCButtonAreaInsetKey";
 
 static NSString *const MDCButtonUserElevationsKey = @"MDCButtonUserElevationsKey";
 static NSString *const MDCButtonBackgroundColorsKey = @"MDCButtonBackgroundColorsKey";
-static NSString *const MDCButtonNontransformedTitlesKey = @"MDCButtonNontransformedTitlesKey";
+// Previous value kept for backwards compatibility.
+static NSString *const MDCButtonNontransformedTitlesKey = @"MDCButtonAccessibilityLabelsKey";
 
 static const NSTimeInterval MDCButtonAnimationDuration = 0.2;
 

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -47,7 +47,7 @@ static NSString *const MDCButtonAreaInsetKey = @"MDCButtonAreaInsetKey";
 
 static NSString *const MDCButtonUserElevationsKey = @"MDCButtonUserElevationsKey";
 static NSString *const MDCButtonBackgroundColorsKey = @"MDCButtonBackgroundColorsKey";
-static NSString *const MDCButtonAccessibilityLabelsKey = @"MDCButtonAccessibilityLabelsKey";
+static NSString *const MDCButtonNontransformedTitlesKey = @"MDCButtonNontransformedTitlesKey";
 
 static const NSTimeInterval MDCButtonAnimationDuration = 0.2;
 
@@ -98,7 +98,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   BOOL _hasCustomDisabledTitleColor;
 
   // Cached accessibility settings.
-  NSMutableDictionary<NSNumber *, NSString *> *_accessibilityLabelForState;
+  NSMutableDictionary<NSNumber *, NSString *> *_nontransformedTitles;
   NSString *_accessibilityLabelExplicitValue;
 
   BOOL _mdc_adjustsFontForContentSizeCategory;
@@ -182,8 +182,8 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
     }
     [self updateBackgroundColor];
 
-    if ([aDecoder containsValueForKey:MDCButtonAccessibilityLabelsKey]) {
-      _accessibilityLabelForState = [aDecoder decodeObjectForKey:MDCButtonAccessibilityLabelsKey];
+    if ([aDecoder containsValueForKey:MDCButtonNontransformedTitlesKey]) {
+      _nontransformedTitles = [aDecoder decodeObjectForKey:MDCButtonNontransformedTitlesKey];
     }
   }
   return self;
@@ -207,7 +207,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [aCoder encodeUIEdgeInsets:self.hitAreaInsets forKey:MDCButtonAreaInsetKey];
   [aCoder encodeObject:_userElevations forKey:MDCButtonUserElevationsKey];
   [aCoder encodeObject:_backgroundColors forKey:MDCButtonBackgroundColorsKey];
-  [aCoder encodeObject:_accessibilityLabelForState forKey:MDCButtonAccessibilityLabelsKey];
+  [aCoder encodeObject:_nontransformedTitles forKey:MDCButtonNontransformedTitlesKey];
 }
 
 - (void)commonMDCButtonInit {
@@ -215,7 +215,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   _shouldRaiseOnTouch = YES;
   _uppercaseTitle = YES;
   _userElevations = [NSMutableDictionary dictionary];
-  _accessibilityLabelForState = [NSMutableDictionary dictionary];
+  _nontransformedTitles = [NSMutableDictionary dictionary];
 
   if (!_backgroundColors) {
     // _backgroundColors may have already been initialized by setting the backgroundColor setter.
@@ -398,9 +398,9 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   // Intercept any setting of the title and store a copy in case the accessibilityLabel
   // is requested and the original non-uppercased version needs to be returned.
   if ([title length]) {
-    _accessibilityLabelForState[@(state)] = [title copy];
+    _nontransformedTitles[@(state)] = [title copy];
   } else {
-    [_accessibilityLabelForState removeObjectForKey:@(state)];
+    [_nontransformedTitles removeObjectForKey:@(state)];
   }
 
   if (_uppercaseTitle) {
@@ -413,9 +413,9 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   // Intercept any setting of the title and store a copy in case the accessibilityLabel
   // is requested and the original non-uppercased version needs to be returned.
   if ([title length]) {
-    _accessibilityLabelForState[@(state)] = [[title string] copy];
+    _nontransformedTitles[@(state)] = [[title string] copy];
   } else {
-    [_accessibilityLabelForState removeObjectForKey:@(state)];
+    [_nontransformedTitles removeObjectForKey:@(state)];
   }
 
   if (_uppercaseTitle) {
@@ -444,12 +444,12 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
     return label;
   }
 
-  label = _accessibilityLabelForState[@(self.state)];
+  label = _nontransformedTitles[@(self.state)];
   if ([label length]) {
     return label;
   }
 
-  label = _accessibilityLabelForState[@(UIControlStateNormal)];
+  label = _nontransformedTitles[@(UIControlStateNormal)];
   if ([label length]) {
     return label;
   }

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -129,6 +129,20 @@ static NSString *controlStateDescription(UIControlState controlState) {
                         [originalTitle uppercaseStringWithLocale:[NSLocale currentLocale]]);
 }
 
+- (void)testUppercaseTitleYesChangedToNo {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+  NSString *originalTitle = @"some Text";
+
+  // When
+  button.uppercaseTitle = YES;
+  [button setTitle:originalTitle forState:UIControlStateNormal];
+  button.uppercaseTitle = NO;
+
+  // Then
+  XCTAssertEqualObjects(button.currentTitle, originalTitle);
+}
+
 - (void)testSetEnabledAnimated {
   // Given
   MDCButton *button = [[MDCButton alloc] init];


### PR DESCRIPTION
Since uppercaseTitle defaults to YES, it was impossible to turn it off with UIAppearance and have titles behave as expected. All existing uppercaseTitle tests still pass and a new test was added to ensure this fix will not regress.