### PR TITLE
[Buttons] Support IB custom fonts

### DIFF
--- a/MaterialComponentsUnitTests.podspec
+++ b/MaterialComponentsUnitTests.podspec
@@ -9,7 +9,8 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/material-components/material-components-ios.git", :tag => "v#{s.version}" }
   s.platform     = :ios, '8.0'
   s.requires_arc = true
-  s.source_files = 'components/*/tests/unit/*.{h,m,swift}', 'components/private/*/tests/unit/*.{h,m,swift}'
+  s.source_files = 'components/*/tests/unit/*.{h,m,swift}', 'components/private/*/tests/unit/*.{h,m,swift}', 'components/*/tests/unit/supplemental/*.{h,m,swift}', 'components/private/*/tests/unit/supplemental/*.{h,m,swift]'
+  s.resources = ['components/*/tests/unit/resources/*', 'components/private/*/tests/unit/resources/*']
   s.framework    = 'XCTest'
   s.dependency 'MaterialComponents'
   s.dependency 'MDFTextAccessibility'

--- a/components/Buttons/BUILD
+++ b/components/Buttons/BUILD
@@ -83,6 +83,8 @@ mdc_objc_library(
     srcs = glob([
         "tests/unit/*.m",
         "tests/unit/*.h",
+        "tests/unit/supplemental/*.m",
+        "tests/unit/supplemental/*.h",
     ]),
     sdk_frameworks = [
         "UIKit",
@@ -95,6 +97,7 @@ mdc_objc_library(
         ":TitleColorAccessibilityMutator",
     ],
     visibility = ["//visibility:private"],
+    xibs = native.glob(["tests/unit/resources/*.xib"]),
 )
 
 ios_unit_test(

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -145,6 +145,11 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 - (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];
   if (self) {
+    // Set up title label attributes.
+    // TODO(#2709): Have a single source of truth for fonts
+    // Migrate to [UIFont standardFont] when possible
+    self.titleLabel.font = [MDCTypography buttonFont];
+
     [self commonMDCButtonInit];
     [self updateBackgroundColor];
   }
@@ -155,6 +160,11 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   self = [super initWithCoder:aDecoder];
   if (self) {
     [self commonMDCButtonInit];
+
+    if (self.titleLabel.font) {
+      _fonts = [@{} mutableCopy];
+      _fonts[@(UIControlStateNormal)] = self.titleLabel.font;
+    }
 
     if ([aDecoder containsValueForKey:MDCButtonInkViewInkStyleKey]) {
       self.inkView.inkStyle = [aDecoder decodeIntegerForKey:MDCButtonInkViewInkStyleKey];
@@ -298,11 +308,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   // Disable default highlight state.
   self.adjustsImageWhenHighlighted = NO;
   self.showsTouchWhenHighlighted = NO;
-
-  // Set up title label attributes.
-  // TODO(#2709): Have a single source of truth for fonts
-  // Migrate to [UIFont standardFont] when possible
-  self.titleLabel.font = [MDCTypography buttonFont];
 
   // Default content insets
   self.contentEdgeInsets = [self defaultContentEdgeInsets];

--- a/components/Buttons/tests/unit/ButtonInterfaceBuilderCompatibilityTests.m
+++ b/components/Buttons/tests/unit/ButtonInterfaceBuilderCompatibilityTests.m
@@ -1,0 +1,44 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import <Foundation/Foundation.h>
+
+#import "ButtonTestView.h"
+
+@interface ButtonInterfaceBuilderCompatibilityTests : XCTestCase
+
+@end
+
+@implementation ButtonInterfaceBuilderCompatibilityTests
+
+- (void)testFontRestoredFromNib {
+  // Given
+  ButtonTestView *buttonView = [[ButtonTestView alloc] initFromNib];
+  UIFont *buttonFont = buttonView.button.titleLabel.font;
+  UIColor *buttonColor = buttonView.button.titleLabel.textColor;
+
+  // When
+  buttonView.button.selected = YES;
+  buttonView.button.selected = NO;
+
+  // Then
+  XCTAssertEqualObjects(buttonFont, [UIFont systemFontOfSize:40]);
+  XCTAssertEqualObjects(buttonColor, [UIColor blackColor]);
+
+}
+
+@end

--- a/components/Buttons/tests/unit/ButtonInterfaceBuilderCompatibilityTests.m
+++ b/components/Buttons/tests/unit/ButtonInterfaceBuilderCompatibilityTests.m
@@ -17,7 +17,7 @@
 #import <XCTest/XCTest.h>
 #import <Foundation/Foundation.h>
 
-#import "ButtonTestView.h"
+#import "supplemental/ButtonTestView.h"
 
 @interface ButtonInterfaceBuilderCompatibilityTests : XCTestCase
 

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -570,40 +570,42 @@ static NSString *controlStateDescription(UIControlState controlState) {
   MDCButton *unarchivedButton = [NSKeyedUnarchiver unarchiveObjectWithData:data];
 
   // Then
-  XCTAssertEqualObjects(button.inkColor, unarchivedButton.inkColor);
-  XCTAssertEqual(button.uppercaseTitle, unarchivedButton.uppercaseTitle);
-  XCTAssertEqual(button.inkStyle, unarchivedButton.inkStyle);
-  XCTAssertEqualWithAccuracy(button.inkMaxRippleRadius,
-                             unarchivedButton.inkMaxRippleRadius,
+  XCTAssertEqualObjects(unarchivedButton.inkColor, button.inkColor);
+  XCTAssertEqual(unarchivedButton.uppercaseTitle, button.uppercaseTitle);
+  XCTAssertEqual(unarchivedButton.inkStyle, button.inkStyle);
+  XCTAssertEqualWithAccuracy(unarchivedButton.inkMaxRippleRadius,
+                             button.inkMaxRippleRadius,
                              kEpsilonAccuracy);
-  XCTAssertEqualWithAccuracy(button.hitAreaInsets.bottom,
-                             unarchivedButton.hitAreaInsets.bottom,
+  XCTAssertEqualWithAccuracy(unarchivedButton.hitAreaInsets.bottom,
+                             button.hitAreaInsets.bottom,
                              kEpsilonAccuracy);
-  XCTAssertEqualWithAccuracy(button.hitAreaInsets.top,
-                             unarchivedButton.hitAreaInsets.top,
+  XCTAssertEqualWithAccuracy(unarchivedButton.hitAreaInsets.top,
+                             button.hitAreaInsets.top,
                              kEpsilonAccuracy);
-  XCTAssertEqualWithAccuracy(button.hitAreaInsets.right,
-                             unarchivedButton.hitAreaInsets.right,
+  XCTAssertEqualWithAccuracy(unarchivedButton.hitAreaInsets.right,
+                             button.hitAreaInsets.right,
                              kEpsilonAccuracy);
-  XCTAssertEqualWithAccuracy(button.hitAreaInsets.left,
-                             unarchivedButton.hitAreaInsets.left,
+  XCTAssertEqualWithAccuracy(unarchivedButton.hitAreaInsets.left,
+                             button.hitAreaInsets.left,
                              kEpsilonAccuracy);
-  XCTAssertEqualObjects(button.underlyingColorHint, unarchivedButton.underlyingColorHint);
-  XCTAssertTrue(CGSizeEqualToSize(button.minimumSize, unarchivedButton.minimumSize));
-  XCTAssertTrue(CGSizeEqualToSize(button.maximumSize, unarchivedButton.maximumSize));
-  XCTAssertEqual(button.enabled, unarchivedButton.enabled);
-  XCTAssertEqualWithAccuracy(button.alpha, unarchivedButton.alpha, (CGFloat)0.0001);
+  XCTAssertEqualObjects(unarchivedButton.underlyingColorHint, button.underlyingColorHint);
+  XCTAssertTrue(CGSizeEqualToSize(unarchivedButton.minimumSize, button.minimumSize));
+  XCTAssertTrue(CGSizeEqualToSize(unarchivedButton.maximumSize, button.maximumSize));
+  XCTAssertEqual(unarchivedButton.enabled, button.enabled);
+  XCTAssertEqualWithAccuracy(unarchivedButton.alpha, button.alpha, (CGFloat)0.0001);
   unarchivedButton.enabled = YES;
-  XCTAssertEqualWithAccuracy(buttonAlpha, unarchivedButton.alpha, (CGFloat)0.0001);
-
+  XCTAssertEqualWithAccuracy(unarchivedButton.alpha, buttonAlpha, (CGFloat)0.0001);
+  XCTAssertEqualObjects(unarchivedButton.titleLabel.font, button.titleLabel.font);
   for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
-    XCTAssertEqualWithAccuracy([button elevationForState:controlState],
-                               [unarchivedButton elevationForState:controlState],
+    XCTAssertEqualWithAccuracy([unarchivedButton elevationForState:controlState],
+                               [button elevationForState:controlState],
                                kEpsilonAccuracy);
-    XCTAssertEqualObjects([button backgroundColorForState:controlState],
-                   [unarchivedButton backgroundColorForState:controlState]);
-    XCTAssertEqualObjects([button shadowColorForState:controlState],
-                          [unarchivedButton shadowColorForState:controlState]);
+    XCTAssertEqualObjects([unarchivedButton backgroundColorForState:controlState],
+                   [button backgroundColorForState:controlState]);
+    XCTAssertEqualObjects([unarchivedButton shadowColorForState:controlState],
+                          [button shadowColorForState:controlState]);
+    XCTAssertEqualObjects([unarchivedButton titleFontForState:controlState],
+                          [button titleFontForState:controlState]);
   }
 }
 
@@ -895,6 +897,14 @@ static NSString *controlStateDescription(UIControlState controlState) {
   // Then
   XCTAssertFalse(button.selected);
   XCTAssertFalse(button.state & UIControlStateSelected);
+}
+
+- (void)testDefaultFont {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+
+  // Then
+  XCTAssertEqualObjects(button.titleLabel.font, [MDCTypography buttonFont]);
 }
 
 - (void)testDefaultAdjustsFontProperty {

--- a/components/Buttons/tests/unit/resources/ButtonTestView.xib
+++ b/components/Buttons/tests/unit/resources/ButtonTestView.xib
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="ButtonTestView">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bGz-KD-fJl" customClass="MDCButton">
+                    <rect key="frame" x="101" y="189" width="150" height="43"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="40"/>
+                    <state key="normal" title="Button">
+                        <color key="titleColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                </button>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <connections>
+                <outlet property="button" destination="bGz-KD-fJl" id="C9B-OB-9jx"/>
+            </connections>
+            <point key="canvasLocation" x="24.5" y="52.5"/>
+        </view>
+    </objects>
+</document>

--- a/components/Buttons/tests/unit/supplemental/ButtonTestView.h
+++ b/components/Buttons/tests/unit/supplemental/ButtonTestView.h
@@ -1,0 +1,24 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "MaterialButtons.h"
+
+@interface ButtonTestView : UIView
+@property (unsafe_unretained, nonatomic) IBOutlet MDCButton *button;
+- (instancetype)initFromNib;
+@end

--- a/components/Buttons/tests/unit/supplemental/ButtonTestView.m
+++ b/components/Buttons/tests/unit/supplemental/ButtonTestView.m
@@ -1,0 +1,25 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "ButtonTestView.h"
+
+@implementation ButtonTestView
+- (instancetype)initFromNib {
+  return [[[NSBundle bundleForClass:[self class]] loadNibNamed:NSStringFromClass(self.class)
+                                                         owner:nil
+                                                       options:nil] firstObject];
+}
+@end


### PR DESCRIPTION
MDCButton should allow custom fonts to be set via Interface Builder. Instead
of overwriting the titleLabel.font to our preferred font, we can initialize
the button's font-for-state dictionary with the font provided by the label.

Closes #2786
