### PR TITLE
[kokoro] Disable verbose output on bazel builds.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -177,11 +177,6 @@ while [[ $# -gt 0 ]]; do
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
-if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-  # Always enable verbose output on kokoro runs.
-  VERBOSE_OUTPUT=1
-fi
-
 if [ -n "$VERBOSE_OUTPUT" ]; then
   # Display commands to stderr.
   set -x


### PR DESCRIPTION
The non-verbose output should typically be sufficient to identify any test or build failures. We had originally been enabling verbose output because some of the failures were happening further upstream in the build toolchain, but now that kokoro has largely stabilized we can step down the verbosity.

If any individual PR needs increased verbosity to identify a failure then `VERBOSE_OUTPUT` can be manually enabled in the script as part of the PR.