### PR TITLE
[Dialogs] Size action buttons during layout

### DIFF
--- a/components/BottomSheet/examples/supplemental/BottomSheetPresenterViewController.m
+++ b/components/BottomSheet/examples/supplemental/BottomSheetPresenterViewController.m
@@ -29,15 +29,19 @@
 
   _button = [[MDCButton alloc] initWithFrame:CGRectZero];
   [_button setTitle:@"Show Bottom Sheet" forState:UIControlStateNormal];
-  [_button sizeToFit];
   _button.autoresizingMask =
   UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin |
   UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
   [_button addTarget:self
               action:@selector(presentBottomSheet)
     forControlEvents:UIControlEventTouchUpInside];
-  _button.center = self.view.center;
   [self.view addSubview:_button];
+}
+
+- (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
+  [_button sizeToFit];
+  _button.center = CGPointMake(CGRectGetMidX(self.view.bounds), CGRectGetMidY(self.view.bounds));
 }
 
 - (void)presentBottomSheet {

--- a/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
@@ -91,13 +91,18 @@ static NSString * const kReusableIdentifierItem = @"cell";
   _dismissButton.autoresizingMask =
       UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |
       UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin;
-  [_dismissButton sizeToFit];
   [_dismissButton addTarget:self
                      action:@selector(dismiss:)
            forControlEvents:UIControlEventTouchUpInside];
 
   [self.view addSubview:_dismissButton];
-  _dismissButton.center = self.view.center;
+}
+
+- (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
+  [_dismissButton sizeToFit];
+  _dismissButton.center = CGPointMake(CGRectGetMidX(self.view.bounds),
+                                      CGRectGetMidY(self.view.bounds));
 }
 
 - (CGSize)preferredContentSize {

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -177,7 +177,6 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   actionButton.mdc_adjustsFontForContentSizeCategory = self.mdc_adjustsFontForContentSizeCategory;
   [actionButton setTitle:action.title forState:UIControlStateNormal];
   // TODO(#1726): Determine default text color values for Normal and Disabled
-  [actionButton sizeToFit];
   CGRect buttonRect = actionButton.bounds;
   buttonRect.size.height = MAX(buttonRect.size.height, MDCDialogActionButtonHeight);
   buttonRect.size.width = MAX(buttonRect.size.width, MDCDialogActionButtonMinimumWidth);
@@ -327,6 +326,10 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
+
+  for (UIButton *button in self.actionButtons) {
+    [button sizeToFit];
+  }
 
   // Recalculate preferredSize, which is based on width available, if the viewSize has changed.
   if (CGRectGetWidth(self.view.bounds) != _previousLayoutSize.width ||


### PR DESCRIPTION
Buttons were previously being sized during `viewDidLoad`, which caused
problems if UIAppearance caused changes to contentEdgeInsets. Instead,
the buttons should be sized before layout of the dialog's subviews.

Also fixing some examples that were incorrectly sizing buttons before
layout.

Closes #1943
