### PR TITLE
[Buttons] Deprecate defaultContentEdgeInsets

### DIFF
--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -243,6 +243,7 @@ static const int kMDCButtonAnimationDuration = 200;
 
 - (void)layoutSubviews {
   [super layoutSubviews];
+  [self.floatingButton sizeToFit];
       self.floatingButton.center =
   [self getFloatingButtonCenterPositionForWidth:CGRectGetWidth(self.bounds)];
   [self renderPathBasedOnFloatingButtonVisibitlityAnimated:NO];

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -49,7 +49,6 @@
   MDCRaisedButton *raisedButton = [[MDCRaisedButton alloc] init];
   [raisedButton setTitleColor:titleColor forState:UIControlStateNormal];
   [raisedButton setTitle:@"Button" forState:UIControlStateNormal];
-  [raisedButton sizeToFit];
   [raisedButton addTarget:self
                    action:@selector(didTap:)
          forControlEvents:UIControlEventTouchUpInside];
@@ -60,7 +59,6 @@
   MDCRaisedButton *disabledRaisedButton = [[MDCRaisedButton alloc] init];
   [disabledRaisedButton setTitleColor:titleColor forState:UIControlStateNormal];
   [disabledRaisedButton setTitle:@"Button" forState:UIControlStateNormal];
-  [disabledRaisedButton sizeToFit];
   [disabledRaisedButton addTarget:self
                            action:@selector(didTap:)
                  forControlEvents:UIControlEventTouchUpInside];
@@ -72,7 +70,6 @@
   MDCFlatButton *flatButton = [[MDCFlatButton alloc] init];
   [flatButton setTitle:@"Button" forState:UIControlStateNormal];
   [flatButton setTitleColor:[UIColor grayColor] forState:UIControlStateNormal];
-  [flatButton sizeToFit];
   [flatButton addTarget:self
                  action:@selector(didTap:)
        forControlEvents:UIControlEventTouchUpInside];
@@ -83,7 +80,6 @@
   MDCFlatButton *disabledFlatButton = [[MDCFlatButton alloc] init];
   [disabledFlatButton setTitle:@"Button" forState:UIControlStateNormal];
   [disabledFlatButton setTitleColor:[UIColor grayColor] forState:UIControlStateNormal];
-  [disabledFlatButton sizeToFit];
   [disabledFlatButton addTarget:self
                          action:@selector(didTap:)
                forControlEvents:UIControlEventTouchUpInside];
@@ -94,7 +90,6 @@
 
   MDCButton *strokedButton = [self buildCustomStrokedButton];
   [strokedButton setTitle:@"Button" forState:UIControlStateNormal];
-  [strokedButton sizeToFit];
   [strokedButton addTarget:self
                     action:@selector(didTap:)
           forControlEvents:UIControlEventTouchUpInside];
@@ -104,7 +99,6 @@
 
   MDCButton *disabledStrokedButton = [self buildCustomStrokedButton];
   [disabledStrokedButton setTitle:@"Button" forState:UIControlStateNormal];
-  [disabledStrokedButton sizeToFit];
   [disabledStrokedButton addTarget:self
                             action:@selector(didTap:)
                   forControlEvents:UIControlEventTouchUpInside];
@@ -115,7 +109,6 @@
 
   self.floatingButton = [[MDCFloatingButton alloc] init];
   [self.floatingButton setTitleColor:titleColor forState:UIControlStateNormal];
-  [self.floatingButton sizeToFit];
   [self.floatingButton addTarget:self
                           action:@selector(didTap:)
                 forControlEvents:UIControlEventTouchUpInside];

--- a/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
+++ b/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
@@ -101,6 +101,7 @@
 
   for (NSUInteger i = range.location; i < NSMaxRange(range); i++) {
     MDCButton *button = self.buttons[i];
+    [button sizeToFit];
     UILabel *label = self.labels[i];
 
     button.center = CGPointMake(centerX + 20 + (CGRectGetWidth(button.bounds) / 2),

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -63,6 +63,10 @@ static const CGFloat MDCButtonMinimumTouchTargetWidth = 48;
 
 static const NSTimeInterval MDCButtonAnimationDuration = 0.2;
 
+// Need to set Material padding values
+// https://material.io/guidelines/components/buttons.html#buttons-style
+const UIEdgeInsets MDCButtonDefaultContentEdgeInsets = {8, 16, 8, 16};
+
 // https://material.io/guidelines/components/buttons.html#buttons-main-buttons
 static const CGFloat MDCButtonDisabledAlpha = 0.12f;
 
@@ -130,6 +134,10 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 + (Class)layerClass {
   return [MDCShadowLayer class];
+}
+
++ (void)initialize {
+  [MDCButton appearance].contentEdgeInsets = MDCButtonDefaultContentEdgeInsets;
 }
 
 - (instancetype)init {
@@ -273,7 +281,13 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   self.titleLabel.font = [MDCTypography buttonFont];
 
   // Default content insets
-  self.contentEdgeInsets = [self defaultContentEdgeInsets];
+  // If a subclass is using the deprecated defaultContentEdgeInsets, fetch that value.
+  if ([self checkIfSubclassDidOverrideMethod:@selector(defaultContentEdgeInsets)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    self.contentEdgeInsets = [self defaultContentEdgeInsets];
+#pragma clang diagnostic pop
+  }
 
   MDCShadowLayer *shadowLayer = self.layer;
   shadowLayer.shadowPath = [self boundingPath].CGPath;
@@ -759,13 +773,28 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   return 2.0f;
 }
 
-- (UIEdgeInsets)defaultContentEdgeInsets {
-  return UIEdgeInsetsMake(8, 16, 8, 16);
-}
-
 - (BOOL)shouldHaveOpaqueBackground {
   BOOL isFlatButton = MDCCGFloatIsExactlyZero([self elevationForState:UIControlStateNormal]);
   return !isFlatButton;
+}
+
+- (BOOL)checkIfSubclassDidOverrideMethod:(SEL)selector {
+  Class superclass = [self superclass];
+  IMP selfIMP = [self methodForSelector:selector];
+  BOOL isOverriden = NO;
+
+  while (superclass) {
+    isOverriden = [superclass instancesRespondToSelector:selector]
+        && selfIMP != [superclass instanceMethodForSelector:selector];
+
+    if (isOverriden) {
+      break;
+    }
+
+    superclass = [superclass superclass];
+  }
+
+  return isOverriden;
 }
 
 - (void)updateAlphaAndBackgroundColorAnimated:(BOOL)animated {

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -282,7 +282,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
   // Default content insets
   // If a subclass is using the deprecated defaultContentEdgeInsets, fetch that value.
-  if ([self checkIfSubclassDidOverrideMethod:@selector(defaultContentEdgeInsets)]) {
+  if ([self didOverrideMethod:@selector(defaultContentEdgeInsets)]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     self.contentEdgeInsets = [self defaultContentEdgeInsets];
@@ -778,7 +778,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   return !isFlatButton;
 }
 
-- (BOOL)checkIfSubclassDidOverrideMethod:(SEL)selector {
+- (BOOL)didOverrideMethod:(SEL)selector {
   Class superclass = [self superclass];
   IMP selfIMP = [self methodForSelector:selector];
   BOOL isOverriden = NO;

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -93,12 +93,6 @@ static NSString *const MDCFloatingButtonShapeKey = @"MDCFloatingButtonShapeKey";
 
 #pragma mark - UIView
 
-- (void)layoutSubviews {
-   // We have to set cornerRadius before laying out subviews so that the boundingPath is correct.
-  self.layer.cornerRadius = CGRectGetHeight(self.bounds) / 2;
-  [super layoutSubviews];
-}
-
 - (CGSize)sizeThatFits:(__unused CGSize)size {
   switch (_shape) {
     case MDCFloatingButtonShapeDefault:

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -63,10 +63,13 @@ static NSString *const MDCFloatingButtonShapeKey = @"MDCFloatingButtonShapeKey";
     switch (_shape) {
       case MDCFloatingButtonShapeDefault:
         self.contentEdgeInsets = UIEdgeInsetsMake(16, 16, 16, 16);
+        break;
       case MDCFloatingButtonShapeMini:
         self.contentEdgeInsets = UIEdgeInsetsMake(8, 8, 8, 8);
+        break;
       case MDCFloatingButtonShapeLargeIcon:
         self.contentEdgeInsets = UIEdgeInsetsMake(10, 10, 10, 10);
+        break;
     }
     self.hitAreaInsets = [self defaultHitAreaInsets];
   }

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -58,9 +58,16 @@ static NSString *const MDCFloatingButtonShapeKey = @"MDCFloatingButtonShapeKey";
   self = [super initWithFrame:frame];
   if (self) {
     _shape = shape;
-    // The superclass sets contentEdgeInsets from defaultContentEdgeInsets before the _shape is set.
-    // Set contentEdgeInsets again to ensure the defaults are for the correct shape.
-    self.contentEdgeInsets = [self defaultContentEdgeInsets];
+    // The superclass sets contentEdgeInsets from UIAppearance.
+    // Set contentEdgeInsets on the instance to ensure the values are appropriate for the shape.
+    switch (_shape) {
+      case MDCFloatingButtonShapeDefault:
+        self.contentEdgeInsets = UIEdgeInsetsMake(16, 16, 16, 16);
+      case MDCFloatingButtonShapeMini:
+        self.contentEdgeInsets = UIEdgeInsetsMake(8, 8, 8, 8);
+      case MDCFloatingButtonShapeLargeIcon:
+        self.contentEdgeInsets = UIEdgeInsetsMake(10, 10, 10, 10);
+    }
     self.hitAreaInsets = [self defaultHitAreaInsets];
   }
   return self;
@@ -82,6 +89,12 @@ static NSString *const MDCFloatingButtonShapeKey = @"MDCFloatingButtonShapeKey";
 }
 
 #pragma mark - UIView
+
+- (void)layoutSubviews {
+   // We have to set cornerRadius before laying out subviews so that the boundingPath is correct.
+  self.layer.cornerRadius = CGRectGetHeight(self.bounds) / 2;
+  [super layoutSubviews];
+}
 
 - (CGSize)sizeThatFits:(__unused CGSize)size {
   switch (_shape) {
@@ -113,17 +126,6 @@ static NSString *const MDCFloatingButtonShapeKey = @"MDCFloatingButtonShapeKey";
 
 - (CGFloat)cornerRadius {
   return CGRectGetWidth(self.bounds) / 2;
-}
-
-- (UIEdgeInsets)defaultContentEdgeInsets {
-  switch (_shape) {
-    case MDCFloatingButtonShapeDefault:
-      return UIEdgeInsetsMake(16, 16, 16, 16);
-    case MDCFloatingButtonShapeMini:
-      return UIEdgeInsetsMake(8, 8, 8, 8);
-    case MDCFloatingButtonShapeLargeIcon:
-      return UIEdgeInsetsMake(10, 10, 10, 10);
-  }
 }
 
 - (UIEdgeInsets)defaultHitAreaInsets {

--- a/components/Buttons/src/MDCRaisedButton.m
+++ b/components/Buttons/src/MDCRaisedButton.m
@@ -17,7 +17,6 @@
 #import "MDCRaisedButton.h"
 
 #import "MaterialShadowElevations.h"
-#import "private/MDCButton+Subclassing.h"
 
 @implementation MDCRaisedButton
 

--- a/components/Buttons/src/private/MDCButton+Subclassing.h
+++ b/components/Buttons/src/private/MDCButton+Subclassing.h
@@ -42,7 +42,10 @@
 /** The corner radius of the button. The shadow will follow that path. */
 - (CGFloat)cornerRadius;
 
-/** The default content edge insets of the button. They are set at initialization time. */
-- (UIEdgeInsets)defaultContentEdgeInsets;
+/**
+ Previously used to set the default content edge insets of the button. This has been deprecated and
+ contentEdgeInsets should be set directly instead.
+ */
+- (UIEdgeInsets)defaultContentEdgeInsets __deprecated_msg("Set contentEdgeInsets explicitly");
 
 @end

--- a/components/Buttons/tests/unit/ButtonSubclassingTests.m
+++ b/components/Buttons/tests/unit/ButtonSubclassingTests.m
@@ -29,10 +29,6 @@ static const CGFloat ButtonTestCornerRadius = 1.234f;
 
 @implementation ButtonSubclass
 
-- (UIEdgeInsets)defaultContentEdgeInsets {
-  return ButtonTestContentEdgeInsets;
-}
-
 - (CGFloat)cornerRadius {
   return ButtonTestCornerRadius;
 }
@@ -43,15 +39,6 @@ static const CGFloat ButtonTestCornerRadius = 1.234f;
 @end
 
 @implementation ButtonSubclassingTests
-
-- (void)testSubclassContentEdgeInsets {
-  // Given
-  MDCButton *button = [[ButtonSubclass alloc] init];
-
-  // Then
-  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(ButtonTestContentEdgeInsets,
-                                              button.contentEdgeInsets));
-}
 
 - (void)testAssignedContentEdgeInsets {
   // Given

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
@@ -41,7 +41,6 @@ static NSString *const reuseIdentifier = @"Cell";
   [self.button setBackgroundColor:[UIColor colorWithWhite:0.1 alpha:1]];
   [self.button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
   [self.button setTitle:@"Action" forState:UIControlStateNormal];
-  [self.button sizeToFit];
   [self.button addTarget:self
                   action:@selector(didTapButton:)
         forControlEvents:UIControlEventTouchUpInside];
@@ -166,7 +165,6 @@ static NSString *const reuseIdentifier = @"Cell";
   [self.button setBackgroundColor:[UIColor colorWithWhite:0.1 alpha:1]];
   [self.button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
   [self.button setTitle:@"Action" forState:UIControlStateNormal];
-  [self.button sizeToFit];
   [self.button addTarget:self
                   action:@selector(didTapButton:)
         forControlEvents:UIControlEventTouchUpInside];

--- a/components/FlexibleHeader/examples/FlexibleHeaderUINavigationBarExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderUINavigationBarExample.m
@@ -88,7 +88,6 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
 
   self.button = [[UIButton alloc] init];
   [self.button setTitle:@"UIButton" forState:UIControlStateNormal];
-  [self.button sizeToFit];
   [self.button addTarget:self
                   action:@selector(didTapButton:)
         forControlEvents:UIControlEventTouchUpInside];
@@ -126,6 +125,7 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
 
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];
+  [self.button sizeToFit];
 
   [self.navigationController setNavigationBarHidden:YES animated:animated];
   self.button.center = CGPointMake(CGRectGetMidX(self.fhvc.headerView.frame),

--- a/components/PageControl/examples/PageControlAnimationBlockExample.m
+++ b/components/PageControl/examples/PageControlAnimationBlockExample.m
@@ -115,6 +115,8 @@
 
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
+  [_incrementButton sizeToFit];
+  [_decrementButton sizeToFit];
   NSInteger pageBeforeFrameChange = _pageControl.currentPage;
   NSInteger pageCount = _pages.count;
   CGFloat boundsWidth = CGRectGetWidth(self.view.bounds);

--- a/components/Snackbar/examples/SnackbarOverlayViewExample.m
+++ b/components/Snackbar/examples/SnackbarOverlayViewExample.m
@@ -69,8 +69,14 @@ static const CGFloat kBottomBarHeight = 44.0f;
   [manager addTarget:self action:@selector(handleOverlayTransition:)];
 }
 
+- (void)viewWillAppear:(BOOL)animated {
+  [super viewWillAppear:animated];
+  [self.floatingButton sizeToFit];
+}
+
 - (void)viewWillDisappear:(BOOL)animated {
   [MDCSnackbarManager setBottomOffset:0];
+  [super viewWillDisappear:animated];
 }
 
 #pragma mark - Event Handling

--- a/components/Tabs/examples/TabBarViewControllerExample.m
+++ b/components/Tabs/examples/TabBarViewControllerExample.m
@@ -22,6 +22,11 @@
 
 #import "TabBarViewControllerExampleSupplemental.h"
 
+@interface TabBarViewControllerExample ()
+@property(nonatomic, weak) MDCRaisedButton *pushAndHideButton;
+@property(nonatomic, weak) MDCRaisedButton *toggleTabBarButton;
+@end
+
 @implementation TabBarViewControllerExample
 
 - (void)viewDidLoad {
@@ -56,6 +61,7 @@
   [button setTitle:@"Push and Hide Tab" forState:UIControlStateNormal];
   [button sizeToFit];
   [child1.view addSubview:button];
+  self.pushAndHideButton = button;
   [button addTarget:self
                 action:@selector(pushHidesNavigation)
       forControlEvents:UIControlEventTouchUpInside];
@@ -66,9 +72,16 @@
   [button setTitle:@"Toggle Tab Bar" forState:UIControlStateNormal];
   [button sizeToFit];
   [child2.view addSubview:button];
+  self.toggleTabBarButton = button;
   [button addTarget:self
                 action:@selector(toggleTabBar)
       forControlEvents:UIControlEventTouchUpInside];
+}
+
+- (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
+  [self.pushAndHideButton sizeToFit];
+  [self.toggleTabBarButton sizeToFit];
 }
 
 @end

--- a/components/Themes/examples/supplemental/ThemerTypicalUseSupplemental.m
+++ b/components/Themes/examples/supplemental/ThemerTypicalUseSupplemental.m
@@ -39,6 +39,13 @@
   [self.navigationController setNavigationBarHidden:YES animated:animated];
 }
 
+- (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
+  [self.floatingButton sizeToFit];
+  [self.alertButton sizeToFit];
+  [self.featureButton sizeToFit];
+}
+
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
   self.scrollView.contentSize = CGSizeMake(self.view.bounds.size.width, 600);
@@ -90,7 +97,6 @@
 
   self.alertButton = [[MDCRaisedButton alloc] init];
   [self.alertButton setTitle:@"Alert" forState:UIControlStateNormal];
-  [self.alertButton sizeToFit];
   self.alertButton.center = CGPointMake(100, 100);
   [self.scrollView addSubview:self.alertButton];
   [self.alertButton addTarget:self
@@ -99,7 +105,6 @@
 
   self.featureButton = [[MDCRaisedButton alloc] init];
   [self.featureButton setTitle:@"Feature Highlight" forState:UIControlStateNormal];
-  [self.featureButton sizeToFit];
   self.featureButton.center = CGPointMake(100, 100);
   [self.scrollView addSubview:self.featureButton];
   [self.featureButton addTarget:self
@@ -118,7 +123,6 @@
 
   self.floatingButton =
       [MDCFloatingButton floatingButtonWithShape:MDCFloatingButtonShapeDefault];
-  [self.floatingButton sizeToFit];
   [self.scrollView addSubview:self.floatingButton];
 
   self.textField = [[MDCTextField alloc] initWithFrame:CGRectMake(0, 0, 250, 50)];


### PR DESCRIPTION
Subclases should no longer use defaultContentEdgeInsets and should
instead set the property directly. This change is need to clients can
customize MDCButton more to suit their needs.

Closes #2250
