### PR TITLE
[FlexibleHeader] Fix bug where shadow layer's opacity wouldn't be set without a tracking scroll view.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -910,6 +910,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 
 - (void)fhv_updateLayout {
   if (!_trackingScrollView) {
+    [self fhv_commitAccumulatorToFrame];
     return;
   }
 


### PR DESCRIPTION
This would result in the flexible header's shadow appearing when it wasn't expected to.

Closes https://github.com/material-components/material-components-ios/issues/3200
