### PR TITLE
Revert "[FeatureHighlight] FeatureHighlightViewController should expose FeatureHighlightView as a property. (#3145)"

### DIFF
--- a/components/FeatureHighlight/examples/FeatureHighlightColorExample.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightColorExample.m
@@ -30,8 +30,7 @@
                                                               completion:nil];
   highlightController.titleText = @"So pretty!";
   highlightController.bodyText = @"What a nice color you've chosen.";
-  MDCFeatureHighlightView *featureHighlightView = highlightController.featureHighlightView;
-  featureHighlightView.outerHighlightColor = cell.accessoryView.backgroundColor;
+  highlightController.outerHighlightColor = cell.accessoryView.backgroundColor;
   [MDCFeatureHighlightAccessibilityMutator mutate:highlightController];
   [self presentViewController:highlightController animated:YES completion:nil];
 }

--- a/components/FeatureHighlight/examples/FeatureHighlightTypicalUseViewController.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightTypicalUseViewController.m
@@ -25,7 +25,7 @@
       [[MDCFeatureHighlightViewController alloc] initWithHighlightedView:_button completion:nil];
   [MDCFeatureHighlightAccessibilityMutator mutate:vc];
 
-  vc.featureHighlightView.mdc_adjustsFontForContentSizeCategory = YES;
+  vc.mdc_adjustsFontForContentSizeCategory = YES;
 
   vc.titleText = @"Hey this is a multi-line title for the Feature Highlight";
   vc.bodyText = @"This is the description of the feature highlight view controller.";

--- a/components/FeatureHighlight/src/FeatureHighlightAccessibilityMutator/MDCFeatureHighlightAccessibilityMutator.m
+++ b/components/FeatureHighlight/src/FeatureHighlightAccessibilityMutator/MDCFeatureHighlightAccessibilityMutator.m
@@ -29,7 +29,7 @@
 
 + (void)mutateTitleColor:(MDCFeatureHighlightViewController *)featureHighlightViewController{
   MDCFeatureHighlightView *featureHighlightView =
-      featureHighlightViewController.featureHighlightView;
+      (MDCFeatureHighlightView *)featureHighlightViewController.view;
   if (![featureHighlightView isKindOfClass:[MDCFeatureHighlightView class]]) {
     NSAssert(NO, @"FeatureHighlightViewController should have FeatureHighlightView");
     return;
@@ -39,9 +39,9 @@
     options |= MDFTextAccessibilityOptionsLargeFont;
   }
 
-  UIColor *textColor = featureHighlightView.titleColor;
+  UIColor *textColor = featureHighlightViewController.titleColor;
   UIColor *backgroundColor =
-      [featureHighlightView.outerHighlightColor colorWithAlphaComponent:1.0f];
+      [featureHighlightViewController.outerHighlightColor colorWithAlphaComponent:1.0f];
   UIColor *titleColor =
       [MDCFeatureHighlightAccessibilityMutator accessibleColorForTextColor:textColor
                                                        withBackgroundColor:backgroundColor
@@ -57,12 +57,12 @@
                               onBackgroundColor:backgroundColor
                                         options:options];
   titleAlpha = MAX([MDCTypography titleFontOpacity], titleAlpha);
-  featureHighlightView.titleColor = [titleColor colorWithAlphaComponent:titleAlpha];
+  featureHighlightViewController.titleColor = [titleColor colorWithAlphaComponent:titleAlpha];
 }
 
 + (void)mutateBodyColor:(MDCFeatureHighlightViewController *)featureHighlightViewController {
   MDCFeatureHighlightView *featureHighlightView =
-      featureHighlightViewController.featureHighlightView;
+      (MDCFeatureHighlightView *)featureHighlightViewController.view;
   if (![featureHighlightView isKindOfClass:[MDCFeatureHighlightView class]]) {
     NSAssert(NO, @"FeatureHighlightViewController should have FeatureHighlightView");
     return;
@@ -72,10 +72,10 @@
     options |= MDFTextAccessibilityOptionsLargeFont;
   }
 
-  UIColor *textColor = featureHighlightView.bodyColor;
+  UIColor *textColor = featureHighlightViewController.bodyColor;
   UIColor *backgroundColor =
-      [featureHighlightView.outerHighlightColor colorWithAlphaComponent:1.0f];
-  featureHighlightView.bodyColor =
+      [featureHighlightViewController.outerHighlightColor colorWithAlphaComponent:1.0f];
+  featureHighlightViewController.bodyColor =
       [MDCFeatureHighlightAccessibilityMutator accessibleColorForTextColor:textColor
                                                        withBackgroundColor:backgroundColor
                                                                    options:options];

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
@@ -16,8 +16,6 @@
 
 #import <UIKit/UIKit.h>
 
-@class MDCFeatureHighlightView;
-
 /** The default alpha for the outer highlight circle. */
 extern const CGFloat kMDCFeatureHighlightOuterHighlightAlpha;
 
@@ -94,9 +92,47 @@ typedef void (^MDCFeatureHighlightCompletion)(BOOL accepted);
 @property(nonatomic, copy, nullable) NSString *bodyText;
 
 /**
- The MDCFeatureHighlightView instance that is being presented by this view controller.
+ Sets the color to be used for the outer highlight. Defaults to blue with an alpha of
+ kMDCFeatureHighlightOuterHighlightAlpha.
+
+ Alpha should be set to kMDCFeatureHighlightOuterHighlightAlpha.
  */
-@property(nonatomic, readonly, nullable) MDCFeatureHighlightView *featureHighlightView;
+@property(nonatomic, strong, null_resettable) UIColor *outerHighlightColor;
+
+/**
+ Sets the color to be used for the inner highlight. Defaults to white.
+
+ Should be opaque.
+ */
+@property(nonatomic, strong, null_resettable) UIColor *innerHighlightColor;
+
+/**
+ Sets the color to be used for the title text. If nil upon presentation, a color of sufficient
+ contrast to the |outerHighlightColor| will be automatically chosen.
+
+ Defaults to nil.
+ */
+@property(nonatomic, strong, nullable) UIColor *titleColor;
+
+/**
+ Sets the color to be used for the body text. If nil upon presentation, a color of sufficient
+ contrast to the |outerHighlightColor| will be automatically chosen upon presentation.
+
+ Defaults to nil.
+ */
+@property(nonatomic, strong, nullable) UIColor *bodyColor;
+
+/**
+ Indicates whether the feature highlight contents should automatically update their font when the
+ device’s UIContentSizeCategory changes.
+
+ This property is modeled after the adjustsFontForContentSizeCategory property in the
+ UIContentSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
+
+ Default value is NO.
+ */
+@property(nonatomic, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
+    BOOL mdc_adjustsFontForContentSizeCategory UI_APPEARANCE_SELECTOR;
 
 /**
  Dismisses the feature highlight using the 'accept' style dismissal animation and triggers the

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -94,6 +94,8 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
   _featureHighlightView.displayedView = _displayedView;
   _featureHighlightView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  _featureHighlightView.mdc_adjustsFontForContentSizeCategory =
+      _mdc_adjustsFontForContentSizeCategory;
 
   __weak MDCFeatureHighlightViewController *weakSelf = self;
   _featureHighlightView.interactionBlock = ^(BOOL accepted) {
@@ -158,6 +160,38 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
                                completion:nil];
 }
 
+- (UIColor *)outerHighlightColor {
+  return self.view.outerHighlightColor;
+}
+
+- (void)setOuterHighlightColor:(UIColor *)outerHighlightColor {
+  self.view.outerHighlightColor = outerHighlightColor;
+}
+
+- (UIColor *)innerHighlightColor {
+  return self.view.innerHighlightColor;
+}
+
+- (void)setInnerHighlightColor:(UIColor *)innerHighlightColor {
+  self.view.innerHighlightColor = innerHighlightColor;
+}
+
+- (UIColor *)titleColor {
+  return self.view.titleColor;
+}
+
+- (void)setTitleColor:(UIColor *)titleColor {
+  self.view.titleColor = titleColor;
+}
+
+- (UIColor *)bodyColor {
+  return self.view.bodyColor;
+}
+
+- (void)setBodyColor:(UIColor *)bodyColor {
+  self.view.bodyColor = bodyColor;
+}
+
 - (void)acceptFeature {
   [self dismiss:YES];
 }
@@ -181,8 +215,32 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
                            }];
 }
 
-- (MDCFeatureHighlightView *)featureHighlightView {
-  return self.view;
+#pragma mark - Dynamic Type
+
+- (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {
+  _mdc_adjustsFontForContentSizeCategory = adjusts;
+
+  if (_mdc_adjustsFontForContentSizeCategory) {
+    [self updateFontsForDynamicType];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(contentSizeCategoryDidChange:)
+                                                 name:UIContentSizeCategoryDidChangeNotification
+                                               object:nil];
+  } else {
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:UIContentSizeCategoryDidChangeNotification
+                                                  object:nil];
+  }
+}
+
+- (void)contentSizeCategoryDidChange:(__unused NSNotification *)notification {
+  [self updateFontsForDynamicType];
+}
+
+- (void)updateFontsForDynamicType {
+  [_featureHighlightView updateTitleFont];
+  [_featureHighlightView updateBodyFont];
+  [_featureHighlightView layoutIfNeeded];
 }
 
 #pragma mark - Accessibility

--- a/components/FeatureHighlight/tests/unit/FeatureHighlightCustomFontTest.m
+++ b/components/FeatureHighlight/tests/unit/FeatureHighlightCustomFontTest.m
@@ -26,31 +26,16 @@
 @end
 
 @interface FeatureHighlightCustomFontTest : XCTestCase
-@property (nonatomic, strong) UIView *highlightedView;
-@property (nonatomic, strong) UIView *showView;
+
 @end
 
 @implementation FeatureHighlightCustomFontTest
 
-- (void)setUp {
-  [super setUp];
-  self.showView = [[UIView alloc] init];
-  self.highlightedView = [[UIView alloc] init];
-  [self.showView addSubview:self.highlightedView];
-}
-
-- (void)tearDown {
-  [super tearDown];
-  self.showView = nil;
-  self.highlightedView = nil;
-}
-
 - (void)testCustomTitleFontUpdateLabel {
-  MDCFeatureHighlightViewController *featureHighlightViewController =
-      [[MDCFeatureHighlightViewController alloc] initWithHighlightedView:self.highlightedView
-                                                             andShowView:self.showView
-                                                              completion:nil];
-  MDCFeatureHighlightView *view = featureHighlightViewController.featureHighlightView;
+
+  // Given
+  MDCFeatureHighlightView *view = [[MDCFeatureHighlightView alloc] init];
+
   // When
   NSString *customFontName = @"Zapfino";
   UIFont *customFont = [UIFont fontWithName:customFontName size:14.0];
@@ -65,11 +50,9 @@
 }
 
 - (void)testCustomBodyFontUpdateLabel {
-  MDCFeatureHighlightViewController *featureHighlightViewController =
-      [[MDCFeatureHighlightViewController alloc] initWithHighlightedView:self.highlightedView
-                                                             andShowView:self.showView
-                                                              completion:nil];
-  MDCFeatureHighlightView *view = featureHighlightViewController.featureHighlightView;
+
+  // Given
+  MDCFeatureHighlightView *view = [[MDCFeatureHighlightView alloc] init];
 
   // When
   NSString *customFontName = @"Chalkduster";


### PR DESCRIPTION
Many internal clients are breaking because of this API change. Instead, we
should follow the deprecation policy so clients can make a gradual migration
to the final API.

This reverts commit 24be789f57aedb732ceddecc36699f52875dc8d6.

Reopens #3144
