### PR TITLE
[Slider] Add appearance properties and enable UIAppearance.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -472,6 +472,7 @@ Pod::Spec.new do |mdc|
     component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
 
     component.dependency "MaterialComponents/Palettes"
+    component.dependency "MaterialComponents/ShadowElevations"
     component.dependency "MaterialComponents/private/ThumbTrack"
   end
 

--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -17,6 +17,8 @@
 #import <UIKit/UIKit.h>
 #import <CoreGraphics/CoreGraphics.h>
 
+#import "MaterialShadowElevations.h"
+
 @protocol MDCSliderDelegate;
 
 /**
@@ -47,22 +49,35 @@ IB_DESIGNABLE
 
  Default color is blue.
  */
-@property(nonatomic, strong, null_resettable) UIColor *color;
+@property(nonatomic, strong, null_resettable) UIColor *color UI_APPEARANCE_SELECTOR;
 
 /**
  The color of the cursor (thumb) and track while the slider is disabled.
 
  Default color is gray.
  */
-@property(nonatomic, strong, null_resettable) UIColor *disabledColor;
+@property(nonatomic, strong, null_resettable) UIColor *disabledColor UI_APPEARANCE_SELECTOR;
 
-/*
+/**
  The color of the unfilled track that the cursor moves along (right side).
 
  Default color is gray.
  */
-@property(nonatomic, strong, null_resettable) UIColor *trackBackgroundColor;
+@property(nonatomic, strong, null_resettable) UIColor *trackBackgroundColor UI_APPEARANCE_SELECTOR;
 
+/**
+ The radius of the cursor (thumb).
+
+ Default value is 6 points.
+ */
+@property(nonatomic, assign) CGFloat thumbRadius UI_APPEARANCE_SELECTOR;
+
+/**
+ The elevation of the cursor (thumb).
+
+ Default value is MDCElevationNone.
+ */
+@property(nonatomic, assign) MDCShadowElevation thumbElevation UI_APPEARANCE_SELECTOR;
 /**
  The number of discrete values that the slider can take.
 

--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -33,7 +33,7 @@
      set the right and left track images (if you wanted a custom track)
      set the right (background track) color
    Same features
-     set color for thumb via @c thumbColor
+     set color for thumb via @c color
      set color of track via @c trackColor
    New features
      making the slider a snap to discrete values via @c numberOfDiscreteValues.

--- a/components/Slider/src/MDCSlider.m
+++ b/components/Slider/src/MDCSlider.m
@@ -23,7 +23,7 @@
 static const CGFloat kSliderDefaultWidth = 100.0f;
 static const CGFloat kSliderFrameHeight = 27.0f;
 static const CGFloat kSliderMinTouchSize = 48.0f;
-static const CGFloat kSliderThumbRadius = 6.0f;
+static const CGFloat kSliderDefaultThumbRadius = 6.0f;
 static const CGFloat kSliderAccessibilityIncrement = 0.1f;  // Matches UISlider's percent increment.
 static const CGFloat kSliderLightThemeTrackAlpha = 0.26f;
 
@@ -59,7 +59,7 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
   _thumbTrack.delegate = self;
   _thumbTrack.disabledTrackHasThumbGaps = YES;
   _thumbTrack.trackEndsAreInset = YES;
-  _thumbTrack.thumbRadius = kSliderThumbRadius;
+  _thumbTrack.thumbRadius = kSliderDefaultThumbRadius;
   _thumbTrack.thumbIsSmallerWhenDisabled = YES;
   _thumbTrack.thumbIsHollowAtStart = YES;
   _thumbTrack.thumbGrowsWhenDragging = YES;
@@ -115,6 +115,22 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
 
 - (UIColor *)color {
   return _thumbTrack.primaryColor;
+}
+
+- (void)setThumbRadius:(CGFloat)thumbRadius {
+  _thumbTrack.thumbRadius = thumbRadius;
+}
+
+- (CGFloat)thumbRadius {
+  return _thumbTrack.thumbRadius;
+}
+
+- (void)setThumbElevation:(MDCShadowElevation)thumbElevation {
+  _thumbTrack.thumbElevation = thumbElevation;
+}
+
+- (MDCShadowElevation)thumbElevation {
+  return _thumbTrack.thumbElevation;
 }
 
 - (NSUInteger)numberOfDiscreteValues {
@@ -227,7 +243,7 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(__unused UIEvent *)event {
-  CGFloat dx = MIN(0, kSliderThumbRadius - kSliderMinTouchSize / 2);
+  CGFloat dx = MIN(0, _thumbTrack.thumbRadius - kSliderMinTouchSize / 2);
   CGFloat dy = MIN(0, (self.bounds.size.height - kSliderMinTouchSize) / 2);
   CGRect rect = CGRectInset(self.bounds, dx, dy);
   return CGRectContainsPoint(rect, point);

--- a/components/Slider/src/MDCSlider.m
+++ b/components/Slider/src/MDCSlider.m
@@ -243,7 +243,7 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(__unused UIEvent *)event {
-  CGFloat dx = MIN(0, _thumbTrack.thumbRadius - kSliderMinTouchSize / 2);
+  CGFloat dx = MIN(0, self.thumbRadius - kSliderMinTouchSize / 2);
   CGFloat dy = MIN(0, (self.bounds.size.height - kSliderMinTouchSize) / 2);
   CGRect rect = CGRectInset(self.bounds, dx, dy);
   return CGRectContainsPoint(rect, point);

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -308,12 +308,14 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   XCTAssertEqualObjects(self.slider.trackBackgroundColor, self.defaultGray);
 }
 
-- (void)testDefaultThumbRadius {
+#pragma mark Thumb
+
+- (void)testThumbRadiusDefault {
   // Then
   XCTAssertEqual(self.slider.thumbRadius, 6);
 }
 
-- (void)testDefaultThumbElevation {
+- (void)testThumbElevationDefault {
   // Then
   XCTAssertEqual(self.slider.thumbElevation, MDCShadowElevationNone);
 }

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -130,16 +130,18 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
   // Then
   XCTAssertEqualWithAccuracy(self.slider.maximumValue, self.slider.minimumValue, kEpsilonAccuracy,
-                             @"setting the self.slider's max to lower than the max must equal the min");
+                             @"Setting the self.slider's max to lower than the max must equal the "
+                             @"min.");
   XCTAssertEqualWithAccuracy(
       newMax, self.slider.minimumValue, kEpsilonAccuracy,
-      @"setting the self.slider's max must change the min when smaller than the min");
+      @"Setting the self.slider's max must change the min when smaller than the min.");
   XCTAssertEqualWithAccuracy(
       newMax, self.slider.maximumValue, kEpsilonAccuracy,
-      @"setting the self.slider's max must equal the value gotten even when smaller than the minimum");
+      @"Setting the self.slider's max must equal the value gotten even when smaller than the "
+      @"minimum.");
   XCTAssertEqualWithAccuracy(
       newMax, self.slider.value, kEpsilonAccuracy,
-      @"setting the self.slider's min to lower than the value must change the value also");
+      @"Setting the self.slider's min to lower than the value must change the value also.");
 }
 
 - (void)testSetMinimumToLowerThanMaximum {
@@ -151,16 +153,18 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
   // Then
   XCTAssertEqualWithAccuracy(self.slider.minimumValue, self.slider.maximumValue, kEpsilonAccuracy,
-                             @"setting the self.slider's min to higher than the max must equal the max");
+                             @"Setting the self.slider's min to higher than the max must equal the "
+                             @"max.");
   XCTAssertEqualWithAccuracy(
       newMin, self.slider.minimumValue, kEpsilonAccuracy,
-      @"setting the self.slider's min must equal the value gotten even when larger than the maximum");
+      @"Setting the self.slider's min must equal the value gotten even when larger than the "
+      @"maximum.");
   XCTAssertEqualWithAccuracy(
       newMin, self.slider.maximumValue, kEpsilonAccuracy,
-      @"setting the self.slider's min to larger than the max must change the max also");
+      @"Setting the self.slider's min to larger than the max must change the max also.");
   XCTAssertEqualWithAccuracy(
       newMin, self.slider.value, kEpsilonAccuracy,
-      @"setting the self.slider's min to higher than the value must change the value also");
+      @"Setting the self.slider's min to higher than the value must change the value also.");
 }
 
 - (void)testDiscreteValues2 {
@@ -344,7 +348,8 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   XCTAssertEqualObjects(
       [testFormatter numberFromString:[self.slider thumbTrack:track stringForValue:1.f]], @(1.));
   XCTAssertEqualObjects(
-      [testFormatter numberFromString:[self.slider thumbTrack:track stringForValue:0.57f]], @(0.57));
+      [testFormatter numberFromString:[self.slider thumbTrack:track stringForValue:0.57f]],
+      @(0.57));
   XCTAssertEqualObjects(
       [testFormatter numberFromString:[self.slider thumbTrack:track stringForValue:0.33333333f]],
       @(0.333));
@@ -378,8 +383,8 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   // Then
   NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
   numberFormatter.numberStyle = NSNumberFormatterPercentStyle;
-  CGFloat percent =
-      (self.slider.value - self.slider.minimumValue) / (self.slider.maximumValue - self.slider.minimumValue);
+  CGFloat percent = (self.slider.value - self.slider.minimumValue) /
+      (self.slider.maximumValue - self.slider.minimumValue);
   NSString *expected = [numberFormatter stringFromNumber:[NSNumber numberWithFloat:(float)percent]];
   XCTAssertEqualObjects([self.slider accessibilityValue], expected);
 }
@@ -424,7 +429,7 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 - (void)testAccessibilityTraits {
   // Given
   self.slider.enabled =
-      (BOOL)arc4random_uniform(2);  // It does not matter if the self.slider is enabled or disabled.
+      (BOOL)arc4random_uniform(2);  // It does not matter if the slider is enabled or disabled.
 
   // Then
   XCTAssertTrue(self.slider.accessibilityTraits & UIAccessibilityTraitAdjustable);

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -38,12 +38,6 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
 @implementation SliderTests
 
-// Archive and then unarchive an object, returning a functional copy of the original object.
-+ (id)archiveAndUnarchiveObject:(id)object {
-  NSData *archived = [NSKeyedArchiver archivedDataWithRootObject:object];
-  return [NSKeyedUnarchiver unarchiveObjectWithData:archived];
-}
-
 - (void)setUp {
   [super setUp];
   self.slider = [[MDCSlider alloc] init];

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -48,13 +48,13 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
 - (void)testValue {
   // Given
-  CGFloat value = [self randomPercent] * self.self.slider.maximumValue;
+  CGFloat value = [self randomPercent] * self.slider.maximumValue;
 
   // When
-  [self.self.slider setValue:value animated:YES];
+  [self.slider setValue:value animated:YES];
 
   // Then
-  XCTAssertEqualWithAccuracy(self.self.slider.value, value, kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy(self.slider.value, value, kEpsilonAccuracy);
 }
 
 - (void)testValueAnimated {

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -264,50 +264,48 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   }
 }
 
-#pragma mark Clors
+#pragma mark Colors
 
-- (void)testDefaultColor {
-  // When
-  UIColor *actualColor = self.slider.color;
-
+- (void)testColorDefault {
   // Then
-  UIColor *expectedColor = self.defaultBlue;
-  XCTAssertEqualObjects(actualColor, expectedColor);
+  XCTAssertEqualObjects(self.slider.color, self.defaultBlue);
 }
 
-- (void)testThumbColorNullResettable {
+- (void)testColorIsNullResettable {
   // When
+  self.slider.color = self.aNonDefaultColor;
   self.slider.color = nil;
 
   // Then
-  UIColor *actualColor = self.slider.color;
-  UIColor *expectedColor = self.defaultBlue;
-  XCTAssertEqualObjects(actualColor, expectedColor);
+  XCTAssertEqualObjects(self.slider.color, self.defaultBlue);
 }
 
-- (void)testTrackColor {
+- (void)testDisabledColorDefault {
+  // Then
+  XCTAssertEqualObjects(self.slider.disabledColor, self.defaultGray);
+}
+
+- (void)testDisabledColorIsNullResettable {
   // When
-  UIColor *actualColor = self.slider.trackBackgroundColor;
+  self.slider.disabledColor = self.aNonDefaultColor;
+  self.slider.disabledColor = nil;
 
   // Then
-  XCTAssertEqualObjects(actualColor, self.defaultGray);
+  XCTAssertEqualObjects(self.slider.disabledColor, self.defaultGray);
 }
 
-- (void)testTrackColorNullResettable {
+- (void)testTrackBackgroundColorDefault {
+  // Then
+  XCTAssertEqualObjects(self.slider.trackBackgroundColor, self.defaultGray);
+}
+
+- (void)testTrackBackgroundColorIsNullResettable {
   // When
+  self.slider.trackBackgroundColor = self.aNonDefaultColor;
   self.slider.trackBackgroundColor = nil;
 
   // Then
-  UIColor *actualColor = self.slider.trackBackgroundColor;
-  XCTAssertEqualObjects(actualColor, self.defaultGray);
-}
-
-- (void)testDisabledColor {
-  // When
-  UIColor *actualColor = self.slider.disabledColor;
-
-  // Then
-  XCTAssertEqualObjects(actualColor, self.defaultGray);
+  XCTAssertEqualObjects(self.slider.trackBackgroundColor, self.defaultGray);
 }
 
 - (void)testDefaultThumbRadius {
@@ -320,16 +318,7 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   XCTAssertEqual(self.slider.thumbElevation, MDCShadowElevationNone);
 }
 
-- (void)testDisabledColorNullResettable {
-  // When
-  self.slider.trackBackgroundColor = nil;
-
-  // Then
-  UIColor *actualColor = self.slider.trackBackgroundColor;
-  XCTAssertEqualObjects(actualColor, self.defaultGray);
-}
-
-#pragma mark numeric value label
+#pragma mark Numeric value label
 
 - (void)testNumericValueLabelString {
   MDCThumbTrack *track = nil;
@@ -355,7 +344,7 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
       @(0.333));
 }
 
-#pragma mark accessibility
+#pragma mark Accessibility
 
 - (void)testAccessibilityValue {
   // Given

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -271,15 +271,6 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   XCTAssertEqualObjects(actualColor, expectedColor);
 }
 
-- (void)testColorCoding {
-  // When
-  self.slider.color = self.aNonDefaultColor;
-  MDCSlider *unarchived = [[self class] archiveAndUnarchiveObject:self.slider];
-
-  // Then
-  XCTAssertEqualObjects(unarchived.color, self.aNonDefaultColor);
-}
-
 - (void)testThumbColorNullResettable {
   // When
   self.slider.color = nil;

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -30,220 +30,206 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 @end
 
 @interface SliderTests : XCTestCase
-
+@property(nonatomic, nonnull) MDCSlider *slider;
+@property(nonatomic, nonnull) UIColor *aNonDefaultColor;
+@property(nonatomic, nonnull) UIColor *defaultBlue;
+@property(nonatomic, nonnull) UIColor *defaultGray;
 @end
 
 @implementation SliderTests
 
-- (void)setUp {
-  [super setUp];
-  // Put setup code here. This method is called before the invocation of each test method in
-  // the class.
+// Archive and then unarchive an object, returning a functional copy of the original object.
++ (id)archiveAndUnarchiveObject:(id)object {
+  NSData *archived = [NSKeyedArchiver archivedDataWithRootObject:object];
+  return [NSKeyedUnarchiver unarchiveObjectWithData:archived];
 }
 
-- (void)tearDown {
-  // Put teardown code here. This method is called after the invocation of each test method in
-  // the class.
-  [super tearDown];
+- (void)setUp {
+  [super setUp];
+  self.slider = [[MDCSlider alloc] init];
+  self.aNonDefaultColor = [UIColor orangeColor];
+  self.defaultBlue = MDCPalette.bluePalette.tint500;
+  self.defaultGray = [[UIColor blackColor] colorWithAlphaComponent:0.26f];
 }
 
 - (void)testValue {
   // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-  CGFloat value = [self randomPercent] * slider.maximumValue;
+  CGFloat value = [self randomPercent] * self.self.slider.maximumValue;
 
   // When
-  [slider setValue:value animated:YES];
+  [self.self.slider setValue:value animated:YES];
 
   // Then
-  XCTAssertEqualWithAccuracy(slider.value, value, kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy(self.self.slider.value, value, kEpsilonAccuracy);
 }
 
 - (void)testValueAnimated {
   // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-  CGFloat value = [self randomPercent] * slider.maximumValue;
+  CGFloat value = [self randomPercent] * self.slider.maximumValue;
 
   // When
-  [slider setValue:value animated:YES];
+  [self.slider setValue:value animated:YES];
 
   // Then
-  XCTAssertEqualWithAccuracy(slider.value, value, kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy(self.slider.value, value, kEpsilonAccuracy);
 }
 
 - (void)testMaximumDefault {
-  // When
-  MDCSlider *slider = [[MDCSlider alloc] init];
-
   // Then
-  XCTAssertEqualWithAccuracy(slider.maximumValue, 1.0f, kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy(self.slider.maximumValue, 1.0f, kEpsilonAccuracy);
 }
 
 - (void)testSetValueToHigherThanMaximum {
-  // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-
   // When
-  slider.value = slider.maximumValue + [self randomNumber];
+  self.slider.value = self.slider.maximumValue + [self randomNumber];
 
   // Then
-  XCTAssertEqualWithAccuracy(slider.value, slider.maximumValue, kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy(self.slider.value, self.slider.maximumValue, kEpsilonAccuracy);
 }
 
 - (void)testSetValueToLowerThanMinimum {
-  // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-
   // When
-  slider.value = slider.minimumValue - [self randomNumber];
+  self.slider.value = self.slider.minimumValue - [self randomNumber];
 
   // Then
-  XCTAssertEqualWithAccuracy(slider.value, slider.minimumValue, kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy(self.slider.value, self.slider.minimumValue, kEpsilonAccuracy);
 }
 
 - (void)testSetMaximumToLowerThanValue {
   // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-  slider.maximumValue = [self randomNumber];
-  slider.value =
-      slider.minimumValue + [self randomPercent] * (slider.maximumValue - slider.minimumValue);
+  self.slider.maximumValue = [self randomNumber];
+  self.slider.value = self.slider.minimumValue +
+      [self randomPercent] * (self.slider.maximumValue - self.slider.minimumValue);
 
   // When
-  slider.maximumValue = slider.value - [self randomPercent] * slider.value;
+  self.slider.maximumValue = self.slider.value - [self randomPercent] * self.slider.value;
 
   // Then
-  XCTAssertEqualWithAccuracy(slider.value, slider.maximumValue, kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy(self.slider.value, self.slider.maximumValue, kEpsilonAccuracy);
 }
 
 - (void)testSetMinimumToHigherThanValue {
   // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-  slider.maximumValue = [self randomNumber];
-  slider.value =
-      slider.minimumValue + [self randomPercent] * (slider.maximumValue - slider.minimumValue);
+  self.slider.maximumValue = [self randomNumber];
+  self.slider.value = self.slider.minimumValue +
+      [self randomPercent] * (self.slider.maximumValue - self.slider.minimumValue);
 
   // When
-  slider.minimumValue = slider.value + [self randomPercent] * slider.value;
+  self.slider.minimumValue = self.slider.value + [self randomPercent] * self.slider.value;
 
   // Then
-  XCTAssertEqualWithAccuracy(slider.value, slider.minimumValue, kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy(self.slider.value, self.slider.minimumValue, kEpsilonAccuracy);
 }
 
 - (void)testSetMaximumToLowerThanMinimum {
   // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-  CGFloat newMax = slider.minimumValue - [self randomNumber];
+  CGFloat newMax = self.slider.minimumValue - [self randomNumber];
 
   // When
-  slider.maximumValue = newMax;
+  self.slider.maximumValue = newMax;
 
   // Then
-  XCTAssertEqualWithAccuracy(slider.maximumValue, slider.minimumValue, kEpsilonAccuracy,
-                             @"setting the slider's max to lower than the max must equal the min");
+  XCTAssertEqualWithAccuracy(self.slider.maximumValue, self.slider.minimumValue, kEpsilonAccuracy,
+                             @"setting the self.slider's max to lower than the max must equal the min");
   XCTAssertEqualWithAccuracy(
-      newMax, slider.minimumValue, kEpsilonAccuracy,
-      @"setting the slider's max must change the min when smaller than the min");
+      newMax, self.slider.minimumValue, kEpsilonAccuracy,
+      @"setting the self.slider's max must change the min when smaller than the min");
   XCTAssertEqualWithAccuracy(
-      newMax, slider.maximumValue, kEpsilonAccuracy,
-      @"setting the slider's max must equal the value gotten even when smaller than the minimum");
+      newMax, self.slider.maximumValue, kEpsilonAccuracy,
+      @"setting the self.slider's max must equal the value gotten even when smaller than the minimum");
   XCTAssertEqualWithAccuracy(
-      newMax, slider.value, kEpsilonAccuracy,
-      @"setting the slider's min to lower than the value must change the value also");
+      newMax, self.slider.value, kEpsilonAccuracy,
+      @"setting the self.slider's min to lower than the value must change the value also");
 }
 
 - (void)testSetMinimumToLowerThanMaximum {
   // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-  CGFloat newMin = slider.maximumValue + [self randomNumber];
+  CGFloat newMin = self.slider.maximumValue + [self randomNumber];
 
   // When
-  slider.minimumValue = newMin;
+  self.slider.minimumValue = newMin;
 
   // Then
-  XCTAssertEqualWithAccuracy(slider.minimumValue, slider.maximumValue, kEpsilonAccuracy,
-                             @"setting the slider's min to higher than the max must equal the max");
+  XCTAssertEqualWithAccuracy(self.slider.minimumValue, self.slider.maximumValue, kEpsilonAccuracy,
+                             @"setting the self.slider's min to higher than the max must equal the max");
   XCTAssertEqualWithAccuracy(
-      newMin, slider.minimumValue, kEpsilonAccuracy,
-      @"setting the slider's min must equal the value gotten even when larger than the maximum");
+      newMin, self.slider.minimumValue, kEpsilonAccuracy,
+      @"setting the self.slider's min must equal the value gotten even when larger than the maximum");
   XCTAssertEqualWithAccuracy(
-      newMin, slider.maximumValue, kEpsilonAccuracy,
-      @"setting the slider's min to larger than the max must change the max also");
+      newMin, self.slider.maximumValue, kEpsilonAccuracy,
+      @"setting the self.slider's min to larger than the max must change the max also");
   XCTAssertEqualWithAccuracy(
-      newMin, slider.value, kEpsilonAccuracy,
-      @"setting the slider's min to higher than the value must change the value also");
+      newMin, self.slider.value, kEpsilonAccuracy,
+      @"setting the self.slider's min to higher than the value must change the value also");
 }
 
 - (void)testDiscreteValues2 {
   // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-  slider.maximumValue = 10;
-  slider.minimumValue = 0;
-  slider.value = arc4random_uniform((u_int32_t)(slider.maximumValue / 2));
+  self.slider.maximumValue = 10;
+  self.slider.minimumValue = 0;
+  self.slider.value = arc4random_uniform((u_int32_t)(self.slider.maximumValue / 2));
 
   // When
-  slider.numberOfDiscreteValues = 2;
+  self.slider.numberOfDiscreteValues = 2;
 
   // Then
-  XCTAssertEqualWithAccuracy(slider.value, slider.minimumValue, kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy(self.slider.value, self.slider.minimumValue, kEpsilonAccuracy);
 }
 
 - (void)testDiscreteValues2SetValue {
   // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-  slider.maximumValue = 10;
-  slider.minimumValue = 0;
-  slider.numberOfDiscreteValues = 2;
+  self.slider.maximumValue = 10;
+  self.slider.minimumValue = 0;
+  self.slider.numberOfDiscreteValues = 2;
 
   // When
-  slider.value = arc4random_uniform((u_int32_t)(slider.maximumValue / 2));
+  self.slider.value = arc4random_uniform((u_int32_t)(self.slider.maximumValue / 2));
 
   // Then
-  XCTAssertEqualWithAccuracy(slider.value, slider.minimumValue, kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy(self.slider.value, self.slider.minimumValue, kEpsilonAccuracy);
 }
 
 - (void)testDiscreteValues3 {
   // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-  slider.maximumValue = 100;
-  slider.minimumValue = 0;
-  slider.value = arc4random_uniform((u_int32_t)(slider.maximumValue / 6));
+  self.slider.maximumValue = 100;
+  self.slider.minimumValue = 0;
+  self.slider.value = arc4random_uniform((u_int32_t)(self.slider.maximumValue / 6));
 
   // When
-  slider.numberOfDiscreteValues = 3;
+  self.slider.numberOfDiscreteValues = 3;
 
   // Then
-  XCTAssertEqualWithAccuracy(slider.value, slider.minimumValue, kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy(self.slider.value, self.slider.minimumValue, kEpsilonAccuracy);
 }
 
 - (void)testDiscreteValues3SetValue {
   // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-  slider.maximumValue = 100;
-  slider.minimumValue = 0;
-  slider.numberOfDiscreteValues = 3;
+  self.slider.maximumValue = 100;
+  self.slider.minimumValue = 0;
+  self.slider.numberOfDiscreteValues = 3;
 
   // When
-  slider.value = arc4random_uniform((u_int32_t)(slider.maximumValue / 6));
+  self.slider.value = arc4random_uniform((u_int32_t)(self.slider.maximumValue / 6));
 
   // Then
-  XCTAssertEqualWithAccuracy(slider.value, slider.minimumValue, kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy(self.slider.value, self.slider.minimumValue, kEpsilonAccuracy);
 }
 
 - (void)testDiscreteValuesWithIntegers {
   for (int i = 0; i < kNumberOfRepeats; ++i) {
     // Given
-    MDCSlider *slider = [[MDCSlider alloc] init];
-    slider.maximumValue = (int)[self randomNumber];
-    slider.minimumValue = 0;
-    slider.value = [self randomPercent] * slider.maximumValue;
-    CGFloat originalValue = slider.value;
+    self.slider = [[MDCSlider alloc] init];
+    self.slider.maximumValue = (int)[self randomNumber];
+    self.slider.minimumValue = 0;
+    self.slider.value = [self randomPercent] * self.slider.maximumValue;
+    CGFloat originalValue = self.slider.value;
 
     // When
-    slider.numberOfDiscreteValues = (NSUInteger)(slider.maximumValue + 1);
+    self.slider.numberOfDiscreteValues = (NSUInteger)(self.slider.maximumValue + 1);
 
     // Then
-    XCTAssertEqualWithAccuracy(slider.value, originalValue, 0.5f + kEpsilonAccuracy);
-    XCTAssertEqualWithAccuracy(slider.value, round(originalValue), kEpsilonAccuracy);
+    XCTAssertEqualWithAccuracy(self.slider.value, originalValue, 0.5f + kEpsilonAccuracy);
+    XCTAssertEqualWithAccuracy(self.slider.value, round(originalValue), kEpsilonAccuracy);
   }
 }
 
@@ -256,108 +242,103 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
     CGFloat originalValue = snapedValue + [self randomPercent] * (delta - kEpsilonAccuracy) -
                             (delta - kEpsilonAccuracy) / 2;
 
-    MDCSlider *slider = [[MDCSlider alloc] init];
-    slider.minimumValue = 0;
-    slider.maximumValue = delta * (numberOfValues - 1);
-    slider.value = originalValue;
+    self.slider = [[MDCSlider alloc] init];
+    self.slider.minimumValue = 0;
+    self.slider.maximumValue = delta * (numberOfValues - 1);
+    self.slider.value = originalValue;
 
     // When
-    slider.numberOfDiscreteValues = numberOfValues;
+    self.slider.numberOfDiscreteValues = numberOfValues;
 
     // Then
-    XCTAssertEqualWithAccuracy(slider.value, originalValue, delta / 2 + kEpsilonAccuracy);
-    XCTAssertEqualWithAccuracy(slider.value, snapedValue, kEpsilonAccuracy);
-    if ((slider.value - kEpsilonAccuracy > snapedValue) ||
-        (slider.value + kEpsilonAccuracy < snapedValue)) {
-      NSLog(@"failed with difference:%f", slider.value - snapedValue);
+    XCTAssertEqualWithAccuracy(self.slider.value, originalValue, delta / 2 + kEpsilonAccuracy);
+    XCTAssertEqualWithAccuracy(self.slider.value, snapedValue, kEpsilonAccuracy);
+    if ((self.slider.value - kEpsilonAccuracy > snapedValue) ||
+        (self.slider.value + kEpsilonAccuracy < snapedValue)) {
+      NSLog(@"failed with difference:%f", self.slider.value - snapedValue);
     }
   }
 }
 
-#pragma mark colors
+#pragma mark Clors
 
-- (void)testThumbColor {
-  // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-
+- (void)testDefaultColor {
   // When
-  UIColor *actualColor = slider.color;
+  UIColor *actualColor = self.slider.color;
 
   // Then
-  UIColor *expectedColor = [self blueColor];
+  UIColor *expectedColor = self.defaultBlue;
   XCTAssertEqualObjects(actualColor, expectedColor);
 }
 
-- (void)testThumbColorNullRestable {
-  // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-
+- (void)testColorCoding {
   // When
-  slider.color = nil;
+  self.slider.color = self.aNonDefaultColor;
+  MDCSlider *unarchived = [[self class] archiveAndUnarchiveObject:self.slider];
 
   // Then
-  UIColor *actualColor = slider.color;
-  UIColor *expectedColor = [self blueColor];
+  XCTAssertEqualObjects(unarchived.color, self.aNonDefaultColor);
+}
+
+- (void)testThumbColorNullResettable {
+  // When
+  self.slider.color = nil;
+
+  // Then
+  UIColor *actualColor = self.slider.color;
+  UIColor *expectedColor = self.defaultBlue;
   XCTAssertEqualObjects(actualColor, expectedColor);
 }
 
 - (void)testTrackColor {
-  // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-
   // When
-  UIColor *actualColor = slider.trackBackgroundColor;
+  UIColor *actualColor = self.slider.trackBackgroundColor;
 
   // Then
-  UIColor *expectedColor = [[UIColor blackColor] colorWithAlphaComponent:0.26f];
-  XCTAssertEqualObjects(actualColor, expectedColor);
+  XCTAssertEqualObjects(actualColor, self.defaultGray);
 }
 
-- (void)testTrackColorNullRestable {
-  // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-
+- (void)testTrackColorNullResettable {
   // When
-  slider.trackBackgroundColor = nil;
+  self.slider.trackBackgroundColor = nil;
 
   // Then
-  UIColor *actualColor = slider.trackBackgroundColor;
-  UIColor *expectedColor = [[UIColor blackColor] colorWithAlphaComponent:0.26f];
-  XCTAssertEqualObjects(actualColor, expectedColor);
+  UIColor *actualColor = self.slider.trackBackgroundColor;
+  XCTAssertEqualObjects(actualColor, self.defaultGray);
 }
 
 - (void)testDisabledColor {
-  // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-
   // When
-  UIColor *actualColor = slider.disabledColor;
+  UIColor *actualColor = self.slider.disabledColor;
 
   // Then
-  UIColor *expectedColor = [[UIColor blackColor] colorWithAlphaComponent:0.26f];
-  XCTAssertEqualObjects(actualColor, expectedColor);
+  XCTAssertEqualObjects(actualColor, self.defaultGray);
 }
 
-- (void)testDisabledColorNullRestable {
-  // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
+- (void)testDefaultThumbRadius {
+  // Then
+  XCTAssertEqual(self.slider.thumbRadius, 6);
+}
 
+- (void)testDefaultThumbElevation {
+  // Then
+  XCTAssertEqual(self.slider.thumbElevation, MDCShadowElevationNone);
+}
+
+- (void)testDisabledColorNullResettable {
   // When
-  slider.trackBackgroundColor = nil;
+  self.slider.trackBackgroundColor = nil;
 
   // Then
-  UIColor *actualColor = slider.trackBackgroundColor;
-  UIColor *expectedColor = [[UIColor blackColor] colorWithAlphaComponent:0.26f];
-  XCTAssertEqualObjects(actualColor, expectedColor);
+  UIColor *actualColor = self.slider.trackBackgroundColor;
+  XCTAssertEqualObjects(actualColor, self.defaultGray);
 }
 
 #pragma mark numeric value label
 
 - (void)testNumericValueLabelString {
-  // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
   MDCThumbTrack *track = nil;
-  for (UIView *view in slider.subviews) {
+  for (UIView *view in self.slider.subviews) {
     if ([view isKindOfClass:[MDCThumbTrack class]]) {
       track = (MDCThumbTrack *)view;
       break;
@@ -370,11 +351,11 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
   // Then
   XCTAssertEqualObjects(
-      [testFormatter numberFromString:[slider thumbTrack:track stringForValue:1.f]], @(1.));
+      [testFormatter numberFromString:[self.slider thumbTrack:track stringForValue:1.f]], @(1.));
   XCTAssertEqualObjects(
-      [testFormatter numberFromString:[slider thumbTrack:track stringForValue:0.57f]], @(0.57));
+      [testFormatter numberFromString:[self.slider thumbTrack:track stringForValue:0.57f]], @(0.57));
   XCTAssertEqualObjects(
-      [testFormatter numberFromString:[slider thumbTrack:track stringForValue:0.33333333f]],
+      [testFormatter numberFromString:[self.slider thumbTrack:track stringForValue:0.33333333f]],
       @(0.333));
 }
 
@@ -382,93 +363,83 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
 - (void)testAccessibilityValue {
   // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
   CGFloat newValue = [self randomPercent];
 
   // When
-  slider.value = newValue;
+  self.slider.value = newValue;
 
   // Then
   NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
   numberFormatter.numberStyle = NSNumberFormatterPercentStyle;
   NSString *expected =
-      [numberFormatter stringFromNumber:[NSNumber numberWithFloat:(float)slider.value]];
-  XCTAssertEqualObjects([slider accessibilityValue], expected);
+      [numberFormatter stringFromNumber:[NSNumber numberWithFloat:(float)self.slider.value]];
+  XCTAssertEqualObjects([self.slider accessibilityValue], expected);
 }
 
 - (void)testAccessibilityValueWithLargerMax {
   // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-  slider.maximumValue = [self randomNumber];
+  self.slider.maximumValue = [self randomNumber];
   CGFloat newValue = [self randomPercent];
 
   // When
-  slider.value = newValue;
+  self.slider.value = newValue;
 
   // Then
   NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
   numberFormatter.numberStyle = NSNumberFormatterPercentStyle;
   CGFloat percent =
-      (slider.value - slider.minimumValue) / (slider.maximumValue - slider.minimumValue);
+      (self.slider.value - self.slider.minimumValue) / (self.slider.maximumValue - self.slider.minimumValue);
   NSString *expected = [numberFormatter stringFromNumber:[NSNumber numberWithFloat:(float)percent]];
-  XCTAssertEqualObjects([slider accessibilityValue], expected);
+  XCTAssertEqualObjects([self.slider accessibilityValue], expected);
 }
 
 - (void)testAccessibilityIncrement {
   // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-  slider.value = [self randomPercent] - 0.1f;
-  CGFloat originalValue = slider.value;
+  self.slider.value = [self randomPercent] - 0.1f;
+  CGFloat originalValue = self.slider.value;
 
   // When
-  [slider accessibilityIncrement];
+  [self.slider accessibilityIncrement];
 
   // Then
-  XCTAssertEqual(originalValue + 0.1f, slider.value);
+  XCTAssertEqual(originalValue + 0.1f, self.slider.value);
 }
 
 - (void)testAccessibilityDecrement {
   // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-  slider.value = [self randomPercent] + 0.1f;
-  CGFloat originalValue = slider.value;
+  self.slider.value = [self randomPercent] + 0.1f;
+  CGFloat originalValue = self.slider.value;
 
   // When
-  [slider accessibilityDecrement];
+  [self.slider accessibilityDecrement];
 
   // Then
-  XCTAssertEqual(originalValue - 0.1f, slider.value);
+  XCTAssertEqual(originalValue - 0.1f, self.slider.value);
 }
 
 - (void)testAccessibilityIncrementWithLargerMax {
   // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-  slider.maximumValue = [self randomNumber];
-  slider.value = ([self randomPercent] - 0.1f) * slider.maximumValue;
-  CGFloat originalValue = slider.value;
+  self.slider.maximumValue = [self randomNumber];
+  self.slider.value = ([self randomPercent] - 0.1f) * self.slider.maximumValue;
+  CGFloat originalValue = self.slider.value;
 
   // When
-  [slider accessibilityIncrement];
+  [self.slider accessibilityIncrement];
 
   // Then
-  XCTAssertEqual(originalValue + 0.1f * slider.maximumValue, slider.value);
+  XCTAssertEqual(originalValue + 0.1f * self.slider.maximumValue, self.slider.value);
 }
 
 - (void)testAccessibilityTraits {
   // Given
-  MDCSlider *slider = [[MDCSlider alloc] init];
-  slider.enabled =
-      (BOOL)arc4random_uniform(2);  // It does not matter if the slider is enabled or disabled.
+  self.slider.enabled =
+      (BOOL)arc4random_uniform(2);  // It does not matter if the self.slider is enabled or disabled.
 
   // Then
-  XCTAssertTrue(slider.accessibilityTraits & UIAccessibilityTraitAdjustable);
+  XCTAssertTrue(self.slider.accessibilityTraits & UIAccessibilityTraitAdjustable);
 }
 
-#pragma mark private test helpers
-
-- (UIColor *)blueColor {
-  return MDCPalette.bluePalette.tint500;
-}
+#pragma mark Private test helpers
 
 - (CGFloat)randomNumber {
   return arc4random_uniform(1000) / (CGFloat)(arc4random_uniform(9) + 1);

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -124,18 +124,16 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
   // Then
   XCTAssertEqualWithAccuracy(self.slider.maximumValue, self.slider.minimumValue, kEpsilonAccuracy,
-                             @"Setting the self.slider's max to lower than the max must equal the "
-                             @"min.");
+                             @"Setting the slider's max to lower than the max must equal the min.");
   XCTAssertEqualWithAccuracy(
       newMax, self.slider.minimumValue, kEpsilonAccuracy,
-      @"Setting the self.slider's max must change the min when smaller than the min.");
+      @"Setting the slider's max must change the min when smaller than the min.");
   XCTAssertEqualWithAccuracy(
       newMax, self.slider.maximumValue, kEpsilonAccuracy,
-      @"Setting the self.slider's max must equal the value gotten even when smaller than the "
-      @"minimum.");
+      @"Setting the slider's max must equal the value gotten even when smaller than the minimum.");
   XCTAssertEqualWithAccuracy(
       newMax, self.slider.value, kEpsilonAccuracy,
-      @"Setting the self.slider's min to lower than the value must change the value also.");
+      @"Setting the slider's min to lower than the value must change the value also.");
 }
 
 - (void)testSetMinimumToLowerThanMaximum {
@@ -147,18 +145,17 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
   // Then
   XCTAssertEqualWithAccuracy(self.slider.minimumValue, self.slider.maximumValue, kEpsilonAccuracy,
-                             @"Setting the self.slider's min to higher than the max must equal the "
+                             @"Setting the slider's min to higher than the max must equal the "
                              @"max.");
   XCTAssertEqualWithAccuracy(
       newMin, self.slider.minimumValue, kEpsilonAccuracy,
-      @"Setting the self.slider's min must equal the value gotten even when larger than the "
-      @"maximum.");
+      @"Setting the slider's min must equal the value gotten even when larger than the maximum.");
   XCTAssertEqualWithAccuracy(
       newMin, self.slider.maximumValue, kEpsilonAccuracy,
-      @"Setting the self.slider's min to larger than the max must change the max also.");
+      @"Setting the slider's min to larger than the max must change the max also.");
   XCTAssertEqualWithAccuracy(
       newMin, self.slider.value, kEpsilonAccuracy,
-      @"Setting the self.slider's min to higher than the value must change the value also.");
+      @"Setting the slider's min to higher than the value must change the value also.");
 }
 
 - (void)testDiscreteValues2 {

--- a/components/private/ThumbTrack/src/MDCThumbTrack.h
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.h
@@ -16,6 +16,8 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialShadowElevations.h"
+
 @class MDCThumbView;
 @protocol MDCThumbTrackDelegate;
 
@@ -93,6 +95,9 @@
 
 /** The radius of the track thumb that moves along the track. */
 @property(nonatomic, assign) CGFloat thumbRadius;
+
+/** The elevation of the track thumb that moves along the track. */
+@property(nonatomic, assign) MDCShadowElevation thumbElevation;
 
 /** Whether or not the thumb should be smaller when the track is disabled. Defaults to NO. */
 @property(nonatomic, assign) BOOL thumbIsSmallerWhenDisabled;

--- a/components/private/ThumbTrack/src/MDCThumbTrack.m
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.m
@@ -246,6 +246,14 @@ static inline CGFloat DistanceFromPointToPoint(CGPoint point1, CGPoint point2) {
   [self setNeedsLayout];
 }
 
+- (void)setThumbElevation:(MDCShadowElevation)thumbElevation {
+  _thumbView.elevation = thumbElevation;
+}
+
+- (MDCShadowElevation)thumbElevation {
+  return _thumbView.elevation;
+}
+
 - (void)setShouldDisplayDiscreteDots:(BOOL)shouldDisplayDiscreteDots {
   if (_shouldDisplayDiscreteDots != shouldDisplayDiscreteDots) {
     if (shouldDisplayDiscreteDots) {

--- a/components/private/ThumbTrack/src/MDCThumbView.h
+++ b/components/private/ThumbTrack/src/MDCThumbView.h
@@ -16,10 +16,19 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialShadowElevations.h"
+
 @interface MDCThumbView : UIView
 
 /** A boolean value indicating whether the thumb view has a shadow. */
-@property(nonatomic, assign) BOOL hasShadow;
+@property(nonatomic, assign) BOOL hasShadow __deprecated_msg("Use `elevation` instead.");
+
+/**
+ The elevation of the thumb view.
+
+ Default is MDCShadowElevationNone (no shadow).
+ */
+@property(nonatomic, assign) MDCShadowElevation elevation;
 
 /** The border width of the thumbview layer. */
 @property(nonatomic, assign) CGFloat borderWidth;

--- a/components/private/ThumbTrack/src/MDCThumbView.m
+++ b/components/private/ThumbTrack/src/MDCThumbView.m
@@ -56,8 +56,15 @@ static const CGFloat kMinTouchSize = 48;
 
 - (void)setHasShadow:(BOOL)hasShadow {
   _hasShadow = hasShadow;
-  [[self shadowLayer]
-      setElevation:(hasShadow) ? MDCShadowElevationCardResting : MDCShadowElevationNone];
+  self.elevation = hasShadow ? MDCShadowElevationCardResting : MDCShadowElevationNone;
+}
+
+- (MDCShadowElevation)elevation {
+  return [self shadowLayer].elevation;
+}
+
+- (void)setElevation:(MDCShadowElevation)elevation {
+  [self shadowLayer].elevation = elevation;
 }
 
 - (MDCShadowLayer *)shadowLayer {


### PR DESCRIPTION
Adds `thumbRadius` and `thumbElevation` as UIAppearance properties.

Makes `color`, `disabledColor`, and `trackBackgroundColor` UIAppearance-compatible.

I tested manually by using UIAppearance to style these properties and verifying that they work. I'd prefer a EarlGrey or other automated test, but we're not set up for that yet.