### PR TITLE
[BottomNavigation] Add separate property for selected title color

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -95,11 +95,16 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarAlignment) {
 @property(nonatomic, strong, nonnull) UIFont *itemTitleFont UI_APPEARANCE_SELECTOR;
 
 /**
- Color of selected item. Applies color to items' icons and text.
- Default color is black.
+ Color of selected item. Applies color to items' icons and text. If set also sets
+ selectedItemTitleColor. Default color is black.
  */
 @property (nonatomic, strong, readwrite, nonnull) UIColor *selectedItemTintColor
     UI_APPEARANCE_SELECTOR;
+
+/**
+ Color of the selected item's title text. Default color is black.
+ */
+@property(nonatomic, strong, readwrite, nonnull) UIColor *selectedItemTitleColor;
 
 /**
  Color of unselected items. Applies color to items' icons. Text is not displayed in unselected mode.

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -163,6 +163,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
 - (void)commonMDCBottomNavigationBarInit {
   _selectedItemTintColor = [UIColor blackColor];
   _unselectedItemTintColor = [UIColor grayColor];
+  _selectedItemTitleColor = _selectedItemTintColor;
   _titleVisibility = MDCBottomNavigationBarTitleVisibilitySelected;
   _alignment = MDCBottomNavigationBarAlignmentJustified;
   _itemsDistributed = YES;
@@ -423,6 +424,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
     itemView.title = item.title;
     itemView.itemTitleFont = self.itemTitleFont;
     itemView.selectedItemTintColor = self.selectedItemTintColor;
+    itemView.selectedItemTitleColor = self.selectedItemTitleColor;
     itemView.unselectedItemTintColor = self.unselectedItemTintColor;
     itemView.titleVisibility = self.titleVisibility;
     itemView.titleBelowIcon = self.titleBelowItem;
@@ -502,6 +504,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
 
 - (void)setSelectedItemTintColor:(UIColor *)selectedItemTintColor {
   _selectedItemTintColor = selectedItemTintColor;
+  _selectedItemTitleColor = selectedItemTintColor;
   for (MDCBottomNavigationItemView *itemView in self.itemViews) {
     itemView.selectedItemTintColor = selectedItemTintColor;
   }
@@ -511,6 +514,13 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   _unselectedItemTintColor = unselectedItemTintColor;
   for (MDCBottomNavigationItemView *itemView in self.itemViews) {
     itemView.unselectedItemTintColor = unselectedItemTintColor;
+  }
+}
+
+- (void)setSelectedItemTitleColor:(UIColor *)selectedItemTitleColor {
+  _selectedItemTitleColor = selectedItemTitleColor;
+  for (MDCBottomNavigationItemView *itemView in self.itemViews) {
+    itemView.selectedItemTitleColor = selectedItemTitleColor;
   }
 }
 

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
@@ -36,6 +36,7 @@
 @property(nonatomic, strong) UIColor *badgeColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong) UIColor *selectedItemTintColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong) UIColor *unselectedItemTintColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong) UIColor *selectedItemTitleColor;
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated;
 

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -154,6 +154,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
   if (!_unselectedItemTintColor) {
     _unselectedItemTintColor = [UIColor grayColor];
   }
+  _selectedItemTitleColor = _selectedItemTintColor;
 
   if (!_iconImageView) {
     _iconImageView = [[UIImageView alloc] initWithFrame:CGRectZero];
@@ -166,7 +167,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
     _label.text = _title;
     _label.font = [UIFont systemFontOfSize:MDCBottomNavigationItemViewTitleFontSize];
     _label.textAlignment = NSTextAlignmentCenter;
-    _label.textColor = _selectedItemTintColor;
+    _label.textColor = _selectedItemTitleColor;
     _label.isAccessibilityElement = NO;
     [self addSubview:_label];
 
@@ -311,7 +312,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {
   _selected = selected;
   if (selected) {
-    self.label.textColor = self.selectedItemTintColor;
+    self.label.textColor = self.selectedItemTitleColor;
     self.iconImageView.tintColor = self.selectedItemTintColor;
     self.button.accessibilityTraits |= UIAccessibilityTraitSelected;
 
@@ -348,9 +349,10 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 
 - (void)setSelectedItemTintColor:(UIColor *)selectedItemTintColor {
   _selectedItemTintColor = selectedItemTintColor;
+  _selectedItemTitleColor = selectedItemTintColor;
   if (self.selected) {
     self.iconImageView.tintColor = self.selectedItemTintColor;
-    self.label.textColor = self.selectedItemTintColor;
+    self.label.textColor = self.selectedItemTitleColor;
     self.inkView.inkColor =
         [self.selectedItemTintColor colorWithAlphaComponent:MDCBottomNavigationItemViewInkOpacity];
   }
@@ -363,6 +365,13 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
     self.label.textColor = self.unselectedItemTintColor;
     CGFloat alpha = MDCBottomNavigationItemViewInkOpacity;
     self.inkView.inkColor = [self.unselectedItemTintColor colorWithAlphaComponent:alpha];
+  }
+}
+
+- (void)setSelectedItemTitleColor:(UIColor *)selectedItemTitleColor {
+  _selectedItemTitleColor = selectedItemTitleColor;
+  if (self.selected) {
+    self.label.textColor = self.selectedItemTitleColor;
   }
 }
 

--- a/components/BottomNavigation/tests/unit/BottomNavigationBarColorThemerTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationBarColorThemerTests.m
@@ -18,6 +18,7 @@
 #import "MDCBottomNavigationBarColorThemer.h"
 #import "MaterialColorScheme.h"
 #import "MaterialBottomNavigation.h"
+#import "../../src/private/MDCBottomNavigationItemView.h"
 
 @interface FakeColorScheme : NSObject<MDCColorScheme>
 @property(nonatomic, strong) UIColor *primaryColor;
@@ -29,6 +30,10 @@
 
 @end
 
+@interface MDCBottomNavigationBar (Testing)
+@property(nonatomic, strong) NSMutableArray<MDCBottomNavigationItemView *> *itemViews;
+@end
+
 @implementation BottomNavigationBarColorThemerTests
 
 - (void)testColorScheming {
@@ -36,7 +41,9 @@
   MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
   colorScheme.primaryColor = [UIColor redColor];
   colorScheme.onPrimaryColor = [UIColor blueColor];
+  UITabBarItem *item = [[UITabBarItem alloc] init];
   MDCBottomNavigationBar *bottomNavigationBar = [[MDCBottomNavigationBar alloc] init];
+  [bottomNavigationBar setItems:@[item]];
   bottomNavigationBar.barTintColor = [UIColor greenColor];
   bottomNavigationBar.selectedItemTintColor = [UIColor yellowColor];
   
@@ -47,6 +54,9 @@
   // Then
   XCTAssertEqualObjects(bottomNavigationBar.barTintColor, colorScheme.primaryColor);
   XCTAssertEqualObjects(bottomNavigationBar.selectedItemTintColor, colorScheme.onPrimaryColor);
+
+  MDCBottomNavigationItemView *firstItemView = [bottomNavigationBar.itemViews firstObject];
+  XCTAssertEqualObjects(firstItemView.selectedItemTitleColor, colorScheme.onPrimaryColor);
 }
 
 - (void)testColorSchemeWithoutOptionalColorProperties {


### PR DESCRIPTION
Exposes a selected item title color. Does not implement the full title color image color for state pattern as MDCNavigationBar does not display a title in its unselected state, which made just this single property addition seem cleaner. 

https://www.pivotaltracker.com/story/show/156742634