### PR TITLE
[FeatureHighlight] Allow setting accessibilityHint

### DIFF
--- a/components/FeatureHighlight/examples/FeatureHighlightTypicalUseViewController.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightTypicalUseViewController.m
@@ -33,6 +33,9 @@
 
   vc.titleText = @"Hey this is a multi-line title for the Feature Highlight";
   vc.bodyText = @"This is the description of the feature highlight view controller.";
+  // TODO(https://github.com/material-components/material-components-ios/issues/3644 ):
+  // Disable the incorrect "Double tap" hint for now
+  vc.accessibilityHint = nil;
   [self presentViewController:vc animated:YES completion:nil];
 }
 

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -97,6 +97,7 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
   _featureHighlightView.mdc_adjustsFontForContentSizeCategory =
       _mdc_adjustsFontForContentSizeCategory;
 
+  _featureHighlightView.accessibilityHint = self.accessibilityHint;
   __weak MDCFeatureHighlightViewController *weakSelf = self;
   _featureHighlightView.interactionBlock = ^(BOOL accepted) {
     MDCFeatureHighlightViewController *strongSelf = weakSelf;
@@ -285,6 +286,18 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
     return _animationController;
   }
   return nil;
+}
+
+#pragma mark - UIAccessibility
+
+- (void)setAccessibilityHint:(NSString *)accessibilityHint {
+  // Set through the property to ensure the view is loaded
+  self.view.accessibilityHint = accessibilityHint;
+}
+
+- (NSString *)accessibilityHint {
+  // Set throught the Ivar to avoid loading the view early
+  return _featureHighlightView ? _featureHighlightView.accessibilityHint : nil;
 }
 
 #pragma mark - Private

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -656,6 +656,16 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   return YES;
 }
 
+#pragma mark - UIAccessibility
+
+- (void)setAccessibilityHint:(NSString *)accessibilityHint {
+  _titleLabel.accessibilityHint = accessibilityHint;
+}
+
+- (NSString *)accessibilityHint {
+  return _titleLabel.accessibilityHint;
+}
+
 #pragma mark - Resource bundle
 
 + (NSBundle *)bundle {

--- a/components/FeatureHighlight/tests/unit/FeatureHighlightAccessibilityTests.m
+++ b/components/FeatureHighlight/tests/unit/FeatureHighlightAccessibilityTests.m
@@ -55,6 +55,8 @@
   (void)controller.view;
 
   // Then
+  // TODO(https://github.com/material-components/material-components-ios/issues/3644 ):
+  // Switch these to XCTAssertNil (or refactor tests) once the default is removed.
   XCTAssertNotNil(controller.accessibilityHint);
   XCTAssertNotNil(controller.view.accessibilityHint);
 }

--- a/components/FeatureHighlight/tests/unit/FeatureHighlightAccessibilityTests.m
+++ b/components/FeatureHighlight/tests/unit/FeatureHighlightAccessibilityTests.m
@@ -1,0 +1,92 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialFeatureHighlight.h"
+#import "MDCFeatureHighlightView+Private.h"
+
+@interface MDCFeatureHighlightViewController (Testing)
+@property(nonatomic, strong) MDCFeatureHighlightView *view;
+@end
+
+@interface FeatureHighlightAccessibilityTests : XCTestCase
+
+@end
+
+@implementation FeatureHighlightAccessibilityTests
+
+- (void)testAccessibilityHintDefaultBeforeLoadingView {
+  // Given
+  UIView *view = [[UIView alloc] init];
+  UIView *view2 = [[UIView alloc] init];
+  MDCFeatureHighlightViewController *controller =
+  [[MDCFeatureHighlightViewController alloc] initWithHighlightedView:view
+                                                         andShowView:view2
+                                                          completion:nil];
+
+  // Then
+  XCTAssertNil(controller.accessibilityHint);
+}
+
+- (void)testAccessibilityHintDefaultAfterLoadingView {
+  // Given
+  UIView *view = [[UIView alloc] init];
+  UIView *view2 = [[UIView alloc] init];
+  MDCFeatureHighlightViewController *controller =
+  [[MDCFeatureHighlightViewController alloc] initWithHighlightedView:view
+                                                         andShowView:view2
+                                                          completion:nil];
+
+  // When (cause the view to load)
+  (void)controller.view;
+
+  // Then
+  XCTAssertNotNil(controller.accessibilityHint);
+  XCTAssertNotNil(controller.view.accessibilityHint);
+}
+
+- (void)testSetAccessibilityHint {
+  // Given
+  NSString *accessibilityHint = @"A great blue ox.";
+  UIView *view = [[UIView alloc] init];
+  UIView *view2 = [[UIView alloc] init];
+  MDCFeatureHighlightViewController *controller =
+      [[MDCFeatureHighlightViewController alloc] initWithHighlightedView:view
+                                                             andShowView:view2
+                                                              completion:nil];
+  controller.accessibilityHint = accessibilityHint;
+
+  // Then
+  XCTAssertEqualObjects(controller.view.accessibilityHint, accessibilityHint);
+}
+
+- (void)testSetAccessibilityHintNil {
+  // Given
+  UIView *view = [[UIView alloc] init];
+  UIView *view2 = [[UIView alloc] init];
+  MDCFeatureHighlightViewController *controller =
+  [[MDCFeatureHighlightViewController alloc] initWithHighlightedView:view
+                                                         andShowView:view2
+                                                          completion:nil];
+  controller.accessibilityHint = nil;
+
+  // Then
+  XCTAssertNil(controller.accessibilityHint);
+  XCTAssertNil(controller.view.accessibilityHint);
+}
+
+@end


### PR DESCRIPTION
Users should be able to override the default `accessibilityHint` on the
title text of the Feature Highlight view. The current hint is incorrect
instructions about dismissing the view.

Since we are not currently making breaking changes to components, this
change will permit teams to override the incorrect hint by assigning
either an empty string (to have no hint) or to set an appropriate hint.

Partially implements #3644
