### PR TITLE
[Tabs] API review: Increase customizable properties

### DIFF
--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -104,13 +104,13 @@ IB_DESIGNABLE
  Padding on the left and right of the tab bar's content for scrollable tabs.
  Default depends on the horizontal size class.
  */
-@property(nonatomic) IBInspectable CGFloat horizontalPadding UI_APPEARANCE_SELECTOR;
+@property(nonatomic) CGFloat horizontalPadding UI_APPEARANCE_SELECTOR;
 
 /**
  Padding on the left and right of each item's content (title or images) for non-justified alignment.
  Default depends on the horizontal size class.
  */
-@property(nonatomic) IBInspectable CGFloat itemHorizontalPadding UI_APPEARANCE_SELECTOR;
+@property(nonatomic) CGFloat itemHorizontalPadding UI_APPEARANCE_SELECTOR;
 
 /**
  Tint color to apply to the tab bar background.
@@ -139,7 +139,7 @@ IB_DESIGNABLE
 
  The default value is MDCTabBarTextTransformAutomatic.
  */
-@property(nonatomic) IBInspectable MDCTabBarTextTransform titleTextTransform UI_APPEARANCE_SELECTOR;
+@property(nonatomic) MDCTabBarTextTransform titleTextTransform UI_APPEARANCE_SELECTOR;
 
 /**
  Template that defines the appearance of the selection indicator.

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -86,19 +86,16 @@ IB_DESIGNABLE
 @property(nonatomic, nonnull) UIColor *inkColor UI_APPEARANCE_SELECTOR;
 
 /**
- Text attributes used for selected item titles.
- Default uses the regular font from the font loader.
+ Font used for selected item titles.
+ By default uses the regular font from the font loader.
  */
-@property(nonatomic, strong, nonnull)
-    NSDictionary<NSAttributedStringKey, id> *selectedItemTitleTextAttributes UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, nonnull) UIFont *selectedItemTitleFont UI_APPEARANCE_SELECTOR;
 
 /**
- Text attributes used for unselected item titles.
- Default uses the regular font from the font loader.
+ Font used for unselected item titles.
+ By default uses the regular font from the font loader.
  */
-@property(nonatomic, strong, nonnull)
-    NSDictionary<NSAttributedStringKey, id> *unselectedItemTitleTextAttributes
-    UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, nonnull) UIFont *unselectedItemTitleFont UI_APPEARANCE_SELECTOR;
 
 /**
  Padding on the left and right of the tab bar's content for scrollable tabs.

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -98,10 +98,10 @@ IB_DESIGNABLE
     UI_APPEARANCE_SELECTOR;
 
 /**
- Spacing between tab bar content (titles or images) for non-justified alignments.
+ Padding on the left and right of each item's content (title or images) for non-justified alignment.
  Default depends on the horizontal size class.
  */
-@property(nonatomic) IBInspectable CGFloat itemSpacing UI_APPEARANCE_SELECTOR;
+@property(nonatomic) IBInspectable CGFloat itemHorizontalPadding UI_APPEARANCE_SELECTOR;
 
 /**
  Tint color to apply to the tab bar background.

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -85,16 +85,18 @@ IB_DESIGNABLE
 @property(nonatomic, nonnull) UIColor *inkColor UI_APPEARANCE_SELECTOR;
 
 /**
- Display font used for selected item titles.
- Default is the regular font from the font loader.
+ Text attributes used for selected item titles.
+ Default uses the regular font from the font loader.
  */
-@property(nonatomic, strong, null_resettable) UIFont *selectedItemTitleFont UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, nonnull)
+    NSDictionary<NSAttributedStringKey, id> *selectedItemTitleTextAttributes UI_APPEARANCE_SELECTOR;
 
 /**
- Display font used for unselected item titles.
- Default is the regular font from the font loader.
+ Text attributes used for unselected item titles.
+ Default uses the regular font from the font loader.
  */
-@property(nonatomic, strong, null_resettable) UIFont *unselectedItemTitleFont
+@property(nonatomic, strong, nonnull)
+    NSDictionary<NSAttributedStringKey, id> *unselectedItemTitleTextAttributes
     UI_APPEARANCE_SELECTOR;
 
 /**

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -85,6 +85,25 @@ IB_DESIGNABLE
 @property(nonatomic, nonnull) UIColor *inkColor UI_APPEARANCE_SELECTOR;
 
 /**
+ Display font used for selected item titles.
+ Default is the regular font from the font loader.
+ */
+@property(nonatomic, strong, null_resettable) UIFont *selectedItemTitleFont UI_APPEARANCE_SELECTOR;
+
+/**
+ Display font used for unselected item titles.
+ Default is the regular font from the font loader.
+ */
+@property(nonatomic, strong, null_resettable) UIFont *unselectedItemTitleFont
+    UI_APPEARANCE_SELECTOR;
+
+/**
+ Spacing between tab bar content (titles or images) for non-justified alignments.
+ Default depends on the horizontal size class.
+ */
+@property(nonatomic) IBInspectable CGFloat itemSpacing UI_APPEARANCE_SELECTOR;
+
+/**
  Tint color to apply to the tab bar background.
 
  If nil, the receiver uses the default background appearance. Default: nil.
@@ -112,7 +131,7 @@ IB_DESIGNABLE
 
  The default value is based on the position and is recommended for most applications.
  */
-@property(nonatomic) IBInspectable BOOL displaysUppercaseTitles;
+@property(nonatomic) IBInspectable BOOL displaysUppercaseTitles UI_APPEARANCE_SELECTOR;
 
 /**
  Template that defines the appearance of the selection indicator.

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -18,6 +18,7 @@
 
 #import "MDCTabBarAlignment.h"
 #import "MDCTabBarItemAppearance.h"
+#import "MDCTabBarTextTransform.h"
 
 @class MDCTabBarItem;
 @protocol MDCTabBarDelegate;
@@ -134,12 +135,11 @@ IB_DESIGNABLE
 @property(nonatomic) MDCTabBarItemAppearance itemAppearance;
 
 /**
- Indicates if all tab titles should be uppercased for display. If NO, item titles will be
- displayed verbatim.
+ Defines how tab bar item titles are transformed for display.
 
- The default value is based on the position and is recommended for most applications.
+ The default value is MDCTabBarTextTransformAutomatic.
  */
-@property(nonatomic) IBInspectable BOOL displaysUppercaseTitles UI_APPEARANCE_SELECTOR;
+@property(nonatomic) IBInspectable MDCTabBarTextTransform titleTextTransform UI_APPEARANCE_SELECTOR;
 
 /**
  Template that defines the appearance of the selection indicator.

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -98,6 +98,12 @@ IB_DESIGNABLE
     UI_APPEARANCE_SELECTOR;
 
 /**
+ Padding on the left and right of the tab bar's content for scrollable tabs.
+ Default depends on the horizontal size class.
+ */
+@property(nonatomic) IBInspectable CGFloat horizontalPadding UI_APPEARANCE_SELECTOR;
+
+/**
  Padding on the left and right of each item's content (title or images) for non-justified alignment.
  Default depends on the horizontal size class.
  */

--- a/components/Tabs/src/MDCTabBarTextTransform.h
+++ b/components/Tabs/src/MDCTabBarTextTransform.h
@@ -1,0 +1,29 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+/** Appearance for content within tab bar items. */
+typedef NS_ENUM(NSInteger, MDCTabBarTextTransform) {
+  /** The default text transform is applied based on the bar's position. */
+  MDCTabBarTextTransformAutomatic,
+
+  /** Text on tabs is displayed verbatim with no transform. */
+  MDCTabBarTextTransformNone,
+
+  /** Text on tabs is uppercased for display. */
+  MDCTabBarTextTransformUppercase,
+};


### PR DESCRIPTION
This is an API review to expand the set of customizable properties on MDCTabBar. It adds the following new customization parameters which will need to be customizable to accommodate new designs:
* item title font, which can now differ based on selection state
* padding for the entire tab bar
* padding for individual tabs

It also makes the `displaysUppercaseTitles` property UIAppearance-proxyable to allow themers to set it.

This PR is to review API changes only and should not be merged. Implementation is in progress separately.