### PR TITLE
[TextFields] fixing color mapping for floatingNormal and floatingActive Colors.

### DIFF
--- a/components/TextFields/src/ColorThemer/MDCFilledTextFieldColorThemer.m
+++ b/components/TextFields/src/ColorThemer/MDCFilledTextFieldColorThemer.m
@@ -41,9 +41,9 @@ static CGFloat const kFilledTextFieldIndicatorLineAlpha = 0.42f;
   textInputControllerFilled.errorColor = colorScheme.errorColor;
   textInputControllerFilled.disabledColor =
       [colorScheme.onSurfaceColor colorWithAlphaComponent:kFilledTextFieldDisabledAlpha];
-  id<MDCTextInputControllerFloatingPlaceholder> textInputControllerFloatingPlaceholder =
-      (id<MDCTextInputControllerFloatingPlaceholder>)textInputControllerFilled;
-  textInputControllerFloatingPlaceholder.floatingPlaceholderActiveColor =
+  textInputControllerFilled.floatingPlaceholderNormalColor =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kFilledTextFieldOnSurfaceAlpha];
+  textInputControllerFilled.floatingPlaceholderActiveColor =
       [colorScheme.primaryColor colorWithAlphaComponent:kFilledTextFieldActiveAlpha];
 }
 

--- a/components/TextFields/src/ColorThemer/MDCOutlinedTextFieldColorThemer.m
+++ b/components/TextFields/src/ColorThemer/MDCOutlinedTextFieldColorThemer.m
@@ -43,6 +43,7 @@ static CGFloat const kOutlinedTextFieldDisabledAlpha = 0.38f;
     (id<MDCTextInputControllerFloatingPlaceholder>)textInputController;
     if ([textInputControllerFloatingPlaceholder
          respondsToSelector:@selector(setFloatingPlaceholderNormalColor:)]) {
+      textInputControllerFloatingPlaceholder.floatingPlaceholderNormalColor = onSurfaceOpacity;
       textInputControllerFloatingPlaceholder.floatingPlaceholderActiveColor =
           [colorScheme.primaryColor colorWithAlphaComponent:kOutlinedTextFieldActiveAlpha];
     }

--- a/components/TextFields/src/ColorThemer/MDCTextFieldColorThemer.m
+++ b/components/TextFields/src/ColorThemer/MDCTextFieldColorThemer.m
@@ -69,12 +69,9 @@
           conformsToProtocol:@protocol(MDCTextInputControllerFloatingPlaceholder)]) {
     id<MDCTextInputControllerFloatingPlaceholder> textInputControllerFloatingPlaceholder =
         (id<MDCTextInputControllerFloatingPlaceholder>)textInputController;
-
-    if ([textInputControllerFloatingPlaceholder
-            respondsToSelector:@selector(setFloatingPlaceholderNormalColor:)]) {
-      UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:0.87f];
-      textInputControllerFloatingPlaceholder.floatingPlaceholderNormalColor = primary87Opacity;
-    }
+    UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:0.87f];
+    textInputControllerFloatingPlaceholder.floatingPlaceholderNormalColor = onSurface60Opacity;
+    textInputControllerFloatingPlaceholder.floatingPlaceholderActiveColor = primary87Opacity;
   }
 }
 
@@ -112,7 +109,9 @@ toAllTextInputControllersOfClass:(Class<MDCTextInputController>)textInputControl
         (Class<MDCTextInputControllerFloatingPlaceholder>)textInputControllerClass;
     UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:0.87f];
     [textInputControllerFloatingPlaceholderClass
-        setFloatingPlaceholderNormalColorDefault:primary87Opacity];
+        setFloatingPlaceholderNormalColorDefault:onSurface60Opacity];
+    [textInputControllerFloatingPlaceholderClass
+        setFloatingPlaceholderActiveColorDefault:primary87Opacity];
   }
 }
 #if !defined(__IPHONE_11_0)

--- a/components/TextFields/tests/unit/TextFieldColorThemerTests.m
+++ b/components/TextFields/tests/unit/TextFieldColorThemerTests.m
@@ -48,8 +48,8 @@
        conformsToProtocol:@protocol(MDCTextInputControllerFloatingPlaceholder)]) {
     Class<MDCTextInputControllerFloatingPlaceholder> textInputControllerFloatingPlaceholderClass =
         (Class<MDCTextInputControllerFloatingPlaceholder>)textInputControllerClass;
-    [textInputControllerFloatingPlaceholderClass
-        setFloatingPlaceholderNormalColorDefault:nil];
+    [textInputControllerFloatingPlaceholderClass setFloatingPlaceholderActiveColorDefault:nil];
+    [textInputControllerFloatingPlaceholderClass setFloatingPlaceholderNormalColorDefault:nil];
   }
 }
 #if !defined(__IPHONE_11_0)
@@ -96,6 +96,8 @@
   XCTAssertEqualObjects(MDCTextInputControllerBase.leadingUnderlineLabelTextColorDefault,
                         onSurface60Opacity);
   XCTAssertEqualObjects(MDCTextInputControllerBase.floatingPlaceholderNormalColorDefault,
+                        onSurface60Opacity);
+  XCTAssertEqualObjects(MDCTextInputControllerBase.floatingPlaceholderActiveColorDefault,
                         primary87Opacity);
 
   XCTAssertEqualObjects(MDCTextInputControllerFullWidth.errorColorDefault, colorScheme.errorColor);


### PR DESCRIPTION
Both Floating active and normal color should be set in color scheme.

Before:
<img width="579" alt="screen shot 2018-05-02 at 11 16 06 am" src="https://user-images.githubusercontent.com/36271115/39531931-4b0120d4-4dfa-11e8-875d-d220250ff64e.png">
<img width="579" alt="screen shot 2018-05-02 at 11 16 23 am" src="https://user-images.githubusercontent.com/36271115/39531932-4b14cf30-4dfa-11e8-95fb-27f21a4e4d72.png">

After:
<img width="579" alt="screen shot 2018-05-02 at 11 14 31 am" src="https://user-images.githubusercontent.com/36271115/39531929-4ab7da96-4dfa-11e8-919a-37c364cc24d2.png">
<img width="579" alt="screen shot 2018-05-02 at 11 14 46 am" src="https://user-images.githubusercontent.com/36271115/39531930-4acf644a-4dfa-11e8-8bee-ea0cfaed6da7.png">

