### PR TITLE
Deprecate the unused MDCButtonBarDelegate API.

### DIFF
--- a/components/ButtonBar/src/MDCButtonBar.h
+++ b/components/ButtonBar/src/MDCButtonBar.h
@@ -136,6 +136,7 @@ typedef NS_OPTIONS(NSUInteger, MDCBarButtonItemLayoutHints) {
 
  @seealso MDCBarButtonItemLayoutHints
  */
+__deprecated_msg("This API will be removed without replacement.")
 @protocol MDCButtonBarDelegate <NSObject>
 @required
 


### PR DESCRIPTION
This API has no public usage and is meant to only be a private implementation detail for ButtonBar.