### PR TITLE
Ensure buttons and cards reset their states correctly

### DIFF
--- a/components/Buttons/src/ButtonThemer/MDCOutlinedButtonThemer.m
+++ b/components/Buttons/src/ButtonThemer/MDCOutlinedButtonThemer.m
@@ -32,10 +32,8 @@
       UIControlStateNormal | UIControlStateSelected | UIControlStateHighlighted |
       UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
-    [button setBorderWidth:0 forState:state];
+    [button setBorderWidth:1.f forState:state];
   }
-  
-  [button setBorderWidth:1.0f forState:UIControlStateNormal];
 }
 
 @end

--- a/components/Buttons/tests/unit/ButtonThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonThemerTests.m
@@ -94,7 +94,7 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
                              kEpsilonAccuracy);
   XCTAssertEqualWithAccuracy([button borderWidthForState:UIControlStateNormal], 1,
                              kEpsilonAccuracy);
-  XCTAssertEqualWithAccuracy([button borderWidthForState:UIControlStateHighlighted], 0,
+  XCTAssertEqualWithAccuracy([button borderWidthForState:UIControlStateHighlighted], 1,
                              kEpsilonAccuracy);
 }
 

--- a/components/Cards/src/CardThemer/MDCCardThemer.m
+++ b/components/Cards/src/CardThemer/MDCCardThemer.m
@@ -27,11 +27,24 @@ static const CGFloat kBorderWidth = 1.f;
 
 + (void)applyScheme:(nonnull id<MDCCardScheming>)scheme
              toCard:(nonnull MDCCard *)card {
+  NSUInteger maximumStateValue =
+      UIControlStateNormal | UIControlStateSelected | UIControlStateHighlighted |
+      UIControlStateDisabled;
+  for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    [card setBorderWidth:0.f forState:state];
+    [card setShadowElevation:0.f forState:state];
+  }
   [MDCCardsColorThemer applySemanticColorScheme:scheme.colorScheme toCard:card];
 }
 
 + (void)applyScheme:(nonnull id<MDCCardScheming>)scheme
          toCardCell:(nonnull MDCCardCollectionCell *)cardCell {
+  for (MDCCardCellState state = MDCCardCellStateNormal;
+       state <= MDCCardCellStateSelected;
+       state++) {
+    [cardCell setShadowElevation:0.f forState:state];
+    [cardCell setBorderWidth:0.f forState:state];
+  }
   [MDCCardsColorThemer applySemanticColorScheme:scheme.colorScheme toCardCell:cardCell];
 }
 


### PR DESCRIPTION
Dont reset other states to 0 within MDCOutlinedButtonThemer, because since its an int thats not resetting, its overriding the behavior of defaulting to UIControlStateNormal

Within MDCCardThemer reset elevation and border to 0 in the non outlined variant. 