### PR TITLE
[Buttons] Extended FAB leading-align text and no minimum width

### DIFF
--- a/components/Buttons/src/MDCFloatingButton.m
+++ b/components/Buttons/src/MDCFloatingButton.m
@@ -167,7 +167,7 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
                                            MDCFloatingButtonMiniDimension);
   const CGSize defaultNormalSize = CGSizeMake(MDCFloatingButtonDefaultDimension,
                                               MDCFloatingButtonDefaultDimension);
-  const CGSize defaultExpandedMinimumSize = CGSizeMake(132, 48);
+  const CGSize defaultExpandedMinimumSize = CGSizeMake(0, 48);
   const CGSize defaultExpandedMaximumSize = CGSizeMake(328, 0);
 
   // Minimum size values for different shape + mode combinations
@@ -339,7 +339,8 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
   // If we are RTL with a trailing image, the image goes on the left.
   if ((isLTR && isLeadingIcon) || (!isLTR && !isLeadingIcon)) {
     const CGFloat imageCenterX = CGRectGetMinX(insetBounds) + (imageViewWidth / 2);
-    const CGFloat titleCenterX = CGRectGetMaxX(insetBounds) - (titleWidthAvailable / 2);
+    const CGFloat titleCenterX = CGRectGetMaxX(insetBounds) - titleWidthAvailable +
+        (titleSize.width / 2);
     titleCenter = CGPointMake(titleCenterX, boundsCenterY);
     imageCenter = CGPointMake(imageCenterX, boundsCenterY);
   }
@@ -347,7 +348,8 @@ static NSString *const MDCFloatingButtonHitAreaInsetsDictionaryKey =
   // If we are RTL with a leading image, the image goes on the right.
   else {
     const CGFloat imageCenterX = CGRectGetMaxX(insetBounds) - (imageViewWidth / 2);
-    const CGFloat titleCenterX = CGRectGetMinX(insetBounds) + (titleWidthAvailable / 2);
+    const CGFloat titleCenterX = CGRectGetMinX(insetBounds) + titleWidthAvailable -
+        (titleSize.width / 2);
     imageCenter = CGPointMake(imageCenterX, boundsCenterY);
     titleCenter = CGPointMake(titleCenterX, boundsCenterY);
   }

--- a/components/Buttons/tests/unit/FloatingButtonTests.m
+++ b/components/Buttons/tests/unit/FloatingButtonTests.m
@@ -390,7 +390,6 @@ static UIImage *fakeImage(void) {
   [defaultButton sizeToFit];
 
   // Then
-  XCTAssertGreaterThanOrEqual(defaultButton.bounds.size.width, 132);
   XCTAssertGreaterThanOrEqual(defaultButton.bounds.size.height, 48);
 }
 
@@ -479,6 +478,31 @@ static UIImage *fakeImage(void) {
       [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeDefault];
   button.mode = MDCFloatingButtonModeExpanded;
   [button setTitle:@"A very long title that can never fit" forState:UIControlStateNormal];
+  [button setImage:fakeImage() forState:UIControlStateNormal];
+  [button setMaximumSize:CGSizeMake(100, 48)
+                forShape:MDCFloatingButtonShapeDefault
+                  inMode:MDCFloatingButtonModeExpanded];
+  button.imageTitleSpace = 12;
+
+  // When
+  [button sizeToFit];
+
+  // Then
+  CGRect buttonBounds = CGRectStandardize(button.bounds);
+  CGRect imageFrame = CGRectStandardize(button.imageView.frame);
+  CGRect titleFrame = CGRectStandardize(button.titleLabel.frame);
+  XCTAssertEqualWithAccuracy(imageFrame.origin.x, 16, 1);
+  XCTAssertEqualWithAccuracy(CGRectGetMaxX(titleFrame), buttonBounds.size.width - 24, 1);
+  XCTAssertEqualWithAccuracy(titleFrame.origin.x,
+                             CGRectGetMaxX(imageFrame) + button.imageTitleSpace, 1);
+}
+
+- (void)testExpandedLayoutShortTitle {
+  // Given
+  MDCFloatingButton *button =
+  [[MDCFloatingButton alloc] initWithFrame:CGRectZero shape:MDCFloatingButtonShapeDefault];
+  button.mode = MDCFloatingButtonModeExpanded;
+  [button setTitle:@"A" forState:UIControlStateNormal];
   [button setImage:fakeImage() forState:UIControlStateNormal];
   [button setMaximumSize:CGSizeMake(100, 48)
                 forShape:MDCFloatingButtonShapeDefault


### PR DESCRIPTION
For shorter text, the extended FAB looks better without a minimum and with a
leading alignment of text.

Closes #2731
