### PR TITLE
[FlexibleHeader] Forward viewWillTransitionToSize events to the flexible header

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1216,6 +1216,7 @@ static BOOL isRunningiOS10_3OrAbove() {
   NSAssert(_interfaceOrientationIsChanging, @"Call to %@::%@ not matched by a call to %@.",
            NSStringFromClass([self class]), NSStringFromSelector(_cmd),
            NSStringFromSelector(@selector(interfaceOrientationWillChange)));
+  [self fhv_updateLayout];
 }
 
 - (void)interfaceOrientationDidChange {

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -459,6 +459,9 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
       _maximumHeight = _minimumHeight;
     }
 
+    // Ignore any content offset delta that occured as a result of any safe area insets change.
+    _shiftAccumulatorLastContentOffset = [self fhv_boundedContentOffset];
+
     // The changes might require us to re-calculate the frame, or update the entire layout.
     if (!_trackingScrollView) {
       CGRect bounds = self.bounds;

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -192,6 +192,12 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
 }
 #endif  // #if !defined(__IPHONE_8_0) || (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0)
 
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+  [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+
+  [_headerView viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+}
+
 #pragma mark - UIScrollViewDelegate
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {


### PR DESCRIPTION
This resolves a class of iPhone X bugs that were related to safe area inset changes not to being propagated on device rotation.

We also now ignore any accumulator changes resulting from safe area insets changes so that we don't inadvertently shift the header during orientation changes.

Note how in the following example the navigation bar's layout isn't updated to the new safe area insets in landscape orientation.

## Before

<img width="964" alt="before" src="https://user-images.githubusercontent.com/45670/31441445-315e9410-ae61-11e7-9242-ecf8d91af80a.png">

## After

<img width="964" alt="after" src="https://user-images.githubusercontent.com/45670/31441450-32545bac-ae61-11e7-9e7f-d6e91de09d94.png">
