### PR TITLE
Default CocoaPods install to update the pods repo.

### DIFF
--- a/scripts/release/manage_pods.py
+++ b/scripts/release/manage_pods.py
@@ -87,8 +87,8 @@ def install_podfile_dir(directory, fast_install):
     fast_install: If True, then skip updating the podspec repo.
   """
   cmd = ['pod', 'install', '--project-directory=%s' % directory]
-  if fast_install:
-    cmd.append("--no-repo-update")
+  if !fast_install:
+    cmd.append("--repo-update")
   subprocess.check_call(cmd)
 
 


### PR DESCRIPTION
CocoaPods updated their default install behavior some time ago to not update the pods repo by default, but our pods management script still appears to be assuming that it did update the repo by default. This change inverts our pod install logic so that it updates the spec repo by default again.

This resolves some Travis CI failures we've seen when downstream pod releases get published but not picked up by the Travis CI instance's pre-imaged pods repo.