### PR TITLE
[Bazel] Fix BUILD files for bazel 0.8.0 and latest apple_rules

### DIFF
--- a/components/AnimationTiming/BUILD
+++ b/components/AnimationTiming/BUILD
@@ -22,6 +22,10 @@ licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "AnimationTiming",
+    sdk_frameworks = [
+        "UIKit",
+        "QuartzCore",
+    ],
 )
 
 mdc_objc_library(

--- a/components/Ink/BUILD
+++ b/components/Ink/BUILD
@@ -23,6 +23,7 @@ licenses(["notice"])  # Apache 2.0
 mdc_public_objc_library(
     name = "Ink",
     sdk_frameworks = [
+        "CoreGraphics",
         "QuartzCore",
         "UIKit",
     ],

--- a/components/ShadowLayer/BUILD
+++ b/components/ShadowLayer/BUILD
@@ -23,6 +23,7 @@ licenses(["notice"])  # Apache 2.0
 mdc_public_objc_library(
     name = "ShadowLayer",
     sdk_frameworks = [
+        "CoreGraphics",
         "QuartzCore",
         "UIKit",
     ],


### PR DESCRIPTION
Bazel and/or apple rules got stricter. Adding some missing SDK dependencies in
our components.
