### PR TITLE
[Warnings Fix] Block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior.

### DIFF
--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -144,12 +144,12 @@ static const CGFloat kSingleCycleRotation =
 
   [self applyPropertiesWithoutAnimation:^{
     // Resize and recenter rotation layer.
-    _outerRotationLayer.bounds = self.bounds;
-    _outerRotationLayer.position =
+    self.outerRotationLayer.bounds = self.bounds;
+    self.outerRotationLayer.position =
         CGPointMake(self.frame.size.width / 2, self.frame.size.height / 2);
 
-    _strokeLayer.bounds = _outerRotationLayer.bounds;
-    _strokeLayer.position = _outerRotationLayer.position;
+    self.strokeLayer.bounds = self.outerRotationLayer.bounds;
+    self.strokeLayer.position = self.outerRotationLayer.position;
 
     [self updateStrokePath];
   }];
@@ -281,11 +281,11 @@ static const CGFloat kSingleCycleRotation =
   [CATransaction begin];
   {
     [CATransaction setCompletionBlock:^{
-      _animationInProgress = NO;
+      self->_animationInProgress = NO;
 
       [self actuallyStartAnimating];
 
-      _cycleColorsIndex = self.cycleColors.count > 0 ? cycleStartIndex % self.cycleColors.count : 0;
+      self.cycleColorsIndex = self.cycleColors.count > 0 ? cycleStartIndex % self.cycleColors.count : 0;
       [self applyPropertiesWithoutAnimation:^{
         [self updateStrokeColor];
       }];
@@ -471,10 +471,10 @@ static const CGFloat kSingleCycleRotation =
   _cycleCount = _cycleStartIndex;
 
   [self applyPropertiesWithoutAnimation:^{
-    _strokeLayer.strokeStart = 0.0f;
-    _strokeLayer.strokeEnd = 0.001f;
-    _strokeLayer.lineWidth = _strokeWidth;
-    _trackLayer.lineWidth = _strokeWidth;
+    self.strokeLayer.strokeStart = 0.0f;
+    self.strokeLayer.strokeEnd = 0.001f;
+    self.strokeLayer.lineWidth = self.strokeWidth;
+    self.trackLayer.lineWidth = self.strokeWidth;
 
     [self resetStrokeColor];
     [self updateStrokePath];
@@ -497,8 +497,8 @@ static const CGFloat kSingleCycleRotation =
 
   [self removeAnimations];
   [self applyPropertiesWithoutAnimation:^{
-    _strokeLayer.strokeStart = 0.0f;
-    _strokeLayer.strokeEnd = 0.0f;
+    self.strokeLayer.strokeStart = 0.0f;
+    self.strokeLayer.strokeEnd = 0.0f;
   }];
 }
 
@@ -531,8 +531,8 @@ static const CGFloat kSingleCycleRotation =
   strokeEnd = strokeEnd > 1 ? strokeEnd - 1 : strokeEnd;
 
   [self applyPropertiesWithoutAnimation:^{
-    _strokeLayer.strokeStart = 0.0f;
-    _strokeLayer.strokeEnd = 0.0f;
+    self.strokeLayer.strokeStart = 0.0f;
+    self.strokeLayer.strokeEnd = 0.0f;
   }];
 
   [CATransaction begin];
@@ -542,8 +542,8 @@ static const CGFloat kSingleCycleRotation =
         stopTransition.completion();
       }
       if (stopTransition == self.stopTransition) {
-        if ([_delegate respondsToSelector:@selector(activityIndicatorAnimationDidFinish:)]) {
-          [_delegate activityIndicatorAnimationDidFinish:self];
+        if ([self.delegate respondsToSelector:@selector(activityIndicatorAnimationDidFinish:)]) {
+          [self.delegate activityIndicatorAnimationDidFinish:self];
         }
         [self removeAnimations];
       }
@@ -676,8 +676,8 @@ static const CGFloat kSingleCycleRotation =
     [CATransaction setCompletionBlock:^{
       [self
           strokeRotationCycleFinishedFromState:MDCActivityIndicatorStateTransitionToIndeterminate];
-      if ([_delegate respondsToSelector:@selector(activityIndicatorModeTransitionDidFinish:)]) {
-        [_delegate activityIndicatorModeTransitionDidFinish:self];
+      if ([self.delegate respondsToSelector:@selector(activityIndicatorModeTransitionDidFinish:)]) {
+        [self.delegate activityIndicatorModeTransitionDidFinish:self];
       }
     }];
     [CATransaction setDisableActions:YES];
@@ -740,8 +740,8 @@ static const CGFloat kSingleCycleRotation =
       [CATransaction setCompletionBlock:^{
         [self
             strokeRotationCycleFinishedFromState:MDCActivityIndicatorStateTransitionToDeterminate];
-        if ([_delegate respondsToSelector:@selector(activityIndicatorModeTransitionDidFinish:)]) {
-          [_delegate activityIndicatorModeTransitionDidFinish:self];
+        if ([self.delegate respondsToSelector:@selector(activityIndicatorModeTransitionDidFinish:)]) {
+          [self.delegate activityIndicatorModeTransitionDidFinish:self];
         }
       }];
       [CATransaction setDisableActions:YES];
@@ -875,10 +875,10 @@ static const CGFloat kSingleCycleRotation =
   [CATransaction begin];
 
   [CATransaction setCompletionBlock:^{
-    if (_animatingOut) {
+    if (self->_animatingOut) {
       [self removeAnimations];
-      if ([_delegate respondsToSelector:@selector(activityIndicatorAnimationDidFinish:)]) {
-        [_delegate activityIndicatorAnimationDidFinish:self];
+      if ([self.delegate respondsToSelector:@selector(activityIndicatorAnimationDidFinish:)]) {
+        [self.delegate activityIndicatorAnimationDidFinish:self];
       }
     }
   }];

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -325,8 +325,8 @@ static const int kMDCButtonAnimationDuration = 200;
     [_floatingButton setElevation:1 forState:UIControlStateNormal];
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, kMDCButtonAnimationDuration * NSEC_PER_MSEC),
                    dispatch_get_main_queue(), ^{
-                     [self insertSubview:_floatingButton atIndex:subViewIndex];
-                     [_floatingButton setElevation:elevation forState:UIControlStateNormal];
+                     [self insertSubview:self.floatingButton atIndex:subViewIndex];
+                     [self.floatingButton setElevation:elevation forState:UIControlStateNormal];
                    });
   } else {
     [self insertSubview:_floatingButton atIndex:subViewIndex];
@@ -361,7 +361,7 @@ static const int kMDCButtonAnimationDuration = 200;
   if (floatingButtonHidden) {
     [self healBottomAppBarViewAnimated:animated];
     [_floatingButton collapse:animated completion:^{
-      _floatingButton.hidden = YES;
+      self.floatingButton.hidden = YES;
     }];
   } else {
     _floatingButton.hidden = NO;

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -143,8 +143,8 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
   [coordinator animateAlongsideTransition:
       ^(__unused id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
-        _sheetView.frame = [self frameOfPresentedViewInContainerView];
-        [_sheetView layoutIfNeeded];
+        self->_sheetView.frame = [self frameOfPresentedViewInContainerView];
+        [self->_sheetView layoutIfNeeded];
         [self updatePreferredSheetHeight];
       }                        completion:nil];
 }

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -252,12 +252,12 @@ static NSString *const MDCButtonBarButtonLayoutPositionKey = @"MDCButtonBarButto
                        context:(void *)context {
   if (context == kKVOContextMDCButtonBar) {
     void (^mainThreadWork)(void) = ^{
-      @synchronized(_buttonItemsLock) {
-        NSUInteger itemIndex = [_items indexOfObject:object];
-        if (itemIndex == NSNotFound || itemIndex > [_buttonViews count]) {
+      @synchronized(self->_buttonItemsLock) {
+        NSUInteger itemIndex = [self.items indexOfObject:object];
+        if (itemIndex == NSNotFound || itemIndex > [self->_buttonViews count]) {
           return;
         }
-        UIButton *button = _buttonViews[itemIndex];
+        UIButton *button = self->_buttonViews[itemIndex];
 
         id newValue = [object valueForKey:keyPath];
         if (newValue == [NSNull null]) {

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -835,7 +835,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (void)updateAlphaAndBackgroundColorAnimated:(BOOL)animated {
   void (^animations)(void) = ^{
-    self.alpha = self.enabled ? _enabledAlpha : _disabledAlpha;
+    self.alpha = self.enabled ? self->_enabledAlpha : self.disabledAlpha;
     [self updateBackgroundColor];
   };
 

--- a/components/Chips/src/MDCChipCollectionViewCell.m
+++ b/components/Chips/src/MDCChipCollectionViewCell.m
@@ -68,8 +68,8 @@ static NSString *const MDCChipCollectionViewCellChipViewKey =
 
   if (animated) {
     [UIView animateWithDuration:0.25 animations:^{
-      _chipView.frame = self.bounds;
-      [_chipView layoutIfNeeded];
+      self.chipView.frame = self.bounds;
+      [self.chipView layoutIfNeeded];
     }];
   } else {
     _chipView.frame = self.bounds;

--- a/components/CollectionCells/src/MDCCollectionViewCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewCell.m
@@ -149,20 +149,18 @@ NSString *const kDeselectedCellAccessibilityHintKey =
         txSelectorTransform = kEditingControlAppearanceOffset;
         break;
     }
-    _editingReorderImageView.alpha = _attr.shouldShowReorderStateMask ? 1.0f : 0.0f;
-    _editingReorderImageView.transform =
-        _attr.shouldShowReorderStateMask ? CGAffineTransformMakeTranslation(txReorderTransform, 0)
-                                         : CGAffineTransformIdentity;
+    self->_editingReorderImageView.alpha = self->_attr.shouldShowReorderStateMask ? 1.0f : 0.0f;
+    self->_editingReorderImageView.transform = self->_attr.shouldShowReorderStateMask ?
+        CGAffineTransformMakeTranslation(txReorderTransform, 0) : CGAffineTransformIdentity;
 
-    _editingSelectorImageView.alpha = _attr.shouldShowSelectorStateMask ? 1.0f : 0.0f;
-    _editingSelectorImageView.transform =
-        _attr.shouldShowSelectorStateMask ? CGAffineTransformMakeTranslation(txSelectorTransform, 0)
-                                          : CGAffineTransformIdentity;
+    self->_editingSelectorImageView.alpha = self->_attr.shouldShowSelectorStateMask ? 1.0f : 0.0f;
+    self->_editingSelectorImageView.transform = self->_attr.shouldShowSelectorStateMask ?
+        CGAffineTransformMakeTranslation(txSelectorTransform, 0) : CGAffineTransformIdentity;
 
-    _accessoryView.alpha = _attr.shouldShowSelectorStateMask ? 0.0f : 1.0f;
-    _accessoryInset.right = _attr.shouldShowSelectorStateMask
-                                ? kAccessoryInsetDefault.right + kEditingControlAppearanceOffset
-                                : kAccessoryInsetDefault.right;
+    self.accessoryView.alpha = self->_attr.shouldShowSelectorStateMask ? 0.0f : 1.0f;
+    self->_accessoryInset.right = self->_attr.shouldShowSelectorStateMask
+                                  ? kAccessoryInsetDefault.right + kEditingControlAppearanceOffset
+                                  : kAccessoryInsetDefault.right;
   };
 
   // Animate editing controls.
@@ -487,7 +485,7 @@ NSString *const kDeselectedCellAccessibilityHintKey =
                           options:UIViewAnimationOptionCurveEaseOut
                        animations:^{
                          self.contentView.alpha = 1;
-                         _separatorView.alpha = 1;
+                         self->_separatorView.alpha = 1;
                        }
                        completion:nil];
     }

--- a/components/Collections/src/private/MDCCollectionInfoBarView.m
+++ b/components/Collections/src/private/MDCCollectionInfoBarView.m
@@ -205,16 +205,16 @@ static inline UIColor *CollectionInfoBarRedColor(void) {
       delay:0
       options:UIViewAnimationOptionCurveEaseOut
       animations:^{
-        _backgroundView.transform = CGAffineTransformIdentity;
+        self.backgroundView.transform = CGAffineTransformIdentity;
       }
       completion:^(__unused BOOL finished) {
-        self.userInteractionEnabled = _allowsTap;
+        self.userInteractionEnabled = self.allowsTap;
 
         // Notify delegate.
-        if ([_delegate respondsToSelector:@selector(infoBar:didShowAnimated:willAutoDismiss:)]) {
-          [_delegate infoBar:self
-              didShowAnimated:animated
-              willAutoDismiss:[self shouldAutoDismiss]];
+        if ([self.delegate respondsToSelector:@selector(infoBar:didShowAnimated:willAutoDismiss:)]) {
+          [self.delegate infoBar:self
+                 didShowAnimated:animated
+                 willAutoDismiss:[self shouldAutoDismiss]];
         }
 
         [self autoDismissIfNecessaryWithAnimation:animated];
@@ -232,17 +232,17 @@ static inline UIColor *CollectionInfoBarRedColor(void) {
       delay:0
       options:UIViewAnimationOptionCurveEaseIn
       animations:^{
-        _backgroundView.transform = CGAffineTransformMakeTranslation(0, _backgroundTransformY);
+        self.backgroundView.transform = CGAffineTransformMakeTranslation(0, self->_backgroundTransformY);
       }
       completion:^(__unused BOOL finished) {
         self.userInteractionEnabled = NO;
-        _backgroundView.hidden = YES;
+        self.backgroundView.hidden = YES;
 
         // Notify delegate.
-        if ([_delegate respondsToSelector:@selector(infoBar:didDismissAnimated:didAutoDismiss:)]) {
-          [_delegate infoBar:self
-              didDismissAnimated:animated
-                  didAutoDismiss:[self shouldAutoDismiss]];
+        if ([self.delegate respondsToSelector:@selector(infoBar:didDismissAnimated:didAutoDismiss:)]) {
+          [self.delegate infoBar:self
+                didDismissAnimated:animated
+                    didAutoDismiss:[self shouldAutoDismiss]];
         }
       }];
 }

--- a/components/Collections/src/private/MDCCollectionInfoBarView.m
+++ b/components/Collections/src/private/MDCCollectionInfoBarView.m
@@ -232,7 +232,8 @@ static inline UIColor *CollectionInfoBarRedColor(void) {
       delay:0
       options:UIViewAnimationOptionCurveEaseIn
       animations:^{
-        self.backgroundView.transform = CGAffineTransformMakeTranslation(0, self->_backgroundTransformY);
+        self.backgroundView.transform =
+            CGAffineTransformMakeTranslation(0, self->_backgroundTransformY);
       }
       completion:^(__unused BOOL finished) {
         self.userInteractionEnabled = NO;

--- a/components/Collections/src/private/MDCCollectionViewEditor.m
+++ b/components/Collections/src/private/MDCCollectionViewEditor.m
@@ -138,8 +138,8 @@ typedef NS_ENUM(NSInteger, MDCAutoscrollPanningDirection) {
 
     [CATransaction setCompletionBlock:^{
       // Notify delegate did begin editing.
-      if ([_delegate respondsToSelector:@selector(collectionViewDidBeginEditing:)]) {
-        [_delegate collectionViewDidBeginEditing:_collectionView];
+      if ([self.delegate respondsToSelector:@selector(collectionViewDidBeginEditing:)]) {
+        [self.delegate collectionViewDidBeginEditing:self.collectionView];
       }
     }];
 
@@ -151,8 +151,8 @@ typedef NS_ENUM(NSInteger, MDCAutoscrollPanningDirection) {
 
     [CATransaction setCompletionBlock:^{
       // Notify delegate did end editing.
-      if ([_delegate respondsToSelector:@selector(collectionViewDidEndEditing:)]) {
-        [_delegate collectionViewDidEndEditing:_collectionView];
+      if ([self.delegate respondsToSelector:@selector(collectionViewDidEndEditing:)]) {
+        [self.delegate collectionViewDidEndEditing:self.collectionView];
       }
     }];
   }
@@ -395,22 +395,22 @@ typedef NS_ENUM(NSInteger, MDCAutoscrollPanningDirection) {
 
         void (^completionBlock)(BOOL finished) = ^(__unused BOOL finished) {
           // Notify delegate dragging has finished.
-          if ([_delegate
+          if ([self.delegate
                   respondsToSelector:@selector(collectionView:didEndDraggingItemAtIndexPath:)]) {
-            [_delegate collectionView:_collectionView
-                didEndDraggingItemAtIndexPath:_reorderingCellIndexPath];
+            [self.delegate collectionView:self.collectionView
+                didEndDraggingItemAtIndexPath:self->_reorderingCellIndexPath];
           }
           [self restoreEditingItem];
 
           // Re-enable scrolling.
-          [_collectionView setScrollEnabled:YES];
+          [self.collectionView setScrollEnabled:YES];
         };
 
         [UIView animateWithDuration:kDismissalAnimationDuration
                               delay:0
                             options:UIViewAnimationOptionBeginFromCurrentState
                          animations:^{
-                           _cellSnapshot.frame = attributes.frame;
+                           self->_cellSnapshot.frame = attributes.frame;
                          }
                          completion:completionBlock];
       }
@@ -661,8 +661,8 @@ typedef NS_ENUM(NSInteger, MDCAutoscrollPanningDirection) {
       delay:0
       options:UIViewAnimationOptionCurveEaseOut
       animations:^{
-        _cellSnapshot.layer.transform = CATransform3DMakeAffineTransform(transform);
-        _cellSnapshot.alpha = 0;
+        self->_cellSnapshot.layer.transform = CATransform3DMakeAffineTransform(transform);
+        self->_cellSnapshot.alpha = 0;
       }
       completion:^(__unused BOOL finished) {
         [self restoreEditingItem];
@@ -807,7 +807,7 @@ typedef NS_ENUM(NSInteger, MDCAutoscrollPanningDirection) {
                          CGPointMake(0, MAX(0, contentYOffset + yOffset));
 
                      // Transform snapshot position when panning.
-                     _cellSnapshot.layer.transform =
+                     self->_cellSnapshot.layer.transform =
                          CATransform3DMakeAffineTransform(snapshotTransform);
                    }
                    completion:nil];

--- a/components/Collections/src/private/MDCCollectionViewStyler.m
+++ b/components/Collections/src/private/MDCCollectionViewStyler.m
@@ -361,7 +361,7 @@ NS_INLINE CGRect RectShift(CGRect rect, CGFloat dx, CGFloat dy) {
     void (^completionBlock)(BOOL finished) = ^(__unused BOOL finished) {
       if ([self.delegate
               respondsToSelector:@selector(collectionView:didApplyInlayToItemAtIndexPaths:)]) {
-        [self.delegate collectionView:_collectionView
+        [self.delegate collectionView:self.collectionView
             didApplyInlayToItemAtIndexPaths:@[ indexPath ]];
       }
     };
@@ -378,7 +378,7 @@ NS_INLINE CGRect RectShift(CGRect rect, CGFloat dx, CGFloat dy) {
   void (^completionBlock)(BOOL finished) = ^(__unused BOOL finished) {
     if ([self.delegate
             respondsToSelector:@selector(collectionView:didRemoveInlayFromItemAtIndexPaths:)]) {
-      [self.delegate collectionView:_collectionView
+      [self.delegate collectionView:self.collectionView
           didRemoveInlayFromItemAtIndexPaths:@[ indexPath ]];
     }
   };
@@ -400,8 +400,8 @@ NS_INLINE CGRect RectShift(CGRect rect, CGFloat dx, CGFloat dy) {
     void (^completionBlock)(BOOL finished) = ^(__unused BOOL finished) {
       if ([self.delegate
               respondsToSelector:@selector(collectionView:didApplyInlayToItemAtIndexPaths:)]) {
-        [self.delegate collectionView:_collectionView
-            didApplyInlayToItemAtIndexPaths:[_inlaidIndexPathSet allObjects]];
+        [self.delegate collectionView:self.collectionView
+            didApplyInlayToItemAtIndexPaths:[self.inlaidIndexPathSet allObjects]];
       }
     };
 
@@ -417,7 +417,7 @@ NS_INLINE CGRect RectShift(CGRect rect, CGFloat dx, CGFloat dy) {
   void (^completionBlock)(BOOL finished) = ^(__unused BOOL finished) {
     if ([self.delegate
             respondsToSelector:@selector(collectionView:didRemoveInlayFromItemAtIndexPaths:)]) {
-      [self.delegate collectionView:_collectionView didRemoveInlayFromItemAtIndexPaths:indexPaths];
+      [self.delegate collectionView:self.collectionView didRemoveInlayFromItemAtIndexPaths:indexPaths];
     }
   };
 
@@ -440,7 +440,7 @@ NS_INLINE CGRect RectShift(CGRect rect, CGFloat dx, CGFloat dy) {
     // Invalidate current layout while allowing animation to new layout.
     [UIView animateWithDuration:0
         animations:^{
-          [_collectionView.collectionViewLayout invalidateLayout];
+          [self.collectionView.collectionViewLayout invalidateLayout];
         }
         completion:^(BOOL finished) {
           if (completion) {

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -178,12 +178,12 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
   [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
   [coordinator animateAlongsideTransition:^(__unused
                    id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
-    CGPoint point = [_highlightedView.superview convertPoint:_highlightedView.center
-                                                      toView:_featureHighlightView];
+    CGPoint point = [self->_highlightedView.superview convertPoint:self->_highlightedView.center
+                                                            toView:self->_featureHighlightView];
 
-    _featureHighlightView.highlightPoint = point;
-    [_featureHighlightView layoutIfNeeded];
-    [_featureHighlightView updateOuterHighlight];
+    self->_featureHighlightView.highlightPoint = point;
+    [self->_featureHighlightView layoutIfNeeded];
+    [self->_featureHighlightView updateOuterHighlight];
   }
                                completion:nil];
 }

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1198,7 +1198,7 @@ static BOOL isRunningiOS10_3OrAbove() {
     }
 
     // When the tracking scroll view is cleared we need a shadow update.
-    if (!_trackingScrollView) {
+    if (!self.trackingScrollView) {
       [self fhv_accumulatorDidChange];
     }
   };

--- a/components/FlexibleHeader/src/private/MDCStatusBarShifter.m
+++ b/components/FlexibleHeader/src/private/MDCStatusBarShifter.m
@@ -235,7 +235,7 @@ typedef NS_ENUM(NSInteger, MDCStatusBarShifterState) {
       // If we're in an invalid state then we have to manage the visibility directly.
       [UIView animateWithDuration:kStatusBarBecomesInvalidAnimationDuration
                        animations:^{
-                         self.prefersStatusBarHidden = _prefersStatusBarHiddenWhileInvalid;
+                         self.prefersStatusBarHidden = self->_prefersStatusBarHiddenWhileInvalid;
                        }];
 
     } else {

--- a/components/Ink/src/MDCInkTouchController.m
+++ b/components/Ink/src/MDCInkTouchController.m
@@ -141,7 +141,7 @@ static const NSTimeInterval kInkTouchDelayInterval = 0.1;
       dispatch_time_t delayTime =
           dispatch_time(DISPATCH_TIME_NOW, (int64_t)(NSEC_PER_SEC * kInkTouchDelayInterval));
       dispatch_after(_delaysInkSpread ? delayTime : 0, dispatch_get_main_queue(), ^(void) {
-        [self touchBeganAtPoint:[recognizer locationInView:_addedInkView]
+        [self touchBeganAtPoint:[recognizer locationInView:self.addedInkView]
                   touchLocation:touchLocation];
       });
       break;

--- a/components/Ink/src/private/MDCInkLayer.m
+++ b/components/Ink/src/private/MDCInkLayer.m
@@ -215,7 +215,7 @@ static NSString *const MDCInkLayerScaleString = @"transform.scale";
     animGroup.fillMode = kCAFillModeForwards;
     animGroup.removedOnCompletion = NO;
     [CATransaction setCompletionBlock:^{
-      _startAnimationActive = NO;
+      self->_startAnimationActive = NO;
     }];
     [self addAnimation:animGroup forKey:nil];
     [CATransaction commit];

--- a/components/MaskedTransition/src/MDCMaskedTransition.m
+++ b/components/MaskedTransition/src/MDCMaskedTransition.m
@@ -174,9 +174,9 @@ static inline CGFloat LengthOfVector(CGVector vector) {
     context.foreViewController.view.frame = originalFrame;
     [originalSuperview addSubview:context.foreViewController.view];
 
-    _sourceView.frame = originalSourceFrame;
-    _sourceView.backgroundColor = originalSourceBackgroundColor;
-    [originalSourceSuperview addSubview:_sourceView];
+    self->_sourceView.frame = originalSourceFrame;
+    self->_sourceView.backgroundColor = originalSourceBackgroundColor;
+    [originalSourceSuperview addSubview:self->_sourceView];
 
     [maskedView removeFromSuperview];
 

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -453,7 +453,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   if (context == kKVOContextMDCNavigationBar) {
     void (^mainThreadWork)(void) = ^{
       @synchronized(self->_observedNavigationItemLock) {
-        if (object != _observedNavigationItem) {
+        if (object != self->_observedNavigationItem) {
           return;
         }
 

--- a/components/PageControl/src/MDCPageControl.m
+++ b/components/PageControl/src/MDCPageControl.m
@@ -173,7 +173,7 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
       // destination.
       dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(duration * NSEC_PER_SEC)),
                      dispatch_get_main_queue(), ^{
-                       [_trackLayer removeTrackTowardsPoint:shouldReverse ? startPoint : endPoint
+                       [self->_trackLayer removeTrackTowardsPoint:shouldReverse ? startPoint : endPoint
                                                  completion:^{
                                                    // Once track is removed, reveal indicators once
                                                    // more to ensure
@@ -269,11 +269,11 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
                      NSInteger currentPage = [self scrolledPageNumber:scrollView];
                      [self setCurrentPage:currentPage animated:YES duration:animation.duration];
 
-                     CGFloat transformX = scrolledPercentage * _trackLength;
-                     [_animatedIndicator updateIndicatorTransformX:transformX
-                                                          animated:YES
-                                                          duration:animation.duration
-                                               mediaTimingFunction:animation.timingFunction];
+                     CGFloat transformX = scrolledPercentage * self->_trackLength;
+                     [self->_animatedIndicator updateIndicatorTransformX:transformX
+                                                                animated:YES
+                                                                duration:animation.duration
+                                                     mediaTimingFunction:animation.timingFunction];
                    });
 
   } else if (scrolledPercentage >= 0 && scrolledPercentage <= 1 && _numberOfPages > 0) {

--- a/components/PageControl/src/private/MDCPageControlTrackLayer.m
+++ b/components/PageControl/src/private/MDCPageControlTrackLayer.m
@@ -64,8 +64,8 @@ static NSString *const kPageControlAnimationKeyDraw = @"drawTrack";
     // After drawn, remove animation and update track frame.
     [self removeAnimationForKey:kPageControlAnimationKeyDraw];
     [self updateTrackFrameWithAnimation:NO completion:nil];
-    _trackHidden = NO;
-    _isAnimating = NO;
+    self->_trackHidden = NO;
+    self->_isAnimating = NO;
   }];
 
   // Get animation keyframes.

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -469,7 +469,7 @@ static const CGFloat kMaximumHeight = 80.0f;
       options:UIViewAnimationOptionCurveEaseInOut
       animations:^{
         // Trigger snackbar animation.
-        [_containingView layoutIfNeeded];
+        [self.containingView layoutIfNeeded];
       }
       completion:^(__unused BOOL finished) {
         if (completion) {

--- a/components/Tabs/src/MDCTabBarViewController.m
+++ b/components/Tabs/src/MDCTabBarViewController.m
@@ -123,8 +123,8 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
           }
           completion:^(__unused BOOL finished) {
             // If we are hiding, set the state after the animation.
-            _tabBar.hidden = hidden;
-            _tabBarShadow.hidden = hidden;
+            self.tabBar.hidden = hidden;
+            self->_tabBarShadow.hidden = hidden;
           }];
     } else {
       _tabBar.hidden = hidden;

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -534,7 +534,7 @@ static void *kItemPropertyContext = &kItemPropertyContext;
     [self updateSelectionIndicatorToIndex:index];
 
     // Force layout so any changes to the selection indicator are captured by the animation block.
-    [_selectionIndicator layoutIfNeeded];
+    [self->_selectionIndicator layoutIfNeeded];
   };
 
   if (animate) {

--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -526,8 +526,8 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
 
     // Set the transforms.
     self.titleLabel.transform = titleTransform;
-    _badgeLabel.transform = imageTransform;
-    _imageView.transform = imageTransform;
+    self->_badgeLabel.transform = imageTransform;
+    self->_imageView.transform = imageTransform;
   };
   void (^completeAnimations)(BOOL) = ^(__unused BOOL finished) {
     if (titleContentsScale != self.titleLabel.layer.contentsScale) {

--- a/components/private/ThumbTrack/src/MDCThumbTrack.m
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.m
@@ -533,11 +533,11 @@ static inline CGFloat DistanceFromPointToPoint(CGPoint point1, CGPoint point2) {
                             delay:0.0f
                           options:options
                        animations:^{
-                         _value = _filledTrackAnchorValue;
+                         self.value = self.filledTrackAnchorValue;
                          [self updateViewsMainIsAnimated:animated
                                             withDuration:animationDurationToAnchor
                                         animationOptions:options];
-                         _value = currentValue;
+                         self.value = currentValue;
                        }
                        completion:afterCrossingAnchorAnimation];
     } else {


### PR DESCRIPTION
Using self./self-> in order to explicitly mention self in the block. 

Fixes  #2932