### PR TITLE
[ActivityIndicator] Fix bug where the indeterminate animation stroke end would animate too quickly

### DIFF
--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -36,6 +36,14 @@ static const CGFloat kOuterRotationIncrement =
 static const CGFloat kSpinnerRadius = 12.f;
 static const CGFloat kStrokeLength = 0.75f;
 
+#ifndef CGFLOAT_EPSILON
+#if CGFLOAT_IS_DOUBLE
+#define CGFLOAT_EPSILON DBL_EPSILON
+#else
+#define CGFLOAT_EPSILON FLT_EPSILON
+#endif
+#endif
+
 // The Bundle for string resources.
 static NSString *const kBundle = @"MaterialActivityIndicator.bundle";
 
@@ -480,8 +488,12 @@ static const CGFloat kSingleCycleRotation =
 
     // Stroke end.
     CABasicAnimation *strokeEndPathAnimation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
-    strokeEndPathAnimation.duration =
-        kPointCycleDuration * ABS(_lastProgress - _currentProgress);
+    strokeEndPathAnimation.duration = kPointCycleDuration;
+    // These values may be equal if we've never received a progress. In this case we don't want our
+    // duration to become zero.
+    if (fabs(_lastProgress - _currentProgress) > CGFLOAT_EPSILON) {
+      strokeEndPathAnimation.duration *= ABS(_lastProgress - _currentProgress);
+    }
     // Ensure the stroke never completely disappears on start by animating from non-zero start and
     // to a value slightly larger than the strokeStart's final value.
     strokeEndPathAnimation.fromValue = @(_minStrokeDifference);


### PR DESCRIPTION
Prior to this change we were accidentally setting the strokeEnd animation's duration to 0, which would cause Core Animation to use its default animation duration of 0.25 rather than the desired motion timing duration. The result was an animation that animated much more jarringly.

The animation now aligns more closely with the intended behavior.

Before:
![before](https://user-images.githubusercontent.com/45670/32393512-25f82ada-c0b0-11e7-91a6-dd9f9bfddb4a.gif)

After:

![after](https://user-images.githubusercontent.com/45670/32393515-2a19fb66-c0b0-11e7-8cf3-683c75f1aae6.gif)

(The gifs don't loop perfectly so there are some hitches in the animations).