### PR TITLE
[Buttons] Set FlatButton inkColor via UIAppearance

### DIFF
--- a/components/Buttons/src/MDCFlatButton.m
+++ b/components/Buttons/src/MDCFlatButton.m
@@ -25,26 +25,11 @@ static NSString *const MDCFlatButtonHasOpaqueBackground = @"MDCFlatButtonHasOpaq
 
 + (void)initialize {
   // Default background colors.
-  [[MDCFlatButton appearance] setBackgroundColor:[UIColor clearColor]
-                                        forState:UIControlStateNormal];
-  [[MDCFlatButton appearance] setTitleColor:[UIColor blackColor]
-                                   forState:UIControlStateNormal];
-  [[MDCFlatButton appearance] setElevation:MDCShadowElevationNone
-                                  forState:UIControlStateNormal];
-  [[MDCFlatButton appearance] setElevation:MDCShadowElevationNone
-                                  forState:UIControlStateHighlighted];
-}
-
-- (instancetype)init {
-  return [self initWithFrame:CGRectZero];
-}
-
-- (instancetype)initWithFrame:(CGRect)frame {
-  self = [super initWithFrame:frame];
-  if (self) {
-    [self commonMDCFlatButtonInit];
-  }
-  return self;
+  [MDCFlatButton.appearance setBackgroundColor:[UIColor clearColor] forState:UIControlStateNormal];
+  [MDCFlatButton.appearance setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
+  [MDCFlatButton.appearance setElevation:MDCShadowElevationNone forState:UIControlStateNormal];
+  [MDCFlatButton.appearance setElevation:MDCShadowElevationNone forState:UIControlStateHighlighted];
+  MDCFlatButton.appearance.inkColor = [UIColor colorWithWhite:0 alpha:0.06f];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
@@ -53,13 +38,8 @@ static NSString *const MDCFlatButtonHasOpaqueBackground = @"MDCFlatButtonHasOpaq
     if ([aDecoder containsValueForKey:MDCFlatButtonHasOpaqueBackground]) {
       self.hasOpaqueBackground = [aDecoder decodeBoolForKey:MDCFlatButtonHasOpaqueBackground];
     }
-    [self commonMDCFlatButtonInit];
   }
   return self;
-}
-
-- (void)commonMDCFlatButtonInit {
-  self.inkColor = [UIColor colorWithWhite:0 alpha:0.06f];
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {

--- a/components/Buttons/tests/unit/FlatButtonTests.m
+++ b/components/Buttons/tests/unit/FlatButtonTests.m
@@ -35,4 +35,15 @@
   XCTAssertEqual([button elevationForState:UIControlStateSelected], MDCShadowElevationNone);
 }
 
+// TODO(#2782): Remove this test and replace it with default checks once UIAppearance is no longer
+//              used for overriding MDCButton
+- (void)testMDCFlatButtonDoesNotModifyInkColorInInit {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+  MDCFlatButton *flatButton = [[MDCFlatButton alloc] init];
+
+  // Then
+  XCTAssertEqualObjects(flatButton.inkColor, button.inkColor);
+}
+
 @end


### PR DESCRIPTION
Instead of disabling UIAppearance on `inkColor` by assigning it a value
in `-init` methods. MDCFlatButton can use UIAppearance to set values the
same way it sets others. This is less than ideal (it should not be using
UIAppearance directly), but is better than disabling UIAppearance
entirely.

Closes #3068