### PR TITLE
[BottomNavigation] Fix example using iOS 10 API

### DIFF
--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -76,7 +76,12 @@
                                       tag:0];
   tabBarItem5.badgeValue = @"999+";
 #if defined(__IPHONE_10_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0)
-  tabBarItem5.badgeColor = [MDCPalette cyanPalette].accent700;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+  if ([tabBarItem5 respondsToSelector:@selector(badgeColor)]) {
+    tabBarItem5.badgeColor = [MDCPalette cyanPalette].accent700;
+  }
+#pragma clang diagnostic pop
 #endif
   _bottomNavBar.items = @[ tabBarItem1, tabBarItem2, tabBarItem3, tabBarItem4, tabBarItem5 ];
   _bottomNavBar.selectedItem = tabBarItem2;


### PR DESCRIPTION
The typical use example uses an iOS 10-only API and needs an @available check
to silence warnings.

Closes #2355
