### PR TITLE
[docs] Updated with new automated release process

### DIFF
--- a/contributing/hotfixing.md
+++ b/contributing/hotfixing.md
@@ -13,11 +13,10 @@ https://github.com/material-components/material-components-ios/issues/294
 
 Run the following command to cut a release:
 
-    scripts/release/cut --hotfix
+    scripts/release cut --hotfix
 
 A hotfix branch is like a release branch, but its scope is limited specifically to the fix. In other
 words, the hotfix branch must start from `origin/stable`.
-
 
 ### Follow the releasing process
 

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -58,15 +58,15 @@ The `scripts/release/cut` script will output the body of an email you should now
 clients can test the release.
 
 > Kokoro will begin testing the release candidate each time the branch is pushed to GitHub.
-> View the [release-candidate job](https://kokoro.corp.google.com/job/MaterialComponents_iOS/job/macos_external/job/release-candidate/)
+> [View the release-candidate jobs](https://kokoro.corp.google.com/job/MaterialComponents_iOS/job/macos_external/)
 > in order to assess the status of the release.
 
 ### Test the release branch
 
-Release testing is automated via the `.kokoro-release` script located in the root of the repo.
+Release testing is automated via the `.kokoro` script located in the root of the repo.
 You can run this script locally if the continuous integration fails.
 
-    ./.kokoro-release
+    ./.kokoro
 
 Identify why any failures occurred and resolve them before landing the release.
 

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -15,17 +15,6 @@ Occasionally there are temporary issues with the release process, check the [`re
 tag](https://github.com/material-components/material-components-ios/labels/is%3ABlocking%20next%20release) for
 anything that might be affecting the release.
 
-### Check the release milestone
-
-We use weekly release milestones to track important issues that need to land in a given release.
-These issues may come from client teams that are shipping to the App Store on a given date.
-
-Look in the [Tasks for Next Release
-milestone](https://github.com/material-components/material-components-ios/milestone/10) for issues
-that must be resolved before or during release. If there are open issues you must identify why the
-issues are still open and either close them if resolved or determine whether it's acceptable to move
-the issue to a subsequent release.
-
 ## Cutting and testing the release
 
 ### Reset your state

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -38,32 +38,37 @@ Releasing is important enough that we want to start with a clean slate:
 
 ### Cut a release branch and notify clients
 
-Verify that there are no existing release-candidate branches either locally or on origin:
-
-    git fetch -a
-    git remote prune origin
-    git branch -a | grep release-candidate
-
 Run the following command to cut a release:
 
     scripts/release/cut
     git add CHANGELOG.md
     git commit -m "Cut release candidate."
 
-You will now have a local `release-candidate` branch and a new section in CHANGELOG.md titled
-"release-candidate".
+> This command will fail if you have already cut a release-candidate. If this happens,
+> inspect the state of your local release-candidate branch and consider deleting it if it is
+> stale.
+>
+>    git branch -D release-candidate
+
+You will now have a local `release-candidate` branch, a new section in CHANGELOG.md titled
+"release-candidate", and the `release-candidate` branch will have been pushed to GitHub.
 
 The `scripts/release/cut` script will output the body of an email you should now send to the
 [discussion list](https://groups.google.com/forum/#!forum/material-components-ios-discuss) so
 clients can test the release.
 
+> Kokoro will begin testing the release candidate each time the branch is pushed to GitHub.
+> View the [release-candidate job](https://kokoro.corp.google.com/job/MaterialComponents_iOS/job/macos_external/job/release-candidate/)
+> in order to assess the status of the release.
+
 ### Test the release branch
 
-    scripts/prep_all
-    scripts/build_all
-    scripts/test_all
+Release testing is automated via the `.kokoro-release` script located in the root of the repo.
+You can run this script locally if the continuous integration fails.
 
-Identify why any failures occurred and resolve them before continuing.
+    ./.kokoro-release
+
+Identify why any failures occurred and resolve them before landing the release.
 
 > Push `release-candidate` to GitHub with `git push origin release-candidate` as you make changes.
 > This allows other people and machines to track the progress of the release.

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -96,15 +96,6 @@ Inspect changes to public component headers and manually generate the API diff b
 
     scripts/release/diff components/*/src/*.h
 
-~~Generate the API diff using scripts/release/api_diff:~~
-
-**The api_diff script is broken. Manually generate the API diff using scripts/release/diff as noted above and continue to the next step, Commit the changes. - Mar.28,2017 (ianegordon)**
-
-    scripts/release/api_diff
-
-- Append the command's output to CHANGELOG.md's "release-candidate" section.
-- Delete any component sections that state "No public API changes detected."
-
 Commit the changes to the release branch.
 
     git add CHANGELOG.md

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -29,7 +29,7 @@ Run the following command to cut a release:
 You will now have a local `release-candidate` branch, a new section in CHANGELOG.md titled
 "release-candidate", and the `release-candidate` branch will have been pushed to GitHub.
 
-The `scripts/release/cut` script will output the body of an email you should now send to the
+The `scripts/release cut` script will output the body of an email you should now send to the
 [discussion list](https://groups.google.com/forum/#!forum/material-components-ios-discuss) so
 clients can test the release.
 

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -50,17 +50,10 @@ clients can test the release.
 > [View the release-candidate jobs](https://kokoro.corp.google.com/job/MaterialComponents_iOS/job/macos_external/)
 > in order to assess the status of the release.
 
-### Test the release branch
+### Resolve any failures
 
-Release testing is automated via the `.kokoro` script located in the root of the repo.
-You can run this script locally if the continuous integration fails.
-
-    ./.kokoro
-
-Identify why any failures occurred and resolve them before landing the release.
-
-> Push `release-candidate` to GitHub with `git push origin release-candidate` as you make changes.
-> This allows other people and machines to track the progress of the release.
+Push `release-candidate` to GitHub with `git push origin release-candidate` as you make changes.
+This allows other people and machines to track the progress of the release.
 
 #### Making changes
 


### PR DESCRIPTION
The release-candidate is now tested automatically using a custom kokoro job that is dedicated to running our release scripts. This removes the need to run the scripts locally and serves as a launching point for automating other aspects of the release.