### PR TITLE
[Catalog] Use new MDCColorScheming APIs for theming the catalog

### DIFF
--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -15,21 +15,25 @@
  */
 
 import Foundation
-import MaterialComponents.MaterialPalettes
-import MaterialComponents.MaterialThemes
+import MaterialComponents.MaterialColorScheme
 
 final class AppTheme {
-  let colorScheme: MDCColorScheme
+  let colorScheme: MDCColorScheming
 
-  init(colorScheme: MDCColorScheme) {
+  init(colorScheme: MDCColorScheming) {
     self.colorScheme = colorScheme
   }
 
-  static let defaultTheme: AppTheme = AppTheme(colorScheme:
-    MDCBasicColorScheme(primaryColor: .init(white: 33 / 255.0, alpha: 1),
-                        primaryLightColor: .init(white: 0.7, alpha: 1),
-                        primaryDarkColor: .init(white: 0, alpha: 1))
-  )
+  static let defaultTheme: AppTheme = {
+    let colorScheme = MDCSemanticColorScheme()
+    colorScheme.primaryColor = .init(white: 33 / 255.0, alpha: 1)
+    colorScheme.primaryColorVariant = .init(white: 0.7, alpha: 1)
+    colorScheme.secondaryColor = UIColor(red: CGFloat(0x00) / 255.0,
+                                         green: CGFloat(0xE6) / 255.0,
+                                         blue: CGFloat(0x76) / 255.0,
+                                         alpha: 1)
+    return AppTheme(colorScheme: colorScheme)
+  }()
 
   static var globalTheme: AppTheme = defaultTheme {
     didSet {

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -103,11 +103,11 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
 
   func themeDidChange(notification: NSNotification) {
     guard let colorScheme = notification.userInfo?[AppTheme.globalThemeNotificationColorSchemeKey]
-          as? MDCColorScheme else {
+          as? MDCColorScheming else {
       return
     }
-    MDCFlexibleHeaderColorThemer.apply(colorScheme,
-                                       toMDCFlexibleHeaderController: headerViewController)
+    MDCFlexibleHeaderColorThemer.applySemanticColorScheme(colorScheme,
+                                                          to: headerViewController.headerView)
 
     collectionView?.collectionViewLayout.invalidateLayout()
     collectionView?.reloadData()
@@ -202,8 +202,8 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
                        multiplier: 1,
                        constant: Constants.logoWidthHeight).isActive = true
 
-    MDCFlexibleHeaderColorThemer.apply(colorScheme,
-                                       toMDCFlexibleHeaderController: headerViewController)
+    MDCFlexibleHeaderColorThemer.applySemanticColorScheme(colorScheme,
+                                                          to: headerViewController.headerView)
 
     headerViewController.headerView.trackingScrollView = collectionView
 

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -102,6 +102,14 @@ class MDCNodeListViewController: CBCNodeListViewController {
       NSForegroundColorAttributeName: UIColor.white,
       NSFontAttributeName: appBarFont ]
     appBar.navigationBar.titleAlignment = .center
+
+    applyColorScheme(AppTheme.globalTheme.colorScheme)
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(self.themeDidChange),
+      name: AppTheme.didChangeGlobalThemeNotificationName,
+      object: nil)
   }
 
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
@@ -133,14 +141,6 @@ class MDCNodeListViewController: CBCNodeListViewController {
     appBar.headerViewController.headerView.trackingScrollView = self.tableView
 
     appBar.addSubviewsToParent()
-
-    applyColorScheme(AppTheme.globalTheme.colorScheme)
-
-    NotificationCenter.default.addObserver(
-      self,
-      selector: #selector(self.themeDidChange),
-      name: AppTheme.didChangeGlobalThemeNotificationName,
-      object: nil)
   }
 
   override func viewWillAppear(_ animated: Bool) {
@@ -161,14 +161,14 @@ class MDCNodeListViewController: CBCNodeListViewController {
 
   func themeDidChange(notification: NSNotification) {
     guard let colorScheme = notification.userInfo?[AppTheme.globalThemeNotificationColorSchemeKey]
-          as? MDCColorScheme else {
+          as? MDCColorScheming else {
       return
     }
     applyColorScheme(colorScheme)
   }
 
-  private func applyColorScheme(_ colorScheme: MDCColorScheme) {
-    MDCAppBarColorThemer.apply(colorScheme, to: appBar)
+  private func applyColorScheme(_ colorScheme: MDCColorScheming) {
+    MDCAppBarColorThemer.applySemanticColorScheme(colorScheme, to: appBar)
 
     appBar.navigationBar.tintColor = UIColor.white
   }
@@ -417,7 +417,8 @@ extension MDCNodeListViewController {
         container.appBar.navigationBar.titleTextAttributes =
             [ NSForegroundColorAttributeName: UIColor.white, NSFontAttributeName: appBarFont ]
 
-        MDCAppBarColorThemer.apply(AppTheme.globalTheme.colorScheme, to: container.appBar)
+        MDCAppBarColorThemer.applySemanticColorScheme(AppTheme.globalTheme.colorScheme,
+                                                      to: container.appBar)
 
         // TODO(featherless): Remove once
         // https://github.com/material-components/material-components-ios/issues/367 is resolved.

--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -18,6 +18,14 @@ import MaterialComponents.MaterialPalettes
 import MaterialComponents.MaterialThemes
 import UIKit
 
+private func createSchemeWithPalette(_ palette: MDCPalette) -> MDCSemanticColorScheme {
+  let scheme = MDCSemanticColorScheme()
+  scheme.primaryColor = palette.tint500
+  scheme.primaryColorVariant = palette.tint900
+  scheme.secondaryColor = scheme.primaryColor
+  return scheme
+}
+
 class MDCThemePickerViewController: UITableViewController {
   convenience init() {
     self.init(style: .plain)
@@ -46,39 +54,27 @@ class MDCThemePickerViewController: UITableViewController {
   private let colorSchemeRows = [
     (
       name: "Blue",
-      colorScheme: MDCBasicColorScheme(primaryColor: MDCPalette.blue.tint500,
-                                       primaryLightColor: MDCPalette.blue.tint100,
-                                       primaryDarkColor: MDCPalette.blue.tint900)
+      colorScheme: { return createSchemeWithPalette(MDCPalette.blue) }
     ),
     (
       name: "Red",
-      colorScheme: MDCBasicColorScheme(primaryColor: MDCPalette.red.tint500,
-                                       primaryLightColor: MDCPalette.red.tint100,
-                                       primaryDarkColor: MDCPalette.red.tint900)
+      colorScheme: { return createSchemeWithPalette(MDCPalette.red) }
     ),
     (
       name: "Green",
-      colorScheme: MDCBasicColorScheme(primaryColor: MDCPalette.green.tint500,
-                                       primaryLightColor: MDCPalette.green.tint100,
-                                       primaryDarkColor: MDCPalette.green.tint900)
+      colorScheme: { return createSchemeWithPalette(MDCPalette.green) }
     ),
     (
       name: "Amber",
-      colorScheme: MDCBasicColorScheme(primaryColor: MDCPalette.amber.tint500,
-                                       primaryLightColor: MDCPalette.amber.tint100,
-                                       primaryDarkColor: MDCPalette.amber.tint900)
+      colorScheme: { return createSchemeWithPalette(MDCPalette.amber) }
     ),
     (
       name: "Pink",
-      colorScheme: MDCBasicColorScheme(primaryColor: MDCPalette.pink.tint500,
-                                       primaryLightColor: MDCPalette.pink.tint100,
-                                       primaryDarkColor: MDCPalette.pink.tint900)
+      colorScheme: { return createSchemeWithPalette(MDCPalette.pink) }
     ),
     (
       name: "Orange",
-      colorScheme: MDCBasicColorScheme(primaryColor: MDCPalette.orange.tint500,
-                                       primaryLightColor: MDCPalette.orange.tint100,
-                                       primaryDarkColor: MDCPalette.orange.tint900)
+      colorScheme: { return createSchemeWithPalette(MDCPalette.orange) }
     )
   ]
   private let cellReuseIdentifier = "cell"
@@ -97,7 +93,7 @@ class MDCThemePickerViewController: UITableViewController {
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     let row = colorSchemeRows[indexPath.row]
     let colorScheme = row.colorScheme
-    AppTheme.globalTheme = AppTheme(colorScheme: colorScheme)
+    AppTheme.globalTheme = AppTheme(colorScheme: colorScheme())
 
     navigationController?.popViewController(animated: true)
   }

--- a/catalog/MaterialCatalog/MDCCatalogTiles.h
+++ b/catalog/MaterialCatalog/MDCCatalogTiles.h
@@ -16,46 +16,46 @@
 
 #import <UIKit/UIKit.h>
 
-@protocol MDCColorScheme;
+@protocol MDCColorScheming;
 
 /** A function that will perform drawing operations in @c frame. */
-typedef void (*MDCDrawFunc)(CGRect frame, id<MDCColorScheme> colorScheme);
+typedef void (*MDCDrawFunc)(CGRect frame, id<MDCColorScheming> colorScheme);
 
 /** Render the drawing operations in @c drawFunc into a new image. */
-UIImage *MDCDrawImage(CGRect frame, MDCDrawFunc drawFunc, id<MDCColorScheme> colorScheme);
+UIImage *MDCDrawImage(CGRect frame, MDCDrawFunc drawFunc, id<MDCColorScheming> colorScheme);
 
 /* Draw logo. */
-void MDCCatalogDrawMDCLogoDark(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawMDCLogoLight(CGRect frame, id<MDCColorScheme> colorScheme);
+void MDCCatalogDrawMDCLogoDark(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawMDCLogoLight(CGRect frame, id<MDCColorScheming> colorScheme);
 
 /* Draw various tiles. */
-void MDCCatalogDrawActivityIndicatorTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawAnimationTimingTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawAppBarTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawBottomAppBarTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawBottomNavTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawBottomSheetTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawButtonBarTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawButtonsTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawCollectionCellsTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawCollectionsTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawDialogsTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawFeatureHighlightTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawFlexibleHeaderTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawHeaderStackViewTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawInkTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawMaskedTransitionTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawMiscTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawNavigationBarTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawOverlayWindow(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawPageControlTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawPalettesTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawProgressViewTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawShadowLayerTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawSliderTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawSnackbarTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawTabsTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawTextFieldTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawThemesTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawTypographyTile(CGRect frame, id<MDCColorScheme> colorScheme);
-void MDCCatalogDrawTypographyCustomFontsTile(CGRect frame, id<MDCColorScheme> colorScheme);
+void MDCCatalogDrawActivityIndicatorTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawAnimationTimingTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawAppBarTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawBottomAppBarTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawBottomNavTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawBottomSheetTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawButtonBarTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawButtonsTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawCollectionCellsTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawCollectionsTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawDialogsTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawFeatureHighlightTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawFlexibleHeaderTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawHeaderStackViewTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawInkTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawMaskedTransitionTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawMiscTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawNavigationBarTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawOverlayWindow(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawPageControlTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawPalettesTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawProgressViewTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawShadowLayerTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawSliderTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawSnackbarTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawTabsTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawTextFieldTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawThemesTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawTypographyTile(CGRect frame, id<MDCColorScheming> colorScheme);
+void MDCCatalogDrawTypographyCustomFontsTile(CGRect frame, id<MDCColorScheming> colorScheme);

--- a/catalog/MaterialCatalog/MDCCatalogTiles.m
+++ b/catalog/MaterialCatalog/MDCCatalogTiles.m
@@ -19,7 +19,7 @@
 #import "MaterialThemes.h"
 #import "MDCCatalogTiles.h"
 
-UIImage* _Nullable MDCDrawImage(CGRect frame, MDCDrawFunc drawFunc, id<MDCColorScheme> colorScheme) {
+UIImage* _Nullable MDCDrawImage(CGRect frame, MDCDrawFunc drawFunc, id<MDCColorScheming> colorScheme) {
   if (CGRectIsEmpty(frame)) {
     return nil;
   }
@@ -36,7 +36,7 @@ UIImage* _Nullable MDCDrawImage(CGRect frame, MDCDrawFunc drawFunc, id<MDCColorS
 #pragma clang diagnostic ignored "-Wassign-enum"
 #pragma clang diagnostic ignored "-Wconversion"
 
-void MDCCatalogDrawMDCLogoDark(CGRect frame, id<MDCColorScheme> colorScheme) {
+void MDCCatalogDrawMDCLogoDark(CGRect frame, id<MDCColorScheming> colorScheme) {
   UIColor* green = [UIColor colorWithRed: 0 green: 0.902 blue: 0.463 alpha: 1];
   UIColor* lightGreen = [UIColor colorWithRed: 0.698 green: 1 blue: 0.349 alpha: 1];
   UIColor* fillColor = [UIColor colorWithRed: 0.129 green: 0.129 blue: 0.129 alpha: 1];
@@ -70,7 +70,7 @@ void MDCCatalogDrawMDCLogoDark(CGRect frame, id<MDCColorScheme> colorScheme) {
   }
 }
 
-void MDCCatalogDrawMDCLogoLight(CGRect frame, id<MDCColorScheme> colorScheme) {
+void MDCCatalogDrawMDCLogoLight(CGRect frame, id<MDCColorScheming> colorScheme) {
   UIColor* white = [UIColor whiteColor];
   UIColor* green = [UIColor colorWithRed: 0 green: 0.902 blue: 0.463 alpha: 1];
   UIColor* lightGreen = [UIColor colorWithRed: 0.698 green: 1 blue: 0.349 alpha: 1];
@@ -104,11 +104,8 @@ void MDCCatalogDrawMDCLogoLight(CGRect frame, id<MDCColorScheme> colorScheme) {
   }
 }
 
-void MDCCatalogDrawActivityIndicatorTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawActivityIndicatorTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect activityIndicatorGroup = CGRectMake(CGRectGetMinX(frame) + 7.67, CGRectGetMinY(frame) + 7.67, floor((frame.size.width - 7.67) * 0.89686 + 7.83) - 7.33, floor((frame.size.height - 7.67) * 0.89686 + 7.83) - 7.33);
   {
     UIBezierPath* bezierPath = [UIBezierPath bezierPath];
@@ -129,11 +126,8 @@ void MDCCatalogDrawActivityIndicatorTile(CGRect frame, id<MDCColorScheme> colorS
   }
 }
 
-void MDCCatalogDrawAnimationTimingTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawAnimationTimingTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect animationGroup = CGRectMake(CGRectGetMinX(frame) + 1, CGRectGetMinY(frame) + 1, floor((frame.size.width - 1) * 0.98765 + 0.5), floor((frame.size.height - 1) * 0.98765 + 0.5));
   {
     UIBezierPath* ringsBezierPath = [UIBezierPath bezierPath];
@@ -178,11 +172,8 @@ void MDCCatalogDrawAnimationTimingTile(CGRect frame, id<MDCColorScheme> colorSch
   }
 }
 
-void MDCCatalogDrawAppBarTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawAppBarTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect appBarGroup = CGRectMake(CGRectGetMinX(frame), CGRectGetMinY(frame), floor((frame.size.width) * 1.00000 + 0.5), floor((frame.size.height) * 1.00000 + 0.5));
   {
     UIBezierPath* bezierPath = [UIBezierPath bezierPath];
@@ -209,11 +200,8 @@ void MDCCatalogDrawAppBarTile(CGRect frame, id<MDCColorScheme> colorScheme) {
   }
 }
 
-void MDCCatalogDrawBottomAppBarTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawBottomAppBarTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect bottomAppBarGroup = CGRectMake(CGRectGetMinX(frame) + 1, CGRectGetMinY(frame) + 1, floor((frame.size.width - 1) * 0.98765 + 0.5), floor((frame.size.height - 1) * 0.98765 + 0.5));
   {
     UIBezierPath* bezierPath = [UIBezierPath bezierPath];
@@ -254,11 +242,8 @@ void MDCCatalogDrawBottomAppBarTile(CGRect frame, id<MDCColorScheme> colorScheme
   }
 }
 
-void MDCCatalogDrawBottomNavTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawBottomNavTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect bottomNavGroup = CGRectMake(CGRectGetMinX(frame) + 1, CGRectGetMinY(frame) + 1, floor((frame.size.width - 1) * 0.98765 + 0.5), floor((frame.size.height - 1) * 0.98765 + 0.5));
   {
     UIBezierPath* bezierPath = [UIBezierPath bezierPath];
@@ -285,11 +270,8 @@ void MDCCatalogDrawBottomNavTile(CGRect frame, id<MDCColorScheme> colorScheme) {
   }
 }
 
-void MDCCatalogDrawBottomSheetTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawBottomSheetTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect bottomSheetGroup = CGRectMake(CGRectGetMinX(frame) + 1, CGRectGetMinY(frame) + 1, floor((frame.size.width - 1) * 0.98765 + 0.5), floor((frame.size.height - 1) * 0.98765 + 0.5));
   {
     UIBezierPath* bezierPath = [UIBezierPath bezierPath];
@@ -312,12 +294,8 @@ void MDCCatalogDrawBottomSheetTile(CGRect frame, id<MDCColorScheme> colorScheme)
   }
 }
 
-void MDCCatalogDrawButtonBarTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawButtonBarTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   UIColor* fillColor2 = [UIColor whiteColor];
   CGRect buttonBarGroup = CGRectMake(CGRectGetMinX(frame) + 8, CGRectGetMinY(frame) + 24, floor((frame.size.width - 8) * 0.89189 + 0.5), floor((frame.size.height - 24) * 0.58621 + 0.5));
   {
@@ -346,11 +324,8 @@ void MDCCatalogDrawButtonBarTile(CGRect frame, id<MDCColorScheme> colorScheme) {
   }
 }
 
-void MDCCatalogDrawButtonsTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawButtonsTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
 
   CGRect buttonsGroup = CGRectMake(CGRectGetMinX(frame) + 1, CGRectGetMinY(frame) + 1, floor((frame.size.width - 1) * 0.98765 + 0.5), floor((frame.size.height - 1) * 0.98765 + 0.5));
   {
@@ -390,11 +365,8 @@ void MDCCatalogDrawButtonsTile(CGRect frame, id<MDCColorScheme> colorScheme) {
   }
 }
 
-void MDCCatalogDrawCollectionCellsTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawCollectionCellsTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect collectionCellsGroup = CGRectMake(CGRectGetMinX(frame) + 1, CGRectGetMinY(frame) + 1, floor((frame.size.width - 1) * 0.98765 + 0.5), floor((frame.size.height - 1) * 0.98765 + 0.5));
   {
     UIBezierPath* outlinesPath = [UIBezierPath bezierPath];
@@ -447,11 +419,8 @@ void MDCCatalogDrawCollectionCellsTile(CGRect frame, id<MDCColorScheme> colorSch
   }
 }
 
-void MDCCatalogDrawCollectionsTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawCollectionsTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect collectionsGroup = CGRectMake(CGRectGetMinX(frame) + 1, CGRectGetMinY(frame) + 1, floor((frame.size.width - 1) * 0.98765 + 0.5), floor((frame.size.height - 1) * 0.98765 + 0.5));
   {
     UIBezierPath* topLeftSquarePath = [UIBezierPath bezierPathWithRect: CGRectMake(CGRectGetMinX(collectionsGroup) + floor(collectionsGroup.size.width * 0.15000 + 0.5), CGRectGetMinY(collectionsGroup) + floor(collectionsGroup.size.height * 0.15000 + 0.5), floor(collectionsGroup.size.width * 0.46825 + 0.04) - floor(collectionsGroup.size.width * 0.15000 + 0.5) + 0.46, floor(collectionsGroup.size.height * 0.46825 + 0.04) - floor(collectionsGroup.size.height * 0.15000 + 0.5) + 0.46)];
@@ -489,11 +458,8 @@ void MDCCatalogDrawCollectionsTile(CGRect frame, id<MDCColorScheme> colorScheme)
   }
 }
 
-void MDCCatalogDrawDialogsTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawDialogsTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect dialogsGroup = CGRectMake(CGRectGetMinX(frame) + 1, CGRectGetMinY(frame) + 1, floor((frame.size.width - 1) * 0.98765 + 0.5), floor((frame.size.height - 1) * 0.98765 + 0.5));
   {
     UIBezierPath* squarePath = [UIBezierPath bezierPathWithRect: CGRectMake(CGRectGetMinX(dialogsGroup) + floor(dialogsGroup.size.width * 0.25000 + 0.5), CGRectGetMinY(dialogsGroup) + floor(dialogsGroup.size.height * 0.25000 + 0.5), floor(dialogsGroup.size.width * 0.75000 + 0.5) - floor(dialogsGroup.size.width * 0.25000 + 0.5), floor(dialogsGroup.size.height * 0.75000 + 0.5) - floor(dialogsGroup.size.height * 0.25000 + 0.5))];
@@ -519,11 +485,8 @@ void MDCCatalogDrawDialogsTile(CGRect frame, id<MDCColorScheme> colorScheme) {
   }
 }
 
-void MDCCatalogDrawFeatureHighlightTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawFeatureHighlightTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect featureHighlightGroup = CGRectMake(CGRectGetMinX(frame) + 1, CGRectGetMinY(frame) + 1, floor((frame.size.width - 1) * 0.98765 + 0.5), floor((frame.size.height - 1) * 0.98765 + 0.5));
   {
     UIBezierPath* circlePath = [UIBezierPath bezierPath];
@@ -559,11 +522,8 @@ void MDCCatalogDrawFeatureHighlightTile(CGRect frame, id<MDCColorScheme> colorSc
   }
 }
 
-void MDCCatalogDrawFlexibleHeaderTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawFlexibleHeaderTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect flexibleHeaderGroup = CGRectMake(CGRectGetMinX(frame) + 1, CGRectGetMinY(frame) + 1, floor((frame.size.width - 1) * 0.98354 + 0.83) - 0.33, floor((frame.size.height - 1) * 0.98354 + 0.83) - 0.33);
   {
     UIBezierPath* bezierPath = [UIBezierPath bezierPath];
@@ -584,15 +544,12 @@ void MDCCatalogDrawFlexibleHeaderTile(CGRect frame, id<MDCColorScheme> colorSche
   }
 }
 
-void MDCCatalogDrawHeaderStackViewTile(CGRect frame, id<MDCColorScheme> colorScheme) {
+void MDCCatalogDrawHeaderStackViewTile(CGRect frame, id<MDCColorScheming> colorScheme) {
   CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
   CGContextRef context = UIGraphicsGetCurrentContext();
 
   UIColor* gradientColor = colorScheme.primaryColor;
-  UIColor* fillColor = UIColor.lightGrayColor;
-  if ([colorScheme respondsToSelector:@selector(primaryLightColor)]) {
-    fillColor = colorScheme.primaryLightColor;
-  }
+  UIColor* fillColor = colorScheme.primaryColor;
 
   CGFloat fillColorRGBA[4];
   [fillColor getRed:&fillColorRGBA[0]
@@ -724,11 +681,8 @@ void MDCCatalogDrawHeaderStackViewTile(CGRect frame, id<MDCColorScheme> colorSch
   CGColorSpaceRelease(colorSpace);
 }
 
-void MDCCatalogDrawInkTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawInkTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect inkGroup = CGRectMake(CGRectGetMinX(frame) + 1, CGRectGetMinY(frame) + 1, floor((frame.size.width - 1) * 0.98765 + 0.5), floor((frame.size.height - 1) * 0.98765 + 0.5));
   {
     UIBezierPath* bezierPath = [UIBezierPath bezierPath];
@@ -752,11 +706,8 @@ void MDCCatalogDrawInkTile(CGRect frame, id<MDCColorScheme> colorScheme) {
   }
 }
 
-void MDCCatalogDrawMaskedTransitionTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawMaskedTransitionTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect maskedTransitionsGroup = CGRectMake(CGRectGetMinX(frame) + 1, CGRectGetMinY(frame) + 1, floor((frame.size.width - 1) * 0.98765 + 0.5), floor((frame.size.height - 1) * 0.98765 + 0.5));
   {
     UIBezierPath* moonPath = [UIBezierPath bezierPath];
@@ -789,11 +740,8 @@ void MDCCatalogDrawMaskedTransitionTile(CGRect frame, id<MDCColorScheme> colorSc
   }
 }
 
-void MDCCatalogDrawMiscTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawMiscTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect miscGroup = CGRectMake(CGRectGetMinX(frame) + 7.67, CGRectGetMinY(frame) + 7.67, floor((frame.size.width - 7.67) * 0.89686 + 7.83) - 7.33, floor((frame.size.height - 7.67) * 0.89686 + 7.83) - 7.33);
   {
     UIBezierPath* bezierPath = [UIBezierPath bezierPath];
@@ -830,16 +778,13 @@ void MDCCatalogDrawMiscTile(CGRect frame, id<MDCColorScheme> colorScheme) {
   }
 }
 
-void MDCCatalogDrawNavigationBarTile(CGRect frame, id<MDCColorScheme> colorScheme) {
+void MDCCatalogDrawNavigationBarTile(CGRect frame, id<MDCColorScheming> colorScheme) {
   CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
   CGContextRef context = UIGraphicsGetCurrentContext();
 
   UIColor* gradientColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:0];
   UIColor* fillColor = colorScheme.primaryColor;
-  UIColor* fillColor2 = UIColor.lightGrayColor;
-  if ([colorScheme respondsToSelector:@selector(primaryLightColor)]) {
-    fillColor2 = colorScheme.primaryLightColor;
-  }
+  UIColor* fillColor2 = colorScheme.primaryColor;
   UIColor* textForeground = [fillColor colorWithAlphaComponent:0.2f];
   UIColor* gradientColor2 = colorScheme.primaryColor;
 
@@ -1032,11 +977,8 @@ void MDCCatalogDrawNavigationBarTile(CGRect frame, id<MDCColorScheme> colorSchem
   CGColorSpaceRelease(colorSpace);
 }
 
-void MDCCatalogDrawOverlayWindow(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.lightGrayColor;
-  if ([colorScheme respondsToSelector:@selector(primaryLightColor)]) {
-    fillColor = colorScheme.primaryLightColor;
-  }
+void MDCCatalogDrawOverlayWindow(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   UIColor* fillColor2 = colorScheme.primaryColor;
   UIColor* fillColor3 = [UIColor colorWithWhite:0.5f alpha:1.0f];
 
@@ -1152,11 +1094,8 @@ void MDCCatalogDrawOverlayWindow(CGRect frame, id<MDCColorScheme> colorScheme) {
   [overlapRectanglePath fill];
 }
 
-void MDCCatalogDrawPageControlTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawPageControlTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect pageControlGroup = CGRectMake(CGRectGetMinX(frame) + 8, CGRectGetMinY(frame) + 34.5, floor((frame.size.width - 8) * 0.89189 + 0.5), floor((frame.size.height - 34.5) * 0.27368 + 0.5));
   {
     UIBezierPath* bezierPath = [UIBezierPath bezierPath];
@@ -1216,11 +1155,8 @@ void MDCCatalogDrawPageControlTile(CGRect frame, id<MDCColorScheme> colorScheme)
   }
 }
 
-void MDCCatalogDrawPalettesTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawPalettesTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect palettesGroup = CGRectMake(CGRectGetMinX(frame) + 7.65, CGRectGetMinY(frame) + 7.67, floor((frame.size.width - 7.65) * 0.89688 + 7.82) - 7.32, floor((frame.size.height - 7.67) * 0.85202 + 8.17) - 7.67);
   {
     UIBezierPath* bucketPath = [UIBezierPath bezierPath];
@@ -1256,19 +1192,13 @@ void MDCCatalogDrawPalettesTile(CGRect frame, id<MDCColorScheme> colorScheme) {
   }
 }
 
-void MDCCatalogDrawProgressViewTile(CGRect frame, id<MDCColorScheme> colorScheme) {
+void MDCCatalogDrawProgressViewTile(CGRect frame, id<MDCColorScheming> colorScheme) {
   CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
   CGContextRef context = UIGraphicsGetCurrentContext();
 
   UIColor* fillColor = colorScheme.primaryColor;
-  UIColor* fillColor2 = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor2 = colorScheme.primaryDarkColor;
-  }
-  UIColor* gradientColor = UIColor.lightGrayColor;
-  if ([colorScheme respondsToSelector:@selector(primaryLightColor)]) {
-    gradientColor = colorScheme.primaryLightColor;
-  }
+  UIColor* fillColor2 = colorScheme.primaryColor;
+  UIColor* gradientColor = colorScheme.secondaryColor;
 
   CGFloat gradientLocations[] = {0.14, 1};
   CGGradientRef gradient = CGGradientCreateWithColors(
@@ -1344,11 +1274,8 @@ void MDCCatalogDrawProgressViewTile(CGRect frame, id<MDCColorScheme> colorScheme
   CGColorSpaceRelease(colorSpace);
 }
 
-void MDCCatalogDrawShadowLayerTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawShadowLayerTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect shadowGroup = CGRectMake(CGRectGetMinX(frame) + 1, CGRectGetMinY(frame) + 1, floor((frame.size.width - 1) * 0.98765 + 0.5), floor((frame.size.height - 1) * 0.98765 + 0.5));
   {
     UIBezierPath* squarePath = [UIBezierPath bezierPath];
@@ -1381,11 +1308,8 @@ void MDCCatalogDrawShadowLayerTile(CGRect frame, id<MDCColorScheme> colorScheme)
   }
 }
 
-void MDCCatalogDrawSliderTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawSliderTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect sliderGroup = CGRectMake(CGRectGetMinX(frame) + 7.67, CGRectGetMinY(frame) + 31, floor((frame.size.width - 7.67) * 0.89686 + 7.83) - 7.33, floor((frame.size.height - 31) * 0.39216 + 0.5));
   {
     UIBezierPath* bezierPath = [UIBezierPath bezierPath];
@@ -1409,11 +1333,8 @@ void MDCCatalogDrawSliderTile(CGRect frame, id<MDCColorScheme> colorScheme) {
   }
 }
 
-void MDCCatalogDrawSnackbarTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawSnackbarTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect snackbarGroup = CGRectMake(CGRectGetMinX(frame) + 7.67, CGRectGetMinY(frame) + 7.67, floor((frame.size.width - 7.67) * 0.89686 + 7.83) - 7.33, floor((frame.size.height - 7.67) * 0.89686 + 7.83) - 7.33);
   {
     UIBezierPath* outlinePath = [UIBezierPath bezierPath];
@@ -1434,11 +1355,8 @@ void MDCCatalogDrawSnackbarTile(CGRect frame, id<MDCColorScheme> colorScheme) {
   }
 }
 
-void MDCCatalogDrawTabsTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawTabsTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect tabBarGroup = CGRectMake(CGRectGetMinX(frame) + 7.67, CGRectGetMinY(frame) + 7.67, floor((frame.size.width - 7.67) * 0.89686 + 7.83) - 7.33, floor((frame.size.height - 7.67) * 0.89686 + 7.83) - 7.33);
   {
     UIBezierPath* bezierPath = [UIBezierPath bezierPath];
@@ -1465,11 +1383,8 @@ void MDCCatalogDrawTabsTile(CGRect frame, id<MDCColorScheme> colorScheme) {
   }
 }
 
-void MDCCatalogDrawTextFieldTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawTextFieldTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect textFieldGroup = CGRectMake(CGRectGetMinX(frame) + 8, CGRectGetMinY(frame) + 11, floor((frame.size.width - 8) * 0.89189 + 0.5), floor((frame.size.height - 11) * 0.84507 + 0.5));
   {
     UIBezierPath* horizontalLinePath = [UIBezierPath bezierPathWithRect: CGRectMake(CGRectGetMinX(textFieldGroup) + floor(textFieldGroup.size.width * 0.00000 + 0.5), CGRectGetMinY(textFieldGroup) + floor(textFieldGroup.size.height * 0.88333 + 0.5), floor(textFieldGroup.size.width * 1.00000 + 0.5) - floor(textFieldGroup.size.width * 0.00000 + 0.5), floor(textFieldGroup.size.height * 1.00000 + 0.5) - floor(textFieldGroup.size.height * 0.88333 + 0.5))];
@@ -1501,11 +1416,8 @@ void MDCCatalogDrawTextFieldTile(CGRect frame, id<MDCColorScheme> colorScheme) {
   }
 }
 
-void MDCCatalogDrawThemesTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawThemesTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   CGRect themesGroup = CGRectMake(CGRectGetMinX(frame) + 11, CGRectGetMinY(frame) + 8, floor((frame.size.width - 11) * 0.88732 + 0.5), floor((frame.size.height - 8) * 0.89189 + 0.5));
   {
     UIBezierPath* trianglePath = [UIBezierPath bezierPath];
@@ -1559,7 +1471,7 @@ void MDCCatalogDrawThemesTile(CGRect frame, id<MDCColorScheme> colorScheme) {
   }
 }
 
-void MDCCatalogDrawTypographyTile(CGRect frame, id<MDCColorScheme> colorScheme) {
+void MDCCatalogDrawTypographyTile(CGRect frame, id<MDCColorScheming> colorScheme) {
   UIColor* fillColor = colorScheme.primaryColor;
 
   UIBezierPath* bezierPath = [UIBezierPath bezierPath];
@@ -1652,11 +1564,8 @@ void MDCCatalogDrawTypographyTile(CGRect frame, id<MDCColorScheme> colorScheme) 
   [bezier2Path fill];
 }
 
-void MDCCatalogDrawTypographyCustomFontsTile(CGRect frame, id<MDCColorScheme> colorScheme) {
-  UIColor* fillColor = UIColor.blackColor;
-  if ([colorScheme respondsToSelector:@selector(primaryDarkColor)]) {
-    fillColor = colorScheme.primaryDarkColor;
-  }
+void MDCCatalogDrawTypographyCustomFontsTile(CGRect frame, id<MDCColorScheming> colorScheme) {
+  UIColor* fillColor = colorScheme.primaryColor;
   
   CGRect typographyCustomFontGroup = CGRectMake(CGRectGetMinX(frame) + 8.02, CGRectGetMinY(frame) + 8, floor((frame.size.width - 8.02) * 0.89213 + 0.5), floor((frame.size.height - 8) * 0.89189 + 0.5));
   {


### PR DESCRIPTION
Updates the AppTheme to make use of the MDCColorScheming APIs.

Pivotal story: https://www.pivotaltracker.com/story/show/156522700

![simulator screen shot - iphone 8 plus - 2018-04-10 at 13 17 38](https://user-images.githubusercontent.com/45670/38572619-9364b66e-3cc1-11e8-877c-d8ef81cc59a3.png)

![simulator screen shot - iphone 8 plus - 2018-04-10 at 13 17 47](https://user-images.githubusercontent.com/45670/38572624-94f0411a-3cc1-11e8-83ac-78497fdd80f1.png)
