### PR TITLE
[Chips] Apply stroke to stroked chips

### DIFF
--- a/components/Chips/examples/ChipsActionExampleViewController.m
+++ b/components/Chips/examples/ChipsActionExampleViewController.m
@@ -101,10 +101,8 @@
 
   // Apply Theming
   if (_isStroked) {
-    [chipView setBorderWidth:1 forState:UIControlStateNormal];
     [MDCChipViewColorThemer applySemanticColorScheme:self.colorScheme toStrokedChipView:chipView];
   } else {
-    [chipView setBorderWidth:0 forState:UIControlStateNormal];
     [MDCChipViewColorThemer applySemanticColorScheme:self.colorScheme toChipView:chipView];
   }
 

--- a/components/Chips/examples/ChipsChoiceExampleViewController.m
+++ b/components/Chips/examples/ChipsChoiceExampleViewController.m
@@ -100,10 +100,8 @@
     [chipView setEnabled:NO];
   }
   if (_isStroked) {
-    [chipView setBorderWidth:1 forState:UIControlStateNormal];
     [MDCChipViewColorThemer applySemanticColorScheme:_colorScheme toStrokedChipView:chipView];
   } else {
-    [chipView setBorderWidth:0 forState:UIControlStateNormal];
     [MDCChipViewColorThemer applySemanticColorScheme:_colorScheme toChipView:chipView];
   }
 

--- a/components/Chips/examples/ChipsFilterExampleViewController.m
+++ b/components/Chips/examples/ChipsFilterExampleViewController.m
@@ -107,10 +107,8 @@
   cell.alwaysAnimateResize = [self shouldAnimateResize];
  
   if (_isStroked) {
-    [chipView setBorderWidth:1 forState:UIControlStateNormal];
     [MDCChipViewColorThemer applySemanticColorScheme:self.colorScheme toStrokedChipView:chipView];
   } else {
-    [chipView setBorderWidth:0 forState:UIControlStateNormal];
     [MDCChipViewColorThemer applySemanticColorScheme:self.colorScheme toChipView:chipView];
   }
 

--- a/components/Chips/examples/ChipsInputExampleViewController.m
+++ b/components/Chips/examples/ChipsInputExampleViewController.m
@@ -54,10 +54,8 @@
 - (void)chipField:(MDCChipField *)chipField didAddChip:(MDCChipView *)chip {
   // Every other chip is stroked
   if (chipField.chips.count%2) {
-    [chip setBorderWidth:1 forState:UIControlStateNormal];
     [MDCChipViewColorThemer applySemanticColorScheme:self.colorScheme toStrokedChipView:chip];
   } else {
-    [chip setBorderWidth:0 forState:UIControlStateNormal];
     [MDCChipViewColorThemer applySemanticColorScheme:self.colorScheme toChipView:chip];
   }
 

--- a/components/Chips/src/ColorThemer/MDCChipViewColorThemer.m
+++ b/components/Chips/src/ColorThemer/MDCChipViewColorThemer.m
@@ -84,6 +84,7 @@
                              forState:UIControlStateDisabled];
   [strokedChipView setBorderColor:[borderColor colorWithAlphaComponent:0.38f]
                          forState:UIControlStateDisabled];
+  [strokedChipView setBorderWidth:1 forState:UIControlStateNormal];
 }
 
 + (void)resetUIControlStatesForChipTheming:(nonnull MDCChipView *)chipView {
@@ -93,6 +94,7 @@
     [chipView setBackgroundColor:nil forState:state];
     [chipView setTitleColor:nil forState:state];
     [chipView setBorderColor:nil forState:state];
+    [chipView setBorderWidth:0 forState:state];
   }
 }
 

--- a/components/Chips/tests/unit/ChipViewColorThemerTests.m
+++ b/components/Chips/tests/unit/ChipViewColorThemerTests.m
@@ -38,8 +38,11 @@
   self.colorScheme = nil;
 }
 
-- (void)testInputChipViewColorThemer {
+- (void)testFilledChipViewColorThemer {
+  // When
   [MDCChipViewColorThemer applySemanticColorScheme:self.colorScheme toChipView:self.chip];
+
+  // Then
   UIColor *onSurface12Opacity = [self.colorScheme.onSurfaceColor colorWithAlphaComponent:0.12f];
   UIColor *onSurface87Opacity = [self.colorScheme.onSurfaceColor colorWithAlphaComponent:0.87f];
   UIColor *onSurface16Opacity = [self.colorScheme.onSurfaceColor colorWithAlphaComponent:0.16f];
@@ -60,6 +63,7 @@
   XCTAssertEqualObjects([self.chip inkColorForState:UIControlStateNormal], onSurface16Opacity);
   XCTAssertEqualObjects([self.chip titleColorForState:UIControlStateNormal], textColor);
   XCTAssertEqualObjects([self.chip backgroundColorForState:UIControlStateNormal], backgroundColor);
+  XCTAssertEqualWithAccuracy([self.chip borderWidthForState:UIControlStateNormal], 0, 0.001);
   XCTAssertEqualObjects([self.chip backgroundColorForState:UIControlStateSelected],
                         selectedBackgroundColor);
   XCTAssertEqualObjects([self.chip titleColorForState:UIControlStateSelected], selectedTextColor);
@@ -67,11 +71,49 @@
                         [backgroundColor colorWithAlphaComponent:0.38f]);
   XCTAssertEqualObjects([self.chip titleColorForState:UIControlStateDisabled],
                         [textColor colorWithAlphaComponent:0.38f]);
+}
 
+- (void)testFilledChipViewColorThemerResetsPreviousValues {
+  // When
+  [MDCChipViewColorThemer applySemanticColorScheme:self.colorScheme toStrokedChipView:self.chip];
+  [MDCChipViewColorThemer applySemanticColorScheme:self.colorScheme toChipView:self.chip];
+
+  // Then
+  UIColor *onSurface12Opacity = [self.colorScheme.onSurfaceColor colorWithAlphaComponent:0.12f];
+  UIColor *onSurface87Opacity = [self.colorScheme.onSurfaceColor colorWithAlphaComponent:0.87f];
+  UIColor *onSurface16Opacity = [self.colorScheme.onSurfaceColor colorWithAlphaComponent:0.16f];
+
+  UIColor *backgroundColor =
+  [MDCSemanticColorScheme blendColor:onSurface12Opacity
+                 withBackgroundColor:self.colorScheme.surfaceColor];
+  UIColor *selectedBackgroundColor =
+  [MDCSemanticColorScheme blendColor:onSurface12Opacity
+                 withBackgroundColor:backgroundColor];
+  UIColor *textColor =
+  [MDCSemanticColorScheme blendColor:onSurface87Opacity
+                 withBackgroundColor:backgroundColor];
+  UIColor *selectedTextColor =
+  [MDCSemanticColorScheme blendColor:onSurface87Opacity
+                 withBackgroundColor:selectedBackgroundColor];
+
+  XCTAssertEqualObjects([self.chip inkColorForState:UIControlStateNormal], onSurface16Opacity);
+  XCTAssertEqualObjects([self.chip titleColorForState:UIControlStateNormal], textColor);
+  XCTAssertEqualObjects([self.chip backgroundColorForState:UIControlStateNormal], backgroundColor);
+  XCTAssertEqualWithAccuracy([self.chip borderWidthForState:UIControlStateNormal], 0, 0.001);
+  XCTAssertEqualObjects([self.chip backgroundColorForState:UIControlStateSelected],
+                        selectedBackgroundColor);
+  XCTAssertEqualObjects([self.chip titleColorForState:UIControlStateSelected], selectedTextColor);
+  XCTAssertEqualObjects([self.chip backgroundColorForState:UIControlStateDisabled],
+                        [backgroundColor colorWithAlphaComponent:0.38f]);
+  XCTAssertEqualObjects([self.chip titleColorForState:UIControlStateDisabled],
+                        [textColor colorWithAlphaComponent:0.38f]);
 }
 
 - (void)testStrokedChipViewColorThemer {
+  // When
   [MDCChipViewColorThemer applySemanticColorScheme:self.colorScheme toStrokedChipView:self.chip];
+
+  // Then
   UIColor *onSurface12Opacity = [self.colorScheme.onSurfaceColor colorWithAlphaComponent:0.12f];
   UIColor *onSurface87Opacity = [self.colorScheme.onSurfaceColor colorWithAlphaComponent:0.87f];
   UIColor *onSurface16Opacity = [self.colorScheme.onSurfaceColor colorWithAlphaComponent:0.16f];
@@ -95,6 +137,46 @@
   XCTAssertEqualObjects([self.chip titleColorForState:UIControlStateNormal], textColor);
   XCTAssertEqualObjects([self.chip backgroundColorForState:UIControlStateNormal],
                         self.colorScheme.surfaceColor);
+  XCTAssertEqualWithAccuracy([self.chip borderWidthForState:UIControlStateNormal], 1, 0.001);
+  XCTAssertEqualObjects([self.chip backgroundColorForState:UIControlStateSelected],
+                        selectedBackgroundColor);
+  XCTAssertEqualObjects([self.chip titleColorForState:UIControlStateSelected], selectedTextColor);
+  XCTAssertEqualObjects([self.chip backgroundColorForState:UIControlStateDisabled],
+                        [self.colorScheme.surfaceColor colorWithAlphaComponent:0.38f]);
+  XCTAssertEqualObjects([self.chip titleColorForState:UIControlStateDisabled],
+                        [textColor colorWithAlphaComponent:0.38f]);
+}
+
+- (void)testStrokedChipViewColorThemerResetsPreviousValues {
+  // When
+  [MDCChipViewColorThemer applySemanticColorScheme:self.colorScheme toChipView:self.chip];
+  [MDCChipViewColorThemer applySemanticColorScheme:self.colorScheme toStrokedChipView:self.chip];
+
+  // Then
+  UIColor *onSurface12Opacity = [self.colorScheme.onSurfaceColor colorWithAlphaComponent:0.12f];
+  UIColor *onSurface87Opacity = [self.colorScheme.onSurfaceColor colorWithAlphaComponent:0.87f];
+  UIColor *onSurface16Opacity = [self.colorScheme.onSurfaceColor colorWithAlphaComponent:0.16f];
+  UIColor *selectedBackgroundColor =
+  [MDCSemanticColorScheme blendColor:onSurface12Opacity
+                 withBackgroundColor:self.colorScheme.surfaceColor];
+  UIColor *borderColor =
+  [MDCSemanticColorScheme blendColor:onSurface12Opacity
+                 withBackgroundColor:self.colorScheme.surfaceColor];
+  UIColor *textColor =
+  [MDCSemanticColorScheme blendColor:onSurface87Opacity
+                 withBackgroundColor:self.colorScheme.surfaceColor];
+  UIColor *selectedTextColor =
+  [MDCSemanticColorScheme blendColor:onSurface87Opacity
+                 withBackgroundColor:selectedBackgroundColor];
+
+  XCTAssertEqualObjects([self.chip borderColorForState:UIControlStateNormal], borderColor);
+  XCTAssertEqualObjects([self.chip borderColorForState:UIControlStateSelected],
+                        [UIColor clearColor]);
+  XCTAssertEqualObjects([self.chip inkColorForState:UIControlStateNormal], onSurface16Opacity);
+  XCTAssertEqualObjects([self.chip titleColorForState:UIControlStateNormal], textColor);
+  XCTAssertEqualObjects([self.chip backgroundColorForState:UIControlStateNormal],
+                        self.colorScheme.surfaceColor);
+  XCTAssertEqualWithAccuracy([self.chip borderWidthForState:UIControlStateNormal], 1, 0.001);
   XCTAssertEqualObjects([self.chip backgroundColorForState:UIControlStateSelected],
                         selectedBackgroundColor);
   XCTAssertEqualObjects([self.chip titleColorForState:UIControlStateSelected], selectedTextColor);


### PR DESCRIPTION
The MDCChipViewColorThemer was not setting the borderWidth for stroked chips,
resulting in chips that were not stroked. Setting a borderColor with a border
width of 0 is effectively a no-op.

Fixes #3508

**Before**
![choice-chips-before](https://user-images.githubusercontent.com/1753199/39311089-fcd22ba2-4939-11e8-8e3e-8a79c1ddd91f.png)

**After**
![choice-chips-after](https://user-images.githubusercontent.com/1753199/39311097-010d2adc-493a-11e8-963e-454c9d293d56.png)
