### PR TITLE
[FlexibleHeader] Fix shadow bug 

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -467,7 +467,11 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
       CGRect bounds = self.bounds;
       bounds.size.height = _minimumHeight;
       self.bounds = bounds;
-      [self fhv_commitAccumulatorToFrame];
+      CGPoint position = self.center;
+      position.y = -MIN([self fhv_accumulatorMax], _shiftAccumulator);
+      position.y += self.bounds.size.height / 2;
+      self.center = position;
+      [self.delegate flexibleHeaderViewFrameDidChange:self];
     } else {
       [self fhv_updateLayout];
     }


### PR DESCRIPTION
We can't use fhv_commitAccumulatorToFrame when we're not tracking a scroll view, as it has the side effect of setting the shadow to the default opacity.
Instead, I extracted the relevant code into safeAreaInsetsDidChange. We should clean this up even further, but I need to ask @jverkoey a few questions before I can do that.