### PR TITLE
[MaskedTransition] Convert motion spec to an Objective-C static class.

### DIFF
--- a/components/MaskedTransition/src/MDCMaskedTransition.m
+++ b/components/MaskedTransition/src/MDCMaskedTransition.m
@@ -81,7 +81,7 @@ static inline CGFloat LengthOfVector(CGVector vector) {
 }
 
 - (void)startWithContext:(NSObject<MDMTransitionContext> *)context {
-  MDCMaskedTransitionMotionSpec spec = motionForContext(context);
+  MDCMaskedTransitionMotionSpecContext spec = motionForContext(context);
   if (context.direction == MDMTransitionDirectionForward) {
     _shouldSlideWhenCollapsed = spec.shouldSlideWhenCollapsed;
   }

--- a/components/MaskedTransition/src/MDCMaskedTransition.m
+++ b/components/MaskedTransition/src/MDCMaskedTransition.m
@@ -81,7 +81,7 @@ static inline CGFloat LengthOfVector(CGVector vector) {
 }
 
 - (void)startWithContext:(NSObject<MDMTransitionContext> *)context {
-  MDCMaskedTransitionMotionSpecContext spec = motionForContext(context);
+  MDCMaskedTransitionMotionSpecContext spec = MDCMaskedTransitionMotionSpecForContext(context);
   if (context.direction == MDMTransitionDirectionForward) {
     _shouldSlideWhenCollapsed = spec.shouldSlideWhenCollapsed;
   }

--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
@@ -86,7 +86,7 @@
 }
 
 - (void)startWithContext:(NSObject<MDMTransitionContext> *)context {
-  MDCMaskedTransitionMotionSpecContext spec = motionForContext(context);
+  MDCMaskedTransitionMotionSpecContext spec = MDCMaskedTransitionMotionSpecForContext(context);
 
   MDMMotionAnimator *animator = [[MDMMotionAnimator alloc] init];
   animator.shouldReverseValues = context.direction == MDMTransitionDirectionBackward;

--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
@@ -86,7 +86,7 @@
 }
 
 - (void)startWithContext:(NSObject<MDMTransitionContext> *)context {
-  MDCMaskedTransitionMotionSpec spec = motionForContext(context);
+  MDCMaskedTransitionMotionSpecContext spec = motionForContext(context);
 
   MDMMotionAnimator *animator = [[MDMMotionAnimator alloc] init];
   animator.shouldReverseValues = context.direction == MDMTransitionDirectionBackward;

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.h
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.h
@@ -20,4 +20,5 @@
 #import "MDCMaskedTransitionMotionSpec.h"
 
 FOUNDATION_EXPORT
-MDCMaskedTransitionMotionSpecContext motionForContext(NSObject<MDMTransitionContext> *context);
+MDCMaskedTransitionMotionSpecContext
+    MDCMaskedTransitionMotionSpecForContext(NSObject<MDMTransitionContext> *context);

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.h
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.h
@@ -19,4 +19,5 @@
 
 #import "MDCMaskedTransitionMotionSpec.h"
 
-FOUNDATION_EXPORT MDCMaskedTransitionMotionSpec motionForContext(NSObject<MDMTransitionContext> *context);
+FOUNDATION_EXPORT
+MDCMaskedTransitionMotionSpecContext motionForContext(NSObject<MDMTransitionContext> *context);

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.h
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.h
@@ -21,4 +21,4 @@
 
 FOUNDATION_EXPORT
 MDCMaskedTransitionMotionSpecContext
-    MDCMaskedTransitionMotionSpecForContext(NSObject<MDMTransitionContext> *context);
+    MDCMaskedTransitionMotionSpecForContext(id<MDMTransitionContext> context);

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.m
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.m
@@ -17,7 +17,7 @@
 #import "MDCMaskedTransitionMotionForContext.h"
 
 MDCMaskedTransitionMotionSpecContext
-    MDCMaskedTransitionMotionSpecForContext(NSObject<MDMTransitionContext> *context) {
+    MDCMaskedTransitionMotionSpecForContext(id<MDMTransitionContext> context) {
   const CGRect foreBounds = context.foreViewController.view.bounds;
   const CGRect foreFrame = context.foreViewController.view.frame;
   const CGRect containerBounds = context.containerView.bounds;

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.m
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.m
@@ -16,26 +16,26 @@
 
 #import "MDCMaskedTransitionMotionForContext.h"
 
-MDCMaskedTransitionMotionSpec motionForContext(NSObject<MDMTransitionContext> *context) {
+MDCMaskedTransitionMotionSpecContext motionForContext(NSObject<MDMTransitionContext> *context) {
   const CGRect foreBounds = context.foreViewController.view.bounds;
   const CGRect foreFrame = context.foreViewController.view.frame;
   const CGRect containerBounds = context.containerView.bounds;
 
   if (CGRectEqualToRect(context.foreViewController.view.frame, containerBounds)) {
-    return fullscreen;
+    return MDCMaskedTransitionMotionSpec.fullscreen;
 
   } else if (foreBounds.size.width == containerBounds.size.width
              && CGRectGetMaxY(foreFrame) == CGRectGetMaxY(containerBounds)) {
     if (foreFrame.size.height > 100) {
-      return bottomSheet;
+      return MDCMaskedTransitionMotionSpec.bottomSheet;
 
     } else {
-      return toolbar;
+      return MDCMaskedTransitionMotionSpec.toolbar;
     }
 
   } else if (foreBounds.size.width < containerBounds.size.width) {
-    return bottomCard;
+    return MDCMaskedTransitionMotionSpec.bottomCard;
   }
 
-  return fullscreen;
+  return MDCMaskedTransitionMotionSpec.fullscreen;
 }

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.m
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.m
@@ -16,7 +16,8 @@
 
 #import "MDCMaskedTransitionMotionForContext.h"
 
-MDCMaskedTransitionMotionSpecContext motionForContext(NSObject<MDMTransitionContext> *context) {
+MDCMaskedTransitionMotionSpecContext
+    MDCMaskedTransitionMotionSpecForContext(NSObject<MDMTransitionContext> *context) {
   const CGRect foreBounds = context.foreViewController.view.bounds;
   const CGRect foreFrame = context.foreViewController.view.frame;
   const CGRect containerBounds = context.containerView.bounds;

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionSpec.h
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionSpec.h
@@ -17,7 +17,7 @@
 #import <Foundation/Foundation.h>
 #import <MotionInterchange/MotionInterchange.h>
 
-struct MDCMaskedTransitionMotionTiming {
+typedef struct MDCMaskedTransitionMotionTiming {
   MDMMotionTiming iconFade;
   MDMMotionTiming contentFade;
   MDMMotionTiming floodBackgroundColor;
@@ -25,18 +25,23 @@ struct MDCMaskedTransitionMotionTiming {
   MDMMotionTiming horizontalMovement;
   MDMMotionTiming verticalMovement;
   MDMMotionTiming scrimFade;
-};
-typedef struct MDCMaskedTransitionMotionTiming MDCMaskedTransitionMotionTiming;
+} MDCMaskedTransitionMotionTiming;
 
-struct MDCMaskedTransitionMotionSpec {
+typedef struct MDCMaskedTransitionMotionSpecContext {
   MDCMaskedTransitionMotionTiming expansion;
   MDCMaskedTransitionMotionTiming collapse;
   BOOL shouldSlideWhenCollapsed;
   BOOL isCentered;
-};
-typedef struct MDCMaskedTransitionMotionSpec MDCMaskedTransitionMotionSpec;
+} MDCMaskedTransitionMotionSpecContext;
 
-FOUNDATION_EXPORT struct MDCMaskedTransitionMotionSpec fullscreen;
-FOUNDATION_EXPORT struct MDCMaskedTransitionMotionSpec bottomSheet;
-FOUNDATION_EXPORT struct MDCMaskedTransitionMotionSpec bottomCard;
-FOUNDATION_EXPORT struct MDCMaskedTransitionMotionSpec toolbar;
+@interface MDCMaskedTransitionMotionSpec: NSObject
+
++ (MDCMaskedTransitionMotionSpecContext)fullscreen;
++ (MDCMaskedTransitionMotionSpecContext)bottomSheet;
++ (MDCMaskedTransitionMotionSpecContext)bottomCard;
++ (MDCMaskedTransitionMotionSpecContext)toolbar;
+
+// This object is not meant to be instantiated.
+- (instancetype)init NS_UNAVAILABLE;
+
+@end

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionSpec.h
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionSpec.h
@@ -36,10 +36,10 @@ typedef struct MDCMaskedTransitionMotionSpecContext {
 
 @interface MDCMaskedTransitionMotionSpec: NSObject
 
-+ (MDCMaskedTransitionMotionSpecContext)fullscreen;
-+ (MDCMaskedTransitionMotionSpecContext)bottomSheet;
-+ (MDCMaskedTransitionMotionSpecContext)bottomCard;
-+ (MDCMaskedTransitionMotionSpecContext)toolbar;
+@property(nonatomic, class, readonly) MDCMaskedTransitionMotionSpecContext fullscreen;
+@property(nonatomic, class, readonly) MDCMaskedTransitionMotionSpecContext bottomSheet;
+@property(nonatomic, class, readonly) MDCMaskedTransitionMotionSpecContext bottomCard;
+@property(nonatomic, class, readonly) MDCMaskedTransitionMotionSpecContext toolbar;
 
 // This object is not meant to be instantiated.
 - (instancetype)init NS_UNAVAILABLE;

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionSpec.m
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionSpec.m
@@ -16,160 +16,190 @@
 
 #import "MDCMaskedTransitionMotionSpec.h"
 
-#define EaseInEaseOut _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f)
-#define EaseIn _MDMBezier(0.4f, 0.0f, 1.0f, 1.0f)
-#define EaseOut _MDMBezier(0.0f, 0.0f, 0.2f, 1.0f)
+@implementation MDCMaskedTransitionMotionSpec
 
-struct MDCMaskedTransitionMotionSpec fullscreen = {
-  .expansion = {
-    .iconFade = {
-      .delay = 0.000, .duration = 0.075, .curve = EaseInEaseOut,
-    },
-    .contentFade = {
-      .delay = 0.150, .duration = 0.225, .curve = EaseInEaseOut,
-    },
-    .floodBackgroundColor = {
-      .delay = 0.000, .duration = 0.075, .curve = EaseInEaseOut,
-    },
-    .maskTransformation = {
-      .delay = 0.000, .duration = 0.105, .curve = EaseIn,
-    },
-    .horizontalMovement = {.curve = { .type = MDMMotionCurveTypeInstant }},
-    .verticalMovement = {
-      .delay = 0.045, .duration = 0.330, .curve = EaseInEaseOut,
-    },
-    .scrimFade = {
-      .delay = 0.000, .duration = 0.150, .curve = EaseInEaseOut,
-    }
-  },
-  .shouldSlideWhenCollapsed = true,
-  .isCentered = false
-};
++ (MDMMotionCurve)easeInEaseOut {
+  return MDMMotionCurveMakeBezier(0.4f, 0.0f, 0.2f, 1.0f);
+}
 
-struct MDCMaskedTransitionMotionSpec bottomSheet = {
-  .expansion = {
-    .iconFade = {
-      .delay = 0.000, .duration = 0.075, .curve = EaseInEaseOut, // No spec
-    },
-    .contentFade = { // No spec for this
-      .delay = 0.100, .duration = 0.200, .curve = EaseInEaseOut,
-    },
-    .floodBackgroundColor = {
-      .delay = 0.000, .duration = 0.075, .curve = EaseInEaseOut,
-    },
-    .maskTransformation = {
-      .delay = 0.000, .duration = 0.105, .curve = EaseIn,
-    },
-    .horizontalMovement = {.curve = { .type = MDMMotionCurveTypeInstant }},
-    .verticalMovement = {
-      .delay = 0.045, .duration = 0.330, .curve = EaseInEaseOut,
-    },
-    .scrimFade = {
-      .delay = 0.000, .duration = 0.150, .curve = EaseInEaseOut,
-    }
-  },
-  .shouldSlideWhenCollapsed = true,
-  .isCentered = false
-};
++ (MDMMotionCurve)easeIn {
+  return MDMMotionCurveMakeBezier(0.4f, 0.0f, 1.0f, 1.0f);
+}
 
-struct MDCMaskedTransitionMotionSpec bottomCard = {
-  .expansion = {
-    .iconFade = {
-      .delay = 0.000, .duration = 0.120, .curve = EaseInEaseOut,
-    },
-    .contentFade = {
-      .delay = 0.150, .duration = 0.150, .curve = EaseInEaseOut,
-    },
-    .floodBackgroundColor = {
-      .delay = 0.075, .duration = 0.075, .curve = EaseInEaseOut,
-    },
-    .maskTransformation = {
-      .delay = 0.045, .duration = 0.225, .curve = EaseIn,
-    },
-    .horizontalMovement = {
-      .delay = 0.000, .duration = 0.150, .curve = EaseInEaseOut,
-    },
-    .verticalMovement = {
-      .delay = 0.000, .duration = 0.345, .curve = EaseInEaseOut,
-    },
-    .scrimFade = {
-      .delay = 0.075, .duration = 0.150, .curve = EaseInEaseOut,
-    }
-  },
-  .collapse = {
-    .iconFade = {
-      .delay = 0.150, .duration = 0.150, .curve = EaseInEaseOut,
-    },
-    .contentFade = {
-      .delay = 0.000, .duration = 0.075, .curve = EaseIn,
-    },
-    .floodBackgroundColor = {
-      .delay = 0.060, .duration = 0.150, .curve = EaseInEaseOut,
-    },
-    .maskTransformation = {
-      .delay = 0.000, .duration = 0.180, .curve = EaseOut,
-    },
-    .horizontalMovement = {
-      .delay = 0.045, .duration = 0.255, .curve = EaseInEaseOut,
-    },
-    .verticalMovement = {
-      .delay = 0.000, .duration = 0.255, .curve = EaseInEaseOut,
-    },
-    .scrimFade = {
-      .delay = 0.000, .duration = 0.150, .curve = EaseInEaseOut,
-    }
-  },
-  .shouldSlideWhenCollapsed = false,
-  .isCentered = true
-};
++ (MDMMotionCurve)easeOut {
+  return MDMMotionCurveMakeBezier(0.0f, 0.0f, 0.2f, 1.0f);
+}
 
-struct MDCMaskedTransitionMotionSpec toolbar = {
-  .expansion = {
-    .iconFade = {
-      .delay = 0.000, .duration = 0.120, .curve = EaseInEaseOut,
++ (MDCMaskedTransitionMotionSpecContext)fullscreen {
+  MDMMotionCurve easeInEaseOut = [self easeInEaseOut];
+  MDMMotionCurve easeIn = [self easeIn];
+  return (MDCMaskedTransitionMotionSpecContext){
+    .expansion = {
+      .iconFade = {
+        .delay = 0.000, .duration = 0.075, .curve = easeInEaseOut,
+      },
+      .contentFade = {
+        .delay = 0.150, .duration = 0.225, .curve = easeInEaseOut,
+      },
+      .floodBackgroundColor = {
+        .delay = 0.000, .duration = 0.075, .curve = easeInEaseOut,
+      },
+      .maskTransformation = {
+        .delay = 0.000, .duration = 0.105, .curve = easeIn,
+      },
+      .horizontalMovement = {.curve = { .type = MDMMotionCurveTypeInstant }},
+      .verticalMovement = {
+        .delay = 0.045, .duration = 0.330, .curve = easeInEaseOut,
+      },
+      .scrimFade = {
+        .delay = 0.000, .duration = 0.150, .curve = easeInEaseOut,
+      }
     },
-    .contentFade = {
-      .delay = 0.150, .duration = 0.150, .curve = EaseInEaseOut,
+    .shouldSlideWhenCollapsed = true,
+    .isCentered = false
+  };
+}
+
++ (MDCMaskedTransitionMotionSpecContext)bottomSheet {
+  MDMMotionCurve easeInEaseOut = [self easeInEaseOut];
+  MDMMotionCurve easeIn = [self easeIn];
+  return (MDCMaskedTransitionMotionSpecContext){
+    .expansion = {
+      .iconFade = {
+        .delay = 0.000, .duration = 0.075, .curve = easeInEaseOut, // No spec
+      },
+      .contentFade = { // No spec for this
+        .delay = 0.100, .duration = 0.200, .curve = easeInEaseOut,
+      },
+      .floodBackgroundColor = {
+        .delay = 0.000, .duration = 0.075, .curve = easeInEaseOut,
+      },
+      .maskTransformation = {
+        .delay = 0.000, .duration = 0.105, .curve = easeIn,
+      },
+      .horizontalMovement = {.curve = { .type = MDMMotionCurveTypeInstant }},
+      .verticalMovement = {
+        .delay = 0.045, .duration = 0.330, .curve = easeInEaseOut,
+      },
+      .scrimFade = {
+        .delay = 0.000, .duration = 0.150, .curve = easeInEaseOut,
+      }
     },
-    .floodBackgroundColor = {
-      .delay = 0.075, .duration = 0.075, .curve = EaseInEaseOut,
+    .shouldSlideWhenCollapsed = true,
+    .isCentered = false
+  };
+}
+
++ (MDCMaskedTransitionMotionSpecContext)bottomCard {
+  MDMMotionCurve easeInEaseOut = [self easeInEaseOut];
+  MDMMotionCurve easeIn = [self easeIn];
+  MDMMotionCurve easeOut = [self easeOut];
+  return (MDCMaskedTransitionMotionSpecContext){
+    .expansion = {
+      .iconFade = {
+        .delay = 0.000, .duration = 0.120, .curve = easeInEaseOut,
+      },
+      .contentFade = {
+        .delay = 0.150, .duration = 0.150, .curve = easeInEaseOut,
+      },
+      .floodBackgroundColor = {
+        .delay = 0.075, .duration = 0.075, .curve = easeInEaseOut,
+      },
+      .maskTransformation = {
+        .delay = 0.045, .duration = 0.225, .curve = easeIn,
+      },
+      .horizontalMovement = {
+        .delay = 0.000, .duration = 0.150, .curve = easeInEaseOut,
+      },
+      .verticalMovement = {
+        .delay = 0.000, .duration = 0.345, .curve = easeInEaseOut,
+      },
+      .scrimFade = {
+        .delay = 0.075, .duration = 0.150, .curve = easeInEaseOut,
+      }
     },
-    .maskTransformation = {
-      .delay = 0.045, .duration = 0.225, .curve = EaseIn,
+    .collapse = {
+      .iconFade = {
+        .delay = 0.150, .duration = 0.150, .curve = easeInEaseOut,
+      },
+      .contentFade = {
+        .delay = 0.000, .duration = 0.075, .curve = easeIn,
+      },
+      .floodBackgroundColor = {
+        .delay = 0.060, .duration = 0.150, .curve = easeInEaseOut,
+      },
+      .maskTransformation = {
+        .delay = 0.000, .duration = 0.180, .curve = easeOut,
+      },
+      .horizontalMovement = {
+        .delay = 0.045, .duration = 0.255, .curve = easeInEaseOut,
+      },
+      .verticalMovement = {
+        .delay = 0.000, .duration = 0.255, .curve = easeInEaseOut,
+      },
+      .scrimFade = {
+        .delay = 0.000, .duration = 0.150, .curve = easeInEaseOut,
+      }
     },
-    .horizontalMovement = {
-      .delay = 0.000, .duration = 0.300, .curve = EaseInEaseOut,
+    .shouldSlideWhenCollapsed = false,
+    .isCentered = true
+  };
+}
+
++ (MDCMaskedTransitionMotionSpecContext)toolbar {
+  MDMMotionCurve easeInEaseOut = [self easeInEaseOut];
+  MDMMotionCurve easeIn = [self easeIn];
+  MDMMotionCurve easeOut = [self easeOut];
+  return (MDCMaskedTransitionMotionSpecContext){
+    .expansion = {
+      .iconFade = {
+        .delay = 0.000, .duration = 0.120, .curve = easeInEaseOut,
+      },
+      .contentFade = {
+        .delay = 0.150, .duration = 0.150, .curve = easeInEaseOut,
+      },
+      .floodBackgroundColor = {
+        .delay = 0.075, .duration = 0.075, .curve = easeInEaseOut,
+      },
+      .maskTransformation = {
+        .delay = 0.045, .duration = 0.225, .curve = easeIn,
+      },
+      .horizontalMovement = {
+        .delay = 0.000, .duration = 0.300, .curve = easeInEaseOut,
+      },
+      .verticalMovement = {
+        .delay = 0.000, .duration = 0.120, .curve = easeInEaseOut,
+      },
+      .scrimFade = {
+        .delay = 0.075, .duration = 0.150, .curve = easeInEaseOut,
+      }
     },
-    .verticalMovement = {
-      .delay = 0.000, .duration = 0.120, .curve = EaseInEaseOut,
+    .collapse = {
+      .iconFade = {
+        .delay = 0.150, .duration = 0.150, .curve = easeInEaseOut,
+      },
+      .contentFade = {
+        .delay = 0.000, .duration = 0.075, .curve = easeIn,
+      },
+      .floodBackgroundColor = {
+        .delay = 0.060, .duration = 0.150, .curve = easeInEaseOut,
+      },
+      .maskTransformation = {
+        .delay = 0.000, .duration = 0.180, .curve = easeOut,
+      },
+      .horizontalMovement = {
+        .delay = 0.105, .duration = 0.195, .curve = easeInEaseOut,
+      },
+      .verticalMovement = {
+        .delay = 0.000, .duration = 0.255, .curve = easeInEaseOut,
+      },
+      .scrimFade = {
+        .delay = 0.000, .duration = 0.150, .curve = easeInEaseOut,
+      }
     },
-    .scrimFade = {
-      .delay = 0.075, .duration = 0.150, .curve = EaseInEaseOut,
-    }
-  },
-  .collapse = {
-    .iconFade = {
-      .delay = 0.150, .duration = 0.150, .curve = EaseInEaseOut,
-    },
-    .contentFade = {
-      .delay = 0.000, .duration = 0.075, .curve = EaseIn,
-    },
-    .floodBackgroundColor = {
-      .delay = 0.060, .duration = 0.150, .curve = EaseInEaseOut,
-    },
-    .maskTransformation = {
-      .delay = 0.000, .duration = 0.180, .curve = EaseOut,
-    },
-    .horizontalMovement = {
-      .delay = 0.105, .duration = 0.195, .curve = EaseInEaseOut,
-    },
-    .verticalMovement = {
-      .delay = 0.000, .duration = 0.255, .curve = EaseInEaseOut,
-    },
-    .scrimFade = {
-      .delay = 0.000, .duration = 0.150, .curve = EaseInEaseOut,
-    }
-  },
-  .shouldSlideWhenCollapsed = false,
-  .isCentered = true
-};
+    .shouldSlideWhenCollapsed = false,
+    .isCentered = true
+  };
+}
+
+@end


### PR DESCRIPTION
The interchange library will soon be dropping support for static spec initialization in favor of runtime APIs. This change moves the MaskedTransition off of all macro-based APIs.