### PR TITLE
[Catalog] Safe Area fixes

### DIFF
--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -27,8 +27,10 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
 
   let spacing = CGFloat(1)
   let inset = CGFloat(16)
+  let headerMinHeight = CGFloat(48)
   let node: CBCNode
   var headerViewController: MDCFlexibleHeaderViewController
+  var titleLabel: UILabel
 
   private lazy var inkController: MDCInkTouchController = {
     let controller = MDCInkTouchController(view: self.collectionView!)
@@ -52,6 +54,8 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
 
     self.headerViewController = MDCFlexibleHeaderViewController()
 
+    self.titleLabel = UILabel()
+
     super.init(collectionViewLayout: layout)
 
     self.title = "Material Design Components"
@@ -59,7 +63,7 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
     self.addChildViewController(self.headerViewController)
 
     self.headerViewController.headerView.maximumHeight = 128
-    self.headerViewController.headerView.minimumHeight = 72
+    self.headerViewController.headerView.minimumHeight = headerMinHeight + 20
 
     self.collectionView?.register(MDCCatalogCollectionViewCell.self,
       forCellWithReuseIdentifier: "MDCCatalogCollectionViewCell")
@@ -99,7 +103,6 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
     let containerView = UIView(frame: self.headerViewController.headerView.bounds)
     containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
-    let titleLabel = UILabel()
     titleLabel.text = self.title!.uppercased()
     titleLabel.textColor = UIColor(white: 1, alpha: 1)
     if #available(iOS 9.0, *) {
@@ -146,6 +149,11 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
     self.headerViewController.didMove(toParentViewController: self)
 
     self.collectionView?.accessibilityIdentifier = "collectionView"
+#if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      self.collectionView?.contentInsetAdjustmentBehavior = .always
+    }
+#endif
   }
 
   override func viewWillAppear(_ animated: Bool) {
@@ -162,6 +170,25 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
   override var childViewControllerForStatusBarStyle: UIViewController? {
     return self.headerViewController
   }
+
+#if swift(>=3.2)
+  @available(iOS 11, *)
+  override func viewSafeAreaInsetsDidChange() {
+    self.headerViewController.headerView.minimumHeight =
+        headerMinHeight + self.view.safeAreaInsets.top
+
+    // Re-constraint the title label to account for changes in safeAreaInsets's left and right.
+    let titleInsets = UIEdgeInsets(top: 0,
+                                   left: inset + self.view.safeAreaInsets.left,
+                                   bottom: inset,
+                                   right: inset + self.view.safeAreaInsets.right)
+    titleLabel.superview!.removeConstraints(titleLabel.superview!.constraints)
+    constrainLabel(label: titleLabel,
+                   containerView: titleLabel.superview!,
+                   insets: titleInsets,
+                   height: titleLabel.bounds.height)
+  }
+#endif
 
   // MARK: UICollectionViewDataSource
 
@@ -221,9 +248,15 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
                       layout collectionViewLayout: UICollectionViewLayout,
                       sizeForItemAtIndexPath indexPath: IndexPath) -> CGSize {
     let pad = CGFloat(1)
-    var cellWidth = (self.view.frame.size.width - 3 * pad) / 2
+    var safeInsets = CGFloat(0)
+#if swift(>=3.2)
+    if #available(iOS 11, *) {
+      safeInsets = self.view.safeAreaInsets.left + self.view.safeAreaInsets.right
+    }
+#endif
+    var cellWidth = (self.view.frame.size.width - 3 * pad - safeInsets) / 2
     if self.view.frame.size.width > self.view.frame.size.height {
-      cellWidth = (self.view.frame.size.width - 4 * pad) / 3
+      cellWidth = (self.view.frame.size.width - 4 * pad - safeInsets) / 3
     }
     return CGSize(width: cellWidth, height: cellWidth * 0.825)
   }

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -52,6 +52,7 @@ class MDCNodeListViewController: CBCNodeListViewController {
   let descriptionSectionHeight = CGFloat(100)
   let additionalExamplesSectionHeight = CGFloat(50)
   let rowHeight = CGFloat(50)
+  let padding = CGFloat(20)
   var componentDescription = ""
 
   enum Section: Int {
@@ -202,16 +203,17 @@ extension MDCNodeListViewController {
 
     let label = UILabel()
     label.text = sectionNames[section]
-    label.frame =  CGRect(x: 20,
+    label.frame =  CGRect(x: 0,
                           y: 0,
-                          width: tableView.frame.size.width - 20,
+                          width: tableView.frame.size.width,
                           height: additionalExamplesSectionHeight)
     label.font = MDCTypography.body2Font()
     label.translatesAutoresizingMaskIntoConstraints = false
     sectionView.addSubview(label)
-    constrainLabel(label: label,
-                   containerView: sectionView,
-                   height: additionalExamplesSectionHeight)
+    constrainView(view: label,
+                 containerView: sectionView,
+                 height: additionalExamplesSectionHeight,
+                 top: 0)
 
     if section == 0 {
       let textView = UITextView()
@@ -232,30 +234,8 @@ extension MDCNodeListViewController {
       sectionView.frame = sectionViewFrame
       sectionView.addSubview(textView)
       let textViewHeight = ceil(MDCTypography.captionFont().lineHeight * 3)
-      // Use AutoLayout to workaround http://www.openradar.me/25505644.
-      if #available(iOS 9.0, *) {
-        NSLayoutConstraint.activate([
-          textView.leadingAnchor.constraint(equalTo: sectionView.leadingAnchor, constant: 20),
-          textView.trailingAnchor.constraint(equalTo: sectionView.trailingAnchor,
-                                             constant: -20),
-          textView.topAnchor.constraint(equalTo: sectionView.topAnchor, constant: 40),
-          textView.heightAnchor.constraint(equalToConstant: textViewHeight)
-          ])
-      } else {
-        let horizontalConstraints =
-          NSLayoutConstraint.constraints(withVisualFormat: "H:|-(20)-[textView]-(20)-|",
-                                         options: [], metrics: nil,
-                                         views: ["textView": textView])
-        let verticalConstraints =
-          NSLayoutConstraint.constraints(withVisualFormat: "V:|-(40)-[textView(==h)]",
-                                         options: [],
-                                         metrics: ["h": textViewHeight],
-                                         views: ["textView": textView])
-        sectionView.addConstraints(horizontalConstraints)
-        sectionView.addConstraints(verticalConstraints)
-      }
+      constrainView(view: textView, containerView: sectionView, height: textViewHeight, top: 40)
     }
-
     return sectionView
   }
   // swiftlint:enable function_body_length
@@ -309,42 +289,62 @@ extension MDCNodeListViewController {
   }
 
   // MARK: Private
-  func constrainLabel(label: UILabel, containerView: UIView, height: CGFloat) {
-    _ = NSLayoutConstraint(
-      item: label,
-      attribute: .leading,
-      relatedBy: .equal,
-      toItem: containerView,
-      attribute: .leading,
-      multiplier: 1.0,
-      constant: 20).isActive = true
-
-    _ = NSLayoutConstraint(
-      item: label,
-      attribute: .trailing,
-      relatedBy: .equal,
-      toItem: containerView,
-      attribute: .trailing,
-      multiplier: 1.0,
-      constant: 0).isActive = true
-
-    _ = NSLayoutConstraint(
-      item: label,
-      attribute: .top,
-      relatedBy: .equal,
-      toItem: containerView,
-      attribute: .top,
-      multiplier: 1.0,
-      constant: 0).isActive = true
-
-    _ = NSLayoutConstraint(
-      item: label,
-      attribute: .height,
-      relatedBy: .equal,
-      toItem: nil,
-      attribute: .notAnAttribute,
-      multiplier: 1.0,
-      constant: height).isActive = true
+  func constrainView(view: UIView, containerView: UIView, height: CGFloat, top: CGFloat) {
+#if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      let safeAreaLayoutGuide = containerView.safeAreaLayoutGuide;
+      NSLayoutConstraint.activate([
+        view.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor,
+                                      constant: padding),
+        view.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor,
+                                       constant: padding),
+        view.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: top),
+        view.heightAnchor.constraint(equalToConstant: height)
+      ])
+    return
+  }
+#endif
+    if #available(iOS 9.0, *) {
+      NSLayoutConstraint.activate([
+        view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: padding),
+        view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: padding),
+        view.topAnchor.constraint(equalTo: containerView.topAnchor, constant: top),
+        view.heightAnchor.constraint(equalToConstant: height)
+      ])
+    } else {
+      _ = NSLayoutConstraint(
+        item: view,
+        attribute: .leading,
+        relatedBy: .equal,
+        toItem: containerView,
+        attribute: .leading,
+        multiplier: 1.0,
+        constant: padding).isActive = true
+      _ = NSLayoutConstraint(
+        item: view,
+        attribute: .trailing,
+        relatedBy: .equal,
+        toItem: containerView,
+        attribute: .trailing,
+        multiplier: 1.0,
+        constant: padding).isActive = true
+      _ = NSLayoutConstraint(
+        item: view,
+        attribute: .top,
+        relatedBy: .equal,
+        toItem: containerView,
+        attribute: .top,
+        multiplier: 1.0,
+        constant: top).isActive = true
+      _ = NSLayoutConstraint(
+        item: view,
+        attribute: .height,
+        relatedBy: .equal,
+        toItem: nil,
+        attribute: .notAnAttribute,
+        multiplier: 1.0,
+        constant: height).isActive = true
+    }
   }
 }
 


### PR DESCRIPTION
One-off fixes in MDCNodeListViewController and MDCCatalogComponentsController.
Closes #2020

The swift(>=3.2) check is for older versions of XCode that otherwise wouldn't compile.

![simulator screen shot - iphone x - 2017-09-21 at 18 07 18](https://user-images.githubusercontent.com/4545451/30721091-544c34be-9ef8-11e7-8df5-8c94ab23d19d.png)

![simulator screen shot - iphone x - 2017-09-21 at 18 07 24](https://user-images.githubusercontent.com/4545451/30721095-581d1e5a-9ef8-11e7-9268-5b8635908965.png)
