### PR TITLE
[PageControl] Fix bug with OOB array lookup when calling scrollViewDidScroll.

### DIFF
--- a/components/PageControl/src/MDCPageControl.m
+++ b/components/PageControl/src/MDCPageControl.m
@@ -276,12 +276,7 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
                                                mediaTimingFunction:animation.timingFunction];
                    });
 
-  } else if (scrolledPercentage >= 0 && scrolledPercentage <= 1) {
-
-    if (_numberOfPages == 0) {
-      return;
-    }
-
+  } else if (scrolledPercentage >= 0 && scrolledPercentage <= 1 && _numberOfPages > 0) {
     // Update active indicator position.
     CGFloat transformX = scrolledPercentage * _trackLength;
     if (!_isDeferredScrolling) {

--- a/components/PageControl/src/MDCPageControl.m
+++ b/components/PageControl/src/MDCPageControl.m
@@ -277,6 +277,11 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
                    });
 
   } else if (scrolledPercentage >= 0 && scrolledPercentage <= 1) {
+
+    if (_numberOfPages == 0) {
+      return;
+    }
+
     // Update active indicator position.
     CGFloat transformX = scrolledPercentage * _trackLength;
     if (!_isDeferredScrolling) {

--- a/components/PageControl/tests/unit/PageControlExampleTests.m
+++ b/components/PageControl/tests/unit/PageControlExampleTests.m
@@ -149,4 +149,23 @@
   XCTAssertNil(exception, @"PageControl crashed with exception: %@", exception);
 }
 
+- (void)testScrollViewDidScrollWithZeroPages {
+  // Given
+  MDCPageControl *pageControl = [[MDCPageControl alloc] init];
+  pageControl.numberOfPages = 0;
+  UIScrollView *scrollView = [[UIScrollView alloc] init];
+  NSException *exception;
+
+  // When
+  @try {
+    [pageControl scrollViewDidScroll:scrollView];
+  }
+  @catch (NSException *e) {
+    exception = e;
+  }
+
+  // Then
+  XCTAssertNil(exception, @"PageControl crashed with exception: %@", exception);
+}
+
 @end


### PR DESCRIPTION
The crash referenced in https://github.com/material-components/material-components-ios/pull/2072#issue-261964446 still applies even after the fix of #2132

This PR covers the invalid lookup in the `scrollViewDidScroll` method; tests included.