### PR TITLE
[Tabs] Add standard Material Design shadow shadow to MDCTabBar

### DIFF
--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -17,8 +17,6 @@
 #import "MDCTabBar.h"
 
 #import "MaterialInk.h"
-#import "MaterialShadowElevations.h"
-#import "MaterialShadowLayer.h"
 #import "MaterialTypography.h"
 #import "private/MDCItemBar.h"
 #import "private/MDCItemBarAlignment.h"
@@ -93,10 +91,6 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 @synthesize displaysUppercaseTitles = _displaysUppercaseTitles;
 @synthesize itemAppearance = _itemAppearance;
 
-+ (Class)layerClass {
-  return [MDCShadowLayer class];
-}
-
 #pragma mark - Initialization
 
 + (void)initialize {
@@ -139,8 +133,6 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   _itemBar.delegate = self;
   _itemBar.alignment = MDCItemBarAlignmentForTabBarAlignment(_alignment);
   [self addSubview:_itemBar];
-
-  [[self shadowLayer] setElevation:MDCShadowElevationMenu];
 
   [self updateItemBarStyle];
 }
@@ -509,12 +501,6 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   style.displaysUppercaseTitles = _displaysUppercaseTitles;
 
   [_itemBar applyStyle:style];
-}
-
-#pragma mark - MDC Shadow
-
-- (MDCShadowLayer *)shadowLayer {
-  return (MDCShadowLayer *)self.layer;
 }
 
 @end

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -17,6 +17,7 @@
 #import "MDCTabBar.h"
 
 #import "MaterialInk.h"
+#import "MaterialTypography.h"
 #import "private/MDCItemBar.h"
 #import "private/MDCItemBarAlignment.h"
 #import "private/MDCItemBarStyle.h"

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -18,8 +18,6 @@
 
 #import "MaterialInk.h"
 #import "MaterialShadowElevations.h"
-#import "MaterialShadowLayer.h"
-#import "MaterialTypography.h"
 #import "private/MDCItemBar.h"
 #import "private/MDCItemBarAlignment.h"
 #import "private/MDCItemBarStyle.h"
@@ -93,10 +91,6 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 @synthesize displaysUppercaseTitles = _displaysUppercaseTitles;
 @synthesize itemAppearance = _itemAppearance;
 
-+ (Class)layerClass {
-  return [MDCShadowLayer class];
-}
-
 #pragma mark - Initialization
 
 + (void)initialize {
@@ -139,8 +133,6 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   _itemBar.delegate = self;
   _itemBar.alignment = MDCItemBarAlignmentForTabBarAlignment(_alignment);
   [self addSubview:_itemBar];
-
-  [[self shadowLayer] setElevation:MDCShadowElevationMenu];
 
   [self updateItemBarStyle];
 }
@@ -509,12 +501,6 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   style.displaysUppercaseTitles = _displaysUppercaseTitles;
 
   [_itemBar applyStyle:style];
-}
-
-#pragma mark - MDC Shadow
-
-- (MDCShadowLayer *)shadowLayer {
-  return (MDCShadowLayer *)self.layer;
 }
 
 @end

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -17,6 +17,8 @@
 #import "MDCTabBar.h"
 
 #import "MaterialInk.h"
+#import "MaterialShadowElevations.h"
+#import "MaterialShadowLayer.h"
 #import "MaterialTypography.h"
 #import "private/MDCItemBar.h"
 #import "private/MDCItemBarAlignment.h"
@@ -91,6 +93,10 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 @synthesize displaysUppercaseTitles = _displaysUppercaseTitles;
 @synthesize itemAppearance = _itemAppearance;
 
++ (Class)layerClass {
+  return [MDCShadowLayer class];
+}
+
 #pragma mark - Initialization
 
 + (void)initialize {
@@ -133,6 +139,8 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   _itemBar.delegate = self;
   _itemBar.alignment = MDCItemBarAlignmentForTabBarAlignment(_alignment);
   [self addSubview:_itemBar];
+
+  [[self shadowLayer] setElevation:MDCShadowElevationMenu];
 
   [self updateItemBarStyle];
 }
@@ -501,6 +509,12 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   style.displaysUppercaseTitles = _displaysUppercaseTitles;
 
   [_itemBar applyStyle:style];
+}
+
+#pragma mark - MDC Shadow
+
+- (MDCShadowLayer *)shadowLayer {
+  return (MDCShadowLayer *)self.layer;
 }
 
 @end

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -17,7 +17,6 @@
 #import "MDCTabBar.h"
 
 #import "MaterialInk.h"
-#import "MaterialShadowElevations.h"
 #import "private/MDCItemBar.h"
 #import "private/MDCItemBarAlignment.h"
 #import "private/MDCItemBarStyle.h"

--- a/components/Tabs/src/MDCTabBarViewController.m
+++ b/components/Tabs/src/MDCTabBarViewController.m
@@ -131,6 +131,7 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
     if (selectedViewController) {
       self.tabBar.selectedItem = selectedViewController.tabBarItem;
     }
+    [self setNeedsStatusBarAppearanceUpdate];
   }
 }
 
@@ -241,5 +242,14 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
   }
 }
 
+#pragma mark - UIViewController status bar
+
+- (nullable UIViewController *)childViewControllerForStatusBarStyle {
+  return _selectedViewController;
+}
+
+- (nullable UIViewController *)childViewControllerForStatusBarHidden {
+  return _selectedViewController;
+}
 
 @end

--- a/components/Tabs/src/MDCTabBarViewController.m
+++ b/components/Tabs/src/MDCTabBarViewController.m
@@ -50,7 +50,7 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
 }
 
 - (void)commonMDCTabBarShadowViewInitialization {
-  MDCShadowLayer *shadowLayer =  (MDCShadowLayer *)self.layer;
+  MDCShadowLayer *shadowLayer = (MDCShadowLayer *)self.layer;
   [shadowLayer setElevation:MDCShadowElevationMenu];
 }
 

--- a/components/Tabs/src/MDCTabBarViewController.m
+++ b/components/Tabs/src/MDCTabBarViewController.m
@@ -16,7 +16,45 @@
 
 #import "MDCTabBarViewController.h"
 
+#import "MaterialShadowElevations.h"
+#import "MaterialShadowLayer.h"
+
 const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
+
+/**
+ * View to host shadow for the tab bar.
+ */
+@interface MDCTabBarShadowView : UIView
+@end
+
+@implementation MDCTabBarShadowView
+
++ (Class)layerClass {
+  return [MDCShadowLayer class];
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+  if (self) {
+    [self commonMDCTabBarShadowViewInitialization];
+  }
+  return self;
+}
+
+- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
+  self = [super initWithCoder:aDecoder];
+  if (self) {
+    [self commonMDCTabBarShadowViewInitialization];
+  }
+  return self;
+}
+
+- (void)commonMDCTabBarShadowViewInitialization {
+  MDCShadowLayer *shadowLayer =  (MDCShadowLayer *)self.layer;
+  [shadowLayer setElevation:MDCShadowElevationMenu];
+}
+
+@end
 
 @interface MDCTabBarViewController ()
 
@@ -27,6 +65,7 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
 @implementation MDCTabBarViewController {
   /** For showing/hiding, Animation needs to know where it wants to end up. */
   BOOL _tabBarWantsToBeHidden;
+  MDCTabBarShadowView *_tabBarShadow;
 }
 
 - (void)viewDidLoad {
@@ -41,6 +80,8 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
   tabBar.alignment = MDCTabBarAlignmentJustified;
   tabBar.delegate = self;
   self.tabBar = tabBar;
+  _tabBarShadow = [[MDCTabBarShadowView alloc] initWithFrame:view.bounds];
+  [view addSubview:_tabBarShadow];
   [view addSubview:tabBar];
   [self updateTabBarItems];
 }
@@ -74,6 +115,7 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
       if (!hidden) {
         // If we are showing, set the state before the animation.
         _tabBar.hidden = hidden;
+        _tabBarShadow.hidden = hidden;
       }
       [UIView animateWithDuration:MDCTabBarViewControllerAnimationDuration
           animations:^{
@@ -82,9 +124,11 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
           completion:^(__unused BOOL finished) {
             // If we are hiding, set the state after the animation.
             _tabBar.hidden = hidden;
+            _tabBarShadow.hidden = hidden;
           }];
     } else {
       _tabBar.hidden = hidden;
+      _tabBarShadow.hidden = hidden;
     }
   }
 }
@@ -182,6 +226,7 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
   } else {
     self.tabBar.itemAppearance = MDCTabBarItemAppearanceTitles;
   }
+  [self.view bringSubviewToFront:_tabBarShadow];
   [self.view bringSubviewToFront:self.tabBar];
 }
 
@@ -204,6 +249,7 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
     CGRectDivide(bounds, &tabBarFrame, &currentViewFrame, tabBarHeight, CGRectMaxYEdge);
   }
   _tabBar.frame = tabBarFrame;
+  _tabBarShadow.frame = tabBarFrame;
   _selectedViewController.view.frame = currentViewFrame;
 }
 

--- a/components/Tabs/src/MDCTabBarViewController.m
+++ b/components/Tabs/src/MDCTabBarViewController.m
@@ -182,6 +182,7 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
   } else {
     self.tabBar.itemAppearance = MDCTabBarItemAppearanceTitles;
   }
+  [self.view bringSubviewToFront:self.tabBar];
 }
 
 - (nullable UIViewController *)controllerWithView:(nullable UIView *)view {


### PR DESCRIPTION
This change adds a Menu-height shadow layer to the MDCTabBar, and ensures that the
tab bar is always at the frontmost view in MDCTabBarViewController.

closes #2112 
