### PR TITLE
[Kokoro / CI] Have Kokoro test multiple iOS versions and simulators on different Xcodes.

### DIFF
--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -14,9 +14,10 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
+     "mdc_objc_library",
+     "ios_runners")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -89,12 +90,13 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
       ":unit_test_swift_sources"
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -15,9 +15,8 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
+     "mdc_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -90,13 +89,9 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
       ":unit_test_swift_sources"
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/AnimationTiming/BUILD
+++ b/components/AnimationTiming/BUILD
@@ -15,9 +15,8 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
+     "mdc_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -41,12 +40,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/AnimationTiming/BUILD
+++ b/components/AnimationTiming/BUILD
@@ -14,9 +14,10 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
+     "mdc_objc_library",
+     "ios_runners")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -40,11 +41,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/AppBar/BUILD
+++ b/components/AppBar/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -89,13 +88,9 @@ swift_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_swift_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )
 

--- a/components/AppBar/BUILD
+++ b/components/AppBar/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -88,11 +89,13 @@ swift_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_swift_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )
+

--- a/components/BottomAppBar/BUILD
+++ b/components/BottomAppBar/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -78,12 +77,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/BottomAppBar/BUILD
+++ b/components/BottomAppBar/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -77,11 +78,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -89,11 +90,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -90,12 +89,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/BottomSheet/BUILD
+++ b/components/BottomSheet/BUILD
@@ -14,9 +14,10 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
+     "mdc_objc_library",
+     "ios_runners")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -45,11 +46,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/BottomSheet/BUILD
+++ b/components/BottomSheet/BUILD
@@ -15,9 +15,8 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
+     "mdc_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -46,12 +45,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -87,13 +86,9 @@ swift_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
       ":unit_test_swift_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -86,12 +87,13 @@ swift_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
       ":unit_test_swift_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/Buttons/BUILD
+++ b/components/Buttons/BUILD
@@ -17,8 +17,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -101,12 +100,8 @@ mdc_objc_library(
     xibs = native.glob(["tests/unit/resources/*.xib"]),
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/Buttons/BUILD
+++ b/components/Buttons/BUILD
@@ -16,8 +16,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -100,11 +101,12 @@ mdc_objc_library(
     xibs = native.glob(["tests/unit/resources/*.xib"]),
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/Cards/BUILD
+++ b/components/Cards/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -52,11 +53,13 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )
+

--- a/components/Cards/BUILD
+++ b/components/Cards/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -53,13 +52,9 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )
 

--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -66,13 +65,9 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )
 

--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -65,12 +66,13 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )
 

--- a/components/CollectionCells/BUILD
+++ b/components/CollectionCells/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -72,11 +73,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/CollectionCells/BUILD
+++ b/components/CollectionCells/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -73,12 +72,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/CollectionLayoutAttributes/BUILD
+++ b/components/CollectionLayoutAttributes/BUILD
@@ -16,8 +16,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -53,11 +54,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/CollectionLayoutAttributes/BUILD
+++ b/components/CollectionLayoutAttributes/BUILD
@@ -17,8 +17,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -54,12 +53,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/Collections/BUILD
+++ b/components/Collections/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -74,11 +75,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/Collections/BUILD
+++ b/components/Collections/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -75,12 +74,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -92,11 +93,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -93,12 +92,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/FeatureHighlight/BUILD
+++ b/components/FeatureHighlight/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -111,12 +110,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/FeatureHighlight/BUILD
+++ b/components/FeatureHighlight/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -110,11 +111,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -14,9 +14,10 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
+     "mdc_objc_library",
+     "ios_runners")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -74,12 +75,13 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
       ":unit_test_swift_sources"
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -15,9 +15,8 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
+     "mdc_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -75,13 +74,9 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
       ":unit_test_swift_sources"
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/HeaderStackView/BUILD
+++ b/components/HeaderStackView/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -63,12 +62,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/HeaderStackView/BUILD
+++ b/components/HeaderStackView/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -62,11 +63,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/Ink/BUILD
+++ b/components/Ink/BUILD
@@ -15,8 +15,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -72,12 +71,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/Ink/BUILD
+++ b/components/Ink/BUILD
@@ -14,8 +14,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -71,11 +72,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/LibraryInfo/BUILD
+++ b/components/LibraryInfo/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -36,12 +35,8 @@ swift_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_swift_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/LibraryInfo/BUILD
+++ b/components/LibraryInfo/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -35,11 +36,12 @@ swift_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_swift_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/MaskedTransition/BUILD
+++ b/components/MaskedTransition/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -59,11 +60,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/MaskedTransition/BUILD
+++ b/components/MaskedTransition/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -60,12 +59,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/NavigationBar/BUILD
+++ b/components/NavigationBar/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -77,13 +76,9 @@ swift_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
       ":unit_test_swift_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/NavigationBar/BUILD
+++ b/components/NavigationBar/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -76,12 +77,13 @@ swift_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
       ":unit_test_swift_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/OverlayWindow/BUILD
+++ b/components/OverlayWindow/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -47,11 +48,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/OverlayWindow/BUILD
+++ b/components/OverlayWindow/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -48,12 +47,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/PageControl/BUILD
+++ b/components/PageControl/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -78,11 +79,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/PageControl/BUILD
+++ b/components/PageControl/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -79,12 +78,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/Palettes/BUILD
+++ b/components/Palettes/BUILD
@@ -15,9 +15,8 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
+     "mdc_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -44,13 +43,9 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
       ":unit_test_swift_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/Palettes/BUILD
+++ b/components/Palettes/BUILD
@@ -14,9 +14,10 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
+     "mdc_objc_library",
+     "ios_runners")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -43,12 +44,13 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
       ":unit_test_swift_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/ProgressView/BUILD
+++ b/components/ProgressView/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -76,11 +77,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/ProgressView/BUILD
+++ b/components/ProgressView/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -77,12 +76,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/ShadowElevations/BUILD
+++ b/components/ShadowElevations/BUILD
@@ -14,9 +14,10 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
+     "mdc_objc_library",
+     "ios_runners")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -43,11 +44,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/ShadowElevations/BUILD
+++ b/components/ShadowElevations/BUILD
@@ -15,9 +15,8 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
+     "mdc_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -44,12 +43,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/ShadowLayer/BUILD
+++ b/components/ShadowLayer/BUILD
@@ -15,9 +15,8 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
+     "mdc_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -48,12 +47,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/ShadowLayer/BUILD
+++ b/components/ShadowLayer/BUILD
@@ -14,9 +14,10 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
+     "mdc_objc_library",
+     "ios_runners")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -47,11 +48,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/Slider/BUILD
+++ b/components/Slider/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -74,12 +73,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/Slider/BUILD
+++ b/components/Slider/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -73,11 +74,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/Snackbar/BUILD
+++ b/components/Snackbar/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -75,14 +74,10 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
       ":unit_test_swift_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )
 

--- a/components/Snackbar/BUILD
+++ b/components/Snackbar/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -74,12 +75,14 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
       ":unit_test_swift_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )
+

--- a/components/Tabs/BUILD
+++ b/components/Tabs/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -106,12 +105,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/Tabs/BUILD
+++ b/components/Tabs/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -105,11 +106,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -15,8 +15,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -78,13 +77,9 @@ swift_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
       ":unit_test_swift_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -14,8 +14,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -77,12 +78,13 @@ swift_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
       ":unit_test_swift_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/Themes/BUILD
+++ b/components/Themes/BUILD
@@ -17,8 +17,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -51,12 +50,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/Themes/BUILD
+++ b/components/Themes/BUILD
@@ -16,8 +16,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -50,11 +51,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/Typography/BUILD
+++ b/components/Typography/BUILD
@@ -14,8 +14,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -44,11 +45,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/Typography/BUILD
+++ b/components/Typography/BUILD
@@ -15,8 +15,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -45,12 +44,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/private/Application/BUILD
+++ b/components/private/Application/BUILD
@@ -14,7 +14,7 @@
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/private/Application/BUILD
+++ b/components/private/Application/BUILD
@@ -14,7 +14,6 @@
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/private/Icons/BUILD
+++ b/components/private/Icons/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -48,9 +49,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
-    deps = [":unit_test_sources"],
+    deps = [
+      ":unit_test_sources",
+    ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/private/Icons/BUILD
+++ b/components/private/Icons/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -49,12 +48,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/private/KeyboardWatcher/BUILD
+++ b/components/private/KeyboardWatcher/BUILD
@@ -15,7 +15,7 @@
 load("//:material_components_ios.bzl",
      "mdc_objc_library",
      "mdc_public_objc_library",
-     "ios_runners")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/private/KeyboardWatcher/BUILD
+++ b/components/private/KeyboardWatcher/BUILD
@@ -16,7 +16,6 @@ load("//:material_components_ios.bzl",
      "mdc_objc_library",
      "mdc_public_objc_library",
      "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -48,13 +47,9 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
     size = "small",
 )

--- a/components/private/KeyboardWatcher/BUILD
+++ b/components/private/KeyboardWatcher/BUILD
@@ -14,8 +14,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_objc_library",
-     "mdc_public_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_public_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -47,12 +48,13 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
     size = "small",
 )

--- a/components/private/Overlay/BUILD
+++ b/components/private/Overlay/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -54,11 +55,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/private/Overlay/BUILD
+++ b/components/private/Overlay/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -55,12 +54,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/private/ShapeLibrary/BUILD
+++ b/components/private/ShapeLibrary/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -49,11 +50,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/private/ShapeLibrary/BUILD
+++ b/components/private/ShapeLibrary/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -50,12 +49,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/private/Shapes/BUILD
+++ b/components/private/Shapes/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -50,11 +51,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/private/Shapes/BUILD
+++ b/components/private/Shapes/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -51,12 +50,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/private/ThumbTrack/BUILD
+++ b/components/private/ThumbTrack/BUILD
@@ -15,8 +15,9 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -53,11 +54,12 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )

--- a/components/private/ThumbTrack/BUILD
+++ b/components/private/ThumbTrack/BUILD
@@ -16,8 +16,7 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -54,12 +53,8 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )

--- a/components/private/UIMetrics/BUILD
+++ b/components/private/UIMetrics/BUILD
@@ -14,7 +14,7 @@
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/private/UIMetrics/BUILD
+++ b/components/private/UIMetrics/BUILD
@@ -14,7 +14,6 @@
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/contributing/bazel_kokoro.md
+++ b/contributing/bazel_kokoro.md
@@ -66,8 +66,9 @@ For a component written in Objective-C with only Objective-C tests and no resour
 ```
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+     "mdc_objc_library",
+     "ios_runners")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -92,12 +93,13 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )
 ```
@@ -109,7 +111,7 @@ Dependencies are added as paths relative to the root of the MDC iOS repo:
 ```
 mdc_public_objc_library(
     name = "ComponentName",
-+    deps = ["//components/Palettes"],
+    deps = ["//components/Palettes"],
 )
 
 ```
@@ -122,20 +124,20 @@ with the following additions:
 ```
 mdc_public_objc_library(
     name = "ComponentName",
-+    bundles = [":Bundle"],
+    bundles = [":Bundle"],
 )
 
-+filegroup(
-+    name = "BundleFiles",
-+    srcs = glob([
-+        "src/ComponentName.bundle/**",
-+    ]),
-+)
-+
-+objc_bundle(
-+    name = "Bundle",
-+    bundle_imports = [":BundleFiles"],
-+)
+filegroup(
+    name = "BundleFiles",
+    srcs = glob([
+        "src/ComponentName.bundle/**",
+    ]),
+)
+
+objc_bundle(
+    name = "Bundle",
+    bundle_imports = [":BundleFiles"],
+)
 ```
 
 ### Exposing private APIs to unit tests
@@ -144,20 +146,20 @@ You can export private APIs such that they are only visible to unit test targets
 rules:
 
 ```
-+mdc_objc_library(
-+    name = "private",
-+    hdrs = native.glob(["src/private/*.h"]),
-+    deps = [":Ink"],
-+    includes = ["src/private"],
-+    visibility = [":test_targets"],
-+)
-+
-+package_group(
-+    name = "test_targets",
-+    packages = [
-+        "//components/ComponentName/...",
-+    ],
-+)
+mdc_objc_library(
+    name = "private",
+    hdrs = native.glob(["src/private/*.h"]),
+    deps = [":Ink"],
+    includes = ["src/private"],
+    visibility = [":test_targets"],
+)
+
+package_group(
+    name = "test_targets",
+    packages = [
+        "//components/ComponentName/...",
+    ],
+)
 
 mdc_objc_library(
     name = "unit_test_sources",
@@ -170,7 +172,7 @@ mdc_objc_library(
     ],
     deps = [
         ":ComponentName",
-+        ":private"
+        ":private"
     ],
     visibility = ["//visibility:private"],
 )
@@ -179,22 +181,23 @@ mdc_objc_library(
 ### Adding Swift unit tests
 
 ```
-+load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
-+swift_library(
-+    name = "unit_test_swift_sources",
-+    srcs = glob(["tests/unit/*.swift"]),
-+    deps = [":ComponentName"],
-+    visibility = ["//visibility:private"],
-+)
+swift_library(
+    name = "unit_test_swift_sources",
+    srcs = glob(["tests/unit/*.swift"]),
+    deps = [":ComponentName"],
+    visibility = ["//visibility:private"],
+)
 
-ios_unit_test(
+ios_unit_test_suite(
     name = "unit_tests",
     deps = [
       ":unit_test_sources",
-+      ":unit_test_swift_sources"
+      ":unit_test_swift_sources"
     ],
     minimum_os_version = "8.0",
+    runners = ios_runners(),
     visibility = ["//visibility:private"],
 )
 ```

--- a/contributing/bazel_kokoro.md
+++ b/contributing/bazel_kokoro.md
@@ -67,8 +67,7 @@ For a component written in Objective-C with only Objective-C tests and no resour
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "ios_runners")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+     "mdc_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -93,14 +92,10 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )
 ```
 
@@ -190,14 +185,10 @@ swift_library(
     visibility = ["//visibility:private"],
 )
 
-ios_unit_test_suite(
-    name = "unit_tests",
+mdc_unit_test_suite(
     deps = [
       ":unit_test_sources",
       ":unit_test_swift_sources"
     ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
 )
 ```

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -1,6 +1,7 @@
 """Bazel macros for building MDC component libraries."""
 
 load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
+load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
 
 def mdc_objc_library(
     name,
@@ -46,3 +47,37 @@ def mdc_public_objc_library(
       includes = ["src"],
       enable_modules = 1,
       **kwargs)
+
+def ios_runners():
+  ios_test_runner(
+    name = "IPHONE_5_IN_8_1",
+    device_type = "iPhone 5",
+    os_version = "8.1",
+  )
+  ios_test_runner(
+    name = "IPAD_PRO_12_9_IN_9_3",
+    device_type = "iPad Pro (12.9-inch)",
+    os_version = "9.3",
+  )
+  ios_test_runner(
+    name = "IPHONE_7_PLUS_IN_10_3",
+    device_type = "iPhone 7 Plus",
+    os_version = "10.3",
+  )
+  ios_test_runner(
+    name = "DYNAMIC_RUNNER",
+    device_type = select({ ":xcode8_3_3": "iPad 2", ":xcode_9_0": "iPhone2017-C", "//conditions:default": "iPhone X" }),
+    os_version = select({ ":xcode8_3_3": "8.4", "//conditions:default": "11.0" }), 
+  )
+
+  native.config_setting(
+      name = "xcode8_3_3",
+      values = {"xcode_version": "8.3.3"},
+  )
+
+  native.config_setting(
+      name = "xcode_9_0",
+      values = {"xcode_version": "9.0"},
+  )
+
+  return [":IPHONE_5_IN_8_1", ":IPAD_PRO_12_9_IN_9_3", ":IPHONE_7_PLUS_IN_10_3", ":DYNAMIC_RUNNER"]

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -49,36 +49,6 @@ def mdc_public_objc_library(
       enable_modules = 1,
       **kwargs)
 
-
-ios_unit_test_suite(
-    name = "unit_tests",
-    deps = [
-      ":unit_test_sources",
-    ],
-    minimum_os_version = "8.0",
-    runners = ios_runners(),
-    visibility = ["//visibility:private"],
-    size = "small",
-)
-
-def mdc_unit_test_suite(
-    name = "unit_tests",
-    deps = [],
-    minimum_os_version = "8.0",
-    visibility = ["//visibility:private"],
-    size = "medium",
-    **kwargs):
-  """Declare a MDC unit_test_suite using the ios_runners matrix.
-  ios_unit_test_suite(
-    name = name,
-    deps = deps,
-    minimum_os_version = minimum_os_version,
-    runners = ios_runners(),
-    visibility = visibility,
-    size = size,
-    **kwargs
-  )
-
 def ios_runners():
   ios_test_runner(
     name = "IPHONE_5_IN_8_1",
@@ -112,3 +82,21 @@ def ios_runners():
   )
 
   return [":IPHONE_5_IN_8_1", ":IPAD_PRO_12_9_IN_9_3", ":IPHONE_7_PLUS_IN_10_3", ":DYNAMIC_RUNNER"]
+
+def mdc_unit_test_suite(
+    name = "unit_tests",
+    deps = [],
+    minimum_os_version = "8.0",
+    visibility = ["//visibility:private"],
+    size = "medium",
+    **kwargs):
+  """Declare a MDC unit_test_suite using the ios_runners matrix."""
+  ios_unit_test_suite(
+    name = name,
+    deps = deps,
+    minimum_os_version = minimum_os_version,
+    runners = ios_runners(),
+    visibility = visibility,
+    size = size,
+    **kwargs
+  )

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -2,6 +2,7 @@
 
 load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
 load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 def mdc_objc_library(
     name,
@@ -47,6 +48,36 @@ def mdc_public_objc_library(
       includes = ["src"],
       enable_modules = 1,
       **kwargs)
+
+
+ios_unit_test_suite(
+    name = "unit_tests",
+    deps = [
+      ":unit_test_sources",
+    ],
+    minimum_os_version = "8.0",
+    runners = ios_runners(),
+    visibility = ["//visibility:private"],
+    size = "small",
+)
+
+def mdc_unit_test_suite(
+    name = "unit_tests",
+    deps = [],
+    minimum_os_version = "8.0",
+    visibility = ["//visibility:private"],
+    size = "medium",
+    **kwargs):
+  """Declare a MDC unit_test_suite using the ios_runners matrix.
+  ios_unit_test_suite(
+    name = name,
+    deps = deps,
+    minimum_os_version = minimum_os_version,
+    runners = ios_runners(),
+    visibility = visibility,
+    size = size,
+    **kwargs
+  )
 
 def ios_runners():
   ios_test_runner(


### PR DESCRIPTION
Now Kokoro supports running on a matrix of different iOS versions, simulators, and Xcodes.

We are now imitating the matrix we currently have set up on Travis so we can remove the dependency on it and have a faster testing/CI turnaround for our code pushes and releases.