### PR TITLE
[Tabs] Use bottom position when determining the bottom tab bar's height

### DIFF
--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -35,6 +35,10 @@
 IB_DESIGNABLE
 @interface MDCTabBar : UIView <UIBarPositioning>
 
+/** The default height for the tab bar with a given position and item appearance. */
++ (CGFloat)defaultHeightForBarPosition:(UIBarPosition)position
+                        itemAppearance:(MDCTabBarItemAppearance)appearance;
+
 /** The default height for the tab bar in the top position, given an item appearance. */
 + (CGFloat)defaultHeightForItemAppearance:(MDCTabBarItemAppearance)appearance;
 
@@ -46,7 +50,7 @@ IB_DESIGNABLE
  * If there was no selection previously or if the old selected item is gone, select the first item.
    Clients that need empty selection to be preserved across updates to `items` must manually reset
    selectedItem to nil after the update.
- 
+
  Changes to this property are not animated.
  */
 @property(nonatomic, copy, nonnull) NSArray<UITabBarItem *> *items;

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -147,8 +147,27 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 
 #pragma mark - Public
 
++ (CGFloat)defaultHeightForBarPosition:(UIBarPosition)position
+                        itemAppearance:(MDCTabBarItemAppearance)appearance {
+  if ([self isTopTabsForPosition:position]) {
+    switch (appearance) {
+      case MDCTabBarItemAppearanceTitledImages:
+        return kTitledImageBarHeight;
+
+      case MDCTabBarItemAppearanceTitles:
+        return kTitleOnlyBarHeight;
+
+      case MDCTabBarItemAppearanceImages:
+        return kImageOnlyBarHeight;
+    }
+  } else {
+    // Bottom navigation has a fixed height.
+    return kBottomNavigationBarHeight;
+  }
+}
+
 + (CGFloat)defaultHeightForItemAppearance:(MDCTabBarItemAppearance)appearance {
-  return [self defaultHeightForPosition:UIBarPositionAny itemAppearance:appearance];
+  return [self defaultHeightForBarPosition:UIBarPositionAny itemAppearance:appearance];
 }
 
 - (void)setDelegate:(id<MDCTabBarDelegate>)delegate {
@@ -289,25 +308,6 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 
 #pragma mark - Private
 
-+ (CGFloat)defaultHeightForPosition:(UIBarPosition)position
-                     itemAppearance:(MDCTabBarItemAppearance)appearance {
-  if ([self isTopTabsForPosition:position]) {
-    switch (appearance) {
-      case MDCTabBarItemAppearanceTitledImages:
-        return kTitledImageBarHeight;
-
-      case MDCTabBarItemAppearanceTitles:
-        return kTitleOnlyBarHeight;
-
-      case MDCTabBarItemAppearanceImages:
-        return kImageOnlyBarHeight;
-    }
-  } else {
-    // Bottom navigation has a fixed height.
-    return kBottomNavigationBarHeight;
-  }
-}
-
 + (MDCItemBarStyle *)defaultStyleForPosition:(UIBarPosition)position
                               itemAppearance:(MDCTabBarItemAppearance)appearance {
   MDCItemBarStyle *style = [[MDCItemBarStyle alloc] init];
@@ -358,7 +358,7 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   style.shouldDisplayTitle = displayTitle;
 
   // Update default height
-  CGFloat defaultHeight = [self defaultHeightForPosition:position itemAppearance:appearance];
+  CGFloat defaultHeight = [self defaultHeightForBarPosition:position itemAppearance:appearance];
   if (defaultHeight == 0) {
     NSAssert(0, @"Missing default height for %zd", appearance);
     defaultHeight = kTitleOnlyBarHeight;
@@ -509,6 +509,9 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   style.displaysUppercaseTitles = _displaysUppercaseTitles;
 
   [_itemBar applyStyle:style];
+
+  // Layout depends on -[MDCItemBar sizeThatFits], which depends on the style.
+  [self setNeedsLayout];
 }
 
 @end

--- a/components/Tabs/src/MDCTabBarViewController.m
+++ b/components/Tabs/src/MDCTabBarViewController.m
@@ -241,7 +241,8 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
 
 - (void)updateLayout {
   CGRect bounds = self.view.bounds;
-  CGFloat tabBarHeight = [[_tabBar class] defaultHeightForItemAppearance:_tabBar.itemAppearance];
+  CGFloat tabBarHeight = [[_tabBar class] defaultHeightForBarPosition:UIBarPositionBottom
+                                                       itemAppearance:_tabBar.itemAppearance];
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     tabBarHeight += self.view.safeAreaInsets.bottom;


### PR DESCRIPTION
Fix for https://github.com/material-components/material-components-ios/issues/2350.

This PR adds missing API that allows clients to determine the preferred height for a tab bar given a position and style, then updates MDCTabBarViewController to use it.

This also fixes a small bug triggered by this change where MDCTabBar wouldn't update its layout at the right times and could leave the item bar with the wrong height.