### PR TITLE
Disable flaky test -[SnackbarManagerTests testMessagesResumedWhenTokenIsDeallocated]

### DIFF
--- a/components/Snackbar/tests/unit/SnackbarManagerTests.m
+++ b/components/Snackbar/tests/unit/SnackbarManagerTests.m
@@ -23,7 +23,8 @@
 
 @implementation SnackbarManagerTests
 
-- (void)testMessagesResumedWhenTokenIsDeallocated {
+// Disabled due to flakiness in CI.
+- (void)disabled_testMessagesResumedWhenTokenIsDeallocated {
   // Given
   MDCSnackbarMessage *suspendedMessage = [MDCSnackbarMessage messageWithText:@"foo1"];
   suspendedMessage.duration = 0.05;


### PR DESCRIPTION
This test is flaky:

```
Test Case '-[SnackbarManagerTests testMessagesResumedWhenTokenIsDeallocated]' started.
<unknown>:0: error: -[SnackbarManagerTests testMessagesResumedWhenTokenIsDeallocated] : Asynchronous wait failed: Exceeded timeout of 1 seconds, with unfulfilled expectations: "completed".
Test Case '-[SnackbarManagerTests testMessagesResumedWhenTokenIsDeallocated]' failed (1.954 seconds).
```

This PR disables the flaky test.
