### PR TITLE
[FlexibleHeader] Fix bug where minimumHeight of 0 would result in odd behavior.

### DIFF
--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
@@ -72,7 +72,7 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.minimumHeaderHeight = self.fhvc.headerView.minimumHeight;
+  self.minimumHeaderHeight = 0;
 
   self.fhvc.headerView.trackingScrollView = self.tableView;
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -595,7 +595,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 - (CGFloat)fhv_accumulatorMax {
   BOOL shouldCollapseToStatusBar = [self fhv_shouldCollapseToStatusBar];
   CGFloat statusBarHeight = [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
-  return (shouldCollapseToStatusBar ? _minimumHeight - statusBarHeight : _minimumHeight);
+  return (shouldCollapseToStatusBar ? MAX(0, _minimumHeight - statusBarHeight) : _minimumHeight);
 }
 
 #pragma mark Logical short forms
@@ -797,7 +797,9 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   [_statusBarShifter setOffset:boundedAccumulator];
 
   // Small performance improvement to not set the hidden property on every scroll tick.
-  BOOL isHidden = boundedAccumulator >= _minimumHeight;
+  BOOL isShiftedOffscreen = boundedAccumulator >= _minimumHeight;
+  BOOL isFullyCollapsed = frame.size.height <= _minimumHeight + DBL_EPSILON;
+  BOOL isHidden = isShiftedOffscreen && isFullyCollapsed;
   if (isHidden != self.hidden) {
     self.hidden = isHidden;
   }


### PR DESCRIPTION
Notably the flexible header would be offset down by the status bar height, leaving empty space behind the status bar.

Before:

![before](https://user-images.githubusercontent.com/45670/31385256-9362cd6a-ad90-11e7-9648-39de201397a7.gif)

After:

![after](https://user-images.githubusercontent.com/45670/31385261-973dde16-ad90-11e7-8665-775385e5702d.gif)
