### PR TITLE
[Catalog] Remove the global theme change notifications.

### DIFF
--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -92,22 +92,6 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
     collectionView?.backgroundColor = UIColor(white: 0.9, alpha: 1)
 
     MDCIcons.ic_arrow_backUseNewStyle(true)
-
-    NotificationCenter.default.addObserver(
-      self,
-      selector: #selector(self.colorThemeChanged),
-      name: NSNotification.Name(rawValue: "ColorThemeChangeNotification"),
-      object: nil)
-  }
-
-  func colorThemeChanged(notification: NSNotification) {
-    guard let colorScheme = notification.userInfo?["colorScheme"] as? MDCColorScheme else {
-      return
-    }
-    AppDelegate.colorScheme = colorScheme
-
-    collectionView?.collectionViewLayout.invalidateLayout()
-    collectionView?.reloadData()
   }
 
   convenience init(node: CBCNode) {

--- a/components/Themes/examples/ThemerCustomSchemePickerController.m
+++ b/components/Themes/examples/ThemerCustomSchemePickerController.m
@@ -220,12 +220,6 @@ static NSString *s_secondaryColorString;
   // Apply color scheme to UIKit components.
   [UISlider appearance].tintColor = colorScheme.primaryColor;
   [UISwitch appearance].onTintColor = colorScheme.primaryColor;
-
-  // Send notification that color scheme has changed so existing components can update if necessary.
-  NSDictionary *userInfo = @{ @"colorScheme" : colorScheme };
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"ColorThemeChangeNotification"
-                                                      object:self
-                                                    userInfo:userInfo];
 }
 
 #pragma mark - Actions

--- a/components/Themes/examples/ThemerTypicalUseViewController.m
+++ b/components/Themes/examples/ThemerTypicalUseViewController.m
@@ -69,12 +69,6 @@
   [UISlider appearance].tintColor = self.colorScheme.primaryColor;
   [UISwitch appearance].onTintColor = self.colorScheme.primaryColor;
 
-  // Send notification that color scheme has changed so existing components can update if necessary.
-  NSDictionary *userInfo = @{ @"colorScheme" : self.colorScheme };
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"ColorThemeChangeNotification"
-                                                      object:self
-                                                    userInfo:userInfo];
-
   [self setupExampleViews];
 }
 


### PR DESCRIPTION
We may add this back in a more well-defined manner in the future, but for now we're removing this pattern.

For future reference, this pattern was implemented in order to allow examples to change the global app theme because examples live outside of the app theme's target space.

In the future, we may add a theme changer to the catalog target so that we don't have to do odd cross-target juggling.

Pivotal story: https://www.pivotaltracker.com/story/show/156449674