### PR TITLE
[Catalog] Fix BottomSheet import

### DIFF
--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -17,7 +17,7 @@ limitations under the License.
 import UIKit
 
 import CatalogByConvention
-import MaterialComponents.MDCBottomSheetController
+import MaterialComponents.MaterialBottomSheet
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {


### PR DESCRIPTION
The AppDelegate was not importing the umbrella header, causing breakages when
building internally.
