### PR TITLE
Simplify podspec

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -299,13 +299,13 @@ Pod::Spec.new do |mdc|
       extension.dependency "MaterialComponents/FeatureHighlight"
       extension.dependency "MaterialComponents/Themes"
     end
-    component.subspec "FontThemer" do |fontthemer|
-      fontthemer.ios.deployment_target = '8.0'
-      fontthemer.public_header_files = "components/FeatureHighlight/src/#{fontthemer.base_name}/*.h"
-      fontthemer.source_files = "components/FeatureHighlight/src/#{fontthemer.base_name}/*.{h,m}"
+    component.subspec "FontThemer" do |extension|
+      extension.ios.deployment_target = '8.0'
+      extension.public_header_files = "components/FeatureHighlight/src/#{extension.base_name}/*.h"
+      extension.source_files = "components/FeatureHighlight/src/#{extension.base_name}/*.{h,m}"
 
-      fontthemer.dependency "MaterialComponents/FeatureHighlight"
-      fontthemer.dependency "MaterialComponents/Themes"
+      extension.dependency "MaterialComponents/FeatureHighlight"
+      extension.dependency "MaterialComponents/Themes"
     end
   end
 


### PR DESCRIPTION
There is no need to have a fonttheme type, we can re-use the existing extension to be consistent.
