### PR TITLE
[Documentation]: iOS Swift tutorial doesn’t build

### DIFF
--- a/howto/tutorial/README.md
+++ b/howto/tutorial/README.md
@@ -374,7 +374,7 @@ First, add a function to ViewController that will be called when the button is t
 <!--<div class="material-code-render" markdown="1">-->
 #### Swift
 ``` swift
-func barButtonDidTap(sender: UIBarButtonItem) {
+func barButtonDidTap(_ sender: UIBarButtonItem) {
   editor.isEditing = !editor.isEditing
 
   let buttonTitle =  editor.isEditing ? "Cancel" : "Edit"
@@ -454,7 +454,7 @@ class ViewController: MDCCollectionViewController {
 
   ...
 
-  func fabDidTap(sender: UIButton) {
+  func fabDidTap(_ sender: UIButton) {
     sender.isSelected = !sender.isSelected
   }
 ```
@@ -597,13 +597,13 @@ class ViewController: MDCCollectionViewController {
     fab.addTarget(self, action: #selector(ViewController.fabDidTap(_:)), for: .touchUpInside)
   }
 
-  func barButtonDidTap(sender: UIBarButtonItem) {
+  func barButtonDidTap(_ sender: UIBarButtonItem) {
     editor.isEditing = !editor.isEditing
 
     navigationItem.rightBarButtonItem = UIBarButtonItem(title: editor.isEditing ? "Cancel" : "Edit", style: .plain, target: self, action: #selector(ViewController.barButtonDidTap(_:)))
   }
 
-  func fabDidTap(sender: UIButton) {
+  func fabDidTap(_ sender: UIButton) {
     sender.isSelected = !sender.isSelected
   }
 

--- a/howto/tutorial/README.md
+++ b/howto/tutorial/README.md
@@ -381,7 +381,7 @@ func barButtonDidTap(sender: UIBarButtonItem) {
   navigationItem.rightBarButtonItem = UIBarButtonItem(title: buttonTitle,
                                                       style: .plain,
                                                       target: self,
-                                                      action: #selector(ViewController.barButtonDidTap))
+                                                      action: #selector(ViewController.barButtonDidTap(_:)))
 }
 ```
 
@@ -410,7 +410,7 @@ override func viewDidLoad() {
   navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Edit",
                                                       style: .plain,
                                                       target: self,
-                                                      action: #selector(ViewController.barButtonDidTap))
+                                                      action: #selector(ViewController.barButtonDidTap(_:)))
 }
 ```
 

--- a/howto/tutorial/README.md
+++ b/howto/tutorial/README.md
@@ -381,7 +381,7 @@ func barButtonDidTap(sender: UIBarButtonItem) {
   navigationItem.rightBarButtonItem = UIBarButtonItem(title: buttonTitle,
                                                       style: .plain,
                                                       target: self,
-                                                      action: #selector(ViewController.barButtonDidTap(_:)))
+                                                      action: #selector(ViewController.barButtonDidTap))
 }
 ```
 
@@ -410,7 +410,7 @@ override func viewDidLoad() {
   navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Edit",
                                                       style: .plain,
                                                       target: self,
-                                                      action: #selector(ViewController.barButtonDidTap(_:)))
+                                                      action: #selector(ViewController.barButtonDidTap))
 }
 ```
 


### PR DESCRIPTION
### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [x] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [x] Link to GitHub issues it solves. ```closes #1234```
- [x] Sign the CLA bot. You can do this once the pull request is submitted.

[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
pull request.

---

### Problem

Example code from the [iOS tutorial](https://material.io/components/ios/docs/tutorial/#6--add-a-button-to-the-app-bar) won’t compile:

![before](https://user-images.githubusercontent.com/1858316/32743688-f5161a12-c861-11e7-92bf-d5792627965d.jpg)

(See https://github.com/swashcap/MDC-Tutorial/blob/8b6a994f1bc4b31f6cc8e0af00a66733101c9918/MDC-Tutorial/ViewController.swift)

### Solution

Remove the `ViewController#barButtonDidTap` invocation from the `#selector`s:

![after](https://user-images.githubusercontent.com/1858316/32743729-14cd22f6-c862-11e7-8f67-708e52369d82.jpg)

(See https://github.com/swashcap/MDC-Tutorial/blob/d107624b00ea37a3241c9ba3ffe242f9b170a928/MDC-Tutorial/ViewController.swift)


closes #2413