### PR TITLE
[Docs] Replaced www.material.io with material.io everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Code coverage](https://img.shields.io/codecov/c/github/material-components/material-components-ios/develop.svg)](https://codecov.io/gh/material-components/material-components-ios/branch/develop)
 [![Chat](https://img.shields.io/discord/259087343246508035.svg)](https://discord.gg/material-components)
 
-Material Components for iOS (MDC-iOS) helps developers execute [Material Design](https://www.material.io). Developed by a core team of engineers and UX designers at Google, these components enable a reliable development workflow to build beautiful and functional iOS apps. Learn more about how Material Components for iOS supports design and usability best practices across platforms in the  [Material Design Platform Adaptation guidelines](https://material.io/guidelines/platforms/platform-adaptation.html).
+Material Components for iOS (MDC-iOS) helps developers execute [Material Design](https://material.io). Developed by a core team of engineers and UX designers at Google, these components enable a reliable development workflow to build beautiful and functional iOS apps. Learn more about how Material Components for iOS supports design and usability best practices across platforms in the  [Material Design Platform Adaptation guidelines](https://material.io/guidelines/platforms/platform-adaptation.html).
 
 Material Components for iOS are written in Objective-C and support Swift and Interface Builder.
 
@@ -17,7 +17,7 @@ Material Components for iOS are written in Objective-C and support Swift and Int
 - [Demo Apps](demos/)
 - [Contributing](contributing/)
 - [MDC-iOS on Stack Overflow](https://www.stackoverflow.com/questions/tagged/material-components+ios) (external site)
-- [Material.io](https://www.material.io) (external site)
+- [Material.io](https://material.io) (external site)
 - [Material Design Guidelines](https://material.io/guidelines) (external site)
 - [Checklist status spreadsheet](https://docs.google.com/spreadsheets/d/e/2PACX-1vRQLFMuo0Q3xsJp1_TdWvImtfdc8dU0lqX2DTct5pOPAEUIrN9OsuPquvv4aKRAwKK_KItpGs7c4Fok/pubhtml)
 - [Discord Chat Room](https://discord.gg/material-components)

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -106,5 +106,5 @@ Use the `supplemental` folder to keep your example code clean and instructive.
 - [Demo Apps](../demos/)
 - [Contributing](../contributing/)
 - [MDC-iOS on Stack Overflow](https://www.stackoverflow.com/questions/tagged/material-components+ios) (external site)
-- [Material.io](https://www.material.io) (external site)
+- [Material.io](https://material.io) (external site)
 - [Material Design Guidelines](https://material.io/guidelines) (external site)

--- a/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
@@ -132,7 +132,7 @@ static NSString * const kReusableIdentifierItem = @"cell";
   self.view.backgroundColor = [UIColor whiteColor];
 
   _dismissButton = [[MDCFlatButton alloc] init];
-  [_dismissButton setTitle:@"www.material.io" forState:UIControlStateNormal];
+  [_dismissButton setTitle:@"material.io" forState:UIControlStateNormal];
   [_dismissButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
   _dismissButton.autoresizingMask =
       UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |
@@ -156,7 +156,7 @@ static NSString * const kReusableIdentifierItem = @"cell";
 }
 
 - (IBAction)dismiss:(id)sender {
-  NSURL *testURL = [NSURL URLWithString:@"https://www.material.io"];
+  NSURL *testURL = [NSURL URLWithString:@"https://material.io"];
   // Use mdc_safeSharedApplication to avoid a compiler warning about extensions
   [[UIApplication mdc_safeSharedApplication] performSelector:@selector(openURL:) withObject:testURL];
 }

--- a/components/README.md
+++ b/components/README.md
@@ -1,6 +1,6 @@
 # Component Documentation
 
-Material Components for iOS (MDC-iOS) help developers execute [Material Design](https://www.material.io). Developed by a core team of engineers and UX designers at Google, these components enable a reliable development workflow to build beautiful and functional iOS apps.
+Material Components for iOS (MDC-iOS) help developers execute [Material Design](https://material.io). Developed by a core team of engineers and UX designers at Google, these components enable a reliable development workflow to build beautiful and functional iOS apps.
 
 Material Components for iOS are written in Objective-C and support Swift and Interface Builder.
 
@@ -136,5 +136,5 @@ Material Components for iOS are written in Objective-C and support Swift and Int
 - [Demo Apps](../demos/)
 - [Contributing](../contributing/)
 - [MDC-iOS on Stack Overflow](https://www.stackoverflow.com/questions/tagged/material-components+ios) (external site)
-- [Material.io](https://www.material.io) (external site)
+- [Material.io](https://material.io) (external site)
 - [Material Design Guidelines](https://material.io/guidelines) (external site)

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -67,5 +67,5 @@ Contributions made by corporations are covered by a different agreement than the
 - [All Components](../components/)
 - [Demo Apps](../demos/)
 - [MDC-iOS on Stack Overflow](https://www.stackoverflow.com/questions/tagged/material-components+ios) (external site)
-- [Material.io](https://www.material.io) (external site)
+- [Material.io](https://material.io) (external site)
 - [Material Design Guidelines](https://material.io/guidelines) (external site)

--- a/demos/README.md
+++ b/demos/README.md
@@ -29,6 +29,6 @@ pod install --project-directory=catalog/
 - [All Components](../components/)
 - [Contributing](../contributing/)
 - [MDC-iOS on Stack Overflow](https://www.stackoverflow.com/questions/tagged/material-components+ios) (external site)
-- [Material.io](https://www.material.io) (external site)
+- [Material.io](https://material.io) (external site)
 - [Material Design Guidelines](https://material.io/guidelines) (external site)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,5 +28,5 @@ Apple's standard development tool chain.
 - [Demo Apps](../demos/)
 - [Contributing](../contributing/)
 - [MDC-iOS on Stack Overflow](https://www.stackoverflow.com/questions/tagged/material-components+ios)
-- [Material.io](https://www.material.io)
+- [Material.io](https://material.io)
 - [Material Design Guidelines](https://material.io/guidelines)


### PR DESCRIPTION
Docs and test strings only.