### PR TITLE
[Chips] Use new layer border properties

### DIFF
--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -354,7 +354,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 }
 
 - (void)updateBorderColor {
-  self.layer.borderColor = [self borderColorForState:self.state].CGColor;
+  self.layer.shapedBorderColor = [self borderColorForState:self.state];
 }
 
 - (CGFloat)borderWidthForState:(UIControlState)state {
@@ -375,7 +375,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 }
 
 - (void)updateBorderWidth {
-  self.layer.borderWidth = [self borderWidthForState:self.state];
+  self.layer.shapedBorderWidth = [self borderWidthForState:self.state];
 }
 
 - (CGFloat)elevationForState:(UIControlState)state {


### PR DESCRIPTION
Chips now uses the new MDCShapedShadowLayer border properties to ensure borders render correctly when using shapes.

Before:
![simulator screen shot - iphone x - 2017-12-14 at 12 23 31](https://user-images.githubusercontent.com/1251373/34005812-216319aa-e0ca-11e7-8655-f58eed5001f4.png)

After:
![simulator screen shot - iphone x - 2017-12-14 at 12 18 38](https://user-images.githubusercontent.com/1251373/34005820-254dec2a-e0ca-11e7-9c35-6dcff5c573b2.png)
