### PR TITLE
[Tabs] TabBarViewController should respect safeAreaInsets

### DIFF
--- a/components/Tabs/src/MDCTabBarViewController.m
+++ b/components/Tabs/src/MDCTabBarViewController.m
@@ -47,7 +47,7 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
   tabBar.alignment = MDCTabBarAlignmentJustified;
   tabBar.delegate = self;
   self.tabBar = tabBar;
-  _tabBarWrapperView = [[UIView alloc] init];
+  _tabBarWrapperView = [[UIView alloc] initWithFrame:CGRectZero];
   [_tabBarWrapperView addSubview:tabBar];
   [self.view addSubview:_tabBarWrapperView];
   [self updateTabBarItems];
@@ -207,7 +207,7 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
     [super viewSafeAreaInsetsDidChange];
   }
 #endif
-  [self updateLayout];
+  [self.view setNeedsLayout];
 }
 
 - (void)updateLayout {

--- a/components/Tabs/src/MDCTabBarViewController.m
+++ b/components/Tabs/src/MDCTabBarViewController.m
@@ -202,7 +202,7 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
 
 - (void)viewSafeAreaInsetsDidChange {
   // TODO(rsmoore): Remove check when we drop Xcode 7/8 support
-#ifdef __IPHONE_11_0
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [super viewSafeAreaInsetsDidChange];
   }
@@ -220,7 +220,7 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
   CGRect tabBarFrame = CGRectMake(0, 0, tabBarWrapperFrame.size.width, tabBarWrapperHeight);
 
   // TODO(rsmoore): Remove check when we drop Xcode 7/8 support
-#ifdef __IPHONE_11_0
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     if ([self positionForBar:_tabBar] == UIBarPositionBottom) {
       tabBarWrapperHeight += self.view.safeAreaInsets.bottom;

--- a/components/Tabs/src/MDCTabBarViewController.m
+++ b/components/Tabs/src/MDCTabBarViewController.m
@@ -201,10 +201,12 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
 }
 
 - (void)viewSafeAreaInsetsDidChange {
-  // TODO(rsmoore): Remove check once our minimum target is iOS 11
+  // TODO(rsmoore): Remove check when we drop Xcode 7/8 support
+#ifdef __IPHONE_11_0
   if (@available(iOS 11.0, *)) {
     [super viewSafeAreaInsetsDidChange];
   }
+#endif
   [self updateLayout];
 }
 
@@ -217,13 +219,15 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
                                          bounds.size.width, tabBarWrapperHeight);
   CGRect tabBarFrame = CGRectMake(0, 0, tabBarWrapperFrame.size.width, tabBarWrapperHeight);
 
-  // TODO(rsmoore): Replace check when our minimum supported version is iOS 11
+  // TODO(rsmoore): Remove check when we drop Xcode 7/8 support
+#ifdef __IPHONE_11_0
   if (@available(iOS 11.0, *)) {
     if ([self positionForBar:_tabBar] == UIBarPositionBottom) {
-      UIEdgeInsets safeAreaInsets = [self.view safeAreaInsets];
-      tabBarWrapperHeight += safeAreaInsets.bottom;
+      tabBarWrapperHeight += self.view.safeAreaInsets.bottom;
     }
   }
+#endif
+
   if (!_tabBarWantsToBeHidden) {
     CGRectDivide(bounds,
                  &tabBarWrapperFrame, &currentViewFrame,


### PR DESCRIPTION
Starting with iOS 11 (primarily due to iPhone X), we need to respect the safeAreaInsets values when positioning elements directly on the edges of the screen. 

* Position the embedded MDCTabBar within the safeArea of the MDCTabBarViewController's view
* Set the backgroundColor of the MDCTabBarViewController to match the barTintColor of the MDCTabBar
* Position the MDCTabBar in `-viewWillLayoutSubviews` rather than in `-viewDidLayoutSubviews` so that subviews can be positioned relative to the MDCTabBar.
* Set `-additionalSafeAreaInsets` on any embedded child View Controllers based on [Apple's documentation for positioning content](https://developer.apple.com/documentation/uikit/uiview/positioning_content_relative_to_the_safe_area)

Closes #1977