### PR TITLE
[Catalog] Pad trailing edge inside.

### DIFF
--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -301,7 +301,7 @@ extension MDCNodeListViewController {
         view.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor,
                                       constant: padding),
         view.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor,
-                                       constant: padding),
+                                       constant: -padding),
         view.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: top),
         view.heightAnchor.constraint(equalToConstant: height)
       ])
@@ -311,7 +311,7 @@ extension MDCNodeListViewController {
     if #available(iOS 9.0, *) {
       NSLayoutConstraint.activate([
         view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: padding),
-        view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: padding),
+        view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -padding),
         view.topAnchor.constraint(equalTo: containerView.topAnchor, constant: top),
         view.heightAnchor.constraint(equalToConstant: height)
       ])
@@ -331,7 +331,7 @@ extension MDCNodeListViewController {
         toItem: containerView,
         attribute: .trailing,
         multiplier: 1.0,
-        constant: padding).isActive = true
+        constant: -padding).isActive = true
       _ = NSLayoutConstraint(
         item: view,
         attribute: .top,


### PR DESCRIPTION
Before:
<img width="336" alt="iphone8 11_before" src="https://user-images.githubusercontent.com/1129082/31855282-5c4044f4-b6a8-11e7-89dd-ab88e543d748.png">

After:
<img width="322" alt="iphone8 11_after" src="https://user-images.githubusercontent.com/1129082/31855263-fd396f44-b6a7-11e7-93c7-5f73fe8313a7.png">

Tested: 
* iPhone X (iOS 11.0) Sim;
* iPhone 8 (iOS 11.0) Sim;
* iPhone 7 (iOS 10.3.1) Sim;
* iPhone 5 (iOS 8.4) Sim.