### PR TITLE
[TextFields] Fix broken MDCMultilineTextField build for iOS 10.

### DIFF
--- a/components/TextFields/src/MDCMultilineTextField.m
+++ b/components/TextFields/src/MDCMultilineTextField.m
@@ -474,13 +474,6 @@ static NSString *const MDCMultilineTextFieldTrailingViewModeKey =
 
 #pragma mark - Properties Implementation
 
-#if defined(__IPHONE_10_0) && (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_10_0)
-- (void)setAdjustsFontForContentSizeCategory:(BOOL)adjustsFontForContentSizeCategory {
-  [super setAdjustsFontForContentSizeCategory:adjustsFontForContentSizeCategory];
-  [self mdc_setAdjustsFontForContentSizeCategory:adjustsFontForContentSizeCategory];
-}
-#endif
-
 - (BOOL)adjustsFontForContentSizeCategory {
   return self.mdc_adjustsFontForContentSizeCategory;
 }

--- a/components/TextFields/src/MDCMultilineTextField.m
+++ b/components/TextFields/src/MDCMultilineTextField.m
@@ -474,14 +474,6 @@ static NSString *const MDCMultilineTextFieldTrailingViewModeKey =
 
 #pragma mark - Properties Implementation
 
-- (BOOL)adjustsFontForContentSizeCategory {
-  return self.mdc_adjustsFontForContentSizeCategory;
-}
-
-- (void)setAdjustsFontForContentSizeCategory:(BOOL)adjustsFontForContentSizeCategory {
-  [self mdc_setAdjustsFontForContentSizeCategory:adjustsFontForContentSizeCategory];
-}
-
 - (NSAttributedString *)attributedPlaceholder {
   return self.fundament.attributedPlaceholder;
 }

--- a/components/TextFields/tests/unit/MultilineTextFieldTests.swift
+++ b/components/TextFields/tests/unit/MultilineTextFieldTests.swift
@@ -93,11 +93,6 @@ class MultilineTextFieldTests: XCTestCase {
 
     textField.mdc_adjustsFontForContentSizeCategory = true
     XCTAssertTrue(textField.mdc_adjustsFontForContentSizeCategory)
-
-    if #available(iOS 10, *) {
-      XCTAssertEqual(textField.mdc_adjustsFontForContentSizeCategory,
-                     textField.adjustsFontForContentSizeCategory)
-    }
   }
 
   func testSerialization() {


### PR DESCRIPTION
It fails to build in it's current state because  setAdjustsFontForContentSizeCategory: is defined twice; once inside the ifdef block and once outside. The version in the ifdef also fails to compile since UIView does not conform to UIContentSizeCategoryAdjusting.