### PR TITLE
[AnimationTiming] Update animation timing README and examples

### DIFF
--- a/components/AnimationTiming/README.md
+++ b/components/AnimationTiming/README.md
@@ -80,7 +80,7 @@ be used in an animation.
 #### Swift
 
 ``` swift
-let materialCurve = MDCAnimationTimingFunction.easeOut
+let materialCurve = MDCAnimationTimingFunction.deceleration
 let timingFunction = CAMediaTimingFunction.mdc_function(withType: materialCurve)
 
 let animation = CABasicAnimation(keyPath:"transform.translation.x")
@@ -90,7 +90,7 @@ animation.timingFunction = timingFunction
 #### Objc
 
 ``` objc
-MDCAnimationTimingFunction materialCurve = MDCAnimationTimingFunctionEaseOut;
+MDCAnimationTimingFunction materialCurve = MDCAnimationTimingFunctionDeceleration;
 CAMediaTimingFunction *timingFunction = [CAMediaTimingFunction mdc_functionWithType:materialCurve];
 
 CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"transform.translation.x"];

--- a/components/AnimationTiming/examples/AnimationTimingExample.m
+++ b/components/AnimationTiming/examples/AnimationTimingExample.m
@@ -48,17 +48,21 @@ const NSTimeInterval kAnimationTimeDelay = 0.5f;
       [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
   [self applyAnimationToView:_linearView withTimingFunction:linearTimingCurve];
 
-  CAMediaTimingFunction *materialEaseInOutCurve =
-      [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionEaseInOut];
-  [self applyAnimationToView:_materialEaseInOutView withTimingFunction:materialEaseInOutCurve];
+  CAMediaTimingFunction *materialStandardCurve =
+      [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionStandard];
+  [self applyAnimationToView:_materialStandardView withTimingFunction:materialStandardCurve];
 
-  CAMediaTimingFunction *materialEaseOutCurve =
-      [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionEaseOut];
-  [self applyAnimationToView:_materialEaseOutView withTimingFunction:materialEaseOutCurve];
+  CAMediaTimingFunction *materialDecelerationCurve =
+      [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionDeceleration];
+  [self applyAnimationToView:_materialDecelerationView withTimingFunction:materialDecelerationCurve];
 
-  CAMediaTimingFunction *materialEaseInCurve =
-      [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionEaseIn];
-  [self applyAnimationToView:_materialEaseInView withTimingFunction:materialEaseInCurve];
+  CAMediaTimingFunction *materialAccelerationCurve =
+      [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionAcceleration];
+  [self applyAnimationToView:_materialAccelerationView withTimingFunction:materialAccelerationCurve];
+   
+  CAMediaTimingFunction *materialSharpCurve =
+      [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionSharp];
+   [self applyAnimationToView:_materialSharpView withTimingFunction:materialSharpCurve];
 }
 
 - (void)applyAnimationToView:(UIView *)view

--- a/components/AnimationTiming/examples/AnimationTimingExample.swift
+++ b/components/AnimationTiming/examples/AnimationTimingExample.swift
@@ -36,9 +36,10 @@ class AnimationTimingExample: UIViewController {
 
    fileprivate let scrollView: UIScrollView = UIScrollView()
    fileprivate let linearView: UIView = UIView()
-   fileprivate let materialEaseInOutView: UIView = UIView()
-   fileprivate let materialEaseOutView: UIView = UIView()
-   fileprivate let materialEaseInView: UIView = UIView()
+   fileprivate let materialStandardView: UIView = UIView()
+   fileprivate let materialDecelerationView: UIView = UIView()
+   fileprivate let materialAccelerationView: UIView = UIView()
+   fileprivate let materialSharpView: UIView = UIView()
 
    override func viewDidLoad() {
       super.viewDidLoad()
@@ -61,24 +62,29 @@ class AnimationTimingExample: UIViewController {
       let linearCurve: CAMediaTimingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionLinear)
       applyAnimation(toView: linearView, withTimingFunction: linearCurve)
 
-      if let materialEaseInOut = CAMediaTimingFunction.mdc_function(withType: .easeInOut) {
-         applyAnimation(toView: materialEaseInOutView, withTimingFunction: materialEaseInOut)
+      if let materialStandard = CAMediaTimingFunction.mdc_function(withType: .standard) {
+         applyAnimation(toView: materialStandardView, withTimingFunction: materialStandard)
       } else {
-         materialEaseInOutView.removeFromSuperview()
+         materialStandardView.removeFromSuperview()
       }
 
-      if let materialEaseOut = CAMediaTimingFunction.mdc_function(withType: .easeOut) {
-         applyAnimation(toView: materialEaseOutView, withTimingFunction: materialEaseOut)
+      if let materialDeceleration = CAMediaTimingFunction.mdc_function(withType: .deceleration) {
+         applyAnimation(toView: materialDecelerationView, withTimingFunction: materialDeceleration)
       } else {
-         materialEaseOutView.removeFromSuperview()
+         materialDecelerationView.removeFromSuperview()
       }
 
-      if let materialEaseIn = CAMediaTimingFunction.mdc_function(withType: .easeIn) {
-         applyAnimation(toView: materialEaseInView, withTimingFunction: materialEaseIn)
+      if let materialAcceleration = CAMediaTimingFunction.mdc_function(withType: .acceleration) {
+         applyAnimation(toView: materialAccelerationView, withTimingFunction: materialAcceleration)
       } else {
-         materialEaseInView.removeFromSuperview()
+         materialAccelerationView.removeFromSuperview()
       }
-
+    
+      if let materialSharp = CAMediaTimingFunction.mdc_function(withType: .sharp) {
+         applyAnimation(toView: materialSharpView, withTimingFunction: materialSharp)
+      } else {
+         materialSharpView.removeFromSuperview()
+      }
    }
 
    func applyAnimation(toView view: UIView, withTimingFunction timingFunction : CAMediaTimingFunction) {
@@ -107,17 +113,19 @@ extension AnimationTimingExample {
       }
 
       let defaultColors: [UIColor] = [UIColor.darkGray.withAlphaComponent(0.8),
-                                      UIColor.darkGray.withAlphaComponent(0.6),
-                                      UIColor.darkGray.withAlphaComponent(0.4),
+                                      UIColor.darkGray.withAlphaComponent(0.65),
+                                      UIColor.darkGray.withAlphaComponent(0.5),
+                                      UIColor.darkGray.withAlphaComponent(0.35),
                                       UIColor.darkGray.withAlphaComponent(0.2)]
 
       scrollView.frame = view.bounds
       scrollView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-      scrollView.contentSize = view.frame.size
+      scrollView.contentSize = CGSize(width: view.frame.width,
+                                      height: view.frame.height + Constants.Sizes.topMargin)
       scrollView.clipsToBounds = true
       view.addSubview(scrollView)
 
-      let lineSpace: CGFloat = (view.frame.size.height - 50.0) / 4.0
+      let lineSpace: CGFloat = (view.frame.size.height - 50.0) / 5.0
       let linearLabel: UILabel = curveLabel("Linear")
       linearLabel.frame = CGRect(x: Constants.Sizes.leftGutter, y: Constants.Sizes.topMargin, width: linearLabel.frame.size.width, height: linearLabel.frame.size.height)
       scrollView.addSubview(linearLabel)
@@ -133,31 +141,41 @@ extension AnimationTimingExample {
       scrollView.addSubview(materialEaseInOutLabel)
 
       let materialEaseInOutViewFrame: CGRect = CGRect(x: Constants.Sizes.leftGutter, y: lineSpace + Constants.Sizes.textOffset, width: Constants.Sizes.circleSize.width, height: Constants.Sizes.circleSize.height)
-      materialEaseInOutView.frame = materialEaseInOutViewFrame
-      materialEaseInOutView.backgroundColor = defaultColors[1]
-      materialEaseInOutView.layer.cornerRadius = Constants.Sizes.circleSize.width / 2.0
-      scrollView.addSubview(materialEaseInOutView)
+      materialStandardView.frame = materialEaseInOutViewFrame
+      materialStandardView.backgroundColor = defaultColors[1]
+      materialStandardView.layer.cornerRadius = Constants.Sizes.circleSize.width / 2.0
+      scrollView.addSubview(materialStandardView)
 
       let materialEaseOutLabel: UILabel = curveLabel("MDCAnimationTimingFunctionEaseOut")
       materialEaseOutLabel.frame = CGRect(x: Constants.Sizes.leftGutter, y: lineSpace * 2.0, width: materialEaseOutLabel.frame.size.width, height: materialEaseOutLabel.frame.size.height)
       scrollView.addSubview(materialEaseOutLabel)
 
       let materialEaseOutViewFrame: CGRect = CGRect(x: Constants.Sizes.leftGutter, y: lineSpace * 2.0 + Constants.Sizes.textOffset, width: Constants.Sizes.circleSize.width, height: Constants.Sizes.circleSize.height)
-      materialEaseOutView.frame = materialEaseOutViewFrame
-      materialEaseOutView.backgroundColor = defaultColors[2]
-      materialEaseOutView.layer.cornerRadius = Constants.Sizes.circleSize.width / 2.0
-      scrollView.addSubview(materialEaseOutView)
+      materialDecelerationView.frame = materialEaseOutViewFrame
+      materialDecelerationView.backgroundColor = defaultColors[2]
+      materialDecelerationView.layer.cornerRadius = Constants.Sizes.circleSize.width / 2.0
+      scrollView.addSubview(materialDecelerationView)
 
       let materialEaseInLabel: UILabel = curveLabel("MDCAnimationTimingFunctionEaseIn")
       materialEaseInLabel.frame = CGRect(x: Constants.Sizes.leftGutter, y: lineSpace * 3.0, width: materialEaseInLabel.frame.size.width, height: materialEaseInLabel.frame.size.height)
       scrollView.addSubview(materialEaseInLabel)
 
       let materialEaseInViewFrame: CGRect = CGRect(x: Constants.Sizes.leftGutter, y: lineSpace * 3.0 + Constants.Sizes.textOffset, width: Constants.Sizes.circleSize.width, height: Constants.Sizes.circleSize.height)
-      materialEaseInView.frame = materialEaseInViewFrame
-      materialEaseInView.backgroundColor = defaultColors[3]
-      materialEaseInView.layer.cornerRadius = Constants.Sizes.circleSize.width / 2.0
-
-      scrollView.addSubview(materialEaseInView)
+      materialAccelerationView.frame = materialEaseInViewFrame
+      materialAccelerationView.backgroundColor = defaultColors[3]
+      materialAccelerationView.layer.cornerRadius = Constants.Sizes.circleSize.width / 2.0
+      scrollView.addSubview(materialAccelerationView)
+    
+      let materialSharpLabel: UILabel = curveLabel("MDCAnimationTimingSharp")
+      materialSharpLabel.frame = CGRect(x: Constants.Sizes.leftGutter, y: lineSpace * 4.0, width: materialSharpLabel.frame.size.width, height: materialSharpLabel.frame.size.height)
+      scrollView.addSubview(materialSharpLabel)
+      
+      let materialSharpViewFrame: CGRect = CGRect(x: Constants.Sizes.leftGutter, y: lineSpace * 4.0 +
+         Constants.Sizes.textOffset, width: Constants.Sizes.circleSize.width, height: Constants.Sizes.circleSize.height)
+      materialSharpView.frame = materialSharpViewFrame
+      materialSharpView.backgroundColor = defaultColors[4]
+      materialSharpView.layer.cornerRadius = Constants.Sizes.circleSize.width / 2.0
+      scrollView.addSubview(materialSharpView)
    }
 
    @objc class func catalogBreadcrumbs() -> [String] {
@@ -167,5 +185,4 @@ extension AnimationTimingExample {
    @objc class func catalogIsPrimaryDemo() -> Bool {
       return false
    }
-
 }

--- a/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.h
+++ b/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.h
@@ -21,9 +21,10 @@
 @property(nonatomic, strong) NSTimer *animationLoop;
 @property(nonatomic, strong) UIScrollView *scrollView;
 @property(nonatomic, strong) UIView *linearView;
-@property(nonatomic, strong) UIView *materialEaseInOutView;
-@property(nonatomic, strong) UIView *materialEaseOutView;
-@property(nonatomic, strong) UIView *materialEaseInView;
+@property(nonatomic, strong) UIView *materialStandardView;
+@property(nonatomic, strong) UIView *materialDecelerationView;
+@property(nonatomic, strong) UIView *materialAccelerationView;
+@property(nonatomic, strong) UIView *materialSharpView;
 
 @end
 

--- a/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
+++ b/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
@@ -21,7 +21,7 @@
 
 const CGFloat kTopMargin = 16.f;
 const CGFloat kLeftGutter = 16.f;
-const CGFloat kTextOffset = 24.f;
+const CGFloat kTextOffset = 16.f;
 
 // Size of the circle we animate.
 static const CGSize kAnimationCircleSize = {48.f, 48.f};
@@ -53,11 +53,12 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
   self.scrollView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
-  self.scrollView.contentSize = self.view.frame.size;
+  self.scrollView.contentSize = CGSizeMake(CGRectGetWidth(self.view.frame),
+                                           CGRectGetHeight(self.view.frame) + kTopMargin);
   self.scrollView.clipsToBounds = YES;
   [self.view addSubview:self.scrollView];
 
-  CGFloat lineSpace = (self.view.frame.size.height - 50.f) / 4.f;
+  CGFloat lineSpace = (CGRectGetHeight(self.view.frame) - 50.f) / 5.f;
   UILabel *linearLabel = [AnimationTimingExample curveLabelWithTitle:@"Linear"];
   linearLabel.frame =
       CGRectMake(kLeftGutter, kTopMargin, linearLabel.frame.size.width, linearLabel.frame.size.height);
@@ -71,7 +72,7 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
   [self.scrollView addSubview:self.linearView];
 
   UILabel *materialEaseInOutLabel =
-      [AnimationTimingExample curveLabelWithTitle:@"MDCAnimationTimingFunctionEaseInOut"];
+      [AnimationTimingExample curveLabelWithTitle:@"MDCAnimationTimingFunctionStandard"];
   materialEaseInOutLabel.frame =
       CGRectMake(kLeftGutter, lineSpace, materialEaseInOutLabel.frame.size.width,
                  materialEaseInOutLabel.frame.size.height);
@@ -80,10 +81,10 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
   CGRect materialEaseInOutViewFrame =
       CGRectMake(kLeftGutter, lineSpace + kTextOffset, kAnimationCircleSize.width,
                  kAnimationCircleSize.height);
-  self.materialEaseInOutView = [[UIView alloc] initWithFrame:materialEaseInOutViewFrame];
-  self.materialEaseInOutView.backgroundColor = [AnimationTimingExample defaultColors][1];
-  self.materialEaseInOutView.layer.cornerRadius = kAnimationCircleSize.width / 2.f;
-  [self.scrollView addSubview:self.materialEaseInOutView];
+  self.materialStandardView = [[UIView alloc] initWithFrame:materialEaseInOutViewFrame];
+  self.materialStandardView.backgroundColor = [AnimationTimingExample defaultColors][1];
+  self.materialStandardView.layer.cornerRadius = kAnimationCircleSize.width / 2.f;
+  [self.scrollView addSubview:self.materialStandardView];
 
   UILabel *materialEaseOutLabel =
       [AnimationTimingExample curveLabelWithTitle:@"MDCAnimationTimingFunctionEaseOut"];
@@ -92,13 +93,13 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
                  materialEaseOutLabel.frame.size.height);
   [self.scrollView addSubview:materialEaseOutLabel];
 
-  CGRect materialEaseOutViewFrame =
+  CGRect materialDecelerationViewFrame =
       CGRectMake(kLeftGutter, lineSpace * 2.f + kTextOffset, kAnimationCircleSize.width,
                  kAnimationCircleSize.height);
-  self.materialEaseOutView = [[UIView alloc] initWithFrame:materialEaseOutViewFrame];
-  self.materialEaseOutView.backgroundColor = [AnimationTimingExample defaultColors][2];
-  self.materialEaseOutView.layer.cornerRadius = kAnimationCircleSize.width / 2.f;
-  [self.scrollView addSubview:self.materialEaseOutView];
+  self.materialDecelerationView = [[UIView alloc] initWithFrame:materialDecelerationViewFrame];
+  self.materialDecelerationView.backgroundColor = [AnimationTimingExample defaultColors][2];
+  self.materialDecelerationView.layer.cornerRadius = kAnimationCircleSize.width / 2.f;
+  [self.scrollView addSubview:self.materialDecelerationView];
 
   UILabel *materialEaseInLabel =
       [AnimationTimingExample curveLabelWithTitle:@"MDCAnimationTimingFunctionEaseIn"];
@@ -107,13 +108,26 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
                  materialEaseInLabel.frame.size.height);
   [self.scrollView addSubview:materialEaseInLabel];
 
-  CGRect materialEaseInViewFrame =
+  CGRect materialAccelerationViewFrame =
       CGRectMake(kLeftGutter, lineSpace * 3.f + kTextOffset, kAnimationCircleSize.width,
                  kAnimationCircleSize.height);
-  self.materialEaseInView = [[UIView alloc] initWithFrame:materialEaseInViewFrame];
-  self.materialEaseInView.backgroundColor = [AnimationTimingExample defaultColors][3];
-  self.materialEaseInView.layer.cornerRadius = kAnimationCircleSize.width / 2.f;
-  [self.scrollView addSubview:self.materialEaseInView];
+  self.materialAccelerationView = [[UIView alloc] initWithFrame:materialAccelerationViewFrame];
+  self.materialAccelerationView.backgroundColor = [AnimationTimingExample defaultColors][3];
+  self.materialAccelerationView.layer.cornerRadius = kAnimationCircleSize.width / 2.f;
+  [self.scrollView addSubview:self.materialAccelerationView];
+   
+   UILabel *materialSharpLabel =
+       [AnimationTimingExample curveLabelWithTitle:@"MDCAnimationTimingFunctionSharp"];
+   materialSharpLabel.frame =
+       CGRectMake(kLeftGutter, lineSpace * 4.f, CGRectGetWidth(materialSharpLabel.frame),
+                  CGRectGetHeight(materialSharpLabel.frame));
+   [self.scrollView addSubview:materialSharpLabel];
+   
+   CGRect materialSharpViewFrame = CGRectMake(kLeftGutter, lineSpace * 4.f + kTextOffset, kAnimationCircleSize.width, kAnimationCircleSize.height);
+   self.materialSharpView = [[UIView alloc] initWithFrame:materialSharpViewFrame];
+   self.materialSharpView.backgroundColor = [AnimationTimingExample defaultColors][4];
+   self.materialSharpView.layer.cornerRadius = kAnimationCircleSize.width / 2.f;
+   [self.scrollView addSubview:self.materialSharpView];
 }
 
 + (UILabel *)curveLabelWithTitle:(NSString *)text {
@@ -132,8 +146,9 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
     UIColor *primaryColor = [UIColor darkGrayColor];
     defaultColors = @[
       [primaryColor colorWithAlphaComponent:0.8],
-      [primaryColor colorWithAlphaComponent:0.6],
-      [primaryColor colorWithAlphaComponent:0.4],
+      [primaryColor colorWithAlphaComponent:0.65],
+      [primaryColor colorWithAlphaComponent:0.5],
+      [primaryColor colorWithAlphaComponent:0.35],
       [primaryColor colorWithAlphaComponent:0.2]
     ];
   });


### PR DESCRIPTION
This pull request updates the examples of animation timing to match the new APIs. Changes made with padding are to make sure animation fits on iPhone 4s. Also, an update to the documentation to the match new APIs.


#2370 is blocking this.