### PR TITLE
[BottomSheet] Add a trackingScrollView API to the bottom sheet controller.

### DIFF
--- a/components/BottomSheet/examples/BottomSheetShortCollectionExample.m
+++ b/components/BottomSheet/examples/BottomSheetShortCollectionExample.m
@@ -28,6 +28,7 @@
 
   MDCBottomSheetController *bottomSheet =
       [[MDCBottomSheetController alloc] initWithContentViewController:viewController];
+  bottomSheet.trackingScrollView = viewController.collectionView;
   [self presentViewController:bottomSheet animated:YES completion:nil];
 }
 

--- a/components/BottomSheet/examples/BottomSheetTypicalUseExample.m
+++ b/components/BottomSheet/examples/BottomSheetTypicalUseExample.m
@@ -29,6 +29,7 @@
 
   MDCBottomSheetController *bottomSheet =
       [[MDCBottomSheetController alloc] initWithContentViewController:viewController];
+  bottomSheet.trackingScrollView = viewController.collectionView;
   [self presentViewController:bottomSheet animated:YES completion:nil];
 }
 

--- a/components/BottomSheet/examples/supplemental/BottomSheetDummyCollectionViewController.h
+++ b/components/BottomSheet/examples/supplemental/BottomSheetDummyCollectionViewController.h
@@ -16,8 +16,9 @@
 
 #import <UIKit/UIKit.h>
 
-@interface BottomSheetDummyCollectionViewController : UIViewController
+@interface BottomSheetDummyCollectionViewController : UICollectionViewController
 - (instancetype)initWithNumItems:(NSInteger)numItems NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout NS_UNAVAILABLE;
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 NS_UNAVAILABLE;

--- a/components/BottomSheet/examples/supplemental/BottomSheetDummyCollectionViewController.m
+++ b/components/BottomSheet/examples/supplemental/BottomSheetDummyCollectionViewController.m
@@ -28,27 +28,29 @@
 }
 
 - (instancetype)initWithNumItems:(NSInteger)numItems {
-  if (self = [super initWithNibName:nil bundle:nil]) {
+  UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
+  layout.minimumInteritemSpacing = 0;
+  layout.minimumLineSpacing = 0;
+  if (self = [super initWithCollectionViewLayout:layout]) {
+    _layout = layout;
+
     _numItems = numItems;
   }
   return self;
 }
 
-- (void)loadView {
-  _layout = [[UICollectionViewFlowLayout alloc] init];
-  _layout.minimumInteritemSpacing = 0;
-  _layout.minimumLineSpacing = 0;
+- (void)viewDidLoad {
+  [super viewDidLoad];
 
-  UICollectionView *collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero
-                                                        collectionViewLayout:_layout];
-  collectionView.backgroundColor = [UIColor whiteColor];
-  [collectionView registerClass:[DummyCollectionViewCell class]
-     forCellWithReuseIdentifier:NSStringFromClass([DummyCollectionViewCell class])];
-  collectionView.dataSource = self;
-  self.view = collectionView;
+  self.collectionView.backgroundColor = [UIColor whiteColor];
+
+  [self.collectionView registerClass:[DummyCollectionViewCell class]
+          forCellWithReuseIdentifier:NSStringFromClass([DummyCollectionViewCell class])];
 }
 
 - (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
+
   CGFloat s = self.view.frame.size.width / 3;
   _layout.itemSize = CGSizeMake(s, s);
 }

--- a/components/BottomSheet/src/MDCBottomSheetController.h
+++ b/components/BottomSheet/src/MDCBottomSheetController.h
@@ -36,6 +36,16 @@
 @property(nonatomic, strong, nonnull, readonly) UIViewController *contentViewController;
 
 /**
+ Interactions with the tracking scroll view will affect the bottom sheet's drag behavior.
+
+ If no trackingScrollView is provided, then one will be inferred from the associated view
+ controller.
+
+ Changes to this value will be ignored after the bottom sheet controller has been presented.
+ */
+@property(nonatomic, weak, nullable) UIScrollView *trackingScrollView;
+
+/**
  The bottom sheet delegate.
  */
 @property(nonatomic, weak, nullable) id<MDCBottomSheetControllerDelegate> delegate;

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -76,6 +76,14 @@
   self.contentViewController.preferredContentSize = preferredContentSize;
 }
 
+- (UIScrollView *)trackingScrollView {
+  return _transitionController.trackingScrollView;
+}
+
+- (void)setTrackingScrollView:(UIScrollView *)trackingScrollView {
+  _transitionController.trackingScrollView = trackingScrollView;
+}
+
 /* Disable setter. Always use internal transition controller */
 - (void)setTransitioningDelegate:
     (__unused id<UIViewControllerTransitioningDelegate>)transitioningDelegate {

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -51,6 +51,14 @@
 @interface MDCBottomSheetPresentationController : UIPresentationController
 
 /**
+ Interactions with the tracking scroll view will affect the bottom sheet's drag behavior.
+
+ If no trackingScrollView is provided, then one will be inferred from the associated view
+ controller.
+ */
+@property(nonatomic, weak, nullable) UIScrollView *trackingScrollView;
+
+/**
  Delegate to tell the presenter when to dismiss.
  */
 @property(nonatomic, weak, nullable) id<MDCBottomSheetPresentationControllerDelegate> delegate;

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -87,7 +87,10 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   _dimmingView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
-  UIScrollView *scrollView = MDCBottomSheetGetPrimaryScrollView(self.presentedViewController);
+  UIScrollView *scrollView = self.trackingScrollView;
+  if (scrollView == nil) {
+    scrollView = MDCBottomSheetGetPrimaryScrollView(self.presentedViewController);
+  }
   CGRect sheetFrame = [self frameOfPresentedViewInContainerView];
   _sheetView = [[MDCSheetContainerView alloc] initWithFrame:sheetFrame
                                                 contentView:self.presentedViewController.view

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.h
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.h
@@ -33,4 +33,13 @@
  */
 @interface MDCBottomSheetTransitionController
     : NSObject <UIViewControllerAnimatedTransitioning, UIViewControllerTransitioningDelegate>
+
+/**
+ Interactions with the tracking scroll view will affect the bottom sheet's drag behavior.
+
+ If no trackingScrollView is provided, then one will be inferred from the associated view
+ controller.
+ */
+@property(nonatomic, weak, nullable) UIScrollView *trackingScrollView;
+
 @end

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.m
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.m
@@ -28,8 +28,11 @@ static const NSTimeInterval MDCBottomSheetTransitionDuration = 0.25;
     presentationControllerForPresentedViewController:(UIViewController *)presented
                             presentingViewController:(UIViewController *)presenting
                                 sourceViewController:(__unused UIViewController *)source {
-  return [[MDCBottomSheetPresentationController alloc] initWithPresentedViewController:presented
-                                                              presentingViewController:presenting];
+  MDCBottomSheetPresentationController *presentationController =
+      [[MDCBottomSheetPresentationController alloc] initWithPresentedViewController:presented
+                                                           presentingViewController:presenting];
+  presentationController.trackingScrollView = self.trackingScrollView;
+  return presentationController;
 }
 
 - (nullable id <UIViewControllerAnimatedTransitioning>)


### PR DESCRIPTION
This API allows clients to specify which view should be considered as the tracking scroll view for the bottom sheet gestural behaviors.

The API name is consistent with the FlexibleHeader component's similar API.
