### PR TITLE
[BottomNavigation] Migrated to MDFi18n.

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -17,8 +17,8 @@
 #import "MDCBottomNavigationBar.h"
 
 #import "MaterialMath.h"
-#import "MaterialRTL.h"
 #import "MaterialShadowLayer.h"
+#import "MDFInternationalization.h"
 #import "private/MaterialBottomNavigationStrings.h"
 #import "private/MaterialBottomNavigationStrings_table.h"
 #import "private/MDCBottomNavigationItemView.h"
@@ -160,7 +160,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
 }
 
 - (void)layoutItemViews {
-  UIUserInterfaceLayoutDirection layoutDirection = self.mdc_effectiveUserInterfaceLayoutDirection;
+  UIUserInterfaceLayoutDirection layoutDirection = self.mdf_effectiveUserInterfaceLayoutDirection;
   NSInteger numItems = self.items.count;
   if (numItems == 0) {
     return;

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -16,10 +16,10 @@
 
 #import "MDCBottomNavigationItemView.h"
 
-#import "MaterialRTL.h"
 #import "MaterialBottomNavigationStrings.h"
 #import "MaterialBottomNavigationStrings_table.h"
 #import "MDCBottomNavigationItemBadge.h"
+#import "MDFInternationalization.h"
 
 static const CGFloat kMDCBottomNavigationItemViewCircleLayerOffset = -6.f;
 static const CGFloat kMDCBottomNavigationItemViewCircleLayerDimension = 36.f;
@@ -146,7 +146,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
     }
     self.label.textAlignment = NSTextAlignmentCenter;
   } else {
-    UIUserInterfaceLayoutDirection layoutDirection = self.mdc_effectiveUserInterfaceLayoutDirection;
+    UIUserInterfaceLayoutDirection layoutDirection = self.mdf_effectiveUserInterfaceLayoutDirection;
     if (layoutDirection == UIUserInterfaceLayoutDirectionLeftToRight) {
       CGPoint iconImageViewCenter =
           CGPointMake(CGRectGetMidX(self.bounds) - CGRectGetWidth(self.bounds) * 0.2f,


### PR DESCRIPTION
Partially addresses #1475.

Components keep adding a dependency on `MaterialRTL`. ATM this is the only user of it. However, by the moment the PRs are merged more usages are being added. Should I send a PR to mark all of `MaterialRTL` code as deprecated? Or do you think I can just send a PR which removes `MaterialRTL` entirely and mark it blocked on this PR?