### PR TITLE
[Buttons] Expose Extended FAB properties

### DIFF
--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -52,7 +52,9 @@
   self.flatButton.inkColor = [UIColor colorWithWhite:1.0 alpha:0.1];
   self.flatButton.contentEdgeInsets = UIEdgeInsetsMake(64, 64, 0, 0);
   self.raisedButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, 64, 64);
-  self.floatingActionButton.contentEdgeInsets = UIEdgeInsetsMake(40, 40, 0, 0);
+  [self.floatingActionButton setContentEdgeInsets:UIEdgeInsetsMake(40, 40, 0, 0)
+                                         forShape:MDCFloatingButtonShapeDefault
+                                           inMode:MDCFloatingButtonModeNormal];
 
   [self updateInkStyle:self.inkBoundingSwitch.isOn ? MDCInkStyleBounded : MDCInkStyleUnbounded];
 }

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -141,9 +141,32 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
 - (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
 
 - (void)setMinimumSize:(CGSize)size NS_UNAVAILABLE;
-- (void)setMinimumSize:(CGSize)size
+
+/**
+ Sets the minimum size when the button has the provided @c shape and in the provided @c mode.
+ Setting a size of @c CGSizeZero will is equivalent to no minimum size.
+
+ @param minimumSize The new minimum size of the button.
+ @param shape The shape that the size constrains.
+ @param mode The mode that the size constrains.
+ */
+- (void)setMinimumSize:(CGSize)minimumSize
               forShape:(MDCFloatingButtonShape)shape
-                inMode:(MDCFloatingButtonMode)mode;
+                inMode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
+
+- (void)setMaximumSize:(CGSize)maximumSize NS_UNAVAILABLE;
+
+/**
+ Sets the maximum size when the button has the provided @c shape and in the provided @c mode.
+ Setting a size of @c CGSizeZero will is equivalent to no maximum size.
+
+ @param maximumSize The new maximum size of the button.
+ @param shape The shape that the size constrains.
+ @param mode The mode that the size constrains.
+ */
+- (void)setMaximumSize:(CGSize)maximumSize
+              forShape:(MDCFloatingButtonShape)shape
+                inMode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
 
 #pragma mark - Deprecations
 

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -143,7 +143,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
 - (void)setMinimumSize:(CGSize)size NS_UNAVAILABLE;
 
 /**
- Sets the minimum size when the button has the specified @c shape and in the specified @c mode.
+ Sets the minimum size when the button has the specified @c shape @c mode.
  Setting a size of @c CGSizeZero will is equivalent to no minimum size.
 
  @param minimumSize The new minimum size of the button.
@@ -157,7 +157,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
 - (void)setMaximumSize:(CGSize)maximumSize NS_UNAVAILABLE;
 
 /**
- Sets the maximum size when the button has the specified @c shape and in the specified @c mode.
+ Sets the maximum size when the button has the specified @c shape and @c mode.
  Setting a size of @c CGSizeZero will is equivalent to no maximum size.
 
  @param maximumSize The new maximum size of the button.
@@ -171,8 +171,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
 - (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets NS_UNAVAILABLE;
 
 /**
- Sets the @c contentEdgeInsets value when the button has the specified @c shape and in the specified
- @c mode.
+ Sets the @c contentEdgeInsets value when the button has the specified @c shape and @c mode.
 
  @param contentEdgeInsets The new content edge insets value.
  @param shape The shape for the content edge insets.
@@ -181,6 +180,19 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
 - (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets
                     forShape:(MDCFloatingButtonShape)shape
                       inMode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
+
+- (void)setHitAreaInsets:(UIEdgeInsets)hitAreaInsets NS_UNAVAILABLE;
+
+/**
+ Sets the @c hitAreaInsets value when the button has the specified @c shape and @c mode.
+
+ @param hitAreaInsets The new hit area insets value.
+ @param shape The shape for the hit area insets.
+ @param mode The mode for the hit area insets.
+ */
+- (void)setHitAreaInsets:(UIEdgeInsets)hitAreaInsets
+                forShape:(MDCFloatingButtonShape)shape
+                  inMode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
 
 #pragma mark - Deprecations
 

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -143,7 +143,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
 - (void)setMinimumSize:(CGSize)size NS_UNAVAILABLE;
 
 /**
- Sets the minimum size when the button has the provided @c shape and in the provided @c mode.
+ Sets the minimum size when the button has the specified @c shape and in the specified @c mode.
  Setting a size of @c CGSizeZero will is equivalent to no minimum size.
 
  @param minimumSize The new minimum size of the button.
@@ -157,7 +157,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
 - (void)setMaximumSize:(CGSize)maximumSize NS_UNAVAILABLE;
 
 /**
- Sets the maximum size when the button has the provided @c shape and in the provided @c mode.
+ Sets the maximum size when the button has the specified @c shape and in the specified @c mode.
  Setting a size of @c CGSizeZero will is equivalent to no maximum size.
 
  @param maximumSize The new maximum size of the button.
@@ -167,6 +167,20 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
 - (void)setMaximumSize:(CGSize)maximumSize
               forShape:(MDCFloatingButtonShape)shape
                 inMode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
+
+- (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets NS_UNAVAILABLE;
+
+/**
+ Sets the @c contentEdgeInsets value when the button has the specified @c shape and in the specified
+ @c mode.
+
+ @param contentEdgeInsets The new content edge insets value.
+ @param shape The shape for the content edge insets.
+ @param mode The mode for the content edge insets.
+ */
+- (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets
+                    forShape:(MDCFloatingButtonShape)shape
+                      inMode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
 
 #pragma mark - Deprecations
 

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -71,6 +71,30 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
  */
 @interface MDCFloatingButton : MDCButton
 
+
+/**
+ The mode of the floating button can either be .normal (a circle) or .expanded (a pill-shaped
+ rounded rectangle).
+
+ The default value is @c .normal .
+ */
+@property(nonatomic, assign) MDCFloatingButtonMode mode;
+
+/**
+ The location of the image relative to the title when the floating button is in @c expanded mode.
+
+ The default value is @c .leading .
+ */
+@property(nonatomic, assign) MDCFloatingButtonImageLocation imageLocation UI_APPEARANCE_SELECTOR;
+
+/**
+ The horizontal spacing in points between the @c imageView and @c titleLabel when the button is in
+ @c .expanded mode. If set to a negative value, the image and title may overlap.
+
+ The default value is 8.
+ */
+@property(nonatomic, assign) CGFloat imageTitleSpacing UI_APPEARANCE_SELECTOR;
+
 /**
  Returns a MDCFloatingButton with default colors and the given @c shape.
 
@@ -115,6 +139,11 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
 - (nonnull instancetype)init;
 
 - (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
+
+- (void)setMinimumSize:(CGSize)size NS_UNAVAILABLE;
+- (void)setMinimumSize:(CGSize)size
+              forShape:(MDCFloatingButtonShape)shape
+                inMode:(MDCFloatingButtonMode)mode;
 
 #pragma mark - Deprecations
 

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -144,7 +144,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
 
 /**
  Sets the minimum size when the button has the specified @c shape @c mode.
- Setting a size of @c CGSizeZero will is equivalent to no minimum size.
+ Setting a size of @c CGSizeZero is equivalent to no minimum size.
 
  @param minimumSize The new minimum size of the button.
  @param shape The shape that the size constrains.
@@ -158,7 +158,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
 
 /**
  Sets the maximum size when the button has the specified @c shape and @c mode.
- Setting a size of @c CGSizeZero will is equivalent to no maximum size.
+ Setting a size of @c CGSizeZero is equivalent to no maximum size.
 
  @param maximumSize The new maximum size of the button.
  @param shape The shape that the size constrains.

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -92,7 +92,9 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
   if (self) {
     _shape = shape;
     [self commonMDCFloatingButtonInit];
-    [self updateShape];
+    // The superclass sets contentEdgeInsets from defaultContentEdgeInsets before the _shape is set.
+    // Set contentEdgeInsets again to ensure the defaults are for the correct shape.
+    [self updateShape:NO];
   }
   return self;
 }
@@ -137,7 +139,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
           [aDecoder decodeObjectForKey:MDCFloatingButtonHitAreaInsetsDictionaryKey];
     }
 
-    [self updateShape];
+    [self updateShape:NO];
   }
   return self;
 }
@@ -206,11 +208,6 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
   _shapeToModeToHitAreaInsets =
       [@{ @(MDCFloatingButtonShapeMini) : miniHitAreaInsets,
           } mutableCopy];
-
-  // The superclass sets contentEdgeInsets from defaultContentEdgeInsets before the _shape is set.
-  // Set contentEdgeInsets again to ensure the defaults are for the correct shape.
-  [self updateContentEdgeInsets];
-  [self updateHitAreaInsets];
 }
 
 #pragma mark - UIView
@@ -350,7 +347,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
   BOOL needsShapeUpdate = _mode != mode;
   _mode = mode;
   if (needsShapeUpdate) {
-    [self updateShape];
+    [self updateShape:YES];
   }
 }
 
@@ -364,7 +361,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
   }
   modeToMinimumSize[@(mode)] = [NSValue valueWithCGSize:size];
   if (shape == _shape && mode == _mode) {
-    [self updateShape];
+    [self updateShape:YES];
   }
 }
 
@@ -403,7 +400,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
   }
   modeToMaximumSize[@(mode)] = [NSValue valueWithCGSize:size];
   if (shape == _shape && mode == self.mode) {
-    [self updateShape];
+    [self updateShape:YES];
   }
 }
 
@@ -443,7 +440,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
   }
   modeToContentEdgeInsets[@(mode)] = [NSValue valueWithUIEdgeInsets:contentEdgeInsets];
   if (shape == _shape && mode == self.mode) {
-    [self updateShape];
+    [self updateShape:YES];
   }
 }
 
@@ -475,7 +472,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
   }
   modeToHitAreaInsets[@(mode)] = [NSValue valueWithUIEdgeInsets:insets];
   if (shape == _shape && mode == self.mode) {
-    [self updateShape];
+    [self updateShape:NO];
   }
 }
 
@@ -497,13 +494,13 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
   super.hitAreaInsets = [self hitAreaInsetsForMode:self.mode];
 }
 
-- (void)updateShape {
+- (void)updateShape:(BOOL)forceResize {
   BOOL needsLayout = [self updateMinimumSize];
   needsLayout |= [self updateMaximumSize];
   [self updateContentEdgeInsets];
   [self updateHitAreaInsets];
 
-  if (needsLayout) {
+  if (forceResize && needsLayout) {
     [self invalidateIntrinsicContentSize];
     [self sizeToFit];
   }

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -154,6 +154,8 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
                 forKey:MDCFloatingButtonMaximumSizeDictionaryKey];
   [aCoder encodeObject:self.shapeToModeToContentEdgeInsets
                 forKey:MDCFloatingButtonContentEdgeInsetsDictionaryKey];
+  [aCoder encodeObject:self.shapeToModeToHitAreaInsets
+                forKey:MDCFloatingButtonHitAreaInsetsDictionaryKey];
 }
 
 - (void)commonMDCFloatingButtonInit {

--- a/components/Buttons/tests/unit/FloatingButtonTests.m
+++ b/components/Buttons/tests/unit/FloatingButtonTests.m
@@ -412,6 +412,18 @@
   button.imageLocation = MDCFloatingButtonImageLocationTrailing;
   [button setImage:[UIImage imageNamed:@"Plus"] forState:UIControlStateNormal];
   [button setTitle:@"Title" forState:UIControlStateNormal];
+  [button setMinimumSize:CGSizeMake(75, 37)
+                forShape:MDCFloatingButtonShapeMini
+                  inMode:MDCFloatingButtonModeExpanded];
+  [button setMaximumSize:CGSizeMake(99, 65)
+                forShape:MDCFloatingButtonShapeMini
+                  inMode:MDCFloatingButtonModeExpanded];
+  [button setContentEdgeInsets:UIEdgeInsetsMake(5, 3, 1, 7)
+                      forShape:MDCFloatingButtonShapeMini
+                        inMode:MDCFloatingButtonModeExpanded];
+  [button setHitAreaInsets:UIEdgeInsetsMake(8, 6, 4, 2)
+                  forShape:MDCFloatingButtonShapeMini
+                    inMode:MDCFloatingButtonModeExpanded];
 
   // When
   NSData *archivedData = [NSKeyedArchiver archivedDataWithRootObject:button];

--- a/components/Buttons/tests/unit/FloatingButtonTests.m
+++ b/components/Buttons/tests/unit/FloatingButtonTests.m
@@ -19,16 +19,88 @@
 #import "MaterialButtons.h"
 #import "MaterialShadowElevations.h"
 
-@interface MDCFloatingButton (Testing)
-@property(nonatomic, assign) MDCFloatingButtonMode mode;
-@property(nonatomic, assign) MDCFloatingButtonImageLocation imageLocation;
-@property(nonatomic, assign) CGFloat imageTitleSpacing;
-@end
-
 @interface FloatingButtonsTests : XCTestCase
 @end
 
 @implementation FloatingButtonsTests
+
+- (void)testDefaultMinimumSizeForShapeInNormalModeSizeToFit {
+  // Given
+  MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init];
+  MDCFloatingButton *miniButton =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
+
+  // When
+  [defaultButton sizeToFit];
+  [miniButton sizeToFit];
+
+  // Then
+  XCTAssertGreaterThanOrEqual(defaultButton.bounds.size.width, 56);
+  XCTAssertGreaterThanOrEqual(defaultButton.bounds.size.height, 56);
+  XCTAssertGreaterThanOrEqual(miniButton.bounds.size.width, 40);
+  XCTAssertGreaterThanOrEqual(miniButton.bounds.size.height, 40);
+}
+
+- (void)testDefaultMinimumSizeForShapeInExpandedModeSizeToFit {
+  // Given
+  MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init];
+  defaultButton.mode = MDCFloatingButtonModeExpanded;
+
+  // When
+  [defaultButton sizeToFit];
+
+  // Then
+  XCTAssertGreaterThanOrEqual(defaultButton.bounds.size.width, 132);
+  XCTAssertGreaterThanOrEqual(defaultButton.bounds.size.height, 48);
+}
+
+- (void)testSetMinimumSizeForShapeInModeNormal {
+  // Given
+  MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
+  MDCFloatingButton *miniButton =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
+  [defaultButton setMinimumSize:CGSizeMake(100, 50)
+                       forShape:MDCFloatingButtonShapeDefault
+                         inMode:MDCFloatingButtonModeNormal];
+  [miniButton setMinimumSize:CGSizeMake(100, 50)
+                    forShape:MDCFloatingButtonShapeMini
+                      inMode:MDCFloatingButtonModeNormal];
+
+  // When
+  [defaultButton sizeToFit];
+  [miniButton sizeToFit];
+
+  // Then
+  XCTAssertGreaterThanOrEqual(defaultButton.bounds.size.width, 100);
+  XCTAssertGreaterThanOrEqual(defaultButton.bounds.size.height, 50);
+  XCTAssertGreaterThanOrEqual(miniButton.bounds.size.width, 100);
+  XCTAssertGreaterThanOrEqual(miniButton.bounds.size.height, 50);
+}
+
+- (void)testSetMinimumSizeForShapeInModeExpanded {
+  // Given
+  MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
+  defaultButton.mode = MDCFloatingButtonModeExpanded;
+  MDCFloatingButton *miniButton =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
+  miniButton.mode = MDCFloatingButtonModeExpanded;
+  [defaultButton setMinimumSize:CGSizeMake(50, 100)
+                       forShape:MDCFloatingButtonShapeDefault
+                         inMode:MDCFloatingButtonModeExpanded];
+  [miniButton setMinimumSize:CGSizeMake(50, 100)
+                    forShape:MDCFloatingButtonShapeMini
+                      inMode:MDCFloatingButtonModeExpanded];
+
+  // When
+  [defaultButton sizeToFit];
+  [miniButton sizeToFit];
+
+  // Then
+  XCTAssertGreaterThanOrEqual(defaultButton.bounds.size.width, 50);
+  XCTAssertGreaterThanOrEqual(defaultButton.bounds.size.height, 100);
+  XCTAssertGreaterThanOrEqual(miniButton.bounds.size.width, 50);
+  XCTAssertGreaterThanOrEqual(miniButton.bounds.size.height, 100);
+}
 
 - (void)testExpandedLayout {
   // Given
@@ -60,8 +132,10 @@
   button.mode = MDCFloatingButtonModeExpanded;
   [button setTitle:@"A very long title that can never fit" forState:UIControlStateNormal];
   [button setImage:[UIImage imageNamed:@"Plus"] forState:UIControlStateNormal];
+  [button setMinimumSize:CGSizeMake(100, 48)
+                forShape:MDCFloatingButtonShapeMini
+                  inMode:MDCFloatingButtonModeExpanded];
   button.maximumSize = CGSizeMake(100, 48);
-  button.minimumSize = CGSizeMake(100, 48);
   button.contentEdgeInsets = UIEdgeInsetsMake(4, -4, 8, -8);
 
   // When
@@ -95,7 +169,10 @@
   [unarchivedButton layoutIfNeeded];
 
   // Then
-  XCTAssertTrue(CGRectEqualToRect(button.bounds, unarchivedButton.bounds));
+  XCTAssertTrue(CGRectEqualToRect(button.bounds, unarchivedButton.bounds),
+                @"Unarchived bounds did not match original button's bounds.\nExpected: %@\n"
+                 "Received: %@",NSStringFromCGRect(button.bounds),
+                NSStringFromCGRect(unarchivedButton.bounds));
   XCTAssertEqual(button.mode, unarchivedButton.mode);
   XCTAssertEqual(button.imageLocation, unarchivedButton.imageLocation);
   XCTAssertEqualObjects(button.currentTitle, unarchivedButton.currentTitle);

--- a/components/Buttons/tests/unit/FloatingButtonTests.m
+++ b/components/Buttons/tests/unit/FloatingButtonTests.m
@@ -24,6 +24,78 @@
 
 @implementation FloatingButtonsTests
 
+#pragma mark - setHitAreaInsets:forShape:inMode:
+
+- (void)testDefaultHitAreaInsetsValues {
+  // Given
+  MDCFloatingButton *defaultButtonNormal =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeDefault];
+  MDCFloatingButton *defaultButtonExpanded =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeDefault];
+  defaultButtonExpanded.mode = MDCFloatingButtonModeExpanded;
+  MDCFloatingButton *miniButtonNormal =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
+  MDCFloatingButton *miniButtonExpanded =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
+  miniButtonExpanded.mode = MDCFloatingButtonModeExpanded;
+
+  // Then
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero, defaultButtonNormal.hitAreaInsets));
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero,
+                                              defaultButtonExpanded.hitAreaInsets));
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(-4, -4, -4, -4),
+                                              miniButtonNormal.hitAreaInsets));
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero, miniButtonExpanded.hitAreaInsets));
+}
+
+- (void)testSetHitAreaInsetsForShapeInNormalMode {
+  // Given
+  MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
+  defaultButton.mode = MDCFloatingButtonModeExpanded;
+  MDCFloatingButton *miniButton =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
+  miniButton.mode = MDCFloatingButtonModeExpanded;
+
+  // When
+  [defaultButton setHitAreaInsets:UIEdgeInsetsMake(1, 2, 3, 4)
+                         forShape:MDCFloatingButtonShapeDefault
+                           inMode:MDCFloatingButtonModeNormal];
+  defaultButton.mode = MDCFloatingButtonModeNormal;
+  [miniButton setHitAreaInsets:UIEdgeInsetsMake(9, 8, 7, 6)
+                          forShape:MDCFloatingButtonShapeMini
+                            inMode:MDCFloatingButtonModeNormal];
+  miniButton.mode = MDCFloatingButtonModeNormal;
+
+  // Then
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(1, 2, 3, 4),
+                                              defaultButton.hitAreaInsets));
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(9, 8, 7, 6),
+                                              miniButton.hitAreaInsets));
+}
+
+- (void)testSetHitAreaInsetsForShapeInExpandedMode {
+  // Given
+  MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
+  MDCFloatingButton *miniButton =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
+
+  // When
+  [defaultButton setHitAreaInsets:UIEdgeInsetsMake(1, 2, 3, 4)
+                         forShape:MDCFloatingButtonShapeDefault
+                           inMode:MDCFloatingButtonModeExpanded];
+  defaultButton.mode = MDCFloatingButtonModeExpanded;
+  [miniButton setHitAreaInsets:UIEdgeInsetsMake(9, 8, 7, 6)
+                      forShape:MDCFloatingButtonShapeMini
+                        inMode:MDCFloatingButtonModeExpanded];
+  miniButton.mode = MDCFloatingButtonModeExpanded;
+
+  // Then
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(1, 2, 3, 4),
+                                              defaultButton.hitAreaInsets));
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(9, 8, 7, 6),
+                                              miniButton.hitAreaInsets));
+}
+
 #pragma mark - setContentEdgeInsets:forShape:inMode:
 
 - (void)testDefaultContentEdgeInsetsValues {
@@ -44,17 +116,65 @@
                                               defaultButtonNormal.contentEdgeInsets));
   XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero,
                                               defaultButtonExpanded.contentEdgeInsets));
-  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(-4, -4, -4, -4),
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(8, 8, 8, 8),
                                               miniButtonNormal.contentEdgeInsets));
   XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero,
                                               miniButtonExpanded.contentEdgeInsets));
+}
+
+- (void)testSetContentEdgeInsetsForShapeInNormalMode {
+  // Given
+  MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
+  defaultButton.mode = MDCFloatingButtonModeExpanded;
+  MDCFloatingButton *miniButton =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
+  miniButton.mode = MDCFloatingButtonModeExpanded;
+
+  // When
+  [defaultButton setContentEdgeInsets:UIEdgeInsetsMake(1, 2, 3, 4)
+                             forShape:MDCFloatingButtonShapeDefault
+                               inMode:MDCFloatingButtonModeNormal];
+  defaultButton.mode = MDCFloatingButtonModeNormal;
+  [miniButton setContentEdgeInsets:UIEdgeInsetsMake(9, 8, 7, 6)
+                          forShape:MDCFloatingButtonShapeMini
+                            inMode:MDCFloatingButtonModeNormal];
+  miniButton.mode = MDCFloatingButtonModeNormal;
+
+  // Then
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(1, 2, 3, 4),
+                                              defaultButton.contentEdgeInsets));
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(9, 8, 7, 6),
+                                              miniButton.contentEdgeInsets));
+}
+
+- (void)testSetContentEdgeInsetsForShapeInExpandedMode {
+  // Given
+  MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
+  MDCFloatingButton *miniButton =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
+
+  // When
+  [defaultButton setContentEdgeInsets:UIEdgeInsetsMake(1, 2, 3, 4)
+                             forShape:MDCFloatingButtonShapeDefault
+                               inMode:MDCFloatingButtonModeExpanded];
+  defaultButton.mode = MDCFloatingButtonModeExpanded;
+  [miniButton setContentEdgeInsets:UIEdgeInsetsMake(9, 8, 7, 6)
+                          forShape:MDCFloatingButtonShapeMini
+                            inMode:MDCFloatingButtonModeExpanded];
+  miniButton.mode = MDCFloatingButtonModeExpanded;
+
+  // Then
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(1, 2, 3, 4),
+                                              defaultButton.contentEdgeInsets));
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(9, 8, 7, 6),
+                                              miniButton.contentEdgeInsets));
 }
 
 #pragma mark - setMaximumSize:forShape:inMode:
 
 - (void)testDefaultMaximumSizeForShapeInNormalModeSizeToFit {
   // Given
-  MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init];
+  MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
   [defaultButton setTitle:@"a very long title" forState:UIControlStateNormal];
   MDCFloatingButton *miniButton =
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
@@ -89,19 +209,21 @@
   // Given
   MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
   [defaultButton setTitle:@"a very long title" forState:UIControlStateNormal];
+  defaultButton.mode = MDCFloatingButtonModeExpanded;
   MDCFloatingButton *miniButton =
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
   [miniButton setTitle:@"a very long title" forState:UIControlStateNormal];
+  miniButton.mode = MDCFloatingButtonModeExpanded;
+
+  // When
   [defaultButton setMaximumSize:CGSizeMake(100, 50)
                        forShape:MDCFloatingButtonShapeDefault
                          inMode:MDCFloatingButtonModeNormal];
+  defaultButton.mode = MDCFloatingButtonModeNormal;
   [miniButton setMaximumSize:CGSizeMake(100, 50)
                     forShape:MDCFloatingButtonShapeMini
                       inMode:MDCFloatingButtonModeNormal];
-
-  // When
-  [defaultButton sizeToFit];
-  [miniButton sizeToFit];
+  miniButton.mode = MDCFloatingButtonModeNormal;
 
   // Then
   XCTAssertLessThanOrEqual(defaultButton.bounds.size.width, 100);
@@ -113,24 +235,22 @@
 - (void)testSetMaximumSizeForShapeInModeExpanded {
   // Given
   MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
-  defaultButton.mode = MDCFloatingButtonModeExpanded;
   [defaultButton setTitle:@"An even longer title that should require more than 328 points to render"
                  forState:UIControlStateNormal];
   MDCFloatingButton *miniButton =
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
   [miniButton setTitle:@"An even longer title that should require more than 328 points to render"
               forState:UIControlStateNormal];
-  miniButton.mode = MDCFloatingButtonModeExpanded;
+
+  // When
   [defaultButton setMaximumSize:CGSizeMake(50, 100)
                        forShape:MDCFloatingButtonShapeDefault
                          inMode:MDCFloatingButtonModeExpanded];
+  defaultButton.mode = MDCFloatingButtonModeExpanded;
   [miniButton setMaximumSize:CGSizeMake(50, 100)
                     forShape:MDCFloatingButtonShapeMini
                       inMode:MDCFloatingButtonModeExpanded];
-
-  // When
-  [defaultButton sizeToFit];
-  [miniButton sizeToFit];
+  miniButton.mode = MDCFloatingButtonModeExpanded;
 
   // Then
   XCTAssertLessThanOrEqual(defaultButton.bounds.size.width, 50);
@@ -174,24 +294,26 @@
 - (void)testSetMinimumSizeForShapeInModeNormal {
   // Given
   MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
+  defaultButton.mode = MDCFloatingButtonModeExpanded;
   MDCFloatingButton *miniButton =
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
+  miniButton.mode = MDCFloatingButtonModeExpanded;
+
+  // When
   [defaultButton setMinimumSize:CGSizeMake(100, 50)
                        forShape:MDCFloatingButtonShapeDefault
                          inMode:MDCFloatingButtonModeNormal];
   [defaultButton setMaximumSize:CGSizeZero
                        forShape:MDCFloatingButtonShapeDefault
                          inMode:MDCFloatingButtonModeNormal];
+  defaultButton.mode = MDCFloatingButtonModeNormal;
   [miniButton setMinimumSize:CGSizeMake(100, 50)
                     forShape:MDCFloatingButtonShapeMini
                       inMode:MDCFloatingButtonModeNormal];
   [miniButton setMaximumSize:CGSizeZero
                     forShape:MDCFloatingButtonShapeMini
                       inMode:MDCFloatingButtonModeNormal];
-
-  // When
-  [defaultButton sizeToFit];
-  [miniButton sizeToFit];
+  miniButton.mode = MDCFloatingButtonModeNormal;
 
   // Then
   XCTAssertGreaterThanOrEqual(defaultButton.bounds.size.width, 100);
@@ -203,20 +325,18 @@
 - (void)testSetMinimumSizeForShapeInModeExpanded {
   // Given
   MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
-  defaultButton.mode = MDCFloatingButtonModeExpanded;
   MDCFloatingButton *miniButton =
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
-  miniButton.mode = MDCFloatingButtonModeExpanded;
+
+  // When
   [defaultButton setMinimumSize:CGSizeMake(50, 100)
                        forShape:MDCFloatingButtonShapeDefault
                          inMode:MDCFloatingButtonModeExpanded];
+  defaultButton.mode = MDCFloatingButtonModeExpanded;
   [miniButton setMinimumSize:CGSizeMake(50, 100)
                     forShape:MDCFloatingButtonShapeMini
                       inMode:MDCFloatingButtonModeExpanded];
-
-  // When
-  [defaultButton sizeToFit];
-  [miniButton sizeToFit];
+  miniButton.mode = MDCFloatingButtonModeExpanded;
 
   // Then
   XCTAssertGreaterThanOrEqual(defaultButton.bounds.size.width, 50);
@@ -309,6 +429,12 @@
   XCTAssertEqual(button.mode, unarchivedButton.mode);
   XCTAssertEqual(button.imageLocation, unarchivedButton.imageLocation);
   XCTAssertEqualObjects(button.currentTitle, unarchivedButton.currentTitle);
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(button.contentEdgeInsets,
+                                              unarchivedButton.contentEdgeInsets));
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(button.hitAreaInsets,
+                                              unarchivedButton.hitAreaInsets));
+  XCTAssertTrue(CGSizeEqualToSize(button.minimumSize, unarchivedButton.minimumSize));
+  XCTAssertTrue(CGSizeEqualToSize(button.maximumSize, unarchivedButton.maximumSize));
 }
 
 - (void)testShapeMigrationFromLargeIcon {
@@ -445,19 +571,6 @@
   // Then
   XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(40, 40), miniSize));
   XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(56, 56), defaultSize));
-}
-
-- (void)testDefaultHitAreaInsets {
-  // Given
-  MDCFloatingButton *defaultButton =
-      [MDCFloatingButton floatingButtonWithShape:MDCFloatingButtonShapeDefault];
-  MDCFloatingButton *miniButton =
-      [MDCFloatingButton floatingButtonWithShape:MDCFloatingButtonShapeMini];
-
-  // Then
-  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero, defaultButton.hitAreaInsets));
-  XCTAssertTrue(
-      UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(-4, -4, -4, -4), miniButton.hitAreaInsets));
 }
 
 - (void)testHitAreaInsetsSurviveSizeThatFits {

--- a/components/Buttons/tests/unit/FloatingButtonTests.m
+++ b/components/Buttons/tests/unit/FloatingButtonTests.m
@@ -24,6 +24,32 @@
 
 @implementation FloatingButtonsTests
 
+#pragma mark - setContentEdgeInsets:forShape:inMode:
+
+- (void)testDefaultContentEdgeInsetsValues {
+  // Given
+  MDCFloatingButton *defaultButtonNormal =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeDefault];
+  MDCFloatingButton *defaultButtonExpanded =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeDefault];
+  defaultButtonExpanded.mode = MDCFloatingButtonModeExpanded;
+  MDCFloatingButton *miniButtonNormal =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
+  MDCFloatingButton *miniButtonExpanded =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
+  miniButtonExpanded.mode = MDCFloatingButtonModeExpanded;
+
+  // Then
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero,
+                                              defaultButtonNormal.contentEdgeInsets));
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero,
+                                              defaultButtonExpanded.contentEdgeInsets));
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(-4, -4, -4, -4),
+                                              miniButtonNormal.contentEdgeInsets));
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero,
+                                              miniButtonExpanded.contentEdgeInsets));
+}
+
 #pragma mark - setMaximumSize:forShape:inMode:
 
 - (void)testDefaultMaximumSizeForShapeInNormalModeSizeToFit {
@@ -239,7 +265,9 @@
   [button setMaximumSize:CGSizeMake(100, 48)
                 forShape:MDCFloatingButtonShapeMini
                   inMode:MDCFloatingButtonModeExpanded];
-  button.contentEdgeInsets = UIEdgeInsetsMake(4, -4, 8, -8);
+  [button setContentEdgeInsets:UIEdgeInsetsMake(4, -4, 8, -8)
+                      forShape:MDCFloatingButtonShapeMini
+                        inMode:MDCFloatingButtonModeExpanded];
 
   // When
   [button sizeToFit];
@@ -417,22 +445,6 @@
   // Then
   XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(40, 40), miniSize));
   XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(56, 56), defaultSize));
-}
-
-- (void)testContentEdgeInsets {
-  // Given
-  MDCFloatingButton *miniButton =
-      [MDCFloatingButton floatingButtonWithShape:MDCFloatingButtonShapeMini];
-  MDCFloatingButton *defaultButton =
-      [MDCFloatingButton floatingButtonWithShape:MDCFloatingButtonShapeDefault];
-
-  // When
-  UIEdgeInsets miniInsets = [miniButton contentEdgeInsets];
-  UIEdgeInsets defaultInsets = [defaultButton contentEdgeInsets];
-
-  // Then
-  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero, miniInsets));
-  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero, defaultInsets));
 }
 
 - (void)testDefaultHitAreaInsets {

--- a/components/Buttons/tests/unit/FloatingButtonTests.m
+++ b/components/Buttons/tests/unit/FloatingButtonTests.m
@@ -185,10 +185,10 @@
   [miniButton sizeToFit];
 
   // Then
-  XCTAssertLessThanOrEqual(defaultButton.bounds.size.width, 56);
-  XCTAssertLessThanOrEqual(defaultButton.bounds.size.height, 56);
-  XCTAssertLessThanOrEqual(miniButton.bounds.size.width, 40);
-  XCTAssertLessThanOrEqual(miniButton.bounds.size.height, 40);
+  XCTAssertLessThanOrEqual(defaultButton.bounds.size.width, [MDCFloatingButton defaultDimension]);
+  XCTAssertLessThanOrEqual(defaultButton.bounds.size.height, [MDCFloatingButton defaultDimension]);
+  XCTAssertLessThanOrEqual(miniButton.bounds.size.width, [MDCFloatingButton miniDimension]);
+  XCTAssertLessThanOrEqual(miniButton.bounds.size.height, [MDCFloatingButton miniDimension]);
 }
 
 - (void)testDefaultMaximumSizeForShapeInExpandedModeSizeToFit {
@@ -272,10 +272,12 @@
   [miniButton sizeToFit];
 
   // Then
-  XCTAssertGreaterThanOrEqual(defaultButton.bounds.size.width, 56);
-  XCTAssertGreaterThanOrEqual(defaultButton.bounds.size.height, 56);
-  XCTAssertGreaterThanOrEqual(miniButton.bounds.size.width, 40);
-  XCTAssertGreaterThanOrEqual(miniButton.bounds.size.height, 40);
+  XCTAssertGreaterThanOrEqual(defaultButton.bounds.size.width,
+                              [MDCFloatingButton defaultDimension]);
+  XCTAssertGreaterThanOrEqual(defaultButton.bounds.size.height,
+                              [MDCFloatingButton defaultDimension]);
+  XCTAssertGreaterThanOrEqual(miniButton.bounds.size.width, [MDCFloatingButton miniDimension]);
+  XCTAssertGreaterThanOrEqual(miniButton.bounds.size.height, [MDCFloatingButton miniDimension]);
 }
 
 - (void)testDefaultMinimumSizeForShapeInExpandedModeSizeToFit {
@@ -462,7 +464,8 @@
   [unarchivedButton sizeToFit];
 
   // Then
-  XCTAssertTrue(CGRectEqualToRect(unarchivedButton.bounds, CGRectMake(0, 0, 56, 56)));
+  CGFloat dimension = [MDCFloatingButton defaultDimension];
+  XCTAssertTrue(CGRectEqualToRect(unarchivedButton.bounds, CGRectMake(0, 0, dimension, dimension)));
   XCTAssertEqualObjects([unarchivedButton valueForKey:@"shape"], @(0));
 }
 
@@ -565,8 +568,10 @@
   CGSize defaultSize = [defaultButton sizeThatFits:CGSizeZero];
 
   // Then
-  XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(40, 40), miniSize));
-  XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(56, 56), defaultSize));
+  CGFloat miniDimension = [MDCFloatingButton miniDimension];
+  CGFloat defaultDimension = [MDCFloatingButton defaultDimension];
+  XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(miniDimension, miniDimension), miniSize));
+  XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(defaultDimension, defaultDimension), defaultSize));
 }
 
 - (void)testIntrinsicContentSize {
@@ -581,8 +586,10 @@
   CGSize defaultSize = [defaultButton intrinsicContentSize];
 
   // Then
-  XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(40, 40), miniSize));
-  XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(56, 56), defaultSize));
+  CGFloat miniDimension = [MDCFloatingButton miniDimension];
+  CGFloat defaultDimension = [MDCFloatingButton defaultDimension];
+  XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(miniDimension, miniDimension), miniSize));
+  XCTAssertTrue(CGSizeEqualToSize(CGSizeMake(defaultDimension, defaultDimension), defaultSize));
 }
 
 - (void)testHitAreaInsetsSurviveSizeThatFits {

--- a/components/Buttons/tests/unit/FloatingButtonTests.m
+++ b/components/Buttons/tests/unit/FloatingButtonTests.m
@@ -24,6 +24,97 @@
 
 @implementation FloatingButtonsTests
 
+#pragma mark - setMaximumSize:forShape:inMode:
+
+- (void)testDefaultMaximumSizeForShapeInNormalModeSizeToFit {
+  // Given
+  MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init];
+  [defaultButton setTitle:@"a very long title" forState:UIControlStateNormal];
+  MDCFloatingButton *miniButton =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
+  [miniButton setTitle:@"a very long title" forState:UIControlStateNormal];
+
+  // When
+  [defaultButton sizeToFit];
+  [miniButton sizeToFit];
+
+  // Then
+  XCTAssertLessThanOrEqual(defaultButton.bounds.size.width, 56);
+  XCTAssertLessThanOrEqual(defaultButton.bounds.size.height, 56);
+  XCTAssertLessThanOrEqual(miniButton.bounds.size.width, 40);
+  XCTAssertLessThanOrEqual(miniButton.bounds.size.height, 40);
+}
+
+- (void)testDefaultMaximumSizeForShapeInExpandedModeSizeToFit {
+  // Given
+  MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init];
+  [defaultButton setTitle:@"An even longer title that should require more than 328 points to render"
+                 forState:UIControlStateNormal];
+  defaultButton.mode = MDCFloatingButtonModeExpanded;
+
+  // When
+  [defaultButton sizeToFit];
+
+  // Then
+  XCTAssertLessThanOrEqual(defaultButton.bounds.size.width, 328);
+}
+
+- (void)testSetMaximumSizeForShapeInModeNormal {
+  // Given
+  MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
+  [defaultButton setTitle:@"a very long title" forState:UIControlStateNormal];
+  MDCFloatingButton *miniButton =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
+  [miniButton setTitle:@"a very long title" forState:UIControlStateNormal];
+  [defaultButton setMaximumSize:CGSizeMake(100, 50)
+                       forShape:MDCFloatingButtonShapeDefault
+                         inMode:MDCFloatingButtonModeNormal];
+  [miniButton setMaximumSize:CGSizeMake(100, 50)
+                    forShape:MDCFloatingButtonShapeMini
+                      inMode:MDCFloatingButtonModeNormal];
+
+  // When
+  [defaultButton sizeToFit];
+  [miniButton sizeToFit];
+
+  // Then
+  XCTAssertLessThanOrEqual(defaultButton.bounds.size.width, 100);
+  XCTAssertLessThanOrEqual(defaultButton.bounds.size.height, 50);
+  XCTAssertLessThanOrEqual(miniButton.bounds.size.width, 100);
+  XCTAssertLessThanOrEqual(miniButton.bounds.size.height, 50);
+}
+
+- (void)testSetMaximumSizeForShapeInModeExpanded {
+  // Given
+  MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
+  defaultButton.mode = MDCFloatingButtonModeExpanded;
+  [defaultButton setTitle:@"An even longer title that should require more than 328 points to render"
+                 forState:UIControlStateNormal];
+  MDCFloatingButton *miniButton =
+      [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
+  [miniButton setTitle:@"An even longer title that should require more than 328 points to render"
+              forState:UIControlStateNormal];
+  miniButton.mode = MDCFloatingButtonModeExpanded;
+  [defaultButton setMaximumSize:CGSizeMake(50, 100)
+                       forShape:MDCFloatingButtonShapeDefault
+                         inMode:MDCFloatingButtonModeExpanded];
+  [miniButton setMaximumSize:CGSizeMake(50, 100)
+                    forShape:MDCFloatingButtonShapeMini
+                      inMode:MDCFloatingButtonModeExpanded];
+
+  // When
+  [defaultButton sizeToFit];
+  [miniButton sizeToFit];
+
+  // Then
+  XCTAssertLessThanOrEqual(defaultButton.bounds.size.width, 50);
+  XCTAssertLessThanOrEqual(defaultButton.bounds.size.height, 100);
+  XCTAssertLessThanOrEqual(miniButton.bounds.size.width, 50);
+  XCTAssertLessThanOrEqual(miniButton.bounds.size.height, 100);
+}
+
+#pragma mark - setMinimumSize:forShape:inMode:
+
 - (void)testDefaultMinimumSizeForShapeInNormalModeSizeToFit {
   // Given
   MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init];
@@ -62,7 +153,13 @@
   [defaultButton setMinimumSize:CGSizeMake(100, 50)
                        forShape:MDCFloatingButtonShapeDefault
                          inMode:MDCFloatingButtonModeNormal];
+  [defaultButton setMaximumSize:CGSizeZero
+                       forShape:MDCFloatingButtonShapeDefault
+                         inMode:MDCFloatingButtonModeNormal];
   [miniButton setMinimumSize:CGSizeMake(100, 50)
+                    forShape:MDCFloatingButtonShapeMini
+                      inMode:MDCFloatingButtonModeNormal];
+  [miniButton setMaximumSize:CGSizeZero
                     forShape:MDCFloatingButtonShapeMini
                       inMode:MDCFloatingButtonModeNormal];
 
@@ -102,6 +199,8 @@
   XCTAssertGreaterThanOrEqual(miniButton.bounds.size.height, 100);
 }
 
+#pragma mark - layoutSubviews
+
 - (void)testExpandedLayout {
   // Given
   MDCFloatingButton *button =
@@ -109,7 +208,9 @@
   button.mode = MDCFloatingButtonModeExpanded;
   [button setTitle:@"A very long title that can never fit" forState:UIControlStateNormal];
   [button setImage:[UIImage imageNamed:@"Plus"] forState:UIControlStateNormal];
-  button.maximumSize = CGSizeMake(100, 48);
+  [button setMaximumSize:CGSizeMake(100, 48)
+                forShape:MDCFloatingButtonShapeDefault
+                  inMode:MDCFloatingButtonModeExpanded];
   button.imageTitleSpacing = 12;
 
   // When
@@ -135,7 +236,9 @@
   [button setMinimumSize:CGSizeMake(100, 48)
                 forShape:MDCFloatingButtonShapeMini
                   inMode:MDCFloatingButtonModeExpanded];
-  button.maximumSize = CGSizeMake(100, 48);
+  [button setMaximumSize:CGSizeMake(100, 48)
+                forShape:MDCFloatingButtonShapeMini
+                  inMode:MDCFloatingButtonModeExpanded];
   button.contentEdgeInsets = UIEdgeInsetsMake(4, -4, 8, -8);
 
   // When
@@ -150,6 +253,8 @@
   XCTAssertEqualWithAccuracy(titleFrame.origin.x,
                              CGRectGetMaxX(imageFrame) + button.imageTitleSpacing, 1);
 }
+
+#pragma mark - Encoding/decoding
 
 - (void)testEncoding {
   // Given
@@ -205,6 +310,8 @@
                  MDCShadowElevationFABPressed);
   XCTAssertEqual([button elevationForState:UIControlStateDisabled], MDCShadowElevationNone);
 }
+
+#pragma mark - Animations
 
 - (void)testCollapseExpandRestoresIdentityTransform {
   // Given
@@ -277,6 +384,8 @@
       @"Collapse and expand did not restore the original transform.\nExpected: %@\nReceived: %@",
       NSStringFromCGAffineTransform(transform), NSStringFromCGAffineTransform(button.transform));
 }
+
+#pragma mark - Sizing methods
 
 - (void)testSizeThatFits {
   // Given


### PR DESCRIPTION
Making the new properties public and also migrating away from simple
property setters to the new forShape:inMode: setters required for
UIAppearance support.

* minimumSize
* maximumSize
* contentEdgeInsets
* hitAreaInsets

Implements #2495