### PR TITLE
[NavigationBar] Use CGRect method instead of properties

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -280,15 +280,15 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 
   CGSize leadingButtonBarSize = [_leadingButtonBar sizeThatFits:self.bounds.size];
   CGRect leadingButtonBarFrame =
-      CGRectMake(0, self.bounds.origin.y, leadingButtonBarSize.width, leadingButtonBarSize.height);
-  _leadingButtonBar.frame = MDCRectFlippedForRTL(leadingButtonBarFrame, self.bounds.size.width,
+      CGRectMake(0, CGRectGetMinY(self.bounds), leadingButtonBarSize.width, leadingButtonBarSize.height);
+  _leadingButtonBar.frame = MDCRectFlippedForRTL(leadingButtonBarFrame, CGRectGetWidth(self.bounds),
                                                  self.mdc_effectiveUserInterfaceLayoutDirection);
 
   CGSize trailingButtonBarSize = [_trailingButtonBar sizeThatFits:self.bounds.size];
   CGRect trailingButtonBarFrame =
-      CGRectMake(self.bounds.size.width - trailingButtonBarSize.width, self.bounds.origin.y,
+      CGRectMake(CGRectGetWidth(self.bounds) - trailingButtonBarSize.width, CGRectGetMinY(self.bounds),
                  trailingButtonBarSize.width, trailingButtonBarSize.height);
-  _trailingButtonBar.frame = MDCRectFlippedForRTL(trailingButtonBarFrame, self.bounds.size.width,
+  _trailingButtonBar.frame = MDCRectFlippedForRTL(trailingButtonBarFrame, CGRectGetWidth(self.bounds),
                                                   self.mdc_effectiveUserInterfaceLayoutDirection);
 
   UIEdgeInsets textInsets = [self usePadInsets] ? kTextPadInsets : kTextInsets;
@@ -311,7 +311,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   titleSize.width = MDCCeil(titleSize.width);
   titleSize.height = MDCCeil(titleSize.height);
   CGRect titleFrame = CGRectMake(textFrame.origin.x, 0, titleSize.width, titleSize.height);
-  titleFrame = MDCRectFlippedForRTL(titleFrame, self.bounds.size.width,
+  titleFrame = MDCRectFlippedForRTL(titleFrame, CGRectGetWidth(self.bounds),
                                     self.mdc_effectiveUserInterfaceLayoutDirection);
   UIControlContentVerticalAlignment titleVerticalAlignment = UIControlContentVerticalAlignmentTop;
   CGRect alignedFrame = [self mdc_frameAlignedVertically:titleFrame
@@ -449,22 +449,23 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
                            alignment:(UIControlContentVerticalAlignment)alignment {
   switch (alignment) {
     case UIControlContentVerticalAlignmentBottom:
-      return CGRectMake(frame.origin.x, CGRectGetMaxY(bounds) - frame.size.height, frame.size.width,
-                        frame.size.height);
+      return CGRectMake(CGRectGetMinX(frame), CGRectGetMaxY(bounds) - CGRectGetHeight(frame),
+                        CGRectGetWidth(frame),
+                        CGRectGetHeight(frame));
 
     case UIControlContentVerticalAlignmentCenter: {
-      CGFloat centeredY = MDCFloor((bounds.size.height - frame.size.height) / 2) + bounds.origin.y;
-      return CGRectMake(frame.origin.x, centeredY, frame.size.width, frame.size.height);
+      CGFloat centeredY = MDCFloor((CGRectGetHeight(bounds) - CGRectGetHeight(frame)) / 2) + CGRectGetMinY(bounds);
+      return CGRectMake(CGRectGetMinX(frame), centeredY, CGRectGetWidth(frame), CGRectGetHeight(frame));
     }
 
     case UIControlContentVerticalAlignmentTop: {
       // The title frame is vertically centered with the back button but will stick to the top of
       // the header regardless of the header's height.
       CGFloat navigationBarCenteredY =
-          MDCFloor(([self intrinsicContentSize].height - frame.size.height) / 2);
+          MDCFloor(([self intrinsicContentSize].height - CGRectGetHeight(frame)) / 2);
       navigationBarCenteredY = MAX(0, navigationBarCenteredY);
-      return CGRectMake(frame.origin.x, navigationBarCenteredY, frame.size.width,
-                        frame.size.height);
+      return CGRectMake(CGRectGetMinX(frame), navigationBarCenteredY, CGRectGetWidth(frame),
+                        CGRectGetHeight(frame));
     }
 
     case UIControlContentVerticalAlignmentFill: {
@@ -510,12 +511,14 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
       // Place the title as close to the center, shifting it slightly in to the side with more space
       if (leftMidSpaceX >= halfFrameWidth) {
         CGFloat frameMaxX = CGRectGetMinX(rightButtonBar.frame) - titleRightInset;
-        return CGRectMake(frameMaxX - frame.size.width, frame.origin.y, frame.size.width,
-                          frame.size.height);
+        return CGRectMake(frameMaxX - CGRectGetWidth(frame), CGRectGetMinY(frame),
+                          CGRectGetWidth(frame),
+                          CGRectGetHeight(frame));
       }
       if (rightMidSpaceX >= halfFrameWidth) {
         CGFloat frameOriginX = CGRectGetMaxX(leftButtonBar.frame) + titleLeftInset;
-        return CGRectMake(frameOriginX, frame.origin.y, frame.size.width, frame.size.height);
+        return CGRectMake(frameOriginX, CGRectGetMinY(frame), CGRectGetWidth(frame),
+                          CGRectGetHeight(frame));
       }
     }
     // Intentional fall through


### PR DESCRIPTION
I opened a new PR because I accidentally changed other files on the previous branch. Use of CGRectGetHeight/Width instead of bounds/frame.size.width/height and CGRectGetMinX/Y instead of bounds/frame.origin.x/y.

Closes #1486 
