### PR TITLE
[Math] MDCRectAlignToScale treats scale 0 as 1

### DIFF
--- a/components/private/Math/src/MDCMath.h
+++ b/components/private/Math/src/MDCMath.h
@@ -105,13 +105,23 @@ static inline CGFloat MDCSqrt(CGFloat value) {
 
 /**
  Expand `rect' to the smallest standardized rect containing it with pixel-aligned origin and size.
+ If @c scale is zero, then a scale of 1 will be used instead.
+
+ @param rect the rectangle to align.
+ @param scale the scale factor to use for pixel alignment.
+
+ @return the input rectangle aligned to the nearest pixels using the provided scale factor.
 
  @see CGRectIntegral
  */
 static inline CGRect MDCRectAlignToScale(CGRect rect, CGFloat scale) {
-  if (CGRectIsNull(rect) || MDCCGFloatEqual(scale, 0)) {
+  if (CGRectIsNull(rect)) {
     return CGRectNull;
   }
+  if (MDCCGFloatEqual(scale, 0)) {
+    scale = 1;
+  }
+
   if (MDCCGFloatEqual(scale, 1)) {
     return CGRectIntegral(rect);
   }

--- a/components/private/Math/tests/unit/MDCMathTests.m
+++ b/components/private/Math/tests/unit/MDCMathTests.m
@@ -132,11 +132,15 @@
 }
 
 /**
- Test that a scale value of zero returns CGRectNull.
+ Test that a scale value of zero returns the same as a scale of 1.
  */
 - (void)testMDCRectAlignScaleZeroScale {
+  // Given
+  CGRect rectangle = CGRectMake(1.1, 2.2, 3.3, 4.4);
+
   // Then
-  XCTAssertTrue(CGRectIsNull(MDCRectAlignToScale(CGRectZero, 0)));
+  XCTAssertTrue(CGRectEqualToRect(MDCRectAlignToScale(rectangle, 0),
+                                  MDCRectAlignToScale(rectangle, 1)));
 }
 
 #pragma mark - MDCPoint


### PR DESCRIPTION
Rather than potentially returning a CGRectNull and causing UIKit crashes
if it's assigned to a view's frame or bounds, treat a scale of 0 as a
scale of 1.  

Closes #2044
