### PR TITLE
[AnimationTiming] Rename animation timing curves to match spec.

### DIFF
--- a/components/AnimationTiming/src/CAMediaTimingFunction+MDCAnimationTiming.h
+++ b/components/AnimationTiming/src/CAMediaTimingFunction+MDCAnimationTiming.h
@@ -28,21 +28,21 @@ typedef NS_ENUM(NSUInteger, MDCAnimationTimingFunction) {
    is slow both at the beginning and end. It has similar characteristics to the system's EaseInOut.
    This is known as Standard in the Material Design spec.
    */
-  MDCAnimationTimingFunctionEaseInOut,
+  MDCAnimationTimingFunctionStandard,
 
   /**
    This curve should be used for motion when entering frame or when fading in from 0% opacity. This
    curve is slow at the end. It has similar characteristics to the system's EaseOut. This is known
    as Deceleration in the Material Design spec.
    */
-  MDCAnimationTimingFunctionEaseOut,
+  MDCAnimationTimingFunctionDeceleration,
 
   /**
    This curve should be used for motion when exiting frame or when fading out to 0% opacity. This
    curve is slow at the beginning. It has similar characteristics to the system's EaseIn. This
    is known as Acceleration in the Material Design spec.
    */
-  MDCAnimationTimingFunctionEaseIn,
+  MDCAnimationTimingFunctionAcceleration,
 
   /**
    This curve should be used for motion when elements quickly accelerate and decelerate. It is
@@ -50,15 +50,22 @@ typedef NS_ENUM(NSUInteger, MDCAnimationTimingFunction) {
    faster than the standard curve since it doesn't follow an exact path to the off-screen point.
    */
   MDCAnimationTimingFunctionSharp,
+  
+  /**
+   Aliases for depreciated names
+   */
+  MDCAnimationTimingFunctionEaseInOut = MDCAnimationTimingFunctionStandard
+  MDCAnimationTimingFunctionEaseOut = MDCAnimationTimingFunctionDeceleration
+  MDCAnimationTimingFunctionEaseIn = MDCAnimationTimingAcceleration
 
   /**
    Aliases for various specific timing curve recommendations.
    */
-  MDCAnimationTimingFunctionTranslate = MDCAnimationTimingFunctionEaseInOut,
-  MDCAnimationTimingFunctionTranslateOnScreen = MDCAnimationTimingFunctionEaseOut,
-  MDCAnimationTimingFunctionTranslateOffScreen = MDCAnimationTimingFunctionEaseIn,
-  MDCAnimationTimingFunctionFadeIn = MDCAnimationTimingFunctionEaseOut,
-  MDCAnimationTimingFunctionFadeOut = MDCAnimationTimingFunctionEaseIn,
+  MDCAnimationTimingFunctionTranslate = MDCAnimationTimingFunctionStandard,
+  MDCAnimationTimingFunctionTranslateOnScreen = MDCAnimationTimingFunctionDeceleration,
+  MDCAnimationTimingFunctionTranslateOffScreen = MDCAnimationTimingFunctionAcceleration,
+  MDCAnimationTimingFunctionFadeIn = MDCAnimationTimingFunctionDeceleration,
+  MDCAnimationTimingFunctionFadeOut = MDCAnimationTimingFunctionAcceleration,
 };
 
 /**

--- a/components/AnimationTiming/src/CAMediaTimingFunction+MDCAnimationTiming.h
+++ b/components/AnimationTiming/src/CAMediaTimingFunction+MDCAnimationTiming.h
@@ -54,9 +54,9 @@ typedef NS_ENUM(NSUInteger, MDCAnimationTimingFunction) {
   /**
    Aliases for depreciated names
    */
-  MDCAnimationTimingFunctionEaseInOut = MDCAnimationTimingFunctionStandard
-  MDCAnimationTimingFunctionEaseOut = MDCAnimationTimingFunctionDeceleration
-  MDCAnimationTimingFunctionEaseIn = MDCAnimationTimingAcceleration
+  MDCAnimationTimingFunctionEaseInOut = MDCAnimationTimingFunctionStandard,
+  MDCAnimationTimingFunctionEaseOut = MDCAnimationTimingFunctionDeceleration,
+  MDCAnimationTimingFunctionEaseIn = MDCAnimationTimingAcceleration,
 
   /**
    Aliases for various specific timing curve recommendations.

--- a/components/AnimationTiming/src/CAMediaTimingFunction+MDCAnimationTiming.h
+++ b/components/AnimationTiming/src/CAMediaTimingFunction+MDCAnimationTiming.h
@@ -56,7 +56,7 @@ typedef NS_ENUM(NSUInteger, MDCAnimationTimingFunction) {
    */
   MDCAnimationTimingFunctionEaseInOut = MDCAnimationTimingFunctionStandard,
   MDCAnimationTimingFunctionEaseOut = MDCAnimationTimingFunctionDeceleration,
-  MDCAnimationTimingFunctionEaseIn = MDCAnimationTimingAcceleration,
+  MDCAnimationTimingFunctionEaseIn = MDCAnimationTimingFunctionAcceleration,
 
   /**
    Aliases for various specific timing curve recommendations.

--- a/components/AnimationTiming/src/CAMediaTimingFunction+MDCAnimationTiming.m
+++ b/components/AnimationTiming/src/CAMediaTimingFunction+MDCAnimationTiming.m
@@ -20,11 +20,11 @@
 
 + (CAMediaTimingFunction *)mdc_functionWithType:(MDCAnimationTimingFunction)type {
   switch (type) {
-    case MDCAnimationTimingFunctionEaseInOut:
+    case MDCAnimationTimingFunctionStandard:
       return [[CAMediaTimingFunction alloc] initWithControlPoints:0.4f:0.0f:0.2f:1.0f];
-    case MDCAnimationTimingFunctionEaseOut:
+    case MDCAnimationTimingFunctionDeceleration:
       return [[CAMediaTimingFunction alloc] initWithControlPoints:0.0f:0.0f:0.2f:1.0f];
-    case MDCAnimationTimingFunctionEaseIn:
+    case MDCAnimationTimingFunctionAcceleration:
       return [[CAMediaTimingFunction alloc] initWithControlPoints:0.4f:0.0f:1.0f:1.0f];
     case MDCAnimationTimingFunctionSharp:
       return [[CAMediaTimingFunction alloc] initWithControlPoints:0.4f:0.0f:0.6f:1.0f];


### PR DESCRIPTION
Renames the curves to match Material Design spec and creates aliases for the old names.

Closes #2348 
