### PR TITLE
[TextFields] Fix for placeholders being colored active when isEditing = NO

### DIFF
--- a/components/TextFields/src/ColorThemer/MDCTextFieldColorThemer.m
+++ b/components/TextFields/src/ColorThemer/MDCTextFieldColorThemer.m
@@ -25,12 +25,12 @@
 
 + (void)applyColorScheme:(NSObject<MDCColorScheme> *)colorScheme
     toTextInputControllerDefault:(MDCTextInputControllerLegacyDefault *)textInputControllerDefault {
-  textInputControllerDefault.floatingPlaceholderColor = colorScheme.primaryColor;
+  textInputControllerDefault.floatingPlaceholderNormalColor = colorScheme.primaryColor;
   textInputControllerDefault.activeColor = colorScheme.primaryColor;
 }
 
 + (void)applyColorSchemeToAllTextInputControllerDefault:(NSObject<MDCColorScheme> *)colorScheme {
-  MDCTextInputControllerLegacyDefault.floatingPlaceholderColorDefault = colorScheme.primaryColor;
+  MDCTextInputControllerLegacyDefault.floatingPlaceholderNormalColorDefault = colorScheme.primaryColor;
   MDCTextInputControllerLegacyDefault.activeColorDefault = colorScheme.primaryColor;
 }
 

--- a/components/TextFields/src/MDCTextInputControllerDefault.h
+++ b/components/TextFields/src/MDCTextInputControllerDefault.h
@@ -56,18 +56,20 @@ extern const CGFloat MDCTextInputDefaultUnderlineActiveHeight;
 
 /**
  The color applied to the placeholder when floating. However, when in error state, it will be
- colored with the error color. Only relevent when floatingEnabled = true.
+ colored with the error color and when in active state, it will be colored with the active color.
 
- Default is floatingPlaceholderColorDefault.
+ Only relevent when floatingEnabled = true.
+
+ Default is floatingPlaceholderNormalColorDefault.
  */
-@property(nonatomic, null_resettable, strong) UIColor *floatingPlaceholderColor;
+@property(nonatomic, null_resettable, strong) UIColor *floatingPlaceholderNormalColor;
 
 /**
- Default value for floatingPlaceholderColor.
+ Default value for floatingPlaceholderNormalColor.
 
  Default is black with Material Design hint text opacity (textInput's tint).
  */
-@property(class, nonatomic, null_resettable, strong) UIColor *floatingPlaceholderColorDefault;
+@property(class, nonatomic, null_resettable, strong) UIColor *floatingPlaceholderNormalColorDefault;
 
 /**
  Where the floating placeholder should arrive when floating up.

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -66,8 +66,8 @@ static NSString *const MDCTextInputControllerDefaultExpandsOnOverflowKey =
     @"MDCTextInputControllerDefaultExpandsOnOverflowKey";
 static NSString *const MDCTextInputControllerDefaultFloatingEnabledKey =
     @"MDCTextInputControllerDefaultFloatingEnabledKey";
-static NSString *const MDCTextInputControllerDefaultFloatingPlaceholderColorKey =
-    @"MDCTextInputControllerDefaultFloatingPlaceholderColorKey";
+static NSString *const MDCTextInputControllerDefaultFloatingPlaceholderNormalColorKey =
+    @"MDCTextInputControllerDefaultFloatingPlaceholderNormalColorKey";
 static NSString *const MDCTextInputControllerDefaultFloatingPlaceholderScaleKey =
     @"MDCTextInputControllerDefaultFloatingPlaceholderScaleKey";
 static NSString *const MDCTextInputControllerDefaultHelperTextKey =
@@ -119,7 +119,7 @@ static UIColor *_activeColorDefault;
 static UIColor *_borderFillColorDefault;
 static UIColor *_disabledColorDefault;
 static UIColor *_errorColorDefault;
-static UIColor *_floatingPlaceholderColorDefault;
+static UIColor *_floatingPlaceholderNormalColorDefault;
 static UIColor *_inlinePlaceholderColorDefault;
 static UIColor *_leadingUnderlineLabelTextColorDefault;
 static UIColor *_normalColorDefault;
@@ -140,7 +140,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   UIColor *_borderFillColor;
   UIColor *_disabledColor;
   UIColor *_errorColor;
-  UIColor *_floatingPlaceholderColor;
+  UIColor *_floatingPlaceholderNormalColor;
   UIColor *_inlinePlaceholderColor;
   UIColor *_leadingUnderlineLabelTextColor;
   UIColor *_normalColor;
@@ -159,8 +159,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 @property(nonatomic, copy) NSString *errorAccessibilityValue;
 @property(nonatomic, copy, readwrite) NSString *errorText;
 @property(nonatomic, copy) NSString *previousLeadingText;
-
-@property(nonatomic, strong) UIColor *previousPlaceholderColor;
 
 @property(nonatomic, strong) UIFont *customLeadingFont;
 @property(nonatomic, strong) UIFont *customPlaceholderFont;
@@ -208,8 +206,8 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
     _expandsOnOverflow =
         [aDecoder decodeBoolForKey:MDCTextInputControllerDefaultExpandsOnOverflowKey];
     _floatingEnabled = [aDecoder decodeBoolForKey:MDCTextInputControllerDefaultFloatingEnabledKey];
-    _floatingPlaceholderColor =
-        [aDecoder decodeObjectForKey:MDCTextInputControllerDefaultFloatingPlaceholderColorKey];
+    _floatingPlaceholderNormalColor =
+        [aDecoder decodeObjectForKey:MDCTextInputControllerDefaultFloatingPlaceholderNormalColorKey];
     _floatingPlaceholderScale =
         [aDecoder decodeObjectForKey:MDCTextInputControllerDefaultFloatingPlaceholderScaleKey];
     _inlinePlaceholderColor =
@@ -259,8 +257,8 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   [aCoder encodeBool:self.expandsOnOverflow
               forKey:MDCTextInputControllerDefaultExpandsOnOverflowKey];
   [aCoder encodeBool:self.isFloatingEnabled forKey:MDCTextInputControllerDefaultFloatingEnabledKey];
-  [aCoder encodeObject:self.floatingPlaceholderColor
-                forKey:MDCTextInputControllerDefaultFloatingPlaceholderColorKey];
+  [aCoder encodeObject:self.floatingPlaceholderNormalColor
+                forKey:MDCTextInputControllerDefaultFloatingPlaceholderNormalColorKey];
   [aCoder encodeObject:self.floatingPlaceholderScale
                 forKey:MDCTextInputControllerDefaultFloatingPlaceholderScaleKey];
   [aCoder encodeObject:self.helperText forKey:MDCTextInputControllerDefaultHelperTextKey];
@@ -292,7 +290,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   copy.errorText = [self.errorText copy];
   copy.expandsOnOverflow = self.expandsOnOverflow;
   copy.floatingEnabled = self.isFloatingEnabled;
-  copy.floatingPlaceholderColor = self.floatingPlaceholderColor;
+  copy.floatingPlaceholderNormalColor = self.floatingPlaceholderNormalColor;
   copy.floatingPlaceholderScale = self.floatingPlaceholderScale;
   copy.helperText = [self.helperText copy];
   copy.inlinePlaceholderColor = self.inlinePlaceholderColor;
@@ -300,7 +298,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   copy.minimumLines = self.minimumLines;
   copy.normalColor = self.normalColor;
   copy.previousLeadingText = [self.previousLeadingText copy];
-  copy.previousPlaceholderColor = self.previousPlaceholderColor;
   copy.textInput = self.textInput;  // Just a pointer value copy
   copy.trailingUnderlineLabelTextColor = self.trailingUnderlineLabelTextColor;
   copy.underlineViewMode = self.underlineViewMode;
@@ -503,14 +500,19 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
     self.textInput.placeholderLabel.font = [[self class] placeholderFont];
   }
 
+  UIColor *placeholderColor;
   if (self.isPlaceholderUp) {
-    self.textInput.placeholderLabel.textColor =
+    UIColor *nonErrorColor = self.textInput.isEditing ? self.activeColor :
+        self.floatingPlaceholderNormalColor;
+    placeholderColor =
         (self.isDisplayingCharacterCountError || self.isDisplayingErrorText)
-            ? self.errorColor
-            : self.floatingPlaceholderColor;
+            ? self.errorColor : nonErrorColor;
   } else {
-    self.textInput.placeholderLabel.textColor = self.inlinePlaceholderColor;
+    placeholderColor = self.textInput.isEditing ? self.activeColor :
+        self.inlinePlaceholderColor;
   }
+  self.textInput.placeholderLabel.textColor = placeholderColor;
+  NSLog(@"%@", placeholderColor);
 }
 
 // Sometimes the text field is not showing the correct layout for its values (like when it's created
@@ -527,9 +529,10 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   [CATransaction begin];
   [CATransaction setDisableActions:YES];
   [self movePlaceholderToUp:isDirectionToUp];
+  [self updateLayout];
+
   [CATransaction commit];
 
-  [self updateLayout];
 
   self.textInput.hidesPlaceholderOnInput = !self.floatingEnabled;
   [self.textInput layoutIfNeeded];
@@ -579,27 +582,17 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
                                       constant:destination.x];
     self.placeholderAnimationConstraints = @[ top, leading ];
 
-    self.previousPlaceholderColor = self.textInput.placeholderLabel.textColor;
-
     animationBlock = ^{
       self.textInput.placeholderLabel.transform = floatingPlaceholderScaleTransform;
 
-      self.textInput.placeholderLabel.textColor =
-          (self.isDisplayingCharacterCountError || self.isDisplayingErrorText)
-              ? self.errorColor
-              : self.floatingPlaceholderColor;
+      [self updatePlaceholder];
       [NSLayoutConstraint activateConstraints:self.placeholderAnimationConstraints];
     };
   } else {
     animationBlock = ^{
       self.textInput.placeholderLabel.transform = CGAffineTransformIdentity;
 
-      if (self.previousPlaceholderColor) {
-        self.textInput.placeholderLabel.textColor = self.previousPlaceholderColor;
-      } else {
-        self.textInput.placeholderLabel.textColor = self.inlinePlaceholderColor;
-      }
-
+      [self updatePlaceholder];
       [NSLayoutConstraint deactivateConstraints:self.placeholderAnimationConstraints];
     };
   }
@@ -869,29 +862,29 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   }
 }
 
-- (UIColor *)floatingPlaceholderColor {
-  return _floatingPlaceholderColor ? _floatingPlaceholderColor
-                                   : [self class].floatingPlaceholderColorDefault;
+- (UIColor *)floatingPlaceholderNormalColor {
+  return _floatingPlaceholderNormalColor ? _floatingPlaceholderNormalColor
+                                   : [self class].floatingPlaceholderNormalColorDefault;
 }
 
-- (void)setFloatingPlaceholderColor:(UIColor *)floatingPlaceholderColor {
-  if (![_floatingPlaceholderColor isEqual:floatingPlaceholderColor]) {
-    _floatingPlaceholderColor = floatingPlaceholderColor;
+- (void)setFloatingPlaceholderNormalColor:(UIColor *)floatingPlaceholderNormalColor {
+  if (![_floatingPlaceholderNormalColor isEqual:floatingPlaceholderNormalColor]) {
+    _floatingPlaceholderNormalColor = floatingPlaceholderNormalColor;
     [self updatePlaceholder];
   }
 }
 
-+ (UIColor *)floatingPlaceholderColorDefault {
-  if (!_floatingPlaceholderColorDefault) {
-    _floatingPlaceholderColorDefault = MDCTextInputDefaultActiveColorDefault();
++ (UIColor *)floatingPlaceholderNormalColorDefault {
+  if (!_floatingPlaceholderNormalColorDefault) {
+    _floatingPlaceholderNormalColorDefault = [self class].inlinePlaceholderColorDefault;
   }
-  return _floatingPlaceholderColorDefault;
+  return _floatingPlaceholderNormalColorDefault;
 }
 
-+ (void)setFloatingPlaceholderColorDefault:(UIColor *)floatingPlaceholderColorDefault {
-  _floatingPlaceholderColorDefault = floatingPlaceholderColorDefault
-                                         ? floatingPlaceholderColorDefault
-                                         : MDCTextInputDefaultActiveColorDefault();
++ (void)setFloatingPlaceholderNormalColorDefault:(UIColor *)floatingPlaceholderNormalColorDefault {
+  _floatingPlaceholderNormalColorDefault = floatingPlaceholderNormalColorDefault
+                                         ? floatingPlaceholderNormalColorDefault
+                                         : [self class].inlinePlaceholderColorDefault;
 }
 
 - (void)setFloatingEnabled:(BOOL)floatingEnabled {
@@ -1044,10 +1037,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
 - (void)setPreviousLeadingText:(NSString *)previousLeadingText {
   _previousLeadingText = [previousLeadingText copy];
-}
-
-- (void)setPreviousPlaceholderColor:(UIColor *)previousPlaceholderColor {
-  _previousPlaceholderColor = previousPlaceholderColor;
 }
 
 - (void)setRoundedCorners:(UIRectCorner)roundedCorners {

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -512,7 +512,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
         self.inlinePlaceholderColor;
   }
   self.textInput.placeholderLabel.textColor = placeholderColor;
-  NSLog(@"%@", placeholderColor);
 }
 
 // Sometimes the text field is not showing the correct layout for its values (like when it's created

--- a/components/TextFields/src/MDCTextInputControllerLegacyDefault.h
+++ b/components/TextFields/src/MDCTextInputControllerLegacyDefault.h
@@ -32,16 +32,16 @@
  The color applied to the placeholder when floating. However, when in error state, it will be
  colored with the error color. Only relevent when floatingEnabled = true.
 
- Default is floatingPlaceholderColorDefault.
+ Default is floatingPlaceholderNormalColorDefault.
  */
-@property(nonatomic, null_resettable, strong) UIColor *floatingPlaceholderColor;
+@property(nonatomic, null_resettable, strong) UIColor *floatingPlaceholderNormalColor;
 
 /**
- Default value for floatingPlaceholderColor.
+ Default value for floatingPlaceholderNormalColor.
 
  Default is black with Material Design hint text opacity (textInput's tint).
  */
-@property(class, nonatomic, null_resettable, strong) UIColor *floatingPlaceholderColorDefault;
+@property(class, nonatomic, null_resettable, strong) UIColor *floatingPlaceholderNormalColorDefault;
 
 /**
  The scale of the the floating placeholder label in comparison to the inline placeholder specified

--- a/components/TextFields/src/MDCTextInputControllerLegacyDefault.h
+++ b/components/TextFields/src/MDCTextInputControllerLegacyDefault.h
@@ -30,7 +30,9 @@
 
 /**
  The color applied to the placeholder when floating. However, when in error state, it will be
- colored with the error color. Only relevent when floatingEnabled = true.
+ colored with the error color and when in active state, it will be colored with the active color.
+
+ Only relevent when floatingEnabled = true.
 
  Default is floatingPlaceholderNormalColorDefault.
  */

--- a/components/TextFields/tests/unit/TextFieldControllerClassPropertiesLegacyTests.swift
+++ b/components/TextFields/tests/unit/TextFieldControllerClassPropertiesLegacyTests.swift
@@ -35,7 +35,7 @@ class TextFieldControllerClassPropertiesLegacyTests: XCTestCase {
     MDCTextInputControllerLegacyDefault.leadingUnderlineLabelTextColorDefault = nil
     MDCTextInputControllerLegacyDefault.trailingUnderlineLabelTextColorDefault = nil
 
-    MDCTextInputControllerLegacyDefault.floatingPlaceholderColorDefault = nil
+    MDCTextInputControllerLegacyDefault.floatingPlaceholderNormalColorDefault = nil
     MDCTextInputControllerLegacyDefault.floatingPlaceholderScaleDefault = 0.75
     MDCTextInputControllerLegacyDefault.isFloatingEnabledDefault = true
 
@@ -71,8 +71,8 @@ class TextFieldControllerClassPropertiesLegacyTests: XCTestCase {
                    MDCTextInputControllerLegacyDefault.inlinePlaceholderColorDefault)
 
     // Default specific properties
-    XCTAssertEqual(MDCTextInputControllerLegacyDefault.floatingPlaceholderColorDefault,
-                   MDCPalette.blue.accent700)
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.floatingPlaceholderNormalColorDefault,
+                   UIColor(white: 0, alpha: CGFloat(Float(0.54))))
     XCTAssertEqual(Float(MDCTextInputControllerLegacyDefault.floatingPlaceholderScaleDefault), 0.75)
     XCTAssertEqual(MDCTextInputControllerLegacyDefault.isFloatingEnabledDefault, true)
 
@@ -97,8 +97,8 @@ class TextFieldControllerClassPropertiesLegacyTests: XCTestCase {
                    MDCTextInputControllerLegacyDefault.trailingUnderlineLabelTextColorDefault)
 
     // Default specific properties
-    XCTAssertEqual(controller.floatingPlaceholderColor,
-                   MDCTextInputControllerLegacyDefault.floatingPlaceholderColorDefault)
+    XCTAssertEqual(controller.floatingPlaceholderNormalColor,
+                   MDCTextInputControllerLegacyDefault.floatingPlaceholderNormalColorDefault)
     XCTAssertEqual(controller.isFloatingEnabled,
                    MDCTextInputControllerLegacyDefault.isFloatingEnabledDefault)
 
@@ -129,8 +129,8 @@ class TextFieldControllerClassPropertiesLegacyTests: XCTestCase {
     XCTAssertEqual(MDCTextInputControllerLegacyDefault.trailingUnderlineLabelTextColorDefault, .white)
 
     // Default specific properties
-    MDCTextInputControllerLegacyDefault.floatingPlaceholderColorDefault = .red
-    XCTAssertEqual(MDCTextInputControllerLegacyDefault.floatingPlaceholderColorDefault, .red)
+    MDCTextInputControllerLegacyDefault.floatingPlaceholderNormalColorDefault = .red
+    XCTAssertEqual(MDCTextInputControllerLegacyDefault.floatingPlaceholderNormalColorDefault, .red)
 
     MDCTextInputControllerLegacyDefault.floatingPlaceholderScaleDefault = 0.6
     XCTAssertEqual(Float(MDCTextInputControllerLegacyDefault.floatingPlaceholderScaleDefault), 0.6)
@@ -158,8 +158,8 @@ class TextFieldControllerClassPropertiesLegacyTests: XCTestCase {
                    MDCTextInputControllerLegacyDefault.trailingUnderlineLabelTextColorDefault)
 
     // Default specific properties
-    XCTAssertEqual(controller.floatingPlaceholderColor,
-                   MDCTextInputControllerLegacyDefault.floatingPlaceholderColorDefault)
+    XCTAssertEqual(controller.floatingPlaceholderNormalColor,
+                   MDCTextInputControllerLegacyDefault.floatingPlaceholderNormalColorDefault)
     XCTAssertEqual(controller.isFloatingEnabled,
                    MDCTextInputControllerLegacyDefault.isFloatingEnabledDefault)
   }

--- a/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
+++ b/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
@@ -37,7 +37,7 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
     MDCTextInputControllerDefault.leadingUnderlineLabelTextColorDefault = nil
     MDCTextInputControllerDefault.trailingUnderlineLabelTextColorDefault = nil
 
-    MDCTextInputControllerDefault.floatingPlaceholderColorDefault = nil
+    MDCTextInputControllerDefault.floatingPlaceholderNormalColorDefault = nil
     MDCTextInputControllerDefault.floatingPlaceholderScaleDefault = 0.75
     MDCTextInputControllerDefault.isFloatingEnabledDefault = true
 
@@ -74,8 +74,8 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
                    MDCTextInputControllerDefault.inlinePlaceholderColorDefault)
 
     // Default specific properties
-    XCTAssertEqual(MDCTextInputControllerDefault.floatingPlaceholderColorDefault,
-                   MDCPalette.blue.accent700)
+    XCTAssertEqual(MDCTextInputControllerDefault.floatingPlaceholderNormalColorDefault,
+                   UIColor(white: 0, alpha: CGFloat(Float(0.54))))
     XCTAssertEqual(Float(MDCTextInputControllerDefault.floatingPlaceholderScaleDefault), 0.75)
     XCTAssertEqual(MDCTextInputControllerDefault.isFloatingEnabledDefault, true)
     XCTAssertEqual(MDCTextInputControllerDefault.roundedCornersDefault, [])
@@ -101,8 +101,8 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
                    MDCTextInputControllerDefault.trailingUnderlineLabelTextColorDefault)
 
     // Default specific properties
-    XCTAssertEqual(controller.floatingPlaceholderColor,
-                   MDCTextInputControllerDefault.floatingPlaceholderColorDefault)
+    XCTAssertEqual(controller.floatingPlaceholderNormalColor,
+                   MDCTextInputControllerDefault.floatingPlaceholderNormalColorDefault)
     XCTAssertEqual(controller.isFloatingEnabled,
                    MDCTextInputControllerDefault.isFloatingEnabledDefault)
     XCTAssertEqual(controller.roundedCorners, MDCTextInputControllerDefault.roundedCornersDefault)
@@ -134,8 +134,8 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
     XCTAssertEqual(MDCTextInputControllerDefault.trailingUnderlineLabelTextColorDefault, .white)
 
     // Default specific properties
-    MDCTextInputControllerDefault.floatingPlaceholderColorDefault = .red
-    XCTAssertEqual(MDCTextInputControllerDefault.floatingPlaceholderColorDefault, .red)
+    MDCTextInputControllerDefault.floatingPlaceholderNormalColorDefault = .red
+    XCTAssertEqual(MDCTextInputControllerDefault.floatingPlaceholderNormalColorDefault, .red)
 
     MDCTextInputControllerDefault.floatingPlaceholderScaleDefault = 0.6
     XCTAssertEqual(Float(MDCTextInputControllerDefault.floatingPlaceholderScaleDefault), 0.6)
@@ -166,8 +166,8 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
                    MDCTextInputControllerDefault.trailingUnderlineLabelTextColorDefault)
 
     // Default specific properties
-    XCTAssertEqual(controller.floatingPlaceholderColor,
-                   MDCTextInputControllerDefault.floatingPlaceholderColorDefault)
+    XCTAssertEqual(controller.floatingPlaceholderNormalColor,
+                   MDCTextInputControllerDefault.floatingPlaceholderNormalColorDefault)
     XCTAssertEqual(controller.isFloatingEnabled,
                    MDCTextInputControllerDefault.isFloatingEnabledDefault)
     XCTAssertEqual(controller.roundedCorners, MDCTextInputControllerDefault.roundedCornersDefault)

--- a/components/TextFields/tests/unit/TextFieldControllerLegacyTests.swift
+++ b/components/TextFields/tests/unit/TextFieldControllerLegacyTests.swift
@@ -29,7 +29,7 @@ class TextFieldControllerDefaultLegacyTests: XCTestCase {
     controller.characterCountViewMode = .always
     controller.disabledColor = .orange
     controller.isFloatingEnabled = false
-    controller.floatingPlaceholderColor = .purple
+    controller.floatingPlaceholderNormalColor = .purple
     controller.floatingPlaceholderScale = 0.1
     controller.helperText = "Helper"
     controller.inlinePlaceholderColor = .green
@@ -44,7 +44,7 @@ class TextFieldControllerDefaultLegacyTests: XCTestCase {
       XCTAssertEqual(controller.characterCountViewMode, controllerCopy.characterCountViewMode)
       XCTAssertEqual(controller.disabledColor, controllerCopy.disabledColor)
       XCTAssertEqual(controller.isFloatingEnabled, controllerCopy.isFloatingEnabled)
-      XCTAssertEqual(controller.floatingPlaceholderColor, controllerCopy.floatingPlaceholderColor)
+      XCTAssertEqual(controller.floatingPlaceholderNormalColor, controllerCopy.floatingPlaceholderNormalColor)
       XCTAssertEqual(controller.floatingPlaceholderScale, controllerCopy.floatingPlaceholderScale)
       XCTAssertEqual(controller.helperText, controllerCopy.helperText)
       XCTAssertEqual(controller.inlinePlaceholderColor, controllerCopy.inlinePlaceholderColor)
@@ -288,7 +288,7 @@ class TextFieldControllerDefaultLegacyTests: XCTestCase {
     controller.characterCountViewMode = .always
     controller.disabledColor = .yellow
     controller.isFloatingEnabled = false
-    controller.floatingPlaceholderColor = .purple
+    controller.floatingPlaceholderNormalColor = .purple
     controller.floatingPlaceholderScale = 0.1
     controller.helperText = "Helper"
     controller.inlinePlaceholderColor = .green
@@ -310,8 +310,8 @@ class TextFieldControllerDefaultLegacyTests: XCTestCase {
                    unserializedController?.characterCountViewMode)
     XCTAssertEqual(controller.disabledColor, unserializedController?.disabledColor)
     XCTAssertEqual(controller.isFloatingEnabled, unserializedController?.isFloatingEnabled)
-    XCTAssertEqual(controller.floatingPlaceholderColor,
-                   unserializedController?.floatingPlaceholderColor)
+    XCTAssertEqual(controller.floatingPlaceholderNormalColor,
+                   unserializedController?.floatingPlaceholderNormalColor)
     XCTAssertEqual(controller.floatingPlaceholderScale,
                    unserializedController?.floatingPlaceholderScale)
     XCTAssertEqual(controller.helperText, unserializedController?.helperText)


### PR DESCRIPTION
Solution is to define the floating placeholder color parameter to be for 'normal' state.