### PR TITLE
[Buttons] Deprecate -cornerRadius method

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -354,12 +354,12 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 - (void)layoutSubviews {
   [super layoutSubviews];
   self.layer.shadowPath = [self boundingPath].CGPath;
+  if ([self respondsToSelector:@selector(cornerRadius)]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  if ([self didOverrideMethod:@selector(cornerRadius)]) {
     self.layer.cornerRadius = [self cornerRadius];
-  }
 #pragma clang diagnostic pop
+  }
 
   // Center unbounded ink view frame taking into account possible insets using contentRectForBounds.
   if (_inkView.inkStyle == MDCInkStyleUnbounded) {
@@ -791,12 +791,14 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (UIBezierPath *)boundingPath {
   CGFloat cornerRadius = self.layer.cornerRadius;
+
+  if ([self respondsToSelector:@selector(cornerRadius)]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  if ([self didOverrideMethod:@selector(cornerRadius)]) {
     cornerRadius = [self cornerRadius];
-  }
 #pragma clang diagnostic pop
+  }
+
 
   return [UIBezierPath bezierPathWithRoundedRect:self.bounds cornerRadius:cornerRadius];
 }
@@ -808,25 +810,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 - (BOOL)shouldHaveOpaqueBackground {
   BOOL isFlatButton = MDCCGFloatIsExactlyZero([self elevationForState:UIControlStateNormal]);
   return !isFlatButton;
-}
-
-- (BOOL)didOverrideMethod:(SEL)selector {
-  Class superclass = [self superclass];
-  IMP selfIMP = [self methodForSelector:selector];
-  BOOL isOverriden = NO;
-
-  while (superclass) {
-    isOverriden = [superclass instancesRespondToSelector:selector]
-        && selfIMP != [superclass instanceMethodForSelector:selector];
-
-    if (isOverriden) {
-      break;
-    }
-
-    superclass = [superclass superclass];
-  }
-
-  return isOverriden;
 }
 
 - (void)updateAlphaAndBackgroundColorAnimated:(BOOL)animated {

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -356,7 +356,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   self.layer.shadowPath = [self boundingPath].CGPath;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  if ([self checkIfSubclassDidOverrideMethod:@selector(cornerRadius)]) {
+  if ([self didOverrideMethod:@selector(cornerRadius)]) {
     self.layer.cornerRadius = [self cornerRadius];
   }
 #pragma clang diagnostic pop
@@ -793,7 +793,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   CGFloat cornerRadius = self.layer.cornerRadius;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  if ([self checkIfSubclassDidOverrideMethod:@selector(cornerRadius)]) {
+  if ([self didOverrideMethod:@selector(cornerRadius)]) {
     cornerRadius = [self cornerRadius];
   }
 #pragma clang diagnostic pop
@@ -810,7 +810,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   return !isFlatButton;
 }
 
-- (BOOL)checkIfSubclassDidOverrideMethod:(SEL)selector {
+- (BOOL)didOverrideMethod:(SEL)selector {
   Class superclass = [self superclass];
   IMP selfIMP = [self methodForSelector:selector];
   BOOL isOverriden = NO;

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -105,15 +105,13 @@ static NSString *const MDCFloatingButtonShapeKey = @"MDCFloatingButtonShapeKey";
   }
 }
 
+- (void)layoutSubviews {
+  // We have to set cornerRadius before laying out subviews so that the boundingPath is correct.
+  self.layer.cornerRadius = CGRectGetHeight(self.bounds) / 2;
+  [super layoutSubviews];
+}
+
 #pragma mark - Subclassing
-
-- (UIBezierPath *)boundingPath {
-  return [UIBezierPath bezierPathWithOvalInRect:self.bounds];
-}
-
-- (CGFloat)cornerRadius {
-  return CGRectGetWidth(self.bounds) / 2;
-}
 
 - (UIEdgeInsets)defaultContentEdgeInsets {
   switch (_shape) {

--- a/components/Buttons/src/private/MDCButton+Subclassing.h
+++ b/components/Buttons/src/private/MDCButton+Subclassing.h
@@ -39,8 +39,11 @@
 /** The bounding path of the button. The shadow will follow that path. */
 - (nonnull UIBezierPath *)boundingPath;
 
-/** The corner radius of the button. The shadow will follow that path. */
-- (CGFloat)cornerRadius;
+/**
+ Previously used to set the corner radius of the button. This has been deprecated and the layer's
+ |cornerRadius| property should be set directly.
+ */
+- (CGFloat)cornerRadius  __deprecated_msg("Set layer.cornerRadius explicitly");
 
 /** The default content edge insets of the button. They are set at initialization time. */
 - (UIEdgeInsets)defaultContentEdgeInsets;

--- a/components/Buttons/tests/unit/ButtonSubclassingTests.m
+++ b/components/Buttons/tests/unit/ButtonSubclassingTests.m
@@ -33,10 +33,6 @@ static const CGFloat ButtonTestCornerRadius = 1.234f;
   return ButtonTestContentEdgeInsets;
 }
 
-- (CGFloat)cornerRadius {
-  return ButtonTestCornerRadius;
-}
-
 @end
 
 @interface ButtonSubclassingTests : XCTestCase
@@ -61,14 +57,6 @@ static const CGFloat ButtonTestCornerRadius = 1.234f;
   // Then
   XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(ButtonTestContentEdgeInsets,
                                               button.contentEdgeInsets));
-}
-
-- (void)testSubclassCornerRadius {
-  // Given
-  MDCButton *button = [[ButtonSubclass alloc] init];
-
-  // Then
-  XCTAssertEqual(ButtonTestCornerRadius, button.layer.cornerRadius);
 }
 
 - (void)testAssignedCornerRadius {

--- a/components/Buttons/tests/unit/ButtonSubclassingTests.m
+++ b/components/Buttons/tests/unit/ButtonSubclassingTests.m
@@ -33,6 +33,10 @@ static const CGFloat ButtonTestCornerRadius = 1.234f;
   return ButtonTestContentEdgeInsets;
 }
 
+- (CGFloat)cornerRadius {
+  return ButtonTestCornerRadius;
+}
+
 @end
 
 @interface ButtonSubclassingTests : XCTestCase
@@ -59,13 +63,25 @@ static const CGFloat ButtonTestCornerRadius = 1.234f;
                                               button.contentEdgeInsets));
 }
 
+- (void)testSubclassCornerRadius {
+  // Given
+  MDCButton *button = [[ButtonSubclass alloc] initWithFrame:CGRectZero];
+  [button sizeToFit];
+  [button layoutIfNeeded];
+
+  // Then
+  XCTAssertEqualWithAccuracy(ButtonTestCornerRadius, button.layer.cornerRadius, 0.0001);
+}
+
 - (void)testAssignedCornerRadius {
   // Given
   MDCButton *button = [[MDCButton alloc] init];
   button.layer.cornerRadius = ButtonTestCornerRadius;
+  [button sizeToFit];
+  [button layoutIfNeeded];
 
   // Then
-  XCTAssertEqual(ButtonTestCornerRadius, button.layer.cornerRadius);
+  XCTAssertEqualWithAccuracy(ButtonTestCornerRadius, button.layer.cornerRadius, 0.0001);
 }
 
 @end

--- a/components/Buttons/tests/unit/FloatingButtonTests.m
+++ b/components/Buttons/tests/unit/FloatingButtonTests.m
@@ -204,4 +204,16 @@
   XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero, largeIconButton.hitAreaInsets));
 }
 
+- (void)testCornerRadius {
+  // Given
+  MDCFloatingButton *button =
+      [MDCFloatingButton floatingButtonWithShape:MDCFloatingButtonShapeDefault];
+  [button sizeToFit];
+  [button layoutIfNeeded];
+
+  // Then
+  XCTAssertNotEqualWithAccuracy(CGRectGetHeight(button.bounds), 0, 0.0001);
+  XCTAssertEqualWithAccuracy(button.layer.cornerRadius, CGRectGetHeight(button.bounds) / 2, 0.0001);
+}
+
 @end


### PR DESCRIPTION
Buttons should no longer use the subclassing method `-cornerRadius` and
should instead depend on the backing layer's `cornerRadius` property.

Closes #2255

Originally part of #1896 