### PR TITLE
[Catalog] Use the Material components colors for the app's color scheme values.

### DIFF
--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -25,9 +25,9 @@ final class AppTheme {
   }
 
   static let defaultTheme = AppTheme(colorScheme:
-    MDCBasicColorScheme(primaryColor: MDCPalette.purple.tint500,
-                        primaryLightColor: MDCPalette.purple.tint100,
-                        primaryDarkColor: MDCPalette.purple.tint900)
+    MDCBasicColorScheme(primaryColor: MDCSemanticColorScheme().primaryColor,
+                        primaryLightColor: MDCSemanticColorScheme().secondaryColor,
+                        primaryDarkColor: MDCSemanticColorScheme().primaryColorVariant)
   )
 
   static var globalTheme = defaultTheme {

--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -25,9 +25,9 @@ final class AppTheme {
   }
 
   static let defaultTheme = AppTheme(colorScheme:
-    MDCBasicColorScheme(primaryColor: MDCSemanticColorScheme().primaryColor,
-                        primaryLightColor: MDCSemanticColorScheme().secondaryColor,
-                        primaryDarkColor: MDCSemanticColorScheme().primaryColorVariant)
+    MDCBasicColorScheme(primaryColor: .init(white: 33 / 255.0, alpha: 1),
+                        primaryLightColor: .init(white: 0.7, alpha: 1),
+                        primaryDarkColor: .init(white: 0, alpha: 1))
   )
 
   static var globalTheme = defaultTheme {


### PR DESCRIPTION
This gets us at least visually closer to an app themed with the Material defaults. A follow-up change will be required to actually make use of the MDCColorTheming themers once they land.

![simulator screen shot - iphone x - 2018-04-06 at 16 27 36](https://user-images.githubusercontent.com/45670/38442809-88140272-39b7-11e8-98af-569241566df1.png)

