### PR TITLE
[NavigationBarExamples] Swapped private/RTL with MDFi18n

### DIFF
--- a/components/NavigationBar/examples/NavigationBarLayoutExample.m
+++ b/components/NavigationBar/examples/NavigationBarLayoutExample.m
@@ -55,7 +55,7 @@
 
   UIBarButtonItem *backButtonItem = [[UIBarButtonItem alloc]
       initWithImage:[[[MDCIcons imageFor_ic_arrow_back]
-                        mdf_imageFlippedForRightToLeftLayoutDirection]
+                        mdf_imageWithHorizontallyFlippedOrientation]
                         imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]
               style:UIBarButtonItemStylePlain
              target:self

--- a/components/NavigationBar/examples/NavigationBarLayoutExample.m
+++ b/components/NavigationBar/examples/NavigationBarLayoutExample.m
@@ -55,7 +55,7 @@
 
   UIBarButtonItem *backButtonItem = [[UIBarButtonItem alloc]
       initWithImage:[[[MDCIcons imageFor_ic_arrow_back]
-                        mdc_imageFlippedForRightToLeftLayoutDirection]
+                        mdf_imageFlippedForRightToLeftLayoutDirection]
                         imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]
               style:UIBarButtonItemStylePlain
              target:self

--- a/components/NavigationBar/examples/NavigationBarLayoutExample.m
+++ b/components/NavigationBar/examples/NavigationBarLayoutExample.m
@@ -19,10 +19,10 @@
 //
 //
 
-#import "MDFInternationalization.h"
 #import "MaterialIcons+ic_arrow_back.h"
 #import "MaterialNavigationBar.h"
 #import "MaterialTextFields.h"
+#import "MDFInternationalization.h"
 
 @interface NavigationBarLayoutExample : UIViewController <UITextFieldDelegate>
 

--- a/components/NavigationBar/examples/NavigationBarLayoutExample.m
+++ b/components/NavigationBar/examples/NavigationBarLayoutExample.m
@@ -19,11 +19,10 @@
 //
 //
 
+#import "MDFInternationalization.h"
 #import "MaterialIcons+ic_arrow_back.h"
 #import "MaterialNavigationBar.h"
 #import "MaterialTextFields.h"
-#import "UIImage+MaterialRTL.h"
-#import "UIView+MaterialRTL.h"
 
 @interface NavigationBarLayoutExample : UIViewController <UITextFieldDelegate>
 


### PR DESCRIPTION
I really don't know how it slipped through. The last piece before `private/RTL` is ready to be removed.

#1475.