### PR TITLE
[NavigationBar] Fix RTL for titleView

### DIFF
--- a/components/NavigationBar/examples/NavigationBarRTLIcons.m
+++ b/components/NavigationBar/examples/NavigationBarRTLIcons.m
@@ -1,0 +1,134 @@
+/*
+ Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+#import <UIKit/UIKit.h>
+
+#import "NavigationBarTypicalUseExampleSupplemental.h"
+
+#import <MDFInternationalization/MDFInternationalization.h>
+
+#import "MaterialIcons+ic_arrow_back.h"
+#import "MaterialIcons+ic_info.h"
+#import "MaterialIcons+ic_reorder.h"
+#import "MaterialIcons+ic_check_circle.h"
+#import "MaterialNavigationBar.h"
+#import "supplemental/NavigationBarTypicalUseExampleSupplemental.h"
+
+@interface NavigationBarRTL : UIViewController
+
+@property(nonatomic, strong) MDCNavigationBar *navigationBar;
+
+@end
+
+
+@implementation NavigationBarRTL
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  self.title = @"Slightly Long Title";
+  self.view.backgroundColor = UIColor.darkGrayColor;
+
+  self.navigationBar = [[MDCNavigationBar alloc] initWithFrame:CGRectZero];
+  self.navigationBar.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.navigationBar observeNavigationItem:self.navigationItem];
+  self.navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName : UIColor.whiteColor};
+
+  UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
+  label.text = self.title;
+  label.textColor = [UIColor whiteColor];
+  self.navigationBar.titleView = label;
+
+  [self.view addSubview:self.navigationBar];
+
+  UIBarButtonItem *infoButtonItem = [[UIBarButtonItem alloc]
+      initWithImage:[[MDCIcons imageFor_ic_info]
+                        imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]
+              style:UIBarButtonItemStylePlain
+             target:nil
+             action:nil];
+  UIBarButtonItem *reorderButtonItem = [[UIBarButtonItem alloc]
+      initWithImage:[[MDCIcons imageFor_ic_reorder]
+                        imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]
+              style:UIBarButtonItemStylePlain
+             target:nil
+             action:nil];
+  UIBarButtonItem *checkCircleButtonItem =
+    [[UIBarButtonItem alloc] initWithImage:[[MDCIcons imageFor_ic_check_circle]
+                                            imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]
+                                     style:UIBarButtonItemStylePlain
+                                    target:nil
+                                    action:nil];
+
+  self.navigationBar.tintColor = UIColor.whiteColor;
+  self.navigationItem.rightBarButtonItems = @[ infoButtonItem, reorderButtonItem, checkCircleButtonItem];
+
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    [self.view.safeAreaLayoutGuide.topAnchor constraintEqualToAnchor:self.navigationBar.topAnchor].active = YES;
+  } else {
+#endif
+    [NSLayoutConstraint constraintWithItem:self.topLayoutGuide
+                                 attribute:NSLayoutAttributeBottom
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:self.navigationBar
+                                 attribute:NSLayoutAttributeTop
+                                multiplier:1.0
+                                  constant:0].active = YES;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  }
+#endif
+  NSDictionary *viewsBindings = NSDictionaryOfVariableBindings(_navigationBar);
+
+  [NSLayoutConstraint
+      activateConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_navigationBar]|"
+                                                                  options:0
+                                                                  metrics:nil
+                                                                    views:viewsBindings]];
+}
+
+- (BOOL)prefersStatusBarHidden {
+  return NO;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+  [super viewWillAppear:animated];
+
+  [self.navigationController setNavigationBarHidden:YES animated:animated];
+}
+
+- (void)didTapBackButton {
+  [self.navigationController popViewControllerAnimated:YES];
+}
+
+#pragma mark - CatalogByConvention
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Navigation Bar", @"Navigation Bar TitleView RTL" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return YES;
+}
+
++ (BOOL)catalogIsPresentable {
+  return NO;
+}
+
+@end

--- a/components/NavigationBar/examples/NavigationBarRTLIcons.m
+++ b/components/NavigationBar/examples/NavigationBarRTLIcons.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -119,6 +119,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 
 @interface MDCNavigationBar (PrivateAPIs)
 
+/// titleLabel is hidden if there is a titleView. When not hidden, displays self.title.
 - (UILabel *)titleLabel;
 - (MDCButtonBar *)leadingButtonBar;
 - (MDCButtonBar *)trailingButtonBar;
@@ -324,6 +325,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 
   UIEdgeInsets textInsets = [self usePadInsets] ? kTextPadInsets : kTextInsets;
 
+  // textFrame is used to determine layout of both TitleLabel and TitleView
   CGRect textFrame = UIEdgeInsetsInsetRect(self.bounds, textInsets);
   textFrame.origin.x += _leadingButtonBar.frame.size.width;
   textFrame.size.width -= _leadingButtonBar.frame.size.width + _trailingButtonBar.frame.size.width;
@@ -334,6 +336,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   }
 #endif
 
+  // Layout TitleLabel
   NSMutableParagraphStyle *paraStyle = [[NSMutableParagraphStyle alloc] init];
   paraStyle.lineBreakMode = _titleLabel.lineBreakMode;
 
@@ -356,8 +359,12 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
                                             withinBounds:textFrame
                                                alignment:titleVerticalAlignment];
   alignedFrame = [self mdc_frameAlignedHorizontally:alignedFrame alignment:self.titleAlignment];
-
   _titleLabel.frame = MDCRectAlignToScale(alignedFrame, self.window.screen.scale);
+
+  // Layout TitleView
+  if (self.mdf_effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
+    textFrame = MDFRectFlippedHorizontally(textFrame, CGRectGetWidth(self.bounds));
+  }
   self.titleView.frame = textFrame;
 
   // Button and title label alignment


### PR DESCRIPTION
We were applying RTL to titleLabel, but not titleView.

cl/190110908

Imported fix and added test sample for Dragons.

Previous RTL with overlapping views

![screen shot 2018-03-29 at 18 44 07](https://user-images.githubusercontent.com/1121006/38117330-5a48a86a-3382-11e8-9b52-d655c8b263f5.png)

Fixed RTL with proper layout

![screen shot 2018-03-29 at 18 36 01](https://user-images.githubusercontent.com/1121006/38117338-636ec032-3382-11e8-824a-567b64b92c91.png)
