### PR TITLE
[WIP] [API] [Slider] Make Slider colors more customizable

### DIFF
--- a/components/Slider/src/ColorThemer/MDCSliderColorThemer.m
+++ b/components/Slider/src/ColorThemer/MDCSliderColorThemer.m
@@ -24,15 +24,15 @@ static const CGFloat kSliderThemerDarkAlpha = 0.3f;
 
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme
                 toSlider:(MDCSlider *)slider {
-  if ([colorScheme respondsToSelector:@selector(primaryLightColor)]) {
-    [slider setTrackBackgroundColor:colorScheme.primaryLightColor forState:UIControlStateNormal];
-  }
+//  if ([colorScheme respondsToSelector:@selector(primaryLightColor)]) {
+//    [slider setTrackBackgroundColor:colorScheme.primaryLightColor forState:UIControlStateNormal];
+//  }
   [slider setThumbColor:colorScheme.primaryColor forState:UIControlStateNormal];
-  [slider setTrackFillColor:colorScheme.primaryColor forState:UIControlStateNormal];
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    [slider setThumbColor:colorScheme.primaryDarkColor forState:UIControlStateDisabled];
-    [slider setTrackFillColor:colorScheme.primaryDarkColor forState:UIControlStateDisabled];
-  }
+//  [slider setTrackFillColor:colorScheme.primaryColor forState:UIControlStateNormal];
+//  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
+//    [slider setThumbColor:colorScheme.primaryDarkColor forState:UIControlStateDisabled];
+//    [slider setTrackFillColor:colorScheme.primaryDarkColor forState:UIControlStateDisabled];
+//  }
 }
 
 #pragma mark - Default color schemes

--- a/components/Slider/src/ColorThemer/MDCSliderColorThemer.m
+++ b/components/Slider/src/ColorThemer/MDCSliderColorThemer.m
@@ -25,11 +25,13 @@ static const CGFloat kSliderThemerDarkAlpha = 0.3f;
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme
                 toSlider:(MDCSlider *)slider {
   if ([colorScheme respondsToSelector:@selector(primaryLightColor)]) {
-    slider.trackBackgroundColor = colorScheme.primaryLightColor;
+    [slider setTrackBackgroundColor:colorScheme.primaryLightColor forState:UIControlStateNormal];
   }
-  slider.color = colorScheme.primaryColor;
+  [slider setThumbColor:colorScheme.primaryColor forState:UIControlStateNormal];
+  [slider setTrackFillColor:colorScheme.primaryColor forState:UIControlStateNormal];
   if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    slider.disabledColor = colorScheme.primaryDarkColor;
+    [slider setThumbColor:colorScheme.primaryDarkColor forState:UIControlStateDisabled];
+    [slider setTrackFillColor:colorScheme.primaryDarkColor forState:UIControlStateDisabled];
   }
 }
 

--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -45,25 +45,128 @@ IB_DESIGNABLE
 @property(nullable, nonatomic, weak) id<MDCSliderDelegate> delegate;
 
 /**
- The color of the cursor (thumb) and filled in portion of the track (left side).
+ Sets the color of the thumb to use for the specified state.
 
- Default color is blue.
+ In general, if a property is not specified for a state, the default is to use the
+ @c UIControlStateNormal value. If the @c UIControlStateNormal value is not set, then the property
+ defaults to a default value. Therefore, at a minimum, you should set the value for the
+ normal state.
+
+ @param thumbColor The color of the thumb (cursor).
+ @param state The state of the slider.
  */
-@property(nonatomic, strong, null_resettable) UIColor *color UI_APPEARANCE_SELECTOR;
+- (void)setThumbColor:(nullable UIColor *)thumbColor forState:(UIControlState)state;
 
 /**
- The color of the cursor (thumb) and track while the slider is disabled.
+ Returns the thumb color associated with the specified state.
 
- Default color is gray.
+ @params state The state that uses the thumb color.
+ @returns The thumb color for the specified state. If no color has been set for the specific state,
+          this method returns the color associated with the @c UIControlStateNormal state.
  */
-@property(nonatomic, strong, null_resettable) UIColor *disabledColor UI_APPEARANCE_SELECTOR;
+- (nullable UIColor *)thumbColorForState:(UIControlState)state;
 
 /**
- The color of the unfilled track that the cursor moves along (right side).
+ Sets the color of the inactive (unfilled) track to use for the specified state.
 
- Default color is gray.
+ In general, if a property is not specified for a state, the default is to use the
+ @c UIControlStateNormal value. If the @c UIControlStateNormal value is not set, then the property
+ defaults to a default value. Therefore, at a minimum, you should set the value for the
+ normal state.
+
+ @param backgroundColor The color of the inactive track.
+ @param state The state of the slider.
  */
-@property(nonatomic, strong, null_resettable) UIColor *trackBackgroundColor UI_APPEARANCE_SELECTOR;
+- (void)setTrackBackgroundColor:(nullable UIColor *)backgroundColor forState:(UIControlState)state;
+
+/**
+ Returns the track background color associated with the specified state.
+
+ @params state The state that uses the track background color.
+ @returns The track background color for the specified state. If no color has been set for the
+          specific state, this method returns the color associated with the @c UIControlStateNormal
+          state.
+ */
+- (nullable UIColor *)trackBackgroundColorForState:(UIControlState)state;
+
+/**
+ Sets the color of the filled track area to use for the specified state.
+
+ In general, if a property is not specified for a state, the default is to use the
+ @c UIControlStateNormal value. If the @c UIControlStateNormal value is not set, then the property
+ defaults to a default value. Therefore, at a minimum, you should set the value for the
+ normal state.
+
+ @param fillColor The color of the filled track.
+ @param state The state of the slider.
+ */
+- (void)setTrackFillColor:(nullable UIColor *)fillColor forState:(UIControlState)state;
+
+/**
+ Returns the track fill color associated with the specified state.
+
+ @params state The state that uses the track fill color.
+ @returns The track fill color for the specified state. If no color has been set for the specific
+          state, this method returns the color associated with the @c UIControlStateNormal state.
+ */
+- (nullable UIColor *)trackFillColorForState:(UIControlState)state;
+
+/**
+ Sets the color of the ticks within the filled track to use for the specified state.
+
+ In general, if a property is not specified for a state, the default is to use the
+ @c UIControlStateNormal value. If the @c UIControlStateNormal value is not set, then the property
+ defaults to a default value. Therefore, at a minimum, you should set the value for the
+ normal state.
+
+ @param tickColor The color of the tick marks within the filled track.
+ @param state The state of the slider.
+ */
+//- (void)setFilledTrackTickColor:(nullable UIColor *)tickColor forState:(UIControlState)state;
+
+/**
+ Returns the tick color for the filled track portion associated with the specified state.
+
+ @params state The state that uses the filled-track tick color.
+ @returns The filled-track tick color for the specified state. If no color has been set for the
+          specific state, this method returns the color associated with the @c UIControlStateNormal
+          state.
+ */
+//- (nullable UIColor *)filledTrackTickColorForState:(UIControlState)state;
+
+/**
+ Sets the color of the ticks for the background (unfilled) track to use for the specified state.
+
+ In general, if a property is not specified for a state, the default is to use the
+ @c UIControlStateNormal value. If the @c UIControlStateNormal value is not set, then the property
+ defaults to a default value. Therefore, at a minimum, you should set the value for the
+ normal state.
+
+ @param tickColor The color of the tick marks outside the filled track.
+ @param state The state of the slider.
+ */
+//- (void)setBackgroundTrackTickColor:(nullable UIColor *)tickColor forState:(UIControlState)state;
+
+/**
+ Returns the tick color for the background (unfilled) track portion associated with the specified
+ state.
+
+ @params state The state that uses the background-track tick color.
+ @returns The background-track tick color for the specified state. If no color has been set for the
+          specific state, this method returns the color associated with the @c UIControlStateNormal
+          state.
+ */
+//- (nullable UIColor *)backgroundTrackTickColor:(UIControlState)state;
+
+/**
+ The color of the discrete value label title text.
+ */
+@property(nullable, nonatomic, strong) UIColor *valueLabelTitleColor;
+
+/**
+ The background color of the discrete value label.
+ */
+@property(nullable, nonatomic, strong) UIColor *valueLabelBackgroundColor;
 
 /**
  The radius of the cursor (thumb).
@@ -174,6 +277,37 @@ IB_DESIGNABLE
  Defaults to YES.
  */
 @property(nonatomic, assign, getter=isThumbHollowAtStart) BOOL thumbHollowAtStart;
+
+#pragma mark - To be deprecated
+
+/**
+ The color of the cursor (thumb) and track while the slider is disabled.
+
+ Default color is gray.
+
+ @note This API is planned for deprecation. Use @c setThumbColor:forState: and
+       @c setTrackFillColor:forState: instead.
+ */
+@property(nonatomic, strong, null_resettable) UIColor *disabledColor UI_APPEARANCE_SELECTOR;
+
+/**
+ The color of the unfilled track that the cursor moves along (right side).
+
+ Default color is gray.
+
+ @note This API is planned for deprecation. Use @c setTrackBackgroundColor:forState instead.
+ */
+@property(nonatomic, strong, null_resettable) UIColor *trackBackgroundColor UI_APPEARANCE_SELECTOR;
+
+/**
+ The color of the cursor (thumb) and filled in portion of the track (left side).
+
+ Default color is blue.
+
+ @note This API is planned for deprecation. Use @c setThumbColor:forState: and
+       @c setTrackFillColor:forState: instead.
+ */
+@property(nonatomic, strong, null_resettable) UIColor *color UI_APPEARANCE_SELECTOR;
 
 @end
 

--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -77,7 +77,7 @@ IB_DESIGNABLE
  @param backgroundColor The color of the inactive track.
  @param state The state of the slider.
  */
-- (void)setTrackBackgroundColor:(nullable UIColor *)backgroundColor forState:(UIControlState)state;
+//- (void)setTrackBackgroundColor:(nullable UIColor *)backgroundColor forState:(UIControlState)state;
 
 /**
  Returns the track background color associated with the specified state.
@@ -87,7 +87,7 @@ IB_DESIGNABLE
           specific state, this method returns the color associated with the @c UIControlStateNormal
           state.
  */
-- (nullable UIColor *)trackBackgroundColorForState:(UIControlState)state;
+//- (nullable UIColor *)trackBackgroundColorForState:(UIControlState)state;
 
 /**
  Sets the color of the filled track area to use for the specified state.
@@ -100,7 +100,7 @@ IB_DESIGNABLE
  @param fillColor The color of the filled track.
  @param state The state of the slider.
  */
-- (void)setTrackFillColor:(nullable UIColor *)fillColor forState:(UIControlState)state;
+//- (void)setTrackFillColor:(nullable UIColor *)fillColor forState:(UIControlState)state;
 
 /**
  Returns the track fill color associated with the specified state.
@@ -109,7 +109,7 @@ IB_DESIGNABLE
  @returns The track fill color for the specified state. If no color has been set for the specific
           state, this method returns the color associated with the @c UIControlStateNormal state.
  */
-- (nullable UIColor *)trackFillColorForState:(UIControlState)state;
+//- (nullable UIColor *)trackFillColorForState:(UIControlState)state;
 
 /**
  Sets the color of the ticks within the filled track to use for the specified state.

--- a/components/Slider/src/MDCSlider.m
+++ b/components/Slider/src/MDCSlider.m
@@ -35,7 +35,13 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
 
 @end
 
-@implementation MDCSlider
+@implementation MDCSlider {
+  NSMutableDictionary *_thumbColorsForState;
+  NSMutableDictionary *_trackFillColorsForState;
+  NSMutableDictionary *_trackBackgroundColorsForState;
+  NSMutableDictionary *_filledTrackTickColorForState;
+  NSMutableDictionary *_backgroundTrackTickColorForState;
+}
 
 - (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];
@@ -87,35 +93,78 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
   [self addSubview:_thumbTrack];
 }
 
-#pragma mark - ThumbTrack passthrough methods
+#pragma mark - Color customization methods
 
-- (void)setTrackBackgroundColor:(UIColor *)trackBackgroundColor {
-  _thumbTrack.trackOffColor =
-      trackBackgroundColor ? trackBackgroundColor : [[self class] defaultTrackOffColor];
+- (void)setTrackBackgroundColor:(UIColor *)backgroundColor forState:(UIControlState)state {
+  _trackBackgroundColorsForState[@(state)] = backgroundColor;
+  if (state == self.state) {
+    [self updateColorsForState];
+  }
 }
 
-- (UIColor *)trackBackgroundColor {
-  return _thumbTrack.trackOffColor;
+- (UIColor *)trackBackgroundColorForState:(UIControlState)state {
+  UIColor *color = _trackBackgroundColorsForState[@(state)];
+  if (color) {
+    return color;
+  }
+  if (state != UIControlStateNormal) {
+    color = _trackBackgroundColorsForState[@(UIControlStateNormal)];
+  }
+  if (color) {
+    return color;
+  }
+  return [[self class] defaultTrackOffColor];
 }
 
-- (void)setDisabledColor:(UIColor *)disabledColor {
-  _thumbTrack.trackDisabledColor =
-      disabledColor ?: [[self class] defaultDisabledColor];
-  _thumbTrack.thumbDisabledColor =
-      disabledColor ?: [[self class] defaultDisabledColor];
+- (void)setTrackFillColor:(UIColor *)fillColor forState:(UIControlState)state {
+  _trackFillColorsForState[@(state)] = fillColor;
+  if (state == self.state) {
+    [self updateColorsForState];
+  }
 }
 
-- (UIColor *)disabledColor {
-  return _thumbTrack.trackDisabledColor;
-}
+- (UIColor *)trackFillColorForState:(UIControlState)state {
+  UIColor *color = _trackFillColorsForState[@(state)];
+  if (color) {
+    return color;
+  }
 
-- (void)setColor:(UIColor *)color {
-  _thumbTrack.primaryColor = color ? color : MDCThumbTrackDefaultColor();
-}
-
-- (UIColor *)color {
+  if (state != UIControlStateNormal) {
+    color = _trackFillColorsForState[@(UIControlStateNormal)];
+  }
+  if (color) {
+    return color;
+  }
   return _thumbTrack.primaryColor;
 }
+
+- (void)setThumbColor:(UIColor *)thumbColor forState:(UIControlState)state {
+  _thumbColorsForState[@(state)] = thumbColor;
+  if (state == self.state) {
+    [self updateColorsForState];
+  }
+}
+
+- (UIColor *)thumbColorForState:(UIControlState)state {
+  UIColor *color = _thumbColorsForState[@(state)];
+  if (color) {
+    return color;
+  }
+  if (state != UIControlStateNormal) {
+    color = _thumbColorsForState[@(UIControlStateNormal)];
+  }
+  if (color) {
+    return color;
+  }
+  return _thumbTrack.thumbEnabledColor;
+}
+
+- (void)updateColorsForState {
+  _thumbTrack.trackOffColor = [self trackBackgroundColorForState:self.state];
+  _thumbTrack.primaryColor = [self trackFillColorForState:self.state];
+}
+
+#pragma mark - ThumbTrack passthrough methods
 
 - (void)setThumbRadius:(CGFloat)thumbRadius {
   _thumbTrack.thumbRadius = thumbRadius;
@@ -355,6 +404,36 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
 
 + (UIColor *)defaultDisabledColor {
   return [[UIColor blackColor] colorWithAlphaComponent:kSliderLightThemeTrackAlpha];
+}
+
+#pragma mark - To be deprecated
+
+- (void)setTrackBackgroundColor:(UIColor *)trackBackgroundColor {
+  _thumbTrack.trackOffColor =
+  trackBackgroundColor ? trackBackgroundColor : [[self class] defaultTrackOffColor];
+}
+
+- (UIColor *)trackBackgroundColor {
+  return _thumbTrack.trackOffColor;
+}
+
+- (void)setDisabledColor:(UIColor *)disabledColor {
+  _thumbTrack.trackDisabledColor =
+  disabledColor ?: [[self class] defaultDisabledColor];
+  _thumbTrack.thumbDisabledColor =
+  disabledColor ?: [[self class] defaultDisabledColor];
+}
+
+- (UIColor *)disabledColor {
+  return _thumbTrack.trackDisabledColor;
+}
+
+- (void)setColor:(UIColor *)color {
+  _thumbTrack.primaryColor = color ? color : MDCThumbTrackDefaultColor();
+}
+
+- (UIColor *)color {
+  return _thumbTrack.primaryColor;
 }
 
 @end

--- a/components/Slider/src/MDCSlider.m
+++ b/components/Slider/src/MDCSlider.m
@@ -16,6 +16,7 @@
 
 #import "MDCSlider.h"
 
+#import "private/MDCSlider+Private.h"
 #import "private/MDCSlider_Subclassable.h"
 #import "MaterialPalettes.h"
 #import "MaterialThumbTrack.h"
@@ -160,8 +161,15 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
 }
 
 - (void)updateColorsForState {
+  if ((self.state & UIControlStateDisabled) == UIControlStateDisabled) {
+    _thumbTrack.thumbDisabledColor = [self thumbColorForState:self.state];
+  } else {
+    _thumbTrack.thumbEnabledColor = [self thumbColorForState:self.state];
+  }
   _thumbTrack.trackOffColor = [self trackBackgroundColorForState:self.state];
   _thumbTrack.primaryColor = [self trackFillColorForState:self.state];
+
+  _thumbTrack.trackDisabledColor = [self trackBackgroundColorForState:UIControlStateDisabled];
 }
 
 #pragma mark - ThumbTrack passthrough methods
@@ -434,6 +442,14 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
 
 - (UIColor *)color {
   return _thumbTrack.primaryColor;
+}
+
+@end
+
+@implementation MDCSlider (Private)
+
+- (MDCThumbTrack *)thumbTrack {
+  return _thumbTrack;
 }
 
 @end

--- a/components/Slider/src/private/MDCSlider+Private.h
+++ b/components/Slider/src/private/MDCSlider+Private.h
@@ -1,0 +1,22 @@
+/*
+ Copyright 2015-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCSlider.h"
+#import "MaterialThumbTrack.h"
+
+@interface MDCSlider (Private)
+@property(nonatomic, nonnull, readonly) MDCThumbTrack *thumbTrack;
+@end

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -16,6 +16,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import "MDCSlider+Private.h"
 #import "MaterialPalettes.h"
 #import "MaterialThumbTrack.h"
 #import "MaterialSlider.h"
@@ -297,6 +298,31 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
   // Then
   XCTAssertEqualObjects(self.slider.trackBackgroundColor, self.defaultGray);
+}
+
+- (void)testThumbColorForStateFallback {
+  // When
+  [self.slider setThumbColor:UIColor.purpleColor forState:UIControlStateNormal];
+
+  // Then
+  NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
+      UIControlStateHighlighted | UIControlStateDisabled;
+  for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    XCTAssertEqualObjects([self.slider thumbColorForState:state], UIColor.purpleColor);
+  }
+}
+
+- (void)testThumbColorForStateAppliesToThumbTrack {
+  // When
+  [self.slider setThumbColor:UIColor.purpleColor forState:UIControlStateNormal];
+
+  // Then
+  NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
+  UIControlStateHighlighted | UIControlStateDisabled;
+  for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    XCTAssertEqualObjects(self.slider.thumbTrack.thumbEnabledColor,
+                          [self.slider thumbColorForState:state]);
+  }
 }
 
 #pragma mark Thumb


### PR DESCRIPTION
The Slider should have more targeted properties for performing customization.
Specifically, it should permit:

* `activeTrackColor` - the "filled" portion of the track. Enabled/Disabled
* `inactiveTrackColor` - the "unfilled" portion of the track. Enabled/Disabled.
* `activeTickMarkColor` - the color of tick marks in the "filled" portion of
   the rail/track. Enabled/Disabled.
* `inactiveTickMarkColor` - the color of tick marks in the "unfilled" portion
   of the rail/track. Enabled/Disabled.
* `thumbColor` - the color of the thumb when not tapped/pressed.
   Normal/Highlighted/Disabled
* `valueLabelTextColor` - the color of the pop-up value label's text
* `valueLabelBackgroundColor` - the color of the pop-up value label's background

# Important
This is an API review. Please do not merge (it's marked WIP for this reason), but provide feedback on the API.

Closes #3137

Pivotal story: https://www.pivotaltracker.com/story/show/155525171