### PR TITLE
[ShadowElevations] Update elevation Swift examples

### DIFF
--- a/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.swift
+++ b/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.swift
@@ -36,7 +36,7 @@ class ShadowElevationsTypicalUseExample: UIViewController {
     let paperDim = CGFloat(200)
     paper.frame =
       CGRect(x: (view.frame.width - paperDim) / 2, y: paperDim, width: paperDim, height: paperDim)
-     view.addSubview(paper)
+    view.addSubview(paper)
 
     paper.elevation = .fabResting
   }

--- a/components/ShadowLayer/README.md
+++ b/components/ShadowLayer/README.md
@@ -133,13 +133,12 @@ Add the custom button to view:
 <!--<div class="material-code-render" markdown="1">-->
 #### Swift
 ``` swift
-let button: ShadowButton = ShadowButton.init(type: .system)
+let button = ShadowButton(type: .system)
 button.frame = CGRect(x: 100, y: 100, width: 200, height: 50)
 button.setTitle("Button", for: .normal)
 let buttonLayer = button.layer as! MDCShadowLayer
-buttonLayer.elevation = 6.0
+buttonLayer.elevation = ShadowElevation(6)
 addSubview(button)
-
 ```
 
 #### Objective C
@@ -169,8 +168,13 @@ class ShadowedView: UIView {
     return self.layer as! MDCShadowLayer
   }
 
-  func setElevation(points: CGFloat) {
-    self.shadowLayer.elevation = points
+  var elevation: ShadowElevation {
+    get {
+      return self.shadowLayer.elevation
+    }
+    set {
+      self.shadowLayer.elevation = newValue
+    }
   }
 
 }

--- a/components/ShadowLayer/examples/ExampleShadowedView.swift
+++ b/components/ShadowLayer/examples/ExampleShadowedView.swift
@@ -29,8 +29,13 @@ class ExampleShadowedView: UIView {
     return self.layer as! MDCShadowLayer
   }
 
-  func setElevation(_ points: ShadowElevation) {
-    self.shadowLayer.elevation = points
+  var elevation: ShadowElevation {
+    get {
+      return self.shadowLayer.elevation
+    }
+    set {
+      self.shadowLayer.elevation = newValue
+    }
   }
 
 }

--- a/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
+++ b/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
@@ -35,7 +35,7 @@ class ShadowDragSquareExampleViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    self.blueView.setElevation(.cardResting)
+    self.blueView.elevation = .cardResting
 
     longPressRecogniser.addTarget(self, action: #selector(longPressedInView))
     longPressRecogniser.minimumPressDuration = 0.0
@@ -46,7 +46,7 @@ class ShadowDragSquareExampleViewController: UIViewController {
     // Elevation of the view is changed to indicate that it has been pressed or released.
     // view.center is changed to follow the touch events.
     if sender.state == .began {
-      self.blueView.setElevation(.cardPickedUp)
+      self.blueView.elevation = .cardPickedUp
 
       let selfPoint = sender.location(in: self.view)
       movingViewOffset.x = selfPoint.x - self.blueView.center.x
@@ -57,7 +57,7 @@ class ShadowDragSquareExampleViewController: UIViewController {
           CGPoint(x: selfPoint.x - movingViewOffset.x, y: selfPoint.y - movingViewOffset.y)
       self.blueView.center = newCenterPoint
     } else if sender.state == .ended {
-      self.blueView.setElevation(.cardResting)
+      self.blueView.elevation = .cardResting
 
       movingViewOffset = CGPoint.zero
     }


### PR DESCRIPTION
Fixing some ShadowLayer examples that won't build due to switching ShadowElevation to a typed enum.

Updating examples to use properties ratter than setter methods.