### PR TITLE
Initial addition of kokoro and bazel continuous integration support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+bazel-*
+.kokoro-ios-runner
+
 # MDC
 
 build_tests/CocoapodsObjCApp/CocoapodsObjCApp.xcworkspace

--- a/.kokoro
+++ b/.kokoro
@@ -56,5 +56,6 @@ popd
 fix_bazel_imports
 
 ./.kokoro-ios-runner/bazel.sh test //components/ActivityIndicator:UnitTests 8.1.0
+./.kokoro-ios-runner/bazel.sh build //components/AnimationTiming:UnitTests 8.1.0
 
 echo "Success!"

--- a/.kokoro
+++ b/.kokoro
@@ -56,6 +56,6 @@ popd
 fix_bazel_imports
 
 ./.kokoro-ios-runner/bazel.sh test //components/ActivityIndicator:UnitTests 8.1.0
-./.kokoro-ios-runner/bazel.sh build //components/AnimationTiming:UnitTests 8.1.0
+./.kokoro-ios-runner/bazel.sh build //components/AnimationTiming 8.1.0
 
 echo "Success!"

--- a/.kokoro
+++ b/.kokoro
@@ -56,6 +56,5 @@ popd
 fix_bazel_imports
 
 ./.kokoro-ios-runner/bazel.sh test //components/... 8.1.0
-./.kokoro-ios-runner/bazel.sh build //components/... 8.1.0
 
 echo "Success!"

--- a/.kokoro
+++ b/.kokoro
@@ -55,7 +55,7 @@ popd
 
 fix_bazel_imports
 
-./.kokoro-ios-runner/bazel.sh test //components/ActivityIndicator:UnitTests 8.1.0
-./.kokoro-ios-runner/bazel.sh build //components/AnimationTiming 8.1.0
+./.kokoro-ios-runner/bazel.sh test //components/... 8.1.0
+./.kokoro-ios-runner/bazel.sh build //components/... 8.1.0
 
 echo "Success!"

--- a/.kokoro
+++ b/.kokoro
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2017-present The Material Foundation Authors. All Rights Reserved.
+# Copyright 2017-present The Material Components for iOS Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.kokoro
+++ b/.kokoro
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Copyright 2017-present The Material Foundation Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fail on any error.
+set -e
+
+# Display commands to stderr.
+set -x
+
+KOKORO_RUNNER_VERSION="v3.*"
+
+fix_bazel_imports() {
+  if [ -z "$KOKORO_BUILD_NUMBER" ]; then
+    tests_dir_prefix=""
+  else
+    tests_dir_prefix="github/repo/"
+  fi
+  
+  rewrite_source() {
+    find "${stashed_dir}${tests_dir_prefix}"components/*/tests/unit -type f -name '*.swift' -exec sed -i '' -E "$1" {} + || true
+  }
+
+  stashed_dir=""
+  rewrite_source "s/import MaterialComponents.Material(.+)/import components_\1_\1/"
+  stashed_dir="$(pwd)/"
+  reset_imports() {
+    # Undoes our source changes from above.
+    rewrite_source "s/import components_(.+)_.+/import MaterialComponents.Material\1/"
+  }
+  trap reset_imports EXIT
+}
+
+if [ ! -d .kokoro-ios-runner ]; then
+  git clone https://github.com/material-foundation/kokoro-ios-runner.git .kokoro-ios-runner
+fi
+
+pushd .kokoro-ios-runner
+git fetch > /dev/null
+TAG=$(git tag --sort=v:refname -l "$KOKORO_RUNNER_VERSION" | tail -n1)
+git checkout "$TAG" > /dev/null
+popd
+
+fix_bazel_imports
+
+./.kokoro-ios-runner/bazel.sh test //components/ActivityIndicator:UnitTests 8.1.0
+
+echo "Success!"

--- a/.kokoro
+++ b/.kokoro
@@ -55,6 +55,6 @@ popd
 
 fix_bazel_imports
 
-./.kokoro-ios-runner/bazel.sh test //components/... 8.1.0
+./.kokoro-ios-runner/bazel.sh test //components/... 8.2.0
 
 echo "Success!"

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,17 @@
+# Copyright 2017-present The Material Foundation Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE"])

--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2017-present The Material Foundation Authors. All Rights Reserved.
+# Copyright 2017-present The Material Components for iOS Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,31 @@
+# Copyright 2017-present The Material Foundation Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+git_repository(
+    name = "build_bazel_rules_apple",
+    remote = "https://github.com/bazelbuild/rules_apple.git",
+    commit = "7ea0557",
+)
+
+git_repository(
+    name = "bazel_ios_warnings",
+    remote = "https://github.com/material-foundation/bazel_ios_warnings.git",
+    tag = "v1.0.1",
+)
+
+git_repository(
+    name = "material_internationalization_ios",
+    remote = "https://github.com/jverkoey/material-internationalization-ios.git",
+    commit = "c4cf7da8fed60c4b7287e50f00db79fa96198dc6",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-# Copyright 2017-present The Material Foundation Authors. All Rights Reserved.
+# Copyright 2017-present The Material Components for iOS Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,6 +26,6 @@ git_repository(
 
 git_repository(
     name = "material_internationalization_ios",
-    remote = "https://github.com/jverkoey/material-internationalization-ios.git",
-    commit = "c4cf7da8fed60c4b7287e50f00db79fa96198dc6",
+    remote = "https://github.com/material-foundation/material-internationalization-ios.git",
+    commit = "fef1a31313a4a8aa0234cce416e1615c7054cf9d",
 )

--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -12,30 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
+load("//:material_components_ios.bzl", "mdc_public_objc_library")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 
 licenses(["notice"])  # Apache 2.0
 
-strict_warnings_objc_library(
+mdc_public_objc_library(
     name = "ActivityIndicator",
-    srcs = glob([
-        "src/*.m",
-        "src/private/*.m",
-    ]),
-    hdrs = glob([
-        "src/*.h",
-        "src/private/*.h",
-    ]),
     deps = [
       "//components/Palettes",
       "//components/private/Application",
       "@material_internationalization_ios//:MDFInternationalization",
     ],
-    enable_modules = 1,
-    includes = ["src"],
-    visibility = ["//visibility:public"],
 )
 
 swift_library(
@@ -50,8 +39,10 @@ swift_library(
 objc_library(
     name = "UnitTestsLib",
     srcs = glob([
-        "tests/unit/*.h",
         "tests/unit/*.m",
+    ]),
+    hdrs = glob([
+        "tests/unit/*.h",
     ]),
     deps = [":ActivityIndicator"],
     visibility = ["//visibility:private"],

--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2017-present The Material Foundation Authors. All Rights Reserved.
+# Copyright 2017-present The Material Components for iOS Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ swift_library(
 objc_library(
     name = "UnitTestsLib",
     srcs = glob([
+        "tests/unit/*.h",
         "tests/unit/*.m",
     ]),
     deps = [":ActivityIndicator"],

--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -1,0 +1,68 @@
+# Copyright 2017-present The Material Foundation Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
+load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+
+licenses(["notice"])  # Apache 2.0
+
+strict_warnings_objc_library(
+    name = "ActivityIndicator",
+    srcs = glob([
+        "src/*.m",
+        "src/private/*.m",
+    ]),
+    hdrs = glob([
+        "src/*.h",
+        "src/private/*.h",
+    ]),
+    deps = [
+      "//components/Palettes",
+      "//components/private/Application",
+      "@material_internationalization_ios//:MDFInternationalization",
+    ],
+    enable_modules = 1,
+    includes = ["src"],
+    visibility = ["//visibility:public"],
+)
+
+swift_library(
+    name = "UnitTestsSwiftLib",
+    srcs = glob([
+        "tests/unit/*.swift",
+    ]),
+    deps = [":ActivityIndicator"],
+    visibility = ["//visibility:private"],
+)
+
+objc_library(
+    name = "UnitTestsLib",
+    srcs = glob([
+        "tests/unit/*.m",
+    ]),
+    deps = [":ActivityIndicator"],
+    visibility = ["//visibility:private"],
+)
+
+ios_unit_test(
+    name = "UnitTests",
+    deps = [
+      ":UnitTestsLib",
+      ":UnitTestsSwiftLib"
+    ],
+    minimum_os_version = "8.0",
+    timeout = "short",
+    visibility = ["//visibility:private"],
+)

--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl", "mdc_public_objc_library")
+load("//:material_components_ios.bzl",
+     "mdc_public_objc_library",
+     "mdc_objc_library")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 
@@ -20,6 +22,10 @@ licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ActivityIndicator",
+    sdk_frameworks = [
+        "QuartzCore",
+        "UIKit",
+    ],
     deps = [
       "//components/Palettes",
       "//components/private/Application",
@@ -28,33 +34,31 @@ mdc_public_objc_library(
 )
 
 swift_library(
-    name = "UnitTestsSwiftLib",
-    srcs = glob([
-        "tests/unit/*.swift",
-    ]),
+    name = "unit_test_swift_sources",
+    srcs = glob(["tests/unit/*.swift"]),
     deps = [":ActivityIndicator"],
     visibility = ["//visibility:private"],
 )
 
-objc_library(
-    name = "UnitTestsLib",
-    srcs = glob([
-        "tests/unit/*.m",
-    ]),
-    hdrs = glob([
-        "tests/unit/*.h",
-    ]),
+mdc_objc_library(
+    name = "unit_test_sources",
+    testonly = 1,
+    srcs = glob(["tests/unit/*.m"]),
+    hdrs = glob(["tests/unit/*.h"]),
+    sdk_frameworks = [
+        "UIKit",
+        "XCTest",
+    ],
     deps = [":ActivityIndicator"],
     visibility = ["//visibility:private"],
 )
 
 ios_unit_test(
-    name = "UnitTests",
+    name = "unit_tests",
     deps = [
-      ":UnitTestsLib",
-      ":UnitTestsSwiftLib"
+      ":unit_test_sources",
+      ":unit_test_swift_sources"
     ],
     minimum_os_version = "8.0",
-    timeout = "short",
     visibility = ["//visibility:private"],
 )

--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -22,6 +22,7 @@ licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ActivityIndicator",
+    bundles = [":Bundle"],
     sdk_frameworks = [
         "QuartzCore",
         "UIKit",
@@ -31,6 +32,18 @@ mdc_public_objc_library(
       "//components/private/Application",
       "@material_internationalization_ios//:MDFInternationalization",
     ],
+)
+
+filegroup(
+    name = "BundleFiles",
+    srcs = glob([
+        "src/MaterialActivityIndicator.bundle/**",
+    ]),
+)
+
+objc_bundle(
+    name = "Bundle",
+    bundle_imports = [":BundleFiles"],
 )
 
 swift_library(

--- a/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.swift
+++ b/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.swift
@@ -15,7 +15,7 @@
  */
 
 import XCTest
-import MaterialComponents
+import MaterialComponents.MaterialActivityIndicator
 
 class ActivityIndicatorTests: XCTestCase {
 

--- a/components/AnimationTiming/BUILD
+++ b/components/AnimationTiming/BUILD
@@ -12,25 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
+load("//:material_components_ios.bzl", "mdc_public_objc_library")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 
 licenses(["notice"])  # Apache 2.0
 
-strict_warnings_objc_library(
+mdc_public_objc_library(
     name = "AnimationTiming",
-    srcs = glob([
-        "src/*.m",
-        "src/private/*.m",
-    ]),
-    hdrs = glob([
-        "src/*.h",
-        "src/private/*.h",
-    ]),
-    enable_modules = 1,
-    includes = ["src"],
-    visibility = ["//visibility:public"],
 )
 
 objc_library(

--- a/components/AnimationTiming/BUILD
+++ b/components/AnimationTiming/BUILD
@@ -32,3 +32,19 @@ strict_warnings_objc_library(
     includes = ["src"],
     visibility = ["//visibility:public"],
 )
+
+objc_library(
+    name = "UnitTestsLib",
+    deps = [":AnimationTiming"],
+    visibility = ["//visibility:private"],
+)
+
+ios_unit_test(
+    name = "UnitTests",
+    deps = [
+      ":UnitTestsLib",
+    ],
+    minimum_os_version = "8.0",
+    timeout = "short",
+    visibility = ["//visibility:private"],
+)

--- a/components/AnimationTiming/BUILD
+++ b/components/AnimationTiming/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2017-present The Material Foundation Authors. All Rights Reserved.
+# Copyright 2017-present The Material Components for iOS Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,6 +35,10 @@ strict_warnings_objc_library(
 
 objc_library(
     name = "UnitTestsLib",
+    srcs = glob([
+        "tests/unit/*.h",
+        "tests/unit/*.m",
+    ]),
     deps = [":AnimationTiming"],
     visibility = ["//visibility:private"],
 )

--- a/components/AnimationTiming/BUILD
+++ b/components/AnimationTiming/BUILD
@@ -1,0 +1,34 @@
+# Copyright 2017-present The Material Foundation Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
+load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+
+licenses(["notice"])  # Apache 2.0
+
+strict_warnings_objc_library(
+    name = "AnimationTiming",
+    srcs = glob([
+        "src/*.m",
+        "src/private/*.m",
+    ]),
+    hdrs = glob([
+        "src/*.h",
+        "src/private/*.h",
+    ]),
+    enable_modules = 1,
+    includes = ["src"],
+    visibility = ["//visibility:public"],
+)

--- a/components/AnimationTiming/BUILD
+++ b/components/AnimationTiming/BUILD
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl", "mdc_public_objc_library")
+load("//:material_components_ios.bzl",
+     "mdc_public_objc_library",
+     "mdc_objc_library")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 
@@ -22,22 +24,23 @@ mdc_public_objc_library(
     name = "AnimationTiming",
 )
 
-objc_library(
-    name = "UnitTestsLib",
-    srcs = glob([
-        "tests/unit/*.h",
-        "tests/unit/*.m",
-    ]),
+mdc_objc_library(
+    name = "unit_test_sources",
+    srcs = glob(["tests/unit/*.m"]),
+    hdrs = glob(["tests/unit/*.h"]),
+    sdk_frameworks = [
+        "UIKit",
+        "XCTest",
+    ],
     deps = [":AnimationTiming"],
     visibility = ["//visibility:private"],
 )
 
 ios_unit_test(
-    name = "UnitTests",
+    name = "unit_tests",
     deps = [
-      ":UnitTestsLib",
+      ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
-    timeout = "short",
     visibility = ["//visibility:private"],
 )

--- a/components/AnimationTiming/tests/unit/AnimationTimingTests.m
+++ b/components/AnimationTiming/tests/unit/AnimationTimingTests.m
@@ -1,0 +1,30 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import "MaterialAnimationTiming.h"
+
+@interface AnimationTimingTests : XCTestCase
+
+@end
+
+@implementation AnimationTimingTests
+
+- (void)testNoop {
+  XCTAssertTrue(YES);
+}
+
+@end

--- a/components/Palettes/BUILD
+++ b/components/Palettes/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2017-present The Material Foundation Authors. All Rights Reserved.
+# Copyright 2017-present The Material Components for iOS Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ swift_library(
 objc_library(
     name = "UnitTestsLib",
     srcs = glob([
+        "tests/unit/*.h",
         "tests/unit/*.m",
     ]),
     deps = [":Palettes"],

--- a/components/Palettes/BUILD
+++ b/components/Palettes/BUILD
@@ -12,25 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
+load("//:material_components_ios.bzl", "mdc_public_objc_library")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 
 licenses(["notice"])  # Apache 2.0
 
-strict_warnings_objc_library(
+mdc_public_objc_library(
     name = "Palettes",
-    srcs = glob([
-        "src/*.m",
-        "src/private/*.m",
-    ]),
-    hdrs = glob([
-        "src/*.h",
-        "src/private/*.h",
-    ]),
-    enable_modules = 1,
-    includes = ["src"],
-    visibility = ["//visibility:public"],
 )
 
 swift_library(

--- a/components/Palettes/BUILD
+++ b/components/Palettes/BUILD
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl", "mdc_public_objc_library")
+load("//:material_components_ios.bzl",
+     "mdc_public_objc_library",
+     "mdc_objc_library")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 
@@ -23,31 +25,30 @@ mdc_public_objc_library(
 )
 
 swift_library(
-    name = "UnitTestsSwiftLib",
-    srcs = glob([
-        "tests/unit/*.swift",
-    ]),
+    name = "unit_test_swift_sources",
+    srcs = glob(["tests/unit/*.swift"]),
     deps = [":Palettes"],
     visibility = ["//visibility:private"],
 )
 
-objc_library(
-    name = "UnitTestsLib",
-    srcs = glob([
-        "tests/unit/*.h",
-        "tests/unit/*.m",
-    ]),
+mdc_objc_library(
+    name = "unit_test_sources",
+    srcs = glob(["tests/unit/*.m"]),
+    hdrs = glob(["tests/unit/*.h"]),
+    sdk_frameworks = [
+        "UIKit",
+        "XCTest",
+    ],
     deps = [":Palettes"],
     visibility = ["//visibility:private"],
 )
 
 ios_unit_test(
-    name = "UnitTests",
+    name = "unit_tests",
     deps = [
-      ":UnitTestsLib",
-      ":UnitTestsSwiftLib"
+      ":unit_test_sources",
+      ":unit_test_swift_sources",
     ],
     minimum_os_version = "8.0",
-    timeout = "short",
     visibility = ["//visibility:private"],
 )

--- a/components/Palettes/BUILD
+++ b/components/Palettes/BUILD
@@ -1,0 +1,63 @@
+# Copyright 2017-present The Material Foundation Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
+load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+
+licenses(["notice"])  # Apache 2.0
+
+strict_warnings_objc_library(
+    name = "Palettes",
+    srcs = glob([
+        "src/*.m",
+        "src/private/*.m",
+    ]),
+    hdrs = glob([
+        "src/*.h",
+        "src/private/*.h",
+    ]),
+    enable_modules = 1,
+    includes = ["src"],
+    visibility = ["//visibility:public"],
+)
+
+swift_library(
+    name = "UnitTestsSwiftLib",
+    srcs = glob([
+        "tests/unit/*.swift",
+    ]),
+    deps = [":Palettes"],
+    visibility = ["//visibility:private"],
+)
+
+objc_library(
+    name = "UnitTestsLib",
+    srcs = glob([
+        "tests/unit/*.m",
+    ]),
+    deps = [":Palettes"],
+    visibility = ["//visibility:private"],
+)
+
+ios_unit_test(
+    name = "UnitTests",
+    deps = [
+      ":UnitTestsLib",
+      ":UnitTestsSwiftLib"
+    ],
+    minimum_os_version = "8.0",
+    timeout = "short",
+    visibility = ["//visibility:private"],
+)

--- a/components/Palettes/tests/unit/PaletteTests.swift
+++ b/components/Palettes/tests/unit/PaletteTests.swift
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import XCTest
-import MaterialComponents
+import MaterialComponents.MaterialPalettes
 
 class PaletteTests: XCTestCase {
   // Creates a UIColor from a 24-bit RGB color encoded as an integer.

--- a/components/private/Application/BUILD
+++ b/components/private/Application/BUILD
@@ -1,0 +1,34 @@
+# Copyright 2017-present The Material Foundation Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
+load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+
+licenses(["notice"])  # Apache 2.0
+
+strict_warnings_objc_library(
+    name = "Application",
+    srcs = glob([
+        "src/*.m",
+        "src/private/*.m",
+    ]),
+    hdrs = glob([
+        "src/*.h",
+        "src/private/*.h",
+    ]),
+    enable_modules = 1,
+    includes = ["src"],
+    visibility = ["//visibility:public"],
+)

--- a/components/private/Application/BUILD
+++ b/components/private/Application/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2017-present The Material Foundation Authors. All Rights Reserved.
+# Copyright 2017-present The Material Components for iOS Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/components/private/Application/BUILD
+++ b/components/private/Application/BUILD
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
+load("//:material_components_ios.bzl", "mdc_public_objc_library")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 
 licenses(["notice"])  # Apache 2.0
 
-strict_warnings_objc_library(
+mdc_public_objc_library(
     name = "Application",
-    srcs = glob([
-        "src/*.m",
-        "src/private/*.m",
-    ]),
-    hdrs = glob([
-        "src/*.h",
-        "src/private/*.h",
-    ]),
-    enable_modules = 1,
-    includes = ["src"],
-    visibility = ["//visibility:public"],
 )

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -6,7 +6,7 @@ def mdc_objc_library(
     name,
     copts = [],
     **kwargs):
-  """Declare an Objective-C library with MDC's common warning flags."""
+  """Declare an Objective-C library with strict_warnings_objc_library."""
   strict_warnings_objc_library(
       name = name,
       copts = copts,

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -24,7 +24,6 @@ def mdc_public_objc_library(
   The conventions for an MDC component are:
   - The public implementation lives inside of src.
   - The private implementation lives inside of src/private.
-  - Headers are imported relative to src.
 
   The default visibility of "//visibility:public" can be overridden, for
   example, "//some/package:__subpackages__".

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -1,4 +1,4 @@
-"""Baze macros for building MDC component libraries."""
+"""Bazel macros for building MDC component libraries."""
 
 load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
 

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -1,0 +1,49 @@
+"""Baze macros for building MDC component libraries."""
+
+load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
+
+def mdc_objc_library(
+    name,
+    copts = [],
+    **kwargs):
+  """Declare an Objective-C library with MDC's common warning flags."""
+  strict_warnings_objc_library(
+      name = name,
+      copts = copts,
+      **kwargs)
+
+def mdc_public_objc_library(
+    name,
+    deps = [],
+    extra_srcs = [],
+    sdk_frameworks = [],
+    visibility = ["//visibility:public"],
+    **kwargs):
+  """Declare a public MDC component as a Objective-C library according to MDC's conventions.
+
+  The conventions for an MDC component are:
+  - The public implementation lives inside of src.
+  - The private implementation lives inside of src/private.
+  - Headers are imported relative to src.
+
+  The default visibility of "//visibility:public" can be overridden, for
+  example, "//some/package:__subpackages__".
+
+  Args:
+    name: The name of the library.
+    deps: The dependencies of the library.
+    extra_srcs: Extra sources to add to the standard ones.
+    sdk_frameworks: The SDK frameworks needed, e.g. "CoreGraphics".
+    visibility: The visibility of the package.
+    **kwargs: Any arguments accepted by _mdc_objc_library().
+  """
+  mdc_objc_library(
+      name = name,
+      deps = deps,
+      sdk_frameworks = sdk_frameworks,
+      visibility = visibility,
+      srcs = native.glob(["src/*.m", "src/private/*.h", "src/private/*.m"]) + extra_srcs,
+      hdrs = native.glob(["src/*.h"]),
+      includes = ["src"],
+      enable_modules = 1,
+      **kwargs)


### PR DESCRIPTION
Only adds support for ActivityIndicator and its dependencies. Will add other components to the continuous integration in follow up changes.

As part of this change we will need to start consistently using more specific import statements throughout our component tests, e.g. `import MaterialComponents.MaterialActivityIndicator`. The reason we need to do this is because bazel's module names differ from CocoaPods'. We do pre&post-processing on the swift tests during continuous integration to transform `import MaterialComponents.MaterialActivityIndicator` into `import components_ActivityIndicator_ActivityIndicator`.