### PR TITLE
[TabBars] Add titleColorForState and imageTintColorForState

### DIFF
--- a/components/Tabs/examples/TabBarIconExample.m
+++ b/components/Tabs/examples/TabBarIconExample.m
@@ -75,7 +75,7 @@
 
   MDCSemanticColorScheme *scheme = [[MDCSemanticColorScheme alloc] init];
   [MDCTabBarColorThemer applySemanticColorScheme:scheme toTabs:tabBar];
-  
+
   tabBar.inkColor = [[UIColor whiteColor] colorWithAlphaComponent:0.1f];
   tabBar.itemAppearance = MDCTabBarItemAppearanceTitledImages;
 

--- a/components/Tabs/src/ColorThemer/MDCTabBarColorThemer.m
+++ b/components/Tabs/src/ColorThemer/MDCTabBarColorThemer.m
@@ -16,7 +16,8 @@
 
 #import "MDCTabBarColorThemer.h"
 
-static const CGFloat kUnselectedOpacity = 0.6f;
+static const CGFloat kUnselectedTitleOpacity = 0.6f;
+static const CGFloat kUnselectedImageOpacity = 0.54f;
 
 @implementation MDCTabBarColorThemer
 
@@ -24,9 +25,14 @@ static const CGFloat kUnselectedOpacity = 0.6f;
                           toTabs:(nonnull MDCTabBar *)tabBar {
   tabBar.barTintColor = colorScheme.primaryColor;
   tabBar.tintColor = colorScheme.onPrimaryColor;
-  tabBar.selectedItemTintColor = colorScheme.onPrimaryColor;
-  tabBar.unselectedItemTintColor =
-      [colorScheme.onPrimaryColor colorWithAlphaComponent:kUnselectedOpacity];
+  [tabBar setTitleColor:colorScheme.onPrimaryColor forState:MDCTabBarItemStateSelected];
+  [tabBar setImageTintColor:colorScheme.onPrimaryColor forState:MDCTabBarItemStateSelected];
+  UIColor *unselectedTitleColor =
+      [colorScheme.onPrimaryColor colorWithAlphaComponent:kUnselectedTitleOpacity];
+  UIColor *unselectedImageColor =
+      [colorScheme.onPrimaryColor colorWithAlphaComponent:kUnselectedImageOpacity];
+  [tabBar setTitleColor:unselectedTitleColor forState:MDCTabBarItemStateNormal];
+  [tabBar setImageTintColor:unselectedImageColor forState:MDCTabBarItemStateNormal];
 }
 
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -24,6 +24,13 @@
 @protocol MDCTabBarDelegate;
 @protocol MDCTabBarIndicatorTemplate;
 
+typedef NS_ENUM(NSInteger, MDCTabBarItemState) {
+  /** State for unselected tab bar item. */
+  MDCTabBarItemStateNormal,
+  /** State for selected tab bar item. */
+  MDCTabBarItemStateSelected,
+};
+
 /**
  A material tab bar for switching between views of grouped content.
 
@@ -74,12 +81,15 @@ IB_DESIGNABLE
 @property(nonatomic, strong, null_resettable) UIColor *tintColor;
 
 /**
- Tint color for selected items. If nil, selected items will be tinted using the tab bar's
- inherited tintColor instead. Default: Opaque white.
+ Tint color for selected items. If set overrides titleColorForState: and imageTintColorForState:
+ for MDCTabBarItemStateSelected. Returns imageTintColorForState: for MDCTabBarItemStateSelected.
  */
 @property(nonatomic, nullable) UIColor *selectedItemTintColor UI_APPEARANCE_SELECTOR;
 
-/** Tint color for unselected items. Default: Semi-transparent white. */
+/**
+ Tint color for unselected items. If set overrides titleColorForState: and imageTintColorForState:
+ for MDCTabBarItemStateNormal. Returns imageTintColorForState: for MDCTabBarItemStateNormal.
+ */
 @property(nonatomic, nonnull) UIColor *unselectedItemTintColor UI_APPEARANCE_SELECTOR;
 
 /** Ink color for taps on tab bar items. Default: Semi-transparent white. */
@@ -162,6 +172,28 @@ IB_DESIGNABLE
 
 /** Updates the alignment with optional animation. */
 - (void)setAlignment:(MDCTabBarAlignment)alignment animated:(BOOL)animated;
+
+/**
+ Sets the color of the title for the specified state.
+ 
+ If the @c MDCTabBarItemState value is not set, then defaults to a default value. Therefore,
+ at a minimum, you should set the value for MDCTabBarItemStateNormal.
+ */
+- (void)setTitleColor:(nullable UIColor *)color forState:(MDCTabBarItemState)state;
+
+/** Returns the title color associated with the specified state. */
+- (nullable UIColor *)titleColorForState:(MDCTabBarItemState)state;
+
+/**
+ Sets the tint color of the image for the specified state.
+
+ If the @c MDCTabBarItemState value is not set, then defaults to a default value. Therefore,
+ at a minimum, you should set the value for MDCTabBarItemStateNormal.
+ */
+- (void)setImageTintColor:(nullable UIColor *)color forState:(MDCTabBarItemState)state;
+
+/** Returns the image tint color associated with the specified state. */
+- (nullable UIColor *)imageTintColorForState:(MDCTabBarItemState)state;
 
 @end
 

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -99,6 +99,9 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   // For properties which have been set, these store the new fixed values.
   MDCTabBarAlignment _alignmentOverride;
   MDCTabBarItemAppearance _itemAppearanceOverride;
+
+  UIColor *_selectedTitleColor;
+  UIColor *_unselectedTitleColor;
 }
 // Inherit UIView's tintColor logic.
 @dynamic tintColor;
@@ -185,6 +188,8 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 - (void)commonMDCTabBarInit {
   _selectedItemTintColor = [UIColor whiteColor];
   _unselectedItemTintColor = [UIColor colorWithWhite:1.0f alpha:0.7f];
+  _selectedTitleColor = _selectedItemTintColor;
+  _unselectedTitleColor = _unselectedItemTintColor;
   _inkColor = [UIColor colorWithWhite:1.0f alpha:0.7f];
 
   self.clipsToBounds = YES;
@@ -262,6 +267,52 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 
 + (CGFloat)defaultHeightForItemAppearance:(MDCTabBarItemAppearance)appearance {
   return [self defaultHeightForBarPosition:UIBarPositionAny itemAppearance:appearance];
+}
+
+- (void)setTitleColor:(nullable UIColor *)color forState:(MDCTabBarItemState)state {
+  switch (state) {
+    case MDCTabBarItemStateNormal:
+      _unselectedTitleColor = color;
+      break;
+    case MDCTabBarItemStateSelected:
+      _selectedTitleColor = color;
+      break;
+  }
+  [self updateItemBarStyle];
+}
+
+- (nullable UIColor *)titleColorForState:(MDCTabBarItemState)state {
+  switch (state) {
+    case MDCTabBarItemStateNormal:
+      return _unselectedTitleColor;
+      break;
+    case MDCTabBarItemStateSelected:
+      return _selectedTitleColor;
+      break;
+  }
+}
+
+- (void)setImageTintColor:(nullable UIColor *)color forState:(MDCTabBarItemState)state {
+  switch (state) {
+    case MDCTabBarItemStateNormal:
+      _unselectedItemTintColor = color;
+      break;
+    case MDCTabBarItemStateSelected:
+      _selectedItemTintColor = color;
+      break;
+  }
+  [self updateItemBarStyle];
+}
+
+- (nullable UIColor *)imageTintColorForState:(MDCTabBarItemState)state {
+  switch (state) {
+    case MDCTabBarItemStateNormal:
+      return _unselectedItemTintColor;
+      break;
+    case MDCTabBarItemStateSelected:
+      return _selectedItemTintColor;
+      break;
+  }
 }
 
 - (void)setDelegate:(id<MDCTabBarDelegate>)delegate {
@@ -346,6 +397,7 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   if (_selectedItemTintColor != selectedItemTintColor &&
       ![_selectedItemTintColor isEqual:selectedItemTintColor]) {
     _selectedItemTintColor = selectedItemTintColor;
+    _selectedTitleColor = selectedItemTintColor;
 
     [self updateItemBarStyle];
   }
@@ -355,6 +407,7 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   if (_unselectedItemTintColor != unselectedItemTintColor &&
       ![_unselectedItemTintColor isEqual:unselectedItemTintColor]) {
     _unselectedItemTintColor = unselectedItemTintColor;
+    _unselectedTitleColor = unselectedItemTintColor;
 
     [self updateItemBarStyle];
   }
@@ -639,9 +692,12 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   style.selectionIndicatorTemplate = self.selectionIndicatorTemplate;
   style.selectionIndicatorColor = self.tintColor;
   style.inkColor = _inkColor;
-  style.selectedTitleColor = (_selectedItemTintColor ? _selectedItemTintColor : self.tintColor);
-  style.titleColor = _unselectedItemTintColor;
   style.displaysUppercaseTitles = self.displaysUppercaseTitles;
+
+  style.selectedTitleColor = _selectedTitleColor ?: self.tintColor;
+  style.titleColor = _unselectedTitleColor;
+  style.selectedImageTintColor = _selectedItemTintColor ?: self.tintColor;
+  style.imageTintColor = _unselectedItemTintColor;
 
   [_itemBar applyStyle:style];
 

--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -202,6 +202,7 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
 
     [self updateDisplayedTitle];
     [self updateTitleTextColor];
+    [self updateImageTintColor];
     [self updateInk];
     [self updateSubviews];
     [self updateTitleLines];
@@ -312,6 +313,7 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
   [super tintColorDidChange];
 
   [self updateTitleTextColor];
+  [self updateImageTintColor];
 }
 
 - (void)didMoveToWindow {
@@ -330,6 +332,7 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
 - (void)prepareForReuse {
   [super prepareForReuse];
   [self updateTitleTextColor];
+  [self updateImageTintColor];
   [self updateAccessibilityTraits];
   [_inkTouchController cancelInkTouchProcessing];
 }
@@ -342,6 +345,7 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
 
   [super setSelected:selected];
   [self updateTitleTextColor];
+  [self updateImageTintColor];
   [self updateAccessibilityTraits];
   [self updateTransformsAnimated:animate];
   [self updateTitleFont];
@@ -350,6 +354,7 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
 - (void)setHighlighted:(BOOL)highlighted {
   [super setHighlighted:highlighted];
   [self updateTitleTextColor];
+  [self updateImageTintColor];
 }
 
 #pragma mark - UIAccessibility
@@ -427,6 +432,8 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
 
       // Display our image in the new image view.
       [self updateDisplayedImage];
+
+      [self updateImageTintColor];
     }
 
     _imageView.hidden = NO;
@@ -475,6 +482,7 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
 
 - (void)updateColors {
   [self updateTitleTextColor];
+  [self updateImageTintColor];
   [self updateInk];
 }
 
@@ -485,7 +493,14 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
   }
   _titleLabel.textColor = textColor;
   _badgeLabel.textColor = textColor;
-  _imageView.tintColor = textColor;
+}
+
+- (void)updateImageTintColor {
+  UIColor *imageTintColor = _style.imageTintColor;
+  if (self.isHighlighted || self.isSelected) {
+    imageTintColor = _style.selectedImageTintColor;
+  }
+  _imageView.tintColor = imageTintColor;
 }
 
 - (void)updateTransformsAnimated:(BOOL)animated {

--- a/components/Tabs/src/private/MDCItemBarStyle.h
+++ b/components/Tabs/src/private/MDCItemBarStyle.h
@@ -58,6 +58,12 @@
 /** Color of title text when selected. Default is opaque white. */
 @property(nonatomic, strong, nonnull) UIColor *selectedTitleColor;
 
+/** Tint color of image when not selected. Default is opaque white. */
+@property(nonatomic, strong, nonnull) UIColor *imageTintColor;
+
+/** Tint color of image when selected. Default is opaque white. */
+@property(nonatomic, strong, nonnull) UIColor *selectedImageTintColor;
+
 /** Font used for selected item titles. */
 @property(nonatomic, strong, nonnull) UIFont *selectedTitleFont;
 

--- a/components/Tabs/src/private/MDCItemBarStyle.m
+++ b/components/Tabs/src/private/MDCItemBarStyle.m
@@ -22,6 +22,7 @@
   self = [super init];
   if (self) {
     _titleColor = [UIColor whiteColor];
+    _imageTintColor = [UIColor whiteColor];
     _displaysUppercaseTitles = YES;
     _shouldDisplayTitle = YES;
     _shouldDisplaySelectionIndicator = YES;
@@ -44,6 +45,8 @@
   newStyle.shouldGrowOnSelection = _shouldGrowOnSelection;
   newStyle.titleColor = _titleColor;
   newStyle.selectedTitleColor = _selectedTitleColor;
+  newStyle.imageTintColor = _imageTintColor;
+  newStyle.selectedImageTintColor = _selectedImageTintColor;
   newStyle.selectedTitleFont = _selectedTitleFont;
   newStyle.unselectedTitleFont = _unselectedTitleFont;
   newStyle.inkStyle = _inkStyle;


### PR DESCRIPTION
Deprecates selectedItemTintColor and unselectedItemTintColor and adds titleColorForState: and imageTintColorForState:, allowing clients to set the color for the title text and image tint separately.

https://www.pivotaltracker.com/story/show/156742602

Before:
![screen shot 2018-04-18 at 4 54 49 pm](https://user-images.githubusercontent.com/1418389/38957808-859f08cc-4329-11e8-9e70-d0e2436636cd.png)
![screen shot 2018-04-18 at 4 54 45 pm](https://user-images.githubusercontent.com/1418389/38957809-85aae5e8-4329-11e8-9eb0-2bde634335ed.png)
![screen shot 2018-04-18 at 4 54 40 pm](https://user-images.githubusercontent.com/1418389/38957810-85b30002-4329-11e8-957f-5cc3ef745e29.png)
![screen shot 2018-04-18 at 4 54 36 pm](https://user-images.githubusercontent.com/1418389/38957811-85bb3ace-4329-11e8-8f4a-7a6ab94074b5.png)
![screen shot 2018-04-18 at 4 54 31 pm](https://user-images.githubusercontent.com/1418389/38957812-85c35d4e-4329-11e8-9c32-22b7cf46d2be.png)
![screen shot 2018-04-18 at 4 54 26 pm](https://user-images.githubusercontent.com/1418389/38957813-85ccaad4-4329-11e8-9c3b-38b87fa15b59.png)
![screen shot 2018-04-18 at 4 54 20 pm](https://user-images.githubusercontent.com/1418389/38957814-85d78b7a-4329-11e8-8a8d-76ee9669dad4.png)
![screen shot 2018-04-18 at 4 54 15 pm](https://user-images.githubusercontent.com/1418389/38957815-85e3a05e-4329-11e8-836b-c1629e28105d.png)

After:
![screen shot 2018-04-18 at 4 48 27 pm](https://user-images.githubusercontent.com/1418389/38957825-8cdc401e-4329-11e8-981d-014441d3793a.png)
![screen shot 2018-04-18 at 4 48 18 pm](https://user-images.githubusercontent.com/1418389/38957826-8ce5e2e0-4329-11e8-9155-27522c002481.png)
![screen shot 2018-04-18 at 4 48 07 pm](https://user-images.githubusercontent.com/1418389/38957827-8cf233a6-4329-11e8-9dc1-e1704f2eaee5.png)
![screen shot 2018-04-18 at 4 48 00 pm](https://user-images.githubusercontent.com/1418389/38957828-8cfda2c2-4329-11e8-9c6f-479d339e9478.png)
![screen shot 2018-04-18 at 4 47 54 pm](https://user-images.githubusercontent.com/1418389/38957829-8d092eda-4329-11e8-8365-11c1160d9f2c.png)
![screen shot 2018-04-18 at 4 47 45 pm](https://user-images.githubusercontent.com/1418389/38957830-8d13e082-4329-11e8-85a0-d391e9b379cb.png)
![screen shot 2018-04-18 at 4 47 40 pm](https://user-images.githubusercontent.com/1418389/38957831-8d216324-4329-11e8-91e4-6ea7afa3bb9b.png)
![screen shot 2018-04-18 at 4 47 25 pm](https://user-images.githubusercontent.com/1418389/38957832-8d2ceeec-4329-11e8-9080-e7047b517312.png)
