### PR TITLE
[ThumbTrack] Remove unused property and method

### DIFF
--- a/components/private/ThumbTrack/src/MDCThumbTrack.h
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.h
@@ -39,10 +39,6 @@
 /** The color of the track disabled color. */
 @property(nullable, nonatomic, strong) UIColor *trackDisabledColor;
 
-/** Dummy property to unbreak internal clients. */
-/** TODO(#1216): Remove this property */
-@property(nonatomic, assign) BOOL interpolateOnOffColors;
-
 /**
  The number of discrete values that the thumb can take along the track. If this property is zero,
  then the slider operates continuously and doesn't do any snapping after the user releases the

--- a/components/private/ThumbTrack/src/MDCThumbTrack.m
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.m
@@ -891,37 +891,6 @@ static inline CGFloat DistanceFromPointToPoint(CGPoint point1, CGPoint point2) {
   [panTarget addGestureRecognizer:_dummyPanRecognizer];
 }
 
-#pragma mark - Color Helpers
-
-- (UIColor *)colorInterpolatedFromColor:(UIColor *)fromColor
-                                toColor:(UIColor *)toColor
-                                percent:(CGFloat)percent {
-  // Clamp percent to [0.0, 1.0]
-  percent = MAX(0, percent);
-  percent = MIN(1, percent);
-
-  CGFloat r1, g1, b1, a1;
-  r1 = g1 = b1 = a1 = 1;
-  if (![fromColor getRed:&r1 green:&g1 blue:&b1 alpha:&a1]) {
-    [fromColor getWhite:&r1 alpha:&a1];
-    g1 = b1 = r1;
-  };
-
-  CGFloat r2, g2, b2, a2;
-  r2 = g2 = b2 = a2 = 1;
-  if (![toColor getRed:&r2 green:&g2 blue:&b2 alpha:&a2]) {
-    [toColor getWhite:&r2 alpha:&a2];
-    g2 = b2 = r2;
-  }
-
-  CGFloat rfinal = r1 * (1 - percent) + r2 * percent;
-  CGFloat gfinal = g1 * (1 - percent) + g2 * percent;
-  CGFloat bfinal = b1 * (1 - percent) + b2 * percent;
-  CGFloat afinal = a1 * (1 - percent) + a2 * percent;
-
-  return [UIColor colorWithRed:rfinal green:gfinal blue:bfinal alpha:afinal];
-}
-
 #pragma mark - UIResponder Events
 
 /**


### PR DESCRIPTION
Closes #1216.

This property is no longer used internally. See cl/171303772.