### PR TITLE
[Tabs] Always call MDCTabBarControllerDelegate methods when a tab is tapped

### DIFF
--- a/components/Tabs/src/MDCTabBarViewController.h
+++ b/components/Tabs/src/MDCTabBarViewController.h
@@ -71,6 +71,9 @@ IB_DESIGNABLE
  If you provide this method, you can control whether tapping on a tab bar item actually
  switches to that viewController. If not provided, MDCTabBarViewController will always switch.
 
+ The tab bar controller calls this method regardless of whether the selected view controller
+ changed.
+
  You can also use this method as a willSelectViewController.
  */
 - (BOOL)tabBarController:(nonnull MDCTabBarViewController *)tabBarController
@@ -80,6 +83,9 @@ IB_DESIGNABLE
  Called when the user taps on a tab bar item. Not called for programmatic selection.
  MDCTabBarViewController will call your delegate once it has responded to the user's tap
  by changing the selected view controller.
+
+ The tab bar controller calls this method regardless of whether the selected view controller
+ changed.
  */
 - (void)tabBarController:(nonnull MDCTabBarViewController *)tabBarController
  didSelectViewController:(nonnull UIViewController *)viewController;

--- a/components/Tabs/src/MDCTabBarViewController.h
+++ b/components/Tabs/src/MDCTabBarViewController.h
@@ -70,9 +70,9 @@ IB_DESIGNABLE
 
  If you provide this method, you can control whether tapping on a tab bar item actually
  switches to that viewController. If not provided, MDCTabBarViewController will always switch.
-
- The tab bar controller calls this method regardless of whether the selected view controller
- changed.
+ 
+ @note The tab bar controller will call this method even when the tapped tab bar
+ item is the currently-selected tab bar item.
 
  You can also use this method as a willSelectViewController.
  */
@@ -84,8 +84,8 @@ IB_DESIGNABLE
  MDCTabBarViewController will call your delegate once it has responded to the user's tap
  by changing the selected view controller.
 
- The tab bar controller calls this method regardless of whether the selected view controller
- changed.
+ @note The tab bar controller will call this method even when the tapped tab bar
+ item is the currently-selected tab bar item.
  */
 - (void)tabBarController:(nonnull MDCTabBarViewController *)tabBarController
  didSelectViewController:(nonnull UIViewController *)viewController;

--- a/components/Tabs/src/MDCTabBarViewController.m
+++ b/components/Tabs/src/MDCTabBarViewController.m
@@ -213,9 +213,7 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
     NSUInteger index = [tabBar.items indexOfObject:item];
     if (index < _viewControllers.count) {
       UIViewController *newSelected = _viewControllers[index];
-      if (newSelected != self.selectedViewController) {
-        return [_delegate tabBarController:self shouldSelectViewController:newSelected];
-      }
+      return [_delegate tabBarController:self shouldSelectViewController:newSelected];
     }
   }
   return YES;
@@ -227,9 +225,9 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
     UIViewController *newSelected = _viewControllers[index];
     if (newSelected != self.selectedViewController) {
       self.selectedViewController = newSelected;
-      if ([_delegate respondsToSelector:@selector(tabBarController:didSelectViewController:)]) {
-        [_delegate tabBarController:self didSelectViewController:newSelected];
-      }
+    }
+    if ([_delegate respondsToSelector:@selector(tabBarController:didSelectViewController:)]) {
+      [_delegate tabBarController:self didSelectViewController:newSelected];
     }
   }
 }


### PR DESCRIPTION
To more closely align with UITabBarController behavior, MDCTabBarController will invoke
the -tabBarController:shouldSelectViewController: and -tabBarController:didSelectViewController: delegate methods any time a tab is tapped, even if the selected view controller is unchanged.

closes #2154 
