### PR TITLE
[Tests/Catalog] Suppress partial availability warnings

### DIFF
--- a/catalog/MaterialCatalog/MDCCatalogTiles.m
+++ b/catalog/MaterialCatalog/MDCCatalogTiles.m
@@ -942,8 +942,17 @@ void MDCCatalogDrawNavigationBarTile(CGRect frame, id<MDCColorScheme> colorSchem
       NSMutableParagraphStyle* labelStyle = [NSMutableParagraphStyle new];
       labelStyle.alignment = NSTextAlignmentCenter;
 
+      UIFont *font;
+      if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+        font = [UIFont systemFontOfSize:11 weight:UIFontWeightMedium];
+#pragma clang diagnostic pop
+      } else {
+        font = [UIFont fontWithName:@"HelveticaNeue" size:11];
+      }
       NSDictionary* labelFontAttributes = @{
-        NSFontAttributeName : [UIFont systemFontOfSize:11 weight: UIFontWeightMedium],
+        NSFontAttributeName : font,
         NSForegroundColorAttributeName : textForeground,
         NSParagraphStyleAttributeName : labelStyle
       };

--- a/catalog/MaterialCatalog/MDCCatalogTiles.m
+++ b/catalog/MaterialCatalog/MDCCatalogTiles.m
@@ -949,7 +949,7 @@ void MDCCatalogDrawNavigationBarTile(CGRect frame, id<MDCColorScheme> colorSchem
         font = [UIFont systemFontOfSize:11 weight:UIFontWeightMedium];
 #pragma clang diagnostic pop
       } else {
-        font = [UIFont fontWithName:@"HelveticaNeue" size:11];
+        font = [UIFont systemFontOfSize:11];
       }
       NSDictionary* labelFontAttributes = @{
         NSFontAttributeName : font,

--- a/components/Typography/tests/unit/SystemFontLoaderTests.m
+++ b/components/Typography/tests/unit/SystemFontLoaderTests.m
@@ -30,6 +30,8 @@
 
   // Then
   if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
     XCTAssertEqual([fontLoader lightFontOfSize:size],
                    [UIFont systemFontOfSize:size weight:UIFontWeightLight]);
     XCTAssertEqual([fontLoader regularFontOfSize:size],
@@ -38,6 +40,7 @@
                    [UIFont systemFontOfSize:size weight:UIFontWeightMedium]);
     XCTAssertEqual([fontLoader boldFontOfSize:size],
                    [UIFont systemFontOfSize:size weight:UIFontWeightSemibold]);
+#pragma clang diagnostic pop
   } else {
     // Fallback on earlier versions
     XCTAssertEqual([fontLoader lightFontOfSize:size],
@@ -110,7 +113,12 @@
   CGFloat MDCFontWeightMedium = (CGFloat)0.23;
   // Ensure that our placehold value for UIFontWeightMedium matches the real value.
   // We are defining it for < iOS 8.2 in MDCTypography.m
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+  if (&UIFontWeightMedium != NULL) {
   XCTAssertEqualWithAccuracy(UIFontWeightMedium, MDCFontWeightMedium, FLT_EPSILON);
+  }
+#pragma clang diagnostic pop
 }
 
 @end

--- a/components/Typography/tests/unit/TypographyTests.m
+++ b/components/Typography/tests/unit/TypographyTests.m
@@ -357,7 +357,7 @@ static const CGFloat kOpacityMedium = 0.87f;
 #pragma clang diagnostic ignored "-Wpartial-availability"
     systemFont = [UIFont systemFontOfSize:mdcFont.pointSize weight:UIFontWeightRegular];
     } else {
-      systemFont = [UIFont fontWithName:@"HelveticaNeue" size:mdcFont.pointSize];
+      systemFont = [UIFont systemFontOfSize:mdcFont.pointSize];
     }
 #pragma clang diagnostic pop
 

--- a/components/Typography/tests/unit/TypographyTests.m
+++ b/components/Typography/tests/unit/TypographyTests.m
@@ -351,7 +351,15 @@ static const CGFloat kOpacityMedium = 0.87f;
     // When
     MDCFontTextStyle style = styleObject.integerValue;
     UIFont *mdcFont = [UIFont mdc_preferredFontForMaterialTextStyle:style];
-    UIFont *systemFont = [UIFont systemFontOfSize:mdcFont.pointSize weight:UIFontWeightRegular];
+    UIFont *systemFont;
+    if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+    systemFont = [UIFont systemFontOfSize:mdcFont.pointSize weight:UIFontWeightRegular];
+    } else {
+      systemFont = [UIFont fontWithName:@"HelveticaNeue" size:mdcFont.pointSize];
+    }
+#pragma clang diagnostic pop
 
     // Then
     XCTAssertEqualObjects(systemFont.familyName, mdcFont.familyName);


### PR DESCRIPTION
`- UIFont systemFontOfSize:weight:` was not introduced until iOS 8.2. Although
most of the code was already performing runtime checks on the selector, the
compiler still emits warnings for the use of the selectors.

Closes 2779
