### PR TITLE
Revert "[FlexibleHeader] Fix bug where shadow layer's opacity wouldn't be set without a tracking scroll view. (#3201)"

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -911,7 +911,6 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 
 - (void)fhv_updateLayout {
   if (!_trackingScrollView) {
-    [self fhv_commitAccumulatorToFrame];
     return;
   }
 


### PR DESCRIPTION
This change is resulting in "stacked" shadows when an MDCAppBar is above an
    MDCTabBar.  In the particular case of Tabs below an MDCAppBar, the shadow effect is discouraged in designs. We may need to provide client teams with advice on how to integrate MDCAppBar and MDCTabBar in a way that still permits the App Bar to cast a shadow on other (non-scrollable) views in an appropriate way.
    
This reverts commit d0af3a729b987b8614b2eadc577ce658cd3d0dcc.
    
Reverts #3201
