### PR TITLE
[ActivityIndicator] Make the gif be not a screenshot.

### DIFF
--- a/components/ActivityIndicator/README.md
+++ b/components/ActivityIndicator/README.md
@@ -16,9 +16,7 @@ time. There are two styles of progress indicators: linear and circular.
 This component only provides the circular implementation. See [Progress View](../ProgressView) for
 the linear implementation.
 
-<div class="article__asset article__asset--screenshot">
-  <img src="docs/assets/activityindicator.gif" alt="An animation showing a determinate and indeterminate activity indicator." width="115">
-</div>
+<img src="docs/assets/activityindicator.gif" alt="An animation showing a determinate and indeterminate activity indicator." width="115">
 
 ## Design & API Documentation
 


### PR DESCRIPTION
It was incorrectly rendering with a dark background on the docsite.

Before:
<img width="792" alt="screen shot 2018-04-26 at 10 49 23 pm" src="https://user-images.githubusercontent.com/45670/39342048-148f8dce-49a4-11e8-8ff6-8225504f7dd9.png">

After:
<img width="784" alt="screen shot 2018-04-26 at 10 48 41 pm" src="https://user-images.githubusercontent.com/45670/39342032-fbf77d6c-49a3-11e8-9a7f-6b8fad6e0644.png">
