### PR TITLE
[TextFields] Reverting textInputFont property on inputController. 

### DIFF
--- a/components/TextFields/examples/TextFieldCustomFontExample.m
+++ b/components/TextFields/examples/TextFieldCustomFontExample.m
@@ -235,7 +235,6 @@
       [UIFont fontWithName:@"Chalkduster" size:12];
   self.customFontController.inlinePlaceholderFont =
       [UIFont fontWithName:@"AmericanTypewriter" size:12];
-  self.customFontController.textInputFont = [UIFont fontWithName:@"Chalkduster" size:16];
   return customFontTextField;
 }
 
@@ -256,7 +255,6 @@
   self.customFontDynamicController.trailingUnderlineLabelFont =
       [UIFont fontWithName:@"Chalkduster" size:12];
   self.customFontDynamicController.inlinePlaceholderFont = [UIFont fontWithName:@"Zapfino" size:12];
-  self.customFontDynamicController.textInputFont = [UIFont fontWithName:@"Zapfino" size:16];
   self.customFontDynamicController.mdc_adjustsFontForContentSizeCategory = YES;
 
   [self.scrollView addSubview:customFontDynamicTextField];
@@ -308,8 +306,6 @@
       [UIFont fontWithName:@"Chalkduster" size:12];
   self.multilineCustomFontDynamicController.inlinePlaceholderFont =
       [UIFont fontWithName:@"Zapfino" size:12];
-  self.multilineCustomFontDynamicController.textInputFont =
-      [UIFont fontWithName:@"AmericanTypewriter" size:16];
   self.multilineCustomFontDynamicController.mdc_adjustsFontForContentSizeCategory = YES;
   return multilineCustomDynamicTextField;
 }

--- a/components/TextFields/src/MDCTextInputController.h
+++ b/components/TextFields/src/MDCTextInputController.h
@@ -184,16 +184,6 @@
 @property(nonatomic, nullable, strong) UIView<MDCTextInput> *textInput;
 
 /**
- The font applied to the text input.
-
- Default is textInputFontDefault.
- */
-@property(nonatomic, null_resettable, strong) UIFont *textInputFont;
-
-/** Default value for textInputFontDefault. */
-@property(class, nonatomic, null_resettable, strong) UIFont *textInputFontDefault;
-
-/**
  The font applied to the trailing side underline label.
 
  Default is trailingUnderlineLabelFontDefault.

--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -138,7 +138,6 @@ static UIColor *_trailingUnderlineLabelTextColorDefault;
 
 static UIFont *_inlinePlaceholderFontDefault;
 static UIFont *_leadingUnderlineLabelFontDefault;
-static UIFont *_textInputFontDefault;
 static UIFont *_trailingUnderlineLabelFontDefault;
 
 static UIRectCorner _roundedCornersDefault = 0;
@@ -164,7 +163,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
   UIFont *_inlinePlaceholderFont;
   UIFont *_leadingUnderlineLabelFont;
-  UIFont *_textInputFont;
   UIFont *_trailingUnderlineLabelFont;
 
   UIRectCorner _roundedCorners;
@@ -565,18 +563,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
           : self.leadingUnderlineLabelTextColor;
 }
 
-#pragma  mark - TextInput Customization
-
-- (void)updateTextInput {
-  UIFont *font = self.textInputFont;
-  if (self.mdc_adjustsFontForContentSizeCategory) {
-    font =
-    [font mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleBody1
-                       scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
-  }
-  self.textInput.font = font;
-}
-
 #pragma mark - Placeholder Customization
 
 // This updates the placeholder's visual characteristics and not its layout. See the section
@@ -899,10 +885,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 }
 
 #pragma mark - Underline Labels Fonts
-
-+ (UIFont *)inputTextFont {
-  return [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleBody1];
-}
 
 + (UIFont *)placeholderFont {
   return [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleBody1];
@@ -1320,25 +1302,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   }
 }
 
-- (UIFont *)textInputFont {
-  return _textInputFont ?: [self class].textInputFontDefault;
-}
-
-- (void)setTextInputFont:(UIFont *)textInputFont {
-  if (![_textInputFont isEqual:textInputFont]) {
-    _textInputFont = textInputFont;
-    [self updateLayout];
-  }
-}
-
-+ (UIFont *)textInputFontDefault {
-  return _textInputFontDefault ?: [[self class] inputTextFont];
-}
-
-+ (void)setTextInputFontDefault:(UIFont *)textInputFontDefault {
-  _textInputFontDefault = textInputFontDefault;
-}
-
 - (UIFont *)trailingUnderlineLabelFont {
   return _trailingUnderlineLabelFont ?: [self class].trailingUnderlineLabelFontDefault;
 }
@@ -1451,7 +1414,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   [self updatePlaceholder];
   [self updateLeadingUnderlineLabel];
   [self updateTrailingUnderlineLabel];
-  [self updateTextInput];
   [self updateUnderline];
   [self updateBorder];
 }

--- a/components/TextFields/src/MDCTextInputControllerFullWidth.m
+++ b/components/TextFields/src/MDCTextInputControllerFullWidth.m
@@ -76,7 +76,6 @@ static UIColor *_inlinePlaceholderColorDefault;
 static UIColor *_trailingUnderlineLabelTextColorDefault;
 
 static UIFont *_inlinePlaceholderFontDefault;
-static UIFont *_textInputFontDefault;
 static UIFont *_trailingUnderlineLabelFontDefault;
 
 @interface MDCTextInputControllerFullWidth () {
@@ -89,7 +88,6 @@ static UIFont *_trailingUnderlineLabelFontDefault;
   UIColor *_trailingUnderlineLabelTextColor;
 
   UIFont *_inlinePlaceholderFont;
-  UIFont *_textInputFont;
   UIFont *_trailingUnderlineLabelFont;
 }
 
@@ -339,18 +337,6 @@ static UIFont *_trailingUnderlineLabelFontDefault;
   self.textInput.leadingUnderlineLabel.textColor = self.leadingUnderlineLabelTextColor;
 }
 
-#pragma  mark - TextInput Customization
-
-- (void)updateTextInput {
-  UIFont *font = self.textInputFont;
-  if (self.mdc_adjustsFontForContentSizeCategory) {
-    font =
-        [font mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleBody1
-                           scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
-  }
-  self.textInput.font = font;
-}
-
 #pragma mark - Placeholder Customization
 
 - (void)updatePlaceholder {
@@ -419,10 +405,6 @@ static UIFont *_trailingUnderlineLabelFontDefault;
 }
 
 #pragma mark - Underline Labels Fonts
-
-+ (UIFont *)inputTextFont {
-  return [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleBody1];
-}
 
 + (UIFont *)placeholderFont {
   return [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleBody1];
@@ -684,25 +666,6 @@ static UIFont *_trailingUnderlineLabelFontDefault;
   }
 }
 
-- (UIFont *)textInputFont {
-  return _textInputFont ?: [self class].textInputFontDefault;
-}
-
-- (void)setTextInputFont:(UIFont *)textInputFont {
-  if (![_textInputFont isEqual:textInputFont]) {
-    _textInputFont = textInputFont;
-    [self updateLayout];
-  }
-}
-
-+ (UIFont *)textInputFontDefault {
-  return _textInputFontDefault ?: [[self class] inputTextFont];
-}
-
-+ (void)setTextInputFontDefault:(UIFont *)textInputFontDefault {
-  _textInputFontDefault = textInputFontDefault;
-}
-
 - (UIFont *)trailingUnderlineLabelFont {
   return _trailingUnderlineLabelFont ?: [self class].trailingUnderlineLabelFontDefault;
 }
@@ -817,7 +780,6 @@ static UIFont *_trailingUnderlineLabelFontDefault;
   [self updatePlaceholder];
   [self updateLeadingUnderlineLabel];
   [self updateTrailingUnderlineLabel];
-  [self updateTextInput];
   [self updateUnderline];
   [self updateConstraints];
 }


### PR DESCRIPTION
Adding textInputFont and TextInputFontDefault properties to inputController was breaking many client who used to set the font straight to textInput font property.

The reason behind adding this property was to fully support dynamic types. 
Reverting this change will break dynamic types support for textfields.
Pivotal issue to address the work needed to add this property: #156518577