### PR TITLE
[BottomSheet] [2/3] Fix layout issues caused by invoking self.dismissOnBackgroundTap in -init

### DIFF
--- a/components/BottomSheet/BUILD
+++ b/components/BottomSheet/BUILD
@@ -15,8 +15,10 @@
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
      "mdc_objc_library",
-     "mdc_unit_test_suite")
+     "mdc_unit_test_suite",
+     "DEFAULT_IOS_RUNNER_TARGETS")
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -43,6 +45,31 @@ mdc_objc_library(
     ],
     deps = [":BottomSheet"],
     visibility = ["//visibility:private"],
+)
+
+mdc_objc_library(
+    name = "app_tests_lib",
+    testonly = 1,
+    srcs = glob(["tests/app/*.m"]),
+    hdrs = glob(["tests/app/*.h"]),
+    sdk_frameworks = [
+        "UIKit",
+        "XCTest",
+    ],
+    deps = [":BottomSheet"],
+    visibility = ["//visibility:private"],
+)
+
+# These are separate from the regular unit test suite because we want to specify
+# test_host so we can exercise tests which depend on UIKit functionality like
+# UIViewController presentation logic.
+ios_unit_test_suite(
+    name = "app_tests",
+    deps = [":app_tests_lib"],
+    minimum_os_version = "8.0",
+    size = "medium",
+    test_host = "@build_bazel_rules_apple//apple/testing/default_host/ios",
+    runners = DEFAULT_IOS_RUNNER_TARGETS,
 )
 
 mdc_unit_test_suite(

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -32,10 +32,9 @@
   if (self = [super initWithNibName:nil bundle:nil]) {
     _contentViewController = contentViewController;
     _transitionController = [[MDCBottomSheetTransitionController alloc] init];
-
+    _transitionController.dismissOnBackgroundTap = YES;
     super.transitioningDelegate = _transitionController;
     super.modalPresentationStyle = UIModalPresentationCustom;
-    self.dismissOnBackgroundTap = YES;
   }
   return self;
 }
@@ -59,6 +58,9 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   self.mdc_bottomSheetPresentationController.delegate = self;
 #pragma clang diagnostic pop
+
+  self.mdc_bottomSheetPresentationController.dismissOnBackgroundTap =
+      _transitionController.dismissOnBackgroundTap;
 
   [self.contentViewController.view layoutIfNeeded];
 }

--- a/components/BottomSheet/tests/app/MaterialBottomSheetAppTest.m
+++ b/components/BottomSheet/tests/app/MaterialBottomSheetAppTest.m
@@ -1,0 +1,133 @@
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+#import "MaterialBottomSheet.h"
+
+static CGSize const kContentSize = {200, 74};
+static NSTimeInterval const kExpectationTimeout = 1;
+
+#define MDCAssertEqualUIEdgeInsets(insets1, insets2)                                     \
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets((insets1), (insets2)), @"Insets %@ != %@", \
+                NSStringFromUIEdgeInsets((insets1)), NSStringFromUIEdgeInsets((insets2)));
+
+@interface MaterialBottomSheetAppTest : XCTestCase
+
+@property(nonatomic) UIWindow *window;
+@property(nonatomic, nullable) UIViewController *viewController;
+@property(nonatomic, nullable) UICollectionViewController *collectionViewController;
+
+@end
+
+@implementation MaterialBottomSheetAppTest
+
+#pragma mark - XCTestCase
+
+- (void)setUp {
+  [super setUp];
+  self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+  self.window.rootViewController = [[UIViewController alloc] initWithNibName:nil bundle:nil];
+  [self.window makeKeyAndVisible];
+}
+
+- (void)tearDown {
+  [self.window.rootViewController dismissViewControllerAnimated:NO completion:nil];
+  self.window = nil;
+  self.viewController = nil;
+  self.collectionViewController = nil;
+  [super tearDown];
+}
+
+#pragma mark - Common bottom sheet presentation logic
+
+- (void)presentViewControllerInBottomSheetAndWaitForCompletion:(UIViewController *)viewController
+                                        withTrackingScrollView:
+                                            (nullable UIScrollView *)trackingScrollView {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Presentation should complete"];
+  MDCBottomSheetController *controller =
+      [[MDCBottomSheetController alloc] initWithContentViewController:viewController];
+  if (trackingScrollView) {
+    controller.trackingScrollView = trackingScrollView;
+  }
+  [self.window.rootViewController presentViewController:controller
+                                               animated:NO
+                                             completion:^{
+                                               [expectation fulfill];
+                                             }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+}
+
+- (void)presentViewControllerInBottomSheetWithTrackingScrollView:
+    (nullable UIScrollView *)trackingScrollView {
+  self.viewController = [[UIViewController alloc] initWithNibName:nil bundle:nil];
+  self.viewController.preferredContentSize = kContentSize;
+  if (trackingScrollView) {
+    trackingScrollView.frame = self.viewController.view.bounds;
+    trackingScrollView.autoresizingMask =
+        UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self.viewController.view addSubview:trackingScrollView];
+  }
+  [self presentViewControllerInBottomSheetAndWaitForCompletion:self.viewController
+                                        withTrackingScrollView:trackingScrollView];
+}
+
+- (void)presentCollectionViewControllerInBottomSheet {
+  self.collectionViewController = [[UICollectionViewController alloc]
+      initWithCollectionViewLayout:[[UICollectionViewFlowLayout alloc] init]];
+  self.collectionViewController.preferredContentSize = kContentSize;
+  self.collectionViewController.collectionView.contentSize = kContentSize;
+  [self presentViewControllerInBottomSheetAndWaitForCompletion:self.collectionViewController
+                                        withTrackingScrollView:nil];
+}
+
+#pragma mark - Test cases
+
+- (void)testCollectionViewControllerSetsContentInset {
+  [self presentCollectionViewControllerInBottomSheet];
+
+  UIEdgeInsets expectedEdgeInsets = UIEdgeInsetsZero;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    expectedEdgeInsets.bottom = self.collectionViewController.view.safeAreaInsets.bottom;
+  }
+#endif
+  MDCAssertEqualUIEdgeInsets(self.collectionViewController.collectionView.contentInset,
+                             expectedEdgeInsets);
+}
+
+- (void)testViewControllerWithTrackingScrollViewSetsContentInset {
+  UIScrollView *scrollView = [[UIScrollView alloc] initWithFrame:CGRectZero];
+  scrollView.contentSize = kContentSize;
+  [self presentViewControllerInBottomSheetWithTrackingScrollView:scrollView];
+
+  UIEdgeInsets expectedEdgeInsets = UIEdgeInsetsZero;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    expectedEdgeInsets.bottom = self.viewController.view.safeAreaInsets.bottom;
+  }
+#endif
+  MDCAssertEqualUIEdgeInsets(scrollView.contentInset, expectedEdgeInsets);
+}
+
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+
+// These tests only make sense for iOS 11 and later.
+- (void)testViewControllerWithTrackingScrollViewAndContentInsetAdjustmentAlwaysSetsContentInset {
+  // Unfortunately, we cannot use if (!@available(...)) { return }; that raises a compiler warning:
+  //
+  //   error: @available does not guard availability here; use if (@available) instead
+  //   [-Werror,-Wunsupported-availability-guard]
+  if (@available(iOS 11.0, *)) {
+    UIScrollView *scrollView = [[UIScrollView alloc] initWithFrame:CGRectZero];
+    scrollView.contentSize = kContentSize;
+    scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
+    [self presentViewControllerInBottomSheetWithTrackingScrollView:scrollView];
+    UIEdgeInsets expectedEdgeInsets = UIEdgeInsetsZero;
+    expectedEdgeInsets.bottom = self.viewController.view.safeAreaInsets.bottom;
+    MDCAssertEqualUIEdgeInsets(scrollView.contentInset, expectedEdgeInsets);
+  }
+}
+
+#endif
+
+@end


### PR DESCRIPTION
MDCBottomSheetController had a few subtle issues when the content view controller
contained a scroll view.

Setting `controller.trackingScrollView` had no effect, because the
call to `self.dismissOnBackgroundTap = YES` added in
a1c6621 had the side effect of invoking
`-[MDCBottomSheetTransitionController presentationControllerForPresentedViewController:presentingViewController:sourceViewController:]`,
and as soon as that method was invoked, the transition controller read the (then-nil)
value of `controller.trackingScrollView`, and never read it again.

This fixes the issue by ensuring we don't access
`self.mdc_bottomSheetPresentationController` in the initializer.

Test Plan: Added new application-hosted tests to reproduce the
issues. I confirmed they failed before this PR and passed after. Ran
tests with:

  ./.kokoro --target //components/BottomSheet/...