### PR TITLE
[BottomNavigation] Add `barTintColor` to replace `backgroundColor`

### DIFF
--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -70,6 +70,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     MDCActivityIndicatorColorThemer.apply(colorScheme, to: MDCActivityIndicator.appearance())
     MDCAlertColorThemer.apply(colorScheme)
     MDCBottomAppBarColorThemer.apply(colorScheme, to: MDCBottomAppBarView.appearance())
+    MDCBottomNavigationBarColorThemer.apply(colorScheme, to:MDCBottomNavigationBar.appearance())
     MDCButtonBarColorThemer.apply(colorScheme, to: MDCButtonBar.appearance())
     MDCButtonColorThemer.apply(colorScheme, to: MDCButton.appearance())
     let clearScheme = MDCBasicColorScheme(primaryColor: .clear)

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -52,11 +52,6 @@
   _bottomNavBar.delegate = self;
   [self.view addSubview:_bottomNavBar];
 
-  MDCBasicColorScheme *scheme =
-      [[MDCBasicColorScheme alloc] initWithPrimaryColor:[MDCPalette purplePalette].tint700
-                                         secondaryColor:[UIColor whiteColor]];
-  [MDCBottomNavigationBarColorThemer applyColorScheme:scheme toBottomNavigationBar:_bottomNavBar];
-
   UITabBarItem *tabBarItem1 =
       [[UITabBarItem alloc] initWithTitle:@"Home"
                                     image:[UIImage imageNamed:@"Home"]

--- a/components/BottomNavigation/src/ColorThemer/MDCBottomNavigationBarColorThemer.m
+++ b/components/BottomNavigation/src/ColorThemer/MDCBottomNavigationBarColorThemer.m
@@ -22,7 +22,7 @@
     toBottomNavigationBar:(MDCBottomNavigationBar *)bottomNavigationBar {
   bottomNavigationBar.selectedItemTintColor = colorScheme.primaryLightColor;
   bottomNavigationBar.unselectedItemTintColor = colorScheme.primaryDarkColor;
-  bottomNavigationBar.backgroundColor = colorScheme.secondaryColor;
+  bottomNavigationBar.barTintColor = colorScheme.secondaryColor;
 }
 
 @end

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -108,6 +108,16 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarAlignment) {
 @property (nonatomic, strong, readwrite, nonnull) UIColor *unselectedItemTintColor
     UI_APPEARANCE_SELECTOR;
 
+/**
+ Color of the background of bottom navigation bar and the bar items.
+ */
+@property(nonatomic, strong, nullable) UIColor *barTintColor UI_APPEARANCE_SELECTOR;
+
+/**
+ To color the background of the view use -barTintColor instead.
+ */
+@property(nullable, nonatomic,copy) UIColor *backgroundColor UI_APPEARANCE_SELECTOR;
+
 @end
 
 #pragma mark - MDCBottomNavigationBarDelegate

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -46,6 +46,8 @@ static NSString *const kMDCBottomNavigationBarItemsDistributedKey =
     @"kMDCBottomNavigationBarItemsDistributedKey";
 static NSString *const kMDCBottomNavigationBarTitleBelowItemKey =
     @"kMDCBottomNavigationBarTitleBelowItemKey";
+static NSString *const kMDCBottomNavigationBarBarTintColorKey =
+    @"kMDCBottomNavigationBarBarTintColorKey";
 
 static const CGFloat kMDCBottomNavigationBarHeight = 56.f;
 static const CGFloat kMDCBottomNavigationBarHeightAdjacentTitles = 40.f;
@@ -75,7 +77,6 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   self = [super initWithFrame:frame];
   if (self) {
     self.autoresizingMask = (UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth);
-    self.backgroundColor = [UIColor whiteColor];
     self.isAccessibilityElement = NO;
     [self commonMDCBottomNavigationBarInit];
   }
@@ -127,6 +128,10 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
       self.selectedItem = [aDecoder decodeObjectOfClass:[UITabBarItem class]
                                                  forKey:kMDCBottomNavigationBarSelectedItemKey];
     }
+    if ([aDecoder containsValueForKey:kMDCBottomNavigationBarBarTintColorKey]) {
+      self.barTintColor = [aDecoder decodeObjectOfClass:[UIColor class]
+                                                 forKey:kMDCBottomNavigationBarBarTintColorKey];
+    }
   }
   return self;
 }
@@ -162,6 +167,8 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   _alignment = MDCBottomNavigationBarAlignmentJustified;
   _itemsDistributed = YES;
   _titleBelowItem = YES;
+  _barTintColor = [UIColor whiteColor];
+  self.backgroundColor = _barTintColor;
 
   // Remove any unarchived subviews and reconfigure the view hierarchy
   if (self.subviews.count) {
@@ -511,6 +518,19 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   for (MDCBottomNavigationItemView *itemView in self.itemViews) {
     itemView.itemTitleFont = itemTitleFont;
   }
+}
+
+- (void)setBarTintColor:(UIColor *)barTintColor {
+  _barTintColor = barTintColor;
+  self.backgroundColor = barTintColor;
+}
+
+- (void)setBackgroundColor:(UIColor *)backgroundColor {
+  super.backgroundColor = backgroundColor;
+}
+
+- (UIColor *)backgroundColor {
+  return super.backgroundColor;
 }
 
 #pragma mark - Resource bundle

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -37,12 +37,12 @@
   self.bottomNavBar = nil;
 }
 
-- (void)testInit {
+- (void)testDefaultValues {
   // When
   MDCBottomNavigationBar *bar = [[MDCBottomNavigationBar alloc] init];
 
   // Then
-  XCTAssertNotNil(bar);
+  XCTAssertEqualObjects(bar.backgroundColor, UIColor.whiteColor);
 }
 
 #pragma mark - Fonts


### PR DESCRIPTION
Here's how the default catalog theme will look:

![mdc-bottomnav-catalog-theme](https://user-images.githubusercontent.com/1753199/37613935-b278bada-2b7f-11e8-8242-fc23f7d397a4.png)


Closes #2832 
