### PR TITLE
[Catalog] Fix Tabs example for rotation

### DIFF
--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
@@ -268,6 +268,16 @@
   return UIStatusBarStyleLightContent;
 }
 
+- (void)viewWillTransitionToSize:(CGSize)size
+       withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+  [coordinator animateAlongsideTransition:
+      ^(__unused id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+    // Update the scrollView position so that the selected view is entirely visible
+    [self tabBar:self.tabBar didSelectItem:self.tabBar.selectedItem];
+  } completion:nil];
+  [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+}
+
 @end
 
 @implementation TabBarIconExample (CatalogByConvention)

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
@@ -268,7 +268,7 @@
   return UIStatusBarStyleLightContent;
 }
 
-- (void)viewWillTransitionToSize:(__unused CGSize)size
+- (void)viewWillTransitionToSize:(CGSize)size
        withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
   [coordinator animateAlongsideTransition:
       ^(__unused id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
@@ -268,7 +268,7 @@
   return UIStatusBarStyleLightContent;
 }
 
-- (void)viewWillTransitionToSize:(CGSize)size
+- (void)viewWillTransitionToSize:(__unused CGSize)size
        withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
   [coordinator animateAlongsideTransition:
       ^(__unused id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
@@ -224,6 +224,15 @@ extension TabBarIconSwiftExample {
   override var childViewControllerForStatusBarStyle: UIViewController? {
     return appBar.headerViewController
   }
+
+  override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    coordinator.animate(alongsideTransition: { (_) in
+      if let selectedItem = self.tabBar.selectedItem {
+        self.tabBar(self.tabBar, didSelect: selectedItem)
+      }
+    }, completion: nil)
+    super.viewWillTransition(to: size, with: coordinator)
+  }
 }
 
 // MARK: - Catalog by convention


### PR DESCRIPTION
When the last tab was selected and the scroll view was all the way to
the right, rotating the device from portrait to landscape would cause
the scroll view to reposition itself. This resulted in half of each of
the two screens being visible.

![tabs-example-rotate-before](https://user-images.githubusercontent.com/1753199/30707430-7197c3ba-9f36-11e7-9338-b97cb75cb70a.png)
