### PR TITLE
[Snackbar] Removed dependency on UIAppearance entirely for color/font customization/theming.

### DIFF
--- a/components/Snackbar/examples/SnackbarSimpleExample.m
+++ b/components/Snackbar/examples/SnackbarSimpleExample.m
@@ -67,7 +67,7 @@
   } else {
     [self.navigationItem.rightBarButtonItems.lastObject setTitle:@"DT Off"];
   }
-  [MDCSnackbarMessageView appearance].mdc_adjustsFontForContentSizeCategory = _dynamicType;
+  [MDCSnackbarManager mdc_setAdjustsFontForContentSizeCategory:_dynamicType];
 }
 
 #pragma mark - Event Handling
@@ -126,24 +126,22 @@
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   action.title = @"Tap Me";
   message.action = action;
-  [[MDCSnackbarMessageView appearance]
-      setButtonTitleColor:MDCPalette.purplePalette.tint400
-                 forState:UIControlStateNormal];
-  [[MDCSnackbarMessageView appearance]
-      setButtonTitleColor:MDCPalette.purplePalette.tint700
-                 forState:UIControlStateHighlighted];
-  [MDCSnackbarMessageView appearance].messageTextColor = MDCPalette.greenPalette.tint500;
+  [MDCSnackbarManager setButtonTitleColor:MDCPalette.purplePalette.tint400
+                                 forState:UIControlStateNormal];
+  [MDCSnackbarManager setButtonTitleColor:MDCPalette.purplePalette.tint700
+                                 forState:UIControlStateHighlighted];
+  MDCSnackbarManager.messageTextColor = MDCPalette.greenPalette.tint500;
   [MDCSnackbarManager showMessage:message];
 }
 
 - (void)showCustomizedSnackbar:(id)sender {
   UIFont *customMessageFont = [UIFont fontWithName:@"Zapfino" size:14.0f];
   NSAssert(customMessageFont, @"Unable to instantiate font");
-  [MDCSnackbarMessageView appearance].messageFont = customMessageFont;
+  MDCSnackbarManager.messageFont = customMessageFont;
 
   UIFont *customButtonFont = [UIFont fontWithName:@"ChalkDuster" size:14.0f];
   NSAssert(customButtonFont, @"Unable to instantiate font");
-  [MDCSnackbarMessageView appearance].buttonFont = customButtonFont;
+  MDCSnackbarManager.buttonFont = customButtonFont;
 
   MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
   message.text = @"Customized Fonts";
@@ -155,15 +153,11 @@
 }
 
 - (void)showDecustomizedSnackbar:(id)sender {
-  [MDCSnackbarMessageView appearance].messageFont = nil;
-  [MDCSnackbarMessageView appearance].buttonFont = nil;
-
-  // Setting back to the default colors as defined in MDCSnackbarMessageView.h.
-  [[MDCSnackbarMessageView appearance] setButtonTitleColor:[UIColor colorWithWhite:1 alpha:0.6f]
-                                                  forState:UIControlStateNormal];
-  [[MDCSnackbarMessageView appearance] setButtonTitleColor:nil
-                                                  forState:UIControlStateHighlighted];
-  [MDCSnackbarMessageView appearance].messageTextColor = nil;
+  MDCSnackbarManager.messageFont = nil;
+  MDCSnackbarManager.buttonFont = nil;
+  [MDCSnackbarManager setButtonTitleColor:nil forState:UIControlStateNormal];
+  [MDCSnackbarManager setButtonTitleColor:nil forState:UIControlStateHighlighted];
+  MDCSnackbarManager.messageTextColor = nil;
 
   MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
   message.text = @"Back to the standard snackbar";

--- a/components/Snackbar/src/FontThemer/MDCSnackbarFontThemer.h
+++ b/components/Snackbar/src/FontThemer/MDCSnackbarFontThemer.h
@@ -34,4 +34,11 @@
 + (void)applyFontScheme:(nonnull id<MDCFontScheme>)fontScheme
     toSnackbarMessageView:(nonnull MDCSnackbarMessageView *)snackbarMessageView;
 
+/**
+ Applies a font scheme to theme to a MDCSnackbarMessageView.
+
+ @param fontScheme The font scheme to apply to MDCSnackbarMessageView.
+ */
++ (void)applyFontScheme:(nonnull id<MDCFontScheme>)fontScheme;
+
 @end

--- a/components/Snackbar/src/FontThemer/MDCSnackbarFontThemer.m
+++ b/components/Snackbar/src/FontThemer/MDCSnackbarFontThemer.m
@@ -24,4 +24,9 @@
   snackbarMessageView.buttonFont = fontScheme.button;
 }
 
++ (void)applyFontScheme:(nonnull id<MDCFontScheme>)fontScheme {
+  MDCSnackbarManager.messageFont = fontScheme.body2;
+  MDCSnackbarManager.buttonFont = fontScheme.button;
+}
+
 @end

--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -142,12 +142,12 @@
 
 
 /**
- When setting this BOOL to YES, then all the styling changes that are set using the class styling
- properties in this class, will apply on the currently presented snackbar too.
+ If enabled, modifications of class styling properties will be applied immediately
+ to the currently presented snackbar.
 
  Default is set to NO.
  */
-@property(class, nonatomic, assign) BOOL applyStylingOnCurrentSnackbar;
+@property(class, nonatomic, assign) BOOL shouldApplyStyleChangesToVisibleSnackbars;
 
 /**
  Returns the button title color for a particular control state.
@@ -178,7 +178,7 @@
  Default is set to NO.
  */
 @property(class, nonatomic, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
-BOOL mdc_adjustsFontForContentSizeCategory;
+    BOOL mdc_adjustsFontForContentSizeCategory;
 
 @end
 

--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -144,6 +144,8 @@
 /**
  When setting this BOOL to YES, then all the styling changes that are set using the class styling
  properties in this class, will apply on the currently presented snackbar too.
+
+ Default is set to NO.
  */
 @property(class, nonatomic, assign) BOOL applyStylingOnCurrentSnackbar;
 
@@ -173,6 +175,7 @@
  If set to YES, this button will base its message font on MDCFontTextStyleBody2
  and its button font on MDCFontTextStyleButton.
 
+ Default is set to NO.
  */
 @property(class, nonatomic, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
 BOOL mdc_adjustsFontForContentSizeCategory;

--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -39,7 +39,7 @@
  ordering. Ordering between completion blocks of different categories is not guaranteed. This method
  is safe to call from any thread.
  */
-+ (void)showMessage:(MDCSnackbarMessage *)message;
++ (void)showMessage:(nullable MDCSnackbarMessage *)message;
 
 /**
  MDCSnackbarManager will display the messages in this view.
@@ -55,7 +55,7 @@
  @note This method must be called from the main thread.
  @note Calling setPresentationHostView will not change the parent of the currently visible message.
  */
-+ (void)setPresentationHostView:(UIView *)hostView;
++ (void)setPresentationHostView:(nullable UIView *)hostView;
 
 /**
  Bypasses showing the messages of the given @c category.
@@ -64,7 +64,7 @@
  messages for the @c category. Calling this method with @c nil will dismiss all messages. This
  method is safe to call from any thread.
  */
-+ (void)dismissAndCallCompletionBlocksWithCategory:(NSString *)category;
++ (void)dismissAndCallCompletionBlocksWithCategory:(nullable NSString *)category;
 
 /**
  How far from the bottom of the screen messages are displayed.
@@ -88,7 +88,7 @@
  @return A token suitable for use in {@c +[MDCSnackbarManager resumeWithToken:]}. Letting this
  object deallocate is equivalent to calling {@c +[MDCSnackbarManager resumeMessagesWithToken:]}.
  */
-+ (id<MDCSnackbarSuspensionToken>)suspendAllMessages;
++ (nullable id <MDCSnackbarSuspensionToken>)suspendAllMessages;
 
 /**
  Suspends the display of all messages in a given category.
@@ -101,7 +101,8 @@
  Letting this object dealloc is equivalent to calling
  {@c +[MDCSnackbarManager resumeMessagesWithToken:]}.
  */
-+ (id<MDCSnackbarSuspensionToken>)suspendMessagesWithCategory:(NSString *)category;
++ (nullable id <MDCSnackbarSuspensionToken>)
+    suspendMessagesWithCategory:(nullable NSString *)category;
 
 /**
  Resumes the display of messages once there are no outstanding suspension tokens.
@@ -110,7 +111,71 @@
 
  @param token The suspension token to invalidate.
  */
-+ (void)resumeMessagesWithToken:(id<MDCSnackbarSuspensionToken>)token;
++ (void)resumeMessagesWithToken:(nullable id <MDCSnackbarSuspensionToken>)token;
+
+#pragma mark Styling
+
+/**
+ The color for the background of the snackbar message view.
+ */
+@property(class, nonatomic, strong, nullable) UIColor *snackbarMessageViewBackgroundColor;
+
+/**
+ The color for the shadow color for the snackbar message view.
+ */
+@property(class, nonatomic, strong, nullable) UIColor *snackbarMessageViewShadowColor;
+
+/**
+ The color for the message text in the snackbar message view.
+ */
+@property(class, nonatomic, strong, nullable) UIColor *messageTextColor;
+
+/**
+ The font for the message text in the snackbar message view.
+ */
+@property(class, nonatomic, strong, nullable) UIFont *messageFont;
+
+/**
+ The font for the button text in the snackbar message view.
+ */
+@property(class, nonatomic, strong, nullable) UIFont *buttonFont;
+
+
+/**
+ When setting this BOOL to YES, then all the styling changes that are set using the class styling
+ properties in this class, will apply on the currently presented snackbar too.
+ */
+@property(class, nonatomic, assign) BOOL applyStylingOnCurrentSnackbar;
+
+/**
+ Returns the button title color for a particular control state.
+
+ @param state The control state.
+ @return The button title color for the requested state.
+ */
++ (nullable UIColor *)buttonTitleColorForState:(UIControlState)state;
+
+/**
+ Sets the button title color for a particular control state.
+
+ @param titleColor The title color.
+ @param state The control state.
+ */
++ (void)setButtonTitleColor:(nullable UIColor *)titleColor forState:(UIControlState)state;
+
+/**
+ Indicates whether the snackbar should automatically update its font when the device’s
+ UIContentSizeCategory is changed.
+
+ This property is modeled after the adjustsFontForContentSizeCategory property in the
+ UIContentSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
+
+ If set to YES, this button will base its message font on MDCFontTextStyleBody2
+ and its button font on MDCFontTextStyleButton.
+
+ */
+@property(class, nonatomic, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
+BOOL mdc_adjustsFontForContentSizeCategory;
 
 @end
 

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -214,7 +214,6 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
   Class viewClass = [message viewClass];
   snackbarView = [[viewClass alloc] initWithMessage:message dismissHandler:dismissHandler];
   self.currentSnackbar = snackbarView;
-
   self.overlayView.accessibilityViewIsModal = ![self isSnackbarTransient:snackbarView];
   self.overlayView.hidden = NO;
   [self activateOverlay:self.overlayView];
@@ -486,6 +485,15 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
 
 @implementation MDCSnackbarManager
 
+static UIColor *_snackbarMessageViewBackgroundColor;
+static UIColor *_snackbarMessageViewShadowColor;
+static UIColor *_messageTextColor;
+static UIFont *_messageFont;
+static UIFont *_buttonFont;
+static NSMutableDictionary<NSNumber *, UIColor *> *_buttonTitleColors;
+static BOOL _mdc_adjustsFontForContentSizeCategory;
+static BOOL _applyStylingOnCurrentSnackbar;
+
 + (void)showMessage:(MDCSnackbarMessage *)inputMessage {
   if (!inputMessage) {
     return;
@@ -560,6 +568,133 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
 
   MDCSnackbarManagerSuspensionToken *token = (MDCSnackbarManagerSuspensionToken *)inToken;
   [self handleInvalidatedIdentifier:token.identifier forCategory:token.category];
+}
+
+#pragma mark - Styling
+
++ (void)setSnackbarMessageViewBackgroundColor:(UIColor *)snackbarMessageViewBackgroundColor {
+  if (snackbarMessageViewBackgroundColor != _snackbarMessageViewBackgroundColor) {
+    _snackbarMessageViewBackgroundColor = snackbarMessageViewBackgroundColor;
+    if (_applyStylingOnCurrentSnackbar) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
+        [manager.currentSnackbar
+            setSnackbarMessageViewBackgroundColor:snackbarMessageViewBackgroundColor];
+      });
+    }
+  }
+}
+
++ (UIColor *)snackbarMessageViewBackgroundColor {
+  return _snackbarMessageViewBackgroundColor;
+}
+
++ (void)setSnackbarMessageViewShadowColor:(UIColor *)snackbarMessageViewShadowColor {
+  if (snackbarMessageViewShadowColor != _snackbarMessageViewShadowColor) {
+    _snackbarMessageViewShadowColor = snackbarMessageViewShadowColor;
+    if (_applyStylingOnCurrentSnackbar) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
+        [manager.currentSnackbar setSnackbarMessageViewShadowColor:snackbarMessageViewShadowColor];
+      });
+    }
+  }
+}
+
++ (UIColor *)snackbarMessageViewShadowColor {
+  return _snackbarMessageViewShadowColor;
+}
+
++ (void)setMessageTextColor:(UIColor *)messageTextColor {
+  if (messageTextColor != _messageTextColor) {
+    _messageTextColor = messageTextColor;
+    if (_applyStylingOnCurrentSnackbar) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
+        [manager.currentSnackbar setMessageTextColor:messageTextColor];
+      });
+    }
+  }
+}
+
++ (UIColor *)messageTextColor {
+  return _messageTextColor;
+}
+
++ (void)setMessageFont:(UIFont *)messageFont {
+  if (messageFont != _messageFont) {
+    _messageFont = messageFont;
+    if (_applyStylingOnCurrentSnackbar) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
+        [manager.currentSnackbar setMessageFont:messageFont];
+      });
+    }
+  }
+}
+
++ (UIFont *)messageFont {
+  return _messageFont;
+}
+
++ (void)setButtonFont:(UIFont *)buttonFont {
+  if (buttonFont != _buttonFont) {
+    _buttonFont = buttonFont;
+    if (_applyStylingOnCurrentSnackbar) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
+        [manager.currentSnackbar setButtonFont:buttonFont];
+      });
+    }
+  }
+}
+
++ (UIFont *)buttonFont {
+  return _buttonFont;
+}
+
++ (void)setButtonTitleColor:(UIColor *)titleColor forState:(UIControlState)state {
+  if (_buttonTitleColors == nil) {
+    _buttonTitleColors = [NSMutableDictionary dictionary];
+  }
+  if (titleColor != _buttonTitleColors[@(state)]) {
+    _buttonTitleColors[@(state)] = titleColor;
+    if (_applyStylingOnCurrentSnackbar) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
+        [manager.currentSnackbar setButtonTitleColor:titleColor forState:state];
+      });
+    }
+  }
+}
+
++ (UIColor *)buttonTitleColorForState:(UIControlState)state {
+  return _buttonTitleColors[@(state)];
+}
+
++ (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)mdc_adjustsFontForContentSizeCategory {
+  if (mdc_adjustsFontForContentSizeCategory != _mdc_adjustsFontForContentSizeCategory) {
+    _mdc_adjustsFontForContentSizeCategory = mdc_adjustsFontForContentSizeCategory;
+    if (_applyStylingOnCurrentSnackbar) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
+        [manager.currentSnackbar
+            mdc_setAdjustsFontForContentSizeCategory:mdc_adjustsFontForContentSizeCategory];
+      });
+    }
+  }
+}
+
++ (BOOL)mdc_adjustsFontForContentSizeCategory {
+  return _mdc_adjustsFontForContentSizeCategory;
+}
+
++ (void)setApplyStylingOnCurrentSnackbar:(BOOL)applyStylingOnCurrentSnackbar {
+  _applyStylingOnCurrentSnackbar = applyStylingOnCurrentSnackbar;
+}
+
++ (BOOL)applyStylingOnCurrentSnackbar {
+  return _applyStylingOnCurrentSnackbar;
 }
 
 @end

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -310,10 +310,10 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
     }
 
     // Apply 'global' attributes along the whole string.
-    _label.attributedText = messageString;
     _label.backgroundColor = [UIColor clearColor];
     _label.textAlignment = NSTextAlignmentNatural;
-//    _label.adjustsFontSizeToFitWidth = YES;
+    _label.adjustsFontSizeToFitWidth = YES;
+    _label.attributedText = messageString;
     _label.numberOfLines = 0;
     [_label setTranslatesAutoresizingMaskIntoConstraints:NO];
     [_label setContentCompressionResistancePriority:UILayoutPriorityDefaultHigh

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -16,6 +16,7 @@
 
 #import <QuartzCore/QuartzCore.h>
 
+#import "MDCSnackbarManager.h"
 #import "MDCSnackbarMessage.h"
 #import "MDCSnackbarMessageView.h"
 
@@ -195,12 +196,23 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
   self = [super initWithFrame:frame];
 
   if (self) {
-    _snackbarMessageViewShadowColor = UIColor.blackColor;
-    _snackbarMessageViewBackgroundColor = MDCRGBAColor(0x32, 0x32, 0x32, 1);
-    _messageTextColor = UIColor.whiteColor;
+    _snackbarMessageViewShadowColor =
+        MDCSnackbarManager.snackbarMessageViewShadowColor ?: UIColor.blackColor;
+    _snackbarMessageViewBackgroundColor =
+        MDCSnackbarManager.snackbarMessageViewBackgroundColor ?: MDCRGBAColor(0x32, 0x32, 0x32, 1);
+    _messageTextColor =
+        MDCSnackbarManager.messageTextColor ?: UIColor.whiteColor;
     _buttonTitleColors = [NSMutableDictionary dictionary];
-    _buttonTitleColors[@(UIControlStateNormal)] = MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f);
-    _buttonTitleColors[@(UIControlStateHighlighted)] = UIColor.whiteColor;
+    _buttonTitleColors[@(UIControlStateNormal)] =
+        [MDCSnackbarManager buttonTitleColorForState:UIControlStateNormal] ?:
+            MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f);
+    _buttonTitleColors[@(UIControlStateHighlighted)] =
+        [MDCSnackbarManager buttonTitleColorForState:UIControlStateHighlighted] ?:
+            UIColor.whiteColor;
+    _mdc_adjustsFontForContentSizeCategory =
+        MDCSnackbarManager.mdc_adjustsFontForContentSizeCategory;
+    _messageFont = MDCSnackbarManager.messageFont;
+    _buttonFont = MDCSnackbarManager.buttonFont;
   }
 
   return self;
@@ -276,35 +288,32 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
     // TODO(#2709): Migrate to a single source of truth for fonts
     // If we are using the default (system) font loader, retrieve the
     // font from the UIFont standardFont API.
-    if ([MDCTypography.fontLoader isKindOfClass:[MDCSystemFontLoader class]]) {
-      _label.font = [UIFont mdc_standardFontForMaterialTextStyle:kMessageTextStyle];
-    } else {
-      // There is a custom font loader, retrieve the font from it.
-      _label.font = [MDCTypography body1Font];
-    }
+    [self updateMessageFont];
 
     NSMutableAttributedString *messageString = [message.attributedText mutableCopy];
 
-    // Find any of the bold attributes in the string, and set the proper font for those ranges.
-    // Use NSAttributedStringEnumerationLongestEffectiveRangeNotRequired as opposed to 0, otherwise
-    // it will only work if bold text is in the end.
-    [messageString
-        enumerateAttribute:MDCSnackbarMessageBoldAttributeName
-                   inRange:NSMakeRange(0, messageString.length)
-                   options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
-                usingBlock:^(id value, NSRange range, __unused BOOL *stop) {
-                  UIFont *font = [MDCTypography body1Font];
-                  if ([value boolValue]) {
-                    font = [MDCTypography body2Font];
-                  }
-                  [messageString setAttributes:@{ NSFontAttributeName : font } range:range];
-                }];
+    if (!_messageFont && !_mdc_adjustsFontForContentSizeCategory) {
+      // Find any of the bold attributes in the string, and set the proper font for those ranges.
+      // Use NSAttributedStringEnumerationLongestEffectiveRangeNotRequired as opposed to 0, otherwise
+      // it will only work if bold text is in the end.
+      [messageString
+          enumerateAttribute:MDCSnackbarMessageBoldAttributeName
+                     inRange:NSMakeRange(0, messageString.length)
+                     options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                  usingBlock:^(id value, NSRange range, __unused BOOL *stop) {
+                    UIFont *font = [MDCTypography body1Font];
+                    if ([value boolValue]) {
+                      font = [MDCTypography body2Font];
+                    }
+                    [messageString setAttributes:@{ NSFontAttributeName : font } range:range];
+                  }];
+    }
 
     // Apply 'global' attributes along the whole string.
+    _label.attributedText = messageString;
     _label.backgroundColor = [UIColor clearColor];
     _label.textAlignment = NSTextAlignmentNatural;
-    _label.adjustsFontSizeToFitWidth = YES;
-    _label.attributedText = messageString;
+//    _label.adjustsFontSizeToFitWidth = YES;
     _label.numberOfLines = 0;
     [_label setTranslatesAutoresizingMaskIntoConstraints:NO];
     [_label setContentCompressionResistancePriority:UILayoutPriorityDefaultHigh
@@ -364,11 +373,6 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
     [_buttonView addSubview:buttonView];
 
     MDCButton *button = [[MDCSnackbarMessageViewButton alloc] init];
-    if (_buttonFont) {
-      [button setTitleFont:_buttonFont forState:UIControlStateNormal];
-      [button setTitleFont:_buttonFont forState:UIControlStateHighlighted];
-    }
-
     [button setTitleColor:_buttonTitleColors[@(UIControlStateNormal)]
                  forState:UIControlStateNormal];
     [button setTitleColor:_buttonTitleColors[@(UIControlStateHighlighted)]
@@ -422,6 +426,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
   }
 
   self.buttons = actions;
+  [self updateButtonFont];
 }
 
 - (void)dismissWithAction:(MDCSnackbarMessageAction *)action userInitiated:(BOOL)userInitiated {
@@ -562,7 +567,6 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
       }
     }
   }
-
   [self setNeedsLayout];
 }
 

--- a/components/Snackbar/tests/unit/MDCSnackbarFontThemerTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarFontThemerTests.m
@@ -22,7 +22,7 @@
 
 @implementation MDCSnackbarFontThemerTests
 
-- (void)testSnackbarFontThemer {
+- (void)testSnackbarFontThemerUsingUIAppearance {
   MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
   message.text = @"How much wood would a woodchuck chuck if a woodchuck could chuck wood?";
   [MDCSnackbarManager showMessage:message];
@@ -34,6 +34,20 @@
   XCTAssertEqualObjects([MDCSnackbarMessageView appearance].messageFont,
                         fontScheme.body2);
   XCTAssertEqualObjects([MDCSnackbarMessageView appearance].buttonFont,
+                        fontScheme.button);
+}
+
+- (void)testSnackbarFontThemer {
+  MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
+  message.text = @"How much wood would a woodchuck chuck if a woodchuck could chuck wood?";
+  [MDCSnackbarManager showMessage:message];
+  MDCBasicFontScheme *fontScheme = [[MDCBasicFontScheme alloc] init];
+  fontScheme.button = [UIFont boldSystemFontOfSize:12.f];
+  fontScheme.body2 = [UIFont systemFontOfSize:13.f];
+  [MDCSnackbarFontThemer applyFontScheme:fontScheme];
+  XCTAssertEqualObjects(MDCSnackbarManager.messageFont,
+                        fontScheme.body2);
+  XCTAssertEqualObjects(MDCSnackbarManager.buttonFont,
                         fontScheme.button);
 }
 


### PR DESCRIPTION
Due to having all styling properties for Snackbar be part of the `MDCSnackbarMessageView`. We were forced to set syling using `UIAppearance` because `MDCSnackbarMessageView` was not exposed to the user. Therefore, I have now additionally defined the styling properties in `MDCSnackbarManager` as class properties, to allow snackbar styling on an app-wide level. These properties are exposed and easily set using `MDCSnackbarManager`.

Also updated examples to stop using `UIAppearance`.

Updated the font themer to have font theming also without the use of `UIAppearance`.

Added another unit test for the font themer.

Exposed a new property to `MDCSnackbarManager` called `applyStylingOnCurrentSnackbar`. It is defaulted to `NO`, but if set to `YES` then the styling changes are applied live also on the currently presented snackbar. This is important because the snackbar is persistent in an overlay window, so if there is an app-wide theme change (dark/light mode as an example), then we might want the snackbar to also propagate these changes.

Completes these Pivotal stories: https://www.pivotaltracker.com/story/show/155533137 , https://www.pivotaltracker.com/story/show/155525172 , https://www.pivotaltracker.com/story/show/156171658