### PR TITLE
[Collections] Fixes weird behaviors if swiping multiple cells simultaneously

### DIFF
--- a/components/Collections/src/private/MDCCollectionViewEditor.m
+++ b/components/Collections/src/private/MDCCollectionViewEditor.m
@@ -101,6 +101,7 @@ typedef NS_ENUM(NSInteger, MDCAutoscrollPanningDirection) {
     SEL panSelector = @selector(handlePanGesture:);
     _panGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:panSelector];
     _panGestureRecognizer.delegate = self;
+    _panGestureRecognizer.maximumNumberOfTouches = 1;
     [_collectionView addGestureRecognizer:_panGestureRecognizer];
   }
   return self;


### PR DESCRIPTION
This helps with issue #2722 

Because there are 2 fingers swiping at the same time, the invocation of `[recognizer locationInView:collectionView]` chooses the location right in between the 2 fingers and then identifies an unwanted cell in between to issue the swiping on.