### PR TITLE
[BottomNav] Reduce default font to `caption`

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -173,7 +173,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   [self addSubview:_containerView];
   [self setElevation:kMDCBottomNavigationBarElevation];
   _itemViews = [NSMutableArray array];
-  _itemTitleFont = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleButton];
+  _itemTitleFont = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleCaption];
 }
 
 - (void)layoutSubviews {


### PR DESCRIPTION
BottomNavigation previously had a nil default font, so a default
`button` style font was set. This is too large (and is Medium weight),
so the font should be changed to something smaller. 'Caption' style
looks better.

Before/Portrait
![bottomnav-before-port](https://user-images.githubusercontent.com/1753199/34566946-75f1d0fa-f12e-11e7-9f98-d69508c8357f.png)


After/Portrait
![bottomnav-after-port](https://user-images.githubusercontent.com/1753199/34566950-7a57875c-f12e-11e7-9915-b11490f42d77.png)


Before/Landscape
![bottomnav-before-land](https://user-images.githubusercontent.com/1753199/34566955-7db9bcc6-f12e-11e7-8c8c-2bdf2f552fdf.png)


After/Landscape
![bottomnav-after-land](https://user-images.githubusercontent.com/1753199/34566959-8124ffba-f12e-11e7-80b9-37d3b7db763d.png)


