### PR TITLE
[BottomSheet] Deprecate to-be-removed APIs.

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -22,7 +22,10 @@
 
 #import <MotionTransitioning/MotionTransitioning.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 @interface MDCBottomSheetController () <MDCBottomSheetPresentationControllerDelegate>
+#pragma clang diagnostic pop
 @end
 
 @implementation MDCBottomSheetController {
@@ -56,7 +59,10 @@
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   self.mdc_bottomSheetPresentationController.delegate = self;
+#pragma clang diagnostic pop
 
   [self.contentViewController.view layoutIfNeeded];
 }
@@ -86,8 +92,11 @@
   _transition.trackingScrollView = trackingScrollView;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)bottomSheetPresentationControllerDidDismissBottomSheet:
     (nonnull __unused MDCBottomSheetPresentationController *)bottomSheet {
+#pragma clang diagnostic pop
   [self.delegate bottomSheetControllerDidDismissBottomSheet:self];
 }
 

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -21,8 +21,7 @@
 /**
  Delegate for MDCBottomSheetPresentationController.
  */
-__deprecated_msg("Assign an instance of MDCBottomSheetTransition to your view controller's "
-                 "mdm_transitionController.transition instead.")
+__deprecated_msg("This API will soon be made private. Use MDCBottomSheetController instead.")
 @protocol MDCBottomSheetPresentationControllerDelegate <UIAdaptivePresentationControllerDelegate>
 @optional
 
@@ -50,8 +49,7 @@ __deprecated_msg("Assign an instance of MDCBottomSheetTransition to your view co
 /**
  A UIPresentationController for presenting a modal view controller as a bottom sheet.
  */
-__deprecated_msg("Assign an instance of MDCBottomSheetTransition to your view controller's "
-                 "mdm_transitionController.transition instead.")
+__deprecated_msg("This API will soon be made private. Use MDCBottomSheetController instead.")
 @interface MDCBottomSheetPresentationController : UIPresentationController
 
 /**

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -21,11 +21,8 @@
 /**
  Delegate for MDCBottomSheetPresentationController.
  */
-// TODO( https://github.com/material-components/material-components-ios/issues/2418 ):
-// Enable deprecation once internal clients have migrated to the new APIs or until a reasonable
-// period of time has passed.
-//__deprecated_msg("Assign an instance of MDCBottomSheetTransition to your view controller's "
-//                 "mdm_transitionController.transition instead.")
+__deprecated_msg("Assign an instance of MDCBottomSheetTransition to your view controller's "
+                 "mdm_transitionController.transition instead.")
 @protocol MDCBottomSheetPresentationControllerDelegate <UIAdaptivePresentationControllerDelegate>
 @optional
 
@@ -53,11 +50,8 @@
 /**
  A UIPresentationController for presenting a modal view controller as a bottom sheet.
  */
-// TODO( https://github.com/material-components/material-components-ios/issues/2418 ):
-// Enable deprecation once internal clients have migrated to the new APIs or until a reasonable
-// period of time has passed.
-//__deprecated_msg("Assign an instance of MDCBottomSheetTransition to your view controller's "
-//                 "mdm_transitionController.transition instead.")
+__deprecated_msg("Assign an instance of MDCBottomSheetTransition to your view controller's "
+                 "mdm_transitionController.transition instead.")
 @interface MDCBottomSheetPresentationController : UIPresentationController
 
 /**

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.h
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.h
@@ -31,11 +31,8 @@
  The presenting UIViewController then calls presentViewController:animated:completion:
  [rootViewController presentViewController:myDialogViewController animated:YES completion:...];
  */
-// TODO( https://github.com/material-components/material-components-ios/issues/2418 ):
-// Enable deprecation once internal clients have migrated to the new APIs or until a reasonable
-// period of time has passed.
-//__deprecated_msg("Assign an instance of MDCBottomSheetTransition to your view controller's "
-//                 "mdm_transitionController.transition instead.")
+__deprecated_msg("Assign an instance of MDCBottomSheetTransition to your view controller's "
+                 "mdm_transitionController.transition instead.")
 @interface MDCBottomSheetTransitionController
     : NSObject <UIViewControllerAnimatedTransitioning, UIViewControllerTransitioningDelegate>
 

--- a/components/BottomSheet/src/UIViewController+MaterialBottomSheet.h
+++ b/components/BottomSheet/src/UIViewController+MaterialBottomSheet.h
@@ -29,12 +29,12 @@
  @return nil if the view controller is not managed by a Material bottom sheet presentation
  controller.
  */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 @property(nonatomic, nullable, readonly)
-    MDCBottomSheetPresentationController *mdc_bottomSheetPresentationController;
-// TODO( https://github.com/material-components/material-components-ios/issues/2418 ):
-// Enable deprecation once internal clients have migrated to the new APIs or until a reasonable
-// period of time has passed.
-//    __deprecated_msg("Assign an instance of MDCBottomSheetTransition to your view controller's "
-//                     "mdm_transitionController.transition instead.");
+    MDCBottomSheetPresentationController *mdc_bottomSheetPresentationController
+    __deprecated_msg("Assign an instance of MDCBottomSheetTransition to your view controller's "
+                     "mdm_transitionController.transition instead.");
+#pragma clang diagnostic pop
 
 @end

--- a/components/BottomSheet/src/UIViewController+MaterialBottomSheet.m
+++ b/components/BottomSheet/src/UIViewController+MaterialBottomSheet.m
@@ -20,11 +20,14 @@
 
 @implementation UIViewController (MaterialBottomSheet)
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (MDCBottomSheetPresentationController *)mdc_bottomSheetPresentationController {
   id presentationController = self.presentationController;
   if ([presentationController isKindOfClass:[MDCBottomSheetPresentationController class]]) {
     return (MDCBottomSheetPresentationController *)presentationController;
   }
+#pragma clang diagnostic pop
 
   return nil;
 }


### PR DESCRIPTION
These APIs will either be made private or deleted altogether in an effort to reduce the public surface area of the BottomSheet component.

The final API will consist of the following:

- `MDCBottomSheetController`: the easiest integration point for a bottom sheet. Implements accessibility escape gesture support.
- `MDCBottomSheetTransition`: the Material Motion transition entry-point. This may be where the transition is customized by clients in the future.