### PR TITLE
[MaskedTransition] Fix bug where transitions wouldn't complete.

### DIFF
--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
@@ -101,10 +101,17 @@
     [context.containerView addSubview:self.scrimView];
   }
 
+  [CATransaction begin];
+  [CATransaction setCompletionBlock:^{
+    [context transitionDidEnd];
+  }];
+
   [animator animateWithTiming:motion.scrimFade
                       toLayer:self.scrimView.layer
                    withValues:@[ @0, @1 ]
                       keyPath:@"opacity"];
+
+  [CATransaction commit];
 }
 
 @end


### PR DESCRIPTION
This bug was introduced by the upgrade to MotionTransitioning 4.0.

4.0 requires that if a presentation controller implements MDMTransition, that its start method eventually invokes transitionDidEnd.