### PR TITLE
[Cards] Added Shapes support for MDCCard and MDCCardCollectionCell + 2 Examples

### DIFF
--- a/components/Cards/BUILD
+++ b/components/Cards/BUILD
@@ -31,6 +31,8 @@ mdc_public_objc_library(
         "//components/ShadowLayer",
         "//components/private/Math",
         "//components/private/Icons/icons/ic_check_circle",
+        "//components/private/ShapeLibrary",
+        "//components/private/Shapes",
     ],
 )
 

--- a/components/Cards/examples/EditReorderShapedCollectionViewController.swift
+++ b/components/Cards/examples/EditReorderShapedCollectionViewController.swift
@@ -1,0 +1,216 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import UIKit
+
+class ShapedCardCollectionCell: MDCCardCollectionCell {
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    commonShapedCardCollectionCellInit()
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    super.init(coder: aDecoder)
+    commonShapedCardCollectionCellInit()
+  }
+
+  func commonShapedCardCollectionCellInit() {
+    let shapeGenerator = MDCRectangleShapeGenerator()
+    shapeGenerator.topLeftCorner = MDCCutCornerTreatment(cut: 20)
+    self.shapeGenerator = shapeGenerator
+  }
+}
+
+class EditReorderShapedCollectionViewController: UIViewController,
+  UICollectionViewDelegate,
+  UICollectionViewDataSource,
+  UICollectionViewDelegateFlowLayout {
+
+  let collectionView = UICollectionView(frame: .zero,
+                                        collectionViewLayout: UICollectionViewFlowLayout())
+  var dataSource = [(Int, Bool)]()
+  var longPressGesture: UILongPressGestureRecognizer!
+  var toggle = ToggleMode.reorder
+  var toggleButton: UIButton!
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    collectionView.frame = view.bounds
+    collectionView.dataSource = self
+    collectionView.delegate = self
+    collectionView.backgroundColor = UIColor(white: 0.9, alpha: 1)
+    collectionView.alwaysBounceVertical = true;
+    collectionView.register(ShapedCardCollectionCell.self, forCellWithReuseIdentifier: "Cell")
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.allowsMultipleSelection = true
+    view.addSubview(collectionView)
+
+    navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Reorder",
+                                                        style: .plain,
+                                                        target: self,
+                                                        action: #selector(toggleModes))
+
+    if #available(iOS 9.0, *) {
+      longPressGesture = UILongPressGestureRecognizer(target: self,
+                                                      action: #selector(handleReordering(gesture:)))
+      longPressGesture.cancelsTouchesInView = false
+      collectionView.addGestureRecognizer(longPressGesture)
+    }
+
+    for i in 0..<20 {
+      dataSource.append((i, false))
+    }
+
+    #if swift(>=3.2)
+      if #available(iOS 11, *) {
+        let guide = view.safeAreaLayoutGuide
+        NSLayoutConstraint.activate([
+          collectionView.leftAnchor.constraint(equalTo: guide.leftAnchor),
+          collectionView.rightAnchor.constraint(equalTo: guide.rightAnchor),
+          collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+          collectionView.bottomAnchor.constraint(equalTo: guide.bottomAnchor)])
+        collectionView.contentInsetAdjustmentBehavior = .always
+      } else {
+        preiOS11Constraints()
+      }
+    #else
+      preiOS11Constraints()
+    #endif
+
+  }
+
+  func preiOS11Constraints() {
+    self.view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[view]|",
+                                                            options: [],
+                                                            metrics: nil,
+                                                            views: ["view": collectionView]));
+    self.view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[view]|",
+                                                            options: [],
+                                                            metrics: nil,
+                                                            views: ["view": collectionView]));
+  }
+
+  func toggleModes() {
+    if toggle == .edit {
+      toggle = .reorder
+      navigationItem.rightBarButtonItem?.title = "Reorder"
+    } else if toggle == .reorder {
+      toggle = .edit
+      navigationItem.rightBarButtonItem?.title = "Edit"
+    }
+    collectionView.reloadData()
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell",
+                                                  for: indexPath) as! MDCCardCollectionCell
+    cell.backgroundColor = .white
+    cell.isSelectable = (toggle == .edit)
+    return cell
+  }
+
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    if toggle == .edit {
+      dataSource[indexPath.item].1 = !dataSource[indexPath.item].1
+    }
+  }
+
+  func numberOfSections(in collectionView: UICollectionView) -> Int {
+    return 1
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      numberOfItemsInSection section: Int) -> Int {
+    return dataSource.count
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      moveItemAt sourceIndexPath: IndexPath,
+                      to destinationIndexPath: IndexPath) {
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      layout collectionViewLayout: UICollectionViewLayout,
+                      sizeForItemAt indexPath: IndexPath) -> CGSize {
+    let cardSize = (collectionView.bounds.size.width / 3) - 12
+    return CGSize(width: cardSize, height: cardSize)
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      layout collectionViewLayout: UICollectionViewLayout,
+                      insetForSectionAt section: Int) -> UIEdgeInsets {
+    return UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      layout collectionViewLayout: UICollectionViewLayout,
+                      minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+    return 8
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      layout collectionViewLayout: UICollectionViewLayout,
+                      minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+    return 8
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      canMoveItemAt indexPath: IndexPath) -> Bool {
+    return toggle == .reorder
+  }
+
+  @available(iOS 9.0, *)
+  @objc func handleReordering(gesture: UILongPressGestureRecognizer) {
+    if toggle == .reorder {
+      switch(gesture.state) {
+      case .began:
+        guard let selectedIndexPath = collectionView.indexPathForItem(at:
+          gesture.location(in: collectionView)) else {
+            break
+        }
+        collectionView.beginInteractiveMovementForItem(at: selectedIndexPath)
+      case .changed:
+        collectionView.updateInteractiveMovementTargetPosition(gesture.location(in: gesture.view!))
+      case .ended:
+        collectionView.endInteractiveMovement()
+      default:
+        collectionView.cancelInteractiveMovement()
+      }
+    }
+  }
+
+}
+
+extension EditReorderShapedCollectionViewController {
+  @objc class func catalogBreadcrumbs() -> [String] {
+    return ["Cards", "Shaped Edit/Reorder"]
+  }
+
+  @objc class func catalogIsPresentable() -> Bool {
+    return false
+  }
+
+  @objc class func catalogIsDebug() -> Bool {
+    return false
+  }
+
+  @objc class func catalogIsPrimaryExample() -> Bool {
+    return true
+  }
+}
+

--- a/components/Cards/examples/ShapedCardViewController.swift
+++ b/components/Cards/examples/ShapedCardViewController.swift
@@ -212,33 +212,3 @@ extension ShapedCardViewController {
     return true
   }
 }
-
-extension UIView {
-  func mask(withRect rect: CGRect, inverse: Bool = false) {
-    let path = UIBezierPath(rect: rect)
-    let maskLayer = CAShapeLayer()
-
-    if inverse {
-      path.append(UIBezierPath(rect: self.bounds))
-      maskLayer.fillRule = kCAFillRuleEvenOdd
-    }
-
-    maskLayer.path = path.cgPath
-
-    self.layer.mask = maskLayer
-  }
-
-  func mask(withPath path: UIBezierPath, inverse: Bool = false) {
-    let path = path
-    let maskLayer = CAShapeLayer()
-
-    if inverse {
-      path.append(UIBezierPath(rect: self.bounds))
-      maskLayer.fillRule = kCAFillRuleEvenOdd
-    }
-
-    maskLayer.path = path.cgPath
-
-    self.layer.mask = maskLayer
-  }
-}

--- a/components/Cards/examples/ShapedCardViewController.swift
+++ b/components/Cards/examples/ShapedCardViewController.swift
@@ -115,17 +115,43 @@ class ShapedCardViewController: UIViewController {
     primarySlider.bottomAnchor.constraint(equalTo: secondarySlider.topAnchor, constant: -20).isActive = true
     primarySlider.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
     primarySlider.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.5, constant: 0).isActive = true
+    primarySlider.addTarget(self,
+                            action: #selector(didChangeSliderValue(slider:)),
+                            for: .valueChanged)
 
     secondarySlider.translatesAutoresizingMaskIntoConstraints = false
     secondarySlider.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -20).isActive = true
     secondarySlider.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
     secondarySlider.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.5, constant: 0).isActive = true
-
+    secondarySlider.addTarget(self,
+                            action: #selector(didChangeSliderValue(slider:)),
+                            for: .valueChanged)
+    
     let barButton = UIBarButtonItem(title: "Change Shape",
                                     style: .plain,
                                     target: self,
                                     action: #selector(changeShape))
     self.navigationItem.rightBarButtonItem = barButton
+  }
+
+  override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+    primarySlider.maximumValue = Float(min(card.bounds.width, card.bounds.height)/2)
+    primarySlider.sendActions(for: .valueChanged)
+    secondarySlider.maximumValue = Float(min(card.bounds.width, card.bounds.height)/2)
+    secondarySlider.sendActions(for: .valueChanged)
+  }
+
+  func didChangeSliderValue(slider: UISlider) {
+    if slider == primarySlider {
+      let cutCornerTreatment = MDCCutCornerTreatment(cut: CGFloat(slider.value))
+      (card.shapeGenerator as! MDCRectangleShapeGenerator).setCorners(cutCornerTreatment)
+    } else if slider == secondarySlider {
+      let triangleEdgeTreatment = MDCTriangleEdgeTreatment(size: CGFloat(slider.value),
+                                                           style: MDCTriangleEdgeStyleCut)
+      (card.shapeGenerator as! MDCRectangleShapeGenerator).setEdges(triangleEdgeTreatment)
+    }
+    card.setNeedsLayout()
   }
 
   override public var traitCollection: UITraitCollection {
@@ -137,6 +163,8 @@ class ShapedCardViewController: UIViewController {
   }
 
   func changeShape() {
+    primarySlider.isHidden = true
+    secondarySlider.isHidden = true
     switch(card.shapeGenerator) {
     case is MDCRectangleShapeGenerator:
       let shapeGenerator = MDCCurvedRectShapeGenerator(cornerSize: CGSize(width: 20,
@@ -147,7 +175,7 @@ class ShapedCardViewController: UIViewController {
       card.shapeGenerator = shapeGenerator
     case is MDCPillShapeGenerator:
       let shapeGenerator = MDCSlantedRectShapeGenerator()
-      shapeGenerator.slant = 80
+      shapeGenerator.slant = 40
       card.shapeGenerator = shapeGenerator
     case is MDCSlantedRectShapeGenerator:
       fallthrough
@@ -158,10 +186,13 @@ class ShapedCardViewController: UIViewController {
   }
 
   func initialShape() {
+    primarySlider.isHidden = false
+    secondarySlider.isHidden = false
+
     let shapeGenerator = MDCRectangleShapeGenerator()
-    let cutCornerTreatment = MDCCutCornerTreatment(cut: 100)
+    let cutCornerTreatment = MDCCutCornerTreatment(cut: 0)
     shapeGenerator.setCorners(cutCornerTreatment)
-    let triangleEdgeTreatment = MDCTriangleEdgeTreatment(size: 30, style: MDCTriangleEdgeStyleCut)
+    let triangleEdgeTreatment = MDCTriangleEdgeTreatment(size: 0, style: MDCTriangleEdgeStyleCut)
     shapeGenerator.setEdges(triangleEdgeTreatment)
     card.shapeGenerator = shapeGenerator
   }

--- a/components/Cards/examples/ShapedCardViewController.swift
+++ b/components/Cards/examples/ShapedCardViewController.swift
@@ -37,7 +37,7 @@ class CardView: MDCCard {
   }
 
   func commonCardViewInit() {
-    self.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 10, right: 0)
+    self.layoutMargins = .zero
     contentView.layoutMargins = .zero
     contentView.translatesAutoresizingMaskIntoConstraints = false
     contentView.isUserInteractionEnabled = false
@@ -112,17 +112,23 @@ class ShapedCardViewController: UIViewController {
     card.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor).isActive = true
 
     primarySlider.translatesAutoresizingMaskIntoConstraints = false
-    primarySlider.bottomAnchor.constraint(equalTo: secondarySlider.topAnchor, constant: -20).isActive = true
+    primarySlider.bottomAnchor.constraint(equalTo: secondarySlider.topAnchor,
+                                          constant: -20).isActive = true
     primarySlider.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
-    primarySlider.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.5, constant: 0).isActive = true
+    primarySlider.widthAnchor.constraint(equalTo: view.widthAnchor,
+                                         multiplier: 0.5,
+                                         constant: 0).isActive = true
     primarySlider.addTarget(self,
                             action: #selector(didChangeSliderValue(slider:)),
                             for: .valueChanged)
 
     secondarySlider.translatesAutoresizingMaskIntoConstraints = false
-    secondarySlider.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -20).isActive = true
+    secondarySlider.bottomAnchor.constraint(equalTo: view.bottomAnchor,
+                                            constant: -20).isActive = true
     secondarySlider.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
-    secondarySlider.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.5, constant: 0).isActive = true
+    secondarySlider.widthAnchor.constraint(equalTo: view.widthAnchor,
+                                           multiplier: 0.5,
+                                           constant: 0).isActive = true
     secondarySlider.addTarget(self,
                             action: #selector(didChangeSliderValue(slider:)),
                             for: .valueChanged)
@@ -143,15 +149,17 @@ class ShapedCardViewController: UIViewController {
   }
 
   func didChangeSliderValue(slider: UISlider) {
-    if slider == primarySlider {
-      let cutCornerTreatment = MDCCutCornerTreatment(cut: CGFloat(slider.value))
-      (card.shapeGenerator as! MDCRectangleShapeGenerator).setCorners(cutCornerTreatment)
-    } else if slider == secondarySlider {
-      let triangleEdgeTreatment = MDCTriangleEdgeTreatment(size: CGFloat(slider.value),
-                                                           style: MDCTriangleEdgeStyleCut)
-      (card.shapeGenerator as! MDCRectangleShapeGenerator).setEdges(triangleEdgeTreatment)
+    if let shape = card.shapeGenerator as? MDCRectangleShapeGenerator {
+      if slider == primarySlider {
+        let cutCornerTreatment = MDCCutCornerTreatment(cut: CGFloat(slider.value))
+        shape.setCorners(cutCornerTreatment)
+      } else if slider == secondarySlider {
+        let triangleEdgeTreatment = MDCTriangleEdgeTreatment(size: CGFloat(slider.value),
+                                                             style: MDCTriangleEdgeStyleCut)
+        shape.setEdges(triangleEdgeTreatment)
+      }
+      card.setNeedsLayout()
     }
-    card.setNeedsLayout()
   }
 
   override public var traitCollection: UITraitCollection {
@@ -167,16 +175,19 @@ class ShapedCardViewController: UIViewController {
     secondarySlider.isHidden = true
     switch(card.shapeGenerator) {
     case is MDCRectangleShapeGenerator:
-      let shapeGenerator = MDCCurvedRectShapeGenerator(cornerSize: CGSize(width: 20,
+      let shapeGenerator = MDCCurvedRectShapeGenerator(cornerSize: CGSize(width: 50,
                                                                           height: 100))
       card.shapeGenerator = shapeGenerator
+      card.contentView.layoutMargins = UIEdgeInsetsMake(0, 40, 0, 40)
     case is MDCCurvedRectShapeGenerator:
       let shapeGenerator = MDCPillShapeGenerator()
       card.shapeGenerator = shapeGenerator
+      card.contentView.layoutMargins = UIEdgeInsetsMake(0, 80, 0, 80)
     case is MDCPillShapeGenerator:
       let shapeGenerator = MDCSlantedRectShapeGenerator()
       shapeGenerator.slant = 40
       card.shapeGenerator = shapeGenerator
+      card.contentView.layoutMargins = UIEdgeInsetsMake(0, 40, 0, 40)
     case is MDCSlantedRectShapeGenerator:
       fallthrough
     default:
@@ -195,6 +206,7 @@ class ShapedCardViewController: UIViewController {
     let triangleEdgeTreatment = MDCTriangleEdgeTreatment(size: 0, style: MDCTriangleEdgeStyleCut)
     shapeGenerator.setEdges(triangleEdgeTreatment)
     card.shapeGenerator = shapeGenerator
+    card.contentView.layoutMargins = UIEdgeInsetsMake(0, 5, 0, 5)
   }
 }
 

--- a/components/Cards/examples/ShapedCardViewController.swift
+++ b/components/Cards/examples/ShapedCardViewController.swift
@@ -91,6 +91,12 @@ class ShapedCardViewController: UIViewController {
     shapeGenerator.setCorners(curvedCornerTreatment)
     card.shapeGenerator = shapeGenerator
     view.addSubview(card)
+
+    let barButton = UIBarButtonItem(title: "Change Shape",
+                                    style: .plain,
+                                    target: self,
+                                    action: #selector(changeShape))
+    self.navigationItem.rightBarButtonItem = barButton
   }
 
   override func viewWillLayoutSubviews() {
@@ -107,6 +113,36 @@ class ShapedCardViewController: UIViewController {
     return super.traitCollection
   }
 
+  func changeShape() {
+    switch(card.shapeGenerator) {
+    case is MDCRectangleShapeGenerator:
+      let shapeGenerator = MDCCurvedRectShapeGenerator(cornerSize: CGSize(width: 10,
+                                                                          height: 20))
+      card.shapeGenerator = shapeGenerator
+    case is MDCCurvedRectShapeGenerator:
+      let shapeGenerator = MDCPillShapeGenerator()
+      card.shapeGenerator = shapeGenerator
+    case is MDCPillShapeGenerator:
+      let shapeGenerator = MDCSlantedRectShapeGenerator()
+      shapeGenerator.slant = 10
+      card.shapeGenerator = shapeGenerator
+    case is MDCSlantedRectShapeGenerator:
+      fallthrough
+    default:
+      let shapeGenerator = MDCRectangleShapeGenerator()
+      let curvedCornerTreatment = MDCCurvedCornerTreatment()
+      curvedCornerTreatment.size = CGSize(width: 10, height: 40)
+      shapeGenerator.setCorners(curvedCornerTreatment)
+      card.shapeGenerator = shapeGenerator
+    }
+    card.setNeedsLayout()
+  }
+
+  func calculateContentInsetForShape() {
+    let shapeLayer = (card.layer as! MDCShapedShadowLayer).shapeLayer
+    let path = shapeLayer.path
+    
+  }
 }
 
 @available(iOS 9.0, *)

--- a/components/Cards/examples/ShapedCardViewController.swift
+++ b/components/Cards/examples/ShapedCardViewController.swift
@@ -1,0 +1,143 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import UIKit
+
+@available(iOS 9.0, *)
+class ShapedCardViewController: UIViewController {
+  var card = MDCCard()
+
+  override func viewDidLoad() {
+    view.backgroundColor = .white
+    super.viewDidLoad()
+
+    card.frame = CGRect(x: 0, y: 0, width: 300, height: 300)
+    let shapeGenerator = MDCRectangleShapeGenerator()
+    let curvedCornerTreatment = MDCCurvedCornerTreatment()
+    curvedCornerTreatment.size = CGSize(width: 10, height: 40)
+    shapeGenerator.setCorners(curvedCornerTreatment)
+    card.shapeGenerator = shapeGenerator
+    view.addSubview(card)
+  }
+
+  override func viewDidLayoutSubviews() {
+    card.center = view.center
+    card.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 10, right: 0)
+
+    let contentView = UIView()
+    contentView.layoutMargins = .zero
+    contentView.translatesAutoresizingMaskIntoConstraints = false
+    contentView.isUserInteractionEnabled = false
+    card.addSubview(contentView)
+    contentView.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor).isActive = true
+    contentView.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor).isActive = true
+    contentView.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor).isActive = true
+    contentView.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor).isActive = true
+    let shapeLayer = (card.layer as! MDCShapedShadowLayer).shapeLayer
+    contentView.layer.mask = shapeLayer
+
+//    let rect = CGRect(x: 20, y: 20, width: 20, height: 20)
+//
+//    // Cuts rectangle inside view, leaving 20pt borders around
+//    contentView.mask(withRect: rect, inverse: true)
+
+//    // Cuts 20pt borders around the view, keeping part inside rect intact
+//    targetView.mask(withRect: rect)
+    let label = UILabel()
+    label.text = "abcde fghi jklm nopq rstuv wxyz abcd efgh ijkl mnop qrst uvw xyz abcde fghi jkl" +
+        "nopq rstuv wxyz abcd efgh ijkl mnop qrst uvw xyz abcde fghi jklm nopq rstuv wxyz abcdefg" +
+        "efgh ijkl mnop qrst uvw xyz abcde fghi jklm nopq rstuv wxyz abcd efgh ijkl abcd efghijkl"
+    label.numberOfLines = 0
+    label.translatesAutoresizingMaskIntoConstraints = false
+    contentView.addSubview(label)
+
+    let imageView = UIImageView()
+    imageView.clipsToBounds = true
+    imageView.contentMode = .scaleAspectFill
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    let bundle = Bundle(for: ShapedCardViewController.self)
+    imageView.image = UIImage(named: "sample-image", in: bundle, compatibleWith: nil)
+    contentView.addSubview(imageView)
+
+    let margins = contentView.layoutMarginsGuide
+    label.leadingAnchor.constraint(equalTo: margins.leadingAnchor).isActive = true
+    label.trailingAnchor.constraint(equalTo: margins.trailingAnchor).isActive = true
+    imageView.leadingAnchor.constraint(equalTo: margins.leadingAnchor).isActive = true
+    imageView.trailingAnchor.constraint(equalTo: margins.trailingAnchor).isActive = true
+
+    imageView.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
+    label.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
+
+    imageView.bottomAnchor.constraint(equalTo: label.topAnchor).isActive = true
+    imageView.heightAnchor.constraint(equalToConstant: card.bounds.height/2).isActive = true
+    label.heightAnchor.constraint(equalToConstant: card.bounds.height/2).isActive = true
+
+  }
+
+  override public var traitCollection: UITraitCollection {
+    if UIDevice.current.userInterfaceIdiom == .pad && UIDevice.current.orientation.isPortrait {
+      return UITraitCollection(traitsFrom:[UITraitCollection(horizontalSizeClass: .compact),
+                                           UITraitCollection(verticalSizeClass: .regular)])
+    }
+    return super.traitCollection
+  }
+
+}
+
+@available(iOS 9.0, *)
+extension ShapedCardViewController {
+  @objc class func catalogBreadcrumbs() -> [String] {
+    return ["Cards", "Shaped Card"]
+  }
+
+  @objc class func catalogIsPresentable() -> Bool {
+    return true
+  }
+
+  @objc class func catalogIsDebug() -> Bool {
+    return true
+  }
+}
+
+extension UIView {
+  func mask(withRect rect: CGRect, inverse: Bool = false) {
+    let path = UIBezierPath(rect: rect)
+    let maskLayer = CAShapeLayer()
+
+    if inverse {
+      path.append(UIBezierPath(rect: self.bounds))
+      maskLayer.fillRule = kCAFillRuleEvenOdd
+    }
+
+    maskLayer.path = path.cgPath
+
+    self.layer.mask = maskLayer
+  }
+
+  func mask(withPath path: UIBezierPath, inverse: Bool = false) {
+    let path = path
+    let maskLayer = CAShapeLayer()
+
+    if inverse {
+      path.append(UIBezierPath(rect: self.bounds))
+      maskLayer.fillRule = kCAFillRuleEvenOdd
+    }
+
+    maskLayer.path = path.cgPath
+
+    self.layer.mask = maskLayer
+  }
+}

--- a/components/Cards/examples/ShapedCardViewController.swift
+++ b/components/Cards/examples/ShapedCardViewController.swift
@@ -216,7 +216,7 @@ extension ShapedCardViewController {
   }
 
   @objc class func catalogIsPresentable() -> Bool {
-    return true
+    return false
   }
 
   @objc class func catalogIsDebug() -> Bool {

--- a/components/Cards/examples/ShapedCardViewController.swift
+++ b/components/Cards/examples/ShapedCardViewController.swift
@@ -44,8 +44,7 @@ class CardView: MDCCard {
     self.addSubview(contentView)
 
     label.text = "abcde fghi jklm nopq rstuv wxyz abcd efgh ijkl mnop qrst uvw xyz abcde fghi jkl" +
-      "nopq rstuv wxyz abcd efgh ijkl mnop qrst uvw xyz abcde fghi jklm nopq rstuv wxyz abcdefg" +
-    "efgh ijkl mnop qrst uvw xyz abcde fghi jklm nopq rstuv wxyz abcd efgh ijkl abcd efghijkl"
+        "nopq rstuv wxyz abcd efgh ijkl mnop qrst uvw xyz abcde fghi jklm nopq rstuv wxyz abcdefg"
     label.numberOfLines = 0
     label.translatesAutoresizingMaskIntoConstraints = false
     self.contentView.addSubview(label)
@@ -221,6 +220,6 @@ extension ShapedCardViewController {
   }
 
   @objc class func catalogIsDebug() -> Bool {
-    return true
+    return false
   }
 }

--- a/components/Cards/examples/ShapedCardViewController.swift
+++ b/components/Cards/examples/ShapedCardViewController.swift
@@ -17,14 +17,74 @@
 import UIKit
 
 @available(iOS 9.0, *)
+class CardView: MDCCard {
+
+  let contentView = UIView()
+  let label = UILabel()
+  let imageView = UIImageView()
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    commonCardViewInit()
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    super.init(coder: aDecoder)
+    commonCardViewInit()
+  }
+
+  func commonCardViewInit() {
+    self.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 10, right: 0)
+    contentView.layoutMargins = .zero
+    contentView.translatesAutoresizingMaskIntoConstraints = false
+    contentView.isUserInteractionEnabled = false
+    self.addSubview(contentView)
+
+    label.text = "abcde fghi jklm nopq rstuv wxyz abcd efgh ijkl mnop qrst uvw xyz abcde fghi jkl" +
+      "nopq rstuv wxyz abcd efgh ijkl mnop qrst uvw xyz abcde fghi jklm nopq rstuv wxyz abcdefg" +
+    "efgh ijkl mnop qrst uvw xyz abcde fghi jklm nopq rstuv wxyz abcd efgh ijkl abcd efghijkl"
+    label.numberOfLines = 0
+    label.translatesAutoresizingMaskIntoConstraints = false
+    self.contentView.addSubview(label)
+
+    imageView.clipsToBounds = true
+    imageView.contentMode = .scaleAspectFill
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    let bundle = Bundle(for: ShapedCardViewController.self)
+    imageView.image = UIImage(named: "sample-image", in: bundle, compatibleWith: nil)
+    self.contentView.addSubview(imageView)
+  }
+
+  override func layoutSubviews() {
+    contentView.leadingAnchor.constraint(equalTo: self.layoutMarginsGuide.leadingAnchor).isActive = true
+    contentView.trailingAnchor.constraint(equalTo: self.layoutMarginsGuide.trailingAnchor).isActive = true
+    contentView.topAnchor.constraint(equalTo: self.layoutMarginsGuide.topAnchor).isActive = true
+    contentView.bottomAnchor.constraint(equalTo: self.layoutMarginsGuide.bottomAnchor).isActive = true
+    let shapeLayer = (self.layer as! MDCShapedShadowLayer).shapeLayer
+    contentView.layer.mask = shapeLayer
+
+    let margins = self.contentView.layoutMarginsGuide
+    label.leadingAnchor.constraint(equalTo: margins.leadingAnchor).isActive = true
+    label.trailingAnchor.constraint(equalTo: margins.trailingAnchor).isActive = true
+    imageView.leadingAnchor.constraint(equalTo: margins.leadingAnchor).isActive = true
+    imageView.trailingAnchor.constraint(equalTo: margins.trailingAnchor).isActive = true
+
+    imageView.topAnchor.constraint(equalTo: self.contentView.topAnchor).isActive = true
+    label.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor).isActive = true
+
+    imageView.bottomAnchor.constraint(equalTo: label.topAnchor).isActive = true
+    imageView.heightAnchor.constraint(equalTo: label.heightAnchor, multiplier: 1).isActive = true
+  }
+}
+
+@available(iOS 9.0, *)
 class ShapedCardViewController: UIViewController {
-  var card = MDCCard()
+  var card = CardView()
 
   override func viewDidLoad() {
     view.backgroundColor = .white
     super.viewDidLoad()
 
-    card.frame = CGRect(x: 0, y: 0, width: 300, height: 300)
     let shapeGenerator = MDCRectangleShapeGenerator()
     let curvedCornerTreatment = MDCCurvedCornerTreatment()
     curvedCornerTreatment.size = CGSize(width: 10, height: 40)
@@ -33,58 +93,10 @@ class ShapedCardViewController: UIViewController {
     view.addSubview(card)
   }
 
-  override func viewDidLayoutSubviews() {
+  override func viewWillLayoutSubviews() {
+    let cardSize = min(self.view.bounds.height, self.view.bounds.width) - 80
+    card.frame = CGRect(x: 0, y: 0, width: cardSize, height: cardSize)
     card.center = view.center
-    card.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 10, right: 0)
-
-    let contentView = UIView()
-    contentView.layoutMargins = .zero
-    contentView.translatesAutoresizingMaskIntoConstraints = false
-    contentView.isUserInteractionEnabled = false
-    card.addSubview(contentView)
-    contentView.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor).isActive = true
-    contentView.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor).isActive = true
-    contentView.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor).isActive = true
-    contentView.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor).isActive = true
-    let shapeLayer = (card.layer as! MDCShapedShadowLayer).shapeLayer
-    contentView.layer.mask = shapeLayer
-
-//    let rect = CGRect(x: 20, y: 20, width: 20, height: 20)
-//
-//    // Cuts rectangle inside view, leaving 20pt borders around
-//    contentView.mask(withRect: rect, inverse: true)
-
-//    // Cuts 20pt borders around the view, keeping part inside rect intact
-//    targetView.mask(withRect: rect)
-    let label = UILabel()
-    label.text = "abcde fghi jklm nopq rstuv wxyz abcd efgh ijkl mnop qrst uvw xyz abcde fghi jkl" +
-        "nopq rstuv wxyz abcd efgh ijkl mnop qrst uvw xyz abcde fghi jklm nopq rstuv wxyz abcdefg" +
-        "efgh ijkl mnop qrst uvw xyz abcde fghi jklm nopq rstuv wxyz abcd efgh ijkl abcd efghijkl"
-    label.numberOfLines = 0
-    label.translatesAutoresizingMaskIntoConstraints = false
-    contentView.addSubview(label)
-
-    let imageView = UIImageView()
-    imageView.clipsToBounds = true
-    imageView.contentMode = .scaleAspectFill
-    imageView.translatesAutoresizingMaskIntoConstraints = false
-    let bundle = Bundle(for: ShapedCardViewController.self)
-    imageView.image = UIImage(named: "sample-image", in: bundle, compatibleWith: nil)
-    contentView.addSubview(imageView)
-
-    let margins = contentView.layoutMarginsGuide
-    label.leadingAnchor.constraint(equalTo: margins.leadingAnchor).isActive = true
-    label.trailingAnchor.constraint(equalTo: margins.trailingAnchor).isActive = true
-    imageView.leadingAnchor.constraint(equalTo: margins.leadingAnchor).isActive = true
-    imageView.trailingAnchor.constraint(equalTo: margins.trailingAnchor).isActive = true
-
-    imageView.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
-    label.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
-
-    imageView.bottomAnchor.constraint(equalTo: label.topAnchor).isActive = true
-    imageView.heightAnchor.constraint(equalToConstant: card.bounds.height/2).isActive = true
-    label.heightAnchor.constraint(equalToConstant: card.bounds.height/2).isActive = true
-
   }
 
   override public var traitCollection: UITraitCollection {

--- a/components/Cards/src/MDCCard.h
+++ b/components/Cards/src/MDCCard.h
@@ -18,6 +18,8 @@
 #import "MaterialInk.h"
 #import "MaterialShadowLayer.h"
 
+@protocol MDCShapeGenerating;
+
 @interface MDCCard : UIControl
 
 /**
@@ -112,5 +114,11 @@
  @return The shadow color for the requested state.
  */
 - (nullable UIColor *)shadowColorForState:(UIControlState)state UI_APPEARANCE_SELECTOR;
+
+/*
+ The shape generator used to define the chip's shape.
+ */
+@property(nullable, nonatomic, strong) id<MDCShapeGenerating> shapeGenerator UI_APPEARANCE_SELECTOR;
+
 
 @end

--- a/components/Cards/src/MDCCard.h
+++ b/components/Cards/src/MDCCard.h
@@ -121,9 +121,9 @@
  If a layer property is explicitly set after the shapeGenerator has been set, it will lead to
  unexpected behavior.
 
- When the shapeGenerator is nil, MDCCard will work like a normal UIControl with
- the default cornerRadius value of 4.
-
+ When the shapeGenerator is nil, MDCCard will use the default underlying layer with
+ its default settings.
+ 
  Default value for shapeGenerator is nil.
  */
 @property(nullable, nonatomic, strong) id<MDCShapeGenerating> shapeGenerator;

--- a/components/Cards/src/MDCCard.h
+++ b/components/Cards/src/MDCCard.h
@@ -116,7 +116,7 @@
 - (nullable UIColor *)shadowColorForState:(UIControlState)state UI_APPEARANCE_SELECTOR;
 
 /*
- The shape generator used to define the chip's shape.
+ The shape generator used to define the card's shape.
  */
 @property(nullable, nonatomic, strong) id<MDCShapeGenerating> shapeGenerator UI_APPEARANCE_SELECTOR;
 

--- a/components/Cards/src/MDCCard.h
+++ b/components/Cards/src/MDCCard.h
@@ -117,8 +117,16 @@
 
 /*
  The shape generator used to define the card's shape.
+ When set, layer properties such as cornerRadius and other layer properties are nullified/zeroed.
+ If a layer property is explicitly set after the shapeGenerator has been set, it will lead to
+ unexpected behavior.
+
+ When the shapeGenerator is nil, MDCCard will work like a normal UIControl with
+ the default cornerRadius value of 4.
+
+ Default value for shapeGenerator is nil.
  */
-@property(nullable, nonatomic, strong) id<MDCShapeGenerating> shapeGenerator UI_APPEARANCE_SELECTOR;
+@property(nullable, nonatomic, strong) id<MDCShapeGenerating> shapeGenerator;
 
 
 @end

--- a/components/Cards/src/MDCCard.m
+++ b/components/Cards/src/MDCCard.m
@@ -291,6 +291,14 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
   self.layer.shapeGenerator = shapeGenerator;
   self.layer.shadowMaskEnabled = NO;
   [self updateBackgroundColor];
+  [self updateInkForShape];
+}
+
+- (void)updateInkForShape {
+  CGRect boundingBox = CGPathGetBoundingBox(self.layer.shapeLayer.path);
+  self.inkView.maxRippleRadius =
+      (CGFloat)(MDCHypot(CGRectGetHeight(boundingBox), CGRectGetWidth(boundingBox)) / 2 + 10.f);
+  self.inkView.layer.masksToBounds = NO;
 }
 
 - (id)shapeGenerator {

--- a/components/Cards/src/MDCCard.m
+++ b/components/Cards/src/MDCCard.m
@@ -17,28 +17,38 @@
 #import "MDCCard.h"
 
 #import "MaterialMath.h"
+#import "MaterialShapes.h"
 
-static NSString *const MDCCardShadowElevationsKey = @"MDCCardShadowElevationsKey";
-static NSString *const MDCCardShadowColorsKey = @"MDCCardShadowColorsKey";
-static NSString *const MDCCardBorderWidthsKey = @"MDCCardBorderWidthsKey";
+static NSString *const MDCCardBackgroundColorsKey = @"MDCCardBackgroundColorsKey";
 static NSString *const MDCCardBorderColorsKey = @"MDCCardBorderColorsKey";
-static NSString *const MDCCardInkViewKey = @"MDCCardInkViewKey";
+static NSString *const MDCCardBorderWidthsKey = @"MDCCardBorderWidthsKey";
 static NSString *const MDCCardCornerRadiusKey = @"MDCCardCornerRadiusKey";
+static NSString *const MDCCardInkViewKey = @"MDCCardInkViewKey";
+static NSString *const MDCCardShadowColorsKey = @"MDCCardShadowColorsKey";
+static NSString *const MDCCardShadowElevationsKey = @"MDCCardShadowElevationsKey";
 
 static const CGFloat MDCCardShadowElevationNormal = 1.f;
 static const CGFloat MDCCardShadowElevationHighlighted = 8.f;
 static const CGFloat MDCCardCornerRadiusDefault = 4.f;
+
+
+@interface MDCCard ()
+@property(nonatomic, readonly, strong) MDCShapedShadowLayer *layer;
+@end
 
 @implementation MDCCard {
   NSMutableDictionary<NSNumber *, NSNumber *> *_shadowElevations;
   NSMutableDictionary<NSNumber *, UIColor *> *_shadowColors;
   NSMutableDictionary<NSNumber *, NSNumber *> *_borderWidths;
   NSMutableDictionary<NSNumber *, UIColor *> *_borderColors;
+  UIColor *_backgroundColor;
   CGPoint _lastTouch;
 }
 
+@dynamic layer;
+
 + (Class)layerClass {
-  return [MDCShadowLayer class];
+  return [MDCShapedShadowLayer class];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)coder {
@@ -57,6 +67,10 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
       self.layer.cornerRadius = (CGFloat)[coder decodeDoubleForKey:MDCCardCornerRadiusKey];
     } else {
       self.layer.cornerRadius = MDCCardCornerRadiusDefault;
+    }
+    if ([coder containsValueForKey:MDCCardBackgroundColorsKey]) {
+      [self.layer setShapedBackgroundColor:[coder decodeObjectOfClass:[UIColor class]
+                                                               forKey:MDCCardBackgroundColorsKey]];
     }
     [self commonMDCCardInit];
   }
@@ -101,10 +115,15 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
     _borderWidths = [NSMutableDictionary dictionary];
   }
 
+  if (_backgroundColor == nil) {
+    _backgroundColor = UIColor.whiteColor;
+  }
+
   [self updateShadowElevation];
   [self updateShadowColor];
   [self updateBorderWidth];
   [self updateBorderColor];
+  [self updateBackgroundColor];
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
@@ -115,11 +134,17 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
   [coder encodeObject:_borderColors forKey:MDCCardBorderColorsKey];
   [coder encodeObject:_inkView forKey:MDCCardInkViewKey];
   [coder encodeDouble:self.layer.cornerRadius forKey:MDCCardCornerRadiusKey];
+  [coder encodeObject:self.layer.shapedBackgroundColor forKey:MDCCardBackgroundColorsKey];
 }
 
 - (void)layoutSubviews {
   [super layoutSubviews];
-  self.layer.shadowPath = [self boundingPath].CGPath;
+
+  if (!self.layer.shapeGenerator) {
+    self.layer.shadowPath = [self boundingPath].CGPath;
+  } else {
+    self.layer.cornerRadius = 0;
+  }
 }
 
 - (void)setCornerRadius:(CGFloat)cornerRadius {
@@ -156,7 +181,9 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
 - (void)updateShadowElevation {
   CGFloat elevation = [self shadowElevationForState:self.state];
   if (!MDCCGFloatEqual(((MDCShadowLayer *)self.layer).elevation, elevation)) {
-    self.layer.shadowPath = [self boundingPath].CGPath;
+    if (!self.layer.shapeGenerator) {
+      self.layer.shadowPath = [self boundingPath].CGPath;
+    }
     [(MDCShadowLayer *)self.layer setElevation:elevation];
   }
 }
@@ -169,7 +196,7 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
 
 - (void)updateBorderWidth {
   CGFloat borderWidth = [self borderWidthForState:self.state];
-  self.layer.borderWidth = borderWidth;
+  self.layer.shapedBorderWidth = borderWidth;
 }
 
 - (CGFloat)borderWidthForState:(UIControlState)state {
@@ -190,8 +217,8 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
 }
 
 - (void)updateBorderColor {
-  CGColorRef borderColorRef = [self borderColorForState:self.state].CGColor;
-  self.layer.borderColor = borderColorRef;
+  UIColor *borderColor = [self borderColorForState:self.state];
+  self.layer.shapedBorderColor = borderColor;
 }
 
 - (UIColor *)borderColorForState:(UIControlState)state {
@@ -242,6 +269,35 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
   CGPoint location = [touch locationInView:self];
   _lastTouch = location;
   return beginTracking;
+}
+
+- (void)setShapeGenerator:(id<MDCShapeGenerating>)shapeGenerator {
+  if (shapeGenerator) {
+    self.layer.cornerRadius = 0;
+    self.layer.shadowPath = nil;
+  }
+
+  self.layer.shapeGenerator = shapeGenerator;
+//  self.layer.mask = self.layer.colorLayer;
+  self.layer.shadowMaskEnabled = NO;
+  [self updateBackgroundColor];
+}
+
+- (id)shapeGenerator {
+  return self.layer.shapeGenerator;
+}
+
+- (void)setBackgroundColor:(UIColor *)backgroundColor {
+  _backgroundColor = backgroundColor;
+  [self updateBackgroundColor];
+}
+
+- (UIColor *)backgroundColor {
+  return _backgroundColor;
+}
+
+- (void)updateBackgroundColor {
+  self.layer.shapedBackgroundColor = _backgroundColor;
 }
 
 @end

--- a/components/Cards/src/MDCCard.m
+++ b/components/Cards/src/MDCCard.m
@@ -104,7 +104,7 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
 
   if (_shadowColors == nil) {
     _shadowColors = [NSMutableDictionary dictionary];
-    _shadowColors[@(UIControlStateNormal)] = [UIColor blackColor];
+    _shadowColors[@(UIControlStateNormal)] = UIColor.blackColor;
   }
 
   if (_borderColors == nil) {

--- a/components/Cards/src/MDCCard.m
+++ b/components/Cards/src/MDCCard.m
@@ -278,7 +278,6 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
   }
 
   self.layer.shapeGenerator = shapeGenerator;
-//  self.layer.mask = self.layer.colorLayer;
   self.layer.shadowMaskEnabled = NO;
   [self updateBackgroundColor];
 }

--- a/components/Cards/src/MDCCard.m
+++ b/components/Cards/src/MDCCard.m
@@ -271,6 +271,17 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
   return beginTracking;
 }
 
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+  if (self.layer.shapeGenerator) {
+    if (CGPathContainsPoint(self.layer.shapeLayer.path, nil, point, true)) {
+      return self;
+    } else {
+      return nil;
+    }
+  }
+  return [super hitTest:point withEvent:event];
+}
+
 - (void)setShapeGenerator:(id<MDCShapeGenerating>)shapeGenerator {
   if (shapeGenerator) {
     self.layer.cornerRadius = 0;

--- a/components/Cards/src/MDCCard.m
+++ b/components/Cards/src/MDCCard.m
@@ -142,8 +142,6 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
 
   if (!self.layer.shapeGenerator) {
     self.layer.shadowPath = [self boundingPath].CGPath;
-  } else {
-    self.layer.cornerRadius = 0;
   }
 }
 
@@ -284,8 +282,9 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
 
 - (void)setShapeGenerator:(id<MDCShapeGenerating>)shapeGenerator {
   if (shapeGenerator) {
-    self.layer.cornerRadius = 0;
     self.layer.shadowPath = nil;
+  } else {
+    self.layer.shadowPath = [self boundingPath].CGPath;
   }
 
   self.layer.shapeGenerator = shapeGenerator;
@@ -294,15 +293,15 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
   [self updateInkForShape];
 }
 
+- (id<MDCShapeGenerating>)shapeGenerator {
+  return self.layer.shapeGenerator;
+}
+
 - (void)updateInkForShape {
   CGRect boundingBox = CGPathGetBoundingBox(self.layer.shapeLayer.path);
   self.inkView.maxRippleRadius =
       (CGFloat)(MDCHypot(CGRectGetHeight(boundingBox), CGRectGetWidth(boundingBox)) / 2 + 10.f);
   self.inkView.layer.masksToBounds = NO;
-}
-
-- (id)shapeGenerator {
-  return self.layer.shapeGenerator;
 }
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor {

--- a/components/Cards/src/MDCCardCollectionCell.h
+++ b/components/Cards/src/MDCCardCollectionCell.h
@@ -91,9 +91,17 @@ typedef NS_ENUM(NSInteger, MDCCardCellVerticalImageAlignment) {
 @property(nonatomic, readonly, strong, nonnull) MDCInkView *inkView;
 
 /*
- The shape generator used to define the card's shape.
+ The shape generator used to define the card cell's shape.
+ When set, layer properties such as cornerRadius and other layer properties are nullified/zeroed.
+ If a layer property is explicitly set after the shapeGenerator has been set, it will lead to
+ unexpected behavior.
+
+ When the shapeGenerator is nil, MDCCardCollectionCell will work like a normal UIControl with
+ the default cornerRadius value of 4.
+
+ Default value for shapeGenerator is nil.
  */
-@property(nullable, nonatomic, strong) id<MDCShapeGenerating> shapeGenerator UI_APPEARANCE_SELECTOR;
+@property(nullable, nonatomic, strong) id<MDCShapeGenerating> shapeGenerator;
 
 /**
  Sets the shadow elevation for an MDCCardViewState state

--- a/components/Cards/src/MDCCardCollectionCell.h
+++ b/components/Cards/src/MDCCardCollectionCell.h
@@ -96,8 +96,8 @@ typedef NS_ENUM(NSInteger, MDCCardCellVerticalImageAlignment) {
  If a layer property is explicitly set after the shapeGenerator has been set, it will lead to
  unexpected behavior.
 
- When the shapeGenerator is nil, MDCCardCollectionCell will work like a normal UIControl with
- the default cornerRadius value of 4.
+ When the shapeGenerator is nil, MDCCardCollectionCell will use the default underlying layer with
+ its default settings.
 
  Default value for shapeGenerator is nil.
  */

--- a/components/Cards/src/MDCCardCollectionCell.h
+++ b/components/Cards/src/MDCCardCollectionCell.h
@@ -18,6 +18,8 @@
 #import "MaterialInk.h"
 #import "MaterialShadowLayer.h"
 
+@protocol MDCShapeGenerating;
+
 /**
  Through the lifecycle of the cell, the cell can go through one of the 3 states,
  normal, highlighted, and selected. The cell starts in its default state, normal.
@@ -87,6 +89,11 @@ typedef NS_ENUM(NSInteger, MDCCardCellVerticalImageAlignment) {
  The inkView for the card that is initiated on tap
  */
 @property(nonatomic, readonly, strong, nonnull) MDCInkView *inkView;
+
+/*
+ The shape generator used to define the card's shape.
+ */
+@property(nullable, nonatomic, strong) id<MDCShapeGenerating> shapeGenerator UI_APPEARANCE_SELECTOR;
 
 /**
  Sets the shadow elevation for an MDCCardViewState state
@@ -260,7 +267,6 @@ UI_APPEARANCE_SELECTOR;
  */
 - (void)setImageTintColor:(nullable UIColor *)imageTintColor forState:(MDCCardCellState)state
 UI_APPEARANCE_SELECTOR;
-
 
 /**
  The state of the card cell.

--- a/components/Cards/src/MDCCardCollectionCell.m
+++ b/components/Cards/src/MDCCardCollectionCell.m
@@ -213,8 +213,6 @@ static const CGFloat MDCCardCellShadowElevationSelected = 8.f;
   [super layoutSubviews];
   if (!self.layer.shapeGenerator) {
     self.layer.shadowPath = [self boundingPath].CGPath;
-  } else {
-    self.layer.cornerRadius = 0;
   }
   [self updateImageAlignment];
 }
@@ -513,8 +511,9 @@ static const CGFloat MDCCardCellShadowElevationSelected = 8.f;
 
 - (void)setShapeGenerator:(id<MDCShapeGenerating>)shapeGenerator {
   if (shapeGenerator) {
-    self.layer.cornerRadius = 0;
     self.layer.shadowPath = nil;
+  } else {
+    self.layer.shadowPath = [self boundingPath].CGPath;
   }
 
   self.layer.shapeGenerator = shapeGenerator;
@@ -523,15 +522,15 @@ static const CGFloat MDCCardCellShadowElevationSelected = 8.f;
   [self updateInkForShape];
 }
 
+- (id)shapeGenerator {
+  return self.layer.shapeGenerator;
+}
+
 - (void)updateInkForShape {
   CGRect boundingBox = CGPathGetBoundingBox(self.layer.shapeLayer.path);
   self.inkView.maxRippleRadius =
   (CGFloat)(MDCHypot(CGRectGetHeight(boundingBox), CGRectGetWidth(boundingBox)) / 2 + 10.f);
   self.inkView.layer.masksToBounds = NO;
-}
-
-- (id)shapeGenerator {
-  return self.layer.shapeGenerator;
 }
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor {

--- a/components/Cards/src/MDCCardCollectionCell.m
+++ b/components/Cards/src/MDCCardCollectionCell.m
@@ -18,32 +18,35 @@
 
 #import "MaterialMath.h"
 #import "MaterialIcons+ic_check_circle.h"
+#import "MaterialShapes.h"
 
-static NSString *const MDCCardCellShadowElevationsKey = @"MDCCardCellShadowElevationsKey";
-static NSString *const MDCCardCellShadowColorsKey = @"MDCCardCellShadowColorsKey";
+static NSString *const MDCCardCellBackgroundColorsKey = @"MDCCardCellBackgroundColorsKey";
 static NSString *const MDCCardCellBorderWidthsKey = @"MDCCardCellBorderWidthsKey";
 static NSString *const MDCCardCellBorderColorsKey = @"MDCCardCellBorderColorsKey";
-static NSString *const MDCCardCellInkViewKey = @"MDCCardCellInkViewKey";
-static NSString *const MDCCardCellSelectedImageViewKey = @"MDCCardCellSelectedImageViewKey";
-static NSString *const MDCCardCellStateKey = @"MDCCardCellStateKey";
-static NSString *const MDCCardCellSelectableKey = @"MDCCardCellSelectableKey";
 static NSString *const MDCCardCellCornerRadiusKey = @"MDCCardCellCornerRadiusKey";
-static NSString *const MDCCardCellImagesKey = @"MDCCardCellImagesKey";
 static NSString *const MDCCardCellHorizontalImageAlignmentsKey =
-    @"MDCCardCellHorizontalImageAlignmentsKey";
+@"MDCCardCellHorizontalImageAlignmentsKey";
+static NSString *const MDCCardCellImageTintColorsKey = @"MDCCardCellImageTintColorsKey";
+static NSString *const MDCCardCellImagesKey = @"MDCCardCellImagesKey";
+static NSString *const MDCCardCellInkViewKey = @"MDCCardCellInkViewKey";
+static NSString *const MDCCardCellSelectableKey = @"MDCCardCellSelectableKey";
+static NSString *const MDCCardCellSelectedImageViewKey = @"MDCCardCellSelectedImageViewKey";
+static NSString *const MDCCardCellShadowElevationsKey = @"MDCCardCellShadowElevationsKey";
+static NSString *const MDCCardCellShadowColorsKey = @"MDCCardCellShadowColorsKey";
+static NSString *const MDCCardCellStateKey = @"MDCCardCellStateKey";
 static NSString *const MDCCardCellVerticalImageAlignmentsKey =
     @"MDCCardCellVerticalImageAlignmentsKey";
-static NSString *const MDCCardCellImageTintColorsKey = @"MDCCardCellImageTintColorsKey";
 
-static const CGFloat MDCCardCellSelectedImagePadding = 8;
-static const CGFloat MDCCardCellShadowElevationNormal = 1.f;
-static const CGFloat MDCCardCellShadowElevationHighlighted = 8.f;
-static const CGFloat MDCCardCellShadowElevationSelected = 8.f;
 static const CGFloat MDCCardCellCornerRadiusDefault = 4.f;
+static const CGFloat MDCCardCellSelectedImagePadding = 8;
+static const CGFloat MDCCardCellShadowElevationHighlighted = 8.f;
+static const CGFloat MDCCardCellShadowElevationNormal = 1.f;
+static const CGFloat MDCCardCellShadowElevationSelected = 8.f;
 
 
 @interface MDCCardCollectionCell ()
 @property(nonatomic, strong, nullable) UIImageView *selectedImageView;
+@property(nonatomic, readonly, strong) MDCShapedShadowLayer *layer;
 @end
 
 @implementation MDCCardCollectionCell  {
@@ -55,11 +58,14 @@ static const CGFloat MDCCardCellCornerRadiusDefault = 4.f;
   NSMutableDictionary<NSNumber *, NSNumber *> *_horizontalImageAlignments;
   NSMutableDictionary<NSNumber *, NSNumber *> *_verticalImageAlignments;
   NSMutableDictionary<NSNumber *, UIColor *> *_imageTintColors;
+  UIColor *_backgroundColor;
   CGPoint _lastTouch;
 }
 
+@dynamic layer;
+
 + (Class)layerClass {
-  return [MDCShadowLayer class];
+  return [MDCShapedShadowLayer class];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)coder {
@@ -91,6 +97,11 @@ static const CGFloat MDCCardCellCornerRadiusDefault = 4.f;
       self.layer.cornerRadius = (CGFloat)[coder decodeDoubleForKey:MDCCardCellCornerRadiusKey];
     } else {
       self.layer.cornerRadius = MDCCardCellCornerRadiusDefault;
+    }
+    if ([coder containsValueForKey:MDCCardCellBackgroundColorsKey]) {
+      [self.layer setShapedBackgroundColor:
+          [coder decodeObjectOfClass:[UIColor class]
+                              forKey:MDCCardCellBackgroundColorsKey]];
     }
     [self commonMDCCardCollectionCellInit];
   }
@@ -134,7 +145,7 @@ static const CGFloat MDCCardCellCornerRadiusDefault = 4.f;
 
   if (_shadowColors == nil) {
     _shadowColors = [NSMutableDictionary dictionary];
-    _shadowColors[@(MDCCardCellStateNormal)] = [UIColor blackColor];
+    _shadowColors[@(MDCCardCellStateNormal)] = UIColor.blackColor;
   }
 
   if (_borderColors == nil) {
@@ -167,12 +178,17 @@ static const CGFloat MDCCardCellCornerRadiusDefault = 4.f;
     _imageTintColors = [NSMutableDictionary dictionary];
   }
 
+  if (_backgroundColor == nil) {
+    _backgroundColor = UIColor.whiteColor;
+  }
+
   [self updateShadowElevation];
   [self updateBorderColor];
   [self updateBorderWidth];
   [self updateShadowColor];
   [self updateImage];
   [self updateImageTintColor];
+  [self updateBackgroundColor];
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
@@ -190,11 +206,16 @@ static const CGFloat MDCCardCellCornerRadiusDefault = 4.f;
   [coder encodeObject:_horizontalImageAlignments forKey:MDCCardCellHorizontalImageAlignmentsKey];
   [coder encodeObject:_verticalImageAlignments forKey:MDCCardCellVerticalImageAlignmentsKey];
   [coder encodeObject:_imageTintColors forKey:MDCCardCellImageTintColorsKey];
+  [coder encodeObject:self.layer.shapedBackgroundColor forKey:MDCCardCellBackgroundColorsKey];
 }
 
 - (void)layoutSubviews {
   [super layoutSubviews];
-  self.layer.shadowPath = [self boundingPath].CGPath;
+  if (!self.layer.shapeGenerator) {
+    self.layer.shadowPath = [self boundingPath].CGPath;
+  } else {
+    self.layer.cornerRadius = 0;
+  }
   [self updateImageAlignment];
 }
 
@@ -288,7 +309,9 @@ static const CGFloat MDCCardCellCornerRadiusDefault = 4.f;
 - (void)updateShadowElevation {
   CGFloat elevation = [self shadowElevationForState:self.state];
   if (!MDCCGFloatEqual(((MDCShadowLayer *)self.layer).elevation, elevation)) {
-    self.layer.shadowPath = [self boundingPath].CGPath;
+    if (!self.layer.shapeGenerator) {
+      self.layer.shadowPath = [self boundingPath].CGPath;
+    }
     [(MDCShadowLayer *)self.layer setElevation:elevation];
   }
 }
@@ -301,7 +324,7 @@ static const CGFloat MDCCardCellCornerRadiusDefault = 4.f;
 
 - (void)updateBorderWidth {
   CGFloat borderWidth = [self borderWidthForState:self.state];
-  self.layer.borderWidth = borderWidth;
+  self.layer.shapedBorderWidth = borderWidth;
 }
 
 - (CGFloat)borderWidthForState:(MDCCardCellState)state {
@@ -322,8 +345,8 @@ static const CGFloat MDCCardCellCornerRadiusDefault = 4.f;
 }
 
 - (void)updateBorderColor {
-  CGColorRef borderColorRef = [self borderColorForState:self.state].CGColor;
-  self.layer.borderColor = borderColorRef;
+  UIColor *borderColor = [self borderColorForState:self.state];
+  self.layer.shapedBorderColor = borderColor;
 }
 
 - (UIColor *)borderColorForState:(MDCCardCellState)state {
@@ -475,6 +498,53 @@ static const CGFloat MDCCardCellCornerRadiusDefault = 4.f;
 - (void)tintColorDidChange {
   [super tintColorDidChange];
   [self setImageTintColor:self.tintColor forState:MDCCardCellStateNormal];
+}
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+  if (self.layer.shapeGenerator) {
+    if (CGPathContainsPoint(self.layer.shapeLayer.path, nil, point, true)) {
+      return self;
+    } else {
+      return nil;
+    }
+  }
+  return [super hitTest:point withEvent:event];
+}
+
+- (void)setShapeGenerator:(id<MDCShapeGenerating>)shapeGenerator {
+  if (shapeGenerator) {
+    self.layer.cornerRadius = 0;
+    self.layer.shadowPath = nil;
+  }
+
+  self.layer.shapeGenerator = shapeGenerator;
+  self.layer.shadowMaskEnabled = NO;
+  [self updateBackgroundColor];
+  [self updateInkForShape];
+}
+
+- (void)updateInkForShape {
+  CGRect boundingBox = CGPathGetBoundingBox(self.layer.shapeLayer.path);
+  self.inkView.maxRippleRadius =
+  (CGFloat)(MDCHypot(CGRectGetHeight(boundingBox), CGRectGetWidth(boundingBox)) / 2 + 10.f);
+  self.inkView.layer.masksToBounds = NO;
+}
+
+- (id)shapeGenerator {
+  return self.layer.shapeGenerator;
+}
+
+- (void)setBackgroundColor:(UIColor *)backgroundColor {
+  _backgroundColor = backgroundColor;
+  [self updateBackgroundColor];
+}
+
+- (UIColor *)backgroundColor {
+  return _backgroundColor;
+}
+
+- (void)updateBackgroundColor {
+  self.layer.shapedBackgroundColor = _backgroundColor;
 }
 
 #pragma mark - UIResponder

--- a/components/Cards/src/MDCCardCollectionCell.m
+++ b/components/Cards/src/MDCCardCollectionCell.m
@@ -498,17 +498,6 @@ static const CGFloat MDCCardCellShadowElevationSelected = 8.f;
   [self setImageTintColor:self.tintColor forState:MDCCardCellStateNormal];
 }
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
-  if (self.layer.shapeGenerator) {
-    if (CGPathContainsPoint(self.layer.shapeLayer.path, nil, point, true)) {
-      return self;
-    } else {
-      return nil;
-    }
-  }
-  return [super hitTest:point withEvent:event];
-}
-
 - (void)setShapeGenerator:(id<MDCShapeGenerating>)shapeGenerator {
   if (shapeGenerator) {
     self.layer.shadowPath = nil;

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -226,7 +226,6 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
    forControlEvents:UIControlEventTouchDragExit];
 
     self.layer.elevation = [self elevationForState:UIControlStateNormal];
-
     [self updateBackgroundColor];
   }
   return self;

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -226,6 +226,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
    forControlEvents:UIControlEventTouchDragExit];
 
     self.layer.elevation = [self elevationForState:UIControlStateNormal];
+
     [self updateBackgroundColor];
   }
   return self;

--- a/components/Ink/src/MDCInkView.m
+++ b/components/Ink/src/MDCInkView.m
@@ -142,7 +142,6 @@ static NSString *const MDCInkViewMaxRippleRadiusKey = @"MDCInkViewMaxRippleRadiu
   if (self.superview.layer.shadowPath) {
     self.maskLayer.path = self.superview.layer.shadowPath;
     self.layer.mask = _maskLayer;
-    self.layer.masksToBounds = YES;
   }
 
   CGRect inkBounds = CGRectMake(0, 0, CGRectGetWidth(self.bounds), CGRectGetHeight(self.bounds));
@@ -154,13 +153,6 @@ static NSString *const MDCInkViewMaxRippleRadiusKey = @"MDCInkViewMaxRippleRadiu
       MDCInkLayer *inkLayer = (MDCInkLayer *)layer;
       inkLayer.bounds = inkBounds;
     }
-  }
-
-  // If the superview has a shadowPath make sure ink does not spread outside of the shadowPath.
-  if (self.superview.layer.shadowPath) {
-    self.maskLayer.path = self.superview.layer.shadowPath;
-    self.layer.mask = _maskLayer;
-    self.layer.masksToBounds = YES;
   }
 }
 

--- a/components/private/ShapeLibrary/src/MDCCutCornerTreatment.h
+++ b/components/private/ShapeLibrary/src/MDCCutCornerTreatment.h
@@ -14,10 +14,28 @@
  limitations under the License.
  */
 
-#import "MDCCurvedCornerTreatment.h"
-#import "MDCCurvedRectShapeGenerator.h"
-#import "MDCPillShapeGenerator.h"
-#import "MDCRoundedCornerTreatment.h"
-#import "MDCSlantedRectShapeGenerator.h"
-#import "MDCTriangleEdgeTreatment.h"
-#import "MDCCutCornerTreatment.h"
+#import <CoreGraphics/CoreGraphics.h>
+
+#import "MaterialShapes.h"
+
+@interface MDCCutCornerTreatment : MDCCornerTreatment
+
+/**
+ The radius of the corner.
+ */
+@property(nonatomic, assign) CGFloat cut;
+
+/**
+ Initializes an MDCRoundedCornerTreatment instance with a given radius.
+ */
+- (nonnull instancetype)initWithCut:(CGFloat)cut NS_DESIGNATED_INITIALIZER;
+
+/**
+ Initializes an MDCRoundedCornerTreatment instance with a radius of zero.
+ */
+- (nonnull instancetype)init;
+
+- (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
+
+
+@end

--- a/components/private/ShapeLibrary/src/MDCCutCornerTreatment.h
+++ b/components/private/ShapeLibrary/src/MDCCutCornerTreatment.h
@@ -21,17 +21,17 @@
 @interface MDCCutCornerTreatment : MDCCornerTreatment
 
 /**
- The radius of the corner.
+ The cut of the corner.
  */
 @property(nonatomic, assign) CGFloat cut;
 
 /**
- Initializes an MDCRoundedCornerTreatment instance with a given radius.
+ Initializes an MDCCutCornerTreatment instance with a given cut.
  */
 - (nonnull instancetype)initWithCut:(CGFloat)cut NS_DESIGNATED_INITIALIZER;
 
 /**
- Initializes an MDCRoundedCornerTreatment instance with a radius of zero.
+ Initializes an MDCCutCornerTreatment instance with a cut of zero.
  */
 - (nonnull instancetype)init;
 

--- a/components/private/ShapeLibrary/src/MDCCutCornerTreatment.h
+++ b/components/private/ShapeLibrary/src/MDCCutCornerTreatment.h
@@ -18,10 +18,31 @@
 
 #import "MaterialShapes.h"
 
+/**
+ A cut corner treatment subclassing MDCCornerTreatment.
+ This can be used to set corners in MDCRectangleShapeGenerator.
+ */
 @interface MDCCutCornerTreatment : MDCCornerTreatment
 
 /**
  The cut of the corner.
+
+ The value of the cut defines by how many UI points starting from the edge of the corner and going
+ equal distance on the X axis and the Y axis will the corner be cut.
+
+ As an example if the shape is a square with a size of 100x100, and we have all its corners set
+ with MDCCutCornerTreatment and a cut value of 50 then the final result will be a diamond with a
+ size of 50x50.
+ +--------------+                     /\
+ |              |                   /    \ 50
+ |              |                 /        \
+ |              | 100   --->    /            \
+ |              |               \            /
+ |              |                 \        /
+ |              |                   \    / 50
+ +--------------+                     \/
+       100
+
  */
 @property(nonatomic, assign) CGFloat cut;
 

--- a/components/private/ShapeLibrary/src/MDCCutCornerTreatment.m
+++ b/components/private/ShapeLibrary/src/MDCCutCornerTreatment.m
@@ -1,0 +1,57 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCCutCornerTreatment.h"
+
+static NSString *const MDCCutCornerTreatmentCutKey = @"MDCCutCornerTreatmentCutKey";
+
+@implementation MDCCutCornerTreatment
+
+- (instancetype)init {
+  return [self initWithCut:0];
+}
+
+- (instancetype)initWithCut:(CGFloat)cut {
+  if (self = [super init]) {
+    _cut = cut;
+  }
+  return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+  if (self = [super initWithCoder:aDecoder]) {
+    _cut = (CGFloat)[aDecoder decodeDoubleForKey:MDCCutCornerTreatmentCutKey];
+  }
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+  [super encodeWithCoder:aCoder];
+  [aCoder encodeDouble:_cut forKey:MDCCutCornerTreatmentCutKey];
+}
+
+- (id)copyWithZone:(NSZone *)__unused zone {
+  return [[[self class] alloc] initWithCut:_cut];
+}
+
+- (MDCPathGenerator *)pathGeneratorForCornerWithAngle:(CGFloat)angle {
+  MDCPathGenerator *path = [MDCPathGenerator pathGeneratorWithStartPoint:CGPointMake(0, _cut)];
+  [path addLineToPoint:CGPointMake(_cut, 0)];
+  return path;
+}
+
+@end
+

--- a/components/private/Shapes/src/MDCShapedShadowLayer.h
+++ b/components/private/Shapes/src/MDCShapedShadowLayer.h
@@ -63,4 +63,7 @@
  */
 @property(nonatomic, strong, nullable) id<MDCShapeGenerating> shapeGenerator;
 
+@property(nonatomic, strong, nonnull) CAShapeLayer *colorLayer;
+
+
 @end

--- a/components/private/Shapes/src/MDCShapedShadowLayer.h
+++ b/components/private/Shapes/src/MDCShapedShadowLayer.h
@@ -64,8 +64,11 @@
 @property(nonatomic, strong, nullable) id<MDCShapeGenerating> shapeGenerator;
 
 /*
- The created CAShapeLayer representing the generated shape layer for the implementing UIView
+ The created CAShapeLayer representing the generated shape path for the implementing UIView
  from the shapeGenerator.
+
+ This layer is exposed to easily mask subviews of the implementing UIView so they won't spill
+ outside the layer to fit the bounds.
  */
 @property(nonatomic, strong, nonnull) CAShapeLayer *shapeLayer;
 

--- a/components/private/Shapes/src/MDCShapedShadowLayer.h
+++ b/components/private/Shapes/src/MDCShapedShadowLayer.h
@@ -63,7 +63,8 @@
  */
 @property(nonatomic, strong, nullable) id<MDCShapeGenerating> shapeGenerator;
 
-@property(nonatomic, strong, nonnull) CAShapeLayer *colorLayer;
+@property(nonatomic, strong, nonnull) CAShapeLayer *shapeLayer;
+
 
 
 @end

--- a/components/private/Shapes/src/MDCShapedShadowLayer.h
+++ b/components/private/Shapes/src/MDCShapedShadowLayer.h
@@ -63,8 +63,10 @@
  */
 @property(nonatomic, strong, nullable) id<MDCShapeGenerating> shapeGenerator;
 
+/*
+ The created CAShapeLayer representing the generated shape layer for the implementing UIView
+ from the shapeGenerator.
+ */
 @property(nonatomic, strong, nonnull) CAShapeLayer *shapeLayer;
-
-
 
 @end

--- a/components/private/Shapes/src/MDCShapedShadowLayer.m
+++ b/components/private/Shapes/src/MDCShapedShadowLayer.m
@@ -19,7 +19,7 @@
 #import "MDCShapeGenerating.h"
 
 @implementation MDCShapedShadowLayer {
-  CAShapeLayer *_colorLayer;
+//  CAShapeLayer *_colorLayer;
 }
 
 - (instancetype)init {
@@ -144,6 +144,10 @@
     self.borderWidth = 0;
     _colorLayer.lineWidth = _shapedBorderWidth;
   }
+}
+
+- (void)setElevation:(MDCShadowElevation)elevation {
+  [super setElevation:elevation];
 }
 
 @end

--- a/components/private/Shapes/src/MDCShapedShadowLayer.m
+++ b/components/private/Shapes/src/MDCShapedShadowLayer.m
@@ -150,8 +150,4 @@
   }
 }
 
-- (void)setElevation:(MDCShadowElevation)elevation {
-  [super setElevation:elevation];
-}
-
 @end

--- a/components/private/Shapes/src/MDCShapedShadowLayer.m
+++ b/components/private/Shapes/src/MDCShapedShadowLayer.m
@@ -87,9 +87,7 @@
 - (void)setPath:(CGPathRef)path {
   self.shadowPath = path;
   _colorLayer.path = path;
-
   _shapeLayer.path = path;
-  _shapeLayer.fillRule = kCAFillRuleEvenOdd;
 
   if (CGPathIsEmpty(path)) {
     self.backgroundColor = self.shapedBackgroundColor.CGColor;

--- a/components/private/Shapes/src/MDCShapedShadowLayer.m
+++ b/components/private/Shapes/src/MDCShapedShadowLayer.m
@@ -19,7 +19,7 @@
 #import "MDCShapeGenerating.h"
 
 @implementation MDCShapedShadowLayer {
-//  CAShapeLayer *_colorLayer;
+  CAShapeLayer *_colorLayer;
 }
 
 - (instancetype)init {
@@ -59,6 +59,7 @@
   self.backgroundColor = [UIColor clearColor].CGColor;
   _colorLayer = [CAShapeLayer layer];
   _colorLayer.delegate = self;
+  _shapeLayer = [CAShapeLayer layer];
   [self addSublayer:_colorLayer];
 }
 
@@ -86,6 +87,9 @@
 - (void)setPath:(CGPathRef)path {
   self.shadowPath = path;
   _colorLayer.path = path;
+
+  _shapeLayer.path = path;
+  _shapeLayer.fillRule = kCAFillRuleEvenOdd;
 
   if (CGPathIsEmpty(path)) {
     self.backgroundColor = self.shapedBackgroundColor.CGColor;

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -53,22 +53,22 @@ def ios_runners():
   ios_test_runner(
     name = "IPHONE_5_IN_8_1",
     device_type = "iPhone 5",
-    os_version = "8.1",
+    os_version = "",
   )
   ios_test_runner(
     name = "IPAD_PRO_12_9_IN_9_3",
     device_type = "iPad Pro (12.9-inch)",
-    os_version = "9.3",
+    os_version = "",
   )
   ios_test_runner(
     name = "IPHONE_7_PLUS_IN_10_3",
     device_type = "iPhone 7 Plus",
-    os_version = "10.3",
+    os_version = "",
   )
   ios_test_runner(
     name = "DYNAMIC_RUNNER",
     device_type = select({ ":xcode8_3_3": "iPad 2", ":xcode_9_0": "iPhone2017-C", "//conditions:default": "iPhone X" }),
-    os_version = select({ ":xcode8_3_3": "8.4", "//conditions:default": "11.0" }), 
+    os_version = "", 
   )
 
   native.config_setting(

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -53,22 +53,22 @@ def ios_runners():
   ios_test_runner(
     name = "IPHONE_5_IN_8_1",
     device_type = "iPhone 5",
-    os_version = "",
+    os_version = "8.1",
   )
   ios_test_runner(
     name = "IPAD_PRO_12_9_IN_9_3",
     device_type = "iPad Pro (12.9-inch)",
-    os_version = "",
+    os_version = "9.3",
   )
   ios_test_runner(
     name = "IPHONE_7_PLUS_IN_10_3",
     device_type = "iPhone 7 Plus",
-    os_version = "",
+    os_version = "10.3",
   )
   ios_test_runner(
     name = "DYNAMIC_RUNNER",
     device_type = select({ ":xcode8_3_3": "iPad 2", ":xcode_9_0": "iPhone2017-C", "//conditions:default": "iPhone X" }),
-    os_version = "", 
+    os_version = select({ ":xcode8_3_3": "8.4", "//conditions:default": "11.0" }), 
   )
 
   native.config_setting(


### PR DESCRIPTION
This PR adds shapes support for MDCCard and MDCCardCollectionCell.
To reach the desired support, aside from making changes to the Card classes, we also had to make some updates to MDCInkView, MDCShapedShadowLayer, and also add a convenience method that allows cut corners for generated shapes.
There are also 2 examples showcasing cards and card cells with shapes.

https://www.pivotaltracker.com/story/show/156167985

![shapedcards](https://user-images.githubusercontent.com/4066863/38251285-b767ca32-3759-11e8-96eb-8c936a0044e7.gif)
![cardcelldemo](https://user-images.githubusercontent.com/4066863/38251286-b78863c8-3759-11e8-86ba-0d0c9d0ba5fc.gif)

