### PR TITLE
update our release script to support CocoaPods publishing

### DIFF
--- a/scripts/README-release.md
+++ b/scripts/README-release.md
@@ -68,6 +68,14 @@ perform any final sanity checks.
 
 And you're done!
 
+## Publish the podspec
+
+At this point you have published your release to Github, and the last step is to push the new version to CocoaPods!
+
+    release podspec
+
+And the release is now public in CocoaPods!
+
 ## Release process commands
 
 Usage: `release cut [--hotfix]`

--- a/scripts/release
+++ b/scripts/release
@@ -407,6 +407,23 @@ publish_release() {
   fi
 }
 
+publish_podspec() {
+  cd "$rootdir"
+  echo "Running a pod spec lint to validate the podspec..."
+  # Checking spec lint
+  pod spec lint MaterialComponents.podspec --allow-warnings > lint_logs.log
+  if grep -Fxq "MaterialComponents.podspec passed validation." lint_logs.log
+  then
+    echo "pod spec lint was successful!"
+    echo
+    echo "running a pod trunk push..."
+    pod trunk push MaterialComponents.podspec
+    rm lint_logs.log
+  else
+    echo "Spec didn't pass validation, please take a look at lint_logs.log for more information"
+  fi
+}
+
 # Generators
 
 generate_release_apidiff() {
@@ -624,6 +641,7 @@ case "$1" in
   bump)       bump_release ${@:2} ;;
   merge)      merge_release ${@:2} ;;
   publish)    publish_release ${@:2} ;;
+  podspec)    publish_podspec ${@:2} ;;
 
   apidiff)    generate_release_apidiff ${@:2} ;;
   authors)    generate_release_authors ${@:2} ;;

--- a/scripts/release
+++ b/scripts/release
@@ -409,19 +409,8 @@ publish_release() {
 
 publish_podspec() {
   cd "$rootdir"
-  echo "Running a pod spec lint to validate the podspec..."
-  # Checking spec lint
-  pod spec lint MaterialComponents.podspec --allow-warnings > lint_logs.log
-  if grep -Fxq "MaterialComponents.podspec passed validation." lint_logs.log
-  then
-    echo "pod spec lint was successful!"
-    echo
-    echo "running a pod trunk push..."
-    pod trunk push MaterialComponents.podspec
-    rm lint_logs.log
-  else
-    echo "Spec didn't pass validation, please take a look at lint_logs.log for more information"
-  fi
+  echo "running a pod trunk push..."
+  pod trunk push MaterialComponents.podspec
 }
 
 # Generators

--- a/scripts/release
+++ b/scripts/release
@@ -409,8 +409,15 @@ publish_release() {
 
 publish_podspec() {
   cd "$rootdir"
-  echo "running a pod trunk push..."
-  pod trunk push MaterialComponents.podspec
+  echo "Verifying Cocoapod trunk permissions"
+  pod trunk me > cocoapods_permissions.log
+  if grep -Fq "MaterialComponents" cocoapods_permissions.log; then
+    echo "Running a pod trunk push..."
+    pod trunk push MaterialComponents.podspec
+  else
+    echo "You do not have the right permissions to push the pod via the CocoaPods API."
+  fi
+  rm cocoapods_permissions.log
 }
 
 # Generators


### PR DESCRIPTION
I had noticed we sometimes forget to push releases to CocoaPods so I added a command to our release script that you run after `release publish <version>`, by issuing `release podspec`. This will issue a lint before pushing the release to CocoaPods.

We could also add this method to be part of, and at the end of the `release publish`, and if it fails then the person releasing will have to fix the podspec and reissue only a `release podspec`. Either way is fine by me.