### PR TITLE
[OverlayWindow] Add BUILD file and no-op test

### DIFF
--- a/components/OverlayWindow/BUILD
+++ b/components/OverlayWindow/BUILD
@@ -32,13 +32,6 @@ mdc_public_objc_library(
     ],
 )
 
-package_group(
-    name = "test_targets",
-    packages = [
-        "//components/OverlayWindow/...",
-    ],
-)
-
 mdc_objc_library(
     name = "unit_test_sources",
     testonly = 1,

--- a/components/OverlayWindow/BUILD
+++ b/components/OverlayWindow/BUILD
@@ -1,0 +1,65 @@
+# Copyright 2017-present The Material Components for iOS Authors. All
+# Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//:material_components_ios.bzl",
+     "mdc_public_objc_library",
+     "mdc_objc_library")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+
+licenses(["notice"])  # Apache 2.0
+
+mdc_public_objc_library(
+    name = "OverlayWindow",
+    sdk_frameworks = [
+        "CoreGraphics",
+        "UIKit",
+    ],
+    deps = [
+        "//components/private/Application",
+    ],
+)
+
+package_group(
+    name = "test_targets",
+    packages = [
+        "//components/OverlayWindow/...",
+    ],
+)
+
+mdc_objc_library(
+    name = "unit_test_sources",
+    testonly = 1,
+    srcs = native.glob([
+        "tests/unit/*.m",
+        "tests/unit/*.h",
+    ]),
+    sdk_frameworks = [
+        "XCTest",
+    ],
+    deps = [
+        ":OverlayWindow",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+ios_unit_test(
+    name = "unit_tests",
+    deps = [
+      ":unit_test_sources",
+    ],
+    minimum_os_version = "8.0",
+    visibility = ["//visibility:private"],
+)

--- a/components/OverlayWindow/BUILD
+++ b/components/OverlayWindow/BUILD
@@ -1,5 +1,4 @@
-# Copyright 2017-present The Material Components for iOS Authors. All
-# Rights Reserved.
+# Copyright 2017-present The Material Components for iOS Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/components/OverlayWindow/tests/unit/OverlayWindowNoopTest.m
+++ b/components/OverlayWindow/tests/unit/OverlayWindowNoopTest.m
@@ -1,0 +1,32 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialOverlayWindow.h"
+
+@interface OverlayWindowNoopTest : XCTestCase
+
+@end
+
+@implementation OverlayWindowNoopTest
+
+- (void)testSimpleBuild {
+  MDCOverlayWindow *window = [[MDCOverlayWindow alloc] init];
+  XCTAssertNotNil(window);
+}
+
+@end


### PR DESCRIPTION
Adding a simple test to ensure that the OverlayWindow can be allocated.
