### PR TITLE
[Snackbar] New Snackbar implementation with legacy toggle to activate

### DIFF
--- a/components/Snackbar/examples/SnackbarOverlayViewExample.m
+++ b/components/Snackbar/examples/SnackbarOverlayViewExample.m
@@ -28,12 +28,21 @@ static const CGFloat kBottomBarHeight = 44.0f;
 @property(nonatomic, assign) CGFloat floatingButtonOffset;
 @end
 
-@implementation SnackbarOverlayViewExample
+@implementation SnackbarOverlayViewExample {
+  BOOL _legacyMode;
+}
 
 - (void)viewDidLoad {
   [super viewDidLoad];
   [self setupExampleViews:@[ @"Show Snackbar", @"Toggle bottom bar" ]];
   self.title = @"Snackbar Overlay View";
+
+  _legacyMode = YES;
+  self.navigationItem.rightBarButtonItem =
+  [[UIBarButtonItem alloc] initWithTitle:@"Legacy"
+                                   style:UIBarButtonItemStylePlain
+                                  target:self
+                                  action:@selector(toggleModes)];
 
   self.floatingButton = [[MDCFloatingButton alloc] init];
   [self.floatingButton sizeToFit];
@@ -73,6 +82,16 @@ static const CGFloat kBottomBarHeight = 44.0f;
   [super viewWillDisappear:animated];
 
   [MDCSnackbarManager setBottomOffset:0];
+}
+
+- (void)toggleModes {
+  _legacyMode = !_legacyMode;
+  if (_legacyMode) {
+    [self.navigationItem.rightBarButtonItem setTitle:@"Legacy"];
+  } else {
+    [self.navigationItem.rightBarButtonItem setTitle:@"New"];
+  }
+  MDCSnackbarMessage.usesLegacySnackbar = _legacyMode;
 }
 
 #pragma mark - Event Handling

--- a/components/Snackbar/examples/SnackbarSimpleExample.m
+++ b/components/Snackbar/examples/SnackbarSimpleExample.m
@@ -36,10 +36,10 @@
   self.title = @"Snackbar";
   _legacyMode = YES;
   self.navigationItem.rightBarButtonItem =
-  [[UIBarButtonItem alloc] initWithTitle:@"Legacy"
-                                   style:UIBarButtonItemStylePlain
-                                  target:self
-                                  action:@selector(toggleModes)];
+      [[UIBarButtonItem alloc] initWithTitle:@"Legacy"
+                                       style:UIBarButtonItemStylePlain
+                                      target:self
+                                      action:@selector(toggleModes)];
 }
 
 - (void)toggleModes {

--- a/components/Snackbar/examples/SnackbarSimpleExample.m
+++ b/components/Snackbar/examples/SnackbarSimpleExample.m
@@ -19,7 +19,9 @@
 #import "MaterialSnackbar.h"
 #import "supplemental/SnackbarExampleSupplemental.h"
 
-@implementation SnackbarSimpleExample
+@implementation SnackbarSimpleExample {
+  BOOL _legacyMode;
+}
 
 - (void)viewDidLoad {
   [super viewDidLoad];
@@ -32,6 +34,21 @@
       @"De-Customize Font Example"
   ]];
   self.title = @"Snackbar";
+  _legacyMode = NO;
+  self.navigationItem.rightBarButtonItem =
+  [[UIBarButtonItem alloc] initWithTitle:@"New"
+                                   style:UIBarButtonItemStylePlain
+                                  target:self
+                                  action:@selector(toggleModes)];
+}
+
+- (void)toggleModes {
+  _legacyMode = !_legacyMode;
+  if (_legacyMode) {
+    [self.navigationItem.rightBarButtonItem setTitle:@"Legacy"];
+  } else {
+    [self.navigationItem.rightBarButtonItem setTitle:@"New"];
+  }
 }
 
 #pragma mark - Event Handling
@@ -39,12 +56,14 @@
 - (void)showSimpleSnackbar:(id)sender {
   MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
   message.text = @"Snackbar Message";
+  message.usesLegacySnackbar = _legacyMode;
   [MDCSnackbarManager showMessage:message];
 }
 
 - (void)showSnackbarWithAction:(id)sender {
   MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
   message.text = @"Snackbar Message";
+  message.usesLegacySnackbar = _legacyMode;
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   action.title = @"Tap Me";
   message.action = action;
@@ -57,10 +76,12 @@
 - (void)showLongSnackbarMessage:(id)sender {
   MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
   message.text = @"A red flair silhouetted the jagged edge of a sublime wing.";
+  message.usesLegacySnackbar = _legacyMode;
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   MDCSnackbarMessageActionHandler actionHandler = ^() {
     MDCSnackbarMessage *answerMessage = [[MDCSnackbarMessage alloc] init];
     answerMessage.text = @"The sky was cloudless and of a deep dark blue.";
+    answerMessage.usesLegacySnackbar = _legacyMode;
     [MDCSnackbarManager showMessage:answerMessage];
   };
   action.handler = actionHandler;
@@ -84,6 +105,7 @@
   [text appendAttributedString:[[NSAttributedString alloc]
                                 initWithString:@" go where no one has gone before."]];
   message.attributedText = text;
+  message.usesLegacySnackbar = _legacyMode;
 
   [MDCSnackbarManager showMessage:message];
 }
@@ -100,6 +122,7 @@
 
   MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
   message.text = @"Customized Fonts";
+  message.usesLegacySnackbar = _legacyMode;
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   action.title = @"Fancy";
   message.action = action;
@@ -112,6 +135,7 @@
   [MDCSnackbarMessageView appearance].buttonFont = nil;
   MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
   message.text = @"Back to the standard fonts";
+  message.usesLegacySnackbar = _legacyMode;
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   action.title = @"Okay";
   message.action = action;

--- a/components/Snackbar/examples/SnackbarSimpleExample.m
+++ b/components/Snackbar/examples/SnackbarSimpleExample.m
@@ -45,7 +45,6 @@
 - (void)showSnackbarWithAction:(id)sender {
   MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
   message.text = @"Snackbar Message";
-  [MDCSnackbarManager showMessage:message];
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   action.title = @"Tap Me";
   message.action = action;

--- a/components/Snackbar/examples/SnackbarSimpleExample.m
+++ b/components/Snackbar/examples/SnackbarSimpleExample.m
@@ -34,9 +34,9 @@
       @"De-Customize Font Example"
   ]];
   self.title = @"Snackbar";
-  _legacyMode = NO;
+  _legacyMode = YES;
   self.navigationItem.rightBarButtonItem =
-  [[UIBarButtonItem alloc] initWithTitle:@"New"
+  [[UIBarButtonItem alloc] initWithTitle:@"Legacy"
                                    style:UIBarButtonItemStylePlain
                                   target:self
                                   action:@selector(toggleModes)];
@@ -49,6 +49,7 @@
   } else {
     [self.navigationItem.rightBarButtonItem setTitle:@"New"];
   }
+  MDCSnackbarMessage.usesLegacySnackbar = _legacyMode;
 }
 
 #pragma mark - Event Handling
@@ -56,14 +57,12 @@
 - (void)showSimpleSnackbar:(id)sender {
   MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
   message.text = @"Snackbar Message";
-  message.usesLegacySnackbar = _legacyMode;
   [MDCSnackbarManager showMessage:message];
 }
 
 - (void)showSnackbarWithAction:(id)sender {
   MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
   message.text = @"Snackbar Message";
-  message.usesLegacySnackbar = _legacyMode;
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   action.title = @"Tap Me";
   message.action = action;
@@ -76,12 +75,10 @@
 - (void)showLongSnackbarMessage:(id)sender {
   MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
   message.text = @"A red flair silhouetted the jagged edge of a sublime wing.";
-  message.usesLegacySnackbar = _legacyMode;
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   MDCSnackbarMessageActionHandler actionHandler = ^() {
     MDCSnackbarMessage *answerMessage = [[MDCSnackbarMessage alloc] init];
     answerMessage.text = @"The sky was cloudless and of a deep dark blue.";
-    answerMessage.usesLegacySnackbar = _legacyMode;
     [MDCSnackbarManager showMessage:answerMessage];
   };
   action.handler = actionHandler;
@@ -105,7 +102,6 @@
   [text appendAttributedString:[[NSAttributedString alloc]
                                 initWithString:@" go where no one has gone before."]];
   message.attributedText = text;
-  message.usesLegacySnackbar = _legacyMode;
 
   [MDCSnackbarManager showMessage:message];
 }
@@ -122,7 +118,6 @@
 
   MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
   message.text = @"Customized Fonts";
-  message.usesLegacySnackbar = _legacyMode;
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   action.title = @"Fancy";
   message.action = action;
@@ -135,7 +130,6 @@
   [MDCSnackbarMessageView appearance].buttonFont = nil;
   MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
   message.text = @"Back to the standard fonts";
-  message.usesLegacySnackbar = _legacyMode;
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   action.title = @"Okay";
   message.action = action;

--- a/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
+++ b/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
@@ -67,6 +67,10 @@ static NSString * const kCellIdentifier = @"Cell";
   return YES;
 }
 
++ (BOOL)catalogIsDebug {
+  return YES;
+}
+
 @end
 
 @implementation SnackbarOverlayViewExample (CatalogByConvention)

--- a/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
+++ b/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
@@ -68,7 +68,7 @@ static NSString * const kCellIdentifier = @"Cell";
 }
 
 + (BOOL)catalogIsDebug {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -205,6 +205,7 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
         // that the dismissal logic will only fire one time for a given Snackbar view.
         if (shouldDismiss) {
           shouldDismiss = NO;
+
           // If the user
           [self hideSnackbarViewReally:snackbarView withAction:action userPrompted:userInitiated];
         }
@@ -381,6 +382,7 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
   // care of getting it on screen. At this moment, @c message is the only message of its category
   // in @c _sPendingMessages.
   [self.pendingMessages addObject:message];
+
   // Pulse the UI as needed.
   [self showNextMessageIfNecessaryMainThread];
 }

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -205,7 +205,6 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
         // that the dismissal logic will only fire one time for a given Snackbar view.
         if (shouldDismiss) {
           shouldDismiss = NO;
-
           // If the user
           [self hideSnackbarViewReally:snackbarView withAction:action userPrompted:userInitiated];
         }
@@ -225,6 +224,7 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
       showSnackbarView:snackbarView
               animated:YES
             completion:^{
+              NSLog(@"show snackback completion");
               if ([self isSnackbarTransient:snackbarView]) {
                 snackbarView.accessibilityElementsHidden = YES;
                 UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
@@ -272,6 +272,7 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
 
   [self.overlayView dismissSnackbarViewAnimated:YES
                                      completion:^{
+                                       NSLog(@"hide snackback completion");
                                        self.overlayView.hidden = YES;
                                        [self deactivateOverlay:self.overlayView];
 
@@ -382,7 +383,7 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
   // care of getting it on screen. At this moment, @c message is the only message of its category
   // in @c _sPendingMessages.
   [self.pendingMessages addObject:message];
-
+  NSLog(@"%ld", self.pendingMessages.count);
   // Pulse the UI as needed.
   [self showNextMessageIfNecessaryMainThread];
 }

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -224,7 +224,6 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
       showSnackbarView:snackbarView
               animated:YES
             completion:^{
-              NSLog(@"show snackback completion");
               if ([self isSnackbarTransient:snackbarView]) {
                 snackbarView.accessibilityElementsHidden = YES;
                 UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
@@ -272,7 +271,6 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
 
   [self.overlayView dismissSnackbarViewAnimated:YES
                                      completion:^{
-                                       NSLog(@"hide snackback completion");
                                        self.overlayView.hidden = YES;
                                        [self deactivateOverlay:self.overlayView];
 
@@ -383,7 +381,6 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
   // care of getting it on screen. At this moment, @c message is the only message of its category
   // in @c _sPendingMessages.
   [self.pendingMessages addObject:message];
-  NSLog(@"%ld", self.pendingMessages.count);
   // Pulse the UI as needed.
   [self showNextMessageIfNecessaryMainThread];
 }

--- a/components/Snackbar/src/MDCSnackbarMessage.h
+++ b/components/Snackbar/src/MDCSnackbarMessage.h
@@ -143,6 +143,11 @@ extern NSString * __nonnull const MDCSnackbarMessageBoldAttributeName;
  */
 @property(nonatomic, readonly, nullable) NSString *voiceNotificationText;
 
+/**
+ Use the older legacy version of snackbar. Default is NO.
+ */
+@property(nonatomic, assign) BOOL usesLegacySnackbar;
+
 @end
 
 /**

--- a/components/Snackbar/src/MDCSnackbarMessage.h
+++ b/components/Snackbar/src/MDCSnackbarMessage.h
@@ -144,7 +144,7 @@ extern NSString * __nonnull const MDCSnackbarMessageBoldAttributeName;
 @property(nonatomic, readonly, nullable) NSString *voiceNotificationText;
 
 /**
- Use the older legacy version of snackbar. Default is NO.
+ Use the older legacy version of snackbar. Default is YES.
  */
 @property(nonatomic, assign) BOOL usesLegacySnackbar;
 

--- a/components/Snackbar/src/MDCSnackbarMessage.h
+++ b/components/Snackbar/src/MDCSnackbarMessage.h
@@ -72,6 +72,11 @@ extern NSString * __nonnull const MDCSnackbarMessageBoldAttributeName;
 + (nonnull instancetype)messageWithAttributedText:(nonnull NSAttributedString *)attributedText;
 
 /**
+ Use the older legacy version of snackbar. Default is YES.
+ */
+@property(class, nonatomic, assign) BOOL usesLegacySnackbar;
+
+/**
  The primary text of the message.
 
  Either @c text or @c attributedText must be set.
@@ -142,11 +147,6 @@ extern NSString * __nonnull const MDCSnackbarMessageBoldAttributeName;
  Text that should be read when the message appears on screen and VoiceOver is enabled.
  */
 @property(nonatomic, readonly, nullable) NSString *voiceNotificationText;
-
-/**
- Use the older legacy version of snackbar. Default is YES.
- */
-@property(nonatomic, assign) BOOL usesLegacySnackbar;
 
 @end
 

--- a/components/Snackbar/src/MDCSnackbarMessage.m
+++ b/components/Snackbar/src/MDCSnackbarMessage.m
@@ -52,7 +52,7 @@ NSString *const MDCSnackbarMessageBoldAttributeName = @"MDCSnackbarMessageBoldAt
   self = [super init];
   if (self) {
     _duration = kDefaultDuration;
-    _usesLegacySnackbar = YES;
+    _usesLegacySnackbar = NO;
   }
   return self;
 }

--- a/components/Snackbar/src/MDCSnackbarMessage.m
+++ b/components/Snackbar/src/MDCSnackbarMessage.m
@@ -52,7 +52,7 @@ NSString *const MDCSnackbarMessageBoldAttributeName = @"MDCSnackbarMessageBoldAt
   self = [super init];
   if (self) {
     _duration = kDefaultDuration;
-    _usesLegacySnackbar = NO;
+    _usesLegacySnackbar = YES;
   }
   return self;
 }
@@ -69,6 +69,7 @@ NSString *const MDCSnackbarMessageBoldAttributeName = @"MDCSnackbarMessageBoldAt
   copy.accessibilityLabel = self.accessibilityLabel;
   copy.buttonTextColor = self.buttonTextColor;
   copy.highlightedButtonTextColor = self.highlightedButtonTextColor;
+  copy.usesLegacySnackbar = self.usesLegacySnackbar;
 
   // Unfortunately there's not really a concept of 'copying' a block (in the same way you would copy
   // a string, for example). A block's pointer is immutable once it is created and copied to the

--- a/components/Snackbar/src/MDCSnackbarMessage.m
+++ b/components/Snackbar/src/MDCSnackbarMessage.m
@@ -32,7 +32,7 @@ NSString *const MDCSnackbarMessageBoldAttributeName = @"MDCSnackbarMessageBoldAt
 @end
 
 @implementation MDCSnackbarMessage
-
+static BOOL _usesLegacySnackbar = YES;
 @synthesize accessibilityIdentifier;
 @dynamic text;
 
@@ -52,7 +52,6 @@ NSString *const MDCSnackbarMessageBoldAttributeName = @"MDCSnackbarMessageBoldAt
   self = [super init];
   if (self) {
     _duration = kDefaultDuration;
-    _usesLegacySnackbar = YES;
   }
   return self;
 }
@@ -69,7 +68,6 @@ NSString *const MDCSnackbarMessageBoldAttributeName = @"MDCSnackbarMessageBoldAt
   copy.accessibilityLabel = self.accessibilityLabel;
   copy.buttonTextColor = self.buttonTextColor;
   copy.highlightedButtonTextColor = self.highlightedButtonTextColor;
-  copy.usesLegacySnackbar = self.usesLegacySnackbar;
 
   // Unfortunately there's not really a concept of 'copying' a block (in the same way you would copy
   // a string, for example). A block's pointer is immutable once it is created and copied to the
@@ -147,6 +145,14 @@ NSString *const MDCSnackbarMessageBoldAttributeName = @"MDCSnackbarMessageBoldAt
       completion();
     }
   });
+}
+
++ (void)setUsesLegacySnackbar:(BOOL)usesLegacySnackbar {
+  _usesLegacySnackbar = usesLegacySnackbar;
+}
+
++ (BOOL)usesLegacySnackbar {
+  return _usesLegacySnackbar;
 }
 
 @end

--- a/components/Snackbar/src/MDCSnackbarMessage.m
+++ b/components/Snackbar/src/MDCSnackbarMessage.m
@@ -52,6 +52,7 @@ NSString *const MDCSnackbarMessageBoldAttributeName = @"MDCSnackbarMessageBoldAt
   self = [super init];
   if (self) {
     _duration = kDefaultDuration;
+    _usesLegacySnackbar = YES;
   }
   return self;
 }

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -45,13 +45,13 @@ static const CGFloat kBorderWidth = 0;
  Shadow coloring.
  */
 static const CGFloat kShadowAlpha = 0.24f;
-static const CGSize kShadowOffset = (CGSize){0.0, 1.0};
-static const CGFloat kShadowSpread = 1.0f;
+static const CGSize kShadowOffset = (CGSize){0.0, 2.0};
+static const CGFloat kShadowSpread = 4.0f;
 
 /**
  The radius of the corners.
  */
-static const CGFloat kCornerRadius = 0;
+static const CGFloat kCornerRadius = 4;
 
 /**
  Padding between the edges of the snackbar and any content.
@@ -916,25 +916,32 @@ static const CGFloat kButtonInkRadius = 64.0f;
 
 #pragma mark - Animation
 
-- (void)animateContentOpacityFrom:(CGFloat)fromOpacity
+- (CABasicAnimation *)animateContentOpacityFrom:(CGFloat)fromOpacity
                                to:(CGFloat)toOpacity
                          duration:(NSTimeInterval)duration
                    timingFunction:(CAMediaTimingFunction *)timingFunction {
-  [CATransaction begin];
-
   CABasicAnimation *opacityAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
-  opacityAnimation.duration = duration;
+//  opacityAnimation.duration = duration;
   opacityAnimation.fromValue = @(fromOpacity);
   opacityAnimation.toValue = @(toOpacity);
-  opacityAnimation.timingFunction = timingFunction;
+//  opacityAnimation.timingFunction = timingFunction;
+//  [self.layer addAnimation:opacityAnimation forKey:@"opacity"];
+  return opacityAnimation;
+}
 
-  // The text and the button do not share a common view that can be animated independently of the
-  // background color, so just animate them both independently here. If this becomes more
-  // complicated, refactor to add a containing view for both and animate that.
-  [self.contentView.layer addAnimation:opacityAnimation forKey:@"opacity"];
-  [self.buttonView.layer addAnimation:opacityAnimation forKey:@"opacity"];
-
-  [CATransaction commit];
+- (CABasicAnimation *)animateSnackbarScaleFrom:(CGFloat)fromScale
+                                       toScale:(CGFloat)toScale
+                        duration:(NSTimeInterval)duration
+                  timingFunction:(CAMediaTimingFunction *)timingFunction {
+  CABasicAnimation *scaleAnimation = [CABasicAnimation animationWithKeyPath:@"transform.scale"];
+  scaleAnimation.fromValue = [NSNumber numberWithDouble:fromScale];
+  scaleAnimation.toValue = [NSNumber numberWithDouble:toScale];
+//  scaleAnimation.duration = duration;
+//  scaleAnimation.timingFunction = timingFunction;
+//  scaleAnimation.fillMode = kCAFillModeForwards;
+//  scaleAnimation.removedOnCompletion = NO;
+//  [self.layer addAnimation:scaleAnimation forKey:@"transform.scale"];
+  return scaleAnimation;
 }
 
 #pragma mark - Resource bundle

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -321,11 +321,17 @@ static const CGFloat kButtonInkRadius = 64.0f;
     _dismissalHandler = [handler copy];
 
     self.backgroundColor = _snackbarMessageViewBackgroundColor;
-    self.layer.cornerRadius = _message.usesLegacySnackbar ? kLegacyCornerRadius : kCornerRadius;
     self.layer.shadowColor = _snackbarMessageViewShadowColor.CGColor;
     self.layer.shadowOpacity = kShadowAlpha;
-    self.layer.shadowOffset = _message.usesLegacySnackbar ? kLegacyShadowOffset : kShadowOffset;
-    self.layer.shadowRadius = _message.usesLegacySnackbar ? kLegacyShadowSpread : kShadowSpread;
+    if (_message.usesLegacySnackbar) {
+      self.layer.cornerRadius = kLegacyCornerRadius;
+      self.layer.shadowOffset = kLegacyShadowOffset;
+      self.layer.shadowRadius = kLegacyShadowSpread;
+    } else {
+      self.layer.cornerRadius = kCornerRadius;
+      self.layer.shadowOffset = kShadowOffset;
+      self.layer.shadowRadius = kShadowSpread;
+    }
 
     _anchoredToScreenEdge = YES;
 
@@ -346,17 +352,19 @@ static const CGFloat kButtonInkRadius = 64.0f;
                        action:@selector(handleBackgroundTapped:)
              forControlEvents:UIControlEventTouchUpInside];
 
-    UISwipeGestureRecognizer *swipeRightGesture =
-        [[UISwipeGestureRecognizer alloc] initWithTarget:self
-                                                  action:@selector(handleBackgroundSwipedRight:)];
-    [swipeRightGesture setDirection:UISwipeGestureRecognizerDirectionRight];
-    [_containerView addGestureRecognizer:swipeRightGesture];
+    if (_message.usesLegacySnackbar) {
+      UISwipeGestureRecognizer *swipeRightGesture =
+          [[UISwipeGestureRecognizer alloc] initWithTarget:self
+                                                    action:@selector(handleBackgroundSwipedRight:)];
+      [swipeRightGesture setDirection:UISwipeGestureRecognizerDirectionRight];
+      [_containerView addGestureRecognizer:swipeRightGesture];
 
-    UISwipeGestureRecognizer *swipeLeftGesture =
-        [[UISwipeGestureRecognizer alloc] initWithTarget:self
-                                                  action:@selector(handleBackgroundSwipedLeft:)];
-    [swipeRightGesture setDirection:UISwipeGestureRecognizerDirectionLeft];
-    [_containerView addGestureRecognizer:swipeLeftGesture];
+      UISwipeGestureRecognizer *swipeLeftGesture =
+          [[UISwipeGestureRecognizer alloc] initWithTarget:self
+                                                    action:@selector(handleBackgroundSwipedLeft:)];
+      [swipeRightGesture setDirection:UISwipeGestureRecognizerDirectionLeft];
+      [_containerView addGestureRecognizer:swipeLeftGesture];
+    }
 
     _contentView = [[UIView alloc] init];
     [_contentView setTranslatesAutoresizingMaskIntoConstraints:NO];
@@ -858,7 +866,7 @@ static const CGFloat kButtonInkRadius = 64.0f;
   CABasicAnimation *translationAnimation =
       [CABasicAnimation animationWithKeyPath:@"transform.translation.x"];
   translationAnimation.toValue = [NSNumber numberWithDouble:-self.frame.size.width];
-  translationAnimation.duration = MDCSnackbarTransitionDuration;
+  translationAnimation.duration = MDCSnackbarLegacyTransitionDuration;
   translationAnimation.timingFunction =
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionTranslateOffScreen];
   translationAnimation.delegate = self;
@@ -871,7 +879,7 @@ static const CGFloat kButtonInkRadius = 64.0f;
   CABasicAnimation *translationAnimation =
       [CABasicAnimation animationWithKeyPath:@"transform.translation.x"];
   translationAnimation.toValue = [NSNumber numberWithDouble:self.frame.size.width];
-  translationAnimation.duration = MDCSnackbarTransitionDuration;
+  translationAnimation.duration = MDCSnackbarLegacyTransitionDuration;
   translationAnimation.timingFunction =
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionTranslateOffScreen];
   translationAnimation.delegate = self;

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -821,9 +821,8 @@ static const CGFloat kButtonInkRadius = 64.0f;
   height += self.safeContentMargin.top + self.safeContentMargin.bottom;
 
   // Make sure that the height of the image and text is larger than the minimum height;
-  height = MAX(kMinimumHeight, height);
-
   height = MAX(kMinimumHeight, height) + self.contentSafeBottomInset;
+
   return CGSizeMake(UIViewNoIntrinsicMetric, height);
 }
 
@@ -831,7 +830,7 @@ static const CGFloat kButtonInkRadius = 64.0f;
   // If a bottom offset has been set to raise the HUD, e.g. above a tab bar, we should ignore
   // any safeAreaInsets, since it is no longer 'anchored' to the bottom of the screen. This is set
   // by the MDCSnackbarOverlayView whenever the bottomOffset is non-zero.
-  if (!self.anchoredToScreenEdge) {
+  if (!self.anchoredToScreenEdge || !_message.usesLegacySnackbar) {
     return 0;
   }
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -323,7 +323,7 @@ static const CGFloat kButtonInkRadius = 64.0f;
     self.backgroundColor = _snackbarMessageViewBackgroundColor;
     self.layer.shadowColor = _snackbarMessageViewShadowColor.CGColor;
     self.layer.shadowOpacity = kShadowAlpha;
-    if (_message.usesLegacySnackbar) {
+    if (MDCSnackbarMessage.usesLegacySnackbar) {
       self.layer.cornerRadius = kLegacyCornerRadius;
       self.layer.shadowOffset = kLegacyShadowOffset;
       self.layer.shadowRadius = kLegacyShadowSpread;
@@ -344,7 +344,7 @@ static const CGFloat kButtonInkRadius = 64.0f;
     [_containerView setTranslatesAutoresizingMaskIntoConstraints:NO];
     _containerView.backgroundColor = [UIColor clearColor];
     _containerView.layer.cornerRadius =
-        _message.usesLegacySnackbar ? kLegacyCornerRadius : kCornerRadius;
+        MDCSnackbarMessage.usesLegacySnackbar ? kLegacyCornerRadius : kCornerRadius;
     _containerView.layer.masksToBounds = YES;
 
     // Listen for taps on the background of the view.
@@ -352,7 +352,7 @@ static const CGFloat kButtonInkRadius = 64.0f;
                        action:@selector(handleBackgroundTapped:)
              forControlEvents:UIControlEventTouchUpInside];
 
-    if (_message.usesLegacySnackbar) {
+    if (MDCSnackbarMessage.usesLegacySnackbar) {
       UISwipeGestureRecognizer *swipeRightGesture =
           [[UISwipeGestureRecognizer alloc] initWithTarget:self
                                                     action:@selector(handleBackgroundSwipedRight:)];
@@ -804,7 +804,7 @@ static const CGFloat kButtonInkRadius = 64.0f;
   // As our layout changes, make sure that the shadow path is kept up-to-date.
   UIBezierPath *path =
       [UIBezierPath bezierPathWithRoundedRect:self.bounds cornerRadius:
-          _message.usesLegacySnackbar ? kLegacyCornerRadius : kCornerRadius];
+          MDCSnackbarMessage.usesLegacySnackbar ? kLegacyCornerRadius : kCornerRadius];
   self.layer.shadowPath = path.CGPath;
 }
 
@@ -830,7 +830,7 @@ static const CGFloat kButtonInkRadius = 64.0f;
   // If a bottom offset has been set to raise the HUD, e.g. above a tab bar, we should ignore
   // any safeAreaInsets, since it is no longer 'anchored' to the bottom of the screen. This is set
   // by the MDCSnackbarOverlayView whenever the bottomOffset is non-zero.
-  if (!self.anchoredToScreenEdge || !_message.usesLegacySnackbar) {
+  if (!self.anchoredToScreenEdge || !MDCSnackbarMessage.usesLegacySnackbar) {
     return 0;
   }
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -923,29 +923,35 @@ static const CGFloat kButtonInkRadius = 64.0f;
 
 #pragma mark - Animation
 
-- (CABasicAnimation *)animateContentOpacityFrom:(CGFloat)fromOpacity
+- (void)animateContentOpacityFrom:(CGFloat)fromOpacity
                                to:(CGFloat)toOpacity
                          duration:(NSTimeInterval)duration
                    timingFunction:(CAMediaTimingFunction *)timingFunction {
+  [CATransaction begin];
+  CABasicAnimation *opacityAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
+  opacityAnimation.duration = duration;
+  opacityAnimation.fromValue = @(fromOpacity);
+  opacityAnimation.toValue = @(toOpacity);
+  opacityAnimation.timingFunction = timingFunction;
+
+  // The text and the button do not share a common view that can be animated independently of the
+  // background color, so just animate them both independently here. If this becomes more
+  // complicated, refactor to add a containing view for both and animate that.
+  [self.contentView.layer addAnimation:opacityAnimation forKey:@"opacity"];
+  [self.buttonView.layer addAnimation:opacityAnimation forKey:@"opacity"];
+  [CATransaction commit];
+}
+
+- (CABasicAnimation *)animateSnackbarOpacityFrom:(CGFloat)fromOpacity
+                                              to:(CGFloat)toOpacity {
   CABasicAnimation *opacityAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
   opacityAnimation.fromValue = @(fromOpacity);
   opacityAnimation.toValue = @(toOpacity);
-
-  if (_message.usesLegacySnackbar) {
-    // The text and the button do not share a common view that can be animated independently of the
-    // background color, so just animate them both independently here. If this becomes more
-    // complicated, refactor to add a containing view for both and animate that.
-    [self.contentView.layer addAnimation:opacityAnimation forKey:@"opacity"];
-    [self.buttonView.layer addAnimation:opacityAnimation forKey:@"opacity"];
-  }
-
   return opacityAnimation;
 }
 
 - (CABasicAnimation *)animateSnackbarScaleFrom:(CGFloat)fromScale
-                                       toScale:(CGFloat)toScale
-                        duration:(NSTimeInterval)duration
-                  timingFunction:(CAMediaTimingFunction *)timingFunction {
+                                       toScale:(CGFloat)toScale {
   CABasicAnimation *scaleAnimation = [CABasicAnimation animationWithKeyPath:@"transform.scale"];
   scaleAnimation.fromValue = [NSNumber numberWithDouble:fromScale];
   scaleAnimation.toValue = [NSNumber numberWithDouble:toScale];

--- a/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
+++ b/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
@@ -88,9 +88,14 @@ typedef void (^MDCSnackbarMessageDismissHandler)(BOOL userInitiated,
 
  Creates and commits a CATransaction to perform the animation.
  */
-- (void)animateContentOpacityFrom:(CGFloat)fromOpacity
+- (CABasicAnimation *_Nullable)animateContentOpacityFrom:(CGFloat)fromOpacity
                                to:(CGFloat)toOpacity
                          duration:(NSTimeInterval)duration
                    timingFunction:(CAMediaTimingFunction *_Nullable)timingFunction;
+
+- (CABasicAnimation *_Nullable)animateSnackbarScaleFrom:(CGFloat)fromScale
+                                                toScale:(CGFloat)toScale
+                      duration:(NSTimeInterval)duration
+                timingFunction:(CAMediaTimingFunction *_Nullable)timingFunction;
 
 @end

--- a/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
+++ b/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
@@ -88,14 +88,15 @@ typedef void (^MDCSnackbarMessageDismissHandler)(BOOL userInitiated,
 
  Creates and commits a CATransaction to perform the animation.
  */
-- (CABasicAnimation *_Nullable)animateContentOpacityFrom:(CGFloat)fromOpacity
+- (void)animateContentOpacityFrom:(CGFloat)fromOpacity
                                to:(CGFloat)toOpacity
                          duration:(NSTimeInterval)duration
                    timingFunction:(CAMediaTimingFunction *_Nullable)timingFunction;
 
+- (CABasicAnimation *_Nullable)animateSnackbarOpacityFrom:(CGFloat)fromOpacity
+                                                       to:(CGFloat)toOpacity;
+
 - (CABasicAnimation *_Nullable)animateSnackbarScaleFrom:(CGFloat)fromScale
-                                                toScale:(CGFloat)toScale
-                      duration:(NSTimeInterval)duration
-                timingFunction:(CAMediaTimingFunction *_Nullable)timingFunction;
+                                                toScale:(CGFloat)toScale;
 
 @end

--- a/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
+++ b/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
@@ -93,9 +93,25 @@ typedef void (^MDCSnackbarMessageDismissHandler)(BOOL userInitiated,
                          duration:(NSTimeInterval)duration
                    timingFunction:(CAMediaTimingFunction *_Nullable)timingFunction;
 
+
+/**
+ Animate the opacity of the snackbar view.
+
+ @param fromOpacity initial opacity to start animation.
+ @param toOpacity opacity to finish animation.
+ @return the opacity animation.
+ */
 - (CABasicAnimation *_Nullable)animateSnackbarOpacityFrom:(CGFloat)fromOpacity
                                                        to:(CGFloat)toOpacity;
 
+
+/**
+ Animate the scale of the snackbar view.
+
+ @param fromScale initial scale to start animation.
+ @param toScale scale to finish animation.
+ @return the scale animation.
+ */
 - (CABasicAnimation *_Nullable)animateSnackbarScaleFrom:(CGFloat)fromScale
                                                 toScale:(CGFloat)toScale;
 

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.h
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.h
@@ -22,7 +22,7 @@
 OBJC_EXTERN NSString *const MDCSnackbarOverlayIdentifier;
 
 /** The time it takes to show or hide the snackbar. */
-OBJC_EXTERN NSTimeInterval const MDCSnackbarTransitionDuration;
+OBJC_EXTERN NSTimeInterval const MDCSnackbarLegacyTransitionDuration;
 
 /**
  Custom overlay view for displaying snackbars.

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -28,7 +28,7 @@
 NSString *const MDCSnackbarOverlayIdentifier = @"MDCSnackbar";
 
 // The time it takes to show or hide the snackbar.
-NSTimeInterval const MDCSnackbarTransitionDuration = 5.25f;
+NSTimeInterval const MDCSnackbarTransitionDuration = 0.5f;
 NSTimeInterval const MDCSnackbarLegacyTransitionDuration = 0.5f;
 
 // How far from the bottom of the screen should the snackbar be.
@@ -493,18 +493,11 @@ static const CGFloat kMaximumHeight = 80.0f;
   animations.fillMode = kCAFillModeForwards;
   animations.removedOnCompletion = NO;
   animations.delegate = self;
-  NSMutableArray *animationsArray =
-  [[NSMutableArray alloc] initWithObjects:
-   [snackbarView animateContentOpacityFrom:fromContentOpacity
-                                        to:toContentOpacity
-                                  duration:MDCSnackbarTransitionDuration
-                            timingFunction:timingFunction], nil];
 
   if (snackbarView.message.usesLegacySnackbar) {
       _snackbarOnscreenConstraint.active = onscreen;
       _snackbarOffscreenConstraint.active = !onscreen;
       [_containingView setNeedsUpdateConstraints];
-
     // We use UIView animation inside a CATransaction in order to use the custom animation curve.
     [UIView animateWithDuration:MDCSnackbarTransitionDuration
                           delay:0
@@ -518,14 +511,17 @@ static const CGFloat kMaximumHeight = 80.0f;
 //                         completion();
 //                       }
                      }];
+    [snackbarView animateContentOpacityFrom:fromContentOpacity
+                                         to:toContentOpacity
+                                   duration:MDCSnackbarTransitionDuration
+                             timingFunction:timingFunction];
   } else {
-    [animationsArray addObject:[snackbarView animateSnackbarScaleFrom:fromScale
-                                                              toScale:toScale
-                                                             duration:MDCSnackbarTransitionDuration
-                                                       timingFunction:timingFunction]];
+    animations.animations = @[[snackbarView animateSnackbarOpacityFrom:fromContentOpacity
+                                                                   to:toContentOpacity],
+                              [snackbarView animateSnackbarScaleFrom:fromScale
+                                                             toScale:toScale]];
   }
 
-  animations.animations = animationsArray;
   [snackbarView.layer addAnimation:animations forKey:@"opacityAndScale"];
   [CATransaction commit];
 

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -32,6 +32,9 @@ NSTimeInterval const MDCSnackbarEnterTransitionDuration = 0.15f;
 NSTimeInterval const MDCSnackbarExitTransitionDuration = 0.075f;
 NSTimeInterval const MDCSnackbarLegacyTransitionDuration = 0.5f;
 
+// The scaling starting point for presenting the new snackbar.
+static const CGFloat MDCSnackbarEnterStartingScale = 0.8f;
+
 // How far from the bottom of the screen should the snackbar be.
 static const CGFloat MDCSnackbarBottomMargin_iPhone = 8.f;
 static const CGFloat MDCSnackbarBottomMargin_iPad = 24.f;
@@ -433,8 +436,6 @@ static const CGFloat kMaximumHeight = 80.0f;
                 onscreen:(BOOL)onscreen
       fromContentOpacity:(CGFloat)fromContentOpacity
         toContentOpacity:(CGFloat)toContentOpacity
-               fromScale:(CGFloat)fromScale
-                 toScale:(CGFloat)toScale
               completion:(void (^)(void))completion {
   // Prepare to move the snackbar.
   NSTimeInterval duration = MDCSnackbarLegacyTransitionDuration;
@@ -474,8 +475,8 @@ static const CGFloat kMaximumHeight = 80.0f;
             [snackbarView animateSnackbarOpacityFrom:fromContentOpacity
                                                   to:toContentOpacity]];
     if (onscreen) {
-      [animations addObject:[snackbarView animateSnackbarScaleFrom:fromScale
-                                                           toScale:toScale]];
+      [animations addObject:[snackbarView animateSnackbarScaleFrom:MDCSnackbarEnterStartingScale
+                                                           toScale:1]];
     }
     animationsGroup.animations = animations;
     [snackbarView.layer addAnimation:animationsGroup forKey:@"snackbarAnimation"];
@@ -499,8 +500,6 @@ static const CGFloat kMaximumHeight = 80.0f;
                 onscreen:YES
       fromContentOpacity:0
         toContentOpacity:1
-               fromScale:0.8
-                 toScale:1
               completion:completion];
 }
 
@@ -513,8 +512,6 @@ static const CGFloat kMaximumHeight = 80.0f;
                 onscreen:NO
       fromContentOpacity:1
         toContentOpacity:0
-               fromScale:1
-                 toScale:0.8
               completion:completion];
 }
 

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -206,6 +206,13 @@ static const CGFloat kMaximumHeight = 80.0f;
 - (CGFloat)dynamicBottomMargin {
   CGFloat keyboardHeight = self.watcher.visibleKeyboardHeight;
   CGFloat userHeight = self.bottomOffset;
+  if (!_snackbarView.message.usesLegacySnackbar) {
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+    if (@available(iOS 11.0, *)) {
+      userHeight += self.window.safeAreaInsets.bottom;
+    }
+#endif
+  }
 
   return MAX(keyboardHeight, userHeight);
 }
@@ -376,7 +383,7 @@ static const CGFloat kMaximumHeight = 80.0f;
   // Maximum height must be extended to include the bottom content safe area.
   CGFloat maximumHeight = kMaximumHeight;
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
-  if (self.anchoredToScreenEdge) {
+  if (self.anchoredToScreenEdge && self.snackbarView.message.usesLegacySnackbar) {
     if (@available(iOS 11.0, *)) {
       maximumHeight += self.safeAreaInsets.bottom;
     }
@@ -402,6 +409,7 @@ static const CGFloat kMaximumHeight = 80.0f;
                 animated:(BOOL)animated
               completion:(void (^)(void))completion {
   self.snackbarView = snackbarView;  // Install the snackbar.
+  self.bottomConstraint.constant = -self.dynamicBottomMargin;
 
   if (animated) {
     [self slideInMessageView:snackbarView completion:completion];

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -151,6 +151,7 @@ static const CGFloat kMaximumHeight = 80.0f;
 
     [self setupContainerConstraints];
   }
+
   return self;
 }
 
@@ -206,10 +207,10 @@ static const CGFloat kMaximumHeight = 80.0f;
 - (CGFloat)dynamicBottomMargin {
   CGFloat keyboardHeight = self.watcher.visibleKeyboardHeight;
   CGFloat userHeight = self.bottomOffset;
-  if (!_snackbarView.message.usesLegacySnackbar) {
+  if (!MDCSnackbarMessage.usesLegacySnackbar) {
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
     if (@available(iOS 11.0, *)) {
-      userHeight = MAX(userHeight, self.window.safeAreaInsets.bottom);
+      userHeight = MAX(userHeight, self.safeAreaInsets.bottom);
     }
 #endif
   }
@@ -221,7 +222,7 @@ static const CGFloat kMaximumHeight = 80.0f;
  The bottom margin which is dependent on device type and cannot change.
  */
 - (CGFloat)staticBottomMargin {
-  if (_snackbarView.message.usesLegacySnackbar) {
+  if (MDCSnackbarMessage.usesLegacySnackbar) {
     return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? MDCSnackbarLegacyBottomMargin_iPad
                                                                 : MDCSnackbarLegacyBottomMargin_iPhone;
   }
@@ -230,7 +231,7 @@ static const CGFloat kMaximumHeight = 80.0f;
 }
 
 - (CGFloat)sideMargin {
-  if (_snackbarView.message.usesLegacySnackbar) {
+  if (MDCSnackbarMessage.usesLegacySnackbar) {
     return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? MDCSnackbarSideMargin_iPad
                                                                 : MDCSnackbarLegacySideMargin_iPhone;
   }
@@ -329,13 +330,13 @@ static const CGFloat kMaximumHeight = 80.0f;
                                                                  attribute:NSLayoutAttributeBottom
                                                                 multiplier:1.0
                                                                   constant:-bottomMargin];
-      _snackbarOnscreenConstraint.active = !_snackbarView.message.usesLegacySnackbar;
-      if (snackbarView.message.usesLegacySnackbar) {
+      _snackbarOnscreenConstraint.active = !MDCSnackbarMessage.usesLegacySnackbar;
+      if (MDCSnackbarMessage.usesLegacySnackbar) {
         _snackbarOnscreenConstraint.priority = UILayoutPriorityDefaultHigh;
       }
       [container addConstraint:_snackbarOnscreenConstraint];
 
-      if (snackbarView.message.usesLegacySnackbar) {
+      if (MDCSnackbarMessage.usesLegacySnackbar) {
         _snackbarOffscreenConstraint = [NSLayoutConstraint constraintWithItem:snackbarView
                                                                     attribute:NSLayoutAttributeTop
                                                                     relatedBy:NSLayoutRelationEqual
@@ -401,7 +402,7 @@ static const CGFloat kMaximumHeight = 80.0f;
   // Maximum height must be extended to include the bottom content safe area.
   CGFloat maximumHeight = kMaximumHeight;
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
-  if (self.anchoredToScreenEdge && self.snackbarView.message.usesLegacySnackbar) {
+  if (self.anchoredToScreenEdge && MDCSnackbarMessage.usesLegacySnackbar) {
     if (@available(iOS 11.0, *)) {
       maximumHeight += self.safeAreaInsets.bottom;
     }
@@ -465,7 +466,7 @@ static const CGFloat kMaximumHeight = 80.0f;
               completion:(void (^)(void))completion {
   // Prepare to move the snackbar.
   NSTimeInterval duration = MDCSnackbarLegacyTransitionDuration;
-  if (!snackbarView.message.usesLegacySnackbar) {
+  if (!MDCSnackbarMessage.usesLegacySnackbar) {
     duration = onscreen ? MDCSnackbarEnterTransitionDuration : MDCSnackbarExitTransitionDuration;
   }
   CAMediaTimingFunction *timingFunction =
@@ -478,14 +479,14 @@ static const CGFloat kMaximumHeight = 80.0f;
   animationsGroup.fillMode = kCAFillModeForwards;
   animationsGroup.removedOnCompletion = NO;
 
-  if (snackbarView.message.usesLegacySnackbar) {
+  if (MDCSnackbarMessage.usesLegacySnackbar) {
     _snackbarOnscreenConstraint.active = onscreen;
     _snackbarOffscreenConstraint.active = !onscreen;
     [_containingView setNeedsUpdateConstraints];
     // We use UIView animation inside a CATransaction in order to use the custom animation curve.
     [UIView animateWithDuration:duration
                           delay:0
-                        options:UIViewAnimationOptionCurveEaseInOut
+                        options:0
                      animations:^{
                        // Trigger snackbar animation.
                        [_containingView layoutIfNeeded];

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -209,7 +209,7 @@ static const CGFloat kMaximumHeight = 80.0f;
   if (!_snackbarView.message.usesLegacySnackbar) {
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
     if (@available(iOS 11.0, *)) {
-      userHeight += self.window.safeAreaInsets.bottom;
+      userHeight = MAX(userHeight, self.window.safeAreaInsets.bottom);
     }
 #endif
   }
@@ -245,7 +245,6 @@ static const CGFloat kMaximumHeight = 80.0f;
 
     CGFloat bottomMargin = [self staticBottomMargin];
     CGFloat sideMargin = [self sideMargin];
-
     BOOL fullWidth = UI_USER_INTERFACE_IDIOM() != UIUserInterfaceIdiomPad;
 
     UIView *container = self.containingView;
@@ -256,23 +255,42 @@ static const CGFloat kMaximumHeight = 80.0f;
       // Pin the snackbar to the bottom of the screen.
       [snackbarView setTranslatesAutoresizingMaskIntoConstraints:NO];
 
-      [container addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
-                                                            attribute:NSLayoutAttributeCenterX
-                                                            relatedBy:NSLayoutRelationEqual
-                                                               toItem:container
-                                                            attribute:NSLayoutAttributeCenterX
-                                                           multiplier:1.0
-                                                             constant:0]];
-
       if (fullWidth) {
+        CGFloat leftMargin = sideMargin;
+        CGFloat rightMargin = sideMargin;
+
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+        if (@available(iOS 11.0, *)) {
+          leftMargin += self.safeAreaInsets.left;
+          rightMargin += self.safeAreaInsets.right;
+        }
+#endif
+
         [container addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
-                                                              attribute:NSLayoutAttributeWidth
+                                                              attribute:NSLayoutAttributeLeading
                                                               relatedBy:NSLayoutRelationEqual
                                                                  toItem:container
-                                                              attribute:NSLayoutAttributeWidth
+                                                              attribute:NSLayoutAttributeLeading
                                                              multiplier:1.0
-                                                               constant:-2 * sideMargin]];
+                                                               constant:leftMargin]];
+
+        [container addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
+                                                              attribute:NSLayoutAttributeTrailing
+                                                              relatedBy:NSLayoutRelationEqual
+                                                                 toItem:container
+                                                              attribute:NSLayoutAttributeTrailing
+                                                             multiplier:1.0
+                                                               constant:-1 * rightMargin]];
       } else {
+
+        [container addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
+                                                              attribute:NSLayoutAttributeCenterX
+                                                              relatedBy:NSLayoutRelationEqual
+                                                                 toItem:container
+                                                              attribute:NSLayoutAttributeCenterX
+                                                             multiplier:1.0
+                                                               constant:0]];
+
         // If not full width, ensure that it doesn't get any larger than our own width.
         [container
             addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -293,15 +293,6 @@ static const CGFloat kMaximumHeight = 80.0f;
                                                         constant:[snackbarView maximumWidth]]];
       }
 
-      // Always pin the snackbar to the bottom of the container.
-//      [container
-//       addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
-//                                                  attribute:NSLayoutAttributeBottom
-//                                                  relatedBy:NSLayoutRelationEqual
-//                                                     toItem:container
-//                                                  attribute:NSLayoutAttributeBottom
-//                                                 multiplier:1.0
-//                                                   constant:-bottomMargin]];
       _snackbarOnscreenConstraint = [NSLayoutConstraint constraintWithItem:snackbarView
                                                                  attribute:NSLayoutAttributeBottom
                                                                  relatedBy:NSLayoutRelationEqual
@@ -495,9 +486,9 @@ static const CGFloat kMaximumHeight = 80.0f;
   animations.delegate = self;
 
   if (snackbarView.message.usesLegacySnackbar) {
-      _snackbarOnscreenConstraint.active = onscreen;
-      _snackbarOffscreenConstraint.active = !onscreen;
-      [_containingView setNeedsUpdateConstraints];
+    _snackbarOnscreenConstraint.active = onscreen;
+    _snackbarOffscreenConstraint.active = !onscreen;
+    [_containingView setNeedsUpdateConstraints];
     // We use UIView animation inside a CATransaction in order to use the custom animation curve.
     [UIView animateWithDuration:MDCSnackbarTransitionDuration
                           delay:0
@@ -506,11 +497,7 @@ static const CGFloat kMaximumHeight = 80.0f;
                        // Trigger snackbar animation.
                        [_containingView layoutIfNeeded];
                      }
-                     completion:^(__unused BOOL finished) {
-//                       if (completion) {
-//                         completion();
-//                       }
-                     }];
+                     completion:nil];
     [snackbarView animateContentOpacityFrom:fromContentOpacity
                                          to:toContentOpacity
                                    duration:MDCSnackbarTransitionDuration

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -511,8 +511,16 @@ static const CGFloat kMaximumHeight = 80.0f;
 
   [CATransaction commit];
 
+  // To support the MDCOverlayObserver seeing frame changes, we need to update the frame of the
+  // new snackbar for the observer, as now it doesn't change frame but rather change opacity.
+  // In future we should add support for opacity to our MDCOverlayObserver and not only frame.
+  CGRect snackbarRect = [self snackbarRectInScreenCoordinates];
+  if (!MDCSnackbarMessage.usesLegacySnackbar && !onscreen) {
+    snackbarRect.origin.y = self.bounds.size.height - [self dynamicBottomMargin];
+  }
+
   // Notify the overlay system.
-  [self notifyOverlayChangeWithFrame:[self snackbarRectInScreenCoordinates]
+  [self notifyOverlayChangeWithFrame:snackbarRect
                             duration:duration
                                curve:0
                       timingFunction:timingFunction];


### PR DESCRIPTION
* Implementation of new Snackbar according to the new Spec:
    * New animation and timing for the displaying and dismissing of snackbar
    * New visual styling (corner radius, hovering rather than pinned to bottom)
* Allowing new Snackbar to be activated using the `usesLegacySnackbar` toggle, default is to use legacy.
* Added iPhone X safe area support for new Snackbar (portrait and landscape).
* Added new/legacy Snackbar toggle and use to example. 
* New Snackbar plays well with `setBottomOffset` to allow moving it based on if it is blocking bottom navigation

There are some open issues remaining such as better VO support, container margins, and additionalSafeArea support that I will open issues about after merging.