### PR TITLE
[Chips] Reset cell selection state to NO on prepare for reuse.

### DIFF
--- a/components/Chips/src/MDCChipCollectionViewCell.m
+++ b/components/Chips/src/MDCChipCollectionViewCell.m
@@ -41,6 +41,14 @@ static NSString *const MDCChipCollectionViewCellChipViewKey =
   return self;
 }
 
+- (void)prepareForReuse {
+  [super prepareForReuse];
+
+  // when reload data we want to make sure we always reset the layout. (Other wise animating layout
+  // could break the chip selection state)
+  self.selected = NO;
+}
+
 - (void)encodeWithCoder:(NSCoder *)aCoder {
   [super encodeWithCoder:aCoder];
 

--- a/components/Chips/src/MDCChipCollectionViewCell.m
+++ b/components/Chips/src/MDCChipCollectionViewCell.m
@@ -44,8 +44,8 @@ static NSString *const MDCChipCollectionViewCellChipViewKey =
 - (void)prepareForReuse {
   [super prepareForReuse];
 
-  // when reload data we want to make sure we always reset the layout. (Other wise animating layout
-  // could break the chip selection state)
+  // When reload data we want to make sure we always reset the state. (Other wise animating layout
+  // could break the chip selection state).
   self.selected = NO;
 }
 


### PR DESCRIPTION
When reload data we want to make sure we always reset the state. (Other wise animating layout could break the chip selection state).
Step to reproduce the issue in pivotal.
Pivotal issue: https://www.pivotaltracker.com/story/show/157009285
