### PR TITLE
Bump requirements to Xcode 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Use `cmd-1` to open the project navigator within Xcode. Peal open the `Pods` pro
 
 ### Requirements
 
-- Xcode 7.0 or higher.
+- Xcode 8.0 or higher.
 - Minimum iOS deployment target of 8.0 or higher
 - Cocoapods
 


### PR DESCRIPTION
We haven't been testing on Xcode 7 for awhile and some of our Swift code is not friendly.
This change just makes it 'official'.

Closes #2800 