### PR TITLE
[Buttons] Added ImageTintColor for theming FAB Button.

### DIFF
--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -135,8 +135,6 @@
       [[UIImage imageNamed:@"Plus"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   [self.floatingButton setImage:plusImage forState:UIControlStateNormal];
   [MDCFloatingButtonColorThemer applySemanticColorScheme:colorScheme toButton:self.floatingButton];
-  [self.floatingButton setImageTintColor:colorScheme.onSecondaryColor
-                                forState:UIControlStateNormal];
   [self.view addSubview:self.floatingButton];
 
   self.buttons = @[

--- a/components/Buttons/examples/FloatingButtonExampleViewController.m
+++ b/components/Buttons/examples/FloatingButtonExampleViewController.m
@@ -54,17 +54,12 @@
                                    inMode:MDCFloatingButtonModeExpanded];
   [MDCFloatingButtonColorThemer applySemanticColorScheme:colorScheme
                                                 toButton:self.miniFloatingButton];
-  [self.miniFloatingButton setImageTintColor:colorScheme.onSecondaryColor
-                                    forState:UIControlStateNormal];
-
 
   self.defaultFloatingButton = [[MDCFloatingButton alloc] init];
   self.defaultFloatingButton.translatesAutoresizingMaskIntoConstraints = NO;
   [self.defaultFloatingButton setImage:plusImage forState:UIControlStateNormal];
   [MDCFloatingButtonColorThemer applySemanticColorScheme:colorScheme
                                                 toButton:self.defaultFloatingButton];
-  [self.defaultFloatingButton setImageTintColor:colorScheme.onSecondaryColor
-                                       forState:UIControlStateNormal];
 
   self.largeIconFloatingButton = [[MDCFloatingButton alloc] init];
   self.largeIconFloatingButton.translatesAutoresizingMaskIntoConstraints = NO;
@@ -74,8 +69,6 @@
                                               inMode:MDCFloatingButtonModeExpanded];
   [MDCFloatingButtonColorThemer applySemanticColorScheme:colorScheme
                                                 toButton:self.largeIconFloatingButton];
-  [self.largeIconFloatingButton setImageTintColor:colorScheme.onSecondaryColor
-                                         forState:UIControlStateNormal];
 
   [self.view addSubview:self.iPadLabel];
   [self.view addSubview:self.miniFloatingButton];

--- a/components/Buttons/src/ColorThemer/MDCFloatingButtonColorThemer.m
+++ b/components/Buttons/src/ColorThemer/MDCFloatingButtonColorThemer.m
@@ -22,6 +22,8 @@
                         toButton:(nonnull MDCFloatingButton *)button {
   [self resetUIControlStatesForButtonTheming:button];
   [button setBackgroundColor:colorScheme.secondaryColor forState:UIControlStateNormal];
+  [button setImageTintColor:colorScheme.onSecondaryColor forState:UIControlStateNormal];
+
   button.disabledAlpha = 1.f;
 }
 

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -235,7 +235,8 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
     if (state == UIControlStateNormal) {
       XCTAssertEqual([button backgroundColorForState:state], colorScheme.secondaryColor);
-    } else {
+      XCTAssertEqual([button imageTintColorForState:state], colorScheme.onSecondaryColor);
+   } else {
       XCTAssertEqual([button backgroundColorForState:state], nil);
     }
   }


### PR DESCRIPTION
Floating button themer now sets the imageTintColor:forState: to customize the color of fab image tint.
Examples/Tests are updated.

Pivotal: https://www.pivotaltracker.com/story/show/157001235
![screen shot 2018-04-20 at 1 14 17 pm](https://user-images.githubusercontent.com/36271115/39136434-39349dee-46e9-11e8-8dfb-99396185e044.png)
