### PR TITLE
[Activity Indicator] Resolve issues caused by restarting activity indicator quickly

### DIFF
--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -206,6 +206,9 @@ static const CGFloat kSingleCycleRotation =
 
 - (void)startAnimating {
   if (_animatingOut) {
+    if ([_delegate respondsToSelector:@selector(activityIndicatorAnimationDidFinish:)]) {
+      [_delegate activityIndicatorAnimationDidFinish:self];
+    }
     [self removeAnimations];
   }
 
@@ -780,6 +783,11 @@ static const CGFloat kSingleCycleRotation =
   _animatingOut = NO;
   [_strokeLayer removeAllAnimations];
   [_outerRotationLayer removeAllAnimations];
+
+  // Reset current and latest progress, to ensure addProgressAnimationIfRequired adds a progress animation
+  // when returning from hidden.
+  _currentProgress = 0;
+  _lastProgress = 0;
 
   // Reset cycle count to 0 rather than cycleStart to reflect default starting position (top).
   _cycleCount = 0;


### PR DESCRIPTION
Ensure MDCActivityIndicator reports to its delegate when stopAnimating is called, even if startAnimating is called again immediately. Additionally, ensure that when stopAnimating is called on a determinate activity indicator and then startAnimating is called immediately afterwards, that the indicator successfully animates in.  