### PR TITLE
[Snackbar] Don't call UIAppearance in +initialize

### DIFF
--- a/components/Snackbar/src/MDCSnackbarMessageView.h
+++ b/components/Snackbar/src/MDCSnackbarMessageView.h
@@ -23,18 +23,24 @@
 
 /**
  The color for the background of the snackbar message view.
+
+ The default color is a dark gray color.
  */
 @property(nonatomic, strong, nullable)
     UIColor *snackbarMessageViewBackgroundColor UI_APPEARANCE_SELECTOR;
 
 /**
  The color for the shadow color for the snackbar message view.
+
+ The default color is @c blackColor.
  */
 @property(nonatomic, strong, nullable)
     UIColor *snackbarMessageViewShadowColor UI_APPEARANCE_SELECTOR;
 
 /**
  The color for the message text in the snackbar message view.
+
+ The default color is @c whiteColor.
  */
 @property(nonatomic, strong, nullable) UIColor *snackbarMessageViewTextColor UI_APPEARANCE_SELECTOR;
 

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -170,10 +170,16 @@ static const CGFloat kButtonInkRadius = 64.0f;
   NSMutableArray<MDCButton *> *_actionButtons;
 }
 
-+ (void)initialize {
-  [[self appearance] setSnackbarMessageViewShadowColor:MDCRGBAColor(0x00, 0x00, 0x00, 1.0f)];
-  [[self appearance] setSnackbarMessageViewBackgroundColor:MDCRGBAColor(0x32, 0x32, 0x32, 1.0f)];
-  [[self appearance] setSnackbarMessageViewTextColor:MDCRGBAColor(0xFF, 0xFF, 0xFF, 1.0f)];
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+
+  if (self) {
+    _snackbarMessageViewTextColor = UIColor.whiteColor;
+    _snackbarMessageViewShadowColor = UIColor.blackColor;
+    _snackbarMessageViewBackgroundColor = MDCRGBAColor(0x32, 0x32, 0x32, 1);
+  }
+
+  return self;
 }
 
 - (void)dismissWithAction:(MDCSnackbarMessageAction *)action userInitiated:(BOOL)userInitiated {

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -1,0 +1,41 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialSnackbar.h"
+
+@interface MDCSnackbarMessageViewTests : XCTestCase
+
+@end
+
+@implementation MDCSnackbarMessageViewTests
+
+- (void)testDefaultColors {
+  // Given
+  MDCSnackbarMessageView *messageView = [[MDCSnackbarMessageView alloc] init];
+
+  // Then
+  XCTAssertEqualObjects(messageView.snackbarMessageViewBackgroundColor,
+                        [UIColor colorWithRed:(float)(0x32 / 255.0)
+                                        green:(float)(0x32 / 255.0)
+                                         blue:(float)(0x32 / 255.0)
+                                        alpha:1]);
+  XCTAssertEqualObjects(messageView.snackbarMessageViewShadowColor, UIColor.blackColor);
+  XCTAssertEqualObjects(messageView.snackbarMessageViewTextColor, UIColor.whiteColor);
+}
+
+@end


### PR DESCRIPTION
Clients can use UIAppearance to theme all MDCSnackbarMessageView instances.
The class itself should rely on initializers to set its default values instead
of UIAppearance.

Closes #3047