### PR TITLE
[Shadow Elevation] Fix the need to unwrap the optional

### DIFF
--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -142,8 +142,8 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
 
     self.headerViewController.headerView.setShadowLayer(MDCShadowLayer()) { (layer, intensity) in
       let shadowLayer = layer as? MDCShadowLayer
-      let elevation = ShadowElevation.appBar
-      shadowLayer!.elevation = ShadowElevation(rawValue: intensity * elevation.rawValue)
+      let elevation = ShadowElevation.appBar.rawValue
+      shadowLayer!.elevation = ShadowElevation(rawValue: intensity * elevation)
     }
 
     self.view.addSubview(self.headerViewController.view)


### PR DESCRIPTION
Fixes the need to unwrap the optional when creating the shadow elevation by getting the raw value when we create the elevation property instead of accessing the 'rawValue' property later.

Closes #2128 