### PR TITLE
[Release] Make release test not check for release-candidate

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -222,8 +222,6 @@ abort_release() {
 }
 
 test_release() {
-  enforce_release_cut
-
   "$dir/prep_all"
   "$dir/build_all" --verbose
   "$dir/test_all"


### PR DESCRIPTION
Release instructions ask us to run it after we have merged.

https://github.com/material-components/material-components-ios/blob/develop/contributing/releasing.md#merge-the-release-candidate-branch

We also may want to just test without having created a release candidate.
