### PR TITLE
[Typography] Add TypographyScheme example

### DIFF
--- a/components/Typography/examples/TypographyCustomFontViewController.m
+++ b/components/Typography/examples/TypographyCustomFontViewController.m
@@ -159,7 +159,7 @@ static inline UIFont *customFont(MDCFontTextStyle style) {
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/Typography/examples/TypographyFontListExample.swift
+++ b/components/Typography/examples/TypographyFontListExample.swift
@@ -156,10 +156,10 @@ extension TypographyFontListExampleViewController {
   }
 
   @objc class func catalogIsPrimaryDemo() -> Bool {
-    return true
+    return false
   }
 
   @objc class func catalogIsPresentable() -> Bool {
-    return true
+    return false
   }
 }

--- a/components/Typography/examples/TypographyMaterialStylesViewController.m
+++ b/components/Typography/examples/TypographyMaterialStylesViewController.m
@@ -203,7 +203,7 @@
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/Typography/examples/TypographySimpleExampleViewController.m
+++ b/components/Typography/examples/TypographySimpleExampleViewController.m
@@ -51,7 +51,7 @@
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/schemes/Typography/examples/MDCTypographySchemeFontListExampleViewController.h
+++ b/components/schemes/Typography/examples/MDCTypographySchemeFontListExampleViewController.h
@@ -1,0 +1,21 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface MDCTypographySchemeFontListExampleViewController : UITableViewController
+
+@end

--- a/components/schemes/Typography/examples/MDCTypographySchemeFontListExampleViewController.m
+++ b/components/schemes/Typography/examples/MDCTypographySchemeFontListExampleViewController.m
@@ -1,0 +1,198 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCTypographySchemeFontListExampleViewController.h"
+
+#import "MaterialColorScheme.h"
+#import "MaterialTypographyScheme.h"
+
+@interface HairlineSeparatorView : UITableViewCell
+
+@end
+
+@implementation HairlineSeparatorView
+
+- (void)layoutSubviews {
+  [super layoutSubviews];
+  CGRect contentBounds = UIEdgeInsetsInsetRect(CGRectStandardize(self.contentView.bounds),
+                                               UIEdgeInsetsMake(0, 16, 0, 16));
+  self.contentView.center = CGPointMake(CGRectGetMidX(self.bounds), CGRectGetMidY(self.bounds));
+  if (CGRectGetHeight(contentBounds) < 0.01f) {
+    contentBounds = CGRectMake(CGRectGetMinX(contentBounds), CGRectGetMinY(contentBounds),
+                               CGRectGetWidth(contentBounds), CGRectGetHeight(self.bounds));
+  }
+  self.contentView.bounds = contentBounds;
+}
+
+@end
+
+@interface MDCTypographySchemeFontListExampleViewController ()
+@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
+@end
+
+@implementation MDCTypographySchemeFontListExampleViewController
+
+static NSArray<NSString *> *DemonstrationStrings() {
+  static NSArray<NSString *> *kDemonstrationStrings;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    kDemonstrationStrings =
+        @[ @"The quick brown fox jumps over the lazy dog.", @"1234567890,.';\"´`˜ˆ…" ];
+  });
+  return kDemonstrationStrings;
+}
+
+static NSArray<NSString *> *FontStyleNames() {
+  static NSArray<NSString *> *kFontStyleNameStrings;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    kFontStyleNameStrings = @[
+      @"Headline 1",
+      @"Headline 2",
+      @"Headline 3",
+      @"Headline 4",
+      @"Headline 5",
+      @"Headline 6",
+      @"Subtitle 1",
+      @"Subtitle 2",
+      @"Body 1",
+      @"Body 2",
+      @"BUTTON",
+      @"Caption",
+      @"OVERLINE",
+    ];
+  });
+  return kFontStyleNameStrings;
+}
+
+static NSArray<UIFont *> *Fonts() {
+  static NSArray<UIFont *> *kTypeFonts;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    MDCTypographyScheme *scheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+    kTypeFonts = @[
+      scheme.headline1,
+      scheme.headline2,
+      scheme.headline3,
+      scheme.headline4,
+      scheme.headline5,
+      scheme.headline6,
+      scheme.subtitle1,
+      scheme.subtitle2,
+      scheme.body1,
+      scheme.body2,
+      scheme.button,
+      scheme.caption,
+      scheme.overline,
+    ];
+  });
+  return kTypeFonts;
+}
+
+- (instancetype)init {
+  return [super initWithStyle:UITableViewStyleGrouped];
+}
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+  return (NSInteger)Fonts().count;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+  return (NSInteger)DemonstrationStrings().count;
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+  self.tableView.rowHeight = UITableViewAutomaticDimension;
+  self.tableView.estimatedRowHeight = 38;
+  self.tableView.sectionFooterHeight = 1 / UIScreen.mainScreen.scale;
+  self.tableView.backgroundColor = self.colorScheme.backgroundColor;
+
+  [self.tableView registerClass:UITableViewCell.class forCellReuseIdentifier:@"cell"];
+  [self.tableView registerClass:[HairlineSeparatorView class] forCellReuseIdentifier:@"footer"];
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView
+         cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell"];
+
+  cell.textLabel.text = DemonstrationStrings()[indexPath.row];
+  cell.textLabel.font = Fonts()[indexPath.section];
+  cell.textLabel.numberOfLines = 3;
+  MDCTypographyScheme *scheme =
+      [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+  if ([cell.textLabel.font isEqual:scheme.button] ||
+      [cell.textLabel.font isEqual:scheme.overline]) {
+    cell.textLabel.text = [cell.textLabel.text uppercaseString];
+  }
+
+  return cell;
+}
+
+- (void)tableView:(UITableView *)tableView
+      willDisplayCell:(UITableViewCell *)cell
+    forRowAtIndexPath:(NSIndexPath *)indexPath {
+  cell.textLabel.textColor = self.colorScheme.onSurfaceColor;
+  cell.textLabel.backgroundColor = self.colorScheme.surfaceColor;
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
+  return FontStyleNames()[section];
+}
+
+- (void)tableView:(UITableView *)tableView
+    willDisplayHeaderView:(UIView *)view
+               forSection:(NSInteger)section {
+  if ([view isKindOfClass:[UITableViewHeaderFooterView class]]) {
+    UITableViewHeaderFooterView *headerView = (UITableViewHeaderFooterView *)view;
+    headerView.textLabel.textColor = UIColor.blackColor;
+    headerView.textLabel.text = FontStyleNames()[section];
+  }
+}
+
+- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section {
+  HairlineSeparatorView *footer =
+      (HairlineSeparatorView *)[tableView dequeueReusableCellWithIdentifier:@"footer"];
+  footer.contentView.backgroundColor = self.colorScheme.onBackgroundColor;
+  return footer;
+}
+
+@end
+
+#pragma mark - Catalog by convention
+@implementation MDCTypographySchemeFontListExampleViewController (CatlogByConvention)
++ (NSArray<NSString *> *)catalogBreadcrumbs {
+  return @[ @"Typography", @"TypographyScheme" ];
+}
+
++ (NSString *)catalogDescription {
+  return @"The Typography component provides methods for displaying text using the type sizes and"
+          " opacities from the Material Design specifications.";
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return YES;
+}
+
++ (BOOL)catalogIsPresentable {
+  return YES;
+}
+
+@end

--- a/components/schemes/Typography/examples/MDCTypographySchemeFontListExampleViewController.m
+++ b/components/schemes/Typography/examples/MDCTypographySchemeFontListExampleViewController.m
@@ -168,9 +168,13 @@ static NSArray<UIFont *> *Fonts() {
 }
 
 - (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section {
+  if (section == (NSInteger)FontStyleNames().count - 1) {
+    return nil;
+  }
   HairlineSeparatorView *footer =
       (HairlineSeparatorView *)[tableView dequeueReusableCellWithIdentifier:@"footer"];
-  footer.contentView.backgroundColor = self.colorScheme.onBackgroundColor;
+  footer.contentView.backgroundColor =
+      [self.colorScheme.onBackgroundColor colorWithAlphaComponent:(CGFloat)0.12];
   return footer;
 }
 


### PR DESCRIPTION
The new Typography Scheme as missing examples and the old Typography examples
did not have sufficient contrast ratios for AA-level accessible text.

Internal: b/77907063

### Screenshots

**iPhone 4s/iOS 8.1**
![typography-screen-ios8 1](https://user-images.githubusercontent.com/1753199/39480386-08643230-4d36-11e8-8ac2-c00bb6b08a1b.png)


**iPhone 4s/iOS 9.0**
![typography-screen-ios9](https://user-images.githubusercontent.com/1753199/39480391-0da4db96-4d36-11e8-8ccc-8303cffd2877.png)


**iPhone SE/iOS 11.3**
![typography-screen-ios11 3](https://user-images.githubusercontent.com/1753199/39480399-121e6872-4d36-11e8-99b4-dd5e6396963d.png)


**iPad Air/iOS 10.0**
![typography-screen-ipad10](https://user-images.githubusercontent.com/1753199/39480402-15db5f38-4d36-11e8-8f6a-1ee211583f5e.png)
