### PR TITLE
[FlexibleHeader] Don't modify the content insets during orientation changes

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -469,7 +469,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
       _maximumHeight = _minimumHeight;
     }
 
-    // We avoid modififying the scroll view insets during rotation because doing so can cause
+    // We avoid modifying the scroll view insets during rotation because doing so can cause
     // collection views to crash during rotation.
     if (!_interfaceOrientationIsChanging) {
       // Adjust the scroll view insets to account for the new Safe Area inset.

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -469,8 +469,12 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
       _maximumHeight = _minimumHeight;
     }
 
-    // Adjust the scroll view insets to account for the new Safe Area inset.
-    [self fhv_adjustTrackingScrollViewInsets];
+    // We avoid modififying the scroll view insets during rotation because doing so can cause
+    // collection views to crash during rotation.
+    if (!_interfaceOrientationIsChanging) {
+      // Adjust the scroll view insets to account for the new Safe Area inset.
+      [self fhv_adjustTrackingScrollViewInsets];
+    }
 
     // Ignore any content offset delta that occured as a result of any safe area insets change.
     _shiftAccumulatorLastContentOffset = [self fhv_boundedContentOffset];


### PR DESCRIPTION
Modifying the content insets can cause crashes with highly-customized collection views during rotation.