### PR TITLE
[FlexibleHeader] Implement a color themer API with the new MDCColorScheming type.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -362,7 +362,7 @@ Pod::Spec.new do |mdc|
       extension.source_files = "components/FlexibleHeader/src/#{extension.base_name}/*.{h,m}"
 
       extension.dependency "MaterialComponents/FlexibleHeader"
-      extension.dependency "MaterialComponents/Themes"
+      extension.dependency "MaterialComponents/schemes/Color"
     end
   end
 

--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -43,7 +43,7 @@ mdc_objc_library(
     ],
     deps = [
         ":FlexibleHeader",
-        "//components/Themes",
+        "//components/schemes/Color",
     ],
     visibility = ["//visibility:public"],
 )

--- a/components/FlexibleHeader/src/ColorThemer/MDCFlexibleHeaderColorThemer.h
+++ b/components/FlexibleHeader/src/ColorThemer/MDCFlexibleHeaderColorThemer.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-#import "MaterialThemes.h"
+#import "MaterialColorScheme.h"
 #import "MaterialFlexibleHeader.h"
 
 /**
@@ -23,8 +23,23 @@
 @interface MDCFlexibleHeaderColorThemer : NSObject
 
 /**
+ Applies a color scheme's properties to an MDCFlexibleHeaderView.
+
+ @param colorScheme The color scheme to apply to MDCFlexibleHeaderView.
+ @param flexibleHeaderView An MDCFlexibleHeaderView instance to which the color scheme should be
+ applied.
+ */
++ (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+            toFlexibleHeaderView:(nonnull MDCFlexibleHeaderView *)flexibleHeaderView;
+
+#pragma mark - Soon to be deprecated
+
+/**
  Applies a color scheme to theme a MDCFlexibleHeaderView. Use a UIAppearance proxy to apply a color
  scheme to all instances of MDCFlexibleHeaderView.
+
+ This method will soon be deprecated. Consider using +applySemanticColorScheme:toFlexibleHeaderView:
+ instead.
 
  @param colorScheme The color scheme to apply to MDCFlexibleHeaderView.
  @param flexibleHeaderView A MDCFlexibleHeaderView instance to apply a color scheme.
@@ -35,6 +50,9 @@
 /**
  Applies a color scheme to theme a MDCFlexibleHeaderViewController. Use a UIAppearance proxy to
  apply a color scheme to all instances of MDCFlexibleHeaderViewController.
+
+ This method will soon be deprecated. Consider using +applySemanticColorScheme:toFlexibleHeaderView:
+ instead.
 
  @param colorScheme The color scheme to apply to MDCFlexibleHeaderView.
  @param flexibleHeaderController A MDCFlexibleHeaderViewController instance to apply a color scheme.

--- a/components/FlexibleHeader/src/ColorThemer/MDCFlexibleHeaderColorThemer.m
+++ b/components/FlexibleHeader/src/ColorThemer/MDCFlexibleHeaderColorThemer.m
@@ -18,6 +18,11 @@
 
 @implementation MDCFlexibleHeaderColorThemer
 
++ (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+            toFlexibleHeaderView:(nonnull MDCFlexibleHeaderView *)flexibleHeaderView {
+  flexibleHeaderView.backgroundColor = colorScheme.primaryColor;
+}
+
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme
     toFlexibleHeaderView:(MDCFlexibleHeaderView *)flexibleHeaderView {
   flexibleHeaderView.backgroundColor = colorScheme.primaryColor;

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderColorThemerTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderColorThemerTests.swift
@@ -1,0 +1,36 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents.MaterialFlexibleHeader
+import MaterialComponents.MDCFlexibleHeaderColorThemer
+
+class FlexibleHeaderColorThemerTests: XCTestCase {
+
+  func testColorThemerChangesTheBackgroundColor() {
+    // Given
+    let colorScheme = MDCSemanticColorScheme()
+    let flexibleHeaderView = MDCFlexibleHeaderView()
+    colorScheme.primaryColor = .red
+    flexibleHeaderView.backgroundColor = .white
+
+    // When
+    MDCFlexibleHeaderColorThemer.applySemanticColorScheme(colorScheme, to: flexibleHeaderView)
+
+    // Then
+    XCTAssertEqual(flexibleHeaderView.backgroundColor, colorScheme.primaryColor)
+  }
+}

--- a/components/schemes/Color/src/MDCSemanticColorScheme.h
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.h
@@ -78,6 +78,7 @@
  @c backgroundColor.
  */
 @property(nonnull, readonly, nonatomic) UIColor *onBackgroundColor;
+
 @end
 
 /**

--- a/components/schemes/Color/src/MDCSemanticColorScheme.h
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.h
@@ -78,7 +78,6 @@
  @c backgroundColor.
  */
 @property(nonnull, readonly, nonatomic) UIColor *onBackgroundColor;
-
 @end
 
 /**


### PR DESCRIPTION
This change also adds unit tests to verify the behavior.

I unfortunately had to make a new API for the new data type because it is not backwards compatible with the MDCColorScheme protocol.

Pivotal story: https://www.pivotaltracker.com/story/show/156522677
