### PR TITLE
[Catalog] Verify all examples provide CatalogByConvention methods

### DIFF
--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -355,7 +355,15 @@ extension MDCNodeListViewController {
     var vc: UIViewController
     if node.isExample() {
       let contentVC = node.createExampleViewController()
-      if contentVC.responds(to: NSSelectorFromString("catalogShouldHideNavigation")) {
+      var shouldHideNavigation = contentVC.responds(to: NSSelectorFromString("catalogShouldHideNavigation"))
+      if (shouldHideNavigation) {
+        if let _ = contentVC.perform(NSSelectorFromString("catalogShouldHideNavigation")) {
+          shouldHideNavigation = true
+        } else {
+          shouldHideNavigation = false
+        }
+      }
+      if shouldHideNavigation {
         vc = contentVC
       } else {
         let appBarFont = UIFont(name: "RobotoMono-Regular", size: 16)

--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
@@ -24,10 +24,9 @@
 #import "ActivityIndicatorExampleSupplemental.h"
 #import "MaterialTypography.h"
 
-#define MDC_CATALOG_GREEN [UIColor colorWithRed:0 green:0xe6/255.0f blue:0x76/255.0f alpha:1]
+#define MDC_CATALOG_GREEN [UIColor colorWithRed:0 green:0xe6 / 255.0f blue:0x76 / 255.0f alpha:1]
 
-static NSString * const kCell = @"Cell";
-
+static NSString *const kCell = @"Cell";
 
 @implementation ActivityIndicatorExample (CatalogByConvention)
 
@@ -53,7 +52,6 @@ static NSString * const kCell = @"Cell";
 @implementation ActivityIndicatorExample (Supplemental)
 
 - (void)setupExampleViews {
-
   [self.collectionView registerClass:[MDCCollectionViewTextCell class]
           forCellWithReuseIdentifier:kCell];
 
@@ -102,15 +100,13 @@ static NSString * const kCell = @"Cell";
 
 - (void)didChangeSliderValue:(UISlider *)slider {
   self.activityIndicator1.progress = slider.value;
-  MDCCollectionViewTextCell *cell =
-      (MDCCollectionViewTextCell *)[self.collectionView cellForItemAtIndexPath:
-                                        [NSIndexPath indexPathForRow:1 inSection:0]];
+  MDCCollectionViewTextCell *cell = (MDCCollectionViewTextCell *)[self.collectionView
+      cellForItemAtIndexPath:[NSIndexPath indexPathForRow:1 inSection:0]];
   cell.textLabel.text = [NSString stringWithFormat:@"%.00f%%", slider.value * 100];
   [cell setNeedsDisplay];
 }
 
-#pragma mark - 
-
+#pragma mark -
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView
      numberOfItemsInSection:(NSInteger)section {
@@ -119,7 +115,9 @@ static NSString * const kCell = @"Cell";
 
 - (CGFloat)collectionView:(UICollectionView *)collectionView
     cellHeightAtIndexPath:(NSIndexPath *)indexPath {
-  if (indexPath.row == 0) return 160;
+  if (indexPath.row == 0) {
+    return 160;
+  }
   return 56;
 }
 
@@ -147,6 +145,5 @@ static NSString * const kCell = @"Cell";
   }
   return cell;
 }
-
 
 @end

--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
@@ -44,6 +44,10 @@ static NSString * const kCell = @"Cell";
   return YES;
 }
 
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end
 
 @implementation ActivityIndicatorExample (Supplemental)

--- a/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
+++ b/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
@@ -41,6 +41,10 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
   return YES;
 }
 
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end
 
 @implementation AnimationTimingExample (Supplemental)

--- a/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
+++ b/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
@@ -63,12 +63,16 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
 
   CGFloat lineSpace = (self.view.frame.size.height - 50.f) / 4.f;
   UILabel *linearLabel = [AnimationTimingExample curveLabelWithTitle:@"Linear"];
-  linearLabel.frame =
-      CGRectMake(kLeftGutter, kTopMargin, linearLabel.frame.size.width, linearLabel.frame.size.height);
+  linearLabel.frame = CGRectMake(kLeftGutter,
+                                 kTopMargin,
+                                 linearLabel.frame.size.width,
+                                 linearLabel.frame.size.height);
   [self.scrollView addSubview:linearLabel];
 
-  CGRect linearViewFrame =
-      CGRectMake(kLeftGutter, kTextOffset + kTopMargin, kAnimationCircleSize.width, kAnimationCircleSize.height);
+  CGRect linearViewFrame = CGRectMake(kLeftGutter,
+                                      kTextOffset + kTopMargin,
+                                      kAnimationCircleSize.width,
+                                      kAnimationCircleSize.height);
   self.linearView = [[UIView alloc] initWithFrame:linearViewFrame];
   self.linearView.backgroundColor = [AnimationTimingExample defaultColors][0];
   self.linearView.layer.cornerRadius = kAnimationCircleSize.width / 2.f;

--- a/components/AppBar/examples/AppBarDelegateForwardingExample.m
+++ b/components/AppBar/examples/AppBarDelegateForwardingExample.m
@@ -82,6 +82,10 @@
   return @[ @"App Bar", @"Delegate Forwarding" ];
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
 - (BOOL)catalogShouldHideNavigation {
   return YES;
 }

--- a/components/AppBar/examples/AppBarDelegateForwardingExample.m
+++ b/components/AppBar/examples/AppBarDelegateForwardingExample.m
@@ -119,12 +119,6 @@
   return self.appBar.headerViewController;
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-  [super viewWillAppear:animated];
-
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
-}
-
 @end
 
 #pragma mark - Typical application code (not Material-specific)

--- a/components/AppBar/examples/AppBarDelegateForwardingExample.swift
+++ b/components/AppBar/examples/AppBarDelegateForwardingExample.swift
@@ -119,6 +119,11 @@ extension AppBarDelegateForwardingExample {
   class func catalogBreadcrumbs() -> [String] {
     return ["App Bar", "Delegate Forwarding (Swift)"]
   }
+
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+
   func catalogShouldHideNavigation() -> Bool {
     return true
   }

--- a/components/AppBar/examples/AppBarDelegateForwardingExample.swift
+++ b/components/AppBar/examples/AppBarDelegateForwardingExample.swift
@@ -137,12 +137,6 @@ extension AppBarDelegateForwardingExample {
   override var childViewControllerForStatusBarStyle: UIViewController? {
     return appBar.headerViewController
   }
-
-  override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-
-    self.navigationController?.setNavigationBarHidden(true, animated: animated)
-  }
 }
 
 // MARK: - Typical application code (not Material-specific)

--- a/components/AppBar/examples/AppBarImageryExample.m
+++ b/components/AppBar/examples/AppBarImageryExample.m
@@ -47,7 +47,7 @@
   // implement -preferredStatusBarStyle.
   self.appBar.navigationBar.tintColor = [UIColor whiteColor];
   self.appBar.navigationBar.titleTextAttributes =
-      @{ NSForegroundColorAttributeName : [UIColor whiteColor] };
+      @{NSForegroundColorAttributeName : [UIColor whiteColor]};
 
   // Make sure navigation bar background color is clear so the image view is visible.
   self.appBar.navigationBar.backgroundColor = [UIColor clearColor];

--- a/components/AppBar/examples/AppBarImageryExample.m
+++ b/components/AppBar/examples/AppBarImageryExample.m
@@ -93,17 +93,16 @@
   return self;
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-  [super viewWillAppear:animated];
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
-}
-
 @end
 
 @implementation AppBarImageryExample (CatalogByConvention)
 
 + (NSArray *)catalogBreadcrumbs {
   return @[ @"App Bar", @"Imagery" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
 }
 
 - (BOOL)catalogShouldHideNavigation {

--- a/components/AppBar/examples/AppBarImageryExample.swift
+++ b/components/AppBar/examples/AppBarImageryExample.swift
@@ -90,6 +90,11 @@ extension AppBarImagerySwiftExample {
   class func catalogBreadcrumbs() -> [String] {
     return ["App Bar", "Imagery (Swift)"]
   }
+
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+  
   func catalogShouldHideNavigation() -> Bool {
     return true
   }

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
@@ -78,6 +78,10 @@
   return @[ @"App Bar", @"Interface Builder" ];
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
 + (NSString *)catalogStoryboardName {
   return @"AppBarInterfaceBuilderExampleController";
 }

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
@@ -70,6 +70,10 @@ extension AppBarInterfaceBuilderSwiftExample {
     return "AppBarInterfaceBuilderExampleController"
   }
 
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+
   func catalogShouldHideNavigation() -> Bool {
     return true
   }

--- a/components/AppBar/examples/AppBarModalPresentationExample.m
+++ b/components/AppBar/examples/AppBarModalPresentationExample.m
@@ -205,6 +205,10 @@
   return @[ @"App Bar", @"Modal Presentation" ];
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
 - (BOOL)catalogShouldHideNavigation {
   return YES;
 }
@@ -239,12 +243,6 @@
 
 - (UIViewController *)childViewControllerForStatusBarStyle {
   return self.appBar.headerViewController;
-}
-
-- (void)viewWillAppear:(BOOL)animated {
-  [super viewWillAppear:animated];
-
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
 }
 
 @end

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -66,12 +66,6 @@ class AppBarModalPresentationSwiftExamplePresented: UITableViewController {
     return appBar.headerViewController
   }
 
-  override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-
-    self.navigationController?.setNavigationBarHidden(true, animated: animated)
-  }
-
   override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     return 50
   }
@@ -153,6 +147,11 @@ extension AppBarModalPresentationSwiftExample {
   class func catalogBreadcrumbs() -> [String] {
     return ["App Bar", "Modal Presentation (Swift)"]
   }
+
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+  
   func catalogShouldHideNavigation() -> Bool {
     return true
   }

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -130,12 +130,6 @@ class AppBarModalPresentationSwiftExample: UITableViewController {
     return appBar.headerViewController
   }
 
-  override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-
-    self.navigationController?.setNavigationBarHidden(true, animated: animated)
-  }
-
   @objc func presentModal() {
     let modalVC = AppBarModalPresentationSwiftExamplePresented()
     self.present(modalVC, animated: true, completion: nil)

--- a/components/AppBar/examples/AppBarTypicalUseExample.m
+++ b/components/AppBar/examples/AppBarTypicalUseExample.m
@@ -83,14 +83,6 @@
   return self.appBar.headerViewController;
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-  [super viewWillAppear:animated];
-
-  // We don't know whether the navigation bar will be visible within the Catalog by Convention, so
-  // we always hide the navigation bar when we're about to appear.
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
-}
-
 @end
 
 @implementation AppBarTypicalUseExample (CatalogByConvention)

--- a/components/AppBar/examples/AppBarTypicalUseExample.m
+++ b/components/AppBar/examples/AppBarTypicalUseExample.m
@@ -40,9 +40,8 @@
     UIColor *color = [UIColor colorWithWhite:0.2 alpha:1];
     _appBar.headerViewController.headerView.backgroundColor = color;
     _appBar.navigationBar.tintColor = [UIColor whiteColor];
-    _appBar.navigationBar.titleTextAttributes = @{
-                                            NSForegroundColorAttributeName : [UIColor whiteColor],
-                                            };
+    _appBar.navigationBar.titleTextAttributes =
+        @{NSForegroundColorAttributeName : [UIColor whiteColor]};
   }
   return self;
 }

--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -72,14 +72,6 @@ class AppBarTypicalUseSwiftExample: UITableViewController {
   override var childViewControllerForStatusBarStyle: UIViewController? {
     return appBar.headerViewController
   }
-
-  override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-
-    // We don't know whether the navigation bar will be visible within the Catalog by Convention, so
-    // we always hide the navigation bar when we're about to appear.
-    self.navigationController?.setNavigationBarHidden(true, animated: animated)
-  }
 }
 
 // MARK: Catalog by convention
@@ -87,6 +79,11 @@ extension AppBarTypicalUseSwiftExample {
   class func catalogBreadcrumbs() -> [String] {
     return ["App Bar", "App Bar (Swift)"]
   }
+
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+  
   func catalogShouldHideNavigation() -> Bool {
     return true
   }

--- a/components/BottomSheet/examples/supplemental/BottomSheetSupplemental.m
+++ b/components/BottomSheet/examples/supplemental/BottomSheetSupplemental.m
@@ -91,8 +91,9 @@
 }
 
 + (NSString *)catalogDescription {
-  return @"The Bottom Sheet is a presentation controller for presenting view controllers as a sheet"
-  " that slides up from the bottom of the screen. The sheet can be dismissed by swiping down.";
+  return
+      @"The Bottom Sheet is a presentation controller for presenting view controllers as a sheet"
+       " that slides up from the bottom of the screen. The sheet can be dismissed by swiping down.";
 }
 
 - (BOOL)catalogShouldHideNavigation {

--- a/components/BottomSheet/examples/supplemental/BottomSheetSupplemental.m
+++ b/components/BottomSheet/examples/supplemental/BottomSheetSupplemental.m
@@ -26,6 +26,10 @@
   return NO;
 }
 
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end
 
 @implementation BottomSheetShortCollectionExample (CatalogByConvention)
@@ -35,6 +39,10 @@
 }
 
 + (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
   return NO;
 }
 
@@ -50,6 +58,10 @@
   return NO;
 }
 
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end
 
 @implementation BottomSheetTallExample (CatalogByConvention)
@@ -59,6 +71,10 @@
 }
 
 + (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
   return NO;
 }
 
@@ -77,6 +93,10 @@
 + (NSString *)catalogDescription {
   return @"The Bottom Sheet is a presentation controller for presenting view controllers as a sheet"
   " that slides up from the bottom of the screen. The sheet can be dismissed by swiping down.";
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/ButtonBar/examples/ButtonBarIconExample.m
+++ b/components/ButtonBar/examples/ButtonBarIconExample.m
@@ -90,6 +90,10 @@
   return NO;
 }
 
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end
 
 #pragma mark - Typical application code (not Material-specific)

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.m
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.m
@@ -47,7 +47,7 @@
   // Set the title text attributes before assigning to buttonBar.items
   // because of https://github.com/material-components/material-components-ios/issues/277
   for (UIBarButtonItem *item in items) {
-    [item setTitleTextAttributes:@{ NSForegroundColorAttributeName : [UIColor whiteColor] }
+    [item setTitleTextAttributes:@{NSForegroundColorAttributeName : [UIColor whiteColor]}
                         forState:UIControlStateNormal];
   }
 

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.m
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.m
@@ -90,6 +90,10 @@
           " horizontally-aligned buttons.";
 }
 
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end
 
 #pragma mark - Typical application code (not Material-specific)

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
@@ -86,6 +86,14 @@ extension ButtonBarTypicalUseSwiftExample {
   class func catalogBreadcrumbs() -> [String] {
     return ["Button Bar", "Button Bar (Swift)"]
   }
+
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+
+  func catalogShouldHideNavigation() -> Bool {
+    return false
+  }
 }
 
 // MARK: - Typical application code (not Material-specific)

--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -37,6 +37,14 @@
   return @"ButtonsContentEdgeInsets";
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 #pragma mark - UIViewController
 
 - (void)viewDidLoad {

--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -21,7 +21,7 @@
 @property(weak, nonatomic) IBOutlet MDCFlatButton *flatButton;
 @property(weak, nonatomic) IBOutlet MDCRaisedButton *raisedButton;
 @property(weak, nonatomic) IBOutlet MDCFloatingButton *floatingActionButton;
-@property (weak, nonatomic) IBOutlet UISwitch *inkBoundingSwitch;
+@property(weak, nonatomic) IBOutlet UISwitch *inkBoundingSwitch;
 
 @end
 

--- a/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
+++ b/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
@@ -23,6 +23,14 @@ class ButtonsDynamicTypeViewController: UIViewController {
     return ["Buttons", "Buttons (DynamicType)"]
   }
 
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+
+  func catalogShouldHideNavigation() -> Bool {
+    return false
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
 

--- a/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
+++ b/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
@@ -25,6 +25,14 @@ class ButtonsSimpleExampleSwiftViewController: UIViewController {
     return ["Buttons", "Buttons (Swift)"]
   }
 
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+
+  func catalogShouldHideNavigation() -> Bool {
+    return false
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
 

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -27,6 +27,14 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
     return "ButtonsStoryboardAndProgrammatic"
   }
 
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+
+  func catalogShouldHideNavigation() -> Bool {
+    return false
+  }
+
   let raisedButton = MDCRaisedButton()
   let flatButton = MDCFlatButton()
   let floatingButton = MDCFloatingButton()

--- a/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
+++ b/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
@@ -43,6 +43,10 @@
   return YES;
 }
 
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end
 
 @implementation ButtonsTypicalUseViewController (Supplemental)

--- a/components/CollectionCells/examples/CollectionCellsLayoutExample.m
+++ b/components/CollectionCells/examples/CollectionCellsLayoutExample.m
@@ -76,10 +76,6 @@ static NSString *const kExampleDetailText =
   NSMutableArray *_content;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collection Cells", @"Cell Layout Example" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -230,6 +226,20 @@ static NSString *const kExampleDetailText =
   UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
   UIGraphicsEndImageContext();
   return image;
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collection Cells", @"Cell Layout Example" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/CollectionCells/examples/CollectionCellsTextExample.m
+++ b/components/CollectionCells/examples/CollectionCellsTextExample.m
@@ -27,20 +27,6 @@ static NSString *const kExampleDetailText =
   NSMutableArray *_content;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collection Cells", @"Cell Text Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (NSString *)catalogDescription {
-  return @"Material Collection Cells enables a native collection view cell to have Material "
-          "design layout and styling. It also provides editing and extensive customization "
-          "capabilities.";
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -118,6 +104,26 @@ static NSString *const kExampleDetailText =
 - (CGFloat)collectionView:(UICollectionView *)collectionView
     cellHeightAtIndexPath:(NSIndexPath *)indexPath {
   return [_content[indexPath.item][4] floatValue];
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collection Cells", @"Cell Text Example" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return YES;
+}
+
++ (NSString *)catalogDescription {
+  return @"Material Collection Cells enables a native collection view cell to have Material "
+  "design layout and styling. It also provides editing and extensive customization "
+  "capabilities.";
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/CollectionCells/examples/CollectionCellsTextExample.m
+++ b/components/CollectionCells/examples/CollectionCellsTextExample.m
@@ -118,8 +118,8 @@ static NSString *const kExampleDetailText =
 
 + (NSString *)catalogDescription {
   return @"Material Collection Cells enables a native collection view cell to have Material "
-  "design layout and styling. It also provides editing and extensive customization "
-  "capabilities.";
+          "design layout and styling. It also provides editing and extensive customization "
+          "capabilities.";
 }
 
 - (BOOL)catalogShouldHideNavigation {

--- a/components/Collections/examples/CollectionsALaCarteExample.m
+++ b/components/Collections/examples/CollectionsALaCarteExample.m
@@ -53,10 +53,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   NSMutableArray *_content;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Collections À la carte" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -122,6 +118,20 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   for (NSIndexPath *indexPath in indexPaths) {
     [_content[indexPath.section] removeObjectAtIndex:indexPath.item];
   }
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collections", @"Collections À la carte" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Collections/examples/CollectionsAppearanceAnimationExample.m
+++ b/components/Collections/examples/CollectionsAppearanceAnimationExample.m
@@ -26,10 +26,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   NSMutableArray *_content;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Appearance Animation Example" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -71,6 +67,20 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
                                                 forIndexPath:indexPath];
   cell.textLabel.text = _content[indexPath.section][indexPath.item];
   return cell;
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collections", @"Appearance Animation Example" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Collections/examples/CollectionsCellAccessoryExample.m
+++ b/components/Collections/examples/CollectionsCellAccessoryExample.m
@@ -23,10 +23,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   NSMutableArray *_content;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Cell Accessory Example" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -111,6 +107,20 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 - (void)didSwitch:(id)sender {
   UISwitch *switchControl = sender;
   [self.editor setEditing:switchControl.isOn animated:YES];
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collections", @"Cell Accessory Example" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Collections/examples/CollectionsCellColorExample.m
+++ b/components/Collections/examples/CollectionsCellColorExample.m
@@ -32,10 +32,11 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
   // Array of cell background colors.
   _cellBackgroundColors = @[
-    [UIColor colorWithWhite:0 alpha:0.2], [UIColor colorWithRed:(CGFloat)0x39 / (CGFloat)255
-                                                          green:(CGFloat)0xA4 / (CGFloat)255
-                                                           blue:(CGFloat)0xDD / (CGFloat)255
-                                                          alpha:1],
+    [UIColor colorWithWhite:0 alpha:0.2],
+    [UIColor colorWithRed:(CGFloat)0x39 / (CGFloat)255
+                    green:(CGFloat)0xA4 / (CGFloat)255
+                     blue:(CGFloat)0xDD / (CGFloat)255
+                    alpha:1],
     [UIColor whiteColor]
   ];
 

--- a/components/Collections/examples/CollectionsCellColorExample.m
+++ b/components/Collections/examples/CollectionsCellColorExample.m
@@ -23,10 +23,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   NSArray *_cellBackgroundColors;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Cell Color Example" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -78,6 +74,20 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 - (UIColor *)collectionView:(UICollectionView *)collectionView
     cellBackgroundColorAtIndexPath:(NSIndexPath *)indexPath {
   return _cellBackgroundColors[indexPath.item];
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collections", @"Cell Color Example" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Collections/examples/CollectionsCellSeparatorExample.m
+++ b/components/Collections/examples/CollectionsCellSeparatorExample.m
@@ -24,10 +24,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   NSMutableArray *_content;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Cell Separator Example" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -123,6 +119,20 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 - (BOOL)collectionView:(UICollectionView *)collectionView
     shouldHideHeaderSeparatorForSection:(NSInteger)section {
   return section == 4;
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collections", @"Cell Separator Example" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Collections/examples/CollectionsContainerExample.m
+++ b/components/Collections/examples/CollectionsContainerExample.m
@@ -27,10 +27,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   NSMutableArray *_content;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Collections in a Container" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -87,6 +83,20 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
                                                 forIndexPath:indexPath];
   cell.textLabel.text = _content[indexPath.section][indexPath.item];
   return cell;
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collections", @"Collections in a Container" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Collections/examples/CollectionsEditingExample.m
+++ b/components/Collections/examples/CollectionsEditingExample.m
@@ -25,10 +25,6 @@ static NSString *const HEADER_REUSE_IDENTIFIER = @"EditingExampleHeader";
   NSMutableArray *_content;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Cell Editing Example" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -166,6 +162,20 @@ static NSString *const HEADER_REUSE_IDENTIFIER = @"EditingExampleHeader";
                              layout:(UICollectionViewLayout *)collectionViewLayout
     referenceSizeForHeaderInSection:(NSInteger)section {
   return CGSizeMake(collectionView.bounds.size.width, MDCCellDefaultOneLineHeight);
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collections", @"Cell Editing Example" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Collections/examples/CollectionsGridExample.m
+++ b/components/Collections/examples/CollectionsGridExample.m
@@ -25,10 +25,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   UIAlertController *_actionController;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Grid Example" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -149,6 +145,20 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   for (NSIndexPath *indexPath in indexPaths) {
     [_content[indexPath.section] removeObjectAtIndex:indexPath.item];
   }
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collections", @"Grid Example" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Collections/examples/CollectionsHeaderFooterExample.m
+++ b/components/Collections/examples/CollectionsHeaderFooterExample.m
@@ -26,10 +26,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   NSMutableArray *_content;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Header / Footer Demo" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -132,6 +128,20 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 - (BOOL)collectionView:(UICollectionView *)collectionView
     shouldHideFooterBackgroundForSection:(NSInteger)section {
   return (section == 2);
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collections", @"Header / Footer Demo" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Collections/examples/CollectionsInkExample.m
+++ b/components/Collections/examples/CollectionsInkExample.m
@@ -22,10 +22,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   NSArray *_content;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Cell Ink Example" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -79,6 +75,20 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
     return [UIColor colorWithRed:1.0 green:0.0 blue:0.0 alpha:0.2];
   }
   return nil;
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collections", @"Cell Ink Example" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Collections/examples/CollectionsInlayExample.m
+++ b/components/Collections/examples/CollectionsInlayExample.m
@@ -22,10 +22,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   NSArray *_colors;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Cell Inlay Example" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -68,6 +64,20 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   } else {
     [self.styler applyInlayToItemAtIndexPath:indexPath animated:YES];
   }
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collections", @"Cell Inlay Example" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Collections/examples/CollectionsSimpleDemo.m
+++ b/components/Collections/examples/CollectionsSimpleDemo.m
@@ -26,20 +26,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   NSMutableArray *_content;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Simple Demo" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (NSString *)catalogDescription {
-  return @"Material Collections enables a native collection view controller to have Material "
-          "design layout and styling. It also provides editing and extensive customization "
-          "capabilities.";
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
   self.title = @"Simple Demo";
@@ -81,6 +67,26 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
                                                 forIndexPath:indexPath];
   cell.textLabel.text = _content[indexPath.section][indexPath.item];
   return cell;
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collections", @"Simple Demo" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return YES;
+}
+
++ (NSString *)catalogDescription {
+  return @"Material Collections enables a native collection view controller to have Material "
+  "design layout and styling. It also provides editing and extensive customization "
+  "capabilities.";
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Collections/examples/CollectionsSimpleDemo.m
+++ b/components/Collections/examples/CollectionsSimpleDemo.m
@@ -81,8 +81,8 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 + (NSString *)catalogDescription {
   return @"Material Collections enables a native collection view controller to have Material "
-  "design layout and styling. It also provides editing and extensive customization "
-  "capabilities.";
+          "design layout and styling. It also provides editing and extensive customization "
+          "capabilities.";
 }
 
 - (BOOL)catalogShouldHideNavigation {

--- a/components/Collections/examples/CollectionsSimpleSwiftDemo.swift
+++ b/components/Collections/examples/CollectionsSimpleSwiftDemo.swift
@@ -58,4 +58,12 @@ extension CollectionsSimpleSwiftDemo {
   class func catalogBreadcrumbs() -> [String] {
     return [ "Collections", "Simple Swift Demo"]
   }
+
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+
+  func catalogShouldHideNavigation() -> Bool {
+    return false
+  }
 }

--- a/components/Collections/examples/CollectionsStoryboardExample.m
+++ b/components/Collections/examples/CollectionsStoryboardExample.m
@@ -28,14 +28,6 @@ static NSString *const kReusableIdentifierItem = @"customCell";
   NSMutableArray *_content;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Storyboard Example" ];
-}
-
-+ (NSString *)catalogStoryboardName {
-  return @"CollectionsStoryboardExample";
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
   self.title = @"Storyboard Demo";
@@ -74,6 +66,24 @@ static NSString *const kReusableIdentifierItem = @"customCell";
   cell.label.text = _content[indexPath.section][indexPath.item];
 
   return cell;
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collections", @"Storyboard Example" ];
+}
+
++ (NSString *)catalogStoryboardName {
+  return @"CollectionsStoryboardExample";
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Collections/examples/CollectionsSwipeToDismissRowExample.m
+++ b/components/Collections/examples/CollectionsSwipeToDismissRowExample.m
@@ -24,10 +24,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   NSMutableArray *_content;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Swipe-To-Dismiss-Row Example" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -95,6 +91,20 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   for (NSIndexPath *indexPath in indexPaths) {
     [_content[indexPath.section] removeObjectAtIndex:indexPath.item];
   }
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collections", @"Swipe-To-Dismiss-Row Example" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Collections/examples/CollectionsSwipeToDismissSectionExample.m
+++ b/components/Collections/examples/CollectionsSwipeToDismissSectionExample.m
@@ -24,10 +24,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   NSMutableArray *_content;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Swipe-To-Dismiss-Section Example" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -94,6 +90,20 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
     willDeleteSections:(NSIndexSet *)sections {
   // Remove these swiped sections from our data.
   [_content removeObjectsAtIndexes:sections];
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collections", @"Swipe-To-Dismiss-Section Example" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Collections/examples/supplemental/CollectionsEditingManyCellsExampleSupplemental.m
+++ b/components/Collections/examples/supplemental/CollectionsEditingManyCellsExampleSupplemental.m
@@ -45,9 +45,9 @@
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
                   cellForItemAtIndexPath:(NSIndexPath *)indexPath {
-  MDCCollectionViewTextCell *cell =
-  [collectionView dequeueReusableCellWithReuseIdentifier:kCollectionsEditingManyCellsCellIdentifierItem
-                                            forIndexPath:indexPath];
+  MDCCollectionViewTextCell *cell = [collectionView
+      dequeueReusableCellWithReuseIdentifier:kCollectionsEditingManyCellsCellIdentifierItem
+                                forIndexPath:indexPath];
   cell.textLabel.text = self.content[indexPath.section][indexPath.item];
   return cell;
 }
@@ -57,16 +57,16 @@
                                  atIndexPath:(NSIndexPath *)indexPath {
   // If you have defined your own supplementary views, deque them here
   if ([kind isEqualToString:UICollectionElementKindSectionHeader]) {
-    MDCCollectionViewTextCell *sectionHeader =
-    [collectionView dequeueReusableSupplementaryViewOfKind:kind
-                                       withReuseIdentifier:kCollectionsEditingManyCellsHeaderReuseIdentifier
-                                              forIndexPath:indexPath];
+    MDCCollectionViewTextCell *sectionHeader = [collectionView
+        dequeueReusableSupplementaryViewOfKind:kind
+                           withReuseIdentifier:kCollectionsEditingManyCellsHeaderReuseIdentifier
+                                  forIndexPath:indexPath];
 
     NSAssert(sectionHeader != nil, @"Unable to dequeue SupplementaryView");
 
     if ([kind isEqualToString:UICollectionElementKindSectionHeader]) {
       sectionHeader.textLabel.text =
-      [NSString stringWithFormat:@"Section %lu Header", (long)indexPath.section];
+          [NSString stringWithFormat:@"Section %lu Header", (long)indexPath.section];
     }
 
     return sectionHeader;
@@ -74,8 +74,8 @@
 
   // Otherwise, pass the kind to super to let MDCCollectionViewController handle the request
   return [super collectionView:collectionView
-viewForSupplementaryElementOfKind:kind
-                   atIndexPath:indexPath];
+      viewForSupplementaryElementOfKind:kind
+                            atIndexPath:indexPath];
 }
 
 #pragma mark - <MDCCollectionViewEditingDelegate>
@@ -93,7 +93,7 @@ viewForSupplementaryElementOfKind:kind
 }
 
 - (void)collectionView:(UICollectionView *)collectionView
-willDeleteItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths {
+    willDeleteItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths {
   // First sort reverse order then remove. This is done because when we delete an index path the
   // higher rows shift down, altering the index paths of those that we would like to delete in the
   // next iteration of this loop.
@@ -104,8 +104,8 @@ willDeleteItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths {
 }
 
 - (void)collectionView:(UICollectionView *)collectionView
-willMoveItemAtIndexPath:(NSIndexPath *)indexPath
-           toIndexPath:(NSIndexPath *)newIndexPath {
+    willMoveItemAtIndexPath:(NSIndexPath *)indexPath
+                toIndexPath:(NSIndexPath *)newIndexPath {
   if (indexPath.section == newIndexPath.section) {
     // Exchange data within same section.
     [self.content[indexPath.section] exchangeObjectAtIndex:indexPath.item
@@ -122,8 +122,8 @@ willMoveItemAtIndexPath:(NSIndexPath *)indexPath
 #pragma mark UICollectionViewFlowLayoutDelegate
 
 - (CGSize)collectionView:(UICollectionView *)collectionView
-                  layout:(UICollectionViewLayout *)collectionViewLayout
-referenceSizeForHeaderInSection:(NSInteger)section {
+                             layout:(UICollectionViewLayout *)collectionViewLayout
+    referenceSizeForHeaderInSection:(NSInteger)section {
   return CGSizeMake(collectionView.bounds.size.width, MDCCellDefaultOneLineHeight);
 }
 

--- a/components/Collections/examples/supplemental/CollectionsEditingManyCellsExampleSupplemental.m
+++ b/components/Collections/examples/supplemental/CollectionsEditingManyCellsExampleSupplemental.m
@@ -18,8 +18,18 @@
 
 @implementation CollectionsEditingManyCellsExample (Supplemental)
 
+#pragma mark - CatalogByConvention
+
 + (NSArray *)catalogBreadcrumbs {
   return @[ @"Collections", @"Cell Editing Example (1000+)" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 #pragma mark - <UICollectionViewDataSource>

--- a/components/Collections/examples/supplemental/CollectionsSectionInsetsExampleSupplemental.m
+++ b/components/Collections/examples/supplemental/CollectionsSectionInsetsExampleSupplemental.m
@@ -18,10 +18,6 @@
 
 @implementation CollectionsSectionInsetsExample (Supplemental)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Custom Section Insets" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
   self.title = @"Custom Section Insets";
@@ -54,6 +50,20 @@
 - (NSInteger)collectionView:(UICollectionView *)collectionView
      numberOfItemsInSection:(NSInteger)section {
   return [self.content[section] count];
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Collections", @"Custom Section Insets" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Dialogs/examples/DialogsLongAlertViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertViewController.swift
@@ -79,7 +79,12 @@ extension DialogsLongAlertViewController {
   class func catalogBreadcrumbs() -> [String] {
     return [ "Dialogs", "Swift Alert Demo"]
   }
-  class func catalogDescription() -> String {
-    return "Swift Alert Example"
+
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+
+  func catalogShouldHideNavigation() -> Bool {
+    return false
   }
 }

--- a/components/Dialogs/examples/supplemental/DialogsAlertViewControllerSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsAlertViewControllerSupplemental.m
@@ -58,11 +58,11 @@ static NSString *const kReusableIdentifierItem = @"cell";
   return @[ @"Dialogs", @"AlertController" ];
 }
 
-+ (NSString *)catalogDescription {
-  return @"Demonstrate Material spec'd alert controllers.";
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
 }
 
-+ (BOOL)catalogIsPrimaryDemo {
+- (BOOL)catalogShouldHideNavigation {
   return NO;
 }
 

--- a/components/Dialogs/examples/supplemental/DialogsKeyboardViewControllerSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsKeyboardViewControllerSupplemental.m
@@ -25,8 +25,7 @@
 
 #pragma mark - DialogsKeyboardViewController
 
-static NSString * const kReusableIdentifierItem = @"cell";
-
+static NSString *const kReusableIdentifierItem = @"cell";
 
 @implementation DialogsKeyboardViewController (Supplemental)
 
@@ -35,7 +34,8 @@ static NSString * const kReusableIdentifierItem = @"cell";
           forCellWithReuseIdentifier:kReusableIdentifierItem];
 }
 
-- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+- (NSInteger)collectionView:(UICollectionView *)collectionView
+     numberOfItemsInSection:(NSInteger)section {
   return 1;
 }
 
@@ -49,7 +49,6 @@ static NSString * const kReusableIdentifierItem = @"cell";
 }
 
 @end
-
 
 @implementation DialogsKeyboardViewController (CatalogByConvention)
 

--- a/components/Dialogs/examples/supplemental/DialogsKeyboardViewControllerSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsKeyboardViewControllerSupplemental.m
@@ -57,8 +57,12 @@ static NSString * const kReusableIdentifierItem = @"cell";
   return @[ @"Dialogs", @"Dialog with an Input Field" ];
 }
 
-+ (NSString *)catalogDescription {
-  return @"Demonstrate Material dialog controller with an input field.";
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
@@ -23,14 +23,13 @@
 
 #import "DialogsTypicalUseSupplemental.h"
 #import "MaterialButtons.h"
+#import "MaterialCollections.h"
 #import "MaterialDialogs.h"
 #import "MaterialTypography.h"
-#import "MaterialCollections.h"
 
 #pragma mark - DialogsTypicalUseViewController
 
-static NSString * const kReusableIdentifierItem = @"cell";
-
+static NSString *const kReusableIdentifierItem = @"cell";
 
 @implementation DialogsTypicalUseViewController (Supplemental)
 
@@ -40,15 +39,16 @@ static NSString * const kReusableIdentifierItem = @"cell";
   self.modes = modes;
 }
 
-- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+- (NSInteger)collectionView:(UICollectionView *)collectionView
+     numberOfItemsInSection:(NSInteger)section {
   return self.modes.count;
 }
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
                   cellForItemAtIndexPath:(NSIndexPath *)indexPath {
   MDCCollectionViewTextCell *cell =
-  [collectionView dequeueReusableCellWithReuseIdentifier:kReusableIdentifierItem
-                                            forIndexPath:indexPath];
+      [collectionView dequeueReusableCellWithReuseIdentifier:kReusableIdentifierItem
+                                                forIndexPath:indexPath];
   cell.textLabel.text = self.modes[indexPath.row];
   return cell;
 }

--- a/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
@@ -70,6 +70,10 @@ static NSString * const kReusableIdentifierItem = @"cell";
   return YES;
 }
 
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end
 
 @interface ProgrammaticViewController ()

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
@@ -25,19 +25,6 @@ static NSString *const reuseIdentifier = @"Cell";
 
 @implementation FeatureHighlightTypicalUseViewController (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Feature Highlight", @"Feature Highlight" ];
-}
-
-+ (NSString *)catalogDescription {
-  return @"The Feature Highlight component is used to introduce users to new features and"
-          " functionality at contextually relevant moments.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -88,17 +75,28 @@ static NSString *const reuseIdentifier = @"Cell";
   self.button.frame = (CGRect){location, self.button.frame.size};
 }
 
-@end
-
-@implementation FeatureHighlightColorExample (CatalogByConvention)
+#pragma mark - CatalogByConvention
 
 + (NSArray *)catalogBreadcrumbs {
-  return @[ @"Feature Highlight", @"Colors" ];
+  return @[ @"Feature Highlight", @"Feature Highlight" ];
+}
+
++ (NSString *)catalogDescription {
+  return @"The Feature Highlight component is used to introduce users to new features and"
+  " functionality at contextually relevant moments.";
 }
 
 + (BOOL)catalogIsPrimaryDemo {
+  return YES;
+}
+
+- (BOOL)catalogShouldHideNavigation {
   return NO;
 }
+
+@end
+
+@implementation FeatureHighlightColorExample (CatalogByConvention)
 
 - (void)viewDidLoad {
   [super viewDidLoad];
@@ -142,13 +140,23 @@ static NSString *const reuseIdentifier = @"Cell";
   return cell;
 }
 
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Feature Highlight", @"Colors" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end
 
 @implementation FeatureHighlightShownViewExample (CatalogByConvention)
-
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Feature Highlight", @"Shown Views" ];
-}
 
 - (void)viewDidLoad {
   [super viewDidLoad];
@@ -187,6 +195,20 @@ static NSString *const reuseIdentifier = @"Cell";
       MDCRectAlignToScale(CGRectMake(self.view.frame.size.width / 2 - labelSize.width / 2, 20,
                                      labelSize.width, labelSize.height),
                           [UIScreen mainScreen].scale);
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Feature Highlight", @"Shown Views" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
@@ -83,7 +83,7 @@ static NSString *const reuseIdentifier = @"Cell";
 
 + (NSString *)catalogDescription {
   return @"The Feature Highlight component is used to introduce users to new features and"
-  " functionality at contextually relevant moments.";
+          " functionality at contextually relevant moments.";
 }
 
 + (BOOL)catalogIsPrimaryDemo {

--- a/components/FlexibleHeader/examples/FlexibleHeaderHorizontalPagingExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderHorizontalPagingExample.m
@@ -85,8 +85,6 @@ static const NSUInteger kNumberOfPages = 10;
   [super viewWillAppear:animated];
 
   [self recalculatePageBounds];
-
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size

--- a/components/FlexibleHeader/examples/FlexibleHeaderPageControlExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderPageControlExample.m
@@ -135,14 +135,6 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
   [self.fhvc.headerView addSubview:self.pageControl];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-  [super viewWillAppear:animated];
-
-  // If the MDCFlexibleHeaderViewController's view is not going to replace a navigation bar,
-  // comment this line:
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
-}
-
 // This method must be implemented for MDCFlexibleHeaderViewController's
 // MDCFlexibleHeaderView to properly support MDCFlexibleHeaderShiftBehavior should you choose
 // to customize it.

--- a/components/FlexibleHeader/examples/FlexibleHeaderTopLayoutGuideExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderTopLayoutGuideExample.m
@@ -86,7 +86,7 @@
   // Create UIView Object
   UIView *constrainedView = [[UIView alloc] init];
   constrainedView.backgroundColor =
-      [UIColor colorWithRed:11/255.0 green:232/255.0 blue:94/255.0 alpha:1];
+      [UIColor colorWithRed:11 / 255.0 green:232 / 255.0 blue:94 / 255.0 alpha:1];
   constrainedView.translatesAutoresizingMaskIntoConstraints = NO;
   self.constrainedView = constrainedView;
   [self.view addSubview:self.constrainedView];

--- a/components/FlexibleHeader/examples/FlexibleHeaderTopLayoutGuideExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderTopLayoutGuideExample.m
@@ -127,14 +127,6 @@
   leading.active = YES;
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-  [super viewWillAppear:animated];
-
-  // If the MDCFlexibleHeaderViewController's view is not going to replace a navigation bar,
-  // comment this line:
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
-}
-
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
 

--- a/components/FlexibleHeader/examples/FlexibleHeaderTypicalUseExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderTypicalUseExample.m
@@ -80,14 +80,6 @@
   [self setupExampleViews];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-  [super viewWillAppear:animated];
-
-  // If the MDCFlexibleHeaderViewController's view is not going to replace a navigation bar,
-  // comment this line:
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
-}
-
 - (UIStatusBarStyle)preferredStatusBarStyle {
   return UIStatusBarStyleLightContent;
 }

--- a/components/FlexibleHeader/examples/FlexibleHeaderTypicalUseExample.swift
+++ b/components/FlexibleHeader/examples/FlexibleHeaderTypicalUseExample.swift
@@ -50,13 +50,4 @@ open class FlexibleHeaderTypicalUseViewControllerSwift: FlexibleHeaderTypicalUse
 
     self.setupExampleViews()
   }
-
-  override open func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-
-    // If the MDCFlexibleHeaderViewController's view is not going to replace a navigation bar,
-    // comment this line:
-    navigationController?.setNavigationBarHidden(true, animated: animated)
-  }
-
 }

--- a/components/FlexibleHeader/examples/FlexibleHeaderUINavigationBarExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderUINavigationBarExample.m
@@ -127,9 +127,6 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];
 
-  // If the MDCFlexibleHeaderViewController's view is not going to replace a navigation bar,
-  // comment this line:
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
   self.button.center = CGPointMake(CGRectGetMidX(self.fhvc.headerView.frame),
                                    CGRectGetMidY(self.fhvc.headerView.frame) + 50.f);
 }

--- a/components/FlexibleHeader/examples/FlexibleHeaderWrappedExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderWrappedExample.m
@@ -90,10 +90,6 @@
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];
 
-  // If the MDCFlexibleHeaderViewController's view is not going to replace a navigation bar,
-  // comment this line:
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
-
   self.label.center = CGPointMake(self.wrappedViewController.view.frame.size.width / 2.f, 120.f);
 }
 

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
@@ -32,6 +32,10 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
   return @[ @"Flexible Header", @"Configurator" ];
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
 - (BOOL)catalogShouldHideNavigation {
   return YES;
 }
@@ -53,12 +57,6 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
     self.title = @"Configurator";
   }
   return self;
-}
-
-- (void)viewWillAppear:(BOOL)animated {
-  [super viewWillAppear:animated];
-
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderFABSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderFABSupplemental.m
@@ -29,6 +29,10 @@
   return @[ @"Flexible Header", @"Floating Action Button" ];
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
 - (BOOL)catalogShouldHideNavigation {
   return YES;
 }

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderHorizontalPagingSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderHorizontalPagingSupplemental.m
@@ -29,6 +29,10 @@
   return @[ @"Flexible Header", @"Horizontal Paging" ];
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
 - (BOOL)catalogShouldHideNavigation {
   return YES;
 }

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderPageControlSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderPageControlSupplemental.m
@@ -29,6 +29,10 @@
   return @[ @"Flexible Header", @"Page Control in Flexible Header" ];
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
 - (BOOL)catalogShouldHideNavigation {
   return YES;
 }

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTopLayoutGuideSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTopLayoutGuideSupplemental.m
@@ -29,6 +29,10 @@
   return @[ @"Flexible Header", @"Utilizing Top Layout Guide" ];
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
 - (BOOL)catalogShouldHideNavigation {
   return YES;
 }

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTypicalUseSupplemental.swift
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTypicalUseSupplemental.swift
@@ -30,11 +30,6 @@ extension FlexibleHeaderTypicalUseViewControllerSwift {
     return [ "Flexible Header", "Flexible Header (Swift)" ]
   }
 
-  class func catalogDescription() -> String {
-    return "The Flexible Header is a container view whose height and vertical offset react to" +
-           " UIScrollViewDelegate events."
-  }
-
   class func catalogIsPrimaryDemo() -> Bool {
     return false
   }

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderUINavigationBarSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderUINavigationBarSupplemental.m
@@ -29,6 +29,10 @@
   return @[ @"Flexible Header", @"Standard UINavigationBar" ];
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
 - (BOOL)catalogShouldHideNavigation {
   return YES;
 }

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderWrappedSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderWrappedSupplemental.m
@@ -29,6 +29,10 @@
   return @[ @"Flexible Header", @"Wrapped View Controller" ];
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
 - (BOOL)catalogShouldHideNavigation {
   return YES;
 }

--- a/components/HeaderStackView/examples/HeaderStackViewTypicalUse.swift
+++ b/components/HeaderStackView/examples/HeaderStackViewTypicalUse.swift
@@ -36,11 +36,6 @@ open class HeaderStackViewTypicalUseSwiftExample: HeaderStackViewTypicalUse {
     view.addSubview(stackView!)
   }
 
-  override open func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-    navigationController?.setNavigationBarHidden(true, animated: animated)
-  }
-
   override open var prefersStatusBarHidden: Bool {
     return true
   }

--- a/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.swift
+++ b/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.swift
@@ -22,15 +22,10 @@ import MaterialComponents
 
 extension HeaderStackViewTypicalUseSwiftExample {
 
-  // (CatalogByConvention)
+  // MARK: - CatalogByConvention
 
   class func catalogBreadcrumbs() -> [String] {
     return [ "Header Stack View", "Header Stack View (Swift)" ]
-  }
-
-  class func catalogDescription() -> String {
-    return "The Header Stack View component is a view that coordinates the layout of two" +
-    "vertically-stacked bar views."
   }
 
   class func catalogIsPrimaryDemo() -> Bool {
@@ -40,5 +35,4 @@ extension HeaderStackViewTypicalUseSwiftExample {
   func catalogShouldHideNavigation() -> Bool {
     return true
   }
-
 }

--- a/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
+++ b/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
@@ -92,6 +92,10 @@
   return YES;
 }
 
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end
 
 @implementation InkTypicalUseViewController (Supplemental)

--- a/components/MaskedTransition/examples/supplemental/MaskedTransitionTypicalUseSupplemental.swift
+++ b/components/MaskedTransition/examples/supplemental/MaskedTransitionTypicalUseSupplemental.swift
@@ -22,18 +22,21 @@ import MaterialComponents
 
 extension MaskedTransitionTypicalUseSwiftExample {
 
-  // (CatalogByConvention)
+  // MARK: - CatalogByConvention
 
   class func catalogBreadcrumbs() -> [String] {
     return [ "Masked Transition", "Masked Transition (Swift)" ]
   }
 
   class func catalogDescription() -> String {
-    return ""
+    return "Examples of how the Floating Action Button can transition to other on-screen views."
   }
 
   class func catalogIsPrimaryDemo() -> Bool {
-    return false
+    return true
   }
 
+  func catalogShouldHideNavigation() -> Bool {
+    return false
+  }
 }

--- a/components/NavigationBar/examples/NavigationBarIconsExample.m
+++ b/components/NavigationBar/examples/NavigationBarIconsExample.m
@@ -103,12 +103,6 @@
   return NO;
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-  [super viewWillAppear:animated];
-
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
-}
-
 - (void)didTapBackButton {
   [self.navigationController popViewControllerAnimated:YES];
 }
@@ -119,6 +113,10 @@
 
 + (NSArray *)catalogBreadcrumbs {
   return @[ @"Navigation Bar", @"Navigation Bar With Icons" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
 }
 
 - (BOOL)catalogShouldHideNavigation {

--- a/components/NavigationBar/examples/NavigationBarLayoutExample.m
+++ b/components/NavigationBar/examples/NavigationBarLayoutExample.m
@@ -145,12 +145,6 @@
   return YES;
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-  [super viewWillAppear:animated];
-
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
-}
-
 - (void)didTapBackButton {
   [self.navigationController popViewControllerAnimated:YES];
 }
@@ -196,6 +190,10 @@
 
 + (NSArray *)catalogBreadcrumbs {
   return @[ @"Navigation Bar", @"Navigation Bar Item Layout" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
 }
 
 - (BOOL)catalogShouldHideNavigation {

--- a/components/NavigationBar/examples/NavigationBarTypicalUseExample.m
+++ b/components/NavigationBar/examples/NavigationBarTypicalUseExample.m
@@ -66,5 +66,4 @@
   return YES;
 }
 
-
 @end

--- a/components/NavigationBar/examples/NavigationBarTypicalUseExample.m
+++ b/components/NavigationBar/examples/NavigationBarTypicalUseExample.m
@@ -66,10 +66,5 @@
   return YES;
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-  [super viewWillAppear:animated];
-
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
-}
 
 @end

--- a/components/NavigationBar/examples/NavigationBarTypicalUseExample.swift
+++ b/components/NavigationBar/examples/NavigationBarTypicalUseExample.swift
@@ -48,11 +48,6 @@ open class NavigationBarTypicalUseSwiftExample: NavigationBarTypicalUseExample {
     self.setupExampleViews()
   }
 
-  override open func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-    navigationController?.setNavigationBarHidden(true, animated: animated)
-  }
-
   override open var prefersStatusBarHidden: Bool {
     return true
   }

--- a/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
+++ b/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
@@ -69,12 +69,6 @@
   [self setupExampleViews];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-  [super viewWillAppear:animated];
-
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
-}
-
 - (void)itemTapped:(id)sender {
   NSAssert([sender respondsToSelector:@selector(title)], @"");
   NSLog(@"%@", [sender title]);
@@ -90,6 +84,10 @@
 
 + (BOOL)catalogIsPrimaryDemo {
   return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return YES;
 }
 
 @end

--- a/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.swift
+++ b/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.swift
@@ -30,11 +30,6 @@ extension NavigationBarTypicalUseSwiftExample {
     return [ "Navigation Bar", "Navigation Bar (Swift)" ]
   }
 
-  class func catalogDescription() -> String {
-    return "The Navigation Bar component is a view composed of a left and right Button Bar and" +
-          " either a title label or a custom title view."
-  }
-
   class func catalogIsPrimaryDemo() -> Bool {
     return false
   }

--- a/components/PageControl/examples/PageControlAnimationBlockExample.m
+++ b/components/PageControl/examples/PageControlAnimationBlockExample.m
@@ -29,10 +29,6 @@
   UIButton *_decrementButton;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Page Control", @"Page Control with animation block" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -174,6 +170,20 @@
                      _scrollView.contentOffset = offset;
                    }
                    completion:nil];
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Page Control", @"Page Control with animation block" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/PageControl/examples/PageControlButtonExample.m
+++ b/components/PageControl/examples/PageControlButtonExample.m
@@ -27,10 +27,6 @@
   NSArray *_pages;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Page Control", @"Page Control with Next Button" ];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -147,6 +143,20 @@
   offset.x = nextPage * CGRectGetWidth(_scrollView.frame);
   [_scrollView setContentOffset:offset animated:YES];
   [_pageControl setCurrentPage:nextPage animated:YES];
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Page Control", @"Page Control with Next Button" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/PageControl/examples/PageControlTypicalUseExample.m
+++ b/components/PageControl/examples/PageControlTypicalUseExample.m
@@ -27,19 +27,6 @@
   NSArray *_pages;
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Page Control", @"Page Control" ];
-}
-
-+ (NSString *)catalogDescription {
-  return @"This control is designed to be a drop-in replacement for UIPageControl, with a user"
-          " experience influenced by Material Design.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -135,6 +122,25 @@
   CGPoint offset = _scrollView.contentOffset;
   offset.x = sender.currentPage * _scrollView.bounds.size.width;
   [_scrollView setContentOffset:offset animated:YES];
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Page Control", @"Page Control" ];
+}
+
++ (NSString *)catalogDescription {
+  return @"This control is designed to be a drop-in replacement for UIPageControl, with a user"
+  " experience influenced by Material Design.";
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return YES;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/PageControl/examples/PageControlTypicalUseExample.m
+++ b/components/PageControl/examples/PageControlTypicalUseExample.m
@@ -34,9 +34,9 @@
   CGFloat boundsHeight = CGRectGetHeight(self.view.bounds);
 
   NSArray *pageColors = @[
-      [UIColor colorWithWhite:0.9 alpha:1.0],
-      [UIColor colorWithWhite:0.8 alpha:1.0],
-      [UIColor colorWithWhite:0.7 alpha:1.0],
+    [UIColor colorWithWhite:0.9 alpha:1.0],
+    [UIColor colorWithWhite:0.8 alpha:1.0],
+    [UIColor colorWithWhite:0.7 alpha:1.0],
   ];
 
   // Scroll view configuration
@@ -132,7 +132,7 @@
 
 + (NSString *)catalogDescription {
   return @"This control is designed to be a drop-in replacement for UIPageControl, with a user"
-  " experience influenced by Material Design.";
+          " experience influenced by Material Design.";
 }
 
 + (BOOL)catalogIsPrimaryDemo {

--- a/components/PageControl/examples/PageControlTypicalUseExample.swift
+++ b/components/PageControl/examples/PageControlTypicalUseExample.swift
@@ -111,12 +111,6 @@ class PageControlSwiftExampleViewController: UIViewController, UIScrollViewDeleg
     scrollView.setContentOffset(offset, animated: true)
   }
 
-  // MARK: CatalogByConvention
-
-  class func catalogBreadcrumbs() -> [String] {
-    return [ "Page Control", "Swift example"]
-  }
-
   // Creates a UIColor from a 24-bit RGB color encoded as an integer.
   // Pass in hex color values like so: ColorFromRGB(0x1EAAF1).
   class func ColorFromRGB(_ rgbValue: UInt32) -> UIColor {
@@ -124,5 +118,19 @@ class PageControlSwiftExampleViewController: UIViewController, UIScrollViewDeleg
         green: ((CGFloat)((rgbValue & 0x00FF00) >> 8)) / 255,
         blue: ((CGFloat)((rgbValue & 0x0000FF) >> 0)) / 255,
         alpha: 1)
+  }
+
+  // MARK: - CatalogByConvention
+
+  class func catalogBreadcrumbs() -> [String] {
+    return [ "Page Control", "Swift example"]
+  }
+
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+
+  func catalogShouldHideNavigation() -> Bool {
+    return false
   }
 }

--- a/components/Palettes/examples/PalettesExpandedExample.swift
+++ b/components/Palettes/examples/PalettesExpandedExample.swift
@@ -43,17 +43,17 @@ class PalettesGeneratedExampleViewController: PalettesExampleViewController {
   }
 }
 
-// MARK: Catalog by convention
+// MARK: - Catalog by convention
 extension PalettesGeneratedExampleViewController {
   class func catalogBreadcrumbs() -> [String] {
     return ["Palettes", "Generated Palettes"]
   }
 
-  class func catalogDescription() -> String {
-    return "The Palettes component provides sets of reference colors that work well together."
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  func catalogShouldHideNavigation() -> Bool {
     return false
   }
 }

--- a/components/Palettes/examples/PalettesStandardExample.swift
+++ b/components/Palettes/examples/PalettesStandardExample.swift
@@ -43,7 +43,7 @@ class PalettesStandardExampleViewController: PalettesExampleViewController {
   }
 }
 
-// MARK: Catalog by convention
+// MARK: - Catalog by convention
 extension PalettesStandardExampleViewController {
   class func catalogBreadcrumbs() -> [String] {
     return ["Palettes", "Standard Palettes"]
@@ -55,5 +55,9 @@ extension PalettesStandardExampleViewController {
 
   class func catalogIsPrimaryDemo() -> Bool {
     return true
+  }
+
+  func catalogShouldHideNavigation() -> Bool {
+    return false
   }
 }

--- a/components/ProgressView/examples/ProgressViewExample.m
+++ b/components/ProgressView/examples/ProgressViewExample.m
@@ -263,7 +263,7 @@ static const CGFloat MDCProgressViewAnimationDuration = 1.f;
                                  }];
 }
 
-#pragma mark - Catalog by Convention
+#pragma mark - CatalogByConvention
 
 + (NSArray *)catalogBreadcrumbs {
   return @[ @"Progress View", @"Progress View" ];
@@ -276,6 +276,10 @@ static const CGFloat MDCProgressViewAnimationDuration = 1.f;
 
 + (BOOL)catalogIsPrimaryDemo {
   return YES;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.m
+++ b/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.m
@@ -139,4 +139,12 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27.0f;
   return @[ @"Shadow", @"Shadow Elevations" ];
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end

--- a/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
+++ b/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
@@ -69,7 +69,7 @@ class ShadowDragSquareExampleViewController: UIViewController {
     }
   }
 
-  // MARK: catalog by convention
+  // MARK: - CatalogByConvention
 
   class func catalogBreadcrumbs() -> [String] {
     return [ "Shadow", "Shadow Layer"]
@@ -87,4 +87,7 @@ class ShadowDragSquareExampleViewController: UIViewController {
     return true
   }
 
+  func catalogShouldHideNavigation() -> Bool {
+    return false
+  }
 }

--- a/components/Slider/examples/SliderAutolayoutExampleViewController.m
+++ b/components/Slider/examples/SliderAutolayoutExampleViewController.m
@@ -56,7 +56,7 @@
   self.vanillaSlider.enabled = newEnabledState;
 }
 
-#pragma mark catalg by convention
+#pragma mark - CatalogByConvention
 
 + (NSArray *)catalogBreadcrumbs {
   return @[ @"Slider", @"Slider Autolayout" ];
@@ -64,6 +64,10 @@
 
 + (NSString *)catalogStoryboardName {
   return @"SliderAutolayoutExample";
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Slider/examples/SliderCompareExampleViewController.m
+++ b/components/Slider/examples/SliderCompareExampleViewController.m
@@ -71,10 +71,18 @@
   NSLog(@"did change %@ value: %f", NSStringFromClass([slider class]), slider.value);
 }
 
-#pragma mark catalg by convention
+#pragma mark - CatalogByConvention
 
 + (NSArray *)catalogBreadcrumbs {
   return @[ @"Slider", @"MDCSlider and UISlider Compared" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Slider/examples/supplemental/SliderCollectionSupplemental.m
+++ b/components/Slider/examples/supplemental/SliderCollectionSupplemental.m
@@ -36,4 +36,8 @@
   return YES;
 }
 
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end

--- a/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
+++ b/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
@@ -65,12 +65,24 @@ static NSString * const kCellIdentifier = @"Cell";
   return YES;
 }
 
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end
 
 @implementation SnackbarOverlayViewExample (CatalogByConvention)
 
 + (NSArray *)catalogBreadcrumbs {
   return @[ @"Snackbar", @"Snackbar Overlay View" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end
@@ -104,6 +116,14 @@ static NSString * const kCellIdentifier = @"Cell";
 
 + (NSArray *)catalogBreadcrumbs {
   return @[ @"Snackbar", @"Snackbar Suspension" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
+++ b/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
@@ -18,7 +18,7 @@
 
 #import "SnackbarExampleSupplemental.h"
 
-static NSString * const kCellIdentifier = @"Cell";
+static NSString *const kCellIdentifier = @"Cell";
 
 @implementation SnackbarExample
 
@@ -35,7 +35,6 @@ static NSString * const kCellIdentifier = @"Cell";
      numberOfItemsInSection:(NSInteger)section {
   return self.choices.count;
 }
-
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
                   cellForItemAtIndexPath:(NSIndexPath *)indexPath {
@@ -92,9 +91,9 @@ static NSString * const kCellIdentifier = @"Cell";
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
                   cellForItemAtIndexPath:(NSIndexPath *)indexPath {
   MDCCollectionViewTextCell *cell =
-  [collectionView dequeueReusableCellWithReuseIdentifier:kCellIdentifier
-                                            forIndexPath:indexPath];
-  
+      [collectionView dequeueReusableCellWithReuseIdentifier:kCellIdentifier
+                                                forIndexPath:indexPath];
+
   cell.textLabel.text = self.choices[indexPath.row];
   if (indexPath.row > 2) {
     UISwitch *editingSwitch = [[UISwitch alloc] initWithFrame:CGRectZero];
@@ -106,7 +105,7 @@ static NSString * const kCellIdentifier = @"Cell";
   } else {
     cell.accessoryView = nil;
   }
-  
+
   return cell;
 }
 

--- a/components/Tabs/examples/BottomNavigationBarExample.m
+++ b/components/Tabs/examples/BottomNavigationBarExample.m
@@ -103,4 +103,12 @@
   return @[ @"Tab Bar", @"Bottom Navigation" ];
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end

--- a/components/Tabs/examples/TabBarInterfaceBuilderExample.m
+++ b/components/Tabs/examples/TabBarInterfaceBuilderExample.m
@@ -104,4 +104,12 @@
   return @"TabBarInterfaceBuilderExample";
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end

--- a/components/Tabs/examples/TabBarViewControllerExample.m
+++ b/components/Tabs/examples/TabBarViewControllerExample.m
@@ -71,10 +71,4 @@
       forControlEvents:UIControlEventTouchUpInside];
 }
 
-// TabBarViewController expect that appBars be inside the tabs, so don't stick
-// an appBar on it.
-- (BOOL)catalogShouldHideNavigation {
-  return YES;
-}
-
 @end

--- a/components/Tabs/examples/TabBarViewControllerInterfaceBuilderExample.m
+++ b/components/Tabs/examples/TabBarViewControllerInterfaceBuilderExample.m
@@ -68,9 +68,8 @@
   return NO;
 }
 
-+ (NSString *)catalogDescription {
-  return @"The tab bar controller is a view controller for switching between views of "
-          "grouped content.";
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
@@ -226,11 +226,16 @@ extension TabBarIconSwiftExample {
   }
 }
 
-// MARK: Catalog by convention
+// MARK: - Catalog by convention
 extension TabBarIconSwiftExample {
   class func catalogBreadcrumbs() -> [String] {
     return ["Tab Bar", "Icons and Text (Swift)"]
   }
+
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+
   func catalogShouldHideNavigation() -> Bool {
     return true
   }

--- a/components/Tabs/examples/supplemental/TabBarTextOnlyExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarTextOnlyExampleSupplemental.m
@@ -124,12 +124,8 @@ static NSString * const kReusableIdentifierItem = @"Cell";
   return @[ @"Tab Bar", @"Text Tabs" ];
 }
 
-+ (NSString *)catalogDescription {
-  return @"The tab bar is a component for switching between views of grouped content.";
-}
-
 + (BOOL)catalogIsPrimaryDemo {
-  return YES;
+  return NO;
 }
 
 - (BOOL)catalogShouldHideNavigation {

--- a/components/Tabs/examples/supplemental/TabBarTextOnlyExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarTextOnlyExampleSupplemental.m
@@ -29,7 +29,7 @@ static CGFloat const kStatusBarHeight = 20;
 static CGFloat const kAppBarMinHeight = 56;
 static CGFloat const kTabBarHeight = 48;
 
-static NSString * const kReusableIdentifierItem = @"Cell";
+static NSString *const kReusableIdentifierItem = @"Cell";
 
 @implementation TabBarTextOnlyExample (Supplemental)
 
@@ -54,29 +54,26 @@ static NSString * const kReusableIdentifierItem = @"Cell";
 
   self.appBar.navigationBar.tintColor = [UIColor whiteColor];
   self.appBar.headerViewController.headerView.tintColor = [UIColor whiteColor];
-  self.appBar.headerViewController.headerView.minimumHeight =
-      kStatusBarHeight + kTabBarHeight;
+  self.appBar.headerViewController.headerView.minimumHeight = kStatusBarHeight + kTabBarHeight;
   self.appBar.headerViewController.headerView.maximumHeight =
       kStatusBarHeight + kAppBarMinHeight + kTabBarHeight;
-  
+
   self.appBar.navigationBar.titleTextAttributes = @{
-      NSForegroundColorAttributeName: [UIColor whiteColor],
-      NSFontAttributeName: [UIFont fontWithName:@"RobotoMono-Regular" size:14] };
+    NSForegroundColorAttributeName : [UIColor whiteColor],
+    NSFontAttributeName : [UIFont fontWithName:@"RobotoMono-Regular" size:14]
+  };
   [self.appBar addSubviewsToParent];
-  
-  
+
   [self.collectionView registerClass:[MDCCollectionViewTextCell class]
           forCellWithReuseIdentifier:kReusableIdentifierItem];
 }
 
 #pragma mark - UICollectionView
 
-
 - (NSInteger)collectionView:(UICollectionView *)collectionView
      numberOfItemsInSection:(NSInteger)section {
   return self.choices.count;
 }
-
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
                   cellForItemAtIndexPath:(NSIndexPath *)indexPath {
@@ -103,7 +100,8 @@ static NSString * const kReusableIdentifierItem = @"Cell";
 
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
   if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-    [self.appBar.headerViewController.headerView trackingScrollViewDidEndDraggingWillDecelerate:decelerate];
+    [self.appBar.headerViewController.headerView
+        trackingScrollViewDidEndDraggingWillDecelerate:decelerate];
   }
 }
 
@@ -111,8 +109,9 @@ static NSString * const kReusableIdentifierItem = @"Cell";
                      withVelocity:(CGPoint)velocity
               targetContentOffset:(inout CGPoint *)targetContentOffset {
   if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-    [self.appBar.headerViewController.headerView trackingScrollViewWillEndDraggingWithVelocity:velocity
-                                                                           targetContentOffset:targetContentOffset];
+    [self.appBar.headerViewController.headerView
+        trackingScrollViewWillEndDraggingWithVelocity:velocity
+                                  targetContentOffset:targetContentOffset];
   }
 }
 

--- a/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
@@ -129,9 +129,8 @@
   return NO;
 }
 
-+ (NSString *)catalogDescription {
-  return @"The tab bar controller is a view controller for switching between views of "
-          "grouped content.";
+- (BOOL)catalogShouldHideNavigation {
+  return YES;
 }
 
 @end

--- a/components/TextFields/examples/MultilineTextFieldLegacyExample.m
+++ b/components/TextFields/examples/MultilineTextFieldLegacyExample.m
@@ -203,12 +203,18 @@
   [self.view endEditing:YES];
 }
 
+#pragma mark - CatalogByConvention
+
 + (NSArray *)catalogBreadcrumbs {
   return @[ @"Text Field", @"[Legacy] Multiline (Objective C)" ];
 }
 
-+ (NSString *)catalogDescription {
-  return @"Simple Legacy MDCMultilineTextField example.";
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end

--- a/components/TextFields/examples/MultilineTextFieldLegacyExample.m
+++ b/components/TextFields/examples/MultilineTextFieldLegacyExample.m
@@ -46,17 +46,13 @@
                               constraintsWithVisualFormat:@"V:|[scrollView]|"
                                                   options:0
                                                   metrics:nil
-                                                    views:@{
-                                                      @"scrollView" : self.scrollView
-                                                    }]];
+                                                    views:@{@"scrollView" : self.scrollView}]];
   [NSLayoutConstraint
       activateConstraints:[NSLayoutConstraint
                               constraintsWithVisualFormat:@"H:|[scrollView]|"
                                                   options:0
                                                   metrics:nil
-                                                    views:@{
-                                                      @"scrollView" : self.scrollView
-                                                    }]];
+                                                    views:@{@"scrollView" : self.scrollView}]];
 
   MDCMultilineTextField *multilineTextFieldUnstyled = [[MDCMultilineTextField alloc] init];
   [self.scrollView addSubview:multilineTextFieldUnstyled];
@@ -95,8 +91,8 @@
   multilineTextFieldCharMaxDefault.placeholder = @"Inline Placeholder Only";
   multilineTextFieldCharMaxDefault.textView.delegate = self;
 
-  self.textFieldControllerDefaultCharMax =
-      [[MDCTextInputControllerLegacyDefault alloc] initWithTextInput:multilineTextFieldCharMaxDefault];
+  self.textFieldControllerDefaultCharMax = [[MDCTextInputControllerLegacyDefault alloc]
+      initWithTextInput:multilineTextFieldCharMaxDefault];
   self.textFieldControllerDefaultCharMax.characterCountMax = 30;
   self.textFieldControllerDefaultCharMax.floatingEnabled = NO;
 

--- a/components/TextFields/examples/TextFieldExample.swift
+++ b/components/TextFields/examples/TextFieldExample.swift
@@ -359,6 +359,8 @@ extension TextFieldLegacySwiftExample {
   }
 }
 
+// MARK: - CatalogByConvention
+
 extension TextFieldLegacySwiftExample {
   class func catalogBreadcrumbs() -> [String] {
     return ["Text Field", "[Legacy] Typical Use"]
@@ -368,7 +370,12 @@ extension TextFieldLegacySwiftExample {
     // swiftlint:disable:next line_length
     return "The Material Design Text Fields take the familiar element to a new level by adding useful animations, character counts, helper text and error states."
   }
+
   class func catalogIsPrimaryDemo() -> Bool {
     return true
+  }
+
+  func catalogShouldHideNavigation() -> Bool {
+    return false
   }
 }

--- a/components/TextFields/examples/TextFieldManualLayoutLegacyExample.m
+++ b/components/TextFields/examples/TextFieldManualLayoutLegacyExample.m
@@ -36,7 +36,8 @@
   textFieldName.delegate = self;
   textFieldName.clearButtonMode = UITextFieldViewModeUnlessEditing;
 
-  self.nameController = [[MDCTextInputControllerLegacyDefault alloc] initWithTextInput:textFieldName];
+  self.nameController =
+      [[MDCTextInputControllerLegacyDefault alloc] initWithTextInput:textFieldName];
 
   textFieldName.frame = CGRectMake(10, 40, CGRectGetWidth(self.view.bounds) - 20, 0);
 
@@ -47,7 +48,8 @@
   textFieldPhone.delegate = self;
   textFieldPhone.clearButtonMode = UITextFieldViewModeUnlessEditing;
 
-  self.phoneController = [[MDCTextInputControllerLegacyDefault alloc] initWithTextInput:textFieldPhone];
+  self.phoneController =
+      [[MDCTextInputControllerLegacyDefault alloc] initWithTextInput:textFieldPhone];
 
   textFieldPhone.frame = CGRectMake(10, CGRectGetMaxY(self.nameController.textInput.frame) + 20,
                                     CGRectGetWidth(self.view.bounds) - 20, 0);

--- a/components/TextFields/examples/TextFieldManualLayoutLegacyExample.m
+++ b/components/TextFields/examples/TextFieldManualLayoutLegacyExample.m
@@ -154,4 +154,12 @@
   return @[ @"Text Field", @"[Legacy] Manual Layout (Objective C)" ];
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end

--- a/components/TextFields/examples/TextFieldManualLayoutLegacyExample.swift
+++ b/components/TextFields/examples/TextFieldManualLayoutLegacyExample.swift
@@ -319,8 +319,17 @@ extension TextFieldManualLayoutLegacySwiftExample {
   }
 }
 
+// MARK: - CatalogByConvention
 extension TextFieldManualLayoutLegacySwiftExample {
   class func catalogBreadcrumbs() -> [String] {
     return ["Text Field", "[Legacy] Manual Layout"]
+  }
+
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+
+  func catalogShouldHideNavigation() -> Bool {
+    return false
   }
 }

--- a/components/TextFields/examples/supplemental/TextFieldInterfaceBuilderLegacyExampleSupplemental.m
+++ b/components/TextFields/examples/supplemental/TextFieldInterfaceBuilderLegacyExampleSupplemental.m
@@ -34,4 +34,12 @@
   return @"TextFieldInterfaceBuilderLegacyExample";
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end

--- a/components/TextFields/examples/supplemental/TextFieldKitchenSinkExampleSupplemental.swift
+++ b/components/TextFields/examples/supplemental/TextFieldKitchenSinkExampleSupplemental.swift
@@ -394,4 +394,12 @@ extension TextFieldKitchenSinkSwiftExample {
   class func catalogBreadcrumbs() -> [String] {
     return ["Text Field", "Kitchen Sink"]
   }
+
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+
+  func catalogShouldHideNavigation() -> Bool {
+    return false
+  }
 }

--- a/components/TextFields/examples/supplemental/TextFieldPresentationStylesLegacyExampleSupplemental.m
+++ b/components/TextFields/examples/supplemental/TextFieldPresentationStylesLegacyExampleSupplemental.m
@@ -65,4 +65,12 @@
   return @[ @"Text Field", @"Controller Styles (Objective C)" ];
 }
 
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end

--- a/components/TextFields/examples/supplemental/TextFieldPresentationStylesLegacyExampleSupplemental.m
+++ b/components/TextFields/examples/supplemental/TextFieldPresentationStylesLegacyExampleSupplemental.m
@@ -32,17 +32,13 @@
                               constraintsWithVisualFormat:@"V:|[scrollView]|"
                                                   options:0
                                                   metrics:nil
-                                                    views:@{
-                                                      @"scrollView" : self.scrollView
-                                                    }]];
+                                                    views:@{@"scrollView" : self.scrollView}]];
   [NSLayoutConstraint
       activateConstraints:[NSLayoutConstraint
                               constraintsWithVisualFormat:@"H:|[scrollView]|"
                                                   options:0
                                                   metrics:nil
-                                                    views:@{
-                                                      @"scrollView" : self.scrollView
-                                                    }]];
+                                                    views:@{@"scrollView" : self.scrollView}]];
 
   CGFloat marginOffset = 16;
   UIEdgeInsets margins = UIEdgeInsetsMake(0, marginOffset, 0, marginOffset);

--- a/components/Themes/examples/ThemerColorSchemeViewController.m
+++ b/components/Themes/examples/ThemerColorSchemeViewController.m
@@ -16,8 +16,8 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialThemes.h"
 #import "MaterialPalettes.h"
+#import "MaterialThemes.h"
 
 #import "ThemerTypicalUseSupplemental.h"
 
@@ -38,14 +38,14 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  [self loadCollectionView: @[ @"Blue Theme",
-                               @"Red Theme",
-                               @"Green Theme",
-                               @"Amber Theme",
-                               @"Pink Theme",
-                               @"Orange Theme",
-                               @"Purple Theme",
-                               @"Teal Theme" ]];
+  [self loadCollectionView:@[ @"Blue Theme",
+                              @"Red Theme",
+                              @"Green Theme",
+                              @"Amber Theme",
+                              @"Pink Theme",
+                              @"Orange Theme",
+                              @"Purple Theme",
+                              @"Teal Theme" ]];
 }
 
 - (void)collectionView:(UICollectionView *)collectionView

--- a/components/Themes/examples/ThemerColorSchemeViewController.m
+++ b/components/Themes/examples/ThemerColorSchemeViewController.m
@@ -164,4 +164,8 @@ static NSString *const kReusableIdentifierItem = @"cell";
   return YES;
 }
 
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end

--- a/components/Themes/examples/ThemerTonalPaletteViewController.m
+++ b/components/Themes/examples/ThemerTonalPaletteViewController.m
@@ -16,8 +16,8 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialThemes.h"
 #import "MaterialPalettes.h"
+#import "MaterialThemes.h"
 
 #import "ThemerTypicalUseSupplemental.h"
 
@@ -38,7 +38,7 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  [self loadCollectionView: @[ @"Tonal Color Scheme Theme" ]];
+  [self loadCollectionView:@[ @"Tonal Color Scheme Theme" ]];
 }
 
 - (void)collectionView:(UICollectionView *)collectionView
@@ -47,41 +47,41 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
   switch (indexPath.item) {
     case 0: {
-      NSArray<UIColor *> *primaryTonalColors = @[ [MDCPalette purplePalette].tint50,
-                                                  [MDCPalette purplePalette].tint100,
-                                                  [MDCPalette purplePalette].tint200,
-                                                  [MDCPalette purplePalette].tint300,
-                                                  [MDCPalette purplePalette].tint400,
-                                                  [MDCPalette purplePalette].tint500,
-                                                  [MDCPalette purplePalette].tint600,
-                                                  [MDCPalette purplePalette].tint700,
-                                                  [MDCPalette purplePalette].tint800,
-                                                  [MDCPalette purplePalette].tint900 ];
+      NSArray<UIColor *> *primaryTonalColors = @[[MDCPalette purplePalette].tint50,
+                                                 [MDCPalette purplePalette].tint100,
+                                                 [MDCPalette purplePalette].tint200,
+                                                 [MDCPalette purplePalette].tint300,
+                                                 [MDCPalette purplePalette].tint400,
+                                                 [MDCPalette purplePalette].tint500,
+                                                 [MDCPalette purplePalette].tint600,
+                                                 [MDCPalette purplePalette].tint700,
+                                                 [MDCPalette purplePalette].tint800,
+                                                 [MDCPalette purplePalette].tint900];
       MDCTonalPalette *primaryTonalPalette =
           [[MDCTonalPalette alloc] initWithColors:primaryTonalColors
                                    mainColorIndex:5
                                   lightColorIndex:1
                                    darkColorIndex:7];
-      
-      NSArray<UIColor *> *secondaryTonalColors = @[ [MDCPalette orangePalette].tint50,
-                                                    [MDCPalette orangePalette].tint100,
-                                                    [MDCPalette orangePalette].tint200,
-                                                    [MDCPalette orangePalette].tint300,
-                                                    [MDCPalette orangePalette].tint400,
-                                                    [MDCPalette orangePalette].tint500,
-                                                    [MDCPalette orangePalette].tint600,
-                                                    [MDCPalette orangePalette].tint700,
-                                                    [MDCPalette orangePalette].tint800,
-                                                    [MDCPalette orangePalette].tint900 ];
+
+      NSArray<UIColor *> *secondaryTonalColors = @[[MDCPalette orangePalette].tint50,
+                                                   [MDCPalette orangePalette].tint100,
+                                                   [MDCPalette orangePalette].tint200,
+                                                   [MDCPalette orangePalette].tint300,
+                                                   [MDCPalette orangePalette].tint400,
+                                                   [MDCPalette orangePalette].tint500,
+                                                   [MDCPalette orangePalette].tint600,
+                                                   [MDCPalette orangePalette].tint700,
+                                                   [MDCPalette orangePalette].tint800,
+                                                   [MDCPalette orangePalette].tint900];
       MDCTonalPalette *secondaryTonalPalette =
-           [[MDCTonalPalette alloc] initWithColors:secondaryTonalColors
-                                    mainColorIndex:5
-                                   lightColorIndex:1
-                                    darkColorIndex:7];
-      
+          [[MDCTonalPalette alloc] initWithColors:secondaryTonalColors
+                                   mainColorIndex:5
+                                  lightColorIndex:1
+                                   darkColorIndex:7];
+
       MDCTonalColorScheme *tonalColorScheme =
-           [[MDCTonalColorScheme alloc] initWithPrimaryTonalPalette:primaryTonalPalette
-                                              secondaryTonalPalette:secondaryTonalPalette];
+          [[MDCTonalColorScheme alloc] initWithPrimaryTonalPalette:primaryTonalPalette
+                                             secondaryTonalPalette:secondaryTonalPalette];
       self.colorScheme = tonalColorScheme;
       break;
     }

--- a/components/Themes/examples/ThemerTonalPaletteViewController.m
+++ b/components/Themes/examples/ThemerTonalPaletteViewController.m
@@ -124,11 +124,11 @@ static NSString *const kReusableIdentifierItem = @"cell";
   return @[ @"Themes", @"Tonal Palette Example" ];
 }
 
-+ (NSString *)catalogDescription {
-  return @"Tonal palettes applied to a variety of components for theming.";
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
 }
 
-+ (BOOL)catalogIsPrimaryDemo {
+- (BOOL)catalogShouldHideNavigation {
   return NO;
 }
 

--- a/components/Themes/examples/supplemental/ThemerTypicalUseSupplemental.m
+++ b/components/Themes/examples/supplemental/ThemerTypicalUseSupplemental.m
@@ -41,7 +41,7 @@
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
   self.scrollView.contentSize = CGSizeMake(self.view.bounds.size.width, 600);
-  
+
   self.activityIndicator.center = CGPointMake(self.view.frame.size.width / 2, 80);
   self.alertButton.center = CGPointMake(self.view.frame.size.width / 2 - 100, 160);
   self.featureButton.center = CGPointMake(self.view.frame.size.width / 2 + 50, 160);
@@ -80,8 +80,7 @@
                                       action:nil];
 
   CGRect defaultRect = CGRectMake(0, 0, 32, 32);
-  self.activityIndicator =
-      [[MDCActivityIndicator alloc] initWithFrame:defaultRect];
+  self.activityIndicator = [[MDCActivityIndicator alloc] initWithFrame:defaultRect];
   self.activityIndicator.indicatorMode = MDCActivityIndicatorModeIndeterminate;
   [self.activityIndicator sizeToFit];
   [self.scrollView addSubview:self.activityIndicator];
@@ -93,8 +92,8 @@
   self.alertButton.center = CGPointMake(100, 100);
   [self.scrollView addSubview:self.alertButton];
   [self.alertButton addTarget:self
-                  action:@selector(didTapShowAlert:)
-        forControlEvents:UIControlEventTouchUpInside];
+                       action:@selector(didTapShowAlert:)
+             forControlEvents:UIControlEventTouchUpInside];
 
   self.featureButton = [[MDCRaisedButton alloc] init];
   [self.featureButton setTitle:@"Feature Highlight" forState:UIControlStateNormal];
@@ -115,8 +114,7 @@
   [self.scrollView addSubview:self.progressView];
   [self animateStep1:self.progressView];
 
-  self.floatingButton =
-      [MDCFloatingButton floatingButtonWithShape:MDCFloatingButtonShapeDefault];
+  self.floatingButton = [MDCFloatingButton floatingButtonWithShape:MDCFloatingButtonShapeDefault];
   [self.floatingButton sizeToFit];
   [self.scrollView addSubview:self.floatingButton];
 

--- a/components/Themes/examples/supplemental/ThemerTypicalUseSupplemental.m
+++ b/components/Themes/examples/supplemental/ThemerTypicalUseSupplemental.m
@@ -36,7 +36,6 @@
 
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
 }
 
 - (void)viewDidLayoutSubviews {

--- a/components/Typography/examples/TypographyFontListExample.swift
+++ b/components/Typography/examples/TypographyFontListExample.swift
@@ -144,7 +144,7 @@ class TypographyFontListExampleViewController: UITableViewController {
   ]
 }
 
-// MARK: Catalog by convention
+// MARK: - CatalogByConvention
 extension TypographyFontListExampleViewController {
   class func catalogBreadcrumbs() -> [String] {
     return ["Typography and Fonts", "Typography"]
@@ -157,5 +157,9 @@ extension TypographyFontListExampleViewController {
 
   class func catalogIsPrimaryDemo() -> Bool {
     return true
+  }
+
+  func catalogShouldHideNavigation() -> Bool {
+    return false
   }
 }

--- a/components/Typography/examples/TypographyMaterialStylesViewController.m
+++ b/components/Typography/examples/TypographyMaterialStylesViewController.m
@@ -100,7 +100,7 @@
   NSLog(@"UIFontWeightBlack %f", UIFontWeightBlack);
 
   UIFont *defaultFont = [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleBody1];
-  NSLog (@"Font Family : %@", defaultFont.familyName);
+  NSLog(@"Font Family : %@", defaultFont.familyName);
 }
 
 - (void)contentSizeCategoryDidChange:(NSNotification *)notification {

--- a/components/Typography/examples/TypographyMaterialStylesViewController.m
+++ b/components/Typography/examples/TypographyMaterialStylesViewController.m
@@ -127,14 +127,6 @@
 
 #pragma mark - UITableViewDataSource
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Typography and Fonts", @"Material Font Styles" ];
-}
-
-#pragma mark - UITableViewDelegate
-
-#pragma mark - UITableViewDataSource
-
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
   return _strings.count;
 }
@@ -166,4 +158,19 @@
 
   return cell;
 }
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Typography and Fonts", @"Material Font Styles" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
+}
+
 @end

--- a/components/Typography/examples/TypographySimpleExampleViewController.m
+++ b/components/Typography/examples/TypographySimpleExampleViewController.m
@@ -39,8 +39,18 @@
   [self.view addSubview:label];
 }
 
+#pragma mark - CatalogByConvention
+
 + (NSArray *)catalogBreadcrumbs {
   return @[ @"Typography and Fonts", @"Read Me Demo" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return NO;
 }
 
 @end


### PR DESCRIPTION
CatalogByConvention classes require two methods to be implemented:

```objectivec
+ (nonnull NSArray<NSString *> *)catalogBreadcrumbs;
+ (BOOL)catalogIsPrimaryDemo;
```

Additionally, MDCNodeListViewController expects the following method to exist for classes that should hide the UINavigationBar.  

```objectivec
- (BOOL)catalogShouldHideNavigation;
```

Previously, the return value of the method was ignored but this commit will allow classes to return the appropriate value.  This approach is less surprising to developers.

Closes #1897