### PR TITLE
[Cards] Replace MDCFlatButton with text button themer in CardExampleViewController.

### DIFF
--- a/components/Cards/examples/CardExampleViewController.swift
+++ b/components/Cards/examples/CardExampleViewController.swift
@@ -15,12 +15,16 @@
  */
 
 import UIKit
+import MaterialComponents.MaterialButtons_ButtonThemer
 
 class CardExampleViewController: UIViewController {
   @IBOutlet var contentView: UIView!
   @IBOutlet weak var imageView: UIImageView!
   @IBOutlet weak var card: MDCCard!
+  @IBOutlet weak var button: MDCButton!
+
   var colorScheme = MDCSemanticColorScheme()
+  var typographyScheme = MDCTypographyScheme()
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -41,8 +45,13 @@ class CardExampleViewController: UIViewController {
     shapeLayer.path = bezierPath.cgPath
     imageView.layer.mask = shapeLayer
 
+    let buttonScheme = MDCButtonScheme();
+    buttonScheme.colorScheme = colorScheme
+    buttonScheme.typographyScheme = typographyScheme
+    MDCTextButtonThemer.applyScheme(buttonScheme, to: button)
+
     let cardScheme = MDCCardScheme();
-    cardScheme.colorScheme = MDCSemanticColorScheme()
+    cardScheme.colorScheme = colorScheme
     MDCCardThemer.applyScheme(cardScheme, to: card)
   }
 

--- a/components/Cards/examples/resources/CardExampleViewController.xib
+++ b/components/Cards/examples/resources/CardExampleViewController.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13770" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13770"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -13,6 +13,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CardExampleViewController" customModule="MaterialComponentsExamples" customModuleProvider="target">
             <connections>
+                <outlet property="button" destination="NWQ-Eq-COf" id="tUV-oY-3Ia"/>
                 <outlet property="card" destination="BAQ-GJ-1pn" id="kH3-zF-uH0"/>
                 <outlet property="contentView" destination="i5M-Pr-FkT" id="Hkq-gw-WEg"/>
                 <outlet property="imageView" destination="ldt-3r-Agk" id="rFC-QD-GJJ"/>
@@ -38,14 +39,14 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" verticalCompressionResistancePriority="749" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tmz-Bt-Hco">
-                            <rect key="frame" x="8" y="353.5" width="299" height="79.5"/>
+                            <rect key="frame" x="8" y="353.5" width="299" height="75.5"/>
                             <string key="text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</string>
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                             <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NWQ-Eq-COf" customClass="MDCFlatButton">
-                            <rect key="frame" x="110.5" y="441" width="94" height="30"/>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NWQ-Eq-COf" customClass="MDCButton">
+                            <rect key="frame" x="102.5" y="437" width="110" height="34"/>
                             <state key="normal" title="Action Button"/>
                         </button>
                     </subviews>


### PR DESCRIPTION
Also fixes a bug where the button was being initialized as a system button instead of as a custom button. This was affecting the highlighted text state.

Pivotal story: https://www.pivotaltracker.com/story/show/157189842

Before (normal / highlighted):

![simulator screen shot - iphone se - 2018-04-30 at 09 31 27](https://user-images.githubusercontent.com/45670/39429671-99e1d420-4c59-11e8-82a1-f1d1a1962298.png) ![simulator screen shot - iphone se - 2018-04-30 at 09 31 28](https://user-images.githubusercontent.com/45670/39429672-9a0db194-4c59-11e8-93f6-dbe9d0615350.png)

After (normal / highlighted):

![simulator screen shot - iphone se - 2018-04-30 at 09 30 31](https://user-images.githubusercontent.com/45670/39429684-a7e0218a-4c59-11e8-991b-c59d96c74e83.png) ![simulator screen shot - iphone se - 2018-04-30 at 09 30 33](https://user-images.githubusercontent.com/45670/39429685-a914b0e8-4c59-11e8-84cf-fd77448ba421.png)
