### PR TITLE
[Chips] Exposing color for surface of chip view. …

### DIFF
--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -162,23 +162,24 @@
     UI_APPEARANCE_SELECTOR;
 
 /*
- A color used as the chip's color for @c state.
+ A color used as the chip's background overlay color for @c state.
 
- If no chip color has been set for a given state, the returned value will fall back to the
- value set for UIControlStateNormal.
+ If no background overlay color has been set for a given state, the returned value will fall back to
+ the value set for UIControlStateNormal.
 
  @param state The control state.
- @return The chip color.
+ @return The background overlay color.
  */
-- (nullable UIColor *)chipColorForState:(UIControlState)state;
+- (nullable UIColor *)backgroundOverlayColorForState:(UIControlState)state;
 
 /*
- A color used as the chip's @c color.
+ A color used as the chip's background overlay @c color.
 
- @param chipColor The chip color.
+ @param backgroundOverlayColor The chip color.
  @param state The control state.
  */
-- (void)setChipColor:(nullable UIColor *)chipColor forState:(UIControlState)state;
+- (void)setBackgroundOverlayColor:(nullable UIColor *)backgroundOverlayColor
+                         forState:(UIControlState)state;
 
 /*
  Returns the border color for a particular control state.

--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -175,8 +175,6 @@
 /*
  A color used as the chip's @c color.
 
- Defaults to blue.
-
  @param chipColor The chip color.
  @param state The control state.
  */

--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -175,7 +175,7 @@
 /*
  A color used as the chip's background overlay @c color.
 
- @param backgroundOverlayColor The chip color.
+ @param backgroundOverlayColor The chip background overlay color.
  @param state The control state.
  */
 - (void)setBackgroundOverlayColor:(nullable UIColor *)backgroundOverlayColor

--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -162,6 +162,27 @@
     UI_APPEARANCE_SELECTOR;
 
 /*
+ A color used as the chip's color for @c state.
+
+ If no chip color has been set for a given state, the returned value will fall back to the
+ value set for UIControlStateNormal.
+
+ @param state The control state.
+ @return The chip color.
+ */
+- (nullable UIColor *)chipColorForState:(UIControlState)state;
+
+/*
+ A color used as the chip's @c color.
+
+ Defaults to blue.
+
+ @param chipColor The chip color.
+ @param state The control state.
+ */
+- (void)setChipColor:(nullable UIColor *)chipColor forState:(UIControlState)state;
+
+/*
  Returns the border color for a particular control state.
 
  If no border width has been set for a given state, the returned value will fall back to the value

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -639,13 +639,13 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
         [UIBezierPath bezierPathWithRoundedRect:self.bounds cornerRadius:cornerRadius].CGPath;
   }
 
-  // make sure chipView layer has the same shape the component
-  CAShapeLayer *shapedLayer = (CAShapeLayer *)_backgroundOverlayView.layer.mask;
-  if (![shapedLayer isKindOfClass:[CAShapeLayer class]]) {
-    shapedLayer = [CAShapeLayer layer];
-    _backgroundOverlayView.layer.mask = shapedLayer;
+  // make sure backgroundOverlayView layer has the same shape the component
+  CAShapeLayer *backgroundOverlayShapedLayer = (CAShapeLayer *)_backgroundOverlayView.layer.mask;
+  if (![backgroundOverlayShapedLayer isKindOfClass:[CAShapeLayer class]]) {
+    backgroundOverlayShapedLayer = [CAShapeLayer layer];
+    _backgroundOverlayView.layer.mask = backgroundOverlayShapedLayer;
   }
-  shapedLayer.path = self.layer.shadowPath;
+  backgroundOverlayShapedLayer.path = self.layer.shadowPath;
 
   // Handle RTL
   if (self.mdf_effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -638,6 +638,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
         [UIBezierPath bezierPathWithRoundedRect:self.bounds cornerRadius:cornerRadius].CGPath;
   }
 
+  // make sure chipView layer has the same shape the component
   CAShapeLayer *shapedLayer = (CAShapeLayer *)_chipView.layer.mask;
   if (![shapedLayer isKindOfClass:[CAShapeLayer class]]) {
     shapedLayer = [CAShapeLayer layer];

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -174,7 +174,6 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
     _backgroundOverlayView.layer.mask = self.layer.shapeLayer;
     [self addSubview:_backgroundOverlayView];
 
-
     _borderColors = [NSMutableDictionary dictionary];
     _borderWidths = [NSMutableDictionary dictionary];
 

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -125,7 +125,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 @interface MDCChipView ()
 @property(nonatomic, readonly) CGRect contentRect;
 @property(nonatomic, readonly, strong) MDCShapedShadowLayer *layer;
-@property(nonatomic, readonly, strong) UIView *chipView;
+@property(nonatomic, readonly, strong) UIView *backgroundOverlayView;
 @property(nonatomic, readonly) BOOL showImageView;
 @property(nonatomic, readonly) BOOL showSelectedImageView;
 @property(nonatomic, readonly) BOOL showAccessoryView;
@@ -135,7 +135,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 
 @implementation MDCChipView {
   // For each UIControlState.
-  NSMutableDictionary<NSNumber *, UIColor *> *_chipColors;
+  NSMutableDictionary<NSNumber *, UIColor *> *_backgroundOverlayColors;
   NSMutableDictionary<NSNumber *, UIColor *> *_backgroundColors;
   NSMutableDictionary<NSNumber *, UIColor *> *_borderColors;
   NSMutableDictionary<NSNumber *, NSNumber *> *_borderWidths;
@@ -169,10 +169,10 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
       _backgroundColors[@(UIControlStateSelected)] = selected;
     }
 
-    _chipColors = [NSMutableDictionary dictionary];
-    _chipView = [[UIView alloc] initWithFrame:self.bounds];
-    _chipView.layer.mask = self.layer.shapeLayer;
-    [self addSubview:_chipView];
+    _backgroundOverlayColors = [NSMutableDictionary dictionary];
+    _backgroundOverlayView = [[UIView alloc] initWithFrame:self.bounds];
+    _backgroundOverlayView.layer.mask = self.layer.shapeLayer;
+    [self addSubview:_backgroundOverlayView];
 
 
     _borderColors = [NSMutableDictionary dictionary];
@@ -372,22 +372,24 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
   }
 }
 
-- (nullable UIColor *)chipColorForState:(UIControlState)state {
-  UIColor *backgroundColor = _chipColors[@(state)];
+- (nullable UIColor *)backgroundOverlayColorForState:(UIControlState)state {
+  UIColor *backgroundColor = _backgroundOverlayColors[@(state)];
   if (!backgroundColor && state != UIControlStateNormal) {
-    backgroundColor = _chipColors[@(UIControlStateNormal)];
+    backgroundColor = _backgroundOverlayColors[@(UIControlStateNormal)];
   }
   return backgroundColor;
+
 }
 
-- (void)setChipColor:(nullable UIColor *)chipColor forState:(UIControlState)state {
-  _chipColors[@(state)] = chipColor;
+- (void)setBackgroundOverlayColor:(nullable UIColor *)backgroundOverlayColor
+                         forState:(UIControlState)state {
+  _backgroundOverlayColors[@(state)] = backgroundOverlayColor;
 
-  [self updateChipColor];
+  [self updateBackgroundOverlayColor];
 }
 
-- (void)updateChipColor {
-  self.chipView.backgroundColor = [self chipColorForState:self.state];
+- (void)updateBackgroundOverlayColor {
+  self.backgroundOverlayView.backgroundColor = [self backgroundOverlayColorForState:self.state];
 }
 
 - (nullable UIColor *)backgroundColorForState:(UIControlState)state {
@@ -586,7 +588,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 
 - (void)updateState {
   [self updateBackgroundColor];
-  [self updateChipColor];
+  [self updateBackgroundOverlayColor];
   [self updateBorderColor];
   [self updateBorderWidth];
   [self updateElevation];
@@ -622,7 +624,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 - (void)layoutSubviews {
   [super layoutSubviews];
 
-  _chipView.frame = self.bounds;
+  _backgroundOverlayView.frame = self.bounds;
   _inkView.frame = self.bounds;
   _imageView.frame = [self imageViewFrame];
   _selectedImageView.frame = [self selectedImageViewFrame];
@@ -639,10 +641,10 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
   }
 
   // make sure chipView layer has the same shape the component
-  CAShapeLayer *shapedLayer = (CAShapeLayer *)_chipView.layer.mask;
+  CAShapeLayer *shapedLayer = (CAShapeLayer *)_backgroundOverlayView.layer.mask;
   if (![shapedLayer isKindOfClass:[CAShapeLayer class]]) {
     shapedLayer = [CAShapeLayer layer];
-    _chipView.layer.mask = shapedLayer;
+    _backgroundOverlayView.layer.mask = shapedLayer;
   }
   shapedLayer.path = self.layer.shadowPath;
 


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/156742616
This is different than background color and sits on top of background color. 
We are required to have these two color properties to theme the component properly.
Chip color can sit on top of expected background color with specific opacity
![screen shot 2018-04-12 at 4 00 52 pm](https://user-images.githubusercontent.com/36271115/38700980-b9df3aee-3e6a-11e8-96aa-d3e61220af83.png)
![screen shot 2018-04-12 at 4 02 34 pm](https://user-images.githubusercontent.com/36271115/38701103-fc80ad4c-3e6a-11e8-91ce-7e55977e7b04.png)
