### PR TITLE
[NavigationBar] Allow flexible height/insets in MDCNavigationBar

### DIFF
--- a/components/AppBar/examples/AppBarTypicalUseExample.m
+++ b/components/AppBar/examples/AppBarTypicalUseExample.m
@@ -42,6 +42,8 @@
 
     MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
     [MDCAppBarColorThemer applySemanticColorScheme:colorScheme toAppBar:_appBar];
+
+    _appBar.navigationBar.useFlexibleTopBottomInsets = YES;
   }
   return self;
 }

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -21,8 +21,9 @@
 #import "MaterialButtons.h"
 #import "private/MDCAppBarButtonBarBuilder.h"
 
-static const CGFloat kDefaultHeight = 56;
-static const CGFloat kDefaultPadHeight = 64;
+static const CGFloat kButtonBarMaxHeight = 56;
+static const CGFloat kButtonBarMaxPadHeight = 64;
+static const CGFloat kButtonBarMinHeight = 24;
 
 // KVO contexts
 static char *const kKVOContextMDCButtonBar = "kKVOContextMDCButtonBar";
@@ -164,7 +165,9 @@ static NSString *const MDCButtonBarButtonLayoutPositionKey = @"MDCButtonBarButto
     totalWidth += width;
   }
 
-  CGFloat height = [self usePadHeight] ? kDefaultPadHeight : kDefaultHeight;
+  CGFloat maxHeight = [self usePadHeight] ? kButtonBarMaxPadHeight : kButtonBarMaxHeight;
+  CGFloat minHeight = kButtonBarMinHeight;
+  CGFloat height = MIN(MAX(size.height, minHeight), maxHeight);
   return CGSizeMake(totalWidth, height);
 }
 

--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -208,7 +208,7 @@ IB_DESIGNABLE
  
  Default is NO.
  
- NOTE: This property will be deprecated and the YES behavior replaces the current default behavior.
+ NOTE: This property will be deprecated and the YES behavior will replace the current behavior.
  All clients who rely on the titleView should set this to YES and implement proper alignment before
  deprecation.
  */

--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -197,6 +197,24 @@ IB_DESIGNABLE
 #pragma mark - To be deprecated
 
 /**
+ Makes the navigation bar use flexible top and bottom insets for buttons and titles, by vertically
+ positioning them based on the height of the navigation bar. Default insets do not allow the height
+ of the navigation bar to be set to anything less than 56.0f, so this property has to be set to YES
+ in that case.
+ 
+ When this is set to YES, the custom titleView is aligned with the button bars and has the same
+ height as them, regardless of the height of the navigation bar. This allows vertically aligning the
+ content of the titleView with the buttons, by vertically centering the content of the titleView.
+ 
+ Default is NO.
+ 
+ NOTE: This property will be deprecated and the YES behavior replaces the current default behavior.
+ All clients who rely on the titleView should set this to YES and implement proper alignment before
+ deprecation.
+ */
+@property(nonatomic) BOOL useFlexibleTopBottomInsets;
+
+/**
  Display attributes for the titleView's title text.
 
  Font attribute will take precedence over titleFont property.

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -429,6 +429,11 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   return CGSizeMake(size.width, height);
 }
 
+- (CGSize)intrinsicContentSize {
+  CGFloat height = [self usePadInsets] ? kNavigationBarPadDefaultHeight : kNavigationBarDefaultHeight;
+  return CGSizeMake(UIViewNoIntrinsicMetric, height);
+}
+
 - (MDCNavigationBarTitleAlignment)titleAlignment {
   return [MDCNavigationBar titleAlignmentFromTextAlignment:_titleLabel.textAlignment];
 }

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -28,6 +28,7 @@
 static const NSUInteger kTitleFontSize = 20;
 static const CGFloat kNavigationBarDefaultHeight = 56;
 static const CGFloat kNavigationBarPadDefaultHeight = 64;
+static const CGFloat kNavigationBarMinHeight = 24;
 static const UIEdgeInsets kTextInsets = {16, 16, 16, 16};
 static const UIEdgeInsets kTextPadInsets = {20, 16, 20, 16};
 
@@ -343,6 +344,10 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   _trailingButtonBar.frame = trailingButtonBarFrame;
 
   UIEdgeInsets textInsets = [self usePadInsets] ? kTextPadInsets : kTextInsets;
+  if (self.useFlexibleTopBottomInsets) {
+    textInsets.top = 0;
+    textInsets.bottom = 0;
+  }
 
   // textFrame is used to determine layout of both TitleLabel and TitleView
   CGRect textFrame = UIEdgeInsetsInsetRect(self.bounds, textInsets);
@@ -384,7 +389,18 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   if (self.mdf_effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
     textFrame = MDFRectFlippedHorizontally(textFrame, CGRectGetWidth(self.bounds));
   }
-  self.titleView.frame = textFrame;
+
+  CGRect titleViewFrame = textFrame;
+  if (self.useFlexibleTopBottomInsets) {
+    // No insets for the titleView, and a height that is the same as the button bars. Clients
+    // can vertically center their titleView subviews to align them with buttons.
+    titleViewFrame.origin.y = 0;
+    CGFloat maxHeight =
+        [self usePadInsets] ? kNavigationBarPadDefaultHeight : kNavigationBarDefaultHeight;
+    CGFloat minHeight = kNavigationBarMinHeight;
+    titleViewFrame.size.height = MIN(MAX(self.bounds.size.height, minHeight), maxHeight);
+  }
+  self.titleView.frame = titleViewFrame;
 
   // Button and title label alignment
 
@@ -405,14 +421,12 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 }
 
 - (CGSize)sizeThatFits:(CGSize)size {
-  CGSize intrinsicContentSize = [self intrinsicContentSize];
-  return CGSizeMake(size.width, intrinsicContentSize.height);
-}
-
-- (CGSize)intrinsicContentSize {
-
-  CGFloat height = ([self usePadInsets] ? kNavigationBarPadDefaultHeight : kNavigationBarDefaultHeight);
-  return CGSizeMake(UIViewNoIntrinsicMetric, height);
+  CGFloat maxHeight =
+      [self usePadInsets] ? kNavigationBarPadDefaultHeight : kNavigationBarDefaultHeight;
+  CGFloat minHeight = kNavigationBarMinHeight;
+  CGFloat height =
+      self.useFlexibleTopBottomInsets ? MIN(MAX(size.height, minHeight), maxHeight) : maxHeight;
+  return CGSizeMake(size.width, height);
 }
 
 - (MDCNavigationBarTitleAlignment)titleAlignment {
@@ -526,8 +540,11 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
     case UIControlContentVerticalAlignmentTop: {
       // The title frame is vertically centered with the back button but will stick to the top of
       // the header regardless of the header's height.
-      CGFloat navigationBarCenteredY =
-          MDCFloor(([self intrinsicContentSize].height - CGRectGetHeight(frame)) / 2);
+      CGFloat maxHeight =
+          [self usePadInsets] ? kNavigationBarPadDefaultHeight : kNavigationBarDefaultHeight;
+      CGFloat height =
+          self.useFlexibleTopBottomInsets ? MIN(CGRectGetHeight(bounds), maxHeight) : maxHeight;
+      CGFloat navigationBarCenteredY = MDCFloor((height - CGRectGetHeight(frame)) / 2);
       navigationBarCenteredY = MAX(0, navigationBarCenteredY);
       return CGRectMake(CGRectGetMinX(frame), navigationBarCenteredY, CGRectGetWidth(frame),
                         CGRectGetHeight(frame));
@@ -550,6 +567,10 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
       MDCButtonBar *leftButtonBar = self.leadingButtonBar;
       MDCButtonBar *rightButtonBar = self.trailingButtonBar;
       UIEdgeInsets textInsets = [self usePadInsets] ? kTextPadInsets : kTextInsets;
+      if (self.useFlexibleTopBottomInsets) {
+        textInsets.top = 0;
+        textInsets.bottom = 0;
+      }
       CGFloat titleLeftInset = textInsets.left;
       CGFloat titleRightInset = textInsets.right;
 


### PR DESCRIPTION
This is a roll-forward for #2974, with fixes for the internal issues. We now have an API, and only change the behavior when the API is used. That API should be mainlined when all clients adopt the new behavior.

[titleLabel with titleView with useFlexibleTopBottomInsets=YES](https://user-images.githubusercontent.com/2232489/38525318-c7890406-3c1f-11e8-81f3-b72afee2dd71.png)
[titleLabel with titleView with useFlexibleTopBottomInsets=YES](https://user-images.githubusercontent.com/2232489/38525320-c7a32570-3c1f-11e8-9e46-e232307a5a0a.png)


[titleLabel with titleView with useFlexibleTopBottomInsets=NO (current behavior)](https://user-images.githubusercontent.com/2232489/38525261-9bf7b2f6-3c1f-11e8-9942-048c139e6163.png)
[titleLabel with titleView with useFlexibleTopBottomInsets=NO (current behavior)](https://user-images.githubusercontent.com/2232489/38525286-b150692c-3c1f-11e8-94b3-167d75393870.png)

[titleView with useFlexibleTopBottomInsets=NO (current behavior)](https://user-images.githubusercontent.com/2232489/38525208-72545e4a-3c1f-11e8-8e5e-eb9b3457c8b3.png)
[titleView with useFlexibleTopBottomInsets=YES](https://user-images.githubusercontent.com/2232489/38525209-725f4012-3c1f-11e8-838d-f6872a760931.png)

Internal testing done in cl/192612758.

closes #2793
closes #253