### PR TITLE
[Chips] Fix sizeToFit sometimes being too small

### DIFF
--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -79,8 +79,7 @@ static const UIEdgeInsets MDCChipAccessoryPadding = {0, 0, 0, 0};
 
 static CGRect CGRectVerticallyCentered(CGRect rect, UIEdgeInsets padding, CGFloat height) {
   CGFloat viewHeight = CGRectGetHeight(rect) + padding.top + padding.bottom;
-  CGRect frame = CGRectOffset(rect, 0, (height - viewHeight) / 2);
-  return MDCRectAlignToScale(frame, [UIScreen mainScreen].scale);
+  return CGRectOffset(rect, 0, (height - viewHeight) / 2);
 }
 
 static inline CGRect MDCChipBuildFrame(UIEdgeInsets insets,


### PR DESCRIPTION
Due to some intricacies of MDCChipView layout, putting each view's frame through MDCRectAlignToScale would sometimes cause the title to be truncated.

Correctly ensuring chips are fully pixel aligned is nontrivial so I'll create an issue once this PR lands.