### PR TITLE
[BottomAppBar] Add simple color themer

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -108,6 +108,16 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/Math"
   end
 
+  mdc.subspec "BottomAppBar+Extensions" do |component|
+    component.subspec "ColorThemer" do |extension|
+      extension.ios.deployment_target = '8.0'
+      extension.public_header_files = "components/BottomAppBar/src/ColorThemer/*.h"
+      extension.source_files = "components/BottomAppBar/src/ColorThemer/*.{h,m}"
+      extension.dependency "MaterialComponents/BottomAppBar"
+      extension.dependency "MaterialComponents/Themes"
+    end
+  end
+
   mdc.subspec "BottomNavigation" do |component|
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"

--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -19,6 +19,7 @@ import UIKit
 import CatalogByConvention
 
 import MaterialComponents.MDCActivityIndicatorColorThemer
+import MaterialComponents.MDCBottomAppBarColorThemer
 import MaterialComponents.MDCButtonBarColorThemer
 import MaterialComponents.MDCButtonColorThemer
 import MaterialComponents.MDCAlertColorThemer
@@ -68,6 +69,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Apply color scheme to material design components using component themers.
     MDCActivityIndicatorColorThemer.apply(colorScheme, to: MDCActivityIndicator.appearance())
     MDCAlertColorThemer.apply(colorScheme)
+    MDCBottomAppBarColorThemer.apply(colorScheme, to: MDCBottomAppBarView.appearance())
     MDCButtonBarColorThemer.apply(colorScheme, to: MDCButtonBar.appearance())
     MDCButtonColorThemer.apply(colorScheme, to: MDCButton.appearance())
     let clearScheme = MDCBasicColorScheme(primaryColor: .clear)

--- a/components/BottomAppBar/BUILD
+++ b/components/BottomAppBar/BUILD
@@ -44,6 +44,21 @@ mdc_objc_library(
 )
 
 mdc_objc_library(
+    name = "ColorThemer",
+    srcs = native.glob(["src/ColorThemer/*.m"]),
+    hdrs = native.glob(["src/ColorThemer/*.h"]),
+    includes = ["src/ColorThemer"],
+    sdk_frameworks = [
+        "Foundation",
+    ],
+    deps = [
+        ":BottomAppBar",
+        "//components/Themes",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+mdc_objc_library(
     name = "unit_test_sources",
     testonly = 1,
     srcs = native.glob([
@@ -56,6 +71,7 @@ mdc_objc_library(
     ],
     deps = [
         ":BottomAppBar",
+        ":ColorThemer",
         ":private",
     ],
     visibility = ["//visibility:private"],

--- a/components/BottomAppBar/src/ColorThemer/MDCBottomAppBarColorThemer.h
+++ b/components/BottomAppBar/src/ColorThemer/MDCBottomAppBarColorThemer.h
@@ -1,0 +1,34 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class MDCBottomAppBarView;
+@protocol MDCColorScheme;
+
+/**
+ Applies a color scheme to an MDCBottomAppBarView or its UIAppearance proxy.
+ */
+@interface MDCBottomAppBarColorThemer : NSObject
+
+/**
+ Applies the secondary color (if present) of the colorScheme to the BottomAppBarView's
+ @c barTintColor to color the background of the bar.
+ */
++ (void)applyColorScheme:(nonnull id<MDCColorScheme>)colorScheme
+      toBottomAppBarView:(nullable MDCBottomAppBarView *)bottomAppBarView;
+
+@end

--- a/components/BottomAppBar/src/ColorThemer/MDCBottomAppBarColorThemer.m
+++ b/components/BottomAppBar/src/ColorThemer/MDCBottomAppBarColorThemer.m
@@ -1,0 +1,29 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCBottomAppBarColorThemer.h"
+
+#import "MaterialBottomAppBar.h"
+#import "MaterialThemes.h"
+
+@implementation MDCBottomAppBarColorThemer
+
++ (void)applyColorScheme:(id<MDCColorScheme>)colorScheme
+      toBottomAppBarView:(MDCBottomAppBarView *)bottomAppBarView {
+  bottomAppBarView.barTintColor = colorScheme.primaryColor;
+}
+
+@end

--- a/components/BottomAppBar/src/MDCBottomAppBarView.h
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.h
@@ -74,6 +74,24 @@ typedef NS_ENUM(NSInteger, MDCBottomAppBarFloatingButtonPosition) {
  */
 @property(nonatomic, copy, nullable) NSArray<UIBarButtonItem *> *trailingBarButtonItems;
 
+
+/**
+ Color of the background of the bottom app bar.
+ */
+@property(nullable, nonatomic, strong) UIColor *barTintColor UI_APPEARANCE_SELECTOR;
+
+/**
+ To color the background of the view use -barTintColor instead.
+ */
+@property(nullable, nonatomic, copy) UIColor *backgroundColor NS_UNAVAILABLE;
+
+/**
+ The color of the shadows below the bottom app bar.
+
+ To set the shadow color of the Floating Action Button, set it directly on the button.
+ */
+@property(nullable, nonatomic, strong) UIColor *shadowColor UI_APPEARANCE_SELECTOR;
+
 /**
  Sets the visibility of the floating action button.
  

--- a/components/BottomAppBar/src/MDCBottomAppBarView.h
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.h
@@ -86,7 +86,7 @@ typedef NS_ENUM(NSInteger, MDCBottomAppBarFloatingButtonPosition) {
 @property(nullable, nonatomic, copy) UIColor *backgroundColor NS_UNAVAILABLE;
 
 /**
- The color of the shadows below the bottom app bar.
+ The color of the shadow under the bottom app bar.
 
  To set the shadow color of the Floating Action Button, set it directly on the button.
  */

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -380,4 +380,20 @@ static const int kMDCButtonAnimationDuration = 200;
   [self showBarButtonItemsWithFloatingButtonPosition:self.floatingButtonPosition];
 }
 
+- (void)setBarTintColor:(UIColor *)barTintColor {
+  _bottomBarLayer.fillColor = barTintColor.CGColor;
+}
+
+- (UIColor *)barTintColor {
+  return [UIColor colorWithCGColor:_bottomBarLayer.fillColor];
+}
+
+- (void)setShadowColor:(UIColor *)shadowColor {
+  _bottomBarLayer.shadowColor = shadowColor.CGColor;
+}
+
+- (UIColor *)shadowColor {
+  return [UIColor colorWithCGColor:_bottomBarLayer.shadowColor];
+}
+
 @end

--- a/components/BottomAppBar/tests/unit/BottomAppBarColorThemerTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarColorThemerTests.m
@@ -1,0 +1,42 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MDCBottomAppBarColorThemer.h"
+#import "MaterialBottomAppBar.h"
+#import "MaterialThemes.h"
+
+@interface BottomAppBarColorThemerTests : XCTestCase
+
+@end
+
+@implementation BottomAppBarColorThemerTests
+
+- (void)testPrimaryColorAppliedToBarTintColor {
+  // Given
+  MDCBottomAppBarView *bottomAppBar = [[MDCBottomAppBarView alloc] init];
+  MDCBasicColorScheme *scheme =
+      [[MDCBasicColorScheme alloc] initWithPrimaryColor:UIColor.cyanColor];
+
+  // When
+  [MDCBottomAppBarColorThemer applyColorScheme:scheme toBottomAppBarView:bottomAppBar];
+
+  // Then
+  XCTAssertEqualObjects(bottomAppBar.barTintColor, scheme.primaryColor);
+}
+
+@end

--- a/components/Themes/examples/ThemerCustomSchemePickerController.m
+++ b/components/Themes/examples/ThemerCustomSchemePickerController.m
@@ -17,6 +17,7 @@
 
 #import "MDCActivityIndicatorColorThemer.h"
 #import "MDCAlertColorThemer.h"
+#import "MDCBottomAppBarColorThemer.h"
 #import "MDCButtonBarColorThemer.h"
 #import "MDCButtonColorThemer.h"
 #import "MDCFeatureHighlightColorThemer.h"
@@ -185,6 +186,8 @@ static NSString *s_secondaryColorString;
   [MDCActivityIndicatorColorThemer applyColorScheme:colorScheme
                                 toActivityIndicator:[MDCActivityIndicator appearance]];
   [MDCAlertColorThemer applyColorScheme:colorScheme];
+  [MDCBottomAppBarColorThemer applyColorScheme:colorScheme
+                            toBottomAppBarView:MDCBottomAppBarView.appearance];
   [MDCButtonBarColorThemer applyColorScheme:colorScheme toButtonBar:[MDCButtonBar appearance]];
   [MDCButtonColorThemer applyColorScheme:colorScheme toButton:self.previewButton];
   [MDCButtonColorThemer applyColorScheme:colorScheme toButton:[MDCButton appearance]];

--- a/components/Themes/examples/ThemerTypicalUseViewController.m
+++ b/components/Themes/examples/ThemerTypicalUseViewController.m
@@ -34,6 +34,8 @@
   [MDCActivityIndicatorColorThemer applyColorScheme:self.colorScheme
                                 toActivityIndicator:[MDCActivityIndicator appearance]];
   [MDCAlertColorThemer applyColorScheme:self.colorScheme];
+  [MDCBottomAppBarColorThemer applyColorScheme:self.colorScheme
+                            toBottomAppBarView:MDCBottomAppBarView.appearance];
   [MDCButtonBarColorThemer applyColorScheme:self.colorScheme toButtonBar:[MDCButtonBar appearance]];
   [MDCButtonColorThemer applyColorScheme:self.colorScheme toButton:[MDCButton appearance]];
   [MDCFeatureHighlightColorThemer applyColorScheme:self.colorScheme

--- a/components/Themes/examples/supplemental/ThemerTypicalUseSupplemental.h
+++ b/components/Themes/examples/supplemental/ThemerTypicalUseSupplemental.h
@@ -27,6 +27,7 @@
 
 #import "MDCActivityIndicatorColorThemer.h"
 #import "MDCAlertColorThemer.h"
+#import "MDCBottomAppBarColorThemer.h"
 #import "MDCButtonBarColorThemer.h"
 #import "MDCButtonColorThemer.h"
 #import "MDCFeatureHighlightColorThemer.h"


### PR DESCRIPTION
Adding a color themer that can apply an id<MDCColorScheme> to the
BottomAppBar.  Uses the `primaryColor` as the bar's background color to
match the behavior of [MDCNavigationBarColorThemer](https://github.com/material-components/material-components-ios/blob/develop/components/NavigationBar/src/ColorThemer/MDCNavigationBarColorThemer.m#L23).

Closes #2279
