### PR TITLE
[kokoro] Add website generator command

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -180,10 +180,7 @@ generate_website() {
     cd github/repo
 
     ./scripts/build_site.sh
-    
-    echo "Node version:"
-    node -v
-    
+
     gem install bundler --no-rdoc --no-ri --no-document --quiet
     brew update
     brew install yarn --without-node

--- a/.kokoro
+++ b/.kokoro
@@ -174,6 +174,25 @@ run_cocoapods() {
   bash <(curl -s https://codecov.io/bash)
 }
 
+generate_website() {
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    # Move into our cloned repo
+    cd github/repo
+
+    gem install bundler --no-rdoc --no-ri --no-document --quiet
+    brew install yarn
+
+    ./scripts/build_site.sh
+  fi
+
+  cd docsite-generator
+  bundle install
+  yarn install
+  cd ../
+
+  ./scripts/build_site.sh
+}
+
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
   key="$1"
@@ -225,6 +244,7 @@ case "$DEPENDENCY_SYSTEM" in
   "bazel")      run_bazel ;;
   "cocoapods")  run_cocoapods ;;
   "cocoapods-podspec")  run_cocoapods ;;
+  "website")    generate_website ;;
 
   *)            run_bazel ;;
 esac

--- a/.kokoro
+++ b/.kokoro
@@ -181,9 +181,12 @@ generate_website() {
 
     ./scripts/build_site.sh
     
+    echo "Node version:"
+    node -v
+    
     gem install bundler --no-rdoc --no-ri --no-document --quiet
     brew update
-    brew install yarn
+    brew install yarn --without-node
   fi
 
   cd docsite-generator

--- a/.kokoro
+++ b/.kokoro
@@ -179,10 +179,11 @@ generate_website() {
     # Move into our cloned repo
     cd github/repo
 
-    gem install bundler --no-rdoc --no-ri --no-document --quiet
-    brew install yarn
-
     ./scripts/build_site.sh
+    
+    gem install bundler --no-rdoc --no-ri --no-document --quiet
+    brew update
+    brew install yarn
   fi
 
   cd docsite-generator

--- a/scripts/build_site.sh
+++ b/scripts/build_site.sh
@@ -19,7 +19,7 @@ args=$*
 
 # Checking prerequisites for folders
 # Getting the link for github repository
-GITHUB_REMOTE="git@github.com:material-components/material-components-site-generator.git"
+GITHUB_REMOTE="https://github.com/material-components/material-components-site-generator.git"
 SITE_SOURCE_BRANCH='master'
 SITE_SOURCE_FOLDER='docsite-generator'
 


### PR DESCRIPTION
This will allow our PRs to generate the documentation website as part of our presubmits. This will let us catch any errors that might otherwise affect the ability for the website to be deployed.

This PR also updates the site generator's git url to an https one so that the kokoro instance can clone the repo.