### PR TITLE
[Tabs] Add missing import

### DIFF
--- a/components/Tabs/src/private/MDCTabBarIndicatorView.h
+++ b/components/Tabs/src/private/MDCTabBarIndicatorView.h
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#import <UIKit/UIKit.h>
+
 @class MDCTabBarIndicatorAttributes;
 
 /** View responsible for drawing the indicator behind tab content and animating changes. */


### PR DESCRIPTION
This was originally part of the 40.1.0 release but didn't land in stable due to an incorrect merge. This will land in a 40.1.1 hot-fix release as a result.