### PR TITLE
[Slider] Added encoding support

### DIFF
--- a/components/Slider/src/MDCSlider.m
+++ b/components/Slider/src/MDCSlider.m
@@ -27,6 +27,21 @@ static const CGFloat kSliderDefaultThumbRadius = 6.0f;
 static const CGFloat kSliderAccessibilityIncrement = 0.1f;  // Matches UISlider's percent increment.
 static const CGFloat kSliderLightThemeTrackAlpha = 0.26f;
 
+static NSString *const MDCSliderColorKey = @"MDCSliderColorKey";
+static NSString *const MDCSliderDisabledColorKey = @"MDCSliderDisabledColorKey";
+static NSString *const MDCSliderTrackBackgroundColorKey = @"MDCSliderTrackBackgroundColorKey";
+static NSString *const MDCSliderThumbRadiusKey = @"MDCSliderThumbRadiusKey";
+static NSString *const MDCSliderThumbElevationKey = @"MDCSliderThumbElevationKey";
+static NSString *const MDCSliderNumberOfDiscreteValuesKey = @"MDCSliderNumberOfDiscreteValuesKey";
+static NSString *const MDCSliderValueKey = @"MDCSliderValueKey";
+static NSString *const MDCSliderMinimumValueKey = @"MDCSliderMinimumValueKey";
+static NSString *const MDCSliderMaximumValueKey = @"MDCSliderMaximumValueKey";
+static NSString *const MDCSliderIsContinuousKey = @"MDCSliderIsContinuousKey";
+static NSString *const MDCSliderFilledTrackAnchorValueKey = @"MDCSliderFilledTrackAnchorValueKey";
+static NSString *const MDCSliderShouldDisplayDiscreteValueLabelKey =
+    @"MDCSliderShouldDisplayDiscreteValueLabelKey";
+static NSString *const MDCSliderIsThumbHollowAtStartKey = @"MDCSliderIsThumbHollowAtStartKey";
+
 static inline UIColor *MDCThumbTrackDefaultColor(void) {
   return MDCPalette.bluePalette.tint500;
 }
@@ -49,8 +64,47 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
   self = [super initWithCoder:aDecoder];
   if (self) {
     [self commonMDCSliderInit];
+    self.color = [aDecoder decodeObjectOfClass:[UIColor class] forKey:MDCSliderColorKey];
+    self.disabledColor = [aDecoder decodeObjectOfClass:[UIColor class]
+                                                forKey:MDCSliderDisabledColorKey];
+    self.trackBackgroundColor = [aDecoder decodeObjectOfClass:[UIColor class]
+                                                       forKey:MDCSliderTrackBackgroundColorKey];
+    self.thumbRadius = (CGFloat)[aDecoder decodeDoubleForKey:MDCSliderThumbRadiusKey];
+    self.thumbElevation =
+        (MDCShadowElevation)[aDecoder decodeDoubleForKey:MDCSliderThumbElevationKey];
+    self.numberOfDiscreteValues =
+        (NSUInteger)[aDecoder decodeIntegerForKey:MDCSliderNumberOfDiscreteValuesKey];
+    self.value = (CGFloat)[aDecoder decodeDoubleForKey:MDCSliderValueKey];
+    self.minimumValue = (CGFloat)[aDecoder decodeDoubleForKey:MDCSliderMinimumValueKey];
+    self.maximumValue = (CGFloat)[aDecoder decodeDoubleForKey:MDCSliderMaximumValueKey];
+    self.continuous = [aDecoder decodeBoolForKey:MDCSliderIsContinuousKey];
+    self.filledTrackAnchorValue =
+        (CGFloat)[aDecoder decodeDoubleForKey:MDCSliderFilledTrackAnchorValueKey];
+    self.shouldDisplayDiscreteValueLabel =
+        [aDecoder decodeBoolForKey:MDCSliderShouldDisplayDiscreteValueLabelKey];
+    self.thumbHollowAtStart = [aDecoder decodeBoolForKey:MDCSliderIsThumbHollowAtStartKey];
   }
   return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+  [super encodeWithCoder:aCoder];
+  [aCoder encodeObject:self.color forKey:MDCSliderColorKey];
+  [aCoder encodeObject:self.disabledColor forKey:MDCSliderDisabledColorKey];
+  [aCoder encodeObject:self.trackBackgroundColor forKey:MDCSliderTrackBackgroundColorKey];
+  [aCoder encodeDouble:(double)self.thumbRadius forKey:MDCSliderThumbRadiusKey];
+  [aCoder encodeDouble:(double)self.thumbElevation forKey:MDCSliderThumbElevationKey];
+  [aCoder encodeInteger:(NSInteger)self.numberOfDiscreteValues
+                 forKey:MDCSliderNumberOfDiscreteValuesKey];
+  [aCoder encodeDouble:(double)self.value forKey:MDCSliderValueKey];
+  [aCoder encodeDouble:(double)self.minimumValue forKey:MDCSliderMinimumValueKey];
+  [aCoder encodeDouble:(double)self.maximumValue forKey:MDCSliderMaximumValueKey];
+  [aCoder encodeBool:self.continuous forKey:MDCSliderIsContinuousKey];
+  [aCoder encodeDouble:(double)self.filledTrackAnchorValue
+                forKey:MDCSliderFilledTrackAnchorValueKey];
+  [aCoder encodeBool:self.shouldDisplayDiscreteValueLabel
+              forKey:MDCSliderShouldDisplayDiscreteValueLabelKey];
+  [aCoder encodeBool:self.thumbHollowAtStart forKey:MDCSliderIsThumbHollowAtStartKey];
 }
 
 - (void)commonMDCSliderInit {

--- a/components/Slider/tests/unit/SliderEncodingTests.swift
+++ b/components/Slider/tests/unit/SliderEncodingTests.swift
@@ -1,0 +1,60 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents.MaterialSlider
+
+class SliderEncodingTests : XCTestCase {
+
+  func testSliderEncoding() {
+    // Given
+    let slider = MDCSlider()
+    slider.color = .yellow
+    slider.disabledColor = .green
+    slider.trackBackgroundColor = .purple
+    slider.thumbRadius = 42
+    slider.thumbElevation = .dialog
+    slider.numberOfDiscreteValues = 5
+    slider.value = 3
+    slider.minimumValue = 2
+    slider.maximumValue = 7
+    slider.isContinuous = false  // default is true
+    slider.filledTrackAnchorValue = -30
+    slider.shouldDisplayDiscreteValueLabel = false  // default is true
+    slider.isThumbHollowAtStart = false  // default is true
+
+    // When
+    let data = NSKeyedArchiver.archivedData(withRootObject: slider)
+    let unarchivedSlider = NSKeyedUnarchiver.unarchiveObject(with: data) as? MDCSlider
+
+    // Then
+    XCTAssertNotNil(unarchivedSlider)
+    XCTAssertEqual(unarchivedSlider?.color, slider.color)
+    XCTAssertEqual(unarchivedSlider?.disabledColor, slider.disabledColor)
+    XCTAssertEqual(unarchivedSlider?.trackBackgroundColor, slider.trackBackgroundColor)
+    XCTAssertEqual(unarchivedSlider?.thumbRadius, slider.thumbRadius)
+    XCTAssertEqual(unarchivedSlider?.thumbElevation, slider.thumbElevation)
+    XCTAssertEqual(unarchivedSlider?.numberOfDiscreteValues, slider.numberOfDiscreteValues)
+    XCTAssertEqual(unarchivedSlider?.value, slider.value)
+    XCTAssertEqual(unarchivedSlider?.minimumValue, slider.minimumValue)
+    XCTAssertEqual(unarchivedSlider?.maximumValue, slider.maximumValue)
+    XCTAssertEqual(unarchivedSlider?.isContinuous, slider.isContinuous)
+    XCTAssertEqual(unarchivedSlider?.filledTrackAnchorValue, slider.filledTrackAnchorValue)
+    XCTAssertEqual(unarchivedSlider?.shouldDisplayDiscreteValueLabel,
+                   slider.shouldDisplayDiscreteValueLabel)
+    XCTAssertEqual(unarchivedSlider?.isThumbHollowAtStart, slider.isThumbHollowAtStart)
+  }
+}


### PR DESCRIPTION
Encode all of the public properties in the header file (except `delegate`).

Fixes #3140.