### PR TITLE
[ShapeLibrary] Add BUILD file and no-op tests

### DIFF
--- a/components/private/ShapeLibrary/BUILD
+++ b/components/private/ShapeLibrary/BUILD
@@ -1,0 +1,59 @@
+# Copyright 2017-present The Material Components for iOS Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//:material_components_ios.bzl",
+     "mdc_public_objc_library",
+     "mdc_objc_library")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+
+licenses(["notice"])  # Apache 2.0
+
+mdc_public_objc_library(
+    name = "ShapeLibrary",
+    sdk_frameworks = [
+        "CoreGraphics",
+        "UIKit",
+    ],
+    deps = [
+        "//components/private/Math",
+        "//components/private/Shapes",
+    ],
+)
+
+mdc_objc_library(
+    name = "unit_test_sources",
+    testonly = 1,
+    srcs = native.glob([
+        "tests/unit/*.m",
+        "tests/unit/*.h",
+    ]),
+    sdk_frameworks = [
+        "UIKit",
+        "XCTest",
+    ],
+    deps = [
+        ":ShapeLibrary",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+ios_unit_test(
+    name = "unit_tests",
+    deps = [
+      ":unit_test_sources",
+    ],
+    minimum_os_version = "8.0",
+    visibility = ["//visibility:private"],
+)

--- a/components/private/ShapeLibrary/src/MDCCurvedCornerTreatment.h
+++ b/components/private/ShapeLibrary/src/MDCCurvedCornerTreatment.h
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#import <CoreGraphics/CoreGraphics.h>
+
 #import "MaterialShapes.h"
 
 /**

--- a/components/private/ShapeLibrary/src/MDCCurvedRectShapeGenerator.h
+++ b/components/private/ShapeLibrary/src/MDCCurvedRectShapeGenerator.h
@@ -15,6 +15,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 #import "MaterialShapes.h"
 

--- a/components/private/ShapeLibrary/src/MDCPillShapeGenerator.m
+++ b/components/private/ShapeLibrary/src/MDCPillShapeGenerator.m
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#import <CoreGraphics/CoreGraphics.h>
+
 #import "MDCPillShapeGenerator.h"
 
 #import "MaterialMath.h"

--- a/components/private/ShapeLibrary/src/MDCRoundedCornerTreatment.h
+++ b/components/private/ShapeLibrary/src/MDCRoundedCornerTreatment.h
@@ -13,6 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
+#import <CoreGraphics/CoreGraphics.h>
 
 #import "MaterialShapes.h"
 

--- a/components/private/ShapeLibrary/src/MDCSlantedRectShapeGenerator.h
+++ b/components/private/ShapeLibrary/src/MDCSlantedRectShapeGenerator.h
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-
+#import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
 
 #import "MaterialShapes.h"

--- a/components/private/ShapeLibrary/src/MDCTriangleEdgeTreatment.h
+++ b/components/private/ShapeLibrary/src/MDCTriangleEdgeTreatment.h
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#import <CoreGraphics/CoreGraphics.h>
+
 #import "MaterialShapes.h"
 
 typedef enum : NSUInteger {

--- a/components/private/ShapeLibrary/tests/unit/ShapeLibraryNoopTest.m
+++ b/components/private/ShapeLibrary/tests/unit/ShapeLibraryNoopTest.m
@@ -1,0 +1,62 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MDCCurvedCornerTreatment.h"
+#import "MDCCurvedRectShapeGenerator.h"
+#import "MDCPillShapeGenerator.h"
+#import "MDCRoundedCornerTreatment.h"
+#import "MDCSlantedRectShapeGenerator.h"
+#import "MDCTriangleEdgeTreatment.h"
+
+@interface ShapeLibraryNoopTest : XCTestCase
+
+@end
+
+@implementation ShapeLibraryNoopTest
+
+- (void)testCurvedCornerInit {
+  MDCCurvedCornerTreatment *treatment = [[MDCCurvedCornerTreatment alloc] init];
+  XCTAssertNotNil(treatment);
+}
+
+- (void)testCurvedRectShapeGeneratorInit {
+  MDCCurvedRectShapeGenerator *generator = [[MDCCurvedRectShapeGenerator alloc] init];
+  XCTAssertNotNil(generator);
+}
+
+- (void)testPillShapeGeneratorInit {
+  MDCPillShapeGenerator *generator = [[MDCPillShapeGenerator alloc] init];
+  XCTAssertNotNil(generator);
+}
+
+- (void)testRoundedCornerTreatmentInit {
+  MDCRoundedCornerTreatment *treatment = [[MDCRoundedCornerTreatment alloc] init];
+  XCTAssertNotNil(treatment);
+}
+
+- (void)testSlantedRectShapeGeneratorInit {
+  MDCSlantedRectShapeGenerator *generator = [[MDCSlantedRectShapeGenerator alloc] init];
+  XCTAssertNotNil(generator);
+}
+
+- (void)testTriangleEdgeTreatmentInit {
+  MDCTriangleEdgeTreatment *treatment =
+      [[MDCTriangleEdgeTreatment alloc] initWithSize:0 style:MDCTriangleEdgeStyleCut];
+  XCTAssertNotNil(treatment);
+}
+@end


### PR DESCRIPTION
There is no umbrella header, so the tests just import all the things and init their main classes.
