### PR TITLE
[Catalog] Make all swift copycat demos be dragons.

### DIFF
--- a/components/ActivityIndicator/examples/ActivityIndicatorExample.swift
+++ b/components/ActivityIndicator/examples/ActivityIndicatorExample.swift
@@ -90,8 +90,4 @@ extension ActivityIndicatorSwiftController : MDCActivityIndicatorDelegate {
    @objc class func catalogIsPrimaryDemo() -> Bool {
       return false
    }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
 }

--- a/components/AnimationTiming/examples/AnimationTimingExample.swift
+++ b/components/AnimationTiming/examples/AnimationTimingExample.swift
@@ -185,9 +185,4 @@ extension AnimationTimingExample {
    @objc class func catalogIsPrimaryDemo() -> Bool {
       return false
    }
-
-   @objc class func catalogIsPresentable() -> Bool {
-     return true
-   }
-  
 }

--- a/components/AppBar/examples/AppBarDelegateForwardingExample.swift
+++ b/components/AppBar/examples/AppBarDelegateForwardingExample.swift
@@ -122,10 +122,6 @@ extension AppBarDelegateForwardingExample {
   func catalogShouldHideNavigation() -> Bool {
     return true
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
 }
 
 extension AppBarDelegateForwardingExample {

--- a/components/AppBar/examples/AppBarImageryExample.swift
+++ b/components/AppBar/examples/AppBarImageryExample.swift
@@ -96,11 +96,6 @@ extension AppBarImagerySwiftExample {
   func catalogShouldHideNavigation() -> Bool {
     return true
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
-  
 }
 
 // MARK: - Typical application code (not Material-specific)

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
@@ -76,9 +76,4 @@ extension AppBarInterfaceBuilderSwiftExample {
   func catalogShouldHideNavigation() -> Bool {
     return true
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
-
 }

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -158,10 +158,6 @@ extension AppBarModalPresentationSwiftExample {
   func catalogShouldHideNavigation() -> Bool {
     return true
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
 }
 
 // MARK: - Typical application code (not Material-specific)

--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -96,10 +96,6 @@ extension AppBarTypicalUseSwiftExample {
   func catalogShouldHideNavigation() -> Bool {
     return true
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
 }
 
 // MARK: - Typical application code (not Material-specific)

--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
@@ -137,8 +137,4 @@ extension BottomAppBarTypicalUseSwiftExample {
   func catalogShouldHideNavigation() -> Bool {
     return true
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
 }

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
@@ -115,8 +115,4 @@ extension BottomNavigationTypicalUseSwiftExample {
   func catalogShouldHideNavigation() -> Bool {
     return true
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
 }

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
@@ -84,9 +84,5 @@ extension ButtonBarTypicalUseSwiftExample {
   @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
 }
 

--- a/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
+++ b/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
@@ -112,10 +112,6 @@ extension FloatingButtonExampleSwiftViewController {
   @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
 }
 
 extension FloatingButtonExampleSwiftViewController {

--- a/components/Cards/examples/EditReorderCollectionViewController.swift
+++ b/components/Cards/examples/EditReorderCollectionViewController.swift
@@ -185,7 +185,7 @@ class EditReorderCollectionViewController: UIViewController,
 
 extension EditReorderCollectionViewController {
   @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Cards", "Edit/Reorder (Swift)"]
+    return ["Cards", "Edit/Reorder"]
   }
 
   @objc class func catalogIsPresentable() -> Bool {

--- a/components/Dialogs/examples/DialogsLongAlertViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertViewController.swift
@@ -83,8 +83,4 @@ extension DialogsLongAlertViewController {
   @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
 }

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTypicalUseSupplemental.swift
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTypicalUseSupplemental.swift
@@ -39,7 +39,6 @@ extension FlexibleHeaderTypicalUseViewControllerSwift {
   }
 
   @objc class func catalogIsPresentable() -> Bool {
-    return true
+    return false
   }
-
 }

--- a/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.swift
+++ b/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.swift
@@ -37,6 +37,6 @@ extension HeaderStackViewTypicalUseSwiftExample {
   }
 
   @objc class func catalogIsPresentable() -> Bool {
-    return true
+    return false
   }
 }

--- a/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.swift
+++ b/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.swift
@@ -39,7 +39,7 @@ extension NavigationBarTypicalUseSwiftExample {
   }
 
   @objc class func catalogIsPresentable() -> Bool {
-    return true
+    return false
   }
 
   override open func setupExampleViews() {

--- a/components/PageControl/examples/PageControlTypicalUseExample.swift
+++ b/components/PageControl/examples/PageControlTypicalUseExample.swift
@@ -129,8 +129,4 @@ class PageControlSwiftExampleViewController: UIViewController, UIScrollViewDeleg
   @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
 }

--- a/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.swift
+++ b/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.swift
@@ -73,8 +73,4 @@ extension ShadowElevationsTypicalUseExample {
   func catalogShouldHideNavigation() -> Bool {
     return true
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
 }

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
@@ -249,8 +249,4 @@ extension TabBarIconSwiftExample {
   func catalogShouldHideNavigation() -> Bool {
     return true
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
 }

--- a/components/TextFields/examples/MultilineTextFieldLegacyExample.m
+++ b/components/TextFields/examples/MultilineTextFieldLegacyExample.m
@@ -256,7 +256,7 @@
 #pragma mark - CatalogByConvention
 
 + (NSArray *)catalogBreadcrumbs {
-  return @[ @"Text Field", @"[Legacy] Multi-line (Objective C)" ];
+  return @[ @"Text Field", @"[Legacy] Multi-line" ];
 }
 
 + (BOOL)catalogIsPrimaryDemo {

--- a/components/TextFields/examples/TextFieldCustomFontExample.m
+++ b/components/TextFields/examples/TextFieldCustomFontExample.m
@@ -429,7 +429,7 @@ replacementString:(NSString *)string {
 @implementation TextFieldCustomFontExample (CatalogByConvention)
 
 + (NSArray *)catalogBreadcrumbs {
-  return @[ @"Text Field", @"Custom Fonts (Objective-C)" ];
+  return @[ @"Text Field", @"Custom Fonts" ];
 }
 
 + (BOOL)catalogIsPrimaryDemo {

--- a/components/TextFields/examples/TextFieldLegacyExample.swift
+++ b/components/TextFields/examples/TextFieldLegacyExample.swift
@@ -419,9 +419,4 @@ extension TextFieldLegacySwiftExample {
   @objc class func catalogBreadcrumbs() -> [String] {
     return ["Text Field", "[Legacy] Typical Use"]
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
-
 }

--- a/components/TextFields/examples/TextFieldManualLayoutLegacyExample.m
+++ b/components/TextFields/examples/TextFieldManualLayoutLegacyExample.m
@@ -154,7 +154,7 @@
 @implementation TextFieldManualLayoutLegacyExample (CatalogByConvention)
 
 + (NSArray *)catalogBreadcrumbs {
-  return @[ @"Text Field", @"[Legacy] Manual Layout (Objective C)" ];
+  return @[ @"Text Field", @"[Legacy] Manual Layout" ];
 }
 
 + (BOOL)catalogIsPrimaryDemo {

--- a/components/TextFields/examples/TextFieldManualLayoutLegacyExample.swift
+++ b/components/TextFields/examples/TextFieldManualLayoutLegacyExample.swift
@@ -346,8 +346,4 @@ extension TextFieldManualLayoutLegacySwiftExample {
   @objc class func catalogIsPrimaryDemo() -> Bool {
     return false
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
 }

--- a/components/TextFields/examples/TextFieldOutlinedExample.m
+++ b/components/TextFields/examples/TextFieldOutlinedExample.m
@@ -411,7 +411,7 @@
 @implementation TextFieldOutlinedObjectiveCExample (CatalogByConvention)
 
 + (NSArray *)catalogBreadcrumbs {
-  return @[ @"Text Field", @"Text Field Typical Use (Objective-C)" ];
+  return @[ @"Text Field", @"Text Field Typical Use" ];
 }
 
 + (BOOL)catalogIsPrimaryDemo {

--- a/components/TextFields/examples/TextFieldOutlinedExample.swift
+++ b/components/TextFields/examples/TextFieldOutlinedExample.swift
@@ -417,8 +417,4 @@ extension TextFieldOutlinedSwiftExample {
   @objc class func catalogBreadcrumbs() -> [String] {
     return ["Text Field", "Outlined Fields & Text Areas"]
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
 }

--- a/components/TextFields/examples/TextFieldStatesViewController.m
+++ b/components/TextFields/examples/TextFieldStatesViewController.m
@@ -269,7 +269,7 @@
 @implementation TextFieldStatesViewController (CatalogByConvention)
 
 + (NSArray *)catalogBreadcrumbs {
-  return @[ @"Text Field", @"States (Objective-C)" ];
+  return @[ @"Text Field", @"States" ];
 }
 
 + (BOOL)catalogIsPrimaryDemo {


### PR DESCRIPTION
Also removed "(Swift)" from any examples that remained as non-dragons. The catalog does not need to advertise which language a given demo is in.

Pivotal story: https://www.pivotaltracker.com/story/show/156939611

## Screenshots

Before:
![simulator screen shot - iphone se - 2018-04-23 at 14 04 14](https://user-images.githubusercontent.com/45670/39144588-36095450-46ff-11e8-868d-bdb7e8ee5438.png)

After:
![simulator screen shot - iphone se - 2018-04-23 at 13 53 39](https://user-images.githubusercontent.com/45670/39144567-2ad7bf9a-46ff-11e8-9fd5-ef0739d427b3.png)
