### PR TITLE
[Dialogs] Set Dialog example button to open material.io

### DIFF
--- a/components/Dialogs/examples/DialogsTypicalUseViewController.m
+++ b/components/Dialogs/examples/DialogsTypicalUseViewController.m
@@ -29,7 +29,7 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  [self loadCollectionView:@[@"Programmatic", @"Storyboard", @"Modal"]];
+  [self loadCollectionView:@[@"Programmatic", @"Storyboard", @"Modal", @"Open URL"]];
   // We must create and store a strong reference to the transitionController.
   // A presented view controller will set this object as its transitioning delegate.
   self.transitionController = [[MDCDialogTransitionController alloc] init];
@@ -43,6 +43,8 @@
     [self didTapStoryboard:nil];
   } else if (indexPath.row == 2) {
     [self didTapModalProgrammatic:nil];
+  } else if (indexPath.row == 3) {
+    [self didTapOpenURL:nil];
   }
 }
 
@@ -68,6 +70,15 @@
   if (presentationController) {
     presentationController.dismissOnBackgroundTap = NO;
   }
+}
+
+- (IBAction)didTapOpenURL:(id)sender {
+  UIViewController *viewController =
+    [[OpenURLViewController alloc] initWithNibName:nil bundle:nil];
+  viewController.modalPresentationStyle = UIModalPresentationCustom;
+  viewController.transitioningDelegate = self.transitionController;
+
+  [self presentViewController:viewController animated:YES completion:NULL];
 }
 
 - (IBAction)didTapStoryboard:(id)sender {

--- a/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.h
+++ b/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.h
@@ -35,3 +35,6 @@
 
 @interface ProgrammaticViewController : UIViewController
 @end
+
+@interface OpenURLViewController : UIViewController
+@end

--- a/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
@@ -87,6 +87,49 @@ static NSString * const kReusableIdentifierItem = @"cell";
   self.view.backgroundColor = [UIColor whiteColor];
 
   _dismissButton = [[MDCFlatButton alloc] init];
+  [_dismissButton setTitle:@"Dismiss" forState:UIControlStateNormal];
+  [_dismissButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
+  _dismissButton.autoresizingMask =
+      UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |
+      UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin;
+  [_dismissButton addTarget:self
+                     action:@selector(dismiss:)
+           forControlEvents:UIControlEventTouchUpInside];
+
+  [self.view addSubview:_dismissButton];
+}
+
+- (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
+  [_dismissButton sizeToFit];
+  _dismissButton.center = CGPointMake(CGRectGetMidX(self.view.bounds),
+                                      CGRectGetMidY(self.view.bounds));
+}
+
+- (CGSize)preferredContentSize {
+  return CGSizeMake(200.0, 140.0);
+}
+
+- (IBAction)dismiss:(id)sender {
+  [self.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
+}
+
+@end
+
+@interface OpenURLViewController ()
+
+@property(nonatomic, strong) MDCFlatButton *dismissButton;
+
+@end
+
+@implementation OpenURLViewController
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  self.view.backgroundColor = [UIColor whiteColor];
+
+  _dismissButton = [[MDCFlatButton alloc] init];
   [_dismissButton setTitle:@"www.material.io" forState:UIControlStateNormal];
   [_dismissButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
   _dismissButton.autoresizingMask =
@@ -112,6 +155,7 @@ static NSString * const kReusableIdentifierItem = @"cell";
 
 - (IBAction)dismiss:(id)sender {
   NSURL *testURL = [NSURL URLWithString:@"https://www.material.io"];
+  // Use mdc_safeSharedApplication to avoid a compiler warning about extensions
   [[UIApplication mdc_safeSharedApplication] performSelector:@selector(openURL:) withObject:testURL];
 }
 

--- a/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
@@ -22,6 +22,7 @@
 #import <Foundation/Foundation.h>
 
 #import "DialogsTypicalUseSupplemental.h"
+#import "MaterialApplication.h"
 #import "MaterialButtons.h"
 #import "MaterialDialogs.h"
 #import "MaterialTypography.h"
@@ -86,7 +87,7 @@ static NSString * const kReusableIdentifierItem = @"cell";
   self.view.backgroundColor = [UIColor whiteColor];
 
   _dismissButton = [[MDCFlatButton alloc] init];
-  [_dismissButton setTitle:@"Dismiss" forState:UIControlStateNormal];
+  [_dismissButton setTitle:@"www.material.io" forState:UIControlStateNormal];
   [_dismissButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
   _dismissButton.autoresizingMask =
       UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |
@@ -110,7 +111,8 @@ static NSString * const kReusableIdentifierItem = @"cell";
 }
 
 - (IBAction)dismiss:(id)sender {
-  [self.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
+  NSURL *testURL = [NSURL URLWithString:@"https://www.material.io"];
+  [[UIApplication mdc_safeSharedApplication] performSelector:@selector(openURL:) withObject:testURL];
 }
 
 @end


### PR DESCRIPTION
This change will assist in diagnosing a problem with our dialog presentation controller not staying consistent.

https://stackoverflow.com/questions/46791185/modal-transition-not-working-after-returning-back-to-the-app