### PR TITLE
Revert "Changing ButtonScheme Header to accept protocols instead of actual class. (#3488)"

### DIFF
--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -23,7 +23,7 @@ final class AppTheme {
   let typographyScheme: MDCTypographyScheming
   let buttonScheme: MDCButtonScheming
 
-  init(colorScheme: MDCColorScheming, typographyScheme: MDCTypographyScheming) {
+  init(colorScheme: MDCSemanticColorScheme, typographyScheme: MDCTypographyScheme) {
     self.colorScheme = colorScheme
     self.typographyScheme = typographyScheme
     let buttonScheme = MDCButtonScheme()

--- a/components/Buttons/src/ButtonThemer/MDCButtonScheme.h
+++ b/components/Buttons/src/ButtonThemer/MDCButtonScheme.h
@@ -41,8 +41,8 @@
 @interface MDCButtonScheme : NSObject <MDCButtonScheming>
 
 // Redeclare protocol properties as readwrite
-@property(nonnull, readwrite, nonatomic) id<MDCColorScheming> colorScheme;
-@property(nonnull, readwrite, nonatomic) id<MDCTypographyScheming> typographyScheme;
+@property(nonnull, readwrite, nonatomic) MDCSemanticColorScheme *colorScheme;
+@property(nonnull, readwrite, nonatomic) MDCTypographyScheme *typographyScheme;
 @property(readwrite, nonatomic) CGFloat cornerRadius;
 @property(readwrite, nonatomic) CGFloat minimumHeight;
 


### PR DESCRIPTION
This reverts commit 61df0f001711add45abe7559cbea7fe6b88803bb.

We do want the properties to be modifiable on the concrete type because it is a mutable representation of design data.