### PR TITLE
[FeatureHighlight] Move Dynamic Type support to the view

### DIFF
--- a/components/FeatureHighlight/src/MDCFeatureHighlightView.h
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightView.h
@@ -23,4 +23,16 @@
 @property(nonatomic, strong, nullable) UIColor *titleColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong, nullable) UIColor *bodyColor UI_APPEARANCE_SELECTOR;
 
+/*
+ Indicates whether the view's contents should automatically update their font when the device’s
+ UIContentSizeCategory changes.
+
+ This property is modeled after the adjustsFontForContentSizeCategory property in the
+ UIContentSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
+
+ Default value is NO.
+ */
+@property(nonatomic, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
+    BOOL mdc_adjustsFontForContentSizeCategory UI_APPEARANCE_SELECTOR;
+
 @end

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -94,6 +94,8 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
   _featureHighlightView.displayedView = _displayedView;
   _featureHighlightView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  _featureHighlightView.mdc_adjustsFontForContentSizeCategory =
+      _mdc_adjustsFontForContentSizeCategory;
 
   __weak __typeof__(self) weakSelf = self;
   _featureHighlightView.interactionBlock = ^(BOOL accepted) {


### PR DESCRIPTION
This moves the implementation from the view controller to the view.
It also requests non-dynamic type fonts if dynamic type is not enabled.
