### PR TITLE
[Themes] Use onTintColor when styling UISwitch

### DIFF
--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -65,7 +65,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // Apply color scheme to UIKit components.
     UISlider.appearance().tintColor = colorScheme?.primaryColor
-    UISwitch.appearance().tintColor = colorScheme?.primaryColor
+    UISwitch.appearance().onTintColor = colorScheme?.primaryColor
 
     return true
   }

--- a/components/Themes/examples/ThemerCustomSchemePickerController.m
+++ b/components/Themes/examples/ThemerCustomSchemePickerController.m
@@ -203,7 +203,7 @@ static NSString *s_secondaryColorString;
 
   // Apply color scheme to UIKit components.
   [UISlider appearance].tintColor = colorScheme.primaryColor;
-  [UISwitch appearance].tintColor = colorScheme.primaryColor;
+  [UISwitch appearance].onTintColor = colorScheme.primaryColor;
 
   // Send notification that color scheme has changed so existing components can update if necessary.
   NSDictionary *userInfo = @{ @"colorScheme" : colorScheme };

--- a/components/Themes/examples/ThemerTypicalUseViewController.m
+++ b/components/Themes/examples/ThemerTypicalUseViewController.m
@@ -56,7 +56,7 @@
 
   // Apply color scheme to UIKit components.
   [UISlider appearance].tintColor = self.colorScheme.primaryColor;
-  [UISwitch appearance].tintColor = self.colorScheme.primaryColor;
+  [UISwitch appearance].onTintColor = self.colorScheme.primaryColor;
 
   // Send notification that color scheme has changed so existing components can update if necessary.
   NSDictionary *userInfo = @{ @"colorScheme" : self.colorScheme };


### PR DESCRIPTION
The tintColor property also changes the tint of the border, and that's not what we want.
Specs: [Material Guidelines](https://material.io/guidelines/platforms/platform-adaptation.html#platform-adaptation-platform-recommendations)

Before:
![simulator screen shot sep 6 2017 3 17 18 pm](https://user-images.githubusercontent.com/4545451/30131023-353cd816-9319-11e7-87e2-6c0fc37f9776.png)

After:
![simulator screen shot sep 6 2017 3 18 42 pm](https://user-images.githubusercontent.com/4545451/30131032-408cc230-9319-11e7-8aa0-a0183fd52fbd.png)

