### PR TITLE
[ButtonBar] Fix layout behavior when using custom button title font.

### DIFF
--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -426,13 +426,15 @@ static NSString *const MDCButtonBarButtonLayoutPositionKey = @"MDCButtonBarButto
 
       if (i < [_items count]) {
         UIBarButtonItem *item = _items[i];
-        [button sizeToFit];
 
+        CGRect frame = button.frame;
         if (item.width > 0) {
-          CGRect frame = button.frame;
           frame.size.width = item.width;
-          button.frame = frame;
+        } else {
+          frame.size.width = [button sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)].width;
         }
+        button.frame = frame;
+
         [self setNeedsLayout];
       }
     }

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -418,14 +418,14 @@ static NSString *const MDCButtonBarButtonLayoutPositionKey = @"MDCButtonBarButto
 - (void)setButtonsTitleFont:(UIFont *)font forState:(UIControlState)state {
   [_defaultBuilder setTitleFont:font forState:state];
 
-  for (NSUInteger ix = 0; ix < [_buttonViews count]; ++ix) {
-    UIView *viewObj = _buttonViews[ix];
+  for (NSUInteger i = 0; i < [_buttonViews count]; ++i) {
+    UIView *viewObj = _buttonViews[i];
     if ([viewObj isKindOfClass:[UIButton class]]) {
       MDCButton *button = (MDCButton *)viewObj;
       [button setTitleFont:font forState:state];
 
-      if (ix < [_items count]) {
-        UIBarButtonItem *item = _items[ix];
+      if (i < [_items count]) {
+        UIBarButtonItem *item = _items[i];
         [button sizeToFit];
 
         if (item.width > 0) {

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -418,10 +418,23 @@ static NSString *const MDCButtonBarButtonLayoutPositionKey = @"MDCButtonBarButto
 - (void)setButtonsTitleFont:(UIFont *)font forState:(UIControlState)state {
   [_defaultBuilder setTitleFont:font forState:state];
 
-  for (UIView *viewObj in _buttonViews) {
+  for (NSUInteger ix = 0; ix < [_buttonViews count]; ++ix) {
+    UIView *viewObj = _buttonViews[ix];
     if ([viewObj isKindOfClass:[UIButton class]]) {
       MDCButton *button = (MDCButton *)viewObj;
       [button setTitleFont:font forState:state];
+
+      if (ix < [_items count]) {
+        UIBarButtonItem *item = _items[ix];
+        [button sizeToFit];
+
+        if (item.width > 0) {
+          CGRect frame = button.frame;
+          frame.size.width = item.width;
+          button.frame = frame;
+        }
+        [self setNeedsLayout];
+      }
     }
   }
 }

--- a/components/ButtonBar/tests/unit/ButtonBarButtonTitleFontTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarButtonTitleFontTests.swift
@@ -75,6 +75,20 @@ class ButtonBarButtonTitleFontTests: XCTestCase {
     }
   }
 
+  func testCustomFontChangesButtonFrames() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    let font = UIFont.systemFont(ofSize: 100)
+
+    // When
+    buttonBar.items = items
+    let initialFrames = buttonBar.subviews.map { $0.frame }
+    buttonBar.setButtonsTitleFont(font, for: .normal)
+    let updatedFrames = buttonBar.subviews.map { $0.frame }
+
+    XCTAssertNotEqual(initialFrames, updatedFrames)
+  }
+
   func testCustomFontFallbackBehavior() {
     // Given
     let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]

--- a/components/ButtonBar/tests/unit/ButtonBarButtonTitleFontTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarButtonTitleFontTests.swift
@@ -89,6 +89,22 @@ class ButtonBarButtonTitleFontTests: XCTestCase {
     XCTAssertNotEqual(initialFrames, updatedFrames)
   }
 
+  func testCustomFontDoesNotChangeFixedWidthButtonFrames() {
+    // Given
+    let item = UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)
+    item.width = 100
+    let items = [item]
+    let font = UIFont.systemFont(ofSize: 100)
+
+    // When
+    buttonBar.items = items
+    let initialFrames = buttonBar.subviews.map { $0.frame }
+    buttonBar.setButtonsTitleFont(font, for: .normal)
+    let updatedFrames = buttonBar.subviews.map { $0.frame }
+
+    XCTAssertEqual(initialFrames, updatedFrames)
+  }
+
   func testCustomFontFallbackBehavior() {
     // Given
     let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]


### PR DESCRIPTION
Button frames need to be updated after the font changes because their frames are not dynamically updated in any layoutSubviews pass.

It may be sensible to update layoutSubviews to do the frame calculations in a follow-up change, but this has the potential to be a behaviorally-breaking change so I've filed a follow-up story: https://www.pivotaltracker.com/story/show/156930078