### PR TITLE
[BottomAppBar] Account for iPhone X insets

### DIFF
--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
@@ -19,7 +19,6 @@ import MaterialComponents
 
 class BottomAppBarTypicalUseSwiftExample: UIViewController {
 
-  let bottomBarViewHeight: CGFloat = 96
   let appBar = MDCAppBar()
   let bottomBarView = MDCBottomAppBarView()
 
@@ -48,11 +47,6 @@ class BottomAppBarTypicalUseSwiftExample: UIViewController {
   }
 
   func commonInitBottomAppBarTypicalUseSwiftExample() {
-    let frame = CGRect(x: 0,
-                       y: self.view.bounds.height - bottomBarViewHeight,
-                       width: self.view.bounds.width,
-                       height: bottomBarViewHeight)
-    bottomBarView.frame = frame
     bottomBarView.autoresizingMask = [ .flexibleWidth, .flexibleTopMargin ]
     view.addSubview(bottomBarView)
 
@@ -100,6 +94,15 @@ class BottomAppBarTypicalUseSwiftExample: UIViewController {
     self.view.backgroundColor = .white
 
     self.navigationController?.setNavigationBarHidden(true, animated: animated)
+  }
+  
+  override func viewWillLayoutSubviews() {
+    let size = bottomBarView.sizeThatFits(view.bounds.size)
+    let bottomBarViewFrame = CGRect(x: 0,
+                                    y: view.bounds.size.height - size.height,
+                                    width: size.width,
+                                    height: size.height)
+    bottomBarView.frame = bottomBarViewFrame
   }
 
 }

--- a/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseViewController.m
+++ b/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseViewController.m
@@ -18,9 +18,6 @@
 
 #import "MDCBottomAppBarView.h"
 
-// The height of the bottom app bar navigation area in collapsed state.
-static const CGFloat kMDCBottomAppBarHeight = 96.f;
-
 @interface BottomAppBarTypicalUseViewController ()
 
 @end
@@ -44,14 +41,19 @@ static const CGFloat kMDCBottomAppBarHeight = 96.f;
 }
 
 - (void)commonMDCBottomAppBarViewControllerInit {
-  CGRect containerFrame = CGRectMake(0,
-                                     CGRectGetHeight(self.view.frame) - kMDCBottomAppBarHeight,
-                                     CGRectGetWidth(self.view.frame),
-                                     kMDCBottomAppBarHeight);
-  _bottomBarView = [[MDCBottomAppBarView alloc] initWithFrame:containerFrame];
+  _bottomBarView = [[MDCBottomAppBarView alloc] initWithFrame:CGRectZero];
   _bottomBarView.autoresizingMask =
       (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin);
   [self.view addSubview:_bottomBarView];
+}
+
+- (void)viewWillLayoutSubviews {
+  CGSize size = [_bottomBarView sizeThatFits:self.view.bounds.size];
+  CGRect bottomBarViewFrame = CGRectMake(0,
+                                         CGRectGetHeight(self.view.bounds) - size.height,
+                                         size.width,
+                                         size.height);
+  _bottomBarView.frame = bottomBarViewFrame;
 }
 
 #pragma mark - Setters

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -201,7 +201,6 @@ static const int kMDCButtonAnimationDuration = 200;
   }
 }
 
-
 - (void)moveFloatingButtonCenterAnimated:(BOOL)animated {
   CGPoint endPoint = [self getFloatingButtonCenterPositionForWidth:CGRectGetWidth(self.bounds)];
   if (animated) {
@@ -248,6 +247,24 @@ static const int kMDCButtonAnimationDuration = 200;
   [self renderPathBasedOnFloatingButtonVisibitlityAnimated:NO];
 }
 
+- (UIEdgeInsets)mdc_safeAreaInsets {
+  UIEdgeInsets insets = UIEdgeInsetsZero;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+
+    // Accommodate insets for iPhone X.
+    insets = self.safeAreaInsets;
+  }
+#endif
+  return insets;
+}
+
+- (CGSize)sizeThatFits:(CGSize)size {
+  UIEdgeInsets insets = self.mdc_safeAreaInsets;
+  CGFloat heightWithInset = kMDCBottomAppBarHeight + insets.bottom;
+  CGSize insetSize = CGSizeMake(size.width, heightWithInset);
+  return insetSize;
+}
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
 


### PR DESCRIPTION
Ensure bottom app bar renders properly on iPhone X and use insets.

Addresses issue: https://github.com/material-components/material-components-ios/issues/2226

![simulator screen shot - iphone x - 2017-10-19 at 15 46 41](https://user-images.githubusercontent.com/760941/31790990-30c306fa-b4e5-11e7-824e-f60ae1927f5a.png)

![simulator screen shot - iphone x - 2017-10-19 at 15 46 40](https://user-images.githubusercontent.com/760941/31790993-33c7872c-b4e5-11e7-9ccb-69aedf475d76.png)
