### PR TITLE
[TabBar] Add safeAreaInsets.bottom to tabBarHeight in MDCTabBarVC

### DIFF
--- a/components/Tabs/src/MDCTabBarViewController.m
+++ b/components/Tabs/src/MDCTabBarViewController.m
@@ -242,6 +242,12 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
 - (void)updateLayout {
   CGRect bounds = self.view.bounds;
   CGFloat tabBarHeight = [[_tabBar class] defaultHeightForItemAppearance:_tabBar.itemAppearance];
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    tabBarHeight += self.view.safeAreaInsets.bottom;
+  }
+#endif
+
   CGRect currentViewFrame = bounds;
   CGRect tabBarFrame = CGRectMake(bounds.origin.x, bounds.origin.y + bounds.size.height,
                                   bounds.size.width, tabBarHeight);


### PR DESCRIPTION
Follow-up to https://github.com/material-components/material-components-ios/pull/2261.

Partially fixes https://github.com/material-components/material-components-ios/issues/2302.