### PR TITLE
[Podspec] Fix comment about bundles

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -21,8 +21,9 @@ Pod::Spec.new do |s|
   #
   # ## Optional properties
   #
-  # resources    		 => If your component has a bundle, add a dictionary mapping from the bundle
-  #                         name to the bundle path. NOTE: Do not use resource_bundle property.
+  # resources        => If your component has a bundle, this property should be an Array 
+  #                     containing the bundle path as a String. 
+  #                     NOTE: Do not use resource_bundle property 
   #
   # # Template subspec
   #


### PR DESCRIPTION
The subspec bundle instructions were out of date and didn't match the
template. Bringing them up to date.
