### PR TITLE
[Buttons] Update README for Extended FAB

### DIFF
--- a/components/Buttons/README.md
+++ b/components/Buttons/README.md
@@ -53,8 +53,8 @@ You should not directly instantiate an MDCButton object.
 
 ### Requirements
 
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
+- Xcode 8.3.3 or higher.
+- iOS SDK version 8.0 or higher.
 
 ### Installation with CocoaPods
 
@@ -98,8 +98,9 @@ import MaterialComponents
 All buttons display animated ink splashes when the user interacts with the button.
 
 ### Background color
-For non-flat buttons, the background color is determined from the enabled, disabled-light, and
-disabled-dark background color properties. Flat buttons have a transparent background.
+For non-flat buttons, the background color is determined from the UIControlState. Changing the
+background color can be accomplished by calling `-setBackgroundColor:forState:`. Flat buttons have a
+transparent background.
 
 ### Disabled state
 When disabled, Material buttons take on a specific semi-transparent appearance which depends on
@@ -207,3 +208,25 @@ MDCFloatingButton *floatingButton = [[MDCFloatingButton alloc] init];
 [self.view addSubview:floatingButton];
 ```
 <!--</div>-->
+
+
+### Configuring a Floating Action Button
+The floating action button can be configured with a combination of `shape` and `mode`. The 
+`.default` shape is a 56-point circle containing a single image or short title. The `.mini` shape
+is a smaller, 40-point circle.  The `.normal` mode is a circle containing an image or short title.
+The `.expanded` mode is a "pill shape" and should include both an image and a single-word title. The
+`.expanded` mode should only be used in the largest layouts. For example, an iPad in full screen.
+
+While in the `.expanded` mode, a floating button can position its `imageView` to either the leading
+or trailing side of the title by setting the `imageLocation` property.
+
+Because of the combination of shapes and modes available to the floating action button, some
+UIButton property setters have been made unavailable and replaced with methods to set them for a 
+specific mode and shape combination.  Although the `shape` value of a floating button cannot change,
+supporting UIAppearance requires providing the `shape` as an argument. Getters for these values are
+not available, and the normal getter will return the current value of the property.
+
+* `-setContentEdgeInsets` is replaced with `-setContentEdgeInsets:forShape:inMode:`
+* `-setHitAreaInsets` is replaced with `-setHitAreaInsets:forShape:inMode:`
+* `-setMinimumSize` is replaced with `-setMinimumSize:forShape:inMode:`
+* `-setMaximumSize` is replaced with `-setMaximumSize:forShape:inMode:`


### PR DESCRIPTION
The README includes usage examples for the FAB. Adding a section to
demonstrate how to configure the FAB in its different shapes and modes.

Documents #2495
