### PR TITLE
[ButtonBar] Expose font and padding properties

### DIFF
--- a/components/ButtonBar/examples/ButtonBarCustomizedFontExample.m
+++ b/components/ButtonBar/examples/ButtonBarCustomizedFontExample.m
@@ -1,0 +1,117 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "MaterialButtonBar.h"
+
+@interface ButtonBarCustomizedFontExample : UIViewController
+@end
+
+@implementation ButtonBarCustomizedFontExample
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  MDCButtonBar *buttonBar = [[MDCButtonBar alloc] init];
+
+  // MDCButtonBar ignores the style of UIBarButtonItem.
+  UIBarButtonItemStyle ignored = UIBarButtonItemStyleDone;
+
+  UIBarButtonItem *actionItem =
+      [[UIBarButtonItem alloc] initWithTitle:@"Disable"
+                                       style:ignored
+                                      target:self
+                                      action:@selector(didTapActionButton:)];
+  UIBarButtonItem *secondActionItem =
+      [[UIBarButtonItem alloc] initWithTitle:@"Customization"
+                                       style:ignored
+                                      target:self
+                                      action:@selector(didTapActionButton:)];
+
+  NSArray *items = @[ actionItem, secondActionItem ];
+
+  // Set the title text attributes before assigning to buttonBar.items
+  // because of https://github.com/material-components/material-components-ios/issues/277
+  for (UIBarButtonItem *item in items) {
+    [item setTitleTextAttributes:@{ NSForegroundColorAttributeName : [UIColor greenColor] }
+                        forState:UIControlStateNormal];
+  }
+
+  buttonBar.items = items;
+
+  // MDCButtonBar's sizeThatFits gives a "best-fit" size of the provided items.
+  CGSize size = [buttonBar sizeThatFits:self.view.bounds.size];
+  CGFloat x = (self.view.bounds.size.width - size.width) / 2;
+  CGFloat y = self.view.bounds.size.height / 2 - size.height;
+  buttonBar.frame = CGRectMake(x, y, size.width, size.height);
+  buttonBar.autoresizingMask =
+      (UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin |
+       UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin);
+  [self.view addSubview:buttonBar];
+
+  // Ensure that the controller's view isn't transparent.
+  self.view.backgroundColor = [UIColor colorWithWhite:0.9f alpha:1.0f];
+}
+
+#pragma mark - User actions
+
+- (void)didTapActionButton:(id)sender {
+  NSLog(@"Did tap action item: %@", sender);
+
+  // Disable CUstomization
+  [[MDCButtonBarButton appearance] setTitleFont:nil forState:UIControlStateNormal];
+}
+
+@end
+
+@implementation ButtonBarCustomizedFontExample (CatalogByConvention)
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Button Bar", @"Button Bar (Customized)" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
++ (NSString *)catalogDescription {
+  return @"A Button Bar with a customized font.";
+}
+
++ (BOOL)catalogIsPresentable {
+  return YES;
+}
+
+@end
+
+#pragma mark - Typical application code (not Material-specific)
+
+@implementation ButtonBarCustomizedFontExample (GeneralApplicationLogic)
+
+- (id)init {
+  self = [super init];
+  if (self) {
+    self.title = @"Button Bar";
+
+    UIFont *customFont = [UIFont fontWithName:@"American Typewriter" size:10.0f];
+    NSAssert(customFont, @"Unable to instantiate font");
+    [[MDCButtonBarButton appearance] setTitleFont:customFont forState:UIControlStateNormal];
+  }
+  return self;
+}
+
+@end

--- a/components/ButtonBar/examples/ButtonBarCustomizedFontExample.m
+++ b/components/ButtonBar/examples/ButtonBarCustomizedFontExample.m
@@ -88,10 +88,6 @@
   return NO;
 }
 
-+ (NSString *)catalogDescription {
-  return @"A Button Bar with a customized font.";
-}
-
 + (BOOL)catalogIsPresentable {
   return YES;
 }

--- a/components/ButtonBar/examples/ButtonBarCustomizedFontExample.m
+++ b/components/ButtonBar/examples/ButtonBarCustomizedFontExample.m
@@ -72,7 +72,7 @@
 - (void)didTapActionButton:(id)sender {
   NSLog(@"Did tap action item: %@", sender);
 
-  // Disable CUstomization
+  // Disable Customization
   [[MDCButtonBarButton appearance] setTitleFont:nil forState:UIControlStateNormal];
 }
 
@@ -103,6 +103,13 @@
   if (self) {
     self.title = @"Button Bar";
 
+    // You would normally set your UIAppearance properties in your AppDelegate in
+    // applicationDidFinishLoading.  We are doing it here to keep the revalent
+    // code in the sample.
+    // Once this code has been executed ALL MDCButtonBar's will have the following
+    // font.
+    // See Apple > UIKit > UIAppearance
+    // https://developer.apple.com/documentation/uikit/uiappearance
     UIFont *customFont = [UIFont fontWithName:@"American Typewriter" size:10.0f];
     NSAssert(customFont, @"Unable to instantiate font");
     [[MDCButtonBarButton appearance] setTitleFont:customFont forState:UIControlStateNormal];

--- a/components/ButtonBar/examples/ButtonBarCustomizedFontExample.m
+++ b/components/ButtonBar/examples/ButtonBarCustomizedFontExample.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/components/ButtonBar/src/MDCButtonBarButton.h
+++ b/components/ButtonBar/src/MDCButtonBarButton.h
@@ -1,0 +1,26 @@
+//
+//  MDCButtonBarButton.h
+//  MaterialComponents
+//
+//  Created by Ian Gordon on 1/17/18.
+//
+
+#import "MaterialButtons.h"
+
+@interface MDCButtonBarButton : MDCFlatButton
+
+// Content padding for the button.
+@property(nonatomic) UIEdgeInsets contentPadding UI_APPEARANCE_SELECTOR;
+
+/**
+ The font used by the button's @c title.
+
+ If left unset or reset to nil for a given state, then a default font is used.
+
+ @param font The font.
+ @param state The state.
+ */
+- (void)setTitleFont:(nullable UIFont *)font forState:(UIControlState)state
+    UI_APPEARANCE_SELECTOR;
+
+@end

--- a/components/ButtonBar/src/MDCButtonBarButton.h
+++ b/components/ButtonBar/src/MDCButtonBarButton.h
@@ -18,7 +18,9 @@
 
 @interface MDCButtonBarButton : MDCFlatButton
 
-// Content padding for the button.
+/**
+ Content padding for the button.
+ */
 @property(nonatomic) UIEdgeInsets contentPadding UI_APPEARANCE_SELECTOR;
 
 /**

--- a/components/ButtonBar/src/MDCButtonBarButton.h
+++ b/components/ButtonBar/src/MDCButtonBarButton.h
@@ -1,9 +1,18 @@
-//
-//  MDCButtonBarButton.h
-//  MaterialComponents
-//
-//  Created by Ian Gordon on 1/17/18.
-//
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
 
 #import "MaterialButtons.h"
 

--- a/components/ButtonBar/src/MaterialButtonBar.h
+++ b/components/ButtonBar/src/MaterialButtonBar.h
@@ -15,3 +15,4 @@
  */
 
 #import "MDCButtonBar.h"
+#import "MDCButtonBarButton.h"

--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
@@ -22,8 +22,7 @@
 #import "MaterialButtons.h"
 #import "MDCButtonBarButton.h"
 #import "MDCButtonBar+Private.h"
-
-static const CGFloat kMinimumItemWidth = 36.f;
+#import "MDCButtonBarButton+Private.h"
 
 // The padding around button contents.
 static const CGFloat kButtonPaddingHorizontal = 12.f;
@@ -287,38 +286,6 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
 @end
 
 @implementation MDCButtonBarSandbagView
-@end
-
-@implementation MDCButtonBarButton
-
-- (CGSize)sizeThatFits:(CGSize)size {
-  CGSize fitSize = [super sizeThatFits:size];
-  fitSize.height =
-      self.contentPadding.top + MAX(kMinimumItemWidth, fitSize.height) + self.contentPadding.bottom;
-  fitSize.width =
-      self.contentPadding.left + MAX(kMinimumItemWidth, fitSize.width) + self.contentPadding.right;
-
-  return fitSize;
-}
-
-- (void)layoutSubviews {
-  [super layoutSubviews];
-
-  // TODO(featherless): Remove this conditional and always set the max ripple radius once
-  // https://github.com/material-components/material-components-ios/issues/329 lands.
-  if (self.inkStyle == MDCInkStyleUnbounded) {
-    self.inkMaxRippleRadius = MIN(self.bounds.size.width, self.bounds.size.height) / 2;
-  } else {
-    self.inkMaxRippleRadius = 0;
-  }
-}
-
-//TODO(#2850): Why do we need this implementation if we just call super?  Removing it causes a
-// method definition error
-- (void)setTitleFont:(nullable UIFont *)font forState:(UIControlState)state {
-  [super setTitleFont:font forState:state];
-}
-
 @end
 
 @implementation UIBarButtonItem (MDCHeaderInternal)

--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
@@ -313,6 +313,8 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
   }
 }
 
+//TODO(#2850): Why do we need this implementation if we just call super?  Removing it causes a
+// method definition error
 - (void)setTitleFont:(nullable UIFont *)font forState:(UIControlState)state {
   [super setTitleFont:font forState:state];
 }

--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
@@ -20,6 +20,7 @@
 #import <MDFInternationalization/MDFInternationalization.h>
 
 #import "MaterialButtons.h"
+#import "MDCButtonBarButton.h"
 #import "MDCButtonBar+Private.h"
 
 static const CGFloat kMinimumItemWidth = 36.f;
@@ -49,10 +50,10 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
 @interface MDCButtonBarSandbagView : UIView
 @end
 
-@interface MDCButtonBarButton : MDCFlatButton
+@interface MDCButtonBarButton (MDCAppBarButtonBarBuilder)
 
-// Content padding for the button.
-@property(nonatomic) UIEdgeInsets contentPadding;
+//// Content padding for the button.
+//@property(nonatomic) UIEdgeInsets contentPadding;
 
 @end
 
@@ -317,6 +318,10 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
   } else {
     self.inkMaxRippleRadius = 0;
   }
+}
+
+- (void)setTitleFont:(nullable UIFont *)font forState:(UIControlState)state {
+  [super setTitleFont:font forState:state];
 }
 
 @end

--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
@@ -50,13 +50,6 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
 @interface MDCButtonBarSandbagView : UIView
 @end
 
-@interface MDCButtonBarButton (MDCAppBarButtonBarBuilder)
-
-//// Content padding for the button.
-//@property(nonatomic) UIEdgeInsets contentPadding;
-
-@end
-
 @interface UIBarButtonItem (MDCHeaderInternal)
 
 // Internal version of the standard -customView property. When an item is pushed onto a

--- a/components/ButtonBar/src/private/MDCButtonBarButton+Private.h
+++ b/components/ButtonBar/src/private/MDCButtonBarButton+Private.h
@@ -14,25 +14,14 @@
  limitations under the License.
  */
 
-#import "MaterialButtons.h"
+#import <UIKit/UIKit.h>
+
+@interface MDCButtonBarButton ()
 
 /**
- The MDCButtonBarButton class is used by MDCButtonBar.
-
- This is publically declared to inform clients they can use the UIAppearance proxy to customize the
- appearance of button bar buttons.
+ Content padding for the button.
  */
-@interface MDCButtonBarButton : MDCFlatButton
-
-/**
- The font used by the button's @c title.
-
- If left unset or reset to nil for a given state, then a default font is used.
-
- @param font The font.
- @param state The state.
- */
-- (void)setTitleFont:(nullable UIFont *)font forState:(UIControlState)state
-    UI_APPEARANCE_SELECTOR;
+//TODO(#2851): Can't we do this with the existing contentEdgeInsets
+@property(nonatomic) UIEdgeInsets contentPadding;
 
 @end

--- a/components/ButtonBar/src/private/MDCButtonBarButton.m
+++ b/components/ButtonBar/src/private/MDCButtonBarButton.m
@@ -1,0 +1,55 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "MDCButtonBarButton.h"
+#import "MDCButtonBarButton+Private.h"
+
+static const CGFloat kMinimumItemWidth = 36.f;
+
+@implementation MDCButtonBarButton
+
+- (CGSize)sizeThatFits:(CGSize)size {
+  CGSize fitSize = [super sizeThatFits:size];
+  fitSize.height =
+      self.contentPadding.top + MAX(kMinimumItemWidth, fitSize.height) + self.contentPadding.bottom;
+  fitSize.width =
+      self.contentPadding.left + MAX(kMinimumItemWidth, fitSize.width) + self.contentPadding.right;
+
+  return fitSize;
+}
+
+- (void)layoutSubviews {
+  [super layoutSubviews];
+
+  // TODO(featherless): Remove this conditional and always set the max ripple radius once
+  // https://github.com/material-components/material-components-ios/issues/329 lands.
+  if (self.inkStyle == MDCInkStyleUnbounded) {
+    self.inkMaxRippleRadius = MIN(self.bounds.size.width, self.bounds.size.height) / 2;
+  } else {
+    self.inkMaxRippleRadius = 0;
+  }
+}
+
+// Because we are explicitly re-declaring this method in our header, we need to explictly
+// re-define in our implementation. Therefore, this method just calls [super].
+- (void)setTitleFont:(nullable UIFont *)font forState:(UIControlState)state {
+  [super setTitleFont:font forState:state];
+}
+
+@end
+


### PR DESCRIPTION
Expose the MDCButtonBarButton and its properties so we can explicitly set a custom font.

Add a sample demonstrating the effect.

![screen shot 2018-01-17 at 15 31 51](https://user-images.githubusercontent.com/1121006/35065569-9818ace0-fb9b-11e7-8d01-57141a9026b0.png)
