### PR TITLE
[ActivityIndicator] Convert motion spec to an Objective-C static class.

### DIFF
--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -457,7 +457,7 @@ static const CGFloat kSingleCycleRotation =
   }];
 
   MDCActivityIndicatorMotionSpecIndeterminate timing =
-      [MDCActivityIndicatorMotionSpec loopIndeterminate];
+      MDCActivityIndicatorMotionSpec.loopIndeterminate;
   // These values may be equal if we've never received a progress. In this case we don't want our
   // duration to become zero.
   if (fabs(_lastProgress - _currentProgress) > CGFLOAT_EPSILON) {
@@ -525,9 +525,9 @@ static const CGFloat kSingleCycleRotation =
   if (targetRotation <= 0.001f) {
     targetRotation = 1.0f;
   }
-  CGFloat pointCycleDuration = (CGFloat)[MDCActivityIndicatorMotionSpec pointCycleDuration];
+  CGFloat pointCycleDuration = (CGFloat)MDCActivityIndicatorMotionSpec.pointCycleDuration;
   CGFloat pointCycleMinimumVariableDuration =
-      (CGFloat)[MDCActivityIndicatorMotionSpec pointCycleMinimumVariableDuration];
+      (CGFloat)MDCActivityIndicatorMotionSpec.pointCycleMinimumVariableDuration;
   CGFloat normalizedDuration = 2 * (targetRotation + _currentProgress) / kSingleCycleRotation *
                                pointCycleDuration;
   CGFloat strokeEndTravelDistance = targetRotation - _currentProgress + _minStrokeDifference;
@@ -546,7 +546,7 @@ static const CGFloat kSingleCycleRotation =
     [CATransaction setDisableActions:YES];
 
     MDCActivityIndicatorMotionSpecTransitionToIndeterminate timing =
-        [MDCActivityIndicatorMotionSpec willChangeToIndeterminate];
+        MDCActivityIndicatorMotionSpec.willChangeToIndeterminate;
 
     _outerRotationLayer.transform = CATransform3DIdentity;
     _strokeLayer.transform = CATransform3DIdentity;
@@ -588,9 +588,9 @@ static const CGFloat kSingleCycleRotation =
     CGFloat rotationDelta = 1.0f - [self normalizedRotationForCycle:_cycleCount];
 
     // Change the duration relative to the distance in order to keep same relative speed.
-    CGFloat pointCycleDuration = (CGFloat)[MDCActivityIndicatorMotionSpec pointCycleDuration];
+    CGFloat pointCycleDuration = (CGFloat)MDCActivityIndicatorMotionSpec.pointCycleDuration;
     CGFloat pointCycleMinimumVariableDuration =
-        (CGFloat)[MDCActivityIndicatorMotionSpec pointCycleMinimumVariableDuration];
+        (CGFloat)MDCActivityIndicatorMotionSpec.pointCycleMinimumVariableDuration;
     CGFloat duration = 2.0f * (rotationDelta + _currentProgress) / kSingleCycleRotation *
                        pointCycleDuration;
     duration = MAX(duration, pointCycleMinimumVariableDuration);
@@ -605,7 +605,7 @@ static const CGFloat kSingleCycleRotation =
       [CATransaction mdm_setTimeScaleFactor:@(duration)];
 
       MDCActivityIndicatorMotionSpecTransitionToDeterminate spec =
-          [MDCActivityIndicatorMotionSpec willChangeToDeterminate];
+          MDCActivityIndicatorMotionSpec.willChangeToDeterminate;
 
       _outerRotationLayer.transform =
           CATransform3DMakeRotation(kOuterRotationIncrement * _cycleCount, 0, 0, 1);
@@ -649,7 +649,7 @@ static const CGFloat kSingleCycleRotation =
     _strokeLayer.transform = CATransform3DIdentity;
     _strokeLayer.strokeStart = 0;
 
-    [_animator animateWithTiming:[MDCActivityIndicatorMotionSpec willChangeProgress].strokeEnd
+    [_animator animateWithTiming:MDCActivityIndicatorMotionSpec.willChangeProgress.strokeEnd
                          toLayer:_strokeLayer
                       withValues:@[@(_lastProgress), @(_currentProgress)]
                          keyPath:MDMKeyPathStrokeEnd];

--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -456,8 +456,8 @@ static const CGFloat kSingleCycleRotation =
     [self strokeRotationCycleFinishedFromState:MDCActivityIndicatorStateIndeterminate];
   }];
 
-  struct MDCActivityIndicatorMotionSpecIndeterminate timing =
-      kMDCActivityIndicatorMotionSpec.indeterminate;
+  MDCActivityIndicatorMotionSpecIndeterminate timing =
+      [MDCActivityIndicatorMotionSpec loopIndeterminate];
   // These values may be equal if we've never received a progress. In this case we don't want our
   // duration to become zero.
   if (fabs(_lastProgress - _currentProgress) > CGFLOAT_EPSILON) {
@@ -525,15 +525,17 @@ static const CGFloat kSingleCycleRotation =
   if (targetRotation <= 0.001f) {
     targetRotation = 1.0f;
   }
+  CGFloat pointCycleDuration = (CGFloat)[MDCActivityIndicatorMotionSpec pointCycleDuration];
+  CGFloat pointCycleMinimumVariableDuration =
+      (CGFloat)[MDCActivityIndicatorMotionSpec pointCycleMinimumVariableDuration];
   CGFloat normalizedDuration = 2 * (targetRotation + _currentProgress) / kSingleCycleRotation *
-                               (CGFloat)kPointCycleDuration;
+                               pointCycleDuration;
   CGFloat strokeEndTravelDistance = targetRotation - _currentProgress + _minStrokeDifference;
   CGFloat totalDistance = targetRotation + strokeEndTravelDistance;
   CGFloat strokeStartDuration =
-      MAX(normalizedDuration * targetRotation / totalDistance,
-          (CGFloat)kPointCycleMinimumVariableDuration);
+      MAX(normalizedDuration * targetRotation / totalDistance, pointCycleMinimumVariableDuration);
   CGFloat strokeEndDuration = MAX(normalizedDuration * strokeEndTravelDistance / totalDistance,
-                                  (CGFloat)kPointCycleMinimumVariableDuration);
+                                  pointCycleMinimumVariableDuration);
 
   [CATransaction begin];
   {
@@ -543,8 +545,8 @@ static const CGFloat kSingleCycleRotation =
     }];
     [CATransaction setDisableActions:YES];
 
-    struct MDCActivityIndicatorMotionSpecTransitionToIndeterminate timing =
-        kMDCActivityIndicatorMotionSpec.transitionToIndeterminate;
+    MDCActivityIndicatorMotionSpecTransitionToIndeterminate timing =
+        [MDCActivityIndicatorMotionSpec willChangeToIndeterminate];
 
     _outerRotationLayer.transform = CATransform3DIdentity;
     _strokeLayer.transform = CATransform3DIdentity;
@@ -586,9 +588,12 @@ static const CGFloat kSingleCycleRotation =
     CGFloat rotationDelta = 1.0f - [self normalizedRotationForCycle:_cycleCount];
 
     // Change the duration relative to the distance in order to keep same relative speed.
+    CGFloat pointCycleDuration = (CGFloat)[MDCActivityIndicatorMotionSpec pointCycleDuration];
+    CGFloat pointCycleMinimumVariableDuration =
+        (CGFloat)[MDCActivityIndicatorMotionSpec pointCycleMinimumVariableDuration];
     CGFloat duration = 2.0f * (rotationDelta + _currentProgress) / kSingleCycleRotation *
-                       (CGFloat)kPointCycleDuration;
-    duration = MAX(duration, (CGFloat)kPointCycleMinimumVariableDuration);
+                       pointCycleDuration;
+    duration = MAX(duration, pointCycleMinimumVariableDuration);
 
     [CATransaction begin];
     {
@@ -599,8 +604,8 @@ static const CGFloat kSingleCycleRotation =
       [CATransaction setDisableActions:YES];
       [CATransaction mdm_setTimeScaleFactor:@(duration)];
 
-      struct MDCActivityIndicatorMotionSpecTransitionToDeterminate spec =
-          kMDCActivityIndicatorMotionSpec.transitionToDeterminate;
+      MDCActivityIndicatorMotionSpecTransitionToDeterminate spec =
+          [MDCActivityIndicatorMotionSpec willChangeToDeterminate];
 
       _outerRotationLayer.transform =
           CATransform3DMakeRotation(kOuterRotationIncrement * _cycleCount, 0, 0, 1);
@@ -644,7 +649,7 @@ static const CGFloat kSingleCycleRotation =
     _strokeLayer.transform = CATransform3DIdentity;
     _strokeLayer.strokeStart = 0;
 
-    [_animator animateWithTiming:kMDCActivityIndicatorMotionSpec.progress.strokeEnd
+    [_animator animateWithTiming:[MDCActivityIndicatorMotionSpec willChangeProgress].strokeEnd
                          toLayer:_strokeLayer
                       withValues:@[@(_lastProgress), @(_currentProgress)]
                          keyPath:MDMKeyPathStrokeEnd];

--- a/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.h
+++ b/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.h
@@ -17,6 +17,14 @@
 #import <Foundation/Foundation.h>
 #import <MotionInterchange/MotionInterchange.h>
 
+#ifndef MDC_SUBCLASSING_RESTRICTED
+#if defined(__has_attribute) && __has_attribute(objc_subclassing_restricted)
+#define MDC_SUBCLASSING_RESTRICTED __attribute__((objc_subclassing_restricted))
+#else
+#define MDC_SUBCLASSING_RESTRICTED
+#endif
+#endif  // #ifndef MDC_SUBCLASSING_RESTRICTED
+
 typedef struct MDCActivityIndicatorMotionSpecIndeterminate {
   MDMMotionTiming outerRotation;
   MDMMotionTiming innerRotation;
@@ -38,6 +46,7 @@ typedef struct MDCActivityIndicatorMotionSpecProgress {
   MDMMotionTiming strokeEnd;
 } MDCActivityIndicatorMotionSpecProgress;
 
+MDC_SUBCLASSING_RESTRICTED
 @interface MDCActivityIndicatorMotionSpec: NSObject
 
 + (NSTimeInterval)pointCycleDuration;

--- a/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.h
+++ b/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.h
@@ -15,35 +15,41 @@
  */
 
 #import <Foundation/Foundation.h>
-
 #import <MotionInterchange/MotionInterchange.h>
 
-struct MDCActivityIndicatorMotionSpec {
-  struct MDCActivityIndicatorMotionSpecIndeterminate {
-    MDMMotionTiming outerRotation;
-    MDMMotionTiming innerRotation;
-    MDMMotionTiming strokeStart;
-    MDMMotionTiming strokeEnd;
-  } indeterminate;
+typedef struct MDCActivityIndicatorMotionSpecIndeterminate {
+  MDMMotionTiming outerRotation;
+  MDMMotionTiming innerRotation;
+  MDMMotionTiming strokeStart;
+  MDMMotionTiming strokeEnd;
+} MDCActivityIndicatorMotionSpecIndeterminate;
 
-  struct MDCActivityIndicatorMotionSpecTransitionToDeterminate {
-    MDMMotionTiming innerRotation;
-    MDMMotionTiming strokeEnd;
-  } transitionToDeterminate;
+typedef struct MDCActivityIndicatorMotionSpecTransitionToDeterminate {
+  MDMMotionTiming innerRotation;
+  MDMMotionTiming strokeEnd;
+} MDCActivityIndicatorMotionSpecTransitionToDeterminate;
 
-  struct MDCActivityIndicatorMotionSpecTransitionToIndeterminate {
-    MDMMotionTiming strokeStart;
-    MDMMotionTiming strokeEnd;
-  } transitionToIndeterminate;
+typedef struct MDCActivityIndicatorMotionSpecTransitionToIndeterminate {
+  MDMMotionTiming strokeStart;
+  MDMMotionTiming strokeEnd;
+} MDCActivityIndicatorMotionSpecTransitionToIndeterminate;
 
-  struct MDCActivityIndicatorMotionSpecProgress {
-    MDMMotionTiming strokeEnd;
-  } progress;
-};
-typedef struct MDCActivityIndicatorMotionSpec MDCActivityIndicatorMotionSpec;
+typedef struct MDCActivityIndicatorMotionSpecProgress {
+  MDMMotionTiming strokeEnd;
+} MDCActivityIndicatorMotionSpecProgress;
 
-FOUNDATION_EXPORT const NSTimeInterval kPointCycleDuration;
-FOUNDATION_EXPORT const NSTimeInterval kPointCycleMinimumVariableDuration;
+@interface MDCActivityIndicatorMotionSpec: NSObject
 
-FOUNDATION_EXPORT const struct MDCActivityIndicatorMotionSpec kMDCActivityIndicatorMotionSpec;
++ (NSTimeInterval)pointCycleDuration;
++ (NSTimeInterval)pointCycleMinimumVariableDuration;
+
++ (MDCActivityIndicatorMotionSpecIndeterminate)loopIndeterminate;
++ (MDCActivityIndicatorMotionSpecTransitionToDeterminate)willChangeToDeterminate;
++ (MDCActivityIndicatorMotionSpecTransitionToIndeterminate)willChangeToIndeterminate;
++ (MDCActivityIndicatorMotionSpecProgress)willChangeProgress;
+
+// This object is not meant to be instantiated.
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
 

--- a/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.m
+++ b/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.m
@@ -16,51 +16,71 @@
 
 #import "MDCActivityIndicatorMotionSpec.h"
 
-const NSTimeInterval kPointCycleDuration = 4.0f / 3.0f;
-const NSTimeInterval kPointCycleMinimumVariableDuration = kPointCycleDuration / 8;
+@implementation MDCActivityIndicatorMotionSpec
 
-const struct MDCActivityIndicatorMotionSpec kMDCActivityIndicatorMotionSpec = {
-  .indeterminate = {
++ (NSTimeInterval)pointCycleDuration {
+  return 4.0f / 3.0f;
+}
+
++ (NSTimeInterval)pointCycleMinimumVariableDuration {
+  return [self pointCycleDuration] / 8;
+}
+
++ (MDCActivityIndicatorMotionSpecIndeterminate)loopIndeterminate {
+  NSTimeInterval pointCycleDuration = [self pointCycleDuration];
+  MDMMotionCurve linear = MDMMotionCurveMakeBezier(0, 0, 1, 1);
+  return (MDCActivityIndicatorMotionSpecIndeterminate){
     .outerRotation = {
-      .duration = kPointCycleDuration, .curve = _MDMBezier(0, 0, 1, 1),
+      .duration = pointCycleDuration, .curve = linear,
     },
     .innerRotation = {
-      .duration = kPointCycleDuration, .curve = _MDMBezier(0, 0, 1, 1),
+      .duration = pointCycleDuration, .curve = linear,
     },
     .strokeStart = {
-      .delay = kPointCycleDuration / 2,
-      .duration = kPointCycleDuration / 2,
-      .curve = _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f),
+      .delay = pointCycleDuration / 2,
+      .duration = pointCycleDuration / 2,
+      .curve = MDMMotionCurveMakeBezier(0.4f, 0.0f, 0.2f, 1.0f),
     },
     .strokeEnd = {
-      .duration = kPointCycleDuration,
-      .curve = _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f),
+      .duration = pointCycleDuration,
+      .curve = MDMMotionCurveMakeBezier(0.4f, 0.0f, 0.2f, 1.0f),
     },
-  },
-  .transitionToDeterminate = {
+  };
+}
+
++ (MDCActivityIndicatorMotionSpecTransitionToDeterminate)willChangeToDeterminate {
+  MDMMotionCurve linear = MDMMotionCurveMakeBezier(0, 0, 1, 1);
+  return (MDCActivityIndicatorMotionSpecTransitionToDeterminate) {
     // Transition timing is calculated at runtime - any duration/delay values provided here will
     // by scaled by the calculated duration.
     .innerRotation = {
-      .duration = 1, .curve = _MDMBezier(0, 0, 1, 1),
+      .duration = 1, .curve = linear,
     },
     .strokeEnd = {
-      .duration = 1, .curve = _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f),
+      .duration = 1, .curve = MDMMotionCurveMakeBezier(0.4f, 0.0f, 0.2f, 1.0f),
     },
-  },
-  .transitionToIndeterminate = {
+  };
+}
+
++ (MDCActivityIndicatorMotionSpecTransitionToIndeterminate)willChangeToIndeterminate {
+  return (MDCActivityIndicatorMotionSpecTransitionToIndeterminate){
     // Transition timing is calculated at runtime.
     .strokeStart = {
-      .curve = _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f),
+      .curve = MDMMotionCurveMakeBezier(0.4f, 0.0f, 0.2f, 1.0f),
     },
     .strokeEnd = {
-      .curve = _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f),
+      .curve = MDMMotionCurveMakeBezier(0.4f, 0.0f, 0.2f, 1.0f),
     },
-  },
-  .progress = {
-    .strokeEnd = {
-      .duration = kPointCycleDuration / 2,
-      .curve = _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f),
-    }
-  }
-};
+  };
+}
 
++ (MDCActivityIndicatorMotionSpecProgress)willChangeProgress {
+  return (MDCActivityIndicatorMotionSpecProgress){
+    .strokeEnd = {
+      .duration = [self pointCycleDuration] / 2,
+      .curve = MDMMotionCurveMakeBezier(0.4f, 0.0f, 0.2f, 1.0f),
+    }
+  };
+}
+
+@end

--- a/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.m
+++ b/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.m
@@ -19,15 +19,15 @@
 @implementation MDCActivityIndicatorMotionSpec
 
 + (NSTimeInterval)pointCycleDuration {
-  return 4.0f / 3.0f;
+  return 4.0 / 3.0;
 }
 
 + (NSTimeInterval)pointCycleMinimumVariableDuration {
-  return [self pointCycleDuration] / 8;
+  return self.pointCycleDuration / 8;
 }
 
 + (MDCActivityIndicatorMotionSpecIndeterminate)loopIndeterminate {
-  NSTimeInterval pointCycleDuration = [self pointCycleDuration];
+  NSTimeInterval pointCycleDuration = self.pointCycleDuration;
   MDMMotionCurve linear = MDMMotionCurveMakeBezier(0, 0, 1, 1);
   return (MDCActivityIndicatorMotionSpecIndeterminate){
     .outerRotation = {
@@ -77,7 +77,7 @@
 + (MDCActivityIndicatorMotionSpecProgress)willChangeProgress {
   return (MDCActivityIndicatorMotionSpecProgress){
     .strokeEnd = {
-      .duration = [self pointCycleDuration] / 2,
+      .duration = self.pointCycleDuration / 2,
       .curve = MDMMotionCurveMakeBezier(0.4f, 0.0f, 0.2f, 1.0f),
     }
   };


### PR DESCRIPTION
The interchange library will soon be dropping support for static spec initialization in favor of runtime APIs. This change moves the ActivityIndicator off of all macro-based APIs.