### PR TITLE
[Snackbar] Update content padding for new snackbar, leave old snackbar padding as is.

### DIFF
--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -84,10 +84,9 @@ static const CGFloat kButtonPadding = 8.0f;
 
 
 /**
- Min/Max Padding for the vertical padding of the buttons to the snackbar
+ Minimum padding for the vertical padding of the buttons to the snackbar
  */
 static const CGFloat kMinVerticalButtonPadding = 6.0f;
-static const CGFloat kMaxVerticalButtonPadding = 16.0f;
 
 /**
  The width of the snackbar.
@@ -394,7 +393,10 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
     button.titleLabel.numberOfLines = 1;
     button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
     button.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
-    button.contentEdgeInsets = UIEdgeInsetsMake(0, buttonContentPadding, 0, buttonContentPadding);
+    button.contentEdgeInsets = UIEdgeInsetsMake(buttonContentPadding,
+                                                buttonContentPadding,
+                                                buttonContentPadding,
+                                                buttonContentPadding);
 
     // Set up the button's accessibility values.
     button.accessibilityIdentifier = message.action.accessibilityIdentifier;
@@ -676,7 +678,6 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
     @"kTitleButtonPadding" : @(kTitleButtonPadding),
     @"kContentSafeBottomInset" : @(kBorderWidth +  self.contentSafeBottomInset),
     @"kMinVerticalButtonPadding": @(kMinVerticalButtonPadding),
-    @"kMaxVerticalButtonPadding": @(kMaxVerticalButtonPadding),
   };
   NSDictionary *views = @{
     @"container" : self.containerView,
@@ -742,10 +743,11 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
   } else {  // This is a horizontal layout, and there are buttons present.
     // Align the content and buttons horizontally.
     formatString = @"H:[content]-(==kTitleButtonPadding)-[buttons]-(==kRightMargin)-|";
-    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:formatString
-                                                                             options:0
-                                                                             metrics:metrics
-                                                                               views:views]];
+    [constraints addObjectsFromArray:
+        [NSLayoutConstraint constraintsWithVisualFormat:formatString
+                                                options:NSLayoutFormatAlignAllCenterY
+                                                metrics:metrics
+                                                  views:views]];
 
     if (MDCSnackbarMessage.usesLegacySnackbar) {
       // The buttons should take up the entire height of the container view.
@@ -755,13 +757,12 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
                                                                                metrics:metrics
                                                                                  views:views]];
     } else {
-      [self snackbarMessageLineCount];
-      formatString = @"V:|-(>=kMinVerticalButtonPadding,<=kMaxVerticalButtonPadding)"
-          "-[buttons]-(>=kMinVerticalButtonPadding,<=kMaxVerticalButtonPadding)-|";
-      [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:formatString
-                                                                               options:0
-                                                                               metrics:metrics
-                                                                                 views:views]];
+      formatString = @"V:|-(>=kMinVerticalButtonPadding)-[buttons]-(>=kMinVerticalButtonPadding)-|";
+      [constraints addObjectsFromArray:
+          [NSLayoutConstraint constraintsWithVisualFormat:formatString
+                                                  options:NSLayoutFormatAlignAllCenterY
+                                                  metrics:metrics
+                                                    views:views]];
     }
 
     // Pin the content to the bottom of the container view, since there's nothing below.
@@ -920,16 +921,6 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
   }];
 
   return constraints;
-}
-
-- (CGFloat)snackbarMessageLineCount {
-  NSInteger lineCount = 0;
-  CGSize textSize = CGSizeMake(_label.frame.size.width, MAXFLOAT);
-  CGFloat rHeight = MDCRound([_label sizeThatFits:textSize].height);
-  CGFloat charSize = MDCRound(_label.font.lineHeight);
-  lineCount = NSInteger( MDCCeil(rHeight/charSize) );
-  NSLog(@"No of lines: %i",lineCount);
-  return lineCount;
 }
 
 - (void)layoutSubviews {

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -21,6 +21,7 @@
 
 #import "MaterialAnimationTiming.h"
 #import "MaterialButtons.h"
+#import "MaterialMath.h"
 #import "MaterialTypography.h"
 #import "private/MaterialSnackbarStrings.h"
 #import "private/MaterialSnackbarStrings_table.h"
@@ -754,7 +755,9 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
                                                                                metrics:metrics
                                                                                  views:views]];
     } else {
-      formatString = @"V:|[buttons]|";
+      [self snackbarMessageLineCount];
+      formatString = @"V:|-(>=kMinVerticalButtonPadding,<=kMaxVerticalButtonPadding)"
+          "-[buttons]-(>=kMinVerticalButtonPadding,<=kMaxVerticalButtonPadding)-|";
       [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:formatString
                                                                                options:0
                                                                                metrics:metrics
@@ -917,6 +920,16 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
   }];
 
   return constraints;
+}
+
+- (CGFloat)snackbarMessageLineCount {
+  NSInteger lineCount = 0;
+  CGSize textSize = CGSizeMake(_label.frame.size.width, MAXFLOAT);
+  CGFloat rHeight = MDCRound([_label sizeThatFits:textSize].height);
+  CGFloat charSize = MDCRound(_label.font.lineHeight);
+  lineCount = NSInteger( MDCCeil(rHeight/charSize) );
+  NSLog(@"No of lines: %i",lineCount);
+  return lineCount;
 }
 
 - (void)layoutSubviews {

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -21,7 +21,6 @@
 
 #import "MaterialAnimationTiming.h"
 #import "MaterialButtons.h"
-#import "MaterialMath.h"
 #import "MaterialTypography.h"
 #import "private/MaterialSnackbarStrings.h"
 #import "private/MaterialSnackbarStrings_table.h"

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -62,7 +62,8 @@ static const CGFloat kLegacyCornerRadius = 0;
 /**
  Padding between the edges of the snackbar and any content.
  */
-static UIEdgeInsets kContentMargin = (UIEdgeInsets){18.0, 24.0, 18.0, 24.0};
+static UIEdgeInsets kContentMargin = (UIEdgeInsets){16.0, 16.0, 16.0, 8.0};
+static UIEdgeInsets kLegacyContentMargin = (UIEdgeInsets){18.0, 24.0, 18.0, 24.0};
 
 /**
  Padding between the image and the main title.
@@ -77,7 +78,8 @@ static const CGFloat kTitleButtonPadding = 8.0f;
 /**
  Padding on the edges of the buttons.
  */
-static const CGFloat kButtonPadding = 5.0f;
+static const CGFloat kLegacyButtonPadding = 5.0f;
+static const CGFloat kButtonPadding = 8.0f;
 
 /**
  The width of the snackbar.
@@ -374,7 +376,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
     }
 #pragma clang diagnostic pop
 
-
+    CGFloat buttonContentPadding = [self buttonContentPadding];
     [button setTranslatesAutoresizingMaskIntoConstraints:NO];
     button.tag = kButtonTagStart;
     [buttonView addSubview:button];
@@ -384,7 +386,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
     button.titleLabel.numberOfLines = 1;
     button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
     button.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
-    button.contentEdgeInsets = UIEdgeInsetsMake(0, kButtonPadding, 0, kButtonPadding);
+    button.contentEdgeInsets = UIEdgeInsetsMake(0, buttonContentPadding, 0, buttonContentPadding);
 
     // Set up the button's accessibility values.
     button.accessibilityIdentifier = message.action.accessibilityIdentifier;
@@ -404,7 +406,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
 
     CGSize buttonSize = [button sizeThatFits:CGSizeMake(CGFLOAT_MAX,CGFLOAT_MAX)];
     availableTextWidth -= buttonSize.width;
-    availableTextWidth -= 2 * kButtonPadding;
+    availableTextWidth -= 2 * buttonContentPadding;
 
     [actions addObject:buttonView];
   }
@@ -611,6 +613,10 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
   }
 
   [self setNeedsLayout];
+}
+
+- (CGFloat)buttonContentPadding {
+  return MDCSnackbarMessage.usesLegacySnackbar ? kLegacyButtonPadding : kButtonPadding;
 }
 
 - (BOOL)shouldWaitForDismissalDuringVoiceover {
@@ -833,7 +839,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
     @"kTitleImagePadding" : @(kTitleImagePadding),
     @"kBorderMargin" : @(kBorderWidth),
     @"kTitleButtonPadding" : @(kTitleButtonPadding),
-    @"kButtonPadding" : @(kButtonPadding),
+    @"kButtonPadding" : @([self buttonContentPadding]),
   };
 
   __block UIView *previousButton = nil;
@@ -940,7 +946,8 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
 }
 
 - (UIEdgeInsets)safeContentMargin {
-  UIEdgeInsets contentMargin = kContentMargin;
+  UIEdgeInsets contentMargin =
+      MDCSnackbarMessage.usesLegacySnackbar ? kLegacyContentMargin : kContentMargin;
 
   UIEdgeInsets safeAreaInsets = UIEdgeInsetsZero;
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -382,7 +382,8 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
     }
 #pragma clang diagnostic pop
 
-    CGFloat buttonContentPadding = [self buttonContentPadding];
+    CGFloat buttonContentPadding =
+        MDCSnackbarMessage.usesLegacySnackbar ? kLegacyButtonPadding : kButtonPadding;
     [button setTranslatesAutoresizingMaskIntoConstraints:NO];
     button.tag = kButtonTagStart;
     [buttonView addSubview:button];
@@ -624,10 +625,6 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
   [self setNeedsLayout];
 }
 
-- (CGFloat)buttonContentPadding {
-  return MDCSnackbarMessage.usesLegacySnackbar ? kLegacyButtonPadding : kButtonPadding;
-}
-
 - (BOOL)shouldWaitForDismissalDuringVoiceover {
   return self.message.action != nil;
 }
@@ -859,7 +856,8 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
     @"kTitleImagePadding" : @(kTitleImagePadding),
     @"kBorderMargin" : @(kBorderWidth),
     @"kTitleButtonPadding" : @(kTitleButtonPadding),
-    @"kButtonPadding" : @([self buttonContentPadding]),
+    @"kButtonPadding" :
+        @(MDCSnackbarMessage.usesLegacySnackbar ? kLegacyButtonPadding : kButtonPadding),
   };
 
   __block UIView *previousButton = nil;

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -81,6 +81,13 @@ static const CGFloat kTitleButtonPadding = 8.0f;
 static const CGFloat kLegacyButtonPadding = 5.0f;
 static const CGFloat kButtonPadding = 8.0f;
 
+
+/**
+ Min/Max Padding for the vertical padding of the buttons to the snackbar
+ */
+static const CGFloat kMinVerticalButtonPadding = 6.0f;
+static const CGFloat kMaxVerticalButtonPadding = 16.0f;
+
 /**
  The width of the snackbar.
  */
@@ -667,6 +674,8 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
     @"kTopMargin" : @(self.safeContentMargin.top),
     @"kTitleButtonPadding" : @(kTitleButtonPadding),
     @"kContentSafeBottomInset" : @(kBorderWidth +  self.contentSafeBottomInset),
+    @"kMinVerticalButtonPadding": @(kMinVerticalButtonPadding),
+    @"kMaxVerticalButtonPadding": @(kMaxVerticalButtonPadding),
   };
   NSDictionary *views = @{
     @"container" : self.containerView,
@@ -737,12 +746,20 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
                                                                              metrics:metrics
                                                                                views:views]];
 
-    // The buttons should take up the entire height of the container view.
-    formatString = @"V:|[buttons]|";
-    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:formatString
-                                                                             options:0
-                                                                             metrics:metrics
-                                                                               views:views]];
+    if (MDCSnackbarMessage.usesLegacySnackbar) {
+      // The buttons should take up the entire height of the container view.
+      formatString = @"V:|[buttons]|";
+      [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:formatString
+                                                                               options:0
+                                                                               metrics:metrics
+                                                                                 views:views]];
+    } else {
+      formatString = @"V:|[buttons]|";
+      [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:formatString
+                                                                               options:0
+                                                                               metrics:metrics
+                                                                                 views:views]];
+    }
 
     // Pin the content to the bottom of the container view, since there's nothing below.
     formatString = @"V:[content]-(==kBottomMargin)-|";


### PR DESCRIPTION
Legacy snackbar should visually look the same before and after changes.

**Before pics for legacy and non-legacy snackbar:**
iPhone X, old snackbar, short text, button not tapped
![screen shot 2018-03-29 at 4 35 41 pm](https://user-images.githubusercontent.com/4066863/38112749-e513e00c-3370-11e8-9f04-e89646e37e55.png)

iPhone X, old snackbar, long text, button not tapped
![screen shot 2018-03-29 at 4 35 45 pm](https://user-images.githubusercontent.com/4066863/38112750-e52ffa76-3370-11e8-811d-ba235ebb19c0.png)

iPhone X, new snackbar, short text, button not tapped
![screen shot 2018-03-29 at 4 35 50 pm](https://user-images.githubusercontent.com/4066863/38112751-e55e3daa-3370-11e8-88a1-bac003c0dd1e.png)

iPhone X, new snackbar, long text, button not tapped
![screen shot 2018-03-29 at 4 35 54 pm](https://user-images.githubusercontent.com/4066863/38112753-e5ad2b7c-3370-11e8-94af-3edb400c0926.png)

iPhone X, new snackbar, short text, button tapped
![untitled](https://user-images.githubusercontent.com/4066863/38112754-e5d1025e-3370-11e8-8343-205c8f9843ba.png)

iPhone X, old snackbar, short text, button tapped
![untitled2](https://user-images.githubusercontent.com/4066863/38112755-e5eef0c0-3370-11e8-8890-ca2ac426a677.png)


**After pics for legacy and non-legacy snackbar:**
iPhone X, new snackbar, long text, button not tapped
![screen shot 2018-03-29 at 4 26 49 pm](https://user-images.githubusercontent.com/4066863/38112406-d48cfb70-336f-11e8-99c0-8a6e9d35e3e5.png)

iPhone X, new snackbar, short text, button not tapped
![screen shot 2018-03-29 at 4 27 05 pm](https://user-images.githubusercontent.com/4066863/38112448-f26a6308-336f-11e8-9837-e740340f62e5.png)

iPhone X, old snackbar, short text, button not tapped
![screen shot 2018-03-29 at 4 27 15 pm](https://user-images.githubusercontent.com/4066863/38112497-22761088-3370-11e8-86fd-e5b01b3171d5.png)

iPhone X, old snackbar, long text, button not tapped
![screen shot 2018-03-29 at 4 27 20 pm](https://user-images.githubusercontent.com/4066863/38112512-2e0f1b74-3370-11e8-95bd-bf9a32008280.png)

iPhone X, new snackbar, long text, button tapped
![untitled](https://user-images.githubusercontent.com/4066863/38112576-648e769a-3370-11e8-9477-b9eb3d532e94.png)

iPhone X, new snackbar, short text, button tapped
![untitled2](https://user-images.githubusercontent.com/4066863/38112577-6496cc5a-3370-11e8-9dc7-b57f3c93ee4b.png)

iPhone X, old snackbar, long text, button tapped
![untitled3](https://user-images.githubusercontent.com/4066863/38112578-64a1ad14-3370-11e8-9654-936a0d90bae1.png)

iPhone X, old snackbar, short text, button tapped
![untitled4](https://user-images.githubusercontent.com/4066863/38112579-64ae3a84-3370-11e8-8019-d2ed4739fbce.png)

iPhone 8, new snackbar, long text, button not tapped
![screen shot 2018-03-29 at 4 29 11 pm](https://user-images.githubusercontent.com/4066863/38112747-e4da4b6c-3370-11e8-9911-bd3858faf808.png)

iPhone 8, old snackbar, long text, button not tapped
![screen shot 2018-03-29 at 4 29 21 pm](https://user-images.githubusercontent.com/4066863/38112748-e4f8b296-3370-11e8-9636-8b476cea4e08.png)

