### PR TITLE
[TextFields] Corrects cheap floating placeholder layout

### DIFF
--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -390,8 +390,9 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
   [_fundament didSetText];
 
   if (!self.isFirstResponder) {
-    [[NSNotificationCenter defaultCenter] postNotificationName:MDCTextFieldTextDidSetTextNotification
-                                                        object:self];
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:MDCTextFieldTextDidSetTextNotification
+                      object:self];
   }
 }
 

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -597,6 +597,9 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
 
   [self updateUnderlinePosition];
   [super updateConstraints];
+  if ([self.positioningDelegate respondsToSelector:@selector(textInputDidUpdateConstraints)]) {
+    [self.positioningDelegate textInputDidUpdateConstraints];
+  }
 }
 
 + (BOOL)requiresConstraintBasedLayout {

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -384,12 +384,15 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
   [self.fundament setPlaceholder:placeholder];
 }
 
-// Note: this is also called by the internals of UITextField when editing ends.
+// Note: this is also called by the internals of UITextField when editing ends (iOS 8 to 10).
 - (void)setText:(NSString *)text {
   [super setText:text];
   [_fundament didSetText];
-  [[NSNotificationCenter defaultCenter] postNotificationName:MDCTextFieldTextDidSetTextNotification
-                                                      object:self];
+
+  if (!self.isFirstResponder) {
+    [[NSNotificationCenter defaultCenter] postNotificationName:MDCTextFieldTextDidSetTextNotification
+                                                        object:self];
+  }
 }
 
 #pragma mark - UITextField Overrides

--- a/components/TextFields/src/MDCTextFieldPositioningDelegate.h
+++ b/components/TextFields/src/MDCTextFieldPositioningDelegate.h
@@ -47,4 +47,7 @@
 /** Called from the end of the input's layoutSubviews. */
 - (void)textInputDidLayoutSubviews;
 
+/** Called from the end of the input's updateConstraints. */
+- (void)textInputDidUpdateConstraints;
+
 @end

--- a/components/TextFields/src/MDCTextInputControllerDefault.h
+++ b/components/TextFields/src/MDCTextInputControllerDefault.h
@@ -74,7 +74,7 @@ extern const CGFloat MDCTextInputDefaultUnderlineActiveHeight;
 /**
  Where the floating placeholder should arrive when floating up.
  */
-@property(nonatomic, readonly) CGPoint floatingPlaceholderDestination;
+@property(nonatomic, readonly) UIOffset floatingPlaceholderOffset;
 
 /**
  The scale of the the floating placeholder label in comparison to the inline placeholder specified

--- a/components/TextFields/src/MDCTextInputControllerDefault.h
+++ b/components/TextFields/src/MDCTextInputControllerDefault.h
@@ -72,7 +72,7 @@ extern const CGFloat MDCTextInputDefaultUnderlineActiveHeight;
 @property(class, nonatomic, null_resettable, strong) UIColor *floatingPlaceholderNormalColorDefault;
 
 /**
- Where the floating placeholder should arrive when floating up.
+ When the placeholder floats up, constraints are created that use this value for constants.
  */
 @property(nonatomic, readonly) UIOffset floatingPlaceholderOffset;
 

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -1277,6 +1277,12 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   [self updateBorder];
 }
 
+- (void)textInputDidUpdateConstraints {
+  if (self.isFloatingEnabled && _textInput.text.length > 0) {
+    [self updatePlaceholderAnimationConstraints:YES];
+  }
+}
+
 #pragma mark - UITextField & UITextView Notification Observation
 
 - (void)textInputDidBeginEditing:(__unused NSNotification *)note {

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -624,6 +624,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   self.placeholderAnimationConstraints = nil;
   self.placeholderAnimationConstraintLeading = nil;
   self.placeholderAnimationConstraintTop = nil;
+  self.placeholderAnimationConstraintTrailing = nil;
 }
 
 - (UIOffset)floatingPlaceholderOffset {

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -550,11 +550,11 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
   // We do this beforehand to flush the layout engine.
   [self.textInput layoutIfNeeded];
+  [self updatePlaceholder];
+  [self updatePlaceholderAnimationConstraints:isToUp];
   [UIView animateWithDuration:[CATransaction animationDuration]
       animations:^{
         self.textInput.placeholderLabel.transform = destinationTransform;
-        [self updatePlaceholder];
-        [self updatePlaceholderAnimationConstraints:isToUp];
 
         [self.textInput layoutIfNeeded];
       }
@@ -615,16 +615,9 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   placeholderY -= self.textInput.placeholderLabel.font.lineHeight *
                   (1 - (CGFloat)self.floatingPlaceholderScale.floatValue) * .5f;
 
-  CGFloat estimatedWidth = MDCCeil(CGRectGetWidth([self.textInput.placeholderLabel.text
-      boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, self.textInput.placeholderLabel.font.lineHeight)
-                   options:0
-                attributes:@{
-                  NSFontAttributeName : self.textInput.font
-                }
-                   context:nil]));
   CGFloat placeholderX =
-      -1 * estimatedWidth * (1 - (CGFloat)self.floatingPlaceholderScale.floatValue) * .5f;
-
+      -1 * CGRectGetWidth(self.textInput.placeholderLabel.bounds) * (1 - (CGFloat)self.floatingPlaceholderScale.floatValue) * .5f;
+  NSLog(@"%@", NSStringFromCGRect(self.textInput.placeholderLabel.bounds));
   placeholderX += self.textInput.textInsets.left;
 
   return CGPointMake(placeholderX, placeholderY);

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -547,7 +547,8 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   // A simple scale transform is also applied. Then it's animated through the UIView animation API
   // (layoutIfNeeded). If in reverse (isToUp == NO), these things are just removed / deactivated.
 
-  CGAffineTransform scaleTransform = isToUp ? floatingPlaceholderScaleTransform : CGAffineTransformIdentity;
+  CGAffineTransform scaleTransform =
+      isToUp ? floatingPlaceholderScaleTransform : CGAffineTransformIdentity;
 
   // We do this beforehand to flush the layout engine.
   [self.textInput layoutIfNeeded];

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -165,7 +165,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
 @property(nonatomic, strong) MDCTextInputAllCharactersCounter *internalCharacterCounter;
 
-@property(nonatomic, strong) NSArray<NSLayoutConstraint *> *placeholderAnimationConstraints;
+@property(nonatomic, copy) NSArray<NSLayoutConstraint *> *placeholderAnimationConstraints;
 
 @property(nonatomic, strong) NSLayoutConstraint *placeholderAnimationConstraintLeading;
 @property(nonatomic, strong) NSLayoutConstraint *placeholderAnimationConstraintTop;
@@ -547,7 +547,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   // A simple scale transform is also applied. Then it's animated through the UIView animation API
   // (layoutIfNeeded). If in reverse (isToUp == NO), these things are just removed / deactivated.
 
-  CGAffineTransform destinationTransform = isToUp ? floatingPlaceholderScaleTransform : CGAffineTransformIdentity;
+  CGAffineTransform scaleTransform = isToUp ? floatingPlaceholderScaleTransform : CGAffineTransformIdentity;
 
   // We do this beforehand to flush the layout engine.
   [self.textInput layoutIfNeeded];
@@ -555,7 +555,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   [self updatePlaceholderAnimationConstraints:isToUp];
   [UIView animateWithDuration:[CATransaction animationDuration]
       animations:^{
-        self.textInput.placeholderLabel.transform = destinationTransform;
+        self.textInput.placeholderLabel.transform = scaleTransform;
 
         [self.textInput layoutIfNeeded];
       }
@@ -568,10 +568,10 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
 - (void)updatePlaceholderAnimationConstraints:(BOOL)isToUp {
   if (isToUp) {
-    UIOffset destination = [self floatingPlaceholderOffset];
+    UIOffset offset = [self floatingPlaceholderOffset];
     UIEdgeInsets insets = self.textInput.textInsets;
 
-    CGFloat horizontalLeading = insets.left - destination.horizontal;
+    CGFloat horizontalLeading = insets.left - offset.horizontal;
     if (!self.placeholderAnimationConstraintLeading) {
       self.placeholderAnimationConstraintLeading =
           [NSLayoutConstraint constraintWithItem:self.textInput.placeholderLabel
@@ -592,11 +592,11 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
                                           toItem:self.textInput
                                        attribute:NSLayoutAttributeTop
                                       multiplier:1
-                                        constant:destination.vertical];
+                                        constant:offset.vertical];
     }
-    self.placeholderAnimationConstraintTop.constant = destination.vertical;
+    self.placeholderAnimationConstraintTop.constant = offset.vertical;
 
-    CGFloat horizontalTrailing = destination.horizontal - insets.right;
+    CGFloat horizontalTrailing = offset.horizontal - insets.right;
     if (!self.placeholderAnimationConstraintTrailing) {
       self.placeholderAnimationConstraintTrailing =
           [NSLayoutConstraint constraintWithItem:self.textInput.placeholderLabel

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -611,13 +611,18 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   CGFloat placeholderY = MDCTextInputDefaultPadding;
 
   // Offsets needed due to transform working on normal (0.5,0.5) anchor point.
-  // Why no anchor point of (0,0)? Because our users wouldn't expect it.
+  // Why no anchor point of (0,0)? Because autolayout doesn't play well with anchor points.
   placeholderY -= self.textInput.placeholderLabel.font.lineHeight *
                   (1 - (CGFloat)self.floatingPlaceholderScale.floatValue) * .5f;
 
+  CGFloat placeholderWidth = CGRectGetWidth(self.textInput.placeholderLabel.bounds);
+  if (MDCCGFloatEqual(placeholderWidth, 0) ) {
+    CGSize intrinsicSize =
+        [self.textInput.placeholderLabel systemLayoutSizeFittingSize:UILayoutFittingCompressedSize];
+    placeholderWidth = intrinsicSize.width;
+  }
   CGFloat placeholderX =
-      -1 * CGRectGetWidth(self.textInput.placeholderLabel.bounds) * (1 - (CGFloat)self.floatingPlaceholderScale.floatValue) * .5f;
-  NSLog(@"%@", NSStringFromCGRect(self.textInput.placeholderLabel.bounds));
+      -1 * placeholderWidth * (1.0f - self.floatingPlaceholderScale.floatValue) * .5f;
   placeholderX += self.textInput.textInsets.left;
 
   return CGPointMake(placeholderX, placeholderY);

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -430,7 +430,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   [defaultCenter removeObserver:self];
 }
 
-
 #pragma mark - Border Customization
 
 - (void)updateBorder {
@@ -600,20 +599,21 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
     CGFloat horizontalTrailing = destination.horizontal - insets.right;
     if (!self.placeholderAnimationConstraintTrailing) {
       self.placeholderAnimationConstraintTrailing =
-      [NSLayoutConstraint constraintWithItem:self.textInput.placeholderLabel
-                                   attribute:NSLayoutAttributeTrailing
-                                   relatedBy:NSLayoutRelationEqual
-                                      toItem:self.textInput
-                                   attribute:NSLayoutAttributeTrailing
-                                  multiplier:1
-                                    constant:horizontalTrailing];
+          [NSLayoutConstraint constraintWithItem:self.textInput.placeholderLabel
+                                       attribute:NSLayoutAttributeTrailing
+                                       relatedBy:NSLayoutRelationEqual
+                                          toItem:self.textInput
+                                       attribute:NSLayoutAttributeTrailing
+                                      multiplier:1
+                                        constant:horizontalTrailing];
       self.placeholderAnimationConstraintTrailing.priority = UILayoutPriorityDefaultHigh - 1;
     }
     self.placeholderAnimationConstraintTrailing.constant = horizontalTrailing;
 
-    self.placeholderAnimationConstraints = @[ self.placeholderAnimationConstraintLeading,
-                                              self.placeholderAnimationConstraintTop,
-                                              self.placeholderAnimationConstraintTrailing ];
+    self.placeholderAnimationConstraints = @[
+      self.placeholderAnimationConstraintLeading, self.placeholderAnimationConstraintTop,
+      self.placeholderAnimationConstraintTrailing
+    ];
     [NSLayoutConstraint activateConstraints:self.placeholderAnimationConstraints];
   } else {
     [NSLayoutConstraint deactivateConstraints:self.placeholderAnimationConstraints];
@@ -632,14 +632,16 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   // Offsets needed due to transform working on normal (0.5,0.5) anchor point.
   // Why no anchor point of (0,0)? Because autolayout doesn't play well with anchor points.
   vertical -= self.textInput.placeholderLabel.font.lineHeight *
-                  (1 - (CGFloat)self.floatingPlaceholderScale.floatValue) * .5f;
+              (1 - (CGFloat)self.floatingPlaceholderScale.floatValue) * .5f;
 
   UIEdgeInsets insets = self.textInput.textInsets;
   CGFloat placeholderMaxWidth =
-      CGRectGetWidth(self.textInput.bounds) / self.floatingPlaceholderScale.floatValue - insets.left - insets.right;
+      CGRectGetWidth(self.textInput.bounds) / self.floatingPlaceholderScale.floatValue -
+      insets.left - insets.right;
 
   CGFloat placeholderWidth =
-      [self.textInput.placeholderLabel systemLayoutSizeFittingSize:UILayoutFittingCompressedSize].width;
+      [self.textInput.placeholderLabel systemLayoutSizeFittingSize:UILayoutFittingCompressedSize]
+          .width;
   if (placeholderWidth > placeholderMaxWidth) {
     placeholderWidth = placeholderMaxWidth;
   }

--- a/components/TextFields/src/MDCTextInputControllerDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerDefault.m
@@ -638,8 +638,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   CGFloat placeholderMaxWidth =
       CGRectGetWidth(self.textInput.bounds) / self.floatingPlaceholderScale.floatValue - insets.left - insets.right;
 
-  // This is the amount negative space we need to compensate for but per side.
-
   CGFloat placeholderWidth =
       [self.textInput.placeholderLabel systemLayoutSizeFittingSize:UILayoutFittingCompressedSize].width;
   if (placeholderWidth > placeholderMaxWidth) {

--- a/components/TextFields/src/MDCTextInputControllerLegacyDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerLegacyDefault.m
@@ -159,7 +159,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
 @property(nonatomic, strong) MDCTextInputAllCharactersCounter *internalCharacterCounter;
 
-@property(nonatomic, strong) NSArray<NSLayoutConstraint *> *placeholderAnimationConstraints;
+@property(nonatomic, copy) NSArray<NSLayoutConstraint *> *placeholderAnimationConstraints;
 
 @property(nonatomic, strong) NSLayoutConstraint *placeholderAnimationConstraintLeading;
 @property(nonatomic, strong) NSLayoutConstraint *placeholderAnimationConstraintTop;
@@ -522,7 +522,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   // A simple scale transform is also applied. Then it's animated through the UIView animation API
   // (layoutIfNeeded). If in reverse (isToUp == NO), these things are just removed / deactivated.
 
-  CGAffineTransform destinationTransform = isToUp ? floatingPlaceholderScaleTransform : CGAffineTransformIdentity;
+  CGAffineTransform scaleTransform = isToUp ? floatingPlaceholderScaleTransform : CGAffineTransformIdentity;
 
   // We do this beforehand to flush the layout engine.
   [self.textInput layoutIfNeeded];
@@ -531,7 +531,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
   [UIView animateWithDuration:[CATransaction animationDuration]
       animations:^{
-        self.textInput.placeholderLabel.transform = destinationTransform;
+        self.textInput.placeholderLabel.transform = scaleTransform;
 
         [self.textInput layoutIfNeeded];
       }
@@ -544,10 +544,10 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
 - (void)updatePlaceholderAnimationConstraints:(BOOL)isToUp {
   if (isToUp) {
-    UIOffset destination = [self floatingPlaceholderOffset];
+    UIOffset offset = [self floatingPlaceholderOffset];
     UIEdgeInsets insets = self.textInput.textInsets;
 
-    CGFloat horizontalLeading = insets.left - destination.horizontal;
+    CGFloat horizontalLeading = insets.left - offset.horizontal;
     if (!self.placeholderAnimationConstraintLeading) {
       self.placeholderAnimationConstraintLeading =
       [NSLayoutConstraint constraintWithItem:self.textInput.placeholderLabel
@@ -568,11 +568,11 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
                                       toItem:self.textInput
                                    attribute:NSLayoutAttributeTop
                                   multiplier:1
-                                    constant:destination.vertical];
+                                    constant:offset.vertical];
     }
-    self.placeholderAnimationConstraintTop.constant = destination.vertical;
+    self.placeholderAnimationConstraintTop.constant = offset.vertical;
 
-    CGFloat horizontalTrailing = destination.horizontal - insets.right;
+    CGFloat horizontalTrailing = offset.horizontal - insets.right;
     if (!self.placeholderAnimationConstraintTrailing) {
       self.placeholderAnimationConstraintTrailing =
       [NSLayoutConstraint constraintWithItem:self.textInput.placeholderLabel

--- a/components/TextFields/src/MDCTextInputControllerLegacyDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerLegacyDefault.m
@@ -522,7 +522,8 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   // A simple scale transform is also applied. Then it's animated through the UIView animation API
   // (layoutIfNeeded). If in reverse (isToUp == NO), these things are just removed / deactivated.
 
-  CGAffineTransform scaleTransform = isToUp ? floatingPlaceholderScaleTransform : CGAffineTransformIdentity;
+  CGAffineTransform scaleTransform =
+      isToUp ? floatingPlaceholderScaleTransform : CGAffineTransformIdentity;
 
   // We do this beforehand to flush the layout engine.
   [self.textInput layoutIfNeeded];
@@ -550,45 +551,46 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
     CGFloat horizontalLeading = insets.left - offset.horizontal;
     if (!self.placeholderAnimationConstraintLeading) {
       self.placeholderAnimationConstraintLeading =
-      [NSLayoutConstraint constraintWithItem:self.textInput.placeholderLabel
-                                   attribute:NSLayoutAttributeLeading
-                                   relatedBy:NSLayoutRelationEqual
-                                      toItem:self.textInput
-                                   attribute:NSLayoutAttributeLeading
-                                  multiplier:1
-                                    constant:horizontalLeading];
+          [NSLayoutConstraint constraintWithItem:self.textInput.placeholderLabel
+                                       attribute:NSLayoutAttributeLeading
+                                       relatedBy:NSLayoutRelationEqual
+                                          toItem:self.textInput
+                                       attribute:NSLayoutAttributeLeading
+                                      multiplier:1
+                                        constant:horizontalLeading];
     }
     self.placeholderAnimationConstraintLeading.constant = horizontalLeading;
 
     if (!self.placeholderAnimationConstraintTop) {
       self.placeholderAnimationConstraintTop =
-      [NSLayoutConstraint constraintWithItem:self.textInput.placeholderLabel
-                                   attribute:NSLayoutAttributeTop
-                                   relatedBy:NSLayoutRelationEqual
-                                      toItem:self.textInput
-                                   attribute:NSLayoutAttributeTop
-                                  multiplier:1
-                                    constant:offset.vertical];
+          [NSLayoutConstraint constraintWithItem:self.textInput.placeholderLabel
+                                       attribute:NSLayoutAttributeTop
+                                       relatedBy:NSLayoutRelationEqual
+                                          toItem:self.textInput
+                                       attribute:NSLayoutAttributeTop
+                                      multiplier:1
+                                        constant:offset.vertical];
     }
     self.placeholderAnimationConstraintTop.constant = offset.vertical;
 
     CGFloat horizontalTrailing = offset.horizontal - insets.right;
     if (!self.placeholderAnimationConstraintTrailing) {
       self.placeholderAnimationConstraintTrailing =
-      [NSLayoutConstraint constraintWithItem:self.textInput.placeholderLabel
-                                   attribute:NSLayoutAttributeTrailing
-                                   relatedBy:NSLayoutRelationEqual
-                                      toItem:self.textInput
-                                   attribute:NSLayoutAttributeTrailing
-                                  multiplier:1
-                                    constant:horizontalTrailing];
+          [NSLayoutConstraint constraintWithItem:self.textInput.placeholderLabel
+                                       attribute:NSLayoutAttributeTrailing
+                                       relatedBy:NSLayoutRelationEqual
+                                          toItem:self.textInput
+                                       attribute:NSLayoutAttributeTrailing
+                                      multiplier:1
+                                        constant:horizontalTrailing];
       self.placeholderAnimationConstraintTrailing.priority = UILayoutPriorityDefaultHigh - 1;
     }
     self.placeholderAnimationConstraintTrailing.constant = horizontalTrailing;
 
-    self.placeholderAnimationConstraints = @[ self.placeholderAnimationConstraintLeading,
-                                              self.placeholderAnimationConstraintTop,       self.placeholderAnimationConstraintTrailing
- ];
+    self.placeholderAnimationConstraints = @[
+      self.placeholderAnimationConstraintLeading, self.placeholderAnimationConstraintTop,
+      self.placeholderAnimationConstraintTrailing
+    ];
     [NSLayoutConstraint activateConstraints:self.placeholderAnimationConstraints];
   } else {
     [NSLayoutConstraint deactivateConstraints:self.placeholderAnimationConstraints];
@@ -617,7 +619,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
   CGFloat placeholderWidth =
       [self.textInput.placeholderLabel systemLayoutSizeFittingSize:UILayoutFittingCompressedSize]
-  .width;
+          .width;
   if (placeholderWidth > placeholderMaxWidth) {
     placeholderWidth = placeholderMaxWidth;
   }

--- a/components/TextFields/src/MDCTextInputControllerOutlined.m
+++ b/components/TextFields/src/MDCTextInputControllerOutlined.m
@@ -152,15 +152,15 @@ static UIRectCorner _roundedCornersDefault = UIRectCornerAllCorners;
   placeholderLabel.horizontalPadding = MDCTextInputOutlinedTextFieldPlaceholderPadding;
 
   if (!self.placeholderLeading) {
-    self.placeholderLeading =
-        [NSLayoutConstraint constraintWithItem:self.textInput.placeholderLabel
-                                     attribute:NSLayoutAttributeLeading
-                                     relatedBy:NSLayoutRelationEqual
-                                        toItem:self.textInput
-                                     attribute:NSLayoutAttributeLeading
-                                    multiplier:1
-                                      constant:MDCTextInputOutlinedTextFieldFullPadding -
-                                               placeholderLabel.horizontalPadding];
+    self.placeholderLeading = [NSLayoutConstraint
+        constraintWithItem:self.textInput.placeholderLabel
+                 attribute:NSLayoutAttributeLeading
+                 relatedBy:NSLayoutRelationEqual
+                    toItem:self.textInput
+                 attribute:NSLayoutAttributeLeading
+                multiplier:1
+                  constant:MDCTextInputOutlinedTextFieldFullPadding -
+                               placeholderLabel.horizontalPadding];
     self.placeholderLeading.priority = UILayoutPriorityDefaultHigh;
     self.placeholderLeading.active = YES;
   }

--- a/components/TextFields/src/MDCTextInputControllerOutlined.m
+++ b/components/TextFields/src/MDCTextInputControllerOutlined.m
@@ -60,13 +60,13 @@ static UIRectCorner _roundedCornersDefault = UIRectCornerAllCorners;
   // Unused. Floating is always enabled.
 }
 
-- (CGPoint)floatingPlaceholderDestination {
-  CGPoint destination = [super floatingPlaceholderDestination];
+- (UIOffset)floatingPlaceholderOffset {
+  UIOffset destination = [super floatingPlaceholderOffset];
   CGFloat offset = self.textInput.placeholderLabel.font.lineHeight -
                    self.textInput.placeholderLabel.font.xHeight;
-  destination.y = -1 * offset;
+  destination.vertical = -1 * offset;
   MDCPaddedLabel *placeholderLabel = (MDCPaddedLabel *)self.textInput.placeholderLabel;
-  destination.x -= placeholderLabel.horizontalPadding;
+  destination.horizontal += placeholderLabel.horizontalPadding;
   return destination;
 }
 

--- a/components/TextFields/src/MDCTextInputControllerOutlined.m
+++ b/components/TextFields/src/MDCTextInputControllerOutlined.m
@@ -152,15 +152,15 @@ static UIRectCorner _roundedCornersDefault = UIRectCornerAllCorners;
   placeholderLabel.horizontalPadding = MDCTextInputOutlinedTextFieldPlaceholderPadding;
 
   if (!self.placeholderLeading) {
-    self.placeholderLeading = [NSLayoutConstraint
-        constraintWithItem:self.textInput.placeholderLabel
-                 attribute:NSLayoutAttributeLeading
-                 relatedBy:NSLayoutRelationEqual
-                    toItem:self.textInput
-                 attribute:NSLayoutAttributeLeading
-                multiplier:1
-                  constant:MDCTextInputOutlinedTextFieldFullPadding -
-                               placeholderLabel.horizontalPadding];
+    self.placeholderLeading =
+        [NSLayoutConstraint constraintWithItem:self.textInput.placeholderLabel
+                                     attribute:NSLayoutAttributeLeading
+                                     relatedBy:NSLayoutRelationEqual
+                                        toItem:self.textInput
+                                     attribute:NSLayoutAttributeLeading
+                                    multiplier:1
+                                      constant:MDCTextInputOutlinedTextFieldFullPadding -
+                                               placeholderLabel.horizontalPadding];
     self.placeholderLeading.priority = UILayoutPriorityDefaultHigh;
     self.placeholderLeading.active = YES;
   }

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -316,6 +316,9 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   _placeholderLabel.translatesAutoresizingMaskIntoConstraints = NO;
   [_placeholderLabel setContentCompressionResistancePriority:UILayoutPriorityDefaultLow - 2
                                                      forAxis:UILayoutConstraintAxisHorizontal];
+  [_placeholderLabel setContentHuggingPriority:UILayoutPriorityDefaultHigh
+                                       forAxis:UILayoutConstraintAxisHorizontal];
+
   _placeholderLabel.textAlignment = NSTextAlignmentNatural;
 
   _placeholderLabel.userInteractionEnabled = NO;

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -314,7 +314,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 - (void)setupPlaceholderLabel {
   _placeholderLabel = [[MDCPaddedLabel alloc] initWithFrame:CGRectZero];
   _placeholderLabel.translatesAutoresizingMaskIntoConstraints = NO;
-  [_placeholderLabel setContentCompressionResistancePriority:UILayoutPriorityDefaultLow - 1
+  [_placeholderLabel setContentCompressionResistancePriority:UILayoutPriorityDefaultLow - 2
                                                      forAxis:UILayoutConstraintAxisHorizontal];
   _placeholderLabel.textAlignment = NSTextAlignmentNatural;
 

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -410,7 +410,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 
   // When push comes to shove, the leading label is more likely to expand than the trailing.
   [_leadingUnderlineLabel setContentHuggingPriority:UILayoutPriorityDefaultLow - 1
-                                            forAxis:UILayoutConstraintAxisHorizontal];
+                                                forAxis:UILayoutConstraintAxisHorizontal];
 
   [_trailingUnderlineLabel
       setContentCompressionResistancePriority:UILayoutPriorityRequired

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -410,7 +410,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 
   // When push comes to shove, the leading label is more likely to expand than the trailing.
   [_leadingUnderlineLabel setContentHuggingPriority:UILayoutPriorityDefaultLow - 1
-                                                forAxis:UILayoutConstraintAxisHorizontal];
+                                            forAxis:UILayoutConstraintAxisHorizontal];
 
   [_trailingUnderlineLabel
       setContentCompressionResistancePriority:UILayoutPriorityRequired


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/1271525/31645637-25a78280-b2cb-11e7-9eac-ae2dff735a43.png)

Now:

![after](https://user-images.githubusercontent.com/1271525/31645523-9865f7b2-b2ca-11e7-80b5-c37328e45c16.png)

Closes #2205
Closes #2204
Closes #2170 
