### PR TITLE
[Buttons] Add outlined button themer

### DIFF
--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -29,18 +29,6 @@
 
 @implementation ButtonsTypicalUseExampleViewController
 
-- (MDCButton *)buildCustomStrokedButton {
-  MDCButton *button = [[MDCButton alloc] init];
-  [button setBackgroundColor:[UIColor clearColor] forState:UIControlStateNormal];
-  [button setTitleColor:[UIColor colorWithWhite:0.1f alpha:1] forState:UIControlStateNormal];
-  button.inkColor = [UIColor colorWithWhite:0 alpha:0.06f];
-
-  [button setBorderWidth:1.0 forState:UIControlStateNormal];
-  [button setBorderColor:[UIColor colorWithWhite:0.1f alpha:1] forState:UIControlStateNormal];
-
-  return button;
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -94,6 +82,29 @@
   [disabledTextButton setEnabled:NO];
   [self.view addSubview:disabledTextButton];
 
+  // Outlined button
+
+  MDCButton *outlinedButton = [[MDCButton alloc] init];
+  [outlinedButton setTitle:@"Button" forState:UIControlStateNormal];
+  [MDCOutlinedButtonThemer applyScheme:buttonScheme toButton:outlinedButton];
+  [outlinedButton sizeToFit];
+  [outlinedButton addTarget:self
+                    action:@selector(didTap:)
+          forControlEvents:UIControlEventTouchUpInside];
+  [self.view addSubview:outlinedButton];
+
+  // Disabled outlined button
+
+  MDCButton *disabledOutlinedButton = [[MDCButton alloc] init];
+  [disabledOutlinedButton setTitle:@"Button" forState:UIControlStateNormal];
+  [MDCOutlinedButtonThemer applyScheme:buttonScheme toButton:disabledOutlinedButton];
+  [disabledOutlinedButton sizeToFit];
+  [disabledOutlinedButton addTarget:self
+                             action:@selector(didTap:)
+                   forControlEvents:UIControlEventTouchUpInside];
+  [disabledOutlinedButton setEnabled:NO];
+  [self.view addSubview:disabledOutlinedButton];
+
   // Floating action button
 
   self.floatingButton = [[MDCFloatingButton alloc] init];
@@ -109,7 +120,8 @@
   [self.view addSubview:self.floatingButton];
 
   self.buttons = @[
-    containedButton, disabledContainedButton, textButton, disabledTextButton, self.floatingButton
+    containedButton, disabledContainedButton, textButton, disabledTextButton, outlinedButton,
+    disabledOutlinedButton,self.floatingButton
   ];
 
   [self setupExampleViews];
@@ -120,11 +132,13 @@
   UILabel *disabledContainedButtonLabel = [self addLabelWithText:@"Disabled Contained"];
   UILabel *textButtonLabel = [self addLabelWithText:@"Text button"];
   UILabel *disabledTextButtonLabel = [self addLabelWithText:@"Disabled text button"];
+  UILabel *outlinedButtonLabel = [self addLabelWithText:@"Outlined"];
+  UILabel *disabledOutlinedButtonLabel = [self addLabelWithText:@"Disabled Outlined"];
   UILabel *floatingButtonLabel = [self addLabelWithText:@"Floating Action"];
 
   self.labels = @[
     containedButtonLabel, disabledContainedButtonLabel, textButtonLabel, disabledTextButtonLabel,
-    floatingButtonLabel
+    outlinedButtonLabel, disabledOutlinedButtonLabel, floatingButtonLabel
   ];
 }
 

--- a/components/Buttons/src/ButtonThemer/MDCOutlinedButtonThemer.h
+++ b/components/Buttons/src/ButtonThemer/MDCOutlinedButtonThemer.h
@@ -14,8 +14,21 @@
  limitations under the License.
  */
 
-#import "MDCButtonColorThemer.h"
-#import "MDCContainedButtonColorThemer.h"
-#import "MDCFloatingButtonColorThemer.h"
-#import "MDCTextButtonColorThemer.h"
-#import "MDCOutlinedButtonColorThemer.h"
+#import "MaterialButtons.h"
+
+#import "MDCButtonScheme.h"
+
+/**
+ The Material Design outlined button themer for instances of MDCButton.
+ */
+@interface MDCOutlinedButtonThemer : NSObject
+
+/**
+ Applies a button scheme's properties to an MDCButton using the outlined button style.
+
+ @param scheme The button scheme to apply to the component instance.
+ @param button A component instance to which the scheme should be applied.
+ */
++ (void)applyScheme:(nonnull id<MDCButtonScheming>)scheme
+           toButton:(nonnull MDCButton *)button;
+@end

--- a/components/Buttons/src/ButtonThemer/MDCOutlinedButtonThemer.m
+++ b/components/Buttons/src/ButtonThemer/MDCOutlinedButtonThemer.m
@@ -1,0 +1,41 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCOutlinedButtonThemer.h"
+
+#import "MaterialButtons+ColorThemer.h"
+#import "MaterialButtons+TypographyThemer.h"
+
+@implementation MDCOutlinedButtonThemer
+
++ (void)applyScheme:(nonnull id<MDCButtonScheming>)scheme
+           toButton:(nonnull MDCButton *)button {
+  [MDCOutlinedButtonColorThemer applySemanticColorScheme:scheme.colorScheme toButton:button];
+  [MDCButtonTypographyThemer applyTypographyScheme:scheme.typographyScheme toButton:button];
+  button.minimumSize = CGSizeMake(0, scheme.minimumHeight);
+  button.layer.cornerRadius = scheme.cornerRadius;
+
+  NSUInteger maximumStateValue =
+      UIControlStateNormal | UIControlStateSelected | UIControlStateHighlighted |
+      UIControlStateDisabled;
+  for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    [button setBorderWidth:0 forState:state];
+  }
+  
+  [button setBorderWidth:1.0f forState:UIControlStateNormal];
+}
+
+@end

--- a/components/Buttons/src/ButtonThemer/MaterialButtons+ButtonThemer.h
+++ b/components/Buttons/src/ButtonThemer/MaterialButtons+ButtonThemer.h
@@ -18,3 +18,4 @@
 #import "MDCContainedButtonThemer.h"
 #import "MDCFloatingActionButtonThemer.h"
 #import "MDCTextButtonThemer.h"
+#import "MDCOutlinedButtonThemer.h"

--- a/components/Buttons/src/ColorThemer/MDCOutlinedButtonColorThemer.h
+++ b/components/Buttons/src/ColorThemer/MDCOutlinedButtonColorThemer.h
@@ -14,8 +14,21 @@
  limitations under the License.
  */
 
-#import "MDCButtonColorThemer.h"
-#import "MDCContainedButtonColorThemer.h"
-#import "MDCFloatingButtonColorThemer.h"
-#import "MDCTextButtonColorThemer.h"
-#import "MDCOutlinedButtonColorThemer.h"
+#import "MaterialButtons.h"
+#import "MaterialColorScheme.h"
+
+/**
+ The Material Design color system's outlined button themer for instances of MDCButton.
+ */
+@interface MDCOutlinedButtonColorThemer : NSObject
+
+/**
+ Applies a color scheme's properties to an MDCButton using the outlined button style.
+
+ @param colorScheme The color scheme to apply to the component instance.
+ @param button A component instance to which the color scheme should be applied.
+ */
++ (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+                        toButton:(nonnull MDCButton *)button;
+
+@end

--- a/components/Buttons/src/ColorThemer/MDCOutlinedButtonColorThemer.m
+++ b/components/Buttons/src/ColorThemer/MDCOutlinedButtonColorThemer.m
@@ -1,0 +1,45 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCOutlinedButtonColorThemer.h"
+
+#import "MDCPalettes.h"
+
+@implementation MDCOutlinedButtonColorThemer
+
++ (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+                        toButton:(nonnull MDCButton *)button {
+  [self resetUIControlStatesForButtonTheming:button];
+  [button setBackgroundColor:UIColor.clearColor forState:UIControlStateNormal];
+  [button setTitleColor:colorScheme.primaryColor forState:UIControlStateNormal];
+  [button setTitleColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:0.38f]
+               forState:UIControlStateDisabled];
+  button.disabledAlpha = 1.f;
+  button.inkColor = [colorScheme.primaryColor colorWithAlphaComponent:0.16f];
+  UIColor *borderColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.12f];
+  [button setBorderColor:borderColor forState:UIControlStateNormal];
+}
+
++ (void)resetUIControlStatesForButtonTheming:(nonnull MDCButton *)button {
+  NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
+  UIControlStateHighlighted | UIControlStateDisabled;
+  for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    [button setBackgroundColor:nil forState:state];
+    [button setTitleColor:nil forState:state];
+    [button setBorderColor:nil forState:state];
+  }
+}
+@end

--- a/components/Buttons/tests/unit/ButtonThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonThemerTests.m
@@ -17,9 +17,10 @@
 #import <XCTest/XCTest.h>
 
 #import "MaterialButtons.h"
+#import "MaterialButtons+ButtonThemer.h"
 #import "MaterialColorScheme.h"
 #import "MaterialTypographyScheme.h"
-#import "MaterialButtons+ButtonThemer.h"
+#import "MDCPalettes.h"
 
 static const CGFloat kEpsilonAccuracy = 0.001f;
 
@@ -57,6 +58,46 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
                         [colorScheme.onSurfaceColor colorWithAlphaComponent:0.38f]);
 }
 
+- (void)testOutlinedButtonThemer {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+  MDCButtonScheme *scheme = [[MDCButtonScheme alloc] init];
+
+  // When
+  [MDCOutlinedButtonThemer applyScheme:scheme toButton:button];
+
+  // Then
+  // Color
+  XCTAssertEqualObjects([button backgroundColorForState:UIControlStateNormal],
+                        [UIColor clearColor]);
+  XCTAssertEqualObjects([button backgroundColorForState:UIControlStateDisabled],
+                        [UIColor clearColor]);
+  XCTAssertEqualObjects([button titleColorForState:UIControlStateNormal],
+                        scheme.colorScheme.primaryColor);
+  XCTAssertEqualWithAccuracy(button.disabledAlpha, 1, kEpsilonAccuracy);
+  XCTAssertEqualObjects(button.inkColor,
+                        [scheme.colorScheme.primaryColor colorWithAlphaComponent:0.16f]);
+  XCTAssertEqualObjects([button borderColorForState:UIControlStateNormal],
+                        MDCPalette.greyPalette.tint300);
+  XCTAssertEqualObjects([button borderColorForState:UIControlStateDisabled],
+                        MDCPalette.greyPalette.tint100);
+
+  // Typography
+  XCTAssertEqualObjects([button titleFontForState:UIControlStateNormal],
+                        scheme.typographyScheme.button);
+
+  // Other
+  XCTAssertEqualWithAccuracy(button.minimumSize.height, scheme.minimumHeight, kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy(button.layer.cornerRadius, scheme.cornerRadius, kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy([button elevationForState:UIControlStateNormal], 0, kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy([button elevationForState:UIControlStateHighlighted], 0,
+                             kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy([button borderWidthForState:UIControlStateNormal], 1,
+                             kEpsilonAccuracy);
+  XCTAssertEqualWithAccuracy([button borderWidthForState:UIControlStateHighlighted], 0,
+                             kEpsilonAccuracy);
+}
+
 - (void)testContainedButtonThemer {
   // Given
   MDCButton *button = [[MDCButton alloc] init];
@@ -86,7 +127,8 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
                         [colorScheme.onSurfaceColor colorWithAlphaComponent:0.12f]);
   XCTAssertEqualObjects([button titleColorForState:UIControlStateDisabled],
                         [colorScheme.onSurfaceColor colorWithAlphaComponent:0.38f]);
-  XCTAssertEqualObjects([button imageTintColorForState:UIControlStateDisabled], [colorScheme.onSurfaceColor colorWithAlphaComponent:0.38f]);
+  XCTAssertEqualObjects([button imageTintColorForState:UIControlStateDisabled],
+                        [colorScheme.onSurfaceColor colorWithAlphaComponent:0.38f]);
 }
 
 - (void)testFloatingButtonThemer {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/157003868

Updated version of: https://github.com/material-components/material-components-ios/pull/3483

Minor cleanup, changes squashed and rebased on develop, reverted changed to TextButtonThemer

Before:
![simulator screen shot - iphone x - 2018-04-27 at 16 29 50](https://user-images.githubusercontent.com/1418389/39383693-387b33f2-4a38-11e8-8691-8312b5c4001d.png)


After:
![simulator screen shot - iphone x - 2018-04-27 at 16 28 33](https://user-images.githubusercontent.com/1418389/39383669-19fb8a4e-4a38-11e8-8a99-539430bbb9a6.png)
