### PR TITLE
[Tabs] MDCTabBarViewController should delegate status bar to children

### DIFF
--- a/components/Tabs/src/MDCTabBarViewController.m
+++ b/components/Tabs/src/MDCTabBarViewController.m
@@ -131,6 +131,7 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
     if (selectedViewController) {
       self.tabBar.selectedItem = selectedViewController.tabBarItem;
     }
+    [self setNeedsStatusBarAppearanceUpdate];
   }
 }
 
@@ -241,5 +242,14 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
   }
 }
 
+#pragma mark - UIViewController status bar
+
+- (nullable UIViewController *)childViewControllerForStatusBarStyle {
+  return _selectedViewController;
+}
+
+- (nullable UIViewController *)childViewControllerForStatusBarHidden {
+  return _selectedViewController;
+}
 
 @end


### PR DESCRIPTION
Because MDCTabBarViewController displays child view controllers that
control the top of the screen, it should delegate control of the
status bar to the currently selected child view controller, and ensure
that the status bar is updated when the selected child changes.

Fix for issue #2111 

### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [x] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [x] Link to GitHub issues it solves. ```closes #1234```
- [ ] Sign the CLA bot. You can do this once the pull request is submitted.

[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
pull request.
