### PR TITLE
Global replace of "utilize" vs "use".

### DIFF
--- a/components/Cards/README.md
+++ b/components/Cards/README.md
@@ -78,13 +78,13 @@ MDCCardThemer exposes apis to theme MDCCard and MDCCardCollectionCell instances 
 
 `MDCCard` subclasses `UIControl` and provides a simple class for developers to subclass and create custom cards with ink, shadows, corner radius, and stroke matching the Material spec.
 
-`MDCCard` utilizes the `highlighted` property that is built-in in `UIControl` and the `UIControlState` to move between states.
+`MDCCard` uses the `highlighted` property that is built-in in `UIControl` and the `UIControlState` to move between states.
 
 #### MDCCardCollectionCell
 
-`MDCCardCollectionCell` subclasses `UICollectionViewCell` and provides a simple collection view cell for developers to utilize in their collections with ink, shadows, corner radius, and stroke matching the Material spec.
+`MDCCardCollectionCell` subclasses `UICollectionViewCell` and provides a simple collection view cell for developers to use in their collections with ink, shadows, corner radius, and stroke matching the Material spec.
 
-`MDCCardCollectionCell` utilizes the `selected` property that is built-in in `UICollectionViewCell` and has its own `MDCCardCellState` to keep track of the current state it is in.
+`MDCCardCollectionCell` uses the `selected` property that is built-in in `UICollectionViewCell` and has its own `MDCCardCellState` to keep track of the current state it is in.
 
 ## Installation
 

--- a/components/Cards/docs/README.md
+++ b/components/Cards/docs/README.md
@@ -51,13 +51,13 @@ MDCCardThemer exposes apis to theme MDCCard and MDCCardCollectionCell instances 
 
 `MDCCard` subclasses `UIControl` and provides a simple class for developers to subclass and create custom cards with ink, shadows, corner radius, and stroke matching the Material spec.
 
-`MDCCard` utilizes the `highlighted` property that is built-in in `UIControl` and the `UIControlState` to move between states.
+`MDCCard` uses the `highlighted` property that is built-in in `UIControl` and the `UIControlState` to move between states.
 
 #### MDCCardCollectionCell
 
-`MDCCardCollectionCell` subclasses `UICollectionViewCell` and provides a simple collection view cell for developers to utilize in their collections with ink, shadows, corner radius, and stroke matching the Material spec.
+`MDCCardCollectionCell` subclasses `UICollectionViewCell` and provides a simple collection view cell for developers to use in their collections with ink, shadows, corner radius, and stroke matching the Material spec.
 
-`MDCCardCollectionCell` utilizes the `selected` property that is built-in in `UICollectionViewCell` and has its own `MDCCardCellState` to keep track of the current state it is in.
+`MDCCardCollectionCell` uses the `selected` property that is built-in in `UICollectionViewCell` and has its own `MDCCardCellState` to keep track of the current state it is in.
 
 ## Installation
 

--- a/components/Collections/src/MDCCollectionViewStyling.h
+++ b/components/Collections/src/MDCCollectionViewStyling.h
@@ -110,7 +110,7 @@ typedef NS_ENUM(NSUInteger, MDCCollectionViewCellLayoutType) {
 - (MDCCollectionViewCellStyle)cellStyleAtSectionIndex:(NSInteger)section;
 
 /**
- The collection view cell background image view (utilized to render the background color and
+ The collection view cell background image view (used to render the background color and
  shadows) edge outsets as determined for a cell and its layout attributes.
 
  @param attr The cell's layout attributes.

--- a/components/Dialogs/README.md
+++ b/components/Dialogs/README.md
@@ -51,7 +51,7 @@ view controller from the root controller to display it as a modal dialog.
 
 ### Presentation and transition controller
 
-Presenting dialogs utilizes two classes: MDCDialogPresentationController and
+Presenting dialogs uses two classes: MDCDialogPresentationController and
 MDCDialogTransitionController. These allow the presentation of view controllers in a material
 specificed manner. MDCDialogPresentationController is a subclass of UIPresentationController
 that observes the presented view controller for preferred content size.

--- a/components/Dialogs/docs/README.md
+++ b/components/Dialogs/docs/README.md
@@ -24,7 +24,7 @@ view controller from the root controller to display it as a modal dialog.
 
 ### Presentation and transition controller
 
-Presenting dialogs utilizes two classes: MDCDialogPresentationController and
+Presenting dialogs uses two classes: MDCDialogPresentationController and
 MDCDialogTransitionController. These allow the presentation of view controllers in a material
 specificed manner. MDCDialogPresentationController is a subclass of UIPresentationController
 that observes the presented view controller for preferred content size.

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -97,7 +97,7 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
   CGFloat keyboardHeight = [MDCKeyboardWatcher sharedKeyboardWatcher].visibleKeyboardHeight;
   containerSafeAreaInsets.bottom = MAX(containerSafeAreaInsets.bottom, keyboardHeight);
 
-  // Area that the presented dialog can utilize.
+  // Area that the presented dialog can use.
   CGRect standardPresentableBounds = UIEdgeInsetsInsetRect(containerBounds, containerSafeAreaInsets);
 
   CGRect presentedViewFrame = CGRectZero;

--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -425,7 +425,7 @@ headerViewController.layoutDelegate = self;
 
 ### Utilizing Top Layout Guide on Parent View Controller
 
-When pairing  MDCFlexibleHeaderViewController with a view controller, it may be desirable to utilize
+When pairing  MDCFlexibleHeaderViewController with a view controller, it may be desirable to use
 the paired view controller's `topLayoutGuide` to constrain additionals views. To constrain the
 `topLayoutGuide` to the bottom point of the MDCFlexibleHeaderViewController, call
 updateTopLayoutGuide on the flexible header view controller within the paired view controller's

--- a/components/FlexibleHeader/docs/reacting-to-frame-changes.md
+++ b/components/FlexibleHeader/docs/reacting-to-frame-changes.md
@@ -36,7 +36,7 @@ headerViewController.layoutDelegate = self;
 
 ### Utilizing Top Layout Guide on Parent View Controller
 
-When pairing  MDCFlexibleHeaderViewController with a view controller, it may be desirable to utilize
+When pairing  MDCFlexibleHeaderViewController with a view controller, it may be desirable to use
 the paired view controller's `topLayoutGuide` to constrain additionals views. To constrain the
 `topLayoutGuide` to the bottom point of the MDCFlexibleHeaderViewController, call
 updateTopLayoutGuide on the flexible header view controller within the paired view controller's

--- a/components/ShadowLayer/README.md
+++ b/components/ShadowLayer/README.md
@@ -31,7 +31,7 @@ elevation.
 ### MDCShadowLayer
 
 `MDCShadowLayer` provides a Core Animation `CALayer` that will render a shadow based on its
-elevation property. `UIViews` can utilize this by overriding their layerClass method to
+elevation property. `UIViews` can use this by overriding their layerClass method to
 return `MDCShadowLayer`.
 
 `elevation` sets the diffusion level of the shadow. The higher the shadow elevation, the more

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.h
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.h
@@ -32,7 +32,7 @@ OBJC_EXTERN NSTimeInterval const MDCSnackbarLegacyTransitionDuration;
 /**
  Designated initializer.
 
- Creates an overlay view which utilizes @c watcher to get its keyboard position information.
+ Creates an overlay view which uses @c watcher to get its keyboard position information.
  */
 - (instancetype)initWithFrame:(CGRect)frame;
 

--- a/contributing/site_development.md
+++ b/contributing/site_development.md
@@ -56,7 +56,7 @@ overview of the directory structure for mdc:
     - _layout: the style defined for document site. You will modify this file for most of the cases.
 
     - _layout-api: the style defined for API reference site. This is a bit confusing but API
-      reference is actually built in as part of the document site and we want to utilize the syle we
+      reference is actually built in as part of the document site and we want to use the syle we
 have for the document site.
 
     - _icons & _step-sequence & _codemirror-syntax-highlighting: These are the utility class for all


### PR DESCRIPTION
https://www.quickanddirtytips.com/education/grammar/use-versus-utilize?page=all

No code changes, documentation only.