### PR TITLE
[FeatureHighlight] Remove use of __typeof__

### DIFF
--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -97,9 +97,9 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
   _featureHighlightView.mdc_adjustsFontForContentSizeCategory =
       _mdc_adjustsFontForContentSizeCategory;
 
-  __weak __typeof__(self) weakSelf = self;
+  __weak MDCFeatureHighlightViewController *weakSelf = self;
   _featureHighlightView.interactionBlock = ^(BOOL accepted) {
-    __typeof__(self) strongSelf = weakSelf;
+    MDCFeatureHighlightViewController *strongSelf = weakSelf;
     [strongSelf dismiss:accepted];
   };
 


### PR DESCRIPTION
Instead of relying on the compiler to determine the pointer type,
explicit type references should be used.

Related to #3017
