### PR TITLE
Make MDCAppBarContainerViewController set bounds of child view controller

### DIFF
--- a/components/AppBar/src/MDCAppBarContainerViewController.m
+++ b/components/AppBar/src/MDCAppBarContainerViewController.m
@@ -50,6 +50,7 @@
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
   [_appBar.headerViewController updateTopLayoutGuide];
+  self.contentViewController.view.frame = self.view.bounds;
 }
 
 - (BOOL)prefersStatusBarHidden {


### PR DESCRIPTION
The contained child view should fill its container's bounds. @jverkoey as owner, does this approach seem reasonable? This fix is triggered specifically by wanting to use a UITableViewController within MDCAppBarContainerViewController - UITableViewController loads its view with a frame inset equal to the window's top layout guide length. This inset would be removed when pushed to a navigation controller, but isnt currently removed when added to a MDCAppBarContainerViewController first. 