### PR TITLE
[FlexibleHeader] Introduce minMaxHeightIncludesSafeArea and fix rotation bugs.

### DIFF
--- a/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
@@ -95,6 +95,10 @@
     case FlexibleHeaderConfiguratorFieldMaximumHeight:
       headerView.maximumHeight = [self heightDenormalized:[value floatValue]];
       break;
+
+    case FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea:
+      headerView.minMaxHeightIncludesSafeArea = [value boolValue];
+      break;
   }
 }
 
@@ -209,6 +213,8 @@ static const CGFloat kHeightScalar = 300;
 
     case FlexibleHeaderConfiguratorFieldMaximumHeight:
       return @([self normalizedHeight:self.fhvc.headerView.maximumHeight]);
+    case FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea:
+      return @(self.fhvc.headerView.minMaxHeightIncludesSafeArea);
   }
 }
 

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.h
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.h
@@ -34,6 +34,7 @@ typedef enum : NSUInteger {
 
   FlexibleHeaderConfiguratorFieldMinimumHeight,
   FlexibleHeaderConfiguratorFieldMaximumHeight,
+  FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea,
 } FlexibleHeaderConfiguratorField;
 
 @interface FlexibleHeaderConfiguratorExample : UITableViewController

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
@@ -134,7 +134,9 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
 
   createSection(@"Header height", @[
     sliderItem(@"Minimum", FlexibleHeaderConfiguratorFieldMinimumHeight),
-    sliderItem(@"Maximum", FlexibleHeaderConfiguratorFieldMaximumHeight)
+    sliderItem(@"Maximum", FlexibleHeaderConfiguratorFieldMaximumHeight),
+    switchItem(@"Min / max height includes Safe Area",
+               FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea)
   ]);
 
   NSMutableArray *fillerItems = [NSMutableArray array];

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -293,6 +293,8 @@ IB_DESIGNABLE
 /**
  The minimum height that this header can shrink to.
 
+ See minMaxHeightIncludesSafeArea to learn how this number is used when the Safe Area changes.
+
  If you change the value of this property and the maximumHeight of the receiver is below the new
  minimumHeight, maximumHeight will be adjusted to match the new minimum value.
  */
@@ -301,10 +303,31 @@ IB_DESIGNABLE
 /**
  The maximum height that this header can expand to.
 
+ See minMaxHeightIncludesSafeArea to learn how this number is used when the Safe Area changes.
+
  If you change the value of this property and the minimumHeight of the receiver is above the new
  maximumHeight, minimumHeight will be adjusted to match the new maximumHeight.
  */
 @property(nonatomic) CGFloat maximumHeight;
+
+/**
+ When this is enabled, the flexible header will assume that minimumHeight and maximumHeight both
+ include the Safe Area top inset. For example, a header whose maximum content height should be 200
+ might set 220 (200 + 20) as the maximumHeight. Notice that if this is enabled and you're setting
+ minimumHeight and or maximumHeight, the flexible header won't automatically adjust its size to
+ account for changes to the Safe Area, as the values provided already include a hardcoded inset.
+
+ When this is disabled, the flexible header will assume that the provided minimumHeight and
+ maximumHeight do not include the Safe Area top inset. For example, a header whose maximum content
+ height should be 200 would set 200 as the maximumHeight, and the flexible header will take care
+ of adjusting itself to account for Safe Area changes internally.
+
+ Clients are recommended to set this to NO, and set the min and max heights to values that don't
+ include the status bar or Safe Area insets.
+
+ Default is YES.
+ */
+@property(nonatomic) BOOL minMaxHeightIncludesSafeArea;
 
 #pragma mark Behaviors
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -400,7 +400,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 #pragma mark - UIView
 
 - (CGSize)sizeThatFits:(CGSize)size {
-  return CGSizeMake(size.width, self.computedTotalMinHeight);
+  return CGSizeMake(size.width, self.computedMinimumHeight);
 }
 
 - (void)layoutSubviews {
@@ -485,7 +485,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
     // The changes might require us to re-calculate the frame, or update the entire layout.
     if (!_trackingScrollView) {
       CGRect bounds = self.bounds;
-      bounds.size.height = self.computedTotalMinHeight;
+      bounds.size.height = self.computedMinimumHeight;
       self.bounds = bounds;
       CGPoint position = self.center;
       position.y = -MIN([self fhv_accumulatorMax], _shiftAccumulator);
@@ -573,8 +573,8 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 
   if (!info.hasInjectedTopContentInset) {
     UIEdgeInsets insets = scrollView.contentInset;
-    insets.top += self.computedTotalMaxHeight - safeAreaAdjustment;
-    info.injectedTopContentInset = self.computedTotalMaxHeight - safeAreaAdjustment;
+    insets.top += self.computedMaximumHeight - safeAreaAdjustment;
+    info.injectedTopContentInset = self.computedMaximumHeight - safeAreaAdjustment;
     info.hasInjectedTopContentInset = YES;
     info.topSafeAreaInsetAdjustment = safeAreaAdjustment;
     info.hasTopSafeAreaInsetAdjustment = YES;
@@ -660,8 +660,8 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 - (CGFloat)fhv_accumulatorMax {
   BOOL shouldCollapseToStatusBar = [self fhv_shouldCollapseToStatusBar];
   CGFloat statusBarHeight = [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
-  return (shouldCollapseToStatusBar ? MAX(0, self.computedTotalMinHeight - statusBarHeight) :
-             self.computedTotalMinHeight);
+  return (shouldCollapseToStatusBar ? MAX(0, self.computedMinimumHeight - statusBarHeight) :
+             self.computedMinimumHeight);
 }
 
 #pragma mark Logical short forms
@@ -709,8 +709,8 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 
   if (frame.origin.y < 0) {
     _scrollPhase = MDCFlexibleHeaderScrollPhaseShifting;
-    _scrollPhaseValue = frame.origin.y + self.computedTotalMinHeight;
-    CGFloat adjustedHeight = self.computedTotalMinHeight;
+    _scrollPhaseValue = frame.origin.y + self.computedMinimumHeight;
+    CGFloat adjustedHeight = self.computedMinimumHeight;
     if ([self fhv_shouldCollapseToStatusBar]) {
       CGFloat statusBarHeight =
           [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
@@ -727,12 +727,12 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 
   _scrollPhaseValue = frame.size.height;
 
-  if (frame.size.height < self.computedTotalMaxHeight) {
+  if (frame.size.height < self.computedMaximumHeight) {
     _scrollPhase = MDCFlexibleHeaderScrollPhaseCollapsing;
 
-    CGFloat heightLength = self.computedTotalMaxHeight - self.computedTotalMinHeight;
+    CGFloat heightLength = self.computedMaximumHeight - self.computedMinimumHeight;
     if (heightLength > 0) {
-      _scrollPhasePercentage = (frame.size.height - self.computedTotalMinHeight) / heightLength;
+      _scrollPhasePercentage = (frame.size.height - self.computedMinimumHeight) / heightLength;
     } else {
       _scrollPhasePercentage = 0;
     }
@@ -741,9 +741,9 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   }
 
   _scrollPhase = MDCFlexibleHeaderScrollPhaseOverExtending;
-  if (self.computedTotalMaxHeight > 0) {
+  if (self.computedMaximumHeight > 0) {
     _scrollPhasePercentage = 1 +
-        (frame.size.height - self.computedTotalMaxHeight) / self.computedTotalMaxHeight;
+        (frame.size.height - self.computedMaximumHeight) / self.computedMaximumHeight;
   } else {
     _scrollPhasePercentage = 0;
   }
@@ -833,7 +833,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
     // Calculate the desired shadow strength for the offset & accumulator and then take the
     // weakest strength.
     CGFloat accumulator = MAX(0, MIN(kShadowScaleLength,
-                                     self.computedTotalMinHeight - boundedAccumulator));
+                                     self.computedMinimumHeight - boundedAccumulator));
     if (self.isInFrontOfInfiniteContent) {
       // When in front of infinite content we only care to hide the shadow when our header is
       // off-screen.
@@ -865,8 +865,8 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   [_statusBarShifter setOffset:boundedAccumulator];
 
   // Small performance improvement to not set the hidden property on every scroll tick.
-  BOOL isShiftedOffscreen = boundedAccumulator >= self.computedTotalMinHeight;
-  BOOL isFullyCollapsed = frame.size.height <= self.computedTotalMinHeight + DBL_EPSILON;
+  BOOL isShiftedOffscreen = boundedAccumulator >= self.computedMinimumHeight;
+  BOOL isFullyCollapsed = frame.size.height <= self.computedMinimumHeight + DBL_EPSILON;
   BOOL isHidden = isShiftedOffscreen && isFullyCollapsed;
   if (isHidden != self.hidden) {
     self.hidden = isHidden;
@@ -943,14 +943,14 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
       CGFloat previousHeaderHeight = headerHeight + deltaY;
 
       // Overshoot coming in
-      if (headerHeight < self.computedTotalMinHeight &&
-          previousHeaderHeight > self.computedTotalMinHeight) {
-        deltaY = self.computedTotalMinHeight - headerHeight;
+      if (headerHeight < self.computedMinimumHeight &&
+          previousHeaderHeight > self.computedMinimumHeight) {
+        deltaY = self.computedMinimumHeight - headerHeight;
 
         // Overshoot going out
-      } else if (headerHeight > self.computedTotalMinHeight &&
-                 previousHeaderHeight < self.computedTotalMinHeight) {
-        deltaY = (headerHeight + deltaY) - self.computedTotalMinHeight;
+      } else if (headerHeight > self.computedMinimumHeight &&
+                 previousHeaderHeight < self.computedMinimumHeight) {
+        deltaY = (headerHeight + deltaY) - self.computedMinimumHeight;
       }
 
       // Calculate the upper bound of the accumulator based on what phase we're in.
@@ -960,7 +960,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
       if (headerHeight < 0) {
         // Header is shifting while detached from content.
         upperBound = [self fhv_accumulatorMax] + [self fhv_anchorLength];
-      } else if (headerHeight < self.computedTotalMinHeight) {
+      } else if (headerHeight < self.computedMinimumHeight) {
         // Header is shifting while attached to content.
         upperBound = [self fhv_accumulatorMax];
       } else {
@@ -980,11 +980,11 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   CGRect bounds = self.bounds;
 
   if (_canOverExtend) {
-    bounds.size.height = MAX(self.computedTotalMinHeight, headerHeight);
+    bounds.size.height = MAX(self.computedMinimumHeight, headerHeight);
 
   } else {
-    bounds.size.height = MAX(self.computedTotalMinHeight,
-                             MIN(self.computedTotalMaxHeight, headerHeight));
+    bounds.size.height = MAX(self.computedMinimumHeight,
+                             MIN(self.computedMaximumHeight, headerHeight));
   }
 
   self.bounds = bounds;
@@ -1350,7 +1350,7 @@ static BOOL isRunningiOS10_3OrAbove() {
   }
 }
 
-- (CGFloat)computedTotalMinHeight {
+- (CGFloat)computedMinimumHeight {
   if (_minMaxHeightIncludesSafeArea) {
     return _minimumHeight;
   } else {
@@ -1358,7 +1358,7 @@ static BOOL isRunningiOS10_3OrAbove() {
   }
 }
 
-- (CGFloat)computedTotalMaxHeight {
+- (CGFloat)computedMaximumHeight {
   if (_minMaxHeightIncludesSafeArea) {
     return _maximumHeight;
   } else {
@@ -1404,12 +1404,12 @@ static BOOL isRunningiOS10_3OrAbove() {
     CGFloat flexHeight = -offsetTargetY;
 
     if ([self fhv_canShiftOffscreen] &&
-        (0 < flexHeight && flexHeight < self.computedTotalMinHeight)) {
+        (0 < flexHeight && flexHeight < self.computedMinimumHeight)) {
       // Don't allow the header to be partially visible.
       if (_wantsToBeHidden) {
         target.y = -[self fhv_rawTopContentInset];
       } else {
-        target.y = -self.computedTotalMinHeight - [self fhv_rawTopContentInset];
+        target.y = -self.computedMinimumHeight - [self fhv_rawTopContentInset];
       }
       *targetContentOffset = target;
       return YES;

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -67,6 +67,8 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
 static NSString *const MDCFlexibleHeaderMinimumHeightKey = @"MDCFlexibleHeaderMinimumHeightKey";
 static NSString *const MDCFlexibleHeaderMaximumHeightKey = @"MDCFlexibleHeaderMaximumHeightKey";
+static NSString *const MDCFlexibleHeaderMinMaxHeightIncludesSafeAreaKey =
+    @"MDCFlexibleHeaderMinMaxHeightIncludesSafeAreaKey";
 static NSString *const MDCFlexibleHeaderShiftBehaviorKey = @"MDCFlexibleHeaderShiftBehaviorKey";
 static NSString *const MDCFlexibleHeaderContentImportanceKey =
     @"MDCFlexibleHeaderContentImportanceKey";
@@ -209,6 +211,11 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
       _maximumHeight = (CGFloat)[aDecoder decodeDoubleForKey:MDCFlexibleHeaderMaximumHeightKey];
     }
 
+    if ([aDecoder containsValueForKey:MDCFlexibleHeaderMinMaxHeightIncludesSafeAreaKey]) {
+      _minMaxHeightIncludesSafeArea =
+          [aDecoder decodeBoolForKey:MDCFlexibleHeaderMinMaxHeightIncludesSafeAreaKey];
+    }
+
     if ([aDecoder containsValueForKey:MDCFlexibleHeaderShiftBehaviorKey]) {
       _shiftBehavior = [aDecoder decodeIntegerForKey:MDCFlexibleHeaderShiftBehaviorKey];
     }
@@ -261,6 +268,8 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 
   [aCoder encodeDouble:self.minimumHeight forKey:MDCFlexibleHeaderMinimumHeightKey];
   [aCoder encodeDouble:self.maximumHeight forKey:MDCFlexibleHeaderMaximumHeightKey];
+  [aCoder encodeBool:self.minMaxHeightIncludesSafeArea
+              forKey:MDCFlexibleHeaderMinMaxHeightIncludesSafeAreaKey];
   [aCoder encodeInteger:self.shiftBehavior forKey:MDCFlexibleHeaderShiftBehaviorKey];
   [aCoder encodeInteger:self.headerContentImportance forKey:MDCFlexibleHeaderContentImportanceKey];
   [aCoder encodeBool:self.canOverExtend forKey:MDCFlexibleHeaderCanOverExtendKey];

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -454,6 +454,12 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 - (void)safeAreaInsetsDidChange {
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
+    if (_isChangingStatusBarVisibility) {
+      // We aren't interest in safe area inset changes due to status bar visibility changes - we're
+      // only interested in hardware-related safe area changes. If we know that we're changing the
+      // status bar visibility then we ignore this safeAreaInsetsDidChange event.
+      return;
+    }
     CGFloat safeAreaTop = [self flexibleHeaderSafeAreaTop];
     if (_currentSafeAreaInsetTop == safeAreaTop) {
       return;

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -322,6 +322,8 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   }
 #endif
   _maximumHeight = _minimumHeight;
+
+  // We start with a current Safe Area inset of -1 to signal that is not a valid 0.
   _currentSafeAreaInsetTop = -1;
 
   _visibleShadowOpacity = kDefaultVisibleShadowOpacity;
@@ -1148,7 +1150,6 @@ static BOOL isRunningiOS10_3OrAbove() {
   if (!_sharedWithManyScrollViews || !_trackingInfo) {
     [self fhv_addInsetsToScrollView:_trackingScrollView];
   }
-  // TODO(chuga): Fix shared many scroll views case.
 
   void (^animate)(void) = ^{
     [self fhv_updateLayout];
@@ -1256,7 +1257,6 @@ static BOOL isRunningiOS10_3OrAbove() {
   CGPoint contentOffset = _trackingScrollView.contentOffset;
   contentOffset.y -= delta;  // Keeps the scroll view offset from jumping.
   _trackingScrollView.contentOffset = contentOffset;
-
   _contentInsetsAreChanging = NO;
 }
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -133,8 +133,12 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   BOOL _wantsToBeHidden;
 
   // This will help us track if the size has been explicitly set or if we're using the defaults.
-  BOOL _hasExplicitlySetMinHeight;
-  BOOL _hasExplicitlySetMaxHeight;
+  BOOL _hasExplicitlySetMinOrMaxHeight;
+
+  // The min and max height values that include the Safe Area insets. These are the numbers that
+  // should be used internally.
+  CGFloat _minHeightIncludingSafeArea;
+  CGFloat _maxHeightIncludingSafeArea;
 
   // Shift behavior state
 
@@ -298,16 +302,25 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   _headerContentImportance = MDCFlexibleHeaderContentImportanceDefault;
   _statusBarHintCanOverlapHeader = YES;
 
+  _minMaxHeightIncludesSafeArea = YES;
   _minimumHeight = kFlexibleHeaderDefaultHeight + kPreIOS11ExpectedStatusBarHeight;
+  _minHeightIncludingSafeArea = _minimumHeight;
+
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
-    // Starting from iOS 11, we should adapt the size of this component to take into account
-    // the new status bar sizes and the "no status bar in landscape" functionality.
-    CGFloat statusBarHeight = [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
-    _minimumHeight = kFlexibleHeaderDefaultHeight + statusBarHeight;
+    // Starting from iOS 11, the default behavior of this component is to adapt its height to
+    // account for changes in the Safe Area insets. We're using the status bar frame instead of
+    // the safeAreaInsets property because at this point this view's Safe Area hasn't been
+    // calculated by the OS.
+    CGFloat statusBarHeight =
+        CGRectGetMaxY([UIApplication mdc_safeSharedApplication].statusBarFrame);
+    _minHeightIncludingSafeArea = kFlexibleHeaderDefaultHeight + statusBarHeight;
+    _minimumHeight = _minHeightIncludingSafeArea;
   }
 #endif
   _maximumHeight = _minimumHeight;
+  _maxHeightIncludingSafeArea = _minHeightIncludingSafeArea;
+
   _visibleShadowOpacity = kDefaultVisibleShadowOpacity;
   _canOverExtend = YES;
 
@@ -382,7 +395,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 #pragma mark - UIView
 
 - (CGSize)sizeThatFits:(CGSize)size {
-  return CGSizeMake(size.width, _minimumHeight);
+  return CGSizeMake(size.width, _minHeightIncludingSafeArea);
 }
 
 - (void)layoutSubviews {
@@ -437,13 +450,6 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [self fhv_adjustInsetsForSafeAreaInScrollView:_trackingScrollView];
-
-    // If the min/max height hasn't been explicitly set, we need to update the layout to reflect
-    // the change in the Safe Area insets.
-    if (_hasExplicitlySetMinHeight && _hasExplicitlySetMaxHeight) {
-      return;
-    }
-
     if (_isChangingStatusBarVisibility) {
       // We aren't interest in safe area inset changes due to status bar visibility changes - we're
       // only interested in hardware-related safe area changes. If we know that we're changing the
@@ -451,20 +457,30 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
       return;
     }
 
-    if (!_hasExplicitlySetMinHeight) {
-      // Edge case for UITableViewController: If we're a subview of _trackingScrollView,
-      // we need to get the Safe Area insets from there and not use ours.
-      if ([self isDescendantOfView:_trackingScrollView]) {
-        _minimumHeight = kFlexibleHeaderDefaultHeight + _trackingScrollView.safeAreaInsets.top;
+    CGFloat safeAreaTop = [self flexibleHeaderSafeAreaTop];
+
+    // If the min or max height have been explicitly set, only adjust if
+    // _minMaxHeightIncludesSafeArea is NO.
+    if (_hasExplicitlySetMinOrMaxHeight) {
+      if (_minMaxHeightIncludesSafeArea) {
+        // No - op.
+        return;
       } else {
-        _minimumHeight = kFlexibleHeaderDefaultHeight + self.safeAreaInsets.top;
+        // The min/max values don't already include the safe area insets.
+        _minHeightIncludingSafeArea = _minimumHeight + safeAreaTop;
+        _maxHeightIncludingSafeArea = _maximumHeight + safeAreaTop;
       }
-    }
-    if (!_hasExplicitlySetMaxHeight) {
-      _maximumHeight = _minimumHeight;
-    }
-    if (_maximumHeight < _minimumHeight) {
-      _maximumHeight = _minimumHeight;
+    } else {
+      // Neither min nor max height have been set, so we use the defaults.
+      _minHeightIncludingSafeArea = kFlexibleHeaderDefaultHeight + safeAreaTop;
+      _maxHeightIncludingSafeArea = kFlexibleHeaderDefaultHeight + safeAreaTop;
+
+      // If _minMaxHeightIncludesSafeArea is YES, we need to also update _minimumHeight and
+      // _maximumHeight.
+      if (_minMaxHeightIncludesSafeArea) {
+        _minimumHeight = _minHeightIncludingSafeArea;
+        _maximumHeight = _maxHeightIncludingSafeArea;
+      }
     }
 
     // Ignore any content offset delta that occured as a result of any safe area insets change.
@@ -473,7 +489,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
     // The changes might require us to re-calculate the frame, or update the entire layout.
     if (!_trackingScrollView) {
       CGRect bounds = self.bounds;
-      bounds.size.height = _minimumHeight;
+      bounds.size.height = _minHeightIncludingSafeArea;
       self.bounds = bounds;
       CGPoint position = self.center;
       position.y = -MIN([self fhv_accumulatorMax], _shiftAccumulator);
@@ -530,8 +546,8 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 
   if (!info.hasInjectedTopContentInset) {
     UIEdgeInsets insets = scrollView.contentInset;
-    insets.top += _maximumHeight;
-    info.injectedTopContentInset = _maximumHeight;
+    insets.top += _maxHeightIncludingSafeArea;
+    info.injectedTopContentInset = _maxHeightIncludingSafeArea;
     info.hasInjectedTopContentInset = YES;
     scrollView.contentInset = insets;
   }
@@ -571,7 +587,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
       scrollView.contentInset = insets;
 
       // Update injectedTopContentInset to account for the scroll view's Safe Area inset.
-      info.injectedTopContentInset = _maximumHeight - info.topSafeAreaInsetAdjustment;
+      info.injectedTopContentInset = _maxHeightIncludingSafeArea - info.topSafeAreaInsetAdjustment;
     }
   }
 #endif
@@ -619,7 +635,8 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 - (CGFloat)fhv_accumulatorMax {
   BOOL shouldCollapseToStatusBar = [self fhv_shouldCollapseToStatusBar];
   CGFloat statusBarHeight = [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
-  return (shouldCollapseToStatusBar ? MAX(0, _minimumHeight - statusBarHeight) : _minimumHeight);
+  return (shouldCollapseToStatusBar ? MAX(0, _minHeightIncludingSafeArea - statusBarHeight) :
+             _minHeightIncludingSafeArea);
 }
 
 #pragma mark Logical short forms
@@ -667,8 +684,8 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 
   if (frame.origin.y < 0) {
     _scrollPhase = MDCFlexibleHeaderScrollPhaseShifting;
-    _scrollPhaseValue = frame.origin.y + _minimumHeight;
-    CGFloat adjustedHeight = _minimumHeight;
+    _scrollPhaseValue = frame.origin.y + _minHeightIncludingSafeArea;
+    CGFloat adjustedHeight = _minHeightIncludingSafeArea;
     if ([self fhv_shouldCollapseToStatusBar]) {
       CGFloat statusBarHeight =
           [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
@@ -685,12 +702,12 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 
   _scrollPhaseValue = frame.size.height;
 
-  if (frame.size.height < _maximumHeight) {
+  if (frame.size.height < _maxHeightIncludingSafeArea) {
     _scrollPhase = MDCFlexibleHeaderScrollPhaseCollapsing;
 
-    CGFloat heightLength = _maximumHeight - _minimumHeight;
+    CGFloat heightLength = _maxHeightIncludingSafeArea - _minHeightIncludingSafeArea;
     if (heightLength > 0) {
-      _scrollPhasePercentage = (frame.size.height - _minimumHeight) / heightLength;
+      _scrollPhasePercentage = (frame.size.height - _minHeightIncludingSafeArea) / heightLength;
     } else {
       _scrollPhasePercentage = 0;
     }
@@ -699,8 +716,9 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   }
 
   _scrollPhase = MDCFlexibleHeaderScrollPhaseOverExtending;
-  if (_maximumHeight > 0) {
-    _scrollPhasePercentage = 1 + (frame.size.height - _maximumHeight) / _maximumHeight;
+  if (_maxHeightIncludingSafeArea > 0) {
+    _scrollPhasePercentage = 1 +
+        (frame.size.height - _maxHeightIncludingSafeArea) / _maxHeightIncludingSafeArea;
   } else {
     _scrollPhasePercentage = 0;
   }
@@ -789,7 +807,8 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   if (self.hidesStatusBarWhenCollapsed) {
     // Calculate the desired shadow strength for the offset & accumulator and then take the
     // weakest strength.
-    CGFloat accumulator = MAX(0, MIN(kShadowScaleLength, _minimumHeight - boundedAccumulator));
+    CGFloat accumulator = MAX(0, MIN(kShadowScaleLength,
+                                     _minHeightIncludingSafeArea - boundedAccumulator));
     if (self.isInFrontOfInfiniteContent) {
       // When in front of infinite content we only care to hide the shadow when our header is
       // off-screen.
@@ -821,8 +840,8 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   [_statusBarShifter setOffset:boundedAccumulator];
 
   // Small performance improvement to not set the hidden property on every scroll tick.
-  BOOL isShiftedOffscreen = boundedAccumulator >= _minimumHeight;
-  BOOL isFullyCollapsed = frame.size.height <= _minimumHeight + DBL_EPSILON;
+  BOOL isShiftedOffscreen = boundedAccumulator >= _minHeightIncludingSafeArea;
+  BOOL isFullyCollapsed = frame.size.height <= _minHeightIncludingSafeArea + DBL_EPSILON;
   BOOL isHidden = isShiftedOffscreen && isFullyCollapsed;
   if (isHidden != self.hidden) {
     self.hidden = isHidden;
@@ -899,25 +918,28 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
       CGFloat previousHeaderHeight = headerHeight + deltaY;
 
       // Overshoot coming in
-      if (headerHeight < _minimumHeight && previousHeaderHeight > _minimumHeight) {
-        deltaY = _minimumHeight - headerHeight;
+      if (headerHeight < _minHeightIncludingSafeArea &&
+          previousHeaderHeight > _minHeightIncludingSafeArea) {
+        deltaY = _minHeightIncludingSafeArea - headerHeight;
 
         // Overshoot going out
-      } else if (headerHeight > _minimumHeight && previousHeaderHeight < _minimumHeight) {
-        deltaY = (headerHeight + deltaY) - _minimumHeight;
+      } else if (headerHeight > _minHeightIncludingSafeArea &&
+                 previousHeaderHeight < _minHeightIncludingSafeArea) {
+        deltaY = (headerHeight + deltaY) - _minHeightIncludingSafeArea;
       }
 
       // Calculate the upper bound of the accumulator based on what phase we're in.
 
       CGFloat upperBound;
 
-      if (headerHeight < 0) {  // Header is shifting while detached from content.
+      if (headerHeight < 0) {
+        // Header is shifting while detached from content.
         upperBound = [self fhv_accumulatorMax] + [self fhv_anchorLength];
-
-      } else if (headerHeight < _minimumHeight) {  // Header is shifting while attached to content.
+      } else if (headerHeight < _minHeightIncludingSafeArea) {
+        // Header is shifting while attached to content.
         upperBound = [self fhv_accumulatorMax];
-
-      } else {  // Header is not shifting.
+      } else {
+        // Header is not shifting.
         upperBound = 0;
       }
 
@@ -933,10 +955,11 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   CGRect bounds = self.bounds;
 
   if (_canOverExtend) {
-    bounds.size.height = MAX(_minimumHeight, headerHeight);
+    bounds.size.height = MAX(_minHeightIncludingSafeArea, headerHeight);
 
   } else {
-    bounds.size.height = MAX(_minimumHeight, MIN(_maximumHeight, headerHeight));
+    bounds.size.height = MAX(_minHeightIncludingSafeArea,
+                             MIN(_maxHeightIncludingSafeArea, headerHeight));
   }
 
   self.bounds = bounds;
@@ -1270,12 +1293,18 @@ static BOOL isRunningiOS10_3OrAbove() {
 }
 
 - (void)setMinimumHeight:(CGFloat)minimumHeight {
-  _hasExplicitlySetMinHeight = YES;
+  _hasExplicitlySetMinOrMaxHeight = YES;
   if (_minimumHeight == minimumHeight) {
     return;
   }
 
   _minimumHeight = minimumHeight;
+
+  if (_minMaxHeightIncludesSafeArea) {
+    _minHeightIncludingSafeArea = _minimumHeight;
+  } else {
+    _minHeightIncludingSafeArea = _minimumHeight + [self flexibleHeaderSafeAreaTop];
+  }
 
   if (_minimumHeight > _maximumHeight) {
     [self setMaximumHeight:_minimumHeight];
@@ -1285,16 +1314,21 @@ static BOOL isRunningiOS10_3OrAbove() {
 }
 
 - (void)setMaximumHeight:(CGFloat)maximumHeight {
-  _hasExplicitlySetMaxHeight = YES;
+  _hasExplicitlySetMinOrMaxHeight = YES;
   if (_maximumHeight == maximumHeight) {
     return;
   }
 
   CGPoint originalOffset = _trackingScrollView.contentOffset;
-
   [self fhv_removeInsetsFromScrollView:_trackingScrollView];
 
   _maximumHeight = maximumHeight;
+
+  if (_minMaxHeightIncludesSafeArea) {
+    _maxHeightIncludingSafeArea = _maximumHeight;
+  } else {
+    _maxHeightIncludingSafeArea = _maximumHeight + [self flexibleHeaderSafeAreaTop];
+  }
 
   CGPoint stashedOffset = _trackingScrollView.contentOffset;
   [self fhv_addInsetsToScrollView:_trackingScrollView];
@@ -1312,6 +1346,39 @@ static BOOL isRunningiOS10_3OrAbove() {
   } else {
     [self fhv_updateLayout];
   }
+}
+
+- (void)setMinMaxHeightIncludesSafeArea:(BOOL)minMaxHeightIncludesSafeArea {
+  if (_minMaxHeightIncludesSafeArea == minMaxHeightIncludesSafeArea) {
+    return;
+  }
+  _minMaxHeightIncludesSafeArea = minMaxHeightIncludesSafeArea;
+
+  CGFloat safeAreaTop = [self flexibleHeaderSafeAreaTop];
+
+  if (_hasExplicitlySetMinOrMaxHeight) {
+    if (_minMaxHeightIncludesSafeArea) {
+      // We went from min / max not including the safe area to including it.
+      _minimumHeight = _minimumHeight + safeAreaTop;
+      _maximumHeight = _maximumHeight + safeAreaTop;
+    } else {
+      // Min / max used to include the safe area.
+      _minimumHeight = _minimumHeight - safeAreaTop;
+      _maximumHeight = _maximumHeight - safeAreaTop;
+    }
+  } else {
+    // Neither min nor max have been explicitly set.
+    if (_minMaxHeightIncludesSafeArea) {
+      _minimumHeight = kFlexibleHeaderDefaultHeight + safeAreaTop;
+      _maximumHeight = kFlexibleHeaderDefaultHeight + safeAreaTop;
+    } else {
+      // Min / max values do not include the safe area.
+      _minimumHeight = kFlexibleHeaderDefaultHeight;
+      _maximumHeight = kFlexibleHeaderDefaultHeight;
+    }
+  }
+
+  [self fhv_updateLayout];
 }
 
 - (void)setInFrontOfInfiniteContent:(BOOL)inFrontOfInfiniteContent {
@@ -1335,12 +1402,13 @@ static BOOL isRunningiOS10_3OrAbove() {
     CGFloat offsetTargetY = target.y + [self fhv_rawTopContentInset];
     CGFloat flexHeight = -offsetTargetY;
 
-    if ([self fhv_canShiftOffscreen] && (0 < flexHeight && flexHeight < _minimumHeight)) {
+    if ([self fhv_canShiftOffscreen] &&
+        (0 < flexHeight && flexHeight < _minHeightIncludingSafeArea)) {
       // Don't allow the header to be partially visible.
       if (_wantsToBeHidden) {
         target.y = -[self fhv_rawTopContentInset];
       } else {
-        target.y = -_minimumHeight - [self fhv_rawTopContentInset];
+        target.y = -_minHeightIncludingSafeArea - [self fhv_rawTopContentInset];
       }
       *targetContentOffset = target;
       return YES;
@@ -1410,6 +1478,23 @@ static BOOL isRunningiOS10_3OrAbove() {
   // Translucent content means that the status bar shifter should not use snapshotting. Otherwise,
   // stale visual content under the status bar region may be snapshotted.
   _statusBarShifter.snapshottingEnabled = !contentIsTranslucent;
+}
+
+- (CGFloat)flexibleHeaderSafeAreaTop {
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    // Edge case for UITableViewController: If we're a subview of _trackingScrollView,
+    // we need to get the Safe Area insets from there and not use ours.
+    // Note: This appears to be fixed on iOS 11.1.
+    if ([self isDescendantOfView:_trackingScrollView]) {
+      return _trackingScrollView.safeAreaInsets.top;
+    } else {
+      return self.safeAreaInsets.top;
+    }
+  }
+#endif
+  // If < iOS 11.0 we should return the hardcoded status bar height for backwards compatibility.
+  return kPreIOS11ExpectedStatusBarHeight;
 }
 
 @end

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -461,7 +461,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
     } else if (!_hasExplicitlySetMinOrMaxHeight && _minMaxHeightIncludesSafeArea) {
       // If we're using the defaults we need to update them to account for the new Safe Area inset.
       _minimumHeight = kFlexibleHeaderDefaultHeight + MDCDeviceTopSafeAreaInset();
-      _maximumHeight = kFlexibleHeaderDefaultHeight + MDCDeviceTopSafeAreaInset();
+      _maximumHeight = _minimumHeight;
     }
 
     // Adjust the scroll view insets to account for the new Safe Area inset.

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -136,6 +136,9 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   // This will help us track if the size has been explicitly set or if we're using the defaults.
   BOOL _hasExplicitlySetMinOrMaxHeight;
 
+  // Since safeAreaInsetsDidChange might be called more than once for the same top safe area inset,
+  // we keep track of the latest one we adjusted for, so that we can ignore any repeated calls with
+  // the same value.
   CGFloat _currentSafeAreaInsetTop;
 
   // Shift behavior state

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
@@ -180,7 +180,8 @@
   [self.vc.scrollView scrollRectToVisible:initialFrame animated:NO];
 
   // Then
-  XCTAssertEqual(self.vc.fhvc.flexibleHeaderViewControllerHeightOffset, randomHeight);
+  XCTAssertEqual(self.vc.fhvc.flexibleHeaderViewControllerHeightOffset,
+                 MIN(self.vc.fhvc.headerView.minimumHeight, randomHeight));
 }
 
 @end

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
@@ -180,8 +180,7 @@
   [self.vc.scrollView scrollRectToVisible:initialFrame animated:NO];
 
   // Then
-  XCTAssertEqual(self.vc.fhvc.flexibleHeaderViewControllerHeightOffset,
-                 MIN(self.vc.fhvc.headerView.minimumHeight, randomHeight));
+  XCTAssertEqual(self.vc.fhvc.flexibleHeaderViewControllerHeightOffset, randomHeight);
 }
 
 @end


### PR DESCRIPTION
Starting on iOS 11, this component adjusts its height to account for changes in the Safe Area insets. But the current solution only works for the default min/max height values, as we've internally de-hardcoded the status bar height from them. We currently don't offer an API for people who want to use a custom mix/max height and still get the same behavior. This PR introduces such API.

The new `minMaxHeightIncludesSafeArea` property lets us know if the provided min/max height already includes the safe area insets or not. If this is set to NO (the default is YES), we take care of adjusting for any safe area changes internally.

Note: This rollbacks the rollback https://github.com/material-components/material-components-ios/pull/2161 + introduces a few fixes.

Closes #2156