### PR TITLE
[FlexibleHeader] Fixes to support scroll views with Safe Area insets.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -73,6 +73,7 @@ Pod::Spec.new do |s|
       sss.dependency "MaterialComponents/HeaderStackView"
       sss.dependency "MaterialComponents/NavigationBar"
       sss.dependency "MaterialComponents/Typography"
+      sss.dependency "MaterialComponents/private/Application"
 
       # Flexible header + shadow
       sss.dependency "MaterialComponents/FlexibleHeader"

--- a/catalog/MDCCatalog/Info.plist
+++ b/catalog/MDCCatalog/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/catalog/MDCCatalog/Info.plist
+++ b/catalog/MDCCatalog/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -171,6 +171,10 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
     return self.headerViewController
   }
 
+  override var childViewControllerForStatusBarHidden: UIViewController? {
+    return self.headerViewController
+  }
+
 #if swift(>=3.2)
   @available(iOS 11, *)
   override func viewSafeAreaInsetsDidChange() {

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -133,6 +133,10 @@ class MDCNodeListViewController: CBCNodeListViewController {
   override var childViewControllerForStatusBarStyle: UIViewController? {
     return appBar.headerViewController
   }
+
+  override var childViewControllerForStatusBarHidden: UIViewController? {
+    return appBar.headerViewController
+  }
 }
 
 // MARK: UIScrollViewDelegate

--- a/components/AppBar/src/MDCAppBar.m
+++ b/components/AppBar/src/MDCAppBar.m
@@ -307,13 +307,21 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
                             views:@{kBarStackKey : self.headerStackView}];
   [self.view addConstraints:horizontalConstraints];
 
-  CGFloat statusBarHeight = [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
+  CGFloat topMargin = 20;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    // Starting from iOS 11, the top margin should be the actual status bar height.
+    // This is because the flexible header could be smaller in height when in landscape mode
+    // due to the status bar being hidden by default on some devices (like the iPhone X).
+    topMargin = [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
+  }
+#endif
   NSArray<NSLayoutConstraint *> *verticalConstraints = [NSLayoutConstraint
       constraintsWithVisualFormat:[NSString stringWithFormat:@"V:|-%@-[%@]|", kStatusBarHeightKey,
                                                              kBarStackKey]
                           options:0
                           metrics:@{
-                            kStatusBarHeightKey : @(statusBarHeight)
+                            kStatusBarHeightKey : @(topMargin)
                           }
                             views:@{kBarStackKey : self.headerStackView}];
   [self.view addConstraints:verticalConstraints];

--- a/components/AppBar/src/MDCAppBar.m
+++ b/components/AppBar/src/MDCAppBar.m
@@ -34,6 +34,7 @@ static NSString *const kStatusBarHeightKey = @"statusBarHeight";
 static NSString *const MDCAppBarHeaderViewControllerKey = @"MDCAppBarHeaderViewControllerKey";
 static NSString *const MDCAppBarNavigationBarKey = @"MDCAppBarNavigationBarKey";
 static NSString *const MDCAppBarHeaderStackViewKey = @"MDCAppBarHeaderStackViewKey";
+static const CGFloat kPreIOS11StatusBarHeight = 20;
 
 // The Bundle for string resources.
 static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
@@ -307,7 +308,7 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
                             views:@{kBarStackKey : self.headerStackView}];
   [self.view addConstraints:horizontalConstraints];
 
-  CGFloat topMargin = 20;
+  CGFloat topMargin = kPreIOS11StatusBarHeight;
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     // Starting from iOS 11, the top margin should be the actual status bar height.

--- a/components/AppBar/src/MDCAppBar.m
+++ b/components/AppBar/src/MDCAppBar.m
@@ -18,6 +18,7 @@
 
 #import "MDCAppBarContainerViewController.h"
 
+#import "MaterialApplication.h"
 #import "MaterialFlexibleHeader.h"
 #import "MaterialIcons+ic_arrow_back.h"
 #import "MaterialRTL.h"
@@ -33,7 +34,6 @@ static NSString *const kStatusBarHeightKey = @"statusBarHeight";
 static NSString *const MDCAppBarHeaderViewControllerKey = @"MDCAppBarHeaderViewControllerKey";
 static NSString *const MDCAppBarNavigationBarKey = @"MDCAppBarNavigationBarKey";
 static NSString *const MDCAppBarHeaderStackViewKey = @"MDCAppBarHeaderStackViewKey";
-static const CGFloat kStatusBarHeight = 20;
 
 // The Bundle for string resources.
 static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
@@ -300,7 +300,6 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
   [self.view addSubview:self.headerStackView];
 
   // Bar stack expands vertically, but has a margin above it for the status bar.
-
   NSArray<NSLayoutConstraint *> *horizontalConstraints = [NSLayoutConstraint
       constraintsWithVisualFormat:[NSString stringWithFormat:@"H:|[%@]|", kBarStackKey]
                           options:0
@@ -308,12 +307,13 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
                             views:@{kBarStackKey : self.headerStackView}];
   [self.view addConstraints:horizontalConstraints];
 
+  CGFloat statusBarHeight = [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
   NSArray<NSLayoutConstraint *> *verticalConstraints = [NSLayoutConstraint
       constraintsWithVisualFormat:[NSString stringWithFormat:@"V:|-%@-[%@]|", kStatusBarHeightKey,
                                                              kBarStackKey]
                           options:0
                           metrics:@{
-                            kStatusBarHeightKey : @(kStatusBarHeight)
+                            kStatusBarHeightKey : @(statusBarHeight)
                           }
                             views:@{kBarStackKey : self.headerStackView}];
   [self.view addConstraints:verticalConstraints];

--- a/components/FlexibleHeader/examples/FlexibleHeaderHorizontalPagingExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderHorizontalPagingExample.m
@@ -146,6 +146,7 @@ static const NSUInteger kNumberOfPages = 10;
 
 - (void)commonMDCFlexibleHeaderViewControllerInit {
   self.fhvc = [[MDCFlexibleHeaderViewController alloc] initWithNibName:nil bundle:nil];
+  self.fhvc.headerView.sharedWithManyScrollViews = YES;
   [self addChildViewController:_fhvc];
 }
 

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTopLayoutGuideSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTopLayoutGuideSupplemental.m
@@ -49,7 +49,10 @@
   UIColor *color =
       [UIColor colorWithRed:(97.0 / 255.0) green:(97.0 / 255.0) blue:(97.0 / 255.0) alpha:1.0];
   UIView *scrollViewContent =
-      [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.scrollView.frame.size.width, 1000)];
+      [[UIView alloc] initWithFrame:CGRectMake(0,
+                                               0,
+                                               self.scrollView.frame.size.width,
+                                               self.scrollView.frame.size.height * 2)];
   scrollViewContent.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   UILabel *pullDownLabel = [[UILabel alloc]

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTopLayoutGuideSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTopLayoutGuideSupplemental.m
@@ -49,7 +49,7 @@
   UIColor *color =
       [UIColor colorWithRed:(97.0 / 255.0) green:(97.0 / 255.0) blue:(97.0 / 255.0) alpha:1.0];
   UIView *scrollViewContent =
-      [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.scrollView.frame.size.width, 700)];
+      [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.scrollView.frame.size.width, 1000)];
   scrollViewContent.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   UILabel *pullDownLabel = [[UILabel alloc]

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -111,7 +111,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 // The adjustment we've made to account for the scroll view's Safe Area.
 @property(nonatomic) CGFloat topSafeAreaInsetAdjustment;
 
-// Whether or not we've adjust the inset to account for the scroll view's Safe Area.
+// Whether or not we've adjusted the inset to account for the scroll view's Safe Area.
 @property(nonatomic) BOOL hasTopSafeAreaInsetAdjustment;
 
 @end

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -436,7 +436,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 - (void)safeAreaInsetsDidChange {
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
-    [self fvh_adjustInsetsForSafeAreaInScrollView:_trackingScrollView];
+    [self fhv_adjustInsetsForSafeAreaInScrollView:_trackingScrollView];
 
     // If the min/max height hasn't been explicitly set, we need to update the layout to reflect
     // the change in the Safe Area insets.
@@ -517,7 +517,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   return info;
 }
 
-- (void)fvh_adjustInsetsForSafeAreaInScrollView:(UIScrollView *)scrollView {
+- (void)fhv_adjustInsetsForSafeAreaInScrollView:(UIScrollView *)scrollView {
   if (!scrollView) {
     return;
   }
@@ -1082,7 +1082,7 @@ static BOOL isRunningiOS10_3OrAbove() {
   }
 
   // Before we update the layout, take into account the scroll view's Safe Area insets.
-  [self fvh_adjustInsetsForSafeAreaInScrollView:_trackingScrollView];
+  [self fhv_adjustInsetsForSafeAreaInScrollView:_trackingScrollView];
 
   void (^animate)(void) = ^{
     [self fhv_updateLayout];
@@ -1110,7 +1110,7 @@ static BOOL isRunningiOS10_3OrAbove() {
 - (void)trackingScrollViewDidScroll {
   // This could've been triggered by a change in the scroll view's Safe Area, so we need to check
   // if it did. If it didn't, this is a no-op.
-  [self fvh_adjustInsetsForSafeAreaInScrollView:_trackingScrollView];
+  [self fhv_adjustInsetsForSafeAreaInScrollView:_trackingScrollView];
 
   [self fhv_contentOffsetDidChange];
 }

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -23,6 +23,8 @@
 float UIAnimationDragCoefficient(void);  // Private API for simulator animation speed
 #endif
 
+static const CGFloat kPreIOS11ExpectedStatusBarHeight = 20;
+
 // The default maximum height for the header. Does not include the status bar height.
 static const CGFloat kFlexibleHeaderDefaultHeight = 56;
 
@@ -130,6 +132,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   // is interacting with the header or if we're presently animating it.
   BOOL _wantsToBeHidden;
 
+  // This will help us track if the size has been explicitly set or if we're using the defaults.
   BOOL _hasExplicitlySetMinHeight;
   BOOL _hasExplicitlySetMaxHeight;
 
@@ -295,8 +298,15 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   _headerContentImportance = MDCFlexibleHeaderContentImportanceDefault;
   _statusBarHintCanOverlapHeader = YES;
 
-  CGFloat statusBarHeight = [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
-  _minimumHeight = kFlexibleHeaderDefaultHeight + statusBarHeight;
+  _minimumHeight = kFlexibleHeaderDefaultHeight + kPreIOS11ExpectedStatusBarHeight;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    // Starting from iOS 11, we should adapt the size of this component to take into account
+    // the new status bar sizes and the "no status bar in landscape" functionality.
+    CGFloat statusBarHeight = [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
+    _minimumHeight = kFlexibleHeaderDefaultHeight + statusBarHeight;
+  }
+#endif
   _maximumHeight = _minimumHeight;
   _visibleShadowOpacity = kDefaultVisibleShadowOpacity;
   _canOverExtend = YES;

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -518,6 +518,9 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 }
 
 - (void)fvh_adjustInsetsForSafeAreaInScrollView:(UIScrollView *)scrollView {
+  if (!scrollView) {
+    return;
+  }
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     if (scrollView.contentInsetAdjustmentBehavior == UIScrollViewContentInsetAdjustmentAlways ||

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -16,6 +16,7 @@
 
 #import "MDCFlexibleHeaderViewController.h"
 
+#import "MaterialApplication.h"
 #import "MDCFlexibleHeaderContainerViewController.h"
 #import "MDCFlexibleHeaderView.h"
 #import "MDFTextAccessibility.h"
@@ -145,7 +146,9 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-  return (ShouldUseLightStatusBarOnBackgroundColor(_headerView.backgroundColor)
+  UIColor *backgroundColor =
+      [MDCFlexibleHeaderView appearance].backgroundColor ?: _headerView.backgroundColor;
+  return (ShouldUseLightStatusBarOnBackgroundColor(backgroundColor)
               ? UIStatusBarStyleLightContent
               : UIStatusBarStyleDefault);
 }
@@ -223,9 +226,13 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
 }
 
 - (CGFloat)headerViewControllerHeight {
+  BOOL shiftEnabledForStatusBar =
+      _headerView.shiftBehavior == MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar;
+  CGFloat statusBarHeight =
+      [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
   CGFloat height =
       MAX(_headerView.frame.origin.y + _headerView.frame.size.height,
-          _headerView.shiftBehavior == MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar ? 0 : 20);
+          shiftEnabledForStatusBar ? 0 : statusBarHeight);
   return height;
 }
 

--- a/components/FlexibleHeader/src/private/MDCStatusBarShifter.m
+++ b/components/FlexibleHeader/src/private/MDCStatusBarShifter.m
@@ -56,6 +56,7 @@ typedef NS_ENUM(NSInteger, MDCStatusBarShifterState) {
   BOOL _prefersStatusBarHidden;
   MDCStatusBarShifterState _snapshotState;
 
+  // The height of the status bar as it is before we do anything to it.
   CGFloat _originalStatusBarHeight;
 }
 
@@ -223,7 +224,7 @@ typedef NS_ENUM(NSInteger, MDCStatusBarShifterState) {
     return;
   }
 
-  // Bound the status bar range to [0...statusBarHeight].
+  // Bound the status bar range to [0..._originalStatusBarHeight].
   CGFloat statusOffsetY = MIN(_originalStatusBarHeight, offset);
 
   // Adjust the frame of the status bar.
@@ -260,7 +261,9 @@ typedef NS_ENUM(NSInteger, MDCStatusBarShifterState) {
 }
 
 - (BOOL)canUpdateStatusBarFrame {
-  return (![[UIApplication mdc_safeSharedApplication] isStatusBarHidden] || _statusBarReplicaView ||
+  CGRect statusBarFrame = [[UIApplication mdc_safeSharedApplication] statusBarFrame];
+  CGFloat statusBarHeight = MIN(statusBarFrame.size.width, statusBarFrame.size.height);
+  return ((statusBarHeight == _originalStatusBarHeight) || _statusBarReplicaView ||
           _snapshotState == MDCStatusBarShifterStateInvalidSnapshot);
 }
 

--- a/components/FlexibleHeader/src/private/MDCStatusBarShifter.m
+++ b/components/FlexibleHeader/src/private/MDCStatusBarShifter.m
@@ -18,7 +18,6 @@
 
 #import "MaterialApplication.h"
 
-static CGFloat kStatusBarExpectedHeight = 20;
 static NSTimeInterval kStatusBarBecomesInvalidAnimationDuration = 0.2;
 
 // If the time changes then we need to invalidate the status bar.
@@ -56,10 +55,13 @@ typedef NS_ENUM(NSInteger, MDCStatusBarShifterState) {
 
   BOOL _prefersStatusBarHidden;
   MDCStatusBarShifterState _snapshotState;
+
+  CGFloat _originalStatusBarHeight;
 }
 
 - (void)dealloc {
   [_replicaInvalidatorTimer invalidate];
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (instancetype)init {
@@ -67,8 +69,22 @@ typedef NS_ENUM(NSInteger, MDCStatusBarShifterState) {
   if (self) {
     _enabled = YES;
     _snapshottingEnabled = YES;
+
+    _originalStatusBarHeight = [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
+    [[NSNotificationCenter defaultCenter]
+        addObserver:self
+           selector:@selector(statusBarDidChangeFrame)
+               name:UIApplicationDidChangeStatusBarFrameNotification
+             object:nil];
   }
   return self;
+}
+
+#pragma mark - Notification
+
+- (void)statusBarDidChangeFrame {
+  CGFloat statusBarHeight = [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
+  _originalStatusBarHeight = statusBarHeight == 0 ? _originalStatusBarHeight : statusBarHeight;
 }
 
 #pragma mark - Private
@@ -157,8 +173,10 @@ typedef NS_ENUM(NSInteger, MDCStatusBarShifterState) {
       // Take a snapshot of the status bar.
       UIView *snapshotView = [[UIScreen mainScreen] snapshotViewAfterScreenUpdates:NO];
       UIView *clippingView = [[UIView alloc] init];
+      CGFloat statusBarHeight =
+          [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
       clippingView.frame =
-          CGRectMake(0, 0, snapshotView.frame.size.width, kStatusBarExpectedHeight);
+          CGRectMake(0, 0, snapshotView.frame.size.width, statusBarHeight);
       clippingView.autoresizingMask =
           (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleBottomMargin);
       clippingView.clipsToBounds = YES;
@@ -205,12 +223,12 @@ typedef NS_ENUM(NSInteger, MDCStatusBarShifterState) {
     return;
   }
 
-  // Bound the status bar range to [0...kStatusBarExpectedHeight].
-  CGFloat statusOffsetY = MIN(kStatusBarExpectedHeight, offset);
+  // Bound the status bar range to [0...statusBarHeight].
+  CGFloat statusOffsetY = MIN(_originalStatusBarHeight, offset);
 
   // Adjust the frame of the status bar.
   if (statusOffsetY > 0) {
-    _prefersStatusBarHiddenWhileInvalid = statusOffsetY >= kStatusBarExpectedHeight;
+    _prefersStatusBarHiddenWhileInvalid = statusOffsetY >= _originalStatusBarHeight;
 
     if (_snapshotState == MDCStatusBarShifterStateInvalidSnapshot) {
       // If we're in an invalid state then we have to manage the visibility directly.
@@ -242,9 +260,7 @@ typedef NS_ENUM(NSInteger, MDCStatusBarShifterState) {
 }
 
 - (BOOL)canUpdateStatusBarFrame {
-  CGRect statusBarFrame = [[UIApplication mdc_safeSharedApplication] statusBarFrame];
-  CGFloat statusBarHeight = MIN(statusBarFrame.size.width, statusBarFrame.size.height);
-  return ((statusBarHeight == kStatusBarExpectedHeight) || _statusBarReplicaView ||
+  return (![[UIApplication mdc_safeSharedApplication] isStatusBarHidden] || _statusBarReplicaView ||
           _snapshotState == MDCStatusBarShifterStateInvalidSnapshot);
 }
 

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
@@ -15,6 +15,7 @@
  */
 
 #import <XCTest/XCTest.h>
+#import "MaterialApplication.h"
 #import "MaterialFlexibleHeader.h"
 
 // Extension to MDCFlexibleHeaderViewController for Tests Only to Expose Private Property
@@ -136,6 +137,10 @@
 }
 
 - (void)testFlexibleHeaderViewControllerTopLayoutGuideHeightOffsetScrollingUpOffscreenKeepStatus {
+  // Given
+  CGFloat statusBarHeight =
+      [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
+
   // When
   self.vc.fhvc.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorEnabled;
   CGRect offScreenScroll =
@@ -144,7 +149,7 @@
   [self.vc.scrollView scrollRectToVisible:offScreenScroll animated:NO];
 
   // Then
-  XCTAssertEqual(self.vc.fhvc.flexibleHeaderViewControllerHeightOffset, 20);
+  XCTAssertEqual(self.vc.fhvc.flexibleHeaderViewControllerHeightOffset, statusBarHeight);
 }
 
 - (void)testFlexibleHeaderViewControllerTopLayoutGuideHeightOffsetScrollingUpOffscreenHideStatus {


### PR DESCRIPTION
### TLDR
This PR adds support for Safe Area insets in Flexible Header by adjusting injectedTopContentInset to account for any Safe Area insets the tracking scroll view might already come with. It also removes all the hardcoded status bar height values. This PR doesn't introduce new API, things should just work as expected.

### Why this change
If the scroll view we're tracking has contentInsetAdjustmentBehavior set to Automatic (the default) or Always, it already comes with an additional inset to account for the Safe Area. Since we don't own these scroll views, and these modes are actually pretty useful as they take care of the Safe Area for you, we can't just turn it off when they're added to the flexible header. The right way to fix it is to take this inset and adjust how much we need to add on top of it to match the height of the header view.

### Default height
The original default height for the flexible header was hardcoded to 56 + 20 (for the status bar).
Since the status bar now can be 44, 20 or 0, the default height should be adjusted accordingly. If a developer is currently setting the height manually, we don't do any adjustments on our end. We should consider adding a flag that might enable that functionality (adding the status bar dynamically), but that should be on a separate PR.

### Testing
This fix has been manually tested on an iPhone X and 6 (both simulators), on iOS 9.3, 10.3 and 11.0 using all the examples we currently maintain in the Catalog for this component.

Closes #2008 and #2004.