### PR TITLE
[ProgressView] Convert motion spec to an Objective-C static class.

### DIFF
--- a/components/ProgressView/src/MDCProgressView.m
+++ b/components/ProgressView/src/MDCProgressView.m
@@ -22,7 +22,7 @@
 #import "MaterialMath.h"
 #import "MaterialPalettes.h"
 #import <MotionAnimator/MotionAnimator.h>
-#import "private/MDCProgressView+MotionSpec.h"
+#import "private/MDCProgressViewMotionSpec.h"
 
 static inline UIColor *MDCProgressViewDefaultTintColor(void) {
   return MDCPalette.bluePalette.tint500;
@@ -144,7 +144,7 @@ static const CGFloat MDCProgressViewTrackColorDesaturation = 0.3f;
     [self updateProgressView];
 
   } else {
-    MDMMotionTiming timing = kMDCProgressViewMotionSpec.setProgress;
+    MDMMotionTiming timing = MDCProgressViewMotionSpec.willChangeProgress;
     [_animator animateWithTiming:timing animations:^{
       [self updateProgressView];
     } completion:^{
@@ -200,7 +200,7 @@ static const CGFloat MDCProgressViewTrackColorDesaturation = 0.3f;
   }
 
   if (animated) {
-    MDMMotionTiming timing = kMDCProgressViewMotionSpec.setHidden;
+    MDMMotionTiming timing = MDCProgressViewMotionSpec.willChangeHidden;
     [_animator animateWithTiming:timing animations:animations completion:^{
       if (hidden) {
         self.animatingHide = NO;

--- a/components/ProgressView/src/private/MDCProgressViewMotionSpec.h
+++ b/components/ProgressView/src/private/MDCProgressViewMotionSpec.h
@@ -15,13 +15,14 @@
  */
 
 #import <Foundation/Foundation.h>
-
 #import <MotionInterchange/MotionInterchange.h>
 
-struct MDCProgressViewMotionSpec {
-  MDMMotionTiming setProgress;
-  MDMMotionTiming setHidden;
-};
-typedef struct MDCProgressViewMotionSpec MDCProgressViewMotionSpec;
+@interface MDCProgressViewMotionSpec: NSObject
 
-FOUNDATION_EXPORT const struct MDCProgressViewMotionSpec kMDCProgressViewMotionSpec;
++ (MDMMotionTiming)willChangeProgress;
++ (MDMMotionTiming)willChangeHidden;
+
+// This object is not meant to be instantiated.
+- (instancetype)init NS_UNAVAILABLE;
+
+@end

--- a/components/ProgressView/src/private/MDCProgressViewMotionSpec.m
+++ b/components/ProgressView/src/private/MDCProgressViewMotionSpec.m
@@ -14,13 +14,21 @@
  limitations under the License.
  */
 
-#import "MDCProgressView+MotionSpec.h"
+#import "MDCProgressViewMotionSpec.h"
 
-const struct MDCProgressViewMotionSpec kMDCProgressViewMotionSpec = {
-  .setProgress = {
-    .duration = 0.250, .curve = _MDMBezier(0, 0, 1, 1),
-  },
-  .setHidden = {
-    .duration = 0.250, .curve = _MDMBezier(0, 0, 1, 1),
-  }
-};
+@implementation MDCProgressViewMotionSpec
+
++ (MDMMotionTiming)willChangeProgress {
+  return (MDMMotionTiming){
+    .duration = 0.250, .curve = MDMMotionCurveMakeBezier(0, 0, 1, 1),
+  };
+}
+
++ (MDMMotionTiming)willChangeHidden {
+  return (MDMMotionTiming){
+    .duration = 0.250, .curve = MDMMotionCurveMakeBezier(0, 0, 1, 1),
+  };
+}
+
+@end
+


### PR DESCRIPTION
The interchange library will soon be dropping support for static spec initialization in favor of runtime APIs. This change moves the ProgressView off of all macro-based APIs.