### PR TITLE
[NavigationBar][ButtonBar] Restore the changed default inkColor

### DIFF
--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
@@ -88,8 +88,10 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
   MDCButtonBarButton *button = [[MDCButtonBarButton alloc] init];
   [button setBackgroundColor:[UIColor clearColor] forState:UIControlStateNormal];
   button.disabledAlpha = kDisabledButtonAlpha;
-  button.inkColor = buttonBar.inkColor ? buttonBar.inkColor : button.inkColor;
-  
+  if (buttonBar.inkColor) {
+    button.inkColor = buttonBar.inkColor;
+  }
+
   button.exclusiveTouch = YES;
 
   [MDCAppBarButtonBarBuilder configureButton:button fromButtonItem:buttonItem];


### PR DESCRIPTION
The issue was caused by #3250, where we override MDCFlatButton's appearance.inkColor with MDCButton's default inkColor.

https://github.com/material-components/material-components-ios/blob/5fe8cf2752dcafad7b07d6f8935910f1597ed963/components/Buttons/src/MDCFlatButton.m#L32