### PR TITLE
[kokoro] Don't upgrade the bazel installation.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -77,8 +77,6 @@ run_bazel() {
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     bazel version
-    use_bazel.sh latest
-    bazel version
   fi
 
   if [ -n "$VERBOSE_OUTPUT" ]; then


### PR DESCRIPTION
Kokoro is now being deployed with the minimum bazel version we need (0.11), so we no longer need to manually update the bazel version. This should also shave off a few minutes of build time from each PR.