### PR TITLE
[FeatureHighlight] Copy block instead of assign

### DIFF
--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.h
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.h
@@ -29,7 +29,7 @@ typedef void (^MDCFeatureHighlightInteractionBlock)(BOOL accepted);
 @property(nonatomic, strong) UIView *displayedView;
 @property(nonatomic, strong) UILabel *titleLabel;
 @property(nonatomic, strong) UILabel *bodyLabel;
-@property(nonatomic, strong) MDCFeatureHighlightInteractionBlock interactionBlock;
+@property(nonatomic, copy) MDCFeatureHighlightInteractionBlock interactionBlock;
 
 @end
 


### PR DESCRIPTION
Since blocks are allocated on the stack, they need to be copied before
being retained within properties to ensure they won't be overwritten.
