### PR TITLE
[FeatureHighlight] Add BUILD file and no-op test

### DIFF
--- a/components/FeatureHighlight/BUILD
+++ b/components/FeatureHighlight/BUILD
@@ -63,14 +63,7 @@ mdc_objc_library(
     name = "private",
     hdrs = native.glob(["src/private/*.h"]),
     includes = ["src/private"],
-    visibility = [":test_targets"],
-)
-
-package_group(
-    name = "test_targets",
-    packages = [
-        "//components/FeatureHighlight/...",
-    ],
+    visibility = ["//visibility:private"],
 )
 
 mdc_objc_library(

--- a/components/FeatureHighlight/BUILD
+++ b/components/FeatureHighlight/BUILD
@@ -1,5 +1,4 @@
-# Copyright 2017-present The Material Components for iOS Authors. All
-# Rights Reserved.
+# Copyright 2017-present The Material Components for iOS Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/components/FeatureHighlight/BUILD
+++ b/components/FeatureHighlight/BUILD
@@ -1,0 +1,102 @@
+# Copyright 2017-present The Material Components for iOS Authors. All
+# Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//:material_components_ios.bzl",
+     "mdc_public_objc_library",
+     "mdc_objc_library")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+
+licenses(["notice"])  # Apache 2.0
+
+mdc_public_objc_library(
+    name = "FeatureHighlight",
+    bundles = [":Bundle"],
+    sdk_frameworks = [
+        "CoreGraphics",
+        "UIKit",
+    ],
+    deps = [
+        "//components/Typography",
+        "//components/private/Math",
+        "@material_text_accessibility_ios//:MDFTextAccessibility",
+    ],
+)
+
+filegroup(
+    name = "BundleFiles",
+    srcs = glob([
+        "src/MaterialFeatureHighlight.bundle/**",
+    ]),
+)
+
+objc_bundle(
+    name = "Bundle",
+    bundle_imports = [":BundleFiles"],
+)
+
+mdc_objc_library(
+    name = "ColorThemer",
+    srcs = native.glob(["src/ColorThemer/*.m"]),
+    hdrs = native.glob(["src/ColorThemer/*.h"]),
+    includes = ["src/ColorThemer"],
+    deps = [
+        ":FeatureHighlight",
+        "//components/Themes",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+mdc_objc_library(
+    name = "private",
+    hdrs = native.glob(["src/private/*.h"]),
+    includes = ["src/private"],
+    visibility = [":test_targets"],
+)
+
+package_group(
+    name = "test_targets",
+    packages = [
+        "//components/FeatureHighlight/...",
+    ],
+)
+
+mdc_objc_library(
+    name = "unit_test_sources",
+    testonly = 1,
+    srcs = native.glob([
+        "tests/unit/*.m",
+        "tests/unit/*.h",
+    ]),
+    sdk_frameworks = [
+        "UIKit",
+        "XCTest",
+    ],
+    deps = [
+        ":FeatureHighlight",
+        ":ColorThemer",
+        ":private",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+ios_unit_test(
+    name = "unit_tests",
+    deps = [
+      ":unit_test_sources",
+    ],
+    minimum_os_version = "8.0",
+    visibility = ["//visibility:private"],
+)

--- a/components/FeatureHighlight/tests/unit/FeatureHighlightNoopTest.m
+++ b/components/FeatureHighlight/tests/unit/FeatureHighlightNoopTest.m
@@ -1,9 +1,12 @@
 /*
  Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
+
  http://www.apache.org/licenses/LICENSE-2.0
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +24,7 @@
 
 @implementation FeatureHighlightNoopTest
 
-- (void)simpleBuildTest {
+- (void)testSimpleBuild {
   MDCFeatureHighlightView *view = [[MDCFeatureHighlightView alloc] init];
   XCTAssertNotNil(view);
 }

--- a/components/FeatureHighlight/tests/unit/FeatureHighlightNoopTest.m
+++ b/components/FeatureHighlight/tests/unit/FeatureHighlightNoopTest.m
@@ -1,0 +1,29 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialFeatureHighlight.h"
+
+@interface FeatureHighlightNoopTest : XCTestCase
+
+@end
+
+@implementation FeatureHighlightNoopTest
+
+- (void)simpleBuildTest {
+  MDCFeatureHighlightView *view = [[MDCFeatureHighlightView alloc] init];
+  XCTAssertNotNil(view);
+}
+
+@end


### PR DESCRIPTION
A simple no-op test that just ensures that Bazel is building/running some of
the code in Feature Highlight.
