### PR TITLE
[Slider] Add text, background color to value label

### DIFF
--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -224,12 +224,14 @@ IB_DESIGNABLE
 /**
  The color of the discrete value label's text.
 
- Defaults and resets to white.
+ Resets to the default color.
  */
 @property(nonatomic, strong, null_resettable) UIColor *valueLabelTextColor;
 
 /**
  The color of the discrete value label's background.
+
+ Resets to the default color.
  */
 @property(nonatomic, strong, null_resettable) UIColor *valueLabelBackgroundColor;
 

--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -230,8 +230,6 @@ IB_DESIGNABLE
 
 /**
  The color of the discrete value label's background.
-
- Defaults and resets to blue.
  */
 @property(nonatomic, strong, null_resettable) UIColor *valueLabelBackgroundColor;
 

--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -222,14 +222,14 @@ IB_DESIGNABLE
 @property(nonatomic, assign) BOOL shouldDisplayDiscreteValueLabel;
 
 /**
- The color of the value label's text.
+ The color of the discrete value label's text.
 
  Defaults and resets to white.
  */
 @property(nonatomic, strong, null_resettable) UIColor *valueLabelTextColor;
 
 /**
- The color of the value label's background.
+ The color of the discrete value label's background.
 
  Defaults and resets to blue.
  */

--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -222,6 +222,20 @@ IB_DESIGNABLE
 @property(nonatomic, assign) BOOL shouldDisplayDiscreteValueLabel;
 
 /**
+ The color of the value label's text.
+
+ Defaults and resets to white.
+ */
+@property(nonatomic, strong, null_resettable) UIColor *valueLabelTextColor;
+
+/**
+ The color of the value label's background.
+
+ Defaults and resets to blue.
+ */
+@property(nonatomic, strong, null_resettable) UIColor *valueLabelBackgroundColor;
+
+/**
  Whether or not the thumb view should be a hollow circle when at the minimum value. For sliders
  where the minimum value indicates that the associated property is off (for example a volume slider
  where a value of 0 = muted), this should be set to YES. In cases where this doesn't make sense (for
@@ -263,7 +277,6 @@ IB_DESIGNABLE
  @note Has no effect if @c statefulAPIEnabled is @c YES.
  */
 @property(nonatomic, strong, null_resettable) UIColor *trackBackgroundColor UI_APPEARANCE_SELECTOR;
-
 
 @end
 

--- a/components/Slider/src/MDCSlider.m
+++ b/components/Slider/src/MDCSlider.m
@@ -279,6 +279,22 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
   return _thumbTrack.inkColor;
 }
 
+- (void)setValueLabelTextColor:(UIColor *)valueLabelTextColor {
+  _thumbTrack.valueLabelTextColor = valueLabelTextColor;
+}
+
+- (UIColor *)valueLabelTextColor {
+  return _thumbTrack.valueLabelTextColor;
+}
+
+- (void)setValueLabelBackgroundColor:(UIColor *)valueLabelBackgroundColor {
+  _thumbTrack.valueLabelBackgroundColor = valueLabelBackgroundColor ?: MDCThumbTrackDefaultColor();
+}
+
+- (UIColor *)valueLabelBackgroundColor {
+  return _thumbTrack.valueLabelBackgroundColor;
+}
+
 #pragma mark - MDCThumbTrackDelegate methods
 
 - (NSString *)thumbTrack:(__unused MDCThumbTrack *)thumbTrack stringForValue:(CGFloat)value {

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -765,6 +765,50 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
       @(0.333));
 }
 
+- (void)testValueLabelTextColorDefalut {
+  // Then
+  XCTAssertEqualObjects(self.slider.valueLabelTextColor, UIColor.whiteColor);
+}
+
+- (void)testSetValueLabelTextColor {
+  // When
+  self.slider.valueLabelTextColor = UIColor.cyanColor;
+
+  // Then
+  XCTAssertEqualObjects(self.slider.thumbTrack.valueLabelTextColor, UIColor.cyanColor);
+}
+
+- (void)testValueLabelTextColorNullResettable {
+  // When
+  self.slider.valueLabelTextColor = UIColor.cyanColor;
+  self.slider.valueLabelTextColor = nil;
+
+  // Then
+  XCTAssertEqualObjects(self.slider.valueLabelTextColor, UIColor.whiteColor);
+}
+
+- (void)testValueLabelBackgroundColorDefault {
+  // Then
+  XCTAssertEqualObjects(self.slider.valueLabelBackgroundColor, MDCPalette.bluePalette.tint500);
+}
+
+- (void)testSetValueLabelBackgroundColor {
+  // When
+  self.slider.valueLabelBackgroundColor = UIColor.magentaColor;
+
+  // Then
+  XCTAssertEqualObjects(self.slider.thumbTrack.valueLabelBackgroundColor, UIColor.magentaColor);
+}
+
+- (void)testValueLabelBackgroundColorNullResettable {
+  // When
+  self.slider.valueLabelBackgroundColor = UIColor.magentaColor;
+  self.slider.valueLabelBackgroundColor = nil;
+
+  // Then
+  XCTAssertEqualObjects(self.slider.valueLabelBackgroundColor, MDCPalette.bluePalette.tint500);
+}
+
 #pragma mark Accessibility
 
 - (void)testAccessibilityValue {


### PR DESCRIPTION
The discrete value label should be customizable instead of inheriting
the color from the track fill color.

Partially implements #3137
Pivotal story: https://www.pivotaltracker.com/story/show/155525171