### PR TITLE
[CocoaPods] Make Earl Grey optional for Catalog

### DIFF
--- a/catalog/Podfile
+++ b/catalog/Podfile
@@ -72,6 +72,11 @@ post_install do |installer|
   # EarlGrey configuration
   earl_grey_dir = "#{File.dirname(__FILE__)}/third_party/EarlGrey"
   `git submodule update --init #{earl_grey_dir}`
-  load "#{earl_grey_dir}/gem/lib/earlgrey/configure_earlgrey.rb"
-  configure_for_earlgrey(installer, PROJECT_NAME, TEST_TARGET, SCHEME_FILE)
+  if $?.exitstatus == 0 
+    load "#{earl_grey_dir}/gem/lib/earlgrey/configure_earlgrey.rb"
+    configure_for_earlgrey(installer, PROJECT_NAME, TEST_TARGET, SCHEME_FILE)
+  else
+    puts "Earl Grey submodule update failed. If this project is not a git "\
+         "repository, then this is fine." 
+  end
 end


### PR DESCRIPTION
The catalog Podfile includes a section to update the Earl Grey git submodule.
However, if the project is downloaded from GitHub as an archive, there is no
git metadata available. Since the Earl Grey Xcode scheme is not necessary to
build the Catalog project, it can be skipped with an error message.

Closes #2493
