### PR TITLE
[Ink] Prevent ink layers from collecting. Copy sublayers before calling removeFromSuperlayer

### DIFF
--- a/components/Ink/src/MDCInkView.m
+++ b/components/Ink/src/MDCInkView.m
@@ -77,7 +77,8 @@
   CGRect inkBounds = CGRectMake(0, 0, CGRectGetWidth(self.bounds), CGRectGetHeight(self.bounds));
 
   // When bounds change ensure all ink layer bounds are changed too.
-  for (CALayer *layer in self.layer.sublayers) {
+  NSArray<CALayer *> *sublayers = [self.layer.sublayers copy];
+  for (CALayer *layer in sublayers) {
     if ([layer isKindOfClass:[MDCInkLayer class]]) {
       MDCInkLayer *inkLayer = (MDCInkLayer *)layer;
       inkLayer.bounds = inkBounds;
@@ -185,7 +186,8 @@
   if (self.usesLegacyInkRipple) {
     [self.inkLayer resetAllInk:animated];
   } else {
-    for (CALayer *layer in self.layer.sublayers) {
+    NSArray<CALayer *> *sublayers = [self.layer.sublayers copy];
+    for (CALayer *layer in sublayers) {
       if ([layer isKindOfClass:[MDCInkLayer class]]) {
         MDCInkLayer *inkLayer = (MDCInkLayer *)layer;
         if (animated) {

--- a/components/Ink/src/MDCInkView.m
+++ b/components/Ink/src/MDCInkView.m
@@ -77,8 +77,7 @@
   CGRect inkBounds = CGRectMake(0, 0, CGRectGetWidth(self.bounds), CGRectGetHeight(self.bounds));
 
   // When bounds change ensure all ink layer bounds are changed too.
-  NSArray<CALayer *> *sublayers = [self.layer.sublayers copy];
-  for (CALayer *layer in sublayers) {
+  for (CALayer *layer in self.layer.sublayers) {
     if ([layer isKindOfClass:[MDCInkLayer class]]) {
       MDCInkLayer *inkLayer = (MDCInkLayer *)layer;
       inkLayer.bounds = inkBounds;


### PR DESCRIPTION
Prevent ink layers from collecting. Copy sublayers before calling removeFromSuperlayer. In cases where the an MDCButton or MDCInkView is removed from a superview and then re-added cancelAllAnimationsAnimated (MDCInkView) is not called unless a copy of the sublayers is kept. 