### PR TITLE
[BottomNavigation] Add NSCoding tests

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -28,6 +28,24 @@
 // The Bundle for string resources.
 static NSString *const kMaterialBottomNavigationBundle = @"MaterialBottomNavigation.bundle";
 
+static NSString *const kMDCBottomNavigationBarDelegateKey = @"kMDCBottomNavigationBarDelegateKey";
+static NSString *const kMDCBottomNavigationBarTitleVisibilityKey =
+    @"kMDCBottomNavigationBarTitleVisibilityKey";
+static NSString *const kMDCBottomNavigationBarAlignmentKey = @"kMDCBottomNavigationBarAlignmentKey";
+static NSString *const KMDCBottomNavigationBarItemsKey = @"KMDCBottomNavigationBarItemsKey";
+static NSString *const kMDCBottomNavigationBarSelectedItemKey =
+    @"kMDCBottomNavigationBarSelectedItemKey";
+static NSString *const kMDCBottomNavigationBarItemTitleFontKey =
+    @"kMDCBottomNavigationBarItemTitleFontKey";
+static NSString *const kMDCBottomNavigationBarSelectedItemTintColorKey =
+    @"kMDCBottomNavigationBarSelectedItemTintColorKey";
+static NSString *const kMDCBottomNavigationBarUnselectedItemTintColorKey =
+    @"kMDCBottomNavigationBarUnselectedItemTintColorKey";
+static NSString *const kMDCBottomNavigationBarItemsDistributedKey =
+    @"kMDCBottomNavigationBarItemsDistributedKey";
+static NSString *const kMDCBottomNavigationBarTitleBelowItemKey =
+    @"kMDCBottomNavigationBarTitleBelowItemKey";
+
 static const CGFloat kMDCBottomNavigationBarHeight = 56.f;
 static const CGFloat kMDCBottomNavigationBarHeightAdjacentTitles = 40.f;
 static const CGFloat kMDCBottomNavigationBarLandscapeContainerWidth = 320.f;
@@ -55,6 +73,9 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
 - (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];
   if (self) {
+    self.autoresizingMask = (UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth);
+    self.backgroundColor = [UIColor whiteColor];
+    self.isAccessibilityElement = NO;
     [self commonMDCBottomNavigationBarInit];
   }
   return self;
@@ -64,20 +85,85 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   self = [super initWithCoder:aDecoder];
   if (self) {
     [self commonMDCBottomNavigationBarInit];
+
+    if ([aDecoder containsValueForKey:kMDCBottomNavigationBarDelegateKey]) {
+      _delegate = [aDecoder decodeObjectForKey:kMDCBottomNavigationBarDelegateKey];
+    }
+    if ([aDecoder containsValueForKey:kMDCBottomNavigationBarTitleVisibilityKey]) {
+      _titleVisibility = [aDecoder decodeIntegerForKey:kMDCBottomNavigationBarTitleVisibilityKey];
+    }
+    if ([aDecoder containsValueForKey:kMDCBottomNavigationBarAlignmentKey]) {
+      _alignment = [aDecoder decodeIntegerForKey:kMDCBottomNavigationBarAlignmentKey];
+    }
+    if ([aDecoder containsValueForKey:kMDCBottomNavigationBarItemTitleFontKey]) {
+      _itemTitleFont = [aDecoder decodeObjectForKey:kMDCBottomNavigationBarItemTitleFontKey];
+    }
+    if ([aDecoder containsValueForKey:kMDCBottomNavigationBarSelectedItemTintColorKey]) {
+      _selectedItemTintColor =
+          [aDecoder decodeObjectForKey:kMDCBottomNavigationBarSelectedItemTintColorKey];
+    }
+    if ([aDecoder containsValueForKey:kMDCBottomNavigationBarUnselectedItemTintColorKey]) {
+      _unselectedItemTintColor =
+          [aDecoder decodeObjectForKey:kMDCBottomNavigationBarUnselectedItemTintColorKey];
+    }
+    if ([aDecoder containsValueForKey:kMDCBottomNavigationBarItemsDistributedKey]) {
+      _itemsDistributed = [aDecoder decodeBoolForKey:kMDCBottomNavigationBarItemsDistributedKey];
+    }
+    if ([aDecoder containsValueForKey:kMDCBottomNavigationBarTitleBelowItemKey]) {
+      _titleBelowItem = [aDecoder decodeBoolForKey:kMDCBottomNavigationBarTitleBelowItemKey];
+    }
+
+    // Should be second-last due to KVO
+    if ([aDecoder containsValueForKey:KMDCBottomNavigationBarItemsKey]) {
+      self.items = [aDecoder decodeObjectForKey:KMDCBottomNavigationBarItemsKey];
+    }
+    // Should be last due to updating views
+    if ([aDecoder containsValueForKey:kMDCBottomNavigationBarSelectedItemKey]) {
+      self.selectedItem = [aDecoder decodeObjectForKey:kMDCBottomNavigationBarSelectedItemKey];
+    }
   }
   return self;
 }
 
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+  [super encodeWithCoder:aCoder];
+  if (self.delegate) {
+    [aCoder encodeObject:self.delegate forKey:kMDCBottomNavigationBarDelegateKey];
+  }
+  [aCoder encodeInteger:self.titleVisibility forKey:kMDCBottomNavigationBarTitleVisibilityKey];
+  [aCoder encodeInteger:self.alignment forKey:kMDCBottomNavigationBarAlignmentKey];
+  [aCoder encodeObject:self.items forKey:KMDCBottomNavigationBarItemsKey];
+  [aCoder encodeObject:self.selectedItem forKey:kMDCBottomNavigationBarSelectedItemKey];
+  if (self.itemTitleFont) {
+    [aCoder encodeObject:self.itemTitleFont forKey:kMDCBottomNavigationBarItemTitleFontKey];
+  }
+  if (self.selectedItemTintColor) {
+    [aCoder encodeObject:self.selectedItemTintColor
+                  forKey:kMDCBottomNavigationBarSelectedItemTintColorKey];
+  }
+  if (self.unselectedItemTintColor) {
+    [aCoder encodeObject:self.unselectedItemTintColor
+                  forKey:kMDCBottomNavigationBarUnselectedItemTintColorKey];
+  }
+  [aCoder encodeBool:self.itemsDistributed forKey:kMDCBottomNavigationBarItemsDistributedKey];
+  [aCoder encodeBool:self.titleBelowItem forKey:kMDCBottomNavigationBarTitleBelowItemKey];
+}
+
 - (void)commonMDCBottomNavigationBarInit {
-  self.autoresizingMask = (UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth);
-  self.backgroundColor = [UIColor whiteColor];
-  self.isAccessibilityElement = NO;
   _selectedItemTintColor = [UIColor blackColor];
   _unselectedItemTintColor = [UIColor grayColor];
   _titleVisibility = MDCBottomNavigationBarTitleVisibilitySelected;
   _alignment = MDCBottomNavigationBarAlignmentJustified;
   _itemsDistributed = YES;
   _titleBelowItem = YES;
+
+  // Remove any unarchived subviews and reconfigure the view hierarchy
+  if (self.subviews.count) {
+    NSArray *subviews = self.subviews;
+    for (UIView *view in subviews) {
+      [view removeFromSuperview];
+    }
+  }
   _maxLandscapeClusterContainerWidth = kMDCBottomNavigationBarLandscapeContainerWidth;
   _containerView = [[UIView alloc] initWithFrame:CGRectZero];
   _containerView.autoresizingMask = (UIViewAutoresizingFlexibleLeftMargin |

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemBadge.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemBadge.m
@@ -16,6 +16,19 @@
 
 #import "MDCBottomNavigationItemBadge.h"
 
+static NSString *const kMDCBottomNavigationItemBadgeCircleWidthKey =
+    @"kMDCBottomNavigationItemBadgeCircleWidthKey";
+static NSString *const kMDCBottomNavigationItemBadgeCircleHeightKey =
+    @"kMDCBottomNavigationItemBadgeCircleHeightKey";
+static NSString *const kMDCBottomNavigationItemBadgeXPaddingKey =
+    @"kMDCBottomNavigationItemBadgeXPaddingKey";
+static NSString *const kMDCBottomNavigationItemBadgeYPaddingKey =
+    @"kMDCBottomNavigationItemBadgeYPaddingKey";
+static NSString *const kMDCBottomNavigationItemBadgeValueKey =
+    @"kMDCBottomNavigationItemBadgeValueKey";
+static NSString *const kMDCBottomNavigationItemBadgeColorKey =
+    @"kMDCBottomNavigationItemBadgeColorKey";
+
 static const CGFloat kMDCBottomNavigationItemBadgeFontSize = 10.f;
 static const CGFloat kMDCBottomNavigationItemBadgeXPadding = 8.f;
 static const CGFloat kMDCBottomNavigationItemBadgeYPadding = 2.f;
@@ -33,21 +46,64 @@ static const CGFloat kMDCBottomNavigationItemBadgeYPadding = 2.f;
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
   self = [super initWithCoder:aDecoder];
   if (self) {
+    if ([aDecoder containsValueForKey:kMDCBottomNavigationItemBadgeCircleWidthKey]) {
+      _badgeCircleWidth =
+          (CGFloat)[aDecoder decodeDoubleForKey:kMDCBottomNavigationItemBadgeCircleWidthKey];
+    }
+    if ([aDecoder containsValueForKey:kMDCBottomNavigationItemBadgeCircleHeightKey]) {
+      _badgeCircleHeight =
+          (CGFloat)[aDecoder decodeDoubleForKey:kMDCBottomNavigationItemBadgeCircleHeightKey];
+    }
+    if ([aDecoder containsValueForKey:kMDCBottomNavigationItemBadgeXPaddingKey]) {
+      _xPadding = (CGFloat)[aDecoder decodeDoubleForKey:kMDCBottomNavigationItemBadgeXPaddingKey];
+    }
+    if ([aDecoder containsValueForKey:kMDCBottomNavigationItemBadgeYPaddingKey]) {
+      _yPadding = (CGFloat)[aDecoder decodeDoubleForKey:kMDCBottomNavigationItemBadgeYPaddingKey];
+    }
+    if ([aDecoder containsValueForKey:kMDCBottomNavigationItemBadgeValueKey]) {
+      _badgeValue = [aDecoder decodeObjectForKey:kMDCBottomNavigationItemBadgeValueKey];
+    }
+    if ([aDecoder containsValueForKey:kMDCBottomNavigationItemBadgeColorKey]) {
+      _badgeColor = [aDecoder decodeObjectForKey:kMDCBottomNavigationItemBadgeColorKey];
+    }
+
     [self commonMDCBottomNavigationItemBadgeInit];
   }
   return self;
 }
 
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+  [super encodeWithCoder:aCoder];
+  [aCoder encodeDouble:self.badgeCircleWidth forKey:kMDCBottomNavigationItemBadgeCircleWidthKey];
+  [aCoder encodeDouble:self.badgeCircleHeight forKey:kMDCBottomNavigationItemBadgeCircleHeightKey];
+  [aCoder encodeDouble:self.xPadding forKey:kMDCBottomNavigationItemBadgeXPaddingKey];
+  [aCoder encodeDouble:self.yPadding forKey:kMDCBottomNavigationItemBadgeYPaddingKey];
+  if (self.badgeValue != nil) {
+    [aCoder encodeObject:self.badgeValue forKey:kMDCBottomNavigationItemBadgeValueKey];
+  }
+  if (self.badgeColor != nil) {
+    [aCoder encodeObject:self.badgeColor forKey:kMDCBottomNavigationItemBadgeColorKey];
+  }
+}
+
 - (void)commonMDCBottomNavigationItemBadgeInit {
-  _badgeColor = [UIColor redColor];
+  if (!_badgeColor) {
+    _badgeColor = [UIColor redColor];
+  }
   self.layer.backgroundColor = _badgeColor.CGColor;
 
-  _badgeValueLabel = [[UILabel alloc] initWithFrame:self.bounds];
-  _badgeValueLabel.textColor = [UIColor whiteColor];
-  _badgeValueLabel.font = [UIFont systemFontOfSize:kMDCBottomNavigationItemBadgeFontSize];
-  _badgeValueLabel.textAlignment = NSTextAlignmentCenter;
-  _badgeValueLabel.isAccessibilityElement = NO;
-  [self addSubview:_badgeValueLabel];
+  if (self.subviews.count == 0) {
+    _badgeValueLabel = [[UILabel alloc] initWithFrame:self.bounds];
+    _badgeValueLabel.textColor = [UIColor whiteColor];
+    _badgeValueLabel.font = [UIFont systemFontOfSize:kMDCBottomNavigationItemBadgeFontSize];
+    _badgeValueLabel.textAlignment = NSTextAlignmentCenter;
+    _badgeValueLabel.isAccessibilityElement = NO;
+    _badgeValueLabel.text = _badgeValue;
+    [self addSubview:_badgeValueLabel];
+  } else {
+    // Badge label was restored during -initWithCoder:
+    _badgeValueLabel = self.subviews.firstObject;
+  }
 }
 
 - (void)layoutSubviews {

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -24,6 +24,22 @@
 #import "MaterialMath.h"
 #import "MDCBottomNavigationItemBadge.h"
 
+static NSString *const MDCBottomNavigationItemViewTitleBelowIconKey =
+    @"MDCBottomNavigationItemViewTitleBelowIconKey";
+static NSString *const MDCBottomNavigationItemViewSelectedKey =
+    @"MDCBottomNavigationItemViewSelectedKey";
+static NSString *const MDCBottomNavigationItemViewTitleVisibilityKey =
+    @"MDCBottomNavigationItemViewTitleVisibilityKey";
+static NSString *const MDCBottomNavigationItemViewTitleKey = @"MDCBottomNavigationItemViewTitleKey";
+static NSString *const MDCBottomNavigationItemViewItemTitleFontKey =
+    @"MDCBottomNavigationItemViewItemTitleFontKey";
+static NSString *const MDCBottomNavigationItemViewBadgeColorKey =
+    @"MDCBottomNavigationItemViewBadgeColorKey";
+static NSString *const MDCBottomNavigationItemViewSelectedItemTintColorKey =
+    @"MDCBottomNavigationItemViewSelectedItemTintColorKey";
+static NSString *const MDCBottomNavigationItemViewUnselectedItemTintColorKey =
+    @"MDCBottomNavigationItemViewUnselectedItemTintColorKey";
+
 static const CGFloat MDCBottomNavigationItemViewInkOpacity = 0.150f;
 static const CGFloat kMDCBottomNavigationItemViewItemInset = 8.f;
 static const CGFloat MDCBottomNavigationItemViewTitleFontSize = 12.f;
@@ -48,6 +64,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 - (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];
   if (self) {
+    _titleBelowIcon = YES;
     [self commonMDCBottomNavigationItemViewInit];
   }
   return self;
@@ -56,47 +73,130 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
   self = [super initWithCoder:aDecoder];
   if (self) {
+    _titleBelowIcon = YES;
+
+    NSUInteger totalViewsProcessed = 0;
+    for (UIView *view in self.subviews) {
+      if ([view isKindOfClass:[MDCInkView class]]) {
+        _inkView = (MDCInkView *)view;
+        ++totalViewsProcessed;
+      } else if ([view isKindOfClass:[UIImageView class]]) {
+        _iconImageView = (UIImageView *)view;
+        _image = _iconImageView.image;
+        ++totalViewsProcessed;
+      } else if ([view isKindOfClass:[UILabel class]]) {
+        _label = (UILabel *)view;
+        ++totalViewsProcessed;
+      } else if ([view isKindOfClass:[MDCBottomNavigationItemBadge class]]) {
+        _badge = (MDCBottomNavigationItemBadge *)view;
+        ++totalViewsProcessed;
+      } else if ([view isKindOfClass:[UIButton class]]) {
+        _button = (UIButton *)view;
+        ++totalViewsProcessed;
+      }
+    }
+    NSAssert(totalViewsProcessed == self.subviews.count,
+             @"Unexpected number of subviews. Expected %lu but restored %lu. Unarchiving may fail.",
+             (unsigned long)self.subviews.count, (unsigned long)totalViewsProcessed);
+
+    if ([aDecoder containsValueForKey:MDCBottomNavigationItemViewTitleBelowIconKey]) {
+      _titleBelowIcon = [aDecoder decodeBoolForKey:MDCBottomNavigationItemViewTitleBelowIconKey];
+    }
+    if ([aDecoder containsValueForKey:MDCBottomNavigationItemViewSelectedKey]) {
+      _selected = [aDecoder decodeBoolForKey:MDCBottomNavigationItemViewSelectedKey];
+    }
+    if ([aDecoder containsValueForKey:MDCBottomNavigationItemViewTitleVisibilityKey]) {
+      _titleVisibility =
+          [aDecoder decodeIntegerForKey:MDCBottomNavigationItemViewTitleVisibilityKey];
+    }
+    if ([aDecoder containsValueForKey:MDCBottomNavigationItemViewTitleKey]) {
+      _title = [aDecoder decodeObjectForKey:MDCBottomNavigationItemViewTitleKey];
+    }
+    if ([aDecoder containsValueForKey:MDCBottomNavigationItemViewItemTitleFontKey]) {
+      _itemTitleFont = [aDecoder decodeObjectForKey:MDCBottomNavigationItemViewItemTitleFontKey];
+    }
+    if ([aDecoder containsValueForKey:MDCBottomNavigationItemViewBadgeColorKey]) {
+      _badgeColor = [aDecoder decodeObjectForKey:MDCBottomNavigationItemViewBadgeColorKey];
+    }
+    if ([aDecoder containsValueForKey:MDCBottomNavigationItemViewSelectedItemTintColorKey]) {
+      _selectedItemTintColor =
+          [aDecoder decodeObjectForKey:MDCBottomNavigationItemViewSelectedItemTintColorKey];
+    }
+    if ([aDecoder containsValueForKey:MDCBottomNavigationItemViewUnselectedItemTintColorKey]) {
+      _unselectedItemTintColor =
+      [aDecoder decodeObjectForKey:MDCBottomNavigationItemViewUnselectedItemTintColorKey];
+    }
+
     [self commonMDCBottomNavigationItemViewInit];
   }
   return self;
 }
 
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+  [super encodeWithCoder:aCoder];
+  [aCoder encodeBool:self.titleBelowIcon forKey:MDCBottomNavigationItemViewTitleBelowIconKey];
+  [aCoder encodeBool:self.selected forKey:MDCBottomNavigationItemViewSelectedKey];
+  [aCoder encodeInteger:self.titleVisibility forKey:MDCBottomNavigationItemViewTitleVisibilityKey];
+  [aCoder encodeObject:self.title forKey:MDCBottomNavigationItemViewTitleKey];
+  [aCoder encodeObject:self.itemTitleFont forKey:MDCBottomNavigationItemViewItemTitleFontKey];
+  [aCoder encodeObject:self.badgeColor  forKey:MDCBottomNavigationItemViewBadgeColorKey];
+  [aCoder encodeObject:self.selectedItemTintColor
+                forKey:MDCBottomNavigationItemViewSelectedItemTintColorKey];
+  [aCoder encodeObject:self.unselectedItemTintColor
+                forKey:MDCBottomNavigationItemViewUnselectedItemTintColorKey];
+}
+
 - (void)commonMDCBottomNavigationItemViewInit {
-  _titleBelowIcon = YES;
-  _selectedItemTintColor = [UIColor blackColor];
-  _unselectedItemTintColor = [UIColor grayColor];
 
-  _iconImageView = [[UIImageView alloc] initWithFrame:CGRectZero];
-  _iconImageView.isAccessibilityElement = NO;
-  [self addSubview:_iconImageView];
+  if (!_selectedItemTintColor) {
+    _selectedItemTintColor = [UIColor blackColor];
+  }
+  if (!_unselectedItemTintColor) {
+    _unselectedItemTintColor = [UIColor grayColor];
+  }
 
-  _label = [[UILabel alloc] initWithFrame:CGRectZero];
-  _label.text = _title;
-  _label.font = [UIFont systemFontOfSize:MDCBottomNavigationItemViewTitleFontSize];
-  _label.textAlignment = NSTextAlignmentCenter;
-  _label.textColor = _selectedItemTintColor;
-  _label.isAccessibilityElement = NO;
-  [self addSubview:_label];
+  if (!_iconImageView) {
+    _iconImageView = [[UIImageView alloc] initWithFrame:CGRectZero];
+    _iconImageView.isAccessibilityElement = NO;
+    [self addSubview:_iconImageView];
+  }
 
-  _badge = [[MDCBottomNavigationItemBadge alloc] initWithFrame:CGRectZero];
-  _badge.isAccessibilityElement = NO;
-  [self addSubview:_badge];
+  if (!_label) {
+    _label = [[UILabel alloc] initWithFrame:CGRectZero];
+    _label.text = _title;
+    _label.font = [UIFont systemFontOfSize:MDCBottomNavigationItemViewTitleFontSize];
+    _label.textAlignment = NSTextAlignmentCenter;
+    _label.textColor = _selectedItemTintColor;
+    _label.isAccessibilityElement = NO;
+    [self addSubview:_label];
+
+  }
+
+  if (!_badge) {
+    _badge = [[MDCBottomNavigationItemBadge alloc] initWithFrame:CGRectZero];
+    _badge.isAccessibilityElement = NO;
+    [self addSubview:_badge];
+  }
 
   if (!_badge.badgeValue) {
     _badge.hidden = YES;
   }
-  
-  _inkView = [[MDCInkView alloc] initWithFrame:self.bounds];
-  _inkView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
-  _inkView.usesLegacyInkRipple = NO;
-  _inkView.clipsToBounds = NO;
-  [self addSubview:_inkView];
 
-  _button = [[UIButton alloc] initWithFrame:self.bounds];
-  _button.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
-  _button.accessibilityLabel = [self accessibilityLabelWithTitle:_title];
-  _button.accessibilityTraits &= ~UIAccessibilityTraitButton;
-  [self addSubview:_button];
+  if (!_inkView) {
+    _inkView = [[MDCInkView alloc] initWithFrame:self.bounds];
+    _inkView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+    _inkView.usesLegacyInkRipple = NO;
+    _inkView.clipsToBounds = NO;
+    [self addSubview:_inkView];
+  }
+
+  if (!_button) {
+    _button = [[UIButton alloc] initWithFrame:self.bounds];
+    _button.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+    _button.accessibilityLabel = [self accessibilityLabelWithTitle:_title];
+    _button.accessibilityTraits &= ~UIAccessibilityTraitButton;
+    [self addSubview:_button];
+  }
 }
 
 - (void)layoutSubviews {

--- a/components/BottomNavigation/tests/unit/BottomNavigationCodingTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationCodingTests.m
@@ -1,0 +1,140 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialBottomNavigation.h"
+
+@interface MDCBottomNavigationBarTestDelegate : NSObject <MDCBottomNavigationBarDelegate, NSCoding>
+@end
+@implementation MDCBottomNavigationBarTestDelegate
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+  return [super init];
+}
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+  // No-op
+}
+@end
+
+/**
+ A simple class that retains the MDCBottomNavigationBarDelegate during coding.
+ */
+@interface MDCBottomNavigationBarEncodingTestHarness : NSObject <NSCoding>
+
+@property(nonatomic, strong) id<MDCBottomNavigationBarDelegate> bottomNavDelegate;
+@property(nonatomic, strong) MDCBottomNavigationBar *bottomNav;
+@end
+
+@implementation MDCBottomNavigationBarEncodingTestHarness
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+  self = [super init];
+  if (self) {
+    // Decode the delegate first so the bottomNav won't nil a weak reference
+    if ([aDecoder containsValueForKey:@"navDel"]) {
+      _bottomNavDelegate = [aDecoder decodeObjectForKey:@"navDel"];
+    } else {
+      _bottomNavDelegate = [[MDCBottomNavigationBarTestDelegate alloc] init];
+    }
+    if ([aDecoder containsValueForKey:@"nav"]) {
+      _bottomNav = [aDecoder decodeObjectForKey:@"nav"];
+      if (_bottomNav.delegate) {
+        _bottomNavDelegate = _bottomNav.delegate;
+      }
+    } else {
+      _bottomNav = [[MDCBottomNavigationBar alloc] init];
+    }
+  }
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+  [aCoder encodeObject:self.bottomNav forKey:@"nav"];
+  [aCoder encodeObject:self.bottomNavDelegate forKey:@"navDel"];
+}
+
+@end
+
+@interface BottomNavigationCodingTests : XCTestCase
+
+@end
+
+@implementation BottomNavigationCodingTests
+
+- (void)testTestHarnessEncoding {
+  // Given
+  MDCBottomNavigationBar *navBar = [[MDCBottomNavigationBar alloc] init];
+  MDCBottomNavigationBarTestDelegate *delegate = [[MDCBottomNavigationBarTestDelegate alloc] init];
+  MDCBottomNavigationBarEncodingTestHarness *harness =
+      [[MDCBottomNavigationBarEncodingTestHarness alloc] init];
+  harness.bottomNav = navBar;
+  harness.bottomNavDelegate = delegate;
+
+  // When
+  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:harness];
+  MDCBottomNavigationBarEncodingTestHarness *unarchivedHarness =
+      [NSKeyedUnarchiver unarchiveObjectWithData:archive];
+
+  // Then
+  XCTAssertNotNil(unarchivedHarness.bottomNav);
+  XCTAssertNotNil(unarchivedHarness.bottomNavDelegate);
+}
+
+- (void)testBasicCoding {
+  // Given
+  MDCBottomNavigationBarTestDelegate *delegate = [[MDCBottomNavigationBarTestDelegate alloc] init];
+
+  MDCBottomNavigationBar *bottomNav = [[MDCBottomNavigationBar alloc] init];
+  bottomNav.delegate = delegate;
+  bottomNav.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+  bottomNav.alignment = MDCBottomNavigationBarAlignmentJustifiedAdjacentTitles;
+  bottomNav.itemTitleFont = [UIFont systemFontOfSize:37];
+  bottomNav.selectedItemTintColor = UIColor.cyanColor;
+  bottomNav.unselectedItemTintColor = UIColor.magentaColor;
+  UITabBarItem *item1 = [[UITabBarItem alloc] init];
+  item1.title = @"1";
+  UITabBarItem *item2 = [[UITabBarItem alloc] init];
+  item2.title = @"2";
+  [bottomNav setItems:@[item1, item2]];
+  bottomNav.selectedItem = item2;
+  
+  MDCBottomNavigationBarEncodingTestHarness *harness =
+      [[MDCBottomNavigationBarEncodingTestHarness alloc] init];
+  harness.bottomNav = bottomNav;
+  harness.bottomNavDelegate = delegate;
+
+  // When
+  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:harness];
+  MDCBottomNavigationBarEncodingTestHarness *unarchivedHarness =
+      [NSKeyedUnarchiver unarchiveObjectWithData:archive];
+  MDCBottomNavigationBar *unarchivedBottomNav = unarchivedHarness.bottomNav;
+
+  // Then
+  XCTAssertNotNil(unarchivedBottomNav.delegate);
+  XCTAssertEqual(bottomNav.titleVisibility, unarchivedBottomNav.titleVisibility);
+  XCTAssertEqual(bottomNav.alignment, unarchivedBottomNav.alignment);
+  XCTAssertEqualObjects(bottomNav.itemTitleFont, unarchivedBottomNav.itemTitleFont);
+  XCTAssertEqualObjects(bottomNav.selectedItemTintColor, unarchivedBottomNav.selectedItemTintColor);
+  XCTAssertEqualObjects(bottomNav.unselectedItemTintColor,
+                        unarchivedBottomNav.unselectedItemTintColor);
+  XCTAssertEqual(bottomNav.items.count, unarchivedBottomNav.items.count);
+  for (NSUInteger i = 0; i < bottomNav.items.count; ++i) {
+    XCTAssertEqualObjects(bottomNav.items[i].title, unarchivedBottomNav.items[i].title);
+  }
+  XCTAssertEqualObjects(bottomNav.selectedItem.title, unarchivedBottomNav.selectedItem.title);
+}
+
+@end

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemBadgeCodingTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemBadgeCodingTests.m
@@ -1,0 +1,69 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "../../src/private/MDCBottomNavigationItemBadge.h"
+
+@interface BottomNavigationItemBadgeCodingTests : XCTestCase
+
+@end
+
+@implementation BottomNavigationItemBadgeCodingTests
+
+- (void)testBasicCoding {
+    // Given
+  MDCBottomNavigationItemBadge *badge = [[MDCBottomNavigationItemBadge alloc] init];
+  badge.badgeCircleWidth = 7;
+  badge.badgeCircleHeight = 8;
+  badge.xPadding = 9;
+  badge.yPadding = 10;
+  badge.badgeValue = @"value";
+  badge.badgeColor = UIColor.orangeColor;
+
+  // When
+  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:badge];
+  MDCBottomNavigationItemBadge *unarchivedBadge =
+      [NSKeyedUnarchiver unarchiveObjectWithData:archive];
+
+  // Then
+  XCTAssertEqualWithAccuracy(badge.badgeCircleWidth, unarchivedBadge.badgeCircleWidth, 0.001);
+  XCTAssertEqualWithAccuracy(badge.badgeCircleHeight, unarchivedBadge.badgeCircleHeight, 0.001);
+  XCTAssertEqualWithAccuracy(badge.xPadding, unarchivedBadge.xPadding, 0.001);
+  XCTAssertEqualWithAccuracy(badge.yPadding, unarchivedBadge.yPadding, 0.001);
+  XCTAssertEqualObjects(badge.badgeValue, unarchivedBadge.badgeValue);
+  XCTAssertEqualObjects(badge.badgeColor, unarchivedBadge.badgeColor);
+  XCTAssertEqualObjects(badge.badgeValueLabel.text, unarchivedBadge.badgeValueLabel.text);
+}
+
+- (void)testMultipleEncodingsKeepSubviewsEqual {
+  // Given
+  MDCBottomNavigationItemBadge *badge = [[MDCBottomNavigationItemBadge alloc] init];
+
+  // When
+  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:badge];
+  MDCBottomNavigationItemBadge *unarchivedBadge =
+      [NSKeyedUnarchiver unarchiveObjectWithData:archive];
+  for (int i = 0; i < 3; ++i) {
+    archive = [NSKeyedArchiver archivedDataWithRootObject:unarchivedBadge];
+    unarchivedBadge = [NSKeyedUnarchiver unarchiveObjectWithData:archive];
+  }
+
+  // Then
+  XCTAssertEqual(badge.subviews.count, unarchivedBadge.subviews.count);
+}
+
+@end

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewCodingTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewCodingTests.m
@@ -1,0 +1,92 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "../../src/private/MDCBottomNavigationItemView.h"
+
+#import "MaterialInk.h"
+
+static UIImage *fakeImage(void) {
+  CGSize imageSize = CGSizeMake(24, 24);
+  UIGraphicsBeginImageContext(imageSize);
+  [UIColor.whiteColor setFill];
+  UIRectFill(CGRectMake(0, 0, imageSize.width, imageSize.height));
+  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+  return image;
+}
+
+@interface BottomNavigationItemViewCodingTests : XCTestCase
+
+@end
+
+@implementation BottomNavigationItemViewCodingTests
+
+- (void)testBasicCoding {
+  // Given
+  MDCBottomNavigationItemView *view = [[MDCBottomNavigationItemView alloc] init];
+  view.titleBelowIcon = NO;
+  view.selected = YES;
+  view.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+  view.inkView.usesLegacyInkRipple = YES;
+  view.badgeValue = @"123";
+  view.title = @"a title";
+  view.itemTitleFont = [UIFont systemFontOfSize:23];
+  [view.button setTitle:@"button" forState:UIControlStateNormal];
+  view.image = fakeImage();
+  view.badgeColor = UIColor.purpleColor;
+  view.selectedItemTintColor = UIColor.redColor;
+  view.unselectedItemTintColor = UIColor.orangeColor;
+
+  // When
+  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:view];
+  MDCBottomNavigationItemView *unarchivedView = [NSKeyedUnarchiver unarchiveObjectWithData:archive];
+
+  // Then
+  XCTAssertEqual(view.titleBelowIcon, unarchivedView.titleBelowIcon);
+  XCTAssertEqual(view.selected, unarchivedView.selected);
+  XCTAssertEqual(view.titleVisibility, unarchivedView.titleVisibility);
+  XCTAssertEqual(view.inkView.usesLegacyInkRipple, unarchivedView.inkView.usesLegacyInkRipple);
+  XCTAssertEqualObjects(view.badgeValue, unarchivedView.badgeValue);
+  XCTAssertEqualObjects(view.title, unarchivedView.title);
+  XCTAssertEqualObjects(view.itemTitleFont, unarchivedView.itemTitleFont);
+  XCTAssertEqualObjects([view.button titleForState:UIControlStateNormal],
+                        [unarchivedView.button titleForState:UIControlStateNormal]);
+  XCTAssertNotNil(unarchivedView.image);
+  XCTAssertEqualObjects(view.badgeColor, unarchivedView.badgeColor);
+  XCTAssertEqualObjects(view.selectedItemTintColor, unarchivedView.selectedItemTintColor);
+  XCTAssertEqualObjects(view.unselectedItemTintColor, unarchivedView.unselectedItemTintColor);
+}
+
+- (void)testMultipleCodingsKeepSubviewsEqual {
+  // Given
+  MDCBottomNavigationItemView *view = [[MDCBottomNavigationItemView alloc] init];
+
+  // When
+  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:view];
+  MDCBottomNavigationItemView *unarchivedView =
+      [NSKeyedUnarchiver unarchiveObjectWithData:archive];
+  for (int i = 0; i < 3; ++i) {
+    archive = [NSKeyedArchiver archivedDataWithRootObject:unarchivedView];
+    unarchivedView = [NSKeyedUnarchiver unarchiveObjectWithData:archive];
+  }
+
+  // Then
+  XCTAssertEqual(view.subviews.count, unarchivedView.subviews.count);
+}
+
+@end


### PR DESCRIPTION
BottomNavigation needs to fully support NSCoding so that clients can use state
restoration if desired.

Closes #2737
