### PR TITLE
[Catalog] Make the catalog's color scheme a static on AppDelegate.

### DIFF
--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -41,7 +41,10 @@ import MaterialComponents.MaterialThemes
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
   var window: UIWindow?
-  var colorScheme: (MDCColorScheme & NSObjectProtocol)!
+  static var colorScheme: MDCColorScheme =
+      MDCBasicColorScheme(primaryColor: .init(white: 33 / 255.0, alpha: 1),
+                          primaryLightColor: .init(white: 0.7, alpha: 1),
+                          primaryDarkColor: .init(white: 0, alpha: 1))
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions
                    launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
@@ -64,11 +67,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     self.window?.rootViewController = navigationController
     self.window?.makeKeyAndVisible()
 
-    colorScheme = MDCBasicColorScheme(primaryColor: .init(white: 33 / 255.0, alpha: 1),
-                                      primaryLightColor: .init(white: 0.7, alpha: 1),
-                                      primaryDarkColor: .init(white: 0, alpha: 1))
-
     // Apply color scheme to material design components using component themers.
+    let colorScheme = AppDelegate.colorScheme
     MDCActivityIndicatorColorThemer.apply(colorScheme, to: MDCActivityIndicator.appearance())
     MDCAlertColorThemer.apply(colorScheme)
     MDCBottomAppBarColorThemer.apply(colorScheme, to: MDCBottomAppBarView.appearance())
@@ -98,8 +98,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                   toAllControllersOfClass: MDCTextInputControllerOutlinedTextArea.self)
 
     // Apply color scheme to UIKit components.
-    UISlider.appearance().tintColor = colorScheme?.primaryColor
-    UISwitch.appearance().onTintColor = colorScheme?.primaryColor
+    UISlider.appearance().tintColor = colorScheme.primaryColor
+    UISwitch.appearance().onTintColor = colorScheme.primaryColor
 
     return true
   }

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -101,9 +101,10 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
   }
 
   func colorThemeChanged(notification: NSNotification) {
-    let colorScheme = notification.userInfo?["colorScheme"]
-    let appDelegate = UIApplication.shared.delegate as! AppDelegate
-    appDelegate.colorScheme = colorScheme as? (MDCColorScheme & NSObjectProtocol)!
+    guard let colorScheme = notification.userInfo?["colorScheme"] as? MDCColorScheme else {
+      return
+    }
+    AppDelegate.colorScheme = colorScheme
 
     collectionView?.collectionViewLayout.invalidateLayout()
     collectionView?.reloadData()
@@ -158,14 +159,12 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
 
     headerViewController.headerView.addSubview(logo)
 
-    let appDelegate = UIApplication.shared.delegate as! AppDelegate
-
     let image = MDCDrawImage(CGRect(x:0,
                                     y:0,
                                     width: Constants.logoWidthHeight,
                                     height: Constants.logoWidthHeight),
                              { MDCCatalogDrawMDCLogoLight($0, $1) },
-                             appDelegate.colorScheme)
+                             AppDelegate.colorScheme)
     logo.image = image
 
     NSLayoutConstraint(item: logo,

--- a/catalog/MDCCatalog/MDCCatalogTileView.swift
+++ b/catalog/MDCCatalog/MDCCatalogTileView.swift
@@ -74,7 +74,7 @@ class MDCCatalogTileView: UIView {
     var newImage: UIImage?
 
     let appDelegate = UIApplication.shared.delegate as! AppDelegate
-    let colorScheme = appDelegate.colorScheme
+    let colorScheme = AppDelegate.colorScheme
 
     switch componentNameString {
     case "Activity Indicator":

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -91,9 +91,8 @@ class MDCNodeListViewController: CBCNodeListViewController {
       appBarFont = UIFont(descriptor: descriptor, size: 16)
     }
 
-    let appDelegate = UIApplication.shared.delegate as! AppDelegate
-    let colorScheme = appDelegate.colorScheme
-    MDCFlexibleHeaderColorThemer.apply(colorScheme!, to: MDCFlexibleHeaderView.appearance())
+    let colorScheme = AppDelegate.colorScheme
+    MDCFlexibleHeaderColorThemer.apply(colorScheme, to: MDCFlexibleHeaderView.appearance())
 
     appBar.navigationBar.tintColor = UIColor.white
     appBar.navigationBar.titleTextAttributes = [
@@ -391,9 +390,8 @@ extension MDCNodeListViewController {
         container.appBar.navigationBar.titleTextAttributes =
             [ NSForegroundColorAttributeName: UIColor.white, NSFontAttributeName: appBarFont ]
 
-        let appDelegate = UIApplication.shared.delegate as! AppDelegate
-        let colorScheme = appDelegate.colorScheme
-        MDCFlexibleHeaderColorThemer.apply(colorScheme!, to: MDCFlexibleHeaderView.appearance())
+        let colorScheme = AppDelegate.colorScheme
+        MDCFlexibleHeaderColorThemer.apply(colorScheme, to: MDCFlexibleHeaderView.appearance())
         let textColor = UIColor.white
         UIBarButtonItem.appearance().setTitleTextAttributes(
           [NSForegroundColorAttributeName: textColor],


### PR DESCRIPTION
This makes it possible to refer to the app's global color scheme without having to cast the app delegate instance.

Part of pivotal story: https://www.pivotaltracker.com/story/show/156387038