### PR TITLE
[Dialogs] Add BUILD file and test

### DIFF
--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -71,14 +71,7 @@ mdc_objc_library(
     name = "private",
     hdrs = native.glob(["src/private/*.h"]),
     includes = ["src/private"],
-    visibility = [":test_targets"],
-)
-
-package_group(
-    name = "test_targets",
-    packages = [
-        "//components/Dialogs/...",
-    ],
+    visibility = ["//visibility:private"],
 )
 
 mdc_objc_library(

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -1,5 +1,4 @@
-# Copyright 2017-present The Material Components for iOS Authors. All
-# Rights Reserved.
+# Copyright 2017-present The Material Components for iOS Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -1,0 +1,110 @@
+# Copyright 2017-present The Material Components for iOS Authors. All
+# Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//:material_components_ios.bzl",
+     "mdc_public_objc_library",
+     "mdc_objc_library")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
+
+licenses(["notice"])  # Apache 2.0
+
+mdc_public_objc_library(
+    name = "Dialogs",
+    bundles = [":Bundle"],
+    sdk_frameworks = [
+        "QuartzCore",
+        "UIKit",
+    ],
+    deps = [
+        "//components/Buttons",
+        "//components/ShadowElevations",
+        "//components/ShadowLayer",
+        "//components/private/KeyboardWatcher",
+        "@material_internationalization_ios//:MDFInternationalization",
+        "@motion_animator_objc//:MotionAnimator",
+        "@motion_transitioning_objc//:MotionTransitioning",
+    ],
+)
+
+filegroup(
+    name = "BundleFiles",
+    srcs = glob([
+        "src/MaterialDialogs.bundle/**",
+    ]),
+)
+
+objc_bundle(
+    name = "Bundle",
+    bundle_imports = [":BundleFiles"],
+)
+
+mdc_objc_library(
+    name = "ColorThemer",
+    srcs = native.glob(["src/ColorThemer/*.m"]),
+    hdrs = native.glob(["src/ColorThemer/*.h"]),
+    includes = ["src/ColorThemer"],
+    sdk_frameworks = [
+        "UIKit",
+    ],
+    deps = [
+        ":Dialogs",
+        "//components/Themes",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+mdc_objc_library(
+    name = "private",
+    hdrs = native.glob(["src/private/*.h"]),
+    includes = ["src/private"],
+    visibility = [":test_targets"],
+)
+
+package_group(
+    name = "test_targets",
+    packages = [
+        "//components/Dialogs/...",
+    ],
+)
+
+mdc_objc_library(
+    name = "unit_test_sources",
+    testonly = 1,
+    srcs = native.glob([
+        "tests/unit/*.m",
+        "tests/unit/*.h",
+    ]),
+    sdk_frameworks = [
+        "UIKit",
+        "XCTest",
+    ],
+    deps = [
+        ":Dialogs",
+        ":ColorThemer",
+        ":private",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+ios_unit_test(
+    name = "unit_tests",
+    deps = [
+      ":unit_test_sources",
+    ],
+    minimum_os_version = "8.0",
+    visibility = ["//visibility:private"],
+)

--- a/components/Dialogs/tests/unit/DialogsNoopTest.m
+++ b/components/Dialogs/tests/unit/DialogsNoopTest.m
@@ -24,7 +24,7 @@
 
 @implementation DialogsNoopTest
 
-- (void)simpleBuildTest {
+- (void)testSimpleBuild {
   MDCAlertController *controller = [[MDCAlertController alloc] init];
   XCTAssertNotNil(controller);
 }

--- a/components/Dialogs/tests/unit/DialogsNoopTest.m
+++ b/components/Dialogs/tests/unit/DialogsNoopTest.m
@@ -1,0 +1,32 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialDialogs.h"
+
+@interface DialogsNoopTest : XCTestCase
+
+@end
+
+@implementation DialogsNoopTest
+
+- (void)simpleBuildTest {
+  MDCAlertController *controller = [[MDCAlertController alloc] init];
+  XCTAssertNotNil(controller);
+}
+
+@end


### PR DESCRIPTION
Adding a single no-op unit test to ensure that Kokoro is actually compiling
the target and that the target settings are correct.
