### PR TITLE
[Buttons] Rename .mode as .mdc_expandedMode

### DIFF
--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -54,7 +54,7 @@
   self.raisedButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, 64, 64);
   [self.floatingActionButton setContentEdgeInsets:UIEdgeInsetsMake(40, 40, 0, 0)
                                          forShape:MDCFloatingButtonShapeDefault
-                                           inMode:MDCFloatingButtonModeNormal];
+                                           inMode:MDCFloatingButtonExpandedModeNormal];
 
   [self updateInkStyle:self.inkBoundingSwitch.isOn ? MDCInkStyleBounded : MDCInkStyleUnbounded];
 }

--- a/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
+++ b/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
@@ -115,15 +115,15 @@ extension FloatingButtonExampleSwiftViewController {
 }
 
 extension FloatingButtonExampleSwiftViewController {
-  func updateFloatingButtons(to mode: MDCFloatingButtonMode) {
-    if (miniFloatingButton.mode != mode) {
-      miniFloatingButton.mode = mode
+  func updateFloatingButtons(to mode: MDCFloatingButtonExpandedMode) {
+    if (miniFloatingButton.mdc_expandedMode != mode) {
+      miniFloatingButton.mdc_expandedMode = mode
     }
-    if (defaultFloatingButton.mode != mode) {
-      defaultFloatingButton.mode = mode
+    if (defaultFloatingButton.mdc_expandedMode != mode) {
+      defaultFloatingButton.mdc_expandedMode = mode
     }
-    if (largeIconFloatingButton.mode != mode) {
-      largeIconFloatingButton.mode = mode
+    if (largeIconFloatingButton.mdc_expandedMode != mode) {
+      largeIconFloatingButton.mdc_expandedMode = mode
     }
   }
 

--- a/components/Buttons/examples/FloatingButtonExampleViewController.m
+++ b/components/Buttons/examples/FloatingButtonExampleViewController.m
@@ -46,7 +46,7 @@
   [self.miniFloatingButton setImage:plusImage forState:UIControlStateNormal];
   [self.miniFloatingButton setMinimumSize:CGSizeMake(96, 40)
                                  forShape:MDCFloatingButtonShapeMini
-                                   inMode:MDCFloatingButtonModeExpanded];
+                                   inMode:MDCFloatingButtonExpandedModeExpanded];
 
   self.defaultFloatingButton = [[MDCFloatingButton alloc] init];
   self.defaultFloatingButton.translatesAutoresizingMaskIntoConstraints = NO;
@@ -57,7 +57,7 @@
   [self.largeIconFloatingButton setImage:plusImage36 forState:UIControlStateNormal];
   [self.largeIconFloatingButton setContentEdgeInsets:UIEdgeInsetsMake(-6, -6, -6, 0)
                                             forShape:MDCFloatingButtonShapeDefault
-                                              inMode:MDCFloatingButtonModeExpanded];
+                                              inMode:MDCFloatingButtonExpandedModeExpanded];
 
   [self.view addSubview:self.iPadLabel];
   [self.view addSubview:self.miniFloatingButton];
@@ -114,18 +114,18 @@
 
 - (void)updateFloatingButtonsWhenSizeClassIsRegularRegular:(BOOL)isRegularRegular {
   if (isRegularRegular) {
-    self.miniFloatingButton.mode = MDCFloatingButtonModeExpanded;
+    self.miniFloatingButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
     [self.miniFloatingButton setTitle:@"Add" forState:UIControlStateNormal];
-    self.defaultFloatingButton.mode = MDCFloatingButtonModeExpanded;
+    self.defaultFloatingButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
     [self.defaultFloatingButton setTitle:@"Create" forState:UIControlStateNormal];
-    self.largeIconFloatingButton.mode = MDCFloatingButtonModeExpanded;
+    self.largeIconFloatingButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
     [self.largeIconFloatingButton setTitle:@"Create" forState:UIControlStateNormal];
   } else {
-    self.miniFloatingButton.mode = MDCFloatingButtonModeNormal;
+    self.miniFloatingButton.mdc_expandedMode = MDCFloatingButtonExpandedModeNormal;
     [self.miniFloatingButton setTitle:nil forState:UIControlStateNormal];
-    self.defaultFloatingButton.mode = MDCFloatingButtonModeNormal;
+    self.defaultFloatingButton.mdc_expandedMode = MDCFloatingButtonExpandedModeNormal;
     [self.defaultFloatingButton setTitle:nil forState:UIControlStateNormal];
-    self.largeIconFloatingButton.mode = MDCFloatingButtonModeNormal;
+    self.largeIconFloatingButton.mdc_expandedMode = MDCFloatingButtonExpandedModeNormal;
     [self.largeIconFloatingButton setTitle:nil forState:UIControlStateNormal];
   }
 }

--- a/components/Buttons/src/MDCFloatingButton.h
+++ b/components/Buttons/src/MDCFloatingButton.h
@@ -36,16 +36,16 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonShape) {
   MDCFloatingButtonShapeMini = 1
 };
 
-typedef NS_ENUM(NSInteger, MDCFloatingButtonMode) {
+typedef NS_ENUM(NSInteger, MDCFloatingButtonExpandedMode) {
   /**
    The floating button is a circle with its contents centered.
    */
-  MDCFloatingButtonModeNormal = 0,
+  MDCFloatingButtonExpandedModeNormal = 0,
 
   /**
    The floating button is a "pill shape" with the image to one side of the title.
    */
-  MDCFloatingButtonModeExpanded = 1,
+  MDCFloatingButtonExpandedModeExpanded = 1,
 };
 
 typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
@@ -78,7 +78,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
 
  The default value is @c .normal .
  */
-@property(nonatomic, assign) MDCFloatingButtonMode mode;
+@property(nonatomic, assign) MDCFloatingButtonExpandedMode mdc_expandedMode;
 
 /**
  The location of the image relative to the title when the floating button is in @c expanded mode.
@@ -152,7 +152,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
  */
 - (void)setMinimumSize:(CGSize)minimumSize
               forShape:(MDCFloatingButtonShape)shape
-                inMode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
+                inMode:(MDCFloatingButtonExpandedMode)mode UI_APPEARANCE_SELECTOR;
 
 - (void)setMaximumSize:(CGSize)maximumSize NS_UNAVAILABLE;
 
@@ -166,7 +166,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
  */
 - (void)setMaximumSize:(CGSize)maximumSize
               forShape:(MDCFloatingButtonShape)shape
-                inMode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
+                inMode:(MDCFloatingButtonExpandedMode)mode UI_APPEARANCE_SELECTOR;
 
 - (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets NS_UNAVAILABLE;
 
@@ -179,7 +179,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
  */
 - (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets
                     forShape:(MDCFloatingButtonShape)shape
-                      inMode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
+                      inMode:(MDCFloatingButtonExpandedMode)mode UI_APPEARANCE_SELECTOR;
 
 - (void)setHitAreaInsets:(UIEdgeInsets)hitAreaInsets NS_UNAVAILABLE;
 
@@ -192,7 +192,7 @@ typedef NS_ENUM(NSInteger, MDCFloatingButtonImageLocation) {
  */
 - (void)setHitAreaInsets:(UIEdgeInsets)hitAreaInsets
                 forShape:(MDCFloatingButtonShape)shape
-                  inMode:(MDCFloatingButtonMode)mode UI_APPEARANCE_SELECTOR;
+                  inMode:(MDCFloatingButtonExpandedMode)mode UI_APPEARANCE_SELECTOR;
 
 #pragma mark - Deprecations
 

--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -27,7 +27,7 @@ static const CGFloat MDCFloatingButtonDefaultImageTitleSpace = 8;
 static const UIEdgeInsets internalLayoutSpacingInsets = (UIEdgeInsets){0, 16, 0, 24};
 
 static NSString *const MDCFloatingButtonShapeKey = @"MDCFloatingButtonShapeKey";
-static NSString *const MDCFloatingButtonModeKey = @"MDCFloatingButtonModeKey";
+static NSString *const MDCFloatingButtonExpandedModeKey = @"MDCFloatingButtonExpandedModeKey";
 static NSString *const MDCFloatingButtonImageLocationKey = @"MDCFloatingButtonImageLocationKey";
 static NSString *const MDCFloatingButtonImageTitleSpaceKey =
     @"MDCFloatingButtonImageTitleSpaceKey";
@@ -112,8 +112,8 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
     // Shape must be set first before the common initialization
     [self commonMDCFloatingButtonInit];
 
-    if ([aDecoder containsValueForKey:MDCFloatingButtonModeKey]) {
-      _mode = [aDecoder decodeIntegerForKey:MDCFloatingButtonModeKey];
+    if ([aDecoder containsValueForKey:MDCFloatingButtonExpandedModeKey]) {
+      _mdc_expandedMode = [aDecoder decodeIntegerForKey:MDCFloatingButtonExpandedModeKey];
     }
     if ([aDecoder containsValueForKey:MDCFloatingButtonImageLocationKey]) {
       _imageLocation = [aDecoder decodeIntegerForKey:MDCFloatingButtonImageLocationKey];
@@ -147,7 +147,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
 - (void)encodeWithCoder:(NSCoder *)aCoder {
   [super encodeWithCoder:aCoder];
   [aCoder encodeInteger:_shape forKey:MDCFloatingButtonShapeKey];
-  [aCoder encodeInteger:self.mode forKey:MDCFloatingButtonModeKey];
+  [aCoder encodeInteger:self.mdc_expandedMode forKey:MDCFloatingButtonExpandedModeKey];
   [aCoder encodeInteger:self.imageLocation forKey:MDCFloatingButtonImageLocationKey];
   [aCoder encodeDouble:self.imageTitleSpace forKey:MDCFloatingButtonImageTitleSpaceKey];
   [aCoder encodeObject:self.shapeToModeToMinimumSize
@@ -172,11 +172,12 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
 
   // Minimum size values for different shape + mode combinations
   NSMutableDictionary *miniShapeMinimumSizeDictionary =
-      [@{ @(MDCFloatingButtonModeNormal) : [NSValue valueWithCGSize:miniNormalSize]
+      [@{ @(MDCFloatingButtonExpandedModeNormal) : [NSValue valueWithCGSize:miniNormalSize]
           } mutableCopy];
   NSMutableDictionary *defaultShapeMinimumSizeDictionary =
-      [@{ @(MDCFloatingButtonModeNormal) : [NSValue valueWithCGSize:defaultNormalSize],
-          @(MDCFloatingButtonModeExpanded) : [NSValue valueWithCGSize:defaultExpandedMinimumSize],
+      [@{ @(MDCFloatingButtonExpandedModeNormal) : [NSValue valueWithCGSize:defaultNormalSize],
+          @(MDCFloatingButtonExpandedModeExpanded) :
+            [NSValue valueWithCGSize:defaultExpandedMinimumSize],
           } mutableCopy];
   _shapeToModeToMinimumSize =
       [@{ @(MDCFloatingButtonShapeMini) : miniShapeMinimumSizeDictionary,
@@ -185,11 +186,12 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
 
   // Maximum size values for different shape + mode combinations
   NSMutableDictionary *miniShapeMaximumSizeDictionary =
-      [@{ @(MDCFloatingButtonModeNormal) : [NSValue valueWithCGSize:miniNormalSize]
+      [@{ @(MDCFloatingButtonExpandedModeNormal) : [NSValue valueWithCGSize:miniNormalSize]
           } mutableCopy];
   NSMutableDictionary *defaultShapeMaximumSizeDictionary =
-      [@{ @(MDCFloatingButtonModeNormal) : [NSValue valueWithCGSize:defaultNormalSize],
-          @(MDCFloatingButtonModeExpanded) : [NSValue valueWithCGSize:defaultExpandedMaximumSize],
+      [@{ @(MDCFloatingButtonExpandedModeNormal) : [NSValue valueWithCGSize:defaultNormalSize],
+          @(MDCFloatingButtonExpandedModeExpanded) :
+            [NSValue valueWithCGSize:defaultExpandedMaximumSize],
           } mutableCopy];
   _shapeToModeToMaximumSize =
       [@{ @(MDCFloatingButtonShapeMini) : miniShapeMaximumSizeDictionary,
@@ -200,7 +202,8 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
   // .mini shape, .normal mode
   const UIEdgeInsets miniNormalContentInsets = UIEdgeInsetsMake(8, 8, 8, 8);
   NSMutableDictionary *miniShapeContentEdgeInsetsDictionary =
-      [@{ @(MDCFloatingButtonModeNormal) : [NSValue valueWithUIEdgeInsets:miniNormalContentInsets]
+      [@{ @(MDCFloatingButtonExpandedModeNormal) :
+            [NSValue valueWithUIEdgeInsets:miniNormalContentInsets]
           } mutableCopy];
   _shapeToModeToContentEdgeInsets =
       [@{ @(MDCFloatingButtonShapeMini) : miniShapeContentEdgeInsetsDictionary
@@ -210,7 +213,8 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
   // .mini shape, .normal mode
   const UIEdgeInsets miniNormalHitAreaInset = UIEdgeInsetsMake(-4, -4, -4, -4);
   NSMutableDictionary *miniShapeHitAreaInsetsDictionary =
-      [@{ @(MDCFloatingButtonModeNormal) : [NSValue valueWithUIEdgeInsets:miniNormalHitAreaInset],
+      [@{ @(MDCFloatingButtonExpandedModeNormal) :
+            [NSValue valueWithUIEdgeInsets:miniNormalHitAreaInset],
           } mutableCopy];
   _shapeToModeToHitAreaInsets =
       [@{ @(MDCFloatingButtonShapeMini) : miniShapeHitAreaInsetsDictionary,
@@ -249,9 +253,9 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
 
 - (CGSize)intrinsicContentSize {
   CGSize contentSize = CGSizeZero;
-  if (self.mode == MDCFloatingButtonModeNormal) {
+  if (self.mdc_expandedMode == MDCFloatingButtonExpandedModeNormal) {
     contentSize = [self intrinsicContentSizeForModeNormal];
-  } else if (self.mode == MDCFloatingButtonModeExpanded) {
+  } else if (self.mdc_expandedMode == MDCFloatingButtonExpandedModeExpanded) {
     contentSize = [self intrinsicContentSizeForModeExpanded];
   }
 
@@ -275,7 +279,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
   self.layer.cornerRadius = CGRectGetHeight(self.bounds) / 2;
   [super layoutSubviews];
 
-   if (self.mode == MDCFloatingButtonModeNormal) {
+   if (self.mdc_expandedMode == MDCFloatingButtonExpandedModeNormal) {
     return;
   }
 
@@ -350,9 +354,9 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
 
 #pragma mark - Property Setters/Getters
 
-- (void)setMode:(MDCFloatingButtonMode)mode {
-  BOOL needsShapeUpdate = self.mode != mode;
-  _mode = mode;
+- (void)setMdc_expandedMode:(MDCFloatingButtonExpandedMode)mode {
+  BOOL needsShapeUpdate = self.mdc_expandedMode != mode;
+  _mdc_expandedMode = mode;
   if (needsShapeUpdate) {
     [self updateShapeForcingResize:YES];
   }
@@ -360,19 +364,19 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
 
 - (void)setMinimumSize:(CGSize)size
               forShape:(MDCFloatingButtonShape)shape
-                inMode:(MDCFloatingButtonMode)mode {
+                inMode:(MDCFloatingButtonExpandedMode)mode {
   NSMutableDictionary *modeToMinimumSize = self.shapeToModeToMinimumSize[@(shape)];
   if (!modeToMinimumSize) {
     modeToMinimumSize = [@{} mutableCopy];
     self.shapeToModeToMinimumSize[@(shape)] = modeToMinimumSize;
   }
   modeToMinimumSize[@(mode)] = [NSValue valueWithCGSize:size];
-  if (shape == _shape && mode == self.mode) {
+  if (shape == _shape && mode == self.mdc_expandedMode) {
     [self updateShapeForcingResize:YES];
   }
 }
 
-- (CGSize)minimumSizeForMode:(MDCFloatingButtonMode)mode {
+- (CGSize)minimumSizeForMode:(MDCFloatingButtonExpandedMode)mode {
   NSMutableDictionary *modeToMinimumSize = self.shapeToModeToMinimumSize[@(_shape)];
   if(!modeToMinimumSize) {
     return CGSizeZero;
@@ -387,7 +391,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
 }
 
 - (BOOL)updateMinimumSize {
-  CGSize newSize = [self minimumSizeForMode:self.mode];
+  CGSize newSize = [self minimumSizeForMode:self.mdc_expandedMode];
   if (CGSizeEqualToSize(newSize, self.minimumSize)) {
     return NO;
   }
@@ -397,19 +401,19 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
 
 - (void)setMaximumSize:(CGSize)size
               forShape:(MDCFloatingButtonShape)shape
-                inMode:(MDCFloatingButtonMode)mode {
+                inMode:(MDCFloatingButtonExpandedMode)mode {
   NSMutableDictionary *modeToMaximumSize = self.shapeToModeToMaximumSize[@(shape)];
   if (!modeToMaximumSize) {
     modeToMaximumSize = [@{} mutableCopy];
     self.shapeToModeToMaximumSize[@(shape)] = modeToMaximumSize;
   }
   modeToMaximumSize[@(mode)] = [NSValue valueWithCGSize:size];
-  if (shape == _shape && mode == self.mode) {
+  if (shape == _shape && mode == self.mdc_expandedMode) {
     [self updateShapeForcingResize:YES];
   }
 }
 
-- (CGSize)maximumSizeForMode:(MDCFloatingButtonMode)mode {
+- (CGSize)maximumSizeForMode:(MDCFloatingButtonExpandedMode)mode {
   NSMutableDictionary *modeToMaximumSize = self.shapeToModeToMaximumSize[@(_shape)];
   if (!modeToMaximumSize) {
     return CGSizeZero;
@@ -424,7 +428,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
 }
 
 - (BOOL)updateMaximumSize {
-  CGSize newSize = [self maximumSizeForMode:self.mode];
+  CGSize newSize = [self maximumSizeForMode:self.mdc_expandedMode];
   if (CGSizeEqualToSize(newSize, self.maximumSize)) {
     return NO;
   }
@@ -434,19 +438,19 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
 
 - (void)setContentEdgeInsets:(UIEdgeInsets)contentEdgeInsets
                     forShape:(MDCFloatingButtonShape)shape
-                      inMode:(MDCFloatingButtonMode)mode {
+                      inMode:(MDCFloatingButtonExpandedMode)mode {
   NSMutableDictionary *modeToContentEdgeInsets = self.shapeToModeToContentEdgeInsets[@(shape)];
   if (!modeToContentEdgeInsets) {
     modeToContentEdgeInsets = [@{} mutableCopy];
     self.shapeToModeToContentEdgeInsets[@(shape)] = modeToContentEdgeInsets;
   }
   modeToContentEdgeInsets[@(mode)] = [NSValue valueWithUIEdgeInsets:contentEdgeInsets];
-  if (shape == _shape && mode == self.mode) {
+  if (shape == _shape && mode == self.mdc_expandedMode) {
     [self updateShapeForcingResize:YES];
   }
 }
 
-- (UIEdgeInsets)contentEdgeInsetsForMode:(MDCFloatingButtonMode)mode {
+- (UIEdgeInsets)contentEdgeInsetsForMode:(MDCFloatingButtonExpandedMode)mode {
   NSMutableDictionary *modeToContentEdgeInsets = self.shapeToModeToContentEdgeInsets[@(_shape)];
   if (!modeToContentEdgeInsets) {
     return UIEdgeInsetsZero;
@@ -461,24 +465,24 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
 }
 
 - (void)updateContentEdgeInsets {
-  super.contentEdgeInsets = [self contentEdgeInsetsForMode:self.mode];
+  super.contentEdgeInsets = [self contentEdgeInsetsForMode:self.mdc_expandedMode];
 }
 
 - (void)setHitAreaInsets:(UIEdgeInsets)insets
                 forShape:(MDCFloatingButtonShape)shape
-                  inMode:(MDCFloatingButtonMode)mode {
+                  inMode:(MDCFloatingButtonExpandedMode)mode {
   NSMutableDictionary *modeToHitAreaInsets = self.shapeToModeToHitAreaInsets[@(shape)];
   if (!modeToHitAreaInsets) {
     modeToHitAreaInsets = [@{} mutableCopy];
     self.shapeToModeToHitAreaInsets[@(shape)] = modeToHitAreaInsets;
   }
   modeToHitAreaInsets[@(mode)] = [NSValue valueWithUIEdgeInsets:insets];
-  if (shape == _shape && mode == self.mode) {
+  if (shape == _shape && mode == self.mdc_expandedMode) {
     [self updateShapeForcingResize:NO];
   }
 }
 
-- (UIEdgeInsets)hitAreaInsetsForMode:(MDCFloatingButtonMode)mode {
+- (UIEdgeInsets)hitAreaInsetsForMode:(MDCFloatingButtonExpandedMode)mode {
   NSMutableDictionary *modeToHitAreaInsets = self.shapeToModeToHitAreaInsets[@(_shape)];
   if (!modeToHitAreaInsets) {
     return UIEdgeInsetsZero;
@@ -493,7 +497,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
 }
 
 - (void)updateHitAreaInsets {
-  super.hitAreaInsets = [self hitAreaInsetsForMode:self.mode];
+  super.hitAreaInsets = [self hitAreaInsetsForMode:self.mdc_expandedMode];
 }
 
 - (void)updateShapeForcingResize:(BOOL)forceResize {

--- a/components/Buttons/tests/unit/FloatingButtonTests.m
+++ b/components/Buttons/tests/unit/FloatingButtonTests.m
@@ -72,12 +72,12 @@
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeDefault];
   MDCFloatingButton *defaultButtonExpanded =
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeDefault];
-  defaultButtonExpanded.mode = MDCFloatingButtonModeExpanded;
+  defaultButtonExpanded.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
   MDCFloatingButton *miniButtonNormal =
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
   MDCFloatingButton *miniButtonExpanded =
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
-  miniButtonExpanded.mode = MDCFloatingButtonModeExpanded;
+  miniButtonExpanded.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
 
   // Then
   XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero, defaultButtonNormal.hitAreaInsets));
@@ -91,20 +91,20 @@
 - (void)testSetHitAreaInsetsForShapeInNormalMode {
   // Given
   MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
-  defaultButton.mode = MDCFloatingButtonModeExpanded;
+  defaultButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
   MDCFloatingButton *miniButton =
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
-  miniButton.mode = MDCFloatingButtonModeExpanded;
+  miniButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
 
   // When
   [defaultButton setHitAreaInsets:UIEdgeInsetsMake(1, 2, 3, 4)
                          forShape:MDCFloatingButtonShapeDefault
-                           inMode:MDCFloatingButtonModeNormal];
-  defaultButton.mode = MDCFloatingButtonModeNormal;
+                           inMode:MDCFloatingButtonExpandedModeNormal];
+  defaultButton.mdc_expandedMode = MDCFloatingButtonExpandedModeNormal;
   [miniButton setHitAreaInsets:UIEdgeInsetsMake(9, 8, 7, 6)
                           forShape:MDCFloatingButtonShapeMini
-                            inMode:MDCFloatingButtonModeNormal];
-  miniButton.mode = MDCFloatingButtonModeNormal;
+                            inMode:MDCFloatingButtonExpandedModeNormal];
+  miniButton.mdc_expandedMode = MDCFloatingButtonExpandedModeNormal;
 
   // Then
   XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(1, 2, 3, 4),
@@ -122,12 +122,12 @@
   // When
   [defaultButton setHitAreaInsets:UIEdgeInsetsMake(1, 2, 3, 4)
                          forShape:MDCFloatingButtonShapeDefault
-                           inMode:MDCFloatingButtonModeExpanded];
-  defaultButton.mode = MDCFloatingButtonModeExpanded;
+                           inMode:MDCFloatingButtonExpandedModeExpanded];
+  defaultButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
   [miniButton setHitAreaInsets:UIEdgeInsetsMake(9, 8, 7, 6)
                       forShape:MDCFloatingButtonShapeMini
-                        inMode:MDCFloatingButtonModeExpanded];
-  miniButton.mode = MDCFloatingButtonModeExpanded;
+                        inMode:MDCFloatingButtonExpandedModeExpanded];
+  miniButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
 
   // Then
   XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(1, 2, 3, 4),
@@ -144,7 +144,7 @@
   // When
   [button setHitAreaInsets:UIEdgeInsetsMake(17, 21, 25, 29)
                   forShape:MDCFloatingButtonShapeDefault
-                    inMode:MDCFloatingButtonModeNormal];
+                    inMode:MDCFloatingButtonExpandedModeNormal];
 
   // Then
   XCTAssertFalse(button.intrinsicContentSizeCalled);
@@ -161,12 +161,12 @@
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeDefault];
   MDCFloatingButton *defaultButtonExpanded =
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeDefault];
-  defaultButtonExpanded.mode = MDCFloatingButtonModeExpanded;
+  defaultButtonExpanded.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
   MDCFloatingButton *miniButtonNormal =
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
   MDCFloatingButton *miniButtonExpanded =
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
-  miniButtonExpanded.mode = MDCFloatingButtonModeExpanded;
+  miniButtonExpanded.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
 
   // Then
   XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero,
@@ -182,20 +182,20 @@
 - (void)testSetContentEdgeInsetsForShapeInNormalMode {
   // Given
   MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
-  defaultButton.mode = MDCFloatingButtonModeExpanded;
+  defaultButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
   MDCFloatingButton *miniButton =
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
-  miniButton.mode = MDCFloatingButtonModeExpanded;
+  miniButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
 
   // When
   [defaultButton setContentEdgeInsets:UIEdgeInsetsMake(1, 2, 3, 4)
                              forShape:MDCFloatingButtonShapeDefault
-                               inMode:MDCFloatingButtonModeNormal];
-  defaultButton.mode = MDCFloatingButtonModeNormal;
+                               inMode:MDCFloatingButtonExpandedModeNormal];
+  defaultButton.mdc_expandedMode = MDCFloatingButtonExpandedModeNormal;
   [miniButton setContentEdgeInsets:UIEdgeInsetsMake(9, 8, 7, 6)
                           forShape:MDCFloatingButtonShapeMini
-                            inMode:MDCFloatingButtonModeNormal];
-  miniButton.mode = MDCFloatingButtonModeNormal;
+                            inMode:MDCFloatingButtonExpandedModeNormal];
+  miniButton.mdc_expandedMode = MDCFloatingButtonExpandedModeNormal;
 
   // Then
   XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(1, 2, 3, 4),
@@ -213,12 +213,12 @@
   // When
   [defaultButton setContentEdgeInsets:UIEdgeInsetsMake(1, 2, 3, 4)
                              forShape:MDCFloatingButtonShapeDefault
-                               inMode:MDCFloatingButtonModeExpanded];
-  defaultButton.mode = MDCFloatingButtonModeExpanded;
+                               inMode:MDCFloatingButtonExpandedModeExpanded];
+  defaultButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
   [miniButton setContentEdgeInsets:UIEdgeInsetsMake(9, 8, 7, 6)
                           forShape:MDCFloatingButtonShapeMini
-                            inMode:MDCFloatingButtonModeExpanded];
-  miniButton.mode = MDCFloatingButtonModeExpanded;
+                            inMode:MDCFloatingButtonExpandedModeExpanded];
+  miniButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
 
   // Then
   XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsMake(1, 2, 3, 4),
@@ -235,7 +235,7 @@
   // When
   [button setContentEdgeInsets:UIEdgeInsetsMake(9, 8, 7, 7)
                       forShape:MDCFloatingButtonShapeDefault
-                        inMode:MDCFloatingButtonModeNormal];
+                        inMode:MDCFloatingButtonExpandedModeNormal];
 
   // Then
   XCTAssertFalse(button.intrinsicContentSizeCalled);
@@ -270,7 +270,7 @@
   MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init];
   [defaultButton setTitle:@"An even longer title that should require more than 328 points to render"
                  forState:UIControlStateNormal];
-  defaultButton.mode = MDCFloatingButtonModeExpanded;
+  defaultButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
 
   // When
   [defaultButton sizeToFit];
@@ -283,21 +283,21 @@
   // Given
   MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
   [defaultButton setTitle:@"a very long title" forState:UIControlStateNormal];
-  defaultButton.mode = MDCFloatingButtonModeExpanded;
+  defaultButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
   MDCFloatingButton *miniButton =
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
   [miniButton setTitle:@"a very long title" forState:UIControlStateNormal];
-  miniButton.mode = MDCFloatingButtonModeExpanded;
+  miniButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
 
   // When
   [defaultButton setMaximumSize:CGSizeMake(100, 50)
                        forShape:MDCFloatingButtonShapeDefault
-                         inMode:MDCFloatingButtonModeNormal];
-  defaultButton.mode = MDCFloatingButtonModeNormal;
+                         inMode:MDCFloatingButtonExpandedModeNormal];
+  defaultButton.mdc_expandedMode = MDCFloatingButtonExpandedModeNormal;
   [miniButton setMaximumSize:CGSizeMake(100, 50)
                     forShape:MDCFloatingButtonShapeMini
-                      inMode:MDCFloatingButtonModeNormal];
-  miniButton.mode = MDCFloatingButtonModeNormal;
+                      inMode:MDCFloatingButtonExpandedModeNormal];
+  miniButton.mdc_expandedMode = MDCFloatingButtonExpandedModeNormal;
 
   // Then
   XCTAssertLessThanOrEqual(defaultButton.bounds.size.width, 100);
@@ -319,12 +319,12 @@
   // When
   [defaultButton setMaximumSize:CGSizeMake(50, 100)
                        forShape:MDCFloatingButtonShapeDefault
-                         inMode:MDCFloatingButtonModeExpanded];
-  defaultButton.mode = MDCFloatingButtonModeExpanded;
+                         inMode:MDCFloatingButtonExpandedModeExpanded];
+  defaultButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
   [miniButton setMaximumSize:CGSizeMake(50, 100)
                     forShape:MDCFloatingButtonShapeMini
-                      inMode:MDCFloatingButtonModeExpanded];
-  miniButton.mode = MDCFloatingButtonModeExpanded;
+                      inMode:MDCFloatingButtonExpandedModeExpanded];
+  miniButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
 
   // Then
   XCTAssertLessThanOrEqual(defaultButton.bounds.size.width, 50);
@@ -341,7 +341,7 @@
   // When
   [button setMaximumSize:CGSizeMake(7, 7)
                 forShape:MDCFloatingButtonShapeDefault
-                  inMode:MDCFloatingButtonModeNormal];
+                  inMode:MDCFloatingButtonExpandedModeNormal];
 
   // Then
   XCTAssertFalse(button.intrinsicContentSizeCalled);
@@ -374,7 +374,7 @@
 - (void)testDefaultMinimumSizeForShapeInExpandedModeSizeToFit {
   // Given
   MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init];
-  defaultButton.mode = MDCFloatingButtonModeExpanded;
+  defaultButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
 
   // When
   [defaultButton sizeToFit];
@@ -387,28 +387,28 @@
 - (void)testSetMinimumSizeForShapeInModeNormal {
   // Given
   MDCFloatingButton *defaultButton = [[MDCFloatingButton alloc] init]; // Default shape
-  defaultButton.mode = MDCFloatingButtonModeExpanded;
+  defaultButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
   MDCFloatingButton *miniButton =
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeMini];
-  miniButton.mode = MDCFloatingButtonModeExpanded;
+  miniButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
 
   // When
   [defaultButton setMinimumSize:CGSizeMake(100, 50)
                        forShape:MDCFloatingButtonShapeDefault
-                         inMode:MDCFloatingButtonModeNormal];
+                         inMode:MDCFloatingButtonExpandedModeNormal];
   [defaultButton setMaximumSize:CGSizeZero
                        forShape:MDCFloatingButtonShapeDefault
-                         inMode:MDCFloatingButtonModeNormal];
-  defaultButton.mode = MDCFloatingButtonModeNormal;
+                         inMode:MDCFloatingButtonExpandedModeNormal];
+  defaultButton.mdc_expandedMode = MDCFloatingButtonExpandedModeNormal;
   [defaultButton sizeToFit];
 
   [miniButton setMinimumSize:CGSizeMake(100, 50)
                     forShape:MDCFloatingButtonShapeMini
-                      inMode:MDCFloatingButtonModeNormal];
+                      inMode:MDCFloatingButtonExpandedModeNormal];
   [miniButton setMaximumSize:CGSizeZero
                     forShape:MDCFloatingButtonShapeMini
-                      inMode:MDCFloatingButtonModeNormal];
-  miniButton.mode = MDCFloatingButtonModeNormal;
+                      inMode:MDCFloatingButtonExpandedModeNormal];
+  miniButton.mdc_expandedMode = MDCFloatingButtonExpandedModeNormal;
   [miniButton sizeToFit];
 
   // Then
@@ -427,14 +427,14 @@
   // When
   [defaultButton setMinimumSize:CGSizeMake(50, 100)
                        forShape:MDCFloatingButtonShapeDefault
-                         inMode:MDCFloatingButtonModeExpanded];
-  defaultButton.mode = MDCFloatingButtonModeExpanded;
+                         inMode:MDCFloatingButtonExpandedModeExpanded];
+  defaultButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
   [defaultButton sizeToFit];
 
   [miniButton setMinimumSize:CGSizeMake(50, 100)
                     forShape:MDCFloatingButtonShapeMini
-                      inMode:MDCFloatingButtonModeExpanded];
-  miniButton.mode = MDCFloatingButtonModeExpanded;
+                      inMode:MDCFloatingButtonExpandedModeExpanded];
+  miniButton.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
   [miniButton sizeToFit];
 
   // Then
@@ -452,7 +452,7 @@
   // When
   [button setMinimumSize:CGSizeMake(12, 12)
                 forShape:MDCFloatingButtonShapeDefault
-                  inMode:MDCFloatingButtonModeNormal];
+                  inMode:MDCFloatingButtonExpandedModeNormal];
 
   // Then
   XCTAssertFalse(button.intrinsicContentSizeCalled);
@@ -467,12 +467,12 @@
   // Given
   MDCFloatingButton *button =
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeDefault];
-  button.mode = MDCFloatingButtonModeExpanded;
+  button.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
   [button setTitle:@"A very long title that can never fit" forState:UIControlStateNormal];
   [button setImage:[UIImage imageNamed:@"Plus"] forState:UIControlStateNormal];
   [button setMaximumSize:CGSizeMake(100, 48)
                 forShape:MDCFloatingButtonShapeDefault
-                  inMode:MDCFloatingButtonModeExpanded];
+                  inMode:MDCFloatingButtonExpandedModeExpanded];
   button.imageTitleSpace = 12;
 
   // When
@@ -492,18 +492,18 @@
   // Given
   MDCFloatingButton *button = [[MDCFloatingButton alloc] initWithFrame:CGRectZero
                                                                  shape:MDCFloatingButtonShapeMini];
-  button.mode = MDCFloatingButtonModeExpanded;
+  button.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
   [button setTitle:@"A very long title that can never fit" forState:UIControlStateNormal];
   [button setImage:[UIImage imageNamed:@"Plus"] forState:UIControlStateNormal];
   [button setMinimumSize:CGSizeMake(100, 48)
                 forShape:MDCFloatingButtonShapeMini
-                  inMode:MDCFloatingButtonModeExpanded];
+                  inMode:MDCFloatingButtonExpandedModeExpanded];
   [button setMaximumSize:CGSizeMake(100, 48)
                 forShape:MDCFloatingButtonShapeMini
-                  inMode:MDCFloatingButtonModeExpanded];
+                  inMode:MDCFloatingButtonExpandedModeExpanded];
   [button setContentEdgeInsets:UIEdgeInsetsMake(4, -4, 8, -8)
                       forShape:MDCFloatingButtonShapeMini
-                        inMode:MDCFloatingButtonModeExpanded];
+                        inMode:MDCFloatingButtonExpandedModeExpanded];
 
   // When
   [button sizeToFit];
@@ -524,22 +524,22 @@
   // Given
   MDCFloatingButton *button = [[MDCFloatingButton alloc] initWithFrame:CGRectMake(1, 2, 3, 4)
                                                                  shape:MDCFloatingButtonShapeMini];
-  button.mode = MDCFloatingButtonModeExpanded;
+  button.mdc_expandedMode = MDCFloatingButtonExpandedModeExpanded;
   button.imageLocation = MDCFloatingButtonImageLocationTrailing;
   [button setImage:[UIImage imageNamed:@"Plus"] forState:UIControlStateNormal];
   [button setTitle:@"Title" forState:UIControlStateNormal];
   [button setMinimumSize:CGSizeMake(75, 37)
                 forShape:MDCFloatingButtonShapeMini
-                  inMode:MDCFloatingButtonModeExpanded];
+                  inMode:MDCFloatingButtonExpandedModeExpanded];
   [button setMaximumSize:CGSizeMake(99, 65)
                 forShape:MDCFloatingButtonShapeMini
-                  inMode:MDCFloatingButtonModeExpanded];
+                  inMode:MDCFloatingButtonExpandedModeExpanded];
   [button setContentEdgeInsets:UIEdgeInsetsMake(5, 3, 1, 7)
                       forShape:MDCFloatingButtonShapeMini
-                        inMode:MDCFloatingButtonModeExpanded];
+                        inMode:MDCFloatingButtonExpandedModeExpanded];
   [button setHitAreaInsets:UIEdgeInsetsMake(8, 6, 4, 2)
                   forShape:MDCFloatingButtonShapeMini
-                    inMode:MDCFloatingButtonModeExpanded];
+                    inMode:MDCFloatingButtonExpandedModeExpanded];
 
   // When
   NSData *archivedData = [NSKeyedArchiver archivedDataWithRootObject:button];
@@ -554,7 +554,7 @@
                 @"Unarchived bounds did not match original button's bounds.\nExpected: %@\n"
                  "Received: %@",NSStringFromCGRect(button.bounds),
                 NSStringFromCGRect(unarchivedButton.bounds));
-  XCTAssertEqual(button.mode, unarchivedButton.mode);
+  XCTAssertEqual(button.mdc_expandedMode, unarchivedButton.mdc_expandedMode);
   XCTAssertEqual(button.imageLocation, unarchivedButton.imageLocation);
   XCTAssertEqualObjects(button.currentTitle, unarchivedButton.currentTitle);
   XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(button.contentEdgeInsets,


### PR DESCRIPTION
MDCFloatingButton has a new property to control whether it is an Extended
Floating Action Button (FAB) or a traditional (normal) FAB. The property name
"mode" conflicted with an internal client and in any case does not align with
Apple's recommendations for method/property names in subclasses and
categories.
