### PR TITLE
[TextFields] Adding the expected opacities to color themer.

### DIFF
--- a/components/TextFields/src/ColorThemer/MDCTextFieldColorThemer.m
+++ b/components/TextFields/src/ColorThemer/MDCTextFieldColorThemer.m
@@ -55,12 +55,14 @@
 
 + (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
            toTextInputController:(id<MDCTextInputController>)textInputController {
+  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.87];
+  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
   textInputController.activeColor = colorScheme.primaryColor;
   textInputController.errorColor = colorScheme.errorColor;
-  textInputController.normalColor = colorScheme.onSurfaceColor;
-  textInputController.inlinePlaceholderColor = colorScheme.onSurfaceColor;
-  textInputController.trailingUnderlineLabelTextColor = colorScheme.onSurfaceColor;
-  textInputController.leadingUnderlineLabelTextColor = colorScheme.onSurfaceColor;
+  textInputController.normalColor = onSurface87Opacity;
+  textInputController.inlinePlaceholderColor = onSurface60Opacity;
+  textInputController.trailingUnderlineLabelTextColor = onSurface60Opacity;
+  textInputController.leadingUnderlineLabelTextColor = onSurface60Opacity;
 
   if ([textInputController
           conformsToProtocol:@protocol(MDCTextInputControllerFloatingPlaceholder)]) {
@@ -69,19 +71,21 @@
 
     if ([textInputControllerFloatingPlaceholder
             respondsToSelector:@selector(setFloatingPlaceholderNormalColor:)]) {
-      textInputControllerFloatingPlaceholder.floatingPlaceholderNormalColor =
-          colorScheme.primaryColor;
+      UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:0.87];
+      textInputControllerFloatingPlaceholder.floatingPlaceholderNormalColor = primary87Opacity;
     }
   }
 }
 
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                      toTextInput:(nonnull id<MDCTextInput>)textInput {
+  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.87];
+  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
   textInput.cursorColor = colorScheme.primaryColor;
-  textInput.textColor = colorScheme.onSurfaceColor;
-  textInput.placeholderLabel.textColor = colorScheme.onSurfaceColor;
-  textInput.trailingUnderlineLabel.textColor = colorScheme.onSurfaceColor;
-  textInput.leadingUnderlineLabel.textColor = colorScheme.onSurfaceColor;
+  textInput.textColor = onSurface87Opacity;
+  textInput.placeholderLabel.textColor = onSurface60Opacity;
+  textInput.trailingUnderlineLabel.textColor = onSurface60Opacity;
+  textInput.leadingUnderlineLabel.textColor = onSurface60Opacity;
 }
 
 // TODO: (larche) Drop this if defined and the pragmas when we drop Xcode 8 support.
@@ -92,19 +96,22 @@
 #endif
 + (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
 toAllTextInputControllersOfClass:(Class<MDCTextInputController>)textInputControllerClass {
+  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.87];
+  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
   [textInputControllerClass setActiveColorDefault:colorScheme.primaryColor];
   [textInputControllerClass setErrorColorDefault:colorScheme.errorColor];
-  [textInputControllerClass setNormalColorDefault:colorScheme.onSurfaceColor];
-  [textInputControllerClass setInlinePlaceholderColorDefault:colorScheme.onSurfaceColor];
-  [textInputControllerClass setTrailingUnderlineLabelTextColorDefault:colorScheme.onSurfaceColor];
-  [textInputControllerClass setLeadingUnderlineLabelTextColorDefault:colorScheme.onSurfaceColor];
+  [textInputControllerClass setNormalColorDefault:onSurface87Opacity];
+  [textInputControllerClass setInlinePlaceholderColorDefault:onSurface60Opacity];
+  [textInputControllerClass setTrailingUnderlineLabelTextColorDefault:onSurface60Opacity];
+  [textInputControllerClass setLeadingUnderlineLabelTextColorDefault:onSurface60Opacity];
 
   if ([textInputControllerClass
           conformsToProtocol:@protocol(MDCTextInputControllerFloatingPlaceholder)]) {
     Class<MDCTextInputControllerFloatingPlaceholder> textInputControllerFloatingPlaceholderClass =
         (Class<MDCTextInputControllerFloatingPlaceholder>)textInputControllerClass;
+    UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:0.87];
     [textInputControllerFloatingPlaceholderClass
-        setFloatingPlaceholderNormalColorDefault:colorScheme.primaryColor];
+        setFloatingPlaceholderNormalColorDefault:primary87Opacity];
   }
 }
 #if !defined(__IPHONE_11_0)

--- a/components/TextFields/src/ColorThemer/MDCTextFieldColorThemer.m
+++ b/components/TextFields/src/ColorThemer/MDCTextFieldColorThemer.m
@@ -55,8 +55,8 @@
 
 + (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
            toTextInputController:(id<MDCTextInputController>)textInputController {
-  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.87];
-  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
+  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.87f];
+  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60f];
   textInputController.activeColor = colorScheme.primaryColor;
   textInputController.errorColor = colorScheme.errorColor;
   textInputController.normalColor = onSurface87Opacity;
@@ -71,7 +71,7 @@
 
     if ([textInputControllerFloatingPlaceholder
             respondsToSelector:@selector(setFloatingPlaceholderNormalColor:)]) {
-      UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:0.87];
+      UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:0.87f];
       textInputControllerFloatingPlaceholder.floatingPlaceholderNormalColor = primary87Opacity;
     }
   }
@@ -79,8 +79,8 @@
 
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                      toTextInput:(nonnull id<MDCTextInput>)textInput {
-  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.87];
-  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
+  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.87f];
+  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60f];
   textInput.cursorColor = colorScheme.primaryColor;
   textInput.textColor = onSurface87Opacity;
   textInput.placeholderLabel.textColor = onSurface60Opacity;
@@ -96,8 +96,8 @@
 #endif
 + (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
 toAllTextInputControllersOfClass:(Class<MDCTextInputController>)textInputControllerClass {
-  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.87];
-  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
+  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.87f];
+  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60f];
   [textInputControllerClass setActiveColorDefault:colorScheme.primaryColor];
   [textInputControllerClass setErrorColorDefault:colorScheme.errorColor];
   [textInputControllerClass setNormalColorDefault:onSurface87Opacity];
@@ -109,7 +109,7 @@ toAllTextInputControllersOfClass:(Class<MDCTextInputController>)textInputControl
           conformsToProtocol:@protocol(MDCTextInputControllerFloatingPlaceholder)]) {
     Class<MDCTextInputControllerFloatingPlaceholder> textInputControllerFloatingPlaceholderClass =
         (Class<MDCTextInputControllerFloatingPlaceholder>)textInputControllerClass;
-    UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:0.87];
+    UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:0.87f];
     [textInputControllerFloatingPlaceholderClass
         setFloatingPlaceholderNormalColorDefault:primary87Opacity];
   }

--- a/components/TextFields/tests/unit/TextFieldColorThemerTests.m
+++ b/components/TextFields/tests/unit/TextFieldColorThemerTests.m
@@ -82,9 +82,9 @@
 
 - (void)testDefaultValuesAreSet {
   MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
-  UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:0.87];
-  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.87];
-  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
+  UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:0.87f];
+  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.87f];
+  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60f];
 
   XCTAssertEqualObjects(MDCTextInputControllerBase.activeColorDefault, colorScheme.primaryColor);
   XCTAssertEqualObjects(MDCTextInputControllerBase.errorColorDefault, colorScheme.errorColor);
@@ -112,8 +112,8 @@
   colorScheme.onSurfaceColor = [UIColor greenColor];
   colorScheme.errorColor = [UIColor redColor];
 
-  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.87];
-  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
+  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.87f];
+  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60f];
   
   MDCTextField *textField = [[MDCTextField alloc] initWithFrame:CGRectZero];
   MDCTextField *baseTextField = [[MDCTextField alloc] initWithFrame:CGRectZero];

--- a/components/TextFields/tests/unit/TextFieldColorThemerTests.m
+++ b/components/TextFields/tests/unit/TextFieldColorThemerTests.m
@@ -82,26 +82,39 @@
 
 - (void)testDefaultValuesAreSet {
   MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
+  UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:0.87];
+  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.87];
+  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
+
   XCTAssertEqualObjects(MDCTextInputControllerBase.activeColorDefault, colorScheme.primaryColor);
   XCTAssertEqualObjects(MDCTextInputControllerBase.errorColorDefault, colorScheme.errorColor);
-  XCTAssertEqualObjects(MDCTextInputControllerBase.normalColorDefault, colorScheme.onSurfaceColor);
+  XCTAssertEqualObjects(MDCTextInputControllerBase.normalColorDefault, onSurface87Opacity);
   XCTAssertEqualObjects(MDCTextInputControllerBase.inlinePlaceholderColorDefault,
-                        colorScheme.onSurfaceColor);
+                        onSurface60Opacity);
   XCTAssertEqualObjects(MDCTextInputControllerBase.trailingUnderlineLabelTextColorDefault,
-                        colorScheme.onSurfaceColor);
+                        onSurface60Opacity);
   XCTAssertEqualObjects(MDCTextInputControllerBase.leadingUnderlineLabelTextColorDefault,
-                        colorScheme.onSurfaceColor);
+                        onSurface60Opacity);
   XCTAssertEqualObjects(MDCTextInputControllerBase.floatingPlaceholderNormalColorDefault,
-                        colorScheme.primaryColor);
+                        primary87Opacity);
 
   XCTAssertEqualObjects(MDCTextInputControllerFullWidth.errorColorDefault, colorScheme.errorColor);
   XCTAssertEqualObjects(MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault,
-                        colorScheme.onSurfaceColor);
+                        onSurface60Opacity);
   XCTAssertEqualObjects(MDCTextInputControllerFullWidth.trailingUnderlineLabelTextColorDefault,
-                        colorScheme.onSurfaceColor);
+                        onSurface60Opacity);
 }
 
 - (void)testInstanceColorValuesAreSet {
+  MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
+  colorScheme.primaryColor = [UIColor blueColor];
+  colorScheme.errorColor = [UIColor yellowColor];
+  colorScheme.onSurfaceColor = [UIColor greenColor];
+  colorScheme.errorColor = [UIColor redColor];
+
+  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.87];
+  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
+  
   MDCTextField *textField = [[MDCTextField alloc] initWithFrame:CGRectZero];
   MDCTextField *baseTextField = [[MDCTextField alloc] initWithFrame:CGRectZero];
   MDCTextField *fullWidthTextField = [[MDCTextField alloc] initWithFrame:CGRectZero];
@@ -110,38 +123,30 @@
   MDCTextInputControllerFullWidth *fullWidthInputController =
       [[MDCTextInputControllerFullWidth alloc] initWithTextInput:fullWidthTextField];
 
-  MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
-  colorScheme.primaryColor = [UIColor blueColor];
-  colorScheme.errorColor = [UIColor yellowColor];
-  colorScheme.onSurfaceColor = [UIColor greenColor];
-  colorScheme.errorColor = [UIColor redColor];
 
   [MDCTextFieldColorThemer applySemanticColorScheme:colorScheme
                                         toTextInput:textField];
   XCTAssertEqualObjects(textField.cursorColor, colorScheme.primaryColor);
-  XCTAssertEqualObjects(textField.textColor, colorScheme.onSurfaceColor);
-  XCTAssertEqualObjects(textField.placeholderLabel.textColor, colorScheme.onSurfaceColor);
-  XCTAssertEqualObjects(textField.trailingUnderlineLabel.textColor, colorScheme.onSurfaceColor);
-  XCTAssertEqualObjects(textField.leadingUnderlineLabel.textColor, colorScheme.onSurfaceColor);
+  XCTAssertEqualObjects(textField.textColor, onSurface87Opacity);
+  XCTAssertEqualObjects(textField.placeholderLabel.textColor, onSurface60Opacity);
+  XCTAssertEqualObjects(textField.trailingUnderlineLabel.textColor, onSurface60Opacity);
+  XCTAssertEqualObjects(textField.leadingUnderlineLabel.textColor, onSurface60Opacity);
 
   [MDCTextFieldColorThemer applySemanticColorScheme:colorScheme
                               toTextInputController:baseInputController];
   XCTAssertEqualObjects(baseInputController.activeColor, colorScheme.primaryColor);
   XCTAssertEqualObjects(baseInputController.errorColor, colorScheme.errorColor);
-  XCTAssertEqualObjects(baseInputController.normalColor, colorScheme.onSurfaceColor);
-  XCTAssertEqualObjects(baseInputController.inlinePlaceholderColor, colorScheme.onSurfaceColor);
-  XCTAssertEqualObjects(baseInputController.trailingUnderlineLabelTextColor,
-                        colorScheme.onSurfaceColor);
-  XCTAssertEqualObjects(baseInputController.leadingUnderlineLabelTextColor,
-                        colorScheme.onSurfaceColor);
+  XCTAssertEqualObjects(baseInputController.normalColor, onSurface87Opacity);
+  XCTAssertEqualObjects(baseInputController.inlinePlaceholderColor, onSurface60Opacity);
+  XCTAssertEqualObjects(baseInputController.trailingUnderlineLabelTextColor, onSurface60Opacity);
+  XCTAssertEqualObjects(baseInputController.leadingUnderlineLabelTextColor, onSurface60Opacity);
 
   [MDCTextFieldColorThemer applySemanticColorScheme:colorScheme
                       toTextInputController:fullWidthInputController];
   XCTAssertEqualObjects(fullWidthInputController.errorColor, colorScheme.errorColor);
-  XCTAssertEqualObjects(fullWidthInputController.inlinePlaceholderColor,
-                        colorScheme.onSurfaceColor);
+  XCTAssertEqualObjects(fullWidthInputController.inlinePlaceholderColor, onSurface60Opacity);
   XCTAssertEqualObjects(fullWidthInputController.trailingUnderlineLabelTextColor,
-                        colorScheme.onSurfaceColor);
+                        onSurface60Opacity);
 }
 
 @end


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/156742677
TextField Color Themer was missing opacity information about the colors.
Opacity info is now added to the themer.
![screen shot 2018-04-12 at 4 44 20 pm](https://user-images.githubusercontent.com/36271115/38703526-775593d8-3e71-11e8-8e8c-f0457bd7902c.png)