### PR TITLE
[NavigationBar] Fix bug where system font traits would be lost.

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -265,8 +265,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 }
 
 - (void)setTitleFont:(UIFont *)titleFont {
-  // Using "fontWithSize:" did not work for system font medium, instead it returned a regular font.
-  _titleFont = [UIFont fontWithName:titleFont.fontName size:kTitleFontSize];
+  _titleFont = [UIFont fontWithDescriptor:titleFont.fontDescriptor size:kTitleFontSize];
   if (!_titleFont) {
     _titleFont = [MDCTypography titleFont];
   }

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -99,23 +99,19 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   XCTAssertNotNil(navBar.titleFont);
   XCTAssertEqual(navBar.titleLabel.font, navBar.titleFont);
 
-  UIFont *testFont = [UIFont boldSystemFontOfSize:24];
-  UIFont *resultFont = [UIFont boldSystemFontOfSize:20];
-  navBar.titleFont = testFont;
+  UIFont *font = [UIFont systemFontOfSize:24];
+  navBar.titleFont = font;
 
-  // To enforce 20 point size we are using "fontWithName:size:" and for some reason even though the
-  // printout looks identical comparing the fonts returns false. (Using "fontWithSize:" did not work
-  // for system font medium, instead it returned a regular font).
-  UIFont *titleFont = navBar.titleLabel.font;
-  XCTAssertEqualObjects(titleFont.fontName, resultFont.fontName);
-  XCTAssertEqual(titleFont.pointSize, resultFont.pointSize);
+  UIFont *resultFont = navBar.titleLabel.font;
+  XCTAssertEqualObjects(resultFont.fontName, font.fontName);
+  XCTAssertEqualWithAccuracy(resultFont.pointSize, 20, 0.01);
 
-  // Weight for Fonts was not introduced on iOS 8
-  // TODO: remove this when we drop iOS 8 support.
-#if defined(__IPHONE_9_0) && __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_9_0
-  XCTAssertEqual([NavigationBarTests weightForFont:titleFont],
-                 [NavigationBarTests weightForFont:resultFont]);
-#endif
+  NSDictionary <NSString *, NSNumber *> *fontTraits =
+      [[font fontDescriptor] objectForKey:UIFontDescriptorTraitsAttribute];
+  NSDictionary <NSString *, NSNumber *> *resultTraits =
+      [[resultFont fontDescriptor] objectForKey:UIFontDescriptorTraitsAttribute];
+
+  XCTAssertEqual(fontTraits, resultTraits);
 }
 
 - (void)testEncoding {


### PR DESCRIPTION
### Context

When setting a font on MDCNavigationBar, we force the font to have a size of 20.

### Prior to this change

We were enforcing the font size by using an older UIFont API - fontWithName:size:. This API does not preserve font descriptor attributes from the provided font, it only preserves the font name and size.

This was resulting in the loss of an important system font descriptor attribute, namely `NSCTFontUIFontDesignTrait` which was set to `NSCTFontUIFontDesignDefault`. This font attribute affects the kerning of fonts when displayed on screen.

### After this change

We are now using the iOS 7 API - fontWithDescriptor:size:. This API preserves all of the underlying font descriptor attributes.

The result of this change is an intentional visual change.

As part of this behavioral change, I've also updated the related unit tests to enforce this behavior in the future.

To see a visual depiction of the change in behavior, open the following two screenshots and flip between them:

Before this fix:
![lossy](https://user-images.githubusercontent.com/45670/38755649-8a172a22-3f34-11e8-9f53-15ca6789e351.png)

After this fix:
![notlossy](https://user-images.githubusercontent.com/45670/38755654-8d998fa0-3f34-11e8-8112-49e3d4b7d76e.png)

Visual delta:
![difference](https://user-images.githubusercontent.com/45670/38755656-91d02f5c-3f34-11e8-8032-36d3ffc8f52e.png)
