### PR TITLE
Revert "[AppBar] Make MDCNavigationBar and MDCButtonBar size dynamically (#2974)"

### DIFF
--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -164,8 +164,7 @@ static NSString *const MDCButtonBarButtonLayoutPositionKey = @"MDCButtonBarButto
     totalWidth += width;
   }
 
-  CGFloat maxHeight = [self usePadHeight] ? kDefaultPadHeight : kDefaultHeight;
-  CGFloat height = size.height > 0 ? MIN(size.height, maxHeight) : maxHeight;
+  CGFloat height = [self usePadHeight] ? kDefaultPadHeight : kDefaultHeight;
   return CGSizeMake(totalWidth, height);
 }
 

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -27,8 +27,8 @@
 
 static const CGFloat kNavigationBarDefaultHeight = 56;
 static const CGFloat kNavigationBarPadDefaultHeight = 64;
-static const UIEdgeInsets kTextInsets = {0, 16, 0, 16};
-static const UIEdgeInsets kTextPadInsets = {0, 16, 0, 16};
+static const UIEdgeInsets kTextInsets = {16, 16, 16, 16};
+static const UIEdgeInsets kTextPadInsets = {20, 16, 20, 16};
 
 // KVO contexts
 static char *const kKVOContextMDCNavigationBar = "kKVOContextMDCNavigationBar";
@@ -387,13 +387,12 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 
 - (CGSize)sizeThatFits:(CGSize)size {
   CGSize intrinsicContentSize = [self intrinsicContentSize];
-  CGFloat height =
-      size.height > 0 ? MIN(size.height, intrinsicContentSize.height) : intrinsicContentSize.height;
-  return CGSizeMake(size.width, height);
+  return CGSizeMake(size.width, intrinsicContentSize.height);
 }
 
 - (CGSize)intrinsicContentSize {
-  CGFloat height = [self usePadInsets] ? kNavigationBarPadDefaultHeight : kNavigationBarDefaultHeight;
+
+  CGFloat height = ([self usePadInsets] ? kNavigationBarPadDefaultHeight : kNavigationBarDefaultHeight);
   return CGSizeMake(UIViewNoIntrinsicMetric, height);
 }
 
@@ -508,8 +507,8 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
     case UIControlContentVerticalAlignmentTop: {
       // The title frame is vertically centered with the back button but will stick to the top of
       // the header regardless of the header's height.
-      CGFloat usableHeight = MIN(CGRectGetHeight(bounds), [self intrinsicContentSize].height);
-      CGFloat navigationBarCenteredY = MDCFloor((usableHeight - CGRectGetHeight(frame)) / 2);
+      CGFloat navigationBarCenteredY =
+          MDCFloor(([self intrinsicContentSize].height - CGRectGetHeight(frame)) / 2);
       navigationBarCenteredY = MAX(0, navigationBarCenteredY);
       return CGRectMake(CGRectGetMinX(frame), navigationBarCenteredY, CGRectGetWidth(frame),
                         CGRectGetHeight(frame));


### PR DESCRIPTION
An internal client has failing screenshot tests (iPad Air 2/iOS 10.2)
where the text has been shifted down as a result of this change. It's
not clear whether the new position is expected or a bug, so the change
is being reverted until the correct behavior (or fix) can be determined.

## Reference Screenshots

Note: The app appears dark because the header is covered with a modal scrim in these screenshots.

**49.0.0 Appearance**
![appbar-original](https://user-images.githubusercontent.com/1753199/38366534-032a0b6a-38ae-11e8-9f6f-470000d927f0.png)

**52.0.0 Appearance**
![appbar-shifted](https://user-images.githubusercontent.com/1753199/38366541-08618f9a-38ae-11e8-8f28-da8efd4fd8e8.png)


Reopens #2793
Reopens #253

This reverts commit 7172657a7b1cd04839eadc10e9d66e895a71bee7.
