### PR TITLE
[Ink] Increase range of accuracy in flaky test to +/-.1.

### DIFF
--- a/components/Ink/tests/unit/MDCInkLayerTests.m
+++ b/components/Ink/tests/unit/MDCInkLayerTests.m
@@ -173,7 +173,7 @@
   CAAnimation *animation = inkLayer.addedAnimations.firstObject;
   if (animation) {
     startTime = [inkLayer convertTime:startTime fromLayer:nil];
-    XCTAssertEqualWithAccuracy(animation.beginTime, startTime, 0.010);
+    XCTAssertEqualWithAccuracy(animation.beginTime, startTime, 0.1f);
   }
 }
 


### PR DESCRIPTION
https://github.com/material-components/material-components-ios/issues/3173
https://www.pivotaltracker.com/story/show/156804989

