### PR TITLE
[Textfields] Completing secure coding for all MDCTextfield and properties of it.

### DIFF
--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -76,7 +76,8 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
     NSString *interfaceBuilderPlaceholder = super.placeholder;
 
     if ([aDecoder containsValueForKey:MDCTextFieldFundamentKey]) {
-      _fundament = [aDecoder decodeObjectForKey:MDCTextFieldFundamentKey];
+      _fundament = [aDecoder decodeObjectOfClass:[MDCTextInputCommonFundament class]
+                                          forKey:MDCTextFieldFundamentKey];
     } else {
       _fundament = [[MDCTextInputCommonFundament alloc] initWithTextInput:self];
     }

--- a/components/TextFields/src/MDCTextInputBorderView.m
+++ b/components/TextFields/src/MDCTextInputBorderView.m
@@ -73,9 +73,12 @@ static inline NSString *_Nullable MDCNSStringFromCGLineJoin(CGLineJoin lineJoin)
 - (instancetype)initWithCoder:(NSCoder *)coder {
   self = [super initWithCoder:coder];
   if (self) {
-    _borderFillColor = [coder decodeObjectForKey:MDCTextInputBorderViewBorderFillColorKey];
-    _borderPath = [coder decodeObjectForKey:MDCTextInputBorderViewBorderPathKey];
-    _borderStrokeColor = [coder decodeObjectForKey:MDCTextInputBorderViewBorderStrokeColorKey];
+    _borderFillColor = [coder decodeObjectOfClass:[UIColor class]
+                                           forKey:MDCTextInputBorderViewBorderFillColorKey];
+    _borderPath = [coder decodeObjectOfClass:[UIBezierPath class]
+                                     forKey:MDCTextInputBorderViewBorderPathKey];
+    _borderStrokeColor = [coder decodeObjectOfClass:[UIColor class]
+                                            forKey:MDCTextInputBorderViewBorderStrokeColorKey];
     [self commonMDCTextInputBorderViewInit];
   }
   return self;

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -159,16 +159,20 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   if (self) {
     [self commonMDCTextInputCommonFundamentInit];
 
-    _borderPath = [aDecoder decodeObjectForKey:MDCTextInputFundamentBorderPathKey];
-    _borderView = [aDecoder decodeObjectForKey:MDCTextInputFundamentBorderViewKey];
-    _clearButton = [aDecoder decodeObjectForKey:MDCTextInputFundamentClearButtonKey];
+    _borderPath = [aDecoder decodeObjectOfClass:[UIBezierPath class]
+                                         forKey:MDCTextInputFundamentBorderPathKey];
+    _borderView = [aDecoder decodeObjectOfClass:[MDCTextInputBorderView class]
+                                         forKey:MDCTextInputFundamentBorderViewKey];
+    _clearButton = [aDecoder decodeObjectOfClass:[UIButton class]
+                                          forKey:MDCTextInputFundamentClearButtonKey];
     _hidesPlaceholderOnInput = [aDecoder decodeBoolForKey:MDCTextInputFundamentHidesPlaceholderKey];
-    _leadingUnderlineLabel = [aDecoder decodeObjectForKey:MDCTextInputFundamentLeadingLabelKey];
+    _leadingUnderlineLabel = [aDecoder decodeObjectOfClass:[UILabel class]
+                                                    forKey:MDCTextInputFundamentLeadingLabelKey];
     _mdc_adjustsFontForContentSizeCategory =
         [aDecoder decodeBoolForKey:MDCTextInputFundamentMDCAdjustsFontsKey];
     _placeholderLabel = [aDecoder decodeObjectOfClass:[UILabel class]
                                                forKey:MDCTextInputFundamentPlaceholderLabelKey];
-    _textInput = [aDecoder decodeObjectOfClass:[UIView<MDCTextInput> class]
+    _textInput = [aDecoder decodeObjectOfClass:[UIView class]
                                         forKey:MDCTextInputFundamentTextInputKey];
     _textColor =
         [aDecoder decodeObjectOfClass:[UIColor class] forKey:MDCTextInputFundamentTextColorKey];


### PR DESCRIPTION
We don't respond to the protocol NSSecureCoding since UIView itself do not support NSSecureCoding. But we use secure encoding/decoding wherever possible. #2991 