### PR TITLE
[travis] Remove pod lib lint step.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ script:
   - xcodebuild -showsdks
   - pod --version
   - pod repo update
-  - pod lib lint MaterialComponents.podspec --verbose
   - scripts/prep_all
   - travis_wait scripts/build_all --verbose
   - travis_wait travis_retry scripts/test_all catalog/MDCCatalog.xcworkspace:MDCUnitTests


### PR DESCRIPTION
It causes Travis to fail because the logs get too long. If we disable logs, travis fails because the invocation takes too long. Soo...we can't lint in travis.