### PR TITLE
[Dialogs] allow modal presentation of a new VC in the alert action handler without warning.

### DIFF
--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -241,11 +241,11 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   NSInteger actionIndex = [self.actionButtons indexOfObject:sender];
   MDCAlertAction *action = self.actions[actionIndex];
 
-  if (action.completionHandler) {
-    action.completionHandler(action);
-  }
-
-  [self.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
+  [self.presentingViewController dismissViewControllerAnimated:YES completion:^{
+    if (action.completionHandler) {
+      action.completionHandler(action);
+    }
+  }];
 }
 
 #pragma mark - UIViewController


### PR DESCRIPTION
This PR helps resolve issue #1885 

By having the completion handler issued only after the current VC (the alert controller) has been dismissed, we are able to present a new VC in the completion handler successfully without a warning. The new behavior is now on par with how the UIAlertController behaves in such a scenario.