### PR TITLE
[WIP] Add dummy implementation to the Themes target.

### DIFF
--- a/components/Themes/src/MDCThemesDummyImplementation.m
+++ b/components/Themes/src/MDCThemesDummyImplementation.m
@@ -1,0 +1,25 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MaterialColorScheme.h"
+
+// This is here so that the Themes target, which doesn't contain any concrete APIs, does not result
+// in an empty library.
+@interface MDCThemesDummyImplementation: NSObject
+@end
+
+@implementation MDCThemesDummyImplementation
+@end


### PR DESCRIPTION
This is being done in an effort to reduce flakiness. The working theory is that because the Themes target is producing an empty library it's causing flaky builds in bazel.

Kokoro should be continually re-run on this PR for at least 5 invocations in order to see if flaky builds happen.