### PR TITLE
[AppBar] Allow setting a custom height on MDCNavigationBar and MDCButtonBar.

### DIFF
--- a/components/ButtonBar/src/MDCButtonBar.h
+++ b/components/ButtonBar/src/MDCButtonBar.h
@@ -107,9 +107,13 @@ IB_DESIGNABLE
 
 /**
  Returns a height adhering to the Material spec for Bars and a width that is able to accommodate
- every item present in the `items` property. The provided size is ignored.
+ every item present in the `items` property. The provided size is ignored. If height is set to a
+ value greater than zero, that is used instead of the default height.
  */
 - (CGSize)sizeThatFits:(CGSize)size;
+
+/* If greater than zero, overrides the default Material height used in sizeThatFits. */
+@property(nonatomic, assign) CGFloat height;
 
 @end
 

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -154,7 +154,8 @@ static NSString *const MDCButtonBarButtonLayoutPositionKey = @"MDCButtonBarButto
     totalWidth += width;
   }
 
-  CGFloat height = [self usePadHeight] ? kDefaultPadHeight : kDefaultHeight;
+  CGFloat height =
+      self.height > 0 ? self.height : ([self usePadHeight] ? kDefaultPadHeight : kDefaultHeight);
   return CGSizeMake(totalWidth, height);
 }
 

--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -88,6 +88,12 @@ IB_DESIGNABLE
 @property(nonatomic, copy, nullable) NSString *title;
 
 /**
+ If greater than zero, overrides the default height that is used for the navigation bar and its
+ leading and trailing button bars.
+ */
+@property(nonatomic, assign) CGFloat height;
+
+/**
  The title view layout differs from the traditional behavior of UINavigationBar.
 
  Due to MDCNavigationBar being able to expand vertically, the titleView's height is updated to match

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -376,8 +376,10 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 }
 
 - (CGSize)intrinsicContentSize {
-
-  CGFloat height = ([self usePadInsets] ? kNavigationBarPadDefaultHeight : kNavigationBarDefaultHeight);
+  CGFloat height =
+      self.height > 0 ?
+          self.height :
+          ([self usePadInsets] ? kNavigationBarPadDefaultHeight : kNavigationBarDefaultHeight);
   return CGSizeMake(UIViewNoIntrinsicMetric, height);
 }
 
@@ -734,6 +736,15 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
                                    context:kKVOContextMDCNavigationBar];
     }
   }
+}
+
+- (void)setHeight:(CGFloat)height {
+  if (_height == height) {
+    return;
+  }
+  _height = height;
+  _leadingButtonBar.height = height;
+  _trailingButtonBar.height = height;
 }
 
 - (void)observeNavigationItem:(UINavigationItem *)navigationItem {


### PR DESCRIPTION
Allow setting a custom height on MDCNavigationBar and MDCButtonBar. Currently, these two components don't respect the height that is used for MDCAppBar, and position the buttons incorrectly when a height other than 56.0f is used.

closes #2793 