### PR TITLE
[NavigationBar] Fix license stanza

### DIFF
--- a/components/NavigationBar/examples/NavigationBarLayoutExample.m
+++ b/components/NavigationBar/examples/NavigationBarLayoutExample.m
@@ -11,14 +11,6 @@
  limitations under the License.
  */
 
-//
-//  NavigationBarLayoutExample.m
-//  Pods
-//
-//  Created by Rob Moore on 7/28/17.
-//
-//
-
 #import "MaterialIcons+ic_arrow_back.h"
 #import "MaterialNavigationBar.h"
 #import "MaterialTextFields.h"


### PR DESCRIPTION
Removing an autogenerated file comment that should have been replaced
with the project license.
