### PR TITLE
[Tabs] Unit tests for two-line text-only tabs

### DIFF
--- a/components/Tabs/src/private/MDCItemBarCell+Private.h
+++ b/components/Tabs/src/private/MDCItemBarCell+Private.h
@@ -1,0 +1,21 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCItemBarCell.h"
+
+@interface MDCItemBarCell ()
+@property(nonatomic, strong) UILabel *titleLabel;
+@end

--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -15,6 +15,7 @@
  */
 
 #import "MDCItemBarCell.h"
+#import "MDCItemBarCell+Private.h"
 
 #import "MDCItemBarStringConstants.h"
 #import "MDCItemBarStyle.h"
@@ -52,7 +53,6 @@ const CGFloat kSelectedNavigationImageYOffset = -2;
 static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
 
 @implementation MDCItemBarCell {
-  UILabel *_titleLabel;
   UIImageView *_imageView;
   UILabel *_badgeLabel;
   MDCInkTouchController *_inkTouchController;
@@ -230,7 +230,7 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
   imageBounds.size = kImageSize;
   imageCenter.x = CGRectGetMidX(contentBounds);
 
-  CGSize titleSize = [_titleLabel sizeThatFits:contentBounds.size];
+  CGSize titleSize = [self.titleLabel sizeThatFits:contentBounds.size];
   titleSize.width = MIN(titleSize.width, CGRectGetWidth(contentBounds));
 
   // Title is a fixed height based on content and is placed full-width, regardless of content style.
@@ -284,8 +284,8 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
   _badgeLabel.bounds = MDCRectAlignToScale(badgeBounds, scale);
   _badgeLabel.center = MDCRoundCenterWithBoundsAndScale(badgeCenter, _badgeLabel.bounds, scale);
 
-  _titleLabel.bounds = MDCRectAlignToScale(titleBounds, scale);
-  _titleLabel.center = MDCRoundCenterWithBoundsAndScale(titleCenter, _titleLabel.bounds, scale);
+  self.titleLabel.bounds = MDCRectAlignToScale(titleBounds, scale);
+  self.titleLabel.center = MDCRoundCenterWithBoundsAndScale(titleCenter, self.titleLabel.bounds, scale);
 }
 
 - (void)tintColorDidChange {
@@ -502,21 +502,21 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
   void (^performAnimations)(void) = ^{
     // Update the title scale and redraw if it'll be ending at a higher scale
     // to minimize aliasing during animation.
-    if (titleContentsScale > _titleLabel.layer.contentsScale) {
-      _titleLabel.layer.contentsScale = titleContentsScale;
-      [_titleLabel setNeedsDisplay];
+    if (titleContentsScale > self.titleLabel.layer.contentsScale) {
+      self.titleLabel.layer.contentsScale = titleContentsScale;
+      [self.titleLabel setNeedsDisplay];
     }
 
     // Set the transforms.
-    _titleLabel.transform = titleTransform;
+    self.titleLabel.transform = titleTransform;
     _badgeLabel.transform = imageTransform;
     _imageView.transform = imageTransform;
   };
   void (^completeAnimations)(BOOL) = ^(__unused BOOL finished) {
-    if (titleContentsScale != _titleLabel.layer.contentsScale) {
+    if (titleContentsScale != self.titleLabel.layer.contentsScale) {
       // Update the title with the final contents scale and redraw.
-      _titleLabel.layer.contentsScale = titleContentsScale;
-      [_titleLabel setNeedsDisplay];
+      self.titleLabel.layer.contentsScale = titleContentsScale;
+      [self.titleLabel setNeedsDisplay];
     }
   };
 

--- a/components/Tabs/tests/unit/MDCItemBarCellTests.m
+++ b/components/Tabs/tests/unit/MDCItemBarCellTests.m
@@ -1,0 +1,62 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MDCItemBarCell.h"
+#import "MDCItemBarCell+Private.h"
+#import "MDCItemBarStyle.h"
+
+@interface MDCItemBarCellTests : XCTestCase
+
+@end
+
+@implementation MDCItemBarCellTests
+
+- (void)testTitleNumberOfLines {
+  // Given
+  MDCItemBarCell *cellWithImageAndText = [[MDCItemBarCell alloc] initWithFrame:CGRectZero];
+  MDCItemBarCell *cellWithImageOnly = [[MDCItemBarCell alloc] initWithFrame:CGRectZero];
+  MDCItemBarCell *cellWithTextAndMissingImage = [[MDCItemBarCell alloc] initWithFrame:CGRectZero];
+  MDCItemBarCell *cellWithTextOnly = [[MDCItemBarCell alloc] initWithFrame:CGRectZero];
+
+  MDCItemBarStyle *style = [[MDCItemBarStyle alloc] init];
+  style.textOnlyNumberOfLines = 2;
+  style.shouldDisplayImage = YES;
+  style.shouldDisplayTitle = YES;
+
+  // When
+  [cellWithImageAndText setImage:[UIImage imageNamed:@"TabBarDemo_ic_info"]];
+  [cellWithImageOnly setImage:[UIImage imageNamed:@"TabBarDemo_ic_info"]];
+
+  [cellWithImageAndText setTitle:@"A title"];
+  [cellWithTextAndMissingImage setTitle:@"A title"];
+  [cellWithTextOnly setTitle:@"A title"];
+
+  [cellWithImageAndText applyStyle:style];
+  [cellWithImageOnly applyStyle:style];
+  [cellWithTextAndMissingImage applyStyle:style];
+  style.shouldDisplayImage = NO;
+  [cellWithTextOnly applyStyle:style];
+
+  // Then
+  XCTAssertEqual(cellWithImageAndText.titleLabel.numberOfLines, 1);
+  XCTAssertEqual(cellWithImageOnly.titleLabel.numberOfLines, 1);
+  XCTAssertEqual(cellWithTextAndMissingImage.titleLabel.numberOfLines, 1);
+  XCTAssertEqual(cellWithTextOnly.titleLabel.numberOfLines, 2);
+}
+
+@end


### PR DESCRIPTION
Exposing `titleLabel` in MDCItemBarCell for unit testing so that the
two-line behavior can be tested. This test already caught a bug in the
original PR before submission.

Related to #2025