### PR TITLE
Replace collection view with table view in indicator example

### DIFF
--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.h
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.h
@@ -30,7 +30,7 @@ static const CGFloat kActivityInitialProgress = 0.6f;
 @class ActivityIndicatorExample;
 @class MDCActivityIndicator;
 
-@interface ActivityIndicatorExample : MDCCollectionViewController <MDCActivityIndicatorDelegate>
+@interface ActivityIndicatorExample : UITableViewController <MDCActivityIndicatorDelegate>
 
 @property(nonatomic, strong) MDCActivityIndicator *activityIndicator1;
 @property(nonatomic, strong) MDCActivityIndicator *activityIndicator2;

--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
@@ -52,8 +52,7 @@ static NSString * const kCell = @"Cell";
 @implementation ActivityIndicatorExample (Supplemental)
 
 - (void)setupExampleViews {
-  [self.collectionView registerClass:[MDCCollectionViewTextCell class]
-          forCellWithReuseIdentifier:kCell];
+  [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:kCell];
 
   // Set up container view of three activity indicators.
   UIView *indicators =
@@ -92,6 +91,9 @@ static NSString * const kCell = @"Cell";
 
   self.activityIndicator2.progress = self.slider.value;
   self.activityIndicator3.progress = self.slider.value;
+
+  self.tableView.layoutMargins = UIEdgeInsetsZero;
+  self.tableView.separatorInset = UIEdgeInsetsZero;
 }
 
 - (void)didChangeOnSwitch:(UISwitch *)onSwitch {
@@ -120,31 +122,27 @@ static NSString * const kCell = @"Cell";
   self.activityIndicator1.progress = slider.value;
   self.activityIndicator2.progress = slider.value;
   self.activityIndicator3.progress = slider.value;
-  MDCCollectionViewTextCell *cell =
-      (MDCCollectionViewTextCell *)[self.collectionView cellForItemAtIndexPath:
-                                        [NSIndexPath indexPathForRow:1 inSection:0]];
+  UITableViewCell *cell =
+      [self.tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:1 inSection:0]];
   cell.textLabel.text = [NSString stringWithFormat:@"%.00f%%", slider.value * 100];
   [cell setNeedsDisplay];
 }
 
 #pragma mark -
 
-
-- (NSInteger)collectionView:(UICollectionView *)collectionView
-     numberOfItemsInSection:(NSInteger)section {
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
   return 4;
 }
 
-- (CGFloat)collectionView:(UICollectionView *)collectionView
-    cellHeightAtIndexPath:(NSIndexPath *)indexPath {
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
   if (indexPath.row == 0) return 160;
   return 56;
 }
 
-- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
-                  cellForItemAtIndexPath:(NSIndexPath *)indexPath {
-  MDCCollectionViewTextCell *cell =
-      [collectionView dequeueReusableCellWithReuseIdentifier:kCell forIndexPath:indexPath];
+- (UITableViewCell *)tableView:(UITableView *)tableView
+         cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+  UITableViewCell *cell =
+      [tableView dequeueReusableCellWithIdentifier:kCell forIndexPath:indexPath];
   cell.textLabel.text = @"";
   switch (indexPath.row) {
     case 0:
@@ -169,6 +167,5 @@ static NSString * const kCell = @"Cell";
   }
   return cell;
 }
-
 
 @end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/156939378

Replace MDCCollectionView usage in activity indicator's examples with a UITableView.

Before:
![simulator screen shot - iphone x - 2018-04-23 at 15 24 56](https://user-images.githubusercontent.com/1418389/39152927-d975e38e-4717-11e8-8681-81d127932f31.png)

After:
![simulator screen shot - iphone x - 2018-04-23 at 17 02 46](https://user-images.githubusercontent.com/1418389/39153120-381d9e54-4718-11e8-8649-1863b091e08f.png)

