### PR TITLE
[Buttons] Disable new ink.

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -301,7 +301,8 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
   // Set up ink layer.
   _inkView = [[MDCInkView alloc] initWithFrame:self.bounds];
-  _inkView.usesLegacyInkRipple = NO;
+// TODO: Enable once we can identify why the ink behavior is regressing for internal clients.
+//  _inkView.usesLegacyInkRipple = NO;
   [self insertSubview:_inkView belowSubview:self.imageView];
 
   // UIButton has a drag enter/exit boundary that is outside of the frame of the button itself.


### PR DESCRIPTION
This is a partial revert of c9d1b7163db9f09c62f2acc596e54897a8b1282b.

This was reverted as part of the v42 release due to regressions with internal clients.