### PR TITLE
[AppBar] Color Themer now composes to the FlexibleHeader and NavigationBar color themers.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -40,6 +40,7 @@ fix_bazel_imports() {
   }
 
   stashed_dir=""
+  rewrite_tests "s/import MaterialComponents.MDC(.+)ColorThemer/import components_\1_ColorThemer/"
   rewrite_tests "s/import MaterialComponents.MaterialMath/import components_private_Math_Math/"
   rewrite_tests "s/import MaterialComponents.Material(.+)/import components_\1_\1/"
   rewrite_source "s/import <Motion(.+)\/Motion.+\.h>/import \"Motion\1.h\"/"
@@ -49,6 +50,7 @@ fix_bazel_imports() {
   stashed_dir="$(pwd)/"
   reset_imports() {
     # Undoes our source changes from above.
+    rewrite_tests "s/import components_(.+)_ColorThemer/import MaterialComponents.MDC\1ColorThemer/"
     rewrite_tests "s/import components_private_Math_Math/import MaterialComponents.MaterialMath/"
     rewrite_tests "s/import components_(.+)_.+/import MaterialComponents.Material\1/"
     rewrite_source "s/import \"Motion(.+)\.h\"/import <Motion\1\/Motion\1.h>/"

--- a/components/AppBar/BUILD
+++ b/components/AppBar/BUILD
@@ -66,6 +66,8 @@ mdc_objc_library(
     deps = [
         ":AppBar",
         "//components/Themes",
+        "//components/FlexibleHeader:ColorThemer",
+        "//components/NavigationBar:ColorThemer",
     ],
     visibility = ["//visibility:public"],
 )

--- a/components/AppBar/src/ColorThemer/MDCAppBarColorThemer.m
+++ b/components/AppBar/src/ColorThemer/MDCAppBarColorThemer.m
@@ -16,11 +16,17 @@
 
 #import "MDCAppBarColorThemer.h"
 
+#import "MDCFlexibleHeaderColorThemer.h"
+#import "MDCNavigationBarColorThemer.h"
+
 @implementation MDCAppBarColorThemer
 
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme
                 toAppBar:(MDCAppBar *)appBar {
-  appBar.headerViewController.headerView.backgroundColor = colorScheme.primaryColor;
+  [MDCFlexibleHeaderColorThemer applyColorScheme:colorScheme
+                   toMDCFlexibleHeaderController:appBar.headerViewController];
+  [MDCNavigationBarColorThemer applyColorScheme:colorScheme
+                                toNavigationBar:appBar.navigationBar];
 }
 
 @end

--- a/components/AppBar/tests/unit/AppBarColorThemerTests.swift
+++ b/components/AppBar/tests/unit/AppBarColorThemerTests.swift
@@ -16,6 +16,7 @@
 
 import XCTest
 import MaterialComponents.MaterialAppBar
+import MaterialComponents.MaterialThemes
 
 class AppBarColorThemerTests: XCTestCase {
 

--- a/components/AppBar/tests/unit/AppBarColorThemerTests.swift
+++ b/components/AppBar/tests/unit/AppBarColorThemerTests.swift
@@ -1,5 +1,5 @@
 /*
- Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -20,11 +20,14 @@ import MaterialComponents.MaterialAppBar
 class AppBarColorThemerTests: XCTestCase {
 
   func testColorThemerAffectsSubComponents() {
+    // Given
     let appBar = MDCAppBar()
     let colorScheme = MDCBasicColorScheme(primaryColor: .red)
 
+    // When
     MDCAppBarColorThemer.apply(colorScheme, to: appBar)
 
+    // Then
     XCTAssertEqual(appBar.headerViewController.headerView.backgroundColor,
                    colorScheme.primaryColor)
     XCTAssertEqual(appBar.navigationBar.backgroundColor,

--- a/components/AppBar/tests/unit/AppBarColorThemerTests.swift
+++ b/components/AppBar/tests/unit/AppBarColorThemerTests.swift
@@ -1,0 +1,33 @@
+/*
+ Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents.MaterialAppBar
+
+class AppBarColorThemerTests: XCTestCase {
+
+  func testColorThemerAffectsSubComponents() {
+    let appBar = MDCAppBar()
+    let colorScheme = MDCBasicColorScheme(primaryColor: .red)
+
+    MDCAppBarColorThemer.apply(colorScheme, to: appBar)
+
+    XCTAssertEqual(appBar.headerViewController.headerView.backgroundColor,
+                   colorScheme.primaryColor)
+    XCTAssertEqual(appBar.navigationBar.backgroundColor,
+                   colorScheme.primaryColor)
+  }
+}

--- a/components/AppBar/tests/unit/AppBarColorThemerTests.swift
+++ b/components/AppBar/tests/unit/AppBarColorThemerTests.swift
@@ -16,6 +16,7 @@
 
 import XCTest
 import MaterialComponents.MaterialAppBar
+import MaterialComponents.MDCAppBarColorThemer
 import MaterialComponents.MaterialThemes
 
 class AppBarColorThemerTests: XCTestCase {


### PR DESCRIPTION
This ensures that we're not duplicating the sub-component themer logic.

Also added a unit test to ensure that the desired mappings do take effect.

Closes pivotal story: https://www.pivotaltracker.com/story/show/156438987