### PR TITLE
Fixed float conversion build errors

### DIFF
--- a/catalog/MaterialCatalog/MDCCatalogTiles.m
+++ b/catalog/MaterialCatalog/MDCCatalogTiles.m
@@ -786,7 +786,7 @@ void MDCCatalogDrawNavigationBarTile(CGRect frame, id<MDCColorScheme> colorSchem
   UIColor* gradientColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:0];
   UIColor* fillColor = colorScheme.primaryColor;
   UIColor* fillColor2 = colorScheme.primaryLightColor;
-  UIColor* textForeground = [fillColor colorWithAlphaComponent:0.2];
+  UIColor* textForeground = [fillColor colorWithAlphaComponent:0.2f];
   UIColor* gradientColor2 = colorScheme.primaryColor;
 
   CGFloat gradientLocations[] = {0.14, 0.5, 1};
@@ -972,7 +972,7 @@ void MDCCatalogDrawNavigationBarTile(CGRect frame, id<MDCColorScheme> colorSchem
 void MDCCatalogDrawOverlayWindow(CGRect frame, id<MDCColorScheme> colorScheme) {
   UIColor* fillColor = colorScheme.primaryLightColor;
   UIColor* fillColor2 = colorScheme.primaryColor;
-  UIColor* fillColor3 = [UIColor colorWithWhite:0.5 alpha:1.0];
+  UIColor* fillColor3 = [UIColor colorWithWhite:0.5f alpha:1.0f];
 
   CGRect overlayWindowGroup = CGRectMake(CGRectGetMinX(frame) + 54, CGRectGetMinY(frame) + 38,
                                          floor((CGRectGetWidth(frame) - 54) * 0.59701 + 0.5),

--- a/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
+++ b/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
@@ -45,7 +45,7 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
 @implementation AnimationTimingExample (Supplemental)
 
 - (void)setupExampleViews {
-  self.view.backgroundColor = [UIColor colorWithWhite:0.9 alpha:1.0];
+  self.view.backgroundColor = [UIColor colorWithWhite:0.9f alpha:1.0f];
   self.title = @"Animation Timing";
 
   self.scrollView = [[UIScrollView alloc] initWithFrame:self.view.bounds];
@@ -144,11 +144,11 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
   dispatch_once(&onceToken, ^{
     UIColor *primaryColor = [UIColor darkGrayColor];
     defaultColors = @[
-      [primaryColor colorWithAlphaComponent:0.8],
-      [primaryColor colorWithAlphaComponent:0.65],
-      [primaryColor colorWithAlphaComponent:0.5],
-      [primaryColor colorWithAlphaComponent:0.35],
-      [primaryColor colorWithAlphaComponent:0.2]
+      [primaryColor colorWithAlphaComponent:0.8f],
+      [primaryColor colorWithAlphaComponent:0.65f],
+      [primaryColor colorWithAlphaComponent:0.5f],
+      [primaryColor colorWithAlphaComponent:0.35f],
+      [primaryColor colorWithAlphaComponent:0.2f]
     ];
   });
   return defaultColors;

--- a/components/AppBar/examples/AppBarDelegateForwardingExample.m
+++ b/components/AppBar/examples/AppBarDelegateForwardingExample.m
@@ -102,7 +102,7 @@
 
     self.title = @"Delegate Forwarding";
 
-    UIColor *color = [UIColor colorWithWhite:0.2 alpha:1];
+    UIColor *color = [UIColor colorWithWhite:0.2f alpha:1];
     _appBar.headerViewController.headerView.backgroundColor = color;
     MDCAppBarTextColorAccessibilityMutator *mutator =
         [[MDCAppBarTextColorAccessibilityMutator alloc] init];

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
@@ -48,7 +48,7 @@
 - (void)commonAppBarInterfaceBuilderExampleSetup {
   self.appBar = [[MDCAppBar alloc] init];
   [self addChildViewController:self.appBar.headerViewController];
-  UIColor *headerColor = [UIColor colorWithWhite:0.2 alpha:1];
+  UIColor *headerColor = [UIColor colorWithWhite:0.2f alpha:1];
   self.appBar.headerViewController.headerView.backgroundColor = headerColor;
 
   MDCAppBarTextColorAccessibilityMutator *mutator =

--- a/components/AppBar/examples/AppBarModalPresentationExample.m
+++ b/components/AppBar/examples/AppBarModalPresentationExample.m
@@ -32,7 +32,7 @@
     [self addChildViewController:_appBar.headerViewController];
 
     // Optional: Change the App Bar's background color and tint color.
-    UIColor *color = [UIColor colorWithWhite:0.2 alpha:1];
+    UIColor *color = [UIColor colorWithWhite:0.2f alpha:1];
     _appBar.headerViewController.headerView.backgroundColor = color;
     MDCAppBarTextColorAccessibilityMutator *mutator =
         [[MDCAppBarTextColorAccessibilityMutator alloc] init];
@@ -228,7 +228,7 @@
 
     self.title = @"Modal Presentation";
 
-    UIColor *color = [UIColor colorWithWhite:0.2 alpha:1];
+    UIColor *color = [UIColor colorWithWhite:0.2f alpha:1];
     _appBar.headerViewController.headerView.backgroundColor = color;
     MDCAppBarTextColorAccessibilityMutator *mutator =
         [[MDCAppBarTextColorAccessibilityMutator alloc] init];

--- a/components/AppBar/examples/AppBarSectionHeadersExample.m
+++ b/components/AppBar/examples/AppBarSectionHeadersExample.m
@@ -37,7 +37,7 @@
     [self addChildViewController:_appBar.headerViewController];
 
     // Optional: Change the App Bar's background color and tint color.
-    UIColor *color = [UIColor colorWithWhite:0.2 alpha:1];
+    UIColor *color = [UIColor colorWithWhite:0.2f alpha:1];
     _appBar.headerViewController.headerView.backgroundColor = color;
     _appBar.navigationBar.tintColor = [UIColor whiteColor];
     _appBar.navigationBar.titleTextAttributes = @{

--- a/components/AppBar/examples/AppBarTypicalUseExample.m
+++ b/components/AppBar/examples/AppBarTypicalUseExample.m
@@ -37,7 +37,7 @@
     [self addChildViewController:_appBar.headerViewController];
 
     // Optional: Change the App Bar's background color and tint color.
-    UIColor *color = [UIColor colorWithWhite:0.2 alpha:1];
+    UIColor *color = [UIColor colorWithWhite:0.2f alpha:1];
     _appBar.headerViewController.headerView.backgroundColor = color;
     _appBar.headerViewController.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorEnabled;
     [_appBar.headerViewController.headerView hideViewWhenShifted:_appBar.headerStackView];

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -160,7 +160,7 @@
 - (void)setupAppBar {
   _appBar = [[MDCAppBar alloc] init];
   [self addChildViewController:_appBar.headerViewController];
-  UIColor *color = [UIColor colorWithWhite:0.2 alpha:1];
+  UIColor *color = [UIColor colorWithWhite:0.2f alpha:1];
   _appBar.headerViewController.headerView.backgroundColor = color;
   _appBar.headerViewController.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorEnabled;
   [_appBar.headerViewController.headerView hideViewWhenShifted:_appBar.headerStackView];

--- a/components/BottomSheet/examples/supplemental/BottomSheetDummyCollectionViewController.m
+++ b/components/BottomSheet/examples/supplemental/BottomSheetDummyCollectionViewController.m
@@ -65,7 +65,7 @@
   NSString *reuseIdent = NSStringFromClass([DummyCollectionViewCell class]);
   DummyCollectionViewCell *cell =
       [collectionView dequeueReusableCellWithReuseIdentifier:reuseIdent forIndexPath:indexPath];
-  cell.backgroundColor = [UIColor colorWithWhite:(indexPath.row % 2) * 0.2 + 0.8 alpha:1.0];
+  cell.backgroundColor = [UIColor colorWithWhite:(indexPath.row % 2) * 0.2f + 0.8f alpha:1.0f];
   return cell;
 }
 

--- a/components/ButtonBar/examples/ButtonBarIconExample.m
+++ b/components/ButtonBar/examples/ButtonBarIconExample.m
@@ -69,7 +69,7 @@
   [self.view addSubview:buttonBar];
 
   // Ensure that the controller's view isn't transparent.
-  self.view.backgroundColor = [UIColor colorWithWhite:0.9 alpha:1.0];
+  self.view.backgroundColor = [UIColor colorWithWhite:0.9f alpha:1.0f];
 }
 
 #pragma mark - User actions

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.m
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.m
@@ -64,7 +64,7 @@
   [self.view addSubview:buttonBar];
 
   // Ensure that the controller's view isn't transparent.
-  self.view.backgroundColor = [UIColor colorWithWhite:0.9 alpha:1.0];
+  self.view.backgroundColor = [UIColor colorWithWhite:0.9f alpha:1.0f];
 }
 
 #pragma mark - User actions

--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -47,9 +47,9 @@
   [super viewDidLoad];
 
   // Force a darker background color to show the button frame
-  [self.flatButton setBackgroundColor:[UIColor colorWithWhite:0.2 alpha:1.0]
+  [self.flatButton setBackgroundColor:[UIColor colorWithWhite:0.2f alpha:1.0f]
                              forState:UIControlStateNormal];
-  self.flatButton.inkColor = [UIColor colorWithWhite:1.0 alpha:0.1];
+  self.flatButton.inkColor = [UIColor colorWithWhite:1.0f alpha:0.1f];
   self.flatButton.contentEdgeInsets = UIEdgeInsetsMake(64, 64, 0, 0);
   self.raisedButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, 64, 64);
   [self.floatingActionButton setContentEdgeInsets:UIEdgeInsetsMake(40, 40, 0, 0)

--- a/components/Buttons/examples/FloatingButtonExampleViewController.m
+++ b/components/Buttons/examples/FloatingButtonExampleViewController.m
@@ -30,7 +30,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.view.backgroundColor = [UIColor colorWithWhite:0.9 alpha:1];
+  self.view.backgroundColor = [UIColor colorWithWhite:0.9f alpha:1];
 
   UIImage *plusImage = [UIImage imageNamed:@"Plus"];
   UIImage *plusImage36 = [UIImage imageNamed:@"plus_white_36"

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.m
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.m
@@ -42,7 +42,7 @@ static UIButton *DeleteButton() {
   image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
 
   UIButton *button = [[UIButton alloc] initWithFrame:CGRectZero];
-  button.tintColor = [UIColor colorWithWhite:0 alpha:0.7];
+  button.tintColor = [UIColor colorWithWhite:0 alpha:0.7f];
   [button setImage:image forState:UIControlStateNormal];
 
   return button;

--- a/components/Collections/examples/CollectionsCellColorExample.m
+++ b/components/Collections/examples/CollectionsCellColorExample.m
@@ -32,7 +32,7 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
   // Array of cell background colors.
   _cellBackgroundColors = @[
-    [UIColor colorWithWhite:0 alpha:0.2],
+    [UIColor colorWithWhite:0 alpha:0.2f],
     [UIColor colorWithRed:(CGFloat)0x39 / (CGFloat)255
                     green:(CGFloat)0xA4 / (CGFloat)255
                      blue:(CGFloat)0xDD / (CGFloat)255
@@ -43,7 +43,7 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   // Populate content.
   _content = [NSMutableArray array];
   [_content addObject:@[
-    @"[UIColor colorWithWhite:0 alpha:0.2]", @"Custom Blue Color", @"Default White Color"
+    @"[UIColor colorWithWhite:0 alpha:0.2f]", @"Custom Blue Color", @"Default White Color"
   ]];
 
   // Customize collection view settings.

--- a/components/Collections/examples/CollectionsInkExample.m
+++ b/components/Collections/examples/CollectionsInkExample.m
@@ -73,7 +73,7 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   if (indexPath.item == 1) {
     return [MDCPalette.lightBluePalette.tint500 colorWithAlphaComponent:0.2f];
   } else if (indexPath.item == 2) {
-    return [UIColor colorWithRed:1.0 green:0.0 blue:0.0 alpha:0.2f];
+    return [UIColor colorWithRed:1.0f green:0.0f blue:0.0f alpha:0.2f];
   }
   return nil;
 }

--- a/components/Collections/examples/CollectionsInkExample.m
+++ b/components/Collections/examples/CollectionsInkExample.m
@@ -73,7 +73,7 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   if (indexPath.item == 1) {
     return [MDCPalette.lightBluePalette.tint500 colorWithAlphaComponent:0.2f];
   } else if (indexPath.item == 2) {
-    return [UIColor colorWithRed:1.0 green:0.0 blue:0.0 alpha:0.2];
+    return [UIColor colorWithRed:1.0 green:0.0 blue:0.0 alpha:0.2f];
   }
   return nil;
 }

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -270,7 +270,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   } else {
     self.messageLabel.font = [MDCTypography body1Font];
   }
-  self.messageLabel.textColor = [UIColor colorWithWhite:0.0 alpha:MDCDialogMessageOpacity];
+  self.messageLabel.textColor = [UIColor colorWithWhite:0.0f alpha:MDCDialogMessageOpacity];
   [self.contentScrollView addSubview:self.messageLabel];
 
   self.titleLabel.text = self.title;

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
@@ -38,7 +38,7 @@ static NSString *const reuseIdentifier = @"Cell";
   [self.view addSubview:self.infoLabel];
 
   self.button = [[MDCRaisedButton alloc] init];
-  [self.button setBackgroundColor:[UIColor colorWithWhite:0.1 alpha:1]];
+  [self.button setBackgroundColor:[UIColor colorWithWhite:0.1f alpha:1]];
   [self.button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
   [self.button setTitle:@"Action" forState:UIControlStateNormal];
   [self.button sizeToFit];
@@ -163,7 +163,7 @@ static NSString *const reuseIdentifier = @"Cell";
   [self.view addSubview:self.infoLabel];
 
   self.button = [[MDCRaisedButton alloc] init];
-  [self.button setBackgroundColor:[UIColor colorWithWhite:0.1 alpha:1]];
+  [self.button setBackgroundColor:[UIColor colorWithWhite:0.1f alpha:1]];
   [self.button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
   [self.button setTitle:@"Action" forState:UIControlStateNormal];
   [self.button sizeToFit];

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -136,7 +136,7 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
       options |= MDFTextAccessibilityOptionsLargeFont;
     }
 
-    UIColor *outerColor = [self.outerHighlightColor colorWithAlphaComponent:1.0];
+    UIColor *outerColor = [self.outerHighlightColor colorWithAlphaComponent:1.0f];
     self.bodyColor =
         [MDFTextAccessibility textColorOnBackgroundColor:outerColor
                                          targetTextAlpha:[MDCTypography captionFontOpacity]
@@ -148,7 +148,7 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
     if ([MDFTextAccessibility isLargeForContrastRatios:_featureHighlightView.titleLabel.font]) {
       options |= MDFTextAccessibilityOptionsLargeFont;
     }
-    UIColor *outerColor = [self.outerHighlightColor colorWithAlphaComponent:1.0];
+    UIColor *outerColor = [self.outerHighlightColor colorWithAlphaComponent:1.0f];
     // Since MDFTextAccessibility can return either a dark value or light value color we want to
     // guarantee that the title and body have the same value.
     CGFloat titleAlpha = [MDFTextAccessibility minAlphaOfTextColor:self.bodyColor

--- a/components/FlexibleHeader/examples/FlexibleHeaderFABExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderFABExample.m
@@ -77,7 +77,7 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1.0];
+  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1f alpha:1.0f];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -88,7 +88,10 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
   [self.navigationController setNavigationBarHidden:YES animated:animated];
 
   self.floatingButton = [[MDCFloatingButton alloc] init];
-  [self.floatingButton setBackgroundColor:[UIColor colorWithRed:11/255.0 green:232/255.0 blue:94/255.0 alpha:1]
+  [self.floatingButton setBackgroundColor:[UIColor colorWithRed:11/255.0f
+                                                          green:232/255.0f
+                                                           blue:94/255.0f
+                                                          alpha:1]
                                  forState:UIControlStateNormal];
   [self.floatingButton sizeToFit];
   self.floatingButton.center = CGPointMake(

--- a/components/FlexibleHeader/examples/FlexibleHeaderHorizontalPagingExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderHorizontalPagingExample.m
@@ -159,7 +159,7 @@ static const NSUInteger kNumberOfPages = 10;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1.0];
+  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1f alpha:1.0f];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {

--- a/components/FlexibleHeader/examples/FlexibleHeaderPageControlExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderPageControlExample.m
@@ -80,15 +80,14 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1];
+  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1f alpha:1];
 
   CGFloat boundsWidth = CGRectGetWidth(self.fhvc.headerView.bounds);
   CGFloat boundsHeight = CGRectGetHeight(self.fhvc.headerView.bounds);
 
-  NSArray *pageColors = @[ [UIColor colorWithWhite:0.1 alpha:1],
-                           [UIColor colorWithWhite:0.2 alpha:1],
-                           [UIColor colorWithWhite:0.3 alpha:1]];
-
+  NSArray *pageColors = @[ [UIColor colorWithWhite:0.1f alpha:1],
+                           [UIColor colorWithWhite:0.2f alpha:1],
+                           [UIColor colorWithWhite:0.3f alpha:1]];
 
   // Scroll view configuration
   CGRect pageScrollViewFrame = CGRectMake(0, 0, boundsWidth, boundsHeight);
@@ -109,7 +108,7 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
     UILabel *page = [[UILabel alloc] initWithFrame:pageFrame];
     page.text = [NSString stringWithFormat:@"Page %zd", i + 1];
     page.font = [UIFont systemFontOfSize:18];
-    page.textColor = [UIColor colorWithWhite:1 alpha:0.8];
+    page.textColor = [UIColor colorWithWhite:1 alpha:0.8f];
     page.textAlignment = NSTextAlignmentCenter;
     page.backgroundColor = pageColors[i];
     page.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;

--- a/components/FlexibleHeader/examples/FlexibleHeaderTopLayoutGuideExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderTopLayoutGuideExample.m
@@ -75,7 +75,7 @@
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1.0];
+  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1f alpha:1.0f];
   self.fhvc.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar;
 
   [self setupScrollViewContent];
@@ -85,7 +85,7 @@
   // Create UIView Object
   UIView *constrainedView = [[UIView alloc] init];
   constrainedView.backgroundColor =
-      [UIColor colorWithRed:11/255.0 green:232/255.0 blue:94/255.0 alpha:1];
+      [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:1];
   constrainedView.translatesAutoresizingMaskIntoConstraints = NO;
   self.constrainedView = constrainedView;
   [self.view addSubview:self.constrainedView];

--- a/components/FlexibleHeader/examples/FlexibleHeaderUINavigationBarExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderUINavigationBarExample.m
@@ -120,7 +120,7 @@ static const CGFloat kFlexibleHeaderMinHeight = 200.f;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1.0];
+  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1f alpha:1.0f];
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/components/FlexibleHeader/examples/FlexibleHeaderWrappedExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderWrappedExample.m
@@ -80,7 +80,7 @@
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1];
+  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1f alpha:1];
 
   [self.scrollView setScrollEnabled:YES];
   [self.scrollView addSubview:self.wrappedViewController.view];

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
@@ -79,7 +79,7 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
   [self.view addSubview:self.fhvc.view];
   [self.fhvc didMoveToParentViewController:self];
 
-  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1.0];
+  self.fhvc.headerView.backgroundColor = [UIColor colorWithWhite:0.1f alpha:1.0f];
 
   UILabel *titleLabel = [[UILabel alloc] init];
   CGRect frame = self.fhvc.headerView.bounds;
@@ -190,7 +190,7 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-  return [self.sections[section] count];
+  return [(NSArray *)self.sections[section] count];
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {

--- a/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.m
+++ b/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.m
@@ -181,13 +181,13 @@
   UIBezierPath *bezierPath = [UIBezierPath bezierPath];
   [bezierPath moveToPoint:CGPointMake(CGRectGetMinX(frame) + 12, CGRectGetMinY(frame) + 4)];
   [bezierPath
-      addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 10.59, CGRectGetMinY(frame) + 5.41)];
-  [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 16.17, CGRectGetMinY(frame) + 11)];
+      addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 10.59f, CGRectGetMinY(frame) + 5.41f)];
+  [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 16.17f, CGRectGetMinY(frame) + 11)];
   [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 4, CGRectGetMinY(frame) + 11)];
   [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 4, CGRectGetMinY(frame) + 13)];
-  [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 16.17, CGRectGetMinY(frame) + 13)];
+  [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 16.17f, CGRectGetMinY(frame) + 13)];
   [bezierPath
-      addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 10.59, CGRectGetMinY(frame) + 18.59)];
+      addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 10.59f, CGRectGetMinY(frame) + 18.59f)];
   [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 12, CGRectGetMinY(frame) + 20)];
   [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 20, CGRectGetMinY(frame) + 12)];
   [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 12, CGRectGetMinY(frame) + 4)];

--- a/components/Ink/examples/InkTypicalUse.m
+++ b/components/Ink/examples/InkTypicalUse.m
@@ -32,7 +32,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  UIColor *blueColor = [MDCPalette.bluePalette.tint500 colorWithAlphaComponent:0.2];
+  UIColor *blueColor = [MDCPalette.bluePalette.tint500 colorWithAlphaComponent:0.2f];
   CGFloat spacing = 16;
   CGRect customFrame = CGRectMake(0, 0, 200, 200);
   CGRect legacyFrame = CGRectMake(spacing / 2, spacing / 2, CGRectGetWidth(customFrame) - spacing,

--- a/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
+++ b/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
@@ -95,7 +95,7 @@
 @implementation InkTypicalUseViewController (Supplemental)
 
 - (void)setupExampleViews {
-  self.view.backgroundColor = [UIColor colorWithWhite:0.95 alpha:1];
+  self.view.backgroundColor = [UIColor colorWithWhite:0.95f alpha:1];
 
   CGRect boundedTitleLabelFrame =
       CGRectMake(0, CGRectGetHeight(self.shapes.frame), CGRectGetWidth(self.shapes.frame), 24);

--- a/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
+++ b/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
@@ -41,7 +41,7 @@
   self.navBar = [[MDCNavigationBar alloc] initWithFrame:CGRectZero];
   [self.navBar observeNavigationItem:self.navigationItem];
 
-  [self.navBar setBackgroundColor:[UIColor colorWithWhite:0.1 alpha:1.0]];
+  [self.navBar setBackgroundColor:[UIColor colorWithWhite:0.1f alpha:1.0f]];
   MDCNavigationBarTextColorAccessibilityMutator *mutator =
       [[MDCNavigationBarTextColorAccessibilityMutator alloc] init];
   [mutator mutate:self.navBar];

--- a/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.m
+++ b/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.m
@@ -140,13 +140,13 @@
   UIBezierPath *bezierPath = [UIBezierPath bezierPath];
   [bezierPath moveToPoint:CGPointMake(CGRectGetMinX(frame) + 12, CGRectGetMinY(frame) + 4)];
   [bezierPath
-      addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 10.59, CGRectGetMinY(frame) + 5.41)];
-  [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 16.17, CGRectGetMinY(frame) + 11)];
+      addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 10.59f, CGRectGetMinY(frame) + 5.41f)];
+  [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 16.17f, CGRectGetMinY(frame) + 11)];
   [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 4, CGRectGetMinY(frame) + 11)];
   [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 4, CGRectGetMinY(frame) + 13)];
-  [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 16.17, CGRectGetMinY(frame) + 13)];
+  [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 16.17f, CGRectGetMinY(frame) + 13)];
   [bezierPath
-      addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 10.59, CGRectGetMinY(frame) + 18.59)];
+      addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 10.59f, CGRectGetMinY(frame) + 18.59f)];
   [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 12, CGRectGetMinY(frame) + 20)];
   [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 20, CGRectGetMinY(frame) + 12)];
   [bezierPath addLineToPoint:CGPointMake(CGRectGetMinX(frame) + 12, CGRectGetMinY(frame) + 4)];

--- a/components/PageControl/examples/PageControlAnimationBlockExample.m
+++ b/components/PageControl/examples/PageControlAnimationBlockExample.m
@@ -36,11 +36,11 @@
   CGFloat boundsHeight = CGRectGetHeight(self.view.bounds);
 
   NSArray *pageColors = @[
-    [UIColor colorWithWhite:0.2 alpha:1.0],
-    [UIColor colorWithWhite:0.3 alpha:1.0],
-    [UIColor colorWithWhite:0.4 alpha:1.0],
-    [UIColor colorWithWhite:0.5 alpha:1.0],
-    [UIColor colorWithWhite:0.6 alpha:1.0],
+    [UIColor colorWithWhite:0.2f alpha:1.0f],
+    [UIColor colorWithWhite:0.3f alpha:1.0f],
+    [UIColor colorWithWhite:0.4f alpha:1.0f],
+    [UIColor colorWithWhite:0.5f alpha:1.0f],
+    [UIColor colorWithWhite:0.6f alpha:1.0f],
   ];
 
   // Scroll view configuration
@@ -60,7 +60,7 @@
     UILabel *page = [[UILabel alloc] initWithFrame:pageFrame];
     page.text = [NSString stringWithFormat:@"Page %zd", i + 1];
     page.font = [UIFont systemFontOfSize:24];
-    page.textColor = [UIColor colorWithWhite:1 alpha:0.8];
+    page.textColor = [UIColor colorWithWhite:1 alpha:0.8f];
     page.textAlignment = NSTextAlignmentCenter;
     page.backgroundColor = pageColors[i];
     page.autoresizingMask =

--- a/components/PageControl/examples/PageControlButtonExample.m
+++ b/components/PageControl/examples/PageControlButtonExample.m
@@ -35,11 +35,11 @@
   CGFloat boundsHeight = CGRectGetHeight(self.view.bounds);
 
   NSArray *pageColors = @[
-      [UIColor colorWithWhite:0.9 alpha:1.0],
-      [UIColor colorWithWhite:0.8 alpha:1.0],
-      [UIColor colorWithWhite:0.7 alpha:1.0],
-      [UIColor colorWithWhite:0.6 alpha:1.0],
-      [UIColor colorWithWhite:0.5 alpha:1.0]  ];
+      [UIColor colorWithWhite:0.9f alpha:1.0f],
+      [UIColor colorWithWhite:0.8f alpha:1.0f],
+      [UIColor colorWithWhite:0.7f alpha:1.0f],
+      [UIColor colorWithWhite:0.6f alpha:1.0f],
+      [UIColor colorWithWhite:0.5f alpha:1.0f]  ];
 
   // Scroll view configuration
   _scrollView = [[UIScrollView alloc] initWithFrame:self.view.bounds];
@@ -58,7 +58,7 @@
     UILabel *page = [[UILabel alloc] initWithFrame:pageFrame];
     page.text = [NSString stringWithFormat:@"Page %zd", i + 1];
     page.font = [UIFont systemFontOfSize:50];
-    page.textColor = [UIColor colorWithWhite:0 alpha:0.8];
+    page.textColor = [UIColor colorWithWhite:0 alpha:0.8f];
     page.textAlignment = NSTextAlignmentCenter;
     page.backgroundColor = pageColors[i];
     page.autoresizingMask =

--- a/components/PageControl/examples/PageControlTypicalUseExample.m
+++ b/components/PageControl/examples/PageControlTypicalUseExample.m
@@ -35,9 +35,9 @@
   CGFloat boundsHeight = CGRectGetHeight(standardizedFrame);
 
   NSArray *pageColors = @[
-      [UIColor colorWithWhite:0.9 alpha:1.0],
-      [UIColor colorWithWhite:0.8 alpha:1.0],
-      [UIColor colorWithWhite:0.7 alpha:1.0],
+      [UIColor colorWithWhite:0.9f alpha:1.0f],
+      [UIColor colorWithWhite:0.8f alpha:1.0f],
+      [UIColor colorWithWhite:0.7f alpha:1.0f],
   ];
 
   // Scroll view configuration
@@ -57,7 +57,7 @@
     UILabel *page = [[UILabel alloc] initWithFrame:pageFrame];
     page.text = [NSString stringWithFormat:@"Page %zd", i + 1];
     page.font = [UIFont systemFontOfSize:50];
-    page.textColor = [UIColor colorWithWhite:0 alpha:0.8];
+    page.textColor = [UIColor colorWithWhite:0 alpha:0.8f];
     page.textAlignment = NSTextAlignmentCenter;
     page.backgroundColor = pageColors[i];
     page.autoresizingMask =

--- a/components/Tabs/examples/BottomNavigationBarExample.m
+++ b/components/Tabs/examples/BottomNavigationBarExample.m
@@ -34,8 +34,8 @@
   _bottomNavigationBar.barTintColor = [UIColor whiteColor];
   _bottomNavigationBar.selectedItemTintColor = nil;
   _bottomNavigationBar.unselectedItemTintColor = [UIColor colorWithWhite:0 alpha:0.50];
-  _bottomNavigationBar.tintColor = [UIColor colorWithRed:0 green:0.5 blue:0 alpha:1];
-  _bottomNavigationBar.inkColor = [UIColor colorWithRed:0 green:0.5 blue:0 alpha:0.15];
+  _bottomNavigationBar.tintColor = [UIColor colorWithRed:0 green:0.5f blue:0 alpha:1];
+  _bottomNavigationBar.inkColor = [UIColor colorWithRed:0 green:0.5f blue:0 alpha:0.15f];
 
   NSBundle *bundle = [NSBundle bundleForClass:[BottomNavigationBarExample class]];
   UIImage *infoImage =

--- a/components/Tabs/examples/TabBarIconExample.m
+++ b/components/Tabs/examples/TabBarIconExample.m
@@ -74,9 +74,9 @@
 
   UIColor *green =  [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:1];
 
-  tabBar.barTintColor = [UIColor colorWithWhite:0.1f alpha:1.0];
+  tabBar.barTintColor = [UIColor colorWithWhite:0.1f alpha:1.0f];
   tabBar.tintColor = green;
-  tabBar.inkColor = [[UIColor whiteColor] colorWithAlphaComponent:0.1];
+  tabBar.inkColor = [[UIColor whiteColor] colorWithAlphaComponent:0.1f];
   tabBar.selectedItemTintColor = [[UIColor whiteColor] colorWithAlphaComponent:.87f];
   tabBar.unselectedItemTintColor = [[UIColor whiteColor] colorWithAlphaComponent:.38f];
   tabBar.itemAppearance = MDCTabBarItemAppearanceTitledImages;

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
@@ -236,8 +236,8 @@
   [self.starPage addSubview:starView];
   [starView sizeToFit];
 
-  CGFloat x = centered ? 1 : (arc4random_uniform(199) + 1.0) / 100.0;  // 0 < x <=2
-  CGFloat y = centered ? 1 : (arc4random_uniform(199) + 1.0) / 100.0;  // 0 < y <=2
+  CGFloat x = centered ? 1 : (arc4random_uniform(199) + 1.0f) / 100.0f;  // 0 < x <=2
+  CGFloat y = centered ? 1 : (arc4random_uniform(199) + 1.0f) / 100.0f;  // 0 < y <=2
 
   [NSLayoutConstraint constraintWithItem:starView
                                attribute:NSLayoutAttributeCenterX

--- a/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
@@ -104,7 +104,7 @@
   NSBundle *bundle = [NSBundle bundleForClass:[TabBarViewControllerExample class]];
   UIViewController *child1 =
       [TBVCSampleViewController sampleWithTitle:@"One" color:UIColor.redColor];
-  UIColor *blue = [UIColor colorWithRed:0x3A / 255. green:0x56 / 255. blue:0xFF / 255. alpha:1];
+  UIColor *blue = [UIColor colorWithRed:0x3A / 255.f green:0x56 / 255.f blue:0xFF / 255.f alpha:1];
   UIViewController *child2 = [TBVCSampleViewController sampleWithTitle:@"Two" color:blue];
   UIImage *starImage =
       [UIImage imageNamed:@"TabBarDemo_ic_star" inBundle:bundle compatibleWithTraitCollection:nil];

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -94,8 +94,8 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 
 + (void)initialize {
   [MDCTabBar appearance].selectedItemTintColor = [UIColor whiteColor];
-  [MDCTabBar appearance].unselectedItemTintColor = [UIColor colorWithWhite:1.0 alpha:0.7f];
-  [MDCTabBar appearance].inkColor = [UIColor colorWithWhite:1.0 alpha:0.7f];
+  [MDCTabBar appearance].unselectedItemTintColor = [UIColor colorWithWhite:1.0f alpha:0.7f];
+  [MDCTabBar appearance].inkColor = [UIColor colorWithWhite:1.0f alpha:0.7f];
   [MDCTabBar appearance].barTintColor = nil;
 
   id<MDCTabBarIndicatorTemplate> template = [[MDCTabBarUnderlineIndicatorTemplate alloc] init];

--- a/components/TextFields/examples/MultilineTextFieldLegacyExample.m
+++ b/components/TextFields/examples/MultilineTextFieldLegacyExample.m
@@ -34,7 +34,7 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  self.view.backgroundColor = [UIColor colorWithWhite:0.97 alpha:1.0];
+  self.view.backgroundColor = [UIColor colorWithWhite:0.97f alpha:1.0f];
 
   self.title = @"Legacy Multi-line Styles";
 

--- a/components/TextFields/examples/TextFieldPresentationStylesExample.m
+++ b/components/TextFields/examples/TextFieldPresentationStylesExample.m
@@ -32,7 +32,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.view.backgroundColor = [UIColor colorWithWhite:0.97 alpha:1.0];
+  self.view.backgroundColor = [UIColor colorWithWhite:0.97f alpha:1.0f];
   self.title = @"Material Text Fields";
 
   [self setupExampleViews];

--- a/components/Themes/examples/ThemerCustomSchemePickerController.m
+++ b/components/Themes/examples/ThemerCustomSchemePickerController.m
@@ -151,8 +151,10 @@ static NSString *s_secondaryColorString;
     return;
   }
 
-  primaryColor =
-      [UIColor colorWithRed:redInt / 255.0 green:greenInt / 255.0 blue:blueInt / 255.0 alpha:1.0];
+  primaryColor = [UIColor colorWithRed:redInt / 255.0f
+                                 green:greenInt / 255.0f
+                                  blue:blueInt / 255.0f
+                                 alpha:1.0f];
   s_primaryColorString = primaryString;
   self.primaryColorPreView.backgroundColor = primaryColor;
 
@@ -166,8 +168,10 @@ static NSString *s_secondaryColorString;
     return;
   }
 
-  secondaryColor =
-      [UIColor colorWithRed:redInt / 255.0 green:greenInt / 255.0 blue:blueInt / 255.0 alpha:1.0];
+  secondaryColor = [UIColor colorWithRed:redInt / 255.0f
+                                   green:greenInt / 255.0f
+                                    blue:blueInt / 255.0f
+                                   alpha:1.0f];
   s_secondaryColorString = secondaryString;
   self.secondaryColorPreView.backgroundColor = secondaryColor;
 


### PR DESCRIPTION
Implicit conversion loses floating-point precision: 'double' to 'CGFloat' (aka 'float')

Found by turning on warnings via: https://github.com/material-components/material-components-ios/pull/2480