### PR TITLE
[TextFields] Updating cursor color for state.

### DIFF
--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -521,6 +521,14 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   }
 }
 
+#pragma mark - Cursor Customization
+
+- (void)updateCursor {
+  self.textInput.cursorColor = (self.isDisplayingErrorText || self.isDisplayingCharacterCountError)
+  ? self.errorColor
+  : self.activeColor;
+}
+
 #pragma mark - Leading Label Customization
 
 - (void)updateLeadingUnderlineLabel {
@@ -859,7 +867,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 - (void)setActiveColor:(UIColor *)activeColor {
   if (![_activeColor isEqual:activeColor]) {
     _activeColor = activeColor;
-    [self updateUnderline];
+    [self updateLayout];
   }
 }
 
@@ -1362,6 +1370,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
     return;
   }
 
+  [self updateCursor];
   [self updatePlaceholder];
   [self updateLeadingUnderlineLabel];
   [self updateTrailingUnderlineLabel];

--- a/components/TextFields/src/MDCTextInputControllerLegacyDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerLegacyDefault.m
@@ -498,6 +498,14 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   return image;
 }
 
+#pragma mark - Cursor Customization
+
+- (void)updateCursor {
+  self.textInput.cursorColor = (self.isDisplayingErrorText || self.isDisplayingCharacterCountError)
+  ? self.errorColor
+  : self.activeColor;
+}
+
 #pragma mark - Leading Label Customization
 
 - (void)updateLeadingUnderlineLabel {
@@ -835,7 +843,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 - (void)setActiveColor:(UIColor *)activeColor {
   if (![_activeColor isEqual:activeColor]) {
     _activeColor = activeColor;
-    [self updateUnderline];
+    [self updateLayout];
   }
 }
 
@@ -1292,6 +1300,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
     return;
   }
 
+  [self updateCursor];
   [self updatePlaceholder];
   [self updateLeadingUnderlineLabel];
   [self updateTrailingUnderlineLabel];

--- a/components/TextFields/tests/unit/MultilineTextFieldTests.swift
+++ b/components/TextFields/tests/unit/MultilineTextFieldTests.swift
@@ -131,7 +131,8 @@ class MultilineTextFieldTests: XCTestCase {
                    unserializedInput?.translatesAutoresizingMaskIntoConstraints)
     XCTAssertEqual(textField.text,
                    unserializedInput?.text)
-    XCTAssertEqual(textField.cursorColor, unserializedInput?.cursorColor)
+
+    XCTAssert(textField.cursorColor?.isEqualAsFloats(unserializedInput?.cursorColor) ?? false)
 
     XCTAssertEqual(textField.leadingUnderlineLabel.text,
                    unserializedInput?.leadingUnderlineLabel.text)

--- a/components/TextFields/tests/unit/UIColor+ForcedFloatComparison.swift
+++ b/components/TextFields/tests/unit/UIColor+ForcedFloatComparison.swift
@@ -1,0 +1,42 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import UIKit
+
+/*
+ There is a bug in UIColor's implementation of `encodeWithCoder:` that causes it to be saved not
+ with CGFloats for each RGB value but Floats. The loss of precision will break comparisons. See
+ https://stackoverflow.com/questions/22338594/why-does-this-code-behave-differently-on-64-bit-builds-ios-uicolor-uikeyed
+ */
+
+/* Casts the RGB CGFloats to Float before comparison. */
+extension UIColor {
+  func isEqualAsFloats(_ other: UIColor?) -> Bool {
+    var red1: CGFloat = 0.0
+    var green1: CGFloat = 0.0
+    var blue1: CGFloat = 0.0
+    var alpha1: CGFloat = 0.0
+    getRed(&red1, green: &green1, blue: &blue1, alpha: &alpha1)
+
+    var red2: CGFloat = 0.0
+    var green2: CGFloat = 0.0
+    var blue2: CGFloat = 0.0
+    var alpha2: CGFloat = 0.0
+    other?.getRed(&red2, green: &green2, blue: &blue2, alpha: &alpha2)
+
+    return Float(red1) == Float(red2) && Float(green1) == Float(green2) && Float(blue1) == Float(blue2) && Float(alpha1) == Float(alpha2)
+  }
+}


### PR DESCRIPTION
Brings correct application of color to cursor in controllers that show `.activeColor` and `.errorColor`.

![simulator screen shot - iphone 7 - 2018-02-16 at 21 05 42](https://user-images.githubusercontent.com/1271525/36337117-7d2bc258-135d-11e8-8299-7c1f2544f7c2.png)
![simulator screen shot - iphone 7 - 2018-02-16 at 21 04 35](https://user-images.githubusercontent.com/1271525/36337116-7d21c820-135d-11e8-9329-ca3ad0ea84b1.png)
![simulator screen shot - iphone 7 - 2018-02-16 at 21 05 51](https://user-images.githubusercontent.com/1271525/36337118-7d37fcbc-135d-11e8-9f22-6d8d5cf943aa.png)
![simulator screen shot - iphone 6s plus - 2018-02-16 at 21 05 57](https://user-images.githubusercontent.com/1271525/36337134-ba0dec00-135d-11e8-9a49-5113f7cf7171.png)
