### PR TITLE
[ActivityIndicator] - Reduce CPU demands of MDCActivityIndicator

### DIFF
--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -432,8 +432,13 @@ static const CGFloat kSingleCycleRotation =
 
   [CATransaction begin];
   {
+    __weak typeof(self) weakSelf = self;
     [CATransaction setCompletionBlock:^{
-      [self strokeRotationCycleFinishedFromState:MDCActivityIndicatorStateIndeterminate];
+      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.03 * NSEC_PER_SEC)),
+                     dispatch_get_main_queue(), ^{
+          MDCActivityIndicator *strongSelf = weakSelf;
+          [strongSelf strokeRotationCycleFinishedFromState:MDCActivityIndicatorStateIndeterminate];
+                     });
     }];
 
     // Outer 5-point star detent rotation.


### PR DESCRIPTION
- Adds a dispatch_after buffer in completion block addStrokeRotationCycle method before calling strokeRotationCycleFInishedFromState: to alleviate CPU intensity

See thread 1
Before:
![before](https://user-images.githubusercontent.com/19916772/29837376-f4ab21d0-8cc5-11e7-9291-c80b8ac9066c.png)

After:
![after](https://user-images.githubusercontent.com/19916772/29837384-f929feb6-8cc5-11e7-980d-f72041b4e0d7.png)

