### PR TITLE
[FlexibleHeader] Change adjusting shift behavior for !ShiftBehaviorDisabled

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -839,7 +839,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   frameBottomEdge = MAX(0, MIN(kShadowScaleLength, frameBottomEdge));
   CGFloat boundedAccumulator = MIN([self fhv_accumulatorMax], _shiftAccumulator);
 
-  if (_shiftBehavior == MDCFlexibleHeaderShiftBehaviorEnabled) {
+  if (_shiftBehavior != MDCFlexibleHeaderShiftBehaviorDisabled) {
     CGFloat contentHeight = self.computedMinimumHeight - MDCDeviceTopSafeAreaInset();
     CGFloat hideThreshold = kContentHidingThreshold;
     CGFloat alpha = MAX(contentHeight - boundedAccumulator / hideThreshold, 0) / contentHeight;


### PR DESCRIPTION
Right now, _viewsToHideWhenShifted are only hidden for MDCFlexibleHeaderShiftBehaviorEnabled.  Changed the condition so that they will hide for both MDCFlexibleHeaderShiftBehaviorEnabled and MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar.

### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [ ] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [ ] Link to GitHub issues it solves. ```closes #1234```
- [ ] Sign the CLA bot. You can do this once the pull request is submitted.

[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
pull request.
