### PR TITLE
[BottomAppBar] Set nav bar frame on layout

### DIFF
--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -238,8 +238,8 @@ static const int kMDCButtonAnimationDuration = 200;
 
 - (void)layoutSubviews {
   [super layoutSubviews];
-      self.floatingButton.center =
-  [self getFloatingButtonCenterPositionForWidth:CGRectGetWidth(self.bounds)];
+  self.floatingButton.center =
+      [self getFloatingButtonCenterPositionForWidth:CGRectGetWidth(self.bounds)];
   [self renderPathBasedOnFloatingButtonVisibitlityAnimated:NO];
 
   CGRect navBarFrame = CGRectMake(0,

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -92,11 +92,7 @@ static const int kMDCButtonAnimationDuration = 200;
 }
 
 - (void)addNavBar {
-  CGRect navBarFrame = CGRectMake(0,
-                                  kMDCBottomAppBarYOffset,
-                                  self.bounds.size.width,
-                                  self.bounds.size.height);
-  _navBar = [[MDCNavigationBar alloc] initWithFrame:navBarFrame];
+  _navBar = [[MDCNavigationBar alloc] initWithFrame:CGRectZero];
   _navBar.autoresizingMask = UIViewAutoresizingFlexibleWidth;
   [self addSubview:_navBar];
 
@@ -245,6 +241,12 @@ static const int kMDCButtonAnimationDuration = 200;
       self.floatingButton.center =
   [self getFloatingButtonCenterPositionForWidth:CGRectGetWidth(self.bounds)];
   [self renderPathBasedOnFloatingButtonVisibitlityAnimated:NO];
+
+  CGRect navBarFrame = CGRectMake(0,
+                                  kMDCBottomAppBarYOffset,
+                                  CGRectGetWidth(self.bounds),
+                                  kMDCBottomAppBarHeight - kMDCBottomAppBarYOffset);
+  self.navBar.frame = navBarFrame;
 }
 
 - (UIEdgeInsets)mdc_safeAreaInsets {


### PR DESCRIPTION
Sets nav bar frame on layout. Fixes an issue where button is not tappable despite frame appearing to be correct size.