### PR TITLE
[Tabs] Don't call UIAppearance in +initialize

### DIFF
--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -108,16 +108,6 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 
 #pragma mark - Initialization
 
-+ (void)initialize {
-  [MDCTabBar appearance].selectedItemTintColor = [UIColor whiteColor];
-  [MDCTabBar appearance].unselectedItemTintColor = [UIColor colorWithWhite:1.0f alpha:0.7f];
-  [MDCTabBar appearance].inkColor = [UIColor colorWithWhite:1.0f alpha:0.7f];
-  [MDCTabBar appearance].barTintColor = nil;
-
-  id<MDCTabBarIndicatorTemplate> template = [[MDCTabBarUnderlineIndicatorTemplate alloc] init];
-  [MDCTabBar appearance].selectionIndicatorTemplate = template;
-}
-
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
   self = [super initWithCoder:aDecoder];
   if (self) {
@@ -193,6 +183,10 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 }
 
 - (void)commonMDCTabBarInit {
+  _selectedItemTintColor = [UIColor whiteColor];
+  _unselectedItemTintColor = [UIColor colorWithWhite:1.0f alpha:0.7f];
+  _inkColor = [UIColor colorWithWhite:1.0f alpha:0.7f];
+
   self.clipsToBounds = YES;
   _barPosition = UIBarPositionAny;
   _hasDefaultItemAppearance = YES;

--- a/components/Tabs/tests/unit/MDCTabBarCodingTests.m
+++ b/components/Tabs/tests/unit/MDCTabBarCodingTests.m
@@ -23,7 +23,7 @@
 
 @implementation MDCTabBarCodingTests
 
-- (void)testCardEncoding {
+- (void)testEncoding {
   MDCTabBar *tabBar = [[MDCTabBar alloc] initWithFrame:CGRectZero];
   UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"item1" image:nil tag:1];
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"item2" image:nil tag:2];

--- a/components/Tabs/tests/unit/MDCTabBarTests.m
+++ b/components/Tabs/tests/unit/MDCTabBarTests.m
@@ -1,0 +1,51 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import "MaterialTabs.h"
+#import "MaterialTypography.h"
+
+@interface MDCTabBarTests : XCTestCase
+
+@end
+
+@implementation MDCTabBarTests
+
+- (void)testDefaultValues {
+  // Given
+  MDCTabBar *tabBar = [[MDCTabBar alloc] init];
+
+  // Then
+  XCTAssertNotNil(tabBar.selectionIndicatorTemplate);
+  XCTAssertEqualObjects(tabBar.selectedItemTintColor, UIColor.whiteColor);
+  XCTAssertEqualObjects(tabBar.unselectedItemTintColor, [UIColor colorWithWhite:1 alpha:0.7f]);
+  XCTAssertEqualObjects(tabBar.inkColor, [UIColor colorWithWhite:1 alpha:0.7f]);
+  XCTAssertNil(tabBar.barTintColor);
+  XCTAssertTrue(tabBar.clipsToBounds);
+  XCTAssertEqual(tabBar.barPosition, UIBarPositionAny);
+  XCTAssertEqual(tabBar.alignment, MDCTabBarAlignmentLeading);
+  XCTAssertEqual(tabBar.titleTextTransform, MDCTabBarTextTransformAutomatic);
+  XCTAssertEqual(tabBar.itemAppearance, MDCTabBarItemAppearanceTitles);
+  XCTAssertEqualObjects(tabBar.selectedItemTitleFont, [MDCTypography buttonFont]);
+  XCTAssertEqualObjects(tabBar.unselectedItemTitleFont, [MDCTypography buttonFont]);
+  XCTAssertNotNil(tabBar.items);
+  XCTAssertEqual(tabBar.items.count, 0U);
+  XCTAssertNil(tabBar.selectedItem);
+  XCTAssertNil(tabBar.delegate);
+  XCTAssertTrue(tabBar.displaysUppercaseTitles);
+}
+
+@end


### PR DESCRIPTION
Instead of calling UIAppearance in +initialize, MDCTabBar should be
assigning its default values during initialization.

Closes #3066