### PR TITLE
[Shapes] Custom properties for consistent behavior

### DIFF
--- a/components/private/Shapes/src/MDCShapedShadowLayer.h
+++ b/components/private/Shapes/src/MDCShapedShadowLayer.h
@@ -26,17 +26,48 @@
 @interface MDCShapedShadowLayer : MDCShadowLayer
 
 /*
+ Sets the shaped background color of the layer.
+
+ Use shapedBackgroundColor instead of backgroundColor to ensure the background appears correct with
+ or without a valid shape.
+
+ @note If you set shapedBackgroundColor, you should not manually write to backgroundColor or
+ fillColor.
+ */
+@property(nonatomic, strong, nullable) UIColor *shapedBackgroundColor;
+
+/*
+ Sets the shaped border color of the layer.
+
+ Use shapedBorderColor instead of borderColor to ensure the border appears correct with or without
+ a valid shape.
+
+ @note If you set shapedBorderColor, you should not manually write to borderColor.
+ */
+@property(nonatomic, strong, nullable) UIColor *shapedBorderColor;
+
+/*
+ Sets the shaped border width of the layer.
+
+ Use shapedBorderWidth instead of borderWidth to ensure the border appears correct with or without
+ a valid shape.
+
+ @note If you set shapedBorderWidth, you should not manually write to borderWidth.
+ */
+@property(nonatomic, assign) CGFloat shapedBorderWidth;
+
+/*
  The fill color of the shape.
 
  @note Make sure to set the backgroundColor to a clear color when setting fillColor.
  */
-@property(nullable, nonatomic) CGColorRef fillColor;
+@property(nonatomic, nullable) CGColorRef fillColor __deprecated_msg("Use shapedBackgroundColor");
 
 /*
  The MDCShapeGenerating object used to set the shape's path and shadow path.
 
  The path will be set upon assignment of this property and whenever layoutSublayers is called.
  */
-@property(nullable, nonatomic, strong) id<MDCShapeGenerating> shapeGenerator;
+@property(nonatomic, strong, nullable) id<MDCShapeGenerating> shapeGenerator;
 
 @end

--- a/components/private/Shapes/src/MDCShapedShadowLayer.m
+++ b/components/private/Shapes/src/MDCShapedShadowLayer.m
@@ -96,13 +96,13 @@
     _colorLayer.strokeColor = nil;
     _colorLayer.lineWidth = 0;
   } else {
-    _colorLayer.fillColor = self.shapedBackgroundColor.CGColor;
-    _colorLayer.strokeColor = self.shapedBorderColor.CGColor;
-    _colorLayer.lineWidth = self.shapedBorderWidth;
-
     self.backgroundColor = nil;
     self.borderColor = nil;
     self.borderWidth = 0;
+
+    _colorLayer.fillColor = self.shapedBackgroundColor.CGColor;
+    _colorLayer.strokeColor = self.shapedBorderColor.CGColor;
+    _colorLayer.lineWidth = self.shapedBorderWidth;
   }
 }
 
@@ -117,8 +117,8 @@
     self.backgroundColor = _shapedBackgroundColor.CGColor;
     _colorLayer.fillColor = nil;
   } else {
-    _colorLayer.fillColor = _shapedBackgroundColor.CGColor;
     self.backgroundColor = nil;
+    _colorLayer.fillColor = _shapedBackgroundColor.CGColor;
   }
 }
 
@@ -129,8 +129,8 @@
     self.borderColor = _shapedBorderColor.CGColor;
     _colorLayer.strokeColor = nil;
   } else {
-    _colorLayer.strokeColor = _shapedBorderColor.CGColor;
     self.borderColor = nil;
+    _colorLayer.strokeColor = _shapedBorderColor.CGColor;
   }
 }
 
@@ -141,8 +141,8 @@
     self.borderWidth = _shapedBorderWidth;
     _colorLayer.lineWidth = 0;
   } else {
-    _colorLayer.lineWidth = _shapedBorderWidth;
     self.borderWidth = 0;
+    _colorLayer.lineWidth = _shapedBorderWidth;
   }
 }
 

--- a/components/private/Shapes/src/MDCShapedShadowLayer.m
+++ b/components/private/Shapes/src/MDCShapedShadowLayer.m
@@ -86,10 +86,64 @@
 - (void)setPath:(CGPathRef)path {
   self.shadowPath = path;
   _colorLayer.path = path;
+
+  if (CGPathIsEmpty(path)) {
+    self.backgroundColor = self.shapedBackgroundColor.CGColor;
+    self.borderColor = self.shapedBorderColor.CGColor;
+    self.borderWidth = self.shapedBorderWidth;
+
+    _colorLayer.fillColor = nil;
+    _colorLayer.strokeColor = nil;
+    _colorLayer.lineWidth = 0;
+  } else {
+    _colorLayer.fillColor = self.shapedBackgroundColor.CGColor;
+    _colorLayer.strokeColor = self.shapedBorderColor.CGColor;
+    _colorLayer.lineWidth = self.shapedBorderWidth;
+
+    self.backgroundColor = nil;
+    self.borderColor = nil;
+    self.borderWidth = 0;
+  }
 }
 
 - (CGPathRef)path {
   return _colorLayer.path;
+}
+
+- (void)setShapedBackgroundColor:(UIColor *)shapedBackgroundColor {
+  _shapedBackgroundColor = shapedBackgroundColor;
+
+  if (CGPathIsEmpty(self.path)) {
+    self.backgroundColor = _shapedBackgroundColor.CGColor;
+    _colorLayer.fillColor = nil;
+  } else {
+    _colorLayer.fillColor = _shapedBackgroundColor.CGColor;
+    self.backgroundColor = nil;
+  }
+}
+
+- (void)setShapedBorderColor:(UIColor *)shapedBorderColor {
+  _shapedBorderColor = shapedBorderColor;
+
+  if (CGPathIsEmpty(self.path)) {
+    self.borderColor = _shapedBorderColor.CGColor;
+    _colorLayer.strokeColor = nil;
+  } else {
+    _colorLayer.strokeColor = _shapedBorderColor.CGColor;
+    self.borderColor = nil;
+  }
+}
+
+- (void)setShapedBorderWidth:(CGFloat)shapedBorderWidth {
+  _shapedBorderWidth = shapedBorderWidth;
+
+  if (CGPathIsEmpty(self.path)) {
+    self.borderWidth = _shapedBorderWidth;
+    _colorLayer.lineWidth = 0;
+  } else {
+    _colorLayer.lineWidth = _shapedBorderWidth;
+    self.borderWidth = 0;
+  }
 }
 
 - (void)setFillColor:(CGColorRef)fillColor {


### PR DESCRIPTION
These 3 properties wrap CALayer+CAShapeLayer properties that are complex for clients to use directly. This is because the rendering is either managed by the MDCShapedShadowLayer or a child CAShapeLayer depending on whether or not there is a valid shape.

Unfortunately we can't override those properties and change the behavior internally because they are read by iOS internals, and so have to accurately reflect their intended state at all time.