### PR TITLE
[kokoro] Fix build breakage.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -41,12 +41,14 @@ fix_bazel_imports() {
   rewrite_tests "s/import MaterialComponents.MaterialMath/import components_private_Math_Math/"
   rewrite_tests "s/import MaterialComponents.Material(.+)/import components_\1_\1/"
   rewrite_source "s/import <Motion(.+)\/Motion.+\.h>/import \"Motion\1.h\"/"
+  rewrite_source "s/import <MDF(.+)\/MDF.+\.h>/import \"MDF\1.h\"/"
   stashed_dir="$(pwd)/"
   reset_imports() {
     # Undoes our source changes from above.
     rewrite_tests "s/import components_private_Math_Math/import MaterialComponents.MaterialMath/"
     rewrite_tests "s/import components_(.+)_.+/import MaterialComponents.Material\1/"
     rewrite_source "s/import \"Motion(.+)\.h\"/import <Motion\1\/Motion\1.h>/"
+    rewrite_source "s/import \"MDF(.+)\.h\"/import <MDF\1\/MDF\1.h>/"
   }
   trap reset_imports EXIT
 }


### PR DESCRIPTION
The build was broken by https://github.com/material-components/material-components-ios/pull/2428 due to the introducion of framework-style header imports. This change adds a kokoro translation step for MDF framework imports.