### PR TITLE
[Swiftlint][Buttons] Cleans up ButtonsStoryboardAndProgrammatic.swift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9
+osx_image: xcode8.3
 sudo: false
 
 # Only do a shallow clone of our Git repo.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.3
+osx_image: xcode9
 sudo: false
 
 # Only do a shallow clone of our Git repo.

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -18,19 +18,6 @@ import Foundation
 import MaterialComponents
 
 class ButtonsSwiftAndStoryboardController: UIViewController {
-
-  class func catalogBreadcrumbs() -> [String] {
-    return ["Buttons", "Buttons (Swift and Storyboard)"]
-  }
-
-  class func catalogStoryboardName() -> String {
-    return "ButtonsStoryboardAndProgrammatic"
-  }
-
-  class func catalogIsPrimaryDemo() -> Bool {
-    return false
-  }
-
   let raisedButton = MDCRaisedButton()
   let flatButton = MDCFlatButton()
   let floatingButton = MDCFloatingButton()
@@ -123,6 +110,18 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
     let titleColor = UIColor.white
     let backgroundColor = UIColor(white: 0.1, alpha: 1.0)
 
+    programmaticButtonSetup()
+
+    let storyboardPlusShapeLayer =
+      ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton)
+    storyboardFloating.layer.addSublayer(storyboardPlusShapeLayer)
+
+    addConstraintsToButtons()
+   
+  }
+  // swiftlint:enable function_body_length
+   
+  private func programmaticButtonSetup() {
     raisedButton.setTitle("Programmatic", for: .normal)
     raisedButton.setTitleColor(titleColor, for: .normal)
     raisedButton.backgroundColor = backgroundColor
@@ -130,33 +129,31 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
     raisedButton.translatesAutoresizingMaskIntoConstraints = false
     raisedButton.addTarget(self, action: #selector(tap), for: .touchUpInside)
     innerContainerView.addSubview(raisedButton)
-
+      
     flatButton.setTitleColor(.gray, for: .normal)
     flatButton.setTitle("Programmatic", for: .normal)
     flatButton.sizeToFit()
     flatButton.translatesAutoresizingMaskIntoConstraints = false
     flatButton.addTarget(self, action: #selector(tap), for: .touchUpInside)
     innerContainerView.addSubview(flatButton)
-
+      
     floatingButton.sizeToFit()
     floatingButton.backgroundColor = backgroundColor
     floatingButton.translatesAutoresizingMaskIntoConstraints = false
     floatingButton.addTarget(self, action: #selector(tap), for: .touchUpInside)
-
+      
     let floatingPlusShapeLayer = ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton)
     floatingButton.layer.addSublayer(floatingPlusShapeLayer)
     innerContainerView.addSubview(floatingButton)
-
-    let storyboardPlusShapeLayer =
-      ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton)
-    storyboardFloating.layer.addSublayer(storyboardPlusShapeLayer)
-
+  }
+   
+  private func addConstraintsToButtons() {
     let views = [
       "raised": raisedButton,
       "flat": flatButton,
       "floating": floatingButton
     ]
-
+   
     view.addConstraint(NSLayoutConstraint(
       item: raisedButton,
       attribute: .leading,
@@ -165,7 +162,7 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
       attribute: .leading,
       multiplier: 1.0,
       constant: 0))
-
+   
     view.addConstraint(NSLayoutConstraint(
       item: raisedButton,
       attribute: .trailing,
@@ -174,7 +171,7 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
       attribute: .trailing,
       multiplier: 1.0,
       constant: 0))
-
+   
     view.addConstraint(NSLayoutConstraint(
       item: raisedButton,
       attribute: .top,
@@ -183,17 +180,30 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
       attribute: .top,
       multiplier: 1.0,
       constant: 0))
-
+   
     view.addConstraints(
       NSLayoutConstraint.constraints(withVisualFormat: "V:|[raised]-22-[flat]-22-[floating]|",
-        options: .alignAllCenterX,
-        metrics: nil,
-        views: views))
+                                     options: .alignAllCenterX,
+                                     metrics: nil,
+                                     views: views))
   }
-  // swiftlint:enable function_body_length
 
   @IBAction func tap(_ sender: Any) {
     print("\(type(of: sender)) was tapped.")
   }
 
+}
+
+extension ButtonsSwiftAndStoryboardController {
+   class func catalogBreadcrumbs() -> [String] {
+      return ["Buttons", "Buttons (Swift and Storyboard)"]
+   }
+   
+   class func catalogStoryboardName() -> String {
+      return "ButtonsStoryboardAndProgrammatic"
+   }
+   
+   class func catalogIsPrimaryDemo() -> Bool {
+      return false
+   }
 }

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -117,7 +117,6 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
     storyboardFloating.layer.addSublayer(storyboardPlusShapeLayer)
 
     addConstraintsToButtons()
-   
   }
   // swiftlint:enable function_body_length
    

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -75,9 +75,6 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
                          constant: 0)
       ])
 
-    let titleColor = UIColor.white
-    let backgroundColor = UIColor(white: 0.1, alpha: 1.0)
-
     programmaticButtonSetup()
 
     let storyboardPlusShapeLayer =
@@ -123,6 +120,9 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
   }
    
   private func programmaticButtonSetup() {
+    let titleColor = UIColor.white
+    let backgroundColor = UIColor(white: 0.1, alpha: 1.0)
+   
     raisedButton.setTitle("Programmatic", for: .normal)
     raisedButton.setTitleColor(titleColor, for: .normal)
     raisedButton.backgroundColor = backgroundColor

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -51,12 +51,43 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
     super.init(coder: aDecoder)
   }
 
-  // swiftlint:disable function_body_length
   override func viewDidLoad() {
     super.viewDidLoad()
 
     view.addSubview(containerView)
 
+    containersSetup()
+   
+    NSLayoutConstraint.activate([
+      NSLayoutConstraint(item: innerContainerView,
+                         attribute: .centerX,
+                         relatedBy: .equal,
+                         toItem: containerView,
+                         attribute: .centerX,
+                         multiplier: 1.0,
+                         constant: 0),
+      NSLayoutConstraint(item: innerContainerView,
+                         attribute: .centerY,
+                         relatedBy: .equal,
+                         toItem: containerView,
+                         attribute: .centerY,
+                         multiplier: 1.0,
+                         constant: 0)
+      ])
+
+    let titleColor = UIColor.white
+    let backgroundColor = UIColor(white: 0.1, alpha: 1.0)
+
+    programmaticButtonSetup()
+
+    let storyboardPlusShapeLayer =
+      ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton)
+    storyboardFloating.layer.addSublayer(storyboardPlusShapeLayer)
+
+    addConstraintsToButtons()
+  }
+
+  private func containersSetup() {
     NSLayoutConstraint.activate([
       NSLayoutConstraint(item: containerView,
                          attribute: .leading,
@@ -86,39 +117,10 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
                          attribute: .width,
                          multiplier: 0.5,
                          constant: 0)
-    ])
-
+      ])
+   
     containerView.addSubview(innerContainerView)
-
-    NSLayoutConstraint.activate([
-      NSLayoutConstraint(item: innerContainerView,
-                         attribute: .centerX,
-                         relatedBy: .equal,
-                         toItem: containerView,
-                         attribute: .centerX,
-                         multiplier: 1.0,
-                         constant: 0),
-      NSLayoutConstraint(item: innerContainerView,
-                         attribute: .centerY,
-                         relatedBy: .equal,
-                         toItem: containerView,
-                         attribute: .centerY,
-                         multiplier: 1.0,
-                         constant: 0)
-    ])
-
-    let titleColor = UIColor.white
-    let backgroundColor = UIColor(white: 0.1, alpha: 1.0)
-
-    programmaticButtonSetup()
-
-    let storyboardPlusShapeLayer =
-      ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton)
-    storyboardFloating.layer.addSublayer(storyboardPlusShapeLayer)
-
-    addConstraintsToButtons()
   }
-  // swiftlint:enable function_body_length
    
   private func programmaticButtonSetup() {
     raisedButton.setTitle("Programmatic", for: .normal)


### PR DESCRIPTION
Pulls the catalog functions into an extension and the button setup and constraints into their own functions. This makes it so that Swiftlint we no longer throw an error if we enable it for viewDidLoad.  
The constraints are in two separate functions because if they are all in one then we have to disable swiftlint. We can put two variables on each line to fix this problem for all of the constraints that we create.

This closes #2048 
