### PR TITLE
[Tabs] Allow customization of fonts and text transform

### DIFF
--- a/components/Tabs/examples/TabBarIndicatorTemplateExample.swift
+++ b/components/Tabs/examples/TabBarIndicatorTemplateExample.swift
@@ -67,6 +67,10 @@ class TabBarIndicatorTemplateExample: UIViewController {
 
     tabBar.itemAppearance = .titles
 
+    // Configure custom title fonts
+    tabBar.selectedItemTitleFont = UIFont.boldSystemFont(ofSize: 12)
+    tabBar.unselectedItemTitleFont = UIFont.systemFont(ofSize: 12)
+
     // Configure custom indicator template
     tabBar.selectionIndicatorTemplate = IndicatorTemplate()
     return tabBar

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -87,7 +87,7 @@ IB_DESIGNABLE
 
 /**
  Font used for selected item titles.
- By default this uses the MDCTypography button font. Ignored for bottom-position tab bars.
+ By default this uses +[MDCTypography buttonFont]. Ignored for bottom-position tab bars.
 
  Note: Tab sizes are determined based on their unselected state and do not vary based on selection.
  To avoid clipped layouts and other layout issues, the font provided here should have similar
@@ -134,6 +134,7 @@ IB_DESIGNABLE
  The default value is based on the position and is recommended for most applications.
 
  NOTE: This property will be deprecated in a future release. Use `titleTextTransform` instead.
+ https://github.com/material-components/material-components-ios/issues/2552
  */
 @property(nonatomic) IBInspectable BOOL displaysUppercaseTitles;
 

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -104,13 +104,13 @@ IB_DESIGNABLE
  Padding on the left and right of the tab bar's content for scrollable tabs.
  Default depends on the horizontal size class.
  */
-@property(nonatomic) IBInspectable CGFloat horizontalPadding UI_APPEARANCE_SELECTOR;
+@property(nonatomic) CGFloat horizontalPadding UI_APPEARANCE_SELECTOR;
 
 /**
  Padding on the left and right of each item's content (title or images) for non-justified alignment.
  Default depends on the horizontal size class.
  */
-@property(nonatomic) IBInspectable CGFloat itemHorizontalPadding UI_APPEARANCE_SELECTOR;
+@property(nonatomic) CGFloat itemHorizontalPadding UI_APPEARANCE_SELECTOR;
 
 /**
  Tint color to apply to the tab bar background.
@@ -139,7 +139,7 @@ IB_DESIGNABLE
 
  The default value is MDCTabBarTextTransformAutomatic.
  */
-@property(nonatomic) IBInspectable MDCTabBarTextTransform titleTextTransform UI_APPEARANCE_SELECTOR;
+@property(nonatomic) MDCTabBarTextTransform titleTextTransform UI_APPEARANCE_SELECTOR;
 
 /**
  Template that defines the appearance of the selection indicator.

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -86,19 +86,16 @@ IB_DESIGNABLE
 @property(nonatomic, nonnull) UIColor *inkColor UI_APPEARANCE_SELECTOR;
 
 /**
- Text attributes used for selected item titles.
- Default uses the regular font from the font loader.
+ Font used for selected item titles.
+ By default uses the regular font from the font loader.
  */
-@property(nonatomic, strong, nonnull)
-    NSDictionary<NSAttributedStringKey, id> *selectedItemTitleTextAttributes UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, nonnull) UIFont *selectedItemTitleFont UI_APPEARANCE_SELECTOR;
 
 /**
- Text attributes used for unselected item titles.
- Default uses the regular font from the font loader.
+ Font used for unselected item titles.
+ By default uses the regular font from the font loader.
  */
-@property(nonatomic, strong, nonnull)
-    NSDictionary<NSAttributedStringKey, id> *unselectedItemTitleTextAttributes
-    UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, nonnull) UIFont *unselectedItemTitleFont UI_APPEARANCE_SELECTOR;
 
 /**
  Padding on the left and right of the tab bar's content for scrollable tabs.

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -98,10 +98,10 @@ IB_DESIGNABLE
     UI_APPEARANCE_SELECTOR;
 
 /**
- Spacing between tab bar content (titles or images) for non-justified alignments.
+ Padding on the left and right of each item's content (title or images) for non-justified alignment.
  Default depends on the horizontal size class.
  */
-@property(nonatomic) IBInspectable CGFloat itemSpacing UI_APPEARANCE_SELECTOR;
+@property(nonatomic) IBInspectable CGFloat itemHorizontalPadding UI_APPEARANCE_SELECTOR;
 
 /**
  Tint color to apply to the tab bar background.

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -85,16 +85,18 @@ IB_DESIGNABLE
 @property(nonatomic, nonnull) UIColor *inkColor UI_APPEARANCE_SELECTOR;
 
 /**
- Display font used for selected item titles.
- Default is the regular font from the font loader.
+ Text attributes used for selected item titles.
+ Default uses the regular font from the font loader.
  */
-@property(nonatomic, strong, null_resettable) UIFont *selectedItemTitleFont UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, nonnull)
+    NSDictionary<NSAttributedStringKey, id> *selectedItemTitleTextAttributes UI_APPEARANCE_SELECTOR;
 
 /**
- Display font used for unselected item titles.
- Default is the regular font from the font loader.
+ Text attributes used for unselected item titles.
+ Default uses the regular font from the font loader.
  */
-@property(nonatomic, strong, null_resettable) UIFont *unselectedItemTitleFont
+@property(nonatomic, strong, nonnull)
+    NSDictionary<NSAttributedStringKey, id> *unselectedItemTitleTextAttributes
     UI_APPEARANCE_SELECTOR;
 
 /**

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -87,13 +87,13 @@ IB_DESIGNABLE
 
 /**
  Font used for selected item titles.
- By default uses the regular font from the font loader.
+ By default this uses the MDCTypography button font. Ignored for bottom-position tab bars.
  */
 @property(nonatomic, strong, nonnull) UIFont *selectedItemTitleFont UI_APPEARANCE_SELECTOR;
 
 /**
  Font used for unselected item titles.
- By default uses the regular font from the font loader.
+ By default this uses the MDCTypography button font. Ignored for bottom-position tab bars.
  */
 @property(nonatomic, strong, nonnull) UIFont *unselectedItemTitleFont UI_APPEARANCE_SELECTOR;
 
@@ -130,6 +130,16 @@ IB_DESIGNABLE
  The default value is based on the position and is recommended for most applications.
  */
 @property(nonatomic) MDCTabBarItemAppearance itemAppearance;
+
+/**
+ Indicates if all tab titles should be uppercased for display. If NO, item titles will be displayed
+ verbatim.
+
+ The default value is based on the position and is recommended for most applications.
+
+ NOTE: This property will be deprecated in a future release. Use `titleTextTransform` instead.
+ */
+@property(nonatomic) IBInspectable BOOL displaysUppercaseTitles;
 
 /**
  Defines how tab bar item titles are transformed for display.

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -85,6 +85,25 @@ IB_DESIGNABLE
 @property(nonatomic, nonnull) UIColor *inkColor UI_APPEARANCE_SELECTOR;
 
 /**
+ Display font used for selected item titles.
+ Default is the regular font from the font loader.
+ */
+@property(nonatomic, strong, null_resettable) UIFont *selectedItemTitleFont UI_APPEARANCE_SELECTOR;
+
+/**
+ Display font used for unselected item titles.
+ Default is the regular font from the font loader.
+ */
+@property(nonatomic, strong, null_resettable) UIFont *unselectedItemTitleFont
+    UI_APPEARANCE_SELECTOR;
+
+/**
+ Spacing between tab bar content (titles or images) for non-justified alignments.
+ Default depends on the horizontal size class.
+ */
+@property(nonatomic) IBInspectable CGFloat itemSpacing UI_APPEARANCE_SELECTOR;
+
+/**
  Tint color to apply to the tab bar background.
 
  If nil, the receiver uses the default background appearance. Default: nil.
@@ -112,7 +131,7 @@ IB_DESIGNABLE
 
  The default value is based on the position and is recommended for most applications.
  */
-@property(nonatomic) IBInspectable BOOL displaysUppercaseTitles;
+@property(nonatomic) IBInspectable BOOL displaysUppercaseTitles UI_APPEARANCE_SELECTOR;
 
 /**
  Template that defines the appearance of the selection indicator.

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -99,13 +99,13 @@ IB_DESIGNABLE
 
 /**
  Padding on the left and right of the tab bar's content for scrollable tabs.
- Default depends on the horizontal size class.
+ Default depends on the device type.
  */
 @property(nonatomic) CGFloat horizontalPadding UI_APPEARANCE_SELECTOR;
 
 /**
  Padding on the left and right of each item's content (title or images) for non-justified alignment.
- Default depends on the horizontal size class.
+ Default depends on the device type.
  */
 @property(nonatomic) CGFloat itemHorizontalPadding UI_APPEARANCE_SELECTOR;
 

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -18,6 +18,7 @@
 
 #import "MDCTabBarAlignment.h"
 #import "MDCTabBarItemAppearance.h"
+#import "MDCTabBarTextTransform.h"
 
 @class MDCTabBarItem;
 @protocol MDCTabBarDelegate;
@@ -134,12 +135,11 @@ IB_DESIGNABLE
 @property(nonatomic) MDCTabBarItemAppearance itemAppearance;
 
 /**
- Indicates if all tab titles should be uppercased for display. If NO, item titles will be
- displayed verbatim.
+ Defines how tab bar item titles are transformed for display.
 
- The default value is based on the position and is recommended for most applications.
+ The default value is MDCTabBarTextTransformAutomatic.
  */
-@property(nonatomic) IBInspectable BOOL displaysUppercaseTitles UI_APPEARANCE_SELECTOR;
+@property(nonatomic) IBInspectable MDCTabBarTextTransform titleTextTransform UI_APPEARANCE_SELECTOR;
 
 /**
  Template that defines the appearance of the selection indicator.

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -98,6 +98,12 @@ IB_DESIGNABLE
     UI_APPEARANCE_SELECTOR;
 
 /**
+ Padding on the left and right of the tab bar's content for scrollable tabs.
+ Default depends on the horizontal size class.
+ */
+@property(nonatomic) IBInspectable CGFloat horizontalPadding UI_APPEARANCE_SELECTOR;
+
+/**
  Padding on the left and right of each item's content (title or images) for non-justified alignment.
  Default depends on the horizontal size class.
  */

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -98,18 +98,6 @@ IB_DESIGNABLE
 @property(nonatomic, strong, nonnull) UIFont *unselectedItemTitleFont UI_APPEARANCE_SELECTOR;
 
 /**
- Padding on the left and right of the tab bar's content for scrollable tabs.
- Default depends on the device type.
- */
-@property(nonatomic) CGFloat horizontalPadding UI_APPEARANCE_SELECTOR;
-
-/**
- Padding on the left and right of each item's content (title or images) for non-justified alignment.
- Default depends on the device type.
- */
-@property(nonatomic) CGFloat itemHorizontalPadding UI_APPEARANCE_SELECTOR;
-
-/**
  Tint color to apply to the tab bar background.
 
  If nil, the receiver uses the default background appearance. Default: nil.

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -88,12 +88,20 @@ IB_DESIGNABLE
 /**
  Font used for selected item titles.
  By default this uses the MDCTypography button font. Ignored for bottom-position tab bars.
+
+ Note: Tab sizes are determined based on their unselected state and do not vary based on selection.
+ To avoid clipped layouts and other layout issues, the font provided here should have similar
+ metrics to `unselectedItemTitleFont`.
  */
 @property(nonatomic, strong, nonnull) UIFont *selectedItemTitleFont UI_APPEARANCE_SELECTOR;
 
 /**
  Font used for unselected item titles.
  By default this uses the MDCTypography button font. Ignored for bottom-position tab bars.
+
+ Note: Tab sizes are determined based on their unselected state and do not vary based on selection.
+ To avoid clipped layouts and other layout issues, the font provided here should have similar
+ metrics to `selectedItemTitleFont`.
  */
 @property(nonatomic, strong, nonnull) UIFont *unselectedItemTitleFont UI_APPEARANCE_SELECTOR;
 

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -370,8 +370,6 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
     // Top tabs
     style.shouldDisplaySelectionIndicator = YES;
     style.shouldGrowOnSelection = NO;
-    style.selectedTitleFont = [MDCTypography buttonFont];
-    style.unselectedTitleFont = [MDCTypography buttonFont];
     style.inkStyle = MDCInkStyleBounded;
     style.titleImagePadding = (kImageTitleSpecPadding + kImageTitlePaddingAdjustment);
     style.textOnlyNumberOfLines = 2;
@@ -380,8 +378,6 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
     style.shouldDisplaySelectionIndicator = NO;
     style.shouldGrowOnSelection = YES;
     style.maximumItemWidth = kBottomNavigationMaximumItemWidth;
-    style.selectedTitleFont = [[MDCTypography fontLoader] regularFontOfSize:12];
-    style.unselectedTitleFont = [[MDCTypography fontLoader] regularFontOfSize:12];
     style.inkStyle = MDCInkStyleUnbounded;
     style.titleImagePadding = kBottomNavigationTitleImagePadding;
     style.textOnlyNumberOfLines = 1;
@@ -545,7 +541,6 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 
   style = [[self class] defaultStyleForPosition:_barPosition itemAppearance:_itemAppearance];
 
-  // Set base style using position.
   if ([MDCTabBar isTopTabsForPosition:_barPosition]) {
     // Top tabs: Use provided fonts.
     style.selectedTitleFont = _selectedItemTitleFont;

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -133,6 +133,8 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   _displaysUppercaseTitles = [self computedDisplaysUppercaseTitles];
   _itemAppearance = [self computedItemAppearance];
   _selectionIndicatorTemplate = [MDCTabBar defaultSelectionIndicatorTemplate];
+  _selectedItemTitleFont = [MDCTypography buttonFont];
+  _unselectedItemTitleFont = [MDCTypography buttonFont];
 
   // Create item bar.
   _itemBar = [[MDCItemBar alloc] initWithFrame:self.bounds];
@@ -218,6 +220,22 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   if (_inkColor != inkColor && ![_inkColor isEqual:inkColor]) {
     _inkColor = inkColor;
 
+    [self updateItemBarStyle];
+  }
+}
+
+- (void)setUnselectedItemTitleFont:(UIFont *)unselectedItemTitleFont {
+  if ((unselectedItemTitleFont != _unselectedItemTitleFont) &&
+      ![unselectedItemTitleFont isEqual:_unselectedItemTitleFont]) {
+    _unselectedItemTitleFont = unselectedItemTitleFont;
+    [self updateItemBarStyle];
+  }
+}
+
+- (void)setSelectedItemTitleFont:(UIFont *)selectedItemTitleFont {
+  if ((selectedItemTitleFont != _selectedItemTitleFont) &&
+      ![selectedItemTitleFont isEqual:_selectedItemTitleFont]) {
+    _selectedItemTitleFont = selectedItemTitleFont;
     [self updateItemBarStyle];
   }
 }
@@ -332,7 +350,8 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
     // Top tabs
     style.shouldDisplaySelectionIndicator = YES;
     style.shouldGrowOnSelection = NO;
-    style.titleFont = [MDCTypography buttonFont];
+    style.selectedTitleFont = [MDCTypography buttonFont];
+    style.unselectedTitleFont = [MDCTypography buttonFont];
     style.inkStyle = MDCInkStyleBounded;
     style.titleImagePadding = (kImageTitleSpecPadding + kImageTitlePaddingAdjustment);
     style.textOnlyNumberOfLines = 2;
@@ -341,7 +360,8 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
     style.shouldDisplaySelectionIndicator = NO;
     style.shouldGrowOnSelection = YES;
     style.maximumItemWidth = kBottomNavigationMaximumItemWidth;
-    style.titleFont = [[MDCTypography fontLoader] regularFontOfSize:12];
+    style.selectedTitleFont = [[MDCTypography fontLoader] regularFontOfSize:12];
+    style.unselectedTitleFont = [[MDCTypography fontLoader] regularFontOfSize:12];
     style.inkStyle = MDCInkStyleUnbounded;
     style.titleImagePadding = kBottomNavigationTitleImagePadding;
     style.textOnlyNumberOfLines = 1;
@@ -520,6 +540,17 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   MDCItemBarStyle *style;
 
   style = [[self class] defaultStyleForPosition:_barPosition itemAppearance:_itemAppearance];
+
+  // Set base style using position.
+  if ([MDCTabBar isTopTabsForPosition:_barPosition]) {
+    // Top tabs: Use provided fonts.
+    style.selectedTitleFont = _selectedItemTitleFont;
+    style.unselectedTitleFont = _unselectedItemTitleFont;
+  } else {
+    // Bottom navigation: Ignore provided fonts.
+    style.selectedTitleFont = [[MDCTypography fontLoader] regularFontOfSize:12];
+    style.unselectedTitleFont = [[MDCTypography fontLoader] regularFontOfSize:12];
+  }
 
   style.selectionIndicatorTemplate = self.selectionIndicatorTemplate;
   style.selectionIndicatorColor = self.tintColor;

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -271,7 +271,7 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 }
 
 - (BOOL)displaysUppercaseTitles {
-  switch (_titleTextTransform) {
+  switch (self.titleTextTransform) {
     case MDCTabBarTextTransformAutomatic:
       return [MDCTabBar displaysUppercaseTitlesByDefaultForPosition:_barPosition];
 
@@ -543,8 +543,8 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 
   if ([MDCTabBar isTopTabsForPosition:_barPosition]) {
     // Top tabs: Use provided fonts.
-    style.selectedTitleFont = _selectedItemTitleFont;
-    style.unselectedTitleFont = _unselectedItemTitleFont;
+    style.selectedTitleFont = self.selectedItemTitleFont;
+    style.unselectedTitleFont = self.unselectedItemTitleFont;
   } else {
     // Bottom navigation: Ignore provided fonts.
     style.selectedTitleFont = [[MDCTypography fontLoader] regularFontOfSize:12];
@@ -556,24 +556,7 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   style.inkColor = _inkColor;
   style.selectedTitleColor = (_selectedItemTintColor ? _selectedItemTintColor : self.tintColor);
   style.titleColor = _unselectedItemTintColor;
-
-  // Set displaysUppercaseTitles based on titleTextTransform.
-  BOOL displaysUppercaseTitles = NO;
-  switch (_titleTextTransform) {
-    case MDCTabBarTextTransformAutomatic:
-      displaysUppercaseTitles =
-          [MDCTabBar displaysUppercaseTitlesByDefaultForPosition:_barPosition];
-      break;
-
-    case MDCTabBarTextTransformUppercase:
-      displaysUppercaseTitles = YES;
-      break;
-
-    case MDCTabBarTextTransformNone:
-      displaysUppercaseTitles = NO;
-      break;
-  }
-  style.displaysUppercaseTitles = displaysUppercaseTitles;
+  style.displaysUppercaseTitles = self.displaysUppercaseTitles;
 
   [_itemBar applyStyle:style];
 

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -284,13 +284,8 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 }
 
 - (void)setDisplaysUppercaseTitles:(BOOL)displaysUppercaseTitles {
-  MDCTabBarTextTransform newTransform = MDCTabBarTextTransformAutomatic;
-  if (displaysUppercaseTitles) {
-    newTransform = MDCTabBarTextTransformUppercase;
-  } else {
-    newTransform = MDCTabBarTextTransformNone;
-  }
-  self.titleTextTransform = newTransform;
+  self.titleTextTransform =
+      displaysUppercaseTitles ? MDCTabBarTextTransformUppercase : MDCTabBarTextTransformNone;
 }
 
 - (void)setTitleTextTransform:(MDCTabBarTextTransform)titleTextTransform {

--- a/components/Tabs/src/MDCTabBarTextTransform.h
+++ b/components/Tabs/src/MDCTabBarTextTransform.h
@@ -1,0 +1,29 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+/** Appearance for content within tab bar items. */
+typedef NS_ENUM(NSInteger, MDCTabBarTextTransform) {
+  /** The default text transform is applied based on the bar's position. */
+  MDCTabBarTextTransformAutomatic,
+
+  /** Text on tabs is displayed verbatim with no transform. */
+  MDCTabBarTextTransformNone,
+
+  /** Text on tabs is uppercased for display. */
+  MDCTabBarTextTransformUppercase,
+};

--- a/components/Tabs/src/MDCTabBarTextTransform.h
+++ b/components/Tabs/src/MDCTabBarTextTransform.h
@@ -19,11 +19,11 @@
 /** Appearance for content within tab bar items. */
 typedef NS_ENUM(NSInteger, MDCTabBarTextTransform) {
   /** The default text transform is applied based on the bar's position. */
-  MDCTabBarTextTransformAutomatic,
+  MDCTabBarTextTransformAutomatic = 0,
 
   /** Text on tabs is displayed verbatim with no transform. */
-  MDCTabBarTextTransformNone,
+  MDCTabBarTextTransformNone = 1,
 
   /** Text on tabs is uppercased for display. */
-  MDCTabBarTextTransformUppercase,
+  MDCTabBarTextTransformUppercase = 2,
 };

--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -108,7 +108,8 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
 
   // Only compute text bounding rect if necessary (all except image-only items)
   if (style.shouldDisplayTitle) {
-    UIFont *font = style.titleFont;
+    // Determine size based on the unselected state because the majority of tabs are unselected.
+    UIFont *font = style.unselectedTitleFont;
     NSDictionary *titleAttributes = @{NSFontAttributeName : font};
     textBounds = [title boundingRectWithSize:size
                                      options:NSStringDrawingTruncatesLastVisibleLine
@@ -343,6 +344,7 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
   [self updateTitleTextColor];
   [self updateAccessibilityTraits];
   [self updateTransformsAnimated:animate];
+  [self updateTitleFont];
 }
 
 - (void)setHighlighted:(BOOL)highlighted {
@@ -558,7 +560,11 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
 }
 
 - (void)updateTitleFont {
-  _titleLabel.font = _style.titleFont;
+  if (self.isSelected) {
+    _titleLabel.font = _style.selectedTitleFont;
+  } else {
+    _titleLabel.font = _style.unselectedTitleFont;
+  }
 }
 
 - (void)updateInk {

--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -560,13 +560,7 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
 }
 
 - (void)updateTitleFont {
-  UIFont *font = nil;
-  if (self.isSelected) {
-    font = _style.selectedTitleFont;
-  } else {
-    font = _style.unselectedTitleFont;
-  }
-  _titleLabel.font = font;
+  _titleLabel.font = self.isSelected ? _style.selectedTitleFont : _style.unselectedTitleFont;
 }
 
 - (void)updateInk {

--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -560,11 +560,13 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
 }
 
 - (void)updateTitleFont {
+  UIFont *font = nil;
   if (self.isSelected) {
-    _titleLabel.font = _style.selectedTitleFont;
+    font = _style.selectedTitleFont;
   } else {
-    _titleLabel.font = _style.unselectedTitleFont;
+    font = _style.unselectedTitleFont;
   }
+  _titleLabel.font = font;
 }
 
 - (void)updateInk {

--- a/components/Tabs/src/private/MDCItemBarStyle.h
+++ b/components/Tabs/src/private/MDCItemBarStyle.h
@@ -59,10 +59,10 @@
 @property(nonatomic, strong, nonnull) UIColor *selectedTitleColor;
 
 /** Font used for selected item titles. */
-@property(nonatomic, nonnull) UIFont *selectedTitleFont;
+@property(nonatomic, strong, nonnull) UIFont *selectedTitleFont;
 
 /** Font used for unselected item titles. */
-@property(nonatomic, nonnull) UIFont *unselectedTitleFont;
+@property(nonatomic, strong, nonnull) UIFont *unselectedTitleFont;
 
 /** Style of ink animations on item interaction. */
 @property(nonatomic) MDCInkStyle inkStyle;

--- a/components/Tabs/src/private/MDCItemBarStyle.h
+++ b/components/Tabs/src/private/MDCItemBarStyle.h
@@ -58,8 +58,11 @@
 /** Color of title text when selected. Default is opaque white. */
 @property(nonatomic, strong, nonnull) UIColor *selectedTitleColor;
 
-/** Font used for item titles. */
-@property(nonatomic, nonnull) UIFont *titleFont;
+/** Font used for selected item titles. */
+@property(nonatomic, nonnull) UIFont *selectedTitleFont;
+
+/** Font used for unselected item titles. */
+@property(nonatomic, nonnull) UIFont *unselectedTitleFont;
 
 /** Style of ink animations on item interaction. */
 @property(nonatomic) MDCInkStyle inkStyle;

--- a/components/Tabs/src/private/MDCItemBarStyle.m
+++ b/components/Tabs/src/private/MDCItemBarStyle.m
@@ -44,7 +44,8 @@
   newStyle.shouldGrowOnSelection = _shouldGrowOnSelection;
   newStyle.titleColor = _titleColor;
   newStyle.selectedTitleColor = _selectedTitleColor;
-  newStyle.titleFont = _titleFont;
+  newStyle.selectedTitleFont = _selectedTitleFont;
+  newStyle.unselectedTitleFont = _unselectedTitleFont;
   newStyle.inkStyle = _inkStyle;
   newStyle.inkColor = _inkColor;
   newStyle.titleImagePadding = _titleImagePadding;


### PR DESCRIPTION
`displaysUppercaseTitles` has been put on the road to deprecation and a replacement has been added called `titleTextTransform`. This new property is UIAppearance-compatible and less magical overall. Existing clients can switch at any time, but will not be required to immediately.

Adds two properties to customize the fonts used for selected and unselected tab titles. This allows a bold/regular or regular/thin pair of fonts (for example) to be specified to indicate selection, if desired. Two documented limitations on these:
* They only apply to top-position navigation bars. This keeps the API simple and is consistent with our longer-term direction towards recommending `MDCBottomNavigationBar` instead of bottom tab bars.
* A soft condition of using the API is that you don't set two drastically differently-sized fonts for these states. If you do, layouts may not be optimal. Reasonable designs shouldn't violate this condition.
