### PR TITLE
[Bundles] Use explicit class in bundleForClass

### DIFF
--- a/components/AppBar/src/MDCAppBar.m
+++ b/components/AppBar/src/MDCAppBar.m
@@ -286,7 +286,7 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
   // In iOS 8+, we could be included by way of a dynamic framework, and our resource bundles may
   // not be in the main .app bundle, but rather in a nested framework, so figure out where we live
   // and use that as the search location.
-  NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+  NSBundle *bundle = [NSBundle bundleForClass:[MDCAppBar class]];
   NSString *resourcePath = [(nil == bundle ? [NSBundle mainBundle] : bundle)resourcePath];
   return [resourcePath stringByAppendingPathComponent:bundleName];
 }

--- a/components/Collections/src/private/MDCCollectionStringResources.m
+++ b/components/Collections/src/private/MDCCollectionStringResources.m
@@ -65,7 +65,7 @@ static NSString *const kBundleName = @"MaterialCollections.bundle";
   // In iOS 8+, we could be included by way of a dynamic framework, and our resource bundles may
   // not be in the main .app bundle, but rather in a nested framework, so figure out where we live
   // and use that as the search location.
-  NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+  NSBundle *bundle = [NSBundle bundleForClass:[MDCCollectionStringResources class]];
   NSString *resourcePath = [(nil == bundle ? [NSBundle mainBundle] : bundle)resourcePath];
   return [resourcePath stringByAppendingPathComponent:bundleName];
 }

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -320,7 +320,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   // In iOS 8+, we could be included by way of a dynamic framework, and our resource bundles may
   // not be in the main .app bundle, but rather in a nested framework, so figure out where we live
   // and use that as the search location.
-  NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+  NSBundle *bundle = [NSBundle bundleForClass:[MDCAlertController class]];
   NSString *resourcePath = [(nil == bundle ? [NSBundle mainBundle] : bundle) resourcePath];
   return [resourcePath stringByAppendingPathComponent:bundleName];
 }

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -568,7 +568,7 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   // In iOS 8+, we could be included by way of a dynamic framework, and our resource bundles may
   // not be in the main .app bundle, but rather in a nested framework, so figure out where we live
   // and use that as the search location.
-  NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+  NSBundle *bundle = [NSBundle bundleForClass:[MDCFeatureHighlightView class]];
   NSString *resourcePath = [(nil == bundle ? [NSBundle mainBundle] : bundle) resourcePath];
   return [resourcePath stringByAppendingPathComponent:bundleName];
 }

--- a/components/PageControl/src/MDCPageControl.m
+++ b/components/PageControl/src/MDCPageControl.m
@@ -512,7 +512,7 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
   // In iOS 8+, we could be included by way of a dynamic framework, and our resource bundles may
   // not be in the main .app bundle, but rather in a nested framework, so figure out where we live
   // and use that as the search location.
-  NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+  NSBundle *bundle = [NSBundle bundleForClass:[MDCPageControl class]];
   NSString *resourcePath = [(nil == bundle ? [NSBundle mainBundle] : bundle)resourcePath];
   return [resourcePath stringByAppendingPathComponent:bundleName];
 }

--- a/components/private/Icons/src/MDCIcons.m
+++ b/components/private/Icons/src/MDCIcons.m
@@ -29,7 +29,7 @@
   
   NSBundle *bundle = [bundleCache objectForKey:bundleName];
   if (!bundle) {
-    NSBundle *baseBundle = [NSBundle bundleForClass:[self class]];
+    NSBundle *baseBundle = [NSBundle bundleForClass:[MDCIcons class]];
     NSString *bundlePath = [baseBundle pathForResource:bundleName ofType:@"bundle"];
     bundle = [NSBundle bundleWithPath:bundlePath];
     [bundleCache setObject:bundle forKey:bundleName];


### PR DESCRIPTION
Using `[self class]` when loading a bundle can result in missed resources when
a method is called from a subclass.  To prevent these errors, components should
be explicit about which class is being used to load bundles.

References #1941 (Components)
