### PR TITLE
[AlertController] Mark init as unavilable

### DIFF
--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -49,6 +49,9 @@
 /** Alert controllers must be created with alertControllerWithTitle:message: */
 - (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder NS_UNAVAILABLE;
 
+/** Alert controllers must be created with alertControllerWithTitle:message: */
+- (nonnull instancetype)init NS_UNAVAILABLE;
+
 /**
  Adds an action to the alert dialog.
 


### PR DESCRIPTION
We marked initWithCoder and initWithFrame unavailable, but we missed this one.
