### PR TITLE
[CocoaPods] Address inconsistencies in the podspec file.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -66,8 +66,8 @@ Pod::Spec.new do |mdc|
     component_name="#{component.base_name}"
 
     component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+    component.public_header_files = "components/#{component_name}/src/*.h"
+    component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
   end
 
   mdc.subspec "AppBar" do |spec|
@@ -108,8 +108,8 @@ Pod::Spec.new do |mdc|
     component_name="#{component.base_name}"
 
     component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+    component.public_header_files = "components/#{component_name}/src/*.h"
+    component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
 
     component.dependency "MDFInternationalization"
     component.dependency "MaterialComponents/Buttons"

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -133,8 +133,8 @@ Pod::Spec.new do |mdc|
     end
     spec.subspec "ColorThemer" do |colorthemer|
       colorthemer.ios.deployment_target = '8.0'
-      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
-      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+      colorthemer.public_header_files = "components/#{component_name}/src/ColorThemer/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/ColorThemer/*.{h,m}"
 
       colorthemer.dependency "MaterialComponents/#{component_name}/Component"
       colorthemer.dependency "MaterialComponents/Themes"
@@ -172,16 +172,16 @@ Pod::Spec.new do |mdc|
     end
     spec.subspec "ColorThemer" do |colorthemer|
       colorthemer.ios.deployment_target = '8.0'
-      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
-      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}", "components/#{component_name}/src/#{component_name}/private/*.{h,m}"
+      colorthemer.public_header_files = "components/#{component_name}/src/ColorThemer/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/ColorThemer/*.{h,m}", "components/#{component_name}/src/ColorThemer/private/*.{h,m}"
 
       colorthemer.dependency "MaterialComponents/#{component_name}/Component"
       colorthemer.dependency "MaterialComponents/Themes"
     end
     spec.subspec "TitleColorAccessibilityMutator" do |mutator|
       mutator.ios.deployment_target = '8.0'
-      mutator.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
-      mutator.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}", "components/#{component_name}/src/#{component_name}/private/*.{h,m}"
+      mutator.public_header_files = "components/#{component_name}/src/#{mutator.base_name}/*.h"
+      mutator.source_files = "components/#{component_name}/src/#{mutator.base_name}/*.{h,m}", "components/#{component_name}/src/#{mutator.base_name}/private/*.{h,m}"
 
       mutator.dependency 'MDFTextAccessibility'
       mutator.dependency "MaterialComponents/Buttons/Component"
@@ -202,8 +202,8 @@ Pod::Spec.new do |mdc|
     end
     spec.subspec "ColorThemer" do |colorthemer|
       colorthemer.ios.deployment_target = '8.0'
-      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
-      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+      colorthemer.public_header_files = "components/#{component_name}/src/ColorThemer/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/ColorThemer/*.{h,m}"
 
       colorthemer.dependency "MaterialComponents/#{component_name}/Component"
       colorthemer.dependency "MaterialComponents/NavigationBar/Component"
@@ -292,8 +292,8 @@ Pod::Spec.new do |mdc|
     end
     spec.subspec "ColorThemer" do |colorthemer|
       colorthemer.ios.deployment_target = '8.0'
-      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
-      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+      colorthemer.public_header_files = "components/#{component_name}/src/ColorThemer/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/ColorThemer/*.{h,m}"
 
       colorthemer.dependency "MaterialComponents/#{component_name}/Component"
       colorthemer.dependency "MaterialComponents/Themes"
@@ -314,8 +314,8 @@ Pod::Spec.new do |mdc|
     end
     spec.subspec "ColorThemer" do |colorthemer|
       colorthemer.ios.deployment_target = '8.0'
-      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
-      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+      colorthemer.public_header_files = "components/#{component_name}/src/ColorThemer/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/ColorThemer/*.{h,m}"
 
       colorthemer.dependency "MaterialComponents/#{component_name}/Component"
       colorthemer.dependency "MaterialComponents/Themes"
@@ -335,8 +335,8 @@ Pod::Spec.new do |mdc|
     end
     spec.subspec "ColorThemer" do |colorthemer|
       colorthemer.ios.deployment_target = '8.0'
-      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
-      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+      colorthemer.public_header_files = "components/#{component_name}/src/ColorThemer/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/ColorThemer/*.{h,m}"
 
       colorthemer.dependency "MaterialComponents/#{component_name}/Component"
       colorthemer.dependency "MaterialComponents/Themes"
@@ -353,8 +353,8 @@ Pod::Spec.new do |mdc|
     end
     spec.subspec "ColorThemer" do |colorthemer|
       colorthemer.ios.deployment_target = '8.0'
-      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
-      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+      colorthemer.public_header_files = "components/#{component_name}/src/ColorThemer/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/ColorThemer/*.{h,m}"
 
       colorthemer.dependency "MaterialComponents/#{component_name}/Component"
       colorthemer.dependency "MaterialComponents/Themes"
@@ -371,8 +371,8 @@ Pod::Spec.new do |mdc|
     end
     spec.subspec "ColorThemer" do |colorthemer|
       colorthemer.ios.deployment_target = '8.0'
-      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
-      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+      colorthemer.public_header_files = "components/#{component_name}/src/ColorThemer/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/ColorThemer/*.{h,m}"
 
       colorthemer.dependency "MaterialComponents/#{component_name}/Component"
       colorthemer.dependency "MaterialComponents/Themes"
@@ -417,8 +417,8 @@ Pod::Spec.new do |mdc|
     end
     spec.subspec "ColorThemer" do |colorthemer|
       colorthemer.ios.deployment_target = '8.0'
-      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
-      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+      colorthemer.public_header_files = "components/#{component_name}/src/ColorThemer/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/ColorThemer/*.{h,m}"
 
       colorthemer.dependency "MaterialComponents/#{component_name}/Component"
       colorthemer.dependency "MaterialComponents/Themes"
@@ -446,8 +446,8 @@ Pod::Spec.new do |mdc|
     end
     spec.subspec "ColorThemer" do |colorthemer|
       colorthemer.ios.deployment_target = '8.0'
-      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
-      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+      colorthemer.public_header_files = "components/#{component_name}/src/ColorThemer/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/ColorThemer/*.{h,m}"
 
       colorthemer.dependency "MaterialComponents/#{component_name}/Component"
       colorthemer.dependency "MaterialComponents/Themes"
@@ -477,8 +477,8 @@ Pod::Spec.new do |mdc|
     end
     spec.subspec "ColorThemer" do |colorthemer|
       colorthemer.ios.deployment_target = '8.0'
-      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
-      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+      colorthemer.public_header_files = "components/#{component_name}/src/ColorThemer/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/ColorThemer/*.{h,m}"
 
       colorthemer.dependency "MaterialComponents/#{component_name}/Component"
       colorthemer.dependency "MaterialComponents/Themes"
@@ -516,8 +516,8 @@ Pod::Spec.new do |mdc|
     end
     spec.subspec "ColorThemer" do |colorthemer|
       colorthemer.ios.deployment_target = '8.0'
-      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
-      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+      colorthemer.public_header_files = "components/#{component_name}/src/ColorThemer/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/ColorThemer/*.{h,m}"
 
       colorthemer.dependency "MaterialComponents/#{component_name}/Component"
       colorthemer.dependency "MaterialComponents/Palettes"
@@ -560,8 +560,8 @@ Pod::Spec.new do |mdc|
     end
     spec.subspec "ColorThemer" do |colorthemer|
       colorthemer.ios.deployment_target = '8.0'
-      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
-      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+      colorthemer.public_header_files = "components/#{component_name}/src/ColorThemer/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/ColorThemer/*.{h,m}"
 
       colorthemer.dependency "MaterialComponents/#{component_name}/Component"
       colorthemer.dependency "MaterialComponents/Themes"
@@ -586,8 +586,8 @@ Pod::Spec.new do |mdc|
     end
     spec.subspec "ColorThemer" do |colorthemer|
       colorthemer.ios.deployment_target = '8.0'
-      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
-      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+      colorthemer.public_header_files = "components/#{component_name}/src/ColorThemer/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/ColorThemer/*.{h,m}"
 
       colorthemer.dependency "MaterialComponents/#{component_name}/Component"
       colorthemer.dependency "MaterialComponents/Themes"

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -28,74 +28,85 @@ Pod::Spec.new do |mdc|
   # # Template subspec
   #
   #  mdc.subspec "ComponentName" do |component|
-  #    component.public_header_files = "components/#{component.base_name}/src/*.h"
-  #    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+  #.   component_name="#{component.base_name}"
+  #
+  #    component.public_header_files = "components/#{component_name}/src/*.h"
+  #    component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
   #
   #    # Only if you have a resource bundle
-  #    component.resources = ["components/#{component.base_name}/src/Material#{component.base_name}.bundle"]
-  #
+  #    component.resources = ["components/#{component_name}/src/Material#{component_name}.bundle"]
   #  end
   #
 
-  mdc.subspec "ActivityIndicator" do |component|
-    component.subspec "Component" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/*.h"
-      spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
-      spec.resources = ["components/#{component.base_name}/src/Material#{component.base_name}.bundle"]
+  mdc.subspec "ActivityIndicator" do |spec|
+    component_name="#{spec.base_name}"
 
-      spec.dependency "MDFInternationalization"
-      spec.dependency "MaterialComponents/Palettes"
-      spec.dependency "MaterialComponents/private/Application"
-      spec.dependency "MotionAnimator", "~> 2.0"
+    spec.subspec "Component" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/#{component_name}/src/*.h"
+      component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
+      component.resources = ["components/#{component_name}/src/Material#{component_name}.bundle"]
+
+      component.dependency "MDFInternationalization"
+      component.dependency "MaterialComponents/Palettes"
+      component.dependency "MaterialComponents/private/Application"
+      component.dependency "MotionAnimator", "~> 2.0"
     end
-    component.subspec "ColorThemer" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}"
-      spec.dependency "MaterialComponents/ActivityIndicator/Component"
-      spec.dependency "MaterialComponents/Themes"
+    spec.subspec "ColorThemer" do |colorthemer|
+      colorthemer.ios.deployment_target = '8.0'
+      colorthemer.public_header_files = "components/#{component_name}/src/ColorThemer/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/ColorThemer/*.{h,m}"
+
+      colorthemer.dependency "MaterialComponents/#{component_name}/Component"
+      colorthemer.dependency "MaterialComponents/Themes"
     end
   end
 
   mdc.subspec "AnimationTiming" do |component|
+    component_name="#{component.base_name}"
+
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"
     component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
   end
 
-  mdc.subspec "AppBar" do |component|
-    component.subspec "Component" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/*.h"
-      spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
-      spec.resources = ["components/#{component.base_name}/src/Material#{component.base_name}.bundle"]
+  mdc.subspec "AppBar" do |spec|
+    component_name="#{spec.base_name}"
+
+    spec.subspec "Component" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/#{component_name}/src/*.h"
+      component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
+      component.resources = ["components/#{component_name}/src/Material#{component_name}.bundle"]
 
       # Navigation bar contents
-      spec.dependency "MaterialComponents/HeaderStackView"
-      spec.dependency "MaterialComponents/NavigationBar"
-      spec.dependency "MaterialComponents/Typography"
-      spec.dependency "MaterialComponents/private/Application"
+      component.dependency "MaterialComponents/HeaderStackView"
+      component.dependency "MaterialComponents/NavigationBar"
+      component.dependency "MaterialComponents/Typography"
+      component.dependency "MaterialComponents/private/Application"
 
       # Flexible header + shadow
-      spec.dependency "MaterialComponents/FlexibleHeader"
-      spec.dependency "MaterialComponents/ShadowElevations"
-      spec.dependency "MaterialComponents/ShadowLayer"
+      component.dependency "MaterialComponents/FlexibleHeader"
+      component.dependency "MaterialComponents/ShadowElevations"
+      component.dependency "MaterialComponents/ShadowLayer"
 
-      spec.dependency "MDFInternationalization"
-      spec.dependency "MaterialComponents/private/Icons/ic_arrow_back"
-      spec.dependency "MaterialComponents/private/UIMetrics"
+      component.dependency "MDFInternationalization"
+      component.dependency "MaterialComponents/private/Icons/ic_arrow_back"
+      component.dependency "MaterialComponents/private/UIMetrics"
     end
-    component.subspec "ColorThemer" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}", "components/#{component.base_name}/src/#{spec.base_name}/private/*.{h,m}"
-      spec.dependency "MaterialComponents/AppBar/Component"
-      spec.dependency "MaterialComponents/Themes"
+    spec.subspec "ColorThemer" do |colorthemer|
+      colorthemer.ios.deployment_target = '8.0'
+      colorthemer.public_header_files = "components/#{component_name}/src/ColorThemer/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/ColorThemer/*.{h,m}", "components/#{component_name}/src/ColorThemer/private/*.{h,m}"
+
+      colorthemer.dependency "MaterialComponents/#{component_name}/Component"
+      colorthemer.dependency "MaterialComponents/Themes"
     end
   end
 
   mdc.subspec "BottomAppBar" do |component|
+    component_name="#{component.base_name}"
+
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"
     component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
@@ -106,31 +117,36 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/Math"
   end
 
-  mdc.subspec "BottomNavigation" do |component|
-    component.subspec "Component" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/*.h"
-      spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
-      spec.resources = ["components/#{component.base_name}/src/Material#{component.base_name}.bundle"]
+  mdc.subspec "BottomNavigation" do |spec|
+    component_name="#{spec.base_name}"
 
-      spec.dependency "MDFInternationalization"
-      spec.dependency "MaterialComponents/ShadowElevations"
-      spec.dependency "MaterialComponents/ShadowLayer"
-      spec.dependency "MaterialComponents/private/Math"
+    spec.subspec "Component" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/#{component_name}/src/*.h"
+      component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
+      component.resources = ["components/#{component_name}/src/Material#{component_name}.bundle"]
+
+      component.dependency "MDFInternationalization"
+      component.dependency "MaterialComponents/ShadowElevations"
+      component.dependency "MaterialComponents/ShadowLayer"
+      component.dependency "MaterialComponents/private/Math"
     end
-    component.subspec "ColorThemer" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}"
-      spec.dependency "MaterialComponents/BottomNavigation/Component"
-      spec.dependency "MaterialComponents/Themes"
+    spec.subspec "ColorThemer" do |colorthemer|
+      colorthemer.ios.deployment_target = '8.0'
+      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+
+      colorthemer.dependency "MaterialComponents/#{component_name}/Component"
+      colorthemer.dependency "MaterialComponents/Themes"
     end
   end
 
   mdc.subspec "BottomSheet" do |component|
+    component_name="#{component.base_name}"
+
     component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+    component.public_header_files = "components/#{component_name}/src/*.h"
+    component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
 
     component.dependency "MaterialComponents/private/KeyboardWatcher"
     component.dependency "MaterialComponents/private/Math"
@@ -138,61 +154,69 @@ Pod::Spec.new do |mdc|
     component.dependency "MotionTransitioning", "~> 4.0"
   end
 
-  mdc.subspec "Buttons" do |component|
-    component.subspec "Component" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/*.h"
-      spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+  mdc.subspec "Buttons" do |spec|
+    component_name="#{spec.base_name}"
 
-      spec.dependency 'MDFTextAccessibility'
-      spec.dependency "MaterialComponents/Ink"
-      spec.dependency "MaterialComponents/ShadowElevations"
-      spec.dependency "MaterialComponents/ShadowLayer"
-      spec.dependency "MaterialComponents/Typography"
+    spec.subspec "Component" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/#{component_name}/src/*.h"
+      component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
+
+      component.dependency 'MDFTextAccessibility'
+      component.dependency "MaterialComponents/Ink"
+      component.dependency "MaterialComponents/ShadowElevations"
+      component.dependency "MaterialComponents/ShadowLayer"
+      component.dependency "MaterialComponents/Typography"
 
       component.dependency "MaterialComponents/private/Math"
     end
-    component.subspec "ColorThemer" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}", "components/#{component.base_name}/src/#{spec.base_name}/private/*.{h,m}"
-      spec.dependency "MaterialComponents/Buttons/Component"
-      spec.dependency "MaterialComponents/Themes"
-    end
-    component.subspec "TitleColorAccessibilityMutator" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}", "components/#{component.base_name}/src/#{spec.base_name}/private/*.{h,m}"
+    spec.subspec "ColorThemer" do |colorthemer|
+      colorthemer.ios.deployment_target = '8.0'
+      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}", "components/#{component_name}/src/#{component_name}/private/*.{h,m}"
 
-      spec.dependency 'MDFTextAccessibility'
-      spec.dependency "MaterialComponents/Buttons/Component"
+      colorthemer.dependency "MaterialComponents/#{component_name}/Component"
+      colorthemer.dependency "MaterialComponents/Themes"
+    end
+    spec.subspec "TitleColorAccessibilityMutator" do |mutator|
+      mutator.ios.deployment_target = '8.0'
+      mutator.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
+      mutator.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}", "components/#{component_name}/src/#{component_name}/private/*.{h,m}"
+
+      mutator.dependency 'MDFTextAccessibility'
+      mutator.dependency "MaterialComponents/Buttons/Component"
     end
 
   end
 
-  mdc.subspec "ButtonBar" do |component|
-    component.subspec "Component" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/*.h"
-      spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+  mdc.subspec "ButtonBar" do |spec|
+    component_name="#{spec.base_name}"
+
+    spec.subspec "Component" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/#{component_name}/src/*.h"
+      component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
 
       component.dependency "MDFInternationalization"
       component.dependency "MaterialComponents/Buttons"
     end
-    component.subspec "ColorThemer" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}"
-      spec.dependency "MaterialComponents/ButtonBar/Component"
-      spec.dependency "MaterialComponents/NavigationBar/Component"
-      spec.dependency "MaterialComponents/Themes"
+    spec.subspec "ColorThemer" do |colorthemer|
+      colorthemer.ios.deployment_target = '8.0'
+      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+
+      colorthemer.dependency "MaterialComponents/#{component_name}/Component"
+      colorthemer.dependency "MaterialComponents/NavigationBar/Component"
+      colorthemer.dependency "MaterialComponents/Themes"
     end
   end
 
   mdc.subspec "Chips" do |component|
+    component_name="#{component.base_name}"
+
     component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+    component.public_header_files = "components/#{component_name}/src/*.h"
+    component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
     component.dependency "MaterialComponents/Ink"
     component.dependency "MaterialComponents/ShadowLayer"
     component.dependency "MaterialComponents/ShadowElevations"
@@ -201,10 +225,12 @@ Pod::Spec.new do |mdc|
   end
 
   mdc.subspec "CollectionCells" do |component|
+    component_name="#{component.base_name}"
+
     component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
-    component.resources = ["components/#{component.base_name}/src/Material#{component.base_name}.bundle"]
+    component.public_header_files = "components/#{component_name}/src/*.h"
+    component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
+    component.resources = ["components/#{component_name}/src/Material#{component_name}.bundle"]
 
     component.framework = "CoreGraphics", "QuartzCore"
 
@@ -223,16 +249,20 @@ Pod::Spec.new do |mdc|
   end
 
   mdc.subspec "CollectionLayoutAttributes" do |component|
+    component_name="#{component.base_name}"
+
     component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}"
+    component.public_header_files = "components/#{component_name}/src/*.h"
+    component.source_files = "components/#{component_name}/src/*.{h,m}"
   end
 
   mdc.subspec "Collections" do |component|
+    component_name="#{component.base_name}"
+
     component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
-    component.resources = ["components/#{component.base_name}/src/Material#{component.base_name}.bundle"]
+    component.public_header_files = "components/#{component_name}/src/*.h"
+    component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
+    component.resources = ["components/#{component_name}/src/Material#{component_name}.bundle"]
 
     component.framework = "CoreGraphics", "QuartzCore"
 
@@ -245,220 +275,262 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/Typography"
   end
 
-  mdc.subspec "Dialogs" do |component|
-    component.subspec "Component" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/*.h"
-      spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
-      spec.resources = ["components/#{component.base_name}/src/Material#{component.base_name}.bundle"]
+  mdc.subspec "Dialogs" do |spec|
+    component_name="#{spec.base_name}"
 
-      spec.dependency "MaterialComponents/Buttons"
-      spec.dependency "MaterialComponents/ShadowElevations"
-      spec.dependency "MaterialComponents/ShadowLayer"
-      spec.dependency "MaterialComponents/private/KeyboardWatcher"
-      spec.dependency "MDFInternationalization"
+    spec.subspec "Component" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/#{component_name}/src/*.h"
+      component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
+      component.resources = ["components/#{component_name}/src/Material#{component_name}.bundle"]
+
+      component.dependency "MaterialComponents/Buttons"
+      component.dependency "MaterialComponents/ShadowElevations"
+      component.dependency "MaterialComponents/ShadowLayer"
+      component.dependency "MaterialComponents/private/KeyboardWatcher"
+      component.dependency "MDFInternationalization"
     end
-    component.subspec "ColorThemer" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}"
-      spec.dependency "MaterialComponents/Dialogs/Component"
-      spec.dependency "MaterialComponents/Themes"
+    spec.subspec "ColorThemer" do |colorthemer|
+      colorthemer.ios.deployment_target = '8.0'
+      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+
+      colorthemer.dependency "MaterialComponents/#{component_name}/Component"
+      colorthemer.dependency "MaterialComponents/Themes"
     end
   end
 
-  mdc.subspec "FeatureHighlight" do |component|
-    component.subspec "Component" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/*.h"
-      spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
-      spec.resources = ["components/#{component.base_name}/src/Material#{component.base_name}.bundle"]
-      spec.dependency "MaterialComponents/private/Math"
-      spec.dependency "MaterialComponents/Typography"
-      spec.dependency "MDFTextAccessibility"
+  mdc.subspec "FeatureHighlight" do |spec|
+    component_name="#{spec.base_name}"
+
+    spec.subspec "Component" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/#{component_name}/src/*.h"
+      component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
+      component.resources = ["components/#{component_name}/src/Material#{component_name}.bundle"]
+      component.dependency "MaterialComponents/private/Math"
+      component.dependency "MaterialComponents/Typography"
+      component.dependency "MDFTextAccessibility"
     end
-    component.subspec "ColorThemer" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}"
-      spec.dependency "MaterialComponents/FeatureHighlight/Component"
-      spec.dependency "MaterialComponents/Themes"
+    spec.subspec "ColorThemer" do |colorthemer|
+      colorthemer.ios.deployment_target = '8.0'
+      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+
+      colorthemer.dependency "MaterialComponents/#{component_name}/Component"
+      colorthemer.dependency "MaterialComponents/Themes"
     end
   end
 
-  mdc.subspec "FlexibleHeader" do |component|
-    component.subspec "Component" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/*.h"
-      spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
-      spec.dependency 'MDFTextAccessibility'
-      spec.dependency "MaterialComponents/private/Application"
-      spec.dependency "MaterialComponents/private/UIMetrics"
+  mdc.subspec "FlexibleHeader" do |spec|
+    component_name="#{spec.base_name}"
+
+    spec.subspec "Component" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/#{component_name}/src/*.h"
+      component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
+      component.dependency 'MDFTextAccessibility'
+      component.dependency "MaterialComponents/private/Application"
+      component.dependency "MaterialComponents/private/UIMetrics"
     end
-    component.subspec "ColorThemer" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}"
-      spec.dependency "MaterialComponents/FlexibleHeader/Component"
-      spec.dependency "MaterialComponents/Themes"
+    spec.subspec "ColorThemer" do |colorthemer|
+      colorthemer.ios.deployment_target = '8.0'
+      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+
+      colorthemer.dependency "MaterialComponents/#{component_name}/Component"
+      colorthemer.dependency "MaterialComponents/Themes"
     end
   end
 
-  mdc.subspec "HeaderStackView" do |component|
-    component.subspec "Component" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/*.h"
-      spec.source_files = "components/#{component.base_name}/src/*.{h,m}"
+  mdc.subspec "HeaderStackView" do |spec|
+    component_name="#{spec.base_name}"
+
+    spec.subspec "Component" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/#{component_name}/src/*.h"
+      component.source_files = "components/#{component_name}/src/*.{h,m}"
     end
-    component.subspec "ColorThemer" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}"
-      spec.dependency "MaterialComponents/HeaderStackView/Component"
-      spec.dependency "MaterialComponents/Themes"
+    spec.subspec "ColorThemer" do |colorthemer|
+      colorthemer.ios.deployment_target = '8.0'
+      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+
+      colorthemer.dependency "MaterialComponents/#{component_name}/Component"
+      colorthemer.dependency "MaterialComponents/Themes"
     end
   end
 
-  mdc.subspec "Ink" do |component|
-    component.subspec "Component" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/*.h"
-      spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+  mdc.subspec "Ink" do |spec|
+    component_name="#{spec.base_name}"
+
+    spec.subspec "Component" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/#{component_name}/src/*.h"
+      component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
     end
-    component.subspec "ColorThemer" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}"
-      spec.dependency "MaterialComponents/Ink/Component"
-      spec.dependency "MaterialComponents/Themes"
+    spec.subspec "ColorThemer" do |colorthemer|
+      colorthemer.ios.deployment_target = '8.0'
+      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+
+      colorthemer.dependency "MaterialComponents/#{component_name}/Component"
+      colorthemer.dependency "MaterialComponents/Themes"
     end
   end
 
   mdc.subspec "LibraryInfo" do |component|
+    component_name="#{component.base_name}"
+
     component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+    component.public_header_files = "components/#{component_name}/src/*.h"
+    component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
   end
 
   mdc.subspec "MaskedTransition" do |component|
+    component_name="#{component.base_name}"
+
     component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+    component.public_header_files = "components/#{component_name}/src/*.h"
+    component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
     component.dependency "MotionTransitioning", "~> 4.0"
     component.dependency "MotionAnimator", "~> 2.0"
     component.dependency "MotionInterchange", "~> 1.0"
   end
 
-  mdc.subspec "NavigationBar" do |component|
-    component.subspec "Component" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/*.h"
-      spec.source_files = "components/#{component.base_name}/src/*.{h,m}"
+  mdc.subspec "NavigationBar" do |spec|
+    component_name="#{spec.base_name}"
+
+    spec.subspec "Component" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/#{component_name}/src/*.h"
+      component.source_files = "components/#{component_name}/src/*.{h,m}"
 
       # Accessibility Configurator
-      spec.dependency "MDFTextAccessibility"
+      component.dependency "MDFTextAccessibility"
 
-      spec.dependency "MaterialComponents/ButtonBar/Component"
-      spec.dependency "MaterialComponents/Typography"
+      component.dependency "MaterialComponents/ButtonBar/Component"
+      component.dependency "MaterialComponents/Typography"
 
-      spec.dependency "MDFInternationalization"
-      spec.dependency "MaterialComponents/private/Math"
+      component.dependency "MDFInternationalization"
+      component.dependency "MaterialComponents/private/Math"
     end
-    component.subspec "ColorThemer" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}"
-      spec.dependency "MaterialComponents/NavigationBar/Component"
-      spec.dependency "MaterialComponents/Themes"
+    spec.subspec "ColorThemer" do |colorthemer|
+      colorthemer.ios.deployment_target = '8.0'
+      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+
+      colorthemer.dependency "MaterialComponents/#{component_name}/Component"
+      colorthemer.dependency "MaterialComponents/Themes"
     end
   end
 
   mdc.subspec "OverlayWindow" do |component|
+    component_name="#{component.base_name}"
+
     component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+    component.public_header_files = "components/#{component_name}/src/*.h"
+    component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
 
     component.dependency "MaterialComponents/private/Application"
   end
 
-  mdc.subspec "PageControl" do |component|
-    component.subspec "Component" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/*.h"
-      spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
-      spec.resources = ["components/#{component.base_name}/src/Material#{component.base_name}.bundle"]
+  mdc.subspec "PageControl" do |spec|
+    component_name="#{spec.base_name}"
+
+    spec.subspec "Component" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/#{component_name}/src/*.h"
+      component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
+      component.resources = ["components/#{component_name}/src/Material#{component_name}.bundle"]
     end
-    component.subspec "ColorThemer" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}"
-      spec.dependency "MaterialComponents/PageControl/Component"
-      spec.dependency "MaterialComponents/Themes"
+    spec.subspec "ColorThemer" do |colorthemer|
+      colorthemer.ios.deployment_target = '8.0'
+      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+
+      colorthemer.dependency "MaterialComponents/#{component_name}/Component"
+      colorthemer.dependency "MaterialComponents/Themes"
     end
   end
 
   mdc.subspec "Palettes" do |component|
+    component_name="#{component.base_name}"
+
     component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+    component.public_header_files = "components/#{component_name}/src/*.h"
+    component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
   end
 
-  mdc.subspec "ProgressView" do |component|
-    component.subspec "Component" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/*.h"
-      spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+  mdc.subspec "ProgressView" do |spec|
+    component_name="#{spec.base_name}"
 
-      spec.dependency "MDFInternationalization"
-      spec.dependency "MaterialComponents/Palettes"
-      spec.dependency "MaterialComponents/private/Math"
-      spec.dependency "MotionAnimator", "~> 2.1"
+    spec.subspec "Component" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/#{component_name}/src/*.h"
+      component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
+
+      component.dependency "MDFInternationalization"
+      component.dependency "MaterialComponents/Palettes"
+      component.dependency "MaterialComponents/private/Math"
+      component.dependency "MotionAnimator", "~> 2.1"
     end
-    component.subspec "ColorThemer" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}"
-      spec.dependency "MaterialComponents/ProgressView/Component"
-      spec.dependency "MaterialComponents/Themes"
+    spec.subspec "ColorThemer" do |colorthemer|
+      colorthemer.ios.deployment_target = '8.0'
+      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+
+      colorthemer.dependency "MaterialComponents/#{component_name}/Component"
+      colorthemer.dependency "MaterialComponents/Themes"
     end
   end
 
   mdc.subspec "ShadowElevations" do |component|
+    component_name="#{component.base_name}"
+
     component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}"
+    component.public_header_files = "components/#{component_name}/src/*.h"
+    component.source_files = "components/#{component_name}/src/*.{h,m}"
   end
 
   mdc.subspec "ShadowLayer" do |component|
+    component_name="#{component.base_name}"
+
     component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}"
+    component.public_header_files = "components/#{component_name}/src/*.h"
+    component.source_files = "components/#{component_name}/src/*.{h,m}"
+
     component.dependency "MaterialComponents/ShadowElevations"
   end
 
-  mdc.subspec "Slider" do |component|
-    component.subspec "Component" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/*.h"
-      spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+  mdc.subspec "Slider" do |spec|
+    component_name="#{spec.base_name}"
 
-      spec.dependency "MaterialComponents/Palettes"
-      spec.dependency "MaterialComponents/private/ThumbTrack"
+    spec.subspec "Component" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/#{component_name}/src/*.h"
+      component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
+
+      component.dependency "MaterialComponents/Palettes"
+      component.dependency "MaterialComponents/private/ThumbTrack"
     end
-    component.subspec "ColorThemer" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}"
-      spec.dependency "MaterialComponents/Palettes"
-      spec.dependency "MaterialComponents/Slider/Component"
-      spec.dependency "MaterialComponents/Themes"
+    spec.subspec "ColorThemer" do |colorthemer|
+      colorthemer.ios.deployment_target = '8.0'
+      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+
+      colorthemer.dependency "MaterialComponents/#{component_name}/Component"
+      colorthemer.dependency "MaterialComponents/Palettes"
+      colorthemer.dependency "MaterialComponents/Themes"
     end
   end
 
   mdc.subspec "Snackbar" do |component|
+    component_name="#{component.base_name}"
+
     component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+    component.public_header_files = "components/#{component_name}/src/*.h"
+    component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
 
     component.dependency "MaterialComponents/AnimationTiming"
     component.dependency "MaterialComponents/Buttons"
@@ -469,63 +541,73 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/Overlay"
   end
 
-  mdc.subspec "Tabs" do |component|
-    component.subspec "Component" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/*.h"
-      spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
-      spec.resources = ["components/#{component.base_name}/src/Material#{component.base_name}.bundle"]
+  mdc.subspec "Tabs" do |spec|
+    component_name="#{spec.base_name}"
 
-      spec.dependency "MDFInternationalization"
-      spec.dependency "MaterialComponents/AnimationTiming"
-      spec.dependency "MaterialComponents/Ink"
-      spec.dependency "MaterialComponents/ShadowElevations"
-      spec.dependency "MaterialComponents/ShadowLayer"
-      spec.dependency "MaterialComponents/Typography"
-      spec.dependency "MaterialComponents/private/Math"
+    spec.subspec "Component" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/#{component_name}/src/*.h"
+      component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
+      component.resources = ["components/#{component_name}/src/Material#{component_name}.bundle"]
+
+      component.dependency "MDFInternationalization"
+      component.dependency "MaterialComponents/AnimationTiming"
+      component.dependency "MaterialComponents/Ink"
+      component.dependency "MaterialComponents/ShadowElevations"
+      component.dependency "MaterialComponents/ShadowLayer"
+      component.dependency "MaterialComponents/Typography"
+      component.dependency "MaterialComponents/private/Math"
     end
-    component.subspec "ColorThemer" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}"
-      spec.dependency "MaterialComponents/Tabs/Component"
-      spec.dependency "MaterialComponents/Themes"
+    spec.subspec "ColorThemer" do |colorthemer|
+      colorthemer.ios.deployment_target = '8.0'
+      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+
+      colorthemer.dependency "MaterialComponents/#{component_name}/Component"
+      colorthemer.dependency "MaterialComponents/Themes"
     end
   end
 
-  mdc.subspec "TextFields" do |component|
-    component.subspec "Component" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/*.h"
-      spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+  mdc.subspec "TextFields" do |spec|
+    component_name="#{spec.base_name}"
 
-      spec.dependency "MaterialComponents/AnimationTiming"
-      spec.dependency "MaterialComponents/Palettes"
-      spec.dependency "MaterialComponents/Typography"
+    spec.subspec "Component" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/#{component_name}/src/*.h"
+      component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
 
-      spec.dependency "MDFInternationalization"
-      spec.dependency "MaterialComponents/private/Math"
-      spec.dependency "MDFInternationalization"
+      component.dependency "MaterialComponents/AnimationTiming"
+      component.dependency "MaterialComponents/Palettes"
+      component.dependency "MaterialComponents/Typography"
+
+      component.dependency "MDFInternationalization"
+      component.dependency "MaterialComponents/private/Math"
+      component.dependency "MDFInternationalization"
     end
-    component.subspec "ColorThemer" do |spec|
-      spec.ios.deployment_target = '8.0'
-      spec.public_header_files = "components/#{component.base_name}/src/#{spec.base_name}/*.h"
-      spec.source_files = "components/#{component.base_name}/src/#{spec.base_name}/*.{h,m}"
-      spec.dependency "MaterialComponents/TextFields/Component"
-      spec.dependency "MaterialComponents/Themes"
+    spec.subspec "ColorThemer" do |colorthemer|
+      colorthemer.ios.deployment_target = '8.0'
+      colorthemer.public_header_files = "components/#{component_name}/src/#{component_name}/*.h"
+      colorthemer.source_files = "components/#{component_name}/src/#{component_name}/*.{h,m}"
+
+      colorthemer.dependency "MaterialComponents/#{component_name}/Component"
+      colorthemer.dependency "MaterialComponents/Themes"
     end
   end
 
   mdc.subspec "Themes" do |component|
+    component_name="#{component.base_name}"
+
     component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+    component.public_header_files = "components/#{component_name}/src/*.h"
+    component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
   end
 
   mdc.subspec "Typography" do |component|
+    component_name="#{component.base_name}"
+
     component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+    component.public_header_files = "components/#{component_name}/src/*.h"
+    component.source_files = "components/#{component_name}/src/*.{h,m}", "components/#{component_name}/src/private/*.{h,m}"
 
     component.dependency "MaterialComponents/private/Application"
   end
@@ -538,53 +620,67 @@ Pod::Spec.new do |mdc|
     registerIcons(private_spec)
 
     private_spec.subspec "Application" do |component|
+      component_name="#{component.base_name}"
+
       component.ios.deployment_target = '8.0'
-      component.public_header_files = "components/private/#{component.base_name}/src/*.h"
-      component.source_files = "components/private/#{component.base_name}/src/*.{h,m}"
+      component.public_header_files = "components/private/#{component_name}/src/*.h"
+      component.source_files = "components/private/#{component_name}/src/*.{h,m}"
     end
 
     private_spec.subspec "KeyboardWatcher" do |component|
+      component_name="#{component.base_name}"
+
       component.ios.deployment_target = '8.0'
-      component.public_header_files = "components/private/#{component.base_name}/src/*.h"
-      component.source_files = "components/private/#{component.base_name}/src/*.{h,m}"
+      component.public_header_files = "components/private/#{component_name}/src/*.h"
+      component.source_files = "components/private/#{component_name}/src/*.{h,m}"
 
       component.dependency "MaterialComponents/private/Application"
     end
 
     private_spec.subspec "Math" do |component|
+      component_name="#{component.base_name}"
+
       component.ios.deployment_target = '8.0'
-      component.public_header_files = "components/private/#{component.base_name}/src/*.h"
-      component.source_files = "components/private/#{component.base_name}/src/*.{h,m}"
+      component.public_header_files = "components/private/#{component_name}/src/*.h"
+      component.source_files = "components/private/#{component_name}/src/*.{h,m}"
     end
 
     private_spec.subspec "Overlay" do |component|
+      component_name="#{component.base_name}"
+
       component.ios.deployment_target = '8.0'
-      component.public_header_files = "components/private/#{component.base_name}/src/*.h"
-      component.source_files = "components/private/#{component.base_name}/src/*.{h,m}", "components/private/#{component.base_name}/src/private/*.{h,m}"
+      component.public_header_files = "components/private/#{component_name}/src/*.h"
+      component.source_files = "components/private/#{component_name}/src/*.{h,m}", "components/private/#{component_name}/src/private/*.{h,m}"
     end
 
     private_spec.subspec "ShapeLibrary" do |component|
+      component_name="#{component.base_name}"
+
       component.ios.deployment_target = '8.0'
-      component.public_header_files = "components/private/#{component.base_name}/src/*.h"
-      component.source_files = "components/private/#{component.base_name}/src/*.{h,m}", "components/private/#{component.base_name}/src/private/*.{h,m}"
+      component.public_header_files = "components/private/#{component_name}/src/*.h"
+      component.source_files = "components/private/#{component_name}/src/*.{h,m}", "components/private/#{component_name}/src/private/*.{h,m}"
 
       component.dependency "MaterialComponents/private/Shapes"
       component.dependency "MaterialComponents/private/Math"
     end
 
     private_spec.subspec "Shapes" do |component|
+      component_name="#{component.base_name}"
+
       component.ios.deployment_target = '8.0'
-      component.public_header_files = "components/private/#{component.base_name}/src/*.h"
-      component.source_files = "components/private/#{component.base_name}/src/*.{h,m}", "components/private/#{component.base_name}/src/private/*.{h,m}"
+      component.public_header_files = "components/private/#{component_name}/src/*.h"
+      component.source_files = "components/private/#{component_name}/src/*.{h,m}", "components/private/#{component_name}/src/private/*.{h,m}"
 
       component.dependency "MaterialComponents/ShadowLayer"
       component.dependency "MaterialComponents/private/Math"
     end
 
     private_spec.subspec "ThumbTrack" do |component|
+      component_name="#{component.base_name}"
+
       component.ios.deployment_target = '8.0'
-      component.public_header_files = "components/private/#{component.base_name}/src/*.h"
-      component.source_files = "components/private/#{component.base_name}/src/*.{h,m}"
+      component.public_header_files = "components/private/#{component_name}/src/*.h"
+      component.source_files = "components/private/#{component_name}/src/*.{h,m}"
 
       component.dependency "MaterialComponents/Ink"
       component.dependency "MaterialComponents/ShadowElevations"
@@ -596,9 +692,11 @@ Pod::Spec.new do |mdc|
     end
 
     private_spec.subspec "UIMetrics" do |component|
+      component_name="#{component.base_name}"
+
       component.ios.deployment_target = '8.0'
-      component.public_header_files = "components/private/#{component.base_name}/src/*.h"
-      component.source_files = "components/private/#{component.base_name}/src/*.{h,m}", "components/private/#{component.base_name}/src/private/*.{h,m}"
+      component.public_header_files = "components/private/#{component_name}/src/*.h"
+      component.source_files = "components/private/#{component_name}/src/*.{h,m}", "components/private/#{component_name}/src/private/*.{h,m}"
 
       component.dependency "MaterialComponents/private/Application"
     end


### PR DESCRIPTION
Some pods were still adding dependencies to the wrong spec. This change ensures that the `component` spec always refers to the spec for the component, which will hopefully alleviate confusion.