### PR TITLE
[BottomSheet] Safe Area fixes

### DIFF
--- a/components/BottomSheet/examples/BottomSheetTypicalUseExample.m
+++ b/components/BottomSheet/examples/BottomSheetTypicalUseExample.m
@@ -24,7 +24,7 @@
 
 - (void)presentBottomSheet {
   BottomSheetDummyCollectionViewController *viewController =
-      [[BottomSheetDummyCollectionViewController alloc] initWithNumItems:100];
+      [[BottomSheetDummyCollectionViewController alloc] initWithNumItems:102];
   viewController.preferredContentSize = CGSizeMake(500, 200);
 
   MDCBottomSheetController *bottomSheet =

--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -166,7 +166,7 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
 
     CGRect scrollViewFrame = CGRectStandardize(self.sheet.scrollView.frame);
     scrollViewFrame.size = CGSizeMake(scrollViewFrame.size.width,
-                                      self.frame.size.height - self.safeAreaInsets.top);
+                                      CGRectGetHeight(self.frame) - self.safeAreaInsets.top);
     self.sheet.scrollView.frame = scrollViewFrame;
   }
 #endif

--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -164,7 +164,7 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
     contentInset.bottom = MAX(contentInset.bottom, self.safeAreaInsets.bottom);
     self.sheet.scrollView.contentInset = contentInset;
 
-    CGRect scrollViewFrame = self.sheet.scrollView.frame;
+    CGRect scrollViewFrame = CGRectStandardize(self.sheet.scrollView.frame);
     scrollViewFrame.size = CGSizeMake(scrollViewFrame.size.width,
                                       self.frame.size.height - self.safeAreaInsets.top);
     self.sheet.scrollView.frame = scrollViewFrame;

--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -37,7 +37,7 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
 @property(nonatomic) UIDynamicAnimator *animator;
 @property(nonatomic) MDCSheetBehavior *sheetBehavior;
 @property(nonatomic) BOOL isDragging;
-@property(nonatomic) CGFloat lastFrameHeight;
+@property(nonatomic) CGFloat originalPreferredSheetHeight;
 
 @end
 
@@ -100,6 +100,14 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
        name:name
        object:nil];
     }
+
+    // Since we handle the SafeAreaInsets ourselves through the contentInset property, we disable
+    // the adjustment behavior to prevent accounting for it twice.
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+    if (@available(iOS 11.0, *)) {
+      scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+    }
+#endif
   }
   return self;
 }
@@ -145,6 +153,25 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
   }
 }
 
+- (void)safeAreaInsetsDidChange {
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    [super safeAreaInsetsDidChange];
+
+    _preferredSheetHeight = self.originalPreferredSheetHeight + self.safeAreaInsets.bottom;
+
+    UIEdgeInsets contentInset = self.sheet.scrollView.contentInset;
+    contentInset.bottom = MAX(contentInset.bottom, self.safeAreaInsets.bottom);
+    self.sheet.scrollView.contentInset = contentInset;
+
+    CGRect scrollViewFrame = self.sheet.scrollView.frame;
+    scrollViewFrame.size = CGSizeMake(scrollViewFrame.size.width,
+                                      self.frame.size.height - self.safeAreaInsets.top);
+    self.sheet.scrollView.frame = scrollViewFrame;
+  }
+#endif
+}
+
 #pragma mark - KVO
 
 - (void)observeValueForKeyPath:(NSString *)keyPath
@@ -165,12 +192,19 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
 #pragma mark - Layout
 
 - (void)setPreferredSheetHeight:(CGFloat)preferredSheetHeight {
-  if (_preferredSheetHeight == preferredSheetHeight && _lastFrameHeight == self.frame.size.height) {
+  self.originalPreferredSheetHeight = preferredSheetHeight;
+
+  CGFloat adjustedPreferredSheetHeight = self.originalPreferredSheetHeight;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    adjustedPreferredSheetHeight += self.safeAreaInsets.bottom;
+  }
+#endif
+
+  if (_preferredSheetHeight == adjustedPreferredSheetHeight) {
     return;
   }
-
-  _preferredSheetHeight = preferredSheetHeight;
-  _lastFrameHeight = self.frame.size.height;
+  _preferredSheetHeight = adjustedPreferredSheetHeight;
 
   [self updateSheetFrame];
 
@@ -219,14 +253,20 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
 
 // Returns the maximum allowable height that the sheet can be dragged to.
 - (CGFloat)maximumSheetHeight {
-  CGSize size = self.bounds.size;
-  CGFloat scrollViewContentHeight = self.sheet.scrollView.contentSize.height;
+  CGFloat boundsHeight = self.bounds.size.height;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    boundsHeight -= self.safeAreaInsets.top;
+  }
+#endif
+  CGFloat scrollViewContentHeight = self.sheet.scrollView.contentInset.top +
+      self.sheet.scrollView.contentSize.height + self.sheet.scrollView.contentInset.bottom;
 
   // If we have a scrollview, the sheet should never get taller than its content height.
   if (scrollViewContentHeight > 0) {
-    return MIN(size.height, scrollViewContentHeight);
+    return MIN(boundsHeight, scrollViewContentHeight);
   } else {
-    return MIN(size.height, self.preferredSheetHeight);
+    return MIN(boundsHeight, self.preferredSheetHeight);
   }
 }
 
@@ -302,7 +342,9 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
           return YES;
         } else {
           // Allow dragging in any direction if the content is not scrollable.
-          return (CGRectGetHeight(scrollView.bounds) >= scrollView.contentSize.height);
+          CGFloat contentHeight = scrollView.contentInset.top + scrollView.contentSize.height +
+              scrollView.contentInset.bottom;
+          return (CGRectGetHeight(scrollView.bounds) >= contentHeight);
         }
       }
       return YES;

--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -253,7 +253,7 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
 
 // Returns the maximum allowable height that the sheet can be dragged to.
 - (CGFloat)maximumSheetHeight {
-  CGFloat boundsHeight = self.bounds.size.height;
+  CGFloat boundsHeight = CGRectGetHeight(self.bounds);
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     boundsHeight -= self.safeAreaInsets.top;


### PR DESCRIPTION
- Adjusts the max height to prevent the content from going below the top safe area inset.
- Sets the scroll view's bottom inset to at least  the bottom safe area inset.
- Stops ignoring the contentInset when calculating the content size of the scroll view.
- Adjusts preferredSheetHeight to include the bottom safe area inset when used internally.

Closes #2005

![](https://im4.ezgif.com/tmp/ezgif-4-41cd45c5f3.gif)
