### PR TITLE
[FlexibleHeader] Ignore safe area inset changes if we know that the status bar visibility is changing

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -443,6 +443,14 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
     if (_hasExplicitlySetMinHeight && _hasExplicitlySetMaxHeight) {
       return;
     }
+
+    if (_isChangingStatusBarVisibility) {
+      // We aren't interest in safe area inset changes due to status bar visibility changes - we're
+      // only interested in hardware-related safe area changes. If we know that we're changing the
+      // status bar visibility then we ignore this safeAreaInsetsDidChange event.
+      return;
+    }
+
     if (!_hasExplicitlySetMinHeight) {
       // Edge case for UITableViewController: If we're a subview of _trackingScrollView,
       // we need to get the Safe Area insets from there and not use ours.


### PR DESCRIPTION
This fixes a class of bugs where the flexible header would cause the content to jump while the header shifted on- or off-screen on non-iPhone X devices.

In essence we ignore safe area inset changes if we know that we're changing the status bar visibility. We primarily care about safe area inset changes that result from the hardware safe area insets changing.
