### PR TITLE
[ButtonBar] Add a stateful buttons title color API.

### DIFF
--- a/components/ButtonBar/src/MDCButtonBar.h
+++ b/components/ButtonBar/src/MDCButtonBar.h
@@ -118,6 +118,25 @@ IB_DESIGNABLE
 - (nullable UIFont *)buttonsTitleFontForState:(UIControlState)state;
 
 /**
+ Sets the title label color for the given state for all buttons.
+
+ @param color The color that should be used on text buttons labels for the given state.
+ @param state The state for which the color should be used.
+ */
+- (void)setButtonsTitleColor:(nullable UIColor *)color forState:(UIControlState)state;
+
+/**
+ Returns the color set for @c state that was set by setButtonsTitleColor:forState:.
+
+ If no value has been set for a given state, the returned value will fall back to the value
+ set for UIControlStateNormal.
+
+ @param state The state for which the color should be returned.
+ @return The color associated with the given state.
+ */
+- (nullable UIColor *)buttonsTitleColorForState:(UIControlState)state;
+
+/**
  The position of the button bar, usually positioned on the leading or trailing edge of the screen.
 
  Default: MDCBarButtonLayoutPositionNone

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -430,6 +430,21 @@ static NSString *const MDCButtonBarButtonLayoutPositionKey = @"MDCButtonBarButto
   return [_defaultBuilder titleFontForState:state];
 }
 
+- (void)setButtonsTitleColor:(nullable UIColor *)color forState:(UIControlState)state {
+  [_defaultBuilder setTitleColor:color forState:state];
+
+  for (UIView *viewObj in _buttonViews) {
+    if ([viewObj isKindOfClass:[UIButton class]]) {
+      MDCButton *button = (MDCButton *)viewObj;
+      [button setTitleColor:color forState:state];
+    }
+  }
+}
+
+- (UIColor *)buttonsTitleColorForState:(UIControlState)state {
+  return [_defaultBuilder titleColorForState:state];
+}
+
 // UISemanticContentAttribute was added in iOS SDK 9.0 but is available on devices running earlier
 // version of iOS. We ignore the partial-availability warning that gets thrown on our use of this
 // symbol.

--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.h
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.h
@@ -45,4 +45,23 @@
  */
 - (UIFont *)titleFontForState:(UIControlState)state;
 
+/**
+ Sets the title label color for the given state for all buttons.
+
+ @param color The color that should be used on text buttons labels for the given state.
+ @param state The state for which the color should be used.
+ */
+- (void)setTitleColor:(UIColor *)color forState:(UIControlState)state;
+
+/**
+ Returns the color set for @c state that was set by setButtonsTitleColor:forState:.
+
+ If no value has been set for a given state, the returned value will fall back to the value
+ set for UIControlStateNormal.
+
+ @param state The state for which the color should be returned.
+ @return The color associated with the given state.
+ */
+- (UIColor *)titleColorForState:(UIControlState)state;
+
 @end

--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
@@ -56,12 +56,14 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
 
 @implementation MDCAppBarButtonBarBuilder {
   NSMutableDictionary<NSNumber *, UIFont *> *_fonts;
+  NSMutableDictionary<NSNumber *, UIColor *> *_titleColors;
 }
 
 - (instancetype)init {
   self = [super init];
   if (self) {
     _fonts = [NSMutableDictionary dictionary];
+    _titleColors = [NSMutableDictionary dictionary];
   }
   return self;
 }
@@ -76,6 +78,18 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
 
 - (void)setTitleFont:(UIFont *)font forState:(UIControlState)state {
   _fonts[@(state)] = font;
+}
+
+- (UIColor *)titleColorForState:(UIControlState)state {
+  UIColor *color = _titleColors[@(state)];
+  if (!color && state != UIControlStateNormal) {
+    color = _titleColors[@(UIControlStateNormal)];
+  }
+  return color;
+}
+
+- (void)setTitleColor:(UIColor *)color forState:(UIControlState)state {
+  _titleColors[@(state)] = color;
 }
 
 #pragma mark - MDCBarButtonItemBuilding
@@ -123,6 +137,10 @@ static const UIEdgeInsets kImageOnlyButtonInset = {0, 12.0f, 0, 12.0f};
   for (NSNumber *state in _fonts) {
     UIFont *font = _fonts[state];
     [button setTitleFont:font forState:(UIControlState)state.intValue];
+  }
+  for (NSNumber *state in _titleColors) {
+    UIColor *color = _titleColors[state];
+    [button setTitleColor:color forState:(UIControlState)state.intValue];
   }
 
   [self updateButton:button withItem:buttonItem barMetrics:UIBarMetricsDefault];

--- a/components/ButtonBar/tests/unit/ButtonBarButtonTitleColorTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarButtonTitleColorTests.swift
@@ -91,9 +91,15 @@ class ButtonBarButtonTitleColorTests: XCTestCase {
       if let button = view as? MDCButton {
         button.isSelected = true
 
+        XCTAssertEqual(button.titleColor(for: .normal), normalColor)
+        XCTAssertEqual(button.titleColor(for: .selected), selectedColor)
+
         XCTAssertEqual(button.titleLabel?.textColor, selectedColor)
 
         button.isSelected = false
+
+        XCTAssertEqual(button.titleColor(for: .normal), normalColor)
+        XCTAssertEqual(button.titleColor(for: .selected), selectedColor)
 
         XCTAssertEqual(button.titleLabel?.textColor, normalColor)
       }

--- a/components/ButtonBar/tests/unit/ButtonBarButtonTitleColorTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarButtonTitleColorTests.swift
@@ -1,0 +1,103 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents.MaterialButtonBar
+import MaterialComponents.MaterialButtons
+
+class ButtonBarButtonTitleColorTests: XCTestCase {
+
+  var buttonBar: MDCButtonBar!
+
+  override func setUp() {
+    buttonBar = MDCButtonBar()
+  }
+
+  func testDefaultColorBehavior() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    buttonBar.items = items
+
+    // Then
+    for view in buttonBar.subviews {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.titleColor(for: .normal), .white)
+      }
+    }
+  }
+
+  func testCustomColorIsSetForNewButtons() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    let color = UIColor.red
+
+    // When
+    buttonBar.setButtonsTitleColor(color, for: .normal)
+    buttonBar.items = items
+
+    // Then
+    for view in buttonBar.subviews {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.titleColor(for: .normal), color)
+        XCTAssertEqual(button.titleLabel?.textColor, color)
+      }
+    }
+  }
+
+  func testCustomColorIsSetForExistingButtons() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    let color = UIColor.red
+
+    // When
+    buttonBar.items = items
+    buttonBar.setButtonsTitleColor(color, for: .normal)
+
+    // Then
+    for view in buttonBar.subviews {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.titleColor(for: .normal), color)
+        XCTAssertEqual(button.titleLabel?.textColor, color)
+      }
+    }
+  }
+
+  func testCustomColorFallbackBehavior() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    let normalColor = UIColor.red
+    let selectedColor = UIColor.blue
+
+    // When
+    buttonBar.setButtonsTitleColor(normalColor, for: .normal)
+    buttonBar.setButtonsTitleColor(selectedColor, for: .selected)
+    buttonBar.items = items
+
+    // Then
+    for view in buttonBar.subviews {
+      if let button = view as? MDCButton {
+        button.isSelected = true
+
+        XCTAssertEqual(button.titleLabel?.textColor, selectedColor)
+
+        button.isSelected = false
+
+        XCTAssertEqual(button.titleLabel?.textColor, normalColor)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This API allows a client to customize the title color for buttons for a given control state.

Related to https://www.pivotaltracker.com/story/show/156934328

Screenshot shows a button with a custom normal and highlighted state. The button on the left is highlighted.

![simulator screen shot - iphone se - 2018-04-19 at 19 51 59](https://user-images.githubusercontent.com/45670/39024065-786db638-440c-11e8-97e8-f6bf3e6c2af7.png)
