### PR TITLE
[CollectionCells] Support images larger than 40x40 in MDCCollectionViewTextCell

### DIFF
--- a/components/CollectionCells/src/MDCCollectionViewTextCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewTextCell.m
@@ -46,6 +46,10 @@ static inline CGFloat CellDefaultDetailTextFontOpacity(void) {
   return [MDCTypography captionFontOpacity];
 }
 
+// Image size.
+static const CGFloat kImageSize = 40;
+// Cell image view padding.
+static const CGFloat kCellImagePaddingLeading = 16;
 // Cell padding top/bottom.
 static const CGFloat kCellTwoLinePaddingTop = 20;
 static const CGFloat kCellTwoLinePaddingBottom = 20;
@@ -54,9 +58,8 @@ static const CGFloat kCellThreeLinePaddingBottom = 20;
 // Cell padding leading/trailing.
 static const CGFloat kCellTextNoImagePaddingLeading = 16;
 static const CGFloat kCellTextNoImagePaddingTrailing = 16;
-static const CGFloat kCellTextWithImagePaddingLeading = 72;
-// Cell image view padding.
-static const CGFloat kCellImagePaddingLeading = 16;
+static const CGFloat kCellTextWithImagePaddingLeading = kCellImagePaddingLeading + kImageSize +
+  kCellTextNoImagePaddingLeading;
 
 // Returns the closest pixel-aligned value higher than |value|, taking the scale factor into
 // account. At a scale of 1, equivalent to Ceil().
@@ -182,8 +185,8 @@ static inline CGRect AlignRectToUpperPixel(CGRect rect) {
   CGFloat boundsHeight = CGRectGetHeight(_contentWrapper.bounds);
 
   // Image layout.
-  [_imageView sizeToFit];
-  CGRect imageFrame = _imageView.frame;
+  CGRect imageFrame = CGRectZero;
+  imageFrame.size = CGSizeMake(kImageSize, kImageSize);
   imageFrame.origin.x = kCellImagePaddingLeading;
   imageFrame.origin.y =
       (CGRectGetHeight(self.contentView.frame) / 2) - (imageFrame.size.height / 2);


### PR DESCRIPTION
Calling -[UIImageView sizeToFit] will resize the view to fit the image inside.

MDCCollectionViewTextCell currently assumes the image will be 40x40, but
doesn't handle images other than this size.

Currently, if the image is larger than 40x40, the -sizeToFit call on
the image view will cause the view to go outside the bounds of
MDCCollectionViewTextCell and overlap the text.

Closes #2911.

Reviewers: I'd like to add unit tests for this, but I'm not sure how to run MDC tests.
Any suggestions?