### PR TITLE
Revert "[Buttons] Re-enable legacy ink. (#2657)"

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -301,8 +301,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
   // Set up ink layer.
   _inkView = [[MDCInkView alloc] initWithFrame:self.bounds];
-// TODO: Enable once we can identify why the ink behavior is regressing for internal clients.
-//  _inkView.usesLegacyInkRipple = NO;
+  _inkView.usesLegacyInkRipple = NO;
   [self insertSubview:_inkView belowSubview:self.imageView];
 
   // UIButton has a drag enter/exit boundary that is outside of the frame of the button itself.


### PR DESCRIPTION
This reverts commit aae4264e412a8db537bfe43d39cf3c3abd48436e.

Closes https://github.com/material-components/material-components-ios/issues/2659

Before we can merge this in we need to perform internal testing to identify why the new ink behavior is causing regressions with client teams.