### PR TITLE
Convert MaskedTransition from a MotionTransitioning Transition type to a vanilla UIKit type

### DIFF
--- a/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
+++ b/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
@@ -94,18 +94,21 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
     tableView.selectRow(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .none)
   }
 
+  let transitionController = MDCMaskedTransitionController()
   func didTapFab(fab: UIView) {
     let target = targets[tableView.indexPathForSelectedRow!.row]
     let vc = target.viewControllerType.init()
 
-    let transition = MDCMaskedTransition(sourceView: fab)
-    transition.calculateFrameOfPresentedView = target.calculateFrame
     vc.view.autoresizingMask = target.autoresizingMask
-    vc.mdm_transitionController.transition = transition
+
+    // Customize the transition
+    transitionController.sourceView = fab
+    transitionController.calculateFrameOfPresentedView = target.calculateFrame
+    vc.modalPresentationStyle = .custom
+    vc.transitioningDelegate = transitionController
 
     showDetailViewController(vc, sender: self)
   }
-
 }
 
 extension MaskedTransitionTypicalUseSwiftExample: UITableViewDataSource {

--- a/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
+++ b/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
@@ -94,7 +94,7 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
     tableView.selectRow(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .none)
   }
 
-  let transitionController = MDCMaskedTransitionController()
+  var transitionController: MDCMaskedTransitionController? = nil
   func didTapFab(fab: UIView) {
     let target = targets[tableView.indexPathForSelectedRow!.row]
     let vc = target.viewControllerType.init()
@@ -102,12 +102,15 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
     vc.view.autoresizingMask = target.autoresizingMask
 
     // Customize the transition
-    transitionController.sourceView = fab
+    let transitionController = MDCMaskedTransitionController(sourceView: fab)
     if target.calculateFrame != nil {
       transitionController.calculateFrameOfPresentedView = target.calculateFrame
       vc.modalPresentationStyle = .custom
     }
     vc.transitioningDelegate = transitionController
+
+    // Must keep a reference to the transition controller
+    self.transitionController = transitionController
 
     showDetailViewController(vc, sender: self)
   }

--- a/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
+++ b/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
@@ -103,8 +103,10 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
 
     // Customize the transition
     transitionController.sourceView = fab
-    transitionController.calculateFrameOfPresentedView = target.calculateFrame
-    vc.modalPresentationStyle = .custom
+    if target.calculateFrame != nil {
+      transitionController.calculateFrameOfPresentedView = target.calculateFrame
+      vc.modalPresentationStyle = .custom
+    }
     vc.transitioningDelegate = transitionController
 
     showDetailViewController(vc, sender: self)

--- a/components/MaskedTransition/src/MDCMaskedTransitionController.h
+++ b/components/MaskedTransition/src/MDCMaskedTransitionController.h
@@ -53,7 +53,7 @@
 /**
  The view from which the next masked transition should emanate.
  */
-@property(nonatomic, strong, nullable) UIView *sourceView;
+@property(nonatomic, strong, nullable, readonly) UIView *sourceView;
 
 /**
  An optional block that may be used to calculate the frame of the presented view controller's view.

--- a/components/MaskedTransition/src/MDCMaskedTransitionController.h
+++ b/components/MaskedTransition/src/MDCMaskedTransitionController.h
@@ -1,0 +1,70 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+/**
+ MDCMaskedTransitionController implements a custom view controller transition that animates the
+ presented view controller using a mask reveal effect from a circular source view.
+
+ The presenting view controller will typically store a reference to an instance of this class and
+ assign it to the transitioningDelegate of a view controller prior to presenting it.
+ 
+ With zero additional configuration, the transition will perform a fullscreen masked reveal
+ presentation, with a slide down dismissal.
+ 
+ It's possible to configure the presented view controller's frame by setting the
+ calculateFrameOfPresentedView property. The provided block should return the desired frame of the
+ presented view controller. When using calculateFrameOfPresentedView you must also change the
+ modalPresentationStyle on the view controller to be presented to `UIModalPresentationCustom`.
+
+ Once the view controller to be presented has been fully configured, you can present the view
+ controller using any of the available view controller presentation APIs.
+ */
+@interface MDCMaskedTransitionController : NSObject <UIViewControllerTransitioningDelegate>
+
+/**
+ Initializes the transition controller with a given source view.
+ */
+- (nonnull instancetype)initWithSourceView:(nonnull UIView *)sourceView;
+
+/**
+ Initializes the transition controller without a source view.
+ 
+ Note that if no source view is available at the time of presentation, the transition will fall back
+ to the default system presentation.
+ */
+- (nonnull instancetype)init NS_DESIGNATED_INITIALIZER;
+
+/**
+ The view from which the next masked transition should emanate.
+ */
+@property(nonatomic, strong, nullable) UIView *sourceView;
+
+/**
+ An optional block that may be used to calculate the frame of the presented view controller's view.
+
+ If provided, the block will be invoked once the presentation transition is initiated. The
+ returned rect will be assigned to the presented view controller's frame.
+
+ You must set the view controller-to-be-presented's modalPresentationStyle property to
+ `UIModalPresentationCustom` in order to use this property.
+ */
+@property(nonatomic, copy, nullable)
+    CGRect (^calculateFrameOfPresentedView)(UIPresentationController * _Nonnull);
+
+@end

--- a/components/MaskedTransition/src/MDCMaskedTransitionController.h
+++ b/components/MaskedTransition/src/MDCMaskedTransitionController.h
@@ -40,7 +40,7 @@
 /**
  Initializes the transition controller with a given source view.
  */
-- (nonnull instancetype)initWithSourceView:(nonnull UIView *)sourceView;
+- (nonnull instancetype)initWithSourceView:(nullable UIView *)sourceView;
 
 /**
  Initializes the transition controller without a source view.

--- a/components/MaskedTransition/src/MDCMaskedTransitionController.m
+++ b/components/MaskedTransition/src/MDCMaskedTransitionController.m
@@ -1,0 +1,67 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCMaskedTransitionController.h"
+
+#import "private/MDCMaskedTransition.h"
+#import "private/MDCMaskedPresentationController.h"
+#import "private/MDCMaskedTransitionMotionForContext.h"
+
+@implementation MDCMaskedTransitionController
+
+- (instancetype)initWithSourceView:(UIView *)sourceView {
+  self = [self init];
+  if (self) {
+    _sourceView = sourceView;
+  }
+  return self;
+}
+
+- (instancetype)init {
+  return [super init];
+}
+
+#pragma mark - UIViewControllerTransitioningDelegate
+
+- (id<UIViewControllerAnimatedTransitioning>)animationControllerForPresentedController:(UIViewController *)presented
+                                                                  presentingController:(UIViewController *)presenting
+                                                                      sourceController:(UIViewController *)source {
+  return [[MDCMaskedTransition alloc] initWithSourceView:_sourceView
+                                               direction:MDMTransitionDirectionForward];
+}
+
+- (id<UIViewControllerAnimatedTransitioning>)animationControllerForDismissedController:(UIViewController *)dismissed {
+  MDCMaskedTransitionMotionSpecContext spec =
+      MDCMaskedTransitionMotionSpecForContext(dismissed.presentingViewController.view.superview,
+                                              dismissed);
+  if (spec.shouldSlideWhenCollapsed) {
+    return nil;
+  }
+  return [[MDCMaskedTransition alloc] initWithSourceView:_sourceView
+                                               direction:MDMTransitionDirectionBackward];
+}
+
+- (UIPresentationController *)presentationControllerForPresentedViewController:(UIViewController *)presented
+                                                      presentingViewController:(UIViewController *)presenting
+                                                          sourceViewController:(UIViewController *)source {
+  return
+      [[MDCMaskedPresentationController alloc] initWithPresentedViewController:presented
+                                                      presentingViewController:presenting
+                                                 calculateFrameOfPresentedView:self.calculateFrameOfPresentedView
+                                                                    sourceView:_sourceView];
+}
+
+@end

--- a/components/MaskedTransition/src/MDCMaskedTransitionController.m
+++ b/components/MaskedTransition/src/MDCMaskedTransitionController.m
@@ -39,11 +39,17 @@
 - (id<UIViewControllerAnimatedTransitioning>)animationControllerForPresentedController:(UIViewController *)presented
                                                                   presentingController:(UIViewController *)presenting
                                                                       sourceController:(UIViewController *)source {
+  if (_sourceView == nil) {
+    return nil;
+  }
   return [[MDCMaskedTransition alloc] initWithSourceView:_sourceView
                                                direction:MDMTransitionDirectionForward];
 }
 
 - (id<UIViewControllerAnimatedTransitioning>)animationControllerForDismissedController:(UIViewController *)dismissed {
+  if (_sourceView == nil) {
+    return nil;
+  }
   MDCMaskedTransitionMotionSpecContext spec =
       MDCMaskedTransitionMotionSpecForContext(dismissed.presentingViewController.view.superview,
                                               dismissed);

--- a/components/MaskedTransition/src/MDCMaskedTransitionController.m
+++ b/components/MaskedTransition/src/MDCMaskedTransitionController.m
@@ -36,38 +36,41 @@
 
 #pragma mark - UIViewControllerTransitioningDelegate
 
-- (id<UIViewControllerAnimatedTransitioning>)animationControllerForPresentedController:(UIViewController *)presented
-                                                                  presentingController:(UIViewController *)presenting
-                                                                      sourceController:(UIViewController *)source {
+- (id<UIViewControllerAnimatedTransitioning>)
+    animationControllerForPresentedController:(UIViewController *)presented
+    presentingController:(UIViewController *)presenting
+    sourceController:(UIViewController *)source {
   if (_sourceView == nil) {
     return nil;
   }
-  return [[MDCMaskedTransition alloc] initWithSourceView:_sourceView
+  return [[MDCMaskedTransition alloc] initWithSourceView:self.sourceView
                                                direction:MDMTransitionDirectionForward];
 }
 
-- (id<UIViewControllerAnimatedTransitioning>)animationControllerForDismissedController:(UIViewController *)dismissed {
+- (id<UIViewControllerAnimatedTransitioning>)
+    animationControllerForDismissedController:(UIViewController *)dismissed {
   if (_sourceView == nil) {
     return nil;
   }
-  MDCMaskedTransitionMotionSpecContext spec =
+  MDCMaskedTransitionMotionSpec motionSpecification =
       MDCMaskedTransitionMotionSpecForContext(dismissed.presentingViewController.view.superview,
                                               dismissed);
-  if (spec.shouldSlideWhenCollapsed) {
+  if (motionSpecification.shouldSlideWhenCollapsed) {
     return nil;
   }
-  return [[MDCMaskedTransition alloc] initWithSourceView:_sourceView
+  return [[MDCMaskedTransition alloc] initWithSourceView:self.sourceView
                                                direction:MDMTransitionDirectionBackward];
 }
 
-- (UIPresentationController *)presentationControllerForPresentedViewController:(UIViewController *)presented
-                                                      presentingViewController:(UIViewController *)presenting
-                                                          sourceViewController:(UIViewController *)source {
+- (UIPresentationController *)
+    presentationControllerForPresentedViewController:(UIViewController *)presented
+    presentingViewController:(UIViewController *)presenting
+    sourceViewController:(UIViewController *)source {
   return
       [[MDCMaskedPresentationController alloc] initWithPresentedViewController:presented
                                                       presentingViewController:presenting
                                                  calculateFrameOfPresentedView:self.calculateFrameOfPresentedView
-                                                                    sourceView:_sourceView];
+                                                                    sourceView:self.sourceView];
 }
 
 @end

--- a/components/MaskedTransition/src/MDCMaskedTransitionController.m
+++ b/components/MaskedTransition/src/MDCMaskedTransitionController.m
@@ -31,7 +31,8 @@
 }
 
 - (instancetype)init {
-  return [super init];
+  self = [super init];
+  return self;
 }
 
 #pragma mark - UIViewControllerTransitioningDelegate

--- a/components/MaskedTransition/src/MaterialMaskedTransition.h
+++ b/components/MaskedTransition/src/MaterialMaskedTransition.h
@@ -14,4 +14,4 @@
  limitations under the License.
  */
 
-#import "MDCMaskedTransition.h"
+#import "MDCMaskedTransitionController.h"

--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.h
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.h
@@ -23,11 +23,12 @@
 - (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController
                        presentingViewController:(UIViewController *)presentingViewController
                   calculateFrameOfPresentedView:(CGRect (^)(UIPresentationController *))calculateFrameOfPresentedView
-NS_DESIGNATED_INITIALIZER;
+                                     sourceView:(UIView *)sourceView
+    NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController
                        presentingViewController:(UIViewController *)presentingViewController
-NS_UNAVAILABLE;
+    NS_UNAVAILABLE;
 
 @property(nonatomic, strong) UIView *sourceView;
 @property(nonatomic, strong) UIView *scrimView;

--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
@@ -24,20 +24,19 @@
 
 #import "MDCMaskedTransitionMotionForContext.h"
 
-@interface MDCMaskedPresentationController () <MDMTransition>
-@end
-
 @implementation MDCMaskedPresentationController {
   CGRect (^_calculateFrameOfPresentedView)(UIPresentationController *);
 }
 
 - (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController
                        presentingViewController:(UIViewController *)presentingViewController
-                  calculateFrameOfPresentedView:(CGRect (^)(UIPresentationController *))calculateFrameOfPresentedView {
+                  calculateFrameOfPresentedView:(CGRect (^)(UIPresentationController *))calculateFrameOfPresentedView
+                                     sourceView:(UIView *)sourceView {
   self = [super initWithPresentedViewController:presentedViewController
                        presentingViewController:presentingViewController];
   if (self) {
     _calculateFrameOfPresentedView = [calculateFrameOfPresentedView copy];
+    _sourceView = sourceView;
   }
   return self;
 }
@@ -62,15 +61,50 @@
   return definitelyFullscreen;
 }
 
-- (void)dismissalTransitionWillBegin {
-  if (!self.presentedViewController.mdm_transitionController.activeTransition) {
-    [self.presentedViewController.transitionCoordinator
-        animateAlongsideTransition:
-            ^(__unused id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
-              self.scrimView.alpha = 0;
-            }           completion:nil];
+- (void)presentationTransitionWillBegin {
+  if (!self.scrimView) {
+    self.scrimView = [[UIView alloc] initWithFrame:self.containerView.bounds];
+    self.scrimView.autoresizingMask = (UIViewAutoresizingFlexibleWidth
+                                       | UIViewAutoresizingFlexibleHeight);
+    self.scrimView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.3f];
+    [self.containerView addSubview:self.scrimView];
+  }
 
+  NSArray *viewControllers = @[self.presentingViewController, self.presentedViewController];
+  MDCMaskedTransitionMotionSpecContext spec =
+      MDCMaskedTransitionMotionSpecForContext(self.containerView, viewControllers[1]);
+
+  MDCMaskedTransitionMotionTiming motion = spec.expansion;
+
+  MDMMotionAnimator *animator = [[MDMMotionAnimator alloc] init];
+  [animator animateWithTiming:motion.scrimFade
+                      toLayer:self.scrimView.layer
+                   withValues:@[ @0, @1 ]
+                      keyPath:MDMKeyPathOpacity];
+}
+
+- (void)dismissalTransitionWillBegin {
+  NSArray *viewControllers = @[self.presentingViewController, self.presentedViewController];
+  MDCMaskedTransitionMotionSpecContext spec =
+      MDCMaskedTransitionMotionSpecForContext(self.containerView, viewControllers[1]);
+  if (spec.shouldSlideWhenCollapsed) {
+    // Immediately reveal the source view because our presented view controller isn't collapsing
+    // back to it.
     self.sourceView.alpha = 1;
+
+    [self.presentedViewController.transitionCoordinator
+        animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+          self.scrimView.alpha = 0;
+        } completion:nil];
+
+  } else {
+    MDCMaskedTransitionMotionTiming motion = spec.collapse;
+
+    MDMMotionAnimator *animator = [[MDMMotionAnimator alloc] init];
+    [animator animateWithTiming:motion.scrimFade
+                        toLayer:self.scrimView.layer
+                     withValues:@[ @1, @0 ]
+                        keyPath:MDMKeyPathOpacity];
   }
 }
 
@@ -86,35 +120,6 @@
     self.scrimView.alpha = 1;
     self.sourceView.alpha = 0;
   }
-}
-
-- (void)startWithContext:(NSObject<MDMTransitionContext> *)context {
-  MDCMaskedTransitionMotionSpecContext spec = MDCMaskedTransitionMotionSpecForContext(context);
-
-  MDMMotionAnimator *animator = [[MDMMotionAnimator alloc] init];
-  animator.shouldReverseValues = context.direction == MDMTransitionDirectionBackward;
-
-  MDCMaskedTransitionMotionTiming motion = (context.direction == MDMTransitionDirectionForward) ? spec.expansion : spec.collapse;
-
-  if (!self.scrimView) {
-    self.scrimView = [[UIView alloc] initWithFrame:context.containerView.bounds];
-    self.scrimView.autoresizingMask = (UIViewAutoresizingFlexibleWidth
-                                       | UIViewAutoresizingFlexibleHeight);
-    self.scrimView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.3f];
-    [context.containerView addSubview:self.scrimView];
-  }
-
-  [CATransaction begin];
-  [CATransaction setCompletionBlock:^{
-    [context transitionDidEnd];
-  }];
-
-  [animator animateWithTiming:motion.scrimFade
-                      toLayer:self.scrimView.layer
-                   withValues:@[ @0, @1 ]
-                      keyPath:@"opacity"];
-
-  [CATransaction commit];
 }
 
 @end

--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
@@ -70,22 +70,22 @@
     [self.containerView addSubview:self.scrimView];
   }
 
-  MDCMaskedTransitionMotionSpecContext spec =
+  MDCMaskedTransitionMotionSpec motionSpecification =
       MDCMaskedTransitionMotionSpecForContext(self.containerView, self.presentedViewController);
 
-  MDCMaskedTransitionMotionTiming motion = spec.expansion;
+  MDCMaskedTransitionMotionTiming motionTiming = motionSpecification.expansion;
 
   MDMMotionAnimator *animator = [[MDMMotionAnimator alloc] init];
-  [animator animateWithTiming:motion.scrimFade
+  [animator animateWithTiming:motionTiming.scrimFade
                       toLayer:self.scrimView.layer
                    withValues:@[ @0, @1 ]
                       keyPath:MDMKeyPathOpacity];
 }
 
 - (void)dismissalTransitionWillBegin {
-  MDCMaskedTransitionMotionSpecContext spec =
+  MDCMaskedTransitionMotionSpec motionSpecification =
       MDCMaskedTransitionMotionSpecForContext(self.containerView, self.presentedViewController);
-  if (spec.shouldSlideWhenCollapsed) {
+  if (motionSpecification.shouldSlideWhenCollapsed) {
     // Immediately reveal the source view because our presented view controller isn't collapsing
     // back to it.
     self.sourceView.alpha = 1;
@@ -96,10 +96,10 @@
         } completion:nil];
 
   } else {
-    MDCMaskedTransitionMotionTiming motion = spec.collapse;
+    MDCMaskedTransitionMotionTiming motionTiming = motionSpecification.collapse;
 
     MDMMotionAnimator *animator = [[MDMMotionAnimator alloc] init];
-    [animator animateWithTiming:motion.scrimFade
+    [animator animateWithTiming:motionTiming.scrimFade
                         toLayer:self.scrimView.layer
                      withValues:@[ @1, @0 ]
                         keyPath:MDMKeyPathOpacity];

--- a/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
+++ b/components/MaskedTransition/src/private/MDCMaskedPresentationController.m
@@ -70,9 +70,8 @@
     [self.containerView addSubview:self.scrimView];
   }
 
-  NSArray *viewControllers = @[self.presentingViewController, self.presentedViewController];
   MDCMaskedTransitionMotionSpecContext spec =
-      MDCMaskedTransitionMotionSpecForContext(self.containerView, viewControllers[1]);
+      MDCMaskedTransitionMotionSpecForContext(self.containerView, self.presentedViewController);
 
   MDCMaskedTransitionMotionTiming motion = spec.expansion;
 
@@ -84,9 +83,8 @@
 }
 
 - (void)dismissalTransitionWillBegin {
-  NSArray *viewControllers = @[self.presentingViewController, self.presentedViewController];
   MDCMaskedTransitionMotionSpecContext spec =
-      MDCMaskedTransitionMotionSpecForContext(self.containerView, viewControllers[1]);
+      MDCMaskedTransitionMotionSpecForContext(self.containerView, self.presentedViewController);
   if (spec.shouldSlideWhenCollapsed) {
     // Immediately reveal the source view because our presented view controller isn't collapsing
     // back to it.

--- a/components/MaskedTransition/src/private/MDCMaskedTransition.h
+++ b/components/MaskedTransition/src/private/MDCMaskedTransition.h
@@ -24,7 +24,7 @@
  It is presently assumed that the mask will be a circular mask and that the source view is a view
  with equal width and height and a corner radius equal to half the view's width.
  */
-@interface MDCMaskedTransition: NSObject <MDMTransition>
+@interface MDCMaskedTransition: NSObject <UIViewControllerAnimatedTransitioning>
 
 /**
  Initializes the transition with the view from which the mask should emanate.
@@ -33,6 +33,7 @@
                    presenting view controller's view hierarchy.
  */
 - (nonnull instancetype)initWithSourceView:(nonnull UIView *)sourceView
+                                 direction:(MDMTransitionDirection)direction
     NS_DESIGNATED_INITIALIZER;
 
 /**

--- a/components/MaskedTransition/src/private/MDCMaskedTransition.m
+++ b/components/MaskedTransition/src/private/MDCMaskedTransition.m
@@ -244,6 +244,16 @@ OrderedViewControllersWithTransitionContext(id<UIViewControllerContextTransition
 
     self->_sourceView.frame = originalSourceFrame;
     self->_sourceView.backgroundColor = originalSourceBackgroundColor;
+    if (motionSpecification.shouldSlideWhenCollapsed
+        && transitionContext.presentationStyle != UIModalPresentationCustom) {
+      // If we're going to slide when collapsed then this transition won't be invoked. If we also
+      // don't have a presentation controller (because of the presentation style) then we need to
+      // restore the source view's visibility somehow. This is the only place I could think of to
+      // do so, but it unfortunately means if the presented view controller is somehow presented
+      // such that the source view is still visible then the source view will appear to flash back
+      // into existence at the end of the transition, breaking the illusion of continuity.
+      self->_sourceView.alpha = 1;
+    }
     [originalSourceSuperview addSubview:self->_sourceView];
 
     [maskedView removeFromSuperview];

--- a/components/MaskedTransition/src/private/MDCMaskedTransition.m
+++ b/components/MaskedTransition/src/private/MDCMaskedTransition.m
@@ -108,6 +108,7 @@ OrderedViewControllersWithTransitionContext(id<UIViewControllerContextTransition
 
 @implementation MDCMaskedTransition {
   UIView *_sourceView;
+  CGFloat _initialSourceViewAlpha;
   MDMTransitionDirection _direction;
 }
 
@@ -151,6 +152,7 @@ OrderedViewControllersWithTransitionContext(id<UIViewControllerContextTransition
            @"Expected two view controllers to be involved in a transition.");
   if ([viewControllers count] != 2) {
     [transitionContext completeTransition:YES];
+    return;
   }
   UIViewController *presentedViewController = viewControllers[1];
 
@@ -266,9 +268,13 @@ OrderedViewControllersWithTransitionContext(id<UIViewControllerContextTransition
   MDMMotionAnimator *animator = [[MDMMotionAnimator alloc] init];
   animator.shouldReverseValues = _direction == MDMTransitionDirectionBackward;
 
+  if (_direction == MDMTransitionDirectionForward) {
+    _initialSourceViewAlpha = _sourceView.alpha;
+  }
+
   [animator animateWithTiming:motion.iconFade
                       toLayer:_sourceView.layer
-                   withValues:@[ @1, @0 ]
+                   withValues:@[ @(_initialSourceViewAlpha), @0 ]
                       keyPath:MDMKeyPathOpacity];
 
   [animator animateWithTiming:motion.contentFade

--- a/components/MaskedTransition/src/private/MDCMaskedTransition.m
+++ b/components/MaskedTransition/src/private/MDCMaskedTransition.m
@@ -121,38 +121,39 @@ PrepareTransitionWithContext(id<UIViewControllerContextTransitioning> transition
 - (void)animateTransition:(id<UIViewControllerContextTransitioning>)transitionContext {
   NSArray<UIViewController *> *viewControllers = PrepareTransitionWithContext(transitionContext,
                                                                               _direction);
-  UIViewController *foreViewController = viewControllers[1];
+  UIViewController *presentedViewController = viewControllers[1];
 
   MDCMaskedTransitionMotionSpecContext spec =
-      MDCMaskedTransitionMotionSpecForContext(transitionContext.containerView, foreViewController);
+      MDCMaskedTransitionMotionSpecForContext(transitionContext.containerView,
+                                              presentedViewController);
 
   // Cache original state.
   // We're going to reparent the fore view, so keep this information for later.
-  UIView *originalSuperview = foreViewController.view.superview;
-  const CGRect originalFrame = foreViewController.view.frame;
+  UIView *originalSuperview = presentedViewController.view.superview;
+  const CGRect originalFrame = presentedViewController.view.frame;
   UIView *originalSourceSuperview = _sourceView.superview;
   const CGRect originalSourceFrame = _sourceView.frame;
   UIColor *originalSourceBackgroundColor = _sourceView.backgroundColor;
 
   // Reparent the fore view into a masked view.
-  UIView *maskedView = [[UIView alloc] initWithFrame:foreViewController.view.frame];
+  UIView *maskedView = [[UIView alloc] initWithFrame:presentedViewController.view.frame];
   {
-    CGRect reparentedFrame = foreViewController.view.frame;
+    CGRect reparentedFrame = presentedViewController.view.frame;
     reparentedFrame.origin = CGPointZero;
-    foreViewController.view.frame = reparentedFrame;
+    presentedViewController.view.frame = reparentedFrame;
 
-    maskedView.layer.cornerRadius = foreViewController.view.layer.cornerRadius;
-    maskedView.clipsToBounds = foreViewController.view.clipsToBounds;
+    maskedView.layer.cornerRadius = presentedViewController.view.layer.cornerRadius;
+    maskedView.clipsToBounds = presentedViewController.view.clipsToBounds;
   }
   [transitionContext.containerView addSubview:maskedView];
 
-  UIView *floodFillView = [[UIView alloc] initWithFrame:foreViewController.view.bounds];
+  UIView *floodFillView = [[UIView alloc] initWithFrame:presentedViewController.view.bounds];
   floodFillView.backgroundColor = _sourceView.backgroundColor;
 
   // TODO(featherless): Profile whether it's more performant to fade the flood fill out or to
   // fade the fore view in (what we're currently doing).
   [maskedView addSubview:floodFillView];
-  [maskedView addSubview:foreViewController.view];
+  [maskedView addSubview:presentedViewController.view];
 
   // All frames are assumed to be relative to the container view unless named otherwise.
   const CGRect initialSourceFrame = [_sourceView convertRect:_sourceView.bounds
@@ -205,8 +206,8 @@ PrepareTransitionWithContext(id<UIViewControllerContextTransitioning> transition
 
   [CATransaction begin];
   [CATransaction setCompletionBlock:^{
-    foreViewController.view.frame = originalFrame;
-    [originalSuperview addSubview:foreViewController.view];
+    presentedViewController.view.frame = originalFrame;
+    [originalSuperview addSubview:presentedViewController.view];
 
     self->_sourceView.frame = originalSourceFrame;
     self->_sourceView.backgroundColor = originalSourceBackgroundColor;
@@ -230,7 +231,7 @@ PrepareTransitionWithContext(id<UIViewControllerContextTransitioning> transition
                       keyPath:MDMKeyPathOpacity];
 
   [animator animateWithTiming:motion.contentFade
-                      toLayer:foreViewController.view.layer
+                      toLayer:presentedViewController.view.layer
                    withValues:@[ @0, @1 ]
                       keyPath:MDMKeyPathOpacity];
 
@@ -241,7 +242,7 @@ PrepareTransitionWithContext(id<UIViewControllerContextTransitioning> transition
     if (!initialColor) {
       initialColor = [UIColor clearColor];
     }
-    UIColor *finalColor = foreViewController.view.backgroundColor;
+    UIColor *finalColor = presentedViewController.view.backgroundColor;
     if (!finalColor) {
       finalColor = [UIColor whiteColor];
     }
@@ -258,7 +259,7 @@ PrepareTransitionWithContext(id<UIViewControllerContextTransitioning> transition
         // Upon completion of the animation we want all of the content to be visible, so we jump
         // to a full bounds mask.
         shapeLayer.transform = CATransform3DIdentity;
-        shapeLayer.path = [[UIBezierPath bezierPathWithRect:foreViewController.view.bounds]
+        shapeLayer.path = [[UIBezierPath bezierPathWithRect:presentedViewController.view.bounds]
                            CGPath];
       };
     }

--- a/components/MaskedTransition/src/private/MDCMaskedTransition.m
+++ b/components/MaskedTransition/src/private/MDCMaskedTransition.m
@@ -87,8 +87,6 @@ PrepareTransitionWithContext(id<UIViewControllerContextTransitioning> transition
       }
     }
   }
-
-  [toView layoutIfNeeded];
 }
 
 // TODO: Pull this out to MotionTransitioning.

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.h
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.h
@@ -17,9 +17,9 @@
 #import <Foundation/Foundation.h>
 #import <MotionTransitioning/MotionTransitioning.h>
 
-#import "MDCMaskedTransitionMotionSpec.h"
+#import "MDCMaskedTransitionMotionSpecs.h"
 
 FOUNDATION_EXPORT
-MDCMaskedTransitionMotionSpecContext
+MDCMaskedTransitionMotionSpec
     MDCMaskedTransitionMotionSpecForContext(UIView *containerView,
                                             UIViewController *presentedViewController);

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.h
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.h
@@ -21,4 +21,5 @@
 
 FOUNDATION_EXPORT
 MDCMaskedTransitionMotionSpecContext
-    MDCMaskedTransitionMotionSpecForContext(id<MDMTransitionContext> context);
+    MDCMaskedTransitionMotionSpecForContext(UIView *containerView,
+                                            UIViewController *presentedViewController);

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.m
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.m
@@ -19,12 +19,13 @@
 #import "MDCMaskedTransitionMotionForContext.h"
 
 MDCMaskedTransitionMotionSpecContext
-    MDCMaskedTransitionMotionSpecForContext(id<MDMTransitionContext> context) {
-  const CGRect foreBounds = context.foreViewController.view.bounds;
-  const CGRect foreFrame = context.foreViewController.view.frame;
-  const CGRect containerBounds = context.containerView.bounds;
+MDCMaskedTransitionMotionSpecForContext(UIView *containerView,
+                                        UIViewController *presentedViewController) {
+  const CGRect foreBounds = presentedViewController.view.bounds;
+  const CGRect foreFrame = presentedViewController.view.frame;
+  const CGRect containerBounds = containerView.bounds;
 
-  if (CGRectEqualToRect(context.foreViewController.view.frame, containerBounds)) {
+  if (CGRectEqualToRect(presentedViewController.view.frame, containerBounds)) {
     return MDCMaskedTransitionMotionSpec.fullscreen;
 
   } else if (foreBounds.size.width == containerBounds.size.width

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.m
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionForContext.m
@@ -18,7 +18,7 @@
 
 #import "MDCMaskedTransitionMotionForContext.h"
 
-MDCMaskedTransitionMotionSpecContext
+MDCMaskedTransitionMotionSpec
 MDCMaskedTransitionMotionSpecForContext(UIView *containerView,
                                         UIViewController *presentedViewController) {
   const CGRect foreBounds = presentedViewController.view.bounds;
@@ -26,20 +26,20 @@ MDCMaskedTransitionMotionSpecForContext(UIView *containerView,
   const CGRect containerBounds = containerView.bounds;
 
   if (CGRectEqualToRect(presentedViewController.view.frame, containerBounds)) {
-    return MDCMaskedTransitionMotionSpec.fullscreen;
+    return MDCMaskedTransitionMotionSpecs.fullscreen;
 
   } else if (foreBounds.size.width == containerBounds.size.width
              && CGRectGetMaxY(foreFrame) == CGRectGetMaxY(containerBounds)) {
     if (foreFrame.size.height > 100) {
-      return MDCMaskedTransitionMotionSpec.bottomSheet;
+      return MDCMaskedTransitionMotionSpecs.bottomSheet;
 
     } else {
-      return MDCMaskedTransitionMotionSpec.toolbar;
+      return MDCMaskedTransitionMotionSpecs.toolbar;
     }
 
   } else if (foreBounds.size.width < containerBounds.size.width) {
-    return MDCMaskedTransitionMotionSpec.bottomCard;
+    return MDCMaskedTransitionMotionSpecs.bottomCard;
   }
 
-  return MDCMaskedTransitionMotionSpec.fullscreen;
+  return MDCMaskedTransitionMotionSpecs.fullscreen;
 }

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionSpecs.h
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionSpecs.h
@@ -25,21 +25,22 @@ typedef struct MDCMaskedTransitionMotionTiming {
   MDMMotionTiming horizontalMovement;
   MDMMotionTiming verticalMovement;
   MDMMotionTiming scrimFade;
+  NSTimeInterval overallDuration;
 } MDCMaskedTransitionMotionTiming;
 
-typedef struct MDCMaskedTransitionMotionSpecContext {
+typedef struct MDCMaskedTransitionMotionSpec {
   MDCMaskedTransitionMotionTiming expansion;
   MDCMaskedTransitionMotionTiming collapse;
   BOOL shouldSlideWhenCollapsed;
   BOOL isCentered;
-} MDCMaskedTransitionMotionSpecContext;
+} MDCMaskedTransitionMotionSpec;
 
-@interface MDCMaskedTransitionMotionSpec: NSObject
+@interface MDCMaskedTransitionMotionSpecs: NSObject
 
-@property(nonatomic, class, readonly) MDCMaskedTransitionMotionSpecContext fullscreen;
-@property(nonatomic, class, readonly) MDCMaskedTransitionMotionSpecContext bottomSheet;
-@property(nonatomic, class, readonly) MDCMaskedTransitionMotionSpecContext bottomCard;
-@property(nonatomic, class, readonly) MDCMaskedTransitionMotionSpecContext toolbar;
+@property(nonatomic, class, readonly) MDCMaskedTransitionMotionSpec fullscreen;
+@property(nonatomic, class, readonly) MDCMaskedTransitionMotionSpec bottomSheet;
+@property(nonatomic, class, readonly) MDCMaskedTransitionMotionSpec bottomCard;
+@property(nonatomic, class, readonly) MDCMaskedTransitionMotionSpec toolbar;
 
 // This object is not meant to be instantiated.
 - (instancetype)init NS_UNAVAILABLE;

--- a/components/MaskedTransition/src/private/MDCMaskedTransitionMotionSpecs.m
+++ b/components/MaskedTransition/src/private/MDCMaskedTransitionMotionSpecs.m
@@ -14,9 +14,9 @@
  limitations under the License.
  */
 
-#import "MDCMaskedTransitionMotionSpec.h"
+#import "MDCMaskedTransitionMotionSpecs.h"
 
-@implementation MDCMaskedTransitionMotionSpec
+@implementation MDCMaskedTransitionMotionSpecs
 
 + (MDMMotionCurve)easeInEaseOut {
   return MDMMotionCurveMakeBezier(0.4f, 0.0f, 0.2f, 1.0f);
@@ -30,10 +30,10 @@
   return MDMMotionCurveMakeBezier(0.0f, 0.0f, 0.2f, 1.0f);
 }
 
-+ (MDCMaskedTransitionMotionSpecContext)fullscreen {
++ (MDCMaskedTransitionMotionSpec)fullscreen {
   MDMMotionCurve easeInEaseOut = [self easeInEaseOut];
   MDMMotionCurve easeIn = [self easeIn];
-  return (MDCMaskedTransitionMotionSpecContext){
+  return (MDCMaskedTransitionMotionSpec){
     .expansion = {
       .iconFade = {
         .delay = 0.000, .duration = 0.075, .curve = easeInEaseOut,
@@ -53,17 +53,18 @@
       },
       .scrimFade = {
         .delay = 0.000, .duration = 0.150, .curve = easeInEaseOut,
-      }
+      },
+      .overallDuration = 0.375
     },
     .shouldSlideWhenCollapsed = true,
     .isCentered = false
   };
 }
 
-+ (MDCMaskedTransitionMotionSpecContext)bottomSheet {
++ (MDCMaskedTransitionMotionSpec)bottomSheet {
   MDMMotionCurve easeInEaseOut = [self easeInEaseOut];
   MDMMotionCurve easeIn = [self easeIn];
-  return (MDCMaskedTransitionMotionSpecContext){
+  return (MDCMaskedTransitionMotionSpec){
     .expansion = {
       .iconFade = {
         .delay = 0.000, .duration = 0.075, .curve = easeInEaseOut, // No spec
@@ -83,18 +84,19 @@
       },
       .scrimFade = {
         .delay = 0.000, .duration = 0.150, .curve = easeInEaseOut,
-      }
+      },
+      .overallDuration = 0.375
     },
     .shouldSlideWhenCollapsed = true,
     .isCentered = false
   };
 }
 
-+ (MDCMaskedTransitionMotionSpecContext)bottomCard {
++ (MDCMaskedTransitionMotionSpec)bottomCard {
   MDMMotionCurve easeInEaseOut = [self easeInEaseOut];
   MDMMotionCurve easeIn = [self easeIn];
   MDMMotionCurve easeOut = [self easeOut];
-  return (MDCMaskedTransitionMotionSpecContext){
+  return (MDCMaskedTransitionMotionSpec){
     .expansion = {
       .iconFade = {
         .delay = 0.000, .duration = 0.120, .curve = easeInEaseOut,
@@ -116,7 +118,8 @@
       },
       .scrimFade = {
         .delay = 0.075, .duration = 0.150, .curve = easeInEaseOut,
-      }
+      },
+      .overallDuration = 0.345
     },
     .collapse = {
       .iconFade = {
@@ -139,18 +142,19 @@
       },
       .scrimFade = {
         .delay = 0.000, .duration = 0.150, .curve = easeInEaseOut,
-      }
+      },
+      .overallDuration = 0.300
     },
     .shouldSlideWhenCollapsed = false,
     .isCentered = true
   };
 }
 
-+ (MDCMaskedTransitionMotionSpecContext)toolbar {
++ (MDCMaskedTransitionMotionSpec)toolbar {
   MDMMotionCurve easeInEaseOut = [self easeInEaseOut];
   MDMMotionCurve easeIn = [self easeIn];
   MDMMotionCurve easeOut = [self easeOut];
-  return (MDCMaskedTransitionMotionSpecContext){
+  return (MDCMaskedTransitionMotionSpec){
     .expansion = {
       .iconFade = {
         .delay = 0.000, .duration = 0.120, .curve = easeInEaseOut,
@@ -172,7 +176,8 @@
       },
       .scrimFade = {
         .delay = 0.075, .duration = 0.150, .curve = easeInEaseOut,
-      }
+      },
+      .overallDuration = 0.300
     },
     .collapse = {
       .iconFade = {
@@ -195,7 +200,8 @@
       },
       .scrimFade = {
         .delay = 0.000, .duration = 0.150, .curve = easeInEaseOut,
-      }
+      },
+      .overallDuration = 0.300
     },
     .shouldSlideWhenCollapsed = false,
     .isCentered = true

--- a/components/MaskedTransition/tests/unit/MaskedTransitionNoopTest.m
+++ b/components/MaskedTransition/tests/unit/MaskedTransitionNoopTest.m
@@ -26,8 +26,9 @@
 
 - (void)testInit {
   UIView *view = [[UIView alloc] init];
-  MDCMaskedTransition *transition = [[MDCMaskedTransition alloc] initWithSourceView:view];
-  XCTAssertNotNil(transition);
+  MDCMaskedTransitionController *transitionController =
+      [[MDCMaskedTransitionController alloc] initWithSourceView:view];
+  XCTAssertNotNil(transitionController);
 }
 
 @end

--- a/components/MaskedTransition/tests/unit/MaskedTransitionNoopTest.m
+++ b/components/MaskedTransition/tests/unit/MaskedTransitionNoopTest.m
@@ -28,7 +28,7 @@
   UIView *view = [[UIView alloc] init];
   MDCMaskedTransitionController *transitionController =
       [[MDCMaskedTransitionController alloc] initWithSourceView:view];
-  XCTAssertNotNil(transitionController);
+  XCTAssertEqual(transitionController.sourceView, view);
 }
 
 @end


### PR DESCRIPTION
This simplifies the layers between the app developer and the transition implementation while also allowing us to reduce the complexity of the MotionTransitioning APIs. In the near future we will remove nearly all of the MotionTransitioning abstractions in favor of providing a small set of tools and APIs for building plain UIKit transitions.

Notably:

- MaskedTransition is now a private API.
- There is a new MaskedTransitionController type that must be instantiated and stored for the lifetime of the presented view controller.
- MaskedTransition is no longer a Transition type.
- MaskedTransition now simply implements the animated view controller transitioning APIs.
- MaskedTransitionController vends MaskedTransition instances as required.

Example usage:

```swift
let transitionController = MDCMaskedTransitionController()
func didTapFab(fab: UIView) {
  let vc = SomeViewController()

  vc.view.autoresizingMask = [.flexibleLeftMargin, .flexibleTopMargin,
                              .flexibleRightMargin, .flexibleBottomMargin]

  // Customize the transition
  transitionController.sourceView = fab
  transitionController.calculateFrameOfPresentedView = { info in
    let size = CGSize(width: 200, height: 200)
    return CGRect(x: (info.containerView!.bounds.width - size.width) / 2,
                  y: (info.containerView!.bounds.height - size.height) / 2,
                  width: size.width,
                  height: size.height)
  }
  vc.modalPresentationStyle = .custom
  vc.transitioningDelegate = transitionController

  showDetailViewController(vc, sender: self)
}
```