### PR TITLE
Add new UIMetrics component.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -255,6 +255,7 @@ Pod::Spec.new do |s|
       sss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
       ss.dependency 'MDFTextAccessibility'
       ss.dependency "MaterialComponents/private/Application"
+      ss.dependency "MaterialComponents/private/UIMetrics"
     end
     ss.subspec "ColorThemer" do |sss|
       sss.ios.deployment_target = '8.0'
@@ -546,6 +547,14 @@ Pod::Spec.new do |s|
 
       ss.dependency "MaterialComponents/private/Math"
       ss.dependency "MaterialComponents/private/RTL"
+    end
+
+    pss.subspec "UIMetrics" do |ss|
+      ss.ios.deployment_target = '8.0'
+      ss.public_header_files = "components/private/#{ss.base_name}/src/*.h"
+      ss.source_files = "components/private/#{ss.base_name}/src/*.{h,m}", "components/private/#{ss.base_name}/src/private/*.{h,m}"
+
+      ss.dependency "MaterialComponents/private/Application"
     end
 
   end

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -255,7 +255,7 @@ Pod::Spec.new do |s|
       sss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
       ss.dependency 'MDFTextAccessibility'
       ss.dependency "MaterialComponents/private/Application"
-      ss.dependency "MaterialComponents/private/UIMetrics"
+      sss.dependency "MaterialComponents/private/UIMetrics"
     end
     ss.subspec "ColorThemer" do |sss|
       sss.ios.deployment_target = '8.0'

--- a/components/private/UIMetrics/src/MDCLayoutMetrics.h
+++ b/components/private/UIMetrics/src/MDCLayoutMetrics.h
@@ -1,0 +1,29 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/**
+ On devices with hardware safe areas, returns the top safe area for the key window. On all other
+ devices, returns the fixed status bar height regardless of status bar visibility.
+
+ This method is only meant for use with views that are placed behind the top safe area of a device
+ and that can be shifted off-screen along with the status bar. These kinds of views must not change
+ their top margin when shifting off-screen because it would cause a visible jump in layout. iOS
+ does not have an API for fetching the status bar's dimensions if it is hidden, so this method
+ ensures that we can always retrieve a non-zero value for our top safe area inset on devices without
+ hardware safe areas, while also ensuring that we receive the proper top safe area inset on devices
+ with hardware safe areas (iPhone X).
+ */
+FOUNDATION_EXPORT CGFloat MDCDeviceTopSafeAreaInset(void);

--- a/components/private/UIMetrics/src/MDCLayoutMetrics.m
+++ b/components/private/UIMetrics/src/MDCLayoutMetrics.m
@@ -1,0 +1,62 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCLayoutMetrics.h"
+
+#import "MaterialApplication.h"
+
+static const CGFloat kFixedStatusBarHeightOnPreiPhoneXDevices = 20;
+
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+static BOOL HasHardwareSafeAreas(void) {
+  static BOOL hasHardwareSafeAreas = NO;
+  if (@available(iOS 11.0, *)) {
+    static BOOL hasCheckedForHardwareSafeAreas = NO;
+    static dispatch_once_t onceToken;
+    if (!hasCheckedForHardwareSafeAreas && [UIApplication mdc_safeSharedApplication].keyWindow) {
+      dispatch_once(&onceToken, ^{
+        UIEdgeInsets insets = [UIApplication mdc_safeSharedApplication].keyWindow.safeAreaInsets;
+        hasHardwareSafeAreas = (insets.top > kFixedStatusBarHeightOnPreiPhoneXDevices
+                                || insets.left > 0
+                                || insets.bottom > 0
+                                || insets.right > 0);
+
+        hasCheckedForHardwareSafeAreas = YES;
+      });
+    }
+  }
+  return hasHardwareSafeAreas;
+}
+#endif
+
+CGFloat MDCDeviceTopSafeAreaInset(void) {
+  CGFloat topInset = kFixedStatusBarHeightOnPreiPhoneXDevices;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    // Devices with hardware safe area insets have fixed insets that depend on the device
+    // orientation. On such devices, we aren't interested in the status bar's height because the
+    // hardware safe area insets are what ultimately define the margins for the app. If we are
+    // running on such a device, we read from the safe area insets instead of the fixed status bar
+    // height so that we react to changes in safe area insets (usually due to orientation changes)
+    // and update the fixed margin accordingly.
+    if (HasHardwareSafeAreas()) {
+      UIEdgeInsets insets = [UIApplication mdc_safeSharedApplication].keyWindow.safeAreaInsets;
+      topInset = insets.top;
+    }
+  }
+#endif
+  return topInset;
+}

--- a/components/private/UIMetrics/src/MaterialUIMetrics.h
+++ b/components/private/UIMetrics/src/MaterialUIMetrics.h
@@ -1,0 +1,17 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCLayoutMetrics.h"


### PR DESCRIPTION
This component includes the new `MDCDeviceTopSafeAreaInset` API designed for working with components that have the following traits:

1. Their layout frame overlaps with the top safe area insets of a device.
2. They can shift on/off screen along with the status bar.
3. On non-iPhone X devices, their top margin must be constant, while on the iPhone X their top margin must be the top safe area inset for the device.