### PR TITLE
[ShadowLayer] Remove excess animation code

### DIFF
--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -199,7 +199,10 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
 
     headerViewController.headerView.setShadowLayer(MDCShadowLayer()) { (layer, intensity) in
       let shadowLayer = layer as? MDCShadowLayer
+      CATransaction.begin()
+      CATransaction.setDisableActions(true)
       shadowLayer!.elevation = ShadowElevation(intensity * ShadowElevation.appBar.rawValue)
+      CATransaction.commit()
     }
 
     view.addSubview(headerViewController.view)

--- a/components/ShadowLayer/examples/ExampleShadowedView.swift
+++ b/components/ShadowLayer/examples/ExampleShadowedView.swift
@@ -28,14 +28,4 @@ class ExampleShadowedView: UIView {
   var shadowLayer: MDCShadowLayer {
     return self.layer as! MDCShadowLayer
   }
-
-  var elevation: ShadowElevation {
-    get {
-      return self.shadowLayer.elevation
-    }
-    set {
-      self.shadowLayer.elevation = newValue
-    }
-  }
-
 }

--- a/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
+++ b/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
@@ -35,7 +35,12 @@ class ShadowDragSquareExampleViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    self.blueView.elevation = .cardResting
+    // MDCShadowLayer's elevation will implicitly animate when changed, so to disable that behavior
+    // we need to disable Core Animation actions inside of a transaction:
+    CATransaction.begin()
+    CATransaction.setDisableActions(true)
+    self.blueView.shadowLayer.elevation = .cardResting
+    CATransaction.commit()
 
     longPressRecogniser.addTarget(self, action: #selector(longPressedInView))
     longPressRecogniser.minimumPressDuration = 0.0
@@ -46,18 +51,20 @@ class ShadowDragSquareExampleViewController: UIViewController {
     // Elevation of the view is changed to indicate that it has been pressed or released.
     // view.center is changed to follow the touch events.
     if sender.state == .began {
-      self.blueView.elevation = .cardPickedUp
+      self.blueView.shadowLayer.elevation = .cardPickedUp
 
       let selfPoint = sender.location(in: self.view)
       movingViewOffset.x = selfPoint.x - self.blueView.center.x
       movingViewOffset.y = selfPoint.y - self.blueView.center.y
+
     } else if sender.state == .changed {
       let selfPoint = sender.location(in: self.view)
       let newCenterPoint =
           CGPoint(x: selfPoint.x - movingViewOffset.x, y: selfPoint.y - movingViewOffset.y)
       self.blueView.center = newCenterPoint
+
     } else if sender.state == .ended {
-      self.blueView.elevation = .cardResting
+      self.blueView.shadowLayer.elevation = .cardResting
 
       movingViewOffset = CGPoint.zero
     }

--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -282,50 +282,9 @@ static NSString *const MDCShadowLayerShadowMaskEnabledKey = @"MDCShadowLayerShad
 
 - (void)setElevation:(CGFloat)elevation {
   _elevation = elevation;
+
   MDCShadowMetrics *shadowMetrics = [MDCShadowMetrics metricsWithElevation:elevation];
-  [self setMetrics:shadowMetrics];
-}
 
-- (void)setMetrics:(MDCShadowMetrics *)shadowMetrics {
-  CABasicAnimation *topOffsetAnimation = [CABasicAnimation animationWithKeyPath:@"shadowOffset"];
-  topOffsetAnimation.fromValue = nil;
-  topOffsetAnimation.toValue = [NSValue valueWithCGSize:shadowMetrics.topShadowOffset];
-
-  CABasicAnimation *bottomOffsetAnimation = [CABasicAnimation animationWithKeyPath:@"shadowOffset"];
-  bottomOffsetAnimation.fromValue = nil;
-  bottomOffsetAnimation.toValue = [NSValue valueWithCGSize:shadowMetrics.bottomShadowOffset];
-
-  CABasicAnimation *topRadiusAnimation = [CABasicAnimation animationWithKeyPath:@"shadowRadius"];
-  topRadiusAnimation.fromValue = nil;
-  topRadiusAnimation.toValue = @(shadowMetrics.topShadowRadius);
-
-  CABasicAnimation *bottomRadiusAnimation = [CABasicAnimation animationWithKeyPath:@"shadowRadius"];
-  bottomRadiusAnimation.fromValue = nil;
-  bottomRadiusAnimation.toValue = @(shadowMetrics.bottomShadowRadius);
-
-  CABasicAnimation *topOpacityAnimation = [CABasicAnimation animationWithKeyPath:@"shadowOpacity"];
-  topOpacityAnimation.fromValue = nil;
-  topOpacityAnimation.toValue = @(shadowMetrics.topShadowOpacity);
-
-  CABasicAnimation *bottomOpacityAnimation =
-      [CABasicAnimation animationWithKeyPath:@"shadowOpacity"];
-  bottomOpacityAnimation.fromValue = nil;
-  bottomOpacityAnimation.toValue = @(shadowMetrics.bottomShadowOpacity);
-
-  // Group all animations together.
-  CAAnimationGroup *topAnimations = [CAAnimationGroup animation];
-  topAnimations.animations = @[ topOffsetAnimation, topRadiusAnimation, topOpacityAnimation ];
-
-  CAAnimationGroup *bottomAnimations = [CAAnimationGroup animation];
-  bottomAnimations.animations =
-      @[ bottomOffsetAnimation, bottomRadiusAnimation, bottomOpacityAnimation ];
-
-  [_topShadow removeAllAnimations];
-  [_bottomShadow removeAllAnimations];
-  [_topShadow addAnimation:topAnimations forKey:nil];
-  [_bottomShadow addAnimation:bottomAnimations forKey:nil];
-
-  // Set the final animation value in to the model layer.
   _topShadow.shadowOffset = shadowMetrics.topShadowOffset;
   _topShadow.shadowRadius = shadowMetrics.topShadowRadius;
   _topShadow.shadowOpacity = shadowMetrics.topShadowOpacity;


### PR DESCRIPTION
The explicit CAAnimations being created in the shadow layer were doing nothing, they have been removed. Instead, the shadow layer now simply sets the sub-layer properties and depends on the client to configure the CATransaction to determine the animation timing.

For example, to change the elevation without animating:

```swift
CATransaction.begin()
CATransaction.setDisableActions(true)
self.blueView.shadowLayer.elevation = .cardResting
CATransaction.commit()
```

To change the elevation with animation:

```swift
CATransaction.begin()
CATransaction.setAnimationDuration(0.2)
self.blueView.shadowLayer.elevation = .cardResting
CATransaction.commit()
```

To change the animation using a MotionAnimator:

```swift
let animator = MotionAnimator()
animator.animate(with: timing) {
  self.blueView.shadowLayer.elevation = .cardPickedUp
}
```
