### PR TITLE
[Typography] Add deprecation notice to the MDCTypography APIs and README

### DIFF
--- a/components/Typography/README.md
+++ b/components/Typography/README.md
@@ -1,14 +1,10 @@
-<!--docs:
-title: "Typography"
-layout: detail
-section: components
-excerpt: "The Typography component provides methods for displaying text using the type sizes and opacities from the Material Design specifications."
-iconId: typography
-path: /catalog/typography/
-api_doc_root: true
--->
-
 # Typography
+
+*Notice*: Much of this component, with exception of the UIFont and UIFontDescriptor APIs, will soon
+be deprecated. Please consider using the [schemes/Typography](../schemes/Typography) component and
+the [Material Theming](../../docs/theming) APIs instead.
+
+---
 
 <div class="article__asset article__asset--screenshot">
   <img src="docs/assets/typography.png" alt="Typography" width="375">

--- a/components/Typography/src/MDCTypography.h
+++ b/components/Typography/src/MDCTypography.h
@@ -16,11 +16,16 @@
 
 #import <UIKit/UIKit.h>
 
+#pragma mark - Soon to be deprecated
+
 /**
  MDCTypography uses this protocol to delegate responsibility of loading the custom fonts.
 
  The spec defines the Roboto font family and uses three fonts in the named styles. Use this
  protocol to define your own fonts if there is a brand need.
+
+ @warning This protocol will soon be deprecated. Consider using MDCTypographyScheme from the
+ schemes/Typography component instead.
 
  @see https://material.io/go/design-typography#typography-styles
  */
@@ -70,6 +75,9 @@
  Typographic constants and helpers.
 
  To use these fonts, you must add MaterialTypography.bundle to your target.
+
+ @warning This class will soon be deprecated. Consider using MDCTypographyScheme from the
+ schemes/Typography component instead.
 
  @see https://material.io/go/design-typography#typography-styles
  */
@@ -176,6 +184,9 @@
 
 /**
  MDCSystemFontLoader allows you to use the system font for @c MDCTypography.
+
+ @warning This class will soon be deprecated. Consider using MDCTypographyScheme from the
+ schemes/Typography component instead.
 
  #### Example
 


### PR DESCRIPTION
This adds deprecation notices to the component's README.md and the individual APIs.

Pivotal story: https://www.pivotaltracker.com/story/show/157238605