### PR TITLE
[Catalog] Flat buttons have clear background

### DIFF
--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -63,6 +63,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     MDCTabBarColorThemer.apply(colorScheme, to: MDCTabBar.appearance())
     MDCTextFieldColorThemer.applyColorScheme(toAllTextInputControllerDefault: colorScheme)
 
+    do {
+      let clearScheme = MDCBasicColorScheme(primaryColor: .clear)
+      MDCButtonColorThemer.apply(clearScheme, to:MDCFlatButton.appearance())
+    }
+
     // Apply color scheme to UIKit components.
     UISlider.appearance().tintColor = colorScheme?.primaryColor
     UISwitch.appearance().onTintColor = colorScheme?.primaryColor

--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -53,6 +53,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     MDCAlertColorThemer.apply(colorScheme)
     MDCButtonBarColorThemer.apply(colorScheme, to: MDCButtonBar.appearance())
     MDCButtonColorThemer.apply(colorScheme, to: MDCButton.appearance())
+    let clearScheme = MDCBasicColorScheme(primaryColor: .clear)
+    MDCButtonColorThemer.apply(clearScheme, to:MDCFlatButton.appearance())
     MDCFeatureHighlightColorThemer.apply(colorScheme, to: MDCFeatureHighlightView.appearance())
     MDCFlexibleHeaderColorThemer.apply(colorScheme, to: MDCFlexibleHeaderView.appearance())
     MDCHeaderStackViewColorThemer.apply(colorScheme, to: MDCHeaderStackView.appearance())
@@ -62,11 +64,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     MDCSliderColorThemer.apply(colorScheme, to: MDCSlider.appearance())
     MDCTabBarColorThemer.apply(colorScheme, to: MDCTabBar.appearance())
     MDCTextFieldColorThemer.applyColorScheme(toAllTextInputControllerDefault: colorScheme)
-
-    do {
-      let clearScheme = MDCBasicColorScheme(primaryColor: .clear)
-      MDCButtonColorThemer.apply(clearScheme, to:MDCFlatButton.appearance())
-    }
 
     // Apply color scheme to UIKit components.
     UISlider.appearance().tintColor = colorScheme?.primaryColor


### PR DESCRIPTION
Even when disabled, flat button should keep a clear background.

### Before
<img width="283" alt="screen shot 2017-10-05 at 9 53 19 pm" src="https://user-images.githubusercontent.com/1753199/31228478-a22bae00-aa18-11e7-8690-123bf3483950.png">


### After
<img width="272" alt="screen shot 2017-10-05 at 9 57 59 pm" src="https://user-images.githubusercontent.com/1753199/31228425-786abc0a-aa18-11e7-85fe-7efa432bc646.png">


Closes #2091
