### PR TITLE
[BottomNavigation] Ensure item top and bottom content insets are identical

### DIFF
--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -123,9 +123,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 - (void)centerLayoutAnimated:(bool)animated {
   if (self.titleBelowIcon) {
     CGPoint iconImageViewCenter =
-        CGPointMake(CGRectGetMidX(self.bounds),
-                    CGRectGetMidY(self.bounds) - CGRectGetHeight(self.bounds) / 2 +
-                    CGRectGetHeight(self.iconImageView.bounds) / 2 +
+        CGPointMake(CGRectGetMidX(self.bounds), CGRectGetHeight(self.iconImageView.bounds) / 2 +
                     kMDCBottomNavigationItemViewItemInset);
     BOOL titleVisibilityNever = self.selected &&
         self.titleVisibility == MDCBottomNavigationBarTitleVisibilityNever;
@@ -141,10 +139,8 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
         CGPointMake(CGRectGetMidX(self.bounds) + CGRectGetWidth(self.iconImageView.bounds) / 2,
                     iconImageViewCenter.y - CGRectGetMidX(self.iconImageView.bounds));
     self.label.center =
-        CGPointMake(CGRectGetMidX(self.bounds),
-                    CGRectGetMidY(self.bounds) + CGRectGetHeight(self.bounds) / 2 -
-                    CGRectGetHeight(self.label.bounds) / 2 -
-                    kMDCBottomNavigationItemViewItemInset);
+        CGPointMake(CGRectGetMidX(self.bounds), CGRectGetHeight(self.bounds) -
+                    CGRectGetHeight(self.label.bounds) / 2 - kMDCBottomNavigationItemViewItemInset);
     if (animated) {
       [UIView animateWithDuration:kMDCBottomNavigationItemViewTransitionDuration animations:^(void) {
         self.iconImageView.center = iconImageViewCenter;

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -29,6 +29,7 @@
 static const CGFloat kMDCBottomNavigationItemViewCircleLayerOffset = -6.f;
 static const CGFloat kMDCBottomNavigationItemViewCircleLayerDimension = 36.f;
 static const CGFloat kMDCBottomNavigationItemViewCircleOpacity = 0.150f;
+static const CGFloat kMDCBottomNavigationItemViewItemInset = 8.f;
 static const CGFloat kMDCBottomNavigationItemViewTitleFontSize = 12.f;
 
 // The duration of the selection transition animation.
@@ -123,7 +124,9 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
   if (self.titleBelowIcon) {
     CGPoint iconImageViewCenter =
         CGPointMake(CGRectGetMidX(self.bounds),
-                    CGRectGetMidY(self.bounds) - CGRectGetHeight(self.bounds) * 0.1f);
+                    CGRectGetMidY(self.bounds) - CGRectGetHeight(self.bounds) / 2 +
+                    CGRectGetHeight(self.iconImageView.bounds) / 2 +
+                    kMDCBottomNavigationItemViewItemInset);
     BOOL titleVisibilityNever = self.selected &&
         self.titleVisibility == MDCBottomNavigationBarTitleVisibilityNever;
     BOOL titleVisibilitySelectedNever = !self.selected &&
@@ -139,7 +142,9 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
                     iconImageViewCenter.y - CGRectGetMidX(self.iconImageView.bounds));
     self.label.center =
         CGPointMake(CGRectGetMidX(self.bounds),
-                    CGRectGetMidY(self.bounds) + CGRectGetHeight(self.bounds) * 0.25f);
+                    CGRectGetMidY(self.bounds) + CGRectGetHeight(self.bounds) / 2 -
+                    CGRectGetHeight(self.label.bounds) / 2 -
+                    kMDCBottomNavigationItemViewItemInset);
     if (animated) {
       [UIView animateWithDuration:kMDCBottomNavigationItemViewTransitionDuration animations:^(void) {
         self.iconImageView.center = iconImageViewCenter;


### PR DESCRIPTION
Ensure item top and bottom content insets are identical.

<img width="587" alt="screen shot 2017-12-04 at 5 28 44 pm" src="https://user-images.githubusercontent.com/760941/33579878-377c011a-d919-11e7-96b8-230bb153bdab.png">
