### PR TITLE
[ShadowElevations] Change shadow elevatoins to functions instead of an enum

### DIFF
--- a/catalog/MDCCatalog/MDCCatalogCollectionViewCell.swift
+++ b/catalog/MDCCatalog/MDCCatalogCollectionViewCell.swift
@@ -17,6 +17,7 @@ limitations under the License.
 import UIKit
 
 import MaterialComponents.MaterialTypography
+import MaterialComponents.MaterialShadowElevations
 
 class MDCCatalogCollectionViewCell: UICollectionViewCell {
 

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -142,8 +142,9 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
 
     self.headerViewController.headerView.setShadowLayer(MDCShadowLayer()) { (layer, intensity) in
       let shadowLayer = layer as? MDCShadowLayer
-      let elevation = ShadowElevation.appBar.rawValue
-      shadowLayer!.elevation = ShadowElevation(rawValue: intensity * elevation)
+      let elevation = MDCShadowElevation()
+      elevation.value = MDCShadowElevation.appBar() * intensity
+      shadowLayer!.elevation = elevation.value
     }
 
     self.view.addSubview(self.headerViewController.view)

--- a/components/AppBar/src/MDCAppBar.m
+++ b/components/AppBar/src/MDCAppBar.m
@@ -135,7 +135,7 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
   MDCFlexibleHeaderView *headerView = _headerViewController.headerView;
   MDCFlexibleHeaderShadowIntensityChangeBlock intensityBlock =
       ^(CALayer *_Nonnull shadowLayer, CGFloat intensity) {
-        CGFloat elevation = MDCShadowElevationAppBar * intensity;
+        CGFloat elevation = [MDCShadowElevation appBar] * intensity;
         [(MDCShadowLayer *)shadowLayer setElevation:elevation];
       };
   [headerView setShadowLayer:[MDCShadowLayer layer] intensityDidChangeBlock:intensityBlock];

--- a/components/Buttons/src/MDCFlatButton.m
+++ b/components/Buttons/src/MDCFlatButton.m
@@ -29,9 +29,9 @@ static NSString *const MDCFlatButtonHasOpaqueBackground = @"MDCFlatButtonHasOpaq
                                         forState:UIControlStateNormal];
   [[MDCFlatButton appearance] setTitleColor:[UIColor blackColor]
                                    forState:UIControlStateNormal];
-  [[MDCFlatButton appearance] setElevation:MDCShadowElevationNone
+  [[MDCFlatButton appearance] setElevation:[MDCShadowElevation none]
                                   forState:UIControlStateNormal];
-  [[MDCFlatButton appearance] setElevation:MDCShadowElevationNone
+  [[MDCFlatButton appearance] setElevation:[MDCShadowElevation none]
                                   forState:UIControlStateHighlighted];
 }
 

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -28,9 +28,9 @@ static NSString *const MDCFloatingButtonShapeKey = @"MDCFloatingButtonShapeKey";
 }
 
 + (void)initialize {
-  [[MDCFloatingButton appearance] setElevation:MDCShadowElevationFABResting
+  [[MDCFloatingButton appearance] setElevation:[MDCShadowElevation fabResting]
                                       forState:UIControlStateNormal];
-  [[MDCFloatingButton appearance] setElevation:MDCShadowElevationFABPressed
+  [[MDCFloatingButton appearance] setElevation:[MDCShadowElevation fabPressed]
                                       forState:UIControlStateHighlighted];
 }
 

--- a/components/Buttons/src/MDCRaisedButton.m
+++ b/components/Buttons/src/MDCRaisedButton.m
@@ -22,9 +22,9 @@
 @implementation MDCRaisedButton
 
 + (void)initialize {
-  [[MDCRaisedButton appearance] setElevation:MDCShadowElevationRaisedButtonResting
+  [[MDCRaisedButton appearance] setElevation:[MDCShadowElevation raisedButtonResting]
                                     forState:UIControlStateNormal];
-  [[MDCRaisedButton appearance] setElevation:MDCShadowElevationRaisedButtonPressed
+  [[MDCRaisedButton appearance] setElevation:[MDCShadowElevation raisedButtonPressed]
                                     forState:UIControlStateHighlighted];
 }
 

--- a/components/Buttons/tests/unit/FlatButtonTests.m
+++ b/components/Buttons/tests/unit/FlatButtonTests.m
@@ -29,10 +29,10 @@
   MDCFlatButton *button = [MDCFlatButton appearance];
 
   // Then
-  XCTAssertEqual([button elevationForState:UIControlStateNormal], MDCShadowElevationNone);
-  XCTAssertEqual([button elevationForState:UIControlStateHighlighted], MDCShadowElevationNone);
-  XCTAssertEqual([button elevationForState:UIControlStateDisabled], MDCShadowElevationNone);
-  XCTAssertEqual([button elevationForState:UIControlStateSelected], MDCShadowElevationNone);
+  XCTAssertEqual([button elevationForState:UIControlStateNormal], [MDCShadowElevation none]);
+  XCTAssertEqual([button elevationForState:UIControlStateHighlighted], [MDCShadowElevation none]);
+  XCTAssertEqual([button elevationForState:UIControlStateDisabled], [MDCShadowElevation none]);
+  XCTAssertEqual([button elevationForState:UIControlStateSelected], [MDCShadowElevation none]);
 }
 
 @end

--- a/components/Buttons/tests/unit/FloatingButtonTests.m
+++ b/components/Buttons/tests/unit/FloatingButtonTests.m
@@ -29,10 +29,10 @@
   MDCFloatingButton *button = [MDCFloatingButton appearance];
 
   // Then
-  XCTAssertEqual([button elevationForState:UIControlStateNormal], MDCShadowElevationFABResting);
+  XCTAssertEqual([button elevationForState:UIControlStateNormal], [MDCShadowElevation fabResting]);
   XCTAssertEqual([button elevationForState:UIControlStateHighlighted],
-                 MDCShadowElevationFABPressed);
-  XCTAssertEqual([button elevationForState:UIControlStateDisabled], MDCShadowElevationNone);
+                 [MDCShadowElevation fabPressed]);
+  XCTAssertEqual([button elevationForState:UIControlStateDisabled], [MDCShadowElevation none]);
 }
 
 - (void)testCollapseExpandRestoresIdentityTransform {

--- a/components/Buttons/tests/unit/RaisedButtonTests.m
+++ b/components/Buttons/tests/unit/RaisedButtonTests.m
@@ -30,10 +30,10 @@
 
   // Then
   XCTAssertEqual([button elevationForState:UIControlStateNormal],
-                 MDCShadowElevationRaisedButtonResting);
+                 [MDCShadowElevation raisedButtonResting]);
   XCTAssertEqual([button elevationForState:UIControlStateHighlighted],
-                 MDCShadowElevationRaisedButtonPressed);
-  XCTAssertEqual([button elevationForState:UIControlStateDisabled], MDCShadowElevationNone);
+                 [MDCShadowElevation raisedButtonPressed]);
+  XCTAssertEqual([button elevationForState:UIControlStateDisabled], [MDCShadowElevation none]);
 }
 
 

--- a/components/Dialogs/src/private/MDCDialogShadowedView.m
+++ b/components/Dialogs/src/private/MDCDialogShadowedView.m
@@ -32,7 +32,7 @@
 - (instancetype)init {
   self = [super init];
   if (self) {
-    [[self shadowLayer] setElevation:MDCShadowElevationDialog];
+    [[self shadowLayer] setElevation:[MDCShadowElevation cardDialog]];
   }
   return self;
 }

--- a/components/ShadowElevations/examples/ShadowElevationsPointsLabel.h
+++ b/components/ShadowElevations/examples/ShadowElevationsPointsLabel.h
@@ -20,6 +20,6 @@
 
 @interface ShadowElevationsPointsLabel : UILabel
 
-@property(nonatomic, assign) MDCShadowElevation elevation;
+@property(nonatomic, assign) MDCShadowElevation* elevation;
 
 @end

--- a/components/ShadowElevations/examples/ShadowElevationsPointsLabel.m
+++ b/components/ShadowElevations/examples/ShadowElevationsPointsLabel.m
@@ -24,8 +24,8 @@
   return [MDCShadowLayer class];
 }
 
-- (void)setElevation:(MDCShadowElevation)elevation {
-  [(MDCShadowLayer *)self.layer setElevation:elevation];
+- (void)setElevation:(MDCShadowElevation *)elevation {
+  [(MDCShadowLayer *)self.layer setElevation:elevation.value];
 }
 
 @end

--- a/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.m
+++ b/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.m
@@ -53,7 +53,9 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27.0f;
     _paper.autoresizingMask =
         (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin |
          UIViewAutoresizingFlexibleRightMargin);
-    [_paper setElevation:kShadowElevationsDefault];
+    MDCShadowElevation *elevation = [[MDCShadowElevation alloc] init];
+    elevation.value = kShadowElevationsDefault;
+    [_paper setElevation:elevation];
     [self addSubview:_paper];
 
     CGFloat margin = 20.f;
@@ -75,26 +77,28 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27.0f;
 - (void)sliderValueChanged:(MDCSlider *)slider {
   NSInteger points = (NSInteger)round(slider.value * kShadowElevationsMax);
   _paper.text = [NSString stringWithFormat:@"%ld pt", (long)points];
-  [_paper setElevation:points];
-  if (points == MDCShadowElevationNone) {
+  MDCShadowElevation *elevation = [[MDCShadowElevation alloc] init];
+  elevation.value = points;
+  [_paper setElevation:elevation];
+  if (points == [MDCShadowElevation none]) {
     _elevationLabel.text = @"MDCShadowElevationNone";
-  } else if (points == MDCShadowElevationRaisedButtonResting) {
+  } else if (points == [MDCShadowElevation raisedButtonResting]) {
     _elevationLabel.text = @"MDCShadowElevationRaisedButtonResting";
-  } else if (points == MDCShadowElevationRefresh) {
+  } else if (points == [MDCShadowElevation refresh]) {
     _elevationLabel.text = @"MDCShadowElevationRefresh";
-  } else if (points == MDCShadowElevationAppBar) {
+  } else if (points == [MDCShadowElevation appBar]) {
     _elevationLabel.text = @"MDCShadowElevationAppBar";
-  } else if (points == MDCShadowElevationFABResting) {
+  } else if (points == [MDCShadowElevation fabResting]) {
     _elevationLabel.text = @"MDCShadowElevationFABResting";
-  } else if (points == MDCShadowElevationRaisedButtonPressed) {
+  } else if (points == [MDCShadowElevation raisedButtonPressed]) {
     _elevationLabel.text = @"MDCShadowElevationRaisedButtonPressed";
-  } else if (points == MDCShadowElevationSubMenu) {
+  } else if (points == [MDCShadowElevation subMenu]) {
     _elevationLabel.text = @"MDCShadowElevationSubMenu";
-  } else if (points == MDCShadowElevationFABPressed) {
+  } else if (points == [MDCShadowElevation fabPressed]) {
     _elevationLabel.text = @"MDCShadowElevationFABPressed";
-  } else if (points == MDCShadowElevationNavDrawer) {
+  } else if (points == [MDCShadowElevation navDrawer]) {
     _elevationLabel.text = @"MDCShadowElevationNavDrawer";
-  } else if (points == MDCShadowElevationDialog) {
+  } else if (points == [MDCShadowElevation cardDialog]) {
     _elevationLabel.text = @"MDCShadowElevationDialog";
   } else {
     _elevationLabel.text = @"";

--- a/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.swift
+++ b/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.swift
@@ -38,7 +38,9 @@ class ShadowElevationsTypicalUseExample: UIViewController {
       CGRect(x: (view.frame.width - paperDim) / 2, y: paperDim, width: paperDim, height: paperDim)
      view.addSubview(paper)
 
-    paper.elevation = .fabResting
+   let elevation = MDCShadowElevation()
+   elevation.value = MDCShadowElevation.fabResting()
+   paper.elevation = elevation
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/components/ShadowElevations/src/MDCShadowElevations.h
+++ b/components/ShadowElevations/src/MDCShadowElevations.h
@@ -19,89 +19,43 @@
 #import <Foundation/Foundation.h>
 
 // This macro is introduced in Xcode 9.
-#ifndef CF_TYPED_ENUM // What follows is backwards compat for Xcode 8 and below.
-#if __has_attribute(swift_wrapper)
-#define CF_TYPED_ENUM __attribute__((swift_wrapper(enum)))
-#else
-#define CF_TYPED_ENUM
-#endif
-#endif
+//#ifndef CF_TYPED_ENUM // What follows is backwards compat for Xcode 8 and below.
+//#if __has_attribute(swift_wrapper)
+//#define CF_TYPED_ENUM __attribute__((swift_wrapper(enum)))
+//#else
+//#define CF_TYPED_ENUM
+//#endif
+//#endif
 
 /**
  Constants for elevation: the relative depth, or distance, between two surfaces along the z-axis.
  https://material.io/guidelines/material-design/elevation-shadows.html
  */
-NS_SWIFT_NAME(ShadowElevation)
-typedef CGFloat MDCShadowElevation CF_TYPED_ENUM;
+@interface MDCShadowElevation : NSObject
 
-/** The shadow elevation of the app bar. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationAppBar NS_SWIFT_NAME(appBar);
+@property(nonatomic, assign) CGFloat value;
 
-/** The shadow elevation of a card in its picked up state. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationCardPickedUp
-    NS_SWIFT_NAME(cardPickedUp);
++ (CGFloat)appBar;
++ (CGFloat)cardPickedUp;
++ (CGFloat)cardResting;
++ (CGFloat)cardDialog;
++ (CGFloat)fabPressed;
++ (CGFloat)fabResting;
++ (CGFloat)menu;
++ (CGFloat)modalBottomSheet;
++ (CGFloat)navDrawer;
++ (CGFloat)none;
++ (CGFloat)picker;
++ (CGFloat)quickEntry;
++ (CGFloat)quickEntryResting;
++ (CGFloat)raisedButtonPressed;
++ (CGFloat)raisedButtonResting;
++ (CGFloat)refresh;
++ (CGFloat)rightDrawer;
++ (CGFloat)searchBarResting;
++ (CGFloat)searchBarScrolled;
++ (CGFloat)snackbar;
++ (CGFloat)subMenu;
++ (CGFloat)switch;
 
-/** The shadow elevation of a card in its resting state. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationCardResting NS_SWIFT_NAME(cardResting);
-
-/** The shadow elevation of dialogs. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationDialog NS_SWIFT_NAME(cardDialog);
-
-/** The shadow elevation of the floating action button in its pressed state. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationFABPressed NS_SWIFT_NAME(fabPressed);
-
-/** The shadow elevation of the floating action button in its resting state. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationFABResting NS_SWIFT_NAME(fabResting);
-
-/** The shadow elevation of a menu. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationMenu NS_SWIFT_NAME(menu);
-
-/** The shadow elevation of a modal bottom sheet. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationModalBottomSheet
-    NS_SWIFT_NAME(modalBottomSheet);
-
-/** The shadow elevation of the navigation drawer. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationNavDrawer NS_SWIFT_NAME(navDrawer);
-
-/** No shadow elevation at all. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationNone NS_SWIFT_NAME(none);
-
-/** The shadow elevation of a picker. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationPicker NS_SWIFT_NAME(picker);
-
-/** The shadow elevation of the quick entry in the scrolled state. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationQuickEntry NS_SWIFT_NAME(quickEntry);
-
-/** The shadow elevation of the quick entry in the resting state. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationQuickEntryResting
-    NS_SWIFT_NAME(quickEntryResting);
-
-/** The shadow elevation of a raised button in the pressed state. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationRaisedButtonPressed NS_SWIFT_NAME(raisedButtonPressed);
-
-/** The shadow elevation of a raised button in the resting state. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationRaisedButtonResting NS_SWIFT_NAME(raisedButtonResting);
-
-/** The shadow elevation of a refresh indicator. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationRefresh NS_SWIFT_NAME(refresh);
-
-/** The shadow elevation of the right drawer. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationRightDrawer NS_SWIFT_NAME(rightDrawer);
-
-/** The shadow elevation of the search bar in the resting state. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationSearchBarResting
-    NS_SWIFT_NAME(searchBarResting);
-
-/** The shadow elevation of the search bar in the scrolled state. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationSearchBarScrolled
-    NS_SWIFT_NAME(searchBarScrolled);
-
-/** The shadow elevation of the snackbar. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationSnackbar NS_SWIFT_NAME(snackbar);
-
-/** The shadow elevation of a sub menu (+1 for each additional sub menu). */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationSubMenu NS_SWIFT_NAME(subMenu);
-
-/** The shadow elevation of a switch. */
-FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationSwitch NS_SWIFT_NAME(switch);
-
+@end

--- a/components/ShadowElevations/src/MDCShadowElevations.m
+++ b/components/ShadowElevations/src/MDCShadowElevations.m
@@ -16,25 +16,80 @@
 
 #import "MDCShadowElevations.h"
 
-const CGFloat MDCShadowElevationAppBar = 4.f;
-const CGFloat MDCShadowElevationBottomNavigationBar = 8.f;
-const CGFloat MDCShadowElevationCardPickedUp = 8.f;
-const CGFloat MDCShadowElevationCardResting = 2.f;
-const CGFloat MDCShadowElevationDialog = 24.f;
-const CGFloat MDCShadowElevationFABPressed = 12.f;
-const CGFloat MDCShadowElevationFABResting = 6.f;
-const CGFloat MDCShadowElevationMenu = 8.f;
-const CGFloat MDCShadowElevationModalBottomSheet = 16.f;
-const CGFloat MDCShadowElevationNavDrawer = 16.f;
-const CGFloat MDCShadowElevationNone = 0;
-const CGFloat MDCShadowElevationPicker = 24.f;
-const CGFloat MDCShadowElevationQuickEntry = 3.f;
-const CGFloat MDCShadowElevationQuickEntryResting = 2.f;
-const CGFloat MDCShadowElevationRaisedButtonPressed = 8.f;
-const CGFloat MDCShadowElevationRaisedButtonResting = 2.f;
-const CGFloat MDCShadowElevationRefresh = 3.f;
-const CGFloat MDCShadowElevationRightDrawer = 16.f;
-const CGFloat MDCShadowElevationSearchBarResting = 2.f;
-const CGFloat MDCShadowElevationSearchBarScrolled = 3.f;
-const CGFloat MDCShadowElevationSnackbar = 6.f;
-const CGFloat MDCShadowElevationSubMenu = 9.f;
+
+@implementation MDCShadowElevation
+
+- (instancetype)init {
+   _value = 0.0f;
+   return self;
+}
+
++ (CGFloat)appBar {
+   return 4.0;
+}
+
++ (CGFloat)cardPickedUp {
+   return 8.0f;
+}
++ (CGFloat)cardResting {
+   return 2.0f;
+}
++ (CGFloat)cardDialog {
+   return 24.0f;
+}
++ (CGFloat)fabPressed {
+   return 12.0f;
+}
++ (CGFloat)fabResting {
+   return 6.0f;
+}
++ (CGFloat)menu {
+   return 8.0f;
+}
++ (CGFloat)modalBottomSheet {
+   return 16.0f;
+}
++ (CGFloat)navDrawer {
+   return 16.0f;
+}
++ (CGFloat)none {
+   return 0.0f;
+}
++ (CGFloat)picker {
+   return 24.0f;
+}
++ (CGFloat)quickEntry {
+   return 3.0f;
+}
++ (CGFloat)quickEntryResting {
+   return 2.0f;
+}
++ (CGFloat)raisedButtonPressed {
+   return 8.0f;
+}
++ (CGFloat)raisedButtonResting {
+   return 2.0f;
+}
++ (CGFloat)refresh {
+   return 3.0f;
+}
++ (CGFloat)rightDrawer {
+   return 16.0f;
+}
++ (CGFloat)searchBarResting {
+   return 2.0f;
+}
++ (CGFloat)searchBarScrolled {
+   return 3.0f;
+}
++ (CGFloat)snackbar {
+   return 6.0f;
+}
++ (CGFloat)subMenu {
+   return 9.0f;
+}
++ (CGFloat)switch {
+   return 1.0f;
+}
+
+@end

--- a/components/ShadowLayer/examples/ExampleShadowedView.swift
+++ b/components/ShadowLayer/examples/ExampleShadowedView.swift
@@ -29,8 +29,8 @@ class ExampleShadowedView: UIView {
     return self.layer as! MDCShadowLayer
   }
 
-  func setElevation(_ points: ShadowElevation) {
-    self.shadowLayer.elevation = points
+  func setElevation(_ points: MDCShadowElevation) {
+    self.shadowLayer.elevation = points.value
   }
 
 }

--- a/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
+++ b/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
@@ -40,8 +40,9 @@ class ShadowDragSquareExampleViewController: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-
-    self.blueView.setElevation(ShadowElevation(rawValue: kRestingCardElevation))
+   let elevation = MDCShadowElevation()
+   elevation.value = MDCShadowElevation.cardResting()
+   self.blueView.setElevation(elevation)
 
     longPressRecogniser.addTarget(self, action: #selector(longPressedInView))
     longPressRecogniser.minimumPressDuration = 0.0
@@ -52,7 +53,9 @@ class ShadowDragSquareExampleViewController: UIViewController {
     // Elevation of the view is changed to indicate that it has been pressed or released.
     // view.center is changed to follow the touch events.
     if sender.state == .began {
-      self.blueView.setElevation(ShadowElevation(rawValue: kSelectedCardElevation))
+      let elevation = MDCShadowElevation()
+      elevation.value = MDCShadowElevation.cardPickedUp()
+      self.blueView.setElevation(elevation)
 
       let selfPoint = sender.location(in: self.view)
       movingViewOffset.x = selfPoint.x - self.blueView.center.x
@@ -63,7 +66,9 @@ class ShadowDragSquareExampleViewController: UIViewController {
           CGPoint(x: selfPoint.x - movingViewOffset.x, y: selfPoint.y - movingViewOffset.y)
       self.blueView.center = newCenterPoint
     } else if sender.state == .ended {
-      self.blueView.setElevation(ShadowElevation(rawValue: kRestingCardElevation))
+      let elevation = MDCShadowElevation()
+      elevation.value = MDCShadowElevation.cardResting()
+      self.blueView.setElevation(elevation)
 
       movingViewOffset = CGPoint.zero
     }

--- a/components/ShadowLayer/src/MDCShadowLayer.h
+++ b/components/ShadowLayer/src/MDCShadowLayer.h
@@ -65,7 +65,7 @@
 
  Negative values act as if zero were specified.
  */
-@property(nonatomic, assign) MDCShadowElevation elevation;
+@property(nonatomic, assign) CGFloat elevation;
 
 /**
  Whether to apply the "cutout" shadow layer mask.

--- a/components/private/ThumbTrack/src/MDCThumbView.m
+++ b/components/private/ThumbTrack/src/MDCThumbView.m
@@ -57,7 +57,7 @@ static const CGFloat kMinTouchSize = 48;
 - (void)setHasShadow:(BOOL)hasShadow {
   _hasShadow = hasShadow;
   [[self shadowLayer]
-      setElevation:(hasShadow) ? MDCShadowElevationCardResting : MDCShadowElevationNone];
+      setElevation:(hasShadow) ? [MDCShadowElevation cardResting] : [MDCShadowElevation none]];
 }
 
 - (MDCShadowLayer *)shadowLayer {


### PR DESCRIPTION
This would allow users to extend ShadowElevations with a function

`extension MDCShadowElevation {
   static func random() -> CGFloat {
     return 762.0
   }
}`

Closes #2105 
