### PR TITLE
[NavigationBar] Add a stateful buttons title color API.

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -139,6 +139,25 @@ IB_DESIGNABLE
  */
 - (nullable UIFont *)buttonsTitleFontForState:(UIControlState)state;
 
+/**
+ Sets the title label color for the given state for all buttons.
+
+ @param color The color that should be used on text buttons labels for the given state.
+ @param state The state for which the color should be used.
+ */
+- (void)setButtonsTitleColor:(nullable UIColor *)color forState:(UIControlState)state;
+
+/**
+ Returns the color set for @c state that was set by setButtonsTitleColor:forState:.
+
+ If no value has been set for a given state, the returned value will fall back to the value
+ set for UIControlStateNormal.
+
+ @param state The state for which the color should be returned.
+ @return The color associated with the given state.
+ */
+- (nullable UIColor *)buttonsTitleColorForState:(UIControlState)state;
+
 /** The back button to be displayed, if any. */
 @property(nonatomic, strong, nullable) UIBarButtonItem *backItem;
 

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -718,6 +718,15 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   return [_leadingButtonBar buttonsTitleFontForState:state];
 }
 
+- (void)setButtonsTitleColor:(UIColor *)color forState:(UIControlState)state {
+  [_leadingButtonBar setButtonsTitleColor:color forState:state];
+  [_trailingButtonBar setButtonsTitleColor:color forState:state];
+}
+
+- (UIColor *)buttonsTitleColorForState:(UIControlState)state {
+  return [_leadingButtonBar buttonsTitleColorForState:state];
+}
+
 - (void)setLeadingBarButtonItems:(NSArray<UIBarButtonItem *> *)leadingBarButtonItems {
   _leadingBarButtonItems = [leadingBarButtonItems copy];
   _leadingButtonBar.items = [self mdc_buttonItemsForLeadingBar];

--- a/components/NavigationBar/tests/unit/NavigationBarButtonTitleColorTests.swift
+++ b/components/NavigationBar/tests/unit/NavigationBarButtonTitleColorTests.swift
@@ -1,0 +1,126 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents.MaterialNavigationBar
+import MaterialComponents.MaterialButtons
+
+class NavigationBarButtonTitleColorTests: XCTestCase {
+
+  var navigationBar: MDCNavigationBar!
+
+  override func setUp() {
+    navigationBar = MDCNavigationBar()
+  }
+
+  private func recursiveSubviews(of superview: UIView) -> [UIView] {
+    var subviews = superview.subviews
+    for subview in superview.subviews {
+      subviews.append(contentsOf: recursiveSubviews(of: subview))
+    }
+    return subviews
+  }
+
+  func testDefaultColorBehavior() {
+    // Given
+    navigationBar.leadingBarButtonItems = [
+      UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)
+    ]
+    navigationBar.trailingBarButtonItems = [
+      UIBarButtonItem(title: "Text 2", style: .plain, target: nil, action: nil)
+    ]
+
+    // Then
+    for view in recursiveSubviews(of: navigationBar) {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.titleColor(for: .normal), .white)
+      }
+    }
+  }
+
+  func testCustomColorIsSetForNewButtons() {
+    // Given
+    let color = UIColor.red
+
+    // When
+    navigationBar.setButtonsTitleColor(color, for: .normal)
+    navigationBar.leadingBarButtonItems = [
+      UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)
+    ]
+    navigationBar.trailingBarButtonItems = [
+      UIBarButtonItem(title: "Text 2", style: .plain, target: nil, action: nil)
+    ]
+
+    // Then
+    for view in recursiveSubviews(of: navigationBar) {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.titleColor(for: .normal), color)
+        XCTAssertEqual(button.titleLabel?.textColor, color)
+      }
+    }
+  }
+
+  func testCustomColorIsSetForExistingButtons() {
+    // Given
+    let color = UIColor.red
+
+    // When
+    navigationBar.leadingBarButtonItems = [
+      UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)
+    ]
+    navigationBar.trailingBarButtonItems = [
+      UIBarButtonItem(title: "Text 2", style: .plain, target: nil, action: nil)
+    ]
+    navigationBar.setButtonsTitleColor(color, for: .normal)
+
+    // Then
+    for view in recursiveSubviews(of: navigationBar) {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.titleColor(for: .normal), color)
+        XCTAssertEqual(button.titleLabel?.textColor, color)
+      }
+    }
+  }
+
+  func testCustomColorFallbackBehavior() {
+    // Given
+    let normalColor = UIColor.red
+    let selectedColor = UIColor.blue
+
+    // When
+    navigationBar.setButtonsTitleColor(normalColor, for: .normal)
+    navigationBar.setButtonsTitleColor(selectedColor, for: .selected)
+    navigationBar.leadingBarButtonItems = [
+      UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)
+    ]
+    navigationBar.trailingBarButtonItems = [
+      UIBarButtonItem(title: "Text 2", style: .plain, target: nil, action: nil)
+    ]
+
+    // Then
+    for view in recursiveSubviews(of: navigationBar) {
+      if let button = view as? MDCButton {
+        button.isSelected = true
+
+        XCTAssertEqual(button.titleLabel?.textColor, selectedColor)
+
+        button.isSelected = false
+
+        XCTAssertEqual(button.titleLabel?.textColor, normalColor)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This API allows a client to customize the title color for buttons for a given control state.

Related to https://www.pivotaltracker.com/story/show/156934328

Screenshot shows a button with a custom normal and highlighted state. The button on the left is highlighted.

![simulator screen shot - iphone se - 2018-04-19 at 19 51 59](https://user-images.githubusercontent.com/45670/39024065-786db638-440c-11e8-97e8-f6bf3e6c2af7.png)