### PR TITLE
[Collections] Fix iOS 11-specific bug where section headers would overlap scroll indicators.

### DIFF
--- a/components/Collections/src/MDCCollectionViewController.m
+++ b/components/Collections/src/MDCCollectionViewController.m
@@ -117,6 +117,23 @@ NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFoote
                  withReuseIdentifier:classIdentifier];
 }
 
+- (void)viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
+
+  // Fixes an iOS 11 bug where supplementary views would be given a zPosition of 1, meaning the
+  // scroll view indicator (with a zPosition of 0) would be placed behind supplementary views.
+  // We know that iOS keeps the scroll indicator as the top-most view in the hierarchy as a subview,
+  // so we grab it and give it a better zPosition ourselves.
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    UIView *maybeScrollViewIndicator = self.collectionView.subviews.lastObject;
+    if ([maybeScrollViewIndicator isKindOfClass:[UIImageView class]]) {
+      maybeScrollViewIndicator.layer.zPosition = 2;
+    }
+  }
+#endif
+}
+
 - (void)setCollectionView:(__kindof UICollectionView *)collectionView {
   [super setCollectionView:collectionView];
 


### PR DESCRIPTION
Closes https://github.com/material-components/material-components-ios/issues/2309

Before:
![uzs0mriaas9](https://user-images.githubusercontent.com/45670/33568132-71018dcc-d8f3-11e7-83cf-766c88283b7d.png)

After:
![t53ospqgcsg](https://user-images.githubusercontent.com/45670/33568139-759f1ba6-d8f3-11e7-8875-3feb9d4f13f0.png)
