### PR TITLE
[Button] Changed text button disabled to do 37% opacity, Ink to use onSurface 16%

### DIFF
--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -47,7 +47,7 @@
   MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
   MDCTypographyScheme *typographyScheme = [[MDCTypographyScheme alloc] init];
 
-  self.view.backgroundColor = [UIColor colorWithWhite:0.9f alpha:1];
+  self.view.backgroundColor = [UIColor whiteColor];
   UIColor *titleColor = [UIColor whiteColor];
 
   // Raised button

--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -50,6 +50,33 @@
   self.view.backgroundColor = [UIColor colorWithWhite:0.9f alpha:1];
   UIColor *titleColor = [UIColor whiteColor];
 
+  // Raised button
+
+  MDCRaisedButton *raisedButton = [[MDCRaisedButton alloc] init];
+  [raisedButton setTitleColor:titleColor forState:UIControlStateNormal];
+  [raisedButton setTitle:@"Button" forState:UIControlStateNormal];
+  [MDCButtonTypographyThemer applyTypographyScheme:typographyScheme toButton:raisedButton];
+  [MDCButtonColorThemer applySemanticColorScheme:colorScheme toRaisedButton:raisedButton];
+  [raisedButton sizeToFit];
+  [raisedButton addTarget:self
+                   action:@selector(didTap:)
+         forControlEvents:UIControlEventTouchUpInside];
+  [self.view addSubview:raisedButton];
+
+  // Disabled raised button
+
+  MDCRaisedButton *disabledRaisedButton = [[MDCRaisedButton alloc] init];
+  [disabledRaisedButton setTitleColor:titleColor forState:UIControlStateNormal];
+  [disabledRaisedButton setTitle:@"Button" forState:UIControlStateNormal];
+  [MDCButtonTypographyThemer applyTypographyScheme:typographyScheme toButton:disabledRaisedButton];
+  [MDCButtonColorThemer applySemanticColorScheme:colorScheme toRaisedButton:disabledRaisedButton];
+  [disabledRaisedButton sizeToFit];
+  [disabledRaisedButton addTarget:self
+                           action:@selector(didTap:)
+                 forControlEvents:UIControlEventTouchUpInside];
+  [disabledRaisedButton setEnabled:NO];
+  [self.view addSubview:disabledRaisedButton];
+
   // Text button
 
   MDCButton *textButton = [[MDCButton alloc] init];
@@ -72,31 +99,6 @@
                forControlEvents:UIControlEventTouchUpInside];
   [disabledTextButton setEnabled:NO];
   [self.view addSubview:disabledTextButton];
-
-  // Flat button
-
-  MDCFlatButton *flatButton = [[MDCFlatButton alloc] init];
-  [flatButton setTitle:@"Button" forState:UIControlStateNormal];
-  [MDCButtonTypographyThemer applyTypographyScheme:typographyScheme toButton:flatButton];
-  [MDCButtonColorThemer applySemanticColorScheme:colorScheme toFlatButton:flatButton];
-  [flatButton sizeToFit];
-  [flatButton addTarget:self
-                 action:@selector(didTap:)
-       forControlEvents:UIControlEventTouchUpInside];
-  [self.view addSubview:flatButton];
-
-  // Disabled flat
-
-  MDCFlatButton *disabledFlatButton = [[MDCFlatButton alloc] init];
-  [disabledFlatButton setTitle:@"Button" forState:UIControlStateNormal];
-  [MDCButtonTypographyThemer applyTypographyScheme:typographyScheme toButton:disabledFlatButton];
-  [MDCButtonColorThemer applySemanticColorScheme:colorScheme toFlatButton:disabledFlatButton];
-  [disabledFlatButton sizeToFit];
-  [disabledFlatButton addTarget:self
-                         action:@selector(didTap:)
-               forControlEvents:UIControlEventTouchUpInside];
-  [disabledFlatButton setEnabled:NO];
-  [self.view addSubview:disabledFlatButton];
 
   // Custom stroked button
 
@@ -140,7 +142,7 @@
   [self.view addSubview:self.floatingButton];
 
   self.buttons = @[
-    textButton, disabledTextButton, flatButton, disabledFlatButton, strokedButton,
+    raisedButton, disabledRaisedButton, textButton, disabledTextButton, strokedButton,
     disabledStrokedButton, self.floatingButton
   ];
 
@@ -148,16 +150,16 @@
 }
 
 - (void)setupExampleViews {
+  UILabel *raisedButtonLabel = [self addLabelWithText:@"Raised"];
+  UILabel *disabledRaisedButtonLabel = [self addLabelWithText:@"Disabled Raised"];
   UILabel *textButtonLabel = [self addLabelWithText:@"Text button"];
   UILabel *disabledTextButtonLabel = [self addLabelWithText:@"Disabled text button"];
-  UILabel *flatButtonLabel = [self addLabelWithText:@"Flat"];
-  UILabel *disabledFlatButtonLabel = [self addLabelWithText:@"Disabled Flat"];
   UILabel *strokedButtonLabel = [self addLabelWithText:@"Stroked"];
   UILabel *disabledStrokedButtonLabel = [self addLabelWithText:@"Disabled Stroked"];
   UILabel *floatingButtonLabel = [self addLabelWithText:@"Floating Action"];
 
   self.labels = @[
-    textButtonLabel, disabledTextButtonLabel, flatButtonLabel, disabledFlatButtonLabel,
+    raisedButtonLabel, disabledRaisedButtonLabel, textButtonLabel, disabledTextButtonLabel,
     strokedButtonLabel, disabledStrokedButtonLabel, floatingButtonLabel
   ];
 }

--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -61,19 +61,17 @@
        forControlEvents:UIControlEventTouchUpInside];
   [self.view addSubview:textButton];
 
-  // Disabled raised button
+  // Disabled Text button
 
-  MDCRaisedButton *disabledRaisedButton = [[MDCRaisedButton alloc] init];
-  [disabledRaisedButton setTitleColor:titleColor forState:UIControlStateNormal];
-  [disabledRaisedButton setTitle:@"Button" forState:UIControlStateNormal];
-  [MDCButtonTypographyThemer applyTypographyScheme:typographyScheme toButton:disabledRaisedButton];
-  [MDCButtonColorThemer applySemanticColorScheme:colorScheme toRaisedButton:disabledRaisedButton];
-  [disabledRaisedButton sizeToFit];
-  [disabledRaisedButton addTarget:self
-                           action:@selector(didTap:)
-                 forControlEvents:UIControlEventTouchUpInside];
-  [disabledRaisedButton setEnabled:NO];
-  [self.view addSubview:disabledRaisedButton];
+  MDCButton *disabledTextButton = [[MDCButton alloc] init];
+  [disabledTextButton setTitle:@"Disabled button" forState:UIControlStateNormal];
+  [MDCTextButtonThemer applyScheme:buttonScheme toButton:disabledTextButton];
+  [disabledTextButton sizeToFit];
+  [disabledTextButton addTarget:self
+                         action:@selector(didTap:)
+               forControlEvents:UIControlEventTouchUpInside];
+  [disabledTextButton setEnabled:NO];
+  [self.view addSubview:disabledTextButton];
 
   // Flat button
 
@@ -142,7 +140,7 @@
   [self.view addSubview:self.floatingButton];
 
   self.buttons = @[
-    textButton, disabledRaisedButton, flatButton, disabledFlatButton, strokedButton,
+    textButton, disabledTextButton, flatButton, disabledFlatButton, strokedButton,
     disabledStrokedButton, self.floatingButton
   ];
 
@@ -151,7 +149,7 @@
 
 - (void)setupExampleViews {
   UILabel *textButtonLabel = [self addLabelWithText:@"Text button"];
-  UILabel *disabledRaisedButtonLabel = [self addLabelWithText:@"Disabled Raised"];
+  UILabel *disabledTextButtonLabel = [self addLabelWithText:@"Disabled text button"];
   UILabel *flatButtonLabel = [self addLabelWithText:@"Flat"];
   UILabel *disabledFlatButtonLabel = [self addLabelWithText:@"Disabled Flat"];
   UILabel *strokedButtonLabel = [self addLabelWithText:@"Stroked"];
@@ -159,7 +157,7 @@
   UILabel *floatingButtonLabel = [self addLabelWithText:@"Floating Action"];
 
   self.labels = @[
-    textButtonLabel, disabledRaisedButtonLabel, flatButtonLabel, disabledFlatButtonLabel,
+    textButtonLabel, disabledTextButtonLabel, flatButtonLabel, disabledFlatButtonLabel,
     strokedButtonLabel, disabledStrokedButtonLabel, floatingButtonLabel
   ];
 }

--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -81,7 +81,7 @@
 
   MDCButton *textButton = [[MDCButton alloc] init];
   [MDCTextButtonThemer applyScheme:buttonScheme toButton:textButton];
-  [textButton setTitle:@"Text button" forState:UIControlStateNormal];
+  [textButton setTitle:@"Button" forState:UIControlStateNormal];
   [textButton sizeToFit];
   [textButton addTarget:self
                  action:@selector(didTap:)
@@ -91,7 +91,7 @@
   // Disabled Text button
 
   MDCButton *disabledTextButton = [[MDCButton alloc] init];
-  [disabledTextButton setTitle:@"Disabled button" forState:UIControlStateNormal];
+  [disabledTextButton setTitle:@"Button" forState:UIControlStateNormal];
   [MDCTextButtonThemer applyScheme:buttonScheme toButton:disabledTextButton];
   [disabledTextButton sizeToFit];
   [disabledTextButton addTarget:self

--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -18,6 +18,9 @@
 #import "MDCButtonTypographyThemer.h"
 #import "MaterialButtons.h"
 #import "MaterialTypography.h"
+#import "MDCTextButtonThemer.h"
+#import "MDCContainedButtonThemer.h"
+
 #import "supplemental/ButtonsTypicalUseSupplemental.h"
 
 @interface ButtonsTypicalUseExampleViewController ()
@@ -40,25 +43,23 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-
+  MDCButtonScheme *buttonScheme = [[MDCButtonScheme alloc] init];
   MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
   MDCTypographyScheme *typographyScheme = [[MDCTypographyScheme alloc] init];
 
   self.view.backgroundColor = [UIColor colorWithWhite:0.9f alpha:1];
   UIColor *titleColor = [UIColor whiteColor];
 
-  // Raised button
+  // Text button
 
-  MDCRaisedButton *raisedButton = [[MDCRaisedButton alloc] init];
-  [raisedButton setTitleColor:titleColor forState:UIControlStateNormal];
-  [raisedButton setTitle:@"Button" forState:UIControlStateNormal];
-  [MDCButtonTypographyThemer applyTypographyScheme:typographyScheme toButton:raisedButton];
-  [MDCButtonColorThemer applySemanticColorScheme:colorScheme toRaisedButton:raisedButton];
-  [raisedButton sizeToFit];
-  [raisedButton addTarget:self
-                   action:@selector(didTap:)
-         forControlEvents:UIControlEventTouchUpInside];
-  [self.view addSubview:raisedButton];
+  MDCButton *textButton = [[MDCButton alloc] init];
+  [MDCTextButtonThemer applyScheme:buttonScheme toButton:textButton];
+  [textButton setTitle:@"Text button" forState:UIControlStateNormal];
+  [textButton sizeToFit];
+  [textButton addTarget:self
+                 action:@selector(didTap:)
+       forControlEvents:UIControlEventTouchUpInside];
+  [self.view addSubview:textButton];
 
   // Disabled raised button
 
@@ -141,7 +142,7 @@
   [self.view addSubview:self.floatingButton];
 
   self.buttons = @[
-    raisedButton, disabledRaisedButton, flatButton, disabledFlatButton, strokedButton,
+    textButton, disabledRaisedButton, flatButton, disabledFlatButton, strokedButton,
     disabledStrokedButton, self.floatingButton
   ];
 
@@ -149,7 +150,7 @@
 }
 
 - (void)setupExampleViews {
-  UILabel *raisedButtonLabel = [self addLabelWithText:@"Raised"];
+  UILabel *textButtonLabel = [self addLabelWithText:@"Text button"];
   UILabel *disabledRaisedButtonLabel = [self addLabelWithText:@"Disabled Raised"];
   UILabel *flatButtonLabel = [self addLabelWithText:@"Flat"];
   UILabel *disabledFlatButtonLabel = [self addLabelWithText:@"Disabled Flat"];
@@ -158,7 +159,7 @@
   UILabel *floatingButtonLabel = [self addLabelWithText:@"Floating Action"];
 
   self.labels = @[
-    raisedButtonLabel, disabledRaisedButtonLabel, flatButtonLabel, disabledFlatButtonLabel,
+    textButtonLabel, disabledRaisedButtonLabel, flatButtonLabel, disabledFlatButtonLabel,
     strokedButtonLabel, disabledStrokedButtonLabel, floatingButtonLabel
   ];
 }

--- a/components/Buttons/src/ColorThemer/MDCTextButtonColorThemer.m
+++ b/components/Buttons/src/ColorThemer/MDCTextButtonColorThemer.m
@@ -24,9 +24,10 @@
   [button setBackgroundColor:UIColor.clearColor forState:UIControlStateNormal];
   [button setBackgroundColor:UIColor.clearColor forState:UIControlStateDisabled];
   [button setTitleColor:colorScheme.primaryColor forState:UIControlStateNormal];
-  [button setTitleColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:0.26f]
-                   forState:UIControlStateDisabled];
+  [button setTitleColor:[colorScheme.primaryColor colorWithAlphaComponent:0.37f]
+               forState:UIControlStateDisabled];
   button.disabledAlpha = 1.f;
+  button.inkColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.16f];
 }
 
 + (void)resetUIControlStatesForButtonTheming:(nonnull MDCButton *)button {

--- a/components/Buttons/src/ColorThemer/MDCTextButtonColorThemer.m
+++ b/components/Buttons/src/ColorThemer/MDCTextButtonColorThemer.m
@@ -24,7 +24,7 @@
   [button setBackgroundColor:UIColor.clearColor forState:UIControlStateNormal];
   [button setBackgroundColor:UIColor.clearColor forState:UIControlStateDisabled];
   [button setTitleColor:colorScheme.primaryColor forState:UIControlStateNormal];
-  [button setTitleColor:[colorScheme.primaryColor colorWithAlphaComponent:0.37f]
+  [button setTitleColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:0.37f]
                forState:UIControlStateDisabled];
   button.disabledAlpha = 1.f;
   button.inkColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.16f];

--- a/components/Buttons/tests/unit/ButtonThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonThemerTests.m
@@ -45,7 +45,11 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   XCTAssertEqualObjects([button titleColorForState:UIControlStateNormal], colorScheme.primaryColor);
   XCTAssertEqualWithAccuracy(button.layer.cornerRadius, 4, kEpsilonAccuracy);
   XCTAssertEqualWithAccuracy([button elevationForState:UIControlStateNormal], 0, kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy([button elevationForState:UIControlStateHighlighted], 0,
+                             kEpsilonAccuracy);
   XCTAssertEqualObjects([button titleFontForState:UIControlStateNormal], typographyScheme.button);
+  XCTAssertEqualObjects(button.inkColor,
+                        [colorScheme.onSurfaceColor colorWithAlphaComponent:0.16f]);
 }
 
 - (void)testContainedButtonThemer {

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -44,7 +44,7 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
                         UIColor.clearColor);
   XCTAssertEqualObjects([button titleColorForState:UIControlStateNormal], colorScheme.primaryColor);
   XCTAssertEqualObjects([button titleColorForState:UIControlStateDisabled],
-                        [colorScheme.onSurfaceColor colorWithAlphaComponent:0.26f]);
+                        [colorScheme.primaryColor colorWithAlphaComponent:0.37f]);
   NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
       UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
@@ -163,8 +163,10 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
     } else {
       XCTAssert(
           CGColorEqualToColor([button titleColorForState:state].CGColor,
-                              [colorScheme.onSurfaceColor colorWithAlphaComponent:0.26f].CGColor));
-      XCTAssertEqual([button backgroundColorForState:state], UIColor.clearColor);
+                              [colorScheme.primaryColor colorWithAlphaComponent:0.37f].CGColor),
+          @"state:%lu", (unsigned long)state);
+      XCTAssertEqual([button backgroundColorForState:state], UIColor.clearColor, @"state:%lu",
+                     (unsigned long)state);
     }
   }
   XCTAssertEqualWithAccuracy(button.disabledAlpha, 1.f, 0.001f);

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -44,7 +44,7 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
                         UIColor.clearColor);
   XCTAssertEqualObjects([button titleColorForState:UIControlStateNormal], colorScheme.primaryColor);
   XCTAssertEqualObjects([button titleColorForState:UIControlStateDisabled],
-                        [colorScheme.primaryColor colorWithAlphaComponent:0.37f]);
+                        [colorScheme.onSurfaceColor colorWithAlphaComponent:0.37f]);
   NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
       UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
@@ -163,7 +163,7 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
     } else {
       XCTAssert(
           CGColorEqualToColor([button titleColorForState:state].CGColor,
-                              [colorScheme.primaryColor colorWithAlphaComponent:0.37f].CGColor),
+                              [colorScheme.onSurfaceColor colorWithAlphaComponent:0.37f].CGColor),
           @"state:%lu", (unsigned long)state);
       XCTAssertEqual([button backgroundColorForState:state], UIColor.clearColor, @"state:%lu",
                      (unsigned long)state);


### PR DESCRIPTION
Changed typical use example to use MDCTextButtonThemer.

https://www.pivotaltracker.com/story/show/156402729

before:
![simulator screen shot - iphone 8 plus - 2018-04-19 at 12 12 57](https://user-images.githubusercontent.com/943565/39004311-096558cc-43cb-11e8-8338-5ab4deb7ed90.png)

after:
![simulator screen shot - iphone 8 plus - 2018-04-19 at 14 00 25](https://user-images.githubusercontent.com/943565/39009598-0fc7c3e4-43da-11e8-9215-1184781ca759.png)

Ink screenshots:
before:
![simulator screen shot - iphone 8 plus - 2018-04-19 at 12 13 58](https://user-images.githubusercontent.com/943565/39004389-334189ae-43cb-11e8-86d1-dd4b0e45e731.png)

after:
![simulator screen shot - iphone 8 plus - 2018-04-19 at 14 00 27](https://user-images.githubusercontent.com/943565/39009606-14209cb8-43da-11e8-9e0b-d1610d45fed2.png)
