### PR TITLE
Consolidate installation requirements in the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Use `cmd-1` to open the project navigator within Xcode. Peal open the `Pods` pro
 
 ## Installation
 
+### Requirements
+
+- Xcode 7.0 or higher.
+- Minimum iOS deployment target of 8.0 or higher
+- Cocoapods
+
 ### Getting Started with a New Project
 
 Check out our [tutorial](howto/tutorial) for a step-by-step guide to setting up a new project using Material Components.

--- a/components/ActivityIndicator/README.md
+++ b/components/ActivityIndicator/README.md
@@ -39,11 +39,6 @@ When indicators are determinate they indicate how long an operation will take wh
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/AnimationTiming/README.md
+++ b/components/AnimationTiming/README.md
@@ -26,11 +26,6 @@ of an animation so that movement doesn't appear mechanical.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -30,11 +30,6 @@ navigation experience.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/BottomSheet/README.md
+++ b/components/BottomSheet/README.md
@@ -27,11 +27,6 @@ Bottom sheets slide up from the bottom of the screen to reveal more content. Bot
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/ButtonBar/README.md
+++ b/components/ButtonBar/README.md
@@ -27,11 +27,6 @@ The Button Bar is a view that represents a list of UIBarButtonItems as horizonta
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/CollectionCells/README.md
+++ b/components/CollectionCells/README.md
@@ -28,11 +28,6 @@ Collection view cell classes that adhere to Material Design layout and styling.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ## Usage
 
 Please see the [Collections](../Collections/) component for more information about using Collection

--- a/components/CollectionLayoutAttributes/README.md
+++ b/components/CollectionLayoutAttributes/README.md
@@ -22,11 +22,6 @@ Allows passing layout attributes to the cells and supplementary views.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/Collections/README.md
+++ b/components/Collections/README.md
@@ -31,11 +31,6 @@ Collection view classes that adhere to Material Design layout and styling.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/Dialogs/README.md
+++ b/components/Dialogs/README.md
@@ -40,11 +40,6 @@ according to the Material spec.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 8.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/FeatureHighlight/README.md
+++ b/components/FeatureHighlight/README.md
@@ -25,11 +25,6 @@ The Feature Highlight component is a way to visually highlight a part of the scr
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -32,11 +32,6 @@ UIScrollViewDelegate events.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/HeaderStackView/README.md
+++ b/components/HeaderStackView/README.md
@@ -28,12 +28,6 @@ bar views.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/Ink/README.md
+++ b/components/Ink/README.md
@@ -30,11 +30,6 @@ outward from the user's touch.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/LibraryInfo/README.md
+++ b/components/LibraryInfo/README.md
@@ -10,11 +10,6 @@ api_doc_root: true
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/MaskedTransition/README.md
+++ b/components/MaskedTransition/README.md
@@ -23,11 +23,6 @@ A masked transition reveals content from a source view using a view controller t
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/NavigationBar/README.md
+++ b/components/NavigationBar/README.md
@@ -30,11 +30,6 @@ Consistent with iOS design guidelines, the title in the navigation bar is center
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/OverlayWindow/README.md
+++ b/components/OverlayWindow/README.md
@@ -19,11 +19,6 @@ displayed message views are always visible to the user by being at the top of th
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/PageControl/README.md
+++ b/components/PageControl/README.md
@@ -28,11 +28,6 @@ desired animation of the control.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher
-- iOS SDK version 7.0 or higher
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/Palettes/README.md
+++ b/components/Palettes/README.md
@@ -27,11 +27,6 @@ The Palettes component provides Material colors organized into similar palettes.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/ProgressView/README.md
+++ b/components/ProgressView/README.md
@@ -30,11 +30,6 @@ few key methods required to achieve the desired animation of the control.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher
-- iOS SDK version 7.0 or higher
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/ShadowElevations/README.md
+++ b/components/ShadowElevations/README.md
@@ -30,11 +30,6 @@ used Material Design elevations for components.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/ShadowLayer/README.md
+++ b/components/ShadowLayer/README.md
@@ -52,12 +52,6 @@ shadow that adheres to defined height and light source principles.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/Slider/README.md
+++ b/components/Slider/README.md
@@ -28,12 +28,6 @@ or discrete set of values.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/Snackbar/README.md
+++ b/components/Snackbar/README.md
@@ -27,11 +27,6 @@ contain a text action, but no icons.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/components/Tabs/README.md
+++ b/components/Tabs/README.md
@@ -25,11 +25,6 @@ Tabs are bars of buttons used to navigate between groups of content.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 9.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the

--- a/components/Typography/README.md
+++ b/components/Typography/README.md
@@ -27,11 +27,6 @@ from the Material Design specifications.
 
 ## Installation
 
-### Requirements
-
-- Xcode 7.0 or higher.
-- iOS SDK version 7.0 or higher.
-
 ### Installation with CocoaPods
 
 To add this component to your Xcode project using CocoaPods, add the following to your `Podfile`:

--- a/contributing/writing_readmes.md
+++ b/contributing/writing_readmes.md
@@ -35,11 +35,6 @@ fill out have been marked with `TODO` statements.
 
     ## Installation
 
-    ### Requirements
-
-    - Xcode 7.0 or higher.
-    - iOS SDK version 7.0 or higher.
-
     ### Installation with CocoaPods
 
     To add this component to your Xcode project using CocoaPods, add the


### PR DESCRIPTION
Move the requirements to a central location to avoid duplication and future copy & paste errors.