### PR TITLE
[API Review] Extended FAB

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -144,6 +144,7 @@ Pod::Spec.new do |mdc|
       spec.public_header_files = "components/#{component.base_name}/src/*.h"
       spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
 
+      spec.dependency 'MDFInternationalization'
       spec.dependency 'MDFTextAccessibility'
       spec.dependency "MaterialComponents/Ink"
       spec.dependency "MaterialComponents/ShadowElevations"

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -323,19 +323,15 @@ static const int kMDCButtonAnimationDuration = 200;
     subViewIndex = 0;
   }
   if (animated) {
-    [_floatingButton setElevation:1 forState:UIControlStateNormal shape:_floatingButton.shape];
+    [_floatingButton setElevation:1 forState:UIControlStateNormal];
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, kMDCButtonAnimationDuration * NSEC_PER_MSEC),
                    dispatch_get_main_queue(), ^{
                      [self insertSubview:_floatingButton atIndex:subViewIndex];
-                     [_floatingButton setElevation:elevation
-                                          forState:UIControlStateNormal
-                                             shape:_floatingButton.shape];
+                     [_floatingButton setElevation:elevation forState:UIControlStateNormal];
                    });
   } else {
     [self insertSubview:_floatingButton atIndex:subViewIndex];
-    [_floatingButton setElevation:elevation
-                         forState:UIControlStateNormal
-                            shape:_floatingButton.shape];
+    [_floatingButton setElevation:elevation forState:UIControlStateNormal];
   }
 }
 

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -323,15 +323,19 @@ static const int kMDCButtonAnimationDuration = 200;
     subViewIndex = 0;
   }
   if (animated) {
-    [_floatingButton setElevation:1 forState:UIControlStateNormal];
+    [_floatingButton setElevation:1 forState:UIControlStateNormal shape:_floatingButton.shape];
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, kMDCButtonAnimationDuration * NSEC_PER_MSEC),
                    dispatch_get_main_queue(), ^{
                      [self insertSubview:_floatingButton atIndex:subViewIndex];
-                     [_floatingButton setElevation:elevation forState:UIControlStateNormal];
+                     [_floatingButton setElevation:elevation
+                                          forState:UIControlStateNormal
+                                             shape:_floatingButton.shape];
                    });
   } else {
     [self insertSubview:_floatingButton atIndex:subViewIndex];
-    [_floatingButton setElevation:elevation forState:UIControlStateNormal];
+    [_floatingButton setElevation:elevation
+                         forState:UIControlStateNormal
+                            shape:_floatingButton.shape];
   }
 }
 

--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -53,7 +53,8 @@
   self.flatButton.contentEdgeInsets = UIEdgeInsetsMake(64, 64, 0, 0);
   self.raisedButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, 64, 64);
   [self.floatingActionButton setContentEdgeInsets:UIEdgeInsetsMake(40, 40, 0, 0)
-                                         forShape:MDCFloatingButtonShapeDefault];
+                                          forType:MDCFloatingButtonTypeDefault
+                                             mode:MDCFloatingButtonModeNormal];
 
   [self updateInkStyle:self.inkBoundingSwitch.isOn ? MDCInkStyleBounded : MDCInkStyleUnbounded];
 }

--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -52,7 +52,8 @@
   self.flatButton.inkColor = [UIColor colorWithWhite:1.0 alpha:0.1];
   self.flatButton.contentEdgeInsets = UIEdgeInsetsMake(64, 64, 0, 0);
   self.raisedButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, 64, 64);
-  self.floatingActionButton.contentEdgeInsets = UIEdgeInsetsMake(40, 40, 0, 0);
+  [self.floatingActionButton setContentEdgeInsets:UIEdgeInsetsMake(40, 40, 0, 0)
+                                         forShape:MDCFloatingButtonShapeDefault];
 
   [self updateInkStyle:self.inkBoundingSwitch.isOn ? MDCInkStyleBounded : MDCInkStyleUnbounded];
 }

--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -53,7 +53,7 @@
   self.flatButton.contentEdgeInsets = UIEdgeInsetsMake(64, 64, 0, 0);
   self.raisedButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, 64, 64);
   [self.floatingActionButton setContentEdgeInsets:UIEdgeInsetsMake(40, 40, 0, 0)
-                                          forType:MDCFloatingButtonTypeDefault
+                                         forShape:MDCFloatingButtonShapeDefault
                                              mode:MDCFloatingButtonModeNormal];
 
   [self updateInkStyle:self.inkBoundingSwitch.isOn ? MDCInkStyleBounded : MDCInkStyleUnbounded];

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -94,9 +94,13 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
   func updateFloatingButtons(to mode: MDCFloatingButtonMode) {
     if (floatingButton.mode != mode) {
       floatingButton.mode = mode
+      NSLog("Prog: %@", String(describing: self.floatingButton.frame))
+
     }
     if (storyboardFloating.mode != mode) {
       storyboardFloating.mode = mode
+      NSLog("Story: %@", String(describing: self.storyboardFloating.frame))
+
     }
   }
 
@@ -226,12 +230,12 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
     super.willTransition(to: newCollection, with: coordinator)
     let currentTraits = self.traitCollection;
     let sizeClassChanged
-      = traitCollection.horizontalSizeClass != currentTraits.horizontalSizeClass
-        || traitCollection.verticalSizeClass != currentTraits.verticalSizeClass
+      = newCollection.horizontalSizeClass != currentTraits.horizontalSizeClass
+        || newCollection.verticalSizeClass != currentTraits.verticalSizeClass
     if (sizeClassChanged) {
       let willBeRegularRegular
-        = traitCollection.horizontalSizeClass == .regular
-          && traitCollection.verticalSizeClass == .regular
+        = newCollection.horizontalSizeClass == .regular
+          && newCollection.verticalSizeClass == .regular
 
 
       coordinator.animate(alongsideTransition:{ (_) in
@@ -241,9 +245,11 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
         } else {
           if (self.floatingButton.mode != .normal) {
             self.floatingButton.mode = .normal
+            NSLog("Prog: %@", String(describing: self.floatingButton.frame))
           }
           if (self.storyboardFloating.mode != .normal) {
             self.storyboardFloating.mode = .normal
+            NSLog("Story: %@", String(describing: self.storyboardFloating.frame))
           }
         }
       }, completion: nil)

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -235,7 +235,6 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
         = newCollection.horizontalSizeClass == .regular
           && newCollection.verticalSizeClass == .regular
 
-
       coordinator.animate(alongsideTransition:{ (_) in
         if (willBeRegularRegular) {
           self.updateFloatingButtons(to: .extended)
@@ -249,7 +248,6 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
       }, completion: nil)
     }
   }
-
 }
 
 extension ButtonsSwiftAndStoryboardController {

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -80,13 +80,11 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
 
     buttonSetup()
 
-    let floatingPlusShapeLayer = ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton)
-    floatingButton.layer.addSublayer(floatingPlusShapeLayer)
+    let plusIcon = UIImage.init(named: "Plus")?.withRenderingMode(.alwaysOriginal)
+    floatingButton.setImage(plusIcon, for: .normal)
     innerContainerView.addSubview(floatingButton)
 
-    let storyboardPlusShapeLayer =
-      ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton)
-    storyboardFloating.layer.addSublayer(storyboardPlusShapeLayer)
+    storyboardFloating.setImage(plusIcon, for: .normal)
 
     addButtonConstraints()
   }
@@ -94,13 +92,9 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
   func updateFloatingButtons(to mode: MDCFloatingButtonMode) {
     if (floatingButton.mode != mode) {
       floatingButton.mode = mode
-      NSLog("Prog: %@", String(describing: self.floatingButton.frame))
-
     }
     if (storyboardFloating.mode != mode) {
       storyboardFloating.mode = mode
-      NSLog("Story: %@", String(describing: self.storyboardFloating.frame))
-
     }
   }
 
@@ -110,8 +104,12 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
     let verticalSizeClass = self.traitCollection.verticalSizeClass
     if (horizontalSizeClass == .regular && verticalSizeClass == .regular) {
       self.updateFloatingButtons(to: .extended)
+      self.floatingButton.setTitle("Button", for: .normal)
+      self.storyboardFloating.setTitle("Button", for: .normal)
     } else {
       self.updateFloatingButtons(to: .normal)
+      self.floatingButton.setTitle(nil, for: .normal)
+      self.storyboardFloating.setTitle(nil, for: .normal)
     }
   }
 
@@ -240,17 +238,13 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
 
       coordinator.animate(alongsideTransition:{ (_) in
         if (willBeRegularRegular) {
-          self.floatingButton.mode = .extended
-          self.storyboardFloating.mode = .extended
+          self.updateFloatingButtons(to: .extended)
+          self.floatingButton.setTitle("Button", for: .normal)
+          self.storyboardFloating.setTitle("Button", for: .normal)
         } else {
-          if (self.floatingButton.mode != .normal) {
-            self.floatingButton.mode = .normal
-            NSLog("Prog: %@", String(describing: self.floatingButton.frame))
-          }
-          if (self.storyboardFloating.mode != .normal) {
-            self.storyboardFloating.mode = .normal
-            NSLog("Story: %@", String(describing: self.storyboardFloating.frame))
-          }
+          self.updateFloatingButtons(to: .normal)
+          self.floatingButton.setTitle(nil, for: .normal)
+          self.storyboardFloating.setTitle(nil, for: .normal)
         }
       }, completion: nil)
     }

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -91,6 +91,26 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
     addButtonConstraints()
   }
 
+  func updateFloatingButtons(to mode: MDCFloatingButtonMode) {
+    if (floatingButton.mode != mode) {
+      floatingButton.mode = mode
+    }
+    if (storyboardFloating.mode != mode) {
+      storyboardFloating.mode = mode
+    }
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    let horizontalSizeClass = self.traitCollection.horizontalSizeClass
+    let verticalSizeClass = self.traitCollection.verticalSizeClass
+    if (horizontalSizeClass == .regular && verticalSizeClass == .regular) {
+      self.updateFloatingButtons(to: .extended)
+    } else {
+      self.updateFloatingButtons(to: .normal)
+    }
+  }
+
   private func layoutContainer() {
     let viewLayoutGuide: Any = {
       #if swift(>=3.2)
@@ -200,6 +220,34 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
 
   @IBAction func tap(_ sender: Any) {
     print("\(type(of: sender)) was tapped.")
+  }
+
+  override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+    super.willTransition(to: newCollection, with: coordinator)
+    let currentTraits = self.traitCollection;
+    let sizeClassChanged
+      = traitCollection.horizontalSizeClass != currentTraits.horizontalSizeClass
+        || traitCollection.verticalSizeClass != currentTraits.verticalSizeClass
+    if (sizeClassChanged) {
+      let willBeRegularRegular
+        = traitCollection.horizontalSizeClass == .regular
+          && traitCollection.verticalSizeClass == .regular
+
+
+      coordinator.animate(alongsideTransition:{ (_) in
+        if (willBeRegularRegular) {
+          self.floatingButton.mode = .extended
+          self.storyboardFloating.mode = .extended
+        } else {
+          if (self.floatingButton.mode != .normal) {
+            self.floatingButton.mode = .normal
+          }
+          if (self.storyboardFloating.mode != .normal) {
+            self.storyboardFloating.mode = .normal
+          }
+        }
+      }, completion: nil)
+    }
   }
 
 }

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -148,9 +148,11 @@
 
       }
       if (self.floatingButton.shape >= MDCFloatingButtonShapeExtendedLeadingIcon) {
+        [self.floatingButton setImage:[UIImage imageNamed:@"Plus"] forState:UIControlStateNormal];
         [self.floatingButton setTitle:@"Extended" forState:UIControlStateNormal];
-      } else {
-        [self.floatingButton setTitle:nil forState:UIControlStateNormal];
+      }  else {
+        [self.floatingButton setImage:nil forState:UIControlStateNormal];
+        [self.floatingButton setTitle:@"New" forState:UIControlStateNormal];
       }
       [self.floatingButton sizeToFit];
     }];

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -173,8 +173,23 @@
   }
 }
 
+- (void)updateFABExtendedMode:(UITraitCollection *)traits {
+  BOOL useExtendedMode = traits.horizontalSizeClass == UIUserInterfaceSizeClassRegular
+      && traits.verticalSizeClass == UIUserInterfaceSizeClassRegular;
+  if (useExtendedMode) {
+    [self.floatingButton setTitle:@"Button" forState:UIControlStateNormal];
+    self.floatingButton.mode = MDCFloatingButtonModeExtended;
+
+  } else {
+    [self.floatingButton setTitle:nil forState:UIControlStateNormal];
+    self.floatingButton.mode = MDCFloatingButtonTypeDefault;
+
+  }
+}
+
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];
+  [self updateFABExtendedMode:self.traitCollection];
   if (animated) {
     [self.floatingButton collapse:NO completion:nil];
   }
@@ -184,6 +199,16 @@
   [super viewDidAppear:animated];
   if (animated) {
     [self.floatingButton expand:YES completion:nil];
+  }
+}
+
+- (void)willTransitionToTraitCollection:(UITraitCollection *)newCollection
+              withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+  UITraitCollection *currentTraits = self.traitCollection;
+  BOOL traitsChange = currentTraits.horizontalSizeClass != newCollection.horizontalSizeClass ||
+  currentTraits.verticalSizeClass != newCollection.verticalSizeClass;
+  if (traitsChange) {
+    [self updateFABExtendedMode:newCollection];
   }
 }
 

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -21,7 +21,6 @@
 
 @interface ButtonsTypicalUseViewController ()
 @property(nonatomic, strong) MDCFloatingButton *floatingButton;
-@property(nonatomic, assign) BOOL styleChanged;
 @end
 
 @implementation ButtonsTypicalUseViewController
@@ -137,39 +136,15 @@
   NSLog(@"%@ was tapped.", NSStringFromClass([sender class]));
   if (sender == self.floatingButton) {
     [UIView animateWithDuration:0.25 animations:^{
-
-      self.floatingButton.mode += 1;
-      if (self.floatingButton.mode > MDCFloatingButtonModeExtended) {
-        self.floatingButton.mode = 0;
-        self.floatingButton.imagePosition += 1;
-        if (self.floatingButton.imagePosition > MDCFloatingButtonImagePositionTrailing) {
-          self.floatingButton.imagePosition = 0;
-          self.floatingButton.contentEdgeInsetsFlippedForTrailingImagePosition
-            = !self.floatingButton.contentEdgeInsetsFlippedForTrailingImagePosition;
-        }
-
-        if (!self.styleChanged) {
-//          MDCBasicColorScheme *scheme = [[MDCBasicColorScheme alloc] initWithPrimaryColor:UIColor.purpleColor
-//                                                                           secondaryColor:UIColor.orangeColor];
-//          [ExampleFloatingButtonThemer applyToButton:self.floatingButton withColorScheme:scheme];
-          self.styleChanged = YES;
-        }
-      }
-      NSLog(@"Mode: %ld, Pos: %ld, Flip: %d\nCEI: %@",
-            self.floatingButton.mode,
-            self.floatingButton.imagePosition,
-            self.floatingButton.contentEdgeInsetsFlippedForTrailingImagePosition,
-            NSStringFromUIEdgeInsets(self.floatingButton.contentEdgeInsets));
-      if (self.floatingButton.mode == MDCFloatingButtonModeExtended) {
-        [self.floatingButton setImage:[UIImage imageNamed:@"Plus"] forState:UIControlStateNormal];
-        [self.floatingButton setTitle:@"Default" forState:UIControlStateNormal];
-      } else {
-        [self.floatingButton setImage:nil forState:UIControlStateNormal];
-        [self.floatingButton setTitle:@"New" forState:UIControlStateNormal];
-      }
-      [self.floatingButton sizeToFit];
+      [self.floatingButton
+         collapse:YES
+       completion:^{
+         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)),
+                        dispatch_get_main_queue(), ^{
+                          [self.floatingButton expand:YES completion:nil];
+                        });
+       }];
     }];
-
   }
 }
 

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -134,14 +134,19 @@
 - (void)didTap:(id)sender {
   NSLog(@"%@ was tapped.", NSStringFromClass([sender class]));
   if (sender == self.floatingButton) {
-    [self.floatingButton
-          collapse:YES
-        completion:^{
-          dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)),
-                         dispatch_get_main_queue(), ^{
-                           [self.floatingButton expand:YES completion:nil];
-                         });
-        }];
+    [UIView animateWithDuration:0.25 animations:^{
+      self.floatingButton.shape += 1;
+      if (self.floatingButton.shape > MDCFloatingButtonShapeExtendedTrailingIcon) {
+        self.floatingButton.shape = 0;
+      }
+      if (self.floatingButton.shape >= MDCFloatingButtonShapeExtendedLeadingIcon) {
+        [self.floatingButton setTitle:@"Extended" forState:UIControlStateNormal];
+      } else {
+        [self.floatingButton setTitle:nil forState:UIControlStateNormal];
+      }
+      [self.floatingButton sizeToFit];
+    }];
+
   }
 }
 

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -21,6 +21,7 @@
 
 @interface ButtonsTypicalUseViewController ()
 @property(nonatomic, strong) MDCFloatingButton *floatingButton;
+@property(nonatomic, assign) BOOL styleChanged;
 @end
 
 @implementation ButtonsTypicalUseViewController
@@ -136,18 +137,29 @@
   NSLog(@"%@ was tapped.", NSStringFromClass([sender class]));
   if (sender == self.floatingButton) {
     [UIView animateWithDuration:0.25 animations:^{
-      self.floatingButton.shape += 1;
-      if (self.floatingButton.shape > MDCFloatingButtonShapeExtendedTrailingIcon) {
-        self.floatingButton.shape = 0;
-        static dispatch_once_t onceToken;
-        dispatch_once(&onceToken, ^{
+      self.floatingButton.mode += 1;
+      if (self.floatingButton.mode > MDCFloatingButtonModeExtended) {
+        self.floatingButton.mode = 0;
+        self.floatingButton.imagePosition += 1;
+        if (self.floatingButton.imagePosition > MDCFloatingButtonImagePositionTrailing) {
+          self.floatingButton.imagePosition = 0;
+          self.floatingButton.contentEdgeInsetsFlippedForTrailingImagePosition
+            = !self.floatingButton.contentEdgeInsetsFlippedForTrailingImagePosition;
+        }
+
+        if (!self.styleChanged) {
           MDCBasicColorScheme *scheme = [[MDCBasicColorScheme alloc] initWithPrimaryColor:UIColor.purpleColor
                                                                            secondaryColor:UIColor.orangeColor];
           [ExampleFloatingButtonThemer applyToButton:self.floatingButton withColorScheme:scheme];
-        });
-
+          self.styleChanged = YES;
+        }
       }
-      if (self.floatingButton.shape >= MDCFloatingButtonShapeExtendedLeadingIcon) {
+      NSLog(@"Mode: %ld, Pos: %ld, Flip: %d\nCEI: %@",
+            self.floatingButton.mode,
+            self.floatingButton.imagePosition,
+            self.floatingButton.contentEdgeInsetsFlippedForTrailingImagePosition,
+            NSStringFromUIEdgeInsets(self.floatingButton.contentEdgeInsets));
+      if (self.floatingButton.mode == MDCFloatingButtonModeExtended) {
         [self.floatingButton setImage:[UIImage imageNamed:@"Plus"] forState:UIControlStateNormal];
         [self.floatingButton setTitle:@"Extended" forState:UIControlStateNormal];
       }  else {

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -182,7 +182,7 @@
 
   } else {
     [self.floatingButton setTitle:nil forState:UIControlStateNormal];
-    self.floatingButton.mode = MDCFloatingButtonTypeDefault;
+    self.floatingButton.mode = MDCFloatingButtonModeNormal;
 
   }
 }

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -17,6 +17,7 @@
 #import "MaterialButtons.h"
 #import "MaterialTypography.h"
 #import "supplemental/ButtonsTypicalUseSupplemental.h"
+#import "ExampleFloatingButtonThemer.h"
 
 @interface ButtonsTypicalUseViewController ()
 @property(nonatomic, strong) MDCFloatingButton *floatingButton;
@@ -138,6 +139,13 @@
       self.floatingButton.shape += 1;
       if (self.floatingButton.shape > MDCFloatingButtonShapeExtendedTrailingIcon) {
         self.floatingButton.shape = 0;
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+          MDCBasicColorScheme *scheme = [[MDCBasicColorScheme alloc] initWithPrimaryColor:UIColor.purpleColor
+                                                                           secondaryColor:UIColor.orangeColor];
+          [ExampleFloatingButtonThemer applyToButton:self.floatingButton withColorScheme:scheme];
+        });
+
       }
       if (self.floatingButton.shape >= MDCFloatingButtonShapeExtendedLeadingIcon) {
         [self.floatingButton setTitle:@"Extended" forState:UIControlStateNormal];

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -148,9 +148,9 @@
         }
 
         if (!self.styleChanged) {
-          MDCBasicColorScheme *scheme = [[MDCBasicColorScheme alloc] initWithPrimaryColor:UIColor.purpleColor
-                                                                           secondaryColor:UIColor.orangeColor];
-          [ExampleFloatingButtonThemer applyToButton:self.floatingButton withColorScheme:scheme];
+//          MDCBasicColorScheme *scheme = [[MDCBasicColorScheme alloc] initWithPrimaryColor:UIColor.purpleColor
+//                                                                           secondaryColor:UIColor.orangeColor];
+//          [ExampleFloatingButtonThemer applyToButton:self.floatingButton withColorScheme:scheme];
           self.styleChanged = YES;
         }
       }
@@ -161,8 +161,8 @@
             NSStringFromUIEdgeInsets(self.floatingButton.contentEdgeInsets));
       if (self.floatingButton.mode == MDCFloatingButtonModeExtended) {
         [self.floatingButton setImage:[UIImage imageNamed:@"Plus"] forState:UIControlStateNormal];
-        [self.floatingButton setTitle:@"Extended" forState:UIControlStateNormal];
-      }  else {
+        [self.floatingButton setTitle:@"Default" forState:UIControlStateNormal];
+      } else {
         [self.floatingButton setImage:nil forState:UIControlStateNormal];
         [self.floatingButton setTitle:@"New" forState:UIControlStateNormal];
       }

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -137,6 +137,7 @@
   NSLog(@"%@ was tapped.", NSStringFromClass([sender class]));
   if (sender == self.floatingButton) {
     [UIView animateWithDuration:0.25 animations:^{
+
       self.floatingButton.mode += 1;
       if (self.floatingButton.mode > MDCFloatingButtonModeExtended) {
         self.floatingButton.mode = 0;

--- a/components/Buttons/examples/resources/ButtonsStoryboardAndProgrammatic.storyboard
+++ b/components/Buttons/examples/resources/ButtonsStoryboardAndProgrammatic.storyboard
@@ -93,9 +93,9 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="storyboardFlat" destination="1Dc-Q4-b6Z" id="tf2-SG-2uQ"/>
-                        <outlet property="storyboardFloating" destination="BDu-tK-SwC" id="AIX-u6-JAL"/>
-                        <outlet property="storyboardRaised" destination="ixI-3k-a3r" id="5z9-aK-IJ5"/>
+                        <outlet property="storyboardFlat" destination="1Dc-Q4-b6Z" id="ymC-xl-wu5"/>
+                        <outlet property="storyboardFloating" destination="BDu-tK-SwC" id="a1m-x5-Gq7"/>
+                        <outlet property="storyboardRaised" destination="ixI-3k-a3r" id="LQt-fl-9az"/>
                     </connections>
                 </viewController>
             </objects>

--- a/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.h
+++ b/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.h
@@ -1,0 +1,28 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MaterialThemes.h"
+#import "MaterialButtons.h"
+
+/**
+ An example Floating Button themer that makes them slightly smaller/thinner than the defaults.
+ */
+@interface ExampleFloatingButtonThemer : NSObject
+
++ (void)applyToButton:(nonnull MDCFloatingButton *)button
+      withColorScheme:(nullable id<MDCColorScheme>)colorScheme;
+
+@end

--- a/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.h
+++ b/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.h
@@ -18,11 +18,11 @@
 #import "MaterialButtons.h"
 
 /**
- An example Floating Button themer that makes them slightly smaller/thinner than the defaults.
+ An example Floating Button themer that makes them slightly taller and less wide than the defaults.
  */
 @interface ExampleFloatingButtonThemer : NSObject
 
 + (void)applyToButton:(nonnull MDCFloatingButton *)button
-      withColorScheme:(nullable id<MDCColorScheme>)colorScheme;
+      withColorScheme:(nullable NSObject<MDCColorScheme> *)colorScheme;
 
 @end

--- a/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
+++ b/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
@@ -29,8 +29,8 @@
   UIEdgeInsets hitAreaCompactDefault = UIEdgeInsetsMake(-8, -8, -8, -8);
   UIEdgeInsets hitAreaCompactMini = UIEdgeInsetsMake(-16, -16, -16, -16);
 
-  CGSize sizeCompactDefault = CGSizeMake(50, 50);
-  CGSize sizeExtendedMinimum = CGSizeMake(100, 32);
+  CGSize sizeCompactDefault = CGSizeMake(40, 40);
+  CGSize sizeExtendedMinimum = CGSizeMake(100, 40);
 
   [button setContentEdgeInsets:expandedLeadingInsets
                        forType:MDCFloatingButtonTypeDefault

--- a/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
+++ b/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
@@ -44,10 +44,10 @@
   [button setMinimumSize:sizeExtendedMinimum forShape:MDCFloatingButtonShapeExtendedLeadingIcon];
   [button setMinimumSize:sizeExtendedMinimum forShape:MDCFloatingButtonShapeExtendedTrailingIcon];
 
-  [button setElevation:3 forState:UIControlStateNormal shape:MDCFloatingButtonShapeMini];
-  [button setElevation:6 forState:UIControlStateHighlighted shape:MDCFloatingButtonShapeMini];
-  [button setElevation:3 forState:UIControlStateNormal shape:MDCFloatingButtonShapeExtendedLeadingIcon];
-  [button setElevation:6 forState:UIControlStateHighlighted shape:MDCFloatingButtonShapeExtendedLeadingIcon];
+  [button setElevation:3 forState:UIControlStateNormal];
+  [button setElevation:6 forState:UIControlStateHighlighted];
+  [button setElevation:3 forState:UIControlStateNormal];
+  [button setElevation:6 forState:UIControlStateHighlighted];
 
   [button setImageTitlePadding:4];
 }

--- a/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
+++ b/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
@@ -15,35 +15,39 @@
   if (colorScheme) {
     [MDCButtonColorThemer applyColorScheme:colorScheme toButton:button];
   }
-  UIEdgeInsets compactInsets = UIEdgeInsetsZero;
-  UIEdgeInsets expandedLeadingInsets = UIEdgeInsetsMake(4, 6, 4, 8);
-  UIEdgeInsets expandedTrailingInsets = UIEdgeInsetsMake(4, 8, 4, 6);
+  UIEdgeInsets expandedLeadingInsets = UIEdgeInsetsMake(4, 6, 4, 12);
 
   UIEdgeInsets hitAreaCompactDefault = UIEdgeInsetsMake(-8, -8, -8, -8);
   UIEdgeInsets hitAreaCompactMini = UIEdgeInsetsMake(-16, -16, -16, -16);
 
   CGSize sizeCompactDefault = CGSizeMake(50, 50);
-  CGSize sizeExtendedMinimum = [CGSizeMake(32, 72);
-                                
-[button setContentEdgeInsets:expandedLeadingInsets forType:<#(MDCFloatingButtonType)#> mode:<#(MDCFloatingButtonMode)#>]
+  CGSize sizeExtendedMinimum = CGSizeMake(100, 32);
+
   [button setContentEdgeInsets:expandedLeadingInsets
-                      forShape:MDCFloatingButtonShapeExtendedLeadingIcon];
-  [button setContentEdgeInsets:expandedTrailingInsets
-                      forShape:MDCFloatingButtonShapeExtendedTrailingIcon];
+                       forType:MDCFloatingButtonTypeDefault
+                          mode:MDCFloatingButtonModeExtended];
 
-  [button setHitAreaInsets:hitAreaCompactDefault forShape:MDCFloatingButtonShapeDefault];
-  [button setHitAreaInsets:hitAreaCompactDefault forShape:MDCFloatingButtonShapeLargeIcon];
-  [button setHitAreaInsets:hitAreaCompactMini forShape:MDCFloatingButtonShapeMini];
+  [button setHitAreaInsets:hitAreaCompactMini
+                   forType:MDCFloatingButtonTypeMini
+                      mode:MDCFloatingButtonModeNormal];
+  [button setHitAreaInsets:hitAreaCompactDefault
+                   forType:MDCFloatingButtonTypeDefault
+                      mode:MDCFloatingButtonModeNormal];
 
-  [button setMinimumSize:sizeCompactDefault forShape:MDCFloatingButtonShapeDefault];
-  [button setMaximumSize:sizeCompactDefault forShape:MDCFloatingButtonShapeDefault];
-  [button setMinimumSize:sizeCompactDefault forShape:MDCFloatingButtonShapeLargeIcon];
-  [button setMaximumSize:sizeCompactDefault forShape:MDCFloatingButtonShapeLargeIcon];
-  [button setMinimumSize:sizeExtendedMinimum forShape:MDCFloatingButtonShapeExtendedLeadingIcon];
-  [button setMinimumSize:sizeExtendedMinimum forShape:MDCFloatingButtonShapeExtendedTrailingIcon];
+  [button setMinimumSize:sizeCompactDefault
+                 forType:MDCFloatingButtonTypeDefault
+                    mode:MDCFloatingButtonModeNormal];
+  [button setMaximumSize:sizeCompactDefault
+                 forType:MDCFloatingButtonTypeDefault
+                    mode:MDCFloatingButtonModeNormal];
 
-  [button setElevation:3 forState:UIControlStateNormal];
-  [button setElevation:6 forState:UIControlStateHighlighted];
+  [button setMinimumSize:sizeExtendedMinimum
+                 forType:MDCFloatingButtonTypeDefault
+                    mode:MDCFloatingButtonModeExtended];
+  [button setMaximumSize:sizeExtendedMinimum
+                 forType:MDCFloatingButtonTypeDefault
+                    mode:MDCFloatingButtonModeExtended];
+
   [button setElevation:3 forState:UIControlStateNormal];
   [button setElevation:6 forState:UIControlStateHighlighted];
 

--- a/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
+++ b/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
@@ -1,0 +1,50 @@
+//
+//  ExampleFloatingButtonThemer.m
+//  MaterialComponents
+//
+//  Created by Rob Moore on 11/15/17.
+//
+
+#import "ExampleFloatingButtonThemer.h"
+#import "MDCButtonColorThemer.h"
+
+@implementation ExampleFloatingButtonThemer
+
++ (void)applyToButton:(nonnull MDCFloatingButton *)button
+      withColorScheme:(nullable id<MDCColorScheme>)colorScheme {
+  if (colorScheme) {
+    [MDCButtonColorThemer applyColorScheme:colorScheme toButton:button];
+  }
+  UIEdgeInsets compactInsets = UIEdgeInsetsZero;
+  UIEdgeInsets expandedLeadingInsets = UIEdgeInsetsMake(4, 6, 4, 8);
+  UIEdgeInsets expandedTrailingInsets = UIEdgeInsetsMake(4, 8, 4, 6);
+
+  UIEdgeInsets hitAreaCompactDefault = UIEdgeInsetsMake(-8, -8, -8, -8);
+  UIEdgeInsets hitAreaCompactMini = UIEdgeInsetsMake(-16, -16, -16, -16);
+
+  CGSize sizeCompactDefault = CGSizeMake(50, 50);
+  CGSize sizeExtendedMinimum = CGSizeMake(32, 72);
+
+  [button setContentEdgeInsets:compactInsets forShape:MDCFloatingButtonShapeDefault];
+  [button setContentEdgeInsets:compactInsets forShape:MDCFloatingButtonShapeMini];
+  [button setContentEdgeInsets:compactInsets forShape:MDCFloatingButtonShapeLargeIcon];
+  [button setContentEdgeInsets:expandedLeadingInsets
+                      forShape:MDCFloatingButtonShapeExtendedLeadingIcon];
+  [button setContentEdgeInsets:expandedTrailingInsets
+                      forShape:MDCFloatingButtonShapeExtendedTrailingIcon];
+
+  [button setHitAreaInsets:hitAreaCompactDefault forShape:MDCFloatingButtonShapeDefault];
+  [button setHitAreaInsets:hitAreaCompactDefault forShape:MDCFloatingButtonShapeLargeIcon];
+  [button setHitAreaInsets:hitAreaCompactMini forShape:MDCFloatingButtonShapeMini];
+
+  [button setMinimumSize:sizeCompactDefault forShape:MDCFloatingButtonShapeDefault];
+  [button setMaximumSize:sizeCompactDefault forShape:MDCFloatingButtonShapeDefault];
+  [button setMinimumSize:sizeCompactDefault forShape:MDCFloatingButtonShapeLargeIcon];
+  [button setMaximumSize:sizeCompactDefault forShape:MDCFloatingButtonShapeLargeIcon];
+  [button setMinimumSize:sizeExtendedMinimum forShape:MDCFloatingButtonShapeExtendedLeadingIcon];
+  [button setMinimumSize:sizeExtendedMinimum forShape:MDCFloatingButtonShapeExtendedTrailingIcon];
+
+  [button setImageTitlePadding:4];
+}
+
+@end

--- a/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
+++ b/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
@@ -1,9 +1,18 @@
-//
-//  ExampleFloatingButtonThemer.m
-//  MaterialComponents
-//
-//  Created by Rob Moore on 11/15/17.
-//
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
 
 #import "ExampleFloatingButtonThemer.h"
 #import "MDCButtonColorThemer.h"

--- a/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
+++ b/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
@@ -23,11 +23,9 @@
   UIEdgeInsets hitAreaCompactMini = UIEdgeInsetsMake(-16, -16, -16, -16);
 
   CGSize sizeCompactDefault = CGSizeMake(50, 50);
-  CGSize sizeExtendedMinimum = CGSizeMake(32, 72);
-
-  [button setContentEdgeInsets:compactInsets forShape:MDCFloatingButtonShapeDefault];
-  [button setContentEdgeInsets:compactInsets forShape:MDCFloatingButtonShapeMini];
-  [button setContentEdgeInsets:compactInsets forShape:MDCFloatingButtonShapeLargeIcon];
+  CGSize sizeExtendedMinimum = [CGSizeMake(32, 72);
+                                
+[button setContentEdgeInsets:expandedLeadingInsets forType:<#(MDCFloatingButtonType)#> mode:<#(MDCFloatingButtonMode)#>]
   [button setContentEdgeInsets:expandedLeadingInsets
                       forShape:MDCFloatingButtonShapeExtendedLeadingIcon];
   [button setContentEdgeInsets:expandedTrailingInsets

--- a/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
+++ b/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
@@ -61,6 +61,7 @@
   [button setElevation:3 forState:UIControlStateNormal];
   [button setElevation:6 forState:UIControlStateHighlighted];
 
+
   [button setImageTitlePadding:4];
 }
 

--- a/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
+++ b/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
@@ -44,6 +44,11 @@
   [button setMinimumSize:sizeExtendedMinimum forShape:MDCFloatingButtonShapeExtendedLeadingIcon];
   [button setMinimumSize:sizeExtendedMinimum forShape:MDCFloatingButtonShapeExtendedTrailingIcon];
 
+  [button setElevation:3 forState:UIControlStateNormal shape:MDCFloatingButtonShapeMini];
+  [button setElevation:6 forState:UIControlStateHighlighted shape:MDCFloatingButtonShapeMini];
+  [button setElevation:3 forState:UIControlStateNormal shape:MDCFloatingButtonShapeExtendedLeadingIcon];
+  [button setElevation:6 forState:UIControlStateHighlighted shape:MDCFloatingButtonShapeExtendedLeadingIcon];
+
   [button setImageTitlePadding:4];
 }
 

--- a/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
+++ b/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
@@ -11,7 +11,7 @@
 @implementation ExampleFloatingButtonThemer
 
 + (void)applyToButton:(nonnull MDCFloatingButton *)button
-      withColorScheme:(nullable id<MDCColorScheme>)colorScheme {
+      withColorScheme:(nullable NSObject<MDCColorScheme> *)colorScheme {
   if (colorScheme) {
     [MDCButtonColorThemer applyColorScheme:colorScheme toButton:button];
   }

--- a/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
+++ b/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
@@ -32,25 +32,25 @@
   CGSize sizeExtendedMinimum = CGSizeMake(100, 40);
 
   [button setContentEdgeInsets:expandedLeadingInsets
-                       forType:MDCFloatingButtonTypeDefault
+                      forShape:MDCFloatingButtonShapeDefault
                           mode:MDCFloatingButtonModeExtended];
-
+  
   [button setHitAreaInsets:hitAreaCompactMini
-                   forType:MDCFloatingButtonTypeMini
+                  forShape:MDCFloatingButtonShapeMini
                       mode:MDCFloatingButtonModeNormal];
-
+  
   [button setMinimumSize:sizeCompactDefault
-                 forType:MDCFloatingButtonTypeDefault
+                forShape:MDCFloatingButtonShapeDefault
                     mode:MDCFloatingButtonModeNormal];
   [button setMaximumSize:sizeCompactDefault
-                 forType:MDCFloatingButtonTypeDefault
+                forShape:MDCFloatingButtonShapeDefault
                     mode:MDCFloatingButtonModeNormal];
-
+  
   [button setMinimumSize:sizeExtendedMinimum
-                 forType:MDCFloatingButtonTypeDefault
+                forShape:MDCFloatingButtonShapeDefault
                     mode:MDCFloatingButtonModeExtended];
   [button setMaximumSize:sizeExtendedMinimum
-                 forType:MDCFloatingButtonTypeDefault
+                forShape:MDCFloatingButtonShapeDefault
                     mode:MDCFloatingButtonModeExtended];
 
   [button setElevation:3 forState:UIControlStateNormal];

--- a/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
+++ b/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
@@ -24,11 +24,9 @@
   if (colorScheme) {
     [MDCButtonColorThemer applyColorScheme:colorScheme toButton:button];
   }
+
+  UIEdgeInsets hitAreaCompactMini = UIEdgeInsetsMake(-4, -4, -4, -4);
   UIEdgeInsets expandedLeadingInsets = UIEdgeInsetsMake(4, 6, 4, 12);
-
-  UIEdgeInsets hitAreaCompactDefault = UIEdgeInsetsMake(-8, -8, -8, -8);
-  UIEdgeInsets hitAreaCompactMini = UIEdgeInsetsMake(-16, -16, -16, -16);
-
 
   CGSize sizeCompactDefault = CGSizeMake(40, 40);
   CGSize sizeExtendedMinimum = CGSizeMake(100, 40);
@@ -39,9 +37,6 @@
 
   [button setHitAreaInsets:hitAreaCompactMini
                    forType:MDCFloatingButtonTypeMini
-                      mode:MDCFloatingButtonModeNormal];
-  [button setHitAreaInsets:hitAreaCompactDefault
-                   forType:MDCFloatingButtonTypeDefault
                       mode:MDCFloatingButtonModeNormal];
 
   [button setMinimumSize:sizeCompactDefault
@@ -60,7 +55,6 @@
 
   [button setElevation:3 forState:UIControlStateNormal];
   [button setElevation:6 forState:UIControlStateHighlighted];
-
 
   [button setImageTitlePadding:4];
 }

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -676,7 +676,9 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (void)setElevation:(CGFloat)elevation forState:(UIControlState)state {
   _userElevations[@(state)] = @(elevation);
-  self.layer.elevation = [self elevationForState:self.state];
+  if (self.state == state) {
+    self.layer.elevation = [self elevationForState:self.state];
+  }
 
   // The elevation of the normal state controls whether this button is flat or not, and flat buttons
   // have different background color requirements than raised buttons.

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -67,6 +67,13 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonShape) {
 @property(nonatomic, assign) MDCFloatingButtonShape shape;
 
 /**
+ The horizontal padding between the |imageView| and |titleLabel| when the button has an "extended"
+ shape (.extendedLeadingIcon and .extendedTrailingIcon).  If set to a negative value, the imageView
+ and titleLabel may overlap.
+ */
+@property(nonatomic, assign) CGFloat imageTitlePadding UI_APPEARANCE_SELECTOR;
+
+/**
  Returns a MDCFloatingButton with default colors and the given @c shape.
 
  @param shape Button shape.

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -138,12 +138,6 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonShape) {
 - (void)setHitAreaInsets:(UIEdgeInsets)insets forShape:(MDCFloatingButtonShape)shape
     UI_APPEARANCE_SELECTOR;
 
-- (void)setElevation:(CGFloat)elevation forState:(UIControlState)state NS_UNAVAILABLE;
-
-- (void)setElevation:(CGFloat)elevation
-            forState:(UIControlState)state
-               shape:(MDCFloatingButtonShape)shape UI_APPEARANCE_SELECTOR;
-
 #pragma mark - Deprecations
 
 + (nonnull instancetype)buttonWithShape:(MDCFloatingButtonShape)shape

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -20,32 +20,45 @@
 #import "MDCButton.h"
 
 /**
- Shapes for Material Floating buttons.
+ Types of Material Floating buttons.
 
  The mini size should only be used when required for visual continuity with other elements on the
  screen.
  */
-typedef NS_ENUM(NSInteger, MDCFloatingButtonShape) {
+typedef NS_ENUM(NSInteger, MDCFloatingButtonType) {
   /**
-   A 56-point circular button surrounding a 24-point square icon or short text.
+   A 56-point circular button surrounding a 24-point or 36-point square icon or short text.
    */
-  MDCFloatingButtonShapeDefault = 0,
+  MDCFloatingButtonTypeDefault = 0,
   /**
    A 40-point circular button surrounding a 24-point square icon or short text.
    */
-  MDCFloatingButtonShapeMini = 1,
+  MDCFloatingButtonTypeMini = 1,
+};
+
+typedef NS_ENUM(NSInteger, MDCFloatingButtonMode) {
   /**
-   A 56-point circular button surrounding a 36-point square icon or short text.
+   The floating button is a circle with its contents centered.
+   @c type initialization argument.
    */
-  MDCFloatingButtonShapeLargeIcon = 2,
+  MDCFloatingButtonModeNormal = 0,
+
   /**
-   An Extended FAB with a 24-point square icon on the leading side of the text.
+   The floating button is a "pill shape" with the image to one side of the title.
    */
-  MDCFloatingButtonShapeExtendedLeadingIcon = 3,
+  MDCFloatingButtonModeExtended = 1,
+};
+
+typedef NS_ENUM(NSInteger, MDCFloatingButtonImagePosition) {
   /**
-   An Extended FAB with a 24-point square icon on the trailing side of the text.
+   The image of the floating button is on the leading side of the title.
    */
-  MDCFloatingButtonShapeExtendedTrailingIcon = 4
+  MDCFloatingButtonImagePositionLeading = 0,
+
+  /**
+   The image of the floating button is on the trailing side of the title.
+   */
+  MDCFloatingButtonImagePositionTrailing = 1,
 };
 
 /**
@@ -60,46 +73,35 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonShape) {
 @interface MDCFloatingButton : MDCButton
 
 /**
- The shape of this floating button.
+ The mode of the floating button can either be .normal (a circle) or .extended (a pill-shaped
+ rounded rectangle).
 
- Changing this value will effect how the title and image are positioned.
+ The default value is @c .normal .
  */
-@property(nonatomic, assign) MDCFloatingButtonShape shape;
+@property(nonatomic, assign) MDCFloatingButtonMode mode;
 
 /**
- The horizontal padding between the |imageView| and |titleLabel| when the button has an "extended"
- shape (.extendedLeadingIcon and .extendedTrailingIcon).  If set to a negative value, the imageView
- and titleLabel may overlap.
+ The position of the image relative to the title.
+
+ The default value is @c .leading .
+ */
+@property(nonatomic, assign) MDCFloatingButtonImagePosition imagePosition;
+
+/**
+ The horizontal padding between the |imageView| and |titleLabel| when the button is in its
+ "extended" mode.  If set to a negative value, the imageView and titleLabel may overlap.
  */
 @property(nonatomic, assign) CGFloat imageTitlePadding UI_APPEARANCE_SELECTOR;
 
 /**
- Returns a MDCFloatingButton with default colors and the given @c shape.
-
- @param shape Button shape.
- @return Button with shape.
- */
-+ (nonnull instancetype)floatingButtonWithShape:(MDCFloatingButtonShape)shape;
-
-/**
- @return The default floating button size dimension.
- */
-+ (CGFloat)defaultDimension;
-
-/**
- @return The mini floating button size dimension.
- */
-+ (CGFloat)miniDimension;
-
-/**
- Initializes self to a button with the given @c shape.
+ Initializes self to a button with the given @c type with a @c .normal mode.
 
  @param frame Button frame.
- @param shape Button shape.
- @return Button with shape.
+ @param type Button type.
+ @return Button with type.
  */
 - (nonnull instancetype)initWithFrame:(CGRect)frame
-                                shape:(MDCFloatingButtonShape)shape NS_DESIGNATED_INITIALIZER;
+                                type:(MDCFloatingButtonType)type NS_DESIGNATED_INITIALIZER;
 
 /**
  Initializes self to a button with the MDCFloatingButtonShapeDefault shape.
@@ -120,27 +122,40 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonShape) {
 
 - (void)setMinimumSize:(CGSize)minimumSize NS_UNAVAILABLE;
 
-- (void)setMinimumSize:(CGSize)minimumSize forShape:(MDCFloatingButtonShape)shape
-    UI_APPEARANCE_SELECTOR;
+- (void)setMinimumSize:(CGSize)minimumSize
+               forType:(MDCFloatingButtonType)type
+                  mode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
 
 - (void)setMaximumSize:(CGSize)maximumSize NS_UNAVAILABLE;
 
-- (void)setMaximumSize:(CGSize)maximumSize forShape:(MDCFloatingButtonShape)shape
-    UI_APPEARANCE_SELECTOR;
+- (void)setMaximumSize:(CGSize)maximumSize
+               forType:(MDCFloatingButtonType)type
+                  mode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
 
 - (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets NS_UNAVAILABLE;
 
-- (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets forShape:(MDCFloatingButtonShape)shape
-    UI_APPEARANCE_SELECTOR;
+- (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets
+                     forType:(MDCFloatingButtonType)type
+                        mode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
 
 - (void)setHitAreaInsets:(UIEdgeInsets)hitAreaInsets NS_UNAVAILABLE;
 
-- (void)setHitAreaInsets:(UIEdgeInsets)insets forShape:(MDCFloatingButtonShape)shape
-    UI_APPEARANCE_SELECTOR;
+- (void)setHitAreaInsets:(UIEdgeInsets)insets
+                 forType:(MDCFloatingButtonType)type
+                    mode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
 
 #pragma mark - Deprecations
 
-+ (nonnull instancetype)buttonWithShape:(MDCFloatingButtonShape)shape
-    __deprecated_msg("Use floatingButtonWithShape: instead.");
++ (nonnull instancetype)buttonWithShape:(MDCFloatingButtonType)shape
+    __deprecated_msg("Use initWithFrame:type: instead.");
+
+/**
+ Returns a MDCFloatingButton with default colors and the given @c shape.
+
+ @param shape Button shape.
+ @return Button with shape.
+ */
++ (nonnull instancetype)floatingButtonWithShape:(MDCFloatingButtonType)shape
+    __deprecated_msg("Use initWithFrame:type: instead");
 
 @end

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -78,14 +78,24 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImagePosition) {
 
  The default value is @c .normal .
  */
-@property(nonatomic, assign) MDCFloatingButtonMode mode;
+@property(nonatomic, assign) MDCFloatingButtonMode mode UI_APPEARANCE_SELECTOR;
 
 /**
  The position of the image relative to the title.
 
  The default value is @c .leading .
  */
-@property(nonatomic, assign) MDCFloatingButtonImagePosition imagePosition;
+@property(nonatomic, assign) MDCFloatingButtonImagePosition imagePosition UI_APPEARANCE_SELECTOR;
+
+/**
+ If @c YES, any values for @c contentEdgeInsets:forType:mode: will be flipped when the FAB is
+ in @c MDCFloatingButtonModeExtended and its @c imagePosition is
+ @c MDCFloatingButtonImagePositionTrailing.
+
+ The default value is NO.
+ */
+@property(nonatomic, assign) BOOL contentEdgeInsetsFlippedForTrailingImagePosition
+    UI_APPEARANCE_SELECTOR;
 
 /**
  The horizontal padding between the |imageView| and |titleLabel| when the button is in its

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -81,7 +81,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImagePosition) {
 @property(nonatomic, assign) MDCFloatingButtonMode mode;
 
 /**
- The position of the image relative to the title.
+ The position of the image relative to the title. Flipped for right-to-left.
 
  The default value is @c .leading .
  */

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -37,7 +37,15 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonShape) {
   /**
    A 56-point circular button surrounding a 36-point square icon or short text.
    */
-  MDCFloatingButtonShapeLargeIcon = 2
+  MDCFloatingButtonShapeLargeIcon = 2,
+  /**
+   An Extended FAB with a 24-point square icon on the leading side of the text.
+   */
+  MDCFloatingButtonShapeExtendedLeadingIcon = 3,
+  /**
+   An Extended FAB with a 24-point square icon on the trailing side of the text.
+   */
+  MDCFloatingButtonShapeExtendedTrailingIcon = 4
 };
 
 /**
@@ -50,6 +58,13 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonShape) {
  @see https://material.io/guidelines/components/buttons.html#buttons-main-buttons
  */
 @interface MDCFloatingButton : MDCButton
+
+/**
+ The shape of this floating button.
+
+ Changing this value will effect how the title and image are positioned.
+ */
+@property(nonatomic, assign) MDCFloatingButtonShape shape;
 
 /**
  Returns a MDCFloatingButton with default colors and the given @c shape.
@@ -95,6 +110,26 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonShape) {
 - (nonnull instancetype)init;
 
 - (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
+
+- (void)setMinimumSize:(CGSize)minimumSize NS_UNAVAILABLE;
+
+- (void)setMinimumSize:(CGSize)minimumSize forShape:(MDCFloatingButtonShape)shape
+    UI_APPEARANCE_SELECTOR;
+
+- (void)setMaximumSize:(CGSize)maximumSize NS_UNAVAILABLE;
+
+- (void)setMaximumSize:(CGSize)maximumSize forShape:(MDCFloatingButtonShape)shape
+    UI_APPEARANCE_SELECTOR;
+
+- (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets NS_UNAVAILABLE;
+
+- (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets forShape:(MDCFloatingButtonShape)shape
+    UI_APPEARANCE_SELECTOR;
+
+- (void)setHitAreaInsets:(UIEdgeInsets)hitAreaInsets NS_UNAVAILABLE;
+
+- (void)setHitAreaInsets:(UIEdgeInsets)insets forShape:(MDCFloatingButtonShape)shape
+    UI_APPEARANCE_SELECTOR;
 
 #pragma mark - Deprecations
 

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -25,15 +25,15 @@
  The mini size should only be used when required for visual continuity with other elements on the
  screen.
  */
-typedef NS_ENUM(NSInteger, MDCFloatingButtonType) {
+typedef NS_ENUM(NSInteger, MDCFloatingButtonShape) {
   /**
    A 56-point circular button surrounding a 24-point or 36-point square icon or short text.
    */
-  MDCFloatingButtonTypeDefault = 0,
+  MDCFloatingButtonShapeDefault = 0,
   /**
    A 40-point circular button surrounding a 24-point square icon or short text.
    */
-  MDCFloatingButtonTypeMini = 1,
+  MDCFloatingButtonShapeMini = 1,
 };
 
 typedef NS_ENUM(NSInteger, MDCFloatingButtonMode) {
@@ -73,6 +73,14 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImagePosition) {
 @interface MDCFloatingButton : MDCButton
 
 /**
+ Returns a MDCFloatingButton with default colors and the given @c shape.
+
+ @param shape Button shape.
+ @return Button with shape.
+ */
++ (nonnull instancetype)floatingButtonWithShape:(MDCFloatingButtonShape)shape;
+
+/**
  The mode of the floating button can either be .normal (a circle) or .extended (a pill-shaped
  rounded rectangle).
 
@@ -88,7 +96,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImagePosition) {
 @property(nonatomic, assign) MDCFloatingButtonImagePosition imagePosition UI_APPEARANCE_SELECTOR;
 
 /**
- If @c YES, any values for @c contentEdgeInsets:forType:mode: will be flipped when the FAB is
+ If @c YES, any values for @c contentEdgeInsets:forShape:mode: will be flipped when the FAB is
  in @c MDCFloatingButtonModeExtended and its @c imagePosition is
  @c MDCFloatingButtonImagePositionTrailing.
 
@@ -104,14 +112,14 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImagePosition) {
 @property(nonatomic, assign) CGFloat imageTitlePadding UI_APPEARANCE_SELECTOR;
 
 /**
- Initializes self to a button with the given @c type with a @c .normal mode.
+ Initializes self to a button with the given @c shape with a @c .normal mode.
 
  @param frame Button frame.
- @param type Button type.
+ @param shape Button type.
  @return Button with type.
  */
 - (nonnull instancetype)initWithFrame:(CGRect)frame
-                                type:(MDCFloatingButtonType)type NS_DESIGNATED_INITIALIZER;
+                                shape:(MDCFloatingButtonShape)shape NS_DESIGNATED_INITIALIZER;
 
 /**
  Initializes self to a button with the MDCFloatingButtonShapeDefault shape.
@@ -133,39 +141,30 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImagePosition) {
 - (void)setMinimumSize:(CGSize)minimumSize NS_UNAVAILABLE;
 
 - (void)setMinimumSize:(CGSize)minimumSize
-               forType:(MDCFloatingButtonType)type
+              forShape:(MDCFloatingButtonShape)shape
                   mode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
 
 - (void)setMaximumSize:(CGSize)maximumSize NS_UNAVAILABLE;
 
 - (void)setMaximumSize:(CGSize)maximumSize
-               forType:(MDCFloatingButtonType)type
+              forShape:(MDCFloatingButtonShape)shape
                   mode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
 
 - (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets NS_UNAVAILABLE;
 
 - (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets
-                     forType:(MDCFloatingButtonType)type
+                    forShape:(MDCFloatingButtonShape)shape
                         mode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
 
 - (void)setHitAreaInsets:(UIEdgeInsets)hitAreaInsets NS_UNAVAILABLE;
 
 - (void)setHitAreaInsets:(UIEdgeInsets)insets
-                 forType:(MDCFloatingButtonType)type
+                forShape:(MDCFloatingButtonShape)shape
                     mode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
 
 #pragma mark - Deprecations
 
-+ (nonnull instancetype)buttonWithShape:(MDCFloatingButtonType)shape
-    __deprecated_msg("Use initWithFrame:type: instead.");
-
-/**
- Returns a MDCFloatingButton with default colors and the given @c shape.
-
- @param shape Button shape.
- @return Button with shape.
- */
-+ (nonnull instancetype)floatingButtonWithShape:(MDCFloatingButtonType)shape
-    __deprecated_msg("Use initWithFrame:type: instead");
++ (nonnull instancetype)buttonWithShape:(MDCFloatingButtonShape)shape
+    __deprecated_msg("Use initWithFrame:shape: instead.");
 
 @end

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -138,6 +138,12 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonShape) {
 - (void)setHitAreaInsets:(UIEdgeInsets)insets forShape:(MDCFloatingButtonShape)shape
     UI_APPEARANCE_SELECTOR;
 
+- (void)setElevation:(CGFloat)elevation forState:(UIControlState)state NS_UNAVAILABLE;
+
+- (void)setElevation:(CGFloat)elevation
+            forState:(UIControlState)state
+               shape:(MDCFloatingButtonShape)shape UI_APPEARANCE_SELECTOR;
+
 #pragma mark - Deprecations
 
 + (nonnull instancetype)buttonWithShape:(MDCFloatingButtonShape)shape

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -225,12 +225,26 @@ static UIEdgeInsets UIEdgeInsetsFlippedHorizonally(UIEdgeInsets insets) {
 }
 
 - (CGSize)intrinsicContentSize {
+  CGSize contentSize = CGSizeZero;
   if (self.mode == MDCFloatingButtonModeNormal) {
-    return [self intrinsicContentSizeForModeNormal];
+    contentSize = [self intrinsicContentSizeForModeNormal];
   } else if (self.mode == MDCFloatingButtonModeExtended) {
-    return [self intrinsicContentSizeForModeExtended];
+    contentSize = [self intrinsicContentSizeForModeExtended];
   }
-  return [super intrinsicContentSize];
+
+  if (self.minimumSize.height > 0) {
+    contentSize.height = MAX(self.minimumSize.height, contentSize.height);
+  }
+  if (self.maximumSize.height > 0) {
+    contentSize.height = MIN(self.maximumSize.height, contentSize.height);
+  }
+  if (self.minimumSize.width > 0) {
+    contentSize.width = MAX(self.minimumSize.width, contentSize.width);
+  }
+  if (self.maximumSize.width > 0) {
+    contentSize.width = MIN(self.maximumSize.width, contentSize.width);
+  }
+  return contentSize;
 }
 
 //- (CGSize)sizeThatFits:(CGSize)size {
@@ -552,6 +566,7 @@ static UIEdgeInsets UIEdgeInsetsFlippedHorizonally(UIEdgeInsets insets) {
   [self updateContentEdgeInsets];
   [self updateHitAreaInsets];
   if (needsLayout) {
+    [self invalidateIntrinsicContentSize];
     [self sizeToFit];
   }
 }

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -28,6 +28,8 @@ static NSString *const MDCFloatingButtonMaximumSizeDictionaryKey
     = @"MDCFloatingButtonMaximumSizeDictionaryKey";
 static NSString *const MDCFloatingButtonContentEdgeInsetsDictionaryKey
     = @"MDCFloatingButtonContentEdgeInsetsDictionaryKey";
+static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
+    = @"MDCFloatingButtonHitAreaInsetsDictionaryKey";
 
 @interface MDCFloatingButton ()
 @property(nonatomic, readonly) NSMutableDictionary<NSNumber *, NSValue *> *shapeToHitAreaInsets;
@@ -71,8 +73,6 @@ static NSString *const MDCFloatingButtonContentEdgeInsetsDictionaryKey
     _shape = shape;
     // The superclass sets contentEdgeInsets from defaultContentEdgeInsets before the _shape is set.
     // Set contentEdgeInsets again to ensure the defaults are for the correct shape.
-    super.contentEdgeInsets = [self defaultContentEdgeInsets];
-    super.hitAreaInsets = [self defaultHitAreaInsets];
     [self commonMDCFloatingButtonInit];
     [self updateShape];
   }
@@ -110,6 +110,8 @@ static NSString *const MDCFloatingButtonContentEdgeInsetsDictionaryKey
       = [NSValue valueWithUIEdgeInsets:UIEdgeInsetsZero];
   self.shapeToHitAreaInsets[@(MDCFloatingButtonShapeMini)]
       = [NSValue valueWithUIEdgeInsets:UIEdgeInsetsMake(-4, -4, -4, -4)];
+  super.contentEdgeInsets = [self defaultContentEdgeInsets];
+  super.hitAreaInsets = [self defaultHitAreaInsets];
 }
 
 #pragma mark - NSCoding
@@ -117,6 +119,7 @@ static NSString *const MDCFloatingButtonContentEdgeInsetsDictionaryKey
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
   self = [super initWithCoder:aDecoder];
   if (self) {
+    [self commonMDCFloatingButtonInit];
     _shape = [aDecoder decodeIntegerForKey:MDCFloatingButtonShapeKey];
     if ([aDecoder containsValueForKey:MDCFloatingButtonMinimumSizeDictionaryKey]) {
       _shapeToMinimumSize = [aDecoder decodeObjectForKey:MDCFloatingButtonMinimumSizeDictionaryKey];
@@ -127,6 +130,10 @@ static NSString *const MDCFloatingButtonContentEdgeInsetsDictionaryKey
     if ([aDecoder containsValueForKey:MDCFloatingButtonContentEdgeInsetsDictionaryKey]) {
       _shapeToContentEdgeInsets
           = [aDecoder decodeObjectForKey:MDCFloatingButtonContentEdgeInsetsDictionaryKey];
+    }
+    if ([aDecoder containsValueForKey:MDCFloatingButtonHitAreaInsetsDictionaryKey]) {
+      _shapeToHitAreaInsets
+          = [aDecoder decodeObjectForKey:MDCFloatingButtonHitAreaInsetsDictionaryKey];
     }
   }
   return self;
@@ -139,6 +146,8 @@ static NSString *const MDCFloatingButtonContentEdgeInsetsDictionaryKey
   [aCoder encodeObject:self.shapeToMaximumSize forKey:MDCFloatingButtonMaximumSizeDictionaryKey];
   [aCoder encodeObject:self.shapeToContentEdgeInsets
                 forKey:MDCFloatingButtonContentEdgeInsetsDictionaryKey];
+  [aCoder encodeObject:self.shapeToHitAreaInsets
+                forKey:MDCFloatingButtonHitAreaInsetsDictionaryKey];
 }
 
 #pragma mark - UIView

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -249,23 +249,6 @@ static UIEdgeInsets UIEdgeInsetsFlippedHorizonally(UIEdgeInsets insets) {
   return contentSize;
 }
 
-//- (CGSize)sizeThatFits:(CGSize)size {
-//  switch(self.shape) {
-//    case MDCFloatingButtonShapeDefault:
-//    case MDCFloatingButtonShapeMini:
-//    case MDCFloatingButtonShapeLargeIcon:
-//      return [super sizeThatFits:size];
-//    case MDCFloatingButtonShapeExtendedLeadingIcon:
-//    case MDCFloatingButtonShapeExtendedTrailingIcon: {
-//      // UIButton will compute the size basically the same as MDCFloatingButton,
-//      // but without the |imageTitlePadding|
-//      const CGSize superSize = [super sizeThatFits:size];
-//      return CGSizeMake(superSize.width + self.imageTitlePadding, superSize.height);
-//    }
-//  }
-//}
-
-
 - (CGSize)sizeThatFits:(__unused CGSize)size {
   return [self intrinsicContentSize];
 }

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -32,15 +32,12 @@ static NSString *const MDCFloatingButtonContentEdgeInsetsDictionaryKey
     = @"MDCFloatingButtonContentEdgeInsetsDictionaryKey";
 static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
     = @"MDCFloatingButtonHitAreaInsetsDictionaryKey";
-static NSString *const MDCFloatingButtonElevationDictionaryKey
-    = @"MDCFloatingButtonElevationDictionaryKey";
 
 @interface MDCFloatingButton ()
 @property(nonatomic, readonly) NSMutableDictionary<NSNumber *, NSValue *> *shapeToHitAreaInsets;
 @property(nonatomic, readonly) NSMutableDictionary<NSNumber *, NSValue *> *shapeToMinimumSize;
 @property(nonatomic, readonly) NSMutableDictionary<NSNumber *, NSValue *> *shapeToMaximumSize;
 @property(nonatomic, readonly) NSMutableDictionary<NSNumber *, NSValue *> *shapeToContentEdgeInsets;
-@property(nonatomic, readonly) NSMutableDictionary<NSNumber *, NSMutableDictionary<NSNumber *, NSNumber *> *> *shapeToStateToElevation;
 @end
 
 @implementation MDCFloatingButton
@@ -108,26 +105,6 @@ static NSString *const MDCFloatingButtonElevationDictionaryKey
       = [NSValue valueWithUIEdgeInsets:UIEdgeInsetsZero];
   self.shapeToHitAreaInsets[@(MDCFloatingButtonShapeMini)]
       = [NSValue valueWithUIEdgeInsets:UIEdgeInsetsMake(-4, -4, -4, -4)];
-  _shapeToStateToElevation = [NSMutableDictionary dictionary];
-  NSMutableDictionary *defaultElevations = [NSMutableDictionary dictionary];
-  NSMutableDictionary *miniElevations = [NSMutableDictionary dictionary];
-  NSMutableDictionary *largeIconElevations = [NSMutableDictionary dictionary];
-  NSMutableDictionary *extendedLeadingElevations = [NSMutableDictionary dictionary];
-  NSMutableDictionary *extendedTrailingElevations = [NSMutableDictionary dictionary];
-  NSArray *dictionaries = @[defaultElevations, miniElevations, largeIconElevations,
-                            extendedLeadingElevations, extendedTrailingElevations];
-  for (NSMutableDictionary *dictionary in dictionaries) {
-    dictionary[@(UIControlStateNormal)] = @(MDCShadowElevationFABResting);
-    dictionary[@(UIControlStateHighlighted)] = @(MDCShadowElevationFABPressed);
-  }
-
-  self.shapeToStateToElevation[@(MDCFloatingButtonShapeDefault)] = defaultElevations;
-  self.shapeToStateToElevation[@(MDCFloatingButtonShapeMini)] = miniElevations;
-  self.shapeToStateToElevation[@(MDCFloatingButtonShapeLargeIcon)] = largeIconElevations;
-  self.shapeToStateToElevation[@(MDCFloatingButtonShapeExtendedLeadingIcon)]
-      = extendedLeadingElevations;
-  self.shapeToStateToElevation[@(MDCFloatingButtonShapeExtendedTrailingIcon)]
-      = extendedTrailingElevations;
 
   super.contentEdgeInsets = [self defaultContentEdgeInsets];
   super.hitAreaInsets = [self defaultHitAreaInsets];
@@ -449,40 +426,11 @@ static NSString *const MDCFloatingButtonElevationDictionaryKey
   }
 }
 
-- (void)setElevation:(CGFloat)elevation
-            forState:(UIControlState)state
-               shape:(MDCFloatingButtonShape)shape {
-  NSMutableDictionary *shapeElevations = self.shapeToStateToElevation[@(shape)];
-  shapeElevations[@(state)] = @(elevation);
-  if (shape == self.shape && self.state == state) {
-    [self updateElevation];
-  }
-}
-
-- (void)setElevation:(CGFloat)elevation forState:(UIControlState)state {
-  [self setElevation:elevation forState:state shape:self.shape];
-}
-
-- (NSDictionary *)elevationsForShape:(MDCFloatingButtonShape)shape {
-  NSMutableDictionary<NSNumber *, NSNumber *> *shapeElevations
-      = self.shapeToStateToElevation[@(shape)];
-  return [shapeElevations copy];
-}
-
-- (void)updateElevation {
-  NSDictionary<NSNumber *, NSNumber *> *elevations = [self elevationsForShape:self.shape];
-
-  for (NSNumber *stateValue in [elevations allKeys]) {
-    [super setElevation:(MDCShadowElevation)elevations[stateValue].doubleValue forState:stateValue.integerValue];
-  }
-}
-
 - (void)updateShape {
   BOOL needsLayout = [self updateMinimumSize];
   needsLayout |= [self updateMaximumSize];
   [self updateContentEdgeInsets];
   [self updateHitAreaInsets];
-  [self updateElevation];
   if (needsLayout) {
     [self sizeToFit];
   }

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -49,6 +49,13 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
 
 @implementation MDCFloatingButton
 
++ (void)initialize {
+  [[MDCFloatingButton appearance] setElevation:MDCShadowElevationFABResting
+                                      forState:UIControlStateNormal];
+  [[MDCFloatingButton appearance] setElevation:MDCShadowElevationFABPressed
+                                      forState:UIControlStateHighlighted];
+}
+
 + (CGFloat)defaultDimension {
   return MDCFloatingButtonDefaultDimension;
 }
@@ -269,7 +276,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
   self.layer.cornerRadius = CGRectGetHeight(self.bounds) / 2;
   [super layoutSubviews];
 
-  if (self.type == MDCFloatingButtonModeNormal) {
+  if (self.mode == MDCFloatingButtonModeNormal) {
     return;
   }
 
@@ -291,7 +298,16 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
   // The diagram above assumes an LTR user interface orientation
   // and a .leadingIcon shape for this button.
 
-  const CGRect insetBounds = UIEdgeInsetsInsetRect(self.bounds, self.contentEdgeInsets);
+  const UIEdgeInsets originalContentEdgeInsets = [self contentEdgeInsetsForMode:self.mode];
+  const UIEdgeInsets adjustedContentEdgeInsets
+      = self.contentEdgeInsetsFlippedForTrailingImagePosition
+          ? UIEdgeInsetsMake(originalContentEdgeInsets.top,
+                             originalContentEdgeInsets.right,
+                             originalContentEdgeInsets.bottom,
+                             originalContentEdgeInsets.left)
+          : originalContentEdgeInsets;
+  const CGRect insetBounds = UIEdgeInsetsInsetRect(self.bounds, adjustedContentEdgeInsets);
+  NSLog(@"\nBounds: %@\nInBnds: %@", NSStringFromCGRect(self.bounds), NSStringFromCGRect(insetBounds));
   const CGFloat imageViewWidth = CGRectGetWidth(self.imageView.bounds);
   const CGFloat boundsCenterY = CGRectGetMidY(insetBounds);
   CGFloat titleWidthAvailable = CGRectGetWidth(insetBounds);
@@ -302,8 +318,8 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
   CGSize titleIntrinsicSize
       = [self.titleLabel sizeThatFits:CGSizeMake(titleWidthAvailable, availableHeight)];
 
-  const CGSize titleSize = CGSizeMake(MIN(titleIntrinsicSize.width, titleWidthAvailable),
-                                      MIN(titleIntrinsicSize.height, availableHeight));
+  const CGSize titleSize = CGSizeMake(MAX(0, MIN(titleIntrinsicSize.width, titleWidthAvailable)),
+                                      MAX(0, MIN(titleIntrinsicSize.height, availableHeight)));
 
   BOOL isRTL = self.mdf_effectiveUserInterfaceLayoutDirection
       == UIUserInterfaceLayoutDirectionRightToLeft;
@@ -332,9 +348,16 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
 
   self.imageView.center = imageCenter;
   self.imageView.frame = UIEdgeInsetsInsetRect(self.imageView.frame, self.imageEdgeInsets);
+  CGRect oldBounds = self.titleLabel.bounds;
   self.titleLabel.center = titleCenter;
-  self.titleLabel.bounds = (CGRect){CGRectStandardize(self.titleLabel.bounds).origin, titleSize};
+  CGRect midBounds = self.titleLabel.bounds;
+  (void)midBounds;
+  (void)oldBounds;
+  CGRect newBounds = CGRectStandardize(self.titleLabel.bounds);
+  self.titleLabel.bounds = (CGRect){newBounds.origin, titleSize};
   self.titleLabel.frame = UIEdgeInsetsInsetRect(self.titleLabel.frame, self.titleEdgeInsets);
+  CGRect lastBounds = self.titleLabel.bounds;
+  (void)lastBounds;
 
 }
 

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -268,17 +268,21 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
   }
 }
 
-- (void)updateContentEdgeInsets {
+- (UIEdgeInsets)insetsForShape:(MDCFloatingButtonShape)shape {
   NSValue *insetsValue = self.shapeToContentEdgeInsets[@(self.shape)];
   if (!insetsValue && self.shape != MDCFloatingButtonShapeDefault) {
     insetsValue = self.shapeToContentEdgeInsets[@(MDCFloatingButtonShapeDefault)];
   }
 
   if (insetsValue) {
-    super.contentEdgeInsets = insetsValue.UIEdgeInsetsValue;
+    return insetsValue.UIEdgeInsetsValue;
   } else {
-    super.contentEdgeInsets = UIEdgeInsetsZero;
+    return = UIEdgeInsetsZero;
   }
+}
+
+- (void)updateContentEdgeInsets {
+
 }
 
 - (void)updateHitAreaInsets {

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -82,8 +82,6 @@ static UIEdgeInsets UIEdgeInsetsFlippedHorizonally(UIEdgeInsets insets) {
   self = [super initWithFrame:frame];
   if (self) {
     _shape = shape;
-    // The superclass sets contentEdgeInsets from defaultContentEdgeInsets before the _shape is set.
-    // Set contentEdgeInsets again to ensure the defaults are for the correct shape.
     [self commonMDCFloatingButtonInit];
     [self updateShape];
   }
@@ -141,8 +139,10 @@ static UIEdgeInsets UIEdgeInsetsFlippedHorizonally(UIEdgeInsets insets) {
            @(MDCFloatingButtonShapeMini) : miniNormalHitAreaInsets,
            } mutableCopy];
 
-  super.contentEdgeInsets = [self defaultContentEdgeInsets];
-  super.hitAreaInsets = [self defaultHitAreaInsets];
+  // The superclass sets contentEdgeInsets from defaultContentEdgeInsets before the _shape is set.
+  // Set contentEdgeInsets again to ensure the defaults are for the correct shape.
+  [self updateContentEdgeInsets];
+  [self updateHitAreaInsets];
   _imageTitlePadding = 8;
   _imagePosition = MDCFloatingButtonImagePositionLeading;
 }
@@ -217,9 +217,12 @@ static UIEdgeInsets UIEdgeInsetsFlippedHorizonally(UIEdgeInsets insets) {
   const CGSize intrinsicImageSize
       = [self.imageView sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)];
   CGFloat intrinsicWidth = intrinsicTitleSize.width + intrinsicImageSize.width
-      + self.imageTitlePadding + self.contentEdgeInsets.left + self.contentEdgeInsets.right;
+      + self.imageTitlePadding + internalLayoutSpacingInsets.left
+      + internalLayoutSpacingInsets.right + self.contentEdgeInsets.left
+      + self.contentEdgeInsets.right;
   CGFloat intrinsicHeight = MAX(intrinsicTitleSize.height, intrinsicImageSize.height)
-      + self.contentEdgeInsets.top + self.contentEdgeInsets.bottom;
+      + self.contentEdgeInsets.top + self.contentEdgeInsets.bottom + internalLayoutSpacingInsets.top
+      + internalLayoutSpacingInsets.bottom;
   return CGSizeMake(intrinsicWidth, intrinsicHeight);
 }
 
@@ -264,21 +267,7 @@ static UIEdgeInsets UIEdgeInsetsFlippedHorizonally(UIEdgeInsets insets) {
 
 
 - (CGSize)sizeThatFits:(__unused CGSize)size {
-  const CGSize intrinsicSize = [self intrinsicContentSize];
-  CGSize finalSize = intrinsicSize;
-  if (self.minimumSize.height > 0) {
-    finalSize.height = MAX(self.minimumSize.height, finalSize.height);
-  }
-  if (self.maximumSize.height > 0) {
-    finalSize.height = MIN(self.maximumSize.height, finalSize.height);
-  }
-  if (self.minimumSize.width > 0) {
-    finalSize.width = MAX(self.minimumSize.width, finalSize.width);
-  }
-  if (self.maximumSize.width > 0) {
-    finalSize.width = MIN(self.maximumSize.width, finalSize.width);
-  }
-  return finalSize;
+  return [self intrinsicContentSize];
 }
 
 - (void)layoutSubviews {
@@ -370,36 +359,6 @@ static UIEdgeInsets UIEdgeInsetsFlippedHorizonally(UIEdgeInsets insets) {
   CGRect lastBounds = self.titleLabel.bounds;
   (void)lastBounds;
 
-}
-
-#pragma mark - Subclassing
-
-- (UIEdgeInsets)defaultContentEdgeInsets {
-  NSMutableDictionary *modeToContentEdgeInsets = self.shapeToModeToContentEdgeInsets[@(self.shape)];
-  if (!modeToContentEdgeInsets) {
-    return UIEdgeInsetsZero;
-  }
-
-  NSValue *insetsValue = modeToContentEdgeInsets[@(self.mode)];
-  if (insetsValue) {
-    return [insetsValue UIEdgeInsetsValue];
-  } else {
-    return UIEdgeInsetsZero;
-  }
-}
-
-- (UIEdgeInsets)defaultHitAreaInsets {
-  NSMutableDictionary *modeToHitAreaInsets = self.shapeToModeToHitAreaInsets[@(self.shape)];
-  if (!modeToHitAreaInsets) {
-    return UIEdgeInsetsZero;
-  }
-
-  NSValue *insetsValue = modeToHitAreaInsets[@(self.mode)];
-  if (insetsValue) {
-    return [insetsValue UIEdgeInsetsValue];
-  } else {
-    return UIEdgeInsetsZero;
-  }
 }
 
 #pragma mark - Extended FAB changes

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -25,6 +25,8 @@ static const CGFloat MDCFloatingButtonDefaultDimension = 56.0f;
 static const CGFloat MDCFloatingButtonMiniDimension = 40.0f;
 static NSString *const MDCFloatingButtonTypeKey = @"MDCFloatingButtonTypeKey";
 static NSString *const MDCFloatingButtonModeKey = @"MDCFloatingButtonModeKey";
+static NSString *const MDCFloatingButtonImagePositionKey = @"MDCFloatingButtonImagePositionKey";
+static NSString *const MDCFloatingImageTitlePaddingKey = @"MDCFloatingImageTitlePaddingKey";
 
 /* Only used to decode previous versions. */
 static NSString *const MDCFloatingButtonShapeKey = @"MDCFloatingButtonShapeKey";
@@ -77,34 +79,39 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
 }
 
 - (void)commonMDCFloatingButtonInit {
+
   const CGSize miniSizeNormal = CGSizeMake(40, 40);
   const CGSize defaultSizeNormal = CGSizeMake(56, 56);
-  const CGSize defaultSizeExtendedMinimum = CGSizeMake(132, 48);
-  const CGSize defaultSizeExtendedMaximum = CGSizeMake(328, 0);
 
-
-  _typetoModeToMinimumSize = [NSMutableDictionary dictionaryWithCapacity:2];
+  NSMutableDictionary *miniMinimumSizes
+    = [@{
+         @(MDCFloatingButtonModeNormal) : [NSValue valueWithCGSize:miniSizeNormal]
+         } mutableCopy];
+  NSMutableDictionary *defaultMinimumSizes
+      = [@{ @(MDCFloatingButtonModeNormal) : [NSValue valueWithCGSize:defaultSizeNormal],
+            @(MDCFloatingButtonModeExtended) : [NSValue valueWithCGSize:CGSizeMake(132, 48)],
+            } mutableCopy];
   _typetoModeToMinimumSize
       = [@{
-           @(MDCFloatingButtonTypeMini) :
-             [@{ @(MDCFloatingButtonModeNormal) :
-                   [NSValue valueWithCGSize:miniSizeNormal] } mutableCopy],
-           @(MDCFloatingButtonTypeDefault) :
-             [@{ @(MDCFloatingButtonModeNormal) : [NSValue valueWithCGSize:defaultSizeNormal],
-                 @(MDCFloatingButtonModeExtended) :
-                   [NSValue valueWithCGSize:defaultSizeExtendedMinimum],
-                 } mutableCopy],
+           @(MDCFloatingButtonTypeMini) : miniMinimumSizes,
+           @(MDCFloatingButtonTypeDefault) : defaultMinimumSizes,
            } mutableCopy];
 
-  NSMutableDictionary *defaultMaxSizes = [NSMutableDictionary dictionaryWithCapacity:2];
-  defaultMaxSizes[@(MDCFloatingButtonModeNormal)] = [NSValue valueWithCGSize:defaultSizeNormal];
-  defaultMaxSizes[@(MDCFloatingButtonModeExtended)]
-      = [NSValue valueWithCGSize:defaultSizeExtendedMaximum];
-  NSMutableDictionary *miniMaxSizes = [NSMutableDictionary dictionaryWithCapacity:1];
-  miniMaxSizes[@(MDCFloatingButtonModeNormal)] = [NSValue valueWithCGSize:miniSizeNormal];
-  _typeToModeToMaximumSize = [NSMutableDictionary dictionaryWithCapacity:2];
-  _typeToModeToMaximumSize[@(MDCFloatingButtonTypeDefault)] = defaultMaxSizes;
-  _typeToModeToMaximumSize[@(MDCFloatingButtonTypeMini)] = miniMaxSizes;
+  NSMutableDictionary *miniMaxSizes
+      = [@{
+           @(MDCFloatingButtonModeNormal) : [NSValue valueWithCGSize:miniSizeNormal]
+           } mutableCopy];
+  NSMutableDictionary *defaultMaxSizes
+      = [@{
+           @(MDCFloatingButtonModeNormal) : [NSValue valueWithCGSize:defaultSizeNormal],
+           @(MDCFloatingButtonModeExtended) : [NSValue valueWithCGSize:CGSizeMake(328, 0)],
+           } mutableCopy];
+
+  _typeToModeToMaximumSize
+      = [@{
+           @(MDCFloatingButtonTypeMini) : miniMaxSizes,
+           @(MDCFloatingButtonTypeDefault) : defaultMaxSizes,
+           } mutableCopy];
 
   NSMutableDictionary *miniContentEdgeInsets
       = [@{
@@ -120,41 +127,20 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
                                        @(MDCFloatingButtonTypeDefault) : defaultContentEdgeInsets,
                                        } mutableCopy];
 
-
-  _shapeToMinimumSize = [NSMutableDictionary dictionaryWithCapacity:5];
-  self.shapeToMinimumSize[@(MDCFloatingButtonShapeDefault)]
-      = [NSValue valueWithCGSize:CGSizeMake(56, 56)];
-  self.shapeToMinimumSize[@(MDCFloatingButtonShapeMini)]
-      = [NSValue valueWithCGSize:CGSizeMake(40, 40)];
-  self.shapeToMinimumSize[@(MDCFloatingButtonShapeExtendedLeadingIcon)]
-      = [NSValue valueWithCGSize:CGSizeMake(132, 48)];
-  self.shapeToMinimumSize[@(MDCFloatingButtonShapeExtendedTrailingIcon)]
-      = [NSValue valueWithCGSize:CGSizeMake(132, 48)];
-  _shapeToMaximumSize = [NSMutableDictionary dictionaryWithCapacity:5];
-  self.shapeToMaximumSize[@(MDCFloatingButtonShapeDefault)]
-      = [NSValue valueWithCGSize:CGSizeMake(56, 56)];
-  self.shapeToMaximumSize[@(MDCFloatingButtonShapeMini)]
-      = [NSValue valueWithCGSize:CGSizeMake(40, 40)];
-  self.shapeToMaximumSize[@(MDCFloatingButtonShapeExtendedLeadingIcon)]
-      = [NSValue valueWithCGSize:CGSizeMake(328, 0)];
-  self.shapeToMaximumSize[@(MDCFloatingButtonShapeExtendedTrailingIcon)]
-      = [NSValue valueWithCGSize:CGSizeMake(328, 0)];
-  _shapeToContentEdgeInsets = [NSMutableDictionary dictionaryWithCapacity:5];
-  self.shapeToContentEdgeInsets[@(MDCFloatingButtonShapeDefault)]
-      = [NSValue valueWithUIEdgeInsets:UIEdgeInsetsZero];
-  self.shapeToContentEdgeInsets[@(MDCFloatingButtonShapeExtendedLeadingIcon)]
-      = [NSValue valueWithUIEdgeInsets:UIEdgeInsetsMake(0, 16, 0, 24)];
-  self.shapeToContentEdgeInsets[@(MDCFloatingButtonShapeExtendedTrailingIcon)]
-      = [NSValue valueWithUIEdgeInsets:UIEdgeInsetsMake(0, 24, 0, 16)];
-  _shapeToHitAreaInsets = [NSMutableDictionary dictionaryWithCapacity:5];
-  self.shapeToHitAreaInsets[@(MDCFloatingButtonShapeDefault)]
-      = [NSValue valueWithUIEdgeInsets:UIEdgeInsetsZero];
-  self.shapeToHitAreaInsets[@(MDCFloatingButtonShapeMini)]
-      = [NSValue valueWithUIEdgeInsets:UIEdgeInsetsMake(-4, -4, -4, -4)];
+  NSMutableDictionary *miniNormalHitAreaInsets
+      = [@{
+           @(MDCFloatingButtonModeNormal) :
+             [NSValue valueWithUIEdgeInsets:UIEdgeInsetsMake(-4, -4, -4, -4)],
+           } mutableCopy];
+  _typeToModeToHitAreaInsets
+      = [@{
+           @(MDCFloatingButtonTypeMini) : miniNormalHitAreaInsets,
+           } mutableCopy];
 
   super.contentEdgeInsets = [self defaultContentEdgeInsets];
   super.hitAreaInsets = [self defaultHitAreaInsets];
   _imageTitlePadding = 8;
+  _imagePosition = MDCFloatingButtonImagePositionLeading;
 }
 
 #pragma mark - NSCoding
@@ -163,20 +149,34 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
   self = [super initWithCoder:aDecoder];
   if (self) {
     [self commonMDCFloatingButtonInit];
-    _shape = [aDecoder decodeIntegerForKey:MDCFloatingButtonShapeKey];
+    _type = [aDecoder decodeIntegerForKey:MDCFloatingButtonTypeKey];
+
+    // Migrate (MDCFloatingButtonShapeLargeIcon = 2) to type value .default
+    if ([aDecoder containsValueForKey:MDCFloatingButtonShapeKey]) {
+      NSInteger shape = [aDecoder decodeIntegerForKey:MDCFloatingButtonShapeKey];
+      if (shape == 2) {
+        _type = MDCFloatingButtonTypeDefault;
+      }
+    }
     if ([aDecoder containsValueForKey:MDCFloatingButtonMinimumSizeDictionaryKey]) {
-      _shapeToMinimumSize = [aDecoder decodeObjectForKey:MDCFloatingButtonMinimumSizeDictionaryKey];
+      _typetoModeToMinimumSize = [aDecoder decodeObjectForKey:MDCFloatingButtonMinimumSizeDictionaryKey];
     }
     if ([aDecoder containsValueForKey:MDCFloatingButtonMaximumSizeDictionaryKey]) {
-      _shapeToMaximumSize = [aDecoder decodeObjectForKey:MDCFloatingButtonMaximumSizeDictionaryKey];
+      _typeToModeToMaximumSize = [aDecoder decodeObjectForKey:MDCFloatingButtonMaximumSizeDictionaryKey];
     }
     if ([aDecoder containsValueForKey:MDCFloatingButtonContentEdgeInsetsDictionaryKey]) {
-      _shapeToContentEdgeInsets
+      _typeToModeToContentEdgeInsets
           = [aDecoder decodeObjectForKey:MDCFloatingButtonContentEdgeInsetsDictionaryKey];
     }
     if ([aDecoder containsValueForKey:MDCFloatingButtonHitAreaInsetsDictionaryKey]) {
-      _shapeToHitAreaInsets
+      _typeToModeToHitAreaInsets
           = [aDecoder decodeObjectForKey:MDCFloatingButtonHitAreaInsetsDictionaryKey];
+    }
+    if ([aDecoder containsValueForKey:MDCFloatingButtonImagePositionKey]) {
+      _imagePosition = [aDecoder decodeIntegerForKey:MDCFloatingButtonImagePositionKey];
+    }
+    if ([aDecoder containsValueForKey:MDCFloatingImageTitlePaddingKey]) {
+      _imageTitlePadding = (CGFloat)[aDecoder decodeDoubleForKey:MDCFloatingImageTitlePaddingKey];
     }
     [self updateType];
   }
@@ -185,39 +185,47 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
   [super encodeWithCoder:aCoder];
-  [aCoder encodeInteger:self.shape forKey:MDCFloatingButtonShapeKey];
-  [aCoder encodeObject:self.shapeToMinimumSize forKey:MDCFloatingButtonMinimumSizeDictionaryKey];
-  [aCoder encodeObject:self.shapeToMaximumSize forKey:MDCFloatingButtonMaximumSizeDictionaryKey];
-  [aCoder encodeObject:self.shapeToContentEdgeInsets
+  [aCoder encodeInteger:self.type forKey:MDCFloatingButtonTypeKey];
+  [aCoder encodeObject:self.typeToModeToHitAreaInsets forKey:MDCFloatingButtonMinimumSizeDictionaryKey];
+  [aCoder encodeObject:self.typeToModeToMaximumSize forKey:MDCFloatingButtonMaximumSizeDictionaryKey];
+  [aCoder encodeObject:self.typeToModeToContentEdgeInsets
                 forKey:MDCFloatingButtonContentEdgeInsetsDictionaryKey];
-  [aCoder encodeObject:self.shapeToHitAreaInsets
+  [aCoder encodeObject:self.typeToModeToHitAreaInsets
                 forKey:MDCFloatingButtonHitAreaInsetsDictionaryKey];
+  [aCoder encodeInteger:self.imagePosition forKey:MDCFloatingButtonImagePositionKey];
+  [aCoder encodeDouble:self.imageTitlePadding forKey:MDCFloatingImageTitlePaddingKey];
 }
 
 #pragma mark - UIView
 
-- (CGSize)intrinsicContentSize {
-  NSLog(@"intrinsicContentSize");
-  switch (_shape) {
-    case MDCFloatingButtonShapeDefault:
-      return CGSizeMake([[self class] defaultDimension], [[self class] defaultDimension]);
-    case MDCFloatingButtonShapeMini:
-      return CGSizeMake([[self class] miniDimension], [[self class] miniDimension]);
-    case MDCFloatingButtonShapeLargeIcon:
-      return CGSizeMake([[self class] defaultDimension], [[self class] defaultDimension]);
-    case MDCFloatingButtonShapeExtendedTrailingIcon:
-    case MDCFloatingButtonShapeExtendedLeadingIcon: {
-      const CGSize intrinsicTitleSize
-          = [self.titleLabel sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)];
-      const CGSize intrinsicImageSize
-          = [self.imageView sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)];
-      CGFloat intrinsicWidth = intrinsicTitleSize.width + intrinsicImageSize.width
-          + self.imageTitlePadding + self.contentEdgeInsets.left + self.contentEdgeInsets.right;
-      CGFloat intrinsicHeight = MAX(intrinsicTitleSize.height, intrinsicImageSize.height)
-          + self.contentEdgeInsets.top + self.contentEdgeInsets.bottom;
-      return CGSizeMake(intrinsicWidth, intrinsicHeight);
-    }
+- (CGSize)intrinsicContentSizeForModeNormal {
+  switch(self.type) {
+    case MDCFloatingButtonTypeMini:
+      return CGSizeMake(40, 40);
+    case MDCFloatingButtonTypeDefault:
+      return CGSizeMake(56, 56);
   }
+}
+
+- (CGSize)intrinsicContentSizeForModeExtended {
+  const CGSize intrinsicTitleSize
+      = [self.titleLabel sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)];
+  const CGSize intrinsicImageSize
+      = [self.imageView sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)];
+  CGFloat intrinsicWidth = intrinsicTitleSize.width + intrinsicImageSize.width
+      + self.imageTitlePadding + self.contentEdgeInsets.left + self.contentEdgeInsets.right;
+  CGFloat intrinsicHeight = MAX(intrinsicTitleSize.height, intrinsicImageSize.height)
+      + self.contentEdgeInsets.top + self.contentEdgeInsets.bottom;
+  return CGSizeMake(intrinsicWidth, intrinsicHeight);
+}
+
+- (CGSize)intrinsicContentSize {
+  if (self.mode == MDCFloatingButtonModeNormal) {
+    return [self intrinsicContentSizeForModeNormal];
+  } else if (self.mode == MDCFloatingButtonModeExtended) {
+    return [self intrinsicContentSizeForModeExtended];
+  }
+  return [super intrinsicContentSize];
 }
 
 //- (CGSize)sizeThatFits:(CGSize)size {
@@ -238,7 +246,6 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
 
 
 - (CGSize)sizeThatFits:(__unused CGSize)size {
-  NSLog(@"sizeThaTFits:");
   const CGSize intrinsicSize = [self intrinsicContentSize];
   CGSize finalSize = intrinsicSize;
   if (self.minimumSize.height > 0) {
@@ -258,14 +265,11 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
 
 
 - (void)layoutSubviews {
-  NSLog(@"Layout");
   // We have to set cornerRadius before laying out subviews so that the boundingPath is correct.
   self.layer.cornerRadius = CGRectGetHeight(self.bounds) / 2;
   [super layoutSubviews];
 
-  if (self.shape == MDCFloatingButtonShapeDefault
-      || self.shape == MDCFloatingButtonShapeMini
-      || self.shape == MDCFloatingButtonShapeLargeIcon) {
+  if (self.type == MDCFloatingButtonModeNormal) {
     return;
   }
 
@@ -303,7 +307,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
 
   BOOL isRTL = self.mdf_effectiveUserInterfaceLayoutDirection
       == UIUserInterfaceLayoutDirectionRightToLeft;
-  BOOL isLeadingIcon = self.shape == MDCFloatingButtonShapeExtendedLeadingIcon;
+  BOOL isLeadingIcon = self.imagePosition == MDCFloatingButtonImagePositionLeading;
 
   CGPoint titleCenter;
   CGPoint imageCenter;
@@ -337,11 +341,12 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
 #pragma mark - Subclassing
 
 - (UIEdgeInsets)defaultContentEdgeInsets {
-  NSValue *insetsValue = self.shapeToContentEdgeInsets[@(self.shape)];
-  if (!insetsValue && self.shape != MDCFloatingButtonShapeDefault) {
-    insetsValue = self.shapeToContentEdgeInsets[@(MDCFloatingButtonShapeDefault)];
+  NSMutableDictionary *modeToContentEdgeInsets = self.typeToModeToContentEdgeInsets[@(self.type)];
+  if (!modeToContentEdgeInsets) {
+    return UIEdgeInsetsZero;
   }
 
+  NSValue *insetsValue = modeToContentEdgeInsets[@(self.mode)];
   if (insetsValue) {
     return [insetsValue UIEdgeInsetsValue];
   } else {
@@ -350,11 +355,12 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
 }
 
 - (UIEdgeInsets)defaultHitAreaInsets {
-  NSValue *insetsValue = self.shapeToHitAreaInsets[@(self.shape)];
-  if (!insetsValue && self.shape != MDCFloatingButtonShapeDefault) {
-    insetsValue = self.shapeToHitAreaInsets[@(MDCFloatingButtonShapeDefault)];
+  NSMutableDictionary *modeToHitAreaInsets = self.typeToModeToHitAreaInsets[@(self.type)];
+  if (!modeToHitAreaInsets) {
+    return UIEdgeInsetsZero;
   }
 
+  NSValue *insetsValue = modeToHitAreaInsets[@(self.mode)];
   if (insetsValue) {
     return [insetsValue UIEdgeInsetsValue];
   } else {
@@ -364,57 +370,90 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
 
 #pragma mark - Extended FAB changes
 - (void)setMinimumSize:(__unused CGSize)size {
-  NSAssert(NO, @"Not available. Use setMinimumSize:forShape: instead");
+  NSAssert(NO, @"Not available. Use setMinimumSize:forType:mode: instead");
 }
 
-- (void)setMinimumSize:(CGSize)size forShape:(MDCFloatingButtonShape)shape {
-  self.shapeToMinimumSize[@(shape)] = [NSValue valueWithCGSize:size];
-  if (shape == self.shape) {
+- (void)setMinimumSize:(CGSize)size
+               forType:(MDCFloatingButtonType)type
+                  mode:(MDCFloatingButtonMode)mode {
+  NSMutableDictionary *modeToMinimumSize = self.typetoModeToMinimumSize[@(self.type)];
+  if (!modeToMinimumSize) {
+    modeToMinimumSize = [@{} mutableCopy];
+    self.typetoModeToMinimumSize[@(self.type)] = modeToMinimumSize;
+  }
+  modeToMinimumSize[@(mode)] = [NSValue valueWithCGSize:size];
+  if (type == self.type && mode == self.mode) {
     [self updateType];
   }
 }
 
 - (void)setMaximumSize:(__unused CGSize)size {
-  NSAssert(NO, @"Not available. Use setMaximumSize:forShape: instead");
+  NSAssert(NO, @"Not available. Use setMaximumSize:forType:mode: instead");
 }
 
-- (void)setMaximumSize:(CGSize)size forShape:(MDCFloatingButtonShape)shape {
-  self.shapeToMaximumSize[@(shape)] = [NSValue valueWithCGSize:size];
-  if (shape == self.shape) {
+- (void)setMaximumSize:(CGSize)size
+               forType:(MDCFloatingButtonType)type
+                  mode:(MDCFloatingButtonMode)mode {
+  NSMutableDictionary *modeToMaximumSize = self.typeToModeToMaximumSize[@(self.type)];
+  if (!modeToMaximumSize) {
+    modeToMaximumSize = [@{} mutableCopy];
+    self.typeToModeToMaximumSize[@(self.type)] = modeToMaximumSize;
+  }
+  modeToMaximumSize[@(mode)] = [NSValue valueWithCGSize:size];
+  if (type == self.type && mode == self.mode) {
     [self updateType];
   }
 }
 
-- (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets forShape:(MDCFloatingButtonShape)shape {
-  self.shapeToContentEdgeInsets[@(shape)] = [NSValue valueWithUIEdgeInsets:contentEdgeInsets];
-  if (shape == self.shape) {
+- (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets
+                     forType:(MDCFloatingButtonType)type
+                        mode:(MDCFloatingButtonMode)mode {
+  NSMutableDictionary *modeToContentEdgeInsets = self.typeToModeToContentEdgeInsets[@(self.type)];
+  if (!modeToContentEdgeInsets) {
+    modeToContentEdgeInsets = [@{} mutableCopy];
+    self.typeToModeToContentEdgeInsets[@(self.type)] = modeToContentEdgeInsets;
+  }
+  modeToContentEdgeInsets[@(mode)] = [NSValue valueWithUIEdgeInsets:contentEdgeInsets];
+  if (type == self.type && mode == self.mode) {
     [self updateType];
   }
 }
 
-- (void)setHitAreaInsets:(UIEdgeInsets)insets forShape:(MDCFloatingButtonShape)shape {
-  self.shapeToHitAreaInsets[@(shape)] = [NSValue valueWithUIEdgeInsets:insets];
-  if (shape == self.shape) {
+- (void)setHitAreaInsets:(UIEdgeInsets)insets
+                 forType:(MDCFloatingButtonType)type
+                    mode:(MDCFloatingButtonMode)mode {
+  NSMutableDictionary *modeToHitAreaInsets = self.typeToModeToHitAreaInsets[@(self.type)];
+  if (!modeToHitAreaInsets) {
+    modeToHitAreaInsets = [@{} mutableCopy];
+    self.typeToModeToHitAreaInsets[@(self.type)] = modeToHitAreaInsets;
+  }
+  modeToHitAreaInsets[@(mode)] = [NSValue valueWithUIEdgeInsets:insets];
+  if (type == self.type && mode == self.mode) {
     [self updateType];
   }
 }
 
-- (void)setShape:(MDCFloatingButtonShape)shape {
-  _shape = shape;
+- (void)setMode:(MDCFloatingButtonMode)mode {
+  _mode = mode;
   [self updateType];
 }
 
-- (BOOL)updateMinimumSize {
-  NSValue *sizeValue = self.shapeToMinimumSize[@(self.shape)];
-  if (!sizeValue && self.shape != MDCFloatingButtonShapeDefault) {
-    sizeValue = self.shapeToMinimumSize[@(MDCFloatingButtonShapeDefault)];
+- (CGSize)minimumSizeForMode:(MDCFloatingButtonMode)mode {
+  NSMutableDictionary *modeToMinimumSize = self.typetoModeToMinimumSize[@(self.type)];
+  if(!modeToMinimumSize) {
+    return CGSizeZero;
   }
 
-  CGSize newSize = CGSizeZero;
+  NSValue *sizeValue = modeToMinimumSize[@(mode)];
   if (sizeValue) {
-    newSize = [sizeValue CGSizeValue];
+    return [sizeValue CGSizeValue];
+  } else {
+    return CGSizeZero;
   }
+}
 
+- (BOOL)updateMinimumSize {
+  CGSize newSize = [self minimumSizeForMode:self.mode];
   BOOL sizeChanged = (newSize.width > self.minimumSize.width)
       || (newSize.height > self.minimumSize.height);
   super.minimumSize = newSize;
@@ -424,16 +463,22 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
   return sizeChanged;
 }
 
-- (BOOL)updateMaximumSize {
-  NSValue *sizeValue = self.shapeToMaximumSize[@(self.shape)];
-  if (!sizeValue && self.shape != MDCFloatingButtonShapeDefault) {
-    sizeValue = self.shapeToMaximumSize[@(MDCFloatingButtonShapeDefault)];
+- (CGSize)maximumSizeForMode:(MDCFloatingButtonMode)mode {
+  NSMutableDictionary *modeToMaximumSize = self.typeToModeToMaximumSize[@(self.type)];
+  if (!modeToMaximumSize) {
+    return CGSizeZero;
   }
 
-  CGSize newSize = CGSizeZero;
+  NSValue *sizeValue = modeToMaximumSize[@(mode)];
   if (sizeValue) {
-    newSize = [sizeValue CGSizeValue];
+    return [sizeValue CGSizeValue];
+  } else {
+    return CGSizeZero;
   }
+}
+
+- (BOOL)updateMaximumSize {
+  CGSize newSize = [self maximumSizeForMode:self.mode];
 
   BOOL sizeChanged = !CGSizeEqualToSize(newSize, CGSizeZero)
       && ((newSize.width < self.maximumSize.width) || (newSize.height < self.maximumSize.height));
@@ -444,32 +489,40 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
   return sizeChanged;
 }
 
-- (UIEdgeInsets)insetsForShape:(MDCFloatingButtonType)shape {
-  NSValue *insetsValue = self.shapeToContentEdgeInsets[@(shape)];
-  if (!insetsValue && shape != MDCFloatingButtonTypeDefault) {
-    insetsValue = self.shapeToContentEdgeInsets[@(MDCFloatingButtonTypeDefault)];
+- (UIEdgeInsets)contentEdgeInsetsForMode:(MDCFloatingButtonMode)mode {
+  NSMutableDictionary *modeToContentEdgeInsets = self.typeToModeToContentEdgeInsets[@(self.type)];
+  if (!modeToContentEdgeInsets) {
+    return UIEdgeInsetsZero;
   }
 
+  NSValue *insetsValue = modeToContentEdgeInsets[@(mode)];
   if (insetsValue) {
-    return insetsValue.UIEdgeInsetsValue;
+    return [insetsValue UIEdgeInsetsValue];
   } else {
     return UIEdgeInsetsZero;
   }
 }
 
 - (void)updateContentEdgeInsets {
-  super.contentEdgeInsets = [self insetsForShape:self.shape];
+  super.contentEdgeInsets = [self contentEdgeInsetsForMode:self.mode];
+}
+
+- (UIEdgeInsets)hitAreaInsetsForMode:(MDCFloatingButtonMode)mode {
+  NSMutableDictionary *modeToHitAreaInsets = self.typeToModeToHitAreaInsets[@(self.type)];
+  if (!modeToHitAreaInsets) {
+    return UIEdgeInsetsZero;
+  }
+
+  NSValue *insetsValue = modeToHitAreaInsets[@(mode)];
+  if (insetsValue) {
+    return [insetsValue UIEdgeInsetsValue];
+  } else {
+    return UIEdgeInsetsZero;
+  }
 }
 
 - (void)updateHitAreaInsets {
-  NSValue *insetsValue = self.shapeToHitAreaInsets[@(self.shape)];
-  if (!insetsValue && self.shape != MDCFloatingButtonTypeDefault) {
-    insetsValue = self.shapeToHitAreaInsets[@(MDCFloatingButtonTypeDefault)];
-  }
-
-  if (insetsValue) {
-    super.hitAreaInsets = [insetsValue UIEdgeInsetsValue];
-  }
+  super.hitAreaInsets = [self hitAreaInsetsForMode:self.mode];
 }
 
 - (void)updateType {
@@ -490,7 +543,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
 }
 
 + (instancetype)buttonWithShape:(MDCFloatingButtonType)type {
-  return [[self class] floatingButtonWithType:type];
+  return [[[self class] alloc] initWithFrame:CGRectZero type:type];
 }
 
 @end

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -268,7 +268,6 @@ static UIEdgeInsets UIEdgeInsetsFlippedHorizonally(UIEdgeInsets insets) {
   return finalSize;
 }
 
-
 - (void)layoutSubviews {
   // We have to set cornerRadius before laying out subviews so that the boundingPath is correct.
   self.layer.cornerRadius = CGRectGetHeight(self.bounds) / 2;

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -77,13 +77,11 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
 }
 
 - (void)commonMDCFloatingButtonInit {
-  NSMutableDictionary *miniTypeMinimumSizeDictionary
-      = [NSMutableDictionary dictionaryWithCapacity:2];
   const CGSize miniSizeNormal = CGSizeMake(40, 40);
   const CGSize defaultSizeNormal = CGSizeMake(56, 56);
   const CGSize defaultSizeExtendedMinimum = CGSizeMake(132, 48);
   const CGSize defaultSizeExtendedMaximum = CGSizeMake(328, 0);
-  miniTypeMinimumSizeDictionary[@(MDCFloatingButtonModeNormal)] =
+
 
   _typetoModeToMinimumSize = [NSMutableDictionary dictionaryWithCapacity:2];
   _typetoModeToMinimumSize
@@ -107,6 +105,20 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
   _typeToModeToMaximumSize = [NSMutableDictionary dictionaryWithCapacity:2];
   _typeToModeToMaximumSize[@(MDCFloatingButtonTypeDefault)] = defaultMaxSizes;
   _typeToModeToMaximumSize[@(MDCFloatingButtonTypeMini)] = miniMaxSizes;
+
+  NSMutableDictionary *miniContentEdgeInsets
+      = [@{
+           @(MDCFloatingButtonModeNormal) : [NSValue valueWithUIEdgeInsets:UIEdgeInsetsZero]
+           } mutableCopy];
+  NSMutableDictionary *defaultContentEdgeInsets
+      = [@{
+           @(MDCFloatingButtonModeNormal) : [NSValue valueWithUIEdgeInsets:UIEdgeInsetsZero],
+           @(MDCFloatingButtonModeExtended) :
+             [NSValue valueWithUIEdgeInsets:UIEdgeInsetsMake(0, 16, 0, 24)],
+           } mutableCopy];
+  _typeToModeToContentEdgeInsets = [@{ @(MDCFloatingButtonTypeMini) : miniContentEdgeInsets,
+                                       @(MDCFloatingButtonTypeDefault) : defaultContentEdgeInsets,
+                                       } mutableCopy];
 
 
   _shapeToMinimumSize = [NSMutableDictionary dictionaryWithCapacity:5];

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -32,22 +32,18 @@ static NSString *const MDCFloatingButtonContentEdgeInsetsDictionaryKey
     = @"MDCFloatingButtonContentEdgeInsetsDictionaryKey";
 static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
     = @"MDCFloatingButtonHitAreaInsetsDictionaryKey";
+static NSString *const MDCFloatingButtonElevationDictionaryKey
+    = @"MDCFloatingButtonElevationDictionaryKey";
 
 @interface MDCFloatingButton ()
 @property(nonatomic, readonly) NSMutableDictionary<NSNumber *, NSValue *> *shapeToHitAreaInsets;
 @property(nonatomic, readonly) NSMutableDictionary<NSNumber *, NSValue *> *shapeToMinimumSize;
 @property(nonatomic, readonly) NSMutableDictionary<NSNumber *, NSValue *> *shapeToMaximumSize;
 @property(nonatomic, readonly) NSMutableDictionary<NSNumber *, NSValue *> *shapeToContentEdgeInsets;
+@property(nonatomic, readonly) NSMutableDictionary<NSNumber *, NSMutableDictionary<NSNumber *, NSNumber *> *> *shapeToStateToElevation;
 @end
 
 @implementation MDCFloatingButton
-
-+ (void)initialize {
-  [[MDCFloatingButton appearance] setElevation:MDCShadowElevationFABResting
-                                      forState:UIControlStateNormal];
-  [[MDCFloatingButton appearance] setElevation:MDCShadowElevationFABPressed
-                                      forState:UIControlStateHighlighted];
-}
 
 + (CGFloat)defaultDimension {
   return MDCFloatingButtonDefaultDimension;
@@ -112,6 +108,27 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
       = [NSValue valueWithUIEdgeInsets:UIEdgeInsetsZero];
   self.shapeToHitAreaInsets[@(MDCFloatingButtonShapeMini)]
       = [NSValue valueWithUIEdgeInsets:UIEdgeInsetsMake(-4, -4, -4, -4)];
+  _shapeToStateToElevation = [NSMutableDictionary dictionary];
+  NSMutableDictionary *defaultElevations = [NSMutableDictionary dictionary];
+  NSMutableDictionary *miniElevations = [NSMutableDictionary dictionary];
+  NSMutableDictionary *largeIconElevations = [NSMutableDictionary dictionary];
+  NSMutableDictionary *extendedLeadingElevations = [NSMutableDictionary dictionary];
+  NSMutableDictionary *extendedTrailingElevations = [NSMutableDictionary dictionary];
+  NSArray *dictionaries = @[defaultElevations, miniElevations, largeIconElevations,
+                            extendedLeadingElevations, extendedTrailingElevations];
+  for (NSMutableDictionary *dictionary in dictionaries) {
+    dictionary[@(UIControlStateNormal)] = @(MDCShadowElevationFABResting);
+    dictionary[@(UIControlStateHighlighted)] = @(MDCShadowElevationFABPressed);
+  }
+
+  self.shapeToStateToElevation[@(MDCFloatingButtonShapeDefault)] = defaultElevations;
+  self.shapeToStateToElevation[@(MDCFloatingButtonShapeMini)] = miniElevations;
+  self.shapeToStateToElevation[@(MDCFloatingButtonShapeLargeIcon)] = largeIconElevations;
+  self.shapeToStateToElevation[@(MDCFloatingButtonShapeExtendedLeadingIcon)]
+      = extendedLeadingElevations;
+  self.shapeToStateToElevation[@(MDCFloatingButtonShapeExtendedTrailingIcon)]
+      = extendedTrailingElevations;
+
   super.contentEdgeInsets = [self defaultContentEdgeInsets];
   super.hitAreaInsets = [self defaultHitAreaInsets];
   _imageTitlePadding = 8;
@@ -138,6 +155,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
       _shapeToHitAreaInsets
           = [aDecoder decodeObjectForKey:MDCFloatingButtonHitAreaInsetsDictionaryKey];
     }
+    [self updateShape];
   }
   return self;
 }
@@ -431,11 +449,40 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
   }
 }
 
+- (void)setElevation:(CGFloat)elevation
+            forState:(UIControlState)state
+               shape:(MDCFloatingButtonShape)shape {
+  NSMutableDictionary *shapeElevations = self.shapeToStateToElevation[@(shape)];
+  shapeElevations[@(state)] = @(elevation);
+  if (shape == self.shape) {
+    [self updateShape];
+  }
+}
+
+- (void)setElevation:(CGFloat)elevation forState:(UIControlState)state {
+  [self setElevation:elevation forState:state shape:self.shape];
+}
+
+- (NSDictionary *)elevationsForShape:(MDCFloatingButtonShape)shape {
+  NSMutableDictionary<NSNumber *, NSNumber *> *shapeElevations
+      = self.shapeToStateToElevation[@(shape)];
+  return [shapeElevations copy];
+}
+
+- (void)updateElevation {
+  NSDictionary<NSNumber *, NSNumber *> *elevations = [self elevationsForShape:self.shape];
+
+  for (NSNumber *stateValue in [elevations allKeys]) {
+    [super setElevation:(MDCShadowElevation)elevations[stateValue].doubleValue forState:stateValue.integerValue];
+  }
+}
+
 - (void)updateShape {
   BOOL needsLayout = [self updateMinimumSize];
   needsLayout |= [self updateMaximumSize];
   [self updateContentEdgeInsets];
   [self updateHitAreaInsets];
+  [self updateElevation];
   if (needsLayout) {
     [self sizeToFit];
   }

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -454,8 +454,8 @@ static NSString *const MDCFloatingButtonElevationDictionaryKey
                shape:(MDCFloatingButtonShape)shape {
   NSMutableDictionary *shapeElevations = self.shapeToStateToElevation[@(shape)];
   shapeElevations[@(state)] = @(elevation);
-  if (shape == self.shape) {
-    [self updateShape];
+  if (shape == self.shape && self.state == state) {
+    [self updateElevation];
   }
 }
 

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -23,13 +23,13 @@
 
 static const CGFloat MDCFloatingButtonDefaultDimension = 56.0f;
 static const CGFloat MDCFloatingButtonMiniDimension = 40.0f;
+static const UIEdgeInsets internalLayoutSpacingInsets = (UIEdgeInsets){0, 16, 0, 24};
+
 static NSString *const MDCFloatingButtonTypeKey = @"MDCFloatingButtonTypeKey";
 static NSString *const MDCFloatingButtonModeKey = @"MDCFloatingButtonModeKey";
 static NSString *const MDCFloatingButtonImagePositionKey = @"MDCFloatingButtonImagePositionKey";
 static NSString *const MDCFloatingImageTitlePaddingKey = @"MDCFloatingImageTitlePaddingKey";
 
-/* Only used to decode previous versions. */
-static NSString *const MDCFloatingButtonShapeKey = @"MDCFloatingButtonShapeKey";
 static NSString *const MDCFloatingButtonMinimumSizeDictionaryKey
     = @"MDCFloatingButtonMinimumSizeDictionaryKey";
 static NSString *const MDCFloatingButtonMaximumSizeDictionaryKey
@@ -38,6 +38,13 @@ static NSString *const MDCFloatingButtonContentEdgeInsetsDictionaryKey
     = @"MDCFloatingButtonContentEdgeInsetsDictionaryKey";
 static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
     = @"MDCFloatingButtonHitAreaInsetsDictionaryKey";
+
+/* Only used to decode previous versions. */
+static NSString *const MDCFloatingButtonShapeKey = @"MDCFloatingButtonShapeKey";
+
+static UIEdgeInsets UIEdgeInsetsFlippedHorizonally(UIEdgeInsets insets) {
+  return UIEdgeInsetsMake(insets.top, insets.right, insets.bottom, insets.left);
+}
 
 @interface MDCFloatingButton ()
 @property(nonatomic, assign) MDCFloatingButtonType type;
@@ -120,16 +127,8 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
            @(MDCFloatingButtonTypeDefault) : defaultMaxSizes,
            } mutableCopy];
 
-  NSMutableDictionary *miniContentEdgeInsets
-      = [@{
-           @(MDCFloatingButtonModeNormal) : [NSValue valueWithUIEdgeInsets:UIEdgeInsetsZero]
-           } mutableCopy];
-  NSMutableDictionary *defaultContentEdgeInsets
-      = [@{
-           @(MDCFloatingButtonModeNormal) : [NSValue valueWithUIEdgeInsets:UIEdgeInsetsZero],
-           @(MDCFloatingButtonModeExtended) :
-             [NSValue valueWithUIEdgeInsets:UIEdgeInsetsMake(0, 16, 0, 24)],
-           } mutableCopy];
+  NSMutableDictionary *miniContentEdgeInsets = [@{} mutableCopy];
+  NSMutableDictionary *defaultContentEdgeInsets = [@{} mutableCopy];
   _typeToModeToContentEdgeInsets = [@{ @(MDCFloatingButtonTypeMini) : miniContentEdgeInsets,
                                        @(MDCFloatingButtonTypeDefault) : defaultContentEdgeInsets,
                                        } mutableCopy];
@@ -298,15 +297,16 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey
   // The diagram above assumes an LTR user interface orientation
   // and a .leadingIcon shape for this button.
 
-  const UIEdgeInsets originalContentEdgeInsets = [self contentEdgeInsetsForMode:self.mode];
-  const UIEdgeInsets adjustedContentEdgeInsets
-      = self.contentEdgeInsetsFlippedForTrailingImagePosition
-          ? UIEdgeInsetsMake(originalContentEdgeInsets.top,
-                             originalContentEdgeInsets.right,
-                             originalContentEdgeInsets.bottom,
-                             originalContentEdgeInsets.left)
-          : originalContentEdgeInsets;
-  const CGRect insetBounds = UIEdgeInsetsInsetRect(self.bounds, adjustedContentEdgeInsets);
+  UIEdgeInsets adjustedLayoutInsets = internalLayoutSpacingInsets;
+  UIEdgeInsets adjustedContentEdgeInsets = self.contentEdgeInsets;
+  if (self.contentEdgeInsetsFlippedForTrailingImagePosition
+      && self.imagePosition == MDCFloatingButtonImagePositionTrailing)  {
+    adjustedLayoutInsets = UIEdgeInsetsFlippedHorizonally(internalLayoutSpacingInsets);
+    adjustedContentEdgeInsets = UIEdgeInsetsFlippedHorizonally(self.contentEdgeInsets);
+  }
+  const CGRect insetBounds = UIEdgeInsetsInsetRect(UIEdgeInsetsInsetRect(self.bounds,
+                                                                         adjustedLayoutInsets),
+                                                   adjustedContentEdgeInsets);
   NSLog(@"\nBounds: %@\nInBnds: %@", NSStringFromCGRect(self.bounds), NSStringFromCGRect(insetBounds));
   const CGFloat imageViewWidth = CGRectGetWidth(self.imageView.bounds);
   const CGFloat boundsCenterY = CGRectGetMidY(insetBounds);

--- a/components/FeatureHighlight/examples/FeatureHighlightShownViewExample.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightShownViewExample.m
@@ -21,8 +21,8 @@
 @implementation FeatureHighlightShownViewExample
 
 - (void)didTapButton:(id)sender {
-  MDCFloatingButton *fab =
-      [MDCFloatingButton floatingButtonWithShape:MDCFloatingButtonShapeDefault];
+  MDCFloatingButton *fab = [[MDCFloatingButton alloc] initWithFrame:CGRectZero
+                                                               type:MDCFloatingButtonTypeDefault];
   [fab setImage:[UIImage imageNamed:@"Plus"] forState:UIControlStateNormal];
   [fab sizeToFit];
   fab.backgroundColor = UIColor.orangeColor;

--- a/components/FeatureHighlight/examples/FeatureHighlightShownViewExample.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightShownViewExample.m
@@ -21,8 +21,7 @@
 @implementation FeatureHighlightShownViewExample
 
 - (void)didTapButton:(id)sender {
-  MDCFloatingButton *fab = [[MDCFloatingButton alloc] initWithFrame:CGRectZero
-                                                               type:MDCFloatingButtonTypeDefault];
+  MDCFloatingButton *fab = [[MDCFloatingButton alloc] init];
   [fab setImage:[UIImage imageNamed:@"Plus"] forState:UIControlStateNormal];
   [fab sizeToFit];
   fab.backgroundColor = UIColor.orangeColor;

--- a/components/Themes/examples/supplemental/ThemerTypicalUseSupplemental.m
+++ b/components/Themes/examples/supplemental/ThemerTypicalUseSupplemental.m
@@ -116,8 +116,8 @@
   [self.scrollView addSubview:self.progressView];
   [self animateStep1:self.progressView];
 
-  self.floatingButton =
-      [MDCFloatingButton floatingButtonWithShape:MDCFloatingButtonShapeDefault];
+  self.floatingButton = [[MDCFloatingButton alloc] initWithFrame:CGRectZero
+                                                            type:MDCFloatingButtonTypeDefault];
   [self.floatingButton sizeToFit];
   [self.scrollView addSubview:self.floatingButton];
 

--- a/components/Themes/examples/supplemental/ThemerTypicalUseSupplemental.m
+++ b/components/Themes/examples/supplemental/ThemerTypicalUseSupplemental.m
@@ -116,8 +116,7 @@
   [self.scrollView addSubview:self.progressView];
   [self animateStep1:self.progressView];
 
-  self.floatingButton = [[MDCFloatingButton alloc] initWithFrame:CGRectZero
-                                                            type:MDCFloatingButtonTypeDefault];
+  self.floatingButton = [[MDCFloatingButton alloc] init];
   [self.floatingButton sizeToFit];
   [self.scrollView addSubview:self.floatingButton];
 


### PR DESCRIPTION
UIAppearance supported properties:
* (New) imageTitlePadding - the space between the title and image views.
* (New) imagePosition - whether the image leads or trails the title.
* contentEdgeInsets (via forMode:)
* minimumSize (via forMode:)
* maximumSize (via forMode:)
* hitAreaInsets (via forMode:)

Replacement of "shape" with "type" concept:
* "Default" and "Mini" will be only remaining types (removes LargeIcon shape)
* Type cannot change for an instance of Floating Button

"Extended" support is provided by a new "mode" property. It is not proxied via
UIAppearance because the design guidance states that usage is based on the
available screen size.