### PR TITLE
[Ink] Fix ink animation timing in time-scaled layers

### DIFF
--- a/components/Ink/src/private/MDCInkLayer.m
+++ b/components/Ink/src/private/MDCInkLayer.m
@@ -235,7 +235,7 @@ static NSString *const MDCInkLayerScaleString = @"transform.scale";
   changeAnim.fromValue = @(currOpacity);
   changeAnim.toValue = @(updatedOpacity);
   changeAnim.duration = MDCInkLayerCommonDuration;
-  changeAnim.beginTime = CACurrentMediaTime() + animationDelay;
+  changeAnim.beginTime = [self convertTime:(CACurrentMediaTime() + animationDelay) fromLayer:nil];
   changeAnim.timingFunction =
       [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
   changeAnim.fillMode = kCAFillModeForwards;
@@ -260,7 +260,8 @@ static NSString *const MDCInkLayerScaleString = @"transform.scale";
   fadeOutAnim.fromValue = @(opacity);
   fadeOutAnim.toValue = @0;
   fadeOutAnim.duration = MDCInkLayerEndFadeOutDuration;
-  fadeOutAnim.beginTime = CACurrentMediaTime() + self.endAnimationDelay;
+  fadeOutAnim.beginTime = [self convertTime:(CACurrentMediaTime() + self.endAnimationDelay)
+                                  fromLayer:nil];
   fadeOutAnim.timingFunction =
       [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
   fadeOutAnim.fillMode = kCAFillModeForwards;


### PR DESCRIPTION
When a CALayer has a speed other than 1.0 (or other manipulations to its local
time coordinate space), animations need to convert beginTime values into this
time space.  For a beginOffset of zero, the layer automatically sets the
beginTime to the current active time of the layer. For non-zero values
(delayed animations), the conversion has to be performed by the caller.

This article has a pretty good explanation:
https://coveller.com/2016/05/core_animation_timing/

Closes internal issue b/72403469
