### PR TITLE
[travis] Use verbose output when linting our podspec.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ script:
   - xcodebuild -showsdks
   - pod --version
   - pod repo update
+  - pod lib lint MaterialComponents.podspec --verbose
   - scripts/prep_all
   - travis_wait scripts/build_all --verbose
   - travis_wait travis_retry scripts/test_all catalog/MDCCatalog.xcworkspace:MDCUnitTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ script:
   - xcodebuild -showsdks
   - pod --version
   - pod repo update
-  - pod lib lint MaterialComponents.podspec
   - scripts/prep_all
   - travis_wait scripts/build_all --verbose
   - travis_wait travis_retry scripts/test_all catalog/MDCCatalog.xcworkspace:MDCUnitTests


### PR DESCRIPTION
Travis doesn't like when commands don't emit any output for more than 10 minutes. Our pod lib lint step takes 15-20 minutes. Enabling verbose output will allow travis to know that the lint step is actually doing something.