### PR TITLE
[Typography | AnimationTiming] Update examples

### DIFF
--- a/components/AnimationTiming/examples/AnimationTimingExample.swift
+++ b/components/AnimationTiming/examples/AnimationTimingExample.swift
@@ -136,7 +136,7 @@ extension AnimationTimingExample {
       linearView.layer.cornerRadius = Constants.Sizes.circleSize.width / 2.0
       scrollView.addSubview(linearView)
 
-      let materialEaseInOutLabel: UILabel = curveLabel("MDCAnimationTimingFunctionEaseInOut")
+      let materialEaseInOutLabel: UILabel = curveLabel("MDCAnimationTimingFunctionStandard")
       materialEaseInOutLabel.frame = CGRect(x: Constants.Sizes.leftGutter, y: lineSpace, width: materialEaseInOutLabel.frame.size.width, height: materialEaseInOutLabel.frame.size.height)
       scrollView.addSubview(materialEaseInOutLabel)
 
@@ -146,7 +146,7 @@ extension AnimationTimingExample {
       materialStandardView.layer.cornerRadius = Constants.Sizes.circleSize.width / 2.0
       scrollView.addSubview(materialStandardView)
 
-      let materialEaseOutLabel: UILabel = curveLabel("MDCAnimationTimingFunctionEaseOut")
+      let materialEaseOutLabel: UILabel = curveLabel("MDCAnimationTimingFunctionDeceleration")
       materialEaseOutLabel.frame = CGRect(x: Constants.Sizes.leftGutter, y: lineSpace * 2.0, width: materialEaseOutLabel.frame.size.width, height: materialEaseOutLabel.frame.size.height)
       scrollView.addSubview(materialEaseOutLabel)
 
@@ -156,7 +156,7 @@ extension AnimationTimingExample {
       materialDecelerationView.layer.cornerRadius = Constants.Sizes.circleSize.width / 2.0
       scrollView.addSubview(materialDecelerationView)
 
-      let materialEaseInLabel: UILabel = curveLabel("MDCAnimationTimingFunctionEaseIn")
+      let materialEaseInLabel: UILabel = curveLabel("MDCAnimationTimingFunctionAcceleration")
       materialEaseInLabel.frame = CGRect(x: Constants.Sizes.leftGutter, y: lineSpace * 3.0, width: materialEaseInLabel.frame.size.width, height: materialEaseInLabel.frame.size.height)
       scrollView.addSubview(materialEaseInLabel)
 

--- a/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
+++ b/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
@@ -91,7 +91,7 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
   [self.scrollView addSubview:self.materialStandardView];
 
   UILabel *materialEaseOutLabel =
-      [AnimationTimingExample curveLabelWithTitle:@"MDCAnimationTimingFunctionEaseOut"];
+      [AnimationTimingExample curveLabelWithTitle:@"MDCAnimationTimingFunctionDeceleration"];
   materialEaseOutLabel.frame =
       CGRectMake(kLeftGutter, lineSpace * 2.f, materialEaseOutLabel.frame.size.width,
                  materialEaseOutLabel.frame.size.height);
@@ -106,7 +106,7 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
   [self.scrollView addSubview:self.materialDecelerationView];
 
   UILabel *materialEaseInLabel =
-      [AnimationTimingExample curveLabelWithTitle:@"MDCAnimationTimingFunctionEaseIn"];
+      [AnimationTimingExample curveLabelWithTitle:@"MDCAnimationTimingFunctionAcceleration"];
   materialEaseInLabel.frame =
       CGRectMake(kLeftGutter, lineSpace * 3.f, materialEaseInLabel.frame.size.width,
                  materialEaseInLabel.frame.size.height);

--- a/components/Typography/examples/TypographyCustomFontViewController.m
+++ b/components/Typography/examples/TypographyCustomFontViewController.m
@@ -151,7 +151,7 @@ static inline UIFont *customFont(MDCFontTextStyle style) {
 #pragma mark - CatalogByConvention
 
 + (NSArray *)catalogBreadcrumbs {
-   return @[ @"Typography Custom Fonts", @"Material Font Styles" ];
+   return @[ @"Typography and Fonts", @"Custom Font Example" ];
 }
 
 + (BOOL)catalogIsPrimaryDemo {


### PR DESCRIPTION
Update custom font example to be in the right cell instead of its own cell.

Update the AnimationTiming examples to showcase the right names.

This closes #2867 & #2868
