### PR TITLE
[Cards] fix bug with ink when dragging an MDCCard

### DIFF
--- a/components/Cards/src/MDCCard.m
+++ b/components/Cards/src/MDCCard.m
@@ -221,16 +221,12 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
 }
 
 - (void)setHighlighted:(BOOL)highlighted {
-  [super setHighlighted: highlighted];
-  if (highlighted) {
-    // Note: setHighlighted: can get getting more calls with YES than NO when clicking rapidly.
-    // To guard against ink never going away and darkening our card we call
-    // startTouchEndedAnimationAtPoint:completion:.
-    [self.inkView startTouchEndedAnimationAtPoint:_lastTouch completion:nil];
+  if (highlighted && !self.highlighted) {
     [self.inkView startTouchBeganAnimationAtPoint:_lastTouch completion:nil];
-  } else {
+  } else if (!highlighted && self.highlighted) {
     [self.inkView startTouchEndedAnimationAtPoint:_lastTouch completion:nil];
   }
+  [super setHighlighted:highlighted];
   [self updateShadowElevation];
   [self updateBorderColor];
   [self updateBorderWidth];


### PR DESCRIPTION
When holding a tap and dragging an MDCCard which subclasses a UIControl, the `setHighlighted` state is called multiple times when dragging causing more ink layers to be displayed. In this state though `self.highlighted` is already set to `YES`, therefore in that case the ink is already there and doesn't need another startTouch. By checking the self and the changing state before calling the super we can see if we are actually changing from `NO` to `YES` or vice versa for highlighted and only there pursue an ink change.