### PR TITLE
[FlexibleHeader] Fix bug where status bar visibility changes could cause the header size to jump.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -411,6 +411,12 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   }
 }
 
+- (void)willMoveToWindow:(UIWindow *)newWindow {
+  [super willMoveToWindow:newWindow];
+
+  _wasStatusBarHiddenIsValid = NO;
+}
+
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
   UIView *hitView = [super hitTest:point withEvent:event];
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -144,7 +144,15 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 
   BOOL _interfaceOrientationIsChanging;
   BOOL _contentInsetsAreChanging;
+
+  // _isChangingStatusBarVisibility documents whether we know that we're adjusting the status bar
+  // visibility, while _wasStatusBarHidden allows us to detect whether someone else has adjusted
+  // the status bar visibility. In either case, we need to counteract any content offsets
+  // adjustments made by UIKit so that our header doesn't shrink/expand in reaction to the status
+  // bar visibility changing.
   BOOL _isChangingStatusBarVisibility;
+  BOOL _wasStatusBarHiddenIsValid;
+  BOOL _wasStatusBarHidden;
 
   MDCStatusBarShifter *_statusBarShifter;
 
@@ -573,6 +581,20 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   if (!UIEdgeInsetsEqualToEdgeInsets(scrollView.contentInset, insets)) {
     scrollView.contentInset = insets;
   }
+
+  BOOL statusBarIsHidden = [UIApplication mdc_safeSharedApplication].statusBarHidden;
+  if (_wasStatusBarHiddenIsValid && _wasStatusBarHidden != statusBarIsHidden
+      && !_isChangingStatusBarVisibility) {
+    // Our status bar state has changed without our knowledge. UIKit will have already adjusted our
+    // content offset by now, so we want to counteract this. This logic is similar to that found in
+    // statusBarShifterNeedsStatusBarAppearanceUpdate:
+    CGPoint contentOffset = scrollView.contentOffset;
+    contentOffset.y -= topInsetAdjustment;
+    scrollView.contentOffset = contentOffset;
+  }
+
+  _wasStatusBarHidden = statusBarIsHidden;
+  _wasStatusBarHiddenIsValid = YES;
 
   return topInsetAdjustment;
 }


### PR DESCRIPTION
If the status bar visibility changes without the header's awareness - e.g. if the app hides the status bar for any reason - then the logic for maintaining a consistent content offset will not be executed and our flexible header's height will appear to "jump". This only happens if the tracking scroll view is scrollable and the flexible header's max height is > min height.

To resolve this, we need to have some awareness of when the status bar visibility has changed. I'm not aware of a good status bar visibility notification (other than KVO'ing the application's statusBarHidden property), so this change introduces a small amount of state that tracks our last known status bar visibility.

The new logic is intentionally written to only take effect in the case where we know the following to be true:

1. We've observed the status bar visibility at least once.
2. The status bar visibility doesn't match our last known visibility.
3. We are not currently knowingly changing the status bar visibility.

If all of this is true, then when we adjust the content insets for the scroll view we use the inset delta to adjust the content offset by the shifted amount. This counteracts the amount that UIKit will have adjusted our content offset by, resulting in a no-op of content offset changes and our header's height stays constant through the status bar visibility change.

The reason we don't want to use UIKit's default content offset adjusting behavior is because UIKit thinks the content insets should change when the status bar visibility changes. Our flexible header does not allow the content inset to change because doing so would mean our flexible header couldn't expand to its full height. So, when UIKit removes the 20 points from our content inset and shifts our content offset by 20 points, we imemdiately add back the 20 points to our content inset and then (now) reset the content offset back by 20 points again.