### PR TITLE
[Ink] Fix flaky test

### DIFF
--- a/components/Ink/tests/unit/MDCInkLayerTests.m
+++ b/components/Ink/tests/unit/MDCInkLayerTests.m
@@ -147,16 +147,13 @@
 
   // When
   NSTimeInterval startTime = CACurrentMediaTime();
+  startTime = [inkLayer convertTime:(startTime + 0.9) fromLayer:nil];
   [inkLayer endAnimationAtPoint:CGPointMake(5, 5)];
-
-
   // Then
   XCTAssertEqual(inkLayer.addedAnimations.count, 1U);
   CAAnimation *animation = inkLayer.addedAnimations.firstObject;
   if (animation) {
-    XCTAssertEqualWithAccuracy(animation.beginTime,
-                               [inkLayer convertTime:(startTime + 0.9) fromLayer:nil],
-                               0.010);
+    XCTAssertEqualWithAccuracy(animation.beginTime, startTime, 0.010);
   }
 }
 
@@ -168,15 +165,14 @@
 
   // When
   NSTimeInterval startTime = CACurrentMediaTime();
+  startTime = [inkLayer convertTime:startTime fromLayer:nil];
   [inkLayer changeAnimationAtPoint:CGPointMake(5, 5)];
 
   // Then
   XCTAssertEqual(inkLayer.addedAnimations.count, 1U);
   CAAnimation *animation = inkLayer.addedAnimations.firstObject;
   if (animation) {
-    XCTAssertEqualWithAccuracy(animation.beginTime,
-                               [inkLayer convertTime:startTime fromLayer:nil],
-                               0.010);
+    XCTAssertEqualWithAccuracy(animation.beginTime, startTime, 0.010);
   }
 }
 

--- a/components/Ink/tests/unit/MDCInkLayerTests.m
+++ b/components/Ink/tests/unit/MDCInkLayerTests.m
@@ -146,13 +146,14 @@
   inkLayer.endAnimationDelay = (CGFloat)0.9;
 
   // When
-  NSTimeInterval startTime = CACurrentMediaTime();
-  startTime = [inkLayer convertTime:(startTime + 0.9) fromLayer:nil];
   [inkLayer endAnimationAtPoint:CGPointMake(5, 5)];
+  NSTimeInterval startTime = CACurrentMediaTime();
+
   // Then
   XCTAssertEqual(inkLayer.addedAnimations.count, 1U);
   CAAnimation *animation = inkLayer.addedAnimations.firstObject;
   if (animation) {
+    startTime = [inkLayer convertTime:(startTime + 0.9) fromLayer:nil];
     XCTAssertEqualWithAccuracy(animation.beginTime, startTime, 0.010);
   }
 }
@@ -164,14 +165,14 @@
   inkLayer.speed = 0.5f;
 
   // When
-  NSTimeInterval startTime = CACurrentMediaTime();
-  startTime = [inkLayer convertTime:startTime fromLayer:nil];
   [inkLayer changeAnimationAtPoint:CGPointMake(5, 5)];
+  NSTimeInterval startTime = CACurrentMediaTime();
 
   // Then
   XCTAssertEqual(inkLayer.addedAnimations.count, 1U);
   CAAnimation *animation = inkLayer.addedAnimations.firstObject;
   if (animation) {
+    startTime = [inkLayer convertTime:startTime fromLayer:nil];
     XCTAssertEqualWithAccuracy(animation.beginTime, startTime, 0.010);
   }
 }

--- a/components/Ink/tests/unit/MDCInkLayerTests.m
+++ b/components/Ink/tests/unit/MDCInkLayerTests.m
@@ -156,7 +156,7 @@
   if (animation) {
     XCTAssertEqualWithAccuracy(animation.beginTime,
                                [inkLayer convertTime:(startTime + 0.9) fromLayer:nil],
-                               0.005);
+                               0.010);
   }
 }
 
@@ -176,7 +176,7 @@
   if (animation) {
     XCTAssertEqualWithAccuracy(animation.beginTime,
                                [inkLayer convertTime:startTime fromLayer:nil],
-                               0.005);
+                               0.010);
   }
 }
 


### PR DESCRIPTION
Depending on the scheduler and the machine the time given for accuracy is too low (even though both times are set synchronously after each other). I have made it so the `convertTime` invocation is done prior to initiating the `animation.beginTime` and made the accuracy less strict.

Resolves #3173 

Pivotal: https://www.pivotaltracker.com/story/show/156520276
