### PR TITLE
[Catalog] Added Import to catalog’s AppDelegate

### DIFF
--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -30,6 +30,7 @@ import MaterialComponents.MDCPageControlColorThemer
 import MaterialComponents.MDCProgressViewColorThemer
 import MaterialComponents.MDCSliderColorThemer
 import MaterialComponents.MDCTabBarColorThemer
+import MaterialComponents.MaterialTextFields
 import MaterialComponents.MDCTextFieldColorThemer
 import MaterialComponents.MaterialThemes
 


### PR DESCRIPTION
this fixes error:

```

material_components_ios/catalog/MDCCatalog/AppDelegate.swift:82:60: error: use of unresolved identifier 'MDCTextInputControllerDefault'
                                  toAllControllersOfClass: MDCTextInputControllerDefault.self)
                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

and others