### PR TITLE
[Tabs] Fix a bug that where an item cell title can be missing

### DIFF
--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -563,9 +563,7 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
 }
 
 - (void)updateDisplayedTitle {
-  if (_style.shouldDisplayTitle) {
-    _titleLabel.text = [[self class] displayedTitleForTitle:_title style:_style];
-  }
+  _titleLabel.text = [[self class] displayedTitleForTitle:_title style:_style];
 }
 
 @end

--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -563,7 +563,7 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
 }
 
 - (void)updateDisplayedTitle {
-  if (!_titleLabel.hidden) {
+  if (_style.shouldDisplayTitle) {
     _titleLabel.text = [[self class] displayedTitleForTitle:_title style:_style];
   }
 }

--- a/components/Tabs/tests/unit/MDCItemBarCellTests.m
+++ b/components/Tabs/tests/unit/MDCItemBarCellTests.m
@@ -39,12 +39,12 @@
   style.shouldDisplayTitle = YES;
 
   // When
-  [cellWithImageAndText setImage:[UIImage imageNamed:@"TabBarDemo_ic_info"]];
-  [cellWithImageOnly setImage:[UIImage imageNamed:@"TabBarDemo_ic_info"]];
+  cellWithImageAndText.image = [UIImage imageNamed:@"TabBarDemo_ic_info"];
+  cellWithImageOnly.image = [UIImage imageNamed:@"TabBarDemo_ic_info"];
 
-  [cellWithImageAndText setTitle:@"A title"];
-  [cellWithTextAndMissingImage setTitle:@"A title"];
-  [cellWithTextOnly setTitle:@"A title"];
+  cellWithImageAndText.title = @"A title";
+  cellWithTextAndMissingImage.title = @"A title";
+  cellWithTextOnly.title = @"A title";
 
   [cellWithImageAndText applyStyle:style];
   [cellWithImageOnly applyStyle:style];
@@ -74,8 +74,8 @@
   // be configured in the app runtime.
   MDCItemBarCell *cell = [[MDCItemBarCell alloc] initWithFrame:CGRectZero];
   [cell applyStyle:iconOnlyStyle];
-  [cell setImage:[UIImage imageNamed:@"TabBarDemo_ic_info"]];
-  [cell setTitle:@"A title"];
+  cell.image = [UIImage imageNamed:@"TabBarDemo_ic_info"];
+  cell.title = @"A title";
   XCTAssertEqual(cell.titleLabel.hidden, YES);
 
   // Change the style to show image-and-title.

--- a/components/Tabs/tests/unit/MDCItemBarCellTests.m
+++ b/components/Tabs/tests/unit/MDCItemBarCellTests.m
@@ -59,4 +59,29 @@
   XCTAssertEqual(cellWithTextOnly.titleLabel.numberOfLines, 2);
 }
 
+/// Tests that a cell that was initially configured as image-only style, and then changed to
+/// image-and-title style, will result in the correct title text.
+- (void)testTitleAfterStyleChange {
+  MDCItemBarStyle *iconOnlyStyle = [[MDCItemBarStyle alloc] init];
+  iconOnlyStyle.shouldDisplayImage = YES;
+  iconOnlyStyle.shouldDisplayTitle = NO;
+
+  MDCItemBarStyle *iconAndTextStyle = [[MDCItemBarStyle alloc] init];
+  iconAndTextStyle.shouldDisplayImage = YES;
+  iconAndTextStyle.shouldDisplayTitle = YES;
+
+  // Create a cell and set the style before settting the image/title. That is the order items will
+  // be configured in the app runtime.
+  MDCItemBarCell *cell = [[MDCItemBarCell alloc] initWithFrame:CGRectZero];
+  [cell applyStyle:iconOnlyStyle];
+  [cell setImage:[UIImage imageNamed:@"TabBarDemo_ic_info"]];
+  [cell setTitle:@"A title"];
+  XCTAssertEqual(cell.titleLabel.hidden, YES);
+
+  // Change the style to show image-and-title.
+  [cell applyStyle:iconAndTextStyle];
+  XCTAssertEqual(cell.titleLabel.hidden, NO);
+  XCTAssertEqualObjects(cell.titleLabel.text, @"A TITLE");
+}
+
 @end


### PR DESCRIPTION
After an appearance change, tab titles might be missing. This is caused by an ordering issue in MDCItemBarCell.m where -updateDisplayedTitle will only set the .text property if the label is already visible. But when the style is changed, the visibility of the label is set after -updateDisplayedTitle is called. This can be resolved by checking _style.shouldDisplayTitle instead.

closes #2201 
