### PR TITLE
[Catalog] @objc annotating all CatalogByConvention funcs

### DIFF
--- a/components/ActivityIndicator/examples/ActivityIndicatorExample.swift
+++ b/components/ActivityIndicator/examples/ActivityIndicatorExample.swift
@@ -83,11 +83,11 @@ extension ActivityIndicatorSwiftController : MDCActivityIndicatorDelegate {
    }
 
    // MARK: Catalog by convention
-   class func catalogBreadcrumbs() -> [String] {
+   @objc class func catalogBreadcrumbs() -> [String] {
       return ["Activity Indicator", "Activity Indicator (Swift)"]
    }
 
-   class func catalogIsPrimaryDemo() -> Bool {
+   @objc class func catalogIsPrimaryDemo() -> Bool {
       return false
    }
 }

--- a/components/AnimationTiming/examples/AnimationTimingExample.swift
+++ b/components/AnimationTiming/examples/AnimationTimingExample.swift
@@ -160,11 +160,11 @@ extension AnimationTimingExample {
       scrollView.addSubview(materialEaseInView)
    }
 
-   class func catalogBreadcrumbs() -> [String] {
+   @objc class func catalogBreadcrumbs() -> [String] {
       return ["Animation Timing", "Animation Timing (Swift)"]
    }
 
-   class func catalogIsPrimaryDemo() -> Bool {
+   @objc class func catalogIsPrimaryDemo() -> Bool {
       return false
    }
 

--- a/components/AppBar/examples/AppBarDelegateForwardingExample.swift
+++ b/components/AppBar/examples/AppBarDelegateForwardingExample.swift
@@ -116,11 +116,11 @@ class AppBarDelegateForwardingExample: UITableViewController {
 
 // MARK: Catalog by convention
 extension AppBarDelegateForwardingExample {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["App Bar", "Delegate Forwarding (Swift)"]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 

--- a/components/AppBar/examples/AppBarImageryExample.swift
+++ b/components/AppBar/examples/AppBarImageryExample.swift
@@ -87,11 +87,11 @@ class AppBarImagerySwiftExample: UITableViewController {
 
 // MARK: Catalog by convention
 extension AppBarImagerySwiftExample {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["App Bar", "Imagery (Swift)"]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
@@ -62,15 +62,15 @@ class AppBarInterfaceBuilderSwiftExample: UIViewController, UIScrollViewDelegate
 
 // MARK: Catalog by convention
 extension AppBarInterfaceBuilderSwiftExample {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["App Bar", "Interface Builder (Swift)"]
   }
 
-  class func catalogStoryboardName() -> String {
+  @objc class func catalogStoryboardName() -> String {
     return "AppBarInterfaceBuilderSwiftExampleController"
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -150,11 +150,11 @@ class AppBarModalPresentationSwiftExample: UITableViewController {
 
 // MARK: Catalog by convention
 extension AppBarModalPresentationSwiftExample {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["App Bar", "Modal Presentation (Swift)"]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 

--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -82,11 +82,11 @@ class AppBarTypicalUseSwiftExample: UITableViewController {
 
 // MARK: Catalog by convention
 extension AppBarTypicalUseSwiftExample {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["App Bar", "App Bar (Swift)"]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 

--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
@@ -109,11 +109,11 @@ class BottomAppBarTypicalUseSwiftExample: UIViewController {
 
 // MARK: Catalog by convention
 extension BottomAppBarTypicalUseSwiftExample {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["Bottom App Bar", "Bottom App Bar (Swift)"]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
@@ -83,11 +83,11 @@ class ButtonBarTypicalUseSwiftExample: UIViewController {
 
 // MARK: Catalog by convention
 extension ButtonBarTypicalUseSwiftExample {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["Button Bar", "Button Bar (Swift)"]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 }

--- a/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
+++ b/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
@@ -19,11 +19,11 @@ import MaterialComponents
 
 class ButtonsDynamicTypeViewController: UIViewController {
 
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["Buttons", "Buttons (DynamicType)"]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 

--- a/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
+++ b/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
@@ -100,11 +100,11 @@ class ButtonsSimpleExampleSwiftViewController: UIViewController {
 }
 
 extension ButtonsSimpleExampleSwiftViewController {
-   class func catalogBreadcrumbs() -> [String] {
+   @objc class func catalogBreadcrumbs() -> [String] {
       return ["Buttons", "Buttons (Swift)"]
    }
    
-   class func catalogIsPrimaryDemo() -> Bool {
+   @objc class func catalogIsPrimaryDemo() -> Bool {
       return false
    }
 }

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -205,15 +205,15 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
 }
 
 extension ButtonsSwiftAndStoryboardController {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["Buttons", "Buttons (Swift and Storyboard)"]
   }
 
-  class func catalogStoryboardName() -> String {
+  @objc class func catalogStoryboardName() -> String {
     return "ButtonsStoryboardAndProgrammatic"
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 }

--- a/components/Collections/examples/CollectionsSimpleSwiftDemo.swift
+++ b/components/Collections/examples/CollectionsSimpleSwiftDemo.swift
@@ -55,11 +55,11 @@ class CollectionsSimpleSwiftDemo: MDCCollectionViewController {
 
 // MARK: Catalog by convention
 extension CollectionsSimpleSwiftDemo {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return [ "Collections", "Simple Swift Demo"]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 }

--- a/components/Dialogs/examples/DialogsLongAlertViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertViewController.swift
@@ -76,11 +76,11 @@ class DialogsLongAlertViewController: UIViewController {
 
 // MARK: Catalog by convention
 extension DialogsLongAlertViewController {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return [ "Dialogs", "Swift Alert Demo"]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 }

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTypicalUseSupplemental.swift
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTypicalUseSupplemental.swift
@@ -26,11 +26,11 @@ extension FlexibleHeaderTypicalUseViewControllerSwift {
 
   // (CatalogByConvention)
 
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return [ "Flexible Header", "Flexible Header (Swift)" ]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 

--- a/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.swift
+++ b/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.swift
@@ -24,11 +24,11 @@ extension HeaderStackViewTypicalUseSwiftExample {
 
   // MARK: - CatalogByConvention
 
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return [ "Header Stack View", "Header Stack View (Swift)" ]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 

--- a/components/MaskedTransition/examples/supplemental/MaskedTransitionTypicalUseSupplemental.swift
+++ b/components/MaskedTransition/examples/supplemental/MaskedTransitionTypicalUseSupplemental.swift
@@ -24,15 +24,15 @@ extension MaskedTransitionTypicalUseSwiftExample {
 
   // MARK: - CatalogByConvention
 
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return [ "Masked Transition", "Masked Transition (Swift)" ]
   }
 
-  class func catalogDescription() -> String {
+  @objc class func catalogDescription() -> String {
     return "Examples of how the Floating Action Button can transition to other on-screen views."
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return true
   }
 }

--- a/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.swift
+++ b/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.swift
@@ -26,11 +26,11 @@ extension NavigationBarTypicalUseSwiftExample {
 
   // (CatalogByConvention)
 
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return [ "Navigation Bar", "Navigation Bar (Swift)" ]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 

--- a/components/PageControl/examples/PageControlTypicalUseExample.swift
+++ b/components/PageControl/examples/PageControlTypicalUseExample.swift
@@ -125,11 +125,11 @@ class PageControlSwiftExampleViewController: UIViewController, UIScrollViewDeleg
 
   // MARK: - CatalogByConvention
 
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return [ "Page Control", "Swift example"]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 }

--- a/components/Palettes/examples/PalettesExpandedExample.swift
+++ b/components/Palettes/examples/PalettesExpandedExample.swift
@@ -45,11 +45,11 @@ class PalettesGeneratedExampleViewController: PalettesExampleViewController {
 
 // MARK: - Catalog by convention
 extension PalettesGeneratedExampleViewController {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["Palettes", "Generated Palettes"]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 }

--- a/components/Palettes/examples/PalettesStandardExample.swift
+++ b/components/Palettes/examples/PalettesStandardExample.swift
@@ -45,15 +45,15 @@ class PalettesStandardExampleViewController: PalettesExampleViewController {
 
 // MARK: - Catalog by convention
 extension PalettesStandardExampleViewController {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["Palettes", "Standard Palettes"]
   }
 
-  class func catalogDescription() -> String {
+  @objc class func catalogDescription() -> String {
     return "The Palettes component provides sets of reference colors that work well together."
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return true
   }
 }

--- a/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.swift
+++ b/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.swift
@@ -62,11 +62,11 @@ class ShadowElevationsTypicalUseExample: UIViewController {
 
 // MARK: Catalog by convention
 extension ShadowElevationsTypicalUseExample {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["Shadow", "Shadow Elevations (Swift)"]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 

--- a/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
+++ b/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
@@ -65,19 +65,19 @@ class ShadowDragSquareExampleViewController: UIViewController {
 
   // MARK: - CatalogByConvention
 
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return [ "Shadow", "Shadow Layer"]
   }
 
-  class func catalogStoryboardName() -> String {
+  @objc class func catalogStoryboardName() -> String {
     return "ShadowDragSquareExample"
   }
 
-  class func catalogDescription() -> String {
+  @objc class func catalogDescription() -> String {
     return "Shadow Layer implements the Material Design specifications for elevation and shadows."
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return true
   }
 }

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
@@ -238,11 +238,11 @@ extension TabBarIconSwiftExample {
 
 // MARK: - Catalog by convention
 extension TabBarIconSwiftExample {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["Tab Bar", "Icons and Text (Swift)"]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 

--- a/components/TextFields/examples/TextFieldExample.swift
+++ b/components/TextFields/examples/TextFieldExample.swift
@@ -430,16 +430,16 @@ extension TextFieldSwiftExample {
 // MARK: - CatalogByConvention
 
 extension TextFieldSwiftExample {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["Text Field", "Typical Use"]
   }
 
-  class func catalogDescription() -> String {
+  @objc class func catalogDescription() -> String {
     // swiftlint:disable:next line_length
     return "The Material Design Text Fields take the familiar element to a new level by adding useful animations, character counts, helper text and error states."
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return true
   }
 }

--- a/components/TextFields/examples/TextFieldFilledExample.swift
+++ b/components/TextFields/examples/TextFieldFilledExample.swift
@@ -419,7 +419,7 @@ extension TextFieldFilledSwiftExample {
 }
 
 extension TextFieldFilledSwiftExample {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["Text Field", "Filled Text Fields"]
   }
 }

--- a/components/TextFields/examples/TextFieldLegacyExample.swift
+++ b/components/TextFields/examples/TextFieldLegacyExample.swift
@@ -407,7 +407,7 @@ extension TextFieldLegacySwiftExample {
 }
 
 extension TextFieldLegacySwiftExample {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["Text Field", "[Legacy] Typical Use"]
   }
 

--- a/components/TextFields/examples/TextFieldManualLayoutLegacyExample.swift
+++ b/components/TextFields/examples/TextFieldManualLayoutLegacyExample.swift
@@ -339,11 +339,11 @@ extension TextFieldManualLayoutLegacySwiftExample {
 
 // MARK: - CatalogByConvention
 extension TextFieldManualLayoutLegacySwiftExample {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["Text Field", "[Legacy] Manual Layout"]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 }

--- a/components/TextFields/examples/TextFieldOutlinedExample.swift
+++ b/components/TextFields/examples/TextFieldOutlinedExample.swift
@@ -397,7 +397,7 @@ extension TextFieldOutlinedSwiftExample {
 }
 
 extension TextFieldOutlinedSwiftExample {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["Text Field", "Outlined Fields & Text Areas"]
   }
 }

--- a/components/TextFields/examples/supplemental/TextFieldKitchenSinkExampleSupplemental.swift
+++ b/components/TextFields/examples/supplemental/TextFieldKitchenSinkExampleSupplemental.swift
@@ -490,11 +490,11 @@ extension TextFieldKitchenSinkSwiftExample {
 }
 
 extension TextFieldKitchenSinkSwiftExample {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["Text Field", "Kitchen Sink"]
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
 }

--- a/components/Typography/examples/TypographyFontListExample.swift
+++ b/components/Typography/examples/TypographyFontListExample.swift
@@ -146,16 +146,16 @@ class TypographyFontListExampleViewController: UITableViewController {
 
 // MARK: - CatalogByConvention
 extension TypographyFontListExampleViewController {
-  class func catalogBreadcrumbs() -> [String] {
+  @objc class func catalogBreadcrumbs() -> [String] {
     return ["Typography and Fonts", "Typography"]
   }
 
-  class func catalogDescription() -> String {
+  @objc class func catalogDescription() -> String {
     return "The Typography component provides methods for displaying text using the type sizes and"
       + " opacities from the Material Design specifications."
   }
 
-  class func catalogIsPrimaryDemo() -> Bool {
+  @objc class func catalogIsPrimaryDemo() -> Bool {
     return true
   }
 }


### PR DESCRIPTION
CatalogByConvention funcs are implicitly `@objc` in Swift3.

In Swift4, this will no longer be the case and could cause runtime failures.