### PR TITLE
[MDCShadowElevations] Remove switch elevation, add bottom navigation bar elevation

### DIFF
--- a/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.m
+++ b/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.m
@@ -90,8 +90,6 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27.0f;
   [_paper setElevation:points];
   if (points == MDCShadowElevationNone) {
     _elevationLabel.text = @"MDCShadowElevationNone";
-  } else if (points == MDCShadowElevationSwitch) {
-    _elevationLabel.text = @"MDCShadowElevationSwitch";
   } else if (points == MDCShadowElevationRaisedButtonResting) {
     _elevationLabel.text = @"MDCShadowElevationRaisedButtonResting";
   } else if (points == MDCShadowElevationRefresh) {

--- a/components/ShadowElevations/src/MDCShadowElevations.m
+++ b/components/ShadowElevations/src/MDCShadowElevations.m
@@ -17,6 +17,7 @@
 #import "MDCShadowElevations.h"
 
 const CGFloat MDCShadowElevationAppBar = 4.f;
+const CGFloat MDCShadowElevationBottomNavigationBar = 8.f;
 const CGFloat MDCShadowElevationCardPickedUp = 8.f;
 const CGFloat MDCShadowElevationCardResting = 2.f;
 const CGFloat MDCShadowElevationDialog = 24.f;
@@ -37,4 +38,3 @@ const CGFloat MDCShadowElevationSearchBarResting = 2.f;
 const CGFloat MDCShadowElevationSearchBarScrolled = 3.f;
 const CGFloat MDCShadowElevationSnackbar = 6.f;
 const CGFloat MDCShadowElevationSubMenu = 9.f;
-const CGFloat MDCShadowElevationSwitch = 1.f;


### PR DESCRIPTION
Remove switch elevation, add bottom navigation bar elevation.

Resolves issue: https://github.com/material-components/material-components-ios/issues/949

Spec:
https://material.io/guidelines/material-design/elevation-shadows.html#elevation-shadows-elevation-android