### PR TITLE
Ensure BottomSheet adjusts its target point when its bounds change

### DIFF
--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -38,6 +38,7 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
 @property(nonatomic) MDCSheetBehavior *sheetBehavior;
 @property(nonatomic) BOOL isDragging;
 @property(nonatomic) CGFloat originalPreferredSheetHeight;
+@property(nonatomic) CGRect previousAnimatedBounds;
 
 @end
 
@@ -191,6 +192,14 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
 
 #pragma mark - Layout
 
+- (void)layoutSubviews {
+  [super layoutSubviews];
+  if (!CGRectEqualToRect(self.bounds, self.previousAnimatedBounds) && self.window) {
+    // Adjusts the pane to the correct snap point if we are visible.
+    [self animatePaneWithInitialVelocity:CGPointZero];
+  }
+}
+
 - (void)setPreferredSheetHeight:(CGFloat)preferredSheetHeight {
   self.originalPreferredSheetHeight = preferredSheetHeight;
 
@@ -273,6 +282,7 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
 #pragma mark - Gesture-driven animation
 
 - (void)animatePaneWithInitialVelocity:(CGPoint)initialVelocity {
+  self.previousAnimatedBounds = self.bounds;
   self.sheetBehavior.targetPoint = [self targetPoint];
   self.sheetBehavior.velocity = initialVelocity;
   __weak MDCSheetContainerView *weakSelf = self;


### PR DESCRIPTION
Fixes a bug I introduced here:

https://github.com/material-components/material-components-ios/pull/3008/commits/4dc58eed4327c59c3b6ba1545bea5d83d620b808

Interesting breakage - Previously the auto resizing mask was causing the layout to occur in two steps on rotation. First the sheet laid out at an incorrect bounds by the mask and then it was corrected manually in:

- (void)viewWillTransitionToSize:(CGSize)size
          withTransitionCoordinator:(id <UIViewControllerTransitionCoordinator>)coordinator 

The change above removed the first step, so that the sheet only laid out at the correct bounds. However, strangely, even though after rotation the MDCSheetContainerView and its child MDCDraggableView were getting positioned to the exact same frame, on iPad MDCSheetContainerView's animator was then updating MDCDraggableView to the wrong position.

This did not happen before because MDCSheetContainerView was observing its scrollView's contentSize and adjusting the sheetBehavior's targetPoint when it changed. When the 2 step layout occurred the change to the incorrect bounds and back triggered this update, and cause it to recompute its target point for its new bounds. However, with the 1 step layout the contentSize does not change, and thus even though the MDCSheetContainerView's bounds have changed the target point is not recalculated.

Ensuring the targetPoint is calculated on every bounds change (in layout subviews) and not just when the scrollview's content size changes, will ensure this value always stays up to date.