### PR TITLE
[Slider] Fix green Slider example color

### DIFF
--- a/components/Slider/examples/SliderCollectionViewController.m
+++ b/components/Slider/examples/SliderCollectionViewController.m
@@ -15,6 +15,7 @@
  */
 
 #import "MaterialCollections.h"
+#import "MaterialPalettes.h"
 #import "MaterialSlider.h"
 #import "MaterialTypography.h"
 #import "supplemental/SliderCollectionSupplemental.h"
@@ -102,6 +103,7 @@ static CGFloat const kSliderVerticalMargin = 12.f;
   _slider.filledTrackAnchorValue = model.anchorValue;
   _slider.shouldDisplayDiscreteValueLabel = model.discreteValueLabel;
   _slider.thumbHollowAtStart = model.hollowCircle;
+  _slider.color = model.sliderColor;
   _slider.enabled = model.enabled;
 
   // Add target/action pair
@@ -185,6 +187,7 @@ static CGFloat const kSliderVerticalMargin = 12.f;
 
     model = [[MDCSliderModel alloc] init];
     model.labelString = @"Green slider without hollow circle at 0";
+    model.sliderColor = MDCPalette.greenPalette.tint700;
     model.hollowCircle = NO;
     model.value = 0.f;
     [_sliders addObject:model];

--- a/components/Slider/examples/SliderCollectionViewController.m
+++ b/components/Slider/examples/SliderCollectionViewController.m
@@ -187,7 +187,7 @@ static CGFloat const kSliderVerticalMargin = 12.f;
 
     model = [[MDCSliderModel alloc] init];
     model.labelString = @"Green slider without hollow circle at 0";
-    model.sliderColor = MDCPalette.greenPalette.tint700;
+    model.sliderColor = MDCPalette.greenPalette.tint800;
     model.hollowCircle = NO;
     model.value = 0.f;
     [_sliders addObject:model];


### PR DESCRIPTION
The "Green slider without hollow circle at 0" was not green.

**Before**
![green-slider-before](https://user-images.githubusercontent.com/1753199/38504890-ead30a42-3be3-11e8-97e9-19e453fa55fd.png)


**After**
![green-slider-after](https://user-images.githubusercontent.com/1753199/38505104-656848e4-3be4-11e8-97a3-67be059168e1.png)

