### PR TITLE
[TextFields] Clear button X value adjustment.

### DIFF
--- a/components/TextFields/src/private/MDCTextInputArt.h
+++ b/components/TextFields/src/private/MDCTextInputArt.h
@@ -18,7 +18,7 @@
 
 #import "MaterialMath.h"
 
-static const CGFloat MDCTextInputClearButtonImageBuiltInPadding = 2.5f;
+static const CGFloat MDCTextInputClearButtonImageBuiltInPadding = 2.0f;
 
 #pragma mark - Drawing
 


### PR DESCRIPTION
Closes #2171 

Here are 3 screenshots with injected color to show it's now in bounds. Tested iPhone X, 7 Plus, 5s.

![screen shot 2017-10-13 at 12 49 37 pm](https://user-images.githubusercontent.com/1271525/31557263-044746b4-b016-11e7-879a-8bd8dfece885.png)

![screen shot 2017-10-13 at 12 49 26 pm](https://user-images.githubusercontent.com/1271525/31557260-fefb4ae8-b015-11e7-8adf-607ec6e5fc37.png)
![screen shot 2017-10-13 at 12 49 13 pm](https://user-images.githubusercontent.com/1271525/31557253-fad76aaa-b015-11e7-8009-ff8eca6fafc7.png)


5s has some antialiasing that's harsh but it's actually cleaner on the right side of the image.