### PR TITLE
[Chips] Ensure MDCChipField notifies delegate when clear button is tapped

### DIFF
--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -87,6 +87,7 @@ mdc_objc_library(
         ":FontThemer",
         ":TypographyThemer",
         ":private",
+        "//components/TextFields:private",
         "//components/private/ShapeLibrary",
     ],
     visibility = ["//visibility:private"],
@@ -97,4 +98,3 @@ mdc_unit_test_suite(
       ":unit_test_sources",
     ],
 )
-

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -130,9 +130,16 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
     chipTextField.autocorrectionType = UITextAutocorrectionTypeNo;
     chipTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
     chipTextField.keyboardType = MDCChipFieldDefaultKeyboardType;
-    [chipTextField addTarget:self
-                      action:@selector(textFieldDidChange)
-            forControlEvents:UIControlEventEditingChanged];
+    // Listen for notifications posted when the text field is the first responder.
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(textFieldDidChange)
+                                                 name:UITextFieldTextDidChangeNotification
+                                               object:chipTextField];
+    // Also listen for notifications posted when the text field is not the first responder.
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(textFieldDidChange)
+                                                 name:MDCTextFieldTextDidSetTextNotification
+                                               object:chipTextField];
     [self addSubview:chipTextField];
     _textField = chipTextField;
   }
@@ -170,6 +177,10 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
     }
   }
   return self;
+}
+
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (void)commonMDCChipFieldInit {

--- a/components/Chips/tests/unit/ChipsDelegateTests.m
+++ b/components/Chips/tests/unit/ChipsDelegateTests.m
@@ -1,0 +1,72 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+#import "MDCTextField+Testing.h"
+#import "MaterialChips.h"
+
+@interface ChipsDelegateTests : XCTestCase <MDCChipFieldDelegate>
+
+@property(nonatomic, nullable) MDCChipField *chip;
+@property(nonatomic, copy, nullable) NSString *delegateTextInput;
+
+@end
+
+@implementation ChipsDelegateTests
+
+- (void)setUp {
+  [super setUp];
+  self.delegateTextInput = nil;
+  self.chip = [[MDCChipField alloc] init];
+  self.chip.delegate = self;
+}
+
+- (void)tearDown {
+  self.chip.delegate = nil;
+  self.chip = nil;
+  [super tearDown];
+}
+
+- (void)testSettingTextInvokesDidChangeInputOnDelegate {
+  // Given
+  self.chip.textField.text = @"Hello World";
+
+  // Then
+  XCTAssertEqualObjects(self.delegateTextInput, @"Hello World");
+}
+
+- (void)testTouchUpOnClearButtonInvokesDidChangeInputOnDelegate {
+  // Given
+  self.chip.textField.text = @"Hello World";
+
+  // When
+  [self.chip.textField clearButtonDidTouch];
+
+  // Then
+  // Check length == 0 instead of looking for nil to handle both nil and @"".
+  // Cast to (unsigned long) to handle 32-bit and 64-bit tests.
+  XCTAssertEqual((unsigned long)self.delegateTextInput.length, 0UL);
+}
+
+#pragma mark - MDCChipFieldDelegate
+
+- (void)chipField:(nonnull MDCChipField *)chipField didChangeInput:(nullable NSString *)input {
+  self.delegateTextInput = input;
+}
+
+@end

--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -20,6 +20,21 @@ load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 
+mdc_objc_library(
+    name = "private",
+    hdrs = native.glob(["src/private/*.h"]),
+    includes = ["src/private"],
+    visibility = [":test_targets"],
+)
+
+package_group(
+    name = "test_targets",
+    packages = [
+        "//components/Chips/...",
+        "//components/TextFields/...",
+    ]
+)
+
 mdc_public_objc_library(
     name = "TextFields",
     sdk_frameworks = [

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -23,6 +23,7 @@
 #import "MDCTextInputBorderView.h"
 #import "MDCTextInputCharacterCounter.h"
 #import "MDCTextInputUnderlineView.h"
+#import "private/MDCTextField+Testing.h"
 #import "private/MDCTextInputCommonFundament.h"
 
 #import "MaterialMath.h"
@@ -706,6 +707,12 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
   }
 
   return [super accessibilityValue];
+}
+
+#pragma mark - Testing
+
+- (void)clearButtonDidTouch {
+  [_fundament clearButtonDidTouch];
 }
 
 @end

--- a/components/TextFields/src/private/MDCTextField+Testing.h
+++ b/components/TextFields/src/private/MDCTextField+Testing.h
@@ -1,0 +1,31 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "MDCTextField.h"
+
+/**
+  Exposes parts of MDCTextField for testing.
+ */
+@interface MDCTextField (Testing)
+
+/**
+  Synthesizes a touch on the clear button of the text field.
+ */
+- (void)clearButtonDidTouch;
+
+@end

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.h
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.h
@@ -63,6 +63,9 @@ UIKIT_EXTERN UIColor *_Nonnull MDCTextInputCursorColor(void);
 /** Mirror of UIView's updateConstraints(). */
 - (void)updateConstraintsOfInput;
 
+/** Clear button did touch event. */
+- (void)clearButtonDidTouch;
+
 - (nullable instancetype)initWithCoder:(NSCoder *_Nonnull)aDecoder NS_DESIGNATED_INITIALIZER;
 
 @end


### PR DESCRIPTION
Previously, `MDCChipField` failed to notify its delegate when the clear
button was tapped.

This was because `-[MDCTextInputCommonFundament clearButtonDidTouch]`
called `-setText:` directly on the text field to clear the text, but
`MDCChipField` only notified its delegate of a text change when it
received `UIControlEventEditingChanged` (which does not happen
in this case).

To fix this, I changed `MDCChipField` to listen to
`UITextFieldTextDidChangeNotification` (posted when the text field is
the first responder) as well as
`MDCTextFieldTextDidSetTextNotification` (posted when the text field
is not the first responder).

Test Plan: New test added. Ran tests with: `./.kokoro --target //components/Chips/...`