### PR TITLE
[kokoro] Add two different simulator runs

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -78,8 +78,8 @@ run_bazel() {
       $verbosity_args \
       --ios_minimum_os=8.0 \
       --ios_multi_cpus=i386,x86_64 \
-      --ios_simulator_device='iPad Pro (12.9-inch)' \
-      --ios_simulator_version='9.3'
+      "--ios_simulator_device='iPad Pro (12.9-inch)'" \
+      "--ios_simulator_version='9.3'"
 
   # The iPhone 5 was chosen because it is a 32-bit device.
   # 8.1 was chosen because it is the earliest iOS offered here.
@@ -88,8 +88,8 @@ run_bazel() {
       $verbosity_args \
       --ios_minimum_os=8.0 \
       --ios_multi_cpus=i386,x86_64 \
-      --ios_simulator_device='iPhone 5' \
-      --ios_simulator_version='8.1'
+      "--ios_simulator_device='iPhone 5'" \
+      "--ios_simulator_version='8.1'"
 }
 
 run_cocoapods() {

--- a/.kokoro
+++ b/.kokoro
@@ -78,7 +78,7 @@ run_bazel() {
       $verbosity_args \
       --ios_minimum_os=8.0 \
       --ios_multi_cpus=i386,x86_64 \
-      --ios_simulator_device="iPad Pro (12.9-inch)" \
+      "--ios_simulator_device=iPad Pro (12.9-inch)" \
       --ios_simulator_version=9.3
 
   # The iPhone 5 was chosen because it is a 32-bit device.
@@ -88,7 +88,7 @@ run_bazel() {
       $verbosity_args \
       --ios_minimum_os=8.0 \
       --ios_multi_cpus=i386,x86_64 \
-      --ios_simulator_device="iPhone 5" \
+      "--ios_simulator_device=iPhone 5" \
       --ios_simulator_version=8.1
 }
 

--- a/.kokoro
+++ b/.kokoro
@@ -78,8 +78,8 @@ run_bazel() {
       $verbosity_args \
       --ios_minimum_os=8.0 \
       --ios_multi_cpus=i386,x86_64 \
-      "--ios_simulator_device='iPad Pro (12.9-inch)'" \
-      "--ios_simulator_version='9.3'"
+      --ios_simulator_device="iPad Pro (12.9-inch)" \
+      --ios_simulator_version=9.3
 
   # The iPhone 5 was chosen because it is a 32-bit device.
   # 8.1 was chosen because it is the earliest iOS offered here.
@@ -88,8 +88,8 @@ run_bazel() {
       $verbosity_args \
       --ios_minimum_os=8.0 \
       --ios_multi_cpus=i386,x86_64 \
-      "--ios_simulator_device='iPhone 5'" \
-      "--ios_simulator_version='8.1'"
+      --ios_simulator_device="iPhone 5" \
+      --ios_simulator_version=8.1
 }
 
 run_cocoapods() {

--- a/.kokoro
+++ b/.kokoro
@@ -71,11 +71,25 @@ run_bazel() {
     verbosity_args="-v"
   fi
 
+  # The iPad Pro 12.9 was chosen because it is the largest resolution we can test on.
+  # 9.3 was chosen to round out the range of iOS versions we are testing on.
   ./.kokoro-ios-runner/bazel.sh test //components/... \
       --min-xcode-version $XCODE_MINIMUM_VERSION \
       $verbosity_args \
       --ios_minimum_os=8.0 \
-      --ios_multi_cpus=i386,x86_64
+      --ios_multi_cpus=i386,x86_64 \
+      --ios_simulator_device='iPad Pro (12.9-inch)' \
+      --ios_simulator_version='9.3'
+
+  # The iPhone 5 was chosen because it is a 32-bit device.
+  # 8.1 was chosen because it is the earliest iOS offered here.
+  ./.kokoro-ios-runner/bazel.sh test //components/... \
+      --min-xcode-version $XCODE_MINIMUM_VERSION \
+      $verbosity_args \
+      --ios_minimum_os=8.0 \
+      --ios_multi_cpus=i386,x86_64 \
+      --ios_simulator_device='iPhone 5' \
+      --ios_simulator_version='8.1'
 }
 
 run_cocoapods() {


### PR DESCRIPTION
We may eventually want to turn this into a parallelized matrix of jobs, but for now our build times are fast enough that we may be able to get away with a sequence of jobs.

Part of https://github.com/material-components/material-components-ios/issues/2461.