### PR TITLE
[ProgressView] Make the motion spec values be class properties.

### DIFF
--- a/components/ProgressView/src/private/MDCProgressViewMotionSpec.h
+++ b/components/ProgressView/src/private/MDCProgressViewMotionSpec.h
@@ -19,8 +19,8 @@
 
 @interface MDCProgressViewMotionSpec: NSObject
 
-+ (MDMMotionTiming)willChangeProgress;
-+ (MDMMotionTiming)willChangeHidden;
+@property(nonatomic, class, readonly) MDMMotionTiming willChangeProgress;
+@property(nonatomic, class, readonly) MDMMotionTiming willChangeHidden;
 
 // This object is not meant to be instantiated.
 - (instancetype)init NS_UNAVAILABLE;


### PR DESCRIPTION
This will provide better Swift support if/when we expose the spec as a public API.