### PR TITLE
[Catalog] Make tile ink bounded.

### DIFF
--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -268,7 +268,7 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
 
   func inkViewForView(_ view: UIView) -> MDCInkView {
     let foundInkView = MDCInkView.injectedInkView(for: view)
-    foundInkView.inkStyle = .unbounded
+    foundInkView.inkStyle = .bounded
     foundInkView.inkColor = UIColor(white:0.957, alpha: 0.2)
     return foundInkView
   }


### PR DESCRIPTION
The tile ink was unbounded, resulting in some odd ink clipping depending on
how the cell was laid-out within the collection view.

**Before**
![catalog-tile-ink-before](https://user-images.githubusercontent.com/1753199/37297850-22b7beb2-25f5-11e8-9c78-97ead329ca52.png)


**After**
![catalog-tile-ink-after](https://user-images.githubusercontent.com/1753199/37297858-25df50aa-25f5-11e8-988a-4703145e34ee.png)
