### PR TITLE
[FlexibleHeader] Fix where we adjust the frame if the safe area changes.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -458,7 +458,16 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
     if (_maximumHeight < _minimumHeight) {
       _maximumHeight = _minimumHeight;
     }
-    [self fhv_updateLayout];
+
+    // The changes might require us to re-calculate the frame, or update the entire layout.
+    if (!_trackingScrollView) {
+      CGRect bounds = self.bounds;
+      bounds.size.height = _minimumHeight;
+      self.bounds = bounds;
+      [self fhv_commitAccumulatorToFrame];
+    } else {
+      [self fhv_updateLayout];
+    }
   }
 #endif
 }
@@ -824,14 +833,6 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 
 - (void)fhv_updateLayout {
   if (!_trackingScrollView) {
-    // Even if we're not tracking a scroll view, our minimumHeight might have changed due to new
-    // safe area insets.
-    if (_minimumHeight > 0 && CGRectGetHeight(self.bounds) != _minimumHeight) {
-      CGRect bounds = self.bounds;
-      bounds.size.height = _minimumHeight;
-      self.bounds = bounds;
-      [self fhv_commitAccumulatorToFrame];
-    }
     return;
   }
 

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderSizeToFitTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderSizeToFitTests.swift
@@ -61,7 +61,7 @@ class FlexibleHeaderSizeToFitTests: XCTestCase {
     XCTAssertEqual(view.frame.origin.x, initialFrame.origin.x)
     XCTAssertEqual(view.frame.origin.y, initialFrame.origin.y)
     XCTAssertEqual(view.frame.size.width, initialFrame.size.width)
-    XCTAssertEqual(view.frame.size.height, view.minimumHeight)
+    XCTAssertEqual(view.frame.size.height, initialFrame.size.height)
 
     XCTAssertEqual(bestFitSize.width, possibleSize.width)
     XCTAssertEqual(bestFitSize.height, view.minimumHeight)


### PR DESCRIPTION
This fixes a bug introduced in #2068, where a shadow would incorrectly appear in the FHV when using custom min/max heights.
Since what we were trying to do there is to adjust the frame when the safe area changes, we should do that outside of fhv_updateLayout anyway.

Before:
![simulator screen shot - iphone 6 - 2017-10-10 at 18 12 20](https://user-images.githubusercontent.com/4545451/31413304-972daf90-ade6-11e7-8dbb-35ae6d9304a0.png)

After:
![simulator screen shot - iphone 6 - 2017-10-10 at 18 12 02](https://user-images.githubusercontent.com/4545451/31413306-9947e76e-ade6-11e7-96bb-df15ed1eaa63.png)
