### PR TITLE
[Buttons] Add basic Floating Button example

### DIFF
--- a/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
+++ b/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
@@ -9,7 +9,6 @@ import UIKit
 
 class FloatingButtonExampleSwiftViewController: UIViewController {
 
-  let floatingButtonPlusDimension = CGFloat(24)
   let miniFloatingButton = MDCFloatingButton(frame: .zero, shape: .mini)
   let defaultFloatingButton = MDCFloatingButton()
   let largeIconFloatingButton = MDCFloatingButton()

--- a/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
+++ b/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
@@ -10,24 +10,9 @@ import UIKit
 class FloatingButtonExampleSwiftViewController: UIViewController {
 
   let floatingButtonPlusDimension = CGFloat(24)
-  let miniFloatingButton : MDCFloatingButton
-  let defaultFloatingButton : MDCFloatingButton
-  let largeIconFloatingButton : MDCFloatingButton
-
-  override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-    miniFloatingButton = MDCFloatingButton(frame: .zero, shape: .mini)
-    defaultFloatingButton = MDCFloatingButton()
-    largeIconFloatingButton = MDCFloatingButton()
-    super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-  }
-
-  required init?(coder aDecoder: NSCoder) {
-    miniFloatingButton = MDCFloatingButton(frame: .zero, shape: .mini)
-    defaultFloatingButton = MDCFloatingButton()
-    largeIconFloatingButton = MDCFloatingButton()
-    super.init(coder: aDecoder)
-  }
-  
+  let miniFloatingButton = MDCFloatingButton(frame: .zero, shape: .mini)
+  let defaultFloatingButton = MDCFloatingButton()
+  let largeIconFloatingButton = MDCFloatingButton()
 
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
+++ b/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
@@ -1,0 +1,173 @@
+//
+//  FloatingButtonExampleSwiftViewController.swift
+//  MaterialComponentsExamples
+//
+//  Created by Rob Moore on 12/1/17.
+//
+
+import UIKit
+
+class FloatingButtonExampleSwiftViewController: UIViewController {
+
+  let floatingButtonPlusDimension = CGFloat(24)
+  let miniFloatingButton : MDCFloatingButton
+  let defaultFloatingButton : MDCFloatingButton
+  let largeIconFloatingButton : MDCFloatingButton
+
+  override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    miniFloatingButton = MDCFloatingButton(frame: .zero, shape: .mini)
+    defaultFloatingButton = MDCFloatingButton()
+    largeIconFloatingButton = MDCFloatingButton()
+    super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    miniFloatingButton = MDCFloatingButton(frame: .zero, shape: .mini)
+    defaultFloatingButton = MDCFloatingButton()
+    largeIconFloatingButton = MDCFloatingButton()
+    super.init(coder: aDecoder)
+  }
+  
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    view.backgroundColor = UIColor(white: 0.9, alpha: 1)
+
+    let plusImage = #imageLiteral(resourceName: "Plus")
+    let plusImage36 = UIImage(named: "plus_white_36", in: Bundle(for: type(of: self)),
+                              compatibleWith: traitCollection)
+
+    miniFloatingButton.sizeToFit()
+    miniFloatingButton.translatesAutoresizingMaskIntoConstraints = false
+    miniFloatingButton.setMinimumSize(CGSize(width: 96, height: 40), for: .mini, in: .expanded)
+    miniFloatingButton.setImage(plusImage, for: .normal)
+
+    defaultFloatingButton.sizeToFit()
+    defaultFloatingButton.translatesAutoresizingMaskIntoConstraints = false
+    defaultFloatingButton.setImage(plusImage, for: .normal)
+
+    largeIconFloatingButton.sizeToFit()
+    largeIconFloatingButton.translatesAutoresizingMaskIntoConstraints = false
+    largeIconFloatingButton.setImage(plusImage36, for: .normal)
+
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.text = "Try me on an iPad!"
+
+    view.addSubview(label)
+    view.addSubview(miniFloatingButton)
+    view.addSubview(defaultFloatingButton)
+    view.addSubview(largeIconFloatingButton)
+
+    let totalHeight = miniFloatingButton.bounds.standardized.height +
+                      defaultFloatingButton.bounds.standardized.height +
+                      largeIconFloatingButton.bounds.standardized.height +
+                      20 // 10 points between buttons
+
+    let miniDefaultDifference = defaultFloatingButton.bounds.standardized.width -
+                                miniFloatingButton.bounds.standardized.width
+
+    leadingAlignView(view: miniFloatingButton, onView: self.view,
+                     horizontalOffset: 10 + miniDefaultDifference / 2,
+                     verticalOffset: -totalHeight / 2)
+    leadingAlignView(view: defaultFloatingButton, onView: miniFloatingButton,
+                     horizontalOffset: -miniDefaultDifference / 2,
+                     verticalOffset: defaultFloatingButton.bounds.standardized.height + 10)
+    leadingAlignView(view: largeIconFloatingButton, onView: defaultFloatingButton,
+                     horizontalOffset: 0,
+                     verticalOffset: defaultFloatingButton.bounds.standardized.height + 10)
+    self.view.addConstraint(NSLayoutConstraint(item: label, attribute: .centerX, relatedBy: .equal,
+                                               toItem: view, attribute: .centerX, multiplier: 1,
+                                               constant: 0))
+    self.view.addConstraint(NSLayoutConstraint(item: label, attribute: .bottom, relatedBy: .equal,
+                                               toItem: miniFloatingButton, attribute: .top,
+                                               multiplier: 1, constant: -20))
+  }
+
+  // MARK: Private
+
+  private func leadingAlignView(view: UIView, onView: UIView, horizontalOffset: CGFloat,
+                                verticalOffset: CGFloat) {
+    self.view.addConstraint(NSLayoutConstraint(
+      item: view,
+      attribute: .leading,
+      relatedBy: .equal,
+      toItem: onView,
+      attribute: .leading,
+      multiplier: 1.0,
+      constant: horizontalOffset))
+
+    self.view.addConstraint(NSLayoutConstraint(
+      item: view,
+      attribute: .centerY,
+      relatedBy: .equal,
+      toItem: onView,
+      attribute: .centerY,
+      multiplier: 1.0,
+      constant: verticalOffset))
+  }
+}
+
+extension FloatingButtonExampleSwiftViewController {
+  @objc class func catalogBreadcrumbs() -> [String] {
+    return ["Buttons", "Floating Action Button (Swift)"]
+  }
+
+  @objc class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+}
+
+extension FloatingButtonExampleSwiftViewController {
+  func updateFloatingButtons(to mode: MDCFloatingButtonMode) {
+    if (miniFloatingButton.mode != mode) {
+      miniFloatingButton.mode = mode
+    }
+    if (defaultFloatingButton.mode != mode) {
+      defaultFloatingButton.mode = mode
+    }
+    if (largeIconFloatingButton.mode != mode) {
+      largeIconFloatingButton.mode = mode
+    }
+  }
+
+  func updateFloatingButtons(whenSizeClass isRegularRegular: Bool) {
+    if (isRegularRegular) {
+      updateFloatingButtons(to: .expanded)
+      miniFloatingButton.setTitle("Add", for: .normal)
+      defaultFloatingButton.setTitle("Create", for: .normal)
+      largeIconFloatingButton.setTitle("Create", for: .normal)
+    } else {
+      updateFloatingButtons(to: .normal)
+      miniFloatingButton.setTitle(nil, for: .normal)
+      defaultFloatingButton.setTitle(nil, for: .normal)
+      largeIconFloatingButton.setTitle(nil, for: .normal)
+    }
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    let horizontalSizeClass = traitCollection.horizontalSizeClass
+    let verticalSizeClass = traitCollection.verticalSizeClass
+    let isRegularRegular = horizontalSizeClass == .regular && verticalSizeClass == .regular
+    updateFloatingButtons(whenSizeClass: isRegularRegular)
+  }
+
+  override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+    super.willTransition(to: newCollection, with: coordinator)
+    let currentTraits = traitCollection
+    let sizeClassChanged
+      = newCollection.horizontalSizeClass != currentTraits.horizontalSizeClass
+        || newCollection.verticalSizeClass != currentTraits.verticalSizeClass
+    if (sizeClassChanged) {
+      let willBeRegularRegular
+        = newCollection.horizontalSizeClass == .regular
+          && newCollection.verticalSizeClass == .regular
+
+      coordinator.animate(alongsideTransition:{ (_) in
+        self.updateFloatingButtons(whenSizeClass: willBeRegularRegular)
+      }, completion: nil)
+    }
+  }
+}

--- a/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
+++ b/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
@@ -50,6 +50,8 @@ class FloatingButtonExampleSwiftViewController: UIViewController {
     largeIconFloatingButton.sizeToFit()
     largeIconFloatingButton.translatesAutoresizingMaskIntoConstraints = false
     largeIconFloatingButton.setImage(plusImage36, for: .normal)
+    largeIconFloatingButton.setContentEdgeInsets(UIEdgeInsetsMake(-6, -6, -6, 0), for: .default,
+                                                 in: .expanded)
 
     let label = UILabel()
     label.translatesAutoresizingMaskIntoConstraints = false

--- a/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
+++ b/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
@@ -1,9 +1,18 @@
-//
-//  FloatingButtonExampleSwiftViewController.swift
-//  MaterialComponentsExamples
-//
-//  Created by Rob Moore on 12/1/17.
-//
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
 
 import UIKit
 

--- a/components/Buttons/examples/FloatingButtonExampleViewController.m
+++ b/components/Buttons/examples/FloatingButtonExampleViewController.m
@@ -1,0 +1,172 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "MaterialButtons.h"
+
+@interface FloatingButtonExampleViewController : UIViewController
+@property(nonatomic, strong) UILabel *iPadLabel;
+@property(nonatomic, strong) MDCFloatingButton *miniFloatingButton;
+@property(nonatomic, strong) MDCFloatingButton *defaultFloatingButton;
+@property(nonatomic, strong) MDCFloatingButton *largeIconFloatingButton;
+@end
+
+@implementation FloatingButtonExampleViewController
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  self.view.backgroundColor = [UIColor colorWithWhite:0.9 alpha:1];
+
+  UIImage *plusImage = [UIImage imageNamed:@"Plus"];
+  UIImage *plusImage36 = [UIImage imageNamed:@"plus_white_36"
+                                    inBundle:[NSBundle bundleForClass:[self class]]
+               compatibleWithTraitCollection:self.traitCollection];
+
+  self.iPadLabel = [[UILabel alloc] init];
+  self.iPadLabel.text = @"Try me on an iPad!";
+
+  self.miniFloatingButton = [[MDCFloatingButton alloc] initWithFrame:CGRectZero
+                                                               shape:MDCFloatingButtonShapeMini];
+  self.miniFloatingButton.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.miniFloatingButton setImage:plusImage forState:UIControlStateNormal];
+  [self.miniFloatingButton setMinimumSize:CGSizeMake(96, 40)
+                                 forShape:MDCFloatingButtonShapeMini
+                                   inMode:MDCFloatingButtonModeExpanded];
+
+  self.defaultFloatingButton = [[MDCFloatingButton alloc] init];
+  self.defaultFloatingButton.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.defaultFloatingButton setImage:plusImage forState:UIControlStateNormal];
+
+  self.largeIconFloatingButton = [[MDCFloatingButton alloc] init];
+  self.largeIconFloatingButton.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.largeIconFloatingButton setImage:plusImage36 forState:UIControlStateNormal];
+  [self.largeIconFloatingButton setContentEdgeInsets:UIEdgeInsetsMake(-6, -6, -6, 0)
+                                            forShape:MDCFloatingButtonShapeDefault
+                                              inMode:MDCFloatingButtonModeExpanded];
+
+  [self.view addSubview:self.iPadLabel];
+  [self.view addSubview:self.miniFloatingButton];
+  [self.view addSubview:self.defaultFloatingButton];
+  [self.view addSubview:self.largeIconFloatingButton];
+}
+
+- (void)viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
+
+  [self.iPadLabel sizeToFit];
+  [self.largeIconFloatingButton sizeToFit];
+  [self.defaultFloatingButton sizeToFit];
+  [self.miniFloatingButton sizeToFit];
+
+  CGFloat totalUsedHeight = self.iPadLabel.intrinsicContentSize.height +
+      self.miniFloatingButton.intrinsicContentSize.height +
+      self.defaultFloatingButton.intrinsicContentSize.height +
+      self.largeIconFloatingButton.intrinsicContentSize.height;
+
+  CGRect bounds = self.view.bounds;
+  if (totalUsedHeight > CGRectGetHeight(bounds)) {
+    totalUsedHeight -= self.iPadLabel.intrinsicContentSize.height;
+    self.iPadLabel.hidden = YES;
+  }
+
+  CGFloat remainingMargins = MAX(0, CGRectGetHeight(bounds) - totalUsedHeight);
+  NSInteger interViewGapCount = self.iPadLabel.hidden ? 2 : 3;
+  CGFloat interViewSpacing = MIN(20, remainingMargins / interViewGapCount);
+  CGFloat viewYOffset = (remainingMargins - interViewSpacing * interViewGapCount) / 2;
+
+  CGSize miniFabSize = self.miniFloatingButton.intrinsicContentSize;
+  CGSize defaultFabSize = self.defaultFloatingButton.intrinsicContentSize;
+  CGSize largeIconFabSize = self.largeIconFloatingButton.intrinsicContentSize;
+
+  CGFloat xOffset = CGRectGetMinX(bounds) + 20;
+  if (!self.iPadLabel.hidden) {
+    self.iPadLabel.center =
+        CGPointMake(CGRectGetMidX(bounds),
+                    viewYOffset + self.iPadLabel.intrinsicContentSize.height / 2);
+    viewYOffset += self.iPadLabel.intrinsicContentSize.height + interViewSpacing;
+  }
+
+  self.miniFloatingButton.center =
+      CGPointMake(xOffset + miniFabSize.width / 2 + (defaultFabSize.width - miniFabSize.width) / 2,
+                  viewYOffset + miniFabSize.height / 2);
+  viewYOffset += miniFabSize.height + interViewSpacing;
+  self.defaultFloatingButton.center =
+      CGPointMake(xOffset + defaultFabSize.width / 2, viewYOffset + defaultFabSize.height / 2);
+  viewYOffset += defaultFabSize.height + interViewSpacing;
+  self.largeIconFloatingButton.center =
+      CGPointMake(xOffset + largeIconFabSize.width / 2, viewYOffset + largeIconFabSize.height / 2);
+}
+
+- (void)updateFloatingButtonsWhenSizeClassIsRegularRegular:(BOOL)isRegularRegular {
+  if (isRegularRegular) {
+    self.miniFloatingButton.mode = MDCFloatingButtonModeExpanded;
+    [self.miniFloatingButton setTitle:@"Add" forState:UIControlStateNormal];
+    self.defaultFloatingButton.mode = MDCFloatingButtonModeExpanded;
+    [self.defaultFloatingButton setTitle:@"Create" forState:UIControlStateNormal];
+    self.largeIconFloatingButton.mode = MDCFloatingButtonModeExpanded;
+    [self.largeIconFloatingButton setTitle:@"Create" forState:UIControlStateNormal];
+  } else {
+    self.miniFloatingButton.mode = MDCFloatingButtonModeNormal;
+    [self.miniFloatingButton setTitle:nil forState:UIControlStateNormal];
+    self.defaultFloatingButton.mode = MDCFloatingButtonModeNormal;
+    [self.defaultFloatingButton setTitle:nil forState:UIControlStateNormal];
+    self.largeIconFloatingButton.mode = MDCFloatingButtonModeNormal;
+    [self.largeIconFloatingButton setTitle:nil forState:UIControlStateNormal];
+  }
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+  [super viewWillAppear:animated];
+
+  UIUserInterfaceSizeClass horizontalSizeClass = self.traitCollection.horizontalSizeClass;
+  UIUserInterfaceSizeClass verticalSizeClass = self.traitCollection.verticalSizeClass;
+  if (horizontalSizeClass == UIUserInterfaceSizeClassRegular &&
+      verticalSizeClass == UIUserInterfaceSizeClassRegular) {
+    [self updateFloatingButtonsWhenSizeClassIsRegularRegular:YES];
+  } else {
+    [self updateFloatingButtonsWhenSizeClassIsRegularRegular:NO];
+  }
+}
+
+- (void)willTransitionToTraitCollection:(UITraitCollection *)newCollection
+              withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+  [super willTransitionToTraitCollection:newCollection withTransitionCoordinator:coordinator];
+
+  UITraitCollection *currentTraits = self.traitCollection;
+  BOOL sizeClassChanged = currentTraits.horizontalSizeClass != newCollection.horizontalSizeClass ||
+      currentTraits.verticalSizeClass != newCollection.verticalSizeClass;
+  if (sizeClassChanged) {
+    BOOL isRegularRegular = newCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular &&
+        newCollection.verticalSizeClass == UIUserInterfaceSizeClassRegular;
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+      [self updateFloatingButtonsWhenSizeClassIsRegularRegular:isRegularRegular];
+    } completion:nil];
+  }
+}
+
+#pragma mark - Catalog by Convention
+
++ (NSArray<NSString *> *)catalogBreadcrumbs {
+  return @[ @"Buttons", @"Floating Action Button" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+@end


### PR DESCRIPTION
Includes automatic adjustment of extended/normal layout depending on size
classes.

![ext-fab-iphone4s](https://user-images.githubusercontent.com/1753199/33493149-2db2591a-d68d-11e7-9514-21ea9772bf8d.png)

![ext-fab-ipad-resized](https://user-images.githubusercontent.com/1753199/33493540-614bb6e4-d68e-11e7-959c-0f6539aaeedf.png)



Demonstrates #2495