### PR TITLE
[BottomNavigation] Remove ink for canceled touch

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -389,6 +389,11 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   [itemView.inkView startTouchEndedAnimationAtPoint:CGPointZero completion:nil];
 }
 
+- (void)didCancelTouchesForButton:(UIButton *)button {
+  MDCBottomNavigationItemView *itemView = (MDCBottomNavigationItemView *)button.superview;
+  [itemView.inkView cancelAllAnimationsAnimated:NO];
+}
+
 #pragma mark - Setters
 
 - (void)setItems:(NSArray<UITabBarItem *> *)items {
@@ -453,7 +458,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
                         action:@selector(didTouchUpOutsideButton:)
               forControlEvents:UIControlEventTouchUpOutside];
     [itemView.button addTarget:self
-                        action:@selector(didTouchUpOutsideButton:)
+                        action:@selector(didCancelTouchesForButton:)
               forControlEvents:UIControlEventTouchCancel];
     [self.itemViews addObject:itemView];
     [self.containerView addSubview:itemView];

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -452,6 +452,9 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
     [itemView.button addTarget:self
                         action:@selector(didTouchUpOutsideButton:)
               forControlEvents:UIControlEventTouchUpOutside];
+    [itemView.button addTarget:self
+                        action:@selector(didTouchUpOutsideButton:)
+              forControlEvents:UIControlEventTouchCancel];
     [self.itemViews addObject:itemView];
     [self.containerView addSubview:itemView];
   }


### PR DESCRIPTION
When a touch was canceled (e.g., by rotating the device) and the touch event
was canceled, the Bottom Navigation Bar was not canceling the ink animation.

Closes #2909