### PR TITLE
[TabBar] Safe Area Insets fixes

### DIFF
--- a/components/Tabs/examples/BottomNavigationBarExample.m
+++ b/components/Tabs/examples/BottomNavigationBarExample.m
@@ -29,8 +29,6 @@
   [super viewDidLoad];
 
   _bottomNavigationBar = [[MDCTabBar alloc] initWithFrame:CGRectZero];
-  _bottomNavigationBar.autoresizingMask =
-      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
   _bottomNavigationBar.delegate = self;
 
   _bottomNavigationBar.barTintColor = [UIColor whiteColor];
@@ -55,21 +53,29 @@
   ];
 
   [self.view addSubview:_bottomNavigationBar];
-
   [self updateDisplay];
-}
 
-- (void)viewWillLayoutSubviews {
-  [super viewWillLayoutSubviews];
-
-  CGRect bounds = self.view.bounds;
-
-  // Place bar at bottom of view
-  CGRect barFrame = CGRectZero;
-  barFrame.size = [_bottomNavigationBar sizeThatFits:self.view.bounds.size];
-
-  barFrame.origin.y = CGRectGetMaxY(bounds) - barFrame.size.height;
-  _bottomNavigationBar.frame = barFrame;
+  [NSLayoutConstraint constraintWithItem:_bottomNavigationBar
+                               attribute:NSLayoutAttributeBottom
+                               relatedBy:NSLayoutRelationEqual
+                                  toItem:self.view
+                               attribute:NSLayoutAttributeBottom
+                              multiplier:1
+                                constant:0].active = YES;
+  [NSLayoutConstraint constraintWithItem:_bottomNavigationBar
+                               attribute:NSLayoutAttributeLeft
+                               relatedBy:NSLayoutRelationEqual
+                                  toItem:self.view
+                               attribute:NSLayoutAttributeLeft
+                              multiplier:1
+                                constant:0].active = YES;
+  [NSLayoutConstraint constraintWithItem:_bottomNavigationBar
+                               attribute:NSLayoutAttributeRight
+                               relatedBy:NSLayoutRelationEqual
+                                  toItem:self.view
+                               attribute:NSLayoutAttributeRight
+                              multiplier:1
+                                constant:0].active = YES;
 }
 
 #pragma mark - MDCTabBarDelegate

--- a/components/Tabs/examples/BottomNavigationBarExample.m
+++ b/components/Tabs/examples/BottomNavigationBarExample.m
@@ -68,19 +68,6 @@
   CGRect barFrame = CGRectZero;
   barFrame.size = [_bottomNavigationBar sizeThatFits:self.view.bounds.size];
 
-  // On the iPhone X, we need to offset
-  if ([self.view respondsToSelector:@selector(safeAreaInsets)]) {
-    NSMethodSignature *safeAreaSignature =
-        [[UIView class] instanceMethodSignatureForSelector:@selector(safeAreaInsets)];
-    NSInvocation *safeAreaInvocation =
-        [NSInvocation invocationWithMethodSignature:safeAreaSignature];
-    [safeAreaInvocation setSelector:@selector(safeAreaInsets)];
-    [safeAreaInvocation setTarget:self.view];
-    [safeAreaInvocation invoke];
-    UIEdgeInsets safeAreaInsets;
-    [safeAreaInvocation getReturnValue:&safeAreaInsets];
-    bounds = UIEdgeInsetsInsetRect(bounds, safeAreaInsets);
-  }
   barFrame.origin.y = CGRectGetMaxY(bounds) - barFrame.size.height;
   _bottomNavigationBar.frame = barFrame;
 }

--- a/components/Tabs/examples/BottomNavigationBarExample.m
+++ b/components/Tabs/examples/BottomNavigationBarExample.m
@@ -28,14 +28,15 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  _bottomNavigationBar = [[MDCTabBar alloc] initWithFrame:CGRectZero];
+  _bottomNavigationBar = [[MDCTabBar alloc] initWithFrame:self.view.bounds];
+  _bottomNavigationBar.translatesAutoresizingMaskIntoConstraints = NO;
   _bottomNavigationBar.delegate = self;
 
   _bottomNavigationBar.barTintColor = [UIColor whiteColor];
-  _bottomNavigationBar.selectedItemTintColor = nil;
+//  _bottomNavigationBar.selectedItemTintColor = nil;
   _bottomNavigationBar.unselectedItemTintColor = [UIColor colorWithWhite:0 alpha:0.50];
   _bottomNavigationBar.tintColor = [UIColor colorWithRed:0 green:0.5 blue:0 alpha:1];
-  _bottomNavigationBar.inkColor = [UIColor colorWithRed:0 green:0.5 blue:0 alpha:0.15];
+//  _bottomNavigationBar.inkColor = [UIColor colorWithRed:0 green:0.5 blue:0 alpha:0.15];
 
   NSBundle *bundle = [NSBundle bundleForClass:[BottomNavigationBarExample class]];
   UIImage *infoImage =
@@ -76,6 +77,13 @@
                                attribute:NSLayoutAttributeRight
                               multiplier:1
                                 constant:0].active = YES;
+}
+
+- (void)viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
+
+  [_bottomNavigationBar invalidateIntrinsicContentSize];
+  [_bottomNavigationBar updateConstraintsIfNeeded];
 }
 
 #pragma mark - MDCTabBarDelegate

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -118,6 +118,8 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 
 - (void)commonMDCTabBarInit {
   self.clipsToBounds = YES;
+  self.translatesAutoresizingMaskIntoConstraints = NO;
+
   _barPosition = UIBarPositionAny;
   _hasDefaultItemAppearance = YES;
   _hasDefaultAlignment = YES;
@@ -293,7 +295,9 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 
 - (void)safeAreaInsetsDidChange {
   [super safeAreaInsetsDidChange];
+
   [self invalidateIntrinsicContentSize];
+  [self updateConstraintsIfNeeded];
 }
 
 - (void)didMoveToWindow {

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -117,6 +117,7 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 }
 
 - (void)commonMDCTabBarInit {
+  self.clipsToBounds = YES;
   _barPosition = UIBarPositionAny;
   _hasDefaultItemAppearance = YES;
   _hasDefaultAlignment = YES;
@@ -129,12 +130,18 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 
   // Create item bar.
   _itemBar = [[MDCItemBar alloc] initWithFrame:self.bounds];
-  _itemBar.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
   _itemBar.delegate = self;
   _itemBar.alignment = MDCItemBarAlignmentForTabBarAlignment(_alignment);
   [self addSubview:_itemBar];
 
   [self updateItemBarStyle];
+}
+
+- (void)layoutSubviews {
+  [super layoutSubviews];
+
+  CGSize sizeThatFits = [_itemBar sizeThatFits:self.bounds.size];
+  _itemBar.frame = CGRectMake(0, 0, sizeThatFits.width, sizeThatFits.height);
 }
 
 #pragma mark - Public
@@ -177,7 +184,7 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
     _barTintColor = barTintColor;
 
     // Update background color.
-    _itemBar.backgroundColor = barTintColor;
+    self.backgroundColor = barTintColor;
   }
 }
 
@@ -265,11 +272,28 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 }
 
 - (CGSize)intrinsicContentSize {
-  return _itemBar.intrinsicContentSize;
+  CGSize size = _itemBar.intrinsicContentSize;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    size.height += self.safeAreaInsets.bottom;
+  }
+#endif
+  return size;
 }
 
 - (CGSize)sizeThatFits:(CGSize)size {
-  return [_itemBar sizeThatFits:size];
+  size = [_itemBar sizeThatFits:size];
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    size.height += self.safeAreaInsets.bottom;
+  }
+#endif
+  return size;
+}
+
+- (void)safeAreaInsetsDidChange {
+  [super safeAreaInsetsDidChange];
+  [self invalidateIntrinsicContentSize];
 }
 
 - (void)didMoveToWindow {

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -294,7 +294,11 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 }
 
 - (void)safeAreaInsetsDidChange {
-  [super safeAreaInsetsDidChange];
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    [super safeAreaInsetsDidChange];
+  }
+#endif
 
   [self invalidateIntrinsicContentSize];
 

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -297,7 +297,9 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   [super safeAreaInsetsDidChange];
 
   [self invalidateIntrinsicContentSize];
-  [self updateConstraintsIfNeeded];
+
+  // TODO(chuga): Figure out why this is needed.
+  [self updateConstraints];
 }
 
 - (void)didMoveToWindow {

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -83,6 +83,9 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   MDCTabBarAlignment _alignmentOverride;
   MDCTabBarItemAppearance _itemAppearanceOverride;
   BOOL _displaysUppercaseTitlesOverride;
+
+  // Keep track of the Safe Area bottom inset to prevent unnecessary layout calls.
+  CGFloat _bottomSafeAreaInset;
 }
 // Inherit UIView's tintColor logic.
 @dynamic tintColor;
@@ -300,9 +303,12 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   }
 #endif
 
-  [self invalidateIntrinsicContentSize];
+  if (self.safeAreaInsets.bottom == _bottomSafeAreaInset) {
+    return;
+  }
+  _bottomSafeAreaInset = self.safeAreaInsets.bottom;
 
-  // TODO(chuga): Figure out why this is needed.
+  [self invalidateIntrinsicContentSize];
   [self updateConstraints];
 }
 

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -280,7 +280,7 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   CGSize size = _itemBar.intrinsicContentSize;
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
-    size.height += self.safeAreaInsets.bottom;
+    size.height += self.window.safeAreaInsets.bottom;
   }
 #endif
   return size;
@@ -290,7 +290,7 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   size = [_itemBar sizeThatFits:size];
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
-    size.height += self.safeAreaInsets.bottom;
+    size.height += self.window.safeAreaInsets.bottom;
   }
 #endif
   return size;
@@ -303,13 +303,15 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   }
 #endif
 
-  if (self.safeAreaInsets.bottom == _bottomSafeAreaInset) {
-    return;
-  }
-  _bottomSafeAreaInset = self.safeAreaInsets.bottom;
+  [self setNeedsLayout];
 
-  [self invalidateIntrinsicContentSize];
-  [self updateConstraints];
+//  if (self.safeAreaInsets.bottom == _bottomSafeAreaInset) {
+//    return;
+//  }
+//  _bottomSafeAreaInset = self.safeAreaInsets.bottom;
+
+//  [self invalidateIntrinsicContentSize];
+//  [self updateConstraintsIfNeeded];
 }
 
 - (void)didMoveToWindow {

--- a/components/Tabs/src/MDCTabBarViewController.m
+++ b/components/Tabs/src/MDCTabBarViewController.m
@@ -91,6 +91,11 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
   [self updateLayout];
 }
 
+- (void)viewSafeAreaInsetsDidChange {
+  [super viewSafeAreaInsetsDidChange];
+  [self.view setNeedsLayout];
+}
+
 #pragma mark - Properties
 
 - (BOOL)tabBarHidden {
@@ -241,12 +246,12 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
 
 - (void)updateLayout {
   CGRect bounds = self.view.bounds;
-  CGFloat tabBarHeight = [[_tabBar class] defaultHeightForItemAppearance:_tabBar.itemAppearance];
   CGRect currentViewFrame = bounds;
+  CGSize tabBarSize = [_tabBar sizeThatFits:currentViewFrame.size];
   CGRect tabBarFrame = CGRectMake(bounds.origin.x, bounds.origin.y + bounds.size.height,
-                                  bounds.size.width, tabBarHeight);
+                                  bounds.size.width, tabBarSize.height);
   if (!_tabBarWantsToBeHidden) {
-    CGRectDivide(bounds, &tabBarFrame, &currentViewFrame, tabBarHeight, CGRectMaxYEdge);
+    CGRectDivide(bounds, &tabBarFrame, &currentViewFrame, tabBarSize.height, CGRectMaxYEdge);
   }
   _tabBar.frame = tabBarFrame;
   _tabBarShadow.frame = tabBarFrame;

--- a/components/Tabs/src/MDCTabBarViewController.m
+++ b/components/Tabs/src/MDCTabBarViewController.m
@@ -71,12 +71,8 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
 - (void)viewDidLoad {
   [super viewDidLoad];
   UIView *view = self.view;
-  view.clipsToBounds = YES;
-  view.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleWidth |
-                          UIViewAutoresizingFlexibleRightMargin |
-                          UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleHeight |
-                          UIViewAutoresizingFlexibleBottomMargin;
   MDCTabBar *tabBar = [[MDCTabBar alloc] initWithFrame:view.bounds];
+  tabBar.translatesAutoresizingMaskIntoConstraints = NO;
   tabBar.alignment = MDCTabBarAlignmentJustified;
   tabBar.delegate = self;
   self.tabBar = tabBar;
@@ -94,6 +90,9 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
 - (void)viewSafeAreaInsetsDidChange {
   [super viewSafeAreaInsetsDidChange];
   [self.view setNeedsLayout];
+
+//  [self.tabBar invalidateIntrinsicContentSize];
+//  [self.tabBar updateConstraintsIfNeeded];
 }
 
 #pragma mark - Properties

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -71,6 +71,7 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   /// Size of the view at last layout, for deduplicating changes.
   CGSize _lastSize;
 
+  /// Width of the collection view accounting for Safe Area insets at last layout.
   CGFloat _lastAdjustedCollectionViewWidth;
 
   /// Horizontal size class at the last item metrics update. Used to calculate deltas.

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -71,6 +71,8 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   /// Size of the view at last layout, for deduplicating changes.
   CGSize _lastSize;
 
+  CGFloat _lastAdjustedCollectionViewWidth;
+
   /// Horizontal size class at the last item metrics update. Used to calculate deltas.
   UIUserInterfaceSizeClass _horizontalSizeClassAtLastMetricsUpdate;
 
@@ -109,14 +111,19 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   UICollectionView *collectionView =
       [[UICollectionView alloc] initWithFrame:self.bounds collectionViewLayout:_flowLayout];
   collectionView.backgroundColor = [UIColor clearColor];
-  collectionView.clipsToBounds = YES;
+  collectionView.clipsToBounds = NO;
   collectionView.scrollsToTop = NO;
   collectionView.showsHorizontalScrollIndicator = NO;
   collectionView.showsVerticalScrollIndicator = NO;
+
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
+  }
+#endif
+
   collectionView.dataSource = self;
   collectionView.delegate = self;
-  collectionView.autoresizingMask =
-      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   [collectionView registerClass:[MDCItemBarCell class] forCellWithReuseIdentifier:kItemReuseID];
 
   _collectionView = collectionView;
@@ -275,13 +282,15 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   _collectionView.frame = bounds;
 
   // Update collection metrics if the size has changed.
-  if (!CGSizeEqualToSize(bounds.size, _lastSize)) {
+  if (!CGSizeEqualToSize(bounds.size, _lastSize) ||
+      self.adjustedCollectionViewWidth != _lastAdjustedCollectionViewWidth) {
     [self updateFlowLayoutMetrics];
 
     // Ensure selected item is aligned properly on resize.
     [self selectItemAtIndex:[self indexForItem:_selectedItem] animated:NO];
   }
   _lastSize = bounds.size;
+  _lastAdjustedCollectionViewWidth = self.adjustedCollectionViewWidth;
 }
 
 - (CGSize)sizeThatFits:(CGSize)size {
@@ -290,7 +299,17 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 }
 
 - (CGSize)intrinsicContentSize {
-  return CGSizeMake(UIViewNoIntrinsicMetric, [[self class] defaultHeightForStyle:_style]);
+  CGFloat height =  [[self class] defaultHeightForStyle:_style];
+  return CGSizeMake(UIViewNoIntrinsicMetric, height);
+}
+
+- (void)safeAreaInsetsDidChange {
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    [super safeAreaInsetsDidChange];
+  }
+#endif
+  [self setNeedsLayout];
 }
 
 - (void)didMoveToWindow {
@@ -394,7 +413,7 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   // Divide justified items evenly across the view.
   if (_alignment == MDCItemBarAlignmentJustified) {
     NSInteger count = [self collectionView:_collectionView numberOfItemsInSection:0];
-    size.width = _collectionView.bounds.size.width / MAX(count, 1);
+    size.width = self.adjustedCollectionViewWidth / MAX(count, 1);
   }
 
   // Constrain to style-based width if necessary.
@@ -403,15 +422,24 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   }
 
   // Constrain to view width
-  size.width = MIN(size.width, CGRectGetWidth(collectionView.frame));
+  size.width = MIN(size.width, self.adjustedCollectionViewWidth);
 
   // Force height to our height.
   size.height = itemHeight;
-
   return size;
 }
 
 #pragma mark - Private
+
+- (CGFloat)adjustedCollectionViewWidth {
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    return CGRectGetWidth(UIEdgeInsetsInsetRect(_collectionView.bounds,
+                                                _collectionView.adjustedContentInset));
+  }
+#endif
+  return CGRectGetWidth(_collectionView.bounds);
+}
 
 + (NSArray *)observableItemKeys {
   static dispatch_once_t onceToken;
@@ -633,23 +661,31 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 
 - (UIEdgeInsets)leadingAlignedInsetsForHorizontalSizeClass:(UIUserInterfaceSizeClass)sizeClass {
   const BOOL isRegular = (sizeClass == UIUserInterfaceSizeClassRegular);
-  const CGFloat inset = isRegular ? kRegularInset : kCompactInset;
+  CGFloat inset = isRegular ? kRegularInset : kCompactInset;
+  // If the collection view has Safe Area insets, we don't want to add an extra horizontal inset.
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    if (_collectionView.safeAreaInsets.left > 0 || _collectionView.safeAreaInsets.right > 0) {
+      inset = 0;
+    }
+  }
+#endif
   return UIEdgeInsetsMake(0.0f, inset, 0.0f, inset);
 }
 
 - (UIEdgeInsets)justifiedInsets {
   // Center items, which will be at most the width of the view.
   CGFloat itemWidths = [self totalWidthOfAllItems];
-  CGFloat sideInsets = floorf((float)(_collectionView.bounds.size.width - itemWidths) / 2.0f);
+  CGFloat sideInsets = floorf((float)(self.adjustedCollectionViewWidth - itemWidths) / 2.0f);
   return UIEdgeInsetsMake(0.0, sideInsets, 0.0, sideInsets);
 }
 
 - (UIEdgeInsets)centeredInsetsForHorizontalSizeClass:(UIUserInterfaceSizeClass)sizeClass {
   CGFloat itemWidths = [self totalWidthOfAllItems];
-  CGFloat viewWidth = _collectionView.bounds.size.width;
+  CGFloat viewWidth = self.adjustedCollectionViewWidth;
   UIEdgeInsets insets = [self leadingAlignedInsetsForHorizontalSizeClass:sizeClass];
   if (itemWidths <= (viewWidth - insets.left - insets.right)) {
-    CGFloat sideInsets = (_collectionView.bounds.size.width - itemWidths) / 2.0f;
+    CGFloat sideInsets = (self.adjustedCollectionViewWidth - itemWidths) / 2.0f;
     return UIEdgeInsetsMake(0.0, sideInsets, 0.0, sideInsets);
   }
   return insets;
@@ -660,8 +696,7 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 
   NSInteger count = [self collectionView:_collectionView numberOfItemsInSection:0];
   if (count > 0) {
-    CGRect bounds = _collectionView.bounds;
-    CGFloat halfBoundsWidth = bounds.size.width / 2.0f;
+    CGFloat halfBoundsWidth = self.adjustedCollectionViewWidth / 2.0f;
 
     CGSize firstSize = [self collectionView:_collectionView
                                      layout:_flowLayout


### PR DESCRIPTION
Consists of two things: sizeThatFits/intrinsicContentSize takes into account any bottom safe area inset the tab bar might have, and a few fixes in the collection view itself to make sure our content is laid out correctly.

I'll be looking into RTL tomorrow as I noticed there's some code that does some calculations with the collection view's bounds. But I wanted to put this out to get feedback asap.

Closes #2012 