### PR TITLE
Update CODEOWNERS to match recursively

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @ianegordon
+**       @ianegordon
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners
@@ -10,37 +10,36 @@
 # *.js    @octocat @github/js
 
 # You can also use email addresses if you prefer.
-components/ActivityIndicator    jmdetloff
-components/AnimationTiming      yarneo
-components/AppBar               jverkoey
-components/BottomAppBar         jmdetloff
-components/BottomNavigation     romoore
-components/BottomSheet          jmdetloff
-components/ButtonBar            romoore
-components/Buttons              randallli
-components/Cards                yarneo
-components/Chips                romoore
-components/CollectionCells      yarneo
-components/CollectionLayoutAttributes ianegordon
-components/Collections          ianegordon
-components/Dialogs              ianegordon
-components/FeatureHighlight     mohammadcazig
-components/FlexibleHeader       jverkoey
-components/HeaderStackView      jverkoey
-components/Ink                  yarneo
-components/LibraryInfo          ajsecord
-components/MaskedTransition     jverkoey
-components/NavigationBar        yarneo, jverkoey
-components/OverlayWindow        yarneo
-components/PageControl          randallli
-components/Palettes             ajsecord
-components/ProgressView         romoore
-components/ShadowElevations     ianegordon
-components/ShadowLayer          ianegordon
-components/Slider               romoore
-components/Snackbar             yarneo
-components/Tabs                 mohammadcazig, brianjmoore
-components/TextFields           willlarche
-components/Themes               jgunaratne
-components/Typography           randallli
-
+components/ActivityIndicator/**    @jmdetloff
+components/AnimationTiming/**      @yarneo
+components/AppBar/**               @jverkoey
+components/BottomAppBar/**         @jmdetloff
+components/BottomNavigation/**     @romoore
+components/BottomSheet/**          @jmdetloff
+components/ButtonBar/**            @romoore
+components/Buttons/**              @randallli
+components/Cards/**                @yarneo
+components/Chips/**                @romoore
+components/CollectionCells/**      @yarneo
+components/CollectionLayoutAttributes/** @ianegordon
+components/Collections/**          @ianegordon
+components/Dialogs/**              @ianegordon
+components/FeatureHighlight/**     @mohammadcazig
+components/FlexibleHeader/**       @jverkoey
+components/HeaderStackView/**      @jverkoey
+components/Ink/**                  @yarneo
+components/LibraryInfo/**          @ajsecord
+components/MaskedTransition/**     @jverkoey
+components/NavigationBar/**        @yarneo, @jverkoey
+components/OverlayWindow/**        @yarneo
+components/PageControl/**          @randallli
+components/Palettes/**             @ajsecord
+components/ProgressView/**         @romoore
+components/ShadowElevations/**     @ianegordon
+components/ShadowLayer/**          @ianegordon
+components/Slider/**               @romoore
+components/Snackbar/**             @yarneo
+components/Tabs/**                 @mohammadcazig, @brianjmoore
+components/TextFields/**           @willlarche
+components/Themes/**               @jgunaratne
+components/Typography/**           @randallli


### PR DESCRIPTION
Our CODEOWNERS file was not doing [recursive matching on directories which require `**` globs](https://git-scm.com/docs/gitattributes). We also failed to use the `@username` syntax [documented in the announcement](https://blog.github.com/2017-07-06-introducing-code-owners/).
