### PR TITLE
Reduce error output from the bump command.

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -252,12 +252,12 @@ bump_release() {
   last_version=${last_version#v}
   last_version=$(echo "$last_version" | sed "s:\.:\\\\.:g")
 
-  grep -Ilr "$last_version" . | grep -v -f "$dir/versionignore" | while read line; do
+  grep -FIlr "$last_version" . 2>/dev/null | grep -v -f "$dir/versionignore" | while read line; do
     sed -i.bak "s:$last_version:$new_version:g" "$line"
     rm "$line.bak"
   done
 
-  grep -Ilr "#develop#" . | grep -v -f "$dir/versionignore" | while read line; do
+  grep -FIlr "#develop#" . 2>/dev/null | grep -v -f "$dir/versionignore" | while read line; do
     sed -i.bak "s:#develop#:$new_version:g" "$line"
     rm "$line.bak"
   done

--- a/scripts/versionignore
+++ b/scripts/versionignore
@@ -6,3 +6,4 @@
 Podfile\.lock
 CHANGELOG\.md
 scripts/release
+^\./bazel


### PR DESCRIPTION
The following changes were made:

- The global grep is now a non-regular expression search. This will avoid treating the version '.' as a wildcard.
- We ignore any of the bazel output directories.
- We pipe stderr to null so that invalid directories don't appear in the output.
