### PR TITLE
Remove redundant copy from our root readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Material Components for iOS uses
 copyright Google Inc. and licensed under
 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
+Several components use
+[MDFTextAccessibility](https://github.com/material-foundation/material-text-accessibility-ios),
+copyright Google Inc. and licensed under
+[Apache 2.0](https://github.com/material-foundation/material-text-accessibility-ios/blob/master/LICENSE)
+without a NOTICE file.
+
 MDCCatalog uses the
 [Roboto font](https://github.com/google/fonts/tree/master/apache/roboto),
 copyright 2011 Google Inc. and licensed under

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Material Components for iOS are written in Objective-C and support Swift and Int
 
 ## Useful Links
 
-- [Documentation](https://material.io/components/ios/)
+- [Documentation](https://material.io/components/ios/) (external site)
 - [How To Use MDC-iOS](docs/)
 - [All Components](components/)
 - [Demo Apps](demos/)

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ Material Components for iOS are written in Objective-C and support Swift and Int
 
 ## Useful Links
 
+- [Documentation](https://material.io/components/ios/)
 - [How To Use MDC-iOS](docs/)
 - [All Components](components/)
 - [Demo Apps](demos/)
+- [Tutorial](docs/tutorial)
 - [Contributing](contributing/)
 - [MDC-iOS on Stack Overflow](https://www.stackoverflow.com/questions/tagged/material-components+ios) (external site)
 - [Material.io](https://material.io) (external site)
@@ -22,37 +24,7 @@ Material Components for iOS are written in Objective-C and support Swift and Int
 - [Checklist status spreadsheet](https://docs.google.com/spreadsheets/d/e/2PACX-1vRQLFMuo0Q3xsJp1_TdWvImtfdc8dU0lqX2DTct5pOPAEUIrN9OsuPquvv4aKRAwKK_KItpGs7c4Fok/pubhtml)
 - [Discord Chat Room](https://discord.gg/material-components)
 
-
 ## Trying out Material Components
-
-Our [catalog](catalog/) showcases Material Components. You can use the `pod try` command from anywhere on your machine to try the components, even if you haven't checked out the repo yet:
-
-```bash
-pod try MaterialComponents
-```
-
-In case you have already checked out the repo, run the following command:
-
-```bash
-pod install --project-directory=catalog/
-```
-
-If you want to take a look at the implementation of the components, you can find the code inside the `Development Pods` folder.
-Use `cmd-1` to open the project navigator within Xcode. Peal open the `Pods` project and inside the `Development Pods` folder you will find the component source code.
-
-## Installation
-
-### Requirements
-
-- Xcode 8.0 or higher.
-- Minimum iOS deployment target of 8.0 or higher
-- Cocoapods
-
-### Getting Started with a New Project
-
-Check out our [tutorial](docs/tutorial) for a step-by-step guide to setting up a new project using Material Components.
-
-### Adding Material Components to an Existing Project
 
 [CocoaPods](https://cocoapods.org/) is the easiest way to get started (if you're new to CocoaPods,
 check out their [getting started documentation](https://guides.cocoapods.org/using/getting-started.html).)
@@ -63,92 +35,25 @@ To install CocoaPods, run the following commands:
 sudo gem install cocoapods
 ```
 
-To integrate Material Components in your existing application, first create a new Podfile:
+Our [catalog](catalog/) showcases Material Components. You can use the `pod try` command from anywhere on your machine to try the components, even if you haven't checked out the repo yet:
 
-```bash
-cd your-project-directory
-pod init
+``` bash
+pod try MaterialComponents
 ```
 
-Next, add the
-[Material Components for iOS pod](https://cocoapods.org/pods/MaterialComponents)
-to your target in your Podfile:
+In case you have already checked out the repo, run the following command:
 
-```ruby
-target "MyApp" do
-  ...
-  pod 'MaterialComponents'
-end
+``` bash
+pod install --project-directory=catalog/
 ```
 
-If you are using Swift, don’t forget to uncomment the `use_frameworks!` line
-at the top of your Podfile.
+The component implementations can be found in Xcode within `Pods > Development Pods > MaterialComponents`.
 
-Then run the command:
+## Requirements
 
-```bash
-pod install
-```
-
-Now you're ready to get started in Xcode. Don't forget to open the workspace Cocoapods created for you instead of the original project:
-
-```bash
-open your-project.xcworkspace
-```
-
-### Usage
-
-The components are built upon familiar UIKit classes and can be added to a view with just a couple of lines. Simply import the Material Components header for the component you're interested in, and add it to your view.
-
-#### Swift
-
-```swift
-import MaterialComponents.MaterialButtons
-
-class ViewController: UIViewController {
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        let raisedButton = MDCRaisedButton()
-        raisedButton.setTitle("Raised Button", for: .normal)
-        raisedButton.sizeToFit()
-        raisedButton.addTarget(self, action: #selector(tapped), for: .touchUpInside)
-        view.addSubview(raisedButton)
-    }
-
-    @objc func tapped(sender: UIButton){
-        print("Button was tapped!")
-    }
-
-}
-```
-
-#### Objective-C
-
-```objc
-#import "MaterialButtons.h"
-
-@implementation ViewController
-
-- (void)viewDidLoad {
-  [super viewDidLoad];
-
-  MDCRaisedButton *raisedButton = [[MDCRaisedButton alloc] init];
-  [raisedButton setTitle:@"Raised Button" forState:UIControlStateNormal];
-  [raisedButton sizeToFit];
-  [raisedButton addTarget:self
-                   action:@selector(tapped:)
-         forControlEvents:UIControlEventTouchUpInside];
-
-  [self.view addSubview:raisedButton];
-}
-
-- (void)tapped:(id)sender {
-  NSLog(@"Button was tapped!");
-}
-
-@end
-```
+- Xcode 8.3.3 or higher.
+- Minimum iOS deployment target of 8.0 or higher
+- CocoaPods
 
 ## Attributions
 
@@ -156,12 +61,6 @@ Material Components for iOS uses
 [Material Design icons](https://github.com/google/material-design-icons),
 copyright Google Inc. and licensed under
 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
-
-Several components use
-[MDFTextAccessibility](https://github.com/material-foundation/material-text-accessibility-ios),
-copyright Google Inc. and licensed under
-[Apache 2.0](https://github.com/material-foundation/material-text-accessibility-ios/blob/master/LICENSE)
-without a NOTICE file.
 
 MDCCatalog uses the
 [Roboto font](https://github.com/google/fonts/tree/master/apache/roboto),


### PR DESCRIPTION
This content is prone to getting stale and is largely a copy of what's found in docs/docsite-index.md. Instead of copying it into the README.md we now link to the documentation website. We may want to consider increasing the visibility of the documentation link as well.

Pivotal story: https://www.pivotaltracker.com/story/show/156775556