### PR TITLE
[Cards] Cards podspec update, examples, and tests.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -196,6 +196,12 @@ Pod::Spec.new do |mdc|
     end
   end
 
+  mdc.subspec "Cards" do |component|
+    component.ios.deployment_target = '8.0'
+    component.public_header_files = "components/#{component.base_name}/src/*.h"
+    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+  end
+
   mdc.subspec "Chips" do |component|
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"

--- a/components/Cards/examples/CardExampleViewController.swift
+++ b/components/Cards/examples/CardExampleViewController.swift
@@ -1,0 +1,70 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import UIKit
+
+class CardExampleViewController: UIViewController {
+  @IBOutlet var contentView: UIView!
+  @IBOutlet weak var imageView: UIImageView!
+  @IBOutlet weak var cardView: MDCCardView!
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    let bundle = Bundle(for: CardExampleViewController.self)
+    bundle.loadNibNamed("CardExampleViewController", owner: self, options: nil)
+    contentView.frame = self.view.bounds
+    self.view.addSubview(contentView)
+
+    let bezierPath = UIBezierPath(roundedRect: imageView.bounds,
+                                  byRoundingCorners: [.topLeft, .topRight],
+                                  cornerRadii: CGSize(width: cardView.cornerRadius,
+                                                      height: cardView.cornerRadius))
+    let shapeLayer = CAShapeLayer()
+    shapeLayer.frame = imageView.bounds
+    shapeLayer.path = bezierPath.cgPath
+    imageView.layer.mask = shapeLayer
+
+  }
+
+  override func didReceiveMemoryWarning() {
+      super.didReceiveMemoryWarning()
+      // Dispose of any resources that can be recreated.
+  }
+
+  override public var traitCollection: UITraitCollection {
+    if UIDevice.current.userInterfaceIdiom == .pad && UIDevice.current.orientation.isPortrait {
+      return UITraitCollection(traitsFrom:[UITraitCollection(horizontalSizeClass: .compact),
+                                           UITraitCollection(verticalSizeClass: .regular)])
+    }
+    return super.traitCollection
+  }
+
+}
+
+extension CardExampleViewController {
+  @objc class func catalogBreadcrumbs() -> [String] {
+    return ["Cards", "Card (Swift)"]
+  }
+
+  @objc class func catalogIsPresentable() -> Bool {
+    return true
+  }
+
+  @objc class func catalogIsDebug() -> Bool {
+    return false
+  }
+}

--- a/components/Cards/examples/CardsCollectionExample.h
+++ b/components/Cards/examples/CardsCollectionExample.h
@@ -1,0 +1,22 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import "MaterialCards.h"
+
+@interface CardsCollectionExample : UICollectionViewController
+
+@end

--- a/components/Cards/examples/CardsCollectionExample.m
+++ b/components/Cards/examples/CardsCollectionExample.m
@@ -1,0 +1,144 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "CardsCollectionExample.h"
+#import "MaterialInk.h"
+#import "UICollectionViewController+MDCCardReordering.h"
+
+@interface CardsCollectionExample ()
+
+@end
+
+@implementation CardsCollectionExample
+
+static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
+@synthesize collectionViewLayout = _collectionViewLayout;
+
+- (instancetype)init {
+  UICollectionViewFlowLayout *defaultLayout = [[UICollectionViewFlowLayout alloc] init];
+  defaultLayout.minimumInteritemSpacing = 0;
+  defaultLayout.minimumLineSpacing = 1;
+  defaultLayout.scrollDirection = UICollectionViewScrollDirectionVertical;
+  return [self initWithCollectionViewLayout:defaultLayout];
+}
+
+- (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout {
+  self = [super initWithCollectionViewLayout:layout];
+  if (self) {
+    _collectionViewLayout = layout;
+  }
+  return self;
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  [self.collectionView setCollectionViewLayout:self.collectionViewLayout];
+  self.collectionView.backgroundColor = [UIColor colorWithWhite:(CGFloat)0.9 alpha:1];
+  self.collectionView.alwaysBounceVertical = YES;
+  // Register cell classes
+  [self.collectionView registerClass:[MDCCollectionViewCardCell class]
+          forCellWithReuseIdentifier:kReusableIdentifierItem];
+
+  [self mdc_setupCardReordering];
+}
+
+#pragma mark <UICollectionViewDataSource>
+
+- (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView {
+  return 1;
+}
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView
+     numberOfItemsInSection:(NSInteger)section {
+  return 20;
+}
+
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
+                  cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+  MDCCollectionViewCardCell *cell =
+  [collectionView dequeueReusableCellWithReuseIdentifier:kReusableIdentifierItem
+                                            forIndexPath:indexPath];
+  [cell setBackgroundColor:[UIColor colorWithRed:107/255.f green:63/255.f blue:238/255.f alpha:1]];
+  return cell;
+}
+
+#pragma mark - <UICollectionViewDelegateFlowLayout>
+
+- (CGSize)collectionView:(UICollectionView *)collectionView
+                  layout:(UICollectionViewLayout *)collectionViewLayout
+  sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
+  CGFloat cardSize = (self.view.bounds.size.width / 3) - 12;
+  return CGSizeMake(cardSize, cardSize);
+}
+
+- (UIEdgeInsets)collectionView:(UICollectionView *)collectionView
+                        layout:(UICollectionViewLayout *)collectionViewLayout
+        insetForSectionAtIndex:(NSInteger)section {
+  return UIEdgeInsetsMake(8, 8, 8, 8);
+}
+
+- (CGFloat)collectionView:(UICollectionView *)collectionView
+                   layout:(UICollectionViewLayout*)collectionViewLayout
+minimumLineSpacingForSectionAtIndex:(NSInteger)section {
+  return 8.f;
+}
+
+- (CGFloat)collectionView:(UICollectionView *)collectionView
+                   layout:(UICollectionViewLayout*)collectionViewLayout
+minimumInteritemSpacingForSectionAtIndex:(NSInteger)section {
+  return 8.f;
+}
+
+#pragma mark - Reordering
+
+- (void)collectionView:(UICollectionView *)collectionView
+   moveItemAtIndexPath:(NSIndexPath *)sourceIndexPath
+           toIndexPath:(NSIndexPath *)destinationIndexPath {
+}
+
+- (BOOL)collectionView:(UICollectionView *)collectionView
+canMoveItemAtIndexPath:(NSIndexPath *)indexPath {
+  return YES;
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Cards", @"Collection Card Cells" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return YES;
+}
+
++ (NSString *)catalogDescription {
+  return @"Material Cards.";
+}
+
++ (BOOL)catalogIsPresentable {
+  return YES;
+}
+
++ (BOOL)catalogIsDebug {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return YES;
+}
+
+@end

--- a/components/Cards/examples/EditReorderCollectionViewController.swift
+++ b/components/Cards/examples/EditReorderCollectionViewController.swift
@@ -1,0 +1,198 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import UIKit
+
+enum ToggleMode: Int {
+  case edit = 1, reorder
+}
+
+class EditReorderCollectionViewController: UIViewController,
+  UICollectionViewDelegate,
+  UICollectionViewDataSource,
+  UICollectionViewDelegateFlowLayout {
+
+  let collectionView = UICollectionView(frame: .zero,
+                                        collectionViewLayout: UICollectionViewFlowLayout())
+  var dataSource = [(Int, Bool)]()
+  var longPressGesture: UILongPressGestureRecognizer!
+  var toggle = ToggleMode.reorder
+  var toggleButton: UIButton!
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    collectionView.frame = view.bounds
+    collectionView.dataSource = self
+    collectionView.delegate = self
+    collectionView.backgroundColor = UIColor(white: 0.9, alpha: 1)
+    collectionView.alwaysBounceVertical = true;
+    collectionView.register(MDCCollectionViewCardCell.self, forCellWithReuseIdentifier: "Cell")
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.allowsMultipleSelection = true
+    view.addSubview(collectionView)
+
+    navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Reorder",
+                                                        style: .plain,
+                                                        target: self,
+                                                        action: #selector(toggleModes))
+
+    if #available(iOS 9.0, *) {
+      longPressGesture = UILongPressGestureRecognizer(target: self,
+                                                      action: #selector(handleReordering(gesture:)))
+      longPressGesture.cancelsTouchesInView = false
+      collectionView.addGestureRecognizer(longPressGesture)
+    }
+
+    for i in 0..<20 {
+      dataSource.append((i, false))
+    }
+
+    #if swift(>=3.2)
+      if #available(iOS 11, *) {
+        let guide = view.safeAreaLayoutGuide
+        NSLayoutConstraint.activate([
+          collectionView.leftAnchor.constraint(equalTo: guide.leftAnchor),
+          collectionView.rightAnchor.constraint(equalTo: guide.rightAnchor),
+          collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+          collectionView.bottomAnchor.constraint(equalTo: guide.bottomAnchor)])
+        collectionView.contentInsetAdjustmentBehavior = .always
+      } else {
+        preiOS11Constraints()
+      }
+    #else
+      preiOS11Constraints()
+    #endif
+
+  }
+
+  func preiOS11Constraints() {
+    collectionView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[view]|",
+                                                                 options: [],
+                                                                 metrics: nil,
+                                                                 views: ["view": collectionView]));
+    collectionView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[view]|",
+                                                                 options: [],
+                                                                 metrics: nil,
+                                                                 views: ["view": collectionView]));
+  }
+
+  func toggleModes() {
+    if toggle == .edit {
+      toggle = .reorder
+      navigationItem.rightBarButtonItem?.title = "Reorder"
+    } else if toggle == .reorder {
+      toggle = .edit
+      navigationItem.rightBarButtonItem?.title = "Edit"
+    }
+    collectionView.reloadData()
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell",
+                                                  for: indexPath) as! MDCCollectionViewCardCell
+    cell.backgroundColor = .white
+    cell.selectedImageTintColor = .blue
+    cell.isSelecting = (toggle == .edit)
+    return cell
+  }
+
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    if toggle == .edit {
+      dataSource[indexPath.item].1 = !dataSource[indexPath.item].1
+    }
+  }
+
+  func numberOfSections(in collectionView: UICollectionView) -> Int {
+    return 1
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      numberOfItemsInSection section: Int) -> Int {
+    return dataSource.count
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      moveItemAt sourceIndexPath: IndexPath,
+                      to destinationIndexPath: IndexPath) {
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      layout collectionViewLayout: UICollectionViewLayout,
+                      sizeForItemAt indexPath: IndexPath) -> CGSize {
+    let cardSize = (collectionView.bounds.size.width / 3) - 12
+    return CGSize(width: cardSize, height: cardSize)
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      layout collectionViewLayout: UICollectionViewLayout,
+                      insetForSectionAt section: Int) -> UIEdgeInsets {
+    return UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      layout collectionViewLayout: UICollectionViewLayout,
+                      minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+    return 8
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      layout collectionViewLayout: UICollectionViewLayout,
+                      minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+    return 8
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      canMoveItemAt indexPath: IndexPath) -> Bool {
+    return toggle == .reorder
+  }
+
+  @available(iOS 9.0, *)
+  @objc func handleReordering(gesture: UILongPressGestureRecognizer) {
+    if toggle == .reorder {
+      switch(gesture.state) {
+      case .began:
+        guard let selectedIndexPath = collectionView.indexPathForItem(at:
+          gesture.location(in: collectionView)) else {
+          break
+        }
+        collectionView.beginInteractiveMovementForItem(at: selectedIndexPath)
+      case .changed:
+        collectionView.updateInteractiveMovementTargetPosition(gesture.location(in: gesture.view!))
+      case .ended:
+        collectionView.endInteractiveMovement()
+      default:
+        collectionView.cancelInteractiveMovement()
+      }
+    }
+  }
+
+}
+
+extension EditReorderCollectionViewController {
+  @objc class func catalogBreadcrumbs() -> [String] {
+    return ["Cards", "Edit/Reorder (Swift)"]
+  }
+
+  @objc class func catalogIsPresentable() -> Bool {
+    return true
+  }
+
+  @objc class func catalogIsDebug() -> Bool {
+    return false
+  }
+}

--- a/components/Cards/examples/resources/CardExampleViewController.xib
+++ b/components/Cards/examples/resources/CardExampleViewController.xib
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CardExampleViewController" customModule="MaterialComponentsExamples" customModuleProvider="target">
+            <connections>
+                <outlet property="cardView" destination="BAQ-GJ-1pn" id="2P6-6Y-Hjh"/>
+                <outlet property="contentView" destination="i5M-Pr-FkT" id="Hkq-gw-WEg"/>
+                <outlet property="imageView" destination="ldt-3r-Agk" id="rFC-QD-GJJ"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BAQ-GJ-1pn" customClass="MDCCardView">
+                    <rect key="frame" x="30" y="94" width="315" height="479"/>
+                    <subviews>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sample-image" translatesAutoresizingMaskIntoConstraints="NO" id="ldt-3r-Agk">
+                            <rect key="frame" x="0.0" y="0.0" width="315" height="315"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="ldt-3r-Agk" secondAttribute="height" multiplier="15:15" id="OUj-9G-eou"/>
+                            </constraints>
+                        </imageView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mpO-dS-0yd">
+                            <rect key="frame" x="8" y="325" width="299" height="20.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" verticalCompressionResistancePriority="749" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tmz-Bt-Hco">
+                            <rect key="frame" x="8" y="353.5" width="299" height="79.5"/>
+                            <string key="text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</string>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NWQ-Eq-COf" customClass="MDCFlatButton">
+                            <rect key="frame" x="110.5" y="441" width="94" height="30"/>
+                            <state key="normal" title="Action Button"/>
+                        </button>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstItem="ldt-3r-Agk" firstAttribute="trailing" secondItem="mpO-dS-0yd" secondAttribute="leading" constant="-8" id="0CE-xb-4pW"/>
+                        <constraint firstAttribute="bottom" secondItem="NWQ-Eq-COf" secondAttribute="bottom" constant="8" id="3Iu-7x-lp7"/>
+                        <constraint firstAttribute="bottom" secondItem="ldt-3r-Agk" secondAttribute="bottom" id="6nf-mh-lPb"/>
+                        <constraint firstItem="mpO-dS-0yd" firstAttribute="top" secondItem="BAQ-GJ-1pn" secondAttribute="top" constant="8" id="DhK-tR-doL"/>
+                        <constraint firstAttribute="trailing" secondItem="mpO-dS-0yd" secondAttribute="trailing" constant="8" id="MFB-Nj-dQU"/>
+                        <constraint firstItem="mpO-dS-0yd" firstAttribute="leading" secondItem="BAQ-GJ-1pn" secondAttribute="leading" constant="8" id="WJn-vb-ReP"/>
+                        <constraint firstItem="mpO-dS-0yd" firstAttribute="top" secondItem="ldt-3r-Agk" secondAttribute="bottom" constant="10" id="Y9S-sz-I8f"/>
+                        <constraint firstItem="NWQ-Eq-COf" firstAttribute="centerX" secondItem="BAQ-GJ-1pn" secondAttribute="centerX" id="YBt-vK-89V"/>
+                        <constraint firstItem="Tmz-Bt-Hco" firstAttribute="top" secondItem="mpO-dS-0yd" secondAttribute="bottom" constant="8" id="bRb-kf-lM3"/>
+                        <constraint firstItem="ldt-3r-Agk" firstAttribute="trailing" secondItem="Tmz-Bt-Hco" secondAttribute="leading" constant="-8" id="bjC-5v-fyc"/>
+                        <constraint firstAttribute="trailing" secondItem="ldt-3r-Agk" secondAttribute="trailing" id="bzX-OZ-rhy"/>
+                        <constraint firstItem="NWQ-Eq-COf" firstAttribute="top" secondItem="Tmz-Bt-Hco" secondAttribute="bottom" constant="8" id="g25-kf-cSZ"/>
+                        <constraint firstItem="ldt-3r-Agk" firstAttribute="top" secondItem="BAQ-GJ-1pn" secondAttribute="top" id="gOK-UO-3cP"/>
+                        <constraint firstItem="Tmz-Bt-Hco" firstAttribute="leading" secondItem="BAQ-GJ-1pn" secondAttribute="leading" constant="8" id="hBu-ah-26L"/>
+                        <constraint firstItem="ldt-3r-Agk" firstAttribute="leading" secondItem="BAQ-GJ-1pn" secondAttribute="leading" id="laW-HO-JiJ"/>
+                        <constraint firstAttribute="trailing" secondItem="Tmz-Bt-Hco" secondAttribute="trailing" constant="8" id="qQK-f0-FLE"/>
+                    </constraints>
+                    <variation key="default">
+                        <mask key="constraints">
+                            <exclude reference="0CE-xb-4pW"/>
+                            <exclude reference="6nf-mh-lPb"/>
+                            <exclude reference="bjC-5v-fyc"/>
+                            <exclude reference="bzX-OZ-rhy"/>
+                            <exclude reference="DhK-tR-doL"/>
+                            <exclude reference="WJn-vb-ReP"/>
+                            <exclude reference="Y9S-sz-I8f"/>
+                            <exclude reference="hBu-ah-26L"/>
+                        </mask>
+                    </variation>
+                    <variation key="heightClass=compact">
+                        <mask key="constraints">
+                            <include reference="0CE-xb-4pW"/>
+                            <include reference="6nf-mh-lPb"/>
+                            <include reference="bjC-5v-fyc"/>
+                            <include reference="DhK-tR-doL"/>
+                        </mask>
+                    </variation>
+                    <variation key="heightClass=regular">
+                        <mask key="constraints">
+                            <exclude reference="bzX-OZ-rhy"/>
+                            <exclude reference="WJn-vb-ReP"/>
+                            <exclude reference="Y9S-sz-I8f"/>
+                            <exclude reference="hBu-ah-26L"/>
+                        </mask>
+                    </variation>
+                    <variation key="heightClass=regular-widthClass=compact">
+                        <mask key="constraints">
+                            <include reference="bzX-OZ-rhy"/>
+                            <include reference="WJn-vb-ReP"/>
+                            <include reference="Y9S-sz-I8f"/>
+                            <include reference="hBu-ah-26L"/>
+                        </mask>
+                    </variation>
+                    <variation key="heightClass=regular-widthClass=regular">
+                        <mask key="constraints">
+                            <include reference="0CE-xb-4pW"/>
+                            <include reference="6nf-mh-lPb"/>
+                            <include reference="bjC-5v-fyc"/>
+                            <include reference="DhK-tR-doL"/>
+                        </mask>
+                    </variation>
+                </view>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="BAQ-GJ-1pn" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" id="57T-Xi-SQb"/>
+                <constraint firstItem="BAQ-GJ-1pn" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="Yc8-Tp-Oxg"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="BAQ-GJ-1pn" secondAttribute="trailing" constant="30" id="bdn-MZ-eeg"/>
+                <constraint firstItem="BAQ-GJ-1pn" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="30" id="qTV-9a-RUO"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="BAQ-GJ-1pn" secondAttribute="bottom" constant="30" id="rBD-rT-QRT"/>
+                <constraint firstItem="BAQ-GJ-1pn" firstAttribute="top" relation="greaterThanOrEqual" secondItem="i5M-Pr-FkT" secondAttribute="topMargin" constant="30" id="tgZ-0g-Sb2"/>
+            </constraints>
+            <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+            <point key="canvasLocation" x="34.5" y="54.5"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="sample-image" width="4824" height="3229"/>
+    </resources>
+</document>

--- a/components/Cards/examples/resources/CardsAssets.xcassets/Contents.json
+++ b/components/Cards/examples/resources/CardsAssets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/components/Cards/examples/resources/CardsAssets.xcassets/sample-image.imageset/Contents.json
+++ b/components/Cards/examples/resources/CardsAssets.xcassets/sample-image.imageset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "filename" : "brooke-lark-385507.jpg",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/components/Cards/src/MDCCardView.h
+++ b/components/Cards/src/MDCCardView.h
@@ -1,0 +1,64 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import "MaterialInk.h"
+#import "MaterialShadowLayer.h"
+
+typedef NS_ENUM(NSInteger, MDCCardViewState) {
+  /** The normal state for the card. */
+  MDCCardViewStateNormal,
+
+  /** The visual state when the card is pressed (i.e. dragging). */
+  MDCCardViewStateHighlighted
+};
+
+@interface MDCCardView : UIView
+
+/**
+ The corner radius for the card
+ */
+@property(nonatomic, assign) CGFloat cornerRadius UI_APPEARANCE_SELECTOR;
+
+/**
+ Returns the current state of the card
+ */
+@property(nonatomic, readonly) MDCCardViewState state;
+
+/**
+ Sets the shadow elevation for an MDCCardViewState state
+
+ @param shadowElevation The shadow elevation
+ @param state MDCCardViewState the card view state
+
+ @note when setting the shadowElevation lower than 0
+ it will produce a hairline border around it with a 0 shadow.
+ This applies also when setting the resting and pressed shadow elevation properties.
+ */
+- (void)setShadowElevation:(CGFloat)shadowElevation forState:(MDCCardViewState)state
+  UI_APPEARANCE_SELECTOR;
+
+/**
+ Returns the shadow elevation for an MDCCardViewState state
+
+ If no elevation has been set for a state, the value for MDCCardViewStateNormal will be returned.
+
+ @param state MDCCardViewState the card view state
+ @return The shadow elevation for the requested state.
+ */
+- (CGFloat)shadowElevationForState:(MDCCardViewState)state;
+
+@end

--- a/components/Cards/src/MDCCardView.m
+++ b/components/Cards/src/MDCCardView.m
@@ -1,0 +1,153 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCCardView.h"
+#import "private/MDCCardView+Private.h"
+
+@implementation MDCCardView {
+  NSMutableDictionary<NSNumber *, NSNumber *> *_shadowElevations;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+  self = [super initWithCoder:coder];
+  if (self) {
+    [self commonMDCCardViewInit];
+  }
+  return self;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+  if (self) {
+    [self commonMDCCardViewInit];
+  }
+  return self;
+}
+
+- (void)commonMDCCardViewInit {
+  _inkView = [[MDCInkView alloc] initWithFrame:self.bounds];
+  _inkView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+  _inkView.usesLegacyInkRipple = NO;
+  _inkView.layer.zPosition = MAXFLOAT;
+  [self addSubview:self.inkView];
+
+  self.cornerRadius = 4.f;
+
+  _shadowElevations = [[NSMutableDictionary alloc] init];
+  _shadowElevations[@(MDCCardViewStateNormal)] = @(1.f);
+  _shadowElevations[@(MDCCardViewStateHighlighted)] = @(8.f);
+  _state = MDCCardViewStateNormal;
+  [self updateShadowElevation];
+}
+
+- (void)layoutSubviews {
+  [super layoutSubviews];
+  self.layer.shadowPath = [self boundingPath].CGPath;
+}
+
+- (void)setCornerRadius:(CGFloat)cornerRadius {
+  self.layer.cornerRadius = cornerRadius;
+  [self setNeedsLayout];
+}
+
+- (CGFloat)cornerRadius {
+  return self.layer.cornerRadius;
+}
+
++ (Class)layerClass {
+  return [MDCShadowLayer class];
+}
+
+- (void)setStyleForState:(MDCCardViewState)state
+         withLocation:(CGPoint)location {
+  _state = state;
+  switch (state) {
+    case MDCCardViewStateNormal: {
+      [self.inkView startTouchEndedAnimationAtPoint:location completion:nil];
+      break;
+    }
+    case MDCCardViewStateHighlighted: {
+      [self.inkView startTouchBeganAnimationAtPoint:location completion:nil];
+      break;
+    }
+    default:
+      break;
+  }
+  [self updateShadowElevation];
+}
+
+- (UIBezierPath *)boundingPath {
+  CGFloat cornerRadius = self.cornerRadius;
+  return [UIBezierPath bezierPathWithRoundedRect:self.bounds cornerRadius:cornerRadius];
+}
+
+- (CGFloat)shadowElevationForState:(MDCCardViewState)state {
+  NSNumber *elevation = _shadowElevations[@(state)];
+  if (elevation == nil) {
+    elevation = _shadowElevations[@(MDCCardViewStateNormal)];
+  }
+  if (elevation != nil) {
+    return (CGFloat)[elevation doubleValue];
+  }
+  return 0;
+}
+
+- (void)setShadowElevation:(CGFloat)shadowElevation forState:(MDCCardViewState)state {
+  _shadowElevations[@(state)] = @(shadowElevation);
+
+  [self updateShadowElevation];
+}
+
+- (void)updateShadowElevation {
+  CGFloat elevation = [self shadowElevationForState:self.state];
+  if (((MDCShadowLayer *)self.layer).elevation != elevation) {
+    if (elevation < 0) {
+      self.layer.borderWidth = 1.f;
+      self.layer.borderColor =
+        [UIColor colorWithRed:218/255.0 green:220/255.0 blue:224/255.0 alpha:1].CGColor;
+    } else {
+      self.layer.borderWidth = 0.f;
+    }
+    CGFloat elevationNormalized = elevation < 0 ? 0 : elevation;
+    self.layer.shadowPath = [self boundingPath].CGPath;
+    [(MDCShadowLayer *)self.layer setElevation:elevationNormalized];
+  }
+}
+
+#pragma mark - UIResponder
+
+- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
+  [super touchesBegan:touches withEvent:event];
+  UITouch *touch = [touches anyObject];
+  CGPoint location = [touch locationInView:self];
+  [self setStyleForState:MDCCardViewStateHighlighted withLocation:location];
+}
+
+- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
+  [super touchesEnded:touches withEvent:event];
+  UITouch *touch = [touches anyObject];
+  CGPoint location = [touch locationInView:self];
+  [self setStyleForState:MDCCardViewStateNormal withLocation:location];
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+  [super touchesCancelled:touches withEvent:event];
+  UITouch *touch = [touches anyObject];
+  CGPoint location = [touch locationInView:self];
+  [self setStyleForState:MDCCardViewStateNormal withLocation:location];
+}
+
+@end

--- a/components/Cards/src/MDCCollectionViewCardCell.h
+++ b/components/Cards/src/MDCCollectionViewCardCell.h
@@ -1,0 +1,61 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import "MDCCardView.h"
+
+typedef NS_ENUM(NSInteger, MDCCardCellSelectionState) {
+  /** The visual state when the cell is in its unselected state. */
+  MDCCardCellSelectionStateUnselected,
+
+  /** The visual state when the cell has been selected. */
+  MDCCardCellSelectionStateSelected
+};
+
+@interface MDCCollectionViewCardCell : UICollectionViewCell
+
+/**
+ The underlying card view for the cell
+ */
+@property(readonly, nonatomic, strong, nonnull) MDCCardView *cardView;
+
+/**
+ selecting for the cell should be set to YES if the
+ cell should react visually to when it is selected.
+ */
+@property(nonatomic, getter=isSelecting) BOOL selecting;
+
+/**
+ The corner radius for the cell and the underlying card
+ */
+@property(nonatomic, assign) CGFloat cornerRadius UI_APPEARANCE_SELECTOR;
+
+/**
+The image for the selected state (by default is a checked circle)
+ */
+@property(nonatomic, strong, nullable) UIImage *selectedImage;
+
+/**
+The tint color for the selected image.
+ */
+@property(nonatomic, strong, nullable) UIColor *selectedImageTintColor UI_APPEARANCE_SELECTOR;
+
+/**
+The selection state of the card cell
+ */
+@property(nonatomic, readonly) MDCCardCellSelectionState selectionState;
+
+@end

--- a/components/Cards/src/MDCCollectionViewCardCell.m
+++ b/components/Cards/src/MDCCollectionViewCardCell.m
@@ -1,0 +1,209 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCCollectionViewCardCell.h"
+
+#import "MaterialIcons+ic_check_circle.h"
+#import <MDFTextAccessibility/MDFTextAccessibility.h>
+#import "private/MDCCardView+Private.h"
+
+@interface MDCCollectionViewCardCell ()
+
+@property(nonatomic, strong, nullable) UIImageView *selectedImageView;
+@property(nonatomic, assign) CGPoint lastTouch;
+
+@end
+
+@implementation MDCCollectionViewCardCell {
+  BOOL _inkAnimating;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+  if (self) {
+    [self commonMDCCollectionViewCardCellInit];
+  }
+  return self;
+}
+
+- (void)commonMDCCollectionViewCardCellInit {
+  _cardView = [[MDCCardView alloc] initWithFrame:self.contentView.bounds];
+  _cardView.autoresizingMask =
+    UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  _cardView.userInteractionEnabled = NO;
+  self.contentView.autoresizingMask =
+    UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  [self.contentView addSubview:self.cardView];
+  _inkAnimating = NO;
+  self.selecting = NO;
+
+  [self initializeSelectedImage];
+
+  self.cornerRadius = 4.f;
+}
+
+- (void)initializeSelectedImage {
+  UIImage *circledCheck = [MDCIcons imageFor_ic_check_circle];
+  circledCheck = [circledCheck imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+  self.selectedImageView = [[UIImageView alloc] initWithImage:circledCheck];
+  self.selectedImageView.center = CGPointMake(
+                                    CGRectGetWidth(self.bounds) - (circledCheck.size.width/2) - 8,
+                                    (circledCheck.size.height/2) + 8);
+  self.selectedImageView.layer.zPosition = MAXFLOAT - 1;
+  self.selectedImageView.autoresizingMask =
+  (UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin |
+   UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleBottomMargin);
+  [self.contentView addSubview:self.selectedImageView];
+  self.selectedImageView.hidden = YES;
+}
+
+- (void)setBackgroundColor:(UIColor *)backgroundColor {
+  super.backgroundColor = backgroundColor;
+  self.cardView.backgroundColor = backgroundColor;
+
+  /**
+   currently the selected check image uses the color
+   based on MDFTextAccessibility to fit the background color.
+   */
+  UIColor *checkColor =
+  [MDFTextAccessibility textColorOnBackgroundColor:backgroundColor
+                                   targetTextAlpha:1.f
+                                           options:MDFTextAccessibilityOptionsNone];
+  self.selectedImageTintColor = checkColor;
+}
+
+- (UIColor *)backgroundColor {
+  return self.cardView.backgroundColor;
+}
+
+- (void)setCornerRadius:(CGFloat)cornerRadius {
+  self.layer.cornerRadius = cornerRadius;
+  self.cardView.cornerRadius = cornerRadius;
+  [self setNeedsLayout];
+}
+
+- (CGFloat)cornerRadius {
+  return self.cardView.cornerRadius;
+}
+
+- (void)selectionState:(MDCCardCellSelectionState)state withAnimation:(BOOL)animation {
+  _selectionState = state;
+  self.selecting = YES;
+  switch (state) {
+    case MDCCardCellSelectionStateSelected: {
+      if (animation) {
+        _inkAnimating = YES;
+        [self.cardView.inkView startTouchBeganAnimationAtPoint:self.lastTouch completion:nil];
+      } else {
+        if (!_inkAnimating) {
+          [self.cardView.inkView cancelAllAnimationsAnimated:NO];
+          [self.cardView.inkView addInkSublayerWithoutAnimation];
+        }
+        _inkAnimating = NO;
+        self.selectedImageView.hidden = NO;
+      }
+      [(MDCShadowLayer *)self.cardView.layer setElevation:
+       [self.cardView shadowElevationForState:MDCCardViewStateNormal]];
+
+      break;
+    }
+    case MDCCardCellSelectionStateUnselected: {
+      if (animation) {
+        [self.cardView.inkView startTouchEndedAnimationAtPoint:self.lastTouch completion:nil];
+      } else {
+        [self.cardView.inkView cancelAllAnimationsAnimated:NO];
+      }
+      [(MDCShadowLayer *)self.cardView.layer setElevation:
+       [self.cardView shadowElevationForState:MDCCardViewStateNormal]];
+      self.selectedImageView.hidden = YES;
+      break;
+    }
+  }
+}
+
+- (void)setSelectedImage:(UIImage *)selectedImage {
+  [self.selectedImageView setImage:selectedImage];
+}
+
+- (UIImage *)selectedImage {
+  return self.selectedImageView.image;
+}
+
+- (void)setSelectedImageTintColor:(UIColor *)selectedImageTintColor {
+  [self.selectedImageView setTintColor:selectedImageTintColor];
+}
+
+- (UIColor *)selectedImageTintColor {
+  return self.selectedImageView.tintColor;
+}
+
+- (void)setSelected:(BOOL)selected {
+  [super setSelected:selected];
+  if (self.selecting) {
+    if (selected) {
+      [self selectionState:MDCCardCellSelectionStateSelected withAnimation:NO];
+    } else {
+      [self selectionState:MDCCardCellSelectionStateUnselected withAnimation:NO];
+    }
+  }
+}
+
+#pragma mark - UIResponder
+
+- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
+  [super touchesBegan:touches withEvent:event];
+
+  UITouch *touch = [touches anyObject];
+  CGPoint location = [touch locationInView:self];
+  self.lastTouch = location;
+  if (self.selecting) {
+    if (!self.selected) {
+      [self selectionState:MDCCardCellSelectionStateSelected withAnimation:YES];
+    }
+  } else {
+    [_cardView setStyleForState:MDCCardViewStateHighlighted withLocation:location];
+  }
+}
+
+- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
+  [super touchesEnded:touches withEvent:event];
+
+  UITouch *touch = [touches anyObject];
+  CGPoint location = [touch locationInView:self];
+  if (self.selecting) {
+    if (!self.selected) {
+      [self selectionState:MDCCardCellSelectionStateUnselected withAnimation:YES];
+    }
+  } else {
+    [_cardView setStyleForState:MDCCardViewStateNormal withLocation:location];
+  }
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+  [super touchesCancelled:touches withEvent:event];
+
+  UITouch *touch = [touches anyObject];
+  CGPoint location = [touch locationInView:self];
+  if (self.selecting) {
+    if (!self.selected) {
+      [self selectionState:MDCCardCellSelectionStateUnselected withAnimation:YES];
+    }
+  } else {
+    [_cardView setStyleForState:MDCCardViewStateNormal withLocation:location];
+  }
+}
+
+@end

--- a/components/Cards/src/MaterialCards.h
+++ b/components/Cards/src/MaterialCards.h
@@ -1,0 +1,19 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCCardView.h"
+#import "MDCCollectionViewCardCell.h"
+

--- a/components/Cards/src/UICollectionViewController+MDCCardReordering.h
+++ b/components/Cards/src/UICollectionViewController+MDCCardReordering.h
@@ -1,0 +1,28 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface UICollectionViewController (MDCCardReordering) <UIGestureRecognizerDelegate>
+
+/**
+ This method should be called when using a UICollectionViewController and want to have
+ the reorder/drag&drop visuals. It will make sure that the underlying longPressGestureRecognizer
+ doesn't cancel the ink tap visual causing the ink to disappear once the reorder begins.
+ */
+- (void)mdc_setupCardReordering;
+
+@end

--- a/components/Cards/src/UICollectionViewController+MDCCardReordering.m
+++ b/components/Cards/src/UICollectionViewController+MDCCardReordering.m
@@ -1,0 +1,45 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "UICollectionViewController+MDCCardReordering.h"
+
+#import "MaterialInk.h"
+#import "MDCCollectionViewCardCell.h"
+
+@implementation UICollectionViewController (MDCCardReordering)
+
+
+- (void)mdc_setupCardReordering {
+  UILongPressGestureRecognizer *longGestureRecognizer = [[UILongPressGestureRecognizer alloc]
+                                                         initWithTarget:self
+                                                         action:nil];
+
+  longGestureRecognizer.delegate = self;
+  longGestureRecognizer.cancelsTouchesInView = NO;
+  [self.collectionView addGestureRecognizer:longGestureRecognizer];
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+       shouldReceiveTouch:(UITouch *)touch {
+  for (UIGestureRecognizer *gesture in self.collectionView.gestureRecognizers) {
+    if ([gesture isKindOfClass:[UILongPressGestureRecognizer class]]) {
+      gesture.cancelsTouchesInView = NO;
+    }
+  }
+  return YES;
+}
+
+@end

--- a/components/Cards/src/private/MDCCardView+Private.h
+++ b/components/Cards/src/private/MDCCardView+Private.h
@@ -1,0 +1,39 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCCardView.h"
+
+@interface MDCCardView ()
+
+/**
+ The inkView for the card that is initiated on tap
+ */
+@property(nonatomic, readonly, strong, nonnull) MDCInkView *inkView;
+
+@end
+
+@interface MDCCardView (Private)
+
+/**
+ Sets the style for the MDCCardView based on the defined state. Please see the MDCCardViewState
+ definition above to see all the possible states.
+
+ @param state MDCCardViewState this defines the state in which the card should visually be set to
+ @param location CGPoint some states may need the touch location to begin/end the ink from
+ */
+- (void)setStyleForState:(MDCCardViewState)state withLocation:(CGPoint)location;
+
+@end

--- a/components/Cards/tests/unit/MDCCardTests.m
+++ b/components/Cards/tests/unit/MDCCardTests.m
@@ -1,0 +1,136 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialCards.h"
+#import "MDCIcons.h"
+#import "MaterialIcons+ic_info.h"
+#import "MDCCardView+Private.h"
+
+@interface MDCCardTests : XCTestCase
+@property(nonatomic, strong) MDCCollectionViewCardCell *cell;
+@property(nonatomic, strong) MDCCardView *card;
+@end
+
+@implementation MDCCardTests
+
+- (void)setUp {
+  [super setUp];
+  self.cell = [[MDCCollectionViewCardCell alloc] init];
+  self.card = [[MDCCardView alloc] init];
+}
+
+- (void)testCellSelectAndUnselect {
+  XCTAssertEqual([self.cell.cardView shadowElevationForState:MDCCardViewStateNormal], 1.f);
+  XCTAssertEqual(self.cell.cornerRadius, 4.f);
+  XCTAssertEqual(self.cell.cardView.inkView.layer.sublayers.count, 1);
+  self.cell.selecting = YES;
+  self.cell.selected = YES;
+  XCTAssertEqual(((MDCShadowLayer *)self.cell.cardView.layer).elevation, 1.f);
+  XCTAssertEqual(self.cell.cardView.inkView.layer.sublayers.count, 2);
+  XCTAssertEqual(((CAShapeLayer *)self.cell.cardView.inkView.layer.sublayers.lastObject).fillColor,
+                 self.cell.cardView.inkView.inkColor.CGColor);
+  self.cell.selected = NO;
+  XCTAssertEqual(((MDCShadowLayer *)self.cell.cardView.layer).elevation, 1.f);
+  XCTAssertEqual(self.cell.cardView.inkView.layer.sublayers.count, 1);
+  self.cell.selected = YES;
+  XCTAssertEqual(((MDCShadowLayer *)self.cell.cardView.layer).elevation, 1.f);
+  XCTAssertEqual(self.cell.cardView.inkView.layer.sublayers.count, 2);
+  XCTAssertEqual(((CAShapeLayer *)self.cell.cardView.inkView.layer.sublayers.lastObject).fillColor,
+                 self.cell.cardView.inkView.inkColor.CGColor);
+  XCTAssert(
+    CGRectEqualToRect(
+      (((CAShapeLayer *)self.cell.cardView.inkView.layer.sublayers.firstObject).frame),
+      self.cell.cardView.inkView.layer.bounds));
+  self.cell.selected = NO;
+  XCTAssertEqual(((MDCShadowLayer *)self.cell.cardView.layer).elevation, 1.f);
+  XCTAssertEqual(self.cell.cornerRadius, 4.f);
+  XCTAssertEqual(self.cell.cardView.inkView.layer.sublayers.count, 1);
+}
+
+- (void)testCellLongPress {
+  NSMutableArray *touchArray = [NSMutableArray new];
+  [touchArray addObject:[UITouch new]];
+  NSSet *touches = [[NSSet alloc] init];
+  [touches setByAddingObjectsFromArray:touchArray];
+  UIEvent *event = [[UIEvent alloc] init];
+  [self.cell touchesBegan:touches withEvent:event];
+
+  XCTAssertEqual(((MDCShadowLayer *)self.cell.cardView.layer).elevation, 8.f);
+  XCTAssertEqual(self.cell.cardView.inkView.layer.sublayers.count, 2);
+
+  [self.cell touchesEnded:touches withEvent:event];
+
+  XCTAssertEqual(((MDCShadowLayer *)self.cell.cardView.layer).elevation, 1.f);
+}
+
+- (void)testDefaultShadowElevations {
+  [self.cell.cardView setShadowElevation:3.5f forState:MDCCardViewStateNormal];
+  [self.cell.cardView setShadowElevation:7.2f forState:MDCCardViewStateHighlighted];
+  XCTAssertEqual(((MDCShadowLayer *)self.cell.cardView.layer).elevation, 3.5f);
+  NSMutableArray *touchArray = [NSMutableArray new];
+  [touchArray addObject:[UITouch new]];
+  NSSet *touches = [[NSSet alloc] init];
+  [touches setByAddingObjectsFromArray:touchArray];
+  UIEvent *event = [[UIEvent alloc] init];
+  [self.cell touchesBegan:touches withEvent:event];
+
+  XCTAssertEqual(((MDCShadowLayer *)self.cell.cardView.layer).elevation, 7.2f);
+  XCTAssertEqual(self.cell.cardView.inkView.layer.sublayers.count, 2);
+
+  [self.cell touchesEnded:touches withEvent:event];
+
+  XCTAssertEqual(((MDCShadowLayer *)self.cell.cardView.layer).elevation, 3.5f);
+}
+
+- (void)testShadowForCard {
+  [self.card layoutSubviews];
+  XCTAssertEqual(((MDCShadowLayer *)self.card.layer).elevation, 1.f);
+  [self.card setShadowElevation:8.f forState:MDCCardViewStateNormal];
+  XCTAssertEqual(((MDCShadowLayer *)self.card.layer).elevation, 8.f);
+}
+
+- (void)testCornerForCard {
+  XCTAssertEqual(self.card.layer.cornerRadius, 4.f);
+  [self.card setCornerRadius:8.f];
+  XCTAssertEqual(self.card.layer.cornerRadius, 8.f);
+}
+
+- (void)testCornerForCell {
+  XCTAssertEqual(self.cell.cardView.layer.cornerRadius, 4.f);
+  XCTAssertEqual(self.cell.layer.cornerRadius, 4.f);
+  [self.cell setCornerRadius:8.f];
+  XCTAssertEqual(self.cell.cardView.layer.cornerRadius, 8.f);
+  XCTAssertEqual(self.cell.layer.cornerRadius, 8.f);
+}
+
+- (void)testSetSelectionImageColor {
+  [self.cell setBackgroundColor:[UIColor blackColor]];
+  XCTAssertEqual(self.cell.selectedImageTintColor, [UIColor whiteColor]);
+  UIColor *color = [UIColor blueColor];
+  [self.cell setSelectedImageTintColor:color];
+  XCTAssertEqual(self.cell.selectedImageTintColor, color);
+}
+
+- (void)testSetSelectionImage {
+  XCTAssertNotNil(self.cell.selectedImage);
+  UIImage *img = self.cell.selectedImage;
+  [self.cell setSelectedImage:[MDCIcons imageFor_ic_info]];
+  XCTAssertNotEqual(img, self.cell.selectedImage);
+}
+
+@end

--- a/components/Ink/src/MDCInkView.h
+++ b/components/Ink/src/MDCInkView.h
@@ -126,6 +126,11 @@ typedef NS_ENUM(NSInteger, MDCInkStyle) {
 - (void)cancelAllAnimationsAnimated:(BOOL)animated;
 
 /**
+ Add an Ink sublayer without any animation
+ */
+- (void)addInkSublayerWithoutAnimation;
+
+/**
  Enumerates the given view's subviews for an instance of MDCInkView and returns it if found, or
  creates and adds a new instance of MDCInkView if not.
 

--- a/components/Ink/src/MDCInkView.m
+++ b/components/Ink/src/MDCInkView.m
@@ -225,16 +225,34 @@ static NSString *const MDCInkViewMaxRippleRadiusKey = @"MDCInkViewMaxRippleRadiu
     [self.inkLayer spreadFromPoint:point completion:completionBlock];
   } else {
     self.startInkRippleCompletionBlock = completionBlock;
-    MDCInkLayer *inkLayer = [MDCInkLayer layer];
-    inkLayer.inkColor = self.inkColor;
+    MDCInkLayer *inkLayer = [self commonInkSublayerInit];
     inkLayer.maxRippleRadius = self.maxRippleRadius;
     inkLayer.animationDelegate = self;
     inkLayer.opacity = 0;
-    inkLayer.frame = self.bounds;
-    [self.layer addSublayer:inkLayer];
-    [inkLayer startAnimationAtPoint:point];
     self.activeInkLayer = inkLayer;
+    [inkLayer startAnimationAtPoint:point];
   }
+}
+
+- (void)addInkSublayerWithoutAnimation {
+  MDCInkLayer *inkLayer = [MDCInkLayer layer];
+  inkLayer.inkColor = self.inkColor;
+  inkLayer.frame = self.bounds;
+  inkLayer.opacity = 1;
+  CGRect rect = self.bounds;
+  UIBezierPath *rectPath = [UIBezierPath bezierPathWithRect:rect];
+  inkLayer.path = rectPath.CGPath;
+  inkLayer.fillColor = self.inkColor.CGColor;
+  [self.layer addSublayer:inkLayer];
+  self.activeInkLayer = inkLayer;
+}
+
+- (MDCInkLayer *)commonInkSublayerInit {
+  MDCInkLayer *inkLayer = [MDCInkLayer layer];
+  inkLayer.inkColor = self.inkColor;
+  inkLayer.frame = self.bounds;
+  [self.layer addSublayer:inkLayer];
+  return inkLayer;
 }
 
 - (void)startTouchEndedAnimationAtPoint:(CGPoint)point


### PR DESCRIPTION
implementation of Cards. The cards have rounded corners, shadow, and ink.
The cards also facilitate the drag and drop (reorder) and selection (editing) actions.

Cards can be used alone as MDCCard, or inside a native UICollectionView using the MDCCollectionViewCardCell.

Card drag and drop using a UICollectionViewController specifically, needs the addition of UICollectionViewController+MDCCardReordering.h in order to work out of the box.

InkView needed another method to allow to have the ink already show without animation.
InkView for the new ink didn't call the completion handler when starting the animation, this was fixed in this PR as well. #2839

For context on the added image, it's taken from here: https://unsplash.com/photos/wMzx2nBdeng
License details: https://unsplash.com/license