### PR TITLE
[Snackbar] Fix text color of snackbar message to use the initialized value for it and not button color

### DIFF
--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -452,7 +452,7 @@ static const CGFloat kButtonInkRadius = 64.0f;
     UIColor *textColor = [self snackbarButtonTextColor];
     UIColor *textColorHighlighted = [self snackbarButtonTextColorHighlighted];
 
-    _label.textColor = textColor;
+    _label.textColor = _snackbarMessageViewTextColor;
 
     if (message.buttonTextColor) {
       textColor = message.buttonTextColor;


### PR DESCRIPTION


Caused by #3048