### PR TITLE
[Cards] API Review

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -196,6 +196,12 @@ Pod::Spec.new do |mdc|
     end
   end
 
+  mdc.subspec "Cards" do |component|
+    component.ios.deployment_target = '8.0'
+    component.public_header_files = "components/#{component.base_name}/src/*.h"
+    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+  end
+
   mdc.subspec "Chips" do |component|
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"

--- a/components/Cards/src/MDCCardView.h
+++ b/components/Cards/src/MDCCardView.h
@@ -1,0 +1,64 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import "MaterialInk.h"
+#import "MaterialShadowLayer.h"
+
+typedef NS_ENUM(NSInteger, MDCCardViewState) {
+  /** The normal state for the card. */
+  MDCCardViewStateNormal,
+
+  /** The visual state when the card is pressed (i.e. dragging). */
+  MDCCardViewStateHighlighted
+};
+
+@interface MDCCardView : UIView
+
+/**
+ The corner radius for the card
+ */
+@property(nonatomic, assign) CGFloat cornerRadius UI_APPEARANCE_SELECTOR;
+
+/**
+ Returns the current state of the card
+ */
+@property(nonatomic, readonly) MDCCardViewState state;
+
+/**
+ Sets the shadow elevation for an MDCCardViewState state
+
+ @param shadowElevation The shadow elevation
+ @param state MDCCardViewState the card view state
+
+ @note when setting the shadowElevation lower than 0
+ it will produce a hairline border around it with a 0 shadow.
+ This applies also when setting the resting and pressed shadow elevation properties.
+ */
+- (void)setShadowElevation:(CGFloat)shadowElevation forState:(MDCCardViewState)state
+  UI_APPEARANCE_SELECTOR;
+
+/**
+ Returns the shadow elevation for an MDCCardViewState state
+
+ If no elevation has been set for a state, the value for MDCCardViewStateNormal will be returned.
+
+ @param state MDCCardViewState the card view state
+ @return The shadow elevation for the requested state.
+ */
+- (CGFloat)shadowElevationForState:(MDCCardViewState)state;
+
+@end

--- a/components/Cards/src/MDCCardView.h
+++ b/components/Cards/src/MDCCardView.h
@@ -22,7 +22,7 @@ typedef NS_ENUM(NSInteger, MDCCardViewState) {
   /** The normal state for the card. */
   MDCCardViewStateNormal,
 
-  /** The visual state when the card is pressed (i.e. dragging). */
+  /** The state when the card is pressed (e.g. dragging). */
   MDCCardViewStateHighlighted
 };
 
@@ -43,10 +43,6 @@ typedef NS_ENUM(NSInteger, MDCCardViewState) {
 
  @param shadowElevation The shadow elevation
  @param state MDCCardViewState the card view state
-
- @note when setting the shadowElevation lower than 0
- it will produce a hairline border around it with a 0 shadow.
- This applies also when setting the resting and pressed shadow elevation properties.
  */
 - (void)setShadowElevation:(CGFloat)shadowElevation forState:(MDCCardViewState)state
   UI_APPEARANCE_SELECTOR;
@@ -60,5 +56,63 @@ typedef NS_ENUM(NSInteger, MDCCardViewState) {
  @return The shadow elevation for the requested state.
  */
 - (CGFloat)shadowElevationForState:(MDCCardViewState)state;
+
+/**
+ Sets the border width for an MDCCardViewState state
+
+ @param borderWidth The border width
+ @param state MDCCardViewState the card view state
+ */
+- (void)setBorderWidth:(CGFloat)borderWidth forState:(MDCCardViewState)state
+  UI_APPEARANCE_SELECTOR;
+
+/**
+ Returns the border width for an MDCCardViewState state
+
+ If no border width has been set for a state, the value for MDCCardViewStateNormal will be returned.
+
+ @param state MDCCardViewState the card view state
+ @return The border width for the requested state.
+ */
+- (CGFloat)borderWidthForState:(MDCCardViewState)state;
+
+/**
+ Sets the border color for an MDCCardViewState state
+
+ @param borderColor The border color
+ @param state MDCCardViewState the card view state
+ */
+- (void)setBorderColor:(UIColor *)borderColor forState:(MDCCardViewState)state
+  UI_APPEARANCE_SELECTOR;
+
+/**
+ Returns the border color for an MDCCardViewState state
+
+ If no border color has been set for a state, the value for MDCCardViewStateNormal will be returned.
+
+ @param state MDCCardViewState the card view state
+ @return The border color for the requested state.
+ */
+- (UIColor *)borderColorForState:(MDCCardViewState)state;
+
+/**
+ Sets the shadow color for an MDCCardViewState state
+
+ @param shadowColor The shadow color
+ @param state MDCCardViewState the card view state
+ */
+- (void)setShadowColor:(UIColor *)shadowColor forState:(MDCCardViewState)state
+UI_APPEARANCE_SELECTOR;
+
+/**
+ Returns the shadow color for an MDCCardViewState state
+
+ If no color has been set for a state, the value for MDCCardViewStateNormal will be returned.
+
+ @param state MDCCardViewState the card view state
+ @return The shadow color for the requested state.
+ */
+- (UIColor *)shadowColorForState:(MDCCardViewState)state;
+
 
 @end

--- a/components/Cards/src/MDCCardView.m
+++ b/components/Cards/src/MDCCardView.m
@@ -1,0 +1,153 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCCardView.h"
+#import "private/MDCCardView+Private.h"
+
+@implementation MDCCardView {
+  NSMutableDictionary<NSNumber *, NSNumber *> *_shadowElevations;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+  self = [super initWithCoder:coder];
+  if (self) {
+    [self commonMDCCardViewInit];
+  }
+  return self;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+  if (self) {
+    [self commonMDCCardViewInit];
+  }
+  return self;
+}
+
+- (void)commonMDCCardViewInit {
+  _inkView = [[MDCInkView alloc] initWithFrame:self.bounds];
+  _inkView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+  _inkView.usesLegacyInkRipple = NO;
+  _inkView.layer.zPosition = MAXFLOAT;
+  [self addSubview:self.inkView];
+
+  self.cornerRadius = 4.f;
+
+  _shadowElevations = [[NSMutableDictionary alloc] init];
+  _shadowElevations[@(MDCCardViewStateNormal)] = @(1.f);
+  _shadowElevations[@(MDCCardViewStateHighlighted)] = @(8.f);
+  _state = MDCCardViewStateNormal;
+  [self updateShadowElevation];
+}
+
+- (void)layoutSubviews {
+  [super layoutSubviews];
+  self.layer.shadowPath = [self boundingPath].CGPath;
+}
+
+- (void)setCornerRadius:(CGFloat)cornerRadius {
+  self.layer.cornerRadius = cornerRadius;
+  [self setNeedsLayout];
+}
+
+- (CGFloat)cornerRadius {
+  return self.layer.cornerRadius;
+}
+
++ (Class)layerClass {
+  return [MDCShadowLayer class];
+}
+
+- (void)setStyleForState:(MDCCardViewState)state
+         withLocation:(CGPoint)location {
+  _state = state;
+  switch (state) {
+    case MDCCardViewStateNormal: {
+      [self.inkView startTouchEndedAnimationAtPoint:location completion:nil];
+      break;
+    }
+    case MDCCardViewStateHighlighted: {
+      [self.inkView startTouchBeganAnimationAtPoint:location completion:nil];
+      break;
+    }
+    default:
+      break;
+  }
+  [self updateShadowElevation];
+}
+
+- (UIBezierPath *)boundingPath {
+  CGFloat cornerRadius = self.cornerRadius;
+  return [UIBezierPath bezierPathWithRoundedRect:self.bounds cornerRadius:cornerRadius];
+}
+
+- (CGFloat)shadowElevationForState:(MDCCardViewState)state {
+  NSNumber *elevation = _shadowElevations[@(state)];
+  if (elevation == nil) {
+    elevation = _shadowElevations[@(MDCCardViewStateNormal)];
+  }
+  if (elevation != nil) {
+    return (CGFloat)[elevation doubleValue];
+  }
+  return 0;
+}
+
+- (void)setShadowElevation:(CGFloat)shadowElevation forState:(MDCCardViewState)state {
+  _shadowElevations[@(state)] = @(shadowElevation);
+
+  [self updateShadowElevation];
+}
+
+- (void)updateShadowElevation {
+  CGFloat elevation = [self shadowElevationForState:self.state];
+  if (((MDCShadowLayer *)self.layer).elevation != elevation) {
+    if (elevation < 0) {
+      self.layer.borderWidth = 1.f;
+      self.layer.borderColor =
+        [UIColor colorWithRed:218/255.0 green:220/255.0 blue:224/255.0 alpha:1].CGColor;
+    } else {
+      self.layer.borderWidth = 0.f;
+    }
+    CGFloat elevationNormalized = elevation < 0 ? 0 : elevation;
+    self.layer.shadowPath = [self boundingPath].CGPath;
+    [(MDCShadowLayer *)self.layer setElevation:elevationNormalized];
+  }
+}
+
+#pragma mark - UIResponder
+
+- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
+  [super touchesBegan:touches withEvent:event];
+  UITouch *touch = [touches anyObject];
+  CGPoint location = [touch locationInView:self];
+  [self setStyleForState:MDCCardViewStateHighlighted withLocation:location];
+}
+
+- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
+  [super touchesEnded:touches withEvent:event];
+  UITouch *touch = [touches anyObject];
+  CGPoint location = [touch locationInView:self];
+  [self setStyleForState:MDCCardViewStateNormal withLocation:location];
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+  [super touchesCancelled:touches withEvent:event];
+  UITouch *touch = [touches anyObject];
+  CGPoint location = [touch locationInView:self];
+  [self setStyleForState:MDCCardViewStateNormal withLocation:location];
+}
+
+@end

--- a/components/Cards/src/MDCCardView.m
+++ b/components/Cards/src/MDCCardView.m
@@ -19,6 +19,9 @@
 
 @implementation MDCCardView {
   NSMutableDictionary<NSNumber *, NSNumber *> *_shadowElevations;
+  NSMutableDictionary<NSNumber *, UIColor *> *_shadowColors;
+  NSMutableDictionary<NSNumber *, NSNumber *> *_borderWidths;
+  NSMutableDictionary<NSNumber *, UIColor *> *_borderColors;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)coder {
@@ -114,17 +117,81 @@
 - (void)updateShadowElevation {
   CGFloat elevation = [self shadowElevationForState:self.state];
   if (((MDCShadowLayer *)self.layer).elevation != elevation) {
-    if (elevation < 0) {
-      self.layer.borderWidth = 1.f;
-      self.layer.borderColor =
-        [UIColor colorWithRed:218/255.0 green:220/255.0 blue:224/255.0 alpha:1].CGColor;
-    } else {
-      self.layer.borderWidth = 0.f;
-    }
-    CGFloat elevationNormalized = elevation < 0 ? 0 : elevation;
     self.layer.shadowPath = [self boundingPath].CGPath;
-    [(MDCShadowLayer *)self.layer setElevation:elevationNormalized];
+    [(MDCShadowLayer *)self.layer setElevation:elevation];
   }
+}
+
+- (void)setBorderWidth:(CGFloat)borderWidth forState:(MDCCardViewState)state {
+  _borderWidths[@(state)] = @(borderWidth);
+
+  [self updateBorderWidth];
+}
+
+- (void)updateBorderWidth {
+  CGFloat borderWidth = [self borderWidthForState:self.state];
+  if (self.layer.borderWidth != borderWidth) {
+    self.layer.borderWidth = borderWidth;
+  }
+}
+
+- (CGFloat)borderWidthForState:(MDCCardViewState)state {
+  NSNumber *borderWidth = _borderWidths[@(state)];
+  if (borderWidth == nil) {
+    borderWidth = _borderWidths[@(MDCCardViewStateNormal)];
+  }
+  if (borderWidth != nil) {
+    return (CGFloat)[borderWidth doubleValue];
+  }
+  return 0;
+}
+
+- (void)setBorderColor:(UIColor *)borderColor forState:(MDCCardViewState)state {
+  _borderColors[@(state)] = borderColor;
+
+  [self updateBorderColor];
+}
+
+- (void)updateBorderColor {
+  CGColorRef borderColorRef = [self borderColorForState:self.state].CGColor;
+  if (self.layer.borderColor != borderColorRef) {
+    self.layer.borderColor = borderColorRef;
+  }
+}
+
+- (UIColor *)borderColorForState:(MDCCardViewState)state {
+  UIColor *borderColor = _borderColors[@(state)];
+  if (borderColor == nil) {
+    borderColor = _borderColors[@(MDCCardViewStateNormal)];
+  }
+  if (borderColor != nil) {
+    return borderColor;
+  }
+  return [UIColor clearColor];
+}
+
+- (void)setShadowColor:(UIColor *)shadowColor forState:(MDCCardViewState)state {
+  _shadowColors[@(state)] = shadowColor;
+
+  [self updateShadowColor];
+}
+
+- (void)updateShadowColor {
+  CGColorRef shadowColor = [self shadowColorForState:MDCCardViewStateNormal].CGColor;
+  if (self.layer.shadowColor != shadowColor) {
+    self.layer.shadowColor = shadowColor;
+  }
+}
+
+- (UIColor *)shadowColorForState:(MDCCardViewState)state {
+  UIColor *shadowColor = _shadowColors[@(state)];
+  if (shadowColor == nil) {
+    shadowColor = _shadowColors[@(MDCCardViewStateNormal)];
+  }
+  if (shadowColor != nil) {
+    return shadowColor;
+  }
+  return [UIColor clearColor];
 }
 
 #pragma mark - UIResponder

--- a/components/Cards/src/MDCCardView.m
+++ b/components/Cards/src/MDCCardView.m
@@ -49,11 +49,27 @@
 
   self.cornerRadius = 4.f;
 
+  _state = MDCCardViewStateNormal;
+
   _shadowElevations = [[NSMutableDictionary alloc] init];
   _shadowElevations[@(MDCCardViewStateNormal)] = @(1.f);
   _shadowElevations[@(MDCCardViewStateHighlighted)] = @(8.f);
-  _state = MDCCardViewStateNormal;
   [self updateShadowElevation];
+
+  _shadowColors = [[NSMutableDictionary alloc] init];
+  _shadowColors[@(MDCCardViewStateNormal)] = [UIColor blackColor];
+  _shadowColors[@(MDCCardViewStateHighlighted)] = [UIColor blackColor];
+  [self updateShadowColor];
+
+  _borderColors = [[NSMutableDictionary alloc] init];
+  _borderColors[@(MDCCardViewStateNormal)] = [UIColor clearColor];
+  _borderColors[@(MDCCardViewStateHighlighted)] = [UIColor clearColor];
+  [self updateBorderColor];
+
+  _borderWidths = [[NSMutableDictionary alloc] init];
+  _borderWidths[@(MDCCardViewStateNormal)] = @(1.f);
+  _borderWidths[@(MDCCardViewStateHighlighted)] = @(0.f);
+  [self updateBorderWidth];
 }
 
 - (void)layoutSubviews {
@@ -130,9 +146,7 @@
 
 - (void)updateBorderWidth {
   CGFloat borderWidth = [self borderWidthForState:self.state];
-  if (self.layer.borderWidth != borderWidth) {
-    self.layer.borderWidth = borderWidth;
-  }
+  self.layer.borderWidth = borderWidth;
 }
 
 - (CGFloat)borderWidthForState:(MDCCardViewState)state {
@@ -154,9 +168,7 @@
 
 - (void)updateBorderColor {
   CGColorRef borderColorRef = [self borderColorForState:self.state].CGColor;
-  if (self.layer.borderColor != borderColorRef) {
-    self.layer.borderColor = borderColorRef;
-  }
+  self.layer.borderColor = borderColorRef;
 }
 
 - (UIColor *)borderColorForState:(MDCCardViewState)state {
@@ -177,10 +189,8 @@
 }
 
 - (void)updateShadowColor {
-  CGColorRef shadowColor = [self shadowColorForState:MDCCardViewStateNormal].CGColor;
-  if (self.layer.shadowColor != shadowColor) {
-    self.layer.shadowColor = shadowColor;
-  }
+  CGColorRef shadowColor = [self shadowColorForState:self.state].CGColor;
+  self.layer.shadowColor = shadowColor;
 }
 
 - (UIColor *)shadowColorForState:(MDCCardViewState)state {

--- a/components/Cards/src/MDCCollectionViewCardCell.h
+++ b/components/Cards/src/MDCCollectionViewCardCell.h
@@ -33,10 +33,11 @@ typedef NS_ENUM(NSInteger, MDCCardCellSelectionState) {
 @property(readonly, nonatomic, strong, nonnull) MDCCardView *cardView;
 
 /**
- selecting for the cell should be set to YES if the
- cell should react visually to when it is selected.
+ When selectionMode is set to YES, a tap on a cell will trigger a visual change between selected
+ and unselected. When it is set to NO, a tap will trigger a normal tap (rather than trigger
+ different visual selection states on the card)
  */
-@property(nonatomic, getter=isSelecting) BOOL selecting;
+@property(nonatomic, assign) BOOL selectionMode;
 
 /**
  The corner radius for the cell and the underlying card

--- a/components/Cards/src/MDCCollectionViewCardCell.h
+++ b/components/Cards/src/MDCCollectionViewCardCell.h
@@ -1,0 +1,61 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import "MDCCardView.h"
+
+typedef NS_ENUM(NSInteger, MDCCardCellSelectionState) {
+  /** The visual state when the cell is in its unselected state. */
+  MDCCardCellSelectionStateUnselected,
+
+  /** The visual state when the cell has been selected. */
+  MDCCardCellSelectionStateSelected
+};
+
+@interface MDCCollectionViewCardCell : UICollectionViewCell
+
+/**
+ The underlying card view for the cell
+ */
+@property(readonly, nonatomic, strong, nonnull) MDCCardView *cardView;
+
+/**
+ selecting for the cell should be set to YES if the
+ cell should react visually to when it is selected.
+ */
+@property(nonatomic, getter=isSelecting) BOOL selecting;
+
+/**
+ The corner radius for the cell and the underlying card
+ */
+@property(nonatomic, assign) CGFloat cornerRadius UI_APPEARANCE_SELECTOR;
+
+/**
+The image for the selected state (by default is a checked circle)
+ */
+@property(nonatomic, strong, nullable) UIImage *selectedImage;
+
+/**
+The tint color for the selected image.
+ */
+@property(nonatomic, strong, nullable) UIColor *selectedImageTintColor UI_APPEARANCE_SELECTOR;
+
+/**
+The selection state of the card cell
+ */
+@property(nonatomic, readonly) MDCCardCellSelectionState selectionState;
+
+@end

--- a/components/Cards/src/MDCCollectionViewCardCell.m
+++ b/components/Cards/src/MDCCollectionViewCardCell.m
@@ -1,0 +1,209 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCCollectionViewCardCell.h"
+
+#import "MaterialIcons+ic_check_circle.h"
+#import <MDFTextAccessibility/MDFTextAccessibility.h>
+#import "private/MDCCardView+Private.h"
+
+@interface MDCCollectionViewCardCell ()
+
+@property(nonatomic, strong, nullable) UIImageView *selectedImageView;
+@property(nonatomic, assign) CGPoint lastTouch;
+
+@end
+
+@implementation MDCCollectionViewCardCell {
+  BOOL _inkAnimating;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+  if (self) {
+    [self commonMDCCollectionViewCardCellInit];
+  }
+  return self;
+}
+
+- (void)commonMDCCollectionViewCardCellInit {
+  _cardView = [[MDCCardView alloc] initWithFrame:self.contentView.bounds];
+  _cardView.autoresizingMask =
+    UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  _cardView.userInteractionEnabled = NO;
+  self.contentView.autoresizingMask =
+    UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  [self.contentView addSubview:self.cardView];
+  _inkAnimating = NO;
+  self.selecting = NO;
+
+  [self initializeSelectedImage];
+
+  self.cornerRadius = 4.f;
+}
+
+- (void)initializeSelectedImage {
+  UIImage *circledCheck = [MDCIcons imageFor_ic_check_circle];
+  circledCheck = [circledCheck imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+  self.selectedImageView = [[UIImageView alloc] initWithImage:circledCheck];
+  self.selectedImageView.center = CGPointMake(
+                                    CGRectGetWidth(self.bounds) - (circledCheck.size.width/2) - 8,
+                                    (circledCheck.size.height/2) + 8);
+  self.selectedImageView.layer.zPosition = MAXFLOAT - 1;
+  self.selectedImageView.autoresizingMask =
+  (UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin |
+   UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleBottomMargin);
+  [self.contentView addSubview:self.selectedImageView];
+  self.selectedImageView.hidden = YES;
+}
+
+- (void)setBackgroundColor:(UIColor *)backgroundColor {
+  super.backgroundColor = backgroundColor;
+  self.cardView.backgroundColor = backgroundColor;
+
+  /**
+   currently the selected check image uses the color
+   based on MDFTextAccessibility to fit the background color.
+   */
+  UIColor *checkColor =
+  [MDFTextAccessibility textColorOnBackgroundColor:backgroundColor
+                                   targetTextAlpha:1.f
+                                           options:MDFTextAccessibilityOptionsNone];
+  self.selectedImageTintColor = checkColor;
+}
+
+- (UIColor *)backgroundColor {
+  return self.cardView.backgroundColor;
+}
+
+- (void)setCornerRadius:(CGFloat)cornerRadius {
+  self.layer.cornerRadius = cornerRadius;
+  self.cardView.cornerRadius = cornerRadius;
+  [self setNeedsLayout];
+}
+
+- (CGFloat)cornerRadius {
+  return self.cardView.cornerRadius;
+}
+
+- (void)selectionState:(MDCCardCellSelectionState)state withAnimation:(BOOL)animation {
+  _selectionState = state;
+  self.selecting = YES;
+  switch (state) {
+    case MDCCardCellSelectionStateSelected: {
+      if (animation) {
+        _inkAnimating = YES;
+        [self.cardView.inkView startTouchBeganAnimationAtPoint:self.lastTouch completion:nil];
+      } else {
+        if (!_inkAnimating) {
+          [self.cardView.inkView cancelAllAnimationsAnimated:NO];
+          [self.cardView.inkView addInkSublayerWithoutAnimation];
+        }
+        _inkAnimating = NO;
+        self.selectedImageView.hidden = NO;
+      }
+      [(MDCShadowLayer *)self.cardView.layer setElevation:
+       [self.cardView shadowElevationForState:MDCCardViewStateNormal]];
+
+      break;
+    }
+    case MDCCardCellSelectionStateUnselected: {
+      if (animation) {
+        [self.cardView.inkView startTouchEndedAnimationAtPoint:self.lastTouch completion:nil];
+      } else {
+        [self.cardView.inkView cancelAllAnimationsAnimated:NO];
+      }
+      [(MDCShadowLayer *)self.cardView.layer setElevation:
+       [self.cardView shadowElevationForState:MDCCardViewStateNormal]];
+      self.selectedImageView.hidden = YES;
+      break;
+    }
+  }
+}
+
+- (void)setSelectedImage:(UIImage *)selectedImage {
+  [self.selectedImageView setImage:selectedImage];
+}
+
+- (UIImage *)selectedImage {
+  return self.selectedImageView.image;
+}
+
+- (void)setSelectedImageTintColor:(UIColor *)selectedImageTintColor {
+  [self.selectedImageView setTintColor:selectedImageTintColor];
+}
+
+- (UIColor *)selectedImageTintColor {
+  return self.selectedImageView.tintColor;
+}
+
+- (void)setSelected:(BOOL)selected {
+  [super setSelected:selected];
+  if (self.selecting) {
+    if (selected) {
+      [self selectionState:MDCCardCellSelectionStateSelected withAnimation:NO];
+    } else {
+      [self selectionState:MDCCardCellSelectionStateUnselected withAnimation:NO];
+    }
+  }
+}
+
+#pragma mark - UIResponder
+
+- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
+  [super touchesBegan:touches withEvent:event];
+
+  UITouch *touch = [touches anyObject];
+  CGPoint location = [touch locationInView:self];
+  self.lastTouch = location;
+  if (self.selecting) {
+    if (!self.selected) {
+      [self selectionState:MDCCardCellSelectionStateSelected withAnimation:YES];
+    }
+  } else {
+    [_cardView setStyleForState:MDCCardViewStateHighlighted withLocation:location];
+  }
+}
+
+- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
+  [super touchesEnded:touches withEvent:event];
+
+  UITouch *touch = [touches anyObject];
+  CGPoint location = [touch locationInView:self];
+  if (self.selecting) {
+    if (!self.selected) {
+      [self selectionState:MDCCardCellSelectionStateUnselected withAnimation:YES];
+    }
+  } else {
+    [_cardView setStyleForState:MDCCardViewStateNormal withLocation:location];
+  }
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+  [super touchesCancelled:touches withEvent:event];
+
+  UITouch *touch = [touches anyObject];
+  CGPoint location = [touch locationInView:self];
+  if (self.selecting) {
+    if (!self.selected) {
+      [self selectionState:MDCCardCellSelectionStateUnselected withAnimation:YES];
+    }
+  } else {
+    [_cardView setStyleForState:MDCCardViewStateNormal withLocation:location];
+  }
+}
+
+@end

--- a/components/Cards/src/MDCCollectionViewCardCell.m
+++ b/components/Cards/src/MDCCollectionViewCardCell.m
@@ -48,7 +48,7 @@
     UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   [self.contentView addSubview:self.cardView];
   _inkAnimating = NO;
-  self.selecting = NO;
+  self.selectionMode = NO;
 
   [self initializeSelectedImage];
 
@@ -101,7 +101,7 @@
 
 - (void)selectionState:(MDCCardCellSelectionState)state withAnimation:(BOOL)animation {
   _selectionState = state;
-  self.selecting = YES;
+  self.selectionMode = YES;
   switch (state) {
     case MDCCardCellSelectionStateSelected: {
       if (animation) {
@@ -152,7 +152,7 @@
 
 - (void)setSelected:(BOOL)selected {
   [super setSelected:selected];
-  if (self.selecting) {
+  if (self.selectionMode) {
     if (selected) {
       [self selectionState:MDCCardCellSelectionStateSelected withAnimation:NO];
     } else {
@@ -169,7 +169,7 @@
   UITouch *touch = [touches anyObject];
   CGPoint location = [touch locationInView:self];
   self.lastTouch = location;
-  if (self.selecting) {
+  if (self.selectionMode) {
     if (!self.selected) {
       [self selectionState:MDCCardCellSelectionStateSelected withAnimation:YES];
     }
@@ -183,7 +183,7 @@
 
   UITouch *touch = [touches anyObject];
   CGPoint location = [touch locationInView:self];
-  if (self.selecting) {
+  if (self.selectionMode) {
     if (!self.selected) {
       [self selectionState:MDCCardCellSelectionStateUnselected withAnimation:YES];
     }
@@ -197,7 +197,7 @@
 
   UITouch *touch = [touches anyObject];
   CGPoint location = [touch locationInView:self];
-  if (self.selecting) {
+  if (self.selectionMode) {
     if (!self.selected) {
       [self selectionState:MDCCardCellSelectionStateUnselected withAnimation:YES];
     }

--- a/components/Cards/src/MaterialCards.h
+++ b/components/Cards/src/MaterialCards.h
@@ -1,0 +1,19 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCCardView.h"
+#import "MDCCollectionViewCardCell.h"
+

--- a/components/Cards/src/UICollectionViewController+MDCCardReordering.h
+++ b/components/Cards/src/UICollectionViewController+MDCCardReordering.h
@@ -1,0 +1,28 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface UICollectionViewController (MDCCardReordering) <UIGestureRecognizerDelegate>
+
+/**
+ This method should be called when using a UICollectionViewController and want to have
+ the reorder/drag&drop visuals. It will make sure that the underlying longPressGestureRecognizer
+ doesn't cancel the ink tap visual causing the ink to disappear once the reorder begins.
+ */
+- (void)mdc_setupCardReordering;
+
+@end

--- a/components/Cards/src/UICollectionViewController+MDCCardReordering.m
+++ b/components/Cards/src/UICollectionViewController+MDCCardReordering.m
@@ -1,0 +1,45 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "UICollectionViewController+MDCCardReordering.h"
+
+#import "MaterialInk.h"
+#import "MDCCollectionViewCardCell.h"
+
+@implementation UICollectionViewController (MDCCardReordering)
+
+
+- (void)mdc_setupCardReordering {
+  UILongPressGestureRecognizer *longGestureRecognizer = [[UILongPressGestureRecognizer alloc]
+                                                         initWithTarget:self
+                                                         action:nil];
+
+  longGestureRecognizer.delegate = self;
+  longGestureRecognizer.cancelsTouchesInView = NO;
+  [self.collectionView addGestureRecognizer:longGestureRecognizer];
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+       shouldReceiveTouch:(UITouch *)touch {
+  for (UIGestureRecognizer *gesture in self.collectionView.gestureRecognizers) {
+    if ([gesture isKindOfClass:[UILongPressGestureRecognizer class]]) {
+      gesture.cancelsTouchesInView = NO;
+    }
+  }
+  return YES;
+}
+
+@end

--- a/components/Cards/src/private/MDCCardView+Private.h
+++ b/components/Cards/src/private/MDCCardView+Private.h
@@ -1,0 +1,39 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCCardView.h"
+
+@interface MDCCardView ()
+
+/**
+ The inkView for the card that is initiated on tap
+ */
+@property(nonatomic, readonly, strong, nonnull) MDCInkView *inkView;
+
+@end
+
+@interface MDCCardView (Private)
+
+/**
+ Sets the style for the MDCCardView based on the defined state. Please see the MDCCardViewState
+ definition above to see all the possible states.
+
+ @param state MDCCardViewState this defines the state in which the card should visually be set to
+ @param location CGPoint some states may need the touch location to begin/end the ink from
+ */
+- (void)setStyleForState:(MDCCardViewState)state withLocation:(CGPoint)location;
+
+@end

--- a/components/Cards/src/private/MDCCardView+Private.h
+++ b/components/Cards/src/private/MDCCardView+Private.h
@@ -29,7 +29,7 @@
 
 /**
  Sets the style for the MDCCardView based on the defined state. Please see the MDCCardViewState
- definition above to see all the possible states.
+ definition to see all the possible states.
 
  @param state MDCCardViewState this defines the state in which the card should visually be set to
  @param location CGPoint some states may need the touch location to begin/end the ink from

--- a/components/Ink/src/MDCInkView.h
+++ b/components/Ink/src/MDCInkView.h
@@ -126,6 +126,11 @@ typedef NS_ENUM(NSInteger, MDCInkStyle) {
 - (void)cancelAllAnimationsAnimated:(BOOL)animated;
 
 /**
+ Add an Ink sublayer without any animation
+ */
+- (void)addInkSublayerWithoutAnimation;
+
+/**
  Enumerates the given view's subviews for an instance of MDCInkView and returns it if found, or
  creates and adds a new instance of MDCInkView if not.
 

--- a/components/Ink/src/MDCInkView.m
+++ b/components/Ink/src/MDCInkView.m
@@ -225,16 +225,34 @@ static NSString *const MDCInkViewMaxRippleRadiusKey = @"MDCInkViewMaxRippleRadiu
     [self.inkLayer spreadFromPoint:point completion:completionBlock];
   } else {
     self.startInkRippleCompletionBlock = completionBlock;
-    MDCInkLayer *inkLayer = [MDCInkLayer layer];
-    inkLayer.inkColor = self.inkColor;
+    MDCInkLayer *inkLayer = [self commonInkSublayerInit];
     inkLayer.maxRippleRadius = self.maxRippleRadius;
     inkLayer.animationDelegate = self;
     inkLayer.opacity = 0;
-    inkLayer.frame = self.bounds;
-    [self.layer addSublayer:inkLayer];
-    [inkLayer startAnimationAtPoint:point];
     self.activeInkLayer = inkLayer;
+    [inkLayer startAnimationAtPoint:point];
   }
+}
+
+- (void)addInkSublayerWithoutAnimation {
+  MDCInkLayer *inkLayer = [MDCInkLayer layer];
+  inkLayer.inkColor = self.inkColor;
+  inkLayer.frame = self.bounds;
+  inkLayer.opacity = 1;
+  CGRect rect = self.bounds;
+  UIBezierPath *rectPath = [UIBezierPath bezierPathWithRect:rect];
+  inkLayer.path = rectPath.CGPath;
+  inkLayer.fillColor = self.inkColor.CGColor;
+  [self.layer addSublayer:inkLayer];
+  self.activeInkLayer = inkLayer;
+}
+
+- (MDCInkLayer *)commonInkSublayerInit {
+  MDCInkLayer *inkLayer = [MDCInkLayer layer];
+  inkLayer.inkColor = self.inkColor;
+  inkLayer.frame = self.bounds;
+  [self.layer addSublayer:inkLayer];
+  return inkLayer;
 }
 
 - (void)startTouchEndedAnimationAtPoint:(CGPoint)point


### PR DESCRIPTION
implementation of Cards. The cards have rounded corners, shadow, and ink.
The cards also facilitate the drag and drop (reorder) and selection (editing) actions.

Cards can be used alone as MDCCard, or inside a native UICollectionView using the MDCCollectionViewCardCell.

Card drag and drop using a UICollectionViewController specifically, needs the addition of UICollectionViewController+MDCCardReordering.h in order to work out of the box.

InkView needed another method to allow to have the ink already show without animation.
InkView for the new ink didn't call the completion handler when starting the animation, this was fixed in this PR as well. #2839

For context on the added image, it's taken from here: https://unsplash.com/photos/wMzx2nBdeng
License details: https://unsplash.com/license