### PR TITLE
[Buttons] Extended FAB API review

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -144,6 +144,7 @@ Pod::Spec.new do |mdc|
       spec.public_header_files = "components/#{component.base_name}/src/*.h"
       spec.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
 
+      spec.dependency 'MDFInternationalization'
       spec.dependency 'MDFTextAccessibility'
       spec.dependency "MaterialComponents/Ink"
       spec.dependency "MaterialComponents/ShadowElevations"

--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -52,7 +52,9 @@
   self.flatButton.inkColor = [UIColor colorWithWhite:1.0 alpha:0.1];
   self.flatButton.contentEdgeInsets = UIEdgeInsetsMake(64, 64, 0, 0);
   self.raisedButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, 64, 64);
-  self.floatingActionButton.contentEdgeInsets = UIEdgeInsetsMake(40, 40, 0, 0);
+  [self.floatingActionButton setContentEdgeInsets:UIEdgeInsetsMake(40, 40, 0, 0)
+                                         forShape:MDCFloatingButtonShapeDefault
+                                             mode:MDCFloatingButtonModeNormal];
 
   [self updateInkStyle:self.inkBoundingSwitch.isOn ? MDCInkStyleBounded : MDCInkStyleUnbounded];
 }

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -80,7 +80,7 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
 
     buttonSetup()
 
-    let plusIcon = UIImage.init(named: "Plus")?.withRenderingMode(.alwaysOriginal)
+    let plusIcon = UIImage(named: "Plus")?.withRenderingMode(.alwaysOriginal)
     floatingButton.setImage(plusIcon, for: .normal)
     innerContainerView.addSubview(floatingButton)
 
@@ -98,19 +98,24 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
     }
   }
 
+  func updateFloatingButtons(whenSizeClass isRegularRegular: Bool) {
+    if (isRegularRegular) {
+      updateFloatingButtons(to: .extended)
+      floatingButton.setTitle("Button", for: .normal)
+      storyboardFloating.setTitle("Button", for: .normal)
+    } else {
+      updateFloatingButtons(to: .normal)
+      floatingButton.setTitle(nil, for: .normal)
+      storyboardFloating.setTitle(nil, for: .normal)
+    }
+  }
+
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
-    let horizontalSizeClass = self.traitCollection.horizontalSizeClass
-    let verticalSizeClass = self.traitCollection.verticalSizeClass
-    if (horizontalSizeClass == .regular && verticalSizeClass == .regular) {
-      self.updateFloatingButtons(to: .extended)
-      self.floatingButton.setTitle("Button", for: .normal)
-      self.storyboardFloating.setTitle("Button", for: .normal)
-    } else {
-      self.updateFloatingButtons(to: .normal)
-      self.floatingButton.setTitle(nil, for: .normal)
-      self.storyboardFloating.setTitle(nil, for: .normal)
-    }
+    let horizontalSizeClass = traitCollection.horizontalSizeClass
+    let verticalSizeClass = traitCollection.verticalSizeClass
+    let isRegularRegular = horizontalSizeClass == .regular && verticalSizeClass == .regular
+    updateFloatingButtons(whenSizeClass: isRegularRegular)
   }
 
   private func layoutContainer() {
@@ -226,7 +231,7 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
 
   override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
     super.willTransition(to: newCollection, with: coordinator)
-    let currentTraits = self.traitCollection;
+    let currentTraits = traitCollection
     let sizeClassChanged
       = newCollection.horizontalSizeClass != currentTraits.horizontalSizeClass
         || newCollection.verticalSizeClass != currentTraits.verticalSizeClass
@@ -236,15 +241,7 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
           && newCollection.verticalSizeClass == .regular
 
       coordinator.animate(alongsideTransition:{ (_) in
-        if (willBeRegularRegular) {
-          self.updateFloatingButtons(to: .extended)
-          self.floatingButton.setTitle("Button", for: .normal)
-          self.storyboardFloating.setTitle("Button", for: .normal)
-        } else {
-          self.updateFloatingButtons(to: .normal)
-          self.floatingButton.setTitle(nil, for: .normal)
-          self.storyboardFloating.setTitle(nil, for: .normal)
-        }
+       self.updateFloatingButtons(whenSizeClass: willBeRegularRegular)
       }, completion: nil)
     }
   }

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -80,15 +80,37 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
 
     buttonSetup()
 
-    let floatingPlusShapeLayer = ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton)
-    floatingButton.layer.addSublayer(floatingPlusShapeLayer)
+    let plusIcon = UIImage.init(named: "Plus")?.withRenderingMode(.alwaysOriginal)
+    floatingButton.setImage(plusIcon, for: .normal)
     innerContainerView.addSubview(floatingButton)
 
-    let storyboardPlusShapeLayer =
-      ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton)
-    storyboardFloating.layer.addSublayer(storyboardPlusShapeLayer)
+    storyboardFloating.setImage(plusIcon, for: .normal)
 
     addButtonConstraints()
+  }
+
+  func updateFloatingButtons(to mode: MDCFloatingButtonMode) {
+    if (floatingButton.mode != mode) {
+      floatingButton.mode = mode
+    }
+    if (storyboardFloating.mode != mode) {
+      storyboardFloating.mode = mode
+    }
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    let horizontalSizeClass = self.traitCollection.horizontalSizeClass
+    let verticalSizeClass = self.traitCollection.verticalSizeClass
+    if (horizontalSizeClass == .regular && verticalSizeClass == .regular) {
+      self.updateFloatingButtons(to: .extended)
+      self.floatingButton.setTitle("Button", for: .normal)
+      self.storyboardFloating.setTitle("Button", for: .normal)
+    } else {
+      self.updateFloatingButtons(to: .normal)
+      self.floatingButton.setTitle(nil, for: .normal)
+      self.storyboardFloating.setTitle(nil, for: .normal)
+    }
   }
 
   private func layoutContainer() {
@@ -202,6 +224,30 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
     print("\(type(of: sender)) was tapped.")
   }
 
+  override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+    super.willTransition(to: newCollection, with: coordinator)
+    let currentTraits = self.traitCollection;
+    let sizeClassChanged
+      = newCollection.horizontalSizeClass != currentTraits.horizontalSizeClass
+        || newCollection.verticalSizeClass != currentTraits.verticalSizeClass
+    if (sizeClassChanged) {
+      let willBeRegularRegular
+        = newCollection.horizontalSizeClass == .regular
+          && newCollection.verticalSizeClass == .regular
+
+      coordinator.animate(alongsideTransition:{ (_) in
+        if (willBeRegularRegular) {
+          self.updateFloatingButtons(to: .extended)
+          self.floatingButton.setTitle("Button", for: .normal)
+          self.storyboardFloating.setTitle("Button", for: .normal)
+        } else {
+          self.updateFloatingButtons(to: .normal)
+          self.floatingButton.setTitle(nil, for: .normal)
+          self.storyboardFloating.setTitle(nil, for: .normal)
+        }
+      }, completion: nil)
+    }
+  }
 }
 
 extension ButtonsSwiftAndStoryboardController {

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -17,6 +17,7 @@
 #import "MaterialButtons.h"
 #import "MaterialTypography.h"
 #import "supplemental/ButtonsTypicalUseSupplemental.h"
+#import "ExampleFloatingButtonThemer.h"
 
 @interface ButtonsTypicalUseViewController ()
 @property(nonatomic, strong) MDCFloatingButton *floatingButton;
@@ -134,19 +135,33 @@
 - (void)didTap:(id)sender {
   NSLog(@"%@ was tapped.", NSStringFromClass([sender class]));
   if (sender == self.floatingButton) {
-    [self.floatingButton
-          collapse:YES
-        completion:^{
-          dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)),
-                         dispatch_get_main_queue(), ^{
-                           [self.floatingButton expand:YES completion:nil];
-                         });
-        }];
+    [self.floatingButton collapse:YES
+                       completion:^{
+                         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)),
+                                        dispatch_get_main_queue(), ^{
+                                          [self.floatingButton expand:YES completion:nil];
+                                        });
+                       }];
+  }
+}
+
+- (void)updateFABExtendedMode:(UITraitCollection *)traits {
+  BOOL useExtendedMode = traits.horizontalSizeClass == UIUserInterfaceSizeClassRegular
+      && traits.verticalSizeClass == UIUserInterfaceSizeClassRegular;
+  if (useExtendedMode) {
+    [self.floatingButton setTitle:@"Button" forState:UIControlStateNormal];
+    self.floatingButton.mode = MDCFloatingButtonModeExtended;
+
+  } else {
+    [self.floatingButton setTitle:nil forState:UIControlStateNormal];
+    self.floatingButton.mode = MDCFloatingButtonModeNormal;
+
   }
 }
 
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];
+  [self updateFABExtendedMode:self.traitCollection];
   if (animated) {
     [self.floatingButton collapse:NO completion:nil];
   }
@@ -156,6 +171,16 @@
   [super viewDidAppear:animated];
   if (animated) {
     [self.floatingButton expand:YES completion:nil];
+  }
+}
+
+- (void)willTransitionToTraitCollection:(UITraitCollection *)newCollection
+              withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+  UITraitCollection *currentTraits = self.traitCollection;
+  BOOL traitsChange = currentTraits.horizontalSizeClass != newCollection.horizontalSizeClass ||
+  currentTraits.verticalSizeClass != newCollection.verticalSizeClass;
+  if (traitsChange) {
+    [self updateFABExtendedMode:newCollection];
   }
 }
 

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -151,7 +151,7 @@
       && traits.verticalSizeClass == UIUserInterfaceSizeClassRegular;
   if (useExtendedMode) {
     [self.floatingButton setTitle:@"Button" forState:UIControlStateNormal];
-    self.floatingButton.mode = MDCFloatingButtonModeExtended;
+    self.floatingButton.mode = MDCFloatingButtonModeExpanded;
 
   } else {
     [self.floatingButton setTitle:nil forState:UIControlStateNormal];

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -135,13 +135,14 @@
 - (void)didTap:(id)sender {
   NSLog(@"%@ was tapped.", NSStringFromClass([sender class]));
   if (sender == self.floatingButton) {
-    [self.floatingButton collapse:YES
-                       completion:^{
-                         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)),
-                                        dispatch_get_main_queue(), ^{
-                                          [self.floatingButton expand:YES completion:nil];
-                                        });
-                       }];
+    [self.floatingButton
+        collapse:YES
+      completion:^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+                         [self.floatingButton expand:YES completion:nil];
+                       });
+      }];
   }
 }
 

--- a/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.h
+++ b/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.h
@@ -1,0 +1,28 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MaterialThemes.h"
+#import "MaterialButtons.h"
+
+/**
+ An example Floating Button themer that makes them slightly taller and less wide than the defaults.
+ */
+@interface ExampleFloatingButtonThemer : NSObject
+
++ (void)applyToButton:(nonnull MDCFloatingButton *)button
+      withColorScheme:(nullable NSObject<MDCColorScheme> *)colorScheme;
+
+@end

--- a/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
+++ b/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
@@ -1,0 +1,59 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "ExampleFloatingButtonThemer.h"
+#import "MDCButtonColorThemer.h"
+
+@implementation ExampleFloatingButtonThemer
+
++ (void)applyToButton:(nonnull MDCFloatingButton *)button
+      withColorScheme:(nullable NSObject<MDCColorScheme> *)colorScheme {
+  if (colorScheme) {
+    [MDCButtonColorThemer applyColorScheme:colorScheme toButton:button];
+  }
+
+  UIEdgeInsets defaultExtendedInsets = UIEdgeInsetsMake(4, 8, 4, 12);
+  CGSize defaultExtendedMinimumSize = CGSizeMake(132, 40);
+  CGSize defaultExtendedMaximumSize = CGSizeZero;
+
+  UIEdgeInsets miniExtendedInsets = UIEdgeInsetsMake(4, 8, 4, 8);
+  CGSize miniExtendedMinimumSize = CGSizeMake(112, 32);
+  CGSize miniExtendedMaximumSize = CGSizeMake(280, 32);
+
+  [button setContentEdgeInsets:defaultExtendedInsets
+                      forShape:MDCFloatingButtonShapeDefault
+                          mode:MDCFloatingButtonModeExtended];
+  [button setContentEdgeInsets:miniExtendedInsets
+                      forShape:MDCFloatingButtonShapeMini
+                          mode:MDCFloatingButtonModeExtended];
+
+  [button setMinimumSize:defaultExtendedMinimumSize
+                forShape:MDCFloatingButtonShapeDefault
+                    mode:MDCFloatingButtonModeExtended];
+  [button setMaximumSize:defaultExtendedMaximumSize
+                forShape:MDCFloatingButtonShapeDefault
+                    mode:MDCFloatingButtonModeExtended];
+  [button setMinimumSize:miniExtendedMinimumSize
+                forShape:MDCFloatingButtonShapeMini
+                    mode:MDCFloatingButtonModeExtended];
+  [button setMaximumSize:miniExtendedMaximumSize
+                forShape:MDCFloatingButtonShapeMini
+                    mode:MDCFloatingButtonModeExtended];
+
+  [button setImageTitlePadding:4];
+}
+
+@end

--- a/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
+++ b/components/Buttons/src/ColorThemer/ExampleFloatingButtonThemer.m
@@ -35,23 +35,23 @@
 
   [button setContentEdgeInsets:defaultExtendedInsets
                       forShape:MDCFloatingButtonShapeDefault
-                          mode:MDCFloatingButtonModeExtended];
+                          mode:MDCFloatingButtonModeExpanded];
   [button setContentEdgeInsets:miniExtendedInsets
                       forShape:MDCFloatingButtonShapeMini
-                          mode:MDCFloatingButtonModeExtended];
+                          mode:MDCFloatingButtonModeExpanded];
 
   [button setMinimumSize:defaultExtendedMinimumSize
                 forShape:MDCFloatingButtonShapeDefault
-                    mode:MDCFloatingButtonModeExtended];
+                    mode:MDCFloatingButtonModeExpanded];
   [button setMaximumSize:defaultExtendedMaximumSize
                 forShape:MDCFloatingButtonShapeDefault
-                    mode:MDCFloatingButtonModeExtended];
+                    mode:MDCFloatingButtonModeExpanded];
   [button setMinimumSize:miniExtendedMinimumSize
                 forShape:MDCFloatingButtonShapeMini
-                    mode:MDCFloatingButtonModeExtended];
+                    mode:MDCFloatingButtonModeExpanded];
   [button setMaximumSize:miniExtendedMaximumSize
                 forShape:MDCFloatingButtonShapeMini
-                    mode:MDCFloatingButtonModeExtended];
+                    mode:MDCFloatingButtonModeExpanded];
 
   [button setImageTitlePadding:4];
 }

--- a/components/Buttons/src/ColorThemer/MDCFloatingButtonBuilder.h
+++ b/components/Buttons/src/ColorThemer/MDCFloatingButtonBuilder.h
@@ -1,0 +1,27 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MaterialButtons.h"
+#import "MaterialThemes.h"
+
+@interface MDCFloatingButtonBuilder : NSObject
+
++ (MDCFloatingButton *)floatingButtonWithScheme:(id<MDCColorScheme>)colorScheme;
++ (MDCFloatingButton *)extendedFloatingButtonWithScheme:(id<MDCColorScheme>)colorScheme;
+
+@end

--- a/components/Buttons/src/ColorThemer/MDCFloatingButtonBuilder.m
+++ b/components/Buttons/src/ColorThemer/MDCFloatingButtonBuilder.m
@@ -1,0 +1,51 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCFloatingButtonBuilder.h"
+
+#import "MDCFloatingButtonColorThemer.h"
+
+@implementation MDCFloatingButtonBuilder
++ (MDCFloatingButton *)floatingButtonWithScheme:(id<MDCColorScheme>)colorScheme {
+  MDCFloatingButton *button
+      = [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeDefault];
+
+  if (colorScheme) {
+    [MDCFloatingButtonColorThemer applyColorScheme:colorScheme toButton:button];
+  }
+
+  [button setElevation:3 forState:UIControlStateNormal];
+  [button setElevation:6 forState:UIControlStateHighlighted];
+
+  return button;
+}
+
++ (MDCFloatingButton *)extendedFloatingButtonWithScheme:(id<MDCColorScheme>)colorScheme {
+  MDCFloatingButton *button
+      = [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeDefault];
+
+  if (colorScheme) {
+    [MDCFloatingButtonColorThemer applyColorScheme:colorScheme toButton:button];
+  }
+
+  [button setElevation:3 forState:UIControlStateNormal];
+  [button setElevation:6 forState:UIControlStateHighlighted];
+
+  button.mode = MDCFloatingButtonModeExtended;
+  return button;
+}
+
+@end

--- a/components/Buttons/src/ColorThemer/MDCFloatingButtonBuilder.m
+++ b/components/Buttons/src/ColorThemer/MDCFloatingButtonBuilder.m
@@ -44,7 +44,7 @@
   [button setElevation:3 forState:UIControlStateNormal];
   [button setElevation:6 forState:UIControlStateHighlighted];
 
-  button.mode = MDCFloatingButtonModeExtended;
+  button.mode = MDCFloatingButtonModeExpanded;
   return button;
 }
 

--- a/components/Buttons/src/ColorThemer/MDCFloatingButtonColorThemer.h
+++ b/components/Buttons/src/ColorThemer/MDCFloatingButtonColorThemer.h
@@ -1,0 +1,26 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MaterialButtons.h"
+#import "MaterialThemes.h"
+
+@interface MDCFloatingButtonColorThemer : NSObject
+
++ (void)applyColorScheme:(id<MDCColorScheme>)colorScheme toButton:(MDCFloatingButton *)button;
+
+@end

--- a/components/Buttons/src/ColorThemer/MDCFloatingButtonColorThemer.m
+++ b/components/Buttons/src/ColorThemer/MDCFloatingButtonColorThemer.m
@@ -1,0 +1,28 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCFloatingButtonColorThemer.h"
+
+
+
+@implementation MDCFloatingButtonColorThemer
+
++ (void)applyColorScheme:(id<MDCColorScheme>)colorScheme toButton:(MDCFloatingButton *)button {
+  [button setBackgroundColor:UIColor.whiteColor forState:UIControlStateNormal];
+  button.tintColor = colorScheme.primaryColor;
+  [button setTitleColor:colorScheme.primaryColor forState:UIControlStateNormal];
+}
+@end

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -20,24 +20,45 @@
 #import "MDCButton.h"
 
 /**
- Shapes for Material Floating buttons.
+ Types of Material Floating buttons.
 
  The mini size should only be used when required for visual continuity with other elements on the
  screen.
  */
 typedef NS_ENUM(NSInteger, MDCFloatingButtonShape) {
   /**
-   A 56-point circular button surrounding a 24-point square icon or short text.
+   A 56-point circular button surrounding a 24-point or 36-point square icon or short text.
    */
   MDCFloatingButtonShapeDefault = 0,
   /**
    A 40-point circular button surrounding a 24-point square icon or short text.
    */
   MDCFloatingButtonShapeMini = 1,
+};
+
+typedef NS_ENUM(NSInteger, MDCFloatingButtonMode) {
   /**
-   A 56-point circular button surrounding a 36-point square icon or short text.
+   The floating button is a circle with its contents centered.
+   @c type initialization argument.
    */
-  MDCFloatingButtonShapeLargeIcon = 2
+  MDCFloatingButtonModeNormal = 0,
+
+  /**
+   The floating button is a "pill shape" with the image to one side of the title.
+   */
+  MDCFloatingButtonModeExtended = 1,
+};
+
+typedef NS_ENUM(NSInteger, MDCFloatingButtonImagePosition) {
+  /**
+   The image of the floating button is on the leading side of the title.
+   */
+  MDCFloatingButtonImagePositionLeading = 0,
+
+  /**
+   The image of the floating button is on the trailing side of the title.
+   */
+  MDCFloatingButtonImagePositionTrailing = 1,
 };
 
 /**
@@ -60,17 +81,38 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonShape) {
 + (nonnull instancetype)floatingButtonWithShape:(MDCFloatingButtonShape)shape;
 
 /**
- @return The default floating button size dimension.
+ The mode of the floating button can either be .normal (a circle) or .extended (a pill-shaped
+ rounded rectangle).
+
+ The default value is @c .normal .
  */
-+ (CGFloat)defaultDimension;
+@property(nonatomic, assign) MDCFloatingButtonMode mode UI_APPEARANCE_SELECTOR;
 
 /**
- @return The mini floating button size dimension.
+ The position of the image relative to the title. Flipped for right-to-left.
+
+ The default value is @c .leading .
  */
-+ (CGFloat)miniDimension;
+@property(nonatomic, assign) MDCFloatingButtonImagePosition imagePosition UI_APPEARANCE_SELECTOR;
 
 /**
- Initializes self to a button with the given @c shape.
+ If @c YES, any values for @c contentEdgeInsets:forShape:mode: will be flipped when the FAB is
+ in @c MDCFloatingButtonModeExtended and its @c imagePosition is
+ @c MDCFloatingButtonImagePositionTrailing.
+
+ The default value is NO.
+ */
+@property(nonatomic, assign) BOOL contentEdgeInsetsFlippedForTrailingImagePosition
+    UI_APPEARANCE_SELECTOR;
+
+/**
+ The horizontal padding between the |imageView| and |titleLabel| when the button is in its
+ "extended" mode.  If set to a negative value, the imageView and titleLabel may overlap.
+ */
+@property(nonatomic, assign) CGFloat imageTitlePadding UI_APPEARANCE_SELECTOR;
+
+/**
+ Initializes self to a button with the given @c shape with a @c .normal mode.
 
  @param frame Button frame.
  @param shape Button shape.
@@ -95,6 +137,30 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonShape) {
 - (nonnull instancetype)init;
 
 - (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
+
+- (void)setMinimumSize:(CGSize)minimumSize NS_UNAVAILABLE;
+
+- (void)setMinimumSize:(CGSize)minimumSize
+              forShape:(MDCFloatingButtonShape)shape
+                  mode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
+
+- (void)setMaximumSize:(CGSize)maximumSize NS_UNAVAILABLE;
+
+- (void)setMaximumSize:(CGSize)maximumSize
+              forShape:(MDCFloatingButtonShape)shape
+                  mode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
+
+- (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets NS_UNAVAILABLE;
+
+- (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets
+                    forShape:(MDCFloatingButtonShape)shape
+                        mode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
+
+- (void)setHitAreaInsets:(UIEdgeInsets)hitAreaInsets NS_UNAVAILABLE;
+
+- (void)setHitAreaInsets:(UIEdgeInsets)insets
+                forShape:(MDCFloatingButtonShape)shape
+                    mode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
 
 #pragma mark - Deprecations
 

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -89,21 +89,11 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImagePosition) {
 @property(nonatomic, assign) MDCFloatingButtonMode mode UI_APPEARANCE_SELECTOR;
 
 /**
- The position of the image relative to the title. Flipped for right-to-left.
+ The position of the image relative to the title.
 
  The default value is @c .leading .
  */
 @property(nonatomic, assign) MDCFloatingButtonImagePosition imagePosition UI_APPEARANCE_SELECTOR;
-
-/**
- If @c YES, any values for @c contentEdgeInsets:forShape:mode: will be flipped when the FAB is
- in @c MDCFloatingButtonModeExtended and its @c imagePosition is
- @c MDCFloatingButtonImagePositionTrailing.
-
- The default value is NO.
- */
-@property(nonatomic, assign) BOOL contentEdgeInsetsFlippedForTrailingImagePosition
-    UI_APPEARANCE_SELECTOR;
 
 /**
  The horizontal padding between the |imageView| and |titleLabel| when the button is in its

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -20,7 +20,7 @@
 #import "MDCButton.h"
 
 /**
- Types of Material Floating buttons.
+ Shapes for Material Floating buttons.
 
  The mini size should only be used when required for visual continuity with other elements on the
  screen.
@@ -46,7 +46,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonMode) {
   /**
    The floating button is a "pill shape" with the image to one side of the title.
    */
-  MDCFloatingButtonModeExtended = 1,
+  MDCFloatingButtonModeExpanded = 1,
 };
 
 typedef NS_ENUM(NSInteger, MDCFloatingButtonImagePosition) {
@@ -81,7 +81,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImagePosition) {
 + (nonnull instancetype)floatingButtonWithShape:(MDCFloatingButtonShape)shape;
 
 /**
- The mode of the floating button can either be .normal (a circle) or .extended (a pill-shaped
+ The mode of the floating button can either be .normal (a circle) or .expanded (a pill-shaped
  rounded rectangle).
 
  The default value is @c .normal .
@@ -97,7 +97,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImagePosition) {
 
 /**
  The horizontal padding between the |imageView| and |titleLabel| when the button is in its
- "extended" mode.  If set to a negative value, the imageView and titleLabel may overlap.
+ "expanded" mode.  If set to a negative value, the imageView and titleLabel may overlap.
  */
 @property(nonatomic, assign) CGFloat imageTitlePadding UI_APPEARANCE_SELECTOR;
 


### PR DESCRIPTION
API/Design review of Extended FAB. Based on previous discussions with
@randallli and @ianegordon.

## UIAppearance supported properties:
* (New) imageTitlePadding - the space between the title and image
  views.
* (New) imagePosition - whether the image leads or trails the title.
* contentEdgeInsets (via forMode:)
* minimumSize (via forMode:)
* maximumSize (via forMode:)
* hitAreaInsets (via forMode:)

## Removal of "LargeIcon" shape in favor of simplified contentEdgeInsets
* "Default" and "Mini" will be only remaining types (removes LargeIcon
  shape)
* Type cannot change for an instance of Floating Button

"Extended" support is provided by a new "mode" property. It is not
proxied via UIAppearance because the design guidance states that usage
is based on the available screen size.

## Example support classes:
* Color themer
* "All the things" themer
* Builder for basic FAB/Extended FAB