### PR TITLE
[Ink] Add NSCoding support to MDCInkView/Layer

### DIFF
--- a/components/Chips/tests/unit/ChipsEncodingTests.m
+++ b/components/Chips/tests/unit/ChipsEncodingTests.m
@@ -61,8 +61,7 @@ static UIImage *FakeImage(void) {
   MDCChipView *unarchivedChip = [NSKeyedUnarchiver unarchiveObjectWithData:archive];
 
   // Then
-  // TODO(#2772): Check for equality once MDCInkView supports encoding
-  XCTAssertNotEqualObjects(unarchivedChip.inkColor, chip.inkColor);
+  XCTAssertEqualObjects(unarchivedChip.inkColor, chip.inkColor);
   XCTAssertEqualObjects(unarchivedChip.titleLabel.text, chip.titleLabel.text);
   XCTAssertNotNil(unarchivedChip.imageView.image);
   XCTAssertNotNil(unarchivedChip.selectedImageView.image);

--- a/components/Ink/src/MDCInkView.m
+++ b/components/Ink/src/MDCInkView.m
@@ -23,7 +23,6 @@ static NSString *const MDCInkViewAnimationDelegateKey = @"MDCInkViewAnimationDel
 static NSString *const MDCInkViewInkStyleKey = @"MDCInkViewInkStyleKey";
 static NSString *const MDCInkViewUsesLegacyInkRippleKey = @"MDCInkViewUsesLegacyInkRippleKey";
 static NSString *const MDCInkViewMaskLayerKey = @"MDCInkViewMaskLayerKey";
-static NSString *const MDCInkViewActiveInkLayerKey = @"MDCInkViewActiveInkLayerKey";
 static NSString *const MDCInkViewUsesCustomInkCenterKey = @"MDCInkViewUsesCustomInkCenterKey";
 static NSString *const MDCInkViewCustomInkCenterKey = @"MDCInkViewCustomInkCenterKey";
 static NSString *const MDCInkViewInkColorKey = @"MDCInkViewInkColorKey";
@@ -82,9 +81,6 @@ static NSString *const MDCInkViewMaxRippleRadiusKey = @"MDCInkViewMaxRippleRadiu
     } else {
       _usesLegacyInkRipple = YES;
     }
-    if ([aDecoder containsValueForKey:MDCInkViewActiveInkLayerKey]) {
-      _activeInkLayer = [aDecoder decodeObjectForKey:MDCInkViewActiveInkLayerKey];
-    }
     if ([aDecoder containsValueForKey:MDCInkViewInkStyleKey]) {
       self.inkStyle = [aDecoder decodeIntegerForKey:MDCInkViewInkStyleKey];
     }
@@ -115,9 +111,6 @@ static NSString *const MDCInkViewMaxRippleRadiusKey = @"MDCInkViewMaxRippleRadiu
   [aCoder encodeInteger:self.inkStyle forKey:MDCInkViewInkStyleKey];
   [aCoder encodeBool:self.usesLegacyInkRipple forKey:MDCInkViewUsesLegacyInkRippleKey];
   [aCoder encodeObject:self.maskLayer forKey:MDCInkViewMaskLayerKey];
-  if (self.activeInkLayer) {
-    [aCoder encodeObject:self.activeInkLayer forKey:MDCInkViewActiveInkLayerKey];
-  }
 
   // The following are derived properties, but `layer` may not get encoded by the superclass
   [aCoder encodeBool:self.usesCustomInkCenter forKey:MDCInkViewUsesCustomInkCenterKey];

--- a/components/Ink/src/MDCInkView.m
+++ b/components/Ink/src/MDCInkView.m
@@ -19,6 +19,16 @@
 #import "private/MDCInkLayer.h"
 #import "private/MDCLegacyInkLayer.h"
 
+static NSString *const MDCInkViewAnimationDelegateKey = @"MDCInkViewAnimationDelegateKey";
+static NSString *const MDCInkViewInkStyleKey = @"MDCInkViewInkStyleKey";
+static NSString *const MDCInkViewUsesLegacyInkRippleKey = @"MDCInkViewUsesLegacyInkRippleKey";
+static NSString *const MDCInkViewMaskLayerKey = @"MDCInkViewMaskLayerKey";
+static NSString *const MDCInkViewActiveInkLayerKey = @"MDCInkViewActiveInkLayerKey";
+static NSString *const MDCInkViewUsesCustomInkCenterKey = @"MDCInkViewUsesCustomInkCenterKey";
+static NSString *const MDCInkViewCustomInkCenterKey = @"MDCInkViewCustomInkCenterKey";
+static NSString *const MDCInkViewInkColorKey = @"MDCInkViewInkColorKey";
+static NSString *const MDCInkViewMaxRippleRadiusKey = @"MDCInkViewMaxRippleRadiusKey";
+
 @interface MDCInkPendingAnimation : NSObject <CAAction>
 
 @property(nonatomic, weak) CALayer *animationSourceLayer;
@@ -57,9 +67,63 @@
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
   self = [super initWithCoder:aDecoder];
   if (self) {
-    [self commonMDCInkViewInit];
+    if ([aDecoder containsValueForKey:MDCInkViewAnimationDelegateKey]) {
+      _animationDelegate = [aDecoder decodeObjectForKey:MDCInkViewAnimationDelegateKey];
+    }
+    if ([aDecoder containsValueForKey:MDCInkViewMaskLayerKey]) {
+      _maskLayer = [aDecoder decodeObjectForKey:MDCInkViewMaskLayerKey];
+      _maskLayer.delegate = self;
+    } else {
+      _maskLayer = [CAShapeLayer layer];
+      _maskLayer.delegate = self;
+    }
+    if ([aDecoder containsValueForKey:MDCInkViewUsesLegacyInkRippleKey]) {
+      _usesLegacyInkRipple = [aDecoder decodeBoolForKey:MDCInkViewUsesLegacyInkRippleKey];
+    } else {
+      _usesLegacyInkRipple = YES;
+    }
+    if ([aDecoder containsValueForKey:MDCInkViewActiveInkLayerKey]) {
+      _activeInkLayer = [aDecoder decodeObjectForKey:MDCInkViewActiveInkLayerKey];
+    }
+    if ([aDecoder containsValueForKey:MDCInkViewInkStyleKey]) {
+      self.inkStyle = [aDecoder decodeIntegerForKey:MDCInkViewInkStyleKey];
+    }
+
+    // The following are derived properties, but `layer` may not have been encoded
+    if ([aDecoder containsValueForKey:MDCInkViewUsesCustomInkCenterKey]) {
+      self.usesCustomInkCenter = [aDecoder decodeBoolForKey:MDCInkViewUsesCustomInkCenterKey];
+    }
+    if ([aDecoder containsValueForKey:MDCInkViewCustomInkCenterKey]) {
+      self.customInkCenter = [aDecoder decodeCGPointForKey:MDCInkViewCustomInkCenterKey];
+    }
+    if ([aDecoder containsValueForKey:MDCInkViewMaxRippleRadiusKey]) {
+      self.maxRippleRadius = (CGFloat)[aDecoder decodeDoubleForKey:MDCInkViewMaxRippleRadiusKey];
+    }
+    if ([aDecoder containsValueForKey:MDCInkViewInkColorKey]) {
+      self.inkColor = [aDecoder decodeObjectForKey:MDCInkViewInkColorKey];
+    }
   }
   return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+  [super encodeWithCoder:aCoder];
+
+  if (self.animationDelegate && [self.animationDelegate conformsToProtocol:@protocol(NSCoding)]) {
+    [aCoder encodeObject:self.animationDelegate forKey:MDCInkViewAnimationDelegateKey];
+  }
+  [aCoder encodeInteger:self.inkStyle forKey:MDCInkViewInkStyleKey];
+  [aCoder encodeBool:self.usesLegacyInkRipple forKey:MDCInkViewUsesLegacyInkRippleKey];
+  [aCoder encodeObject:self.maskLayer forKey:MDCInkViewMaskLayerKey];
+  if (self.activeInkLayer) {
+    [aCoder encodeObject:self.activeInkLayer forKey:MDCInkViewActiveInkLayerKey];
+  }
+
+  // The following are derived properties, but `layer` may not get encoded by the superclass
+  [aCoder encodeBool:self.usesCustomInkCenter forKey:MDCInkViewUsesCustomInkCenterKey];
+  [aCoder encodeCGPoint:self.customInkCenter forKey:MDCInkViewCustomInkCenterKey];
+  [aCoder encodeDouble:self.maxRippleRadius forKey:MDCInkViewMaxRippleRadiusKey];
+  [aCoder encodeObject:self.inkColor forKey:MDCInkViewInkColorKey];
 }
 
 - (void)commonMDCInkViewInit {

--- a/components/Ink/src/private/MDCInkLayer.m
+++ b/components/Ink/src/private/MDCInkLayer.m
@@ -17,6 +17,14 @@
 #import "MDCInkLayer.h"
 #import "MaterialMath.h"
 
+static NSString *const MDCInkLayerAnimationDelegateClassNameKey = @"MDCInkLayerAnimationDelegateClassNameKey";
+static NSString *const MDCInkLayerAnimationDelegateKey = @"MDCInkLayerAnimationDelegateKey";
+static NSString *const MDCInkLayerEndAnimationDelayKey = @"MDCInkLayerEndAnimationDelayKey";
+static NSString *const MDCInkLayerFinalRadiusKey = @"MDCInkLayerFinalRadiusKey";
+static NSString *const MDCInkLayerInitialRadiusKey = @"MDCInkLayerInitialRadiusKey";
+static NSString *const MDCInkLayerMaxRippleRadiusKey = @"MDCInkLayerMaxRippleRadiusKey";
+static NSString *const MDCInkLayerInkColorKey = @"MDCInkLayerInkColorKey";
+
 static const CGFloat MDCInkLayerCommonDuration = 0.083f;
 static const CGFloat MDCInkLayerEndFadeOutDuration = 0.15f;
 static const CGFloat MDCInkLayerStartScalePositionDuration = 0.333f;
@@ -33,13 +41,25 @@ static NSString *const MDCInkLayerScaleString = @"transform.scale";
 
 @implementation MDCInkLayer
 
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _inkColor = [UIColor colorWithWhite:0 alpha:(CGFloat)0.08];
+  }
+  return self;
+}
+
 - (instancetype)initWithLayer:(id)layer {
   self = [super initWithLayer:layer];
   if (self) {
     _endAnimationDelay = 0;
     _finalRadius = 0;
     _initialRadius = 0;
-    _inkColor = [UIColor colorWithWhite:0 alpha:0.08f];
+    _inkColor = [UIColor colorWithWhite:0 alpha:(CGFloat)0.08];
     _startAnimationActive = NO;
     if ([layer isKindOfClass:[MDCInkLayer class]]) {
       MDCInkLayer *inkLayer = (MDCInkLayer *)layer;
@@ -52,6 +72,57 @@ static NSString *const MDCInkLayerScaleString = @"transform.scale";
     }
   }
   return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+  self = [super initWithCoder:aDecoder];
+
+  if (self) {
+    NSString *delegateClassName;
+    if ([aDecoder containsValueForKey:MDCInkLayerAnimationDelegateClassNameKey]) {
+      delegateClassName = [aDecoder decodeObjectOfClass:[NSString class]
+                                                 forKey:MDCInkLayerAnimationDelegateClassNameKey];
+    }
+    if (delegateClassName.length > 0 &&
+        [aDecoder containsValueForKey:MDCInkLayerAnimationDelegateKey]) {
+      _animationDelegate = [aDecoder decodeObjectOfClass:NSClassFromString(delegateClassName)
+                                                  forKey:MDCInkLayerAnimationDelegateKey];
+    }
+    if ([aDecoder containsValueForKey:MDCInkLayerInkColorKey]) {
+      _inkColor = [aDecoder decodeObjectOfClass:[UIColor class] forKey:MDCInkLayerInkColorKey];
+    } else {
+      _inkColor = [UIColor colorWithWhite:0 alpha:(CGFloat)0.08];
+    }
+    if ([aDecoder containsValueForKey:MDCInkLayerEndAnimationDelayKey]) {
+      _endAnimationDelay = (CGFloat)[aDecoder decodeDoubleForKey:MDCInkLayerEndAnimationDelayKey];
+    }
+    if ([aDecoder containsValueForKey:MDCInkLayerFinalRadiusKey]) {
+      _finalRadius = (CGFloat)[aDecoder decodeDoubleForKey:MDCInkLayerFinalRadiusKey];
+    }
+    if ([aDecoder containsValueForKey:MDCInkLayerInitialRadiusKey]) {
+      _initialRadius = (CGFloat)[aDecoder decodeDoubleForKey:MDCInkLayerInitialRadiusKey];
+    }
+    if ([aDecoder containsValueForKey:MDCInkLayerMaxRippleRadiusKey]) {
+      _maxRippleRadius = (CGFloat)[aDecoder decodeDoubleForKey:MDCInkLayerMaxRippleRadiusKey];
+    }
+  }
+
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+  [super encodeWithCoder:aCoder];
+
+  if (self.animationDelegate && [self.animationDelegate conformsToProtocol:@protocol(NSCoding)]) {
+    [aCoder encodeObject:NSStringFromClass([self.animationDelegate class])
+                  forKey:MDCInkLayerAnimationDelegateClassNameKey];
+    [aCoder encodeObject:self.animationDelegate forKey:MDCInkLayerAnimationDelegateKey];
+  }
+  [aCoder encodeDouble:self.endAnimationDelay forKey:MDCInkLayerEndAnimationDelayKey];
+  [aCoder encodeDouble:self.finalRadius forKey:MDCInkLayerFinalRadiusKey];
+  [aCoder encodeDouble:self.initialRadius forKey:MDCInkLayerInitialRadiusKey];
+  [aCoder encodeDouble:self.maxRippleRadius forKey:MDCInkLayerMaxRippleRadiusKey];
+  [aCoder encodeObject:self.inkColor forKey:MDCInkLayerInkColorKey];
 }
 
 - (void)setNeedsLayout {

--- a/components/Ink/src/private/MDCLegacyInkLayer.m
+++ b/components/Ink/src/private/MDCLegacyInkLayer.m
@@ -19,6 +19,18 @@
 
 #import <UIKit/UIKit.h>
 
+static NSString *const MDCLegacyInkLayerBoundedKey = @"MDCLegacyInkLayerBoundedKey";
+static NSString *const MDCLegacyInkLayerMaxRippleRadiusKey = @"MDCLegacyInkLayerMaxRippleRadiusKey";
+static NSString *const MDCLegacyInkLayerInkColorKey = @"MDCLegacyInkLayerInkColorKey";
+static NSString *const MDCLegacyInkLayerSpreadDurationKey = @"MDCLegacyInkLayerSpreadDurationKey";
+static NSString *const MDCLegacyInkLayerEvaporateDurationKey =
+    @"MDCLegacyInkLayerEvaporateDurationKey";
+static NSString *const MDCLegacyInkLayerUseCustomInkCenterKey =
+    @"MDCLegacyInkLayerUseCustomInkCenterKey";
+static NSString *const MDCLegacyInkLayerCustomInkCenterKey = @"MDCLegacyInkLayerCustomInkCenterKey";
+static NSString *const MDCLegacyInkLayerUseLinearExpansionKey =
+    @"MDCLegacyInkLayerUseLinearExpansionKey";
+
 static inline CGPoint MDCLegacyInkLayerInterpolatePoint(CGPoint start,
                                                         CGPoint end,
                                                         CGFloat offsetPercent) {
@@ -470,10 +482,15 @@ static NSString *const kInkLayerBackgroundOpacityAnim = @"backgroundOpacityAnim"
 
 @implementation MDCLegacyInkLayer
 
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
 - (instancetype)init {
   self = [super init];
   if (self) {
     self.masksToBounds = YES;
+    _inkColor = [UIColor colorWithWhite:0 alpha:(CGFloat)0.08];
     _bounded = YES;
     _compositeRipple = [CAShapeLayer layer];
     _foregroundRipples = [NSMutableArray array];
@@ -481,6 +498,68 @@ static NSString *const kInkLayerBackgroundOpacityAnim = @"backgroundOpacityAnim"
     [self addSublayer:_compositeRipple];
   }
   return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+  self = [super initWithCoder:aDecoder];
+
+  if (self) {
+    if ([aDecoder containsValueForKey:MDCLegacyInkLayerBoundedKey]) {
+      _bounded = [aDecoder decodeBoolForKey:MDCLegacyInkLayerBoundedKey];
+    } else {
+      _bounded = YES;
+    }
+    if ([aDecoder containsValueForKey:MDCLegacyInkLayerMaxRippleRadiusKey]) {
+      _maxRippleRadius = (CGFloat)[aDecoder decodeDoubleForKey:MDCLegacyInkLayerMaxRippleRadiusKey];
+    }
+    if ([aDecoder containsValueForKey:MDCLegacyInkLayerInkColorKey]) {
+      _inkColor = [aDecoder decodeObjectOfClass:[UIColor class]
+                                         forKey:MDCLegacyInkLayerInkColorKey];
+    } else {
+      _inkColor = [UIColor colorWithWhite:0 alpha:(CGFloat)0.08];
+    }
+    if ([aDecoder containsValueForKey:MDCLegacyInkLayerSpreadDurationKey]) {
+      _spreadDuration = [aDecoder decodeDoubleForKey:MDCLegacyInkLayerSpreadDurationKey];
+    }
+    if ([aDecoder containsValueForKey:MDCLegacyInkLayerEvaporateDurationKey]) {
+      _evaporateDuration = [aDecoder decodeDoubleForKey:MDCLegacyInkLayerEvaporateDurationKey];
+    }
+    if ([aDecoder containsValueForKey:MDCLegacyInkLayerUseCustomInkCenterKey]) {
+      _useCustomInkCenter = [aDecoder decodeBoolForKey:MDCLegacyInkLayerUseCustomInkCenterKey];
+    }
+    if ([aDecoder containsValueForKey:MDCLegacyInkLayerCustomInkCenterKey]) {
+      _customInkCenter = [aDecoder decodeCGPointForKey:MDCLegacyInkLayerCustomInkCenterKey];
+    }
+    if ([aDecoder containsValueForKey:MDCLegacyInkLayerUseLinearExpansionKey]) {
+      _userLinearExpansion = [aDecoder decodeBoolForKey:MDCLegacyInkLayerUseLinearExpansionKey];
+    }
+
+    // Discard any sublayers, which should be the composite ripple and any active ripples
+    if (self.sublayers.count > 0) {
+      NSArray<CALayer *> *sublayers = [self.sublayers copy];
+      for (CALayer *sublayer in sublayers) {
+        [sublayer removeFromSuperlayer];
+      }
+    }
+    _compositeRipple = [CAShapeLayer layer];
+    _foregroundRipples = [NSMutableArray array];
+    _backgroundRipples = [NSMutableArray array];
+    [self addSublayer:_compositeRipple];
+  }
+
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+  [super encodeWithCoder:aCoder];
+  [aCoder encodeBool:self.bounded forKey:MDCLegacyInkLayerBoundedKey];
+  [aCoder encodeDouble:self.maxRippleRadius forKey:MDCLegacyInkLayerMaxRippleRadiusKey];
+  [aCoder encodeObject:self.inkColor forKey:MDCLegacyInkLayerInkColorKey];
+  [aCoder encodeDouble:self.spreadDuration forKey:MDCLegacyInkLayerSpreadDurationKey];
+  [aCoder encodeDouble:self.evaporateDuration forKey:MDCLegacyInkLayerEvaporateDurationKey];
+  [aCoder encodeBool:self.useCustomInkCenter forKey:MDCLegacyInkLayerUseCustomInkCenterKey];
+  [aCoder encodeCGPoint:self.customInkCenter forKey:MDCLegacyInkLayerCustomInkCenterKey];
+  [aCoder encodeBool:self.userLinearExpansion forKey:MDCLegacyInkLayerUseLinearExpansionKey];
 }
 
 - (void)layoutSublayers {

--- a/components/Ink/tests/unit/MDCInkLayerTests.m
+++ b/components/Ink/tests/unit/MDCInkLayerTests.m
@@ -1,0 +1,95 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MDCInkLayer.h"
+
+#pragma mark - Fake classes
+
+@interface FakeMDCInkLayerAnimationDelegate : NSObject <MDCInkLayerDelegate, NSCoding>
+@property(nonatomic, strong) MDCInkLayer *inkLayer;
+@end
+
+@implementation FakeMDCInkLayerAnimationDelegate
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+  self = [super init];
+  if (self) {
+    _inkLayer = [aDecoder decodeObjectForKey:@"inkLayer"];
+  }
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+  [aCoder encodeObject:self.inkLayer forKey:@"inkLayer"];
+}
+
+@end
+
+#pragma mark - Tests
+
+@interface MDCInkLayerTests : XCTestCase
+
+@end
+
+@implementation MDCInkLayerTests
+
+- (void)testInit {
+  // Given
+  MDCInkLayer *inkLayer = [[MDCInkLayer alloc] init];
+
+  // Then
+  XCTAssertNil(inkLayer.delegate);
+  XCTAssertFalse(inkLayer.isStartAnimationActive);
+  XCTAssertEqualWithAccuracy(inkLayer.endAnimationDelay, 0, 0.0001);
+  XCTAssertEqualWithAccuracy(inkLayer.initialRadius, 0, 0.0001);
+  XCTAssertEqualWithAccuracy(inkLayer.finalRadius, 0, 0.0001);
+  XCTAssertEqualWithAccuracy(inkLayer.maxRippleRadius, 0, 0.0001);
+  XCTAssertEqualObjects(inkLayer.inkColor, [UIColor colorWithWhite:0 alpha:(CGFloat)0.08]);
+}
+
+- (void)testEncoding {
+  // Given
+  FakeMDCInkLayerAnimationDelegate *delegate = [[FakeMDCInkLayerAnimationDelegate alloc] init];
+  MDCInkLayer *inkLayer = [[MDCInkLayer alloc] init];
+  delegate.inkLayer = inkLayer;
+  inkLayer.delegate = delegate;
+  inkLayer.endAnimationDelay = 1;
+  inkLayer.initialRadius = 2;
+  inkLayer.finalRadius = 3;
+  inkLayer.maxRippleRadius = 4;
+  inkLayer.inkColor = UIColor.magentaColor;
+
+  // When
+  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:delegate];
+  FakeMDCInkLayerAnimationDelegate *unarchivedDelegate =
+      [NSKeyedUnarchiver unarchiveObjectWithData:archive];
+  MDCInkLayer *unarchivedInkLayer = unarchivedDelegate.inkLayer;
+
+  // Then
+  XCTAssertEqual(unarchivedInkLayer.delegate, unarchivedDelegate);
+  XCTAssertEqualWithAccuracy(unarchivedInkLayer.endAnimationDelay,
+                             inkLayer.endAnimationDelay,
+                             0.0001);
+  XCTAssertEqualWithAccuracy(unarchivedInkLayer.initialRadius, inkLayer.initialRadius, 0.0001);
+  XCTAssertEqualWithAccuracy(unarchivedInkLayer.finalRadius, inkLayer.finalRadius, 0.0001);
+  XCTAssertEqualWithAccuracy(unarchivedInkLayer.maxRippleRadius, inkLayer.maxRippleRadius, 0.0001);
+  XCTAssertEqualObjects(unarchivedInkLayer.inkColor, inkLayer.inkColor);
+  XCTAssertEqual(unarchivedInkLayer.sublayers.count, inkLayer.sublayers.count);
+}
+
+@end

--- a/components/Ink/tests/unit/MDCInkLayerTests.m
+++ b/components/Ink/tests/unit/MDCInkLayerTests.m
@@ -20,16 +20,20 @@
 
 #pragma mark - Fake classes
 
-@interface FakeMDCInkLayerAnimationDelegate : NSObject <MDCInkLayerDelegate, NSCoding>
+@interface FakeMDCInkLayerAnimationDelegate : NSObject <MDCInkLayerDelegate, NSSecureCoding>
 @property(nonatomic, strong) MDCInkLayer *inkLayer;
 @end
 
 @implementation FakeMDCInkLayerAnimationDelegate
 
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
   self = [super init];
   if (self) {
-    _inkLayer = [aDecoder decodeObjectForKey:@"inkLayer"];
+    _inkLayer = [aDecoder decodeObjectOfClass:[MDCInkLayer class] forKey:@"inkLayer"];
   }
   return self;
 }
@@ -62,12 +66,37 @@
   XCTAssertEqualObjects(inkLayer.inkColor, [UIColor colorWithWhite:0 alpha:(CGFloat)0.08]);
 }
 
-- (void)testEncoding {
+- (void)testInitWithLayer {
   // Given
   FakeMDCInkLayerAnimationDelegate *delegate = [[FakeMDCInkLayerAnimationDelegate alloc] init];
   MDCInkLayer *inkLayer = [[MDCInkLayer alloc] init];
   delegate.inkLayer = inkLayer;
   inkLayer.delegate = delegate;
+  inkLayer.endAnimationDelay = 1;
+  inkLayer.initialRadius = 2;
+  inkLayer.finalRadius = 3;
+  inkLayer.maxRippleRadius = 4;
+  inkLayer.inkColor = UIColor.magentaColor;
+
+  // When
+  MDCInkLayer *copiedLayer = [[MDCInkLayer alloc] initWithLayer:inkLayer];
+
+  // Then
+  XCTAssertNil(copiedLayer.delegate);
+  XCTAssertEqualWithAccuracy(copiedLayer.endAnimationDelay, inkLayer.endAnimationDelay, 0.0001);
+  XCTAssertEqualWithAccuracy(copiedLayer.initialRadius, inkLayer.initialRadius, 0.0001);
+  XCTAssertEqualWithAccuracy(copiedLayer.finalRadius, inkLayer.finalRadius, 0.0001);
+  XCTAssertEqualWithAccuracy(copiedLayer.maxRippleRadius, inkLayer.maxRippleRadius, 0.0001);
+  XCTAssertEqualObjects(copiedLayer.inkColor, inkLayer.inkColor);
+  XCTAssertEqual(copiedLayer.sublayers.count, inkLayer.sublayers.count);
+}
+
+- (void)testEncoding {
+  // Given
+  FakeMDCInkLayerAnimationDelegate *delegate = [[FakeMDCInkLayerAnimationDelegate alloc] init];
+  MDCInkLayer *inkLayer = [[MDCInkLayer alloc] init];
+  delegate.inkLayer = inkLayer;
+  inkLayer.animationDelegate = delegate;
   inkLayer.endAnimationDelay = 1;
   inkLayer.initialRadius = 2;
   inkLayer.finalRadius = 3;

--- a/components/Ink/tests/unit/MDCInkLayerTests.m
+++ b/components/Ink/tests/unit/MDCInkLayerTests.m
@@ -110,7 +110,7 @@
   MDCInkLayer *unarchivedInkLayer = unarchivedDelegate.inkLayer;
 
   // Then
-  XCTAssertEqual(unarchivedInkLayer.delegate, unarchivedDelegate);
+  XCTAssertEqual(unarchivedInkLayer.animationDelegate, unarchivedDelegate);
   XCTAssertEqualWithAccuracy(unarchivedInkLayer.endAnimationDelay,
                              inkLayer.endAnimationDelay,
                              0.0001);

--- a/components/Ink/tests/unit/MDCInkViewTests.m
+++ b/components/Ink/tests/unit/MDCInkViewTests.m
@@ -76,7 +76,7 @@
   inkView.animationDelegate = delegate;
   inkView.inkColor = UIColor.purpleColor;
   inkView.inkStyle = MDCInkStyleUnbounded;
-  inkView.maxRippleRadius = 9.1;
+  inkView.maxRippleRadius = (CGFloat)9.1;
 
   // When
   NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:delegate];
@@ -108,7 +108,7 @@
   inkView.animationDelegate = delegate;
   inkView.inkColor = UIColor.purpleColor;
   inkView.inkStyle = MDCInkStyleUnbounded;
-  inkView.maxRippleRadius = 9.1;
+  inkView.maxRippleRadius = (CGFloat)9.1;
 
   // When
   NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:delegate];

--- a/components/Ink/tests/unit/MDCInkViewTests.m
+++ b/components/Ink/tests/unit/MDCInkViewTests.m
@@ -1,0 +1,132 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialInk.h"
+
+#pragma mark - Fake classes
+
+@interface FakeMDCInkViewAnimationDelegate : NSObject <MDCInkViewDelegate, NSCoding>
+@property(nonatomic, strong) MDCInkView *inkView;
+@end
+
+@implementation FakeMDCInkViewAnimationDelegate
+
+- (void)encodeWithCoder:(nonnull NSCoder *)aCoder {
+  [aCoder encodeObject:self.inkView forKey:@"inkView"];
+}
+
+- (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder {
+  self = [super init];
+  if (self) {
+    _inkView = [aDecoder decodeObjectForKey:@"inkView"];
+  }
+  return self;
+}
+
+@end
+
+#pragma mark - Tests
+
+@interface MDCInkViewTests : XCTestCase
+
+@end
+
+@implementation MDCInkViewTests
+
+- (void)testInit {
+  // Given
+  MDCInkView *inkView = [[MDCInkView alloc] init];
+
+  // Then
+  XCTAssertTrue(inkView.usesLegacyInkRipple);
+  XCTAssertFalse(inkView.usesCustomInkCenter);
+  XCTAssertTrue(CGPointEqualToPoint(inkView.customInkCenter, CGPointZero),
+                @"%@ is not equal to %@",
+                NSStringFromCGPoint(inkView.customInkCenter),
+                NSStringFromCGPoint(CGPointZero));
+  XCTAssertNil(inkView.animationDelegate);
+  XCTAssertEqualObjects(inkView.inkColor, inkView.defaultInkColor);
+  XCTAssertEqual(inkView.inkStyle, MDCInkStyleBounded);
+  XCTAssertEqualWithAccuracy(inkView.maxRippleRadius, 0.0, 0.0001);
+}
+
+- (void)testEncodingWithoutLegacyInk {
+  // Given
+  FakeMDCInkViewAnimationDelegate *delegate = [[FakeMDCInkViewAnimationDelegate alloc] init];
+  MDCInkView *inkView = [[MDCInkView alloc] init];
+  delegate.inkView = inkView;
+  inkView.usesLegacyInkRipple = NO;
+  inkView.usesCustomInkCenter = YES;
+  inkView.customInkCenter = CGPointMake(5,8);
+  inkView.animationDelegate = delegate;
+  inkView.inkColor = UIColor.purpleColor;
+  inkView.inkStyle = MDCInkStyleUnbounded;
+  inkView.maxRippleRadius = 9.1;
+
+  // When
+  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:delegate];
+  FakeMDCInkViewAnimationDelegate *unarchivedDelegate =
+      [NSKeyedUnarchiver unarchiveObjectWithData:archive];
+  MDCInkView *unarchivedInkView = unarchivedDelegate.inkView;
+
+  // Then
+  XCTAssertEqual(unarchivedInkView.usesLegacyInkRipple, inkView.usesLegacyInkRipple);
+  XCTAssertEqual(unarchivedInkView.usesCustomInkCenter, inkView.usesCustomInkCenter);
+  XCTAssertTrue(CGPointEqualToPoint(unarchivedInkView.customInkCenter, inkView.customInkCenter),
+                @"%@ is not equal to %@",
+                NSStringFromCGPoint(unarchivedInkView.customInkCenter),
+                NSStringFromCGPoint(inkView.customInkCenter));
+  XCTAssertEqual(unarchivedInkView.animationDelegate, unarchivedDelegate);
+  XCTAssertEqualObjects(unarchivedInkView.inkColor, inkView.inkColor);
+  XCTAssertEqual(unarchivedInkView.inkStyle, inkView.inkStyle);
+  XCTAssertEqualWithAccuracy(unarchivedInkView.maxRippleRadius, inkView.maxRippleRadius, 0.0001);
+}
+
+- (void)testEncodingWithLegacyInk {
+  // Given
+  FakeMDCInkViewAnimationDelegate *delegate = [[FakeMDCInkViewAnimationDelegate alloc] init];
+  MDCInkView *inkView = [[MDCInkView alloc] init];
+  delegate.inkView = inkView;
+  inkView.usesLegacyInkRipple = YES;
+  inkView.usesCustomInkCenter = YES;
+  inkView.customInkCenter = CGPointMake(5,8);
+  inkView.animationDelegate = delegate;
+  inkView.inkColor = UIColor.purpleColor;
+  inkView.inkStyle = MDCInkStyleUnbounded;
+  inkView.maxRippleRadius = 9.1;
+
+  // When
+  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:delegate];
+  FakeMDCInkViewAnimationDelegate *unarchivedDelegate =
+      [NSKeyedUnarchiver unarchiveObjectWithData:archive];
+  MDCInkView *unarchivedInkView = unarchivedDelegate.inkView;
+
+  // Then
+  XCTAssertEqual(unarchivedInkView.usesLegacyInkRipple, inkView.usesLegacyInkRipple);
+  XCTAssertEqual(unarchivedInkView.usesCustomInkCenter, inkView.usesCustomInkCenter);
+  XCTAssertTrue(CGPointEqualToPoint(unarchivedInkView.customInkCenter, inkView.customInkCenter),
+                @"%@ is not equal to %@",
+                NSStringFromCGPoint(unarchivedInkView.customInkCenter),
+                NSStringFromCGPoint(inkView.customInkCenter));
+  XCTAssertEqual(unarchivedInkView.animationDelegate, unarchivedDelegate);
+  XCTAssertEqualObjects(unarchivedInkView.inkColor, inkView.inkColor);
+  XCTAssertEqual(unarchivedInkView.inkStyle, inkView.inkStyle);
+  XCTAssertEqualWithAccuracy(unarchivedInkView.maxRippleRadius, inkView.maxRippleRadius, 0.0001);
+}
+
+@end

--- a/components/Ink/tests/unit/MDCLegacyInkLayerTests.m
+++ b/components/Ink/tests/unit/MDCLegacyInkLayerTests.m
@@ -88,6 +88,54 @@
   self.inkLayer = nil;
 }
 
+- (void)testInit {
+  // Given
+  self.inkLayer = [[MDCLegacyInkLayer alloc] init];
+
+  // Then
+  XCTAssertTrue(self.inkLayer.isBounded);
+  XCTAssertFalse(self.inkLayer.useCustomInkCenter);
+  XCTAssertTrue(CGPointEqualToPoint(self.inkLayer.customInkCenter, CGPointZero),
+                @"%@ is not equal to %@",
+                NSStringFromCGPoint(self.inkLayer.customInkCenter),
+                NSStringFromCGPoint(CGPointZero));
+  XCTAssertFalse(self.inkLayer.userLinearExpansion);
+  XCTAssertEqualWithAccuracy(self.inkLayer.evaporateDuration, 0, 0.0001);
+  XCTAssertEqualWithAccuracy(self.inkLayer.spreadDuration, 0, 0.0001);
+  XCTAssertEqualWithAccuracy(self.inkLayer.maxRippleRadius, 0, 0.0001);
+  XCTAssertNotNil(self.inkLayer.inkColor);
+}
+
+- (void)testEncoding {
+  // Given
+  self.inkLayer = [[MDCLegacyInkLayer alloc] init];
+  self.inkLayer.bounded = NO;
+  self.inkLayer.useCustomInkCenter = YES;
+  self.inkLayer.customInkCenter = CGPointMake(2, 3);
+  self.inkLayer.userLinearExpansion = YES;
+  self.inkLayer.maxRippleRadius = 3;
+  self.inkLayer.inkColor = UIColor.orangeColor;
+
+  // When
+  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:self.inkLayer];
+  MDCLegacyInkLayer *unarchivedInkLayer = [NSKeyedUnarchiver unarchiveObjectWithData:archive];
+
+  // Then
+  XCTAssertEqual(unarchivedInkLayer.isBounded, self.inkLayer.isBounded);
+  XCTAssertEqual(unarchivedInkLayer.useCustomInkCenter, self.inkLayer.useCustomInkCenter);
+  XCTAssertTrue(CGPointEqualToPoint(unarchivedInkLayer.customInkCenter,
+                                    self.inkLayer.customInkCenter),
+                @"%@ is not equal to %@",
+                NSStringFromCGPoint(unarchivedInkLayer.customInkCenter),
+                NSStringFromCGPoint(self.inkLayer.customInkCenter));
+  XCTAssertEqual(unarchivedInkLayer.userLinearExpansion, self.inkLayer.userLinearExpansion);
+  XCTAssertEqualWithAccuracy(unarchivedInkLayer.maxRippleRadius,
+                             self.inkLayer.maxRippleRadius,
+                             0.0001);
+  XCTAssertEqualObjects(unarchivedInkLayer.inkColor, self.inkLayer.inkColor);
+  XCTAssertEqual(unarchivedInkLayer.sublayers.count, self.inkLayer.sublayers.count);
+}
+
 - (void)testResetRipplesWithoutAnimation {
   // Given
   MDCLegacyInkLayer *inkLayer = [[MDCLegacyInkLayer alloc] init];


### PR DESCRIPTION
Both MDCInkLayer (and MDCLegacyInkLayer) and MDCInkView should support
NSCoding methods since their superclasses conform to an NSCoding (or
NSSecureCoding) protocol.

Closes #2772
