### PR TITLE
[Palettes] Add API to support "walking" the palette colors

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -170,6 +170,7 @@ Pod::Spec.new do |mdc|
 
       extension.dependency 'MDFTextAccessibility'
       extension.dependency "MaterialComponents/Buttons"
+      extension.dependency "MaterialComponents/Palettes"
     end
   end
 

--- a/components/Buttons/BUILD
+++ b/components/Buttons/BUILD
@@ -58,6 +58,7 @@ mdc_objc_library(
     includes = ["src/TitleColorAccessibilityMutator"],
     deps = [
         ":Buttons",
+        "//components/Palettes",
         "@material_text_accessibility_ios//:MDFTextAccessibility",
     ],
     visibility = ["//visibility:public"],

--- a/components/Buttons/src/TitleColorAccessibilityMutator/MDCButtonTitleColorAccessibilityMutator.m
+++ b/components/Buttons/src/TitleColorAccessibilityMutator/MDCButtonTitleColorAccessibilityMutator.m
@@ -19,8 +19,73 @@
 #import <MDFTextAccessibility/MDFTextAccessibility.h>
 #import "MaterialButtons.h"
 #import "MaterialTypography.h"
+#import "MaterialPalettes.h"
 
 @implementation MDCButtonTitleColorAccessibilityMutator
+
++ (UIColor *)passingPaletteColorForColor:(UIColor *)color
+                            onBackground:(UIColor *)background
+                                 options:(MDFTextAccessibilityOptions)options
+                      searchDarkerColors:(BOOL)searchDarkerColors {
+
+  if (searchDarkerColors && [MDCPalette nextDarkerColorInPaletteForColor:color]) {
+    UIColor *nextDarkerColor = [MDCPalette nextDarkerColorInPaletteForColor:color];
+    if ([MDFTextAccessibility textColor:nextDarkerColor
+                passesOnBackgroundColor:background
+                                options:options]) {
+      return nextDarkerColor;
+    }
+    return [[self class] passingPaletteColorForColor:nextDarkerColor
+                                        onBackground:background
+                                             options:options
+                                  searchDarkerColors:YES];
+  }
+  if (!searchDarkerColors && [MDCPalette nextLighterColorInPaletteForColor:color]) {
+    UIColor *nextLighterColor = [MDCPalette nextLighterColorInPaletteForColor:color];
+    if ([MDFTextAccessibility textColor:nextLighterColor
+                passesOnBackgroundColor:background
+                                options:options]) {
+      return nextLighterColor;
+    }
+    return [[self class] passingPaletteColorForColor:nextLighterColor
+                                        onBackground:background
+                                             options:options
+                                  searchDarkerColors:NO];
+  }
+  return nil;
+}
+
++ (UIColor *)passingPaletteColorForColor:(UIColor *)color
+                            onBackground:(UIColor *)background
+                                 options:(MDFTextAccessibilityOptions) options {
+  CGFloat colorContrast = [MDFTextAccessibility contrastRatioForTextColor:color
+                                                        onBackgroundColor:background];
+  if ([MDCPalette nextDarkerColorInPaletteForColor:color]) {
+    UIColor *nextDarkerColor = [MDCPalette nextDarkerColorInPaletteForColor:color];
+    CGFloat darkerContrast =
+        [MDFTextAccessibility contrastRatioForTextColor:nextDarkerColor
+                                      onBackgroundColor:background];
+    if (darkerContrast > colorContrast) {
+      return [[self class] passingPaletteColorForColor:color
+                                          onBackground:background
+                                               options:options
+                                    searchDarkerColors:YES];
+    }
+  }
+  if ([MDCPalette nextLighterColorInPaletteForColor:color]) {
+    UIColor *nextLighterColor = [MDCPalette nextLighterColorInPaletteForColor:color];
+    CGFloat lighterContrast =
+        [MDFTextAccessibility contrastRatioForTextColor:nextLighterColor
+                                      onBackgroundColor:background];
+    if (lighterContrast > colorContrast) {
+      return [[self class] passingPaletteColorForColor:color
+                                          onBackground:background
+                                               options:options
+                                    searchDarkerColors:NO];
+    }
+  }
+  return nil;
+}
 
 + (void)changeTitleColorOfButton:(MDCButton *)button {
   // This ensures title colors will be accessible against the buttons backgrounds.
@@ -41,10 +106,15 @@
       if (![MDFTextAccessibility textColor:existingColor
                    passesOnBackgroundColor:backgroundColor
                                    options:options]) {
-        UIColor *color =
-            [MDFTextAccessibility textColorOnBackgroundColor:backgroundColor
-                                             targetTextAlpha:[MDCTypography buttonFontOpacity]
-                                                     options:options];
+
+        UIColor *color = [[self class] passingPaletteColorForColor:existingColor
+                                                      onBackground:backgroundColor
+                                                           options:options];
+        if (!color) {
+          color = [MDFTextAccessibility textColorOnBackgroundColor:backgroundColor
+                                                   targetTextAlpha:[MDCTypography buttonFontOpacity]
+                                                           options:options];
+        }
         [button setTitleColor:color forState:controlState];
       }
     }

--- a/components/Buttons/src/TitleColorAccessibilityMutator/MDCButtonTitleColorAccessibilityMutator.m
+++ b/components/Buttons/src/TitleColorAccessibilityMutator/MDCButtonTitleColorAccessibilityMutator.m
@@ -23,10 +23,10 @@
 
 @implementation MDCButtonTitleColorAccessibilityMutator
 
-+ (UIColor *)passingPaletteColorForColor:(UIColor *)color
-                            onBackground:(UIColor *)background
-                                 options:(MDFTextAccessibilityOptions)options
-                      searchDarkerColors:(BOOL)searchDarkerColors {
++ (UIColor *)nearestPassingPaletteColorForColor:(UIColor *)color
+                                   onBackground:(UIColor *)background
+                                        options:(MDFTextAccessibilityOptions)options
+                             searchDarkerColors:(BOOL)searchDarkerColors {
 
   if (searchDarkerColors && [MDCPalette nextDarkerColorInPaletteForColor:color]) {
     UIColor *nextDarkerColor = [MDCPalette nextDarkerColorInPaletteForColor:color];
@@ -35,10 +35,10 @@
                                 options:options]) {
       return nextDarkerColor;
     }
-    return [[self class] passingPaletteColorForColor:nextDarkerColor
-                                        onBackground:background
-                                             options:options
-                                  searchDarkerColors:YES];
+    return [[self class] nearestPassingPaletteColorForColor:nextDarkerColor
+                                               onBackground:background
+                                                    options:options
+                                         searchDarkerColors:YES];
   }
   if (!searchDarkerColors && [MDCPalette nextLighterColorInPaletteForColor:color]) {
     UIColor *nextLighterColor = [MDCPalette nextLighterColorInPaletteForColor:color];
@@ -47,17 +47,17 @@
                                 options:options]) {
       return nextLighterColor;
     }
-    return [[self class] passingPaletteColorForColor:nextLighterColor
-                                        onBackground:background
-                                             options:options
-                                  searchDarkerColors:NO];
+    return [[self class] nearestPassingPaletteColorForColor:nextLighterColor
+                                               onBackground:background
+                                                    options:options
+                                         searchDarkerColors:NO];
   }
   return nil;
 }
 
-+ (UIColor *)passingPaletteColorForColor:(UIColor *)color
-                            onBackground:(UIColor *)background
-                                 options:(MDFTextAccessibilityOptions) options {
++ (UIColor *)nearestPassingPaletteColorForColor:(UIColor *)color
+                                   onBackground:(UIColor *)background
+                                        options:(MDFTextAccessibilityOptions) options {
   CGFloat colorContrast = [MDFTextAccessibility contrastRatioForTextColor:color
                                                         onBackgroundColor:background];
   if ([MDCPalette nextDarkerColorInPaletteForColor:color]) {
@@ -66,10 +66,10 @@
         [MDFTextAccessibility contrastRatioForTextColor:nextDarkerColor
                                       onBackgroundColor:background];
     if (darkerContrast > colorContrast) {
-      return [[self class] passingPaletteColorForColor:color
-                                          onBackground:background
-                                               options:options
-                                    searchDarkerColors:YES];
+      return [[self class] nearestPassingPaletteColorForColor:color
+                                                 onBackground:background
+                                                      options:options
+                                           searchDarkerColors:YES];
     }
   }
   if ([MDCPalette nextLighterColorInPaletteForColor:color]) {
@@ -78,10 +78,10 @@
         [MDFTextAccessibility contrastRatioForTextColor:nextLighterColor
                                       onBackgroundColor:background];
     if (lighterContrast > colorContrast) {
-      return [[self class] passingPaletteColorForColor:color
-                                          onBackground:background
-                                               options:options
-                                    searchDarkerColors:NO];
+      return [[self class] nearestPassingPaletteColorForColor:color
+                                                 onBackground:background
+                                                      options:options
+                                           searchDarkerColors:NO];
     }
   }
   return nil;
@@ -107,9 +107,9 @@
                    passesOnBackgroundColor:backgroundColor
                                    options:options]) {
 
-        UIColor *color = [[self class] passingPaletteColorForColor:existingColor
-                                                      onBackground:backgroundColor
-                                                           options:options];
+        UIColor *color = [[self class] nearestPassingPaletteColorForColor:existingColor
+                                                             onBackground:backgroundColor
+                                                                  options:options];
         if (!color) {
           color = [MDFTextAccessibility textColorOnBackgroundColor:backgroundColor
                                                    targetTextAlpha:[MDCTypography buttonFontOpacity]

--- a/components/Buttons/tests/unit/ButtonTitleColorAccessibilityMutatorTests.m
+++ b/components/Buttons/tests/unit/ButtonTitleColorAccessibilityMutatorTests.m
@@ -18,6 +18,7 @@
 
 #import "MDCButtonTitleColorAccessibilityMutator.h"
 #import "MaterialButtons.h"
+#import "MaterialPalettes.h"
 
 // A value greater than the largest value created by combining normal values of UIControlState.
 // This is a complete hack, but UIControlState doesn't expose anything useful here.
@@ -108,6 +109,39 @@ static NSString *controlStateDescription(UIControlState controlState);
                                @"for control state:%@ ", controlStateDescription(controlState));
     }
   }
+}
+
+- (void)testPalettableColorMutatorWithPaletteColorSucceeding {
+  // Given
+  MDCPalette *bluePalette = MDCPalette.bluePalette;
+  UIColor *backgroundColor = bluePalette.tint50;
+  UIColor *originalTextColor = backgroundColor;
+  MDCButton *button = [[MDCButton alloc] init];
+  [button setTitleColor:originalTextColor forState:UIControlStateNormal];
+  [button setBackgroundColor:backgroundColor forState:UIControlStateNormal];
+
+  // When
+  [MDCButtonTitleColorAccessibilityMutator changeTitleColorOfButton:button];
+
+  // Then
+  XCTAssertEqual([button titleColorForState:UIControlStateNormal], bluePalette.tint800);
+}
+
+- (void)testPalettableColorMuatatorWithPaletteColorFailing {
+  // Given
+  MDCPalette *bluePalette = MDCPalette.bluePalette;
+  UIColor *backgroundColor = bluePalette.tint500;
+  UIColor *originalTextColor = backgroundColor;
+  MDCButton *button = [[MDCButton alloc] init];
+  [button setTitleColor:originalTextColor forState:UIControlStateNormal];
+  [button setBackgroundColor:backgroundColor forState:UIControlStateNormal];
+
+  // When
+  [MDCButtonTitleColorAccessibilityMutator changeTitleColorOfButton:button];
+
+  // Then
+  XCTAssertEqualObjects([button titleColorForState:UIControlStateNormal],
+                        [UIColor colorWithWhite:0 alpha:0.87f]);
 }
 
 @end

--- a/components/Palettes/BUILD
+++ b/components/Palettes/BUILD
@@ -22,6 +22,7 @@ licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "Palettes",
+    sdk_frameworks = ["CoreGraphics"],
 )
 
 swift_library(

--- a/components/Palettes/src/MDCPalettes.h
+++ b/components/Palettes/src/MDCPalettes.h
@@ -215,4 +215,24 @@ CG_EXTERN const MDCPaletteAccent _Nonnull MDCPaletteAccent700Name;
 /** The A700 accent color, the darkest accent color. */
 @property(nonatomic, nullable, readonly) UIColor *accent700;
 
+/**
+ Returns the next darker color within the Palette and section (tint or accent). If no darker color
+ exists or @c color is not a predefined palette color, then @c nil is returned.
+
+ @param color used as the base color to perform a palette search for the next darker color.
+
+ @returns the next darker color in the palette, if it exists.
+ */
++ (nullable UIColor *)nextDarkerColorInPaletteForColor:(nullable UIColor *)color;
+
+/**
+ Returns the next lighter color within the Palette and section (tint or accent). If no lighter color
+ exists or @c color is not a predefined palette color, then @c nil is returned.
+
+ @param color used as the base color to perform a palette search for the next lighter color.
+
+ @returns the next lighter color in the palette, if it exists.
+ */
++ (nullable UIColor *)nextLighterColorInPaletteForColor:(nullable UIColor *)color;
+
 @end


### PR DESCRIPTION
When a color is chosen from a Palette, it can be helpful to be able to
find darker/lighter colors within the same palette at runtime. For
example, an accessibility mutator can use a darker palette color before
using black.  Even when opacity is used (and adjusted), the resulting
color may not fall within a palette and therefore is less desirable than
one preselected by designers.

This change will introduce two new API methods to MDCPalette:
```objectivec
+ nextDarkerColorInPaletteForColor:(UIColor *)
+ nextLighterColorInPaletteForColor:(UIColor *)
```

Each of these methods will search the predefined palettes for the
provided color, identify that color's position in the palette (e.g.,
tint500 or accent200), and return the next "stepped" color in the
palette.  For example, the next darker color from tint800 is tint900,
and the next lighter color is tint700.  If a next color does not exist
(e.g., darker from tint900), then `nil` is returned.

MDCButtonTitleColorAccessibilityMutator was updated to demonstrate how
the new API can be used.

## Button mutator example
As a demonstration of the behavior, I tested two different buttons that have barely-visible colors set on them.  For each button, I captured the output of the original accessibility mutator and the new mutator.

| Baseline Image       | Original Mutator       | Mutator with "walkable" palette |
|-------------------|----------|-----------|
|<img width="101" alt="flat-tint50-on-grey-baseline" src="https://user-images.githubusercontent.com/1753199/37422621-faec4fee-2791-11e8-94c6-bc9031c9dcc1.png"> | <img width="112" alt="flat-tint50-on-grey-before" src="https://user-images.githubusercontent.com/1753199/37422626-fe737200-2791-11e8-9590-a6921e31dbdc.png"> | <img width="110" alt="flat-tint50-on-grey-after" src="https://user-images.githubusercontent.com/1753199/37422635-03d8c2c2-2792-11e8-8777-b2be61ce614e.png"> |
|<img width="105" alt="raised-tint900-on-black-baseline" src="https://user-images.githubusercontent.com/1753199/37422658-14bd5864-2792-11e8-8a1e-5c4c9b5e91e7.png">|<img width="117" alt="raised-tint900-on-black-before" src="https://user-images.githubusercontent.com/1753199/37422662-195994f0-2792-11e8-819e-f17403b45493.png">|<img width="118" alt="raised-tint900-on-black-after" src="https://user-images.githubusercontent.com/1753199/37422671-1c75d9dc-2792-11e8-8aad-606174455460.png">|








