### PR TITLE
[ActivityIndicator] Fix bug where outer rotation was incorrect in determinate state.

### DIFF
--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -489,8 +489,6 @@ static const CGFloat kSingleCycleRotation =
                     withValues:@[@(_minStrokeDifference), @(kStrokeLength + _minStrokeDifference)]
                        keyPath:MDMKeyPathStrokeEnd];
 
-  [CATransaction setDisableActions:YES];
-
   [CATransaction commit];
 
   _animationInProgress = YES;

--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -489,6 +489,8 @@ static const CGFloat kSingleCycleRotation =
                     withValues:@[@(_minStrokeDifference), @(kStrokeLength + _minStrokeDifference)]
                        keyPath:MDMKeyPathStrokeEnd];
 
+  [CATransaction setDisableActions:YES];
+
   [CATransaction commit];
 
   _animationInProgress = YES;
@@ -599,10 +601,14 @@ static const CGFloat kSingleCycleRotation =
       [CATransaction setDisableActions:YES];
       [CATransaction mdm_setTimeScaleFactor:@(duration)];
 
-      CGFloat startRotation = _cycleCount * (CGFloat)M_PI;
-      CGFloat endRotation = startRotation + rotationDelta * 2.0f * (CGFloat)M_PI;
       struct MDCActivityIndicatorMotionSpecTransitionToDeterminate spec =
           kMDCActivityIndicatorMotionSpec.transitionToDeterminate;
+
+      _outerRotationLayer.transform =
+          CATransform3DMakeRotation(kOuterRotationIncrement * _cycleCount, 0, 0, 1);
+
+      CGFloat startRotation = _cycleCount * (CGFloat)M_PI;
+      CGFloat endRotation = startRotation + rotationDelta * 2.0f * (CGFloat)M_PI;
       [_animator animateWithTiming:spec.innerRotation
                            toLayer:_strokeLayer
                         withValues:@[@(startRotation), @(endRotation)]


### PR DESCRIPTION
When transitioning from indeterminate to determinate we have to reset the outer rotation. This logic was unintentionally removed in 8e6da0f4973b202f4f7334e33bd2747f7ff05bec. This change adds the logic back. [View the original logic](https://github.com/material-components/material-components-ios/commit/8e6da0f4973b202f4f7334e33bd2747f7ff05bec#commitcomment-25535317).

Repro steps:

1. Open the activity indicator example.
2. Enable the "Show determinate" state. Wait for the animation to settle.
3. Disable the "Show determinate" state and then immediately enable "Show determinate" state again.

Expected result:

<img width="183" alt="screen shot 2017-11-10 at 11 20 52 am" src="https://user-images.githubusercontent.com/45670/32667653-43bddab6-c609-11e7-8f7a-2bcd0aa71255.png">

Actual result:
<img width="197" alt="screen shot 2017-11-10 at 11 20 27 am" src="https://user-images.githubusercontent.com/45670/32667650-4177a340-c609-11e7-92e6-cdf3b9fdae8e.png">

Notice that the indicators are incorrectly rotated.