### PR TITLE
[FlexibleHeader] Add a 'hideViewWhenShifted' API to the flexible header

### DIFF
--- a/components/AppBar/examples/AppBarImageryExample.m
+++ b/components/AppBar/examples/AppBarImageryExample.m
@@ -57,7 +57,7 @@
   self.appBar.navigationBar.backgroundColor = [UIColor clearColor];
 
   // Allow the header to show more of the image.
-  self.appBar.headerViewController.headerView.maximumHeight = 200;
+  self.appBar.headerViewController.headerView.maximumHeight = 300;
 
   // Typical use
   self.appBar.headerViewController.headerView.trackingScrollView = self.tableView;

--- a/components/AppBar/examples/AppBarTypicalUseExample.m
+++ b/components/AppBar/examples/AppBarTypicalUseExample.m
@@ -39,6 +39,9 @@
     // Optional: Change the App Bar's background color and tint color.
     UIColor *color = [UIColor colorWithWhite:0.2 alpha:1];
     _appBar.headerViewController.headerView.backgroundColor = color;
+    _appBar.headerViewController.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorEnabled;
+    [_appBar.headerViewController.headerView hideViewWhenShifted:_appBar.headerStackView];
+
     _appBar.navigationBar.tintColor = [UIColor whiteColor];
     _appBar.navigationBar.titleTextAttributes = @{
                                             NSForegroundColorAttributeName : [UIColor whiteColor],

--- a/components/AppBar/src/MDCAppBar.h
+++ b/components/AppBar/src/MDCAppBar.h
@@ -44,8 +44,8 @@
  The MDCAppBar class creates and configures the constellation of components required to represent a
  Material App Bar.
 
- A Material App Bar consists of a Flexible View with a shadow, a Navigation Bar, and space for
- flexible content such as a photo.
+ A Material App Bar consists of a Flexible Header View with a shadow, a Navigation Bar, and space
+ for flexible content such as a photo.
 
  Learn more at the [Material
  spec](https://material.io/guidelines/patterns/scrolling-techniques.html)

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -335,6 +335,15 @@ IB_DESIGNABLE
 @property(nonatomic) MDCFlexibleHeaderShiftBehavior shiftBehavior;
 
 /**
+ Hides the view by changing its alpha when the header shifts. Note that this only happens when the
+ header shifting behavior is set to MDCFlexibleHeaderShiftBehaviorEnabled.
+ */
+- (void)hideViewWhenShifted:(nonnull UIView *)view;
+
+/** Stops hiding the view when the header shifts. */
+- (void)stopHidingViewWhenShifted:(nonnull UIView *)view;
+
+/**
  If shiftBehavior is enabled, this property affects the manner in which the Header reappears when
  pulling content down in the tracking scroll view.
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -30,6 +30,11 @@ static const CGFloat kFlexibleHeaderDefaultHeight = 56;
 // The maximum default opacity of the shadow.
 static const float kDefaultVisibleShadowOpacity = 0.4f;
 
+// The threshold in which the _viewsToHideWhenShifted should be fully hidden. 0.5 means the views
+// are completely hidden when the header has shifted half of its content height upwards. This should
+// never be 0.
+static const float kContentHidingThreshold = 0.5f;
+
 // This length defines the moment at which the shadow will be fully visible as the header shifts
 // on-screen.
 static const CGFloat kShadowScaleLength = 8;
@@ -118,6 +123,9 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   // events for a view that's been removed from the header view. If we held a strong reference here
   // then the removed view would never be deallocated.
   NSHashTable *_forwardingViews;  // [UIView]
+
+  // Views that should be hidden during shifting. These views are kept as weak references.
+  NSHashTable *_viewsToHideWhenShifted;  // [UIView]
 
   // A weak reference map of scroll views to info that have been tracked by this header view.
   NSMapTable *_trackedScrollViews;  // {UIScrollView:MDCFlexibleHeaderScrollViewInfo}
@@ -290,6 +298,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   NSPointerFunctionsOptions options =
       (NSPointerFunctionsWeakMemory | NSPointerFunctionsObjectPointerPersonality);
   _forwardingViews = [NSHashTable hashTableWithOptions:options];
+  _viewsToHideWhenShifted = [NSHashTable hashTableWithOptions:options];
 
   NSPointerFunctionsOptions keyOptions =
       (NSPointerFunctionsWeakMemory | NSPointerFunctionsObjectPointerPersonality);
@@ -776,7 +785,6 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   if (!_trackingScrollView) {
     // Set the shadow opacity directly.
     self.layer.shadowOpacity = _visibleShadowOpacity;
-
     return;
   }
 
@@ -784,8 +792,16 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 
   CGFloat frameBottomEdge = [self fhv_projectedHeaderBottomEdge];
   frameBottomEdge = MAX(0, MIN(kShadowScaleLength, frameBottomEdge));
-
   CGFloat boundedAccumulator = MIN([self fhv_accumulatorMax], _shiftAccumulator);
+
+  if (_shiftBehavior == MDCFlexibleHeaderShiftBehaviorEnabled) {
+    CGFloat contentHeight = self.computedMinimumHeight - MDCDeviceTopSafeAreaInset();
+    CGFloat hideThreshold = kContentHidingThreshold;
+    CGFloat alpha = MAX(contentHeight - boundedAccumulator / hideThreshold, 0) / contentHeight;
+    for (UIView *view in _viewsToHideWhenShifted) {
+      view.alpha = alpha;
+    }
+  }
 
   CGFloat shadowIntensity;
   if (self.hidesStatusBarWhenCollapsed) {
@@ -803,14 +819,13 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
       // top of our content.
       shadowIntensity = MAX(0, MIN(1, MIN(accumulator, frameBottomEdge) / kShadowScaleLength));
     }
-
   } else if (self.isInFrontOfInfiniteContent) {
     shadowIntensity = 1;
-
   } else {
     // Adjust the opacity as the bottom edge of the header increasingly overlaps the contents
     shadowIntensity = frameBottomEdge / kShadowScaleLength;
   }
+
   if (_defaultShadowLayer.hidden && _customShadowLayer.hidden) {
     self.layer.shadowOpacity = (float)(_visibleShadowOpacity * shadowIntensity);
   } else {
@@ -1275,6 +1290,14 @@ static BOOL isRunningiOS10_3OrAbove() {
       completion:^(__unused id<UIViewControllerTransitionCoordinatorContext> context) {
         [self interfaceOrientationDidChange];
       }];
+}
+
+- (void)hideViewWhenShifted:(UIView *)view {
+  [_viewsToHideWhenShifted addObject:view];
+}
+
+- (void)stopHidingViewWhenShifted:(UIView *)view {
+  [_viewsToHideWhenShifted removeObject:view];
 }
 
 - (void)forwardTouchEventsForView:(UIView *)view {


### PR DESCRIPTION
This PR introduces a new API that will allow client teams to easily hide the content of the flexible header when its shift behavior is set to MDCFlexibleHeaderShiftBehaviorEnabled. This is fully opt-in to prevent regressions.

Closes https://github.com/material-components/material-components-ios/issues/2127.

![ezgif-4-081414844b](https://user-images.githubusercontent.com/4545451/32251870-484095b2-be69-11e7-9fe8-d585d896cbbc.gif)
