### PR TITLE
[Chips] Vertically center chips within available space

### DIFF
--- a/components/Chips/examples/ChipsInputExampleViewController.m
+++ b/components/Chips/examples/ChipsInputExampleViewController.m
@@ -35,6 +35,7 @@
   _chipField = [[MDCChipField alloc] initWithFrame:CGRectZero];
   _chipField.delegate = self;
   _chipField.textField.placeholderLabel.text = @"This is a chip field.";
+  _chipField.chipHeight = 48;
   _chipField.backgroundColor = [UIColor whiteColor];
   [self.view addSubview:_chipField];
 }

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -562,8 +562,9 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
       row++;
       currentOriginX = self.contentEdgeInsets.left;
     }
-    CGFloat currentOriginY =
-        self.contentEdgeInsets.top + (row * (self.chipHeight + MDCChipFieldVerticalMargin));
+    CGFloat chipCenteringOffset = (self.chipHeight - chipSize.height) / 2;
+    CGFloat currentOriginY = self.contentEdgeInsets.top +
+        (row * (self.chipHeight + MDCChipFieldVerticalMargin)) + chipCenteringOffset;
     CGRect chipFrame =
         CGRectMake(currentOriginX, currentOriginY, chipSize.width, chipSize.height);
     [chipFrames addObject:[NSValue valueWithCGRect:chipFrame]];
@@ -577,7 +578,11 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
   CGFloat textFieldWidth =
       chipFieldSize.width - self.contentEdgeInsets.left - self.contentEdgeInsets.right;
   CGFloat textFieldHeight = [self.textField sizeThatFits:chipFieldSize].height;
-  CGFloat originY = lastChipFrame.origin.y + (self.chipHeight - textFieldHeight) / 2.f;
+  CGFloat textFieldCenterOffset = 0;
+  if (!CGRectIsEmpty(lastChipFrame)) {
+    textFieldCenterOffset = (CGRectGetHeight(lastChipFrame) - textFieldHeight) / 2;
+  }
+  CGFloat originY = lastChipFrame.origin.y + (self.chipHeight - textFieldHeight) / 2.f + textFieldCenterOffset;
 
   // If no chip exists, make the text field the full width minus padding.
   if (CGRectIsEmpty(lastChipFrame)) {


### PR DESCRIPTION
When a Chip Field's `chipHeight` value is greater than the actual height of a
chip, the chip is not aligned with the input text. Although baseline is ideal
(to ensure multiple fonts work, etc.), vertically centering works sufficiently
well when the text field and the chip have the same font.

Partially implements #3507

**Before**
![chipfield-size-before](https://user-images.githubusercontent.com/1753199/39321042-d532df64-4953-11e8-85a3-e7108a1106a6.png)

**After**
![chipfield-size-after](https://user-images.githubusercontent.com/1753199/39321048-d8e33e06-4953-11e8-9845-4fb38964886b.png)
