### PR TITLE
[Cards] Add missing Shapes dependency.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -211,6 +211,7 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/ShadowLayer"
     component.dependency "MaterialComponents/private/Icons/ic_check_circle"
     component.dependency "MaterialComponents/private/Math"
+    component.dependency "MaterialComponents/private/Shapes"
   end
 
   mdc.subspec "Chips" do |component|


### PR DESCRIPTION
https://github.com/material-components/material-components-ios/commit/af2a3c89d2db301ad05fd2d3eb1e6dae5f057e46 updated the BUILD deps but not the CocoaPods dependencies.