### PR TITLE
[OverlayObserver] Unregister in dealloc

### DIFF
--- a/components/private/Overlay/src/MDCOverlayObserver.m
+++ b/components/private/Overlay/src/MDCOverlayObserver.m
@@ -91,6 +91,10 @@ static MDCOverlayObserver *_sOverlayObserver;
   return self;
 }
 
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
 #pragma mark - Overlays
 
 - (MDCOverlayObserverOverlay *)overlayWithIdentifier:(NSString *)identifier {


### PR DESCRIPTION
When being deallocated, the OverlayObserver should unregister notifications.
On iOS versions before 9 (8 and below), the NSNotificationCenter unsafely
retains references to any observers. On iOS 9 and above, it will keep safe
unretained references.  This bug wasn't found previously because only the
static singleton was ever used by client components and there were no unit
tests for the component.

Closes #2685