### PR TITLE
[FeatureHighlight] Exposing title and body font for FeatureHighlightViewController.

### DIFF
--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
@@ -123,6 +123,20 @@ typedef void (^MDCFeatureHighlightCompletion)(BOOL accepted);
 @property(nonatomic, strong, nullable) UIColor *bodyColor;
 
 /**
+ Sets the font to be used for the title text.
+
+ Defaults to nil.
+ */
+@property(nonatomic, strong, nullable) UIFont *titleFont;
+
+/**
+ Sets the font to be used for the body text.
+
+ Defaults to nil.
+ */
+@property(nonatomic, strong, nullable) UIFont *bodyFont;
+
+/**
  Indicates whether the feature highlight contents should automatically update their font when the
  device’s UIContentSizeCategory changes.
 

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -192,6 +192,22 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
   self.view.bodyColor = bodyColor;
 }
 
+- (void)setTitleFont:(UIFont *)titleFont {
+  self.view.titleFont = titleFont;
+}
+
+- (UIFont *)titleFont {
+  return self.view.titleFont;
+}
+
+- (void)setBodyFont:(UIFont *)bodyFont {
+  self.view.bodyFont = bodyFont;
+}
+
+- (UIFont *)bodyFont {
+  return self.view.bodyFont;
+}
+
 - (void)acceptFeature {
   [self dismiss:YES];
 }


### PR DESCRIPTION
PR was reverted to expose the FeatureHighlightView (it was a breaking change), so I am simply exposing title and body font properties in the view Controller.