### PR TITLE
[Math] Round CGPoint and align UIView centers

### DIFF
--- a/components/private/Math/src/MDCMath.h
+++ b/components/private/Math/src/MDCMath.h
@@ -125,3 +125,35 @@ static inline CGRect MDCRectAlignToScale(CGRect rect, CGFloat scale) {
                     MDCCeil((CGRectGetWidth(rect) + adjustWidthHeight.width) * scale) / scale,
                     MDCCeil((CGRectGetHeight(rect) + adjustWidthHeight.height) * scale) / scale);
 }
+
+static inline CGPoint MDCPointAlignToScale(CGPoint point, CGFloat scale) {
+  if (MDCCGFloatEqual(scale, 0)) {
+    return CGPointZero;
+  }
+
+  return CGPointMake(MDCRound(point.x * scale) / scale, MDCRound(point.y * scale) / scale);
+}
+
+/**
+ Align the centerPoint of a view so that its origin is pixel-aligned. Returns @c CGRectZero if
+ @c scale is zero or @c bounds is @c CGRectNull.
+
+ @param center the unaligned center of the view.
+ @param bounds the bounds of the view.
+ @param scale the native scaling factor for pixel alignment.
+
+ @return the center point of the view such that its origin will be pixel-aligned.
+ */
+static inline CGPoint MDCAlignCenterWithBoundsAndScale(CGPoint center,
+                                                       CGRect bounds,
+                                                       CGFloat scale) {
+  if (MDCCGFloatEqual(scale, 0) || CGRectIsNull(bounds)) {
+    return CGPointZero;
+  }
+
+  CGFloat halfWidth = CGRectGetWidth(bounds) / 2;
+  CGFloat halfHeight = CGRectGetHeight(bounds) / 2;
+  CGPoint origin = CGPointMake(center.x - halfWidth, center.y - halfHeight);
+  origin = MDCPointAlignToScale(origin, scale);
+  return CGPointMake(origin.x + halfWidth, origin.y + halfHeight);
+}

--- a/components/private/Math/src/MDCMath.h
+++ b/components/private/Math/src/MDCMath.h
@@ -126,7 +126,7 @@ static inline CGRect MDCRectAlignToScale(CGRect rect, CGFloat scale) {
                     MDCCeil((CGRectGetHeight(rect) + adjustWidthHeight.height) * scale) / scale);
 }
 
-static inline CGPoint MDCPointAlignToScale(CGPoint point, CGFloat scale) {
+static inline CGPoint MDCPointRoundWithScale(CGPoint point, CGFloat scale) {
   if (MDCCGFloatEqual(scale, 0)) {
     return CGPointZero;
   }
@@ -144,7 +144,7 @@ static inline CGPoint MDCPointAlignToScale(CGPoint point, CGFloat scale) {
 
  @return the center point of the view such that its origin will be pixel-aligned.
  */
-static inline CGPoint MDCAlignCenterWithBoundsAndScale(CGPoint center,
+static inline CGPoint MDCRoundCenterWithBoundsAndScale(CGPoint center,
                                                        CGRect bounds,
                                                        CGFloat scale) {
   if (MDCCGFloatEqual(scale, 0) || CGRectIsNull(bounds)) {
@@ -154,6 +154,6 @@ static inline CGPoint MDCAlignCenterWithBoundsAndScale(CGPoint center,
   CGFloat halfWidth = CGRectGetWidth(bounds) / 2;
   CGFloat halfHeight = CGRectGetHeight(bounds) / 2;
   CGPoint origin = CGPointMake(center.x - halfWidth, center.y - halfHeight);
-  origin = MDCPointAlignToScale(origin, scale);
+  origin = MDCPointRoundWithScale(origin, scale);
   return CGPointMake(origin.x + halfWidth, origin.y + halfHeight);
 }

--- a/components/private/Math/src/MDCMath.h
+++ b/components/private/Math/src/MDCMath.h
@@ -135,8 +135,8 @@ static inline CGPoint MDCPointRoundWithScale(CGPoint point, CGFloat scale) {
 }
 
 /**
- Align the centerPoint of a view so that its origin is pixel-aligned. Returns @c CGRectZero if
- @c scale is zero or @c bounds is @c CGRectNull.
+ Align the centerPoint of a view so that its origin is pixel-aligned to the nearest pixel.
+ Returns @c CGRectZero if @c scale is zero or @c bounds is @c CGRectNull.
 
  @param center the unaligned center of the view.
  @param bounds the bounds of the view.

--- a/components/private/Math/tests/unit/MDCMathTests.m
+++ b/components/private/Math/tests/unit/MDCMathTests.m
@@ -141,7 +141,7 @@
 
 #pragma mark - MDCPoint
 
-- (void)testMDCPointAlignScale {
+- (void)testMDCPointRoundWithScale {
   // Given
   CGPoint misalignedPoint = CGPointMake(0.7, -1.3);
   CGPoint alignedScale1Point = CGPointMake(1.0, -1.0);
@@ -149,19 +149,22 @@
   CGPoint alignedScale3Point = CGPointMake((CGFloat)(2.0 / 3.0), (CGFloat)(-4.0 / 3.0));
 
   // Then
-  XCTAssertTrue(CGPointEqualToPoint(alignedScale1Point, MDCPointAlignToScale(misalignedPoint, 1)));
-  XCTAssertTrue(CGPointEqualToPoint(alignedScale2Point, MDCPointAlignToScale(misalignedPoint, 2)));
-  XCTAssertTrue(CGPointEqualToPoint(alignedScale3Point, MDCPointAlignToScale(misalignedPoint, 3)));
+  XCTAssertTrue(CGPointEqualToPoint(alignedScale1Point,
+                                    MDCPointRoundWithScale(misalignedPoint, 1)));
+  XCTAssertTrue(CGPointEqualToPoint(alignedScale2Point,
+                                    MDCPointRoundWithScale(misalignedPoint, 2)));
+  XCTAssertTrue(CGPointEqualToPoint(alignedScale3Point,
+                                    MDCPointRoundWithScale(misalignedPoint, 3)));
 }
 
-- (void)testMDCPointAlignScaleZeroScale {
+- (void)testMDCPointRoundScaleZeroScale {
   // Then
-  XCTAssertTrue(CGPointEqualToPoint(CGPointZero, MDCPointAlignToScale(CGPointMake(5.5, 13), 0)));
+  XCTAssertTrue(CGPointEqualToPoint(CGPointZero, MDCPointRoundWithScale(CGPointMake(5.5, 13), 0)));
 }
 
 #pragma mark - MDCCenter
 
-- (void)testMDCAlignCenterWithBoundsAndScale {
+- (void)testMDCRoundCenterWithBoundsAndScale {
   // Given
   CGPoint misalignedCenter = CGPointMake(0.7, -1.3);
   CGRect bounds = CGRectMake(0, 0, 20, 21);
@@ -170,29 +173,56 @@
   CGPoint alignedScale3Center = CGPointMake((CGFloat)(2.0 / 3.0), (CGFloat)(-7.0 / 6.0));
 
   // Then
-  CGPoint outputScale1Center = MDCAlignCenterWithBoundsAndScale(misalignedCenter, bounds, 1);
+  CGPoint outputScale1Center = MDCRoundCenterWithBoundsAndScale(misalignedCenter, bounds, 1);
   XCTAssertTrue(MDCCGFloatEqual(alignedScale1Center.x, outputScale1Center.x));
   XCTAssertTrue(MDCCGFloatEqual(alignedScale1Center.y, outputScale1Center.y));
-  CGPoint outputScale2Center = MDCAlignCenterWithBoundsAndScale(misalignedCenter, bounds, 2);
+  CGPoint outputScale2Center = MDCRoundCenterWithBoundsAndScale(misalignedCenter, bounds, 2);
   XCTAssertTrue(MDCCGFloatEqual(alignedScale2Center.x, outputScale2Center.x));
   XCTAssertTrue(MDCCGFloatEqual(alignedScale2Center.y, outputScale2Center.y));
-  CGPoint outputScale3Center = MDCAlignCenterWithBoundsAndScale(misalignedCenter, bounds, 3);
+  CGPoint outputScale3Center = MDCRoundCenterWithBoundsAndScale(misalignedCenter, bounds, 3);
   XCTAssertTrue(MDCCGFloatEqual(alignedScale3Center.x, outputScale3Center.x));
   XCTAssertTrue(MDCCGFloatEqual(alignedScale3Center.y, outputScale3Center.y));
 }
 
-- (void)testMDCAlignCenterWithBoundsAndScaleZero {
+- (void)testMDCRoundCenterWithBoundsAndScaleRoundingErrors {
+  // Given
+#if CGFLOAT_IS_DOUBLE
+  const CGFloat acceptableRoundingError = 5E-15;
+#else
+  const CGFloat acceptableRoundingError = 5E-7f;
+#endif
+  CGPoint misalignedCenter = CGPointMake(0.3, 9.99);
+  CGRect bounds = CGRectMake(0, 0, 20.1, 21.9);
+  CGPoint alignedScale1Center = CGPointMake((CGFloat)0.05, (CGFloat)9.95);
+  CGPoint alignedScale2Center = CGPointMake((CGFloat)0.05, (CGFloat)9.95);
+  CGPoint alignedScale3Center = CGPointMake((CGFloat)(0.05 + 1.0 / 3.0), (CGFloat)(9.95));
+
+  // Then
+  CGPoint outputScale1Center = MDCRoundCenterWithBoundsAndScale(misalignedCenter, bounds, 1);
+  XCTAssertLessThan(MDCFabs(alignedScale1Center.x - outputScale1Center.x), acceptableRoundingError);
+  XCTAssertLessThan(MDCFabs(alignedScale1Center.y - outputScale1Center.y), acceptableRoundingError);
+
+  CGPoint outputScale2Center = MDCRoundCenterWithBoundsAndScale(misalignedCenter, bounds, 2);
+  XCTAssertLessThan(MDCFabs(alignedScale2Center.x - outputScale2Center.x), acceptableRoundingError);
+  XCTAssertLessThan(MDCFabs(alignedScale2Center.y - outputScale2Center.y), acceptableRoundingError);
+
+  CGPoint outputScale3Center = MDCRoundCenterWithBoundsAndScale(misalignedCenter, bounds, 3);
+  XCTAssertLessThan(MDCFabs(alignedScale3Center.x - outputScale3Center.x), acceptableRoundingError);
+  XCTAssertLessThan(MDCFabs(alignedScale3Center.y - outputScale3Center.y), acceptableRoundingError);
+}
+
+- (void)testMDCRoundCenterWithBoundsAndScaleZero {
   // Then
   XCTAssertTrue(CGPointEqualToPoint(CGPointZero,
-                                    MDCAlignCenterWithBoundsAndScale(CGPointMake(-5, 10),
+                                    MDCRoundCenterWithBoundsAndScale(CGPointMake(-5, 10),
                                                                      CGRectMake(0, 0, 20, 20),
                                                                      0)));
 }
 
-- (void)testMDCAlignCenterWithBoundsAndScaleNullBounds {
+- (void)testMDCRoundCenterWithBoundsAndScaleNullBounds {
   // Then
   XCTAssertTrue(CGPointEqualToPoint(CGPointZero,
-                                    MDCAlignCenterWithBoundsAndScale(CGPointMake(1, 2),
+                                    MDCRoundCenterWithBoundsAndScale(CGPointMake(1, 2),
                                                                      CGRectNull,
                                                                      1)));
 }

--- a/components/private/Math/tests/unit/MDCMathTests.m
+++ b/components/private/Math/tests/unit/MDCMathTests.m
@@ -23,6 +23,8 @@
 
 @implementation MDCMathTests
 
+#pragma mark - MDCRect
+
 /**
  Basic test for alignment.
  */
@@ -135,6 +137,64 @@
 - (void)testMDCRectAlignScaleZeroScale {
   // Then
   XCTAssertTrue(CGRectIsNull(MDCRectAlignToScale(CGRectZero, 0)));
+}
+
+#pragma mark - MDCPoint
+
+- (void)testMDCPointAlignScale {
+  // Given
+  CGPoint misalignedPoint = CGPointMake(0.7, -1.3);
+  CGPoint alignedScale1Point = CGPointMake(1.0, -1.0);
+  CGPoint alignedScale2Point = CGPointMake(0.5, -1.5);
+  CGPoint alignedScale3Point = CGPointMake((CGFloat)(2.0 / 3.0), (CGFloat)(-4.0 / 3.0));
+
+  // Then
+  XCTAssertTrue(CGPointEqualToPoint(alignedScale1Point, MDCPointAlignToScale(misalignedPoint, 1)));
+  XCTAssertTrue(CGPointEqualToPoint(alignedScale2Point, MDCPointAlignToScale(misalignedPoint, 2)));
+  XCTAssertTrue(CGPointEqualToPoint(alignedScale3Point, MDCPointAlignToScale(misalignedPoint, 3)));
+}
+
+- (void)testMDCPointAlignScaleZeroScale {
+  // Then
+  XCTAssertTrue(CGPointEqualToPoint(CGPointZero, MDCPointAlignToScale(CGPointMake(5.5, 13), 0)));
+}
+
+#pragma mark - MDCCenter
+
+- (void)testMDCAlignCenterWithBoundsAndScale {
+  // Given
+  CGPoint misalignedCenter = CGPointMake(0.7, -1.3);
+  CGRect bounds = CGRectMake(0, 0, 20, 21);
+  CGPoint alignedScale1Center = CGPointMake(1, -1.5);
+  CGPoint alignedScale2Center = CGPointMake(0.5, -1.5);
+  CGPoint alignedScale3Center = CGPointMake((CGFloat)(2.0 / 3.0), (CGFloat)(-7.0 / 6.0));
+
+  // Then
+  CGPoint outputScale1Center = MDCAlignCenterWithBoundsAndScale(misalignedCenter, bounds, 1);
+  XCTAssertTrue(MDCCGFloatEqual(alignedScale1Center.x, outputScale1Center.x));
+  XCTAssertTrue(MDCCGFloatEqual(alignedScale1Center.y, outputScale1Center.y));
+  CGPoint outputScale2Center = MDCAlignCenterWithBoundsAndScale(misalignedCenter, bounds, 2);
+  XCTAssertTrue(MDCCGFloatEqual(alignedScale2Center.x, outputScale2Center.x));
+  XCTAssertTrue(MDCCGFloatEqual(alignedScale2Center.y, outputScale2Center.y));
+  CGPoint outputScale3Center = MDCAlignCenterWithBoundsAndScale(misalignedCenter, bounds, 3);
+  XCTAssertTrue(MDCCGFloatEqual(alignedScale3Center.x, outputScale3Center.x));
+  XCTAssertTrue(MDCCGFloatEqual(alignedScale3Center.y, outputScale3Center.y));
+}
+
+- (void)testMDCAlignCenterWithBoundsAndScaleZero {
+  // Then
+  XCTAssertTrue(CGPointEqualToPoint(CGPointZero,
+                                    MDCAlignCenterWithBoundsAndScale(CGPointMake(-5, 10),
+                                                                     CGRectMake(0, 0, 20, 20),
+                                                                     0)));
+}
+
+- (void)testMDCAlignCenterWithBoundsAndScaleNullBounds {
+  // Then
+  XCTAssertTrue(CGPointEqualToPoint(CGPointZero,
+                                    MDCAlignCenterWithBoundsAndScale(CGPointMake(1, 2),
+                                                                     CGRectNull,
+                                                                     1)));
 }
 
 @end


### PR DESCRIPTION
Although it is possible to currently align a CGRect (frame) to a
pixel-aligned bounding rectangle, in some cases manipulating the frame
is neither possible nor desirable (such as when the transform is not the
identity).  Adding two new methods to support rounding a CGPoint to a
pixel and aligning the center point of a UIVIew given its bounds.
