### PR TITLE
[TabBar] Remove tint color from themer

### DIFF
--- a/components/Tabs/src/ColorThemer/MDCTabBarColorThemer.m
+++ b/components/Tabs/src/ColorThemer/MDCTabBarColorThemer.m
@@ -20,8 +20,6 @@
 
 + (void)applyColorScheme:(NSObject<MDCColorScheme> *)colorScheme
                 toTabBar:(MDCTabBar *)tabBar {
-  tabBar.tintColor = colorScheme.primaryColor;
-  tabBar.barTintColor = colorScheme.primaryColor;
   tabBar.selectedItemTintColor = colorScheme.primaryDarkColor;
   tabBar.unselectedItemTintColor = colorScheme.primaryLightColor;
   tabBar.inkColor = colorScheme.primaryLightColor;


### PR DESCRIPTION
Using the tab bar themer causes some visual issues since it is setting tint color. This removes tint color from the tab bar themer. Design will need to provide more guidance on how to theme tab bars appropriately.

Addresses issue: https://github.com/material-components/material-components-ios/issues/1953