### PR TITLE
Revert "[FlexibleHeader] Introduce minMaxHeightIncludesSafeArea."

### DIFF
--- a/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
@@ -95,10 +95,6 @@
     case FlexibleHeaderConfiguratorFieldMaximumHeight:
       headerView.maximumHeight = [self heightDenormalized:[value floatValue]];
       break;
-
-    case FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea:
-      headerView.minMaxHeightIncludesSafeArea = [value boolValue];
-      break;
   }
 }
 
@@ -213,8 +209,6 @@ static const CGFloat kHeightScalar = 300;
 
     case FlexibleHeaderConfiguratorFieldMaximumHeight:
       return @([self normalizedHeight:self.fhvc.headerView.maximumHeight]);
-    case FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea:
-      return @(self.fhvc.headerView.minMaxHeightIncludesSafeArea);
   }
 }
 

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.h
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.h
@@ -34,7 +34,6 @@ typedef enum : NSUInteger {
 
   FlexibleHeaderConfiguratorFieldMinimumHeight,
   FlexibleHeaderConfiguratorFieldMaximumHeight,
-  FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea,
 } FlexibleHeaderConfiguratorField;
 
 @interface FlexibleHeaderConfiguratorExample : UITableViewController

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
@@ -134,9 +134,7 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
 
   createSection(@"Header height", @[
     sliderItem(@"Minimum", FlexibleHeaderConfiguratorFieldMinimumHeight),
-    sliderItem(@"Maximum", FlexibleHeaderConfiguratorFieldMaximumHeight),
-    switchItem(@"Min / max height includes Safe Area",
-               FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea)
+    sliderItem(@"Maximum", FlexibleHeaderConfiguratorFieldMaximumHeight)
   ]);
 
   NSMutableArray *fillerItems = [NSMutableArray array];

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -293,8 +293,6 @@ IB_DESIGNABLE
 /**
  The minimum height that this header can shrink to.
 
- See minMaxHeightIncludesSafeArea to learn how this number is used when the Safe Area changes.
-
  If you change the value of this property and the maximumHeight of the receiver is below the new
  minimumHeight, maximumHeight will be adjusted to match the new minimum value.
  */
@@ -303,31 +301,10 @@ IB_DESIGNABLE
 /**
  The maximum height that this header can expand to.
 
- See minMaxHeightIncludesSafeArea to learn how this number is used when the Safe Area changes.
-
  If you change the value of this property and the minimumHeight of the receiver is above the new
  maximumHeight, minimumHeight will be adjusted to match the new maximumHeight.
  */
 @property(nonatomic) CGFloat maximumHeight;
-
-/**
- When this is enabled, the flexible header will assume that minimumHeight and maximumHeight both
- include the Safe Area top inset. For example, a header whose maximum content height should be 200
- might set 220 (200 + 20) as the maximumHeight. Notice that if this is enabled and you're setting
- minimumHeight and or maximumHeight, the flexible header won't automatically adjust its size to
- account for changes to the Safe Area, as the values provided already include a hardcoded inset.
-
- When this is disabled, the flexible header will assume that the provided minimumHeight and
- maximumHeight do not include the Safe Area top inset. For example, a header whose maximum content
- height should be 200 would set 200 as the maximumHeight, and the flexible header will take care
- of adjusting itself to account for Safe Area changes internally.
-
- Clients are recommended to set this to NO, and set the min and max heights to values that don't
- include the status bar or Safe Area insets.
-
- Default is YES.
- */
-@property(nonatomic) BOOL minMaxHeightIncludesSafeArea;
 
 #pragma mark Behaviors
 

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
@@ -180,8 +180,7 @@
   [self.vc.scrollView scrollRectToVisible:initialFrame animated:NO];
 
   // Then
-  XCTAssertEqual(self.vc.fhvc.flexibleHeaderViewControllerHeightOffset,
-                 MIN(self.vc.fhvc.headerView.minimumHeight, randomHeight));
+  XCTAssertEqual(self.vc.fhvc.flexibleHeaderViewControllerHeightOffset, randomHeight);
 }
 
 @end


### PR DESCRIPTION
Reverts material-components/material-components-ios#2123.

That PR introduced a bug with the header taking into account the safe area twice.