### PR TITLE
[schemes/Color] Update the default error color to match spec.

### DIFF
--- a/components/schemes/Color/src/MDCSemanticColorScheme.m
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.m
@@ -50,7 +50,7 @@ static CGFloat blendColorChannel(CGFloat value, CGFloat bValue, CGFloat alpha, C
         _primaryColor = ColorFromRGB(0x6200EE);
         _primaryColorVariant = ColorFromRGB(0x3700B3);
         _secondaryColor = ColorFromRGB(0x03DAC6);
-        _errorColor = ColorFromRGB(0xFF1744);
+        _errorColor = ColorFromRGB(0xB00020);
         _surfaceColor = ColorFromRGB(0xFFFFFF);
         _backgroundColor = ColorFromRGB(0xFFFFFF);
         _onPrimaryColor = ColorFromRGB(0xFFFFFF);

--- a/components/schemes/Color/tests/unit/MDCSemanticColorSchemeTests.m
+++ b/components/schemes/Color/tests/unit/MDCSemanticColorSchemeTests.m
@@ -58,7 +58,7 @@ static UIColor *ColorFromRGB(uint32_t colorValue) {
   XCTAssertEqualObjects(colorScheme.primaryColor, ColorFromRGB(0x6200EE));
   XCTAssertEqualObjects(colorScheme.primaryColorVariant, ColorFromRGB(0x3700B3));
   XCTAssertEqualObjects(colorScheme.secondaryColor, ColorFromRGB(0x03DAC6));
-  XCTAssertEqualObjects(colorScheme.errorColor, ColorFromRGB(0xFF1744));
+  XCTAssertEqualObjects(colorScheme.errorColor, ColorFromRGB(0xB00020));
   XCTAssertEqualObjects(colorScheme.surfaceColor, ColorFromRGB(0xFFFFFF));
   XCTAssertEqualObjects(colorScheme.backgroundColor, ColorFromRGB(0xFFFFFF));
   XCTAssertEqualObjects(colorScheme.onPrimaryColor, ColorFromRGB(0xFFFFFF));


### PR DESCRIPTION
This is a request from the design team and the changes have been updated in the spec accordingly.

Before/after:

![before](https://user-images.githubusercontent.com/45670/39480788-48e17a74-4d37-11e8-97ad-889061e75b5e.png) ![after](https://user-images.githubusercontent.com/45670/39480790-4acc2a32-4d37-11e8-9ea9-eadf4132caa0.png)
