### PR TITLE
[Buttons] Rename to `imageTitleSpace`

### DIFF
--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -93,7 +93,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
 
  The default value is 8.
  */
-@property(nonatomic, assign) CGFloat imageTitleSpacing UI_APPEARANCE_SELECTOR;
+@property(nonatomic, assign) CGFloat imageTitleSpace UI_APPEARANCE_SELECTOR;
 
 /**
  Returns a MDCFloatingButton with default colors and the given @c shape.

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -23,14 +23,14 @@
 
 static const CGFloat MDCFloatingButtonDefaultDimension = 56;
 static const CGFloat MDCFloatingButtonMiniDimension = 40;
-static const CGFloat MDCFloatingButtonDefaultImageTitleSpacing = 8;
+static const CGFloat MDCFloatingButtonDefaultImageTitleSpace = 8;
 static const UIEdgeInsets internalLayoutSpacingInsets = (UIEdgeInsets){0, 16, 0, 24};
 
 static NSString *const MDCFloatingButtonShapeKey = @"MDCFloatingButtonShapeKey";
 static NSString *const MDCFloatingButtonModeKey = @"MDCFloatingButtonModeKey";
 static NSString *const MDCFloatingButtonImageLocationKey = @"MDCFloatingButtonImageLocationKey";
-static NSString *const MDCFloatingButtonImageTitleSpacingKey =
-    @"MDCFloatingButtonImageTitleSpacingKey";
+static NSString *const MDCFloatingButtonImageTitleSpaceKey =
+    @"MDCFloatingButtonImageTitleSpaceKey";
 static NSString *const MDCFloatingButtonMinimumSizeDictionaryKey =
     @"MDCFloatingButtonMinimumSizeDictionaryKey";
 static NSString *const MDCFloatingButtonMaximumSizeDictionaryKey =
@@ -118,9 +118,9 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
     if ([aDecoder containsValueForKey:MDCFloatingButtonImageLocationKey]) {
       _imageLocation = [aDecoder decodeIntegerForKey:MDCFloatingButtonImageLocationKey];
     }
-    if ([aDecoder containsValueForKey:MDCFloatingButtonImageTitleSpacingKey]) {
-      _imageTitleSpacing =
-          (CGFloat)[aDecoder decodeDoubleForKey:MDCFloatingButtonImageTitleSpacingKey];
+    if ([aDecoder containsValueForKey:MDCFloatingButtonImageTitleSpaceKey]) {
+      _imageTitleSpace =
+          (CGFloat)[aDecoder decodeDoubleForKey:MDCFloatingButtonImageTitleSpaceKey];
     }
     if ([aDecoder containsValueForKey:MDCFloatingButtonMinimumSizeDictionaryKey]) {
       _shapeToModeToMinimumSize = (NSMutableDictionary *)
@@ -149,7 +149,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
   [aCoder encodeInteger:_shape forKey:MDCFloatingButtonShapeKey];
   [aCoder encodeInteger:self.mode forKey:MDCFloatingButtonModeKey];
   [aCoder encodeInteger:self.imageLocation forKey:MDCFloatingButtonImageLocationKey];
-  [aCoder encodeDouble:self.imageTitleSpacing forKey:MDCFloatingButtonImageTitleSpacingKey];
+  [aCoder encodeDouble:self.imageTitleSpace forKey:MDCFloatingButtonImageTitleSpaceKey];
   [aCoder encodeObject:self.shapeToModeToMinimumSize
                 forKey:MDCFloatingButtonMinimumSizeDictionaryKey];
   [aCoder encodeObject:self.shapeToModeToMaximumSize
@@ -161,7 +161,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
 }
 
 - (void)commonMDCFloatingButtonInit {
-  _imageTitleSpacing = MDCFloatingButtonDefaultImageTitleSpacing;
+  _imageTitleSpace = MDCFloatingButtonDefaultImageTitleSpace;
 
   const CGSize miniNormalSize = CGSizeMake(MDCFloatingButtonMiniDimension,
                                            MDCFloatingButtonMiniDimension);
@@ -238,7 +238,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
   const CGSize intrinsicImageSize =
       [self.imageView sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)];
   CGFloat intrinsicWidth = intrinsicTitleSize.width + intrinsicImageSize.width +
-      self.imageTitleSpacing + internalLayoutSpacingInsets.left +
+      self.imageTitleSpace + internalLayoutSpacingInsets.left +
       internalLayoutSpacingInsets.right + self.contentEdgeInsets.left +
       self.contentEdgeInsets.right;
   CGFloat intrinsicHeight = MAX(intrinsicTitleSize.height, intrinsicImageSize.height) +
@@ -309,7 +309,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
   const CGFloat boundsCenterY = CGRectGetMidY(insetBounds);
   CGFloat titleWidthAvailable = CGRectGetWidth(insetBounds);
   titleWidthAvailable -= imageViewWidth;
-  titleWidthAvailable -= self.imageTitleSpacing;
+  titleWidthAvailable -= self.imageTitleSpace;
 
   const CGFloat availableHeight = CGRectGetHeight(insetBounds);
   CGSize titleIntrinsicSize

--- a/components/Buttons/tests/unit/FloatingButtonTests.m
+++ b/components/Buttons/tests/unit/FloatingButtonTests.m
@@ -473,7 +473,7 @@
   [button setMaximumSize:CGSizeMake(100, 48)
                 forShape:MDCFloatingButtonShapeDefault
                   inMode:MDCFloatingButtonModeExpanded];
-  button.imageTitleSpacing = 12;
+  button.imageTitleSpace = 12;
 
   // When
   [button sizeToFit];
@@ -485,7 +485,7 @@
   XCTAssertEqualWithAccuracy(imageFrame.origin.x, 16, 1);
   XCTAssertEqualWithAccuracy(CGRectGetMaxX(titleFrame), buttonBounds.size.width - 24, 1);
   XCTAssertEqualWithAccuracy(titleFrame.origin.x,
-                             CGRectGetMaxX(imageFrame) + button.imageTitleSpacing, 1);
+                             CGRectGetMaxX(imageFrame) + button.imageTitleSpace, 1);
 }
 
 - (void)testExpandedLayoutWithNonZeroContentEdgeInsets {
@@ -515,7 +515,7 @@
   XCTAssertEqualWithAccuracy(imageFrame.origin.x, 12, 1);
   XCTAssertEqualWithAccuracy(CGRectGetMaxX(titleFrame), buttonBounds.size.width - 16, 1);
   XCTAssertEqualWithAccuracy(titleFrame.origin.x,
-                             CGRectGetMaxX(imageFrame) + button.imageTitleSpacing, 1);
+                             CGRectGetMaxX(imageFrame) + button.imageTitleSpace, 1);
 }
 
 #pragma mark - Encoding/decoding


### PR DESCRIPTION
The previous name, `imageTitleSpacing` sounds too much like a protocol name,
one that would adjust the space between things.

Amends #2563
Implements #2495