### PR TITLE
[TextField] floating placeholder overlaps with border.

### DIFF
--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -651,6 +651,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
       animations:^{
         self.textInput.placeholderLabel.transform = scaleTransform;
         [self updatePlaceholder];
+        [self updateBorder];
         [self.textInput layoutIfNeeded];
       }
       completion:^(__unused BOOL finished) {

--- a/components/TextFields/src/MDCTextInputControllerOutlined.m
+++ b/components/TextFields/src/MDCTextInputControllerOutlined.m
@@ -178,26 +178,26 @@ static UIRectCorner _roundedCornersDefault = UIRectCornerAllCorners;
   [path addLineToPoint:CGPointMake(f.size.width - radius + xOffset, yOffset)];
   [path addArcWithCenter:CGPointMake(f.size.width - radius + xOffset, radius + yOffset)
                   radius:radius
-              startAngle:- (M_PI / 2)
+              startAngle:- (CGFloat)(M_PI / 2)
                 endAngle:0
                clockwise:YES];
   [path addLineToPoint:CGPointMake(f.size.width + xOffset, f.size.height - radius + yOffset)];
   [path addArcWithCenter:CGPointMake(f.size.width - radius + xOffset, f.size.height - radius + yOffset)
                   radius:radius
               startAngle:0
-                endAngle:- ((M_PI * 3) / 2)
+                endAngle:- (CGFloat)((M_PI * 3) / 2)
                clockwise:YES];
   [path addLineToPoint:CGPointMake(radius + xOffset, f.size.height + yOffset)];
   [path addArcWithCenter:CGPointMake(radius + xOffset, f.size.height - radius + yOffset)
                   radius:radius
-              startAngle:- ((M_PI * 3) / 2)
-                endAngle:- M_PI
+              startAngle:- (CGFloat)((M_PI * 3) / 2)
+                endAngle:- (CGFloat)M_PI
                clockwise:YES];
   [path addLineToPoint:CGPointMake(xOffset, radius + yOffset)];
   [path addArcWithCenter:CGPointMake(radius + xOffset, radius + yOffset)
                   radius:radius
-              startAngle:- M_PI
-                endAngle:- (M_PI / 2)
+              startAngle:- (CGFloat)M_PI
+                endAngle:- (CGFloat)(M_PI / 2)
                clockwise:YES];
 
   return path;

--- a/components/TextFields/src/MDCTextInputControllerOutlined.m
+++ b/components/TextFields/src/MDCTextInputControllerOutlined.m
@@ -133,13 +133,21 @@ static UIRectCorner _roundedCornersDefault = UIRectCornerAllCorners;
 
   CGRect pathRect = self.textInput.bounds;
   pathRect.origin.y = pathRect.origin.y + self.textInput.placeholderLabel.font.lineHeight * .5f;
-
   pathRect.size.height = [self borderHeight];
-  UIBezierPath *path = [UIBezierPath
-      bezierPathWithRoundedRect:pathRect
-              byRoundingCorners:self.roundedCorners
-                    cornerRadii:CGSizeMake(MDCTextInputControllerBaseDefaultBorderRadius,
-                                           MDCTextInputControllerBaseDefaultBorderRadius)];
+  UIBezierPath *path;
+  if ([self isPlaceholderUp]) {
+    CGFloat placeholderWidth =
+    [self.textInput.placeholderLabel systemLayoutSizeFittingSize:UILayoutFittingCompressedSize]
+    .width * (CGFloat)self.floatingPlaceholderScale.floatValue;
+
+    path = [self roundedPathFromRect:pathRect withTextSpace:placeholderWidth  leftOffset:MDCTextInputOutlinedTextFieldFullPadding - 3];
+  } else {
+    CGSize cornerRadius = CGSizeMake(MDCTextInputControllerBaseDefaultBorderRadius,
+                                     MDCTextInputControllerBaseDefaultBorderRadius);
+    path = [UIBezierPath bezierPathWithRoundedRect:pathRect
+                                 byRoundingCorners:self.roundedCorners
+                                       cornerRadii:cornerRadius];
+  }
   self.textInput.borderPath = path;
 
   UIColor *borderColor = self.textInput.isEditing ? self.activeColor : self.normalColor;
@@ -150,6 +158,49 @@ static UIRectCorner _roundedCornersDefault = UIRectCornerAllCorners;
 
   [self updatePlaceholder];
 }
+
+- (UIBezierPath *)roundedPathFromRect:(CGRect)f
+                        withTextSpace:(CGFloat)textSpace
+                           leftOffset:(CGFloat)offset {
+  UIBezierPath *path = [[UIBezierPath alloc] init];
+  CGFloat radius = MDCTextInputControllerBaseDefaultBorderRadius;
+  CGFloat yOffset = f.origin.y;
+  CGFloat xOffset = f.origin.x;
+
+  // Draw the path
+  [path moveToPoint:CGPointMake(radius + xOffset, yOffset)];
+  [path addLineToPoint:CGPointMake(offset + xOffset, yOffset)];
+
+  [path moveToPoint:CGPointMake(textSpace + offset + xOffset, yOffset)];
+
+  [path addLineToPoint:CGPointMake(f.size.width - radius + xOffset, yOffset)];
+  [path addArcWithCenter:CGPointMake(f.size.width - radius + xOffset, radius + yOffset)
+                  radius:radius
+              startAngle:- (M_PI / 2)
+                endAngle:0
+               clockwise:YES];
+  [path addLineToPoint:CGPointMake(f.size.width + xOffset, f.size.height - radius + yOffset)];
+  [path addArcWithCenter:CGPointMake(f.size.width - radius + xOffset, f.size.height - radius + yOffset)
+                  radius:radius
+              startAngle:0
+                endAngle:- ((M_PI * 3) / 2)
+               clockwise:YES];
+  [path addLineToPoint:CGPointMake(radius + xOffset, f.size.height + yOffset)];
+  [path addArcWithCenter:CGPointMake(radius + xOffset, f.size.height - radius + yOffset)
+                  radius:radius
+              startAngle:- ((M_PI * 3) / 2)
+                endAngle:- M_PI
+               clockwise:YES];
+  [path addLineToPoint:CGPointMake(xOffset, radius + yOffset)];
+  [path addArcWithCenter:CGPointMake(radius + xOffset, radius + yOffset)
+                  radius:radius
+              startAngle:- M_PI
+                endAngle:- (M_PI / 2)
+               clockwise:YES];
+
+  return path;
+}
+
 
 - (void)updatePlaceholder {
   [super updatePlaceholder];

--- a/components/TextFields/src/MDCTextInputControllerOutlined.m
+++ b/components/TextFields/src/MDCTextInputControllerOutlined.m
@@ -137,10 +137,12 @@ static UIRectCorner _roundedCornersDefault = UIRectCornerAllCorners;
   UIBezierPath *path;
   if ([self isPlaceholderUp]) {
     CGFloat placeholderWidth =
-    [self.textInput.placeholderLabel systemLayoutSizeFittingSize:UILayoutFittingCompressedSize]
-    .width * (CGFloat)self.floatingPlaceholderScale.floatValue;
+        [self.textInput.placeholderLabel systemLayoutSizeFittingSize:UILayoutFittingCompressedSize]
+        .width * (CGFloat)self.floatingPlaceholderScale.floatValue;
 
-    path = [self roundedPathFromRect:pathRect withTextSpace:placeholderWidth  leftOffset:MDCTextInputOutlinedTextFieldFullPadding - 3];
+    path = [self roundedPathFromRect:pathRect
+                       withTextSpace:placeholderWidth
+                          leftOffset:MDCTextInputOutlinedTextFieldFullPadding];
   } else {
     CGSize cornerRadius = CGSizeMake(MDCTextInputControllerBaseDefaultBorderRadius,
                                      MDCTextInputControllerBaseDefaultBorderRadius);
@@ -169,9 +171,9 @@ static UIRectCorner _roundedCornersDefault = UIRectCornerAllCorners;
 
   // Draw the path
   [path moveToPoint:CGPointMake(radius + xOffset, yOffset)];
-  [path addLineToPoint:CGPointMake(offset + xOffset, yOffset)];
+  [path addLineToPoint:CGPointMake(offset + xOffset - radius, yOffset)];
 
-  [path moveToPoint:CGPointMake(textSpace + offset + xOffset, yOffset)];
+  [path moveToPoint:CGPointMake(textSpace + offset + xOffset - radius, yOffset)];
 
   [path addLineToPoint:CGPointMake(f.size.width - radius + xOffset, yOffset)];
   [path addArcWithCenter:CGPointMake(f.size.width - radius + xOffset, radius + yOffset)

--- a/components/TextFields/src/private/MDCTextInputControllerBase+Subclassing.h
+++ b/components/TextFields/src/private/MDCTextInputControllerBase+Subclassing.h
@@ -31,4 +31,7 @@
 /** Refreshes the layout and style of the placeholder label. Called within updateLayout. */
 - (void)updatePlaceholder;
 
+/** Refreshes the layout and style of the border view. Called within updateLayout. */
+- (BOOL)isPlaceholderUp;
+
 @end


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/157163089
New Color scheme makes the placeholder background transparent so when it floats it overlaps with the border.
Instead of relying on background color we now set the proper border path to achieve the same behavior.
No animation for path change.

![screen shot 2018-05-01 at 11 19 50 am](https://user-images.githubusercontent.com/36271115/39478986-eb0fc95a-4d31-11e8-8798-64841e896ac0.png)
