### PR TITLE
[Buttons] Fix example storyboard module

### DIFF
--- a/components/Buttons/examples/resources/ButtonsStoryboardAndProgrammatic.storyboard
+++ b/components/Buttons/examples/resources/ButtonsStoryboardAndProgrammatic.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="rmZ-Mt-scB">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="rmZ-Mt-scB">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,7 +14,8 @@
         <!--Buttons Swift And Storyboard Controller-->
         <scene sceneID="4Dd-I6-MBs">
             <objects>
-                <viewController id="rmZ-Mt-scB" customClass="ButtonsSwiftAndStoryboardController" customModule="MaterialComponentsCatalog" sceneMemberID="viewController">
+                <placeholder placeholderIdentifier="IBFirstResponder" id="LO5-z8-Ix6" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <viewController id="rmZ-Mt-scB" customClass="ButtonsSwiftAndStoryboardController" customModule="MaterialComponentsExamples" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="dkA-v6-Opi"/>
                         <viewControllerLayoutGuide type="bottom" id="QjK-x9-gr9"/>
@@ -97,7 +98,6 @@
                         <outlet property="storyboardRaised" destination="ixI-3k-a3r" id="5z9-aK-IJ5"/>
                     </connections>
                 </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="LO5-z8-Ix6" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="442.39999999999998" y="467.3163418290855"/>
         </scene>


### PR DESCRIPTION
The Storyboard example had the wrong module name (catalog) instead of
the "examples" module.

Closes #2425
