### PR TITLE
[Docs] Correcting PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 #### Don't forget:
 - [ ] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
 - [ ] Link to GitHub issues it solves. ```closes #1234```
-- [ ] Sign the CLA bot. You can do this once the pull request is submitted.
+- [ ] Sign the CLA bot. You can do this once the pull request is opened.
 
 [Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
 pull request.


### PR DESCRIPTION
Fixing the wording about when a CLA can be signed. Previously it indicated the PR had to be submitted, now it will reflect that the appropriate time is when a PR is opened.