### PR TITLE
[Shapes] Expose color sublayer for shapes

### DIFF
--- a/components/private/Shapes/src/MDCShapedShadowLayer.h
+++ b/components/private/Shapes/src/MDCShapedShadowLayer.h
@@ -72,4 +72,12 @@
  */
 @property(nonatomic, strong, nonnull) CAShapeLayer *shapeLayer;
 
+/*
+ A sublayer of @c shapeLayer that is responsible for the background color of the shape layer.
+
+ The colorLayer imitates the path of shapeLayer and is added as a sublayer. It is updated when
+ shapedBackgroundColor is set on the layer.
+ */
+@property(nonatomic, strong, nonnull) CAShapeLayer *colorLayer;
+
 @end

--- a/components/private/Shapes/src/MDCShapedShadowLayer.m
+++ b/components/private/Shapes/src/MDCShapedShadowLayer.m
@@ -18,9 +18,7 @@
 
 #import "MDCShapeGenerating.h"
 
-@implementation MDCShapedShadowLayer {
-  CAShapeLayer *_colorLayer;
-}
+@implementation MDCShapedShadowLayer
 
 - (instancetype)init {
   self = [super init];


### PR DESCRIPTION
This is useful for components to access the backgroundColor sublayer to allow correct ordering between layers within the component (ink, internal subviews, etc.)