### PR TITLE
[BottomNavigation] Simplify color themer

### DIFF
--- a/components/BottomNavigation/src/ColorThemer/MDCBottomNavigationBarColorThemer.m
+++ b/components/BottomNavigation/src/ColorThemer/MDCBottomNavigationBarColorThemer.m
@@ -20,9 +20,7 @@
 
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme
     toBottomNavigationBar:(MDCBottomNavigationBar *)bottomNavigationBar {
-  bottomNavigationBar.selectedItemTintColor = colorScheme.primaryLightColor;
-  bottomNavigationBar.unselectedItemTintColor = colorScheme.primaryDarkColor;
-  bottomNavigationBar.barTintColor = colorScheme.secondaryColor;
+  bottomNavigationBar.selectedItemTintColor = colorScheme.primaryColor;
 }
 
 @end

--- a/components/BottomNavigation/tests/unit/BottomNavigationBarColorThemerTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationBarColorThemerTests.m
@@ -1,0 +1,62 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import "MDCBottomNavigationBarColorThemer.h"
+#import "MaterialBottomNavigation.h"
+#import "MaterialThemes.h"
+
+@interface FakeColorScheme : NSObject<MDCColorScheme>
+@property(nonatomic, strong) UIColor *primaryColor;
+@end
+@implementation FakeColorScheme
+@end
+
+@interface BottomNavigationBarColorThemerTests : XCTestCase
+
+@end
+
+@implementation BottomNavigationBarColorThemerTests
+
+- (void)testColorSchemeWithoutOptionalColorProperties {
+  // Given
+  FakeColorScheme *colorScheme = [[FakeColorScheme alloc] init];
+  colorScheme.primaryColor = UIColor.redColor;
+  MDCBottomNavigationBar *bottomNavigationBar = [[MDCBottomNavigationBar alloc] init];
+
+  // When
+  [MDCBottomNavigationBarColorThemer applyColorScheme:colorScheme
+                                toBottomNavigationBar:bottomNavigationBar];
+
+  // Then
+  XCTAssertEqualObjects(bottomNavigationBar.selectedItemTintColor, colorScheme.primaryColor);
+}
+
+- (void)testApplyBasicColorScheme {
+  // Given
+  MDCBasicColorScheme *colorScheme =
+      [[MDCBasicColorScheme alloc] initWithPrimaryColor:UIColor.blackColor];
+  MDCBottomNavigationBar *bottomNavigationBar = [[MDCBottomNavigationBar alloc] init];
+
+  // When
+  [MDCBottomNavigationBarColorThemer applyColorScheme:colorScheme
+                                toBottomNavigationBar:bottomNavigationBar];
+
+  // Then
+  XCTAssertEqualObjects(bottomNavigationBar.selectedItemTintColor, colorScheme.primaryColor);
+}
+
+@end


### PR DESCRIPTION
The BottomNavigationBarColorThemer would not work for color schemes generated
from some named UIColors (like .red, .orange). It also generated a poor
contrast ratio when using the MDC Catalog color scheme (dark greys). Instead,
it should use the `primaryColor` for the selected item and leave the other
at the default.  This should generally create a simple, effective set of
colors.

Mitigates #3115
