### PR TITLE
[kokoro] Add CocoaPods support for specific Xcode jobs + podspec validation

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -138,7 +138,7 @@ run_cocoapods() {
     echo "$xcode_version_as_number" >> "$SEEN_XCODES_FILE_PATH"
 
     if [ -n "$XCODE_VERSION" ]; then
-      if [ "$xcode_version_as_number" -ne "$XCODE_VERSION" ]; then
+      if [ "$xcode_version_as_number" -ne "$(version_as_number $XCODE_VERSION)" ]; then
         continue
       fi
     elif [ -n "$xcode_min_version_as_number" ]; then

--- a/.kokoro
+++ b/.kokoro
@@ -118,15 +118,26 @@ run_cocoapods() {
     pod --version
   fi
 
-  ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
+  BUILDS_TMP_PATH=$(mktemp -d)
+  SEEN_XCODES_FILE_PATH="$BUILDS_TMP_PATH/seen_xcodes"
+  touch "$SEEN_XCODES_FILE_PATH"
+  xcodes=$(ls /Applications/ | grep "Xcode")
+  for xcode_path in $xcodes; do
     xcode_version=$(cat /Applications/$xcode_path/Contents/version.plist \
       | grep "CFBundleShortVersionString" -A1 \
       | grep string \
       | cut -d'>' -f2 \
       | cut -d'<' -f1)
-    if [ -n "$xcode_min_version_as_number" ]; then
-      xcode_version_as_number="$(version_as_number $xcode_version)"
+    xcode_version_as_number="$(version_as_number $xcode_version)"
 
+    # Ignore duplicate Xcode installations
+    if grep -xq "$xcode_version_as_number" "$SEEN_XCODES_FILE_PATH"; then
+      continue
+    fi
+
+    echo "$xcode_version_as_number" >> "$SEEN_XCODES_FILE_PATH"
+
+    if [ -n "$xcode_min_version_as_number" ]; then
       if [ "$xcode_version_as_number" -lt "$xcode_min_version_as_number" ]; then
         continue
       fi
@@ -139,12 +150,17 @@ run_cocoapods() {
     # "Failed to locate a valid instance of CoreSimulatorService in the bootstrap"
     launchctl remove com.apple.CoreSimulator.CoreSimulatorService || true
 
-    scripts/prep_all
-    scripts/build_all --verbose
-    if [ "$IS_RELEASE" -eq "1" ]; then
-      scripts/test_all
+    if [ "$xcode_version_as_number" -eq "920" ]; then
+      echo "Validating podspec with Xcode 9.2..."
+      pod lib lint MaterialComponents.podspec
+    fi
+
+    bash scripts/prep_all
+    bash scripts/build_all --verbose
+    if [ -n "$IS_RELEASE" ]; then
+      bash scripts/test_all
     else
-      scripts/test_all catalog/MDCCatalog.xcworkspace:MDCUnitTests
+      bash scripts/test_all catalog/MDCCatalog.xcworkspace:MDCUnitTests
     fi
   done
 

--- a/.kokoro
+++ b/.kokoro
@@ -137,7 +137,11 @@ run_cocoapods() {
 
     echo "$xcode_version_as_number" >> "$SEEN_XCODES_FILE_PATH"
 
-    if [ -n "$xcode_min_version_as_number" ]; then
+    if [ -n "$XCODE_VERSION" ]; then
+      if [ "$xcode_version_as_number" -ne "$XCODE_VERSION" ]; then
+        continue
+      fi
+    elif [ -n "$xcode_min_version_as_number" ]; then
       if [ "$xcode_version_as_number" -lt "$xcode_min_version_as_number" ]; then
         continue
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ script:
   - xcodebuild -version
   - xcodebuild -showsdks
   - pod --version
+  - pod repo update
   - pod lib lint MaterialComponents.podspec
   - scripts/prep_all
   - travis_wait scripts/build_all --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ script:
   - xcodebuild -version
   - xcodebuild -showsdks
   - pod --version
+  - pod lib lint MaterialComponents.podspec
   - scripts/prep_all
   - travis_wait scripts/build_all --verbose
   - travis_wait travis_retry scripts/test_all catalog/MDCCatalog.xcworkspace:MDCUnitTests


### PR DESCRIPTION
We will now validate the podspec when building against Xcode 9.2.0.

This change also adds support for running individual Xcode instances against CocoaPods.