### PR TITLE
Remove CocoaPods attributions from our README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,12 +157,6 @@ Material Components for iOS uses
 copyright Google Inc. and licensed under
 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
-Several components use
-[MDFTextAccessibility](https://github.com/material-foundation/material-text-accessibility-ios),
-copyright Google Inc. and licensed under
-[Apache 2.0](https://github.com/material-foundation/material-text-accessibility-ios/blob/master/LICENSE)
-without a NOTICE file.
-
 MDCCatalog uses the
 [Roboto font](https://github.com/google/fonts/tree/master/apache/roboto),
 copyright 2011 Google Inc. and licensed under


### PR DESCRIPTION
Attributions for downstream dependencies must be handled at the app level and presented at runtime in an app open source attributions page. This is not the responsibility of our README.md.