### PR TITLE
[Buttons] Add missing IS_BAZEL_BUILD compile time flag.

### DIFF
--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -19,7 +19,11 @@
 #import "MaterialShadowElevations.h"
 #import "private/MDCButton+Subclassing.h"
 
+#ifdef IS_BAZEL_BUILD
+#import "MDFInternationalization.h"
+#else
 #import <MDFInternationalization/MDFInternationalization.h>
+#endif  // IS_BAZEL_BUILD
 
 static const CGFloat MDCFloatingButtonDefaultDimension = 56;
 static const CGFloat MDCFloatingButtonMiniDimension = 40;


### PR DESCRIPTION
This is related to #2550. This import was added after #2562 was pushed.