### PR TITLE
[TextFields] Restore Dynamic Type to textInput

### DIFF
--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -563,6 +563,15 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
           : self.leadingUnderlineLabelTextColor;
 }
 
+#pragma  mark - TextInput Customization
+
+- (void)updateTextInput {
+  if (self.mdc_adjustsFontForContentSizeCategory) {
+    UIFont *textFont = [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleBody1];
+    self.textInput.font = textFont;
+  }
+}
+
 #pragma mark - Placeholder Customization
 
 // This updates the placeholder's visual characteristics and not its layout. See the section
@@ -1414,6 +1423,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   [self updatePlaceholder];
   [self updateLeadingUnderlineLabel];
   [self updateTrailingUnderlineLabel];
+  [self updateTextInput];
   [self updateUnderline];
   [self updateBorder];
 }


### PR DESCRIPTION
The controller's `textInput.font` was originally updated if
`mdc_adjustsFontForContentSizeCategory` was YES. Recent reverts have
removed the original functionality instead of restoring it to the
behavior in 49.0.0. This commit will should restore the original
behavior:

* Font values set on the MDCTextInput will be preserved when Dynamic
  Type is disabled on the controller.
* When Dynamic Type is enabled, the MDCTextInput font will be replaced
  with the preferred Material font for the category size.
