### PR TITLE
[PageControl] Fixing example layout

### DIFF
--- a/components/PageControl/examples/PageControlTypicalUseExample.m
+++ b/components/PageControl/examples/PageControlTypicalUseExample.m
@@ -101,8 +101,7 @@
   [_scrollView setContentOffset:offset animated:NO];
   _scrollView.frame = self.view.bounds;
 
-  // We want the page control to span the bottom of the screen.
-	[_pageControl sizeThatFits:standardizedFrame.size];
+  // We want the page control to hug the bottom of the screen.
   UIEdgeInsets edgeInsets = UIEdgeInsetsZero;
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
@@ -110,6 +109,7 @@
     edgeInsets = self.view.safeAreaInsets;
   }
 #endif
+  [_pageControl sizeToFit];
   CGFloat yOffset =
       CGRectGetHeight(self.view.frame) - CGRectGetHeight(_pageControl.frame) - edgeInsets.bottom;
   _pageControl.frame =


### PR DESCRIPTION
The page control was not being sized before being positioned within the
view, so it was cut-off by half the height.  This bug was also present on an iPhone SE (simualtor).

**Before**
![simulator screen shot - iphone se - 2018-03-07 at 12 26 26](https://user-images.githubusercontent.com/1753199/37107827-6059b5e0-2203-11e8-86ef-4a22aed1e281.png)

**After**
![simulator screen shot - iphone se - 2018-03-07 at 12 25 41](https://user-images.githubusercontent.com/1753199/37107841-64f60856-2203-11e8-84ff-2e7dc25e6029.png)


Closes #2858 
