### PR TITLE
[NavBar, ButtonBar] Add NavBar tests, fix ButtonBar KVO

### DIFF
--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -64,16 +64,17 @@ static NSString *const MDCButtonBarButtonLayoutPositionKey = @"MDCButtonBarButto
   self = [super initWithCoder:coder];
   if (self) {
     [self commonMDCButtonBarInit];
-    if ([coder containsValueForKey:MDCButtonBarItemsKey]) {
-      _items = [coder decodeObjectForKey:MDCButtonBarItemsKey];
-    }
-
     if ([coder containsValueForKey:MDCButtonBarButtonTitleBaselineKey]) {
       _buttonTitleBaseline = (CGFloat)[coder decodeDoubleForKey:MDCButtonBarButtonTitleBaselineKey];
     }
 
     if ([coder containsValueForKey:MDCButtonBarButtonLayoutPositionKey]) {
       _layoutPosition = [coder decodeIntegerForKey:MDCButtonBarButtonLayoutPositionKey];
+    }
+
+    if ([coder containsValueForKey:MDCButtonBarItemsKey]) {
+      // Force going through the setter to ensure KVO is observed for these items
+      self.items = [coder decodeObjectForKey:MDCButtonBarItemsKey];
     }
   }
   return self;

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -119,13 +119,13 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   XCTAssertNotNil(unarchivedBar.backItem);
   XCTAssertEqualObjects(navBar.backItem.title, unarchivedBar.backItem.title);
   XCTAssertEqual(navBar.hidesBackButton, unarchivedBar.hidesBackButton);
-  XCTAssertEqual(2, unarchivedBar.leadingBarButtonItems.count);
+  XCTAssertEqual(2U, unarchivedBar.leadingBarButtonItems.count);
   XCTAssertEqual(navBar.leadingBarButtonItems.count, unarchivedBar.leadingBarButtonItems.count);
   for (int i = 0; i < navBar.leadingBarButtonItems.count; ++i) {
     XCTAssertEqualObjects(navBar.leadingBarButtonItems[i].title,
                           unarchivedBar.leadingBarButtonItems[i].title);
   }
-  XCTAssertEqual(2, unarchivedBar.trailingBarButtonItems.count);
+  XCTAssertEqual(2U, unarchivedBar.trailingBarButtonItems.count);
   XCTAssertEqual(navBar.trailingBarButtonItems.count, unarchivedBar.trailingBarButtonItems.count);
   for (int i = 0; i < navBar.trailingBarButtonItems.count; ++i) {
     XCTAssertEqualObjects(navBar.trailingBarButtonItems[i].title,

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -86,4 +86,54 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   XCTAssertEqual(alignment, MDCNavigationBarTitleAlignmentCenter);
 }
 
+- (void)testEncoding {
+  // Given
+  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
+  navBar.title = @"A title";
+  navBar.titleView = [[UIView alloc] init];
+  navBar.titleView.contentMode = UIViewContentModeTop;
+  navBar.titleTextAttributes = @{NSFontAttributeName : [UIFont systemFontOfSize:12]};
+  UIBarButtonItem *backItem = [[UIBarButtonItem alloc] init];
+  backItem.title = @"Go back!";
+  navBar.backItem = backItem;
+  navBar.hidesBackButton = YES;
+  UIBarButtonItem *item1 = [[UIBarButtonItem alloc] init];
+  item1.title = @"Item 1";
+  UIBarButtonItem *item2 = [[UIBarButtonItem alloc] init];
+  item2.title = @"Item 2";
+  navBar.leadingBarButtonItems = @[item1, item2];
+  navBar.trailingBarButtonItems = @[item2, item1];
+  navBar.leadingItemsSupplementBackButton = YES;
+  navBar.titleAlignment = MDCNavigationBarTitleAlignmentCenter;
+
+  // When
+  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:navBar];
+  MDCNavigationBar *unarchivedBar =
+      (MDCNavigationBar *)[NSKeyedUnarchiver unarchiveObjectWithData:archive];
+
+  // Then
+  XCTAssertEqualObjects(navBar.title, unarchivedBar.title);
+  XCTAssertNotNil(unarchivedBar.titleView);
+  XCTAssertEqual(navBar.titleView.contentMode, unarchivedBar.titleView.contentMode);
+  XCTAssertEqualObjects(navBar.titleTextAttributes, unarchivedBar.titleTextAttributes);
+  XCTAssertNotNil(unarchivedBar.backItem);
+  XCTAssertEqualObjects(navBar.backItem.title, unarchivedBar.backItem.title);
+  XCTAssertEqual(navBar.hidesBackButton, unarchivedBar.hidesBackButton);
+  XCTAssertEqual(2, unarchivedBar.leadingBarButtonItems.count);
+  XCTAssertEqual(navBar.leadingBarButtonItems.count, unarchivedBar.leadingBarButtonItems.count);
+  for (int i = 0; i < navBar.leadingBarButtonItems.count; ++i) {
+    XCTAssertEqualObjects(navBar.leadingBarButtonItems[i].title,
+                          unarchivedBar.leadingBarButtonItems[i].title);
+  }
+  XCTAssertEqual(2, unarchivedBar.trailingBarButtonItems.count);
+  XCTAssertEqual(navBar.trailingBarButtonItems.count, unarchivedBar.trailingBarButtonItems.count);
+  for (int i = 0; i < navBar.trailingBarButtonItems.count; ++i) {
+    XCTAssertEqualObjects(navBar.trailingBarButtonItems[i].title,
+                          unarchivedBar.trailingBarButtonItems[i].title);
+  }
+  XCTAssertEqual(navBar.leadingItemsSupplementBackButton,
+                unarchivedBar.leadingItemsSupplementBackButton);
+  XCTAssertEqual(navBar.titleAlignment, unarchivedBar.titleAlignment);
+}
+
 @end

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -121,13 +121,13 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   XCTAssertEqual(navBar.hidesBackButton, unarchivedBar.hidesBackButton);
   XCTAssertEqual(2U, unarchivedBar.leadingBarButtonItems.count);
   XCTAssertEqual(navBar.leadingBarButtonItems.count, unarchivedBar.leadingBarButtonItems.count);
-  for (int i = 0; i < navBar.leadingBarButtonItems.count; ++i) {
+  for (NSUInteger i = 0; i < navBar.leadingBarButtonItems.count; ++i) {
     XCTAssertEqualObjects(navBar.leadingBarButtonItems[i].title,
                           unarchivedBar.leadingBarButtonItems[i].title);
   }
   XCTAssertEqual(2U, unarchivedBar.trailingBarButtonItems.count);
   XCTAssertEqual(navBar.trailingBarButtonItems.count, unarchivedBar.trailingBarButtonItems.count);
-  for (int i = 0; i < navBar.trailingBarButtonItems.count; ++i) {
+  for (NSUInteger i = 0; i < navBar.trailingBarButtonItems.count; ++i) {
     XCTAssertEqualObjects(navBar.trailingBarButtonItems[i].title,
                           unarchivedBar.trailingBarButtonItems[i].title);
   }


### PR DESCRIPTION
ButtonBar was not correctly setting up KVO when it was created with an NSCoder (restored from an
archive). In that case, dealloc would generate an exception and crash.  Instead of writing to the
backing iVar during initWithCoder:, the ButtonBar should call through to its setter instead.  This
is less safe (because the subclass may not be initialized) but guarantees observing the objects it
is restoring.

Added a simple NavBar encoding test that discovered the ButtonBar bug.
