### PR TITLE
[FlexibleHeader] Add a surface variant color themer API.

### DIFF
--- a/components/FlexibleHeader/src/ColorThemer/MDCFlexibleHeaderColorThemer.h
+++ b/components/FlexibleHeader/src/ColorThemer/MDCFlexibleHeaderColorThemer.h
@@ -25,12 +25,26 @@
 /**
  Applies a color scheme's properties to an MDCFlexibleHeaderView.
 
+ Uses the primary color as the most important color for the component.
+
  @param colorScheme The color scheme to apply to MDCFlexibleHeaderView.
  @param flexibleHeaderView An MDCFlexibleHeaderView instance to which the color scheme should be
  applied.
  */
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
             toFlexibleHeaderView:(nonnull MDCFlexibleHeaderView *)flexibleHeaderView;
+
+/**
+ Applies a color scheme's properties to an MDCFlexibleHeaderView using the surface variant.
+
+ Uses the surface color as the most important color for the component.
+
+ @param colorScheme The color scheme to apply to MDCNavigationBar.
+ @param flexibleHeaderView An MDCFlexibleHeaderView instance to which the color scheme should be
+ applied.
+ */
++ (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+                      toFlexibleHeaderView:(nonnull MDCFlexibleHeaderView *)flexibleHeaderView;
 
 #pragma mark - Soon to be deprecated
 

--- a/components/FlexibleHeader/src/ColorThemer/MDCFlexibleHeaderColorThemer.h
+++ b/components/FlexibleHeader/src/ColorThemer/MDCFlexibleHeaderColorThemer.h
@@ -39,7 +39,7 @@
 
  Uses the surface color as the most important color for the component.
 
- @param colorScheme The color scheme to apply to MDCNavigationBar.
+ @param colorScheme The color scheme to apply to MDCFlexibleHeaderView.
  @param flexibleHeaderView An MDCFlexibleHeaderView instance to which the color scheme should be
  applied.
  */

--- a/components/FlexibleHeader/src/ColorThemer/MDCFlexibleHeaderColorThemer.m
+++ b/components/FlexibleHeader/src/ColorThemer/MDCFlexibleHeaderColorThemer.m
@@ -23,6 +23,11 @@
   flexibleHeaderView.backgroundColor = colorScheme.primaryColor;
 }
 
++ (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+                      toFlexibleHeaderView:(nonnull MDCFlexibleHeaderView *)flexibleHeaderView {
+  flexibleHeaderView.backgroundColor = colorScheme.surfaceColor;
+}
+
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme
     toFlexibleHeaderView:(MDCFlexibleHeaderView *)flexibleHeaderView {
   flexibleHeaderView.backgroundColor = colorScheme.primaryColor;

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderColorThemerTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderColorThemerTests.swift
@@ -33,4 +33,19 @@ class FlexibleHeaderColorThemerTests: XCTestCase {
     // Then
     XCTAssertEqual(flexibleHeaderView.backgroundColor, colorScheme.primaryColor)
   }
+
+  func testSurfaceVariantColorThemerChangesTheBackgroundColor() {
+    // Given
+    let colorScheme = MDCSemanticColorScheme()
+    let flexibleHeaderView = MDCFlexibleHeaderView()
+    colorScheme.surfaceColor = .red
+    flexibleHeaderView.backgroundColor = .white
+
+    // When
+    MDCFlexibleHeaderColorThemer.applySurfaceVariant(withColorScheme: colorScheme,
+                                                     to: flexibleHeaderView)
+
+    // Then
+    XCTAssertEqual(flexibleHeaderView.backgroundColor, colorScheme.surfaceColor)
+  }
 }


### PR DESCRIPTION
Pivotal story: https://www.pivotaltracker.com/story/show/156844807

In the following screenshot the flexible header is white, because it's being themed with the surface color which is white.

![simulator screen shot - iphone se - 2018-04-17 at 09 23 22](https://user-images.githubusercontent.com/45670/38872663-cbfd638a-4221-11e8-8468-28d44689e2e6.png)
