### PR TITLE
[Dialogs] Replace MDCRaisedButton with themer APIs in DialogWithPreferredContentSizeViewController.

### DIFF
--- a/components/Dialogs/examples/DialogsTypicalUseViewController.m
+++ b/components/Dialogs/examples/DialogsTypicalUseViewController.m
@@ -16,6 +16,7 @@
 
 #import "MaterialDialogs.h"
 #import "supplemental/DialogsTypicalUseSupplemental.h"
+#import "supplemental/DialogWithPreferredContentSizeViewController.h"
 
 @interface DialogsTypicalUseViewController ()
 
@@ -86,11 +87,12 @@
       [UIStoryboard storyboardWithName:@"DialogWithPreferredContentSize" bundle:bundle];
   NSString *identifier = @"DialogID";
 
-  UIViewController *viewController =
+  DialogWithPreferredContentSizeViewController *viewController =
       [storyboard instantiateViewControllerWithIdentifier:identifier];
   viewController.modalPresentationStyle = UIModalPresentationCustom;
   viewController.transitioningDelegate = self.transitionController;
-
+  viewController.colorScheme = self.colorScheme;
+  viewController.typographyScheme = self.typographyScheme;
   [self presentViewController:viewController animated:YES completion:NULL];
 }
 

--- a/components/Dialogs/examples/resources/DialogWithPreferredContentSize.storyboard
+++ b/components/Dialogs/examples/resources/DialogWithPreferredContentSize.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13770" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13770"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -23,7 +23,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Storyboard" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="90p-55-soM">
-                                <rect key="frame" x="16" y="28" width="208" height="41"/>
+                                <rect key="frame" x="16" y="8" width="208" height="41"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="41" id="WYg-Oo-3ho"/>
                                 </constraints>
@@ -32,21 +32,19 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This view controller has a preferredContentSize which is observed by our presentation controller. " lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CKe-6Q-X99">
-                                <rect key="frame" x="16" y="77" width="208" height="99"/>
+                                <rect key="frame" x="16" y="57" width="208" height="119"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eMP-C9-zSz" customClass="MDCRaisedButton">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eMP-C9-zSz" customClass="MDCButton">
                                 <rect key="frame" x="110" y="184" width="114" height="36"/>
                                 <color key="backgroundColor" red="0.0" green="0.50196081400000003" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="114" id="Xs0-2D-eQT"/>
                                     <constraint firstAttribute="height" constant="36" id="hWD-nJ-iWR"/>
                                 </constraints>
-                                <state key="normal" title="Okay">
-                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
+                                <state key="normal" title="Okay"/>
                                 <connections>
                                     <action selector="buttonPushed:" destination="qQc-Ib-5lF" eventType="touchUpInside" id="A7U-Zd-q5z"/>
                                 </connections>
@@ -68,6 +66,9 @@
                     <value key="contentSizeForViewInPopover" type="size" width="240" height="240"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="240" height="240"/>
+                    <connections>
+                        <outlet property="button" destination="eMP-C9-zSz" id="yuv-Mo-pAN"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="L5k-yb-utR" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeViewController.h
+++ b/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeViewController.h
@@ -19,8 +19,14 @@
  instructions. It is not necessary to import this file to use Material Components for iOS.
  */
 
+#import "MaterialColorScheme.h"
+#import "MaterialTypographyScheme.h"
+
 #import <UIKit/UIKit.h>
 
 @interface DialogWithPreferredContentSizeViewController : UIViewController
+
+@property(nonatomic, strong, nullable) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong, nullable) MDCTypographyScheme *typographyScheme;
 
 @end

--- a/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeViewController.m
@@ -26,6 +26,8 @@
 
 @interface DialogWithPreferredContentSizeViewController()
 @property(nonatomic, strong) IBOutlet MDCButton *button;
+@property(nonatomic, strong, nullable) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong, nullable) MDCTypographyScheme *typographyScheme;
 @end
 
 @implementation DialogWithPreferredContentSizeViewController
@@ -34,6 +36,8 @@
   [super viewDidLoad];
 
   MDCButtonScheme *scheme = [[MDCButtonScheme alloc] init];
+  scheme.colorScheme = self.colorScheme;
+  scheme.typographyScheme = self.typographyScheme;
   [MDCContainedButtonThemer applyScheme:scheme toButton:self.button];
 }
 

--- a/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeViewController.m
@@ -21,7 +21,21 @@
 
 #import "DialogWithPreferredContentSizeViewController.h"
 
+#import "MaterialButtons.h"
+#import "MaterialButtons+ButtonThemer.h"
+
+@interface DialogWithPreferredContentSizeViewController()
+@property(nonatomic, strong) IBOutlet MDCButton *button;
+@end
+
 @implementation DialogWithPreferredContentSizeViewController
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  MDCButtonScheme *scheme = [[MDCButtonScheme alloc] init];
+  [MDCContainedButtonThemer applyScheme:scheme toButton:self.button];
+}
 
 - (IBAction)buttonPushed:(id)sender {
   [self.presentingViewController dismissViewControllerAnimated:YES completion:NULL];

--- a/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeViewController.m
@@ -26,8 +26,6 @@
 
 @interface DialogWithPreferredContentSizeViewController()
 @property(nonatomic, strong) IBOutlet MDCButton *button;
-@property(nonatomic, strong, nullable) MDCSemanticColorScheme *colorScheme;
-@property(nonatomic, strong, nullable) MDCTypographyScheme *typographyScheme;
 @end
 
 @implementation DialogWithPreferredContentSizeViewController

--- a/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.h
+++ b/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.h
@@ -22,11 +22,13 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialCollections.h"
-
-//@class DialogsTypicalUseViewController;
+#import "MaterialColorScheme.h"
+#import "MaterialTypographyScheme.h"
 
 @interface DialogsTypicalUseViewController : MDCCollectionViewController
 @property(nonatomic, strong, nullable) NSArray *modes;
+@property(nonatomic, strong, nullable) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong, nullable) MDCTypographyScheme *typographyScheme;
 @end
 
 @interface DialogsTypicalUseViewController (Supplemental)


### PR DESCRIPTION
This also fixed a bug where the raised button's title text was getting tinted. This was because the button was being initialized as a "system" button in interface builder rather than as a "custom" button.

Pivotal story: https://www.pivotaltracker.com/story/show/157096622

## Screenshots

### Before

Normal state.

![simulator screen shot - iphone se - 2018-04-25 at 16 28 15](https://user-images.githubusercontent.com/45670/39271103-02e61600-48a6-11e8-9659-26acfed7e8ab.png)

Highlighted state. Note that the title text is faded.

![simulator screen shot - iphone se - 2018-04-25 at 16 28 17](https://user-images.githubusercontent.com/45670/39271111-0a6981be-48a6-11e8-809e-b2314b23cad3.png)

### After

Normal state.

![simulator screen shot - iphone se - 2018-04-25 at 16 47 40](https://user-images.githubusercontent.com/45670/39271943-7d19d482-48a8-11e8-8c5a-09adc224f5f5.png)

Highlighted state.

![simulator screen shot - iphone se - 2018-04-25 at 16 47 42](https://user-images.githubusercontent.com/45670/39271947-800afcca-48a8-11e8-9c5a-eca9aeb07ac6.png)
