### PR TITLE
[Catalog] Fix button examples

### DIFF
--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -70,7 +70,7 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
 
     view.addSubview(containerView)
 
-    let viewLayoutGuide : Any = {
+    let viewLayoutGuide: Any = {
 #if swift(>=3.2)
     if #available(iOS 11.0, *) {
       return view.safeAreaLayoutGuide

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -70,32 +70,41 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
 
     view.addSubview(containerView)
 
+    let viewLayoutGuide : Any = {
+#if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      return view.safeAreaLayoutGuide
+    }
+#endif
+      return view
+    }()
+
     NSLayoutConstraint.activate([
       NSLayoutConstraint(item: containerView,
                          attribute: .leading,
                          relatedBy: .equal,
-                         toItem: view,
+                         toItem: viewLayoutGuide,
                          attribute: .leading,
                          multiplier: 1.0,
                          constant: 0),
       NSLayoutConstraint(item: containerView,
                          attribute: .top,
                          relatedBy: .equal,
-                         toItem: view,
+                         toItem: viewLayoutGuide,
                          attribute: .top,
                          multiplier: 1.0,
                          constant: 0),
       NSLayoutConstraint(item: containerView,
                          attribute: .bottom,
                          relatedBy: .equal,
-                         toItem: view,
+                         toItem: viewLayoutGuide,
                          attribute: .bottom,
                          multiplier: 1.0,
                          constant: 0),
       NSLayoutConstraint(item: containerView,
                          attribute: .width,
                          relatedBy: .equal,
-                         toItem: view,
+                         toItem: viewLayoutGuide,
                          attribute: .width,
                          multiplier: 0.5,
                          constant: 0)

--- a/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
+++ b/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
@@ -120,7 +120,10 @@
   for (NSInteger i = range.location; i < NSMaxRange(range); i++) {
     MDCButton *button = self.buttons[i];
     UILabel *label = self.labels[i];
-    button.center = CGPointMake(button.center.x, button.center.y + verticalCenterY);
+    button.center = MDCRoundCenterWithBoundsAndScale(CGPointMake(button.center.x,
+                                                                 button.center.y + verticalCenterY),
+                                                     button.bounds,
+                                                     self.view.window.screen.scale);
 
     CGFloat labelWidth = CGRectGetWidth(label.bounds);
     CGFloat labelHeight = CGRectGetHeight(label.bounds);


### PR DESCRIPTION
The FAB in Typical Use was misaligned, resulting in a blurry image. The
Storyboard and Swift example had misaligned buttons due to
safeAreaInsets on iOS 11.

### FAB Before
<img width="108" alt="fab-misaligned" src="https://user-images.githubusercontent.com/1753199/30876497-ca16990e-a331-11e7-8e6a-19d3efa5b314.png">


### FAB After
<img width="102" alt="fab-aligned" src="https://user-images.githubusercontent.com/1753199/30876494-c868d1c6-a331-11e7-8894-ebbc316237a7.png">


### Buttons Storyboard and Swift example
![misaligned-buttons](https://user-images.githubusercontent.com/1753199/30876338-4e538f48-a331-11e7-924d-9bee56955cd9.png)

