### PR TITLE
[PageControl] Fixed crasher when resetting -numberOfPages to 0

### DIFF
--- a/components/PageControl/src/MDCPageControl.m
+++ b/components/PageControl/src/MDCPageControl.m
@@ -480,7 +480,7 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
   // Add animated indicator that will travel freely across the container. Its transform will be
   // updated by calling its -updateIndicatorTransformX method.
   CGPoint center = CGPointMake(radius, radius);
-  CGPoint point = [_indicatorPositions[_currentPage] CGPointValue];
+  CGPoint point = _numberOfPages ? [_indicatorPositions[_currentPage] CGPointValue] : CGPointZero;
   _animatedIndicator = [[MDCPageControlIndicator alloc] initWithCenter:center radius:radius];
   [_animatedIndicator updateIndicatorTransformX:point.x - kPageControlIndicatorRadius];
   [_containerView.layer addSublayer:_animatedIndicator];

--- a/components/PageControl/src/MDCPageControl.m
+++ b/components/PageControl/src/MDCPageControl.m
@@ -108,7 +108,7 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
 
 - (void)layoutSubviews {
   [super layoutSubviews];
-  if (_hidesForSinglePage && [_indicators count] == 1) {
+  if (_numberOfPages == 0 || (_hidesForSinglePage && [_indicators count] == 1)) {
     self.hidden = YES;
     return;
   }
@@ -151,6 +151,10 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
   NSInteger previousPage = _currentPage;
   BOOL shouldReverse = (previousPage > currentPage);
   _currentPage = currentPage;
+
+  if (_numberOfPages == 0) {
+    return;
+  }
 
   if (animated) {
     // Draw and extend track.
@@ -456,6 +460,11 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
   _indicators = [NSMutableArray arrayWithCapacity:_numberOfPages];
   _indicatorPositions = [NSMutableArray arrayWithCapacity:_numberOfPages];
 
+  if (_numberOfPages == 0) {
+    [self setNeedsLayout];
+    return;
+  }
+
   // Create indicators.
   CGFloat radius = kPageControlIndicatorRadius;
   CGFloat margin = kPageControlIndicatorMargin;
@@ -480,7 +489,7 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
   // Add animated indicator that will travel freely across the container. Its transform will be
   // updated by calling its -updateIndicatorTransformX method.
   CGPoint center = CGPointMake(radius, radius);
-  CGPoint point = _numberOfPages ? [_indicatorPositions[_currentPage] CGPointValue] : CGPointZero;
+  CGPoint point = [_indicatorPositions[_currentPage] CGPointValue];
   _animatedIndicator = [[MDCPageControlIndicator alloc] initWithCenter:center radius:radius];
   [_animatedIndicator updateIndicatorTransformX:point.x - kPageControlIndicatorRadius];
   [_containerView.layer addSublayer:_animatedIndicator];

--- a/components/PageControl/tests/unit/PageControlExampleTests.m
+++ b/components/PageControl/tests/unit/PageControlExampleTests.m
@@ -134,12 +134,19 @@
   // Given
   MDCPageControl *pageControl = [[MDCPageControl alloc] init];
   pageControl.numberOfPages = 3;
+  NSException *exception;
 
   // When
-  pageControl.numberOfPages = 0;
-  pageControl.currentPage = 0;
+  @try {
+    pageControl.numberOfPages = 0;
+    pageControl.currentPage = 0;
+  }
+  @catch (NSException *e) {
+    exception = e;
+  }
 
-  // Then, no crash
+  // Then
+  XCTAssertNil(exception, @"PageControl crashed with exception: %@", exception);
 }
 
 @end

--- a/components/PageControl/tests/unit/PageControlExampleTests.m
+++ b/components/PageControl/tests/unit/PageControlExampleTests.m
@@ -130,4 +130,15 @@
   XCTAssertEqual(pageControl.currentPage, page);
 }
 
+- (void)testResetNumberOfPagesToZero {
+  // Given
+  MDCPageControl *pageControl = [[MDCPageControl alloc] init];
+  pageControl.numberOfPages = 3;
+
+  // When
+  pageControl.numberOfPages = 0;
+
+  // Then, no crash
+}
+
 @end

--- a/components/PageControl/tests/unit/PageControlExampleTests.m
+++ b/components/PageControl/tests/unit/PageControlExampleTests.m
@@ -137,6 +137,7 @@
 
   // When
   pageControl.numberOfPages = 0;
+  pageControl.currentPage = 0;
 
   // Then, no crash
 }


### PR DESCRIPTION
This is otherwise supported by UIPageControl, which MDCPageControl aims to be a drop-in replacement for.

Crasher details:
Test Case '-[PageControlExampleTests testResetNumberOfPagesToZero]' started.
~/material-components-ios/components/PageControl/tests/unit/PageControlExampleTests.m:139: error: -[PageControlExampleTests testResetNumberOfPagesToZero] : failed: caught "NSRangeException", "*** -[__NSArrayM objectAtIndexedSubscript:]: index 0 beyond bounds for empty array"
(
	0   CoreFoundation                      0x000000010e3ed03b __exceptionPreprocess + 171
	1   libobjc.A.dylib                     0x000000010da81f41 objc_exception_throw + 48
	2   CoreFoundation                      0x000000010e42ce2c _CFThrowFormattedException + 194
	3   CoreFoundation                      0x000000010e41e714 -[__NSArrayM objectAtIndexedSubscript:] + 148
	4   MaterialComponents                  0x0000000128271441 -[MDCPageControl resetControl] + 2193
	5   MaterialComponents                  0x000000012826e489 -[MDCPageControl setNumberOfPages:] + 281
