### PR TITLE
[AppBar] Make use of MDCDeviceTopSafeAreaInset.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -83,6 +83,7 @@ Pod::Spec.new do |s|
 
       sss.dependency "MaterialComponents/private/Icons/ic_arrow_back"
       sss.dependency "MaterialComponents/private/RTL"
+      sss.dependency "MaterialComponents/private/UIMetrics"
     end
     ss.subspec "ColorThemer" do |sss|
       sss.ios.deployment_target = '8.0'

--- a/components/AppBar/src/MDCAppBar.m
+++ b/components/AppBar/src/MDCAppBar.m
@@ -25,6 +25,7 @@
 #import "MaterialShadowElevations.h"
 #import "MaterialShadowLayer.h"
 #import "MaterialTypography.h"
+#import "MaterialUIMetrics.h"
 #import "MDFTextAccessibility.h"
 #import "private/MaterialAppBarStrings.h"
 #import "private/MaterialAppBarStrings_table.h"
@@ -34,7 +35,6 @@ static NSString *const kStatusBarHeightKey = @"statusBarHeight";
 static NSString *const MDCAppBarHeaderViewControllerKey = @"MDCAppBarHeaderViewControllerKey";
 static NSString *const MDCAppBarNavigationBarKey = @"MDCAppBarNavigationBarKey";
 static NSString *const MDCAppBarHeaderStackViewKey = @"MDCAppBarHeaderStackViewKey";
-static const CGFloat kPreIOS11StatusBarHeight = 20;
 
 // The Bundle for string resources.
 static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
@@ -310,17 +310,7 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
                             views:@{kBarStackKey : self.headerStackView}];
   [self.view addConstraints:horizontalConstraints];
 
-  CGFloat topMargin = kPreIOS11StatusBarHeight;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
-  if (@available(iOS 11.0, *)) {
-    // We only get the actual status bar height if we're on iOS 11, because previously we were not
-    // adjusting the header height to make it smaller when the status bar is hidden.
-    // Note: We should switch to using self.view.safeAreaLayoutGuide.topAnchor once 11.1 is
-    // the min iOS 11 we support. 11.0 has a bug where the Safe Area is incorrectly calculated for
-    // this view.
-    topMargin = CGRectGetMaxY([UIApplication mdc_safeSharedApplication].statusBarFrame);
-  }
-#endif
+  CGFloat topMargin = MDCDeviceTopSafeAreaInset();
   _verticalConstraint = [NSLayoutConstraint constraintWithItem:self.headerStackView
                                                      attribute:NSLayoutAttributeTop
                                                      relatedBy:NSLayoutRelationEqual

--- a/components/AppBar/src/MDCAppBar.m
+++ b/components/AppBar/src/MDCAppBar.m
@@ -343,10 +343,9 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
 
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
-    // We only get the actual status bar height if we're on iOS 11, because previously we were not
-    // adjusting the header height to make it smaller when the status bar is hidden.
-    _verticalConstraint.constant =
-        CGRectGetMaxY([UIApplication mdc_safeSharedApplication].statusBarFrame);
+    // We only update the top inset on iOS 11 because previously we were not adjusting the header
+    // height to make it smaller when the status bar is hidden.
+    _verticalConstraint.constant = MDCDeviceTopSafeAreaInset();
   }
 #endif
 }


### PR DESCRIPTION
This improves the stability of our app bar top margin calculations across all devices running iOS 11.