### PR TITLE
[CocoaPods] adding the framework search paths to the runpath search paths to fix IB_DESIGNABLE auto layout rendering errors

### DIFF
--- a/catalog/Podfile
+++ b/catalog/Podfile
@@ -89,4 +89,10 @@ post_install do |installer|
     puts "Earl Grey submodule update failed. If this project is not a git "\
          "repository, then this is fine." 
   end
+
+  installer.pods_project.build_configurations.each do |config|
+    config.build_settings['LD_RUNPATH_SEARCH_PATHS'] = [
+      '$(FRAMEWORK_SEARCH_PATHS)'
+    ]
+  end
 end


### PR DESCRIPTION
As of now, we get errors when using IB_DESIGNABLE components in XIBs and Storyboards in our Catalog app.

![screen shot 2018-02-16 at 2 27 25 pm](https://user-images.githubusercontent.com/4066863/36325365-97d5c92e-1325-11e8-92a3-49416a4f627a.png)

This resolves #2946 