### PR TITLE
[NavigationBar] Fix the surface variation themer's text/icon colors to match spec.

### DIFF
--- a/components/AppBar/tests/unit/AppBarColorThemerTests.swift
+++ b/components/AppBar/tests/unit/AppBarColorThemerTests.swift
@@ -61,8 +61,12 @@ class AppBarColorThemerTests: XCTestCase {
     XCTAssertEqual(appBar.headerViewController.headerView.backgroundColor,
                    colorScheme.surfaceColor)
     XCTAssertEqual(appBar.navigationBar.backgroundColor, colorScheme.surfaceColor)
-    XCTAssertEqual(appBar.navigationBar.titleTextColor, colorScheme.onSurfaceColor)
-    XCTAssertEqual(appBar.navigationBar.tintColor, colorScheme.onSurfaceColor)
+    XCTAssertEqual(appBar.navigationBar.titleTextColor,
+                   colorScheme.onSurfaceColor.withAlphaComponent(0.87))
+    XCTAssertEqual(appBar.navigationBar.buttonsTitleColor(for: .normal),
+                   colorScheme.onSurfaceColor.withAlphaComponent(0.87))
+    XCTAssertEqual(appBar.navigationBar.tintColor,
+                   colorScheme.onSurfaceColor.withAlphaComponent(0.54))
   }
 
   func testColorThemerAffectsSubComponents() {

--- a/components/NavigationBar/src/ColorThemer/MDCNavigationBarColorThemer.m
+++ b/components/NavigationBar/src/ColorThemer/MDCNavigationBarColorThemer.m
@@ -27,14 +27,27 @@
 
 + (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                            toNavigationBar:(nonnull MDCNavigationBar *)navigationBar {
+  [self resetUIControlStatesForNavigationBar:navigationBar];
+
   navigationBar.backgroundColor = colorScheme.surfaceColor;
-  navigationBar.titleTextColor = colorScheme.onSurfaceColor;
-  navigationBar.tintColor = colorScheme.onSurfaceColor;
+  // Note that we must set the tint color before setting the buttons title color. Otherwise the
+  // button title colors will be set with the tint color.
+  navigationBar.tintColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.54];
+  navigationBar.titleTextColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
+  [navigationBar setButtonsTitleColor:navigationBar.titleTextColor forState:UIControlStateNormal];
 }
 
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme
          toNavigationBar:(MDCNavigationBar *)navigationBar {
   navigationBar.backgroundColor = colorScheme.primaryColor;
+}
+
++ (void)resetUIControlStatesForNavigationBar:(nonnull MDCNavigationBar *)navigationBar {
+  NSUInteger maximumStateValue = (UIControlStateNormal | UIControlStateSelected |
+                                  UIControlStateHighlighted | UIControlStateDisabled);
+  for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    [navigationBar setButtonsTitleColor:nil forState:state];
+  }
 }
 
 @end

--- a/components/NavigationBar/tests/unit/NavigationBarColorThemerTests.swift
+++ b/components/NavigationBar/tests/unit/NavigationBarColorThemerTests.swift
@@ -53,8 +53,10 @@ class NavigationBarColorThemerTests: XCTestCase {
     MDCNavigationBarColorThemer.applySurfaceVariant(withColorScheme: colorScheme, to: navigationBar)
 
     // Then
-    XCTAssertEqual(navigationBar.backgroundColor, colorScheme.surfaceColor)
-    XCTAssertEqual(navigationBar.titleTextColor, colorScheme.onSurfaceColor)
-    XCTAssertEqual(navigationBar.tintColor, colorScheme.onSurfaceColor)
+    XCTAssertEqual(navigationBar.titleTextColor,
+                   colorScheme.onSurfaceColor.withAlphaComponent(0.87))
+    XCTAssertEqual(navigationBar.buttonsTitleColor(for: .normal),
+                   colorScheme.onSurfaceColor.withAlphaComponent(0.87))
+    XCTAssertEqual(navigationBar.tintColor, colorScheme.onSurfaceColor.withAlphaComponent(0.54))
   }
 }


### PR DESCRIPTION
For the variant themer, text is supposed to be onSurface @ 87% opacity, while icons are onSurface @ 54% opacity.

Closes pivotal story: https://www.pivotaltracker.com/story/show/156934328
Closes pivotal story: https://www.pivotaltracker.com/story/show/156934114

Before:

![simulator screen shot - iphone se - 2018-04-19 at 21 04 58](https://user-images.githubusercontent.com/45670/39065696-aa4df430-44a0-11e8-897f-3bc71b8b4c7e.png)

After:

![simulator screen shot - iphone se - 2018-04-19 at 21 04 03](https://user-images.githubusercontent.com/45670/39065699-ad47ffaa-44a0-11e8-9a40-e2d2cb92f908.png)
