### PR TITLE
[FeatureHighlight] Fix crash in Dynamic Type handling

### DIFF
--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -266,7 +266,8 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
 }
 
 - (void)updateFontsForDynamicType {
-  [_featureHighlightView updateFontsForDynamicType];
+  [_featureHighlightView updateTitleFont];
+  [_featureHighlightView updateBodyFont];
   [_featureHighlightView layoutIfNeeded];
 }
 

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.h
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.h
@@ -44,6 +44,7 @@ typedef void (^MDCFeatureHighlightInteractionBlock)(BOOL accepted);
 - (void)animateRejected:(NSTimeInterval)duration;
 - (void)animatePulse;
 
-- (void)updateFontsForDynamicType;
+- (void)updateTitleFont;
+- (void)updateBodyFont;
 
 @end


### PR DESCRIPTION
We were still calling [MDCFeatureHighlightView updateFontsForDynamicType] which doesn't exist anymore.
