### PR TITLE
[TextFields] Adds cursor color as parameter

### DIFF
--- a/components/TextFields/examples/TextFieldKitchenSinkExample.swift
+++ b/components/TextFields/examples/TextFieldKitchenSinkExample.swift
@@ -261,6 +261,7 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
     textFieldCustomFontFloating.font = UIFont.preferredFont(forTextStyle: .headline)
     textFieldCustomFontFloating.delegate = self
     textFieldCustomFontFloating.clearButtonMode = .whileEditing
+    textFieldCustomFontFloating.cursorColor = .orange
 
     let textFieldControllerDefaultCustomFontFloating =
       MDCTextInputControllerDefault(textInput: textFieldCustomFontFloating)

--- a/components/TextFields/src/MDCMultilineTextField.m
+++ b/components/TextFields/src/MDCMultilineTextField.m
@@ -25,6 +25,8 @@
 #import "MaterialRTL.h"
 #import "MaterialTypography.h"
 
+static NSString *const MDCMultilineTextFieldCursorColorKey =
+    @"MDCMultilineTextFieldCursorColorKey";
 static NSString *const MDCMultilineTextFieldExpandsOnOverflowKey =
     @"MDCMultilineTextFieldExpandsOnOverflowKey";
 static NSString *const MDCMultilineTextFieldFundamentKey = @"MDCMultilineTextFieldFundamentKey";
@@ -38,6 +40,8 @@ static NSString *const MDCMultilineTextFieldTrailingViewModeKey =
     @"MDCMultilineTextFieldTrailingViewModeKey";
 
 @interface MDCMultilineTextField () {
+  UIColor *_cursorColor;
+
   UITextView *_textView;
 }
 
@@ -80,12 +84,14 @@ static NSString *const MDCMultilineTextFieldTrailingViewModeKey =
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
   self = [super initWithCoder:aDecoder];
   if (self) {
+
     MDCTextInputCommonFundament *fundament =
         [aDecoder decodeObjectForKey:MDCMultilineTextFieldFundamentKey];
     _fundament =
         fundament ? fundament : [[MDCTextInputCommonFundament alloc] initWithTextInput:self];
 
     [self commonMDCMultilineTextFieldInitialization];
+    _cursorColor = [aDecoder decodeObjectForKey:MDCMultilineTextFieldCursorColorKey];
 
     if ([aDecoder containsValueForKey:MDCMultilineTextFieldExpandsOnOverflowKey]) {
       _expandsOnOverflow = [aDecoder decodeBoolForKey:MDCMultilineTextFieldExpandsOnOverflowKey];
@@ -113,6 +119,7 @@ static NSString *const MDCMultilineTextFieldTrailingViewModeKey =
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
   [super encodeWithCoder:aCoder];
+  [aCoder encodeObject:self.cursorColor forKey:MDCMultilineTextFieldCursorColorKey];
   [aCoder encodeBool:self.expandsOnOverflow forKey:MDCMultilineTextFieldExpandsOnOverflowKey];
   [aCoder encodeObject:self.fundament forKey:MDCMultilineTextFieldFundamentKey];
   [aCoder encodeConditionalObject:self.layoutDelegate
@@ -128,9 +135,10 @@ static NSString *const MDCMultilineTextFieldTrailingViewModeKey =
   MDCMultilineTextField *copy = [[[self class] alloc] initWithFrame:self.frame];
 
   copy.expandsOnOverflow = self.expandsOnOverflow;
+  copy.cursorColor = self.cursorColor;
 
-  // The .fundament creates a .clearButton so setting the .tintColor must wait for the final
-  // .fundament to be created.
+  // The .fundament creates a .clearButton so setting the clearButton's .tintColor must wait for the
+  // final .fundament to be created.
   copy.fundament = [self.fundament copy];
   copy.clearButton.tintColor = self.clearButton.tintColor;
 
@@ -152,6 +160,9 @@ static NSString *const MDCMultilineTextFieldTrailingViewModeKey =
   self.textColor = _fundament.textColor;
   self.font = [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleBody1];
   self.clearButton.tintColor = [UIColor colorWithWhite:0 alpha:[MDCTypography captionFontOpacity]];
+
+  _cursorColor = MDCTextInputCursorColor();
+  [self applyCursorColor];
 
   self.editable = YES;
 
@@ -295,6 +306,7 @@ static NSString *const MDCMultilineTextFieldTrailingViewModeKey =
 
   [self.fundament layoutSubviewsOfInput];
   [self updateBorder];
+  [self applyCursorColor];
 
   if ([self.positioningDelegate respondsToSelector:@selector(textInputDidLayoutSubviews)]) {
     [self.positioningDelegate textInputDidLayoutSubviews];
@@ -484,6 +496,12 @@ static NSString *const MDCMultilineTextFieldTrailingViewModeKey =
   self.borderView.borderPath = self.borderPath;
 }
 
+#pragma mark - Applying Color
+
+- (void)applyCursorColor {
+  self.textView.tintColor = self.cursorColor;
+}
+
 #pragma mark - Properties Implementation
 
 - (NSAttributedString *)attributedPlaceholder {
@@ -532,6 +550,15 @@ static NSString *const MDCMultilineTextFieldTrailingViewModeKey =
 
 - (void)setClearButtonMode:(UITextFieldViewMode)clearButtonMode {
   self.fundament.clearButtonMode = clearButtonMode;
+}
+
+- (UIColor *)cursorColor {
+  return _cursorColor ?: MDCTextInputCursorColor();
+}
+
+- (void)setCursorColor:(UIColor *)cursorColor {
+  _cursorColor = cursorColor;
+  [self applyCursorColor];
 }
 
 - (void)setEditable:(BOOL)editable {

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -23,6 +23,7 @@
 #import "MaterialRTL.h"
 #import "MaterialTypography.h"
 
+static NSString *const MDCTextFieldCursorColorKey = @"MDCTextFieldCursorColorKey";
 static NSString *const MDCTextFieldFundamentKey = @"MDCTextFieldFundamentKey";
 static NSString *const MDCTextFieldLeftViewModeKey = @"MDCTextFieldLeftViewModeKey";
 static NSString *const MDCTextFieldRightViewModeKey = @"MDCTextFieldRightViewModeKey";
@@ -34,7 +35,9 @@ NSString *const MDCTextFieldTextDidSetTextNotification = @"MDCTextFieldTextDidSe
 static const CGFloat MDCTextInputClearButtonImageBuiltInPadding = -2.5f;
 static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
 
-@interface MDCTextField ()
+@interface MDCTextField () {
+  UIColor *_cursorColor;
+}
 
 @property(nonatomic, strong) MDCTextInputCommonFundament *fundament;
 
@@ -72,6 +75,7 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
         fundament ? fundament : [[MDCTextInputCommonFundament alloc] initWithTextInput:self];
 
     [self commonMDCTextFieldInitialization];
+    _cursorColor = [aDecoder decodeObjectForKey:MDCTextFieldCursorColorKey];;
 
     self.leftViewMode =
         (UITextFieldViewMode)[aDecoder decodeIntegerForKey:MDCTextFieldLeftViewModeKey];
@@ -94,6 +98,7 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
   [super encodeWithCoder:aCoder];
+  [aCoder encodeObject:self.cursorColor forKey:MDCTextFieldCursorColorKey];
   [aCoder encodeObject:self.fundament forKey:MDCTextFieldFundamentKey];
   [aCoder encodeInteger:self.leftViewMode forKey:MDCTextFieldLeftViewModeKey];
   [aCoder encodeInteger:self.rightViewMode forKey:MDCTextFieldRightViewModeKey];
@@ -102,6 +107,7 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
 - (instancetype)copyWithZone:(__unused NSZone *)zone {
   MDCTextField *copy = [[[self class] alloc] initWithFrame:self.frame];
 
+  copy.cursorColor = self.cursorColor;
   copy.fundament = [self.fundament copy];
   copy.enabled = self.isEnabled;
   if ([self.leadingView conformsToProtocol:@protocol(NSCopying)]) {
@@ -116,6 +122,7 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
   }
   copy.trailingViewMode = self.trailingViewMode;
 
+
   return copy;
 }
 
@@ -124,6 +131,9 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
 
   // Set the clear button color to black with 54% opacity.
   self.clearButton.tintColor = [UIColor colorWithWhite:0 alpha:[MDCTypography captionFontOpacity]];
+
+  _cursorColor = MDCTextInputCursorColor();
+  [self applyCursorColor];
 
   [self setupUnderlineConstraints];
 
@@ -207,6 +217,12 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
   self.borderView.borderPath = self.borderPath;
 }
 
+#pragma mark - Applying Color
+
+- (void)applyCursorColor {
+  self.tintColor = self.cursorColor;
+}
+
 #pragma mark - Properties Implementation
 
 - (UIBezierPath *)borderPath {
@@ -230,6 +246,15 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
 
 - (UIButton *)clearButton {
   return _fundament.clearButton;
+}
+
+- (UIColor *)cursorColor {
+  return _cursorColor ?: MDCTextInputCursorColor();
+}
+
+- (void)setCursorColor:(UIColor *)cursorColor {
+  _cursorColor = cursorColor;
+  [self applyCursorColor];
 }
 
 - (BOOL)hidesPlaceholderOnInput {
@@ -587,6 +612,7 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
     [self setNeedsUpdateConstraints];
   }
   [self updateBorder];
+  [self applyCursorColor];
 
   if ([self.positioningDelegate respondsToSelector:@selector(textInputDidLayoutSubviews)]) {
     [self.positioningDelegate textInputDidLayoutSubviews];

--- a/components/TextFields/src/MDCTextInput.h
+++ b/components/TextFields/src/MDCTextInput.h
@@ -86,6 +86,15 @@ typedef NS_ENUM(NSUInteger, MDCTextInputTextInsetsMode) {
  */
 @property(nonatomic, assign) UITextFieldViewMode clearButtonMode UI_APPEARANCE_SELECTOR;
 
+/**
+ The color of the blinking cursor (in the text).
+
+ Applied via .tintColor on the UITextField or UITextView instance.
+
+ Default is [MDCPalette bluePalette].accent700.
+ */
+@property(nonatomic, nullable, strong) UIColor *cursorColor UI_APPEARANCE_SELECTOR;
+
 /** A Boolean value indicating whether the text field is currently in edit mode. */
 @property(nonatomic, assign, readonly, getter=isEditing) BOOL editing;
 

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.h
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.h
@@ -21,11 +21,10 @@ extern const CGFloat MDCTextInputBorderRadius;
 extern const CGFloat MDCTextInputFullPadding;
 extern const CGFloat MDCTextInputHalfPadding;
 
+UIKIT_EXTERN UIColor *_Nonnull MDCTextInputCursorColor(void);
+
 /** A controller for common traits shared by text inputs. */
 @interface MDCTextInputCommonFundament : NSObject <MDCTextInput, NSCopying, NSCoding>
-
-/** The color of the caret indicating where inputted characters will be placed (in the text.) */
-@property(nonatomic, nullable, strong) UIColor *cursorColor;
 
 /**
  An overlay view on the side of the input where reading and writing lines begin. In LTR this is

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -61,7 +61,7 @@ static const CGFloat MDCTextInputOverlayViewToEditingRectPadding = 2.f;
 const CGFloat MDCTextInputFullPadding = 16.f;
 const CGFloat MDCTextInputHalfPadding = 8.f;
 
-static inline UIColor *_Nonnull MDCTextInputCursorColor() {
+UIColor *_Nonnull MDCTextInputCursorColor() {
   return [MDCPalette bluePalette].accent700;
 }
 
@@ -137,7 +137,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
     [self setupClearButton];
     [self setupUnderlineLabels];
 
-    [self updateColors];
+    [self updateTextColor];
     [self mdc_setAdjustsFontForContentSizeCategory:NO];
 
     [self setupBorder];
@@ -225,7 +225,6 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 }
 
 - (void)commonMDCTextInputCommonFundamentInit {
-  _cursorColor = MDCTextInputCursorColor();
   _textColor = MDCTextInputTextColor();
   _textInsetsMode = MDCTextInputTextInsetsModeIfContent;
   _clearButtonMode = UITextFieldViewModeWhileEditing;
@@ -506,7 +505,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
     [self.textInput setNeedsUpdateConstraints];
   }
 
-  [self updateColors];
+  [self updateTextColor];
   [self updateClearButton];
 }
 
@@ -690,6 +689,14 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   [self updateClearButton];
 }
 
+- (UIColor *)cursorColor {
+  return self.textInput.cursorColor;
+}
+
+- (void)setCursorColor:(UIColor *)cursorColor {
+  self.textInput.cursorColor = cursorColor;
+}
+
 - (void)setEnabled:(BOOL)enabled {
   _enabled = enabled;
   self.underline.enabled = enabled;
@@ -744,7 +751,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 
   if (_textColor != textColor) {
     _textColor = textColor;
-    [self updateColors];
+    [self updateTextColor];
   }
 }
 
@@ -808,8 +815,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 
 #pragma mark - Layout
 
-- (void)updateColors {
-  self.textInput.tintColor = self.cursorColor;
+- (void)updateTextColor {
   self.textInput.textColor = self.textColor;
 }
 
@@ -976,7 +982,6 @@ static inline UIColor *MDCTextInputUnderlineColor() {
     if (!self.underline.color) {
       self.underline.color = MDCTextInputUnderlineColor();
     }
-    [self updateColors];
   } else if ([keyPath isEqualToString:MDCTextInputUnderlineKVOKeyLineHeight]) {
     [self.textInput setNeedsUpdateConstraints];
   } else {

--- a/components/TextFields/tests/unit/MultilineTextFieldTests.swift
+++ b/components/TextFields/tests/unit/MultilineTextFieldTests.swift
@@ -42,6 +42,7 @@ class MultilineTextFieldTests: XCTestCase {
     textField.borderView?.borderStrokeColor = .green
     textField.clearButton.tintColor = .red
     textField.clearButtonMode = .always
+    textField.cursorColor = .white
     textField.font = UIFont.systemFont(ofSize: UIFont.labelFontSize)
     textField.hidesPlaceholderOnInput = false
     textField.isEnabled = false
@@ -65,6 +66,7 @@ class MultilineTextFieldTests: XCTestCase {
       XCTAssertEqual(textField.borderView?.borderStrokeColor, textFieldCopy.borderView?.borderStrokeColor)
       XCTAssertEqual(textField.clearButton.tintColor, textFieldCopy.clearButton.tintColor)
       XCTAssertEqual(textField.clearButtonMode, textFieldCopy.clearButtonMode)
+      XCTAssertEqual(textField.cursorColor, textFieldCopy.cursorColor)
       XCTAssertEqual(textField.font, textFieldCopy.font)
       XCTAssertEqual(textField.hidesPlaceholderOnInput, textFieldCopy.hidesPlaceholderOnInput)
       XCTAssertEqual(textField.isEnabled, textFieldCopy.isEnabled)
@@ -99,6 +101,7 @@ class MultilineTextFieldTests: XCTestCase {
     let textField = MDCMultilineTextField()
     textField.translatesAutoresizingMaskIntoConstraints = false
     textField.text = "Lorem ipsum dolor sit amet, consectetuer adipiscing"
+    textField.cursorColor = .red
 
     let controller = MDCTextInputControllerDefault(textInput: textField)
     XCTAssertNotNil(controller.textInput)
@@ -119,6 +122,7 @@ class MultilineTextFieldTests: XCTestCase {
                    unserializedInput?.translatesAutoresizingMaskIntoConstraints)
     XCTAssertEqual(textField.text,
                    unserializedInput?.text)
+    XCTAssertEqual(textField.cursorColor, unserializedInput?.cursorColor)
 
     XCTAssertEqual(textField.leadingUnderlineLabel.text,
                    unserializedInput?.leadingUnderlineLabel.text)

--- a/components/TextFields/tests/unit/TextFieldTests.swift
+++ b/components/TextFields/tests/unit/TextFieldTests.swift
@@ -53,6 +53,7 @@ class TextFieldTests: XCTestCase {
     textField.borderView?.borderStrokeColor = .yellow
     textField.clearButton.tintColor = .red
     textField.clearButtonMode = .always
+    textField.cursorColor = .white
     textField.font = UIFont.systemFont(ofSize: UIFont.labelFontSize)
     textField.hidesPlaceholderOnInput = false
     textField.isEnabled = false
@@ -74,6 +75,7 @@ class TextFieldTests: XCTestCase {
       XCTAssertEqual(textField.borderView?.borderStrokeColor, textFieldCopy.borderView?.borderStrokeColor)
       XCTAssertEqual(textField.clearButton.tintColor, textFieldCopy.clearButton.tintColor)
       XCTAssertEqual(textField.clearButtonMode, textFieldCopy.clearButtonMode)
+      XCTAssertEqual(textField.cursorColor, textFieldCopy.cursorColor)
       XCTAssertEqual(textField.font, textFieldCopy.font)
       XCTAssertEqual(textField.hidesPlaceholderOnInput, textFieldCopy.hidesPlaceholderOnInput)
       XCTAssertEqual(textField.isEnabled, textFieldCopy.isEnabled)
@@ -152,6 +154,8 @@ class TextFieldTests: XCTestCase {
     textField.borderView?.borderPath = UIBezierPath(ovalIn: CGRect(x: 0, y: 0, width: 100, height: 100))
     textField.borderView?.borderStrokeColor = .yellow
 
+    textField.cursorColor = .white
+
     let leadingView = UILabel()
     leadingView.text = "$"
 
@@ -197,6 +201,8 @@ class TextFieldTests: XCTestCase {
     XCTAssertEqual(textField.borderView?.borderStrokeColor, unserializedInput?.borderView?.borderStrokeColor)
     XCTAssertEqual(textField.leadingUnderlineLabel.text,
                    unserializedInput?.leadingUnderlineLabel.text)
+
+    XCTAssertEqual(textField.cursorColor, unserializedInput?.cursorColor)
 
     XCTAssertEqual(textField.trailingUnderlineLabel.text, "51 / 40")
     XCTAssertEqual(textField.trailingUnderlineLabel.text,

--- a/components/TextFields/tests/unit/TextInputProtocolTests.swift
+++ b/components/TextFields/tests/unit/TextInputProtocolTests.swift
@@ -21,6 +21,7 @@ class TextInputTests: XCTestCase {
   func testMDCTextInputProtocolConformanceSingleline() {
     let textField = MDCTextField()
 
+    XCTAssertNotNil(textField.cursorColor)
     XCTAssertNotNil(textField.leadingUnderlineLabel)
     XCTAssertNotNil(textField.trailingUnderlineLabel)
     XCTAssertNotNil(textField.placeholderLabel)
@@ -37,6 +38,9 @@ class TextInputTests: XCTestCase {
 
     textField.clearButton.tintColor = .red
     XCTAssertEqual(textField.clearButton.tintColor, .red)
+
+    textField.cursorColor = .yellow
+    XCTAssertEqual(textField.cursorColor, .yellow)
 
     textField.borderView?.borderFillColor = nil
     XCTAssertNotEqual(textField.borderView?.borderFillColor, .purple)
@@ -103,6 +107,12 @@ class TextInputTests: XCTestCase {
 
     textField.borderView?.borderStrokeColor = nil
     XCTAssertNotEqual(textField.borderView?.borderStrokeColor, .orange)
+
+    textField.clearButton.tintColor = .red
+    XCTAssertEqual(textField.clearButton.tintColor, .red)
+
+    textField.cursorColor = .yellow
+    XCTAssertEqual(textField.cursorColor, .yellow)
 
     let gray = UIColor.gray
 


### PR DESCRIPTION
Found issue at [stack overflow](https://stackoverflow.com/questions/46792078/how-do-i-set-the-caret-cursor-color-on-an-mdctextfield).

Closes #2296