### PR TITLE
[kokoro] Add :ColorThemer targets

### DIFF
--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -48,10 +48,28 @@ objc_bundle(
     bundle_imports = [":BundleFiles"],
 )
 
+mdc_objc_library(
+    name = "ColorThemer",
+    srcs = native.glob(["src/ColorThemer/*.m"]),
+    hdrs = native.glob(["src/ColorThemer/*.h"]),
+    includes = ["src/ColorThemer"],
+    sdk_frameworks = [
+        "UIKit",
+    ],
+    deps = [
+        ":ActivityIndicator",
+        "//components/Themes",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
-    deps = [":ActivityIndicator"],
+    deps = [
+        ":ActivityIndicator",
+        ":ColorThemer",
+    ],
     visibility = ["//visibility:private"],
 )
 
@@ -64,7 +82,10 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
-    deps = [":ActivityIndicator"],
+    deps = [
+        ":ActivityIndicator",
+        ":ColorThemer",
+    ],
     visibility = ["//visibility:private"],
 )
 

--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -33,10 +33,28 @@ mdc_public_objc_library(
     ],
 )
 
+mdc_objc_library(
+    name = "ColorThemer",
+    srcs = native.glob(["src/ColorThemer/*.m"]),
+    hdrs = native.glob(["src/ColorThemer/*.h"]),
+    includes = ["src/ColorThemer"],
+    sdk_frameworks = [
+        "UIKit",
+    ],
+    deps = [
+        ":FlexibleHeader",
+        "//components/Themes",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
-    deps = [":FlexibleHeader"],
+    deps = [
+        ":FlexibleHeader",
+        ":ColorThemer",
+    ],
     visibility = ["//visibility:private"],
 )
 
@@ -49,7 +67,10 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
-    deps = [":FlexibleHeader"],
+    deps = [
+        ":FlexibleHeader",
+        ":ColorThemer",
+    ],
     visibility = ["//visibility:private"],
 )
 

--- a/components/Ink/BUILD
+++ b/components/Ink/BUILD
@@ -15,7 +15,6 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 
 licenses(["notice"])  # Apache 2.0
@@ -33,18 +32,26 @@ mdc_public_objc_library(
 )
 
 mdc_objc_library(
+    name = "ColorThemer",
+    srcs = native.glob(["src/ColorThemer/*.m"]),
+    hdrs = native.glob(["src/ColorThemer/*.h"]),
+    includes = ["src/ColorThemer"],
+    sdk_frameworks = [
+        "UIKit",
+    ],
+    deps = [
+        ":Ink",
+        "//components/Themes",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+mdc_objc_library(
     name = "private",
     hdrs = native.glob(["src/private/*.h"]),
     deps = [":Ink"],
     includes = ["src/private"],
-    visibility = [":test_targets"],
-)
-
-package_group(
-    name = "test_targets",
-    packages = [
-        "//components/Ink/...",
-    ],
+    visibility = ["//visibility:private"],
 )
 
 mdc_objc_library(
@@ -58,6 +65,7 @@ mdc_objc_library(
     ],
     deps = [
         ":Ink",
+        ":ColorThemer",
         ":private"
     ],
     visibility = ["//visibility:private"],

--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -35,6 +35,21 @@ mdc_public_objc_library(
 )
 
 mdc_objc_library(
+    name = "ColorThemer",
+    srcs = native.glob(["src/ColorThemer/*.m"]),
+    hdrs = native.glob(["src/ColorThemer/*.h"]),
+    includes = ["src/ColorThemer"],
+    sdk_frameworks = [
+        "UIKit",
+    ],
+    deps = [
+        ":TextFields",
+        "//components/Themes",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+mdc_objc_library(
     name = "unit_test_sources",
     testonly = 1,
     srcs = glob(["tests/unit/*.m"]),
@@ -42,6 +57,10 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
         "XCTest",
+    ],
+    deps = [
+        ":TextFields",
+        ":ColorThemer",
     ],
     visibility = ["//visibility:private"],
 )
@@ -51,6 +70,7 @@ swift_library(
     srcs = glob(["tests/unit/*.swift"]),
     deps = [
         ":TextFields",
+        ":ColorThemer",
         "//components/private/Math",
         "//components/Palettes",
     ],


### PR DESCRIPTION
These components were missing BUILD definitions for their ColorThemer extensions

