### PR TITLE
[ButtonBar] Make left/right insets for image and text buttons consistent

### DIFF
--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
@@ -23,7 +23,7 @@
 #import "MDCButtonBarButton.h"
 #import "MDCButtonBar+Private.h"
 
-// Additional insets for the left-most or right-most items, primarily for image buttons.
+// Additional insets for the left-most or right-most items.
 static const CGFloat kEdgeButtonAdditionalMarginPhone = 4.f;
 static const CGFloat kEdgeButtonAdditionalMarginPad = 12.f;
 
@@ -32,11 +32,8 @@ static const CGFloat kEdgeButtonAdditionalMarginPad = 12.f;
 // button should look like when it is disabled.
 static const CGFloat kDisabledButtonAlpha = 0.45f;
 
-// Content insets for text-only buttons.
-static const UIEdgeInsets kTextOnlyButtonInset = {0, 24.f, 0, 24.f};
-
-// Content insets for image-only buttons.
-static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
+// Default content inset for buttons.
+static const UIEdgeInsets kButtonInset = {0, 12.0f, 0, 12.0f};
 
 // Indiana Jones style placeholder view for UINavigationBar. Ownership of UIBarButtonItem.customView
 // and UINavigationItem.titleView are normally transferred to UINavigationController but we plan to
@@ -146,23 +143,8 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
                            layoutHints:(MDCBarButtonItemLayoutHints)layoutHints
                        layoutDirection:(UIUserInterfaceLayoutDirection)layoutDirection
                     userInterfaceIdiom:(UIUserInterfaceIdiom)userInterfaceIdiom {
-  UIEdgeInsets contentInsets = UIEdgeInsetsZero;
-
-  UIEdgeInsets (^addInsets)(UIEdgeInsets, UIEdgeInsets) = ^(UIEdgeInsets i1, UIEdgeInsets i2) {
-    UIEdgeInsets sum = i1;
-    sum.left += i2.left;
-    sum.top += i2.top;
-    sum.right += i2.right;
-    sum.bottom += i2.bottom;
-    return sum;
-  };
-
-  if ([[button currentTitle] length]) {  // Text-only buttons.
-    contentInsets = addInsets(contentInsets, kTextOnlyButtonInset);
-
-  } else if ([button currentImage]) {  // Image-only buttons.
-    contentInsets = addInsets(contentInsets, kImageOnlyButtonInset);
-
+  UIEdgeInsets contentInsets = kButtonInset;
+  if ([button currentImage] || [button currentTitle].length) {
     BOOL isPad = userInterfaceIdiom == UIUserInterfaceIdiomPad;
     CGFloat additionalInset =
         (isPad ? kEdgeButtonAdditionalMarginPad : kEdgeButtonAdditionalMarginPhone);

--- a/components/ButtonBar/tests/unit/ButtonBarBuilderTests.m
+++ b/components/ButtonBar/tests/unit/ButtonBarBuilderTests.m
@@ -39,37 +39,10 @@
 #pragma mark - +contentInsetsForButton:layoutPosition:layoutHints:layoutDirection:userInterfaceIdiom:
 - (void)testContentInsetsEqualForInterfaceLayoutIdiomPhone {
   // Given
-  MDCButton *titleButton = [[MDCButton alloc] initWithFrame:CGRectZero];
-  [titleButton setTitle:@"Title" forState:UIControlStateNormal];
   MDCButton *imageButton = [[MDCButton alloc] initWithFrame:CGRectZero];
   [imageButton setImage:[[UIImage alloc] init] forState:UIControlStateNormal];
 
   // When
-  UIEdgeInsets ltrTitleInsetsFirst =
-      [MDCAppBarButtonBarBuilder contentInsetsForButton:titleButton
-                                         layoutPosition:MDCButtonBarLayoutPositionLeading
-                                            layoutHints:MDCBarButtonItemLayoutHintsIsFirstButton
-                                        layoutDirection:UIUserInterfaceLayoutDirectionLeftToRight
-                                     userInterfaceIdiom:UIUserInterfaceIdiomPhone];
-  UIEdgeInsets rtlTitleInsetsFirst =
-      [MDCAppBarButtonBarBuilder contentInsetsForButton:titleButton
-                                         layoutPosition:MDCButtonBarLayoutPositionLeading
-                                            layoutHints:MDCBarButtonItemLayoutHintsIsFirstButton
-                                        layoutDirection:UIUserInterfaceLayoutDirectionRightToLeft
-                                     userInterfaceIdiom:UIUserInterfaceIdiomPhone];
-  UIEdgeInsets ltrTitleInsetsLast =
-      [MDCAppBarButtonBarBuilder contentInsetsForButton:titleButton
-                                         layoutPosition:MDCButtonBarLayoutPositionLeading
-                                            layoutHints:MDCBarButtonItemLayoutHintsIsLastButton
-                                        layoutDirection:UIUserInterfaceLayoutDirectionLeftToRight
-                                     userInterfaceIdiom:UIUserInterfaceIdiomPhone];
-  UIEdgeInsets rtlTitleInsetsLast =
-      [MDCAppBarButtonBarBuilder contentInsetsForButton:titleButton
-                                         layoutPosition:MDCButtonBarLayoutPositionLeading
-                                            layoutHints:MDCBarButtonItemLayoutHintsIsLastButton
-                                        layoutDirection:UIUserInterfaceLayoutDirectionRightToLeft
-                                     userInterfaceIdiom:UIUserInterfaceIdiomPhone];
-
   UIEdgeInsets ltrImageInsetsFirst =
       [MDCAppBarButtonBarBuilder contentInsetsForButton:imageButton
                                          layoutPosition:MDCButtonBarLayoutPositionLeading
@@ -96,16 +69,6 @@
                                      userInterfaceIdiom:UIUserInterfaceIdiomPhone];
 
   // Then
-  XCTAssertEqual(ltrTitleInsetsFirst.left, rtlTitleInsetsFirst.right);
-  XCTAssertEqual(ltrTitleInsetsFirst.right, rtlTitleInsetsFirst.left);
-  XCTAssertEqual(ltrTitleInsetsFirst.top, rtlTitleInsetsFirst.top);
-  XCTAssertEqual(ltrTitleInsetsFirst.bottom, rtlTitleInsetsFirst.bottom);
-
-  XCTAssertEqual(ltrTitleInsetsLast.left, rtlTitleInsetsLast.right);
-  XCTAssertEqual(ltrTitleInsetsLast.right, rtlTitleInsetsLast.left);
-  XCTAssertEqual(ltrTitleInsetsLast.top, rtlTitleInsetsLast.top);
-  XCTAssertEqual(ltrTitleInsetsLast.bottom, rtlTitleInsetsLast.bottom);
-
   XCTAssertEqual(ltrImageInsetsFirst.left, rtlImageInsetsFirst.right);
   XCTAssertEqual(ltrImageInsetsFirst.right, rtlImageInsetsFirst.left);
   XCTAssertEqual(ltrImageInsetsFirst.top, rtlImageInsetsFirst.top);
@@ -119,37 +82,10 @@
 
 - (void)testContentInsetsEqualForInterfaceLayoutIdiomPad {
   // Given
-  MDCButton *titleButton = [[MDCButton alloc] initWithFrame:CGRectZero];
-  [titleButton setTitle:@"Title" forState:UIControlStateNormal];
   MDCButton *imageButton = [[MDCButton alloc] initWithFrame:CGRectZero];
   [imageButton setImage:[[UIImage alloc] init] forState:UIControlStateNormal];
 
   // When
-  UIEdgeInsets ltrTitleInsetsFirst =
-      [MDCAppBarButtonBarBuilder contentInsetsForButton:titleButton
-                                         layoutPosition:MDCButtonBarLayoutPositionLeading
-                                            layoutHints:MDCBarButtonItemLayoutHintsIsFirstButton
-                                        layoutDirection:UIUserInterfaceLayoutDirectionLeftToRight
-                                     userInterfaceIdiom:UIUserInterfaceIdiomPad];
-  UIEdgeInsets rtlTitleInsetsFirst =
-      [MDCAppBarButtonBarBuilder contentInsetsForButton:titleButton
-                                         layoutPosition:MDCButtonBarLayoutPositionLeading
-                                            layoutHints:MDCBarButtonItemLayoutHintsIsFirstButton
-                                        layoutDirection:UIUserInterfaceLayoutDirectionRightToLeft
-                                     userInterfaceIdiom:UIUserInterfaceIdiomPad];
-  UIEdgeInsets ltrTitleInsetsLast =
-      [MDCAppBarButtonBarBuilder contentInsetsForButton:titleButton
-                                         layoutPosition:MDCButtonBarLayoutPositionLeading
-                                            layoutHints:MDCBarButtonItemLayoutHintsIsLastButton
-                                        layoutDirection:UIUserInterfaceLayoutDirectionLeftToRight
-                                     userInterfaceIdiom:UIUserInterfaceIdiomPad];
-  UIEdgeInsets rtlTitleInsetsLast =
-      [MDCAppBarButtonBarBuilder contentInsetsForButton:titleButton
-                                         layoutPosition:MDCButtonBarLayoutPositionLeading
-                                            layoutHints:MDCBarButtonItemLayoutHintsIsLastButton
-                                        layoutDirection:UIUserInterfaceLayoutDirectionRightToLeft
-                                     userInterfaceIdiom:UIUserInterfaceIdiomPad];
-
   UIEdgeInsets ltrImageInsetsFirst =
       [MDCAppBarButtonBarBuilder contentInsetsForButton:imageButton
                                          layoutPosition:MDCButtonBarLayoutPositionLeading
@@ -176,16 +112,6 @@
                                      userInterfaceIdiom:UIUserInterfaceIdiomPad];
 
   // Then
-  XCTAssertEqual(ltrTitleInsetsFirst.left, rtlTitleInsetsFirst.right);
-  XCTAssertEqual(ltrTitleInsetsFirst.right, rtlTitleInsetsFirst.left);
-  XCTAssertEqual(ltrTitleInsetsFirst.top, rtlTitleInsetsFirst.top);
-  XCTAssertEqual(ltrTitleInsetsFirst.bottom, rtlTitleInsetsFirst.bottom);
-
-  XCTAssertEqual(ltrTitleInsetsLast.left, rtlTitleInsetsLast.right);
-  XCTAssertEqual(ltrTitleInsetsLast.right, rtlTitleInsetsLast.left);
-  XCTAssertEqual(ltrTitleInsetsLast.top, rtlTitleInsetsLast.top);
-  XCTAssertEqual(ltrTitleInsetsLast.bottom, rtlTitleInsetsLast.bottom);
-
   XCTAssertEqual(ltrImageInsetsFirst.left, rtlImageInsetsFirst.right);
   XCTAssertEqual(ltrImageInsetsFirst.right, rtlImageInsetsFirst.left);
   XCTAssertEqual(ltrImageInsetsFirst.top, rtlImageInsetsFirst.top);
@@ -201,7 +127,7 @@
   // Given
   MDCButton *imageButton = [[MDCButton alloc] initWithFrame:CGRectZero];
   [imageButton setImage:[[UIImage alloc] init] forState:UIControlStateNormal];
-  
+
   // When
   UIEdgeInsets insetsFirstLeading =
       [MDCAppBarButtonBarBuilder contentInsetsForButton:imageButton
@@ -232,6 +158,86 @@
   // Then
   XCTAssertEqual(insetsFirstLeading.left, insetsFirstTrailing.right);
   XCTAssertEqual(insetsLastLeading.right, insetsLastTrailing.left);
+}
+
+- (void)testContentInsetsEqualForTitleAndImageButtonIdiomPhone {
+  // Given
+  MDCButton *titleButton = [[MDCButton alloc] initWithFrame:CGRectZero];
+  [titleButton setTitle:@"Title" forState:UIControlStateNormal];
+  MDCButton *imageButton = [[MDCButton alloc] initWithFrame:CGRectZero];
+  [imageButton setImage:[[UIImage alloc] init] forState:UIControlStateNormal];
+
+  // When
+  UIEdgeInsets imageInsetsFirst =
+  [MDCAppBarButtonBarBuilder contentInsetsForButton:imageButton
+                                     layoutPosition:MDCButtonBarLayoutPositionLeading
+                                        layoutHints:MDCBarButtonItemLayoutHintsIsFirstButton
+                                    layoutDirection:UIUserInterfaceLayoutDirectionLeftToRight
+                                 userInterfaceIdiom:UIUserInterfaceIdiomPhone];
+  UIEdgeInsets titleInsetsFirst =
+  [MDCAppBarButtonBarBuilder contentInsetsForButton:titleButton
+                                     layoutPosition:MDCButtonBarLayoutPositionLeading
+                                        layoutHints:MDCBarButtonItemLayoutHintsIsFirstButton
+                                    layoutDirection:UIUserInterfaceLayoutDirectionLeftToRight
+                                 userInterfaceIdiom:UIUserInterfaceIdiomPhone];
+  UIEdgeInsets imageInsetsLast =
+  [MDCAppBarButtonBarBuilder contentInsetsForButton:imageButton
+                                     layoutPosition:MDCButtonBarLayoutPositionLeading
+                                        layoutHints:MDCBarButtonItemLayoutHintsIsLastButton
+                                    layoutDirection:UIUserInterfaceLayoutDirectionLeftToRight
+                                 userInterfaceIdiom:UIUserInterfaceIdiomPhone];
+  UIEdgeInsets titleInsetsLast =
+  [MDCAppBarButtonBarBuilder contentInsetsForButton:titleButton
+                                     layoutPosition:MDCButtonBarLayoutPositionLeading
+                                        layoutHints:MDCBarButtonItemLayoutHintsIsLastButton
+                                    layoutDirection:UIUserInterfaceLayoutDirectionLeftToRight
+                                 userInterfaceIdiom:UIUserInterfaceIdiomPhone];
+
+  // Then
+  XCTAssertEqual(imageInsetsFirst.left, titleInsetsFirst.left);
+  XCTAssertEqual(imageInsetsFirst.right, titleInsetsFirst.right);
+  XCTAssertEqual(imageInsetsLast.left, titleInsetsLast.left);
+  XCTAssertEqual(imageInsetsLast.right, titleInsetsLast.right);
+}
+
+- (void)testContentInsetsEqualForTitleAndImageButtonIdiomPad {
+  // Given
+  MDCButton *titleButton = [[MDCButton alloc] initWithFrame:CGRectZero];
+  [titleButton setTitle:@"Title" forState:UIControlStateNormal];
+  MDCButton *imageButton = [[MDCButton alloc] initWithFrame:CGRectZero];
+  [imageButton setImage:[[UIImage alloc] init] forState:UIControlStateNormal];
+
+  // When
+  UIEdgeInsets imageInsetsFirst =
+  [MDCAppBarButtonBarBuilder contentInsetsForButton:imageButton
+                                     layoutPosition:MDCButtonBarLayoutPositionLeading
+                                        layoutHints:MDCBarButtonItemLayoutHintsIsFirstButton
+                                    layoutDirection:UIUserInterfaceLayoutDirectionLeftToRight
+                                 userInterfaceIdiom:UIUserInterfaceIdiomPad];
+  UIEdgeInsets titleInsetsFirst =
+  [MDCAppBarButtonBarBuilder contentInsetsForButton:titleButton
+                                     layoutPosition:MDCButtonBarLayoutPositionLeading
+                                        layoutHints:MDCBarButtonItemLayoutHintsIsFirstButton
+                                    layoutDirection:UIUserInterfaceLayoutDirectionLeftToRight
+                                 userInterfaceIdiom:UIUserInterfaceIdiomPad];
+  UIEdgeInsets imageInsetsLast =
+  [MDCAppBarButtonBarBuilder contentInsetsForButton:imageButton
+                                     layoutPosition:MDCButtonBarLayoutPositionLeading
+                                        layoutHints:MDCBarButtonItemLayoutHintsIsLastButton
+                                    layoutDirection:UIUserInterfaceLayoutDirectionLeftToRight
+                                 userInterfaceIdiom:UIUserInterfaceIdiomPad];
+  UIEdgeInsets titleInsetsLast =
+  [MDCAppBarButtonBarBuilder contentInsetsForButton:titleButton
+                                     layoutPosition:MDCButtonBarLayoutPositionLeading
+                                        layoutHints:MDCBarButtonItemLayoutHintsIsLastButton
+                                    layoutDirection:UIUserInterfaceLayoutDirectionLeftToRight
+                                 userInterfaceIdiom:UIUserInterfaceIdiomPad];
+
+  // Then
+  XCTAssertEqual(imageInsetsFirst.left, titleInsetsFirst.left);
+  XCTAssertEqual(imageInsetsFirst.right, titleInsetsFirst.right);
+  XCTAssertEqual(imageInsetsLast.left, titleInsetsLast.left);
+  XCTAssertEqual(imageInsetsLast.right, titleInsetsLast.right);
 }
 
 #pragma mark - +configureButton:fromButtonItem:


### PR DESCRIPTION
Internal testing of this PR is done in cl/193415210. This is a behavior change for text button insets in MDCButtonBar.

NOTE: This doesn't *change* insets for text buttons that are the only button in the bar on iPad, since it still adds a 12pt inset on both sides for it. on iPhone, the additional inset for edge buttons is 4pt, which results in a 16pt inset on the edge side(s).

Before screenshots:
[Text buttons on both sides](https://user-images.githubusercontent.com/2232489/38957009-57ca20fa-4327-11e8-9f62-a92a61c7f20f.png)
[Text button on one side](https://user-images.githubusercontent.com/2232489/38957010-57d6b784-4327-11e8-8971-2c565833052d.png)

After screenshots:
[Text buttons on both sides](https://user-images.githubusercontent.com/2232489/38957016-5c719ee4-4327-11e8-886c-a7b6bdece4b5.png)
[Text button on one side](https://user-images.githubusercontent.com/2232489/38957017-5c7ebd36-4327-11e8-868b-5fde087eb382.png)

closes #3342