### PR TITLE
Release candidate 36.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# release-candidate TODO: Replace me with version number. 
+# 36.3.0
+
+## API Changes
+
+### Flexible Header
+
+* Added `minMaxHeightIncludesSafeArea` to inform the component if the `minimumHeight` and `maximumHeight` properties include the safe area inset. 
 
 # 36.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release-candidate TODO: Replace me with version number. 
+
 # 36.2.0
 
 ## API Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 * Added `minMaxHeightIncludesSafeArea` to inform the component if the `minimumHeight` and `maximumHeight` properties include the safe area inset. 
 
+## Component changes
+
+### FlexibleHeader
+
+#### Changes
+
+* [Introduce minMaxHeightIncludesSafeArea and fix rotation bugs. (#2184)](https://github.com/material-components/material-components-ios/commit/100d18816b7574f4c210df9c7c3afa716f661b78) (Andrés)
+* [Split _hasExplicitlySetMinOrMaxHeight into two. (#2196)](https://github.com/material-components/material-components-ios/commit/1c754aee3b1dda7166babc97306c315c4d7b901d) (Andrés)
+
 # 36.2.0
 
 ## API Changes

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -434,6 +434,7 @@ Pod::Spec.new do |s|
       sss.dependency "MaterialComponents/AnimationTiming"
       sss.dependency "MaterialComponents/Ink"
       sss.dependency "MaterialComponents/ShadowElevations"
+      sss.dependency "MaterialComponents/ShadowLayer"
       sss.dependency "MaterialComponents/Typography"
       sss.dependency "MaterialComponents/private/Math"
       sss.dependency "MaterialComponents/private/RTL"

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -2,7 +2,7 @@ load 'scripts/generated/icons.rb'
 
 Pod::Spec.new do |s|
   s.name         = "MaterialComponents"
-  s.version      = "36.2.0"
+  s.version      = "36.3.0"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/MaterialComponentsCatalog.podspec
+++ b/MaterialComponentsCatalog.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsCatalog"
-  s.version      = "36.2.0"
+  s.version      = "36.3.0"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/MaterialComponentsEarlGreyTests.podspec
+++ b/MaterialComponentsEarlGreyTests.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsEarlGreyTests"
-  s.version      = "36.2.0"
+  s.version      = "36.3.0"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/MaterialComponentsUnitTests.podspec
+++ b/MaterialComponentsUnitTests.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsUnitTests"
-  s.version      = "36.2.0"
+  s.version      = "36.3.0"
   s.authors      = "The Material Components authors."
   s.summary      = "A collection of stand-alone production-ready UI libraries focused on design details."
   s.homepage     = "https://github.com/material-components/material-components-ios"

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -28,7 +28,6 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
 
   let spacing = CGFloat(1)
   let inset = CGFloat(16)
-  let headerMinHeight = CGFloat(48)
   let node: CBCNode
   var headerViewController: MDCFlexibleHeaderViewController
   var titleLabel: UILabel
@@ -63,8 +62,8 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
 
     self.addChildViewController(self.headerViewController)
 
-    self.headerViewController.headerView.maximumHeight = 128
-    self.headerViewController.headerView.minimumHeight = headerMinHeight + 20
+    self.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+    self.headerViewController.headerView.maximumHeight = 108
 
     self.collectionView?.register(MDCCatalogCollectionViewCell.self,
       forCellWithReuseIdentifier: "MDCCatalogCollectionViewCell")
@@ -179,9 +178,6 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
 #if swift(>=3.2)
   @available(iOS 11, *)
   override func viewSafeAreaInsetsDidChange() {
-    self.headerViewController.headerView.minimumHeight =
-        headerMinHeight + self.view.safeAreaInsets.top
-
     // Re-constraint the title label to account for changes in safeAreaInsets's left and right.
     let titleInsets = UIEdgeInsets(top: 0,
                                    left: inset + self.view.safeAreaInsets.left,

--- a/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
@@ -95,6 +95,10 @@
     case FlexibleHeaderConfiguratorFieldMaximumHeight:
       headerView.maximumHeight = [self heightDenormalized:[value floatValue]];
       break;
+
+    case FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea:
+      headerView.minMaxHeightIncludesSafeArea = [value boolValue];
+      break;
   }
 }
 
@@ -209,6 +213,8 @@ static const CGFloat kHeightScalar = 300;
 
     case FlexibleHeaderConfiguratorFieldMaximumHeight:
       return @([self normalizedHeight:self.fhvc.headerView.maximumHeight]);
+    case FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea:
+      return @(self.fhvc.headerView.minMaxHeightIncludesSafeArea);
   }
 }
 

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.h
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.h
@@ -34,6 +34,7 @@ typedef enum : NSUInteger {
 
   FlexibleHeaderConfiguratorFieldMinimumHeight,
   FlexibleHeaderConfiguratorFieldMaximumHeight,
+  FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea,
 } FlexibleHeaderConfiguratorField;
 
 @interface FlexibleHeaderConfiguratorExample : UITableViewController

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
@@ -134,7 +134,9 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
 
   createSection(@"Header height", @[
     sliderItem(@"Minimum", FlexibleHeaderConfiguratorFieldMinimumHeight),
-    sliderItem(@"Maximum", FlexibleHeaderConfiguratorFieldMaximumHeight)
+    sliderItem(@"Maximum", FlexibleHeaderConfiguratorFieldMaximumHeight),
+    switchItem(@"Min / max height includes Safe Area",
+               FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea)
   ]);
 
   NSMutableArray *fillerItems = [NSMutableArray array];

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -293,6 +293,8 @@ IB_DESIGNABLE
 /**
  The minimum height that this header can shrink to.
 
+ See minMaxHeightIncludesSafeArea to learn how this number is used when the Safe Area changes.
+
  If you change the value of this property and the maximumHeight of the receiver is below the new
  minimumHeight, maximumHeight will be adjusted to match the new minimum value.
  */
@@ -301,10 +303,31 @@ IB_DESIGNABLE
 /**
  The maximum height that this header can expand to.
 
+ See minMaxHeightIncludesSafeArea to learn how this number is used when the Safe Area changes.
+
  If you change the value of this property and the minimumHeight of the receiver is above the new
  maximumHeight, minimumHeight will be adjusted to match the new maximumHeight.
  */
 @property(nonatomic) CGFloat maximumHeight;
+
+/**
+ When this is enabled, the flexible header will assume that minimumHeight and maximumHeight both
+ include the Safe Area top inset. For example, a header whose maximum content height should be 200
+ might set 220 (200 + 20) as the maximumHeight. Notice that if this is enabled and you're setting
+ minimumHeight and or maximumHeight, the flexible header won't automatically adjust its size to
+ account for changes to the Safe Area, as the values provided already include a hardcoded inset.
+
+ When this is disabled, the flexible header will assume that the provided minimumHeight and
+ maximumHeight do not include the Safe Area top inset. For example, a header whose maximum content
+ height should be 200 would set 200 as the maximumHeight, and the flexible header will take care
+ of adjusting itself to account for Safe Area changes internally.
+
+ Clients are recommended to set this to NO, and set the min and max heights to values that don't
+ include the status bar or Safe Area insets.
+
+ Default is YES.
+ */
+@property(nonatomic) BOOL minMaxHeightIncludesSafeArea;
 
 #pragma mark Behaviors
 

--- a/demos/Bare/Podfile.lock
+++ b/demos/Bare/Podfile.lock
@@ -1,59 +1,59 @@
 PODS:
-  - MaterialComponents (36.2.0):
-    - MaterialComponents/ActivityIndicator (= 36.2.0)
-    - MaterialComponents/AnimationTiming (= 36.2.0)
-    - MaterialComponents/AppBar (= 36.2.0)
-    - MaterialComponents/BottomAppBar (= 36.2.0)
-    - MaterialComponents/BottomSheet (= 36.2.0)
-    - MaterialComponents/ButtonBar (= 36.2.0)
-    - MaterialComponents/Buttons (= 36.2.0)
-    - MaterialComponents/CollectionCells (= 36.2.0)
-    - MaterialComponents/CollectionLayoutAttributes (= 36.2.0)
-    - MaterialComponents/Collections (= 36.2.0)
-    - MaterialComponents/Dialogs (= 36.2.0)
-    - MaterialComponents/FeatureHighlight (= 36.2.0)
-    - MaterialComponents/FlexibleHeader (= 36.2.0)
-    - MaterialComponents/HeaderStackView (= 36.2.0)
-    - MaterialComponents/Ink (= 36.2.0)
-    - MaterialComponents/MaskedTransition (= 36.2.0)
-    - MaterialComponents/NavigationBar (= 36.2.0)
-    - MaterialComponents/OverlayWindow (= 36.2.0)
-    - MaterialComponents/PageControl (= 36.2.0)
-    - MaterialComponents/Palettes (= 36.2.0)
-    - MaterialComponents/private (= 36.2.0)
-    - MaterialComponents/ProgressView (= 36.2.0)
-    - MaterialComponents/ShadowElevations (= 36.2.0)
-    - MaterialComponents/ShadowLayer (= 36.2.0)
-    - MaterialComponents/Slider (= 36.2.0)
-    - MaterialComponents/Snackbar (= 36.2.0)
-    - MaterialComponents/Tabs (= 36.2.0)
-    - MaterialComponents/TextFields (= 36.2.0)
-    - MaterialComponents/Themes (= 36.2.0)
-    - MaterialComponents/Typography (= 36.2.0)
-  - MaterialComponents/ActivityIndicator (36.2.0):
-    - MaterialComponents/ActivityIndicator/ColorThemer (= 36.2.0)
-    - MaterialComponents/ActivityIndicator/Component (= 36.2.0)
+  - MaterialComponents (36.3.0):
+    - MaterialComponents/ActivityIndicator (= 36.3.0)
+    - MaterialComponents/AnimationTiming (= 36.3.0)
+    - MaterialComponents/AppBar (= 36.3.0)
+    - MaterialComponents/BottomAppBar (= 36.3.0)
+    - MaterialComponents/BottomSheet (= 36.3.0)
+    - MaterialComponents/ButtonBar (= 36.3.0)
+    - MaterialComponents/Buttons (= 36.3.0)
+    - MaterialComponents/CollectionCells (= 36.3.0)
+    - MaterialComponents/CollectionLayoutAttributes (= 36.3.0)
+    - MaterialComponents/Collections (= 36.3.0)
+    - MaterialComponents/Dialogs (= 36.3.0)
+    - MaterialComponents/FeatureHighlight (= 36.3.0)
+    - MaterialComponents/FlexibleHeader (= 36.3.0)
+    - MaterialComponents/HeaderStackView (= 36.3.0)
+    - MaterialComponents/Ink (= 36.3.0)
+    - MaterialComponents/MaskedTransition (= 36.3.0)
+    - MaterialComponents/NavigationBar (= 36.3.0)
+    - MaterialComponents/OverlayWindow (= 36.3.0)
+    - MaterialComponents/PageControl (= 36.3.0)
+    - MaterialComponents/Palettes (= 36.3.0)
+    - MaterialComponents/private (= 36.3.0)
+    - MaterialComponents/ProgressView (= 36.3.0)
+    - MaterialComponents/ShadowElevations (= 36.3.0)
+    - MaterialComponents/ShadowLayer (= 36.3.0)
+    - MaterialComponents/Slider (= 36.3.0)
+    - MaterialComponents/Snackbar (= 36.3.0)
+    - MaterialComponents/Tabs (= 36.3.0)
+    - MaterialComponents/TextFields (= 36.3.0)
+    - MaterialComponents/Themes (= 36.3.0)
+    - MaterialComponents/Typography (= 36.3.0)
+  - MaterialComponents/ActivityIndicator (36.3.0):
+    - MaterialComponents/ActivityIndicator/ColorThemer (= 36.3.0)
+    - MaterialComponents/ActivityIndicator/Component (= 36.3.0)
     - MaterialComponents/Palettes
     - MaterialComponents/private/Application
     - MaterialComponents/private/RTL
-  - MaterialComponents/ActivityIndicator/ColorThemer (36.2.0):
+  - MaterialComponents/ActivityIndicator/ColorThemer (36.3.0):
     - MaterialComponents/ActivityIndicator/Component
     - MaterialComponents/Palettes
     - MaterialComponents/private/Application
     - MaterialComponents/private/RTL
     - MaterialComponents/Themes
-  - MaterialComponents/ActivityIndicator/Component (36.2.0):
+  - MaterialComponents/ActivityIndicator/Component (36.3.0):
     - MaterialComponents/Palettes
     - MaterialComponents/private/Application
     - MaterialComponents/private/RTL
-  - MaterialComponents/AnimationTiming (36.2.0)
-  - MaterialComponents/AppBar (36.2.0):
-    - MaterialComponents/AppBar/ColorThemer (= 36.2.0)
-    - MaterialComponents/AppBar/Component (= 36.2.0)
-  - MaterialComponents/AppBar/ColorThemer (36.2.0):
+  - MaterialComponents/AnimationTiming (36.3.0)
+  - MaterialComponents/AppBar (36.3.0):
+    - MaterialComponents/AppBar/ColorThemer (= 36.3.0)
+    - MaterialComponents/AppBar/Component (= 36.3.0)
+  - MaterialComponents/AppBar/ColorThemer (36.3.0):
     - MaterialComponents/AppBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/AppBar/Component (36.2.0):
+  - MaterialComponents/AppBar/Component (36.3.0):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
     - MaterialComponents/NavigationBar
@@ -64,39 +64,39 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/BottomAppBar (36.2.0):
+  - MaterialComponents/BottomAppBar (36.3.0):
     - MaterialComponents/Buttons
     - MaterialComponents/NavigationBar
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
-  - MaterialComponents/BottomSheet (36.2.0):
+  - MaterialComponents/BottomSheet (36.3.0):
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/Math
-  - MaterialComponents/ButtonBar (36.2.0):
-    - MaterialComponents/ButtonBar/ColorThemer (= 36.2.0)
-    - MaterialComponents/ButtonBar/Component (= 36.2.0)
+  - MaterialComponents/ButtonBar (36.3.0):
+    - MaterialComponents/ButtonBar/ColorThemer (= 36.3.0)
+    - MaterialComponents/ButtonBar/Component (= 36.3.0)
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/ButtonBar/ColorThemer (36.2.0):
+  - MaterialComponents/ButtonBar/ColorThemer (36.3.0):
     - MaterialComponents/ButtonBar/Component
     - MaterialComponents/Buttons
     - MaterialComponents/NavigationBar/Component
     - MaterialComponents/private/RTL
     - MaterialComponents/Themes
-  - MaterialComponents/ButtonBar/Component (36.2.0):
+  - MaterialComponents/ButtonBar/Component (36.3.0):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/Buttons (36.2.0):
-    - MaterialComponents/Buttons/ColorThemer (= 36.2.0)
-    - MaterialComponents/Buttons/Component (= 36.2.0)
-    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 36.2.0)
+  - MaterialComponents/Buttons (36.3.0):
+    - MaterialComponents/Buttons/ColorThemer (= 36.3.0)
+    - MaterialComponents/Buttons/Component (= 36.3.0)
+    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 36.3.0)
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/ColorThemer (36.2.0):
+  - MaterialComponents/Buttons/ColorThemer (36.3.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -105,14 +105,14 @@ PODS:
     - MaterialComponents/Themes
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/Component (36.2.0):
+  - MaterialComponents/Buttons/Component (36.3.0):
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (36.2.0):
+  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (36.3.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -120,7 +120,7 @@ PODS:
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/CollectionCells (36.2.0):
+  - MaterialComponents/CollectionCells (36.3.0):
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/Palettes
@@ -133,167 +133,167 @@ PODS:
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/CollectionLayoutAttributes (36.2.0)
-  - MaterialComponents/Collections (36.2.0):
+  - MaterialComponents/CollectionLayoutAttributes (36.3.0)
+  - MaterialComponents/Collections (36.3.0):
     - MaterialComponents/CollectionCells
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/Dialogs (36.2.0):
-    - MaterialComponents/Dialogs/ColorThemer (= 36.2.0)
-    - MaterialComponents/Dialogs/Component (= 36.2.0)
-  - MaterialComponents/Dialogs/ColorThemer (36.2.0):
+  - MaterialComponents/Dialogs (36.3.0):
+    - MaterialComponents/Dialogs/ColorThemer (= 36.3.0)
+    - MaterialComponents/Dialogs/Component (= 36.3.0)
+  - MaterialComponents/Dialogs/ColorThemer (36.3.0):
     - MaterialComponents/Dialogs/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Dialogs/Component (36.2.0):
+  - MaterialComponents/Dialogs/Component (36.3.0):
     - MaterialComponents/Buttons
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MDFInternationalization
-  - MaterialComponents/FeatureHighlight (36.2.0):
-    - MaterialComponents/FeatureHighlight/ColorThemer (= 36.2.0)
-    - MaterialComponents/FeatureHighlight/Component (= 36.2.0)
-  - MaterialComponents/FeatureHighlight/ColorThemer (36.2.0):
+  - MaterialComponents/FeatureHighlight (36.3.0):
+    - MaterialComponents/FeatureHighlight/ColorThemer (= 36.3.0)
+    - MaterialComponents/FeatureHighlight/Component (= 36.3.0)
+  - MaterialComponents/FeatureHighlight/ColorThemer (36.3.0):
     - MaterialComponents/FeatureHighlight/Component
     - MaterialComponents/Themes
-  - MaterialComponents/FeatureHighlight/Component (36.2.0):
+  - MaterialComponents/FeatureHighlight/Component (36.3.0):
     - MaterialComponents/private/Math
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader (36.2.0):
-    - MaterialComponents/FlexibleHeader/ColorThemer (= 36.2.0)
-    - MaterialComponents/FlexibleHeader/Component (= 36.2.0)
+  - MaterialComponents/FlexibleHeader (36.3.0):
+    - MaterialComponents/FlexibleHeader/ColorThemer (= 36.3.0)
+    - MaterialComponents/FlexibleHeader/Component (= 36.3.0)
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/ColorThemer (36.2.0):
+  - MaterialComponents/FlexibleHeader/ColorThemer (36.3.0):
     - MaterialComponents/FlexibleHeader/Component
     - MaterialComponents/private/Application
     - MaterialComponents/Themes
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/Component (36.2.0):
+  - MaterialComponents/FlexibleHeader/Component (36.3.0):
     - MaterialComponents/private/Application
     - MaterialComponents/private/UIMetrics
     - MDFTextAccessibility
-  - MaterialComponents/HeaderStackView (36.2.0):
-    - MaterialComponents/HeaderStackView/ColorThemer (= 36.2.0)
-    - MaterialComponents/HeaderStackView/Component (= 36.2.0)
-  - MaterialComponents/HeaderStackView/ColorThemer (36.2.0):
+  - MaterialComponents/HeaderStackView (36.3.0):
+    - MaterialComponents/HeaderStackView/ColorThemer (= 36.3.0)
+    - MaterialComponents/HeaderStackView/Component (= 36.3.0)
+  - MaterialComponents/HeaderStackView/ColorThemer (36.3.0):
     - MaterialComponents/HeaderStackView/Component
     - MaterialComponents/Themes
-  - MaterialComponents/HeaderStackView/Component (36.2.0)
-  - MaterialComponents/Ink (36.2.0):
-    - MaterialComponents/Ink/ColorThemer (= 36.2.0)
-    - MaterialComponents/Ink/Component (= 36.2.0)
-  - MaterialComponents/Ink/ColorThemer (36.2.0):
+  - MaterialComponents/HeaderStackView/Component (36.3.0)
+  - MaterialComponents/Ink (36.3.0):
+    - MaterialComponents/Ink/ColorThemer (= 36.3.0)
+    - MaterialComponents/Ink/Component (= 36.3.0)
+  - MaterialComponents/Ink/ColorThemer (36.3.0):
     - MaterialComponents/Ink/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Ink/Component (36.2.0)
-  - MaterialComponents/MaskedTransition (36.2.0):
+  - MaterialComponents/Ink/Component (36.3.0)
+  - MaterialComponents/MaskedTransition (36.3.0):
     - MotionAnimator (~> 1.0)
     - MotionInterchange (~> 1.0)
     - MotionTransitioning (~> 3.3)
-  - MaterialComponents/NavigationBar (36.2.0):
-    - MaterialComponents/NavigationBar/ColorThemer (= 36.2.0)
-    - MaterialComponents/NavigationBar/Component (= 36.2.0)
-  - MaterialComponents/NavigationBar/ColorThemer (36.2.0):
+  - MaterialComponents/NavigationBar (36.3.0):
+    - MaterialComponents/NavigationBar/ColorThemer (= 36.3.0)
+    - MaterialComponents/NavigationBar/Component (= 36.3.0)
+  - MaterialComponents/NavigationBar/ColorThemer (36.3.0):
     - MaterialComponents/NavigationBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/NavigationBar/Component (36.2.0):
+  - MaterialComponents/NavigationBar/Component (36.3.0):
     - MaterialComponents/ButtonBar/Component
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/OverlayWindow (36.2.0):
+  - MaterialComponents/OverlayWindow (36.3.0):
     - MaterialComponents/private/Application
-  - MaterialComponents/PageControl (36.2.0):
-    - MaterialComponents/PageControl/ColorThemer (= 36.2.0)
-    - MaterialComponents/PageControl/Component (= 36.2.0)
-  - MaterialComponents/PageControl/ColorThemer (36.2.0):
+  - MaterialComponents/PageControl (36.3.0):
+    - MaterialComponents/PageControl/ColorThemer (= 36.3.0)
+    - MaterialComponents/PageControl/Component (= 36.3.0)
+  - MaterialComponents/PageControl/ColorThemer (36.3.0):
     - MaterialComponents/PageControl/Component
     - MaterialComponents/Themes
-  - MaterialComponents/PageControl/Component (36.2.0)
-  - MaterialComponents/Palettes (36.2.0)
-  - MaterialComponents/private (36.2.0):
-    - MaterialComponents/private/Application (= 36.2.0)
-    - MaterialComponents/private/Icons (= 36.2.0)
-    - MaterialComponents/private/KeyboardWatcher (= 36.2.0)
-    - MaterialComponents/private/Math (= 36.2.0)
-    - MaterialComponents/private/Overlay (= 36.2.0)
-    - MaterialComponents/private/RTL (= 36.2.0)
-    - MaterialComponents/private/ShapeLibrary (= 36.2.0)
-    - MaterialComponents/private/Shapes (= 36.2.0)
-    - MaterialComponents/private/ThumbTrack (= 36.2.0)
-    - MaterialComponents/private/UIMetrics (= 36.2.0)
-  - MaterialComponents/private/Application (36.2.0)
-  - MaterialComponents/private/Icons (36.2.0):
-    - MaterialComponents/private/Icons/Base (= 36.2.0)
-    - MaterialComponents/private/Icons/ic_arrow_back (= 36.2.0)
-    - MaterialComponents/private/Icons/ic_check (= 36.2.0)
-    - MaterialComponents/private/Icons/ic_check_circle (= 36.2.0)
-    - MaterialComponents/private/Icons/ic_chevron_right (= 36.2.0)
-    - MaterialComponents/private/Icons/ic_info (= 36.2.0)
-    - MaterialComponents/private/Icons/ic_radio_button_unchecked (= 36.2.0)
-    - MaterialComponents/private/Icons/ic_reorder (= 36.2.0)
-  - MaterialComponents/private/Icons/Base (36.2.0)
-  - MaterialComponents/private/Icons/ic_arrow_back (36.2.0):
+  - MaterialComponents/PageControl/Component (36.3.0)
+  - MaterialComponents/Palettes (36.3.0)
+  - MaterialComponents/private (36.3.0):
+    - MaterialComponents/private/Application (= 36.3.0)
+    - MaterialComponents/private/Icons (= 36.3.0)
+    - MaterialComponents/private/KeyboardWatcher (= 36.3.0)
+    - MaterialComponents/private/Math (= 36.3.0)
+    - MaterialComponents/private/Overlay (= 36.3.0)
+    - MaterialComponents/private/RTL (= 36.3.0)
+    - MaterialComponents/private/ShapeLibrary (= 36.3.0)
+    - MaterialComponents/private/Shapes (= 36.3.0)
+    - MaterialComponents/private/ThumbTrack (= 36.3.0)
+    - MaterialComponents/private/UIMetrics (= 36.3.0)
+  - MaterialComponents/private/Application (36.3.0)
+  - MaterialComponents/private/Icons (36.3.0):
+    - MaterialComponents/private/Icons/Base (= 36.3.0)
+    - MaterialComponents/private/Icons/ic_arrow_back (= 36.3.0)
+    - MaterialComponents/private/Icons/ic_check (= 36.3.0)
+    - MaterialComponents/private/Icons/ic_check_circle (= 36.3.0)
+    - MaterialComponents/private/Icons/ic_chevron_right (= 36.3.0)
+    - MaterialComponents/private/Icons/ic_info (= 36.3.0)
+    - MaterialComponents/private/Icons/ic_radio_button_unchecked (= 36.3.0)
+    - MaterialComponents/private/Icons/ic_reorder (= 36.3.0)
+  - MaterialComponents/private/Icons/Base (36.3.0)
+  - MaterialComponents/private/Icons/ic_arrow_back (36.3.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check (36.2.0):
+  - MaterialComponents/private/Icons/ic_check (36.3.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check_circle (36.2.0):
+  - MaterialComponents/private/Icons/ic_check_circle (36.3.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_chevron_right (36.2.0):
+  - MaterialComponents/private/Icons/ic_chevron_right (36.3.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_info (36.2.0):
+  - MaterialComponents/private/Icons/ic_info (36.3.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_radio_button_unchecked (36.2.0):
+  - MaterialComponents/private/Icons/ic_radio_button_unchecked (36.3.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_reorder (36.2.0):
+  - MaterialComponents/private/Icons/ic_reorder (36.3.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/KeyboardWatcher (36.2.0):
+  - MaterialComponents/private/KeyboardWatcher (36.3.0):
     - MaterialComponents/private/Application
-  - MaterialComponents/private/Math (36.2.0)
-  - MaterialComponents/private/Overlay (36.2.0)
-  - MaterialComponents/private/RTL (36.2.0)
-  - MaterialComponents/private/ShapeLibrary (36.2.0):
+  - MaterialComponents/private/Math (36.3.0)
+  - MaterialComponents/private/Overlay (36.3.0)
+  - MaterialComponents/private/RTL (36.3.0)
+  - MaterialComponents/private/ShapeLibrary (36.3.0):
     - MaterialComponents/private/Math
     - MaterialComponents/private/Shapes
-  - MaterialComponents/private/Shapes (36.2.0):
+  - MaterialComponents/private/Shapes (36.3.0):
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowLayer
-  - MaterialComponents/private/ThumbTrack (36.2.0):
+  - MaterialComponents/private/ThumbTrack (36.3.0):
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/private/UIMetrics (36.2.0):
+  - MaterialComponents/private/UIMetrics (36.3.0):
     - MaterialComponents/private/Application
-  - MaterialComponents/ProgressView (36.2.0):
-    - MaterialComponents/ProgressView/ColorThemer (= 36.2.0)
-    - MaterialComponents/ProgressView/Component (= 36.2.0)
-  - MaterialComponents/ProgressView/ColorThemer (36.2.0):
+  - MaterialComponents/ProgressView (36.3.0):
+    - MaterialComponents/ProgressView/ColorThemer (= 36.3.0)
+    - MaterialComponents/ProgressView/Component (= 36.3.0)
+  - MaterialComponents/ProgressView/ColorThemer (36.3.0):
     - MaterialComponents/ProgressView/Component
     - MaterialComponents/Themes
-  - MaterialComponents/ProgressView/Component (36.2.0):
+  - MaterialComponents/ProgressView/Component (36.3.0):
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
-  - MaterialComponents/ShadowElevations (36.2.0)
-  - MaterialComponents/ShadowLayer (36.2.0):
+  - MaterialComponents/ShadowElevations (36.3.0)
+  - MaterialComponents/ShadowLayer (36.3.0):
     - MaterialComponents/ShadowElevations
-  - MaterialComponents/Slider (36.2.0):
-    - MaterialComponents/Slider/ColorThemer (= 36.2.0)
-    - MaterialComponents/Slider/Component (= 36.2.0)
-  - MaterialComponents/Slider/ColorThemer (36.2.0):
+  - MaterialComponents/Slider (36.3.0):
+    - MaterialComponents/Slider/ColorThemer (= 36.3.0)
+    - MaterialComponents/Slider/Component (= 36.3.0)
+  - MaterialComponents/Slider/ColorThemer (36.3.0):
     - MaterialComponents/Slider/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Slider/Component (36.2.0):
+  - MaterialComponents/Slider/Component (36.3.0):
     - MaterialComponents/private/ThumbTrack
-  - MaterialComponents/Snackbar (36.2.0):
+  - MaterialComponents/Snackbar (36.3.0):
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Buttons
     - MaterialComponents/OverlayWindow
@@ -301,32 +301,34 @@ PODS:
     - MaterialComponents/private/KeyboardWatcher
     - MaterialComponents/private/Overlay
     - MaterialComponents/Typography
-  - MaterialComponents/Tabs (36.2.0):
-    - MaterialComponents/Tabs/ColorThemer (= 36.2.0)
-    - MaterialComponents/Tabs/Component (= 36.2.0)
-  - MaterialComponents/Tabs/ColorThemer (36.2.0):
+  - MaterialComponents/Tabs (36.3.0):
+    - MaterialComponents/Tabs/ColorThemer (= 36.3.0)
+    - MaterialComponents/Tabs/Component (= 36.3.0)
+  - MaterialComponents/Tabs/ColorThemer (36.3.0):
     - MaterialComponents/Tabs/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Tabs/Component (36.2.0):
+  - MaterialComponents/Tabs/Component (36.3.0):
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
+    - MaterialComponents/ShadowElevations
+    - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/TextFields (36.2.0):
-    - MaterialComponents/TextFields/ColorThemer (= 36.2.0)
-    - MaterialComponents/TextFields/Component (= 36.2.0)
-  - MaterialComponents/TextFields/ColorThemer (36.2.0):
+  - MaterialComponents/TextFields (36.3.0):
+    - MaterialComponents/TextFields/ColorThemer (= 36.3.0)
+    - MaterialComponents/TextFields/Component (= 36.3.0)
+  - MaterialComponents/TextFields/ColorThemer (36.3.0):
     - MaterialComponents/TextFields/Component
     - MaterialComponents/Themes
-  - MaterialComponents/TextFields/Component (36.2.0):
+  - MaterialComponents/TextFields/Component (36.3.0):
     - MaterialComponents/AnimationTiming
     - MaterialComponents/Palettes
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/Themes (36.2.0)
-  - MaterialComponents/Typography (36.2.0):
+  - MaterialComponents/Themes (36.3.0)
+  - MaterialComponents/Typography (36.3.0):
     - MaterialComponents/private/Application
   - MDFInternationalization (1.0.1)
   - MDFTextAccessibility (1.2.0)
@@ -343,7 +345,7 @@ EXTERNAL SOURCES:
     :path: ../../
 
 SPEC CHECKSUMS:
-  MaterialComponents: 41af870e63f8641c0b6b4c9bdccc14b8645acedc
+  MaterialComponents: 504a97d8eb8d91258c43fc1c26ddd45d924d7519
   MDFInternationalization: 264e30a0966b36d4f7fe9b7617c316f266837bfb
   MDFTextAccessibility: 94098925e0853551c5a311ce7c1ecefbe297cdb6
   MotionAnimator: 5a1893b58fcf7a4664d81d69c9a09a0078c67e06

--- a/demos/Pesto/Podfile.lock
+++ b/demos/Pesto/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
-  - MaterialComponents/AnimationTiming (36.2.0)
-  - MaterialComponents/AppBar (36.2.0):
-    - MaterialComponents/AppBar/ColorThemer (= 36.2.0)
-    - MaterialComponents/AppBar/Component (= 36.2.0)
-  - MaterialComponents/AppBar/ColorThemer (36.2.0):
+  - MaterialComponents/AnimationTiming (36.3.0)
+  - MaterialComponents/AppBar (36.3.0):
+    - MaterialComponents/AppBar/ColorThemer (= 36.3.0)
+    - MaterialComponents/AppBar/Component (= 36.3.0)
+  - MaterialComponents/AppBar/ColorThemer (36.3.0):
     - MaterialComponents/AppBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/AppBar/Component (36.2.0):
+  - MaterialComponents/AppBar/Component (36.3.0):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
     - MaterialComponents/NavigationBar
@@ -17,20 +17,20 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ButtonBar/Component (36.2.0):
+  - MaterialComponents/ButtonBar/Component (36.3.0):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/Buttons (36.2.0):
-    - MaterialComponents/Buttons/ColorThemer (= 36.2.0)
-    - MaterialComponents/Buttons/Component (= 36.2.0)
-    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 36.2.0)
+  - MaterialComponents/Buttons (36.3.0):
+    - MaterialComponents/Buttons/ColorThemer (= 36.3.0)
+    - MaterialComponents/Buttons/Component (= 36.3.0)
+    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 36.3.0)
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/ColorThemer (36.2.0):
+  - MaterialComponents/Buttons/ColorThemer (36.3.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -39,14 +39,14 @@ PODS:
     - MaterialComponents/Themes
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/Component (36.2.0):
+  - MaterialComponents/Buttons/Component (36.3.0):
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (36.2.0):
+  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (36.3.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -54,7 +54,7 @@ PODS:
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/CollectionCells (36.2.0):
+  - MaterialComponents/CollectionCells (36.3.0):
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/Palettes
@@ -67,80 +67,80 @@ PODS:
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
-  - MaterialComponents/CollectionLayoutAttributes (36.2.0)
-  - MaterialComponents/Collections (36.2.0):
+  - MaterialComponents/CollectionLayoutAttributes (36.3.0)
+  - MaterialComponents/Collections (36.3.0):
     - MaterialComponents/CollectionCells
     - MaterialComponents/CollectionLayoutAttributes
     - MaterialComponents/Ink
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/FlexibleHeader (36.2.0):
-    - MaterialComponents/FlexibleHeader/ColorThemer (= 36.2.0)
-    - MaterialComponents/FlexibleHeader/Component (= 36.2.0)
+  - MaterialComponents/FlexibleHeader (36.3.0):
+    - MaterialComponents/FlexibleHeader/ColorThemer (= 36.3.0)
+    - MaterialComponents/FlexibleHeader/Component (= 36.3.0)
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/ColorThemer (36.2.0):
+  - MaterialComponents/FlexibleHeader/ColorThemer (36.3.0):
     - MaterialComponents/FlexibleHeader/Component
     - MaterialComponents/private/Application
     - MaterialComponents/Themes
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/Component (36.2.0):
+  - MaterialComponents/FlexibleHeader/Component (36.3.0):
     - MaterialComponents/private/Application
     - MaterialComponents/private/UIMetrics
     - MDFTextAccessibility
-  - MaterialComponents/HeaderStackView (36.2.0):
-    - MaterialComponents/HeaderStackView/ColorThemer (= 36.2.0)
-    - MaterialComponents/HeaderStackView/Component (= 36.2.0)
-  - MaterialComponents/HeaderStackView/ColorThemer (36.2.0):
+  - MaterialComponents/HeaderStackView (36.3.0):
+    - MaterialComponents/HeaderStackView/ColorThemer (= 36.3.0)
+    - MaterialComponents/HeaderStackView/Component (= 36.3.0)
+  - MaterialComponents/HeaderStackView/ColorThemer (36.3.0):
     - MaterialComponents/HeaderStackView/Component
     - MaterialComponents/Themes
-  - MaterialComponents/HeaderStackView/Component (36.2.0)
-  - MaterialComponents/Ink (36.2.0):
-    - MaterialComponents/Ink/ColorThemer (= 36.2.0)
-    - MaterialComponents/Ink/Component (= 36.2.0)
-  - MaterialComponents/Ink/ColorThemer (36.2.0):
+  - MaterialComponents/HeaderStackView/Component (36.3.0)
+  - MaterialComponents/Ink (36.3.0):
+    - MaterialComponents/Ink/ColorThemer (= 36.3.0)
+    - MaterialComponents/Ink/Component (= 36.3.0)
+  - MaterialComponents/Ink/ColorThemer (36.3.0):
     - MaterialComponents/Ink/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Ink/Component (36.2.0)
-  - MaterialComponents/NavigationBar (36.2.0):
-    - MaterialComponents/NavigationBar/ColorThemer (= 36.2.0)
-    - MaterialComponents/NavigationBar/Component (= 36.2.0)
-  - MaterialComponents/NavigationBar/ColorThemer (36.2.0):
+  - MaterialComponents/Ink/Component (36.3.0)
+  - MaterialComponents/NavigationBar (36.3.0):
+    - MaterialComponents/NavigationBar/ColorThemer (= 36.3.0)
+    - MaterialComponents/NavigationBar/Component (= 36.3.0)
+  - MaterialComponents/NavigationBar/ColorThemer (36.3.0):
     - MaterialComponents/NavigationBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/NavigationBar/Component (36.2.0):
+  - MaterialComponents/NavigationBar/Component (36.3.0):
     - MaterialComponents/ButtonBar/Component
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Palettes (36.2.0)
-  - MaterialComponents/private/Application (36.2.0)
-  - MaterialComponents/private/Icons/Base (36.2.0)
-  - MaterialComponents/private/Icons/ic_arrow_back (36.2.0):
+  - MaterialComponents/Palettes (36.3.0)
+  - MaterialComponents/private/Application (36.3.0)
+  - MaterialComponents/private/Icons/Base (36.3.0)
+  - MaterialComponents/private/Icons/ic_arrow_back (36.3.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check (36.2.0):
+  - MaterialComponents/private/Icons/ic_check (36.3.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_check_circle (36.2.0):
+  - MaterialComponents/private/Icons/ic_check_circle (36.3.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_chevron_right (36.2.0):
+  - MaterialComponents/private/Icons/ic_chevron_right (36.3.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_info (36.2.0):
+  - MaterialComponents/private/Icons/ic_info (36.3.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_radio_button_unchecked (36.2.0):
+  - MaterialComponents/private/Icons/ic_radio_button_unchecked (36.3.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Icons/ic_reorder (36.2.0):
+  - MaterialComponents/private/Icons/ic_reorder (36.3.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Math (36.2.0)
-  - MaterialComponents/private/RTL (36.2.0)
-  - MaterialComponents/private/UIMetrics (36.2.0):
+  - MaterialComponents/private/Math (36.3.0)
+  - MaterialComponents/private/RTL (36.3.0)
+  - MaterialComponents/private/UIMetrics (36.3.0):
     - MaterialComponents/private/Application
-  - MaterialComponents/ShadowElevations (36.2.0)
-  - MaterialComponents/ShadowLayer (36.2.0):
+  - MaterialComponents/ShadowElevations (36.3.0)
+  - MaterialComponents/ShadowLayer (36.3.0):
     - MaterialComponents/ShadowElevations
-  - MaterialComponents/Themes (36.2.0)
-  - MaterialComponents/Typography (36.2.0):
+  - MaterialComponents/Themes (36.3.0)
+  - MaterialComponents/Typography (36.3.0):
     - MaterialComponents/private/Application
   - MDFTextAccessibility (1.2.0)
 
@@ -159,7 +159,7 @@ EXTERNAL SOURCES:
     :path: ../../
 
 SPEC CHECKSUMS:
-  MaterialComponents: 41af870e63f8641c0b6b4c9bdccc14b8645acedc
+  MaterialComponents: 504a97d8eb8d91258c43fc1c26ddd45d924d7519
   MDFTextAccessibility: 94098925e0853551c5a311ce7c1ecefbe297cdb6
 
 PODFILE CHECKSUM: cdec7a9b5bf338e8f41916eb1ec5588703a9dc16

--- a/demos/Shrine/Podfile.lock
+++ b/demos/Shrine/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - MaterialComponents/AppBar (36.2.0):
-    - MaterialComponents/AppBar/ColorThemer (= 36.2.0)
-    - MaterialComponents/AppBar/Component (= 36.2.0)
-  - MaterialComponents/AppBar/ColorThemer (36.2.0):
+  - MaterialComponents/AppBar (36.3.0):
+    - MaterialComponents/AppBar/ColorThemer (= 36.3.0)
+    - MaterialComponents/AppBar/Component (= 36.3.0)
+  - MaterialComponents/AppBar/ColorThemer (36.3.0):
     - MaterialComponents/AppBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/AppBar/Component (36.2.0):
+  - MaterialComponents/AppBar/Component (36.3.0):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
     - MaterialComponents/NavigationBar
@@ -16,20 +16,20 @@ PODS:
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
-  - MaterialComponents/ButtonBar/Component (36.2.0):
+  - MaterialComponents/ButtonBar/Component (36.3.0):
     - MaterialComponents/Buttons
     - MaterialComponents/private/RTL
-  - MaterialComponents/Buttons (36.2.0):
-    - MaterialComponents/Buttons/ColorThemer (= 36.2.0)
-    - MaterialComponents/Buttons/Component (= 36.2.0)
-    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 36.2.0)
+  - MaterialComponents/Buttons (36.3.0):
+    - MaterialComponents/Buttons/ColorThemer (= 36.3.0)
+    - MaterialComponents/Buttons/Component (= 36.3.0)
+    - MaterialComponents/Buttons/TitleColorAccessibilityMutator (= 36.3.0)
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/ColorThemer (36.2.0):
+  - MaterialComponents/Buttons/ColorThemer (36.3.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -38,14 +38,14 @@ PODS:
     - MaterialComponents/Themes
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/Component (36.2.0):
+  - MaterialComponents/Buttons/Component (36.3.0):
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowElevations
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (36.2.0):
+  - MaterialComponents/Buttons/TitleColorAccessibilityMutator (36.3.0):
     - MaterialComponents/Buttons/Component
     - MaterialComponents/Ink
     - MaterialComponents/private/Math
@@ -53,69 +53,69 @@ PODS:
     - MaterialComponents/ShadowLayer
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader (36.2.0):
-    - MaterialComponents/FlexibleHeader/ColorThemer (= 36.2.0)
-    - MaterialComponents/FlexibleHeader/Component (= 36.2.0)
+  - MaterialComponents/FlexibleHeader (36.3.0):
+    - MaterialComponents/FlexibleHeader/ColorThemer (= 36.3.0)
+    - MaterialComponents/FlexibleHeader/Component (= 36.3.0)
     - MaterialComponents/private/Application
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/ColorThemer (36.2.0):
+  - MaterialComponents/FlexibleHeader/ColorThemer (36.3.0):
     - MaterialComponents/FlexibleHeader/Component
     - MaterialComponents/private/Application
     - MaterialComponents/Themes
     - MDFTextAccessibility
-  - MaterialComponents/FlexibleHeader/Component (36.2.0):
+  - MaterialComponents/FlexibleHeader/Component (36.3.0):
     - MaterialComponents/private/Application
     - MaterialComponents/private/UIMetrics
     - MDFTextAccessibility
-  - MaterialComponents/HeaderStackView (36.2.0):
-    - MaterialComponents/HeaderStackView/ColorThemer (= 36.2.0)
-    - MaterialComponents/HeaderStackView/Component (= 36.2.0)
-  - MaterialComponents/HeaderStackView/ColorThemer (36.2.0):
+  - MaterialComponents/HeaderStackView (36.3.0):
+    - MaterialComponents/HeaderStackView/ColorThemer (= 36.3.0)
+    - MaterialComponents/HeaderStackView/Component (= 36.3.0)
+  - MaterialComponents/HeaderStackView/ColorThemer (36.3.0):
     - MaterialComponents/HeaderStackView/Component
     - MaterialComponents/Themes
-  - MaterialComponents/HeaderStackView/Component (36.2.0)
-  - MaterialComponents/Ink (36.2.0):
-    - MaterialComponents/Ink/ColorThemer (= 36.2.0)
-    - MaterialComponents/Ink/Component (= 36.2.0)
-  - MaterialComponents/Ink/ColorThemer (36.2.0):
+  - MaterialComponents/HeaderStackView/Component (36.3.0)
+  - MaterialComponents/Ink (36.3.0):
+    - MaterialComponents/Ink/ColorThemer (= 36.3.0)
+    - MaterialComponents/Ink/Component (= 36.3.0)
+  - MaterialComponents/Ink/ColorThemer (36.3.0):
     - MaterialComponents/Ink/Component
     - MaterialComponents/Themes
-  - MaterialComponents/Ink/Component (36.2.0)
-  - MaterialComponents/NavigationBar (36.2.0):
-    - MaterialComponents/NavigationBar/ColorThemer (= 36.2.0)
-    - MaterialComponents/NavigationBar/Component (= 36.2.0)
-  - MaterialComponents/NavigationBar/ColorThemer (36.2.0):
+  - MaterialComponents/Ink/Component (36.3.0)
+  - MaterialComponents/NavigationBar (36.3.0):
+    - MaterialComponents/NavigationBar/ColorThemer (= 36.3.0)
+    - MaterialComponents/NavigationBar/Component (= 36.3.0)
+  - MaterialComponents/NavigationBar/ColorThemer (36.3.0):
     - MaterialComponents/NavigationBar/Component
     - MaterialComponents/Themes
-  - MaterialComponents/NavigationBar/Component (36.2.0):
+  - MaterialComponents/NavigationBar/Component (36.3.0):
     - MaterialComponents/ButtonBar/Component
     - MaterialComponents/private/Math
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
     - MDFTextAccessibility
-  - MaterialComponents/PageControl (36.2.0):
-    - MaterialComponents/PageControl/ColorThemer (= 36.2.0)
-    - MaterialComponents/PageControl/Component (= 36.2.0)
-  - MaterialComponents/PageControl/ColorThemer (36.2.0):
+  - MaterialComponents/PageControl (36.3.0):
+    - MaterialComponents/PageControl/ColorThemer (= 36.3.0)
+    - MaterialComponents/PageControl/Component (= 36.3.0)
+  - MaterialComponents/PageControl/ColorThemer (36.3.0):
     - MaterialComponents/PageControl/Component
     - MaterialComponents/Themes
-  - MaterialComponents/PageControl/Component (36.2.0)
-  - MaterialComponents/private/Application (36.2.0)
-  - MaterialComponents/private/Icons/Base (36.2.0)
-  - MaterialComponents/private/Icons/ic_arrow_back (36.2.0):
+  - MaterialComponents/PageControl/Component (36.3.0)
+  - MaterialComponents/private/Application (36.3.0)
+  - MaterialComponents/private/Icons/Base (36.3.0)
+  - MaterialComponents/private/Icons/ic_arrow_back (36.3.0):
     - MaterialComponents/private/Icons/Base
-  - MaterialComponents/private/Math (36.2.0)
-  - MaterialComponents/private/RTL (36.2.0)
-  - MaterialComponents/private/UIMetrics (36.2.0):
+  - MaterialComponents/private/Math (36.3.0)
+  - MaterialComponents/private/RTL (36.3.0)
+  - MaterialComponents/private/UIMetrics (36.3.0):
     - MaterialComponents/private/Application
-  - MaterialComponents/ShadowElevations (36.2.0)
-  - MaterialComponents/ShadowLayer (36.2.0):
+  - MaterialComponents/ShadowElevations (36.3.0)
+  - MaterialComponents/ShadowLayer (36.3.0):
     - MaterialComponents/ShadowElevations
-  - MaterialComponents/Themes (36.2.0)
-  - MaterialComponents/Typography (36.2.0):
+  - MaterialComponents/Themes (36.3.0)
+  - MaterialComponents/Typography (36.3.0):
     - MaterialComponents/private/Application
   - MDFTextAccessibility (1.2.0)
-  - RemoteImageServiceForMDCDemos (36.2.0)
+  - RemoteImageServiceForMDCDemos (36.3.0)
 
 DEPENDENCIES:
   - MaterialComponents/AppBar (from `../../`)
@@ -129,9 +129,9 @@ EXTERNAL SOURCES:
     :path: ../supplemental
 
 SPEC CHECKSUMS:
-  MaterialComponents: 41af870e63f8641c0b6b4c9bdccc14b8645acedc
+  MaterialComponents: 504a97d8eb8d91258c43fc1c26ddd45d924d7519
   MDFTextAccessibility: 94098925e0853551c5a311ce7c1ecefbe297cdb6
-  RemoteImageServiceForMDCDemos: 68afe97ba541d53c0264d265cf51758c8392fe30
+  RemoteImageServiceForMDCDemos: c1f06bcc1fa949997377fe97870d035d49e9229d
 
 PODFILE CHECKSUM: 5eb94d7fb8deeb6709b7300f5d0e0e1a75902cca
 

--- a/demos/ZShadow/Podfile.lock
+++ b/demos/ZShadow/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - MaterialComponents/ShadowElevations (36.2.0)
-  - MaterialComponents/ShadowLayer (36.2.0):
+  - MaterialComponents/ShadowElevations (36.3.0)
+  - MaterialComponents/ShadowLayer (36.3.0):
     - MaterialComponents/ShadowElevations
 
 DEPENDENCIES:
@@ -12,7 +12,7 @@ EXTERNAL SOURCES:
     :path: ../../
 
 SPEC CHECKSUMS:
-  MaterialComponents: 41af870e63f8641c0b6b4c9bdccc14b8645acedc
+  MaterialComponents: 504a97d8eb8d91258c43fc1c26ddd45d924d7519
 
 PODFILE CHECKSUM: 238ed9ba58d5e4a3638e6cea92b00109641989f8
 

--- a/demos/supplemental/RemoteImageServiceForMDCDemos.podspec
+++ b/demos/supplemental/RemoteImageServiceForMDCDemos.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RemoteImageServiceForMDCDemos"
-  s.version      = "36.2.0"
+  s.version      = "36.3.0"
   s.summary      = "A helper image class for the MDC demos."
   s.description  = "This spec is made for use in the MDC demos. It gets images via url."
   s.homepage     = "https://github.com/material-components/material-components-ios"


### PR DESCRIPTION
## API Changes

### Flexible Header

* Added `minMaxHeightIncludesSafeArea` to inform the component if the `minimumHeight` and `maximumHeight` properties include the safe area inset. 

## Component changes

### FlexibleHeader

#### Changes

* [Introduce minMaxHeightIncludesSafeArea and fix rotation bugs. (#2184)](https://github.com/material-components/material-components-ios/commit/100d18816b7574f4c210df9c7c3afa716f661b78) (Andrés)
* [Split _hasExplicitlySetMinOrMaxHeight into two. (#2196)](https://github.com/material-components/material-components-ios/commit/1c754aee3b1dda7166babc97306c315c4d7b901d) (Andrés)
