### PR TITLE
[ActivityIndicator] Make the motion spec values be class properties.

### DIFF
--- a/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.h
+++ b/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.h
@@ -49,13 +49,15 @@ typedef struct MDCActivityIndicatorMotionSpecProgress {
 MDC_SUBCLASSING_RESTRICTED
 @interface MDCActivityIndicatorMotionSpec: NSObject
 
-+ (NSTimeInterval)pointCycleDuration;
-+ (NSTimeInterval)pointCycleMinimumVariableDuration;
+@property(nonatomic, class, readonly) NSTimeInterval pointCycleDuration;
+@property(nonatomic, class, readonly) NSTimeInterval pointCycleMinimumVariableDuration;
 
-+ (MDCActivityIndicatorMotionSpecIndeterminate)loopIndeterminate;
-+ (MDCActivityIndicatorMotionSpecTransitionToDeterminate)willChangeToDeterminate;
-+ (MDCActivityIndicatorMotionSpecTransitionToIndeterminate)willChangeToIndeterminate;
-+ (MDCActivityIndicatorMotionSpecProgress)willChangeProgress;
+@property(nonatomic, class, readonly) MDCActivityIndicatorMotionSpecIndeterminate loopIndeterminate;
+@property(nonatomic, class, readonly)
+    MDCActivityIndicatorMotionSpecTransitionToDeterminate willChangeToDeterminate;
+@property(nonatomic, class, readonly)
+    MDCActivityIndicatorMotionSpecTransitionToIndeterminate willChangeToIndeterminate;
+@property(nonatomic, class, readonly) MDCActivityIndicatorMotionSpecProgress willChangeProgress;
 
 // This object is not meant to be instantiated.
 - (instancetype)init NS_UNAVAILABLE;


### PR DESCRIPTION
This will provide better Swift support if/when we expose the spec as a public API.