### PR TITLE
[Catalog] Bottom Navigation example should use safeAreaInsets

### DIFF
--- a/components/Tabs/examples/BottomNavigationBarExample.m
+++ b/components/Tabs/examples/BottomNavigationBarExample.m
@@ -54,17 +54,35 @@
     [UIColor colorWithRed:0 green:0 blue:0.5 alpha:1]
   ];
 
+  [self.view addSubview:_bottomNavigationBar];
+
+  [self updateDisplay];
+}
+
+- (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
+
   CGRect bounds = self.view.bounds;
 
   // Place bar at bottom of view
   CGRect barFrame = CGRectZero;
   barFrame.size = [_bottomNavigationBar sizeThatFits:self.view.bounds.size];
+
+  // On the iPhone X, we need to offset 
+  if ([self.view respondsToSelector:@selector(safeAreaInsets)]) {
+    NSMethodSignature *safeAreaSignature =
+        [[UIView class] instanceMethodSignatureForSelector:@selector(safeAreaInsets)];
+    NSInvocation *safeAreaInvocation =
+        [NSInvocation invocationWithMethodSignature:safeAreaSignature];
+    [safeAreaInvocation setSelector:@selector(safeAreaInsets)];
+    [safeAreaInvocation setTarget:self.view];
+    [safeAreaInvocation invoke];
+    UIEdgeInsets safeAreaInsets;
+    [safeAreaInvocation getReturnValue:&safeAreaInsets];
+    bounds = UIEdgeInsetsInsetRect(bounds, safeAreaInsets);
+  }
   barFrame.origin.y = CGRectGetMaxY(bounds) - barFrame.size.height;
   _bottomNavigationBar.frame = barFrame;
-
-  [self.view addSubview:_bottomNavigationBar];
-
-  [self updateDisplay];
 }
 
 #pragma mark - MDCTabBarDelegate


### PR DESCRIPTION
The Bottom Navigation example for Tabs was overlapping with the Home Screen
indicator on the iPhone X. The example will now use safeAreaInsets if available
to calculate the position of the tab bar.

Closes #1975

### How it looks

**iPhone 4s/iOS 8.3**
![bottomnav-ip4s-ios8](https://user-images.githubusercontent.com/1753199/30383918-c5f695ee-98dd-11e7-97fc-b942f928be98.png)

**iPhone 5s/iOS 11**
![bottomnav-ip5s-ios11](https://user-images.githubusercontent.com/1753199/30383937-d40d4cae-98dd-11e7-91bb-0d7e5716bc8d.png)

**iPhone X**
![bottomnav-ipx](https://user-images.githubusercontent.com/1753199/30383948-db0d3d2a-98dd-11e7-90a8-5d2cd32d5579.png)
