### PR TITLE
[SnackBar] Extending the timeout for a flaky test.

### DIFF
--- a/components/Snackbar/tests/unit/SnackbarManagerTests.m
+++ b/components/Snackbar/tests/unit/SnackbarManagerTests.m
@@ -42,7 +42,7 @@
   }
 
   // Then
-  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  [self waitForExpectationsWithTimeout:3.0 handler:nil];
 }
 
 @end


### PR DESCRIPTION
copying the swift test: https://github.com/material-components/material-components-ios/pull/2750
