### PR TITLE
[Tabs] Replace mdc_animateWithTimingFunction with standard UIKit/QuartzCore APIs.

### DIFF
--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -618,14 +618,16 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   };
 
   if (animate) {
-    CAMediaTimingFunction *easeInOutFunction =
+    [CATransaction begin];
+    CAMediaTimingFunction *easeInOut =
         [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionEaseInOut];
-    [UIView mdc_animateWithTimingFunction:easeInOutFunction
-                                 duration:kDefaultAnimationDuration
-                                    delay:0.0f
-                                  options:UIViewAnimationOptionBeginFromCurrentState
-                               animations:animationBlock
-                               completion:nil];
+    [CATransaction setAnimationTimingFunction:easeInOut];
+    [UIView animateWithDuration:kDefaultAnimationDuration
+                          delay:0.0f
+                        options:UIViewAnimationOptionBeginFromCurrentState
+                     animations:animationBlock
+                     completion:nil];
+    [CATransaction commit];
   } else {
     animationBlock();
   }

--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -543,14 +543,16 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
   };
 
   if (animated) {
+    [CATransaction begin];
     CAMediaTimingFunction *translateTimingFunction =
         [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionTranslate];
-    [UIView mdc_animateWithTimingFunction:translateTimingFunction
-                                 duration:kSelectionAnimationDuration
-                                    delay:0
-                                  options:0
-                               animations:performAnimations
-                               completion:completeAnimations];
+    [CATransaction setAnimationTimingFunction:translateTimingFunction];
+    [UIView animateWithDuration:kSelectionAnimationDuration
+                          delay:0
+                        options:0
+                     animations:performAnimations
+                     completion:completeAnimations];
+    [CATransaction commit];
   } else {
     performAnimations();
     completeAnimations(YES);


### PR DESCRIPTION
We will be removing this convenience API in the near future in favor of more explicit client code.