### PR TITLE
[BottomAppBar] Implement viewSafeAreaInsetsDidChange in examples

### DIFF
--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
@@ -89,14 +89,7 @@ class BottomAppBarTypicalUseSwiftExample: UIViewController {
     }
   }
 
-  override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-    self.view.backgroundColor = .white
-
-    self.navigationController?.setNavigationBarHidden(true, animated: animated)
-  }
-  
-  override func viewWillLayoutSubviews() {
+  func layoutBottomAppBar() {
     let size = bottomBarView.sizeThatFits(view.bounds.size)
     let bottomBarViewFrame = CGRect(x: 0,
                                     y: view.bounds.size.height - size.height,
@@ -104,6 +97,26 @@ class BottomAppBarTypicalUseSwiftExample: UIViewController {
                                     height: size.height)
     bottomBarView.frame = bottomBarViewFrame
   }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    self.view.backgroundColor = .white
+
+    self.navigationController?.setNavigationBarHidden(true, animated: animated)
+  }
+
+  override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+    layoutBottomAppBar()
+  }
+
+  #if swift(>=3.2)
+  @available(iOS 11, *)
+  override func viewSafeAreaInsetsDidChange() {
+    super.viewSafeAreaInsetsDidChange()
+    layoutBottomAppBar()
+  }
+  #endif
 
 }
 

--- a/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseViewController.m
+++ b/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseViewController.m
@@ -47,7 +47,7 @@
   [self.view addSubview:_bottomBarView];
 }
 
-- (void)viewWillLayoutSubviews {
+- (void)layoutBottomAppBar {
   CGSize size = [_bottomBarView sizeThatFits:self.view.bounds.size];
   CGRect bottomBarViewFrame = CGRectMake(0,
                                          CGRectGetHeight(self.view.bounds) - size.height,
@@ -55,6 +55,20 @@
                                          size.height);
   _bottomBarView.frame = bottomBarViewFrame;
 }
+
+- (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
+  [self layoutBottomAppBar];
+}
+
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+- (void)viewSafeAreaInsetsDidChange {
+  if (@available(iOS 11.0, *)) {
+    [super viewSafeAreaInsetsDidChange];
+  }
+  [self layoutBottomAppBar];
+}
+#endif
 
 #pragma mark - Setters
 


### PR DESCRIPTION
Implement viewSafeAreaInsetsDidChange in examples to fix inset layout issue in iOS 11.2.
