### PR TITLE
[Buttons] Add property layerCornerRadius

### DIFF
--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -102,7 +102,7 @@
  */
 // See https://github.com/material-components/material-components-ios/pull/2256 for a discussion on
 // why the button needs to be layed-out after setting the cornerRadius.
-@property(nonatomic, assign) CGFloat mdc_layerCornerRadius;
+@property(nonatomic, assign) CGFloat layerCornerRadius;
 
 /**
  The apparent background color as seen by the user, i.e. the color of the view behind the button.

--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -89,6 +89,20 @@
  */
 @property(nonatomic, assign) CGSize maximumSize UI_APPEARANCE_SELECTOR;
 
+/**
+ When set, overrides the value returned by |-cornerRadius| and will become the
+ value of the button's layer's cornerRadius. If unset, |-cornerRadius| will return
+ a default value.
+
+ If changing the value of this property while the button is on-screen, it is important to layout
+ the button so that its shadowPath can be updated with the new value.
+
+ @note Do not override the implementation of this property. It will be removed in a future version of
+ MDCButton and clients will need to migrate to setting CALayer's |cornerRadius| property directly.
+ */
+// See https://github.com/material-components/material-components-ios/pull/2256 for a discussion on
+// why the button needs to be layed-out after setting the cornerRadius.
+@property(nonatomic, assign) CGFloat mdc_layerCornerRadius;
 
 /**
  The apparent background color as seen by the user, i.e. the color of the view behind the button.

--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -97,8 +97,7 @@
  If changing the value of this property while the button is on-screen, it is important to layout
  the button so that its shadowPath can be updated with the new value.
 
- @note Do not override the implementation of this property. It will be removed in a future version of
- MDCButton and clients will need to migrate to setting CALayer's |cornerRadius| property directly.
+ @note Do not override the implementation of this property.
  */
 // See https://github.com/material-components/material-components-ios/pull/2256 for a discussion on
 // why the button needs to be layed-out after setting the cornerRadius.

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -125,8 +125,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 }
 @property(nonatomic, strong) MDCInkView *inkView;
 @property(nonatomic, readonly, strong) MDCShadowLayer *layer;
-@property(nonatomic, assign, getter=ismdc_layerCornerRadiusAssigned)
-    BOOL mdc_layerCornerRadiusAssigned;
+@property(nonatomic, assign, getter=isLayerCornerRadiusAssigned) BOOL layerCornerRadiusAssigned;
 @end
 
 @implementation MDCButton
@@ -216,8 +215,8 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
     }
 
     if ([aDecoder containsValueForKey:MDCButtonLayerCornerRadiusKey]) {
-      _mdc_layerCornerRadius = (CGFloat)[aDecoder decodeDoubleForKey:MDCButtonLayerCornerRadiusKey];
-      _mdc_layerCornerRadiusAssigned = YES;
+      _layerCornerRadius = (CGFloat)[aDecoder decodeDoubleForKey:MDCButtonLayerCornerRadiusKey];
+      _layerCornerRadiusAssigned = YES;
     }
 
     if ([aDecoder containsValueForKey:MDCButtonBackgroundColorsKey]) {
@@ -264,8 +263,8 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [aCoder encodeObject:_nontransformedTitles forKey:MDCButtonNontransformedTitlesKey];
   [aCoder encodeObject:_borderColors forKey:MDCButtonBorderColorsKey];
   [aCoder encodeObject:_borderWidths forKey:MDCButtonBorderWidthsKey];
-  if (self.ismdc_layerCornerRadiusAssigned) {
-    [aCoder encodeDouble:self.mdc_layerCornerRadius forKey:MDCButtonLayerCornerRadiusKey];
+  if (self.isLayerCornerRadiusAssigned) {
+    [aCoder encodeDouble:self.layerCornerRadius forKey:MDCButtonLayerCornerRadiusKey];
   }
   if (_shadowColors) {
     [aCoder encodeObject:_shadowColors forKey:MDCButtonShadowColorsKey];
@@ -797,15 +796,15 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   return [UIBezierPath bezierPathWithRoundedRect:self.bounds cornerRadius:[self cornerRadius]];
 }
 
-- (void)setMdc_layerCornerRadius:(CGFloat)mdc_layerCornerRadius {
-  self.mdc_layerCornerRadiusAssigned = YES;
-  _mdc_layerCornerRadius = mdc_layerCornerRadius;
+- (void)setLayerCornerRadius:(CGFloat)layerCornerRadius {
+  self.layerCornerRadiusAssigned = YES;
+  _layerCornerRadius = layerCornerRadius;
   [self setNeedsLayout];
 }
 
 - (CGFloat)cornerRadius {
-  if (self.ismdc_layerCornerRadiusAssigned) {
-    return self.mdc_layerCornerRadius;
+  if (self.isLayerCornerRadiusAssigned) {
+    return self.layerCornerRadius;
   }
   return 2;
 }

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -57,6 +57,7 @@ static NSString *const MDCButtonBorderColorsKey = @"MDCButtonBorderColorsKey";
 static NSString *const MDCButtonBorderWidthsKey = @"MDCButtonBorderWidthsKey";
 
 static NSString *const MDCButtonShadowColorsKey = @"MDCButtonShadowColorsKey";
+static NSString *const MDCButtonLayerCornerRadiusKey = @"MDCButtonLayerCornerRadiusKey";
 
 // Specified in Material Guidelines
 // https://material.io/guidelines/layout/metrics-keylines.html#metrics-keylines-touch-target-size
@@ -124,6 +125,8 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 }
 @property(nonatomic, strong) MDCInkView *inkView;
 @property(nonatomic, readonly, strong) MDCShadowLayer *layer;
+@property(nonatomic, assign, getter=ismdc_layerCornerRadiusAssigned)
+    BOOL mdc_layerCornerRadiusAssigned;
 @end
 
 @implementation MDCButton
@@ -212,6 +215,11 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
       _borderWidths = [aDecoder decodeObjectForKey:MDCButtonBorderWidthsKey];
     }
 
+    if ([aDecoder containsValueForKey:MDCButtonLayerCornerRadiusKey]) {
+      _mdc_layerCornerRadius = (CGFloat)[aDecoder decodeDoubleForKey:MDCButtonLayerCornerRadiusKey];
+      _mdc_layerCornerRadiusAssigned = YES;
+    }
+
     if ([aDecoder containsValueForKey:MDCButtonBackgroundColorsKey]) {
       _backgroundColors = [aDecoder decodeObjectForKey:MDCButtonBackgroundColorsKey];
     } else {
@@ -256,6 +264,9 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [aCoder encodeObject:_nontransformedTitles forKey:MDCButtonNontransformedTitlesKey];
   [aCoder encodeObject:_borderColors forKey:MDCButtonBorderColorsKey];
   [aCoder encodeObject:_borderWidths forKey:MDCButtonBorderWidthsKey];
+  if (self.ismdc_layerCornerRadiusAssigned) {
+    [aCoder encodeDouble:self.mdc_layerCornerRadius forKey:MDCButtonLayerCornerRadiusKey];
+  }
   if (_shadowColors) {
     [aCoder encodeObject:_shadowColors forKey:MDCButtonShadowColorsKey];
   }
@@ -786,8 +797,17 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   return [UIBezierPath bezierPathWithRoundedRect:self.bounds cornerRadius:[self cornerRadius]];
 }
 
+- (void)setMdc_layerCornerRadius:(CGFloat)mdc_layerCornerRadius {
+  self.mdc_layerCornerRadiusAssigned = YES;
+  _mdc_layerCornerRadius = mdc_layerCornerRadius;
+  [self setNeedsLayout];
+}
+
 - (CGFloat)cornerRadius {
-  return 2.0f;
+  if (self.ismdc_layerCornerRadiusAssigned) {
+    return self.mdc_layerCornerRadius;
+  }
+  return 2;
 }
 
 - (UIEdgeInsets)defaultContentEdgeInsets {

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -86,15 +86,17 @@ static NSString *controlStateDescription(UIControlState controlState) {
 static const CGFloat MDCButtonTestingSubclassRadius = 9;
 
 /*
- A simple testing subclass used to verify the behavior of mdc_layerCornerRadius.
+ A simple testing subclass used to verify the behavior of layerCornerRadius.
  */
 @interface MDCButtonTestingSubclass : MDCButton
 @end
 
 @implementation MDCButtonTestingSubclass
+
 - (CGFloat)cornerRadius {
   return MDCButtonTestingSubclassRadius;
 }
+
 @end
 
 @interface ButtonsTests : XCTestCase
@@ -509,7 +511,7 @@ static const CGFloat MDCButtonTestingSubclassRadius = 9;
   button.underlyingColorHint = randomColor();
   button.minimumSize = CGSizeMake(15, 33);
   button.maximumSize = CGSizeMake(17, 41);
-  button.mdc_layerCornerRadius = 5;
+  button.layerCornerRadius = 5;
   CGFloat buttonAlpha = 0.5;
   button.alpha = buttonAlpha;
   button.enabled = NO;
@@ -560,8 +562,8 @@ static const CGFloat MDCButtonTestingSubclassRadius = 9;
     XCTAssertEqualObjects([button shadowColorForState:controlState],
                           [unarchivedButton shadowColorForState:controlState]);
   }
-  XCTAssertEqualWithAccuracy(unarchivedButton.mdc_layerCornerRadius,
-                             button.mdc_layerCornerRadius,
+  XCTAssertEqualWithAccuracy(unarchivedButton.layerCornerRadius,
+                             button.layerCornerRadius,
                              0.0001);
 }
 
@@ -939,7 +941,7 @@ static const CGFloat MDCButtonTestingSubclassRadius = 9;
                 NSStringFromCGRect(button.frame));
 }
 
-#pragma mark - mdc_layerCornerRadius
+#pragma mark - layerCornerRadius
 
 - (void)testSettingMdcLayerCornerRadiusDoesNotImpactSubclasses {
   // Given
@@ -948,7 +950,7 @@ static const CGFloat MDCButtonTestingSubclassRadius = 9;
   XCTAssertEqualWithAccuracy(button.layer.cornerRadius, MDCButtonTestingSubclassRadius, 0.0001);
 
   // When
-  button.mdc_layerCornerRadius = MDCButtonTestingSubclassRadius + 2;
+  button.layerCornerRadius = MDCButtonTestingSubclassRadius + 2;
   [button layoutIfNeeded];
 
   // Then
@@ -964,7 +966,7 @@ static const CGFloat MDCButtonTestingSubclassRadius = 9;
 
   // When
   CGFloat expectedRadius = button.layer.cornerRadius + 1.5;
-  button.mdc_layerCornerRadius = expectedRadius;
+  button.layerCornerRadius = expectedRadius;
   [button layoutIfNeeded];
 
   // Then

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -16,6 +16,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import "MDCButton+Subclassing.h"
 #import "MaterialButtons.h"
 #import "MaterialShadowElevations.h"
 #import "MaterialTypography.h"
@@ -81,6 +82,20 @@ static NSString *controlStateDescription(UIControlState controlState) {
   }
   return [string copy];
 }
+
+static const CGFloat MDCButtonTestingSubclassRadius = 9;
+
+/*
+ A simple testing subclass used to verify the behavior of mdc_layerCornerRadius.
+ */
+@interface MDCButtonTestingSubclass : MDCButton
+@end
+
+@implementation MDCButtonTestingSubclass
+- (CGFloat)cornerRadius {
+  return MDCButtonTestingSubclassRadius;
+}
+@end
 
 @interface ButtonsTests : XCTestCase
 @end
@@ -494,6 +509,7 @@ static NSString *controlStateDescription(UIControlState controlState) {
   button.underlyingColorHint = randomColor();
   button.minimumSize = CGSizeMake(15, 33);
   button.maximumSize = CGSizeMake(17, 41);
+  button.mdc_layerCornerRadius = 5;
   CGFloat buttonAlpha = 0.5;
   button.alpha = buttonAlpha;
   button.enabled = NO;
@@ -544,6 +560,9 @@ static NSString *controlStateDescription(UIControlState controlState) {
     XCTAssertEqualObjects([button shadowColorForState:controlState],
                           [unarchivedButton shadowColorForState:controlState]);
   }
+  XCTAssertEqualWithAccuracy(unarchivedButton.mdc_layerCornerRadius,
+                             button.mdc_layerCornerRadius,
+                             0.0001);
 }
 
 - (void)testDecodeOnUpgradeFromVersionWithoutShadowColors {
@@ -918,6 +937,38 @@ static NSString *controlStateDescription(UIControlState controlState) {
                 @"\nE: %@\nA: %@",
                 NSStringFromCGRect(expectedFrame),
                 NSStringFromCGRect(button.frame));
+}
+
+#pragma mark - mdc_layerCornerRadius
+
+- (void)testSettingMdcLayerCornerRadiusDoesNotImpactSubclasses {
+  // Given
+  MDCButtonTestingSubclass *button = [[MDCButtonTestingSubclass alloc] initWithFrame:CGRectZero];
+  [button layoutIfNeeded];
+  XCTAssertEqualWithAccuracy(button.layer.cornerRadius, MDCButtonTestingSubclassRadius, 0.0001);
+
+  // When
+  button.mdc_layerCornerRadius = MDCButtonTestingSubclassRadius + 2;
+  [button layoutIfNeeded];
+
+  // Then
+  XCTAssertEqualWithAccuracy(button.layer.cornerRadius, MDCButtonTestingSubclassRadius, 0.0001);
+}
+
+- (void)testSettingCornerRadius {
+  // Given
+  MDCButton *button = [[MDCButton alloc] initWithFrame:CGRectZero];
+  [button layoutIfNeeded];
+  XCTAssertNotEqualWithAccuracy(button.layer.cornerRadius, 0, 0.0001);
+  XCTAssertEqualWithAccuracy(button.layer.cornerRadius, [button cornerRadius], 0.0001);
+
+  // When
+  CGFloat expectedRadius = button.layer.cornerRadius + 1.5;
+  button.mdc_layerCornerRadius = expectedRadius;
+  [button layoutIfNeeded];
+
+  // Then
+  XCTAssertEqualWithAccuracy(expectedRadius, button.layer.cornerRadius, 0.0001);
 }
 
 @end


### PR DESCRIPTION
As an intermediate step toward eliminating the |-cornerRadius| subclassing
method, a new property is introduced. When set, -cornerRadius will return the
value of mdc_layerCornerRadius instead of its default value.

Closes #2334