### PR TITLE
[ThumbTrack] Fix valueLabel backgroundColor

### DIFF
--- a/components/private/ThumbTrack/src/MDCThumbTrack.m
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.m
@@ -248,6 +248,7 @@ static inline CGFloat DistanceFromPointToPoint(CGPoint point1, CGPoint point2) {
 
   _touchController.defaultInkView.inkColor =
       [self.primaryColor colorWithAlphaComponent:kTrackOnAlpha];
+  _valueLabelBackgroundColor = self.primaryColor;
   [self setNeedsLayout];
 }
 

--- a/components/private/ThumbTrack/tests/unit/ThumbTrackTests.m
+++ b/components/private/ThumbTrack/tests/unit/ThumbTrackTests.m
@@ -46,6 +46,7 @@
   XCTAssertEqualObjects(thumbTrack.thumbEnabledColor, thumbTrack.primaryColor);
   XCTAssertEqualObjects(thumbTrack.inkColor,
                         [thumbTrack.primaryColor colorWithAlphaComponent:0.5f]);
+  XCTAssertEqualObjects(thumbTrack.valueLabelBackgroundColor, thumbTrack.primaryColor);
 }
 
 #pragma mark - thumbEnabledColor


### PR DESCRIPTION
The discrete value label's background color was not being set when
setting the `primaryColor`. Since there is currently no public API (via
MDCSlider) to set the color, this can cause undesirable color mismatches
in clients.

**Before**
![slider-valuelabel-bug](https://user-images.githubusercontent.com/1753199/38622949-66f54cd6-3d72-11e8-8c33-df8b28ddb319.png)

**After**
![slider-valuelabel-fixed](https://user-images.githubusercontent.com/1753199/38622957-6c0c4e2c-3d72-11e8-9e9c-34c6a3b14dbc.png)


Fixes #3321
Pivotal story: https://www.pivotaltracker.com/story/show/155525171