### PR TITLE
[Buttons] Replace MDCFlatButton with MDCButton + text themer in content edge insets example.

### DIFF
--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -17,11 +17,10 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialButtons.h"
-#import "MDCButtonScheme.h"
-#import "MDCContainedButtonThemer.h"
+#import "MaterialButtons+ButtonThemer.h"
 
 @interface ButtonsContentEdgeInsetsExample : UIViewController
-@property(weak, nonatomic) IBOutlet MDCFlatButton *flatButton;
+@property(weak, nonatomic) IBOutlet MDCButton *textButton;
 @property(weak, nonatomic) IBOutlet MDCButton *containedButton;
 @property(weak, nonatomic) IBOutlet MDCFloatingButton *floatingActionButton;
 @property(weak, nonatomic) IBOutlet UISwitch *inkBoundingSwitch;
@@ -50,12 +49,9 @@
 
   MDCButtonScheme *buttonScheme = [[MDCButtonScheme alloc] init];
   [MDCContainedButtonThemer applyScheme:buttonScheme toButton:self.containedButton];
+  [MDCTextButtonThemer applyScheme:buttonScheme toButton:self.textButton];
 
-  // Force a darker background color to show the button frame
-  [self.flatButton setBackgroundColor:[UIColor colorWithWhite:0.2f alpha:1.0f]
-                             forState:UIControlStateNormal];
-  self.flatButton.inkColor = [UIColor colorWithWhite:1.0f alpha:0.1f];
-  self.flatButton.contentEdgeInsets = UIEdgeInsetsMake(64, 64, 0, 0);
+  self.textButton.contentEdgeInsets = UIEdgeInsetsMake(64, 64, 0, 0);
   self.containedButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, 64, 64);
   [self.floatingActionButton setContentEdgeInsets:UIEdgeInsetsMake(40, 40, 0, 0)
                                          forShape:MDCFloatingButtonShapeDefault
@@ -65,7 +61,7 @@
 }
 
 - (void)updateInkStyle:(MDCInkStyle)inkStyle {
-  self.flatButton.inkStyle = inkStyle;
+  self.textButton.inkStyle = inkStyle;
   self.containedButton.inkStyle = inkStyle;
   self.floatingActionButton.inkStyle = inkStyle;
 }

--- a/components/Buttons/examples/resources/ButtonsContentEdgeInsets.storyboard
+++ b/components/Buttons/examples/resources/ButtonsContentEdgeInsets.storyboard
@@ -25,7 +25,7 @@
                                 <rect key="frame" x="104.5" y="83" width="166" height="38"/>
                                 <color key="tintColor" red="0.19254023644059035" green="0.53181806153905575" blue="0.91669365284974091" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <inset key="contentEdgeInsets" minX="0.0" minY="0.0" maxX="16" maxY="16"/>
-                                <state key="normal" title="Flat Button">
+                                <state key="normal" title="Text Button">
                                     <color key="titleColor" cocoaTouchSystemColor="lightTextColor"/>
                                 </state>
                             </button>

--- a/components/Buttons/examples/resources/ButtonsContentEdgeInsets.storyboard
+++ b/components/Buttons/examples/resources/ButtonsContentEdgeInsets.storyboard
@@ -21,23 +21,23 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bvE-5P-0PG" customClass="MDCFlatButton">
-                                <rect key="frame" x="115.5" y="83" width="144" height="34"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bvE-5P-0PG" customClass="MDCButton">
+                                <rect key="frame" x="104.5" y="83" width="166" height="38"/>
                                 <color key="tintColor" red="0.19254023644059035" green="0.53181806153905575" blue="0.91669365284974091" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <inset key="contentEdgeInsets" minX="0.0" minY="0.0" maxX="16" maxY="16"/>
                                 <state key="normal" title="Flat Button">
                                     <color key="titleColor" cocoaTouchSystemColor="lightTextColor"/>
                                 </state>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dqo-nu-adB" customClass="MDCRaisedButton">
-                                <rect key="frame" x="115" y="133" width="144" height="18"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dqo-nu-adB" customClass="MDCRaisedButton">
+                                <rect key="frame" x="104" y="137" width="166" height="22"/>
                                 <inset key="contentEdgeInsets" minX="0.0" minY="0.0" maxX="24" maxY="0.0"/>
                                 <state key="normal" title="Contained Button">
                                     <color key="titleColor" cocoaTouchSystemColor="lightTextColor"/>
                                 </state>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YCS-6P-hwz" customClass="MDCFloatingButton">
-                                <rect key="frame" x="161" y="167" width="52" height="52"/>
+                                <rect key="frame" x="161" y="175" width="52" height="52"/>
                                 <inset key="contentEdgeInsets" minX="16" minY="16" maxX="0.0" maxY="0.0"/>
                                 <state key="normal" image="plus_white_36">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -85,9 +85,9 @@
                     </view>
                     <connections>
                         <outlet property="containedButton" destination="Dqo-nu-adB" id="wM8-hW-eZt"/>
-                        <outlet property="flatButton" destination="bvE-5P-0PG" id="8px-6Z-f5o"/>
                         <outlet property="floatingActionButton" destination="YCS-6P-hwz" id="Mw6-3r-5YL"/>
                         <outlet property="inkBoundingSwitch" destination="2pb-ML-fiY" id="LUP-MI-2Lq"/>
+                        <outlet property="textButton" destination="bvE-5P-0PG" id="8px-6Z-f5o"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Z12-Wq-Srl" userLabel="First Responder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
Also fixes a bug where the button was being initialized as a system button instead of as a custom button. This was affecting the highlighted text state.

Pivotal story: https://www.pivotaltracker.com/story/show/157189341

Before (normal / highlighted):
![simulator screen shot - iphone se - 2018-04-30 at 09 21 34](https://user-images.githubusercontent.com/45670/39429179-18130c08-4c58-11e8-972a-b96dd827ee26.png) ![simulator screen shot - iphone se - 2018-04-30 at 09 21 36](https://user-images.githubusercontent.com/45670/39429181-193b0ff4-4c58-11e8-8dab-dcdfcf86a7cf.png)

After (normal / highlighted):
![simulator screen shot - iphone se - 2018-04-30 at 09 21 03](https://user-images.githubusercontent.com/45670/39429211-2e171710-4c58-11e8-95e6-07eb614857c8.png) ![simulator screen shot - iphone se - 2018-04-30 at 09 21 04](https://user-images.githubusercontent.com/45670/39429215-30bde2c8-4c58-11e8-882a-e585da609684.png)
