### PR TITLE
[Snackbar] Implement a typography themer.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -41,6 +41,7 @@ fix_bazel_imports() {
 
   stashed_dir=""
   rewrite_tests "s/import MaterialComponents.MDC(.+)ColorThemer/import components_\1_ColorThemer/"
+  rewrite_tests "s/import MaterialComponents.MDC(.+)TypographyThemer/import components_\1_TypographyThemer/"
   rewrite_tests "s/import MaterialComponents.MaterialMath/import components_private_Math_Math/"
   rewrite_tests "s/import MaterialComponents.Material(.+)/import components_\1_\1/"
   rewrite_source "s/import <Motion(.+)\/Motion.+\.h>/import \"Motion\1.h\"/"
@@ -51,6 +52,7 @@ fix_bazel_imports() {
   reset_imports() {
     # Undoes our source changes from above.
     rewrite_tests "s/import components_(.+)_ColorThemer/import MaterialComponents.MDC\1ColorThemer/"
+    rewrite_tests "s/import components_(.+)_TypographyThemer/import MaterialComponents.MDC\1TypographyThemer/"
     rewrite_tests "s/import components_private_Math_Math/import MaterialComponents.MaterialMath/"
     rewrite_tests "s/import components_(.+)_.+/import MaterialComponents.Material\1/"
     rewrite_source "s/import \"Motion(.+)\.h\"/import <Motion\1\/Motion\1.h>/"

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -564,6 +564,14 @@ mdc.subspec "Snackbar+Extensions" do |component|
     extension.dependency "MaterialComponents/Snackbar"
     extension.dependency "MaterialComponents/Themes"
   end
+  component.subspec "TypographyThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Snackbar/src/#{extension.base_name}/*.h"
+    extension.source_files = "components/Snackbar/src/#{extension.base_name}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/Snackbar"
+    extension.dependency "MaterialComponents/schemes/Typography"
+  end
 end
 
   mdc.subspec "Tabs" do |component|

--- a/components/Snackbar/BUILD
+++ b/components/Snackbar/BUILD
@@ -70,6 +70,18 @@ mdc_objc_library(
 )
 
 mdc_objc_library(
+    name = "TypographyThemer",
+    srcs = native.glob(["src/TypographyThemer/*.m"]),
+    hdrs = native.glob(["src/TypographyThemer/*.h"]),
+    includes = ["src/TypographyThemer"],
+    deps = [
+        ":Snackbar",
+        "//components/schemes/Typography",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+mdc_objc_library(
     name = "private",
     hdrs = native.glob(["src/private/*.h"]),
     includes = ["src/private"],
@@ -82,6 +94,7 @@ swift_library(
     deps = [
         ":Snackbar",
         ":private",
+        ":TypographyThemer",
     ],
     visibility = ["//visibility:private"],
 )

--- a/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
+++ b/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
@@ -15,6 +15,7 @@
  */
 
 #import "SnackbarExampleSupplemental.h"
+#import "MDCSnackbarTypographyThemer.h"
 
 static NSString * const kCellIdentifier = @"Cell";
 
@@ -25,6 +26,8 @@ static NSString * const kCellIdentifier = @"Cell";
   self.view.backgroundColor = [UIColor whiteColor];
   [self.collectionView registerClass:[MDCCollectionViewTextCell class]
           forCellWithReuseIdentifier:kCellIdentifier];
+  MDCTypographyScheme *typographyScheme = [[MDCTypographyScheme alloc] init];
+  [MDCSnackbarTypographyThemer applyTypographyScheme:typographyScheme];
 }
 
 #pragma mark - UICollectionView

--- a/components/Snackbar/src/FontThemer/MDCSnackbarFontThemer.h
+++ b/components/Snackbar/src/FontThemer/MDCSnackbarFontThemer.h
@@ -21,6 +21,7 @@
 
 /**
  Used to apply a font scheme to theme to MDCSnackbarMessageView.
+ This class will soon be deprecated, please use MDCSnackbarTypographyThemer instead.
  */
 @interface MDCSnackbarFontThemer : NSObject
 

--- a/components/Snackbar/src/TypographyThemer/MDCSnackbarTypographyThemer.h
+++ b/components/Snackbar/src/TypographyThemer/MDCSnackbarTypographyThemer.h
@@ -1,0 +1,31 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MaterialSnackbar.h"
+#import "MaterialTypographyScheme.h"
+
+/**
+ Used to apply a typography scheme to theme MDCSnackbarManager.
+ */
+@interface MDCSnackbarTypographyThemer : NSObject
+
+/**
+ Applies a typography scheme to theme a MDCSnackbarManager.
+ @param typographyScheme The typography scheme to apply to MDCSnackbarManager.
+ */
++ (void)applyTypographyScheme:(nonnull id<MDCTypographyScheming>)typographyScheme;
+
+@end

--- a/components/Snackbar/src/TypographyThemer/MDCSnackbarTypographyThemer.m
+++ b/components/Snackbar/src/TypographyThemer/MDCSnackbarTypographyThemer.m
@@ -1,0 +1,26 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCSnackbarTypographyThemer.h"
+
+@implementation MDCSnackbarTypographyThemer
+
++ (void)applyTypographyScheme:(nonnull id<MDCTypographyScheming>)typographyScheme {
+  MDCSnackbarManager.buttonFont = typographyScheme.button;
+  MDCSnackbarManager.messageFont = typographyScheme.body2;
+}
+
+@end

--- a/components/Snackbar/tests/unit/MDCSnackbarTypographyThemerTests.swift
+++ b/components/Snackbar/tests/unit/MDCSnackbarTypographyThemerTests.swift
@@ -1,0 +1,43 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents.MaterialSnackbar
+import MaterialComponents.MDCSnackbarTypographyThemer
+
+class MDCSnackbarTypographyThemerTests: XCTestCase {
+    
+  func testSnackbarTypographyThemer() {
+    // Given
+    let typographyScheme = MDCTypographyScheme()
+    let message = MDCSnackbarMessage()
+    message.text = "How much wood would a woodchuck chuck if a woodchuck could chuck wood?"
+    typographyScheme.button = UIFont.boldSystemFont(ofSize: 12)
+    typographyScheme.body2 = UIFont.systemFont(ofSize: 19)
+    MDCSnackbarManager.buttonFont = UIFont.systemFont(ofSize: 21)
+    MDCSnackbarManager.messageFont = UIFont.systemFont(ofSize: 30)
+
+    // When
+    MDCSnackbarTypographyThemer.applyTypographyScheme(typographyScheme)
+
+    MDCSnackbarManager.show(message)
+
+    // Then
+    XCTAssertEqual(MDCSnackbarManager.buttonFont, typographyScheme.button)
+    XCTAssertEqual(MDCSnackbarManager.messageFont, typographyScheme.body2)
+  }
+    
+}


### PR DESCRIPTION
Addition of a unit test, and updated the examples to use the new typography themer. This is in addition to the current FontThemer, and doesn't replace it.

Had to also update .kokoro to fix bazel imports for Typography.

Pivotal: https://www.pivotaltracker.com/story/show/156171658

![simulator screen shot - iphone 8 - 2018-04-08 at 15 12 11](https://user-images.githubusercontent.com/4066863/38467328-46c43ac4-3b3f-11e8-8d97-04b4f71711e2.png)
