### PR TITLE
[ActivityIndicator] Extract motion spec and use the Material Motion Animator for all animations.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -47,6 +47,7 @@ Pod::Spec.new do |s|
       ss.dependency "MDFInternationalization"
       ss.dependency "MaterialComponents/Palettes"
       ss.dependency "MaterialComponents/private/Application"
+      ss.dependency "MotionAnimator", "~> 2.0"
     end
     ss.subspec "ColorThemer" do |sss|
       sss.ios.deployment_target = '8.0'

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,3 +35,15 @@ git_repository(
     remote = "https://github.com/material-foundation/material-text-accessibility-ios.git",
     commit = "fd570d71ae0124c75ad5af00e6b8b4b1668d5e40",
 )
+
+git_repository(
+    name = "motion_interchange_objc",
+    remote = "https://github.com/material-motion/motion-interchange-objc.git",
+    tag = "v1.2.0",
+)
+
+git_repository(
+    name = "motion_animator_objc",
+    remote = "https://github.com/material-motion/motion-animator-objc.git",
+    commit = "0f081454f5cea39a51e1575d9b961b4a9c7488c0",
+)

--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -31,6 +31,8 @@ mdc_public_objc_library(
       "//components/Palettes",
       "//components/private/Application",
       "@material_internationalization_ios//:MDFInternationalization",
+      "@motion_interchange_objc//:MotionInterchange",
+      "@motion_animator_objc//:MotionAnimator",
     ],
 )
 

--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -621,22 +621,22 @@ static const CGFloat kSingleCycleRotation =
   [_animator animateWithTiming:timing.outerRotation
                        toLayer:_outerRotationLayer
                     withValues:outerRotation
-                       keyPath:@"transform.rotation.z"];
+                       keyPath:MDMKeyPathRotation];
 
   [_animator animateWithTiming:timing.innerRotation
                        toLayer:_strokeLayer
                     withValues:innerRotation
-                       keyPath:@"transform.rotation.z"];
+                       keyPath:MDMKeyPathRotation];
 
   [_animator animateWithTiming:timing.strokeStart
                        toLayer:_strokeLayer
                     withValues:strokeStart
-                       keyPath:@"strokeStart"];
+                       keyPath:MDMKeyPathStrokeStart];
 
   [_animator animateWithTiming:timing.strokeEnd
                        toLayer:_strokeLayer
                     withValues:strokeEnd
-                       keyPath:@"strokeEnd"];
+                       keyPath:MDMKeyPathStrokeEnd];
 
   [CATransaction commit];
 }

--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -537,11 +537,11 @@ static const CGFloat kSingleCycleRotation =
     }];
     [CATransaction setDisableActions:YES];
 
-    _outerRotationLayer.transform = CATransform3DIdentity;
-    _strokeLayer.transform = CATransform3DIdentity;
-
     struct MDCActivityIndicatorMotionSpecTransitionToIndeterminate timing =
         kMotionSpec.transitionToIndeterminate;
+
+    _outerRotationLayer.transform = CATransform3DIdentity;
+    _strokeLayer.transform = CATransform3DIdentity;
 
     timing.strokeStart.duration = strokeStartDuration;
     timing.strokeStart.delay = strokeEndDuration;
@@ -593,14 +593,14 @@ static const CGFloat kSingleCycleRotation =
       [CATransaction setDisableActions:YES];
       [CATransaction mdm_setTimeScaleFactor:@(duration)];
 
-      _strokeLayer.strokeStart = 0;
-
       CGFloat startRotation = _cycleCount * (CGFloat)M_PI;
       CGFloat endRotation = startRotation + rotationDelta * 2.0f * (CGFloat)M_PI;
       [_animator animateWithTiming:kMotionSpec.transitionToDeterminate.innerRotation
                            toLayer:_strokeLayer
                         withValues:@[@(startRotation), @(endRotation)]
                            keyPath:MDMKeyPathRotation];
+
+      _strokeLayer.strokeStart = 0;
 
       [_animator animateWithTiming:kMotionSpec.transitionToDeterminate.strokeEnd
                            toLayer:_strokeLayer

--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -20,6 +20,8 @@
 
 #import "MDFInternationalization.h"
 #import "MaterialApplication.h"
+#import "MotionAnimator.h"
+#import "private/MDCActivityIndicatorMotionSpec.h"
 #import "private/MDCActivityIndicator+Private.h"
 #import "private/MaterialActivityIndicatorStrings.h"
 #import "private/MaterialActivityIndicatorStrings_table.h"
@@ -27,9 +29,6 @@
 
 static const NSInteger kTotalDetentCount = 5;
 static const NSTimeInterval kAnimateOutDuration = 0.1f;
-static const NSTimeInterval kPointCycleDuration = 4.0f / 3.0f;
-static const NSTimeInterval kPointCycleMinimumVariableDuration =
-    kPointCycleDuration / 8;
 static const CGFloat kCycleRotation = 3.0f / 2.0f;
 static const CGFloat kOuterRotationIncrement =
     (1.0f / kTotalDetentCount) * (CGFloat)M_PI;
@@ -106,6 +105,8 @@ static const CGFloat kSingleCycleRotation =
   BOOL _cycleInProgress;
   CGFloat _currentProgress;
   CGFloat _lastProgress;
+
+  MDMMotionAnimator *_animator;
 }
 
 #pragma mark - Init
@@ -162,6 +163,9 @@ static const CGFloat kSingleCycleRotation =
   // The activity indicator reflects the passage of time (a spatial semantic context) and so
   // will not be mirrored in RTL languages.
   self.mdf_semanticContentAttribute = UISemanticContentAttributeSpatial;
+
+  _animator = [[MDMMotionAnimator alloc] init];
+  _animator.additive = NO;
 
   _cycleStartIndex = 0;
   _indicatorMode = MDCActivityIndicatorModeIndeterminate;
@@ -443,66 +447,28 @@ static const CGFloat kSingleCycleRotation =
   }
 
   [CATransaction begin];
-  {
-    [CATransaction setCompletionBlock:^{
-      [self strokeRotationCycleFinishedFromState:MDCActivityIndicatorStateIndeterminate];
-    }];
+  [CATransaction setCompletionBlock:^{
+    [self strokeRotationCycleFinishedFromState:MDCActivityIndicatorStateIndeterminate];
+  }];
 
-    // Outer 5-point star detent rotation.
-    CABasicAnimation *outerRotationAnimation =
-        [CABasicAnimation animationWithKeyPath:@"transform.rotation.z"];
-    outerRotationAnimation.duration = kPointCycleDuration;
-    outerRotationAnimation.fromValue = @(kOuterRotationIncrement * _cycleCount);
-    outerRotationAnimation.toValue = @(kOuterRotationIncrement * (_cycleCount + 1));
-    outerRotationAnimation.fillMode = kCAFillModeForwards;
-    outerRotationAnimation.removedOnCompletion = NO;
-    [_outerRotationLayer addAnimation:outerRotationAnimation forKey:@"transform.rotation.z"];
-
-    // Stroke rotation.
-    CGFloat startRotation = _cycleCount * (CGFloat)M_PI;
-    CGFloat endRotation = startRotation + kCycleRotation * (CGFloat)M_PI;
-
-    CABasicAnimation *strokeRotationAnimation =
-        [CABasicAnimation animationWithKeyPath:@"transform.rotation.z"];
-    strokeRotationAnimation.duration = kPointCycleDuration;
-    strokeRotationAnimation.fromValue = @(startRotation);
-    strokeRotationAnimation.toValue = @(endRotation);
-    strokeRotationAnimation.fillMode = kCAFillModeForwards;
-    strokeRotationAnimation.removedOnCompletion = NO;
-    [_strokeLayer addAnimation:strokeRotationAnimation forKey:@"transform.rotation.z"];
-
-    // Stroke start.
-    CABasicAnimation *strokeStartPathAnimation =
-        [CABasicAnimation animationWithKeyPath:@"strokeStart"];
-    strokeStartPathAnimation.duration = kPointCycleDuration / 2;
-    // It is always critical to convertTime:fromLayer: for animations, since changes to layer.speed
-    // on this layer or parent layers will alter the offset of beginTime.
-    CFTimeInterval currentTime = [_strokeLayer convertTime:CACurrentMediaTime() fromLayer:nil];
-    strokeStartPathAnimation.beginTime = currentTime + kPointCycleDuration / 2;
-    strokeStartPathAnimation.fromValue = @(0.0f);
-    strokeStartPathAnimation.toValue = @(kStrokeLength);
-    strokeStartPathAnimation.timingFunction = [self materialEaseInOut];
-    strokeStartPathAnimation.fillMode = kCAFillModeBoth;
-    strokeStartPathAnimation.removedOnCompletion = NO;
-    [_strokeLayer addAnimation:strokeStartPathAnimation forKey:@"strokeStart"];
-
-    // Stroke end.
-    CABasicAnimation *strokeEndPathAnimation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
-    strokeEndPathAnimation.duration = kPointCycleDuration;
-    // These values may be equal if we've never received a progress. In this case we don't want our
-    // duration to become zero.
-    if (fabs(_lastProgress - _currentProgress) > CGFLOAT_EPSILON) {
-      strokeEndPathAnimation.duration *= ABS(_lastProgress - _currentProgress);
-    }
-    // Ensure the stroke never completely disappears on start by animating from non-zero start and
-    // to a value slightly larger than the strokeStart's final value.
-    strokeEndPathAnimation.fromValue = @(_minStrokeDifference);
-    strokeEndPathAnimation.toValue = @(kStrokeLength + _minStrokeDifference);
-    strokeEndPathAnimation.timingFunction = [self materialEaseInOut];
-    strokeEndPathAnimation.fillMode = kCAFillModeBoth;
-    strokeEndPathAnimation.removedOnCompletion = NO;
-    [_strokeLayer addAnimation:strokeEndPathAnimation forKey:@"strokeEnd"];
+  MDCActivityIndicatorTiming timing = kMotionSpec.indeterminate;
+  // These values may be equal if we've never received a progress. In this case we don't want our
+  // duration to become zero.
+  if (fabs(_lastProgress - _currentProgress) > CGFLOAT_EPSILON) {
+    timing.strokeEnd.duration *= ABS(_lastProgress - _currentProgress);
   }
+
+  CGFloat startRotation = _cycleCount * (CGFloat)M_PI;
+  CGFloat endRotation = startRotation + kCycleRotation * (CGFloat)M_PI;
+  [self animateWithTiming:timing
+            outerRotation:@[@(kOuterRotationIncrement * _cycleCount),
+                            @(kOuterRotationIncrement * (_cycleCount + 1))]
+            innerRotation:@[@(startRotation), @(endRotation)]
+              strokeStart:@[@0, @(kStrokeLength)]
+   // Ensure the stroke never completely disappears on start by animating from non-zero start and
+   // to a value slightly larger than the strokeStart's final value.
+                strokeEnd:@[@(_minStrokeDifference), @(kStrokeLength + _minStrokeDifference)]];
+
   [CATransaction commit];
 
   _animationInProgress = YES;
@@ -556,31 +522,16 @@ static const CGFloat kSingleCycleRotation =
           strokeRotationCycleFinishedFromState:MDCActivityIndicatorStateTransitionToIndeterminate];
     }];
 
-    // Stroke start.
-    CABasicAnimation *strokeStartPathAnimation =
-        [CABasicAnimation animationWithKeyPath:@"strokeStart"];
-    strokeStartPathAnimation.duration = strokeStartDuration;
-    CFTimeInterval currentTime = [_strokeLayer convertTime:CACurrentMediaTime() fromLayer:nil];
-    strokeStartPathAnimation.beginTime = currentTime + strokeEndDuration;
-    strokeStartPathAnimation.fromValue = @(0.0f);
-    strokeStartPathAnimation.toValue = @(targetRotation);
-    strokeStartPathAnimation.timingFunction = [self materialEaseInOut];
-    ;
-    strokeStartPathAnimation.fillMode = kCAFillModeBoth;
-    strokeStartPathAnimation.removedOnCompletion = NO;
-    [_strokeLayer addAnimation:strokeStartPathAnimation forKey:@"strokeStart"];
-
-    // Stroke end.
-    CABasicAnimation *strokeEndPathAnimation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
-    strokeEndPathAnimation.duration = strokeEndDuration;
-    // Ensure the stroke never completely disappears on start by animating from non-zero start and
-    // to a value slightly larger than the strokeStart's final value.
-    strokeEndPathAnimation.fromValue = @(_currentProgress);
-    strokeEndPathAnimation.toValue = @(targetRotation + _minStrokeDifference);
-    strokeEndPathAnimation.timingFunction = [self materialEaseInOut];
-    strokeEndPathAnimation.fillMode = kCAFillModeBoth;
-    strokeEndPathAnimation.removedOnCompletion = NO;
-    [_strokeLayer addAnimation:strokeEndPathAnimation forKey:@"strokeEnd"];
+    MDCActivityIndicatorTiming timing = kMotionSpec.transitionToIndeterminate;
+    timing.strokeStart.duration = strokeStartDuration;
+    timing.strokeStart.delay = strokeEndDuration;
+    timing.strokeEnd.duration = strokeEndDuration;
+    timing.strokeEnd.delay = 0;
+    [self animateWithTiming:timing
+              outerRotation:@[@0, @0]
+              innerRotation:@[@0, @0]
+                strokeStart:@[@0, @(targetRotation)]
+                  strokeEnd:@[@(_currentProgress), @(targetRotation + _minStrokeDifference)]];
   }
   [CATransaction commit];
 
@@ -607,8 +558,8 @@ static const CGFloat kSingleCycleRotation =
     // Change the duration relative to the distance in order to keep same relative speed.
     CGFloat duration = 2.0f * (rotationDelta + _currentProgress) / kSingleCycleRotation *
                        (CGFloat)kPointCycleDuration;
-
     duration = MAX(duration, (CGFloat)kPointCycleMinimumVariableDuration);
+
     [CATransaction begin];
     {
       [CATransaction setCompletionBlock:^{
@@ -616,69 +567,22 @@ static const CGFloat kSingleCycleRotation =
             strokeRotationCycleFinishedFromState:MDCActivityIndicatorStateTransitionToDeterminate];
       }];
 
-      // Outer 5-point star detent rotation. Required for passing from transitionToIndeterminate to
-      // transitionToDeterminate.
-      CABasicAnimation *outerRotationAnimation =
-          [CABasicAnimation animationWithKeyPath:@"transform.rotation.z"];
-      outerRotationAnimation.duration = duration;
-      outerRotationAnimation.fromValue = @(kOuterRotationIncrement * _cycleCount);
-      outerRotationAnimation.toValue = @(kOuterRotationIncrement * _cycleCount);
-      outerRotationAnimation.fillMode = kCAFillModeForwards;
-      outerRotationAnimation.removedOnCompletion = NO;
-      [_outerRotationLayer addAnimation:outerRotationAnimation forKey:@"transform.rotation.z"];
+      [CATransaction mdm_setTimeScaleFactor:@(duration)];
 
-      // Stroke rotation.
       CGFloat startRotation = _cycleCount * (CGFloat)M_PI;
       CGFloat endRotation = startRotation + rotationDelta * 2.0f * (CGFloat)M_PI;
-
-      CABasicAnimation *strokeRotationAnimation =
-          [CABasicAnimation animationWithKeyPath:@"transform.rotation.z"];
-      strokeRotationAnimation.duration = duration;
-      strokeRotationAnimation.fromValue = @(startRotation);
-      strokeRotationAnimation.toValue = @(endRotation);
-      strokeRotationAnimation.fillMode = kCAFillModeForwards;
-      strokeRotationAnimation.removedOnCompletion = NO;
-      [_strokeLayer addAnimation:strokeRotationAnimation forKey:@"transform.rotation.z"];
-
-      // Stroke start.
-      CABasicAnimation *strokeStartPathAnimation =
-          [CABasicAnimation animationWithKeyPath:@"strokeStart"];
-      strokeStartPathAnimation.duration = duration;
-      // It is always critical to convertTime:fromLayer: for animations, since changes to
-      // layer.speed on this layer or parent layers will alter the offset of beginTime.
-      CFTimeInterval currentTime = [_strokeLayer convertTime:CACurrentMediaTime() fromLayer:nil];
-      strokeStartPathAnimation.beginTime = currentTime;
-      strokeStartPathAnimation.fromValue = @(0.0f);
-      strokeStartPathAnimation.toValue = @(0.0f);
-      strokeStartPathAnimation.timingFunction = [self materialEaseInOut];
-      strokeStartPathAnimation.fillMode = kCAFillModeBoth;
-      strokeStartPathAnimation.removedOnCompletion = NO;
-      [_strokeLayer addAnimation:strokeStartPathAnimation forKey:@"strokeStart"];
-
-      // Stroke end.
-      CABasicAnimation *strokeEndPathAnimation =
-          [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
-      strokeEndPathAnimation.duration = duration;
-      // Ensure the stroke never completely disappears on start by animating from non-zero start and
-      // to a value slightly larger than the strokeStart's final value.
-      strokeEndPathAnimation.fromValue = @(_minStrokeDifference);
-      strokeEndPathAnimation.toValue = @(_currentProgress);
-      strokeEndPathAnimation.timingFunction = [self materialEaseInOut];
-      strokeEndPathAnimation.fillMode = kCAFillModeBoth;
-      strokeEndPathAnimation.removedOnCompletion = NO;
-      [_strokeLayer addAnimation:strokeEndPathAnimation forKey:@"strokeEnd"];
+      [self animateWithTiming:kMotionSpec.transitionToDeterminate
+                outerRotation:@[@(kOuterRotationIncrement * _cycleCount),
+                                @(kOuterRotationIncrement * _cycleCount)]
+                innerRotation:@[@(startRotation), @(endRotation)]
+                  strokeStart:@[@0, @0]
+                    strokeEnd:@[@(_minStrokeDifference), @(_currentProgress)]];
     }
     [CATransaction commit];
 
     _animationInProgress = YES;
     _lastProgress = _currentProgress;
   }
-}
-
-- (CAMediaTimingFunction *)materialEaseInOut {
-  // This curve is slow both at the beginning and end.
-  // Visualization of curve  http://cubic-bezier.com/#.4,0,.2,1
-  return [[CAMediaTimingFunction alloc] initWithControlPoints:0.4f:0.0f:0.2f:1.0f];
 }
 
 - (void)addProgressAnimation {
@@ -694,21 +598,47 @@ static const CGFloat kSingleCycleRotation =
       [self strokeRotationCycleFinishedFromState:MDCActivityIndicatorStateDeterminate];
     }];
 
-    // Stroke end.
-    CABasicAnimation *strokeEndPathAnimation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
-    strokeEndPathAnimation.duration = kPointCycleDuration / 2;
-    strokeEndPathAnimation.fromValue = @(_lastProgress);
-    strokeEndPathAnimation.toValue = @(_currentProgress);
-    strokeEndPathAnimation.timingFunction = [self materialEaseInOut];
-    strokeEndPathAnimation.fillMode = kCAFillModeBoth;
-    strokeEndPathAnimation.removedOnCompletion = NO;
-    [_strokeLayer addAnimation:strokeEndPathAnimation forKey:@"strokeEnd"];
+    [self animateWithTiming:kMotionSpec.progress
+              outerRotation:@[@0, @0]
+              innerRotation:@[@0, @0]
+                strokeStart:@[@0, @0]
+                  strokeEnd:@[@(_lastProgress), @(_currentProgress)]];
   }
 
   [CATransaction commit];
 
   _lastProgress = _currentProgress;
   _animationInProgress = YES;
+}
+
+- (void)animateWithTiming:(MDCActivityIndicatorTiming)timing
+            outerRotation:(NSArray *)outerRotation
+            innerRotation:(NSArray *)innerRotation
+              strokeStart:(NSArray *)strokeStart
+                strokeEnd:(NSArray *)strokeEnd {
+  [CATransaction begin];
+
+  [_animator animateWithTiming:timing.outerRotation
+                       toLayer:_outerRotationLayer
+                    withValues:outerRotation
+                       keyPath:@"transform.rotation.z"];
+
+  [_animator animateWithTiming:timing.innerRotation
+                       toLayer:_strokeLayer
+                    withValues:innerRotation
+                       keyPath:@"transform.rotation.z"];
+
+  [_animator animateWithTiming:timing.strokeStart
+                       toLayer:_strokeLayer
+                    withValues:strokeStart
+                       keyPath:@"strokeStart"];
+
+  [_animator animateWithTiming:timing.strokeEnd
+                       toLayer:_strokeLayer
+                    withValues:strokeEnd
+                       keyPath:@"strokeEnd"];
+
+  [CATransaction commit];
 }
 
 - (void)strokeRotationCycleFinishedFromState:(MDCActivityIndicatorState)state {

--- a/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.h
+++ b/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.h
@@ -1,0 +1,41 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MotionInterchange.h"
+
+struct MDCActivityIndicatorTiming {
+  MDMMotionTiming outerRotation;
+  MDMMotionTiming innerRotation;
+  MDMMotionTiming strokeStart;
+  MDMMotionTiming strokeEnd;
+};
+typedef struct MDCActivityIndicatorTiming MDCActivityIndicatorTiming;
+
+struct MDCActivityIndicatorMotionSpec {
+  MDCActivityIndicatorTiming indeterminate;
+  MDCActivityIndicatorTiming transitionToDeterminate;
+  MDCActivityIndicatorTiming transitionToIndeterminate;
+  MDCActivityIndicatorTiming progress;
+};
+typedef struct MDCActivityIndicatorMotionSpec MDCActivityIndicatorMotionSpec;
+
+FOUNDATION_EXPORT const NSTimeInterval kPointCycleDuration;
+FOUNDATION_EXPORT const NSTimeInterval kPointCycleMinimumVariableDuration;
+
+// The complete motion spec for the activity indicator.
+FOUNDATION_EXPORT struct MDCActivityIndicatorMotionSpec kMotionSpec;

--- a/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.h
+++ b/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.h
@@ -18,24 +18,32 @@
 
 #import "MotionInterchange.h"
 
-struct MDCActivityIndicatorTiming {
-  MDMMotionTiming outerRotation;
-  MDMMotionTiming innerRotation;
-  MDMMotionTiming strokeStart;
-  MDMMotionTiming strokeEnd;
-};
-typedef struct MDCActivityIndicatorTiming MDCActivityIndicatorTiming;
-
 struct MDCActivityIndicatorMotionSpec {
-  MDCActivityIndicatorTiming indeterminate;
-  MDCActivityIndicatorTiming transitionToDeterminate;
-  MDCActivityIndicatorTiming transitionToIndeterminate;
-  MDCActivityIndicatorTiming progress;
+  struct MDCActivityIndicatorMotionSpecIndeterminate {
+    MDMMotionTiming outerRotation;
+    MDMMotionTiming innerRotation;
+    MDMMotionTiming strokeStart;
+    MDMMotionTiming strokeEnd;
+  } indeterminate;
+
+  struct MDCActivityIndicatorMotionSpecTransitionToDeterminate {
+    MDMMotionTiming innerRotation;
+    MDMMotionTiming strokeEnd;
+  } transitionToDeterminate;
+
+  struct MDCActivityIndicatorMotionSpecTransitionToIndeterminate {
+    MDMMotionTiming strokeStart;
+    MDMMotionTiming strokeEnd;
+  } transitionToIndeterminate;
+
+  struct MDCActivityIndicatorMotionSpecProgress {
+    MDMMotionTiming strokeEnd;
+  } progress;
 };
 typedef struct MDCActivityIndicatorMotionSpec MDCActivityIndicatorMotionSpec;
 
 FOUNDATION_EXPORT const NSTimeInterval kPointCycleDuration;
 FOUNDATION_EXPORT const NSTimeInterval kPointCycleMinimumVariableDuration;
 
-// The complete motion spec for the activity indicator.
-FOUNDATION_EXPORT struct MDCActivityIndicatorMotionSpec kMotionSpec;
+FOUNDATION_EXPORT const struct MDCActivityIndicatorMotionSpec kMotionSpec;
+

--- a/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.m
+++ b/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.m
@@ -19,7 +19,7 @@
 const NSTimeInterval kPointCycleDuration = 4.0f / 3.0f;
 const NSTimeInterval kPointCycleMinimumVariableDuration = kPointCycleDuration / 8;
 
-struct MDCActivityIndicatorMotionSpec kMotionSpec = {
+const struct MDCActivityIndicatorMotionSpec kMotionSpec = {
   .indeterminate = {
     .outerRotation = {
       .duration = kPointCycleDuration, .curve = _MDMBezier(0, 0, 1, 1),
@@ -40,14 +40,8 @@ struct MDCActivityIndicatorMotionSpec kMotionSpec = {
   .transitionToDeterminate = {
     // Transition timing is calculated at runtime - any duration/delay values provided here will
     // by scaled by the calculated duration.
-    .outerRotation = {
-      .duration = 1, .curve = _MDMBezier(0, 0, 1, 1),
-    },
     .innerRotation = {
       .duration = 1, .curve = _MDMBezier(0, 0, 1, 1),
-    },
-    .strokeStart = {
-      .duration = 1, .curve = _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f),
     },
     .strokeEnd = {
       .duration = 1, .curve = _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f),
@@ -66,6 +60,7 @@ struct MDCActivityIndicatorMotionSpec kMotionSpec = {
     .strokeEnd = {
       .duration = kPointCycleDuration / 2,
       .curve = _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f),
-    },
+    }
   }
 };
+

--- a/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.m
+++ b/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.m
@@ -1,0 +1,71 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCActivityIndicatorMotionSpec.h"
+
+const NSTimeInterval kPointCycleDuration = 4.0f / 3.0f;
+const NSTimeInterval kPointCycleMinimumVariableDuration = kPointCycleDuration / 8;
+
+struct MDCActivityIndicatorMotionSpec kMotionSpec = {
+  .indeterminate = {
+    .outerRotation = {
+      .duration = kPointCycleDuration, .curve = _MDMBezier(0, 0, 1, 1),
+    },
+    .innerRotation = {
+      .duration = kPointCycleDuration, .curve = _MDMBezier(0, 0, 1, 1),
+    },
+    .strokeStart = {
+      .delay = kPointCycleDuration / 2,
+      .duration = kPointCycleDuration / 2,
+      .curve = _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f),
+    },
+    .strokeEnd = {
+      .duration = kPointCycleDuration,
+      .curve = _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f),
+    },
+  },
+  .transitionToDeterminate = {
+    // Transition timing is calculated at runtime - any duration/delay values provided here will
+    // by scaled by the calculated duration.
+    .outerRotation = {
+      .duration = 1, .curve = _MDMBezier(0, 0, 1, 1),
+    },
+    .innerRotation = {
+      .duration = 1, .curve = _MDMBezier(0, 0, 1, 1),
+    },
+    .strokeStart = {
+      .duration = 1, .curve = _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f),
+    },
+    .strokeEnd = {
+      .duration = 1, .curve = _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f),
+    },
+  },
+  .transitionToIndeterminate = {
+    // Transition timing is calculated at runtime.
+    .strokeStart = {
+      .curve = _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f),
+    },
+    .strokeEnd = {
+      .curve = _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f),
+    },
+  },
+  .progress = {
+    .strokeEnd = {
+      .duration = kPointCycleDuration / 2,
+      .curve = _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f),
+    },
+  }
+};


### PR DESCRIPTION
This conversion revealed a bug in the motion timing where the indeterminate strokeEnd animation's duration was inheriting Core Animation's default duration of 0.25 seconds rather than the spec's duration. This resulted in the stroke animating in a much more jarring way than intended. This bug was fixed in https://github.com/material-components/material-components-ios/pull/2345.

Before:
![before](https://user-images.githubusercontent.com/45670/32393512-25f82ada-c0b0-11e7-91a6-dd9f9bfddb4a.gif)

After:

![after](https://user-images.githubusercontent.com/45670/32393515-2a19fb66-c0b0-11e7-8cf3-683c75f1aae6.gif)

(The gifs don't loop perfectly so there are some hitches in the animations).