### PR TITLE
[Catalog] Implement an app-wide theme system.

### DIFF
--- a/catalog/MDCCatalog.xcodeproj/project.pbxproj
+++ b/catalog/MDCCatalog.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		664524BE1C6BA62A001ADBF8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 664524BD1C6BA62A001ADBF8 /* Assets.xcassets */; };
 		664524C11C6BA62A001ADBF8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 664524BF1C6BA62A001ADBF8 /* LaunchScreen.storyboard */; };
 		6681FDFD1CC586660013A0C7 /* MDCCatalogTileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6681FDFC1CC586660013A0C7 /* MDCCatalogTileView.swift */; };
+		66CD19292072A54000DE6340 /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CD19282072A54000DE6340 /* AppTheme.swift */; };
+		66D3389520730A3E00FFA1AB /* MDCThemePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66D3389420730A3E00FFA1AB /* MDCThemePickerViewController.swift */; };
 		75F4516F2130AB879A7EDBD5 /* Pods_MDCCatalog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A55EA1CC69E40D5EF866144 /* Pods_MDCCatalog.framework */; };
 		7D6BB3DC630E39F27A3BA3F6 /* EarlGrey.framework in EarlGrey Copy Files */ = {isa = PBXBuildFile; fileRef = E94681B7591B9CD40924C92C /* EarlGrey.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		DE309CF31C8DEB8400E73247 /* MDCCatalogComponentsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE309CF21C8DEB8400E73247 /* MDCCatalogComponentsController.swift */; };
@@ -137,6 +139,8 @@
 		664524C21C6BA62A001ADBF8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		665A34D91C6BD01900962055 /* MDCCatalog-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MDCCatalog-Bridging-Header.h"; sourceTree = "<group>"; };
 		6681FDFC1CC586660013A0C7 /* MDCCatalogTileView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MDCCatalogTileView.swift; sourceTree = "<group>"; };
+		66CD19282072A54000DE6340 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
+		66D3389420730A3E00FFA1AB /* MDCThemePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDCThemePickerViewController.swift; sourceTree = "<group>"; };
 		88AB955E76304B684707293E /* Pods_MDCActionExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MDCActionExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		90B4FE989AA27838D0FB6A13 /* Pods-MDCCatalog.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MDCCatalog.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MDCCatalog/Pods-MDCCatalog.debug.xcconfig"; sourceTree = "<group>"; };
 		93314CA227FB65FEC87098C3 /* EarlGrey.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = EarlGrey.framework; path = Pods/EarlGrey/EarlGrey/EarlGrey.framework; sourceTree = SOURCE_ROOT; };
@@ -239,6 +243,7 @@
 			isa = PBXGroup;
 			children = (
 				664524B61C6BA62A001ADBF8 /* AppDelegate.swift */,
+				66CD19282072A54000DE6340 /* AppTheme.swift */,
 				665A34D91C6BD01900962055 /* MDCCatalog-Bridging-Header.h */,
 				DEF64EA31C8DEE83007C4EA0 /* MDCCatalogCollectionViewCell.swift */,
 				DE309CF21C8DEB8400E73247 /* MDCCatalogComponentsController.swift */,
@@ -247,6 +252,7 @@
 				0B4A5E6C1CC9307A00D2AC5D /* MDCCatalogWindow.swift */,
 				64F6D8821F915CA600AA4B24 /* MDCDebugSafeAreaInsetsView.swift */,
 				664524B81C6BA62A001ADBF8 /* MDCNodeListViewController.swift */,
+				66D3389420730A3E00FFA1AB /* MDCThemePickerViewController.swift */,
 				665A34DE1C6BDAE700962055 /* Resources */,
 			);
 			path = MDCCatalog;
@@ -663,9 +669,11 @@
 				DE309CF31C8DEB8400E73247 /* MDCCatalogComponentsController.swift in Sources */,
 				6681FDFD1CC586660013A0C7 /* MDCCatalogTileView.swift in Sources */,
 				0B4A5E6D1CC9307A00D2AC5D /* MDCCatalogWindow.swift in Sources */,
+				66CD19292072A54000DE6340 /* AppTheme.swift in Sources */,
 				664524B91C6BA62A001ADBF8 /* MDCNodeListViewController.swift in Sources */,
 				64F6D8811F91522A00AA4B24 /* MDCCatalogDebugAlert.swift in Sources */,
 				64F6D8831F915CA600AA4B24 /* MDCDebugSafeAreaInsetsView.swift in Sources */,
+				66D3389520730A3E00FFA1AB /* MDCThemePickerViewController.swift in Sources */,
 				664524B71C6BA62A001ADBF8 /* AppDelegate.swift in Sources */,
 				DEF64EA41C8DEE83007C4EA0 /* MDCCatalogCollectionViewCell.swift in Sources */,
 			);

--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -41,10 +41,6 @@ import MaterialComponents.MaterialThemes
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
   var window: UIWindow?
-  static var colorScheme: MDCColorScheme =
-      MDCBasicColorScheme(primaryColor: .init(white: 33 / 255.0, alpha: 1),
-                          primaryLightColor: .init(white: 0.7, alpha: 1),
-                          primaryDarkColor: .init(white: 0, alpha: 1))
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions
                    launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {

--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -1,0 +1,45 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+import MaterialComponents.MaterialThemes
+
+final class AppTheme {
+  let colorScheme: MDCColorScheme
+
+  init(colorScheme: MDCColorScheme) {
+    self.colorScheme = colorScheme
+  }
+
+  static let defaultTheme = AppTheme(colorScheme:
+    MDCBasicColorScheme(primaryColor: MDCPalette.purple.tint500,
+                        primaryLightColor: MDCPalette.purple.tint100,
+                        primaryDarkColor: MDCPalette.purple.tint900)
+  )
+
+  static var globalTheme = defaultTheme {
+    didSet {
+      NotificationCenter.default.post(name: AppTheme.didChangeGlobalThemeNotificationName,
+                                      object: nil,
+                                      userInfo:
+        [AppTheme.globalThemeNotificationColorSchemeKey: AppTheme.globalTheme.colorScheme]
+      )
+    }
+  }
+
+  static let didChangeGlobalThemeNotificationName = Notification.Name("MDCCatalogDidChangeGlobalTheme")
+  static let globalThemeNotificationColorSchemeKey = "colorScheme"
+}

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -18,6 +18,7 @@ import CatalogByConvention
 import MaterialCatalog
 
 import MaterialComponents.MaterialFlexibleHeader
+import MaterialComponents.MDCFlexibleHeaderColorThemer
 import MaterialComponents.MaterialIcons_ic_arrow_back
 import MaterialComponents.MaterialInk
 import MaterialComponents.MaterialLibraryInfo
@@ -87,11 +88,32 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
     headerViewController.headerView.maximumHeight = 128
     headerViewController.headerView.minimumHeight = 56
 
+    MDCFlexibleHeaderColorThemer.apply(AppTheme.globalTheme.colorScheme,
+                                       toMDCFlexibleHeaderController: headerViewController)
+
     collectionView?.register(MDCCatalogCollectionViewCell.self,
       forCellWithReuseIdentifier: "MDCCatalogCollectionViewCell")
     collectionView?.backgroundColor = UIColor(white: 0.9, alpha: 1)
 
     MDCIcons.ic_arrow_backUseNewStyle(true)
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(self.themeDidChange),
+      name: AppTheme.didChangeGlobalThemeNotificationName,
+      object: nil)
+  }
+
+  func themeDidChange(notification: NSNotification) {
+    guard let colorScheme = notification.userInfo?[AppTheme.globalThemeNotificationColorSchemeKey]
+          as? MDCColorScheme else {
+      return
+    }
+    MDCFlexibleHeaderColorThemer.apply(colorScheme,
+                                       toMDCFlexibleHeaderController: headerViewController)
+
+    collectionView?.collectionViewLayout.invalidateLayout()
+    collectionView?.reloadData()
   }
 
   convenience init(node: CBCNode) {
@@ -148,7 +170,7 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
                                     width: Constants.logoWidthHeight,
                                     height: Constants.logoWidthHeight),
                              { MDCCatalogDrawMDCLogoLight($0, $1) },
-                             AppDelegate.colorScheme)
+                             AppTheme.globalTheme.colorScheme)
     logo.image = image
 
     NSLayoutConstraint(item: logo,
@@ -181,7 +203,9 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
                        multiplier: 1,
                        constant: Constants.logoWidthHeight).isActive = true
 
-    headerViewController.headerView.backgroundColor = UIColor(white: 0.1, alpha: 1.0)
+    MDCFlexibleHeaderColorThemer.apply(AppTheme.globalTheme.colorScheme,
+                                       toMDCFlexibleHeaderController: headerViewController)
+
     headerViewController.headerView.trackingScrollView = collectionView
 
     headerViewController.headerView.setShadowLayer(MDCShadowLayer()) { (layer, intensity) in

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -88,9 +88,6 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
     headerViewController.headerView.maximumHeight = 128
     headerViewController.headerView.minimumHeight = 56
 
-    MDCFlexibleHeaderColorThemer.apply(AppTheme.globalTheme.colorScheme,
-                                       toMDCFlexibleHeaderController: headerViewController)
-
     collectionView?.register(MDCCatalogCollectionViewCell.self,
       forCellWithReuseIdentifier: "MDCCatalogCollectionViewCell")
     collectionView?.backgroundColor = UIColor(white: 0.9, alpha: 1)

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -162,12 +162,14 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
 
     headerViewController.headerView.addSubview(logo)
 
+    let colorScheme = AppTheme.globalTheme.colorScheme
+
     let image = MDCDrawImage(CGRect(x:0,
                                     y:0,
                                     width: Constants.logoWidthHeight,
                                     height: Constants.logoWidthHeight),
                              { MDCCatalogDrawMDCLogoLight($0, $1) },
-                             AppTheme.globalTheme.colorScheme)
+                             colorScheme)
     logo.image = image
 
     NSLayoutConstraint(item: logo,
@@ -200,7 +202,7 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
                        multiplier: 1,
                        constant: Constants.logoWidthHeight).isActive = true
 
-    MDCFlexibleHeaderColorThemer.apply(AppTheme.globalTheme.colorScheme,
+    MDCFlexibleHeaderColorThemer.apply(colorScheme,
                                        toMDCFlexibleHeaderController: headerViewController)
 
     headerViewController.headerView.trackingScrollView = collectionView

--- a/catalog/MDCCatalog/MDCCatalogTileView.swift
+++ b/catalog/MDCCatalog/MDCCatalogTileView.swift
@@ -33,14 +33,34 @@ class MDCCatalogTileView: UIView {
   private lazy var imageView = UIImageView()
   private let imageCache = NSCache<AnyObject, UIImage>()
 
+  deinit {
+    NotificationCenter.default.removeObserver(self,
+                                              name: AppTheme.didChangeGlobalThemeNotificationName,
+                                              object: nil)
+  }
+
   override init(frame: CGRect) {
     super.init(frame: frame)
+
     self.backgroundColor = UIColor.clear
     self.addSubview(imageView)
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(self.themeDidChange),
+      name: AppTheme.didChangeGlobalThemeNotificationName,
+      object: nil)
   }
 
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
+  }
+
+  func themeDidChange(notification: NSNotification) {
+    guard notification.userInfo?[AppTheme.globalThemeNotificationColorSchemeKey] != nil else {
+        return
+    }
+    imageCache.removeAllObjects()
   }
 
   override func layoutSubviews() {
@@ -73,8 +93,7 @@ class MDCCatalogTileView: UIView {
   func createImage() -> UIImage {
     var newImage: UIImage?
 
-    let appDelegate = UIApplication.shared.delegate as! AppDelegate
-    let colorScheme = AppDelegate.colorScheme
+    let colorScheme = AppTheme.globalTheme.colorScheme
 
     switch componentNameString {
     case "Activity Indicator":

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -63,6 +63,12 @@ class MDCNodeListViewController: CBCNodeListViewController {
     case additionalExamples = 1
   }
 
+  deinit {
+    NotificationCenter.default.removeObserver(self,
+                                              name: AppTheme.didChangeGlobalThemeNotificationName,
+                                              object: nil)
+  }
+
   override init(node: CBCNode) {
     super.init(node: node)
 
@@ -75,6 +81,12 @@ class MDCNodeListViewController: CBCNodeListViewController {
       childrenNodes.remove(at: primaryDemoNodeIndex)
       childrenNodes.insert(primaryDemoNode, at: 0)
     }
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(self.themeDidChange),
+      name: AppTheme.didChangeGlobalThemeNotificationName,
+      object: nil)
 
     node.children = childrenNodes
 
@@ -90,6 +102,9 @@ class MDCNodeListViewController: CBCNodeListViewController {
       let descriptor: UIFontDescriptor = UIFontDescriptor(fontAttributes: attribute)
       appBarFont = UIFont(descriptor: descriptor, size: 16)
     }
+
+    let colorScheme = AppTheme.globalTheme.colorScheme
+    MDCAppBarColorThemer.apply(colorScheme, to: appBar)
 
     appBar.navigationBar.tintColor = UIColor.white
     appBar.navigationBar.titleTextAttributes = [
@@ -142,6 +157,14 @@ class MDCNodeListViewController: CBCNodeListViewController {
 
   override var childViewControllerForStatusBarHidden: UIViewController? {
     return appBar.headerViewController
+  }
+
+  func themeDidChange(notification: NSNotification) {
+    guard let colorScheme = notification.userInfo?[AppTheme.globalThemeNotificationColorSchemeKey]
+          as? MDCColorScheme else {
+      return
+    }
+    MDCAppBarColorThemer.apply(colorScheme, to: appBar)
   }
 }
 
@@ -388,7 +411,7 @@ extension MDCNodeListViewController {
         container.appBar.navigationBar.titleTextAttributes =
             [ NSForegroundColorAttributeName: UIColor.white, NSFontAttributeName: appBarFont ]
 
-        MDCAppBarColorThemer.apply(AppDelegate.colorScheme, to: container.appBar)
+        MDCAppBarColorThemer.apply(AppTheme.globalTheme.colorScheme, to: container.appBar)
 
         // TODO(featherless): Remove once
         // https://github.com/material-components/material-components-ios/issues/367 is resolved.

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -103,15 +103,13 @@ class MDCNodeListViewController: CBCNodeListViewController {
       appBarFont = UIFont(descriptor: descriptor, size: 16)
     }
 
-    let colorScheme = AppTheme.globalTheme.colorScheme
-    MDCAppBarColorThemer.apply(colorScheme, to: appBar)
+    MDCAppBarColorThemer.apply(AppTheme.globalTheme.colorScheme, to: appBar)
 
     appBar.navigationBar.tintColor = UIColor.white
     appBar.navigationBar.titleTextAttributes = [
       NSForegroundColorAttributeName: UIColor.white,
       NSFontAttributeName: appBarFont ]
     appBar.navigationBar.titleAlignment = .center
-    MDCAppBarColorThemer.apply(AppDelegate.colorScheme, to: appBar)
   }
 
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -103,8 +103,6 @@ class MDCNodeListViewController: CBCNodeListViewController {
       appBarFont = UIFont(descriptor: descriptor, size: 16)
     }
 
-    applyColorScheme(AppTheme.globalTheme.colorScheme)
-
     appBar.navigationBar.titleTextAttributes = [
       NSForegroundColorAttributeName: UIColor.white,
       NSFontAttributeName: appBarFont ]
@@ -140,6 +138,8 @@ class MDCNodeListViewController: CBCNodeListViewController {
     appBar.headerViewController.headerView.trackingScrollView = self.tableView
 
     appBar.addSubviewsToParent()
+
+    applyColorScheme(AppTheme.globalTheme.colorScheme)
   }
 
   override func viewWillAppear(_ animated: Bool) {
@@ -161,7 +161,9 @@ class MDCNodeListViewController: CBCNodeListViewController {
           as? MDCColorScheme else {
       return
     }
-    applyColorScheme(colorScheme)
+    if isViewLoaded {
+      applyColorScheme(colorScheme)
+    }
   }
 
   private func applyColorScheme(_ colorScheme: MDCColorScheme) {

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -82,12 +82,6 @@ class MDCNodeListViewController: CBCNodeListViewController {
       childrenNodes.insert(primaryDemoNode, at: 0)
     }
 
-    NotificationCenter.default.addObserver(
-      self,
-      selector: #selector(self.themeDidChange),
-      name: AppTheme.didChangeGlobalThemeNotificationName,
-      object: nil)
-
     node.children = childrenNodes
 
     componentDescription = childrenNodes.first?.exampleDescription() ?? ""
@@ -140,12 +134,20 @@ class MDCNodeListViewController: CBCNodeListViewController {
     appBar.addSubviewsToParent()
 
     applyColorScheme(AppTheme.globalTheme.colorScheme)
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(self.themeDidChange),
+      name: AppTheme.didChangeGlobalThemeNotificationName,
+      object: nil)
   }
 
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
 
     self.navigationController?.setNavigationBarHidden(true, animated: animated)
+
+    applyColorScheme(AppTheme.globalTheme.colorScheme)
   }
 
   override var childViewControllerForStatusBarStyle: UIViewController? {
@@ -161,9 +163,7 @@ class MDCNodeListViewController: CBCNodeListViewController {
           as? MDCColorScheme else {
       return
     }
-    if isViewLoaded {
-      applyColorScheme(colorScheme)
-    }
+    applyColorScheme(colorScheme)
   }
 
   private func applyColorScheme(_ colorScheme: MDCColorScheme) {

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -103,9 +103,8 @@ class MDCNodeListViewController: CBCNodeListViewController {
       appBarFont = UIFont(descriptor: descriptor, size: 16)
     }
 
-    MDCAppBarColorThemer.apply(AppTheme.globalTheme.colorScheme, to: appBar)
+    applyColorScheme(AppTheme.globalTheme.colorScheme)
 
-    appBar.navigationBar.tintColor = UIColor.white
     appBar.navigationBar.titleTextAttributes = [
       NSForegroundColorAttributeName: UIColor.white,
       NSFontAttributeName: appBarFont ]
@@ -162,7 +161,13 @@ class MDCNodeListViewController: CBCNodeListViewController {
           as? MDCColorScheme else {
       return
     }
+    applyColorScheme(colorScheme)
+  }
+
+  private func applyColorScheme(_ colorScheme: MDCColorScheme) {
     MDCAppBarColorThemer.apply(colorScheme, to: appBar)
+
+    appBar.navigationBar.tintColor = UIColor.white
   }
 }
 

--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -1,0 +1,110 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import MaterialComponents.MaterialThemes
+import UIKit
+
+class MDCThemePickerViewController: UITableViewController {
+  init() {
+    super.init(style: .plain)
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellReuseIdentifier)
+
+    view.backgroundColor = .white
+  }
+
+  private let colorSchemeRows = [
+    (
+      name: "Blue",
+      colorScheme: MDCBasicColorScheme(primaryColor: MDCPalette.blue.tint500,
+                                       primaryLightColor: MDCPalette.blue.tint100,
+                                       primaryDarkColor: MDCPalette.blue.tint900)
+    ),
+    (
+      name: "Red",
+      colorScheme: MDCBasicColorScheme(primaryColor: MDCPalette.red.tint500,
+                                       primaryLightColor: MDCPalette.red.tint100,
+                                       primaryDarkColor: MDCPalette.red.tint900)
+    ),
+    (
+      name: "Green",
+      colorScheme: MDCBasicColorScheme(primaryColor: MDCPalette.green.tint500,
+                                       primaryLightColor: MDCPalette.green.tint100,
+                                       primaryDarkColor: MDCPalette.green.tint900)
+    ),
+    (
+      name: "Amber",
+      colorScheme: MDCBasicColorScheme(primaryColor: MDCPalette.amber.tint500,
+                                       primaryLightColor: MDCPalette.amber.tint100,
+                                       primaryDarkColor: MDCPalette.amber.tint900)
+    ),
+    (
+      name: "Pink",
+      colorScheme: MDCBasicColorScheme(primaryColor: MDCPalette.pink.tint500,
+                                       primaryLightColor: MDCPalette.pink.tint100,
+                                       primaryDarkColor: MDCPalette.pink.tint900)
+    ),
+    (
+      name: "Orange",
+      colorScheme: MDCBasicColorScheme(primaryColor: MDCPalette.orange.tint500,
+                                       primaryLightColor: MDCPalette.orange.tint100,
+                                       primaryDarkColor: MDCPalette.orange.tint900)
+    )
+  ]
+  private let cellReuseIdentifier = "cell"
+
+  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return colorSchemeRows.count
+  }
+
+  override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    let cell = tableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier, for: indexPath)
+    let row = colorSchemeRows[indexPath.row]
+    cell.textLabel?.text = row.name
+    return cell
+  }
+
+  override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    let row = colorSchemeRows[indexPath.row]
+    let colorScheme = row.colorScheme
+    AppTheme.globalTheme = AppTheme(colorScheme: colorScheme)
+
+    navigationController?.popViewController(animated: true)
+  }
+}
+
+// MARK: Catalog by convention
+extension MDCThemePickerViewController {
+  class func catalogBreadcrumbs() -> [String] {
+    return ["Themes", "Change current theme"]
+  }
+
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+
+  @objc class func catalogIsPresentable() -> Bool {
+    return true
+  }
+}

--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -18,8 +18,16 @@ import MaterialComponents.MaterialThemes
 import UIKit
 
 class MDCThemePickerViewController: UITableViewController {
-  init() {
-    super.init(style: .plain)
+  convenience init() {
+    self.init(style: .plain)
+  }
+
+  override init(style: UITableViewStyle) {
+    super.init(style: style)
+  }
+
+  override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
   }
 
   required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
This change introduces a couple concepts to the Catalog:

- AppTheme. This type houses the various scheme types our app will make use of.
- A "default theme" and a "global theme". The global theme is initialized to the default theme.
- A new view controller, `MDCThemePickerViewController`, that lives in the Catalog target. This view controller lists itself in the "Themes" examples for now, but we may want to move it elsewhere (e.g. an app Settings page).
- An NSNotification for responding to changes to the app's theme. The catalog's various view controllers and views have implemented this notification.

## Screenshots

![theme-picker](https://user-images.githubusercontent.com/45670/38247097-07f85f7c-3712-11e8-85f6-644343e2bce5.gif)

Pivotal tracker story: https://www.pivotaltracker.com/story/show/156387038