### PR TITLE
[Buttons] Replace MDCRaisedButton with contained button APIs in content edge insets example.

### DIFF
--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -17,13 +17,14 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialButtons.h"
+#import "MDCButtonScheme.h"
+#import "MDCContainedButtonThemer.h"
 
 @interface ButtonsContentEdgeInsetsExample : UIViewController
 @property(weak, nonatomic) IBOutlet MDCFlatButton *flatButton;
-@property(weak, nonatomic) IBOutlet MDCRaisedButton *raisedButton;
+@property(weak, nonatomic) IBOutlet MDCButton *containedButton;
 @property(weak, nonatomic) IBOutlet MDCFloatingButton *floatingActionButton;
 @property(weak, nonatomic) IBOutlet UISwitch *inkBoundingSwitch;
-
 @end
 
 @implementation ButtonsContentEdgeInsetsExample
@@ -47,12 +48,15 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
+  MDCButtonScheme *buttonScheme = [[MDCButtonScheme alloc] init];
+  [MDCContainedButtonThemer applyScheme:buttonScheme toButton:self.containedButton];
+
   // Force a darker background color to show the button frame
   [self.flatButton setBackgroundColor:[UIColor colorWithWhite:0.2f alpha:1.0f]
                              forState:UIControlStateNormal];
   self.flatButton.inkColor = [UIColor colorWithWhite:1.0f alpha:0.1f];
   self.flatButton.contentEdgeInsets = UIEdgeInsetsMake(64, 64, 0, 0);
-  self.raisedButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, 64, 64);
+  self.containedButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, 64, 64);
   [self.floatingActionButton setContentEdgeInsets:UIEdgeInsetsMake(40, 40, 0, 0)
                                          forShape:MDCFloatingButtonShapeDefault
                                            inMode:MDCFloatingButtonModeNormal];
@@ -62,7 +66,7 @@
 
 - (void)updateInkStyle:(MDCInkStyle)inkStyle {
   self.flatButton.inkStyle = inkStyle;
-  self.raisedButton.inkStyle = inkStyle;
+  self.containedButton.inkStyle = inkStyle;
   self.floatingActionButton.inkStyle = inkStyle;
 }
 

--- a/components/Buttons/examples/resources/ButtonsContentEdgeInsets.storyboard
+++ b/components/Buttons/examples/resources/ButtonsContentEdgeInsets.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Uhh-iX-aVf">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13770" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Uhh-iX-aVf">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13770"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,7 +22,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bvE-5P-0PG" customClass="MDCFlatButton">
-                                <rect key="frame" x="127.5" y="83" width="120" height="34"/>
+                                <rect key="frame" x="115.5" y="83" width="144" height="34"/>
                                 <color key="tintColor" red="0.19254023644059035" green="0.53181806153905575" blue="0.91669365284974091" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <inset key="contentEdgeInsets" minX="0.0" minY="0.0" maxX="16" maxY="16"/>
                                 <state key="normal" title="Flat Button">
@@ -30,9 +30,9 @@
                                 </state>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dqo-nu-adB" customClass="MDCRaisedButton">
-                                <rect key="frame" x="127" y="133" width="120" height="18"/>
+                                <rect key="frame" x="115" y="133" width="144" height="18"/>
                                 <inset key="contentEdgeInsets" minX="0.0" minY="0.0" maxX="24" maxY="0.0"/>
-                                <state key="normal" title="Raised Button">
+                                <state key="normal" title="Contained Button">
                                     <color key="titleColor" cocoaTouchSystemColor="lightTextColor"/>
                                 </state>
                             </button>
@@ -84,10 +84,10 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="containedButton" destination="Dqo-nu-adB" id="wM8-hW-eZt"/>
                         <outlet property="flatButton" destination="bvE-5P-0PG" id="8px-6Z-f5o"/>
                         <outlet property="floatingActionButton" destination="YCS-6P-hwz" id="Mw6-3r-5YL"/>
                         <outlet property="inkBoundingSwitch" destination="2pb-ML-fiY" id="LUP-MI-2Lq"/>
-                        <outlet property="raisedButton" destination="Dqo-nu-adB" id="rEm-SL-wQr"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Z12-Wq-Srl" userLabel="First Responder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
Pivotal story: https://www.pivotaltracker.com/story/show/157045336

Before:
![simulator screen shot - iphone se - 2018-04-24 at 07 30 07](https://user-images.githubusercontent.com/45670/39184503-995e4cda-4791-11e8-9ba7-6049c1a4d905.png)

After:
![simulator screen shot - iphone se - 2018-04-24 at 07 29 48](https://user-images.githubusercontent.com/45670/39184509-9bf4893c-4791-11e8-9fdf-a58c36fd90ce.png)
