### PR TITLE
[scripts] Implement a templatized readme generator.

### DIFF
--- a/contributing/documentation.md
+++ b/contributing/documentation.md
@@ -1,0 +1,101 @@
+# Documentation
+
+Every component is expected to provide complete API documentation for every public API and a
+top-level README.md file that includes the following:
+
+- A description of the component in relation to the Material spec.
+- A looping, animated gif of the component.
+- Links to Design and API documentation.
+- A list of related components, if any.
+- An overview that describes the primary APIs for the component.
+- Installation steps.
+- Usage guides. Must include at least one typical use article.
+- Extensions articles, if any.
+
+## Documentation conventions
+
+```
+components/
+  Component/
+    .vars        <- A list of variables that can be used by the template generators.
+    README.md    <- This is an auto-generated file. Do not modify it directly.
+    docs/        <- All documentation source lives here.
+      README.md  <- The root index of your component's documentation.
+      article.md <- An article that is linked to from your root index.
+      assets/    <- All pngs, gifs live here.
+```
+
+## docs/README.md template
+
+Use the following template command as a starting point for component documentation:
+
+```bash
+./scripts/apply_template ComponentName scripts/templates/component/docs/README.md.template components/ComponentName/docs/README.md
+```
+
+This will create a README.md in your component's `docs/` directory.
+
+### .vars file
+
+The `.vars` defines common template variables for a component. This file should be a list of
+`variable_name=value` lines.
+
+The list of possible variables are:
+
+```markdown
+component=
+component_name=
+a_component_name=
+root_path=
+icon_id=
+short_description=
+color_themer_api=
+typography_themer_api=
+themer_parameter_name=
+```
+
+### Design & API links
+
+To generate a list that uses icons as bullets, use the `*` list format;
+
+```markdown
+* [Material Design guidelines: Progress & activity](https://material.io/go/design-progress-indicators)
+```
+
+### Embedding articles
+
+To embed an article in the generated readme, use the following syntax:
+
+```markdown
+- [Article title](article-file.md)
+```
+
+### Showing a table of contents
+
+The following snippet will tell the readme generator to create a table of contents.
+
+```markdown
+<!-- toc -->
+```
+
+### Showing installation steps
+
+Use the following snippet to generate installation docs for your component:
+
+```markdown
+## Installation
+
+- [Typical installation](../../../docs/component-installation.md)
+```
+
+- - -
+
+## Generating documentation
+
+To generate the root README.md file for a given component, run:
+
+```bash
+./scripts/generate_readme ActivityIndicator
+```
+
+This will generate the root README.md from `docs/README.md` and any linked-to articles.

--- a/contributing/documentation.md
+++ b/contributing/documentation.md
@@ -54,6 +54,9 @@ typography_themer_api=
 themer_parameter_name=
 ```
 
+If a variable is not provided and a template requires it, then the template will be generated with
+the missing variables shown as placeholders still.
+
 ### Design & API links
 
 To generate a list that uses icons as bullets, use the `*` list format;

--- a/docs/component-installation.md
+++ b/docs/component-installation.md
@@ -1,0 +1,31 @@
+### Installation with CocoaPods
+
+Add the following to your `Podfile`:
+
+```bash
+pod 'MaterialComponents/<#ComponentName#>'
+```
+<!--{: .code-renderer.code-renderer--install }-->
+
+Then, run the following command:
+
+```bash
+pod install
+```
+
+### Importing
+
+To import the component:
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+import MaterialComponents.Material<#ComponentName#>
+```
+
+#### Objective-C
+
+```objc
+#import "Material<#ComponentName#>.h"
+```
+<!--</div>-->

--- a/scripts/apply_all_templates
+++ b/scripts/apply_all_templates
@@ -21,7 +21,7 @@ find components -type d | grep ColorThemer | sort | uniq | while read line; do
   
   echo "Generating color theming documentation for $component..."
 
-  ./scripts/apply_template $component scripts/templates/component/docs/color-theming.md.template
+  ./scripts/apply_template $component scripts/templates/component/docs/color-theming.md.template components/$component/docs/color-theming.md
 done
 
 find components -type d | grep TypographyThemer | sort | uniq | while read line; do
@@ -30,5 +30,5 @@ find components -type d | grep TypographyThemer | sort | uniq | while read line;
   
   echo "Generating typography theming documentation for $component..."
 
-  ./scripts/apply_template $component scripts/templates/component/docs/typography-theming.md.template
+  ./scripts/apply_template $component scripts/templates/component/docs/typography-theming.md.template components/$component/docs/typography-theming.md
 done

--- a/scripts/apply_template
+++ b/scripts/apply_template
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 usage() {
-  echo "Usage: $0 <ComponentName> <path_to_.template_file>"
+  echo "Usage: $0 <ComponentName> <path_to_.template_file> <destination>"
   echo
   echo "Copies the template into the component directory and replaces all of the symbols defined"
   echo "in the component's .vars file."
@@ -31,16 +31,17 @@ usage() {
   echo "This script will replace all instances of <#symbol#> in the .template with the given"
   echo "replacement."
   echo
-  echo "Example usage: $0 ActivityIndicator scripts/templates/component/docs/ColorTheming.md.template"
+  echo "Example usage: $0 scripts/templates/component/docs/color-theming.md.template components/ActivityIndicator/docs/color-theming.md"
 }
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -ne 3 ]; then
   usage
   exit 1
 fi
 
 COMPONENT="$1"
 TEMPLATE_PATH="$2"
+DESTINATION_PATH="$3"
 
 if [ ! -f "$TEMPLATE_PATH" ]; then
   echo "$TEMPLATE_PATH is not a file."
@@ -49,8 +50,6 @@ if [ ! -f "$TEMPLATE_PATH" ]; then
   exit 1
 fi
 
-COMPONENT_PATH="components/$COMPONENT"
-DESTINATION_PATH="$COMPONENT_PATH/$(echo "$TEMPLATE_PATH" | cut -d'/' -f4- | sed 's/.template//')"
 mkdir -p $(dirname "$DESTINATION_PATH")
 
 COMPONENT_VARS="components/$COMPONENT/.vars"

--- a/scripts/generate_readme
+++ b/scripts/generate_readme
@@ -1,0 +1,114 @@
+#!/bin/bash -e
+#
+# Copyright 2018-present The Material Components for iOS Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+usage() {
+  echo "Usage: $0 <ComponentName>"
+  echo
+  echo "Generates a root readme file from a component's documentation."
+  echo
+  echo "Example usage: $0 ActivityIndicator"
+}
+
+if [ "$#" -ne 1 ]; then
+  usage
+  exit 1
+fi
+
+COMPONENT="$1"
+
+COMPONENT_PATH="components/$COMPONENT"
+SITE_README_PATH="$COMPONENT_PATH/README.md"
+
+mkdir -p $(dirname "$SITE_README_PATH")
+
+TMP_PATH=$(mktemp -d)
+TMP_README_PATH="$TMP_PATH/README.md"
+TMP_EXPANDED_README_PATH="$TMP_PATH/README.md.expanded"
+TMP_TOC_PATH="$TMP_PATH/toc.md"
+TOC_STRING="<!-- toc -->"
+
+./scripts/apply_template "$COMPONENT" scripts/templates/component/README.md.template "$TMP_README_PATH"
+
+echo "<!-- This file was auto-generated using $0 $COMPONENT -->" >> "$TMP_README_PATH"
+echo "" >> "$TMP_README_PATH"
+
+cat "$COMPONENT_PATH/docs/README.md" >> "$TMP_README_PATH"
+
+# Rewrite asset paths
+perl -pi -e "s|src=\"assets|src=\"docs/assets|g" "$TMP_README_PATH"
+
+# Convert * spec urls to stylized lists
+perl -pi -e "s|\* \[(.+)\]\\((.+?)/go/design-(.+)\\)|  <li class=\"icon-list-item icon-list-item--spec\"><a href=\"\2/go/design-\3\">\1</a></li>|g" "$TMP_README_PATH"
+
+# Convert * list urls to stylized lists
+perl -pi -e "s|\* \[(.+)\]\\((.+)\\)|  <li class=\"icon-list-item icon-list-item--link\"><a href=\"\2\">\1</a></li>|g" "$TMP_README_PATH"
+
+# Convert * list text to stylized lists.
+perl -pi -e "s|\* (.+)$|  <li class=\"icon-list-item icon-list-item--spec\">\1</li>|g" "$TMP_README_PATH"
+
+# Prefix lists with <ul>
+perl -p0i -e "s|\n\n  <li|\n\n<ul class=\"icon-list\">\n  <li|g" "$TMP_README_PATH"
+
+# Postfix lists with </ul>
+perl -p0i -e "s|li>\n\n|li>\n</ul>\n\n|g" "$TMP_README_PATH"
+
+# Expand all files inline
+IFS='' # Don't trim whitespace from lines
+cat "$TMP_README_PATH" | while read line; do
+  if [[ $(echo $line | grep -e "^- \[.*\]\(.*\)$") ]]; then
+    file=$(echo $line | cut -d'(' -f2 | cut -d')' -f1)
+    file_path="$COMPONENT_PATH/docs/$file"
+    echo "<!-- Extracted from docs/$file -->" >> "$TMP_EXPANDED_README_PATH"
+    echo >> "$TMP_EXPANDED_README_PATH"
+    cat "$file_path" | sed "s/<#ComponentName#>/$COMPONENT/" >> "$TMP_EXPANDED_README_PATH"
+    echo >> "$TMP_EXPANDED_README_PATH" # Ensure that there is always a newline between files.
+  else
+    echo "$line" >> "$TMP_EXPANDED_README_PATH"
+  fi
+done
+
+rm "$TMP_README_PATH"
+
+# Write the table of contents
+cat "$TMP_EXPANDED_README_PATH" | while read line; do
+  if [ "$line" = "$TOC_STRING" ]; then
+    echo "## Table of contents" >> "$TMP_README_PATH"
+    echo "" >> "$TMP_README_PATH"
+    grep -e "^#" -e "^$TOC_STRING" "$TMP_EXPANDED_README_PATH" \
+      | grep -v "####" \
+      | grep -v "#import" \
+      | sed -n '/ toc /,$p' \
+      | tail -n +2  > "$TMP_TOC_PATH"
+
+    cat "$TMP_TOC_PATH" | while read toc; do
+      indent=$(echo $toc | cut -d' ' -f1 | sed "s/###/  -/" | sed "s/##/-/g")
+      text=$(echo $toc | cut -d' ' -f2-)
+      url=$(echo $text | awk '{print tolower($0)}')
+      url=${url//:} # Strip invalid characters
+      url=${url// /-} # Turn spaces into dashes
+      echo "$indent [$text](#$url)" >> "$TMP_README_PATH"
+    done
+  else
+    echo "$line" >> "$TMP_README_PATH"
+  fi
+done
+
+# Rewrite relative paths
+perl -pi -e "s|\(\.\./|(|g" "$TMP_README_PATH"
+perl -pi -e "s|href=\"\.\./|href=\"|g" "$TMP_README_PATH"
+perl -pi -e "s|\[(.+)\]\((.+)\.md\)|[\1](docs/\2.md)|g" "$TMP_README_PATH"
+
+mv "$TMP_README_PATH" "$SITE_README_PATH"

--- a/scripts/templates/component/README.md.template
+++ b/scripts/templates/component/README.md.template
@@ -1,0 +1,10 @@
+<!--docs:
+title: "<#component_name#>"
+layout: detail
+section: components
+excerpt: "<#short_description#>"
+iconId: <#icon_id#>
+path: <#root_path#>/
+api_doc_root: true
+-->
+

--- a/scripts/templates/component/docs/README.md.template
+++ b/scripts/templates/component/docs/README.md.template
@@ -1,0 +1,57 @@
+# <#component_name#>
+
+<!-- Template: Short component description, summarized from the spec, connecting the Material spec
+terminology to the terminology being used in this component. Avoid talking about any specific API
+names here.
+-->
+
+<!-- Template:
+Cropped, animated gif of the component. Avoid including any iOS chrome such as status bar.
+
+<img src="assets/component.gif" alt="Description of the animation.">
+-->
+
+## Design & API documentation
+
+* [Material Design guidelines: Progress & activity](https://material.io/go/design-progress-indicators)
+<!-- Template:
+Replace the url with the API's URL.
+* [API: SomeClass](https://material.io/components/ios/catalog/progress-indicators/activity-indicators/api-docs/Classes/MDCActivityIndicator.html)
+-->
+
+<!-- Template:
+## Related components
+
+* [OtherComponent](../../OtherComponent)
+-->
+
+<!-- toc -->
+
+- - -
+
+## Overview
+
+<!-- Template:
+Detailed summary of the important APIs that are provided by this component.
+-->
+
+## Installation
+
+- [Typical installation](../../../docs/component-installation.md)
+
+## Usage
+
+<!-- Template: Include at least one typical use article demonstrating the most common use case for
+the component.
+
+- [Typical use](typical-use.md)
+- [An article covering a specific topic](article.md)
+-->
+
+## Extensions
+
+<!-- Template: Extensions should be called out separately from Usage docs.
+
+- [Color Theming](color-theming.md)
+-->
+

--- a/scripts/templates/component/docs/color-theming.md.template
+++ b/scripts/templates/component/docs/color-theming.md.template
@@ -1,13 +1,4 @@
-<!--docs:
-title: "Color Theming"
-layout: detail
-section: components
-excerpt: "How to theme <#component_name#> using the Material Design color system."
-iconId: <#icon_id#>
-path: <#root_path#>/color-theming/
--->
-
-# <#component_name#> Color Theming
+# Color Theming
 
 You can theme <#a_component_name#> with your app's color scheme using the ColorThemer extension.
 

--- a/scripts/templates/component/docs/typography-theming.md.template
+++ b/scripts/templates/component/docs/typography-theming.md.template
@@ -1,13 +1,4 @@
-<!--docs:
-title: "Typography Theming"
-layout: detail
-section: components
-excerpt: "How to theme <#component_name#> using the Material Design typography system."
-iconId: <#icon_id#>
-path: <#root_path#>/typography-theming/
--->
-
-# <#component_name#> Typography Theming
+# Typography Theming
 
 You can theme <#a_component_name#> with your app's typography scheme using the TypographyThemer extension.
 


### PR DESCRIPTION
This PR adds a new script, `scripts/generate_readme`, which will generate a root README.md file for a component from the component's docs/ content.

The advantages of this script over our current process of writing readmes:

- Documentation articles can be broken out into separate files, making it easier to generate and apply templates.
- Our component readmes now have auto-generated table of contents.
- Our documentation can be written in plain markdown with minimal material.io html magic.
- Having docs in separate files doesn't result in multiple "component pages" on material.io - everything ends up in a single component document on the site. E.g. the "Color Theming" article no longer shows up as its own link on material.io.

Example usage:

```bash
./scripts/generate_readme ActivityIndicator
```

---

The script makes the following assumptions:

A component has the following directory structure:

```
components/
  Component/
    README.md <- The component's main readme.
                 This is the readme that will show up on material.io.
    docs/
      README.md       <- A skeletal readme with links to other docs files.
      some-article.md <- An article that may be linked to.
```

`components/Component/docs/README.md` is treated as a standard markdown file, with the additional interpretations:

```
* [Text](url)
Treated as an icon list for the material.io website.
If the url links to any go/design- url, the link will use the spec icon

- [Text](some-article.md)
Indicates that the linked article should be added verbatim to the main README.md

<!-- toc -->
A table of contents should be generated here.
```

The script then does the following:

1. Generates a template README from the component's .vars file.
2. Appends the component's docs/README.md to the readme.
3. Rewrites any asset and relative url paths.
4. Transforms all `* [text](link)`-formatted link lists into icon-list lists.
4b. If an icon list url points to a design site, the spec icon will be used for the list item.
5. Replaces every `- [text](link)`-formatted link list item with the contents of the file.
6. Generates a table of contents if `<!-- toc -->` is found. The table of contents will include all level 2 and 3 headers found after the toc tag.
7. Copies the output to the component's root README.md.

The implication of this script is that we can now write documentation as small files which are easier to templatize. These smaller files can be aggregated together into a single larger README.md that is consumable by the material.io website.

Example of table of contents on material.io:

<img width="460" alt="screen shot 2018-05-01 at 9 07 31 am" src="https://user-images.githubusercontent.com/45670/39473887-1fa6c85c-4d1f-11e8-8620-d6b151a315c6.png">