### PR TITLE
[MDCIcon] fixed bundle cache call because bundle may not exist

### DIFF
--- a/components/private/Icons/src/MDCIcons.m
+++ b/components/private/Icons/src/MDCIcons.m
@@ -32,7 +32,9 @@
     NSBundle *baseBundle = [NSBundle bundleForClass:[MDCIcons class]];
     NSString *bundlePath = [baseBundle pathForResource:bundleName ofType:@"bundle"];
     bundle = [NSBundle bundleWithPath:bundlePath];
-    [bundleCache setObject:bundle forKey:bundleName];
+    if (bundle) {
+      [bundleCache setObject:bundle forKey:bundleName];
+    }
   }
   return bundle;
 }

--- a/components/private/Icons/tests/unit/MDCIconsTests.m
+++ b/components/private/Icons/tests/unit/MDCIconsTests.m
@@ -40,6 +40,17 @@
   XCTAssertNotNil([MDCIcons imageFor_ic_reorder], @"No image was returned for ic_reorder");
 }
 
+- (void)testBundleNamed {
+  // Given
+  NSString *badBundleName = @"someNameThatDoesNotExist";
+
+  // When
+  NSBundle *bundle = [MDCIcons bundleNamed:badBundleName];
+
+  // Then
+  XCTAssertNil(bundle);
+}
+
 - (void)testImageForArrowBackOldStyle {
   // When
   [MDCIcons ic_arrow_backUseNewStyle:NO];


### PR DESCRIPTION
The bundle may not be there so we should guard against adding it to the cache since that may crash the any app that uses this code.

Partial fix to https://github.com/material-components/material-components-ios/issues/2917