### PR TITLE
[FlexibleHeader] Only disable automaticallyAdjustsScrollViewInsets on the parent controller when the device is running an OS older than iOS 11.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -103,7 +103,19 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
 - (void)willMoveToParentViewController:(UIViewController *)parent {
   [super willMoveToParentViewController:parent];
 
-  parent.automaticallyAdjustsScrollViewInsets = NO;
+  BOOL shouldDisableAutomaticInsetting = YES;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  // Prior to iOS 11 there was no way to know whether UIKit had injected insets into our
+  // UIScrollView, so we disable automatic insetting on these devices. iOS 11 provides
+  // the adjustedContentInset API which allows us to respond to changes in the safe area
+  // insets, so on iOS 11 we actually expect iOS to manage the safe area insets.
+  if (@available(iOS 11.0, *)) {
+    shouldDisableAutomaticInsetting = NO;
+  }
+#endif
+  if (shouldDisableAutomaticInsetting) {
+    parent.automaticallyAdjustsScrollViewInsets = NO;
+  }
 }
 
 - (void)didMoveToParentViewController:(UIViewController *)parent {


### PR DESCRIPTION
Disabling `automaticallyAdjustsScrollViewInsets` on iOS 11 means that UIKit will not adjust the contentInset for a scroll view when the scroll view's `contentInsetAdjustmentBehavior` is set to `.automatic`.

Our flexible header assumes that if the `contentInsetAdjustmentBehavior` is anything but `.never`, then UIKit will be add insets to the scroll view's contentInsets. `automaticallyAdjustsScrollViewInsets` being NO breaks this assumption.

On pre-iOS 11 devices, we don't have any safeAreaInsets APIs so we do want to disable any content inset adjustment.