### PR TITLE
Replace Motion relative imports with framework imports throughout the repo

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -29,16 +29,22 @@ fix_bazel_imports() {
     tests_dir_prefix="github/repo/"
   fi
   
-  rewrite_source() {
+  rewrite_tests() {
     find "${stashed_dir}${tests_dir_prefix}"components/*/tests/unit -type f -name '*.swift' -exec sed -i '' -E "$1" {} + || true
+  }
+  rewrite_source() {
+    find "${stashed_dir}${tests_dir_prefix}"components/*/src -type f -name '*.h' -exec sed -i '' -E "$1" {} + || true
+    find "${stashed_dir}${tests_dir_prefix}"components/*/src -type f -name '*.m' -exec sed -i '' -E "$1" {} + || true
   }
 
   stashed_dir=""
-  rewrite_source "s/import MaterialComponents.Material(.+)/import components_\1_\1/"
+  rewrite_tests "s/import MaterialComponents.Material(.+)/import components_\1_\1/"
+  rewrite_source "s/import <Motion(.+)\/Motion.+\.h>/import \"Motion\1.h\"/"
   stashed_dir="$(pwd)/"
   reset_imports() {
     # Undoes our source changes from above.
-    rewrite_source "s/import components_(.+)_.+/import MaterialComponents.Material\1/"
+    rewrite_tests "s/import components_(.+)_.+/import MaterialComponents.Material\1/"
+    rewrite_source "s/import \"Motion(.+)\.h\"/import <Motion\1\/Motion\1.h>/"
   }
   trap reset_imports EXIT
 }

--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -20,7 +20,7 @@
 
 #import "MDFInternationalization.h"
 #import "MaterialApplication.h"
-#import "MotionAnimator.h"
+#import <MotionAnimator/MotionAnimator.h>
 #import "private/MDCActivityIndicatorMotionSpec.h"
 #import "private/MDCActivityIndicator+Private.h"
 #import "private/MaterialActivityIndicatorStrings.h"

--- a/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.h
+++ b/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "MotionInterchange.h"
+#import <MotionInterchange/MotionInterchange.h>
 
 struct MDCActivityIndicatorMotionSpec {
   struct MDCActivityIndicatorMotionSpecIndeterminate {

--- a/components/ProgressView/src/MDCProgressView.m
+++ b/components/ProgressView/src/MDCProgressView.m
@@ -21,7 +21,7 @@
 #import "MDFInternationalization.h"
 #import "MaterialMath.h"
 #import "MaterialPalettes.h"
-#import "MotionAnimator.h"
+#import <MotionAnimator/MotionAnimator.h>
 #import "private/MDCProgressView+MotionSpec.h"
 
 static inline UIColor *MDCProgressViewDefaultTintColor(void) {

--- a/components/ProgressView/src/private/MDCProgressView+MotionSpec.h
+++ b/components/ProgressView/src/private/MDCProgressView+MotionSpec.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "MotionInterchange.h"
+#import <MotionInterchange/MotionInterchange.h>
 
 struct MDCProgressViewMotionSpec {
   MDMMotionTiming setProgress;


### PR DESCRIPTION
Updated the kokoro script to automatically replace framework imports with relative imports.