### PR TITLE
[Catalog] Remove all references to UIAppearance.

### DIFF
--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -67,40 +67,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     self.window?.rootViewController = navigationController
     self.window?.makeKeyAndVisible()
 
-    // Apply color scheme to material design components using component themers.
-    let colorScheme = AppDelegate.colorScheme
-    MDCActivityIndicatorColorThemer.apply(colorScheme, to: MDCActivityIndicator.appearance())
-    MDCAlertColorThemer.apply(colorScheme)
-    MDCBottomAppBarColorThemer.apply(colorScheme, to: MDCBottomAppBarView.appearance())
-    MDCBottomNavigationBarColorThemer.apply(colorScheme, to:MDCBottomNavigationBar.appearance())
-    MDCButtonBarColorThemer.apply(colorScheme, to: MDCButtonBar.appearance())
-    MDCButtonColorThemer.apply(colorScheme, to: MDCButton.appearance())
-    let clearScheme = MDCBasicColorScheme(primaryColor: .clear)
-    MDCButtonColorThemer.apply(clearScheme, to:MDCFlatButton.appearance())
-    MDCFeatureHighlightColorThemer.apply(colorScheme, to: MDCFeatureHighlightView.appearance())
-    MDCFlexibleHeaderColorThemer.apply(colorScheme, to: MDCFlexibleHeaderView.appearance())
-    MDCHeaderStackViewColorThemer.apply(colorScheme, to: MDCHeaderStackView.appearance())
-    MDCNavigationBarColorThemer.apply(colorScheme, to: MDCNavigationBar.appearance())
-    MDCPageControlColorThemer.apply(colorScheme, to: MDCPageControl.appearance())
-    MDCProgressViewColorThemer.apply(colorScheme, to: MDCProgressView.appearance())
-    MDCSliderColorThemer.apply(colorScheme, to: MDCSlider.appearance())
-    MDCTabBarColorThemer.apply(colorScheme, to: MDCTabBar.appearance())
-
-    MDCTextFieldColorThemer.apply(colorScheme,
-                                  toAllControllersOfClass: MDCTextInputControllerUnderline.self)
-    MDCTextFieldColorThemer.apply(colorScheme,
-                                  toAllControllersOfClass: MDCTextInputControllerLegacyDefault.self)
-    MDCTextFieldColorThemer.apply(colorScheme,
-                                  toAllControllersOfClass: MDCTextInputControllerFilled.self)
-    MDCTextFieldColorThemer.apply(colorScheme,
-                                  toAllControllersOfClass: MDCTextInputControllerOutlined.self)
-    MDCTextFieldColorThemer.apply(colorScheme,
-                                  toAllControllersOfClass: MDCTextInputControllerOutlinedTextArea.self)
-
-    // Apply color scheme to UIKit components.
-    UISlider.appearance().tintColor = colorScheme.primaryColor
-    UISwitch.appearance().onTintColor = colorScheme.primaryColor
-
     return true
   }
 }

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -91,14 +91,12 @@ class MDCNodeListViewController: CBCNodeListViewController {
       appBarFont = UIFont(descriptor: descriptor, size: 16)
     }
 
-    let colorScheme = AppDelegate.colorScheme
-    MDCFlexibleHeaderColorThemer.apply(colorScheme, to: MDCFlexibleHeaderView.appearance())
-
     appBar.navigationBar.tintColor = UIColor.white
     appBar.navigationBar.titleTextAttributes = [
       NSForegroundColorAttributeName: UIColor.white,
       NSFontAttributeName: appBarFont ]
     appBar.navigationBar.titleAlignment = .center
+    MDCAppBarColorThemer.apply(AppDelegate.colorScheme, to: appBar)
   }
 
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
@@ -389,13 +387,6 @@ extension MDCNodeListViewController {
         container.appBar.navigationBar.tintColor = UIColor.white
         container.appBar.navigationBar.titleTextAttributes =
             [ NSForegroundColorAttributeName: UIColor.white, NSFontAttributeName: appBarFont ]
-
-        let colorScheme = AppDelegate.colorScheme
-        MDCFlexibleHeaderColorThemer.apply(colorScheme, to: MDCFlexibleHeaderView.appearance())
-        let textColor = UIColor.white
-        UIBarButtonItem.appearance().setTitleTextAttributes(
-          [NSForegroundColorAttributeName: textColor],
-          for: UIControlState())
 
         // TODO(featherless): Remove once
         // https://github.com/material-components/material-components-ios/issues/367 is resolved.

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -388,6 +388,8 @@ extension MDCNodeListViewController {
         container.appBar.navigationBar.titleTextAttributes =
             [ NSForegroundColorAttributeName: UIColor.white, NSFontAttributeName: appBarFont ]
 
+        MDCAppBarColorThemer.apply(AppDelegate.colorScheme, to: container.appBar)
+
         // TODO(featherless): Remove once
         // https://github.com/material-components/material-components-ios/issues/367 is resolved.
         contentVC.title = node.title


### PR DESCRIPTION
This change has the notable effect of making all of our examples un-themed, which is intended within the scope of this change. We will need to address per-example theming and our approach to that in a follow-up change.

For the purposes of this change, the only parts of the app that will remain themed are the catalog-owned UI components (mainly the home screen and the example list view controllers).

## Screenshots

Note that the first two screenshots are themed with the app's default color scheme. The third screenshot's chrome is themed, but not the contents.

![simulator screen shot - iphone x - 2018-04-02 at 16 25 31](https://user-images.githubusercontent.com/45670/38214487-be9f82c6-3692-11e8-94f0-484757f7a674.png) ![simulator screen shot - iphone x - 2018-04-02 at 16 25 34](https://user-images.githubusercontent.com/45670/38214491-c052ee5a-3692-11e8-82c4-a843a1f4ce0f.png)

![simulator screen shot - iphone x - 2018-04-02 at 16 29 01](https://user-images.githubusercontent.com/45670/38214545-f9910134-3692-11e8-91ef-b464dc676786.png)

Pivotal story: https://www.pivotaltracker.com/story/show/156448937