### PR TITLE
[I18n] Move to a private category to avoid name collision.

### DIFF
--- a/components/private/RTL/src/UIImage+MaterialRTL.h
+++ b/components/private/RTL/src/UIImage+MaterialRTL.h
@@ -26,7 +26,7 @@
  https://github.com/material-components/material-components-ios/issues/599
  */
 
-@interface UIImage (MaterialRTL)
+@interface UIImage (PrivateMaterialRTL)
 
 /**
  On iOS 9 and above, returns a copy of the current image, prepared to flip horizontally if it's in a

--- a/components/private/RTL/src/UIImage+MaterialRTL.m
+++ b/components/private/RTL/src/UIImage+MaterialRTL.m
@@ -109,7 +109,7 @@ static UIImage *MDCRTLFlippedImage(UIImage *image) {
   return flippedImage;
 }
 
-@implementation UIImage (MaterialRTL)
+@implementation UIImage (PrivateMaterialRTL)
 
 - (UIImage *)mdc_imageFlippedForRightToLeftLayoutDirection {
   // On iOS 9 and above, UIImage supports being prepared for flipping. Otherwise, do the flip

--- a/components/private/RTL/src/UIView+MaterialRTL.h
+++ b/components/private/RTL/src/UIView+MaterialRTL.h
@@ -23,7 +23,7 @@
  `+[UIView userInterfaceLayoutDirectionForSemanticContentAttribute:relativeToLayoutDirection:]`.
  */
 
-@interface UIView (MaterialRTL)
+@interface UIView (PrivateMaterialRTL)
 
 /**
  A semantic description of the view's contents, used to determine whether the view should be flipped

--- a/components/private/RTL/src/UIView+MaterialRTL.m
+++ b/components/private/RTL/src/UIView+MaterialRTL.m
@@ -48,7 +48,7 @@ static inline UIUserInterfaceLayoutDirection
 
 @end
 
-@implementation UIView (MaterialRTL)
+@implementation UIView (PrivateMaterialRTL)
 
 - (UISemanticContentAttribute)mdc_semanticContentAttribute {
 #if MDC_BASE_SDK_EQUAL_OR_ABOVE(9_0)


### PR DESCRIPTION
Rename our Class (MaterialRTL) categories to Class (PrivateMaterialRTL) to avoid a name collision with MDFInternationalization.
