### PR TITLE
[Activity Indicator] Update the minimum radius documented in the header

### DIFF
--- a/components/ActivityIndicator/src/MDCActivityIndicator.h
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.h
@@ -58,7 +58,7 @@ IB_DESIGNABLE
 @property(nonatomic, assign, getter=isAnimating) BOOL animating;
 
 /**
- Spinner radius width. Defaults to 12dp (24x24dp circle), constrained to range [8dp, 72dp]. The
+ Spinner radius width. Defaults to 12dp (24x24dp circle), constrained to range [5dp, 72dp]. The
  spinner is centered in the view's bounds. If the bounds are smaller than the diameter of the
  spinner, the spinner may be clipped when clipToBounds is true.
  */


### PR DESCRIPTION
The actual implementation is changed in https://github.com/material-components/material-components-ios/pull/887, but it seems that the documentation hasn't been updated.