### PR TITLE
[Snackbar] custom font and dynamic type support, UI_APPEARANCE support for color theming 

### DIFF
--- a/components/Snackbar/examples/SnackbarSimpleExample.m
+++ b/components/Snackbar/examples/SnackbarSimpleExample.m
@@ -68,8 +68,8 @@
   message.action = action;
   [MDCSnackbarMessageView appearance].buttonTextColor =
       [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:1];
-//  message.buttonTextColor =
-//      [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:1];
+  [MDCSnackbarMessageView appearance].highlightedButtonTextColor =
+      [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:0.7];
   [MDCSnackbarManager showMessage:message];
 }
 
@@ -87,7 +87,6 @@
   action.title = @"Action";
   message.action = action;
   [MDCSnackbarMessageView appearance].buttonTextColor =
-//  message.buttonTextColor =
       [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:1];
 
   [MDCSnackbarManager showMessage:message];

--- a/components/Snackbar/examples/SnackbarSimpleExample.m
+++ b/components/Snackbar/examples/SnackbarSimpleExample.m
@@ -16,6 +16,7 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialPalettes.h"
 #import "MaterialSnackbar.h"
 #import "supplemental/SnackbarExampleSupplemental.h"
 
@@ -31,6 +32,7 @@
       @"Snackbar with Action Button",
       @"Snackbar with Long Text",
       @"Attributed Text Example",
+      @"Color Themed Snackbar",
       @"Customize Font Example",
       @"De-Customize Font Example"
   ]];
@@ -82,10 +84,6 @@
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   action.title = @"Tap Me";
   message.action = action;
-  [MDCSnackbarMessageView appearance].buttonTextColor =
-      [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:1];
-  [MDCSnackbarMessageView appearance].highlightedButtonTextColor =
-      [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:0.7f];
   [MDCSnackbarManager showMessage:message];
 }
 
@@ -102,8 +100,6 @@
   action.handler = actionHandler;
   action.title = @"Action";
   message.action = action;
-  [MDCSnackbarMessageView appearance].buttonTextColor =
-      [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:1];
 
   [MDCSnackbarManager showMessage:message];
 }
@@ -124,6 +120,21 @@
   [MDCSnackbarManager showMessage:message];
 }
 
+- (void)showColorThemedSnackbar:(id)sender {
+  MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
+  message.text = @"Snackbar Message";
+  MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
+  action.title = @"Tap Me";
+  message.action = action;
+  [[MDCSnackbarMessageView appearance]
+      setButtonTitleColor:MDCPalette.purplePalette.tint400
+                 forState:UIControlStateNormal];
+  [[MDCSnackbarMessageView appearance]
+      setButtonTitleColor:MDCPalette.purplePalette.tint700
+                 forState:UIControlStateHighlighted];
+  [MDCSnackbarMessageView appearance].messageTextColor = MDCPalette.greenPalette.tint500;
+  [MDCSnackbarManager showMessage:message];
+}
 
 - (void)showCustomizedSnackbar:(id)sender {
   UIFont *customMessageFont = [UIFont fontWithName:@"Zapfino" size:14.0f];
@@ -173,9 +184,12 @@
       [self showBoldSnackbar:nil];
       break;
     case 4:
-      [self showCustomizedSnackbar:nil];
+      [self showColorThemedSnackbar:nil];
       break;
     case 5:
+      [self showCustomizedSnackbar:nil];
+      break;
+    case 6:
       [self showDecustomizedSnackbar:nil];
       break;
     default:

--- a/components/Snackbar/examples/SnackbarSimpleExample.m
+++ b/components/Snackbar/examples/SnackbarSimpleExample.m
@@ -21,6 +21,7 @@
 
 @implementation SnackbarSimpleExample {
   BOOL _legacyMode;
+  BOOL _dynamicType;
 }
 
 - (void)viewDidLoad {
@@ -35,21 +36,36 @@
   ]];
   self.title = @"Snackbar";
   _legacyMode = YES;
-  self.navigationItem.rightBarButtonItem =
-      [[UIBarButtonItem alloc] initWithTitle:@"Legacy"
-                                       style:UIBarButtonItemStylePlain
-                                      target:self
-                                      action:@selector(toggleModes)];
+  _dynamicType = NO;
+  self.navigationItem.rightBarButtonItems =
+      @[[[UIBarButtonItem alloc] initWithTitle:@"Legacy"
+                                         style:UIBarButtonItemStylePlain
+                                        target:self
+                                        action:@selector(toggleModes)],
+        [[UIBarButtonItem alloc] initWithTitle:@"DT Off"
+                                         style:UIBarButtonItemStylePlain
+                                        target:self
+                                        action:@selector(toggleDynamicType)]];
 }
 
 - (void)toggleModes {
   _legacyMode = !_legacyMode;
   if (_legacyMode) {
-    [self.navigationItem.rightBarButtonItem setTitle:@"Legacy"];
+    [self.navigationItem.rightBarButtonItems.firstObject setTitle:@"Legacy"];
   } else {
-    [self.navigationItem.rightBarButtonItem setTitle:@"New"];
+    [self.navigationItem.rightBarButtonItems.firstObject setTitle:@"New"];
   }
   MDCSnackbarMessage.usesLegacySnackbar = _legacyMode;
+}
+
+- (void)toggleDynamicType {
+  _dynamicType = !_dynamicType;
+  if (_dynamicType) {
+    [self.navigationItem.rightBarButtonItems.lastObject setTitle:@"DT On"];
+  } else {
+    [self.navigationItem.rightBarButtonItems.lastObject setTitle:@"DT Off"];
+  }
+  [MDCSnackbarMessageView appearance].mdc_adjustsFontForContentSizeCategory = _dynamicType;
 }
 
 #pragma mark - Event Handling
@@ -138,8 +154,6 @@
 
   [MDCSnackbarManager showMessage:message];
 }
-
-
 
 #pragma mark - UICollectionView
 

--- a/components/Snackbar/examples/SnackbarSimpleExample.m
+++ b/components/Snackbar/examples/SnackbarSimpleExample.m
@@ -85,7 +85,7 @@
   [MDCSnackbarMessageView appearance].buttonTextColor =
       [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:1];
   [MDCSnackbarMessageView appearance].highlightedButtonTextColor =
-      [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:0.7];
+      [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:0.7f];
   [MDCSnackbarManager showMessage:message];
 }
 

--- a/components/Snackbar/examples/SnackbarSimpleExample.m
+++ b/components/Snackbar/examples/SnackbarSimpleExample.m
@@ -66,8 +66,10 @@
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   action.title = @"Tap Me";
   message.action = action;
-  message.buttonTextColor =
+  [MDCSnackbarMessageView appearance].buttonTextColor =
       [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:1];
+//  message.buttonTextColor =
+//      [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:1];
   [MDCSnackbarManager showMessage:message];
 }
 
@@ -84,7 +86,8 @@
   action.handler = actionHandler;
   action.title = @"Action";
   message.action = action;
-  message.buttonTextColor =
+  [MDCSnackbarMessageView appearance].buttonTextColor =
+//  message.buttonTextColor =
       [UIColor colorWithRed:11/255.0f green:232/255.0f blue:94/255.0f alpha:1];
 
   [MDCSnackbarManager showMessage:message];

--- a/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
+++ b/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
@@ -68,7 +68,7 @@ static NSString * const kCellIdentifier = @"Cell";
 }
 
 + (BOOL)catalogIsDebug {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
+++ b/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
@@ -68,7 +68,7 @@ static NSString * const kCellIdentifier = @"Cell";
 }
 
 + (BOOL)catalogIsDebug {
-  return NO;
+  return YES;
 }
 
 @end

--- a/components/Snackbar/src/MDCSnackbarMessage.h
+++ b/components/Snackbar/src/MDCSnackbarMessage.h
@@ -100,20 +100,6 @@ extern NSString * __nonnull const MDCSnackbarMessageBoldAttributeName;
 @property(nonatomic, strong, nullable) MDCSnackbarMessageAction *action;
 
 /**
- The color used for button text on the snackbar in normal state.
-
- Default is white.
- */
-@property(nonatomic, strong, nullable) UIColor *buttonTextColor;
-
-/**
- The color used for button text on the snackbar in highlighted state.
-
- Default is white.
- */
-@property(nonatomic, strong, nullable) UIColor *highlightedButtonTextColor;
-
-/**
  How long the message should be displayed.
 
  Defaults to 4 seconds and can be set up to the maximum duration defined by

--- a/components/Snackbar/src/MDCSnackbarMessage.m
+++ b/components/Snackbar/src/MDCSnackbarMessage.m
@@ -66,8 +66,6 @@ static BOOL _usesLegacySnackbar = YES;
   copy.duration = self.duration;
   copy.category = self.category;
   copy.accessibilityLabel = self.accessibilityLabel;
-  copy.buttonTextColor = self.buttonTextColor;
-  copy.highlightedButtonTextColor = self.highlightedButtonTextColor;
 
   // Unfortunately there's not really a concept of 'copying' a block (in the same way you would copy
   // a string, for example). A block's pointer is immutable once it is created and copied to the

--- a/components/Snackbar/src/MDCSnackbarMessageView.h
+++ b/components/Snackbar/src/MDCSnackbarMessageView.h
@@ -55,18 +55,25 @@
 @property(nonatomic, strong, nullable) UIFont *buttonFont UI_APPEARANCE_SELECTOR;
 
 /**
- The color used for button text on the snackbar in normal state.
+ Returns the button title color for a particular control state.
 
- Default is white.
+ Default for UIControlStateNormal is white.
+ Default for UIControlStatehighlighted is MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f).
+
+ @param state The control state.
+ @return The button title color for the requested state.
  */
-@property(nonatomic, strong, nullable) UIColor *buttonTextColor UI_APPEARANCE_SELECTOR;
+- (nullable UIColor *)buttonTitleColorForState:(UIControlState)state UI_APPEARANCE_SELECTOR;
 
 /**
- The color used for button text on the snackbar in highlighted state.
+ Sets the button title color for a particular control state.
 
- Default is white.
+ @param titleColor The title color.
+ @param state The control state.
  */
-@property(nonatomic, strong, nullable) UIColor *highlightedButtonTextColor UI_APPEARANCE_SELECTOR;
+- (void)setButtonTitleColor:(nullable UIColor *)titleColor forState:(UIControlState)state
+UI_APPEARANCE_SELECTOR;
+
 
 /**
  Indicates whether the snackbar should automatically update its font when the device’s

--- a/components/Snackbar/src/MDCSnackbarMessageView.h
+++ b/components/Snackbar/src/MDCSnackbarMessageView.h
@@ -42,7 +42,7 @@
 
  The default color is @c whiteColor.
  */
-@property(nonatomic, strong, nullable) UIColor *snackbarMessageViewTextColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, nullable) UIColor *messageTextColor UI_APPEARANCE_SELECTOR;
 
 /**
  The font for the message text in the snackbar message view.
@@ -62,13 +62,6 @@
 @property(nonatomic, strong, nullable) UIColor *buttonTextColor UI_APPEARANCE_SELECTOR;
 
 /**
- The color used for label text on the snackbar in normal state.
-
- Default is white.
- */
-@property(nonatomic, strong, nullable) UIColor *labelTextColor UI_APPEARANCE_SELECTOR;
-
-/**
  The color used for button text on the snackbar in highlighted state.
 
  Default is white.
@@ -76,3 +69,13 @@
 @property(nonatomic, strong, nullable) UIColor *highlightedButtonTextColor UI_APPEARANCE_SELECTOR;
 
 @end
+
+// clang-format off
+@interface MDCSnackbarMessageView ()
+
+/** @see messsageTextColor */
+@property(nonatomic, strong, nullable) UIColor *snackbarMessageViewTextColor UI_APPEARANCE_SELECTOR
+__deprecated_msg("Use messsageTextColor instead.");
+
+@end
+// clang-format on

--- a/components/Snackbar/src/MDCSnackbarMessageView.h
+++ b/components/Snackbar/src/MDCSnackbarMessageView.h
@@ -68,6 +68,21 @@
  */
 @property(nonatomic, strong, nullable) UIColor *highlightedButtonTextColor UI_APPEARANCE_SELECTOR;
 
+/**
+ Indicates whether the snackbar should automatically update its font when the device’s
+ UIContentSizeCategory is changed.
+
+ This property is modeled after the adjustsFontForContentSizeCategory property in the
+ UIContentSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
+
+ If set to YES, this button will base its message font on MDCFontTextStyleBody2
+ and its button font on MDCFontTextStyleButton.
+
+ Default value is NO.
+ */
+@property(nonatomic, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
+BOOL mdc_adjustsFontForContentSizeCategory UI_APPEARANCE_SELECTOR;
+
 @end
 
 // clang-format off

--- a/components/Snackbar/src/MDCSnackbarMessageView.h
+++ b/components/Snackbar/src/MDCSnackbarMessageView.h
@@ -54,4 +54,25 @@
  */
 @property(nonatomic, strong, nullable) UIFont *buttonFont UI_APPEARANCE_SELECTOR;
 
+/**
+ The color used for button text on the snackbar in normal state.
+
+ Default is white.
+ */
+@property(nonatomic, strong, nullable) UIColor *buttonTextColor UI_APPEARANCE_SELECTOR;
+
+/**
+ The color used for label text on the snackbar in normal state.
+
+ Default is white.
+ */
+@property(nonatomic, strong, nullable) UIColor *labelTextColor UI_APPEARANCE_SELECTOR;
+
+/**
+ The color used for button text on the snackbar in highlighted state.
+
+ Default is white.
+ */
+@property(nonatomic, strong, nullable) UIColor *highlightedButtonTextColor UI_APPEARANCE_SELECTOR;
+
 @end

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -182,141 +182,12 @@ static const CGFloat kButtonInkRadius = 64.0f;
     _snackbarMessageViewTextColor = UIColor.whiteColor;
     _snackbarMessageViewShadowColor = UIColor.blackColor;
     _snackbarMessageViewBackgroundColor = MDCRGBAColor(0x32, 0x32, 0x32, 1);
+    _buttonTextColor = MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f);
+    _highlightedButtonTextColor = MDCRGBAColor(0xFF, 0xFF, 0xFF, 1.0f);
+    _labelTextColor = MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f);
   }
 
   return self;
-}
-
-- (void)dismissWithAction:(MDCSnackbarMessageAction *)action userInitiated:(BOOL)userInitiated {
-  if (self.dismissalHandler) {
-    self.dismissalHandler(userInitiated, action);
-
-    // In case our dismissal handler has a reference to us, release the block.
-    self.dismissalHandler = nil;
-  }
-}
-
-#pragma mark - Subclass overrides
-
-+ (BOOL)requiresConstraintBasedLayout {
-  return YES;
-}
-
-- (CGFloat)minimumWidth {
-  return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? kMinimumViewWidth_iPad
-                                                              : kMinimumViewWidth_iPhone;
-}
-
-- (CGFloat)maximumWidth {
-  return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? kMaximumViewWidth_iPad
-                                                              : kMaximumViewWidth_iPhone;
-}
-
-#pragma mark - Styling the view
-
-- (UIColor *)snackbarButtonTextColor {
-  return MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f);
-}
-
-- (UIColor *)snackbarButtonTextColorHighlighted {
-  return MDCRGBAColor(0xFF, 0xFF, 0xFF, 1.0f);
-}
-
-- (UIColor *)snackbarSeparatorColor {
-  return MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.5f);
-}
-
-- (void)setSnackbarMessageViewBackgroundColor:(UIColor *)snackbarMessageViewBackgroundColor {
-  _snackbarMessageViewBackgroundColor = snackbarMessageViewBackgroundColor;
-  self.backgroundColor = snackbarMessageViewBackgroundColor;
-}
-
-- (void)setSnackbarShadowColor:(UIColor *)snackbarMessageViewShadowColor {
-  _snackbarMessageViewShadowColor = snackbarMessageViewShadowColor;
-  self.layer.shadowColor = snackbarMessageViewShadowColor.CGColor;
-}
-
-- (void)setSnackbarMessageViewTextColor:(UIColor *)snackbarMessageViewTextColor {
-  _snackbarMessageViewTextColor = snackbarMessageViewTextColor;
-  self.label.textColor = _snackbarMessageViewTextColor;
-}
-
-- (void)addColorToMessageLabel:(UIColor *)color {
-  NSMutableAttributedString *messageString = [_label.attributedText mutableCopy];
-  [messageString addAttributes:@{
-    NSForegroundColorAttributeName : color,
-  }
-                         range:NSMakeRange(0, messageString.length)];
-  _label.attributedText = messageString;
-}
-
-- (UIFont *)messageFont {
-  return _messageFont;
-}
-
-- (void)setMessageFont:(UIFont *)font {
-  _messageFont = font;
-
-  [self updateMessageFont];
-}
-
-- (void)updateMessageFont {
-  // If we have a custom font apply it to the label.
-  // If not, fall back to the Material specified font.
-  if (_messageFont) {
-    _label.font = _messageFont;
-  } else {
-    // TODO(#2709): Migrate to a single source of truth for fonts
-    // There is no custom font, so use the default font.
-    // If we are using the default (system) font loader, retrieve the
-    // font from the UIFont standardFont API.
-    if ([MDCTypography.fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
-      _label.font = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleBody2];
-    } else {
-      // There is a custom font loader, retrieve the font from it.
-      _label.font = [MDCTypography body2Font];
-    }
-  }
-
-  [self setNeedsLayout];
-}
-
-- (UIFont *)buttonFont {
-  return _buttonFont;
-}
-
-- (void)setButtonFont:(UIFont *)font {
-  _buttonFont = font;
-
-  [self updateButtonFont];
-}
-
-- (void)updateButtonFont {
-  UIFont *finalButtonFont;
-
-  // If we have a custom font apply it to the button.
-  // If not, fall back to the Material specified font.
-  if (_buttonFont) {
-    finalButtonFont = _buttonFont;
-  } else {
-    // TODO(#2709): Migrate to a single source of truth for fonts
-    // There is no custom font, so use the default font.
-    // If we are using the default (system) font loader, retrieve the
-    // font from the UIFont standardFont API.
-    if ([MDCTypography.fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
-      finalButtonFont = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleButton];
-    } else {
-      // There is a custom font loader, retrieve the font from it.
-      finalButtonFont = [MDCTypography buttonFont];
-    }
-  }
-
-  for (MDCButton *button in _actionButtons) {
-    [button setTitleFont:finalButtonFont forState:UIControlStateNormal];
-    [button setTitleFont:finalButtonFont forState:UIControlStateHighlighted];
-  }
-
-  [self setNeedsLayout];
 }
 
 - (instancetype)initWithMessage:(MDCSnackbarMessage *)message
@@ -449,18 +320,7 @@ static const CGFloat kButtonInkRadius = 64.0f;
       availableTextWidth -= kTitleButtonPadding;
     }
 
-    UIColor *textColor = [self snackbarButtonTextColor];
-    UIColor *textColorHighlighted = [self snackbarButtonTextColorHighlighted];
-
-    _label.textColor = _snackbarMessageViewTextColor;
-
-    if (message.buttonTextColor) {
-      textColor = message.buttonTextColor;
-    }
-
-    if (message.highlightedButtonTextColor) {
-      textColorHighlighted = message.highlightedButtonTextColor;
-    }
+    _label.textColor = _labelTextColor;
 
     // Add buttons to the view. We'll use this opportunity to determine how much space a button will
     // need, to inform the layout direction.
@@ -475,8 +335,8 @@ static const CGFloat kButtonInkRadius = 64.0f;
         [button setTitleFont:_buttonFont forState:UIControlStateNormal];
         [button setTitleFont:_buttonFont forState:UIControlStateHighlighted];
       }
-      [button setTitleColor:textColor forState:UIControlStateNormal];
-      [button setTitleColor:textColorHighlighted forState:UIControlStateHighlighted];
+      [button setTitleColor:_buttonTextColor forState:UIControlStateNormal];
+      [button setTitleColor:_highlightedButtonTextColor forState:UIControlStateHighlighted];
       [button setTranslatesAutoresizingMaskIntoConstraints:NO];
       button.tag = kButtonTagStart;
       [buttonView addSubview:button];
@@ -494,10 +354,6 @@ static const CGFloat kButtonInkRadius = 64.0f;
 
       [button setTitle:message.action.title forState:UIControlStateNormal];
       [button setTitle:message.action.title forState:UIControlStateHighlighted];
-
-      if (message.buttonTextColor) {
-        [button setTitleColor:textColor forState:UIControlStateNormal];
-      }
 
       // Make sure the button doesn't get too compressed.
       [button setContentCompressionResistancePriority:UILayoutPriorityRequired
@@ -519,6 +375,126 @@ static const CGFloat kButtonInkRadius = 64.0f;
   }
 
   return self;
+}
+
+- (void)dismissWithAction:(MDCSnackbarMessageAction *)action userInitiated:(BOOL)userInitiated {
+  if (self.dismissalHandler) {
+    self.dismissalHandler(userInitiated, action);
+
+    // In case our dismissal handler has a reference to us, release the block.
+    self.dismissalHandler = nil;
+  }
+}
+
+#pragma mark - Subclass overrides
+
++ (BOOL)requiresConstraintBasedLayout {
+  return YES;
+}
+
+- (CGFloat)minimumWidth {
+  return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? kMinimumViewWidth_iPad
+                                                              : kMinimumViewWidth_iPhone;
+}
+
+- (CGFloat)maximumWidth {
+  return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? kMaximumViewWidth_iPad
+                                                              : kMaximumViewWidth_iPhone;
+}
+
+#pragma mark - Styling the view
+
+- (void)setSnackbarMessageViewBackgroundColor:(UIColor *)snackbarMessageViewBackgroundColor {
+  _snackbarMessageViewBackgroundColor = snackbarMessageViewBackgroundColor;
+  self.backgroundColor = snackbarMessageViewBackgroundColor;
+}
+
+- (void)setSnackbarShadowColor:(UIColor *)snackbarMessageViewShadowColor {
+  _snackbarMessageViewShadowColor = snackbarMessageViewShadowColor;
+  self.layer.shadowColor = snackbarMessageViewShadowColor.CGColor;
+}
+
+- (void)setSnackbarMessageViewTextColor:(UIColor *)snackbarMessageViewTextColor {
+  _snackbarMessageViewTextColor = snackbarMessageViewTextColor;
+  self.label.textColor = _snackbarMessageViewTextColor;
+}
+
+- (void)addColorToMessageLabel:(UIColor *)color {
+  NSMutableAttributedString *messageString = [_label.attributedText mutableCopy];
+  [messageString addAttributes:@{
+    NSForegroundColorAttributeName : color,
+  }
+                         range:NSMakeRange(0, messageString.length)];
+  _label.attributedText = messageString;
+}
+
+- (UIFont *)messageFont {
+  return _messageFont;
+}
+
+- (void)setMessageFont:(UIFont *)font {
+  _messageFont = font;
+
+  [self updateMessageFont];
+}
+
+- (void)updateMessageFont {
+  // If we have a custom font apply it to the label.
+  // If not, fall back to the Material specified font.
+  if (_messageFont) {
+    _label.font = _messageFont;
+  } else {
+    // TODO(#2709): Migrate to a single source of truth for fonts
+    // There is no custom font, so use the default font.
+    // If we are using the default (system) font loader, retrieve the
+    // font from the UIFont standardFont API.
+    if ([MDCTypography.fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
+      _label.font = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleBody2];
+    } else {
+      // There is a custom font loader, retrieve the font from it.
+      _label.font = [MDCTypography body2Font];
+    }
+  }
+
+  [self setNeedsLayout];
+}
+
+- (UIFont *)buttonFont {
+  return _buttonFont;
+}
+
+- (void)setButtonFont:(UIFont *)font {
+  _buttonFont = font;
+
+  [self updateButtonFont];
+}
+
+- (void)updateButtonFont {
+  UIFont *finalButtonFont;
+
+  // If we have a custom font apply it to the button.
+  // If not, fall back to the Material specified font.
+  if (_buttonFont) {
+    finalButtonFont = _buttonFont;
+  } else {
+    // TODO(#2709): Migrate to a single source of truth for fonts
+    // There is no custom font, so use the default font.
+    // If we are using the default (system) font loader, retrieve the
+    // font from the UIFont standardFont API.
+    if ([MDCTypography.fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
+      finalButtonFont = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleButton];
+    } else {
+      // There is a custom font loader, retrieve the font from it.
+      finalButtonFont = [MDCTypography buttonFont];
+    }
+  }
+
+  for (MDCButton *button in _actionButtons) {
+    [button setTitleFont:finalButtonFont forState:UIControlStateNormal];
+    [button setTitleFont:finalButtonFont forState:UIControlStateHighlighted];
+  }
+
+  [self setNeedsLayout];
 }
 
 - (BOOL)shouldWaitForDismissalDuringVoiceover {

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -434,8 +434,11 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
 }
 
 - (void)setSnackbarMessageViewTextColor:(UIColor *)snackbarMessageViewTextColor {
-  _snackbarMessageViewTextColor = snackbarMessageViewTextColor;
   self.messageTextColor = snackbarMessageViewTextColor;
+}
+
+- (UIColor *)snackbarMessageViewTextColor {
+  return self.messageTextColor;
 }
 
 - (void)setMessageTextColor:(UIColor *)messageTextColor {

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -182,141 +182,12 @@ static const CGFloat kButtonInkRadius = 64.0f;
     _snackbarMessageViewTextColor = UIColor.whiteColor;
     _snackbarMessageViewShadowColor = UIColor.blackColor;
     _snackbarMessageViewBackgroundColor = MDCRGBAColor(0x32, 0x32, 0x32, 1);
+    _buttonTextColor = MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f);
+    _highlightedButtonTextColor = MDCRGBAColor(0xFF, 0xFF, 0xFF, 1.0f);
+    _labelTextColor = MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f);
   }
 
   return self;
-}
-
-- (void)dismissWithAction:(MDCSnackbarMessageAction *)action userInitiated:(BOOL)userInitiated {
-  if (self.dismissalHandler) {
-    self.dismissalHandler(userInitiated, action);
-
-    // In case our dismissal handler has a reference to us, release the block.
-    self.dismissalHandler = nil;
-  }
-}
-
-#pragma mark - Subclass overrides
-
-+ (BOOL)requiresConstraintBasedLayout {
-  return YES;
-}
-
-- (CGFloat)minimumWidth {
-  return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? kMinimumViewWidth_iPad
-                                                              : kMinimumViewWidth_iPhone;
-}
-
-- (CGFloat)maximumWidth {
-  return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? kMaximumViewWidth_iPad
-                                                              : kMaximumViewWidth_iPhone;
-}
-
-#pragma mark - Styling the view
-
-- (UIColor *)snackbarButtonTextColor {
-  return MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f);
-}
-
-- (UIColor *)snackbarButtonTextColorHighlighted {
-  return MDCRGBAColor(0xFF, 0xFF, 0xFF, 1.0f);
-}
-
-- (UIColor *)snackbarSeparatorColor {
-  return MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.5f);
-}
-
-- (void)setSnackbarMessageViewBackgroundColor:(UIColor *)snackbarMessageViewBackgroundColor {
-  _snackbarMessageViewBackgroundColor = snackbarMessageViewBackgroundColor;
-  self.backgroundColor = snackbarMessageViewBackgroundColor;
-}
-
-- (void)setSnackbarShadowColor:(UIColor *)snackbarMessageViewShadowColor {
-  _snackbarMessageViewShadowColor = snackbarMessageViewShadowColor;
-  self.layer.shadowColor = snackbarMessageViewShadowColor.CGColor;
-}
-
-- (void)setSnackbarMessageViewTextColor:(UIColor *)snackbarMessageViewTextColor {
-  _snackbarMessageViewTextColor = snackbarMessageViewTextColor;
-  self.label.textColor = _snackbarMessageViewTextColor;
-}
-
-- (void)addColorToMessageLabel:(UIColor *)color {
-  NSMutableAttributedString *messageString = [_label.attributedText mutableCopy];
-  [messageString addAttributes:@{
-    NSForegroundColorAttributeName : color,
-  }
-                         range:NSMakeRange(0, messageString.length)];
-  _label.attributedText = messageString;
-}
-
-- (UIFont *)messageFont {
-  return _messageFont;
-}
-
-- (void)setMessageFont:(UIFont *)font {
-  _messageFont = font;
-
-  [self updateMessageFont];
-}
-
-- (void)updateMessageFont {
-  // If we have a custom font apply it to the label.
-  // If not, fall back to the Material specified font.
-  if (_messageFont) {
-    _label.font = _messageFont;
-  } else {
-    // TODO(#2709): Migrate to a single source of truth for fonts
-    // There is no custom font, so use the default font.
-    // If we are using the default (system) font loader, retrieve the
-    // font from the UIFont standardFont API.
-    if ([MDCTypography.fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
-      _label.font = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleBody2];
-    } else {
-      // There is a custom font loader, retrieve the font from it.
-      _label.font = [MDCTypography body2Font];
-    }
-  }
-
-  [self setNeedsLayout];
-}
-
-- (UIFont *)buttonFont {
-  return _buttonFont;
-}
-
-- (void)setButtonFont:(UIFont *)font {
-  _buttonFont = font;
-
-  [self updateButtonFont];
-}
-
-- (void)updateButtonFont {
-  UIFont *finalButtonFont;
-
-  // If we have a custom font apply it to the button.
-  // If not, fall back to the Material specified font.
-  if (_buttonFont) {
-    finalButtonFont = _buttonFont;
-  } else {
-    // TODO(#2709): Migrate to a single source of truth for fonts
-    // There is no custom font, so use the default font.
-    // If we are using the default (system) font loader, retrieve the
-    // font from the UIFont standardFont API.
-    if ([MDCTypography.fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
-      finalButtonFont = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleButton];
-    } else {
-      // There is a custom font loader, retrieve the font from it.
-      finalButtonFont = [MDCTypography buttonFont];
-    }
-  }
-
-  for (MDCButton *button in _actionButtons) {
-    [button setTitleFont:finalButtonFont forState:UIControlStateNormal];
-    [button setTitleFont:finalButtonFont forState:UIControlStateHighlighted];
-  }
-
-  [self setNeedsLayout];
 }
 
 - (instancetype)initWithMessage:(MDCSnackbarMessage *)message
@@ -449,18 +320,7 @@ static const CGFloat kButtonInkRadius = 64.0f;
       availableTextWidth -= kTitleButtonPadding;
     }
 
-    UIColor *textColor = [self snackbarButtonTextColor];
-    UIColor *textColorHighlighted = [self snackbarButtonTextColorHighlighted];
-
-    _label.textColor = textColor;
-
-    if (message.buttonTextColor) {
-      textColor = message.buttonTextColor;
-    }
-
-    if (message.highlightedButtonTextColor) {
-      textColorHighlighted = message.highlightedButtonTextColor;
-    }
+    _label.textColor = _labelTextColor;
 
     // Add buttons to the view. We'll use this opportunity to determine how much space a button will
     // need, to inform the layout direction.
@@ -475,8 +335,8 @@ static const CGFloat kButtonInkRadius = 64.0f;
         [button setTitleFont:_buttonFont forState:UIControlStateNormal];
         [button setTitleFont:_buttonFont forState:UIControlStateHighlighted];
       }
-      [button setTitleColor:textColor forState:UIControlStateNormal];
-      [button setTitleColor:textColorHighlighted forState:UIControlStateHighlighted];
+      [button setTitleColor:_buttonTextColor forState:UIControlStateNormal];
+      [button setTitleColor:_highlightedButtonTextColor forState:UIControlStateHighlighted];
       [button setTranslatesAutoresizingMaskIntoConstraints:NO];
       button.tag = kButtonTagStart;
       [buttonView addSubview:button];
@@ -494,10 +354,6 @@ static const CGFloat kButtonInkRadius = 64.0f;
 
       [button setTitle:message.action.title forState:UIControlStateNormal];
       [button setTitle:message.action.title forState:UIControlStateHighlighted];
-
-      if (message.buttonTextColor) {
-        [button setTitleColor:textColor forState:UIControlStateNormal];
-      }
 
       // Make sure the button doesn't get too compressed.
       [button setContentCompressionResistancePriority:UILayoutPriorityRequired
@@ -519,6 +375,126 @@ static const CGFloat kButtonInkRadius = 64.0f;
   }
 
   return self;
+}
+
+- (void)dismissWithAction:(MDCSnackbarMessageAction *)action userInitiated:(BOOL)userInitiated {
+  if (self.dismissalHandler) {
+    self.dismissalHandler(userInitiated, action);
+
+    // In case our dismissal handler has a reference to us, release the block.
+    self.dismissalHandler = nil;
+  }
+}
+
+#pragma mark - Subclass overrides
+
++ (BOOL)requiresConstraintBasedLayout {
+  return YES;
+}
+
+- (CGFloat)minimumWidth {
+  return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? kMinimumViewWidth_iPad
+                                                              : kMinimumViewWidth_iPhone;
+}
+
+- (CGFloat)maximumWidth {
+  return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? kMaximumViewWidth_iPad
+                                                              : kMaximumViewWidth_iPhone;
+}
+
+#pragma mark - Styling the view
+
+- (void)setSnackbarMessageViewBackgroundColor:(UIColor *)snackbarMessageViewBackgroundColor {
+  _snackbarMessageViewBackgroundColor = snackbarMessageViewBackgroundColor;
+  self.backgroundColor = snackbarMessageViewBackgroundColor;
+}
+
+- (void)setSnackbarShadowColor:(UIColor *)snackbarMessageViewShadowColor {
+  _snackbarMessageViewShadowColor = snackbarMessageViewShadowColor;
+  self.layer.shadowColor = snackbarMessageViewShadowColor.CGColor;
+}
+
+- (void)setSnackbarMessageViewTextColor:(UIColor *)snackbarMessageViewTextColor {
+  _snackbarMessageViewTextColor = snackbarMessageViewTextColor;
+  self.label.textColor = _snackbarMessageViewTextColor;
+}
+
+- (void)addColorToMessageLabel:(UIColor *)color {
+  NSMutableAttributedString *messageString = [_label.attributedText mutableCopy];
+  [messageString addAttributes:@{
+    NSForegroundColorAttributeName : color,
+  }
+                         range:NSMakeRange(0, messageString.length)];
+  _label.attributedText = messageString;
+}
+
+- (UIFont *)messageFont {
+  return _messageFont;
+}
+
+- (void)setMessageFont:(UIFont *)font {
+  _messageFont = font;
+
+  [self updateMessageFont];
+}
+
+- (void)updateMessageFont {
+  // If we have a custom font apply it to the label.
+  // If not, fall back to the Material specified font.
+  if (_messageFont) {
+    _label.font = _messageFont;
+  } else {
+    // TODO(#2709): Migrate to a single source of truth for fonts
+    // There is no custom font, so use the default font.
+    // If we are using the default (system) font loader, retrieve the
+    // font from the UIFont standardFont API.
+    if ([MDCTypography.fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
+      _label.font = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleBody2];
+    } else {
+      // There is a custom font loader, retrieve the font from it.
+      _label.font = [MDCTypography body2Font];
+    }
+  }
+
+  [self setNeedsLayout];
+}
+
+- (UIFont *)buttonFont {
+  return _buttonFont;
+}
+
+- (void)setButtonFont:(UIFont *)font {
+  _buttonFont = font;
+
+  [self updateButtonFont];
+}
+
+- (void)updateButtonFont {
+  UIFont *finalButtonFont;
+
+  // If we have a custom font apply it to the button.
+  // If not, fall back to the Material specified font.
+  if (_buttonFont) {
+    finalButtonFont = _buttonFont;
+  } else {
+    // TODO(#2709): Migrate to a single source of truth for fonts
+    // There is no custom font, so use the default font.
+    // If we are using the default (system) font loader, retrieve the
+    // font from the UIFont standardFont API.
+    if ([MDCTypography.fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
+      finalButtonFont = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleButton];
+    } else {
+      // There is a custom font loader, retrieve the font from it.
+      finalButtonFont = [MDCTypography buttonFont];
+    }
+  }
+
+  for (MDCButton *button in _actionButtons) {
+    [button setTitleFont:finalButtonFont forState:UIControlStateNormal];
+    [button setTitleFont:finalButtonFont forState:UIControlStateHighlighted];
+  }
+
+  [self setNeedsLayout];
 }
 
 - (BOOL)shouldWaitForDismissalDuringVoiceover {

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -18,6 +18,7 @@
 
 #import "MDCSnackbarMessage.h"
 #import "MDCSnackbarMessageView.h"
+
 #import "MaterialAnimationTiming.h"
 #import "MaterialButtons.h"
 #import "MaterialTypography.h"
@@ -101,6 +102,9 @@ static const NSInteger kButtonTagStart = 20000;
  */
 static const CGFloat kButtonInkRadius = 64.0f;
 
+static const MDCFontTextStyle kMessageTextStyle = MDCFontTextStyleBody2;
+static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
+
 #if defined(__IPHONE_10_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0)
 @interface MDCSnackbarMessageView () <CAAnimationDelegate>
 @end
@@ -173,18 +177,19 @@ static const CGFloat kButtonInkRadius = 64.0f;
 
   // Holds the instances of MDCButton
   NSMutableArray<MDCButton *> *_actionButtons;
+
+  BOOL _mdc_adjustsFontForContentSizeCategory;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];
 
   if (self) {
-    _snackbarMessageViewTextColor = UIColor.whiteColor;
     _snackbarMessageViewShadowColor = UIColor.blackColor;
     _snackbarMessageViewBackgroundColor = MDCRGBAColor(0x32, 0x32, 0x32, 1);
+    _messageTextColor = UIColor.whiteColor;
     _buttonTextColor = MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f);
-    _highlightedButtonTextColor = MDCRGBAColor(0xFF, 0xFF, 0xFF, 1.0f);
-    _labelTextColor = MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f);
+    _highlightedButtonTextColor = UIColor.whiteColor;
   }
 
   return self;
@@ -258,6 +263,16 @@ static const CGFloat kButtonInkRadius = 64.0f;
     _label = [[UILabel alloc] initWithFrame:CGRectZero];
     [_contentView addSubview:_label];
 
+    // TODO(#2709): Migrate to a single source of truth for fonts
+    // If we are using the default (system) font loader, retrieve the
+    // font from the UIFont standardFont API.
+    if ([MDCTypography.fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
+      _label.font = [UIFont mdc_standardFontForMaterialTextStyle:kMessageTextStyle];
+    } else {
+      // There is a custom font loader, retrieve the font from it.
+      _label.font = [MDCTypography body2Font];
+    }
+
     NSMutableAttributedString *messageString = [message.attributedText mutableCopy];
 
     // Find any of the bold attributes in the string, and set the proper font for those ranges.
@@ -306,75 +321,79 @@ static const CGFloat kButtonInkRadius = 64.0f;
       _label.accessibilityLabel = message.accessibilityLabel;
     }
 
-    // Figure out how much horizontal space the main text needs, in order to decide if the buttons
-    // are laid out horizontally or vertically.
-    __block CGFloat availableTextWidth = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
-                                             ? kMaximumViewWidth_iPad
-                                             : kMaximumViewWidth_iPhone;
+    _label.textColor = _messageTextColor;
 
-    // Take into account the content padding.
-    availableTextWidth -= (self.safeContentMargin.left + self.safeContentMargin.right);
-
-    // If there are buttons, account for the padding between the title and the buttons.
-    if (message.action) {
-      availableTextWidth -= kTitleButtonPadding;
-    }
-
-    _label.textColor = _labelTextColor;
-
-    // Add buttons to the view. We'll use this opportunity to determine how much space a button will
-    // need, to inform the layout direction.
-    NSMutableArray *actions = [NSMutableArray array];
-    if (message.action) {
-      UIView *buttonView = [[UIView alloc] init];
-      [buttonView setTranslatesAutoresizingMaskIntoConstraints:NO];
-      [_buttonView addSubview:buttonView];
-
-      MDCButton *button = [[MDCSnackbarMessageViewButton alloc] init];
-      if (_buttonFont) {
-        [button setTitleFont:_buttonFont forState:UIControlStateNormal];
-        [button setTitleFont:_buttonFont forState:UIControlStateHighlighted];
-      }
-      [button setTitleColor:_buttonTextColor forState:UIControlStateNormal];
-      [button setTitleColor:_highlightedButtonTextColor forState:UIControlStateHighlighted];
-      [button setTranslatesAutoresizingMaskIntoConstraints:NO];
-      button.tag = kButtonTagStart;
-      [buttonView addSubview:button];
-      [_actionButtons addObject:button];
-
-      // Style the text in the button.
-      button.titleLabel.numberOfLines = 1;
-      button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
-      button.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
-      button.contentEdgeInsets = UIEdgeInsetsMake(0, kButtonPadding, 0, kButtonPadding);
-
-      // Set up the button's accessibility values.
-      button.accessibilityIdentifier = message.action.accessibilityIdentifier;
-      button.accessibilityHint = message.action.accessibilityHint;
-
-      [button setTitle:message.action.title forState:UIControlStateNormal];
-      [button setTitle:message.action.title forState:UIControlStateHighlighted];
-
-      // Make sure the button doesn't get too compressed.
-      [button setContentCompressionResistancePriority:UILayoutPriorityRequired
-                                              forAxis:UILayoutConstraintAxisHorizontal];
-      [button setContentHuggingPriority:UILayoutPriorityDefaultHigh
-                                forAxis:UILayoutConstraintAxisHorizontal];
-      [button addTarget:self
-                    action:@selector(handleButtonTapped:)
-          forControlEvents:UIControlEventTouchUpInside];
-
-      CGSize buttonSize = [button sizeThatFits:CGSizeMake(CGFLOAT_MAX,CGFLOAT_MAX)];
-      availableTextWidth -= buttonSize.width;
-      availableTextWidth -= 2 * kButtonPadding;
-
-      [actions addObject:buttonView];
-    }
-
-    self.buttons = actions;
+    [self initializeMDCSnackbarMessageViewButtons:message];
   }
 
   return self;
+}
+
+- (void)initializeMDCSnackbarMessageViewButtons:(MDCSnackbarMessage *)message {
+  // Figure out how much horizontal space the main text needs, in order to decide if the buttons
+  // are laid out horizontally or vertically.
+  __block CGFloat availableTextWidth = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
+                                           ? kMaximumViewWidth_iPad
+                                           : kMaximumViewWidth_iPhone;
+
+  // Take into account the content padding.
+  availableTextWidth -= (self.safeContentMargin.left + self.safeContentMargin.right);
+
+  // If there are buttons, account for the padding between the title and the buttons.
+  if (message.action) {
+    availableTextWidth -= kTitleButtonPadding;
+  }
+
+  // Add buttons to the view. We'll use this opportunity to determine how much space a button will
+  // need, to inform the layout direction.
+  NSMutableArray *actions = [NSMutableArray array];
+  if (message.action) {
+    UIView *buttonView = [[UIView alloc] init];
+    [buttonView setTranslatesAutoresizingMaskIntoConstraints:NO];
+    [_buttonView addSubview:buttonView];
+
+    MDCButton *button = [[MDCSnackbarMessageViewButton alloc] init];
+    if (_buttonFont) {
+      [button setTitleFont:_buttonFont forState:UIControlStateNormal];
+      [button setTitleFont:_buttonFont forState:UIControlStateHighlighted];
+    }
+    [button setTitleColor:_buttonTextColor forState:UIControlStateNormal];
+    [button setTitleColor:_highlightedButtonTextColor forState:UIControlStateHighlighted];
+    [button setTranslatesAutoresizingMaskIntoConstraints:NO];
+    button.tag = kButtonTagStart;
+    [buttonView addSubview:button];
+    [_actionButtons addObject:button];
+
+    // Style the text in the button.
+    button.titleLabel.numberOfLines = 1;
+    button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
+    button.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
+    button.contentEdgeInsets = UIEdgeInsetsMake(0, kButtonPadding, 0, kButtonPadding);
+
+    // Set up the button's accessibility values.
+    button.accessibilityIdentifier = message.action.accessibilityIdentifier;
+    button.accessibilityHint = message.action.accessibilityHint;
+
+    [button setTitle:message.action.title forState:UIControlStateNormal];
+    [button setTitle:message.action.title forState:UIControlStateHighlighted];
+
+    // Make sure the button doesn't get too compressed.
+    [button setContentCompressionResistancePriority:UILayoutPriorityRequired
+                                            forAxis:UILayoutConstraintAxisHorizontal];
+    [button setContentHuggingPriority:UILayoutPriorityDefaultHigh
+                              forAxis:UILayoutConstraintAxisHorizontal];
+    [button addTarget:self
+               action:@selector(handleButtonTapped:)
+     forControlEvents:UIControlEventTouchUpInside];
+
+    CGSize buttonSize = [button sizeThatFits:CGSizeMake(CGFLOAT_MAX,CGFLOAT_MAX)];
+    availableTextWidth -= buttonSize.width;
+    availableTextWidth -= 2 * kButtonPadding;
+
+    [actions addObject:buttonView];
+  }
+
+  self.buttons = actions;
 }
 
 - (void)dismissWithAction:(MDCSnackbarMessageAction *)action userInitiated:(BOOL)userInitiated {
@@ -416,7 +435,26 @@ static const CGFloat kButtonInkRadius = 64.0f;
 
 - (void)setSnackbarMessageViewTextColor:(UIColor *)snackbarMessageViewTextColor {
   _snackbarMessageViewTextColor = snackbarMessageViewTextColor;
-  self.label.textColor = _snackbarMessageViewTextColor;
+  self.messageTextColor = snackbarMessageViewTextColor;
+}
+
+- (void)setMessageTextColor:(UIColor *)messageTextColor {
+  _messageTextColor = messageTextColor;
+  self.label.textColor = _messageTextColor;
+}
+
+- (void)setButtonTextColor:(UIColor *)buttonTextColor {
+  _buttonTextColor = buttonTextColor;
+  for (MDCButton *button in _actionButtons) {
+    [button setTitleColor:buttonTextColor forState:UIControlStateNormal];
+  }
+}
+
+- (void)setHighlightedButtonTextColor:(UIColor *)highlightedButtonTextColor {
+  _highlightedButtonTextColor = highlightedButtonTextColor;
+  for (MDCButton *button in _actionButtons) {
+    [button setTitleColor:highlightedButtonTextColor forState:UIControlStateHighlighted];
+  }
 }
 
 - (void)addColorToMessageLabel:(UIColor *)color {
@@ -442,17 +480,38 @@ static const CGFloat kButtonInkRadius = 64.0f;
   // If we have a custom font apply it to the label.
   // If not, fall back to the Material specified font.
   if (_messageFont) {
-    _label.font = _messageFont;
+    // If we are automatically adjusting for Dynamic Type resize the font based on the text style
+    if (_mdc_adjustsFontForContentSizeCategory) {
+      _label.font =
+          [_messageFont mdc_fontSizedForMaterialTextStyle:kMessageTextStyle
+                                     scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
+    } else {
+      _label.font = _messageFont;
+    }
   } else {
     // TODO(#2709): Migrate to a single source of truth for fonts
     // There is no custom font, so use the default font.
-    // If we are using the default (system) font loader, retrieve the
-    // font from the UIFont standardFont API.
-    if ([MDCTypography.fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
-      _label.font = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleBody2];
+    if (_mdc_adjustsFontForContentSizeCategory) {
+      // If we are using the default (system) font loader, retrieve the
+      // font from the UIFont preferredFont API.
+      if ([MDCTypography.fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
+        _label.font = [UIFont mdc_preferredFontForMaterialTextStyle:kMessageTextStyle];
+      } else {
+        // There is a custom font loader, retrieve the font and scale it.
+        UIFont *customTypographyFont = [MDCTypography body2Font];
+        _label.font =
+            [customTypographyFont mdc_fontSizedForMaterialTextStyle:kMessageTextStyle
+                scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
+      }
     } else {
-      // There is a custom font loader, retrieve the font from it.
-      _label.font = [MDCTypography body2Font];
+      // If we are using the default (system) font loader, retrieve the
+      // font from the UIFont standardFont API.
+      if ([MDCTypography.fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
+        _label.font = [UIFont mdc_standardFontForMaterialTextStyle:kMessageTextStyle];
+      } else {
+        // There is a custom font loader, retrieve the font from it.
+        _label.font = [MDCTypography body2Font];
+      }
     }
   }
 
@@ -472,20 +531,41 @@ static const CGFloat kButtonInkRadius = 64.0f;
 - (void)updateButtonFont {
   UIFont *finalButtonFont;
 
-  // If we have a custom font apply it to the button.
+  // If we have a custom font apply it to the label.
   // If not, fall back to the Material specified font.
   if (_buttonFont) {
-    finalButtonFont = _buttonFont;
+    // If we are automatically adjusting for Dynamic Type resize the font based on the text style
+    if (_mdc_adjustsFontForContentSizeCategory) {
+      finalButtonFont =
+          [_buttonFont mdc_fontSizedForMaterialTextStyle:kButtonTextStyle
+                                    scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
+    } else {
+      finalButtonFont = _buttonFont;
+    }
   } else {
     // TODO(#2709): Migrate to a single source of truth for fonts
     // There is no custom font, so use the default font.
-    // If we are using the default (system) font loader, retrieve the
-    // font from the UIFont standardFont API.
-    if ([MDCTypography.fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
-      finalButtonFont = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleButton];
+    if (_mdc_adjustsFontForContentSizeCategory) {
+      // If we are using the default (system) font loader, retrieve the
+      // font from the UIFont preferredFont API.
+      if ([MDCTypography.fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
+        finalButtonFont = [UIFont mdc_preferredFontForMaterialTextStyle:kButtonTextStyle];
+      } else {
+        // There is a custom font loader, retrieve the font and scale it.
+        UIFont *customTypographyFont = [MDCTypography buttonFont];
+        finalButtonFont =
+            [customTypographyFont mdc_fontSizedForMaterialTextStyle:kButtonTextStyle
+                scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
+      }
     } else {
-      // There is a custom font loader, retrieve the font from it.
-      finalButtonFont = [MDCTypography buttonFont];
+      // If we are using the default (system) font loader, retrieve the
+      // font from the UIFont standardFont API.
+      if ([MDCTypography.fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
+        finalButtonFont = [UIFont mdc_standardFontForMaterialTextStyle:kButtonTextStyle];
+      } else {
+        // There is a custom font loader, retrieve the font from it.
+        finalButtonFont = [MDCTypography buttonFont];
+      }
     }
   }
 
@@ -966,6 +1046,36 @@ static const CGFloat kButtonInkRadius = 64.0f;
   NSBundle *bundle = [NSBundle bundleForClass:[MDCSnackbarMessageView class]];
   NSString *resourcePath = [(nil == bundle ? [NSBundle mainBundle] : bundle) resourcePath];
   return [resourcePath stringByAppendingPathComponent:bundleName];
+}
+
+#pragma mark - Dynamic Type Support
+
+- (BOOL)mdc_adjustsFontForContentSizeCategory {
+  return _mdc_adjustsFontForContentSizeCategory;
+}
+
+- (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {
+  _mdc_adjustsFontForContentSizeCategory = adjusts;
+
+  if (_mdc_adjustsFontForContentSizeCategory) {
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(contentSizeCategoryDidChange:)
+                                                 name:UIContentSizeCategoryDidChangeNotification
+                                               object:nil];
+  } else {
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:UIContentSizeCategoryDidChangeNotification
+                                                  object:nil];
+  }
+
+  [self updateMessageFont];
+  [self updateButtonFont];
+}
+
+// Handles UIContentSizeCategoryDidChangeNotifications
+- (void)contentSizeCategoryDidChange:(__unused NSNotification *)notification {
+  [self updateMessageFont];
+  [self updateButtonFont];
 }
 
 @end

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -178,6 +178,8 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
   // Holds the instances of MDCButton
   NSMutableArray<MDCButton *> *_actionButtons;
 
+  NSMutableDictionary<NSNumber *, UIColor *> *_buttonTitleColors;
+
   BOOL _mdc_adjustsFontForContentSizeCategory;
 }
 
@@ -188,8 +190,11 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
     _snackbarMessageViewShadowColor = UIColor.blackColor;
     _snackbarMessageViewBackgroundColor = MDCRGBAColor(0x32, 0x32, 0x32, 1);
     _messageTextColor = UIColor.whiteColor;
-    _buttonTextColor = MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f);
-    _highlightedButtonTextColor = UIColor.whiteColor;
+//    _buttonTextColor = MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f);
+//    _highlightedButtonTextColor = UIColor.whiteColor;
+    _buttonTitleColors = [NSMutableDictionary dictionary];
+    _buttonTitleColors[@(UIControlStateNormal)] = MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f);
+    _buttonTitleColors[@(UIControlStateHighlighted)] = UIColor.whiteColor;
   }
 
   return self;
@@ -357,8 +362,10 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
       [button setTitleFont:_buttonFont forState:UIControlStateNormal];
       [button setTitleFont:_buttonFont forState:UIControlStateHighlighted];
     }
-    [button setTitleColor:_buttonTextColor forState:UIControlStateNormal];
-    [button setTitleColor:_highlightedButtonTextColor forState:UIControlStateHighlighted];
+    [button setTitleColor:_buttonTitleColors[@(UIControlStateNormal)]
+                 forState:UIControlStateNormal];
+    [button setTitleColor:_buttonTitleColors[@(UIControlStateHighlighted)]
+                 forState:UIControlStateHighlighted];
     [button setTranslatesAutoresizingMaskIntoConstraints:NO];
     button.tag = kButtonTagStart;
     [buttonView addSubview:button];
@@ -446,17 +453,15 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
   self.label.textColor = _messageTextColor;
 }
 
-- (void)setButtonTextColor:(UIColor *)buttonTextColor {
-  _buttonTextColor = buttonTextColor;
-  for (MDCButton *button in _actionButtons) {
-    [button setTitleColor:buttonTextColor forState:UIControlStateNormal];
-  }
+- (nullable UIColor *)buttonTitleColorForState:(UIControlState)state {
+  return _buttonTitleColors[@(state)];
 }
 
-- (void)setHighlightedButtonTextColor:(UIColor *)highlightedButtonTextColor {
-  _highlightedButtonTextColor = highlightedButtonTextColor;
+- (void)setButtonTitleColor:(nullable UIColor *)buttonTitleColor forState:(UIControlState)state {
+  _buttonTitleColors[@(state)] = buttonTitleColor;
+
   for (MDCButton *button in _actionButtons) {
-    [button setTitleColor:highlightedButtonTextColor forState:UIControlStateHighlighted];
+    [button setTitleColor:buttonTitleColor forState:state];
   }
 }
 

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -262,7 +262,6 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
     // Set up the title label.
     _label = [[UILabel alloc] initWithFrame:CGRectZero];
     [_contentView addSubview:_label];
-
     // TODO(#2709): Migrate to a single source of truth for fonts
     // If we are using the default (system) font loader, retrieve the
     // font from the UIFont standardFont API.
@@ -293,6 +292,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
     // Apply 'global' attributes along the whole string.
     _label.backgroundColor = [UIColor clearColor];
     _label.textAlignment = NSTextAlignmentNatural;
+    _label.adjustsFontSizeToFitWidth = YES;
     _label.attributedText = messageString;
     _label.numberOfLines = 0;
     [_label setTranslatesAutoresizingMaskIntoConstraints:NO];

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -35,7 +35,7 @@
                                          blue:(float)(0x32 / 255.0)
                                         alpha:1]);
   XCTAssertEqualObjects(messageView.snackbarMessageViewShadowColor, UIColor.blackColor);
-  XCTAssertEqualObjects(messageView.snackbarMessageViewTextColor, UIColor.whiteColor);
+  XCTAssertEqualObjects(messageView.messageTextColor, UIColor.whiteColor);
 }
 
 @end


### PR DESCRIPTION
* Moved `buttonTextColor` and `highlightedTextColor` to `MDCSnackbarMessageView` so they can be set using `UI_APPEARANCE`.
* Renamed and deprecated `snackbarMessageViewTextColor` to `messageTextColor` to better fit naming conventions.
* Added dynamic type support for `buttonFont` and `messageFont` for Snackbars.
* Exposed `mdc_adjustsFontForContentSizeCategory` for dynamic type toggling
* Added DT on/off toggle in the Snackbar simple example.
* Removed redundant code and small bug fixes.