### PR TITLE
[FlexibleHeader] Forward taps on contentView to the tracking scroll view

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -436,7 +436,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   UIView *hitView = [super hitTest:point withEvent:event];
 
   // Forwards taps to the scroll view.
-  if (hitView == self || [_forwardingViews containsObject:hitView]) {
+  if (hitView == self || hitView == _contentView || [_forwardingViews containsObject:hitView]) {
     hitView = _trackingScrollView;
   }
 


### PR DESCRIPTION
In our project, we have a container UIView that is added as a direct subview (not under contentView) to the MDCFlexibleHeaderView. The container view has a relatively deep subview tree, and several full-size descendant container views, due to legacy reasons. We would like to have the touches on the container view and its descendant container views forwarded to the tracking scroll view. We are currently passing the tracking scroll view directly into those views, an approach I find inelegant. I have also considered using -forwardTouchEventsForView:, but that also increases the coupling between the flexible header and the multiple container views.

I am trying to apply the hitTest trick to my container views by returning nil when the hitView is those container views themselves, so the flexible header can eventually receive the touch event and forward it to the tracking scroll view. However, I noticed that _contentView actually received the touch event since it's the only other subview inside flexible view that's handling the touch event. That's why I am making the change in this PR to also check for _contentView when forwarding the touch event.

As mentioned above, I am not using contentView at all in my use case. However, even in the case where subviews are added to contentView, touches on contentView should still be forwarded since it means that the subviews do not wish to handle the touch target. (This also made me wonder - since contentView is always added as a subview and will always have the same size as the flexible header, will hitView == self ever be true?)