### PR TITLE
[Dialogs] Migrate to Material Motion.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -257,6 +257,8 @@ Pod::Spec.new do |mdc|
       spec.dependency "MaterialComponents/ShadowLayer"
       spec.dependency "MaterialComponents/private/KeyboardWatcher"
       spec.dependency "MDFInternationalization"
+      spec.dependency "MotionAnimator", "~> 2.5"
+      spec.dependency "MotionTransitioning", "~> 4.0"
     end
     component.subspec "ColorThemer" do |spec|
       spec.ios.deployment_target = '8.0'

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -45,7 +45,7 @@ git_repository(
 git_repository(
     name = "motion_animator_objc",
     remote = "https://github.com/material-motion/motion-animator-objc.git",
-    tag = "v2.3.0",
+    tag = "v2.5.0",
 )
 
 git_repository(

--- a/components/Dialogs/examples/DialogsKeyboardViewController.m
+++ b/components/Dialogs/examples/DialogsKeyboardViewController.m
@@ -17,20 +17,12 @@
 #import "MaterialDialogs.h"
 #import "supplemental/DialogsKeyboardViewControllerSupplemental.h"
 
-@interface DialogsKeyboardViewController ()
-
-@property(nonatomic, strong) MDCDialogTransitionController *transitionController;
-
-@end
-
 @implementation DialogsKeyboardViewController
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+
   [self loadCollectionView];
-  // We must create and store a strong reference to the transitionController.
-  // A presented view controller will set this object as its transitioning delegate.
-  self.transitionController = [[MDCDialogTransitionController alloc] init];
 }
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
@@ -44,8 +36,7 @@
 
   UIViewController *viewController =
       [storyboard instantiateViewControllerWithIdentifier:identifier];
-  viewController.modalPresentationStyle = UIModalPresentationCustom;
-  viewController.transitioningDelegate = self.transitionController;
+  viewController.mdm_transitionController.transition = [[MDCDialogTransition alloc] init];
 
   [self presentViewController:viewController animated:YES completion:NULL];
 }

--- a/components/Dialogs/examples/DialogsTypicalUseViewController.m
+++ b/components/Dialogs/examples/DialogsTypicalUseViewController.m
@@ -17,11 +17,21 @@
 #import "MaterialDialogs.h"
 #import "supplemental/DialogsTypicalUseSupplemental.h"
 
+@interface DialogsTypicalUseViewController ()
+
+@property(nonatomic, strong) MDCDialogTransitionController *transitionController;
+
+@end
+
 @implementation DialogsTypicalUseViewController
 
 - (void)viewDidLoad {
   [super viewDidLoad];
   [self loadCollectionView:@[@"Programmatic", @"Storyboard", @"Modal", @"Open URL"]];
+
+  // We must create and store a strong reference to the transitionController.
+  // A presented view controller will set this object as its transitioning delegate.
+  self.transitionController = [[MDCDialogTransitionController alloc] init];
 }
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
@@ -40,7 +50,9 @@
 - (IBAction)didTapProgrammatic {
   UIViewController *viewController =
       [[ProgrammaticViewController alloc] initWithNibName:nil bundle:nil];
-  viewController.mdm_transitionController.transition = [[MDCDialogTransition alloc] init];
+
+  viewController.modalPresentationStyle = UIModalPresentationCustom;
+  viewController.transitioningDelegate = self.transitionController;
 
   [self presentViewController:viewController animated:YES completion:NULL];
 }

--- a/components/Dialogs/examples/DialogsTypicalUseViewController.m
+++ b/components/Dialogs/examples/DialogsTypicalUseViewController.m
@@ -17,20 +17,11 @@
 #import "MaterialDialogs.h"
 #import "supplemental/DialogsTypicalUseSupplemental.h"
 
-@interface DialogsTypicalUseViewController ()
-
-@property(nonatomic, strong) MDCDialogTransitionController *transitionController;
-
-@end
-
 @implementation DialogsTypicalUseViewController
 
 - (void)viewDidLoad {
   [super viewDidLoad];
   [self loadCollectionView:@[@"Programmatic", @"Storyboard", @"Modal", @"Open URL"]];
-  // We must create and store a strong reference to the transitionController.
-  // A presented view controller will set this object as its transitioning delegate.
-  self.transitionController = [[MDCDialogTransitionController alloc] init];
 }
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
@@ -49,8 +40,7 @@
 - (IBAction)didTapProgrammatic {
   UIViewController *viewController =
       [[ProgrammaticViewController alloc] initWithNibName:nil bundle:nil];
-  viewController.modalPresentationStyle = UIModalPresentationCustom;
-  viewController.transitioningDelegate = self.transitionController;
+  viewController.mdm_transitionController.transition = [[MDCDialogTransition alloc] init];
 
   [self presentViewController:viewController animated:YES completion:NULL];
 }
@@ -58,8 +48,7 @@
 - (IBAction)didTapModalProgrammatic {
   UIViewController *viewController =
       [[ProgrammaticViewController alloc] initWithNibName:nil bundle:nil];
-  viewController.modalPresentationStyle = UIModalPresentationCustom;
-  viewController.transitioningDelegate = self.transitionController;
+  viewController.mdm_transitionController.transition = [[MDCDialogTransition alloc] init];
 
   [self presentViewController:viewController animated:YES completion:NULL];
 
@@ -73,8 +62,7 @@
 - (IBAction)didTapOpenURL {
   UIViewController *viewController =
     [[OpenURLViewController alloc] initWithNibName:nil bundle:nil];
-  viewController.modalPresentationStyle = UIModalPresentationCustom;
-  viewController.transitioningDelegate = self.transitionController;
+  viewController.mdm_transitionController.transition = [[MDCDialogTransition alloc] init];
 
   [self presentViewController:viewController animated:YES completion:NULL];
 }
@@ -88,8 +76,7 @@
 
   UIViewController *viewController =
       [storyboard instantiateViewControllerWithIdentifier:identifier];
-  viewController.modalPresentationStyle = UIModalPresentationCustom;
-  viewController.transitioningDelegate = self.transitionController;
+  viewController.mdm_transitionController.transition = [[MDCDialogTransition alloc] init];
 
   [self presentViewController:viewController animated:YES completion:NULL];
 }

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -18,9 +18,9 @@
 
 #import <MDFInternationalization/MDFInternationalization.h>
 
-#import "MDCDialogTransitionController.h"
 #import "MaterialButtons.h"
 #import "MaterialTypography.h"
+#import "MDCDialogTransition.h"
 #import "private/MaterialDialogsStrings.h"
 #import "private/MaterialDialogsStrings_table.h"
 
@@ -82,8 +82,6 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
 @property(nonatomic, getter=isVerticalActionsLayout) BOOL verticalActionsLayout;
 
-@property(nonatomic, strong) MDCDialogTransitionController *transitionController;
-
 - (nonnull instancetype)initWithTitle:(nullable NSString *)title
                               message:(nullable NSString *)message;
 
@@ -121,24 +119,9 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     _actions = [[NSMutableArray alloc] init];
     _actionButtons = [[NSMutableArray alloc] init];
 
-    _transitionController = [[MDCDialogTransitionController alloc] init];
-    super.transitioningDelegate = _transitionController;
-    super.modalPresentationStyle = UIModalPresentationCustom;
+    self.mdm_transitionController.transition = [[MDCDialogTransition alloc] init];
   }
   return self;
-}
-
-/* Disable setter. Always use internal transition controller */
-- (void)setTransitioningDelegate:
-    (__unused id<UIViewControllerTransitioningDelegate>)transitioningDelegate {
-  NSAssert(NO, @"MDCAlertController.transitioningDelegate cannot be changed.");
-  return;
-}
-
-/* Disable setter. Always use custom presentation style */
-- (void)setModalPresentationStyle:(__unused UIModalPresentationStyle)modalPresentationStyle {
-  NSAssert(NO, @"MDCAlertController.modalPresentationStyle cannot be changed.");
-  return;
 }
 
 - (NSString *)title {

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -18,9 +18,9 @@
 
 #import <MDFInternationalization/MDFInternationalization.h>
 
+#import "MDCDialogTransition.h"
 #import "MaterialButtons.h"
 #import "MaterialTypography.h"
-#import "MDCDialogTransition.h"
 #import "private/MaterialDialogsStrings.h"
 #import "private/MaterialDialogsStrings_table.h"
 

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -29,7 +29,7 @@ static CGFloat MDCDialogMinimumWidth = 280.0f;
 // Side margins set to 20 until we have a resolution
 static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
 
-@interface MDCDialogPresentationController () <MDMTransitionWithCustomDuration>
+@interface MDCDialogPresentationController () <MDMTransition>
 
 // View matching the container's bounds that dims the entire screen and catchs taps to dismiss.
 @property(nonatomic) UIView *dimmingView;
@@ -342,16 +342,6 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
                      self.presentedView.frame = presentedViewFrame;
                    }
                    completion:NULL];
-}
-
-#pragma mark - MDMTransitionWithCustomDuration
-
-- (NSTimeInterval)transitionDurationWithContext:(id<MDMTransitionContext>)context {
-  if (context.direction == MDMTransitionDirectionForward) {
-    return MDCDialogTransitionMotionSpec.appearance.scrimOpacity.duration;
-  } else {
-    return MDCDialogTransitionMotionSpec.disappearance.scrimOpacity.duration;
-  }
 }
 
 #pragma mark - MDMTransition

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -16,8 +16,8 @@
 
 #import "MDCDialogPresentationController.h"
 
-#import "MaterialKeyboardWatcher.h"
 #import "MDCDialogTransition.h"
+#import "MaterialKeyboardWatcher.h"
 #import "private/MDCDialogShadowedView.h"
 #import "private/MDCDialogTransitionMotionSpec.h"
 #import <MotionAnimator/MotionAnimator.h>
@@ -34,8 +34,7 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
 // View matching the container's bounds that dims the entire screen and catchs taps to dismiss.
 @property(nonatomic) UIView *dimmingView;
 
-// Tracking view that adds a shadow under the presented view. This view's frame should always match
-// the presented view's.
+// A settable version of the parent presentedView API.
 @property(nonatomic) UIView *presentedView;
 
 @end

--- a/components/Dialogs/src/MDCDialogTransition.h
+++ b/components/Dialogs/src/MDCDialogTransition.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
  limitations under the License.
  */
 
-#import "MaterialShadowLayer.h"
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+#import <MotionTransitioning/MotionTransitioning.h>
 
-@interface MDCDialogShadowedView : UIView
+@interface MDCDialogTransition : NSObject <MDMTransition>
 @end

--- a/components/Dialogs/src/MDCDialogTransition.h
+++ b/components/Dialogs/src/MDCDialogTransition.h
@@ -17,5 +17,13 @@
 #import <Foundation/Foundation.h>
 #import <MotionTransitioning/MotionTransitioning.h>
 
-@interface MDCDialogTransition : NSObject <MDMTransition>
+@interface MDCDialogTransition : NSObject <MDMTransitionWithPresentation>
+
+/**
+ Should a tap on the dimmed background view dismiss the presented controller.
+
+ Defaults to YES.
+ */
+@property(nonatomic, assign) BOOL dismissOnBackgroundTap;
+
 @end

--- a/components/Dialogs/src/MDCDialogTransition.m
+++ b/components/Dialogs/src/MDCDialogTransition.m
@@ -1,0 +1,49 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCDialogTransition.h"
+
+#import "MDCDialogPresentationController.h"
+#import "MDCDialogTransitionMotionSpec.h"
+
+#import <MotionAnimator/MotionAnimator.h>
+
+@interface MDCDialogTransition() <MDMTransitionWithPresentation>
+@end
+
+@implementation MDCDialogTransition
+
+#pragma mark - MDMTransitionWithPresentation
+
+- (UIPresentationController *)
+    presentationControllerForPresentedViewController:(UIViewController *)presented
+    presentingViewController:(UIViewController *)presenting
+    sourceViewController:(__unused UIViewController *)source {
+  return [[MDCDialogPresentationController alloc] initWithPresentedViewController:presented
+                                                         presentingViewController:presenting];
+}
+
+- (UIModalPresentationStyle)defaultModalPresentationStyle {
+  return UIModalPresentationCustom;
+}
+
+#pragma mark - MDMTransition
+
+- (void)startWithContext:(id<MDMTransitionContext>)context {
+  [context transitionDidEnd]; // All animations are handled in the presentation controller.
+}
+
+@end

--- a/components/Dialogs/src/MDCDialogTransition.m
+++ b/components/Dialogs/src/MDCDialogTransition.m
@@ -21,7 +21,7 @@
 
 #import <MotionAnimator/MotionAnimator.h>
 
-@interface MDCDialogTransition() <MDMTransitionWithPresentation>
+@interface MDCDialogTransition() <MDMTransitionWithCustomDuration, MDMTransitionWithPresentation>
 @end
 
 @implementation MDCDialogTransition {
@@ -54,6 +54,16 @@
 
 - (UIModalPresentationStyle)defaultModalPresentationStyle {
   return UIModalPresentationCustom;
+}
+
+#pragma mark - MDMTransitionWithCustomDuration
+
+- (NSTimeInterval)transitionDurationWithContext:(id<MDMTransitionContext>)context {
+  if (context.direction == MDMTransitionDirectionForward) {
+    return MDCDialogTransitionMotionSpec.appearance.contentOpacity.duration;
+  } else {
+    return MDCDialogTransitionMotionSpec.disappearance.contentOpacity.duration;
+  }
 }
 
 #pragma mark - MDMTransition

--- a/components/Dialogs/src/MDCDialogTransition.m
+++ b/components/Dialogs/src/MDCDialogTransition.m
@@ -60,9 +60,9 @@
 
 - (NSTimeInterval)transitionDurationWithContext:(id<MDMTransitionContext>)context {
   if (context.direction == MDMTransitionDirectionForward) {
-    return MDCDialogTransitionMotionSpec.appearance.contentOpacity.duration;
+    return MDCDialogTransitionMotionSpec.appearance.transitionDuration;
   } else {
-    return MDCDialogTransitionMotionSpec.disappearance.contentOpacity.duration;
+    return MDCDialogTransitionMotionSpec.disappearance.transitionDuration;
   }
 }
 

--- a/components/Dialogs/src/MDCDialogTransition.m
+++ b/components/Dialogs/src/MDCDialogTransition.m
@@ -24,7 +24,17 @@
 @interface MDCDialogTransition() <MDMTransitionWithPresentation>
 @end
 
-@implementation MDCDialogTransition
+@implementation MDCDialogTransition {
+  MDCDialogPresentationController *_presentationController;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _dismissOnBackgroundTap = YES;
+  }
+  return self;
+}
 
 #pragma mark - MDMTransitionWithPresentation
 
@@ -32,8 +42,14 @@
     presentationControllerForPresentedViewController:(UIViewController *)presented
     presentingViewController:(UIViewController *)presenting
     sourceViewController:(__unused UIViewController *)source {
-  return [[MDCDialogPresentationController alloc] initWithPresentedViewController:presented
-                                                         presentingViewController:presenting];
+  if (_presentationController) {
+    return _presentationController;
+  }
+  _presentationController =
+      [[MDCDialogPresentationController alloc] initWithPresentedViewController:presented
+                                                      presentingViewController:presenting];
+  _presentationController.dismissOnBackgroundTap = self.dismissOnBackgroundTap;
+  return _presentationController;
 }
 
 - (UIModalPresentationStyle)defaultModalPresentationStyle {
@@ -44,6 +60,14 @@
 
 - (void)startWithContext:(id<MDMTransitionContext>)context {
   [context transitionDidEnd]; // All animations are handled in the presentation controller.
+}
+
+#pragma mark - Public
+
+- (void)setDismissOnBackgroundTap:(BOOL)dismissOnBackgroundTap {
+  _dismissOnBackgroundTap = dismissOnBackgroundTap;
+
+  _presentationController.dismissOnBackgroundTap = dismissOnBackgroundTap;
 }
 
 @end

--- a/components/Dialogs/src/MDCDialogTransition.m
+++ b/components/Dialogs/src/MDCDialogTransition.m
@@ -59,7 +59,27 @@
 #pragma mark - MDMTransition
 
 - (void)startWithContext:(id<MDMTransitionContext>)context {
-  [context transitionDidEnd]; // All animations are handled in the presentation controller.
+  [CATransaction begin];
+  [CATransaction setCompletionBlock:^{
+    [context transitionDidEnd];
+  }];
+
+  MDMMotionAnimator *animator = [[MDMMotionAnimator alloc] init];
+  animator.shouldReverseValues = context.direction == MDMTransitionDirectionBackward;
+
+  MDMMotionTiming contentOpacity;
+  if (context.direction == MDMTransitionDirectionForward) {
+    contentOpacity = MDCDialogTransitionMotionSpec.appearance.contentOpacity;
+  } else {
+    contentOpacity = MDCDialogTransitionMotionSpec.disappearance.contentOpacity;
+  }
+
+  [animator animateWithTiming:contentOpacity
+                      toLayer:context.presentationController.presentedView.layer
+                   withValues:@[@0, @1]
+                      keyPath:MDMKeyPathOpacity];
+
+  [CATransaction commit];
 }
 
 #pragma mark - Public

--- a/components/Dialogs/src/MDCDialogTransitionController.m
+++ b/components/Dialogs/src/MDCDialogTransitionController.m
@@ -49,7 +49,6 @@ static const NSTimeInterval MDCDialogTransitionDuration = 0.27;
   UIViewController *toPresentingViewController = toViewController.presentingViewController;
   BOOL presenting = (toPresentingViewController == fromViewController) ? YES : NO;
 
-  UIViewController *animatingViewController = presenting ? toViewController : fromViewController;
   UIView *animatingView = presenting ? toView : fromView;
 
   UIView *containerView = transitionContext.containerView;
@@ -61,7 +60,6 @@ static const NSTimeInterval MDCDialogTransitionDuration = 0.27;
   CGFloat startingAlpha = presenting ? 0.0f : 1.0f;
   CGFloat endingAlpha = presenting ? 1.0f : 0.0f;
 
-  animatingView.frame = [transitionContext finalFrameForViewController:animatingViewController];
   animatingView.alpha = startingAlpha;
 
   NSTimeInterval transitionDuration = [self transitionDuration:transitionContext];

--- a/components/Dialogs/src/MaterialDialogs.h
+++ b/components/Dialogs/src/MaterialDialogs.h
@@ -15,6 +15,7 @@
  */
 
 #import "MDCAlertController.h"
+#import "MDCDialogTransition.h"
 #import "MDCDialogPresentationController.h"
 #import "MDCDialogTransitionController.h"
 #import "UIViewController+MaterialDialogs.h"

--- a/components/Dialogs/src/private/MDCDialogShadowedView.m
+++ b/components/Dialogs/src/private/MDCDialogShadowedView.m
@@ -17,7 +17,6 @@
 #import "MDCDialogShadowedView.h"
 
 #import "MaterialShadowElevations.h"
-#import "MaterialShadowLayer.h"
 
 @implementation MDCDialogShadowedView
 

--- a/components/Dialogs/src/private/MDCDialogTransitionMotionSpec.h
+++ b/components/Dialogs/src/private/MDCDialogTransitionMotionSpec.h
@@ -1,0 +1,41 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <MotionInterchange/MotionInterchange.h>
+#import <MotionTransitioning/MotionTransitioning.h>
+
+typedef struct MDCDialogTransitionAppearanceTimings {
+  MDMMotionTiming contentOpacity;
+  MDMMotionTiming scrimOpacity;
+  MDMMotionTiming contentScale;
+  CGFloat contentScaleFromValue;
+} MDCDialogTransitionAppearanceTimings;
+
+typedef struct MDCDialogTransitionDisappearanceTimings {
+  MDMMotionTiming contentOpacity;
+  MDMMotionTiming scrimOpacity;
+} MDCDialogTransitionDisappearanceTimings;
+
+@interface MDCDialogTransitionMotionSpec: NSObject
+
++ (MDCDialogTransitionAppearanceTimings)appearance;
++ (MDCDialogTransitionDisappearanceTimings)disappearance;
+
+// This object is not meant to be instantiated.
+- (instancetype)init NS_UNAVAILABLE;
+
+@end

--- a/components/Dialogs/src/private/MDCDialogTransitionMotionSpec.h
+++ b/components/Dialogs/src/private/MDCDialogTransitionMotionSpec.h
@@ -23,11 +23,13 @@ typedef struct MDCDialogTransitionAppearanceTimings {
   MDMMotionTiming scrimOpacity;
   MDMMotionTiming contentScale;
   CGFloat contentScaleFromValue;
+  NSTimeInterval transitionDuration;
 } MDCDialogTransitionAppearanceTimings;
 
 typedef struct MDCDialogTransitionDisappearanceTimings {
   MDMMotionTiming contentOpacity;
   MDMMotionTiming scrimOpacity;
+  NSTimeInterval transitionDuration;
 } MDCDialogTransitionDisappearanceTimings;
 
 @interface MDCDialogTransitionMotionSpec: NSObject

--- a/components/Dialogs/src/private/MDCDialogTransitionMotionSpec.m
+++ b/components/Dialogs/src/private/MDCDialogTransitionMotionSpec.m
@@ -37,7 +37,7 @@
     .contentScale = {
       .duration = 0.150, .delay = 0.000, .curve = [self deceleration]
     },
-    .contentScaleFromValue = 0.8,
+    .contentScaleFromValue = (CGFloat)0.8,
     .transitionDuration = 0.150,
   };
 }

--- a/components/Dialogs/src/private/MDCDialogTransitionMotionSpec.m
+++ b/components/Dialogs/src/private/MDCDialogTransitionMotionSpec.m
@@ -37,7 +37,8 @@
     .contentScale = {
       .duration = 0.150, .delay = 0.000, .curve = [self deceleration]
     },
-    .contentScaleFromValue = 0.8
+    .contentScaleFromValue = 0.8,
+    .transitionDuration = 0.150,
   };
 }
 
@@ -49,6 +50,7 @@
     .scrimOpacity = {
       .duration = 0.150, .delay = 0.000, .curve = [self linear]
     },
+    .transitionDuration = 0.150,
   };
 }
 

--- a/components/Dialogs/src/private/MDCDialogTransitionMotionSpec.m
+++ b/components/Dialogs/src/private/MDCDialogTransitionMotionSpec.m
@@ -1,0 +1,55 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCDialogTransitionMotionSpec.h"
+
+@implementation MDCDialogTransitionMotionSpec
+
++ (MDMMotionCurve)linear {
+  return MDMLinearMotionCurve;
+}
+
++ (MDMMotionCurve)deceleration {
+  return MDMMotionCurveMakeBezier(0.00f, 0.00f, 0.20f, 1.00f);
+}
+
++ (MDCDialogTransitionAppearanceTimings)appearance {
+  return (MDCDialogTransitionAppearanceTimings){
+    .contentOpacity = {
+      .duration = 0.150, .delay = 0.000, .curve = [self linear]
+    },
+    .scrimOpacity = {
+      .duration = 0.150, .delay = 0.000, .curve = [self linear]
+    },
+    .contentScale = {
+      .duration = 0.150, .delay = 0.000, .curve = [self deceleration]
+    },
+    .contentScaleFromValue = 0.8
+  };
+}
+
++ (MDCDialogTransitionDisappearanceTimings)disappearance {
+  return (MDCDialogTransitionDisappearanceTimings){
+    .contentOpacity = {
+      .duration = 0.150, .delay = 0.000, .curve = [self linear]
+    },
+    .scrimOpacity = {
+      .duration = 0.150, .delay = 0.000, .curve = [self linear]
+    },
+  };
+}
+
+@end


### PR DESCRIPTION
This change implements the Material Motion spec for the Dialogs component using the Motion Interchange, Animator, and Transitioning APIs.

Many of the existing APIs will be able to be deprecated or made private in the future, though there is considerable existing downstream client usage of many of these APIs so this will need to be done with some care.

The client migration path for this change will look something like this on average:

```objc
// Old API
_transitionController = [[MDCDialogTransitionController alloc] init];
self.transitioningDelegate = _transitionController;		
self.modalPresentationStyle = UIModalPresentationCustom;

// New API
self.mdm_transitionController.transition = [[MDCDialogTransition alloc] init];
```