### PR TITLE
Clean up warning flags

### DIFF
--- a/catalog/MaterialComponentsWarnings.xcconfig
+++ b/catalog/MaterialComponentsWarnings.xcconfig
@@ -1,1 +1,18 @@
-WARNING_CFLAGS = $(inherited) -Wall -Wcast-align -Wconversion -Werror -Wextra -Wno-partial-availability -Wimplicit-atomic-properties -Wmissing-prototypes -Wnewline-eof -Wno-error=deprecated -Wno-error=deprecated-implementations -Wno-sign-conversion -Woverlength-strings -Wshadow -Wstrict-selector-match -Wundeclared-selector -Wunreachable-code -Wstrict-prototypes -Wunused-comparison -Wunused-const-variable -Wunused-exception-parameter -Wunused-function -Wunused-label -Wunused-member-function -Wunused-private-field -Wunused-property-ivar -Wunused-result -Wunused-value -Wunused-variable -Wunused-volatile-lvalue -Wused-but-marked-unused
+// Warning flags to be used for all library and example code.
+//
+// Clang's warning reference: https://clang.llvm.org/docs/DiagnosticsReference.html
+// General xcconfig docs: https://pewpewthespells.com/blog/xcconfig_guide.html
+//
+// * Our basic warnings cover most things and make warnings into errors.
+// * If a warning is (transitively) enabled by our basic warnings, do not include it separately.
+// * For warnings not enabled by our basic warnings, add them to the extra warnings.
+// * To change a warning-as-error into just a warning, add it to the ignorable warnings.
+// * To disable a warning completely, add it to the disabled warnings. 
+//
+
+MDC_BASIC_WARNINGS = -Wall -Wextra -Werror
+MDC_EXTRA_WARNINGS = -Wcast-align -Wconversion -Watomic-properties -Wmissing-prototypes -Wnewline-eof -Woverlength-strings -Wshadow-all -Wstrict-selector-match -Wundeclared-selector -Wunreachable-code -Wstrict-prototypes
+MDC_IGNORABLE_WARNINGS = -Wno-error=deprecated -Wno-error=deprecated-implementations
+MDC_DISABLED_WARNINGS = $(MDC_DEPRECATION_WARNINGS) -Wno-partial-availability -Wno-sign-conversion -Wno-unused-parameter
+
+WARNING_CFLAGS = $(inherited) $(MDC_BASIC_WARNINGS) $(MDC_EXTRA_WARNINGS) $(MDC_IGNORABLE_WARNINGS) $(MDC_DISABLED_WARNINGS)

--- a/catalog/MaterialComponentsWarnings.xcconfig
+++ b/catalog/MaterialComponentsWarnings.xcconfig
@@ -13,6 +13,6 @@
 MDC_BASIC_WARNINGS = -Wall -Wextra -Werror
 MDC_EXTRA_WARNINGS = -Wcast-align -Wconversion -Watomic-properties -Wmissing-prototypes -Wnewline-eof -Woverlength-strings -Wshadow-all -Wstrict-selector-match -Wundeclared-selector -Wunreachable-code -Wstrict-prototypes
 MDC_IGNORABLE_WARNINGS = -Wno-error=deprecated -Wno-error=deprecated-implementations
-MDC_DISABLED_WARNINGS = $(MDC_DEPRECATION_WARNINGS) -Wno-partial-availability -Wno-sign-conversion -Wno-unused-parameter
+MDC_DISABLED_WARNINGS = -Wno-partial-availability -Wno-sign-conversion -Wno-unused-parameter
 
 WARNING_CFLAGS = $(inherited) $(MDC_BASIC_WARNINGS) $(MDC_EXTRA_WARNINGS) $(MDC_IGNORABLE_WARNINGS) $(MDC_DISABLED_WARNINGS)

--- a/catalog/MaterialComponentsWarnings.xcconfig
+++ b/catalog/MaterialComponentsWarnings.xcconfig
@@ -12,7 +12,7 @@
 //   `-Wno-<warning>`.
 //
 MDC_BASIC_WARNINGS = -Wall -Wextra -Werror
-MDC_EXTRA_WARNINGS = -Wcast-align -Wconversion -Watomic-properties -Wmissing-prototypes -Wnewline-eof -Woverlength-strings -Wshadow-all -Wstrict-selector-match -Wundeclared-selector -Wunreachable-code -Wstrict-prototypes
+MDC_EXTRA_WARNINGS = -Wcast-align -Wconversion -Watomic-properties -Wmissing-prototypes -Wnewline-eof -Woverlength-strings -Wshadow -Wstrict-selector-match -Wundeclared-selector -Wunreachable-code -Wstrict-prototypes
 MDC_IGNORABLE_WARNINGS = -Wno-error=deprecated -Wno-error=deprecated-implementations
 MDC_DISABLED_WARNINGS = -Wno-partial-availability -Wno-sign-conversion -Wno-unused-parameter
 

--- a/catalog/MaterialComponentsWarnings.xcconfig
+++ b/catalog/MaterialComponentsWarnings.xcconfig
@@ -6,10 +6,11 @@
 // * Our basic warnings cover most things and make warnings into errors.
 // * If a warning is (transitively) enabled by our basic warnings, do not include it separately.
 // * For warnings not enabled by our basic warnings, add them to the extra warnings.
-// * To change a warning-as-error into just a warning, add it to the ignorable warnings.
-// * To disable a warning completely, add it to the disabled warnings. 
+// * To change a warning-as-error into just a warning, add it to the ignorable warnings using the
+//   format `-Wno-error=<warning>`.
+// * To disable a warning completely, add it to the disabled warnings using the format
+//   `-Wno-<warning>`.
 //
-
 MDC_BASIC_WARNINGS = -Wall -Wextra -Werror
 MDC_EXTRA_WARNINGS = -Wcast-align -Wconversion -Watomic-properties -Wmissing-prototypes -Wnewline-eof -Woverlength-strings -Wshadow-all -Wstrict-selector-match -Wundeclared-selector -Wunreachable-code -Wstrict-prototypes
 MDC_IGNORABLE_WARNINGS = -Wno-error=deprecated -Wno-error=deprecated-implementations

--- a/components/LibraryInfo/src/MDCLibraryInfo.h
+++ b/components/LibraryInfo/src/MDCLibraryInfo.h
@@ -38,6 +38,6 @@ MDC_SUBCLASSING_RESTRICTED
  - Y is the minor version number of the library.
  - Z is the patch version number of the library.
  */
-@property(class, nonnull, readonly) NSString *versionString;
+@property(class, nonatomic, nonnull, readonly) NSString *versionString;
 
 @end

--- a/components/Palettes/src/MDCPalettes.h
+++ b/components/Palettes/src/MDCPalettes.h
@@ -76,61 +76,61 @@ CG_EXTERN const MDCPaletteAccent _Nonnull MDCPaletteAccent700Name;
 @interface MDCPalette : NSObject
 
 /** The red palette. */
-@property(class, readonly, strong, nonnull) MDCPalette *redPalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *redPalette;
 
 /** The pink palette. */
-@property(class, readonly, strong, nonnull) MDCPalette *pinkPalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *pinkPalette;
 
 /** The purple palette. */
-@property(class, readonly, strong, nonnull) MDCPalette *purplePalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *purplePalette;
 
 /** The deep purple palette. */
-@property(class, readonly, strong, nonnull) MDCPalette *deepPurplePalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *deepPurplePalette;
 
 /** The indigo palette. */
-@property(class, readonly, strong, nonnull) MDCPalette *indigoPalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *indigoPalette;
 
 /** The blue palette. */
-@property(class, readonly, strong, nonnull) MDCPalette *bluePalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *bluePalette;
 
 /** The light blue palette. */
-@property(class, readonly, strong, nonnull) MDCPalette *lightBluePalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *lightBluePalette;
 
 /** The cyan palette. */
-@property(class, readonly, strong, nonnull) MDCPalette *cyanPalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *cyanPalette;
 
 /** The teal palette. */
-@property(class, readonly, strong, nonnull) MDCPalette *tealPalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *tealPalette;
 
 /** The green palette. */
-@property(class, readonly, strong, nonnull) MDCPalette *greenPalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *greenPalette;
 
 /** The light green palette. */
-@property(class, readonly, strong, nonnull) MDCPalette *lightGreenPalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *lightGreenPalette;
 
 /** The lime palette. */
-@property(class, readonly, strong, nonnull) MDCPalette *limePalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *limePalette;
 
 /** The yellow palette. */
-@property(class, readonly, strong, nonnull) MDCPalette *yellowPalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *yellowPalette;
 
 /** The amber palette. */
-@property(class, readonly, strong, nonnull) MDCPalette *amberPalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *amberPalette;
 
 /** The orange palette. */
-@property(class, readonly, strong, nonnull) MDCPalette *orangePalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *orangePalette;
 
 /** The deep orange palette. */
-@property(class, readonly, strong, nonnull) MDCPalette *deepOrangePalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *deepOrangePalette;
 
 /** The brown palette (no accents). */
-@property(class, readonly, strong, nonnull) MDCPalette *brownPalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *brownPalette;
 
 /** The grey palette (no accents). */
-@property(class, readonly, strong, nonnull) MDCPalette *greyPalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *greyPalette;
 
 /** The blue grey palette (no accents). */
-@property(class, readonly, strong, nonnull) MDCPalette *blueGreyPalette;
+@property(class, nonatomic, readonly, strong, nonnull) MDCPalette *blueGreyPalette;
 
 /**
  Returns a palette generated from a single target 500 tint color.

--- a/components/private/Shapes/src/MDCShapedShadowLayer.h
+++ b/components/private/Shapes/src/MDCShapedShadowLayer.h
@@ -30,7 +30,7 @@
 
  @note Make sure to set the backgroundColor to a clear color when setting fillColor.
  */
-@property(nullable) CGColorRef fillColor;
+@property(nullable, nonatomic) CGColorRef fillColor;
 
 /*
  The MDCShapeGenerating object used to set the shape's path and shadow path.


### PR DESCRIPTION
- Removed redundant `-Wunused-*` flags.
- Disabled the problematic `-Wunused-parameter` flag.
- Documented and broke up flags into groups.

One cleanup ended up enabling [`-Wcustom-atomic-properties`](https://clang.llvm.org/docs/DiagnosticsReference.html#wcustom-atomic-properties), so I fixed those errors.

