### PR TITLE
[Color] Implement a swift-friendly API for color scheme defaults.

### DIFF
--- a/components/schemes/Color/src/MDCSemanticColorScheme.h
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.h
@@ -114,7 +114,7 @@ typedef NS_ENUM(NSInteger, MDCColorSchemeDefaults) {
 - (nonnull instancetype)init;
 
 /**
- Initializes a new instance of MDCSemanticColorScheme with the given defaults.
+ Initializes the color scheme with the colors associated with the given defaults.
  */
 - (nonnull instancetype)initWithDefaults:(MDCColorSchemeDefaults)defaults;
 

--- a/components/schemes/Color/src/MDCSemanticColorScheme.h
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.h
@@ -81,6 +81,16 @@
 @end
 
 /**
+ An enum of default color schemes that are supported.
+ */
+typedef NS_ENUM(NSInteger, MDCColorSchemeDefaults) {
+  /**
+   The Material defaults, circa April 2018.
+   */
+  MDCColorSchemeDefaultsMaterial
+};
+
+/**
  A simple implementation of @c MDCColorScheming that provides Material default color values from
  which basic customizations can be made.
  */
@@ -99,13 +109,13 @@
 @property(nonnull, readwrite, nonatomic) UIColor *onBackgroundColor;
 
 /**
- Convenience initializer that calls @c initWithMaterialDefaults.
+ Initializes the color scheme with the latest material defaults.
  */
 - (nonnull instancetype)init;
 
 /**
- Initializes an instance of MDCSemanticColorScheme with the Material default color values.
+ Initializes a new instance of MDCSemanticColorScheme with the given defaults.
  */
-- (nonnull instancetype)initWithMaterialDefaults;
+- (nonnull instancetype)initWithDefaults:(MDCColorSchemeDefaults)defaults;
 
 @end

--- a/components/schemes/Color/src/MDCSemanticColorScheme.h
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.h
@@ -87,7 +87,7 @@ typedef NS_ENUM(NSInteger, MDCColorSchemeDefaults) {
   /**
    The Material defaults, circa April 2018.
    */
-  MDCColorSchemeDefaultsMaterial
+  MDCColorSchemeDefaultsMaterial201804
 };
 
 /**

--- a/components/schemes/Color/src/MDCSemanticColorScheme.m
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.m
@@ -28,7 +28,7 @@ static UIColor *ColorFromRGB(uint32_t colorValue) {
   return [self initWithDefaults:MDCColorSchemeDefaultsMaterial];
 }
 
-- (nonnull instancetype)initWithDefaults:(MDCColorSchemeDefaults)defaults {
+- (instancetype)initWithDefaults:(MDCColorSchemeDefaults)defaults {
   self = [super init];
   if (self) {
     switch (defaults) {

--- a/components/schemes/Color/src/MDCSemanticColorScheme.m
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.m
@@ -25,14 +25,14 @@ static UIColor *ColorFromRGB(uint32_t colorValue) {
 @implementation MDCSemanticColorScheme
 
 - (instancetype)init {
-  return [self initWithDefaults:MDCColorSchemeDefaultsMaterial];
+  return [self initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
 }
 
 - (instancetype)initWithDefaults:(MDCColorSchemeDefaults)defaults {
   self = [super init];
   if (self) {
     switch (defaults) {
-      case MDCColorSchemeDefaultsMaterial:
+      case MDCColorSchemeDefaultsMaterial201804:
         _primaryColor = ColorFromRGB(0x6200EE);
         _primaryColorVariant = ColorFromRGB(0x3700B3);
         _secondaryColor = ColorFromRGB(0x03DAC6);

--- a/components/schemes/Color/src/MDCSemanticColorScheme.m
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.m
@@ -25,22 +25,26 @@ static UIColor *ColorFromRGB(uint32_t colorValue) {
 @implementation MDCSemanticColorScheme
 
 - (instancetype)init {
-  return [self initWithMaterialDefaults];
+  return [self initWithDefaults:MDCColorSchemeDefaultsMaterial];
 }
 
-- (instancetype)initWithMaterialDefaults {
+- (nonnull instancetype)initWithDefaults:(MDCColorSchemeDefaults)defaults {
   self = [super init];
   if (self) {
-    _primaryColor = ColorFromRGB(0x6200EE);
-    _primaryColorVariant = ColorFromRGB(0x3700B3);
-    _secondaryColor = ColorFromRGB(0x03DAC6);
-    _errorColor = ColorFromRGB(0xFF1744);
-    _surfaceColor = ColorFromRGB(0xFFFFFF);
-    _backgroundColor = ColorFromRGB(0xFFFFFF);
-    _onPrimaryColor = ColorFromRGB(0xFFFFFF);
-    _onSecondaryColor = ColorFromRGB(0x000000);
-    _onSurfaceColor = ColorFromRGB(0x000000);
-    _onBackgroundColor = ColorFromRGB(0x000000);
+    switch (defaults) {
+      case MDCColorSchemeDefaultsMaterial:
+        _primaryColor = ColorFromRGB(0x6200EE);
+        _primaryColorVariant = ColorFromRGB(0x3700B3);
+        _secondaryColor = ColorFromRGB(0x03DAC6);
+        _errorColor = ColorFromRGB(0xFF1744);
+        _surfaceColor = ColorFromRGB(0xFFFFFF);
+        _backgroundColor = ColorFromRGB(0xFFFFFF);
+        _onPrimaryColor = ColorFromRGB(0xFFFFFF);
+        _onSecondaryColor = ColorFromRGB(0x000000);
+        _onSurfaceColor = ColorFromRGB(0x000000);
+        _onBackgroundColor = ColorFromRGB(0x000000);
+        break;
+    }
   }
   return self;
 }

--- a/components/schemes/Color/tests/unit/MDCSemanticColorSchemeTests.m
+++ b/components/schemes/Color/tests/unit/MDCSemanticColorSchemeTests.m
@@ -33,8 +33,8 @@ static UIColor *ColorFromRGB(uint32_t colorValue) {
 - (void)testInitMatchesInitWithMaterialDefaults {
   // Given
   MDCSemanticColorScheme *initScheme = [[MDCSemanticColorScheme alloc] init];
-  MDCSemanticColorScheme *mdDefaultScheme = [[MDCSemanticColorScheme alloc]
-                                             initWithMaterialDefaults];
+  MDCSemanticColorScheme *mdDefaultScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial];
 
   // Then
   XCTAssertEqualObjects(initScheme.primaryColor, mdDefaultScheme.primaryColor);
@@ -51,7 +51,8 @@ static UIColor *ColorFromRGB(uint32_t colorValue) {
 
 - (void)testInitWithMaterialDefaults {
   // Given
-  MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] initWithMaterialDefaults];
+  MDCSemanticColorScheme *colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial];
 
   // Then
   XCTAssertEqualObjects(colorScheme.primaryColor, ColorFromRGB(0x6200EE));

--- a/components/schemes/Color/tests/unit/MDCSemanticColorSchemeTests.m
+++ b/components/schemes/Color/tests/unit/MDCSemanticColorSchemeTests.m
@@ -34,7 +34,7 @@ static UIColor *ColorFromRGB(uint32_t colorValue) {
   // Given
   MDCSemanticColorScheme *initScheme = [[MDCSemanticColorScheme alloc] init];
   MDCSemanticColorScheme *mdDefaultScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial];
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
 
   // Then
   XCTAssertEqualObjects(initScheme.primaryColor, mdDefaultScheme.primaryColor);
@@ -52,7 +52,7 @@ static UIColor *ColorFromRGB(uint32_t colorValue) {
 - (void)testInitWithMaterialDefaults {
   // Given
   MDCSemanticColorScheme *colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial];
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
 
   // Then
   XCTAssertEqualObjects(colorScheme.primaryColor, ColorFromRGB(0x6200EE));


### PR DESCRIPTION
The old API required swift code like so:

    MDCSemanticColorScheme(materialDefaults: ())

The new API allows swift code like so:

    MDCSemanticColorScheme(defaults: .material)

Pivotal story: https://www.pivotaltracker.com/story/show/156527002