### PR TITLE
[Tabs] fix uppercase title override

### DIFF
--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -224,7 +224,7 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 }
 
 - (void)setDisplaysUppercaseTitles:(BOOL)displaysUppercaseTitles {
-  _hasDefaultAlignment = NO;
+  _hasDefaultDisplaysUppercaseTitles = NO;
   _displaysUppercaseTitlesOverride = displaysUppercaseTitles;
   [self internalSetDisplaysUppercaseTitles:[self computedDisplaysUppercaseTitles]];
 }


### PR DESCRIPTION
This PR fixes what I believe is a typo in `MDCTabBar#setDisplaysUppercaseTitles`. Currently, instead of setting `_hasDefaultDisplaysUppercaseTitles` to `NO` that method sets `_hasDefaultAlignment` to `NO`, a variable which, as far as I can tell, is unrelated. When I make the submitted change locally, tabs work as expected (namely, titles are not forced to uppercase).