### PR TITLE
[NavigationBar, TabBar] Hide `safeAreaInsets` from unsupported SDKs

### DIFF
--- a/components/NavigationBar/examples/NavigationBarIconsExample.m
+++ b/components/NavigationBar/examples/NavigationBarIconsExample.m
@@ -77,10 +77,13 @@
   self.navigationItem.rightBarButtonItem = trailingButtonItem;
   self.navigationItem.backBarButtonItem = backButtonItem;
 
-  if ([self.view respondsToSelector:@selector(safeAreaLayoutGuide)]) {
-    UILayoutGuide *layoutGuide = [self.view performSelector:@selector(safeAreaLayoutGuide)];
+  // TODO(rsmoore): Remove this check when we drop support for Xcode 7/8
+#ifdef __IPHONE_11_0
+  if (@available(iOS 11.0, *)) {
+    UILayoutGuide *layoutGuide = self.view.safeAreaLayoutGuide;
     [layoutGuide.topAnchor constraintEqualToAnchor:self.navigationBar.topAnchor].active = YES;
   } else {
+#endif
     [NSLayoutConstraint constraintWithItem:self.topLayoutGuide
                                  attribute:NSLayoutAttributeBottom
                                  relatedBy:NSLayoutRelationEqual
@@ -89,7 +92,9 @@
                                 multiplier:1.0
                                   constant:0]
         .active = YES;
+#ifdef __IPHONE_11_0
   }
+#endif
   NSDictionary *viewsBindings = NSDictionaryOfVariableBindings(_navigationBar);
 
   [NSLayoutConstraint

--- a/components/NavigationBar/examples/NavigationBarIconsExample.m
+++ b/components/NavigationBar/examples/NavigationBarIconsExample.m
@@ -77,13 +77,19 @@
   self.navigationItem.rightBarButtonItem = trailingButtonItem;
   self.navigationItem.backBarButtonItem = backButtonItem;
 
-  // TODO(rsmoore): Remove this check when we drop support for Xcode 7/8
+  // TODO(rsmoore): Remove this check when we drop support for iOS 8 and can use anchors
+  if ([self.topLayoutGuide respondsToSelector:@selector(bottomAnchor)]) {
+    NSLayoutYAxisAnchor *topLayoutAnchor = self.topLayoutGuide.bottomAnchor;
+    // TODO(rsmoore): Remove this check when we drop support for Xcode 7/8
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
-  if (@available(iOS 11.0, *)) {
-    UILayoutGuide *layoutGuide = self.view.safeAreaLayoutGuide;
-    [layoutGuide.topAnchor constraintEqualToAnchor:self.navigationBar.topAnchor].active = YES;
-  } else {
+    if (@available(iOS 11.0, *)) {
+      if ([self.view respondsToSelector:@selector(safeAreaLayoutGuide)]) {
+        topLayoutAnchor = self.view.safeAreaLayoutGuide.topAnchor;
+      }
+    }
 #endif
+     [topLayoutAnchor constraintEqualToAnchor:self.navigationBar.topAnchor].active = YES;
+  }  else {
     [NSLayoutConstraint constraintWithItem:self.topLayoutGuide
                                  attribute:NSLayoutAttributeBottom
                                  relatedBy:NSLayoutRelationEqual
@@ -92,11 +98,9 @@
                                 multiplier:1.0
                                   constant:0]
         .active = YES;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   }
-#endif
-  NSDictionary *viewsBindings = NSDictionaryOfVariableBindings(_navigationBar);
 
+  NSDictionary *viewsBindings = NSDictionaryOfVariableBindings(_navigationBar);
   [NSLayoutConstraint
       activateConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_navigationBar]|"
                                                                   options:0

--- a/components/NavigationBar/examples/NavigationBarIconsExample.m
+++ b/components/NavigationBar/examples/NavigationBarIconsExample.m
@@ -78,7 +78,7 @@
   self.navigationItem.backBarButtonItem = backButtonItem;
 
   // TODO(rsmoore): Remove this check when we drop support for Xcode 7/8
-#ifdef __IPHONE_11_0
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     UILayoutGuide *layoutGuide = self.view.safeAreaLayoutGuide;
     [layoutGuide.topAnchor constraintEqualToAnchor:self.navigationBar.topAnchor].active = YES;
@@ -92,7 +92,7 @@
                                 multiplier:1.0
                                   constant:0]
         .active = YES;
-#ifdef __IPHONE_11_0
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   }
 #endif
   NSDictionary *viewsBindings = NSDictionaryOfVariableBindings(_navigationBar);

--- a/components/Tabs/examples/BottomNavigationBarExample.m
+++ b/components/Tabs/examples/BottomNavigationBarExample.m
@@ -68,19 +68,12 @@
   CGRect barFrame = CGRectZero;
   barFrame.size = [_bottomNavigationBar sizeThatFits:self.view.bounds.size];
 
-  // On the iPhone X, we need to offset 
-  if ([self.view respondsToSelector:@selector(safeAreaInsets)]) {
-    NSMethodSignature *safeAreaSignature =
-        [[UIView class] instanceMethodSignatureForSelector:@selector(safeAreaInsets)];
-    NSInvocation *safeAreaInvocation =
-        [NSInvocation invocationWithMethodSignature:safeAreaSignature];
-    [safeAreaInvocation setSelector:@selector(safeAreaInsets)];
-    [safeAreaInvocation setTarget:self.view];
-    [safeAreaInvocation invoke];
-    UIEdgeInsets safeAreaInsets;
-    [safeAreaInvocation getReturnValue:&safeAreaInsets];
-    bounds = UIEdgeInsetsInsetRect(bounds, safeAreaInsets);
+  // TODO(rsmoore): Remove this check once we drop support for Xcode 7/8
+#ifdef __IPHONE_11_0
+  if (@available(iOS 11.0, *)) {
+    bounds = UIEdgeInsetsInsetRect(bounds, self.view.safeAreaInsets);
   }
+#endif
   barFrame.origin.y = CGRectGetMaxY(bounds) - barFrame.size.height;
   _bottomNavigationBar.frame = barFrame;
 }

--- a/components/Tabs/examples/BottomNavigationBarExample.m
+++ b/components/Tabs/examples/BottomNavigationBarExample.m
@@ -69,7 +69,7 @@
   barFrame.size = [_bottomNavigationBar sizeThatFits:self.view.bounds.size];
 
   // TODO(rsmoore): Remove this check once we drop support for Xcode 7/8
-#ifdef __IPHONE_11_0
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     bounds = UIEdgeInsetsInsetRect(bounds, self.view.safeAreaInsets);
   }


### PR DESCRIPTION
Xcode 7 and 8 (and iOS before 11) do not support `safeAreaInsets` and
`safeAreaLayoutGuide` selectors. Using compile-time checks to hide these
from previous SDKs and new iOS 11 runtime checks to prevent them from
being used on older iOS versions.

Related to #1975, #1866
