### PR TITLE
[FlexibleHeader] Fix status bar not disappearing for edge case

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -426,6 +426,12 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   _wasStatusBarHiddenIsValid = NO;
 }
 
+- (void)didMoveToWindow {
+  [super didMoveToWindow];
+
+  [_statusBarShifter didMoveToWindow];
+}
+
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
   UIView *hitView = [super hitTest:point withEvent:event];
 

--- a/components/FlexibleHeader/src/private/MDCStatusBarShifter.h
+++ b/components/FlexibleHeader/src/private/MDCStatusBarShifter.h
@@ -85,6 +85,9 @@
 /** Must be called when the owning UIViewController's interface orientation has changed. */
 - (void)interfaceOrientationDidChange;
 
+/** Must be called when the owning UIViewController's view moves to a window. */
+- (void)didMoveToWindow;
+
 @end
 
 /**

--- a/components/FlexibleHeader/src/private/MDCStatusBarShifter.m
+++ b/components/FlexibleHeader/src/private/MDCStatusBarShifter.m
@@ -279,4 +279,8 @@ typedef NS_ENUM(NSInteger, MDCStatusBarShifterState) {
   _statusBarReplicaView.hidden = NO;
 }
 
+- (void)didMoveToWindow {
+  _originalStatusBarHeight = [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
+}
+
 @end


### PR DESCRIPTION
Closes #2690

[Before](https://gfycat.com/ScaryRevolvingAchillestang) | [After](https://gfycat.com/WindingGrouchyBilby)

This fixes status bar shifting for flexible headers on view controllers presented to a navigation controller stack that had hidden the status bar.