### PR TITLE
[ActivityIndicator] Use explicit class for bundle

### DIFF
--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -830,7 +830,7 @@ static const CGFloat kSingleCycleRotation =
   // In iOS 8+, we could be included by way of a dynamic framework, and our resource bundles may
   // not be in the main .app bundle, but rather in a nested framework, so figure out where we live
   // and use that as the search location.
-  NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+  NSBundle *bundle = [NSBundle bundleForClass:[MDCActivityIndicator class]];
   NSString *resourcePath = [(nil == bundle ? [NSBundle mainBundle] : bundle)resourcePath];
   return [resourcePath stringByAppendingPathComponent:bundleName];
 }


### PR DESCRIPTION
Using [self class] to determine the bundle to load resources/strings here breaks if you subclass MDCActivityIndicator and that subclass ends up being placed in a different bundle. Writing MDCActivityIndicator here explicitly ensures that we find the intended resources: those included alongside the base definition.