### PR TITLE
Flatten all +Extensions CocoaPods targets into standalone targets. 

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -53,10 +53,10 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "ActivityIndicator+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/ActivityIndicator/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/ActivityIndicator/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/ActivityIndicator"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Color"
   end
 
@@ -93,9 +93,9 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "AppBar+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/AppBar/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/AppBar/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/AppBar/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
-    extension.dependency "MaterialComponents/AppBar"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/FlexibleHeader+ColorThemer"
     extension.dependency "MaterialComponents/NavigationBar+ColorThemer"
     extension.dependency "MaterialComponents/Themes"
@@ -103,9 +103,9 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "AppBar+TypographyThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/AppBar/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/AppBar/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/AppBar/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
-    extension.dependency "MaterialComponents/AppBar"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/NavigationBar+TypographyThemer"
   end
 
@@ -124,9 +124,9 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "BottomAppBar+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/BottomAppBar/src/ColorThemer/*.h"
-    extension.source_files = "components/BottomAppBar/src/ColorThemer/*.{h,m}"
-    extension.dependency "MaterialComponents/BottomAppBar"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Themes"
   end
 
@@ -148,17 +148,17 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "BottomNavigation+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/BottomNavigation/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/BottomNavigation/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
-    extension.dependency "MaterialComponents/BottomNavigation"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Color"
   end
 
   mdc.subspec "BottomNavigation+TypographyThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/BottomNavigation/src/TypographyThemer/*.h"
-    extension.source_files = "components/BottomNavigation/src/TypographyThemer/*.{h,m}"
-    extension.dependency "MaterialComponents/BottomNavigation"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 
@@ -192,35 +192,35 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "Buttons+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Buttons/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Buttons/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/Buttons/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
-    extension.dependency "MaterialComponents/Buttons"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Color"
   end
 
   mdc.subspec "Buttons+TitleColorAccessibilityMutator" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Buttons/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Buttons/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/Buttons/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
 
     extension.dependency 'MDFTextAccessibility'
-    extension.dependency "MaterialComponents/Buttons"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
   end
 
   mdc.subspec "Buttons+TypographyThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Buttons/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Buttons/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/Buttons"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 
   mdc.subspec "Buttons+ButtonThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Buttons/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Buttons/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/Buttons/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
-    extension.dependency "MaterialComponents/Buttons"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Buttons+ColorThemer"
     extension.dependency "MaterialComponents/Buttons+TypographyThemer"
   end
@@ -238,19 +238,19 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "ButtonBar+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/ButtonBar/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/ButtonBar/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/ButtonBar"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Themes"
   end
 
   mdc.subspec "ButtonBar+TypographyThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/ButtonBar/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/ButtonBar/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/ButtonBar"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 
@@ -269,18 +269,18 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "Cards+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Cards/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Cards/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/Cards"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Color"
   end
 
   mdc.subspec "Cards+CardThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Cards/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Cards/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
-    extension.dependency "MaterialComponents/Cards"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Cards+ColorThemer"
   end
 
@@ -301,40 +301,40 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/Shapes"
   end
 
+  mdc.subspec "Chips+ChipThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/Chips+ColorThemer"
+    extension.dependency "MaterialComponents/Chips+TypographyThemer"
+  end
+
   mdc.subspec "Chips+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Chips/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Chips/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/Chips"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Color"
   end
 
   mdc.subspec "Chips+FontThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Chips/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Chips/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/Chips"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Typography"
-  end
-
-  mdc.subspec "Chips+ChipThemer" do |extension|
-    extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Chips/src/#{extension.base_name}/*.h"
-    extension.source_files = "components/Chips/src/#{extension.base_name}/*.{h,m}"
-
-    extension.dependency "MaterialComponents/Chips"
-    extension.dependency "MaterialComponents/Chips+Extensions/ColorThemer"
-    extension.dependency "MaterialComponents/Chips+Extensions/TypographyThemer"
   end
 
   mdc.subspec "Chips+TypographyThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Chips/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Chips/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/Chips"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 
@@ -405,19 +405,19 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "Dialogs+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Dialogs/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Dialogs/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/Dialogs"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Themes"
   end
 
   mdc.subspec "Dialogs+TypographyThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Dialogs/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Dialogs/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/Dialogs"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 
@@ -436,37 +436,37 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "FeatureHighlight+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/FeatureHighlight/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/FeatureHighlight/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/FeatureHighlight"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Themes"
   end
 
   mdc.subspec "FeatureHighlight+FontThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/FeatureHighlight/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/FeatureHighlight/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/FeatureHighlight"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Themes"
   end
 
   mdc.subspec "FeatureHighlight+TypographyThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/FeatureHighlight/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/FeatureHighlight/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/FeatureHighlight"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 
   mdc.subspec "FeatureHighlight+FeatureHighlightAccessibilityMutator" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/FeatureHighlight/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/FeatureHighlight/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/FeatureHighlight"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency 'MDFTextAccessibility'
   end
 
@@ -484,10 +484,10 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "FlexibleHeader+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/FlexibleHeader/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/FlexibleHeader/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/FlexibleHeader"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Color"
   end
 
@@ -501,10 +501,10 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "HeaderStackView+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/HeaderStackView/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/HeaderStackView/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/HeaderStackView"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Themes"
   end
 
@@ -520,10 +520,10 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "Ink+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Ink/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Ink/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/Ink"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Themes"
   end
 
@@ -565,19 +565,19 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "NavigationBar+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/NavigationBar/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/NavigationBar/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/NavigationBar"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Color"
   end
 
   mdc.subspec "NavigationBar+TypographyThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/NavigationBar/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/NavigationBar/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/NavigationBar"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 
@@ -602,10 +602,10 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "PageControl+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/PageControl/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/PageControl/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/PageControl"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Themes"
   end
 
@@ -632,10 +632,10 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "ProgressView+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/ProgressView/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/ProgressView/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/ProgressView"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Themes"
   end
 
@@ -671,11 +671,11 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "Slider+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Slider/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Slider/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
     extension.dependency "MaterialComponents/Palettes"
-    extension.dependency "MaterialComponents/Slider"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Color"
   end
 
@@ -697,28 +697,28 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "Snackbar+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Snackbar/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Snackbar/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/Snackbar"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Color"
   end
 
   mdc.subspec "Snackbar+FontThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Snackbar/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Snackbar/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/Snackbar"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Themes"
   end
 
   mdc.subspec "Snackbar+TypographyThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Snackbar/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Snackbar/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/Snackbar"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 
@@ -741,28 +741,28 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "Tabs+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Tabs/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Tabs/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
     extension.dependency "MaterialComponents/schemes/Color"
-    extension.dependency "MaterialComponents/Tabs"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
   end
 
   mdc.subspec "Tabs+FontThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Tabs/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Tabs/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/Tabs"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Themes"
   end
 
   mdc.subspec "Tabs+TypographyThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Tabs/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/Tabs/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/Tabs"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 
@@ -783,28 +783,28 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "TextFields+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/TextFields/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/TextFields/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/TextFields"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Themes"
   end
 
   mdc.subspec "TextFields+FontThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/TextFields/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/TextFields/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/TextFields"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Themes"
   end
 
   mdc.subspec "TextFields+TypographyThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/TextFields/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/TextFields/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-    extension.dependency "MaterialComponents/TextFields"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -326,7 +326,7 @@ Pod::Spec.new do |mdc|
     extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
-    extension.dependency "MaterialComponents/schemes/Typography"
+    extension.dependency "MaterialComponents/Themes"
   end
 
   mdc.subspec "Chips+TypographyThemer" do |extension|

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -303,8 +303,8 @@ Pod::Spec.new do |mdc|
 
   mdc.subspec "Chips+ChipThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name}/*.h"
-    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name}/*.{h,m}"
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Chips+ColorThemer"

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -37,6 +37,8 @@ Pod::Spec.new do |mdc|
   #  end
   #
 
+  # ActivityIndicator
+
   mdc.subspec "ActivityIndicator" do |component|
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"
@@ -49,22 +51,24 @@ Pod::Spec.new do |mdc|
     component.dependency "MotionAnimator", "~> 2.0"
   end
 
-  mdc.subspec "ActivityIndicator+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/ActivityIndicator/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/ActivityIndicator/src/#{extension.base_name}/*.{h,m}"
+  mdc.subspec "ActivityIndicator+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/ActivityIndicator/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/ActivityIndicator/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-      extension.dependency "MaterialComponents/ActivityIndicator"
-      extension.dependency "MaterialComponents/schemes/Color"
-    end
+    extension.dependency "MaterialComponents/ActivityIndicator"
+    extension.dependency "MaterialComponents/schemes/Color"
   end
+
+  # AnimationTiming
 
   mdc.subspec "AnimationTiming" do |component|
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"
     component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
   end
+
+  # AppBar
 
   mdc.subspec "AppBar" do |component|
     component.ios.deployment_target = '8.0'
@@ -87,24 +91,25 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/UIMetrics"
   end
 
-  mdc.subspec "AppBar+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/AppBar/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/AppBar/src/#{extension.base_name}/*.{h,m}", "components/AppBar/src/#{extension.base_name}/private/*.{h,m}"
-      extension.dependency "MaterialComponents/AppBar"
-      extension.dependency "MaterialComponents/FlexibleHeader+Extensions/ColorThemer"
-      extension.dependency "MaterialComponents/NavigationBar+Extensions/ColorThemer"
-      extension.dependency "MaterialComponents/Themes"
-    end
-    component.subspec "TypographyThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/AppBar/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/AppBar/src/#{extension.base_name}/*.{h,m}", "components/AppBar/src/#{extension.base_name}/private/*.{h,m}"
-      extension.dependency "MaterialComponents/AppBar"
-      extension.dependency "MaterialComponents/NavigationBar+Extensions/TypographyThemer"
-    end
+  mdc.subspec "AppBar+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/AppBar/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/AppBar/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/AppBar/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponents/AppBar"
+    extension.dependency "MaterialComponents/FlexibleHeader+ColorThemer"
+    extension.dependency "MaterialComponents/NavigationBar+ColorThemer"
+    extension.dependency "MaterialComponents/Themes"
   end
+
+  mdc.subspec "AppBar+TypographyThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/AppBar/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/AppBar/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/AppBar/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponents/AppBar"
+    extension.dependency "MaterialComponents/NavigationBar+TypographyThemer"
+  end
+
+  # BottomAppBar
 
   mdc.subspec "BottomAppBar" do |component|
     component.ios.deployment_target = '8.0'
@@ -117,15 +122,15 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/Math"
   end
 
-  mdc.subspec "BottomAppBar+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/BottomAppBar/src/ColorThemer/*.h"
-      extension.source_files = "components/BottomAppBar/src/ColorThemer/*.{h,m}"
-      extension.dependency "MaterialComponents/BottomAppBar"
-      extension.dependency "MaterialComponents/Themes"
-    end
+  mdc.subspec "BottomAppBar+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/BottomAppBar/src/ColorThemer/*.h"
+    extension.source_files = "components/BottomAppBar/src/ColorThemer/*.{h,m}"
+    extension.dependency "MaterialComponents/BottomAppBar"
+    extension.dependency "MaterialComponents/Themes"
   end
+
+  # BottomNavigation
 
   mdc.subspec "BottomNavigation" do |component|
     component.ios.deployment_target = '8.0'
@@ -141,22 +146,23 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/Math"
   end
 
-  mdc.subspec "BottomNavigation+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/BottomNavigation/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/BottomNavigation/src/#{extension.base_name}/*.{h,m}"
-      extension.dependency "MaterialComponents/BottomNavigation"
-      extension.dependency "MaterialComponents/schemes/Color"
-    end
-    component.subspec "TypographyThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/BottomNavigation/src/TypographyThemer/*.h"
-      extension.source_files = "components/BottomNavigation/src/TypographyThemer/*.{h,m}"
-      extension.dependency "MaterialComponents/BottomNavigation"
-      extension.dependency "MaterialComponents/schemes/Typography"
-    end
+  mdc.subspec "BottomNavigation+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/BottomNavigation/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/BottomNavigation/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.dependency "MaterialComponents/BottomNavigation"
+    extension.dependency "MaterialComponents/schemes/Color"
   end
+
+  mdc.subspec "BottomNavigation+TypographyThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/BottomNavigation/src/TypographyThemer/*.h"
+    extension.source_files = "components/BottomNavigation/src/TypographyThemer/*.{h,m}"
+    extension.dependency "MaterialComponents/BottomNavigation"
+    extension.dependency "MaterialComponents/schemes/Typography"
+  end
+
+  # BottomSheet
 
   mdc.subspec "BottomSheet" do |component|
     component.ios.deployment_target = '8.0'
@@ -166,6 +172,8 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/KeyboardWatcher"
     component.dependency "MaterialComponents/private/Math"
   end
+
+  # Buttons
 
   mdc.subspec "Buttons" do |component|
     component.ios.deployment_target = '8.0'
@@ -182,39 +190,42 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/Shapes"
   end
 
-  mdc.subspec "Buttons+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Buttons/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Buttons/src/#{extension.base_name}/*.{h,m}", "components/Buttons/src/#{extension.base_name}/private/*.{h,m}"
-      extension.dependency "MaterialComponents/Buttons"
-      extension.dependency "MaterialComponents/schemes/Color"
-    end
-    component.subspec "TitleColorAccessibilityMutator" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Buttons/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Buttons/src/#{extension.base_name}/*.{h,m}", "components/Buttons/src/#{extension.base_name}/private/*.{h,m}"
-
-      extension.dependency 'MDFTextAccessibility'
-      extension.dependency "MaterialComponents/Buttons"
-    end
-    component.subspec "TypographyThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Buttons/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Buttons/src/#{extension.base_name}/*.{h,m}"
-
-      extension.dependency "MaterialComponents/Buttons"
-      extension.dependency "MaterialComponents/schemes/Typography"
-    end
-    component.subspec "ButtonThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Buttons/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Buttons/src/#{extension.base_name}/*.{h,m}", "components/Buttons/src/#{extension.base_name}/private/*.{h,m}"
-      extension.dependency "MaterialComponents/Buttons"
-      extension.dependency "MaterialComponents/Buttons+Extensions/ColorThemer"
-      extension.dependency "MaterialComponents/Buttons+Extensions/TypographyThemer"
-    end
+  mdc.subspec "Buttons+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Buttons/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Buttons/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/Buttons/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponents/Buttons"
+    extension.dependency "MaterialComponents/schemes/Color"
   end
+
+  mdc.subspec "Buttons+TitleColorAccessibilityMutator" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Buttons/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Buttons/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/Buttons/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+
+    extension.dependency 'MDFTextAccessibility'
+    extension.dependency "MaterialComponents/Buttons"
+  end
+
+  mdc.subspec "Buttons+TypographyThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Buttons/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Buttons/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/Buttons"
+    extension.dependency "MaterialComponents/schemes/Typography"
+  end
+
+  mdc.subspec "Buttons+ButtonThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Buttons/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Buttons/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/Buttons/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponents/Buttons"
+    extension.dependency "MaterialComponents/Buttons+ColorThemer"
+    extension.dependency "MaterialComponents/Buttons+TypographyThemer"
+  end
+
+  # ButtonBar
 
   mdc.subspec "ButtonBar" do |component|
     component.ios.deployment_target = '8.0'
@@ -225,24 +236,25 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/Buttons"
   end
 
-  mdc.subspec "ButtonBar+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/ButtonBar/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/ButtonBar/src/#{extension.base_name}/*.{h,m}"
+  mdc.subspec "ButtonBar+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/ButtonBar/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/ButtonBar/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-      extension.dependency "MaterialComponents/ButtonBar"
-      extension.dependency "MaterialComponents/Themes"
-    end
-    component.subspec "TypographyThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/ButtonBar/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/ButtonBar/src/#{extension.base_name}/*.{h,m}"
-
-      extension.dependency "MaterialComponents/ButtonBar"
-      extension.dependency "MaterialComponents/schemes/Typography"
-    end
+    extension.dependency "MaterialComponents/ButtonBar"
+    extension.dependency "MaterialComponents/Themes"
   end
+
+  mdc.subspec "ButtonBar+TypographyThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/ButtonBar/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/ButtonBar/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/ButtonBar"
+    extension.dependency "MaterialComponents/schemes/Typography"
+  end
+
+  # Cards
 
   mdc.subspec "Cards" do |component|
     component.ios.deployment_target = '8.0'
@@ -255,23 +267,24 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/Shapes"
   end
 
-  mdc.subspec "Cards+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Cards/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Cards/src/#{extension.base_name}/*.{h,m}"
+  mdc.subspec "Cards+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Cards/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Cards/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-      extension.dependency "MaterialComponents/Cards"
-      extension.dependency "MaterialComponents/schemes/Color"
-    end
-    component.subspec "CardThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Cards/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Cards/src/#{extension.base_name}/*.{h,m}"
-      extension.dependency "MaterialComponents/Cards"
-      extension.dependency "MaterialComponents/Cards+Extensions/ColorThemer"
-    end
+    extension.dependency "MaterialComponents/Cards"
+    extension.dependency "MaterialComponents/schemes/Color"
   end
+
+  mdc.subspec "Cards+CardThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Cards/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Cards/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+    extension.dependency "MaterialComponents/Cards"
+    extension.dependency "MaterialComponents/Cards+ColorThemer"
+  end
+
+  # Chips
 
   mdc.subspec "Chips" do |component|
     component.ios.deployment_target = '8.0'
@@ -288,41 +301,44 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/Shapes"
   end
 
-  mdc.subspec "Chips+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Chips/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Chips/src/#{extension.base_name}/*.{h,m}"
+  mdc.subspec "Chips+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Chips/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Chips/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-      extension.dependency "MaterialComponents/Chips"
-      extension.dependency "MaterialComponents/schemes/Color"
-    end
-    component.subspec "FontThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Chips/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Chips/src/#{extension.base_name}/*.{h,m}"
-
-      extension.dependency "MaterialComponents/Chips"
-      extension.dependency "MaterialComponents/Themes"
-    end
-    component.subspec "TypographyThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Chips/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Chips/src/#{extension.base_name}/*.{h,m}"
-
-      extension.dependency "MaterialComponents/Chips"
-      extension.dependency "MaterialComponents/schemes/Typography"
-    end
-    component.subspec "ChipThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Chips/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Chips/src/#{extension.base_name}/*.{h,m}"
-
-      extension.dependency "MaterialComponents/Chips"
-      extension.dependency "MaterialComponents/Chips+Extensions/ColorThemer"
-      extension.dependency "MaterialComponents/Chips+Extensions/TypographyThemer"
-    end
+    extension.dependency "MaterialComponents/Chips"
+    extension.dependency "MaterialComponents/schemes/Color"
   end
+
+  mdc.subspec "Chips+FontThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Chips/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Chips/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/Chips"
+    extension.dependency "MaterialComponents/schemes/Typography"
+  end
+
+  mdc.subspec "Chips+ChipThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Chips/src/#{extension.base_name}/*.h"
+    extension.source_files = "components/Chips/src/#{extension.base_name}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/Chips"
+    extension.dependency "MaterialComponents/Chips+Extensions/ColorThemer"
+    extension.dependency "MaterialComponents/Chips+Extensions/TypographyThemer"
+  end
+
+  mdc.subspec "Chips+TypographyThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Chips/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Chips/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/Chips"
+    extension.dependency "MaterialComponents/schemes/Typography"
+  end
+
+  # CollectionCells
 
   mdc.subspec "CollectionCells" do |component|
     component.ios.deployment_target = '8.0'
@@ -345,11 +361,15 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/Math"
   end
 
+  # CollectionLayoutAttributes
+
   mdc.subspec "CollectionLayoutAttributes" do |component|
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"
     component.source_files = "components/#{component.base_name}/src/*.{h,m}"
   end
+
+  # Collections
 
   mdc.subspec "Collections" do |component|
     component.ios.deployment_target = '8.0'
@@ -367,6 +387,8 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/Typography"
   end
 
+  # Dialogs
+
   mdc.subspec "Dialogs" do |component|
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"
@@ -381,24 +403,25 @@ Pod::Spec.new do |mdc|
     component.dependency "MDFInternationalization"
   end
 
-  mdc.subspec "Dialogs+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Dialogs/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Dialogs/src/#{extension.base_name}/*.{h,m}"
+  mdc.subspec "Dialogs+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Dialogs/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Dialogs/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-      extension.dependency "MaterialComponents/Dialogs"
-      extension.dependency "MaterialComponents/Themes"
-    end
-    component.subspec "TypographyThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Dialogs/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Dialogs/src/#{extension.base_name}/*.{h,m}"
+    extension.dependency "MaterialComponents/Dialogs"
+    extension.dependency "MaterialComponents/Themes"
+  end
 
-      extension.dependency "MaterialComponents/Dialogs"
-      extension.dependency "MaterialComponents/schemes/Typography"
-    end
- end
+  mdc.subspec "Dialogs+TypographyThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Dialogs/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Dialogs/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/Dialogs"
+    extension.dependency "MaterialComponents/schemes/Typography"
+  end
+
+  # FeatureHighlight
 
   mdc.subspec "FeatureHighlight" do |component|
     component.ios.deployment_target = '8.0'
@@ -411,40 +434,43 @@ Pod::Spec.new do |mdc|
     component.dependency "MDFTextAccessibility"
   end
 
-  mdc.subspec "FeatureHighlight+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/FeatureHighlight/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/FeatureHighlight/src/#{extension.base_name}/*.{h,m}"
+  mdc.subspec "FeatureHighlight+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/FeatureHighlight/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/FeatureHighlight/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-      extension.dependency "MaterialComponents/FeatureHighlight"
-      extension.dependency "MaterialComponents/Themes"
-    end
-    component.subspec "FontThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/FeatureHighlight/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/FeatureHighlight/src/#{extension.base_name}/*.{h,m}"
-
-      extension.dependency "MaterialComponents/FeatureHighlight"
-      extension.dependency "MaterialComponents/Themes"
-    end
-    component.subspec "TypographyThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/FeatureHighlight/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/FeatureHighlight/src/#{extension.base_name}/*.{h,m}"
-
-      extension.dependency "MaterialComponents/FeatureHighlight"
-      extension.dependency "MaterialComponents/schemes/Typography"
-    end
-    component.subspec "FeatureHighlightAccessibilityMutator" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/FeatureHighlight/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/FeatureHighlight/src/#{extension.base_name}/*.{h,m}"
-
-      extension.dependency "MaterialComponents/FeatureHighlight"
-      extension.dependency 'MDFTextAccessibility'
-    end
+    extension.dependency "MaterialComponents/FeatureHighlight"
+    extension.dependency "MaterialComponents/Themes"
   end
+
+  mdc.subspec "FeatureHighlight+FontThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/FeatureHighlight/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/FeatureHighlight/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/FeatureHighlight"
+    extension.dependency "MaterialComponents/Themes"
+  end
+
+  mdc.subspec "FeatureHighlight+TypographyThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/FeatureHighlight/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/FeatureHighlight/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/FeatureHighlight"
+    extension.dependency "MaterialComponents/schemes/Typography"
+  end
+
+  mdc.subspec "FeatureHighlight+FeatureHighlightAccessibilityMutator" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/FeatureHighlight/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/FeatureHighlight/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/FeatureHighlight"
+    extension.dependency 'MDFTextAccessibility'
+  end
+
+  # FlexibleHeader
 
   mdc.subspec "FlexibleHeader" do |component|
     component.ios.deployment_target = '8.0'
@@ -456,16 +482,16 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/UIMetrics"
   end
 
-  mdc.subspec "FlexibleHeader+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/FlexibleHeader/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/FlexibleHeader/src/#{extension.base_name}/*.{h,m}"
+  mdc.subspec "FlexibleHeader+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/FlexibleHeader/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/FlexibleHeader/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-      extension.dependency "MaterialComponents/FlexibleHeader"
-      extension.dependency "MaterialComponents/schemes/Color"
-    end
+    extension.dependency "MaterialComponents/FlexibleHeader"
+    extension.dependency "MaterialComponents/schemes/Color"
   end
+
+  # HeaderStackView
 
   mdc.subspec "HeaderStackView" do |component|
     component.ios.deployment_target = '8.0'
@@ -473,16 +499,16 @@ Pod::Spec.new do |mdc|
     component.source_files = "components/#{component.base_name}/src/*.{h,m}"
   end
 
-  mdc.subspec "HeaderStackView+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/HeaderStackView/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/HeaderStackView/src/#{extension.base_name}/*.{h,m}"
+  mdc.subspec "HeaderStackView+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/HeaderStackView/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/HeaderStackView/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-      extension.dependency "MaterialComponents/HeaderStackView"
-      extension.dependency "MaterialComponents/Themes"
-    end
+    extension.dependency "MaterialComponents/HeaderStackView"
+    extension.dependency "MaterialComponents/Themes"
   end
+
+  # Ink
 
   mdc.subspec "Ink" do |component|
     component.ios.deployment_target = '8.0'
@@ -492,22 +518,24 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/Math"
   end
 
-  mdc.subspec "Ink+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Ink/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Ink/src/#{extension.base_name}/*.{h,m}"
+  mdc.subspec "Ink+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Ink/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Ink/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-      extension.dependency "MaterialComponents/Ink"
-      extension.dependency "MaterialComponents/Themes"
-    end
+    extension.dependency "MaterialComponents/Ink"
+    extension.dependency "MaterialComponents/Themes"
   end
+
+  # LibraryInfo
 
   mdc.subspec "LibraryInfo" do |component|
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"
     component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
   end
+
+  # MaskedTransition
 
   mdc.subspec "MaskedTransition" do |component|
     component.ios.deployment_target = '8.0'
@@ -518,6 +546,8 @@ Pod::Spec.new do |mdc|
     component.dependency "MotionAnimator", "~> 2.0"
     component.dependency "MotionInterchange", "~> 1.0"
   end
+
+  # NavigationBar
 
   mdc.subspec "NavigationBar" do |component|
     component.ios.deployment_target = '8.0'
@@ -533,24 +563,25 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/Math"
   end
 
-  mdc.subspec "NavigationBar+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/NavigationBar/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/NavigationBar/src/#{extension.base_name}/*.{h,m}"
+  mdc.subspec "NavigationBar+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/NavigationBar/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/NavigationBar/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-      extension.dependency "MaterialComponents/NavigationBar"
-      extension.dependency "MaterialComponents/schemes/Color"
-    end
-    component.subspec "TypographyThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/NavigationBar/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/NavigationBar/src/#{extension.base_name}/*.{h,m}"
-
-      extension.dependency "MaterialComponents/NavigationBar"
-      extension.dependency "MaterialComponents/schemes/Typography"
-    end
+    extension.dependency "MaterialComponents/NavigationBar"
+    extension.dependency "MaterialComponents/schemes/Color"
   end
+
+  mdc.subspec "NavigationBar+TypographyThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/NavigationBar/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/NavigationBar/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/NavigationBar"
+    extension.dependency "MaterialComponents/schemes/Typography"
+  end
+
+  # OverlayWindow
 
   mdc.subspec "OverlayWindow" do |component|
     component.ios.deployment_target = '8.0'
@@ -560,6 +591,8 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/Application"
   end
 
+  # PageControl
+
   mdc.subspec "PageControl" do |component|
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"
@@ -567,22 +600,24 @@ Pod::Spec.new do |mdc|
     component.resources = ["components/#{component.base_name}/src/Material#{component.base_name}.bundle"]
   end
 
-  mdc.subspec "PageControl+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/PageControl/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/PageControl/src/#{extension.base_name}/*.{h,m}"
+  mdc.subspec "PageControl+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/PageControl/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/PageControl/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-      extension.dependency "MaterialComponents/PageControl"
-      extension.dependency "MaterialComponents/Themes"
-    end
+    extension.dependency "MaterialComponents/PageControl"
+    extension.dependency "MaterialComponents/Themes"
   end
+
+  # Palettes
 
   mdc.subspec "Palettes" do |component|
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"
     component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
   end
+
+  # ProgressView
 
   mdc.subspec "ProgressView" do |component|
     component.ios.deployment_target = '8.0'
@@ -595,22 +630,24 @@ Pod::Spec.new do |mdc|
     component.dependency "MotionAnimator", "~> 2.1"
   end
 
-  mdc.subspec "ProgressView+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/ProgressView/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/ProgressView/src/#{extension.base_name}/*.{h,m}"
+  mdc.subspec "ProgressView+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/ProgressView/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/ProgressView/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-      extension.dependency "MaterialComponents/ProgressView"
-      extension.dependency "MaterialComponents/Themes"
-    end
+    extension.dependency "MaterialComponents/ProgressView"
+    extension.dependency "MaterialComponents/Themes"
   end
+
+  # ShadowElevations
 
   mdc.subspec "ShadowElevations" do |component|
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"
     component.source_files = "components/#{component.base_name}/src/*.{h,m}"
   end
+
+  # ShadowLayer
 
   mdc.subspec "ShadowLayer" do |component|
     component.ios.deployment_target = '8.0'
@@ -619,6 +656,8 @@ Pod::Spec.new do |mdc|
 
     component.dependency "MaterialComponents/ShadowElevations"
   end
+
+  # Slider
 
   mdc.subspec "Slider" do |component|
     component.ios.deployment_target = '8.0'
@@ -630,17 +669,17 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/ThumbTrack"
   end
 
-  mdc.subspec "Slider+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Slider/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Slider/src/#{extension.base_name}/*.{h,m}"
+  mdc.subspec "Slider+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Slider/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Slider/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-      extension.dependency "MaterialComponents/Palettes"
-      extension.dependency "MaterialComponents/Slider"
-      extension.dependency "MaterialComponents/schemes/Color"
-    end
+    extension.dependency "MaterialComponents/Palettes"
+    extension.dependency "MaterialComponents/Slider"
+    extension.dependency "MaterialComponents/schemes/Color"
   end
+
+  # Snackbar
 
   mdc.subspec "Snackbar" do |component|
     component.ios.deployment_target = '8.0'
@@ -656,32 +695,34 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/Overlay"
   end
 
-mdc.subspec "Snackbar+Extensions" do |component|
-  component.subspec "ColorThemer" do |extension|
+  mdc.subspec "Snackbar+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Snackbar/src/#{extension.base_name}/*.h"
-    extension.source_files = "components/Snackbar/src/#{extension.base_name}/*.{h,m}"
+    extension.public_header_files = "components/Snackbar/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Snackbar/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
     extension.dependency "MaterialComponents/Snackbar"
     extension.dependency "MaterialComponents/schemes/Color"
   end
-  component.subspec "FontThemer" do |extension|
+
+  mdc.subspec "Snackbar+FontThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Snackbar/src/#{extension.base_name}/*.h"
-    extension.source_files = "components/Snackbar/src/#{extension.base_name}/*.{h,m}"
+    extension.public_header_files = "components/Snackbar/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Snackbar/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
     extension.dependency "MaterialComponents/Snackbar"
     extension.dependency "MaterialComponents/Themes"
   end
-  component.subspec "TypographyThemer" do |extension|
+
+  mdc.subspec "Snackbar+TypographyThemer" do |extension|
     extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/Snackbar/src/#{extension.base_name}/*.h"
-    extension.source_files = "components/Snackbar/src/#{extension.base_name}/*.{h,m}"
+    extension.public_header_files = "components/Snackbar/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Snackbar/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
     extension.dependency "MaterialComponents/Snackbar"
     extension.dependency "MaterialComponents/schemes/Typography"
   end
-end
+
+  # Tabs
 
   mdc.subspec "Tabs" do |component|
     component.ios.deployment_target = '8.0'
@@ -698,33 +739,34 @@ end
     component.dependency "MaterialComponents/private/Math"
   end
 
-  mdc.subspec "Tabs+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Tabs/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Tabs/src/#{extension.base_name}/*.{h,m}"
+  mdc.subspec "Tabs+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Tabs/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Tabs/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-      extension.dependency "MaterialComponents/schemes/Color"
-      extension.dependency "MaterialComponents/Tabs"
-    end
-    component.subspec "FontThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Tabs/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Tabs/src/#{extension.base_name}/*.{h,m}"
-
-      extension.dependency "MaterialComponents/Tabs"
-      extension.dependency "MaterialComponents/Themes"
-    end
-    component.subspec "TypographyThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/Tabs/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/Tabs/src/#{extension.base_name}/*.{h,m}"
-
-      extension.dependency "MaterialComponents/Tabs"
-      extension.dependency "MaterialComponents/schemes/Typography"
-    end
-
+    extension.dependency "MaterialComponents/schemes/Color"
+    extension.dependency "MaterialComponents/Tabs"
   end
+
+  mdc.subspec "Tabs+FontThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Tabs/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Tabs/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/Tabs"
+    extension.dependency "MaterialComponents/Themes"
+  end
+
+  mdc.subspec "Tabs+TypographyThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/Tabs/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/Tabs/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/Tabs"
+    extension.dependency "MaterialComponents/schemes/Typography"
+  end
+
+  # TextFields
 
   mdc.subspec "TextFields" do |component|
     component.ios.deployment_target = '8.0'
@@ -739,33 +781,34 @@ end
     component.dependency "MDFInternationalization"
   end
 
-  mdc.subspec "TextFields+Extensions" do |component|
-    component.subspec "ColorThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/TextFields/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/TextFields/src/#{extension.base_name}/*.{h,m}"
+  mdc.subspec "TextFields+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/TextFields/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/TextFields/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
 
-      extension.dependency "MaterialComponents/TextFields"
-      extension.dependency "MaterialComponents/Themes"
-    end
-    component.subspec "FontThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/TextFields/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/TextFields/src/#{extension.base_name}/*.{h,m}"
-
-      extension.dependency "MaterialComponents/TextFields"
-      extension.dependency "MaterialComponents/Themes"
-    end
-    component.subspec "TypographyThemer" do |extension|
-      extension.ios.deployment_target = '8.0'
-      extension.public_header_files = "components/TextFields/src/#{extension.base_name}/*.h"
-      extension.source_files = "components/TextFields/src/#{extension.base_name}/*.{h,m}"
-
-      extension.dependency "MaterialComponents/TextFields"
-      extension.dependency "MaterialComponents/schemes/Typography"
-    end
-
+    extension.dependency "MaterialComponents/TextFields"
+    extension.dependency "MaterialComponents/Themes"
   end
+
+  mdc.subspec "TextFields+FontThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/TextFields/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/TextFields/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/TextFields"
+    extension.dependency "MaterialComponents/Themes"
+  end
+
+  mdc.subspec "TextFields+TypographyThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/TextFields/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/TextFields/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/TextFields"
+    extension.dependency "MaterialComponents/schemes/Typography"
+  end
+
+  # Themes
 
   mdc.subspec "Themes" do |component|
     component.ios.deployment_target = '8.0'
@@ -776,12 +819,27 @@ end
     component.dependency "MaterialComponents/schemes/Typography"
   end
 
+  # Typography
+
   mdc.subspec "Typography" do |component|
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"
     component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
 
     component.dependency "MaterialComponents/private/Application"
+  end
+
+  mdc.subspec "schemes" do |scheme_spec|
+    scheme_spec.subspec "Color" do |scheme|
+      scheme.ios.deployment_target = '8.0'
+      scheme.public_header_files = "components/schemes/#{scheme.base_name}/src/*.h"
+      scheme.source_files = "components/schemes/#{scheme.base_name}/src/*.{h,m}"
+    end
+    scheme_spec.subspec "Typography" do |scheme|
+      scheme.ios.deployment_target = '8.0'
+      scheme.public_header_files = "components/schemes/#{scheme.base_name}/src/*.h"
+      scheme.source_files = "components/schemes/#{scheme.base_name}/src/*.{h,m}"
+    end
   end
 
   mdc.subspec "private" do |private_spec|
@@ -853,19 +911,6 @@ end
       component.source_files = "components/private/#{component.base_name}/src/*.{h,m}", "components/private/#{component.base_name}/src/private/*.{h,m}"
 
       component.dependency "MaterialComponents/private/Application"
-    end
-  end
-
-  mdc.subspec "schemes" do |scheme_spec|
-    scheme_spec.subspec "Color" do |scheme|
-      scheme.ios.deployment_target = '8.0'
-      scheme.public_header_files = "components/schemes/#{scheme.base_name}/src/*.h"
-      scheme.source_files = "components/schemes/#{scheme.base_name}/src/*.{h,m}"
-    end
-    scheme_spec.subspec "Typography" do |scheme|
-      scheme.ios.deployment_target = '8.0'
-      scheme.public_header_files = "components/schemes/#{scheme.base_name}/src/*.h"
-      scheme.source_files = "components/schemes/#{scheme.base_name}/src/*.{h,m}"
     end
   end
 end

--- a/components/ActivityIndicator/README.md
+++ b/components/ActivityIndicator/README.md
@@ -213,7 +213,7 @@ You can theme an activity indicator with your app's color scheme using the Color
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/ActivityIndicator+Extensions/ColorThemer'
+pod 'MaterialComponents/ActivityIndicator+ColorThemer'
 ```
 
 Run `pod install` again.

--- a/components/ActivityIndicator/docs/color-theming.md
+++ b/components/ActivityIndicator/docs/color-theming.md
@@ -5,7 +5,7 @@ You can theme an activity indicator with your app's color scheme using the Color
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/ActivityIndicator+Extensions/ColorThemer'
+pod 'MaterialComponents/ActivityIndicator+ColorThemer'
 ```
 
 Run `pod install` again.

--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -246,7 +246,7 @@ You can theme an app bar with your app's color scheme using the ColorThemer exte
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/AppBar+Extensions/ColorThemer'
+pod 'MaterialComponents/AppBar+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->
@@ -286,7 +286,7 @@ You can theme an app bar with your app's typography scheme using the TypographyT
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/AppBar+Extensions/TypographyThemer'
+pod 'MaterialComponents/AppBar+TypographyThemer'
 ```
 
 ## Example code

--- a/components/AppBar/docs/color-theming.md
+++ b/components/AppBar/docs/color-theming.md
@@ -5,7 +5,7 @@ You can theme an app bar with your app's color scheme using the ColorThemer exte
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/AppBar+Extensions/ColorThemer'
+pod 'MaterialComponents/AppBar+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/AppBar/docs/typography-theming.md
+++ b/components/AppBar/docs/typography-theming.md
@@ -5,7 +5,7 @@ You can theme an app bar with your app's typography scheme using the TypographyT
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/AppBar+Extensions/TypographyThemer'
+pod 'MaterialComponents/AppBar+TypographyThemer'
 ```
 
 ## Example code

--- a/components/BottomNavigation/README.md
+++ b/components/BottomNavigation/README.md
@@ -110,7 +110,7 @@ You can theme a bottom navigation with your app's color scheme using the ColorTh
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/BottomNavigation+Extensions/ColorThemer'
+pod 'MaterialComponents/BottomNavigation+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->
@@ -150,7 +150,7 @@ You can theme a bottom navigation with your app's typography scheme using the Ty
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/BottomNavigation+Extensions/TypographyThemer'
+pod 'MaterialComponents/BottomNavigation+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/BottomNavigation/docs/color-theming.md
+++ b/components/BottomNavigation/docs/color-theming.md
@@ -5,7 +5,7 @@ You can theme a bottom navigation with your app's color scheme using the ColorTh
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/BottomNavigation+Extensions/ColorThemer'
+pod 'MaterialComponents/BottomNavigation+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/BottomNavigation/docs/typography-theming.md
+++ b/components/BottomNavigation/docs/typography-theming.md
@@ -5,7 +5,7 @@ You can theme a bottom navigation with your app's typography scheme using the Ty
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/BottomNavigation+Extensions/TypographyThemer'
+pod 'MaterialComponents/BottomNavigation+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/ButtonBar/README.md
+++ b/components/ButtonBar/README.md
@@ -183,7 +183,7 @@ You can theme a button bar with your app's color scheme using the ColorThemer ex
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/ButtonBar+Extensions/ColorThemer'
+pod 'MaterialComponents/ButtonBar+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->
@@ -223,7 +223,7 @@ You can theme a button bar with your app's typography scheme using the Typograph
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/ButtonBar+Extensions/TypographyThemer'
+pod 'MaterialComponents/ButtonBar+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/ButtonBar/docs/color-theming.md
+++ b/components/ButtonBar/docs/color-theming.md
@@ -5,7 +5,7 @@ You can theme a button bar with your app's color scheme using the ColorThemer ex
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/ButtonBar+Extensions/ColorThemer'
+pod 'MaterialComponents/ButtonBar+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/ButtonBar/docs/typography-theming.md
+++ b/components/ButtonBar/docs/typography-theming.md
@@ -5,7 +5,7 @@ You can theme a button bar with your app's typography scheme using the Typograph
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/ButtonBar+Extensions/TypographyThemer'
+pod 'MaterialComponents/ButtonBar+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Buttons/README.md
+++ b/components/Buttons/README.md
@@ -218,7 +218,7 @@ schemes in the ButtonThemer extension.
 You must first add the ButtonThemer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Buttons+Extensions/ButtonThemer'
+pod 'MaterialComponents/Buttons+ButtonThemer'
 ```
 
 You can then import the extension and create an `MDCButtonScheme` instance. A button scheme defines
@@ -336,7 +336,7 @@ You can theme buttons with your app's color scheme using the ColorThemer extensi
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Buttons+Extensions/ColorThemer'
+pod 'MaterialComponents/Buttons+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->
@@ -382,7 +382,7 @@ You can theme buttons with your app's typography scheme using the TypographyThem
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Buttons+Extensions/TypographyThemer'
+pod 'MaterialComponents/Buttons+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Buttons/docs/color-theming.md
+++ b/components/Buttons/docs/color-theming.md
@@ -5,7 +5,7 @@ You can theme buttons with your app's color scheme using the ColorThemer extensi
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Buttons+Extensions/ColorThemer'
+pod 'MaterialComponents/Buttons+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Buttons/docs/theming.md
+++ b/components/Buttons/docs/theming.md
@@ -6,7 +6,7 @@ schemes in the ButtonThemer extension.
 You must first add the ButtonThemer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Buttons+Extensions/ButtonThemer'
+pod 'MaterialComponents/Buttons+ButtonThemer'
 ```
 
 You can then import the extension and create an `MDCButtonScheme` instance. A button scheme defines

--- a/components/Buttons/docs/typography-theming.md
+++ b/components/Buttons/docs/typography-theming.md
@@ -5,7 +5,7 @@ You can theme buttons with your app's typography scheme using the TypographyThem
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Buttons+Extensions/TypographyThemer'
+pod 'MaterialComponents/Buttons+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Cards/README.md
+++ b/components/Cards/README.md
@@ -216,7 +216,7 @@ You can theme a card with your app's color scheme using the ColorThemer extensio
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Cards+Extensions/ColorThemer'
+pod 'MaterialComponents/Cards+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Cards/docs/color-theming.md
+++ b/components/Cards/docs/color-theming.md
@@ -5,7 +5,7 @@ You can theme a card with your app's color scheme using the ColorThemer extensio
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Cards+Extensions/ColorThemer'
+pod 'MaterialComponents/Cards+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Cards/docs/theming.md
+++ b/components/Cards/docs/theming.md
@@ -7,7 +7,7 @@ MDCCardThemer exposes apis to theme MDCCard and MDCCardCollectionCell instances 
 You must first add the Card Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Cards+Extensions/CardThemer'
+pod 'MaterialComponents/Cards+CardThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Chips/README.md
+++ b/components/Chips/README.md
@@ -323,7 +323,7 @@ You can theme a chip with your app's color scheme using the ColorThemer extensio
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Chips+Extensions/ColorThemer'
+pod 'MaterialComponents/Chips+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->
@@ -364,7 +364,7 @@ You can theme a chip with your app's typography scheme using the TypographyTheme
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Chips+Extensions/TypographyThemer'
+pod 'MaterialComponents/Chips+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Chips/docs/color-theming.md
+++ b/components/Chips/docs/color-theming.md
@@ -5,7 +5,7 @@ You can theme a chip with your app's color scheme using the ColorThemer extensio
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Chips+Extensions/ColorThemer'
+pod 'MaterialComponents/Chips+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Chips/docs/typography-theming.md
+++ b/components/Chips/docs/typography-theming.md
@@ -5,7 +5,7 @@ You can theme a chip with your app's typography scheme using the TypographyTheme
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Chips+Extensions/TypographyThemer'
+pod 'MaterialComponents/Chips+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Dialogs/README.md
+++ b/components/Dialogs/README.md
@@ -187,7 +187,7 @@ You can theme a dialog with your app's color scheme using the ColorThemer extens
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Dialogs+Extensions/ColorThemer'
+pod 'MaterialComponents/Dialogs+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->
@@ -227,7 +227,7 @@ You can theme a dialog with your app's typography scheme using the TypographyThe
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Dialogs+Extensions/TypographyThemer'
+pod 'MaterialComponents/Dialogs+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Dialogs/docs/color-theming.md
+++ b/components/Dialogs/docs/color-theming.md
@@ -5,7 +5,7 @@ You can theme a dialog with your app's color scheme using the ColorThemer extens
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Dialogs+Extensions/ColorThemer'
+pod 'MaterialComponents/Dialogs+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Dialogs/docs/typography-theming.md
+++ b/components/Dialogs/docs/typography-theming.md
@@ -5,7 +5,7 @@ You can theme a dialog with your app's typography scheme using the TypographyThe
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Dialogs+Extensions/TypographyThemer'
+pod 'MaterialComponents/Dialogs+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/FeatureHighlight/README.md
+++ b/components/FeatureHighlight/README.md
@@ -154,7 +154,7 @@ You can theme feature highlight with your app's color scheme using the ColorThem
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/FeatureHighlight+Extensions/ColorThemer'
+pod 'MaterialComponents/FeatureHighlight+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->
@@ -194,7 +194,7 @@ You can theme feature highlight with your app's typography scheme using the Typo
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/FeatureHighlight+Extensions/TypographyThemer'
+pod 'MaterialComponents/FeatureHighlight+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/FeatureHighlight/docs/color-theming.md
+++ b/components/FeatureHighlight/docs/color-theming.md
@@ -5,7 +5,7 @@ You can theme feature highlight with your app's color scheme using the ColorThem
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/FeatureHighlight+Extensions/ColorThemer'
+pod 'MaterialComponents/FeatureHighlight+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/FeatureHighlight/docs/typography-theming.md
+++ b/components/FeatureHighlight/docs/typography-theming.md
@@ -5,7 +5,7 @@ You can theme feature highlight with your app's typography scheme using the Typo
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/FeatureHighlight+Extensions/TypographyThemer'
+pod 'MaterialComponents/FeatureHighlight+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -777,7 +777,7 @@ You can theme a flexible header with your app's color scheme using the ColorThem
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/FlexibleHeader+Extensions/ColorThemer'
+pod 'MaterialComponents/FlexibleHeader+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/FlexibleHeader/docs/color-theming.md
+++ b/components/FlexibleHeader/docs/color-theming.md
@@ -5,7 +5,7 @@ You can theme a flexible header with your app's color scheme using the ColorThem
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/FlexibleHeader+Extensions/ColorThemer'
+pod 'MaterialComponents/FlexibleHeader+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/NavigationBar/README.md
+++ b/components/NavigationBar/README.md
@@ -168,7 +168,7 @@ You can theme a navigation bar with your app's color scheme using the ColorTheme
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/NavigationBar+Extensions/ColorThemer'
+pod 'MaterialComponents/NavigationBar+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->
@@ -208,7 +208,7 @@ You can theme a navigation bar with your app's typography scheme using the Typog
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/NavigationBar+Extensions/TypographyThemer'
+pod 'MaterialComponents/NavigationBar+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/NavigationBar/docs/color-theming.md
+++ b/components/NavigationBar/docs/color-theming.md
@@ -5,7 +5,7 @@ You can theme a navigation bar with your app's color scheme using the ColorTheme
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/NavigationBar+Extensions/ColorThemer'
+pod 'MaterialComponents/NavigationBar+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/NavigationBar/docs/typography-theming.md
+++ b/components/NavigationBar/docs/typography-theming.md
@@ -5,7 +5,7 @@ You can theme a navigation bar with your app's typography scheme using the Typog
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/NavigationBar+Extensions/TypographyThemer'
+pod 'MaterialComponents/NavigationBar+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Slider/README.md
+++ b/components/Slider/README.md
@@ -181,7 +181,7 @@ You can theme a slider with your app's color scheme using the ColorThemer extens
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Slider+Extensions/ColorThemer'
+pod 'MaterialComponents/Slider+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Slider/docs/color-theming.md
+++ b/components/Slider/docs/color-theming.md
@@ -5,7 +5,7 @@ You can theme a slider with your app's color scheme using the ColorThemer extens
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Slider+Extensions/ColorThemer'
+pod 'MaterialComponents/Slider+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Snackbar/README.md
+++ b/components/Snackbar/README.md
@@ -177,7 +177,7 @@ You can theme an snackbar with your app's color scheme using the ColorThemer ext
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Snackbar+Extensions/ColorThemer'
+pod 'MaterialComponents/Snackbar+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->
@@ -216,7 +216,7 @@ You can theme an snackbar with your app's typography scheme using the Typography
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Snackbar+Extensions/TypographyThemer'
+pod 'MaterialComponents/Snackbar+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Snackbar/docs/color-theming.md
+++ b/components/Snackbar/docs/color-theming.md
@@ -5,7 +5,7 @@ You can theme an snackbar with your app's color scheme using the ColorThemer ext
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Snackbar+Extensions/ColorThemer'
+pod 'MaterialComponents/Snackbar+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Snackbar/docs/typography-theming.md
+++ b/components/Snackbar/docs/typography-theming.md
@@ -5,7 +5,7 @@ You can theme an snackbar with your app's typography scheme using the Typography
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Snackbar+Extensions/TypographyThemer'
+pod 'MaterialComponents/Snackbar+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Tabs/README.md
+++ b/components/Tabs/README.md
@@ -200,7 +200,7 @@ You can theme a tab bar with your app's color scheme using the ColorThemer exten
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Tabs+Extensions/ColorThemer'
+pod 'MaterialComponents/Tabs+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->
@@ -246,7 +246,7 @@ You can theme a tab bar with your app's typography scheme using the TypographyTh
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Tabs+Extensions/TypographyThemer'
+pod 'MaterialComponents/Tabs+TypographyThemer'
 ```
 <!--<div class="material-code-render" markdown="1">-->
 #### Swift

--- a/components/Tabs/docs/color-theming.md
+++ b/components/Tabs/docs/color-theming.md
@@ -5,7 +5,7 @@ You can theme a tab bar with your app's color scheme using the ColorThemer exten
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Tabs+Extensions/ColorThemer'
+pod 'MaterialComponents/Tabs+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/Tabs/docs/typography-theming.md
+++ b/components/Tabs/docs/typography-theming.md
@@ -5,7 +5,7 @@ You can theme a tab bar with your app's typography scheme using the TypographyTh
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/Tabs+Extensions/TypographyThemer'
+pod 'MaterialComponents/Tabs+TypographyThemer'
 ```
 <!--<div class="material-code-render" markdown="1">-->
 #### Swift

--- a/components/TextFields/README.md
+++ b/components/TextFields/README.md
@@ -233,7 +233,7 @@ You can theme a text field with your app's color scheme using the ColorThemer ex
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/TextFields+Extensions/ColorThemer'
+pod 'MaterialComponents/TextFields+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->
@@ -292,7 +292,7 @@ You can theme a text field with your app's typography scheme using the Typograph
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/TextFields+Extensions/TypographyThemer'
+pod 'MaterialComponents/TextFields+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/TextFields/docs/color-theming.md
+++ b/components/TextFields/docs/color-theming.md
@@ -5,7 +5,7 @@ You can theme a text field with your app's color scheme using the ColorThemer ex
 You must first add the Color Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/TextFields+Extensions/ColorThemer'
+pod 'MaterialComponents/TextFields+ColorThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/components/TextFields/docs/typography-theming.md
+++ b/components/TextFields/docs/typography-theming.md
@@ -5,7 +5,7 @@ You can theme a text field with your app's typography scheme using the Typograph
 You must first add the Typography Themer extension to your project:
 
 ```bash
-pod 'MaterialComponents/TextFields+Extensions/TypographyThemer'
+pod 'MaterialComponents/TextFields+TypographyThemer'
 ```
 
 <!--<div class="material-code-render" markdown="1">-->

--- a/docs/theming/README.md
+++ b/docs/theming/README.md
@@ -65,8 +65,8 @@ Podfile. You can see which themers a given component supports by looking at the 
 directory.
 
 ```bash
-pod 'MaterialComponents/AppBar+Extensions/ColorThemer'
-pod 'MaterialComponents/AppBar+Extensions/TypographyThemer'
+pod 'MaterialComponents/AppBar+ColorThemer'
+pod 'MaterialComponents/AppBar+TypographyThemer'
 ```
 
 You can now access the AppBar themers.


### PR DESCRIPTION
This discourages depending on all of a component's extensions and aligns our targets more closely with how we expect them to be imported and depended upon.

This is a breaking change.

Pivotal story: https://www.pivotaltracker.com/story/show/157118721