### PR TITLE
[ButtonBar] Expose APIs for setting custom button fonts.

### DIFF
--- a/components/ButtonBar/src/MDCButtonBar.h
+++ b/components/ButtonBar/src/MDCButtonBar.h
@@ -109,6 +109,9 @@ IB_DESIGNABLE
 /**
  Returns the font set for @c state that was set by setButtonsTitleFont:forState:.
 
+ If no font has been set for a given state, the returned value will fall back to the value
+ set for UIControlStateNormal.
+
  @param state The state for which the font should be returned.
  @return The font associated with the given state.
  */

--- a/components/ButtonBar/src/MDCButtonBar.h
+++ b/components/ButtonBar/src/MDCButtonBar.h
@@ -99,6 +99,19 @@ IB_DESIGNABLE
 @property(nonatomic) CGFloat buttonTitleBaseline;
 
 /**
+ Sets the button title font for the given state.
+
+ @param font The font that should be displayed on text buttons for the given state.
+ @param state The state for which the font should be displayed.
+ */
+- (void)setButtonTitleFont:(nullable UIFont *)font forState:(UIControlState)state;
+
+/**
+ Returns the font used by text button titles for @c state.
+ */
+- (nullable UIFont *)buttonTitleFontForState:(UIControlState)state;
+
+/**
  The position of the button bar, usually positioned on the leading or trailing edge of the screen.
 
  Default: MDCBarButtonLayoutPositionNone

--- a/components/ButtonBar/src/MDCButtonBar.h
+++ b/components/ButtonBar/src/MDCButtonBar.h
@@ -99,17 +99,20 @@ IB_DESIGNABLE
 @property(nonatomic) CGFloat buttonTitleBaseline;
 
 /**
- Sets the button title font for the given state.
+ Sets the title font for the given state for all buttons.
 
  @param font The font that should be displayed on text buttons for the given state.
  @param state The state for which the font should be displayed.
  */
-- (void)setButtonTitleFont:(nullable UIFont *)font forState:(UIControlState)state;
+- (void)setButtonsTitleFont:(nullable UIFont *)font forState:(UIControlState)state;
 
 /**
- Returns the font used by text button titles for @c state.
+ Returns the font set for @c state that was set by setButtonsTitleFont:forState:.
+
+ @param state The state for which the font should be returned.
+ @return The font associated with the given state.
  */
-- (nullable UIFont *)buttonTitleFontForState:(UIControlState)state;
+- (nullable UIFont *)buttonsTitleFontForState:(UIControlState)state;
 
 /**
  The position of the button bar, usually positioned on the leading or trailing edge of the screen.

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -415,6 +415,21 @@ static NSString *const MDCButtonBarButtonLayoutPositionKey = @"MDCButtonBarButto
   }
 }
 
+- (nullable UIFont *)buttonTitleFontForState:(UIControlState)state {
+  return [_defaultBuilder titleFontForState:state];
+}
+
+- (void)setButtonTitleFont:(UIFont *)font forState:(UIControlState)state {
+  [_defaultBuilder setTitleFont:font forState:state];
+
+  for (UIView *viewObj in _buttonViews) {
+    if ([viewObj isKindOfClass:[UIButton class]]) {
+      MDCButton *button = (MDCButton *)viewObj;
+      [button setTitleFont:font forState:state];
+    }
+  }
+}
+
 // UISemanticContentAttribute was added in iOS SDK 9.0 but is available on devices running earlier
 // version of iOS. We ignore the partial-availability warning that gets thrown on our use of this
 // symbol.

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -415,11 +415,7 @@ static NSString *const MDCButtonBarButtonLayoutPositionKey = @"MDCButtonBarButto
   }
 }
 
-- (nullable UIFont *)buttonTitleFontForState:(UIControlState)state {
-  return [_defaultBuilder titleFontForState:state];
-}
-
-- (void)setButtonTitleFont:(UIFont *)font forState:(UIControlState)state {
+- (void)setButtonsTitleFont:(UIFont *)font forState:(UIControlState)state {
   [_defaultBuilder setTitleFont:font forState:state];
 
   for (UIView *viewObj in _buttonViews) {
@@ -428,6 +424,10 @@ static NSString *const MDCButtonBarButtonLayoutPositionKey = @"MDCButtonBarButto
       [button setTitleFont:font forState:state];
     }
   }
+}
+
+- (nullable UIFont *)buttonsTitleFontForState:(UIControlState)state {
+  return [_defaultBuilder titleFontForState:state];
 }
 
 // UISemanticContentAttribute was added in iOS SDK 9.0 but is available on devices running earlier

--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.h
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.h
@@ -37,6 +37,9 @@
 /**
  Gets the desired button title font for a given state.
 
+ If no font has been set for a given state, the returned value will fall back to the value
+ set for UIControlStateNormal.
+
  @param state The state for which the font should be returned.
  @return The font associated with the given state.
  */

--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.h
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.h
@@ -25,4 +25,15 @@
 /** The underlying color for the bar button items. */
 @property(nonatomic, strong) UIColor *buttonUnderlyingColor;
 
+/**
+ Sets the desired button title font for a given state. Will only affect buttons created after this
+ invocation.
+ */
+- (void)setTitleFont:(UIFont *)font forState:(UIControlState)state;
+
+/**
+ Gets the desired button title font for a given state.
+ */
+- (UIFont *)titleFontForState:(UIControlState)state;
+
 @end

--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.h
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.h
@@ -28,11 +28,17 @@
 /**
  Sets the desired button title font for a given state. Will only affect buttons created after this
  invocation.
+
+ @param font The font that should be displayed on text buttons for the given state.
+ @param state The state for which the font should be displayed.
  */
 - (void)setTitleFont:(UIFont *)font forState:(UIControlState)state;
 
 /**
  Gets the desired button title font for a given state.
+
+ @param state The state for which the font should be returned.
+ @return The font associated with the given state.
  */
 - (UIFont *)titleFontForState:(UIControlState)state;
 

--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
@@ -54,7 +54,25 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
 
 @end
 
-@implementation MDCAppBarButtonBarBuilder
+@implementation MDCAppBarButtonBarBuilder {
+  NSMutableDictionary<NSNumber *, UIFont *> *_fonts;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _fonts = [NSMutableDictionary dictionary];
+  }
+  return self;
+}
+
+- (nullable UIFont *)titleFontForState:(UIControlState)state {
+  return _fonts[@(state)];
+}
+
+- (void)setTitleFont:(UIFont *)font forState:(UIControlState)state {
+  _fonts[@(state)] = font;
+}
 
 #pragma mark - MDCBarButtonItemBuilding
 
@@ -98,6 +116,10 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
 
   [button setTitleColor:self.buttonTitleColor forState:UIControlStateNormal];
   [button setUnderlyingColorHint:self.buttonUnderlyingColor];
+  for (NSNumber *state in _fonts) {
+    UIFont *font = _fonts[state];
+    [button setTitleFont:font forState:(UIControlState)state.intValue];
+  }
 
   [self updateButton:button withItem:buttonItem barMetrics:UIBarMetricsDefault];
 

--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
@@ -67,7 +67,11 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
 }
 
 - (nullable UIFont *)titleFontForState:(UIControlState)state {
-  return _fonts[@(state)];
+  UIFont *font = _fonts[@(state)];
+  if (!font && state != UIControlStateNormal) {
+    font = _fonts[@(UIControlStateNormal)];
+  }
+  return font;
 }
 
 - (void)setTitleFont:(UIFont *)font forState:(UIControlState)state {

--- a/components/ButtonBar/tests/unit/ButtonBarButtonTitleFontTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarButtonTitleFontTests.swift
@@ -45,7 +45,7 @@ class ButtonBarButtonTitleFontTests: XCTestCase {
     let font = UIFont.systemFont(ofSize: 100)
 
     // When
-    buttonBar.setButtonTitleFont(font, for: .normal)
+    buttonBar.setButtonsTitleFont(font, for: .normal)
     buttonBar.items = items
 
     // Then
@@ -63,7 +63,7 @@ class ButtonBarButtonTitleFontTests: XCTestCase {
 
     // When
     buttonBar.items = items
-    buttonBar.setButtonTitleFont(font, for: .normal)
+    buttonBar.setButtonsTitleFont(font, for: .normal)
 
     // Then
     for view in buttonBar.subviews {
@@ -79,7 +79,7 @@ class ButtonBarButtonTitleFontTests: XCTestCase {
     let font = UIFont.systemFont(ofSize: 100)
 
     // When
-    buttonBar.setButtonTitleFont(font, for: .selected)
+    buttonBar.setButtonsTitleFont(font, for: .selected)
     buttonBar.items = items
 
     // Then

--- a/components/ButtonBar/tests/unit/ButtonBarButtonTitleFontTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarButtonTitleFontTests.swift
@@ -1,0 +1,101 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents.MaterialButtonBar
+import MaterialComponents.MaterialButtons
+
+class ButtonBarButtonTitleFontTests: XCTestCase {
+
+  var buttonBar: MDCButtonBar!
+
+  override func setUp() {
+    buttonBar = MDCButtonBar()
+  }
+
+  func testDefaultFontBehavior() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    buttonBar.items = items
+
+    // Then
+    for view in buttonBar.subviews {
+      if let button = view as? MDCButton {
+        XCTAssertNil(button.titleFont(for: .normal))
+      }
+    }
+  }
+
+  func testCustomFontIsSetForNewButtons() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    let font = UIFont.systemFont(ofSize: 100)
+
+    // When
+    buttonBar.setButtonTitleFont(font, for: .normal)
+    buttonBar.items = items
+
+    // Then
+    for view in buttonBar.subviews {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.titleFont(for: .normal), font)
+      }
+    }
+  }
+
+  func testCustomFontIsSetForExistingButtons() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    let font = UIFont.systemFont(ofSize: 100)
+
+    // When
+    buttonBar.items = items
+    buttonBar.setButtonTitleFont(font, for: .normal)
+
+    // Then
+    for view in buttonBar.subviews {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.titleFont(for: .normal), font)
+      }
+    }
+  }
+
+  func testCustomFontFallbackBehavior() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    let font = UIFont.systemFont(ofSize: 100)
+
+    // When
+    buttonBar.setButtonTitleFont(font, for: .selected)
+    buttonBar.items = items
+
+    // Then
+    for view in buttonBar.subviews {
+      if let button = view as? MDCButton {
+        let defaultFont = button.titleLabel?.font
+
+        button.isSelected = true
+
+        XCTAssertEqual(button.titleLabel?.font, font)
+
+        button.isSelected = false
+
+        XCTAssertEqual(button.titleLabel?.font, defaultFont)
+      }
+    }
+  }
+
+}

--- a/components/ButtonBar/tests/unit/ButtonBarButtonTitleFontTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarButtonTitleFontTests.swift
@@ -52,6 +52,7 @@ class ButtonBarButtonTitleFontTests: XCTestCase {
     for view in buttonBar.subviews {
       if let button = view as? MDCButton {
         XCTAssertEqual(button.titleFont(for: .normal), font)
+        XCTAssertEqual(button.titleLabel?.font, font)
       }
     }
   }
@@ -69,6 +70,7 @@ class ButtonBarButtonTitleFontTests: XCTestCase {
     for view in buttonBar.subviews {
       if let button = view as? MDCButton {
         XCTAssertEqual(button.titleFont(for: .normal), font)
+        XCTAssertEqual(button.titleLabel?.font, font)
       }
     }
   }

--- a/components/ButtonBar/tests/unit/ButtonBarButtonTitleFontTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarButtonTitleFontTests.swift
@@ -76,24 +76,24 @@ class ButtonBarButtonTitleFontTests: XCTestCase {
   func testCustomFontFallbackBehavior() {
     // Given
     let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
-    let font = UIFont.systemFont(ofSize: 100)
+    let normalFont = UIFont.systemFont(ofSize: 100)
+    let selectedFont = UIFont.systemFont(ofSize: 50)
 
     // When
-    buttonBar.setButtonsTitleFont(font, for: .selected)
+    buttonBar.setButtonsTitleFont(normalFont, for: .normal)
+    buttonBar.setButtonsTitleFont(selectedFont, for: .selected)
     buttonBar.items = items
 
     // Then
     for view in buttonBar.subviews {
       if let button = view as? MDCButton {
-        let defaultFont = button.titleLabel?.font
-
         button.isSelected = true
 
-        XCTAssertEqual(button.titleLabel?.font, font)
+        XCTAssertEqual(button.titleLabel?.font, selectedFont)
 
         button.isSelected = false
 
-        XCTAssertEqual(button.titleLabel?.font, defaultFont)
+        XCTAssertEqual(button.titleLabel?.font, normalFont)
       }
     }
   }


### PR DESCRIPTION
This introduces a new API to MDCButtonBar that allows the title font to be customized for a given state. This is part of the work required to allow MDCNavigationBar to support custom button title fonts.

Pivotal story: https://www.pivotaltracker.com/story/show/156769836

Example of customization:

![simulator screen shot - iphone se - 2018-04-18 at 12 07 32](https://user-images.githubusercontent.com/45670/38945147-b7971dea-4303-11e8-86ca-31eaf45f416f.png)
