### PR TITLE
[Ink] Use updated ink for bottom navigation

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -265,7 +265,6 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
 
 - (void)didTouchDownButton:(UIButton *)button {
   MDCBottomNavigationItemView *itemView = (MDCBottomNavigationItemView *)button.superview;
-  itemView.circleHighlightHidden = NO;
   CGPoint centerPoint = CGPointMake(CGRectGetMidX(itemView.inkView.bounds),
                                     CGRectGetMidY(itemView.inkView.bounds));
   [itemView.inkView startTouchBeganAnimationAtPoint:centerPoint completion:nil];
@@ -286,7 +285,6 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
           [self.delegate bottomNavigationBar:self didSelectItem:item];
         }
       }
-      itemView.circleHighlightHidden = YES;
       [itemView.inkView startTouchEndedAnimationAtPoint:CGPointZero completion:nil];
     }
   }
@@ -294,7 +292,6 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
 
 - (void)didTouchUpOutsideButton:(UIButton *)button {
   MDCBottomNavigationItemView *itemView = (MDCBottomNavigationItemView *)button.superview;
-  itemView.circleHighlightHidden = YES;
   [itemView.inkView startTouchEndedAnimationAtPoint:CGPointZero completion:nil];
 }
 

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -81,6 +81,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   _containerView = [[UIView alloc] initWithFrame:CGRectZero];
   _containerView.autoresizingMask = (UIViewAutoresizingFlexibleLeftMargin |
                                      UIViewAutoresizingFlexibleRightMargin);
+  _containerView.clipsToBounds = YES;
   [self addSubview:_containerView];
   [self setElevation:kMDCBottomNavigationBarElevation];
   _itemViews = [NSMutableArray array];
@@ -265,6 +266,9 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
 - (void)didTouchDownButton:(UIButton *)button {
   MDCBottomNavigationItemView *itemView = (MDCBottomNavigationItemView *)button.superview;
   itemView.circleHighlightHidden = NO;
+  CGPoint centerPoint = CGPointMake(CGRectGetMidX(itemView.inkView.bounds),
+                                    CGRectGetMidY(itemView.inkView.bounds));
+  [itemView.inkView startTouchBeganAnimationAtPoint:centerPoint completion:nil];
 }
 
 - (void)didTouchUpInsideButton:(UIButton *)button {
@@ -283,6 +287,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
         }
       }
       itemView.circleHighlightHidden = YES;
+      [itemView.inkView startTouchEndedAnimationAtPoint:CGPointZero completion:nil];
     }
   }
 }
@@ -290,6 +295,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
 - (void)didTouchUpOutsideButton:(UIButton *)button {
   MDCBottomNavigationItemView *itemView = (MDCBottomNavigationItemView *)button.superview;
   itemView.circleHighlightHidden = YES;
+  [itemView.inkView startTouchEndedAnimationAtPoint:CGPointZero completion:nil];
 }
 
 #pragma mark - Setters

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
@@ -21,7 +21,6 @@
 
 @interface MDCBottomNavigationItemView : UIView
 
-@property(nonatomic, assign) BOOL circleHighlightHidden;
 @property(nonatomic, assign) BOOL titleBelowIcon;
 @property(nonatomic, assign) BOOL selected;
 @property(nonatomic, assign) MDCBottomNavigationBarTitleVisibility titleVisibility;

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
@@ -17,6 +17,7 @@
 #import <UIKit/UIKit.h>
 
 #import "MDCBottomNavigationBar.h"
+#import "MaterialInk.h"
 
 @interface MDCBottomNavigationItemView : UIView
 
@@ -24,6 +25,7 @@
 @property(nonatomic, assign) BOOL titleBelowIcon;
 @property(nonatomic, assign) BOOL selected;
 @property(nonatomic, assign) MDCBottomNavigationBarTitleVisibility titleVisibility;
+@property(nonatomic, strong) MDCInkView *inkView;
 
 @property(nonatomic, copy) NSString *badgeValue;
 @property(nonatomic, copy) NSString *title;

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -22,10 +22,9 @@
 #import "MaterialBottomNavigationStrings_table.h"
 #import "MDCBottomNavigationItemBadge.h"
 
-static const CGFloat kMDCBottomNavigationItemViewCircleLayerOffset = -6.f;
-static const CGFloat kMDCBottomNavigationItemViewCircleLayerDimension = 36.f;
-static const CGFloat kMDCBottomNavigationItemViewCircleOpacity = 0.150f;
-static const CGFloat kMDCBottomNavigationItemViewTitleFontSize = 12.f;
+static const CGFloat MDCBottomNavigationItemViewInkOpacity = 0.150f;
+static const CGFloat MDCBottomNavigationItemViewInkRadius = 18.f;
+static const CGFloat MDCBottomNavigationItemViewTitleFontSize = 12.f;
 
 // The duration of the selection transition animation.
 static const NSTimeInterval kMDCBottomNavigationItemViewTransitionDuration = 0.180f;
@@ -36,10 +35,10 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 
 @interface MDCBottomNavigationItemView ()
 
-@property(nonatomic, strong) CAShapeLayer *circleLayer;
 @property(nonatomic, strong) MDCBottomNavigationItemBadge *badge;
 @property(nonatomic, strong) UIImageView *iconImageView;
 @property(nonatomic, strong) UILabel *label;
+@property(nonatomic, strong) UIView *circleView;
 
 @end
 
@@ -72,7 +71,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 
   _label = [[UILabel alloc] initWithFrame:CGRectZero];
   _label.text = _title;
-  _label.font = [UIFont systemFontOfSize:kMDCBottomNavigationItemViewTitleFontSize];
+  _label.font = [UIFont systemFontOfSize:MDCBottomNavigationItemViewTitleFontSize];
   _label.textAlignment = NSTextAlignmentCenter;
   _label.textColor = _selectedItemTintColor;
   _label.isAccessibilityElement = NO;
@@ -85,17 +84,13 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
   if (!_badge.badgeValue) {
     _badge.hidden = YES;
   }
-
-  _circleLayer = [CAShapeLayer layer];
-  CGRect circleLayerRect = CGRectMake(kMDCBottomNavigationItemViewCircleLayerOffset,
-                                      kMDCBottomNavigationItemViewCircleLayerOffset,
-                                      kMDCBottomNavigationItemViewCircleLayerDimension,
-                                      kMDCBottomNavigationItemViewCircleLayerDimension);
-  UIBezierPath *bezierPath = [UIBezierPath bezierPathWithOvalInRect:circleLayerRect];
-  _circleLayer.path = bezierPath.CGPath;
-  _circleLayer.fillColor = _selectedItemTintColor.CGColor;
-  _circleLayer.opacity = 0;
-  [_iconImageView.layer addSublayer:_circleLayer];
+  
+  _inkView = [[MDCInkView alloc] initWithFrame:self.bounds];
+  _inkView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+  _inkView.usesLegacyInkRipple = NO;
+  _inkView.maxRippleRadius = MDCBottomNavigationItemViewInkRadius;
+  _inkView.clipsToBounds = NO;
+  [_iconImageView addSubview:_inkView];
 
   _button = [[UIButton alloc] initWithFrame:self.bounds];
   _button.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
@@ -249,25 +244,11 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
   [self centerLayoutAnimated:animated];
 }
 
-- (void)setCircleHighlightHidden:(BOOL)circleHighlightHidden {
-  _circleHighlightHidden = circleHighlightHidden;
-  if (!circleHighlightHidden) {
-    self.circleLayer.opacity = kMDCBottomNavigationItemViewCircleOpacity;
-    self.iconImageView.tintColor = self.selectedItemTintColor;
-  } else {
-    self.circleLayer.opacity = 0;
-    if (self.selected) {
-      self.iconImageView.tintColor = self.selectedItemTintColor;
-    } else {
-      self.iconImageView.tintColor = self.unselectedItemTintColor;
-    }
-  }
-}
-
 - (void)setSelectedItemTintColor:(UIColor *)selectedItemTintColor {
   _selectedItemTintColor = selectedItemTintColor;
   self.label.textColor = self.selectedItemTintColor;
-  self.circleLayer.fillColor = self.selectedItemTintColor.CGColor;
+  self.inkView.inkColor =
+      [self.selectedItemTintColor colorWithAlphaComponent:MDCBottomNavigationItemViewInkOpacity];
 }
 
 - (void)setUnselectedItemTintColor:(UIColor *)unselectedItemTintColor {

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -20,10 +20,10 @@
 
 #import "MaterialBottomNavigationStrings.h"
 #import "MaterialBottomNavigationStrings_table.h"
+#import "MaterialMath.h"
 #import "MDCBottomNavigationItemBadge.h"
 
 static const CGFloat MDCBottomNavigationItemViewInkOpacity = 0.150f;
-static const CGFloat MDCBottomNavigationItemViewInkRadius = 18.f;
 static const CGFloat MDCBottomNavigationItemViewTitleFontSize = 12.f;
 
 // The duration of the selection transition animation.
@@ -88,9 +88,8 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
   _inkView = [[MDCInkView alloc] initWithFrame:self.bounds];
   _inkView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
   _inkView.usesLegacyInkRipple = NO;
-  _inkView.maxRippleRadius = MDCBottomNavigationItemViewInkRadius;
   _inkView.clipsToBounds = NO;
-  [_iconImageView addSubview:_inkView];
+  [self addSubview:_inkView];
 
   _button = [[UIButton alloc] initWithFrame:self.bounds];
   _button.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
@@ -107,6 +106,8 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
                                            attributes:@{ NSFontAttributeName:self.label.font }
                                               context:nil].size;
   self.label.frame = CGRectMake(0, 0, labelSize.width, labelSize.height);
+  self.inkView.maxRippleRadius =
+      (CGFloat)(MDCHypot(CGRectGetHeight(self.bounds), CGRectGetWidth(self.bounds)) / 2);
   [self centerLayoutAnimated:NO];
 }
 

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -38,7 +38,6 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 @property(nonatomic, strong) MDCBottomNavigationItemBadge *badge;
 @property(nonatomic, strong) UIImageView *iconImageView;
 @property(nonatomic, strong) UILabel *label;
-@property(nonatomic, strong) UIView *circleView;
 
 @end
 

--- a/components/Ink/src/MDCInkView.m
+++ b/components/Ink/src/MDCInkView.m
@@ -153,16 +153,6 @@
     inkLayer.inkColor = self.inkColor;
     inkLayer.maxRippleRadius = self.maxRippleRadius;
     inkLayer.animationDelegate = self;
-
-    switch (self.inkStyle) {
-      case MDCInkStyleBounded:
-        self.clipsToBounds = YES;
-        break;
-      case MDCInkStyleUnbounded:
-        self.clipsToBounds = NO;
-        break;
-    }
-
     inkLayer.opacity = 0;
     inkLayer.frame = self.bounds;
     [self.layer addSublayer:inkLayer];

--- a/components/Ink/src/private/MDCInkLayer.m
+++ b/components/Ink/src/private/MDCInkLayer.m
@@ -21,6 +21,7 @@ static const CGFloat MDCInkLayerCommonDuration = 0.083f;
 static const CGFloat MDCInkLayerStartScalePositionDuration = 0.333f;
 static const CGFloat MDCInkLayerStartFadeHalfDuration = 0.167f;
 static const CGFloat MDCInkLayerStartFadeHalfBeginTimeFadeOutDuration = 0.25f;
+static const CGFloat MDCInkLayerEndFadeOutDuration = 0.15f;
 
 static const CGFloat MDCInkLayerScaleStartMin = 0.2f;
 static const CGFloat MDCInkLayerScaleStartMax = 0.6f;
@@ -187,7 +188,7 @@ static NSString *const MDCInkLayerScaleString = @"transform.scale";
   fadeOutAnim.keyPath = MDCInkLayerOpacityString;
   fadeOutAnim.fromValue = @(opacity);
   fadeOutAnim.toValue = @0;
-  fadeOutAnim.duration = MDCInkLayerStartScalePositionDuration;
+  fadeOutAnim.duration = MDCInkLayerEndFadeOutDuration;
   fadeOutAnim.beginTime = CACurrentMediaTime() + self.endAnimationDelay;
   fadeOutAnim.timingFunction =
       [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];

--- a/components/Ink/src/private/MDCInkLayer.m
+++ b/components/Ink/src/private/MDCInkLayer.m
@@ -21,7 +21,6 @@ static const CGFloat MDCInkLayerCommonDuration = 0.083f;
 static const CGFloat MDCInkLayerStartScalePositionDuration = 0.333f;
 static const CGFloat MDCInkLayerStartFadeHalfDuration = 0.167f;
 static const CGFloat MDCInkLayerStartFadeHalfBeginTimeFadeOutDuration = 0.25f;
-static const CGFloat MDCInkLayerEndFadeOutDuration = 0.15f;
 
 static const CGFloat MDCInkLayerScaleStartMin = 0.2f;
 static const CGFloat MDCInkLayerScaleStartMax = 0.6f;
@@ -188,7 +187,7 @@ static NSString *const MDCInkLayerScaleString = @"transform.scale";
   fadeOutAnim.keyPath = MDCInkLayerOpacityString;
   fadeOutAnim.fromValue = @(opacity);
   fadeOutAnim.toValue = @0;
-  fadeOutAnim.duration = MDCInkLayerEndFadeOutDuration;
+  fadeOutAnim.duration = MDCInkLayerStartScalePositionDuration;
   fadeOutAnim.beginTime = CACurrentMediaTime() + self.endAnimationDelay;
   fadeOutAnim.timingFunction =
       [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];


### PR DESCRIPTION
[Ink] Use updated ink for bottom navigation. Uses smaller ink ripple closer to bounds of item frame.

Removes use of MDCInkStyle for updated ink ripple since MDCInkStyle should only be used with legacy ink ripple.

![simulator screen shot - iphone 8 - 2017-12-04 at 15 09 51](https://user-images.githubusercontent.com/760941/33573899-46b913d4-d905-11e7-8ac6-902bdbf98fc0.png)


