### PR TITLE
[Buttons] Restore alpha when re-enabled

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -42,6 +42,7 @@ static NSString *const MDCButtonUppercaseTitleKey = @"MDCButtonShouldCapitalizeT
 // Previous value kept for backwards compatibility.
 static NSString *const MDCButtonUnderlyingColorHintKey = @"MDCButtonUnderlyingColorKey";
 static NSString *const MDCButtonDisableAlphaKey = @"MDCButtonDisableAlphaKey";
+static NSString *const MDCButtonEnableAlphaKey = @"MDCButtonEnableAlphaKey";
 static NSString *const MDCButtonCustomTitleColorKey = @"MDCButtonCustomTitleColorKey";
 static NSString *const MDCButtonAreaInsetKey = @"MDCButtonAreaInsetKey";
 
@@ -110,6 +111,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   NSMutableDictionary<NSNumber *, NSNumber *> *_borderWidths;
   NSMutableDictionary<NSNumber *, UIColor *> *_shadowColors;
 
+  CGFloat _enabledAlpha;
   BOOL _hasCustomDisabledTitleColor;
 
   // Cached accessibility settings.
@@ -180,6 +182,10 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
       _disabledAlpha = (CGFloat)[aDecoder decodeDoubleForKey:MDCButtonDisableAlphaKey];
     }
 
+    if ([aDecoder containsValueForKey:MDCButtonEnableAlphaKey]) {
+      _enabledAlpha = (CGFloat)[aDecoder decodeDoubleForKey:MDCButtonEnableAlphaKey];
+    }
+
     if ([aDecoder containsValueForKey:MDCButtonAreaInsetKey]) {
       self.hitAreaInsets = [aDecoder decodeUIEdgeInsetsForKey:MDCButtonAreaInsetKey];
     }
@@ -231,6 +237,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
     [aCoder encodeObject:_underlyingColorHint forKey:MDCButtonUnderlyingColorHintKey];
   }
   [aCoder encodeDouble:self.disabledAlpha forKey:MDCButtonDisableAlphaKey];
+  [aCoder encodeDouble:_enabledAlpha forKey:MDCButtonEnableAlphaKey];
   [aCoder encodeUIEdgeInsets:self.hitAreaInsets forKey:MDCButtonAreaInsetKey];
   [aCoder encodeObject:_userElevations forKey:MDCButtonUserElevationsKey];
   [aCoder encodeObject:_backgroundColors forKey:MDCButtonBackgroundColorsKey];
@@ -244,6 +251,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (void)commonMDCButtonInit {
   _disabledAlpha = MDCButtonDisabledAlpha;
+  _enabledAlpha = self.alpha;
   _shouldRaiseOnTouch = YES;
   _uppercaseTitle = YES;
   _userElevations = [NSMutableDictionary dictionary];
@@ -402,6 +410,9 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 #pragma mark - UIControl methods
 
 - (void)setEnabled:(BOOL)enabled {
+  if (self.enabled && !enabled) {
+    _enabledAlpha = self.alpha;
+  }
   [self setEnabled:enabled animated:NO];
 }
 
@@ -755,7 +766,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (void)updateAlphaAndBackgroundColorAnimated:(BOOL)animated {
   void (^animations)(void) = ^{
-    self.alpha = self.enabled ? 1.0f : _disabledAlpha;
+    self.alpha = self.enabled ? _enabledAlpha : _disabledAlpha;
     [self updateBackgroundColor];
   };
 

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -321,6 +321,13 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [self updateAlphaAndBackgroundColorAnimated:NO];
 }
 
+- (void)setAlpha:(CGFloat)alpha {
+  if (self.enabled) {
+    _enabledAlpha = alpha;
+  }
+  [super setAlpha:alpha];
+}
+
 - (void)setDisabledAlpha:(CGFloat)disabledAlpha {
   _disabledAlpha = disabledAlpha;
   [self updateAlphaAndBackgroundColorAnimated:NO];
@@ -410,9 +417,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 #pragma mark - UIControl methods
 
 - (void)setEnabled:(BOOL)enabled {
-  if (self.enabled && !enabled) {
-    _enabledAlpha = self.alpha;
-  }
   [self setEnabled:enabled animated:NO];
 }
 

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -438,9 +438,35 @@ static NSString *controlStateDescription(UIControlState controlState) {
  TODO: things to unit test
  (should these even be a thing?)
  - hitAreaInset
- - disabledAlpha
  - underlyingColor (text color)
  */
+
+- (void)testAlphaRestoredWhenReenabled {
+  // Given
+  MDCButton *button = [[MDCButton alloc] initWithFrame:CGRectMake(0, 0, 80, 48)];
+  CGFloat alpha = 0.5;
+
+  // When
+  button.alpha = alpha;
+  button.enabled = NO;
+  button.enabled = YES;
+
+  // Then
+  XCTAssertEqualWithAccuracy(alpha, button.alpha, 0.0001);
+}
+
+- (void)testDisabledAlpha {
+  // Given
+  MDCButton *button = [[MDCButton alloc] initWithFrame:CGRectMake(0, 0, 80, 48)];
+  CGFloat alpha = 0.5;
+
+  // When
+  [button setDisabledAlpha:alpha];
+  button.enabled = NO;
+
+  // Then
+  XCTAssertEqualWithAccuracy(alpha, button.alpha, 0.0001);
+}
 
 - (void)testEncode {
   // Given
@@ -451,6 +477,9 @@ static NSString *controlStateDescription(UIControlState controlState) {
   button.hitAreaInsets = UIEdgeInsetsMake(10, 10, 10, 10);
   button.inkColor = randomColor();
   button.underlyingColorHint = randomColor();
+  CGFloat buttonAlpha = 0.5;
+  button.alpha = buttonAlpha;
+  button.enabled = NO;
 
   for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
     [button setBackgroundColor:randomColor() forState:controlState];
@@ -482,6 +511,11 @@ static NSString *controlStateDescription(UIControlState controlState) {
                              unarchivedButton.hitAreaInsets.left,
                              kEpsilonAccuracy);
   XCTAssertEqualObjects(button.underlyingColorHint, unarchivedButton.underlyingColorHint);
+  XCTAssertEqual(button.enabled, unarchivedButton.enabled);
+  XCTAssertEqualWithAccuracy(button.alpha, unarchivedButton.alpha, 0.0001);
+  unarchivedButton.enabled = YES;
+  XCTAssertEqualWithAccuracy(buttonAlpha, unarchivedButton.alpha, 0.0001);
+
   for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
     XCTAssertEqualWithAccuracy([button elevationForState:controlState],
                                [unarchivedButton elevationForState:controlState],

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -455,6 +455,21 @@ static NSString *controlStateDescription(UIControlState controlState) {
   XCTAssertEqualWithAccuracy(alpha, button.alpha, 0.0001);
 }
 
+- (void)testEnabledAlphaNotSetWhileDisabled {
+  // Given
+  MDCButton *button = [[MDCButton alloc] initWithFrame:CGRectMake(0, 0, 80, 48)];
+  CGFloat alpha = 0.2;
+
+  // When
+  button.alpha = alpha;
+  button.enabled = NO;
+  button.alpha = 1 - alpha;
+  button.enabled = YES;
+
+  // Then
+  XCTAssertEqualWithAccuracy(alpha, button.alpha, 0.0001);
+}
+
 - (void)testDisabledAlpha {
   // Given
   MDCButton *button = [[MDCButton alloc] initWithFrame:CGRectMake(0, 0, 80, 48)];


### PR DESCRIPTION
When re-enabled, MDCButton previously set its alpha avalue to 1 instead
of the previously-set value.

Closes #1964
