### PR TITLE
Forcing Font size now does save the right FontName for every case.

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -264,6 +264,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 }
 
 - (void)setTitleFont:(UIFont *)titleFont {
+  // Using "fontWithSize:" did not work for system font medium, instead it returned a regular font.
   _titleFont = [UIFont fontWithName:titleFont.fontName size:kTitleFontSize];
   if (!_titleFont) {
     _titleFont = [MDCTypography titleFont];

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -264,7 +264,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 }
 
 - (void)setTitleFont:(UIFont *)titleFont {
-  _titleFont = [titleFont fontWithSize:kTitleFontSize];
+  _titleFont = [UIFont fontWithName:titleFont.fontName size:kTitleFontSize];
   if (!_titleFont) {
     _titleFont = [MDCTypography titleFont];
   }

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -295,7 +295,7 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   // The default font weight is UIFontWeightRegular, which is 0.0.
   CGFloat weight = 0.0;
 
-  NSDictionary *fontTraits = [self.fontDescriptor objectForKey:UIFontDescriptorTraitsAttribute];
+  NSDictionary *fontTraits = [font.fontDescriptor objectForKey:UIFontDescriptorTraitsAttribute];
   if (fontTraits) {
     NSNumber *weightNumber = fontTraits[UIFontWeightTrait];
     if (weightNumber != nil) {

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -108,7 +108,8 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   UIFont *titleFont = navBar.titleLabel.font;
   XCTAssertEqualObjects(titleFont.fontName, resultFont.fontName);
   XCTAssertEqual(titleFont.pointSize, resultFont.pointSize);
-  XCTAssertEqual([NavigationBarTests weightForFont:titleFont], resultFont.mdc_weight);
+  XCTAssertEqual([NavigationBarTests weightForFont:titleFont],
+                 [NavigationBarTests weightForFont:resultFont]);
 }
 
 - (void)testEncoding {

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -103,8 +103,8 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   UIFont *resultFont = [UIFont boldSystemFontOfSize:20];
   navBar.titleFont = testFont;
 
-  // To enforce 20 point size we are using fontWithName:size: and for some reason even though the
-  // printout looks idential comparing the fonts returns false. (Using fontWithSize: did not work
+  // To enforce 20 point size we are using "fontWithName:size:" and for some reason even though the
+  // printout looks identical comparing the fonts returns false. (Using "fontWithSize:" did not work
   // for system font medium, instead it returned a regular font).
   XCTAssertEqualObjects(navBar.titleLabel.font.fontName, resultFont.fontName);
   XCTAssertEqual(navBar.titleLabel.font.pointSize, resultFont.pointSize);

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -18,6 +18,7 @@
 
 #import "MaterialButtonBar.h"
 #import "MaterialNavigationBar.h"
+#import "UIFont+MaterialTypographyPrivate.h"
 
 static const CGFloat kEpsilonAccuracy = 0.001f;
 
@@ -101,7 +102,13 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   UIFont *testFont = [UIFont boldSystemFontOfSize:24];
   UIFont *resultFont = [UIFont boldSystemFontOfSize:20];
   navBar.titleFont = testFont;
-  XCTAssertEqual(navBar.titleLabel.font, resultFont);
+
+  // To enforce 20 point size we are using fontWithName:size: and for some reason even though the
+  // printout looks idential comparing the fonts returns false. (Using fontWithSize: did not work
+  // for system font medium, instead it returned a regular font).
+  XCTAssertEqualObjects(navBar.titleLabel.font.fontName, resultFont.fontName);
+  XCTAssertEqual(navBar.titleLabel.font.pointSize, resultFont.pointSize);
+  XCTAssertEqual(navBar.titleLabel.font.mdc_weight, resultFont.mdc_weight);
 }
 
 - (void)testEncoding {

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -108,8 +108,13 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   UIFont *titleFont = navBar.titleLabel.font;
   XCTAssertEqualObjects(titleFont.fontName, resultFont.fontName);
   XCTAssertEqual(titleFont.pointSize, resultFont.pointSize);
+
+  // Weight for Fonts was not introduced on iOS 8
+  // TODO: remove this when we drop iOS 8 support.
+#if defined(__IPHONE_9_0) && __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_9_0
   XCTAssertEqual([NavigationBarTests weightForFont:titleFont],
                  [NavigationBarTests weightForFont:resultFont]);
+#endif
 }
 
 - (void)testEncoding {

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -18,7 +18,6 @@
 
 #import "MaterialButtonBar.h"
 #import "MaterialNavigationBar.h"
-#import "UIFont+MaterialTypographyPrivate.h"
 
 static const CGFloat kEpsilonAccuracy = 0.001f;
 
@@ -106,9 +105,10 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   // To enforce 20 point size we are using "fontWithName:size:" and for some reason even though the
   // printout looks identical comparing the fonts returns false. (Using "fontWithSize:" did not work
   // for system font medium, instead it returned a regular font).
-  XCTAssertEqualObjects(navBar.titleLabel.font.fontName, resultFont.fontName);
-  XCTAssertEqual(navBar.titleLabel.font.pointSize, resultFont.pointSize);
-  XCTAssertEqual(navBar.titleLabel.font.mdc_weight, resultFont.mdc_weight);
+  UIFont *titleFont = navBar.titleLabel.font;
+  XCTAssertEqualObjects(titleFont.fontName, resultFont.fontName);
+  XCTAssertEqual(titleFont.pointSize, resultFont.pointSize);
+  XCTAssertEqual([NavigationBarTests weightForFont:titleFont], resultFont.mdc_weight);
 }
 
 - (void)testEncoding {
@@ -285,6 +285,25 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
     MDCButtonBar *trailingButtonBar = (MDCButtonBar *)secondItem;
     XCTAssertEqual(2U, trailingButtonBar.subviews.count);
   }
+}
+
+// I really don't like doing this but just to make sure the font has the right weight for the test
+// I had to do this. Couldn't find any other way around it. When Apple support FontWithSize:
+// properly for all fonts we can get rid of this.
++ (CGFloat)weightForFont:(UIFont *)font {
+  // The default font weight is UIFontWeightRegular, which is 0.0.
+  CGFloat weight = 0.0;
+
+  NSDictionary *fontTraits = [self.fontDescriptor objectForKey:UIFontDescriptorTraitsAttribute];
+  if (fontTraits) {
+    NSNumber *weightNumber = fontTraits[UIFontWeightTrait];
+    if (weightNumber != nil) {
+      weight = [weightNumber floatValue];
+    }
+  }
+
+  return weight;
+
 }
 
 @end


### PR DESCRIPTION
To enforce 20 point size we are using fontWithName:size:.
For some reason even though the printout looks identical comparing the fonts returns false. (Using fontWithSize: did not work for custom fonts - Medium, instead it returned a regular font).