### PR TITLE
Make all of the AppBar implementation component examples be dragons.

### DIFF
--- a/components/ButtonBar/examples/ButtonBarCustomizedFontExample.m
+++ b/components/ButtonBar/examples/ButtonBarCustomizedFontExample.m
@@ -85,10 +85,6 @@
   return NO;
 }
 
-+ (BOOL)catalogIsPresentable {
-  return YES;
-}
-
 @end
 
 #pragma mark - Typical application code (not Material-specific)

--- a/components/ButtonBar/examples/ButtonBarIconExample.m
+++ b/components/ButtonBar/examples/ButtonBarIconExample.m
@@ -90,10 +90,6 @@
   return NO;
 }
 
-+ (BOOL)catalogIsPresentable {
-  return YES;
-}
-
 @end
 
 #pragma mark - Typical application code (not Material-specific)

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.m
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.m
@@ -86,10 +86,6 @@
           " horizontally-aligned buttons.";
 }
 
-+ (BOOL)catalogIsPresentable {
-  return YES;
-}
-
 @end
 
 #pragma mark - Typical application code (not Material-specific)

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
@@ -40,7 +40,7 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderFABSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderFABSupplemental.m
@@ -38,7 +38,7 @@
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderHorizontalPagingSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderHorizontalPagingSupplemental.m
@@ -36,7 +36,7 @@
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderPageControlSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderPageControlSupplemental.m
@@ -38,7 +38,7 @@
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTopLayoutGuideSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTopLayoutGuideSupplemental.m
@@ -39,7 +39,7 @@
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTypicalUseSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTypicalUseSupplemental.m
@@ -41,7 +41,7 @@
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderUINavigationBarSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderUINavigationBarSupplemental.m
@@ -38,7 +38,7 @@
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderWrappedSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderWrappedSupplemental.m
@@ -36,7 +36,7 @@
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.m
+++ b/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.m
@@ -116,7 +116,7 @@
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/NavigationBar/examples/NavigationBarIconsExample.m
+++ b/components/NavigationBar/examples/NavigationBarIconsExample.m
@@ -135,7 +135,7 @@
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/NavigationBar/examples/NavigationBarLayoutExample.m
+++ b/components/NavigationBar/examples/NavigationBarLayoutExample.m
@@ -220,7 +220,7 @@
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
+++ b/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
@@ -108,7 +108,7 @@
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/NavigationBar/examples/NavigationbarWithCustomFont.m
+++ b/components/NavigationBar/examples/NavigationbarWithCustomFont.m
@@ -106,4 +106,8 @@
   return YES;
 }
 
++ (BOOL)catalogIsPresentable {
+  return NO;
+}
+
 @end

--- a/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.m
+++ b/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.m
@@ -74,7 +74,7 @@
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end


### PR DESCRIPTION
ButtonBar, FlexibleHeader, HeaderStackView, and NavigationBar are all implementation details of AppBar. While these components can be used on their own, in practice we expect most typical usage to rely on AppBar. FlexibleHeader is a bit blurry in that there is often value in relying on it solely, but because it is not a true concept in the spec and its behavioral demos largely overlap with AppBar's, it is now a dragons demo.

Pivotal story: https://www.pivotaltracker.com/story/show/156982162