### PR TITLE
[Collections] Take into account the safe area when calculating the section inset

### DIFF
--- a/components/Collections/src/MDCCollectionViewController.m
+++ b/components/Collections/src/MDCCollectionViewController.m
@@ -254,6 +254,16 @@ NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFoote
   if (isCardStyle) {
     insets.left = inset;
     insets.right = inset;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+    if (@available(iOS 11.0, *)) {
+      if (collectionView.contentInsetAdjustmentBehavior
+          == UIScrollViewContentInsetAdjustmentAlways) {
+        // We don't need section insets if there are already safe area insets.
+        insets.left = MAX(0, insets.left - collectionView.safeAreaInsets.left);
+        insets.right = MAX(0, insets.right - collectionView.safeAreaInsets.right);
+      }
+    }
+#endif
   }
   // Set top/bottom insets.
   if (isCardStyle || isGroupedStyle) {


### PR DESCRIPTION
We're currently not adjusting the default inset for cards when there's a safe area. This PR fixes that.

Before:
![simulator screen shot - iphone x - 2017-10-23 at 11 40 06](https://user-images.githubusercontent.com/4545451/31898401-168942e0-b7e7-11e7-8e49-b468c2e54c2f.png)

After:
![simulator screen shot - iphone x - 2017-10-23 at 11 39 38](https://user-images.githubusercontent.com/4545451/31898410-1ae2398c-b7e7-11e7-9cb6-566521d926ad.png)
