### PR TITLE
[BottomNavigation] Fix memory leak in example

### DIFF
--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -135,7 +135,7 @@
   self.badgeCount++;
   self.bottomNavBar.items[1].badgeValue = [NSNumber numberWithInt:self.badgeCount].stringValue;
 
-  __weak __typeof__(self) weakSelf = self;
+  __weak BottomNavigationTypicalUseExample *weakSelf = self;
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
     [weakSelf updateBadgeItemCount];
   });

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -135,8 +135,9 @@
   self.badgeCount++;
   self.bottomNavBar.items[1].badgeValue = [NSNumber numberWithInt:self.badgeCount].stringValue;
 
+  __weak __typeof__(self) weakSelf = self;
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-    [self updateBadgeItemCount];
+    [weakSelf updateBadgeItemCount];
   });
 }
 


### PR DESCRIPTION
The `BottomNavigationTypicalUseExample` has a retain cycle in the
`dispatch_after` block it uses to update the badge value. This causes
example VCs to be accumulated if they are opened repeatedly. A simple
fix is to keep a weak reference in the dispatched block making the next
update call a no-op.
