### PR TITLE
[BottomSheet] Remove umbrella imports from source files.

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -14,7 +14,11 @@
  limitations under the License.
  */
 
-#import "MaterialBottomSheet.h"
+#import "MDCBottomSheetController.h"
+
+#import "MDCBottomSheetPresentationController.h"
+#import "MDCBottomSheetTransitionController.h"
+#import "UIViewController+MaterialBottomSheet.h"
 
 @interface MDCBottomSheetController () <MDCBottomSheetPresentationControllerDelegate>
 @end

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -14,7 +14,9 @@
  limitations under the License.
  */
 
-#import "MaterialBottomSheet.h"
+#import "MDCBottomSheetPresentationController.h"
+
+#import "MDCBottomSheetController.h"
 
 #import "MaterialMath.h"
 #import "private/MDCSheetContainerView.h"

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.m
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.m
@@ -14,7 +14,9 @@
  limitations under the License.
  */
 
-#import "MaterialBottomSheet.h"
+#import "MDCBottomSheetTransitionController.h"
+
+#import "MDCBottomSheetPresentationController.h"
 
 static const NSTimeInterval MDCBottomSheetTransitionDuration = 0.25;
 


### PR DESCRIPTION
Convention is to import only the headers needed to build the compilation unit.