### PR TITLE
[MaskedTransition] Fix imports of private headers

### DIFF
--- a/components/MaskedTransition/src/MDCMaskedTransition.m
+++ b/components/MaskedTransition/src/MDCMaskedTransition.m
@@ -18,9 +18,9 @@
 
 #import <MotionAnimator/MotionAnimator.h>
 
-#import "MDCMaskedPresentationController.h"
-#import "MDCMaskedTransitionMotionForContext.h"
-#import "MDCMaskedTransitionMotionSpec.h"
+#import "private/MDCMaskedPresentationController.h"
+#import "private/MDCMaskedTransitionMotionForContext.h"
+#import "private/MDCMaskedTransitionMotionSpec.h"
 
 // Math utilities
 

--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.h
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @protocol MDMTransitionContext;
 


### PR DESCRIPTION
Correcting some private import statements instead of relying on the include path.