### PR TITLE
[NavigationBar] Pixel-align title

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -317,8 +317,13 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   CGRect alignedFrame = [self mdc_frameAlignedVertically:titleFrame
                                             withinBounds:textFrame
                                                alignment:titleVerticalAlignment];
-  _titleLabel.frame =
-      [self mdc_frameAlignedHorizontally:alignedFrame alignment:self.titleAlignment];
+  alignedFrame = [self mdc_frameAlignedHorizontally:alignedFrame alignment:self.titleAlignment];
+  CGFloat scale = self.window.screen.scale;
+  if (!MDCCGFloatEqual(0, scale)) {
+    alignedFrame = MDCRectAlignToScale(alignedFrame, scale);
+  }
+
+  _titleLabel.frame = alignedFrame;
   self.titleView.frame = textFrame;
 
   // Button and title label alignment

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -318,12 +318,8 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
                                             withinBounds:textFrame
                                                alignment:titleVerticalAlignment];
   alignedFrame = [self mdc_frameAlignedHorizontally:alignedFrame alignment:self.titleAlignment];
-  CGFloat scale = self.window.screen.scale;
-  if (!MDCCGFloatEqual(0, scale)) {
-    alignedFrame = MDCRectAlignToScale(alignedFrame, scale);
-  }
 
-  _titleLabel.frame = alignedFrame;
+  _titleLabel.frame = MDCRectAlignToScale(alignedFrame, self.window.screen.scale);
   self.titleView.frame = textFrame;
 
   // Button and title label alignment


### PR DESCRIPTION
On 3x devices, centering the Title label was not aligning the origin to
pixels, resulting in blurry text.

### Misaligned
![navbar-title-misaligned](https://user-images.githubusercontent.com/1753199/30869322-c63f5052-a31b-11e7-9f51-4b1777947463.png)


### Aligned
![navbar-title-aligned](https://user-images.githubusercontent.com/1753199/30869329-ca184d8c-a31b-11e7-94a2-5dd794793a7f.png)


Closes #2039
