### PR TITLE
Revert "Make MDCAppBarContainerViewController set bounds of child view controller (#3450)"

### DIFF
--- a/components/AppBar/src/MDCAppBarContainerViewController.m
+++ b/components/AppBar/src/MDCAppBarContainerViewController.m
@@ -50,7 +50,6 @@
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
   [_appBar.headerViewController updateTopLayoutGuide];
-  self.contentViewController.view.frame = self.view.bounds;
 }
 
 - (BOOL)prefersStatusBarHidden {


### PR DESCRIPTION
This reverts commit 3db1410ede9045b22663284b7c0830ddf80a360a.

The original change caused a visual regression in many of our Catalog examples. The regression is technically correct, but the examples have been written to the incorrect behavior and are now often appearing behind the App Bar.

Before/after rollback:

![simulator screen shot - iphone se - 2018-04-30 at 16 29 18](https://user-images.githubusercontent.com/45670/39448747-dc78230e-4c93-11e8-94bf-fb681bd16369.png) ![simulator screen shot - iphone se - 2018-04-30 at 16 30 38](https://user-images.githubusercontent.com/45670/39448750-dec6ef28-4c93-11e8-9361-c2c5a6613c5b.png)
