### PR TITLE
[bazel] Fix BUILD file paths to match file system casing

### DIFF
--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -58,7 +58,7 @@ mdc_objc_library(
     ],
     deps = [
         ":ActivityIndicator",
-        "//components/Schemes/Color",
+        "//components/schemes/Color",
     ],
     visibility = ["//visibility:public"],
 )

--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -58,7 +58,7 @@ mdc_objc_library(
     ],
     deps = [
         ":BottomNavigation",
-        "//components/Schemes/Color",
+        "//components/schemes/Color",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Some of our BUILD file dependencies were using casing that did not match the file system.

I believe this was causing the flaky behavior we started seeing sometime after de1119c (most-recent likely non-flaky SHA via https://github.com/material-components/material-components-ios/pull/3356) and before f9b0349 (earliest confirmed flaky SHA via https://github.com/material-components/material-components-ios/pull/3351).

The incorrect casings was first introduced by eb3167032ff65c854dd5a8a8e3fe637aadda4f81, which lies between the flaky-builds window described above. f31cd3010dd3568e22b41bc637ef8c7a3df59119 also landed later on.

Closes #3340
Closes #3332
Closes #3328
Closes #3327