### PR TITLE
Have Travis-CI test an iPhone 7 plus sim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     # The iPhone 7 Plus was chosen because it is a device with a 3x screen and also changes
     # its size category trait on rotation.
     # 10.3 was chosen a the latest generally available iOS version.
-    - DESTINATION="platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3" SDK="iphonesimulator10.3.1"
+    - DESTINATION="platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3.1" SDK="iphonesimulator10.3.1"
     # The iPhone 5 was chosen because it is a 32-bit device.
     # 8.1 was chosen because it is the earliest iOS offered here.
     - DESTINATION="platform=iOS Simulator,name=iPhone 5,OS=8.1" SDK="iphonesimulator8.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,10 @@ env:
   - LC_CTYPE=en_US.UTF-8
   - LANG=en_US.UTF-8
   matrix:
-    - DESTINATION="platform=iOS Simulator,name=iPhone 7,OS=10.3.1" SDK="iphonesimulator10.3.1"
+    # The iPhone 7 Plus was chosen because it is a device with a 3x screen and also changes
+    # its size category trait on rotation.
+    # 10.3 was chosen a the latest generally available iOS version.
+    - DESTINATION="platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3" SDK="iphonesimulator10.3.1"
     # The iPhone 5 was chosen because it is a 32-bit device.
     # 8.1 was chosen because it is the earliest iOS offered here.
     - DESTINATION="platform=iOS Simulator,name=iPhone 5,OS=8.1" SDK="iphonesimulator8.1"


### PR DESCRIPTION
Changes our travis setup from using an iPhone 7 to an iPhone 7 plus.

This adds a device with a 3x screen to our testing matrix.

Closes #1916 