### PR TITLE
[Collections] Change image when accessoryType changes

### DIFF
--- a/components/CollectionCells/src/MDCCollectionViewCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewCell.m
@@ -222,7 +222,8 @@ NSString *const kDeselectedCellAccessibilityHintKey =
 - (void)setAccessoryType:(MDCCollectionViewCellAccessoryType)accessoryType {
   _accessoryType = accessoryType;
 
-  UIImageView *accessoryImageView = nil;
+  UIImageView *accessoryImageView =
+      [_accessoryView isKindOfClass:[UIImageView class]] ? (UIImageView *)_accessoryView : nil;
   if (!_accessoryView && accessoryType != MDCCollectionViewCellAccessoryNone) {
     // Add accessory view.
     accessoryImageView = [[MDCAccessoryTypeImageView alloc] initWithFrame:CGRectZero];

--- a/components/CollectionCells/tests/unit/MDCCollectionViewCellTests.m
+++ b/components/CollectionCells/tests/unit/MDCCollectionViewCellTests.m
@@ -1,0 +1,42 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing software
+ distributed under the License is distributed on an "AS IS" BASIS
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import "MaterialCollections.h"
+
+@interface MDCCollectionViewCellTests : XCTestCase
+
+@end
+
+@implementation MDCCollectionViewCellTests
+
+- (void)testAccessoryChange {
+  // Given
+  MDCCollectionViewCell *cell = [[MDCCollectionViewCell alloc] initWithFrame:CGRectZero];
+  cell.accessoryType = MDCCollectionViewCellAccessoryCheckmark;
+  XCTAssertTrue([cell.accessoryView isKindOfClass:[UIImageView class]]);
+  UIImageView *accessoryImageView = (UIImageView *)cell.accessoryView;
+  UIImage *originalImage = accessoryImageView.image;
+
+  // When
+  cell.accessoryType = MDCCollectionViewCellAccessoryDetailButton;
+
+  // Then
+  UIImage *newImage = accessoryImageView.image;
+  XCTAssertNotEqualObjects(originalImage, newImage);
+}
+
+@end


### PR DESCRIPTION
Clients were unable to change the image of a cell's accessory type without
reloading the entire cell in the collectionView.

Closes #2353
