### PR TITLE
[TextFields] Placeholder background color

### DIFF
--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -93,6 +93,7 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
     if (interfaceBuilderPlaceholder.length) {
       self.placeholder = interfaceBuilderPlaceholder;
     }
+    self.placeholderLabel.backgroundColor = self.backgroundColor;
 
     [self setNeedsLayout];
   }


### PR DESCRIPTION
Fixes a case where the background color is set in IB but it doesn't also change the placeholder label since the setter isn't used.