### PR TITLE
[BottomNavigation] Implement viewSafeAreaInsetsDidChange in examples

### DIFF
--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -92,12 +92,7 @@
   [self updateBadgeItemCount];
 }
 
-- (void)viewDidLoad {
-  [super viewDidLoad];
-  [self.appBar addSubviewsToParent];
-}
-
-- (void)viewWillLayoutSubviews {
+- (void)layoutBottomNavBar {
   CGSize size = [_bottomNavBar sizeThatFits:self.view.bounds.size];
   CGRect bottomNavBarFrame = CGRectMake(0,
                                         CGRectGetHeight(self.view.bounds) - size.height,
@@ -105,6 +100,25 @@
                                         size.height);
   _bottomNavBar.frame = bottomNavBarFrame;
 }
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  [self.appBar addSubviewsToParent];
+}
+
+- (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
+  [self layoutBottomNavBar];
+}
+
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+- (void)viewSafeAreaInsetsDidChange {
+  if (@available(iOS 11.0, *)) {
+    [super viewSafeAreaInsetsDidChange];
+  }
+  [self layoutBottomNavBar];
+}
+#endif
 
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
@@ -68,8 +68,8 @@ class BottomNavigationTypicalUseSwiftExample: UIViewController {
     // Select a bottom navigation bar item.
     bottomNavBar.selectedItem = tabBarItem2;
   }
-
-  override func viewWillLayoutSubviews() {
+  
+  func layoutBottomNavBar() {
     let size = bottomNavBar.sizeThatFits(view.bounds.size)
     let bottomNavBarFrame = CGRect(x: 0,
                                    y: view.bounds.height - size.height,
@@ -77,6 +77,19 @@ class BottomNavigationTypicalUseSwiftExample: UIViewController {
                                    height: size.height)
     bottomNavBar.frame = bottomNavBarFrame
   }
+
+  override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+    layoutBottomNavBar()
+  }
+
+  #if swift(>=3.2)
+  @available(iOS 11, *)
+  override func viewSafeAreaInsetsDidChange() {
+    super.viewSafeAreaInsetsDidChange()
+    layoutBottomNavBar()
+  }
+  #endif
 
   override func viewDidLoad() {
     super.viewDidLoad()


### PR DESCRIPTION
Implement viewSafeAreaInsetsDidChange in examples to fix inset layout issue in iOS 11.2.

Addresses issue: https://github.com/material-components/material-components-ios/issues/2455

![simulator screen shot - iphone x - 2017-11-16 at 18 41 35](https://user-images.githubusercontent.com/760941/32922081-76926566-cafe-11e7-847b-9ccdea12c828.png)
