### PR TITLE
[FlexibleHeader] Fix bug where insets wouldn't be removed from the old tracking scroll view when a new one was set.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -519,7 +519,9 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 }
 
 - (void)fhv_removeInsetsFromScrollView:(UIScrollView *)scrollView {
-  if (!scrollView) {
+  NSAssert(scrollView != _trackingScrollView,
+           @"Invalid attempt to remove insets from the tracking scroll view.");
+  if (!scrollView || scrollView == _trackingScrollView) {
     return;
   }
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1164,15 +1164,16 @@ static BOOL isRunningiOS10_3OrAbove() {
 #endif  // #if 0
 #endif  // #if DEBUG
 
-  // If this header is shared by many scroll views then we leave the insets when switching the
-  // tracking scroll view.
-  if (!_sharedWithManyScrollViews) {
-    [self fhv_removeInsetsFromScrollView:_trackingScrollView];
-  }
+  UIScrollView *oldTrackingScrollView = _trackingScrollView;
 
   BOOL wasTrackingScrollView = _trackingScrollView != nil;
-
   _trackingScrollView = trackingScrollView;
+
+  // If this header is shared by many scroll views then we leave the insets when switching the
+  // tracking scroll view.
+  if (!_sharedWithManyScrollViews && wasTrackingScrollView) {
+    [self fhv_removeInsetsFromScrollView:oldTrackingScrollView];
+  }
 
   _shiftAccumulatorLastContentOffsetIsValid = NO;
   _shiftAccumulatorLastContentOffset = _trackingScrollView.contentOffset;


### PR DESCRIPTION
We now change the tracking scroll view before removing insets on the old scroll view.

Prior to this change, we would invoke `fhv_removeInsetsFromScrollView` on the current tracking scroll view. This would result in the tracking scroll view's `scrollViewDidScroll` event immediately firing, and our `fhv_enforceInsetsForScrollView` method being called on the same tracking scroll view. This resulted in the content insets not actually being removed from the old tracking scroll view.

After this change, we update the trackingScrollView property's ivar prior to calling `fhv_removeInsetsFromScrollView` so that when the `scrollViewDidScroll` event gets fired we don't process the event.