### PR TITLE
[NavigationBar] Fix layoutSubviews to take into account the safe area insets.

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -278,7 +278,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 - (void)layoutSubviews {
   [super layoutSubviews];
 
-  UIEdgeInsets RTLFriendlySafeAreaInsets;
+  UIEdgeInsets RTLFriendlySafeAreaInsets = UIEdgeInsetsZero;
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     RTLFriendlySafeAreaInsets =

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -281,6 +281,11 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   CGSize leadingButtonBarSize = [_leadingButtonBar sizeThatFits:self.bounds.size];
   CGRect leadingButtonBarFrame =
       CGRectMake(0, CGRectGetMinY(self.bounds), leadingButtonBarSize.width, leadingButtonBarSize.height);
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    leadingButtonBarFrame.origin.x = self.safeAreaInsets.left;
+  }
+#endif
   _leadingButtonBar.frame = MDCRectFlippedForRTL(leadingButtonBarFrame, CGRectGetWidth(self.bounds),
                                                  self.mdc_effectiveUserInterfaceLayoutDirection);
 
@@ -288,6 +293,11 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   CGRect trailingButtonBarFrame =
       CGRectMake(CGRectGetWidth(self.bounds) - trailingButtonBarSize.width, CGRectGetMinY(self.bounds),
                  trailingButtonBarSize.width, trailingButtonBarSize.height);
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    trailingButtonBarFrame.origin.x -= self.safeAreaInsets.right;
+  }
+#endif
   _trailingButtonBar.frame = MDCRectFlippedForRTL(trailingButtonBarFrame, CGRectGetWidth(self.bounds),
                                                   self.mdc_effectiveUserInterfaceLayoutDirection);
 
@@ -296,6 +306,12 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   CGRect textFrame = UIEdgeInsetsInsetRect(self.bounds, textInsets);
   textFrame.origin.x += _leadingButtonBar.frame.size.width;
   textFrame.size.width -= _leadingButtonBar.frame.size.width + _trailingButtonBar.frame.size.width;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    textFrame.origin.x += self.safeAreaInsets.left;
+    textFrame.size.width -= self.safeAreaInsets.left + self.safeAreaInsets.right;
+  }
+#endif
 
   NSMutableParagraphStyle *paraStyle = [[NSMutableParagraphStyle alloc] init];
   paraStyle.lineBreakMode = _titleLabel.lineBreakMode;

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -295,7 +295,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
       CGRectMake(0, CGRectGetMinY(self.bounds), leadingButtonBarSize.width, leadingButtonBarSize.height);
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
-    leadingButtonBarFrame.origin.x = rtlFriendlySafeAreaInsets.left;
+    leadingButtonBarFrame.origin.x += rtlFriendlySafeAreaInsets.left;
   }
 #endif
   _leadingButtonBar.frame = MDCRectFlippedForRTL(leadingButtonBarFrame, CGRectGetWidth(self.bounds),

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -278,10 +278,10 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 - (void)layoutSubviews {
   [super layoutSubviews];
 
-  UIEdgeInsets rtlFriendlySafeAreaInsets;
+  UIEdgeInsets RTLFriendlySafeAreaInsets;
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
-    rtlFriendlySafeAreaInsets =
+    RTLFriendlySafeAreaInsets =
         MDCInsetsMakeWithLayoutDirection(self.safeAreaInsets.top,
                                          self.safeAreaInsets.left,
                                          self.safeAreaInsets.bottom,
@@ -295,7 +295,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
       CGRectMake(0, CGRectGetMinY(self.bounds), leadingButtonBarSize.width, leadingButtonBarSize.height);
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
-    leadingButtonBarFrame.origin.x += rtlFriendlySafeAreaInsets.left;
+    leadingButtonBarFrame.origin.x += RTLFriendlySafeAreaInsets.left;
   }
 #endif
   _leadingButtonBar.frame = MDCRectFlippedForRTL(leadingButtonBarFrame, CGRectGetWidth(self.bounds),
@@ -307,7 +307,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
                  trailingButtonBarSize.width, trailingButtonBarSize.height);
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
-    trailingButtonBarFrame.origin.x -= rtlFriendlySafeAreaInsets.right;
+    trailingButtonBarFrame.origin.x -= RTLFriendlySafeAreaInsets.right;
   }
 #endif
   _trailingButtonBar.frame = MDCRectFlippedForRTL(trailingButtonBarFrame, CGRectGetWidth(self.bounds),

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -307,7 +307,8 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
                                              CGRectGetMinY(self.bounds),
                                              trailingButtonBarSize.width,
                                              trailingButtonBarSize.height);
-  _trailingButtonBar.frame = MDCRectFlippedForRTL(trailingButtonBarFrame, CGRectGetWidth(self.bounds),
+  _trailingButtonBar.frame = MDCRectFlippedForRTL(trailingButtonBarFrame,
+                                                  CGRectGetWidth(self.bounds),
                                                   self.mdc_effectiveUserInterfaceLayoutDirection);
 
   UIEdgeInsets textInsets = [self usePadInsets] ? kTextPadInsets : kTextInsets;

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -278,12 +278,24 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 - (void)layoutSubviews {
   [super layoutSubviews];
 
+  UIEdgeInsets rtlFriendlySafeAreaInsets;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    rtlFriendlySafeAreaInsets =
+        MDCInsetsMakeWithLayoutDirection(self.safeAreaInsets.top,
+                                         self.safeAreaInsets.left,
+                                         self.safeAreaInsets.bottom,
+                                         self.safeAreaInsets.right,
+                                         self.mdc_effectiveUserInterfaceLayoutDirection);
+  }
+#endif
+
   CGSize leadingButtonBarSize = [_leadingButtonBar sizeThatFits:self.bounds.size];
   CGRect leadingButtonBarFrame =
       CGRectMake(0, CGRectGetMinY(self.bounds), leadingButtonBarSize.width, leadingButtonBarSize.height);
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
-    leadingButtonBarFrame.origin.x = self.safeAreaInsets.left;
+    leadingButtonBarFrame.origin.x = rtlFriendlySafeAreaInsets.left;
   }
 #endif
   _leadingButtonBar.frame = MDCRectFlippedForRTL(leadingButtonBarFrame, CGRectGetWidth(self.bounds),
@@ -295,7 +307,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
                  trailingButtonBarSize.width, trailingButtonBarSize.height);
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
-    trailingButtonBarFrame.origin.x -= self.safeAreaInsets.right;
+    trailingButtonBarFrame.origin.x -= rtlFriendlySafeAreaInsets.right;
   }
 #endif
   _trailingButtonBar.frame = MDCRectFlippedForRTL(trailingButtonBarFrame, CGRectGetWidth(self.bounds),

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -278,6 +278,8 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 - (void)layoutSubviews {
   [super layoutSubviews];
 
+  // For pre iOS 11 devices, it's safe to assume that the Safe Area insets' left and right
+  // values are zero. DO NOT use this to get the top or bottom Safe Area insets.
   UIEdgeInsets RTLFriendlySafeAreaInsets = UIEdgeInsetsZero;
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
@@ -291,25 +293,20 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 #endif
 
   CGSize leadingButtonBarSize = [_leadingButtonBar sizeThatFits:self.bounds.size];
-  CGRect leadingButtonBarFrame =
-      CGRectMake(0, CGRectGetMinY(self.bounds), leadingButtonBarSize.width, leadingButtonBarSize.height);
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
-  if (@available(iOS 11.0, *)) {
-    leadingButtonBarFrame.origin.x += RTLFriendlySafeAreaInsets.left;
-  }
-#endif
+  CGRect leadingButtonBarFrame = CGRectMake(RTLFriendlySafeAreaInsets.left,
+                                            CGRectGetMinY(self.bounds),
+                                            leadingButtonBarSize.width,
+                                            leadingButtonBarSize.height);
   _leadingButtonBar.frame = MDCRectFlippedForRTL(leadingButtonBarFrame, CGRectGetWidth(self.bounds),
                                                  self.mdc_effectiveUserInterfaceLayoutDirection);
 
   CGSize trailingButtonBarSize = [_trailingButtonBar sizeThatFits:self.bounds.size];
-  CGRect trailingButtonBarFrame =
-      CGRectMake(CGRectGetWidth(self.bounds) - trailingButtonBarSize.width, CGRectGetMinY(self.bounds),
-                 trailingButtonBarSize.width, trailingButtonBarSize.height);
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
-  if (@available(iOS 11.0, *)) {
-    trailingButtonBarFrame.origin.x -= RTLFriendlySafeAreaInsets.right;
-  }
-#endif
+  CGFloat xOrigin =
+      CGRectGetWidth(self.bounds) - RTLFriendlySafeAreaInsets.right - trailingButtonBarSize.width;
+  CGRect trailingButtonBarFrame = CGRectMake(xOrigin,
+                                             CGRectGetMinY(self.bounds),
+                                             trailingButtonBarSize.width,
+                                             trailingButtonBarSize.height);
   _trailingButtonBar.frame = MDCRectFlippedForRTL(trailingButtonBarFrame, CGRectGetWidth(self.bounds),
                                                   self.mdc_effectiveUserInterfaceLayoutDirection);
 


### PR DESCRIPTION
On iOS 11 need to take into account the safe area insets when laying out the nav bar's subviews.

![simulator screen shot - iphone x - 2017-09-29 at 15 22 54](https://user-images.githubusercontent.com/4545451/31032468-177c8e2a-a52a-11e7-87eb-d73505bee5a8.png)

Tested on iPhone X on iOS 11, and iPhone 6 on iOS 11 and iOS 9.3, both in LTR and RTL languages.

Related to #2009
