### PR TITLE
[Buttons] Update layer elevation only on change

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -676,7 +676,12 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (void)setElevation:(CGFloat)elevation forState:(UIControlState)state {
   _userElevations[@(state)] = @(elevation);
-  self.layer.elevation = [self elevationForState:self.state];
+  MDCShadowElevation newElevation = [self elevationForState:self.state];
+  // If no change to the current elevation, don't perform updates
+  if (MDCCGFloatEqual(newElevation, self.layer.elevation)) {
+    return;
+  }
+  self.layer.elevation = newElevation;
 
   // The elevation of the normal state controls whether this button is flat or not, and flat buttons
   // have different background color requirements than raised buttons.


### PR DESCRIPTION
When a button's elevation is assigned, it animates a change to the underlying
shadow elevation.  However, this causes animation "jumps" when elevations for
multiple states are being assigned simultaneously. Instead of blindly
assigning the new value to the layer, a check for a change should be performed
instead.

Closes #2483
