### PR TITLE
[BottomSheet] [3/3] Fix layout issues with bottom sheets containing scroll views

### DIFF
--- a/components/BottomSheet/BUILD
+++ b/components/BottomSheet/BUILD
@@ -15,8 +15,10 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "mdc_unit_test_suite")
+     "mdc_unit_test_suite",
+     "DEFAULT_IOS_RUNNER_TARGETS")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -43,6 +45,31 @@ mdc_objc_library(
     ],
     deps = [":BottomSheet"],
     visibility = ["//visibility:private"],
+)
+
+mdc_objc_library(
+    name = "app_tests_lib",
+    testonly = 1,
+    srcs = glob(["tests/app/*.m"]),
+    hdrs = glob(["tests/app/*.h"]),
+    sdk_frameworks = [
+        "UIKit",
+        "XCTest",
+    ],
+    deps = [":BottomSheet"],
+    visibility = ["//visibility:private"],
+)
+
+# These are separate from the regular unit test suite because we want to specify
+# test_host so we can exercise tests which depend on UIKit functionality like
+# UIViewController presentation logic.
+ios_unit_test_suite(
+    name = "app_tests",
+    deps = [":app_tests_lib"],
+    minimum_os_version = "8.0",
+    size = "medium",
+    test_host = "@build_bazel_rules_apple//apple/testing/default_host/ios",
+    runners = DEFAULT_IOS_RUNNER_TARGETS,
 )
 
 mdc_unit_test_suite(

--- a/components/BottomSheet/examples/supplemental/BottomSheetDummyCollectionViewController.m
+++ b/components/BottomSheet/examples/supplemental/BottomSheetDummyCollectionViewController.m
@@ -43,6 +43,8 @@
   [super viewDidLoad];
 
   self.collectionView.backgroundColor = [UIColor whiteColor];
+  self.collectionView.contentSize =
+      CGSizeMake(self.view.bounds.size.width, (self.view.bounds.size.width / 3) * _numItems);
 
   [self.collectionView registerClass:[DummyCollectionViewCell class]
           forCellWithReuseIdentifier:NSStringFromClass([DummyCollectionViewCell class])];

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -32,10 +32,9 @@
   if (self = [super initWithNibName:nil bundle:nil]) {
     _contentViewController = contentViewController;
     _transitionController = [[MDCBottomSheetTransitionController alloc] init];
-
+    _transitionController.dismissOnBackgroundTap = YES;
     super.transitioningDelegate = _transitionController;
     super.modalPresentationStyle = UIModalPresentationCustom;
-    self.dismissOnBackgroundTap = YES;
   }
   return self;
 }
@@ -59,6 +58,9 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   self.mdc_bottomSheetPresentationController.delegate = self;
 #pragma clang diagnostic pop
+
+  self.mdc_bottomSheetPresentationController.dismissOnBackgroundTap =
+      _transitionController.dismissOnBackgroundTap;
 
   [self.contentViewController.view layoutIfNeeded];
 }

--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -234,11 +234,17 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
   self.sheet.frame = sheetRect;
 
   CGRect contentFrame = self.sheet.bounds;
-  contentFrame.size.height -= kSheetBounceBuffer;
   if (!self.sheet.scrollView) {
     // If the content doesn't scroll then we have to set its frame to the size we are making
     // visible. This ensures content using autolayout lays out correctly.
     contentFrame.size.height = [self truncatedPreferredSheetHeight];
+  } else if (self.sheet.scrollView.contentSize.height > 0) {
+    // If the content does scroll and has contentSize set, make it the
+    // larger of the contentSize height and the preferred height (if
+    // we don't set the frame at all, it has whatever random size
+    // UIKit assigned to it).
+    contentFrame.size.height =
+        MAX(self.sheet.scrollView.contentSize.height, [self truncatedPreferredSheetHeight]);
   }
   self.contentView.frame = contentFrame;
 }

--- a/components/BottomSheet/tests/app/MaterialBottomSheetAppTest.m
+++ b/components/BottomSheet/tests/app/MaterialBottomSheetAppTest.m
@@ -6,6 +6,10 @@
 static CGSize const kContentSize = {200, 74};
 static NSTimeInterval const kExpectationTimeout = 1;
 
+#define MDCAssertEqualCGSizes(size1, size2)                            \
+  XCTAssertTrue(CGSizeEqualToSize((size1), (size2)), @"Size %@ != %@", \
+                NSStringFromCGSize((size1)), NSStringFromCGSize((size2)));
+
 #define MDCAssertEqualUIEdgeInsets(insets1, insets2)                                     \
   XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets((insets1), (insets2)), @"Insets %@ != %@", \
                 NSStringFromUIEdgeInsets((insets1)), NSStringFromUIEdgeInsets((insets2)));
@@ -82,6 +86,18 @@ static NSTimeInterval const kExpectationTimeout = 1;
 
 #pragma mark - Test cases
 
+- (void)testPlainViewControllerUsesPreferredContentSize {
+  [self presentViewControllerInBottomSheetWithTrackingScrollView:nil];
+
+  CGSize expectedSize = kContentSize;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    expectedSize.height += self.viewController.view.safeAreaInsets.bottom;
+  }
+#endif
+  MDCAssertEqualCGSizes(self.viewController.view.bounds.size, expectedSize);
+}
+
 - (void)testCollectionViewControllerSetsContentInset {
   [self presentCollectionViewControllerInBottomSheet];
 
@@ -93,6 +109,18 @@ static NSTimeInterval const kExpectationTimeout = 1;
 #endif
   MDCAssertEqualUIEdgeInsets(self.collectionViewController.collectionView.contentInset,
                              expectedEdgeInsets);
+}
+
+- (void)testCollectionViewControllerSetsBoundsToPreferredContentSize {
+  [self presentCollectionViewControllerInBottomSheet];
+
+  CGSize expectedSize = kContentSize;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    expectedSize.height += self.collectionViewController.view.safeAreaInsets.bottom;
+  }
+#endif
+  MDCAssertEqualCGSizes(self.collectionViewController.view.bounds.size, expectedSize);
 }
 
 - (void)testViewControllerWithTrackingScrollViewSetsContentInset {
@@ -107,6 +135,20 @@ static NSTimeInterval const kExpectationTimeout = 1;
   }
 #endif
   MDCAssertEqualUIEdgeInsets(scrollView.contentInset, expectedEdgeInsets);
+}
+
+- (void)testViewControllerWithTrackingScrollViewSetsBoundsToPreferredSize {
+  UIScrollView *scrollView = [[UIScrollView alloc] initWithFrame:CGRectZero];
+  scrollView.contentSize = kContentSize;
+  [self presentViewControllerInBottomSheetWithTrackingScrollView:scrollView];
+
+  CGSize expectedSize = kContentSize;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    expectedSize.height += self.viewController.view.safeAreaInsets.bottom;
+  }
+#endif
+  MDCAssertEqualCGSizes(self.viewController.view.bounds.size, expectedSize);
 }
 
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
@@ -125,6 +167,18 @@ static NSTimeInterval const kExpectationTimeout = 1;
     UIEdgeInsets expectedEdgeInsets = UIEdgeInsetsZero;
     expectedEdgeInsets.bottom = self.viewController.view.safeAreaInsets.bottom;
     MDCAssertEqualUIEdgeInsets(scrollView.contentInset, expectedEdgeInsets);
+  }
+}
+
+- (void)testViewControllerWithTrackingScrollViewAndContentInsetAdjustmentAlwaysSetsBounds {
+  if (@available(iOS 11.0, *)) {
+    UIScrollView *scrollView = [[UIScrollView alloc] initWithFrame:CGRectZero];
+    scrollView.contentSize = kContentSize;
+    scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
+    [self presentViewControllerInBottomSheetWithTrackingScrollView:scrollView];
+    CGSize expectedSize = kContentSize;
+    expectedSize.height += self.viewController.view.safeAreaInsets.bottom;
+    MDCAssertEqualCGSizes(self.viewController.view.bounds.size, expectedSize);
   }
 }
 

--- a/components/BottomSheet/tests/app/MaterialBottomSheetAppTest.m
+++ b/components/BottomSheet/tests/app/MaterialBottomSheetAppTest.m
@@ -1,0 +1,133 @@
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+#import "MaterialBottomSheet.h"
+
+static CGSize const kContentSize = {200, 74};
+static NSTimeInterval const kExpectationTimeout = 1;
+
+#define MDCAssertEqualUIEdgeInsets(insets1, insets2)                                     \
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets((insets1), (insets2)), @"Insets %@ != %@", \
+                NSStringFromUIEdgeInsets((insets1)), NSStringFromUIEdgeInsets((insets2)));
+
+@interface MaterialBottomSheetAppTest : XCTestCase
+
+@property(nonatomic) UIWindow *window;
+@property(nonatomic, nullable) UIViewController *viewController;
+@property(nonatomic, nullable) UICollectionViewController *collectionViewController;
+
+@end
+
+@implementation MaterialBottomSheetAppTest
+
+#pragma mark - XCTestCase
+
+- (void)setUp {
+  [super setUp];
+  self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+  self.window.rootViewController = [[UIViewController alloc] initWithNibName:nil bundle:nil];
+  [self.window makeKeyAndVisible];
+}
+
+- (void)tearDown {
+  [self.window.rootViewController dismissViewControllerAnimated:NO completion:nil];
+  self.window = nil;
+  self.viewController = nil;
+  self.collectionViewController = nil;
+  [super tearDown];
+}
+
+#pragma mark - Common bottom sheet presentation logic
+
+- (void)presentViewControllerInBottomSheetAndWaitForCompletion:(UIViewController *)viewController
+                                        withTrackingScrollView:
+                                            (nullable UIScrollView *)trackingScrollView {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Presentation should complete"];
+  MDCBottomSheetController *controller =
+      [[MDCBottomSheetController alloc] initWithContentViewController:viewController];
+  if (trackingScrollView) {
+    controller.trackingScrollView = trackingScrollView;
+  }
+  [self.window.rootViewController presentViewController:controller
+                                               animated:NO
+                                             completion:^{
+                                               [expectation fulfill];
+                                             }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+}
+
+- (void)presentViewControllerInBottomSheetWithTrackingScrollView:
+    (nullable UIScrollView *)trackingScrollView {
+  self.viewController = [[UIViewController alloc] initWithNibName:nil bundle:nil];
+  self.viewController.preferredContentSize = kContentSize;
+  if (trackingScrollView) {
+    trackingScrollView.frame = self.viewController.view.bounds;
+    trackingScrollView.autoresizingMask =
+        UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self.viewController.view addSubview:trackingScrollView];
+  }
+  [self presentViewControllerInBottomSheetAndWaitForCompletion:self.viewController
+                                        withTrackingScrollView:trackingScrollView];
+}
+
+- (void)presentCollectionViewControllerInBottomSheet {
+  self.collectionViewController = [[UICollectionViewController alloc]
+      initWithCollectionViewLayout:[[UICollectionViewFlowLayout alloc] init]];
+  self.collectionViewController.preferredContentSize = kContentSize;
+  self.collectionViewController.collectionView.contentSize = kContentSize;
+  [self presentViewControllerInBottomSheetAndWaitForCompletion:self.collectionViewController
+                                        withTrackingScrollView:nil];
+}
+
+#pragma mark - Test cases
+
+- (void)testCollectionViewControllerSetsContentInset {
+  [self presentCollectionViewControllerInBottomSheet];
+
+  UIEdgeInsets expectedEdgeInsets = UIEdgeInsetsZero;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    expectedEdgeInsets.bottom = self.collectionViewController.view.safeAreaInsets.bottom;
+  }
+#endif
+  MDCAssertEqualUIEdgeInsets(self.collectionViewController.collectionView.contentInset,
+                             expectedEdgeInsets);
+}
+
+- (void)testViewControllerWithTrackingScrollViewSetsContentInset {
+  UIScrollView *scrollView = [[UIScrollView alloc] initWithFrame:CGRectZero];
+  scrollView.contentSize = kContentSize;
+  [self presentViewControllerInBottomSheetWithTrackingScrollView:scrollView];
+
+  UIEdgeInsets expectedEdgeInsets = UIEdgeInsetsZero;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    expectedEdgeInsets.bottom = self.viewController.view.safeAreaInsets.bottom;
+  }
+#endif
+  MDCAssertEqualUIEdgeInsets(scrollView.contentInset, expectedEdgeInsets);
+}
+
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+
+// These tests only make sense for iOS 11 and later.
+- (void)testViewControllerWithTrackingScrollViewAndContentInsetAdjustmentAlwaysSetsContentInset {
+  // Unfortunately, we cannot use if (!@available(...)) { return }; that raises a compiler warning:
+  //
+  //   error: @available does not guard availability here; use if (@available) instead
+  //   [-Werror,-Wunsupported-availability-guard]
+  if (@available(iOS 11.0, *)) {
+    UIScrollView *scrollView = [[UIScrollView alloc] initWithFrame:CGRectZero];
+    scrollView.contentSize = kContentSize;
+    scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
+    [self presentViewControllerInBottomSheetWithTrackingScrollView:scrollView];
+    UIEdgeInsets expectedEdgeInsets = UIEdgeInsetsZero;
+    expectedEdgeInsets.bottom = self.viewController.view.safeAreaInsets.bottom;
+    MDCAssertEqualUIEdgeInsets(scrollView.contentInset, expectedEdgeInsets);
+  }
+}
+
+#endif
+
+@end


### PR DESCRIPTION
`MDCBottomSheetController` had a few subtle issues when the content view controller
contained a scroll view.

Contained scroll views always had their height set to the maximum
height of the `MDCSheetContainerView`, which might be larger than the
contained scroll view's content size.

With this PR, we ensure we never make the contained scroll view height
larger than the larger of (content size, desired sheet height).

Test Plan: Added new application-hosted tests to reproduce the
issues. I confirmed they failed before this PR and passed after. Ran
tests with:

  ./.kokoro --target //components/BottomSheet/...
