### PR TITLE
[Slider] Use MDCPalettes for default thumb track color

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -421,6 +421,7 @@ Pod::Spec.new do |mdc|
       spec.public_header_files = "components/#{component.base_name}/src/*.h"
       spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
 
+      spec.dependency "MaterialComponents/Palettes"
       spec.dependency "MaterialComponents/private/ThumbTrack"
     end
     component.subspec "ColorThemer" do |spec|

--- a/components/Slider/src/MDCSlider.m
+++ b/components/Slider/src/MDCSlider.m
@@ -17,6 +17,7 @@
 #import "MDCSlider.h"
 
 #import "private/MDCSlider_Subclassable.h"
+#import "MaterialPalettes.h"
 #import "MaterialThumbTrack.h"
 
 static const CGFloat kSliderDefaultWidth = 100.0f;
@@ -26,15 +27,8 @@ static const CGFloat kSliderThumbRadius = 6.0f;
 static const CGFloat kSliderAccessibilityIncrement = 0.1f;  // Matches UISlider's percent increment.
 static const CGFloat kSliderLightThemeTrackAlpha = 0.26f;
 
-// Blue 500 from https://material.io/guidelines/style/color.html#color-color-palette .
-static const uint32_t MDCBlueColor = 0x2196F3;
-
-// Creates a UIColor from a 24-bit RGB color encoded as an integer.
-static inline UIColor *MDCColorFromRGB(uint32_t rgbValue) {
-  return [UIColor colorWithRed:((CGFloat)((rgbValue & 0xFF0000) >> 16)) / 255
-                         green:((CGFloat)((rgbValue & 0x00FF00) >> 8)) / 255
-                          blue:((CGFloat)((rgbValue & 0x0000FF) >> 0)) / 255
-                         alpha:1];
+static inline UIColor *MDCThumbTrackDefaultColor(void) {
+  return MDCPalette.bluePalette.tint500;
 }
 
 @interface MDCSlider () <MDCThumbTrackDelegate>
@@ -61,7 +55,7 @@ static inline UIColor *MDCColorFromRGB(uint32_t rgbValue) {
 
 - (void)commonMDCSliderInit {
   _thumbTrack =
-      [[MDCThumbTrack alloc] initWithFrame:self.bounds onTintColor:[[self class] defaultColor]];
+      [[MDCThumbTrack alloc] initWithFrame:self.bounds onTintColor:MDCThumbTrackDefaultColor()];
   _thumbTrack.delegate = self;
   _thumbTrack.disabledTrackHasThumbGaps = YES;
   _thumbTrack.trackEndsAreInset = YES;
@@ -106,7 +100,7 @@ static inline UIColor *MDCColorFromRGB(uint32_t rgbValue) {
 }
 
 - (void)setColor:(UIColor *)color {
-  _thumbTrack.primaryColor = color ? color : [[self class] defaultColor];
+  _thumbTrack.primaryColor = color ? color : MDCThumbTrackDefaultColor();
 }
 
 - (UIColor *)color {
@@ -327,10 +321,6 @@ static inline UIColor *MDCColorFromRGB(uint32_t rgbValue) {
 
 - (void)thumbTrackTouchCanceled:(__unused MDCThumbTrack *)thumbTrack {
   [self sendActionsForControlEvents:UIControlEventTouchCancel];
-}
-
-+ (UIColor *)defaultColor {
-  return MDCColorFromRGB(MDCBlueColor);
 }
 
 + (UIColor *)defaultTrackOffColor {

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -16,22 +16,12 @@
 
 #import <XCTest/XCTest.h>
 
+#import "MaterialPalettes.h"
 #import "MaterialThumbTrack.h"
 #import "MaterialSlider.h"
 
 static const int kNumberOfRepeats = 20;
 static const CGFloat kEpsilonAccuracy = 0.001f;
-
-// Blue 500 from https://material.io/guidelines/style/color.html#color-color-palette .
-static const uint32_t MDCBlueColor = 0x2196F3;
-
-// Creates a UIColor from a 24-bit RGB color encoded as an integer.
-static inline UIColor *MDCColorFromRGB(uint32_t rgbValue) {
-  return [UIColor colorWithRed:((CGFloat)((rgbValue & 0xFF0000) >> 16)) / 255
-                         green:((CGFloat)((rgbValue & 0x00FF00) >> 8)) / 255
-                          blue:((CGFloat)((rgbValue & 0x0000FF) >> 0)) / 255
-                         alpha:1];
-}
 
 @interface MDCSlider (TestInterface)
 
@@ -452,7 +442,7 @@ static inline UIColor *MDCColorFromRGB(uint32_t rgbValue) {
 #pragma mark private test helpers
 
 - (UIColor *)blueColor {
-  return MDCColorFromRGB(MDCBlueColor);
+  return MDCPalette.bluePalette.tint500;
 }
 
 - (CGFloat)randomNumber {


### PR DESCRIPTION
Partially addresses #1221 and #1222.