### PR TITLE
[Buttons] Implement a semantic color scheme color themer API.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -173,7 +173,7 @@ Pod::Spec.new do |mdc|
       extension.public_header_files = "components/Buttons/src/#{extension.base_name}/*.h"
       extension.source_files = "components/Buttons/src/#{extension.base_name}/*.{h,m}", "components/Buttons/src/#{extension.base_name}/private/*.{h,m}"
       extension.dependency "MaterialComponents/Buttons"
-      extension.dependency "MaterialComponents/Themes"
+      extension.dependency "MaterialComponents/schemes/Color"
     end
     component.subspec "TitleColorAccessibilityMutator" do |extension|
       extension.ios.deployment_target = '8.0'

--- a/components/Buttons/BUILD
+++ b/components/Buttons/BUILD
@@ -46,7 +46,7 @@ mdc_objc_library(
     includes = ["src/ColorThemer"],
     deps = [
         ":Buttons",
-        "//components/Themes",
+        "//components/schemes/Color",
     ],
     visibility = ["//visibility:public"],
 )

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -30,7 +30,6 @@
   [button setBackgroundColor:[UIColor clearColor] forState:UIControlStateNormal];
   [button setTitleColor:[UIColor colorWithWhite:0.1f alpha:1] forState:UIControlStateNormal];
   button.inkColor = [UIColor colorWithWhite:0 alpha:0.06f];
-  button.disabledAlpha = 0.38f;
 
   [button setBorderWidth:1.0 forState:UIControlStateNormal];
   [button setBorderColor:[UIColor colorWithWhite:0.1f alpha:1] forState:UIControlStateNormal];

--- a/components/Buttons/examples/ButtonsTypicalUse.m
+++ b/components/Buttons/examples/ButtonsTypicalUse.m
@@ -14,6 +14,7 @@
  limitations under the License.
  */
 
+#import "MDCButtonColorThemer.h"
 #import "MaterialButtons.h"
 #import "MaterialTypography.h"
 #import "supplemental/ButtonsTypicalUseSupplemental.h"
@@ -33,6 +34,9 @@
 
   [button setBorderWidth:1.0 forState:UIControlStateNormal];
   [button setBorderColor:[UIColor colorWithWhite:0.1f alpha:1] forState:UIControlStateNormal];
+
+  id<MDCColorScheming> colorScheme = [[MDCSemanticColorScheme alloc] init];
+  [MDCButtonColorThemer applySemanticColorScheme:colorScheme toButton:button];
 
   return button;
 }

--- a/components/Buttons/src/ColorThemer/MDCButtonColorThemer.h
+++ b/components/Buttons/src/ColorThemer/MDCButtonColorThemer.h
@@ -15,7 +15,7 @@
  */
 
 #import "MaterialButtons.h"
-#import "MaterialThemes.h"
+#import "MaterialColorScheme.h"
 
 /**
  Used to apply a color scheme to theme MDCTabBar.
@@ -23,8 +23,18 @@
 @interface MDCButtonColorThemer : NSObject
 
 /**
+ Applies a color scheme to theme to a MDCButton.
+
+ @param colorScheme The color scheme to apply to MDCButton.
+ */
++ (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+                        toButton:(nonnull MDCButton *)button;
+
+/**
  Applies a color scheme to theme a MDCButton. Use a UIAppearance proxy to apply a color scheme to
  all instances of MDCButton.
+
+ This method is deprecated. Consider using applySemanticColorScheme:colorScheme.
 
  @param colorScheme The color scheme to apply to MDCButton.
  @param button A MDCButton instance to apply a color scheme.

--- a/components/Buttons/src/ColorThemer/MDCButtonColorThemer.h
+++ b/components/Buttons/src/ColorThemer/MDCButtonColorThemer.h
@@ -34,7 +34,7 @@
  Applies a color scheme to theme a MDCButton. Use a UIAppearance proxy to apply a color scheme to
  all instances of MDCButton.
 
- This method is deprecated. Consider using applySemanticColorScheme:colorScheme.
+ This method will soon be deprecated. Consider using applySemanticColorScheme:colorScheme.
 
  @param colorScheme The color scheme to apply to MDCButton.
  @param button A MDCButton instance to apply a color scheme.

--- a/components/Buttons/src/ColorThemer/MDCButtonColorThemer.m
+++ b/components/Buttons/src/ColorThemer/MDCButtonColorThemer.m
@@ -18,6 +18,20 @@
 
 @implementation MDCButtonColorThemer
 
++ (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+                        toButton:(nonnull MDCButton *)button {
+  [button setBackgroundColor:colorScheme.primaryColor forState:UIControlStateNormal];
+  [button setBackgroundColor:colorScheme.primaryColor forState:UIControlStateHighlighted];
+  [button setBackgroundColor:colorScheme.primaryColor forState:UIControlStateSelected];
+  [button setBackgroundColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:0.12f]
+                    forState:UIControlStateDisabled];
+  [button setTitleColor:colorScheme.onPrimaryColor forState:UIControlStateNormal];
+  [button setTitleColor:colorScheme.onPrimaryColor forState:UIControlStateHighlighted];
+  [button setTitleColor:colorScheme.onPrimaryColor forState:UIControlStateSelected];
+  [button setTitleColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:0.26f]
+               forState:UIControlStateDisabled];
+}
+
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme
                 toButton:(MDCButton *)button {
   [button setBackgroundColor:colorScheme.primaryColor forState:UIControlStateNormal];

--- a/components/Buttons/src/ColorThemer/MDCButtonColorThemer.m
+++ b/components/Buttons/src/ColorThemer/MDCButtonColorThemer.m
@@ -30,6 +30,7 @@
   [button setTitleColor:colorScheme.onPrimaryColor forState:UIControlStateSelected];
   [button setTitleColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:0.26f]
                forState:UIControlStateDisabled];
+  button.disabledAlpha = 1.f;
 }
 
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -1,0 +1,65 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialButtons.h"
+#import "MDCButtonColorThemer.h"
+
+@interface ButtonsColorThemerTests : XCTestCase
+
+@end
+
+@implementation ButtonsColorThemerTests
+
+- (void)testMDCButtonColorThemer {
+  // Given
+  MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
+  MDCButton *button = [[MDCButton alloc] init];
+  [button setTitle:@"Hello World" forState:UIControlStateNormal];
+  colorScheme.primaryColor = UIColor.redColor;
+  colorScheme.onPrimaryColor = UIColor.greenColor;
+  colorScheme.onSurfaceColor = UIColor.blueColor;
+  [button setTitleColor:UIColor.whiteColor forState:UIControlStateNormal];
+  [button setTitleColor:UIColor.greenColor forState:UIControlStateHighlighted];
+  [button setTitleColor:UIColor.blueColor forState:UIControlStateSelected];
+  [button setTitleColor:UIColor.grayColor forState:UIControlStateDisabled];
+  [button setBackgroundColor:UIColor.purpleColor forState:UIControlStateNormal];
+  [button setBackgroundColor:UIColor.redColor forState:UIControlStateHighlighted];
+  [button setBackgroundColor:UIColor.blueColor forState:UIControlStateSelected];
+  [button setBackgroundColor:UIColor.darkGrayColor forState:UIControlStateDisabled];
+
+  // Where
+  [MDCButtonColorThemer applySemanticColorScheme:colorScheme toButton:button];
+
+  NSLog(@"%d",CGColorEqualToColor([button titleColorForState:UIControlStateDisabled].CGColor,
+                                  [colorScheme.onSurfaceColor colorWithAlphaComponent:0.26f].CGColor));
+  // Then
+  XCTAssertEqual([button titleColorForState:UIControlStateNormal], colorScheme.onPrimaryColor);
+  XCTAssertEqual([button titleColorForState:UIControlStateHighlighted], colorScheme.onPrimaryColor);
+  XCTAssertEqual([button titleColorForState:UIControlStateSelected], colorScheme.onPrimaryColor);
+  XCTAssert(
+            CGColorEqualToColor([button titleColorForState:UIControlStateDisabled].CGColor,
+                                [colorScheme.onSurfaceColor colorWithAlphaComponent:0.26f].CGColor));
+  XCTAssertEqual([button backgroundColorForState:UIControlStateNormal], colorScheme.primaryColor);
+  XCTAssertEqual([button titleColorForState:UIControlStateHighlighted], colorScheme.onPrimaryColor);
+  XCTAssertEqual([button titleColorForState:UIControlStateSelected], colorScheme.onPrimaryColor);
+  XCTAssert(
+      CGColorEqualToColor([button backgroundColorForState:UIControlStateDisabled].CGColor,
+                          [colorScheme.onSurfaceColor colorWithAlphaComponent:0.12f].CGColor));
+}
+
+@end

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -45,8 +45,6 @@
   // Where
   [MDCButtonColorThemer applySemanticColorScheme:colorScheme toButton:button];
 
-  NSLog(@"%d",CGColorEqualToColor([button titleColorForState:UIControlStateDisabled].CGColor,
-                                  [colorScheme.onSurfaceColor colorWithAlphaComponent:0.26f].CGColor));
   // Then
   XCTAssertEqual([button titleColorForState:UIControlStateNormal], colorScheme.onPrimaryColor);
   XCTAssertEqual([button titleColorForState:UIControlStateHighlighted], colorScheme.onPrimaryColor);

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -53,7 +53,8 @@
       CGColorEqualToColor([button titleColorForState:UIControlStateDisabled].CGColor,
                           [colorScheme.onSurfaceColor colorWithAlphaComponent:0.26f].CGColor));
   XCTAssertEqual([button backgroundColorForState:UIControlStateNormal], colorScheme.primaryColor);
-  XCTAssertEqual([button backgroundColorForState:UIControlStateHighlighted], colorScheme.primaryColor);
+  XCTAssertEqual([button backgroundColorForState:UIControlStateHighlighted],
+                 colorScheme.primaryColor);
   XCTAssertEqual([button backgroundColorForState:UIControlStateSelected], colorScheme.primaryColor);
   XCTAssert(
       CGColorEqualToColor([button backgroundColorForState:UIControlStateDisabled].CGColor,

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -50,8 +50,8 @@
   XCTAssertEqual([button titleColorForState:UIControlStateHighlighted], colorScheme.onPrimaryColor);
   XCTAssertEqual([button titleColorForState:UIControlStateSelected], colorScheme.onPrimaryColor);
   XCTAssert(
-            CGColorEqualToColor([button titleColorForState:UIControlStateDisabled].CGColor,
-                                [colorScheme.onSurfaceColor colorWithAlphaComponent:0.26f].CGColor));
+      CGColorEqualToColor([button titleColorForState:UIControlStateDisabled].CGColor,
+                          [colorScheme.onSurfaceColor colorWithAlphaComponent:0.26f].CGColor));
   XCTAssertEqual([button backgroundColorForState:UIControlStateNormal], colorScheme.primaryColor);
   XCTAssertEqual([button backgroundColorForState:UIControlStateHighlighted], colorScheme.primaryColor);
   XCTAssertEqual([button backgroundColorForState:UIControlStateSelected], colorScheme.primaryColor);

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -53,8 +53,8 @@
             CGColorEqualToColor([button titleColorForState:UIControlStateDisabled].CGColor,
                                 [colorScheme.onSurfaceColor colorWithAlphaComponent:0.26f].CGColor));
   XCTAssertEqual([button backgroundColorForState:UIControlStateNormal], colorScheme.primaryColor);
-  XCTAssertEqual([button titleColorForState:UIControlStateHighlighted], colorScheme.onPrimaryColor);
-  XCTAssertEqual([button titleColorForState:UIControlStateSelected], colorScheme.onPrimaryColor);
+  XCTAssertEqual([button backgroundColorForState:UIControlStateHighlighted], colorScheme.onPrimaryColor);
+  XCTAssertEqual([button backgroundColorForState:UIControlStateSelected], colorScheme.onPrimaryColor);
   XCTAssert(
       CGColorEqualToColor([button backgroundColorForState:UIControlStateDisabled].CGColor,
                           [colorScheme.onSurfaceColor colorWithAlphaComponent:0.12f].CGColor));

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -59,6 +59,7 @@
   XCTAssert(
       CGColorEqualToColor([button backgroundColorForState:UIControlStateDisabled].CGColor,
                           [colorScheme.onSurfaceColor colorWithAlphaComponent:0.12f].CGColor));
+  XCTAssertEqual(button.disabledAlpha, 1.f);
 }
 
 @end

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -53,8 +53,8 @@
             CGColorEqualToColor([button titleColorForState:UIControlStateDisabled].CGColor,
                                 [colorScheme.onSurfaceColor colorWithAlphaComponent:0.26f].CGColor));
   XCTAssertEqual([button backgroundColorForState:UIControlStateNormal], colorScheme.primaryColor);
-  XCTAssertEqual([button backgroundColorForState:UIControlStateHighlighted], colorScheme.onPrimaryColor);
-  XCTAssertEqual([button backgroundColorForState:UIControlStateSelected], colorScheme.onPrimaryColor);
+  XCTAssertEqual([button backgroundColorForState:UIControlStateHighlighted], colorScheme.primaryColor);
+  XCTAssertEqual([button backgroundColorForState:UIControlStateSelected], colorScheme.primaryColor);
   XCTAssert(
       CGColorEqualToColor([button backgroundColorForState:UIControlStateDisabled].CGColor,
                           [colorScheme.onSurfaceColor colorWithAlphaComponent:0.12f].CGColor));


### PR DESCRIPTION
Addition of a unit test, and updated example to use the new themer.

Pivotal: https://www.pivotaltracker.com/story/show/156169780

Flat button and raised button theming are separate stories and will be added in separate PRs.

![simulator screen shot - iphone 8 - 2018-04-10 at 15 09 20](https://user-images.githubusercontent.com/4066863/38556139-4d9f5606-3cd1-11e8-9707-6b8ad32751e2.png)
