### PR TITLE
[ActivityIndicator] Apply the color themer template to the docs.

### DIFF
--- a/components/ActivityIndicator/.vars
+++ b/components/ActivityIndicator/.vars
@@ -1,0 +1,7 @@
+component=ActivityIndicator
+component_name=Activity Indicator
+a_component_name=an activity indicator
+root_path=/catalog/progress-indicators/activity-indicators
+color_themer_api=MDCActivityIndicatorColorThemer
+themer_parameter_name=ActivityIndicator
+icon_id=progress_activity

--- a/components/ActivityIndicator/README.md
+++ b/components/ActivityIndicator/README.md
@@ -27,6 +27,12 @@ the linear implementation.
   <li class="icon-list-item icon-list-item--link"><a href="https://material.io/components/ios/catalog/progress-indicators/activity-indicators/api-docs/Protocols/MDCActivityIndicatorDelegate.html">API: MDCActivityIndicatorDelegate</a></li>
 </ul>
 
+## Extensions
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--link"><a href="docs/ColorTheming.md">Color Theming</a></li>
+</ul>
+
 ## Related Components
 
 <ul class="icon-list">
@@ -152,54 +158,6 @@ activityIndicator.progress = 0.5;
 
 // To make the activity indicator disappear:
 [activityIndicator stopAnimating];
-```
-<!--</div>-->
-
-### Theming
-
-You can theme an activity indicator with your app's color scheme using the ColorThemer extension.
-
-You must first add the Color Themer extension to your project:
-
-``` bash
-pod 'MaterialComponents/ActivityIndicator+Extensions/ColorThemer'
-```
-
-You can then import the theming APIs:
-
-<!--<div class="material-code-render" markdown="1">-->
-#### Swift
-``` swift
-import MaterialComponents.MaterialActivityIndicator_ColorThemer
-```
-
-#### Objective-C
-
-``` objc
-#import "MaterialActivityIndicator+ColorThemer.h"
-```
-<!--</div>-->
-
-MDCActivityIndicatorColorThemer allows you to theme an activity indicator with your app's color
-scheme.
-
-<!--<div class="material-code-render" markdown="1">-->
-#### Swift
-``` swift
-let colorScheme: MDCSemanticColorScheme()
-
-let activityIndicator = MDCActivityIndicator()
-MDCActivityIndicatorColorThemer.applySemanticColorScheme(colorScheme, to: activityIndicator)
-```
-
-#### Objective-C
-
-``` objc
-id<MDCColorScheming> colorScheme = [[MDCSemanticColorScheme alloc] init];
-
-MDCActivityIndicator *activityIndicator = [[MDCActivityIndicator alloc] init];
-[MDCActivityIndicatorColorThemer applySemanticColorScheme:colorScheme
-                                      toActivityIndicator:activityIndicator];
 ```
 <!--</div>-->
 

--- a/components/ActivityIndicator/docs/ColorTheming.md
+++ b/components/ActivityIndicator/docs/ColorTheming.md
@@ -17,8 +17,7 @@ You must first add the Color Themer extension to your project:
 pod 'MaterialComponents/ActivityIndicator+Extensions/ColorThemer'
 ```
 
-`MDCActivityIndicatorColorThemer` allows you to theme an activity indicator with your app's color
-scheme.
+## Example code
 
 <!--<div class="material-code-render" markdown="1">-->
 #### Swift
@@ -44,6 +43,6 @@ id<MDCColorScheming> colorScheme = [[MDCSemanticColorScheme alloc] init];
 
 // Step 3: Apply the color scheme to your component
 [MDCActivityIndicatorColorThemer applySemanticColorScheme:colorScheme
-                                      toActivityIndicator:component];
+     toActivityIndicator:component];
 ```
 <!--</div>-->

--- a/components/ActivityIndicator/docs/ColorTheming.md
+++ b/components/ActivityIndicator/docs/ColorTheming.md
@@ -1,0 +1,49 @@
+<!--docs:
+title: "Color Theming"
+layout: detail
+section: components
+excerpt: "How to theme Activity Indicator using the Material Design color system."
+iconId: progress_activity
+path: /catalog/progress-indicators/activity-indicators/ColorTheming/
+-->
+
+# Activity Indicator Color Theming
+
+You can theme an activity indicator with your app's color scheme using the ColorThemer extension.
+
+You must first add the Color Themer extension to your project:
+
+``` bash
+pod 'MaterialComponents/ActivityIndicator+Extensions/ColorThemer'
+```
+
+`MDCActivityIndicatorColorThemer` allows you to theme an activity indicator with your app's color
+scheme.
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+``` swift
+// Step 1: Import the ColorThemer extension
+import MaterialComponents.MaterialActivityIndicator_ColorThemer
+
+// Step 2: Create or get a color scheme
+let colorScheme = MDCSemanticColorScheme()
+
+// Step 3: Apply the color scheme to your component
+MDCActivityIndicatorColorThemer.applySemanticColorScheme(colorScheme, to: component)
+```
+
+#### Objective-C
+
+``` objc
+// Step 1: Import the ColorThemer extension
+#import "MaterialActivityIndicator+ColorThemer.h"
+
+// Step 2: Create or get a color scheme
+id<MDCColorScheming> colorScheme = [[MDCSemanticColorScheme alloc] init];
+
+// Step 3: Apply the color scheme to your component
+[MDCActivityIndicatorColorThemer applySemanticColorScheme:colorScheme
+                                      toActivityIndicator:component];
+```
+<!--</div>-->


### PR DESCRIPTION
This applies the template defined in #3555 to the ActivityIndicator.

<img width="826" alt="screen shot 2018-04-27 at 10 39 07 am" src="https://user-images.githubusercontent.com/45670/39368314-3bf94662-4a07-11e8-9977-ff4fc6cd6943.png">

<img width="820" alt="screen shot 2018-04-27 at 10 36 03 am" src="https://user-images.githubusercontent.com/45670/39368272-260dd26e-4a07-11e8-8196-134b3f3b731a.png">
