### PR TITLE
[BottomNavigation] Update bottom navigation bar height to match native component height

### DIFF
--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -45,7 +45,7 @@
 
   _bottomNavBar = [[MDCBottomNavigationBar alloc] initWithFrame:CGRectZero];
   _bottomNavBar.titleVisibility = MDCBottomNavigationBarTitleVisibilitySelected;
-  _bottomNavBar.alignment = MDCBottomNavigationBarAlignmentJustified;
+  _bottomNavBar.alignment = MDCBottomNavigationBarAlignmentJustifiedAdjacentTitles;
   _bottomNavBar.delegate = self;
   [self.view addSubview:_bottomNavBar];
 

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -26,8 +26,8 @@
 // The Bundle for string resources.
 static NSString *const kMaterialBottomNavigationBundle = @"MaterialBottomNavigation.bundle";
 
-static const CGFloat kMDCBottomNavigationBarHeight = 72.f;
-static const CGFloat kMDCBottomNavigationBarHeightAdjacentTitles = 60.f;
+static const CGFloat kMDCBottomNavigationBarHeight = 56.f;
+static const CGFloat kMDCBottomNavigationBarHeightAdjacentTitles = 40.f;
 static const CGFloat kMDCBottomNavigationBarLandscapeContainerWidth = 320.f;
 static const MDCShadowElevation kMDCBottomNavigationBarElevation = 6.f;
 static NSString *const kMDCBottomNavigationBarBadgeColorString = @"badgeColor";
@@ -103,7 +103,8 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   self.maxLandscapeClusterContainerWidth = MIN(size.width, size.height);
   UIEdgeInsets insets = self.mdc_safeAreaInsets;
   CGFloat heightWithInset = kMDCBottomNavigationBarHeight + insets.bottom;
-  if (self.alignment == MDCBottomNavigationBarAlignmentJustifiedAdjacentTitles) {
+  if (self.alignment == MDCBottomNavigationBarAlignmentJustifiedAdjacentTitles &&
+      UIDeviceOrientationIsLandscape([UIDevice currentDevice].orientation)) {
     heightWithInset = kMDCBottomNavigationBarHeightAdjacentTitles + insets.bottom;
   }
   CGSize insetSize = CGSizeMake(size.width, heightWithInset);
@@ -146,7 +147,8 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
                         withBottomNavSize:(CGSize)bottomNavSize
                            containerWidth:(CGFloat)containerWidth {
   CGFloat barHeight = kMDCBottomNavigationBarHeight;
-  if (self.alignment == MDCBottomNavigationBarAlignmentJustifiedAdjacentTitles) {
+  if (self.alignment == MDCBottomNavigationBarAlignmentJustifiedAdjacentTitles &&
+      UIDeviceOrientationIsLandscape([UIDevice currentDevice].orientation)) {
     barHeight = kMDCBottomNavigationBarHeightAdjacentTitles;
   }
   if (itemsDistributed) {


### PR DESCRIPTION
Update bottom navigation bar height to match native component height.

![simulator screen shot - iphone 8 - 2017-11-13 at 13 17 35](https://user-images.githubusercontent.com/760941/32742338-1c85e0a4-c877-11e7-80dd-9bd9a65f9a0a.png)

![simulator screen shot - iphone 8 - 2017-11-13 at 13 17 38](https://user-images.githubusercontent.com/760941/32742341-1f01dec8-c877-11e7-8a0a-980bc602af07.png)

