### PR TITLE
[TextFields] expose input text font property on controller.

### DIFF
--- a/components/TextFields/examples/TextFieldCustomFontExample.m
+++ b/components/TextFields/examples/TextFieldCustomFontExample.m
@@ -235,6 +235,7 @@
       [UIFont fontWithName:@"Chalkduster" size:12];
   self.customFontController.inlinePlaceholderFont =
       [UIFont fontWithName:@"AmericanTypewriter" size:12];
+  self.customFontController.textInputFont = [UIFont fontWithName:@"Chalkduster" size:16];
   return customFontTextField;
 }
 
@@ -255,6 +256,7 @@
   self.customFontDynamicController.trailingUnderlineLabelFont =
       [UIFont fontWithName:@"Chalkduster" size:12];
   self.customFontDynamicController.inlinePlaceholderFont = [UIFont fontWithName:@"Zapfino" size:12];
+  self.customFontDynamicController.textInputFont = [UIFont fontWithName:@"Zapfino" size:16];
   self.customFontDynamicController.mdc_adjustsFontForContentSizeCategory = YES;
 
   [self.scrollView addSubview:customFontDynamicTextField];
@@ -306,6 +308,8 @@
       [UIFont fontWithName:@"Chalkduster" size:12];
   self.multilineCustomFontDynamicController.inlinePlaceholderFont =
       [UIFont fontWithName:@"Zapfino" size:12];
+  self.multilineCustomFontDynamicController.textInputFont =
+      [UIFont fontWithName:@"AmericanTypewriter" size:16];
   self.multilineCustomFontDynamicController.mdc_adjustsFontForContentSizeCategory = YES;
   return multilineCustomDynamicTextField;
 }

--- a/components/TextFields/src/MDCTextInputController.h
+++ b/components/TextFields/src/MDCTextInputController.h
@@ -113,6 +113,17 @@
 @property(class, nonatomic, null_resettable, strong) UIColor *inlinePlaceholderColorDefault;
 
 /**
+ The font applied to the text input.
+
+ Default is textInputFontDefault. if textInputFontDefault is nil, textInput.font will be default.
+ */
+@property(nonatomic, null_resettable, strong) UIFont *textInputFont;
+
+/** Default value for textInputFontDefault. if nil, textInput.font will be default.  */
+@property(class, nonatomic, nullable, strong) UIFont *textInputFontDefault;
+
+
+/**
  The font applied to the placeholder when inline (not floating).
 
  Default is inlinePlaceholderFontDefault;

--- a/components/TextFields/src/MDCTextInputController.h
+++ b/components/TextFields/src/MDCTextInputController.h
@@ -115,11 +115,12 @@
 /**
  The font applied to the text input.
 
- Default is textInputFontDefault. if textInputFontDefault is nil, textInput.font will be default.
+ Default or in case this property is nil, the value will be textInputFontDefault.
+ If textInputFontDefault is nil, textInput.font would be the fallback.
  */
 @property(nonatomic, null_resettable, strong) UIFont *textInputFont;
 
-/** Default value for textInputFontDefault. if nil, textInput.font will be default.  */
+/** Default value for textInputFontDefault. If nil, textInput.font would be the fallback.  */
 @property(class, nonatomic, nullable, strong) UIFont *textInputFontDefault;
 
 

--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -138,6 +138,7 @@ static UIColor *_trailingUnderlineLabelTextColorDefault;
 
 static UIFont *_inlinePlaceholderFontDefault;
 static UIFont *_leadingUnderlineLabelFontDefault;
+static UIFont *_textInputFontDefault;
 static UIFont *_trailingUnderlineLabelFontDefault;
 
 static UIRectCorner _roundedCornersDefault = 0;
@@ -163,6 +164,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
   UIFont *_inlinePlaceholderFont;
   UIFont *_leadingUnderlineLabelFont;
+  UIFont *_textInputFont;
   UIFont *_trailingUnderlineLabelFont;
 
   UIRectCorner _roundedCorners;
@@ -566,10 +568,12 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 #pragma  mark - TextInput Customization
 
 - (void)updateTextInput {
+  UIFont *font = self.textInputFont;
   if (self.mdc_adjustsFontForContentSizeCategory) {
-    UIFont *textFont = [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleBody1];
-    self.textInput.font = textFont;
+    font = [font mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleBody1
+                              scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
   }
+  self.textInput.font = font;
 }
 
 #pragma mark - Placeholder Customization
@@ -1309,6 +1313,28 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
     _textInput = textInput;
     [self setupInput];
   }
+}
+
+- (UIFont *)textInputFont {
+  if (_textInputFont) {
+    return _textInputFont;
+  }
+  return [self class].textInputFontDefault ?: self.textInput.font;
+}
+
+- (void)setTextInputFont:(UIFont *)textInputFont {
+  if (![_textInputFont isEqual:textInputFont]) {
+    _textInputFont = textInputFont;
+    [self updateLayout];
+  }
+}
+
++ (UIFont *)textInputFontDefault {
+  return _textInputFontDefault;
+}
+
++ (void)setTextInputFontDefault:(UIFont *)textInputFontDefault {
+    _textInputFontDefault = textInputFontDefault;
 }
 
 - (UIFont *)trailingUnderlineLabelFont {

--- a/components/TextFields/src/MDCTextInputControllerFullWidth.m
+++ b/components/TextFields/src/MDCTextInputControllerFullWidth.m
@@ -76,6 +76,7 @@ static UIColor *_inlinePlaceholderColorDefault;
 static UIColor *_trailingUnderlineLabelTextColorDefault;
 
 static UIFont *_inlinePlaceholderFontDefault;
+static UIFont *_textInputFontDefault;
 static UIFont *_trailingUnderlineLabelFontDefault;
 
 @interface MDCTextInputControllerFullWidth () {
@@ -88,6 +89,7 @@ static UIFont *_trailingUnderlineLabelFontDefault;
   UIColor *_trailingUnderlineLabelTextColor;
 
   UIFont *_inlinePlaceholderFont;
+  UIFont *_textInputFont;
   UIFont *_trailingUnderlineLabelFont;
 }
 
@@ -328,6 +330,18 @@ static UIFont *_trailingUnderlineLabelFontDefault;
     _characterCountMax = characterCountMax;
     [self updateLayout];
   }
+}
+
+#pragma  mark - TextInput Customization
+
+- (void)updateTextInput {
+  UIFont *font = self.textInputFont;
+  if (self.mdc_adjustsFontForContentSizeCategory) {
+    font =
+        [font mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleBody1
+                           scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
+  }
+  self.textInput.font = font;
 }
 
 #pragma mark - Leading Label Customization
@@ -666,6 +680,28 @@ static UIFont *_trailingUnderlineLabelFontDefault;
   }
 }
 
+- (UIFont *)textInputFont {
+  if (_textInputFont) {
+    return _textInputFont;
+  }
+  return [self class].textInputFontDefault ?: self.textInput.font;
+}
+
+- (void)setTextInputFont:(UIFont *)textInputFont {
+  if (![_textInputFont isEqual:textInputFont]) {
+    _textInputFont = textInputFont;
+    [self updateLayout];
+  }
+}
+
++ (UIFont *)textInputFontDefault {
+  return _textInputFontDefault;
+}
+
++ (void)setTextInputFontDefault:(UIFont *)textInputFontDefault {
+  _textInputFontDefault = textInputFontDefault;
+}
+
 - (UIFont *)trailingUnderlineLabelFont {
   return _trailingUnderlineLabelFont ?: [self class].trailingUnderlineLabelFontDefault;
 }
@@ -780,6 +816,7 @@ static UIFont *_trailingUnderlineLabelFontDefault;
   [self updatePlaceholder];
   [self updateLeadingUnderlineLabel];
   [self updateTrailingUnderlineLabel];
+  [self updateTextInput];
   [self updateUnderline];
   [self updateConstraints];
 }


### PR DESCRIPTION
In order to expose inputTextFont property on text field controller without making breaking change, I had to make sure the default would fall back to textInput.font which used to be the primary way of setting font on textFields.

Pivotal: https://www.pivotaltracker.com/story/show/156518577