### PR TITLE
[kokoro] Specify ios_multi_cpus and ios_minimum_os when building against bazel.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -64,10 +64,14 @@ run_bazel() {
   fix_bazel_imports
 
   if [ -n "$VERBOSE_OUTPUT" ]; then
-    extra_args="-v"
+    verbosity_args="-v"
   fi
 
-  ./.kokoro-ios-runner/bazel.sh test //components/... --min-xcode-version $XCODE_MINIMUM_VERSION $extra_args
+  ./.kokoro-ios-runner/bazel.sh test //components/... \
+      --min-xcode-version $XCODE_MINIMUM_VERSION \
+      $verbosity_args \
+      --ios_minimum_os=8.0 \
+      --ios_multi_cpus=i386,x86_64
 }
 
 run_cocoapods() {

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
@@ -129,7 +129,7 @@
 // Test the Flexible Header View Height Offset After Initial Setup
 - (void)testFlexibleHeaderViewControllerTopLayoutGuideHeightOffsetSettingMinHeight {
   // When
-  CGFloat randomHeight = (CGFloat)arc4random_uniform(200.0) + 20.0;  // Height Greater Than Status Bar
+  CGFloat randomHeight = (CGFloat)(arc4random_uniform(200.0) + 20.0);  // Height Greater Than Status Bar
   self.vc.fhvc.headerView.minimumHeight = randomHeight;
 
   // Then
@@ -166,7 +166,7 @@
 
 - (void)testFlexibleHeaderViewControllerTopLayoutGuideHeightOffPullDownRelease {
   // When
-  CGFloat randomHeight = (CGFloat)arc4random_uniform(50.0) + 20.0;
+  CGFloat randomHeight = (CGFloat)(arc4random_uniform(50.0) + 20.0);
   self.vc.fhvc.headerView.maximumHeight = randomHeight;
   CGRect initialFrame =
       CGRectMake(0, self.vc.scrollView.contentInset.top, [UIScreen mainScreen].bounds.size.width,

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderViewControllerTopLayoutGuideTests.m
@@ -129,7 +129,7 @@
 // Test the Flexible Header View Height Offset After Initial Setup
 - (void)testFlexibleHeaderViewControllerTopLayoutGuideHeightOffsetSettingMinHeight {
   // When
-  CGFloat randomHeight = arc4random_uniform(200.0) + 20.0;  // Height Greater Than Status Bar
+  CGFloat randomHeight = (CGFloat)arc4random_uniform(200.0) + 20.0;  // Height Greater Than Status Bar
   self.vc.fhvc.headerView.minimumHeight = randomHeight;
 
   // Then
@@ -166,7 +166,7 @@
 
 - (void)testFlexibleHeaderViewControllerTopLayoutGuideHeightOffPullDownRelease {
   // When
-  CGFloat randomHeight = arc4random_uniform(50.0) + 20.0;
+  CGFloat randomHeight = (CGFloat)arc4random_uniform(50.0) + 20.0;
   self.vc.fhvc.headerView.maximumHeight = randomHeight;
   CGRect initialFrame =
       CGRectMake(0, self.vc.scrollView.contentInset.top, [UIScreen mainScreen].bounds.size.width,


### PR DESCRIPTION
This ensures that our bazel builds will catch architecture-specific warnings and errors.