### PR TITLE
[ProgressView] Fix type error in +defaultProgressTintColor

### DIFF
--- a/components/ProgressView/src/MDCProgressView.m
+++ b/components/ProgressView/src/MDCProgressView.m
@@ -273,7 +273,7 @@ static inline UIColor *MDCColorFromRGB(uint32_t rgbValue) {
 #pragma mark Private
 
 + (UIColor *)defaultProgressTintColor {
-  return MDCColorFromRGB(MDCProgressViewDefaultTintColor);
+  return MDCProgressViewDefaultTintColor();
 }
 
 + (UIColor *)defaultTrackTintColorForProgressTintColor:(UIColor *)progressTintColor {


### PR DESCRIPTION
MDCColorFromRGB takes a uint32. MDCProgressViewDefaultTintColor is a function. I assume calling it is what was intended.

Fixes build breakage