### PR TITLE
[scripts] Add support for API list generation and improve the script's messages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ build_tests/CocoapodsSwiftApp/CocoapodsSwiftApp.xcworkspace
 scripts/external/material-design-icons/
 scripts/external/objc-diff/
 
+*apidocs/
+
 # Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore

--- a/contributing/documentation.md
+++ b/contributing/documentation.md
@@ -52,6 +52,8 @@ short_description=
 color_themer_api=
 typography_themer_api=
 themer_parameter_name=
+guidelines_short_link=
+guidelines_title=
 ```
 
 If a variable is not provided and a template requires it, then the template will be generated with
@@ -59,10 +61,11 @@ the missing variables shown as placeholders still.
 
 ### Design & API links
 
-To generate a list that uses icons as bullets, use the `*` list format;
+To generate design and API links, use the following snippet. Note that this requires that you've
+installed [jazzy](https://github.com/realm/jazzy).
 
 ```markdown
-* [Material Design guidelines: Progress & activity](https://material.io/go/design-progress-indicators)
+<!-- design-and-api -->
 ```
 
 ### Embedding articles

--- a/scripts/generate_readme
+++ b/scripts/generate_readme
@@ -27,6 +27,26 @@ if [ "$#" -ne 1 ]; then
   exit 1
 fi
 
+JAZZY_VERSION=`jazzy --version`
+if [[ $? != 0 ]]; then
+	echo "Cannot find jazzy. jazzy is required to generate API links. To install try:"
+	echo "[sudo] gem install jazzy"
+	exit 1
+fi
+
+# Generates a list of urls to APIs
+# Args: $1 - Jazzy API type name. E.g. Classes
+#       $2 - Docs API type name. E.g. Class
+extract_apis_of_type() {
+  type="$1"
+  type_name="$2"
+  cat apidocs/search.json | tr , '\n' | grep "$type/" | grep -v "#" | while read line; do
+    url=$(echo "$line" | cut -d'"' -f2)
+    api=$(echo "$line" | cut -d'"' -f6)
+    echo "* $type_name: [$api](${SITE_URL_BASE}${COMPONENT_SITE_PATH}/api-docs/$url)"
+  done
+}
+
 COMPONENT="$1"
 
 COMPONENT_PATH="components/$COMPONENT"
@@ -39,12 +59,16 @@ TMP_README_PATH="$TMP_PATH/README.md"
 TMP_EXPANDED_README_PATH="$TMP_PATH/README.md.expanded"
 TMP_TOC_PATH="$TMP_PATH/toc.md"
 TOC_STRING="<!-- toc -->"
+DESIGN_AND_API_STRING="<!-- design-and-api -->"
 VARS_PATH="$COMPONENT_PATH/.vars"
+SITE_URL_BASE="https://material.io/components/ios"
 
 touch "$TMP_README_PATH"
 
+echo "Generating template readme..."
 if [[ $(grep -e "^root_path=" "$VARS_PATH") ]]; then
-  ./scripts/apply_template "$COMPONENT" scripts/templates/component/README.md.template "$TMP_README_PATH"
+  ./scripts/apply_template "$COMPONENT" scripts/templates/component/README.md.template "$TMP_README_PATH" >> /dev/null
+  COMPONENT_SITE_PATH=$(grep -e "^root_path=" "$VARS_PATH" | cut -d'=' -f2-)
 fi
 
 COMPONENT_NAME=$(grep -e "^component=" "$VARS_PATH" | cut -d'=' -f2-)
@@ -54,20 +78,7 @@ echo "" >> "$TMP_README_PATH"
 
 cat "$COMPONENT_PATH/docs/README.md" >> "$TMP_README_PATH"
 
-# Convert * spec urls to stylized lists
-perl -pi -e "s|\* \[(.+)\]\\((.+?)/go/design-(.+)\\)|  <li class=\"icon-list-item icon-list-item--spec\"><a href=\"\2/go/design-\3\">\1</a></li>|g" "$TMP_README_PATH"
-
-# Convert * list urls to stylized lists
-perl -pi -e "s|\* \[(.+)\]\\((.+)\\)|  <li class=\"icon-list-item icon-list-item--link\"><a href=\"\2\">\1</a></li>|g" "$TMP_README_PATH"
-
-# Convert * list text to stylized lists.
-perl -pi -e "s|\* (.+)$|  <li class=\"icon-list-item icon-list-item--spec\">\1</li>|g" "$TMP_README_PATH"
-
-# Prefix lists with <ul>
-perl -p0i -e "s|\n\n  <li|\n\n<ul class=\"icon-list\">\n  <li|g" "$TMP_README_PATH"
-
-# Postfix lists with </ul>
-perl -p0i -e "s|li>\n\n|li>\n</ul>\n\n|g" "$TMP_README_PATH"
+echo "Expanding all articles inline..."
 
 # Expand all files inline
 IFS='' # Don't trim whitespace from lines
@@ -86,9 +97,37 @@ done
 
 rm "$TMP_README_PATH"
 
-# Write the table of contents
+echo "Generating table of contents..."
+
+# Write the table of contents and design/api links
 cat "$TMP_EXPANDED_README_PATH" | while read line; do
-  if [ "$line" = "$TOC_STRING" ]; then
+  if [ "$line" = "$DESIGN_AND_API_STRING" ]; then
+    echo "## Design & API documentation" >> "$TMP_README_PATH"
+    echo "" >> "$TMP_README_PATH"
+
+    if [[ $(grep -e "^guidelines_short_link=" "$VARS_PATH") && $(grep -e "^guidelines_title=" "$VARS_PATH") ]]; then
+      guidelines_short_link=$(grep -e "^guidelines_short_link=" "$VARS_PATH" | cut -d'=' -f2-)
+      guidelines_title=$(grep -e "^guidelines_title=" "$VARS_PATH" | cut -d'=' -f2-)
+      echo "* [Material Design guidelines: $guidelines_title](https://material.io/go/$guidelines_short_link)" >> "$TMP_README_PATH"
+    else
+      echo ".vars is missing guidelines_short_link= and guidelines_title=."
+      echo "No Material Design guidelines link will be generated."
+    fi
+
+    if [ -z "$COMPONENT_SITE_PATH" ]; then
+      echo "No root_path= value found in .vars, skipping API generation."
+      continue
+    fi
+
+    pushd "$COMPONENT_PATH" >> /dev/null
+    echo "Generating jazzy docs for API links..."
+    jazzy . --output apidocs
+    extract_apis_of_type "Classes" "Class" >> "$TMP_README_PATH"
+    extract_apis_of_type "Protocols" "Protocol" >> "$TMP_README_PATH"
+    extract_apis_of_type "Enums" "Enumeration" >> "$TMP_README_PATH"
+    popd >> /dev/null
+
+  elif [ "$line" = "$TOC_STRING" ]; then
     echo "## Table of contents" >> "$TMP_README_PATH"
     echo "" >> "$TMP_README_PATH"
     grep -e "^#" -e "^$TOC_STRING" "$TMP_EXPANDED_README_PATH" \
@@ -109,6 +148,25 @@ cat "$TMP_EXPANDED_README_PATH" | while read line; do
     echo "$line" >> "$TMP_README_PATH"
   fi
 done
+
+echo "Generating pretty lists..."
+
+# Convert * spec urls to stylized lists
+perl -pi -e "s|\* \[(.+)\]\\((.+?)/go/design-(.+)\\)|  <li class=\"icon-list-item icon-list-item--spec\"><a href=\"\2/go/design-\3\">\1</a></li>|g" "$TMP_README_PATH"
+
+# Convert * list urls to stylized lists
+perl -pi -e "s|\* (.*)\[(.+)\]\\((.+)\\)|* \1<a href=\"\3\">\2</a>|g" "$TMP_README_PATH"
+
+# Convert * list text to stylized lists.
+perl -pi -e "s|\* (.+)$|  <li class=\"icon-list-item icon-list-item--link\">\1</li>|g" "$TMP_README_PATH"
+
+# Prefix lists with <ul>
+perl -p0i -e "s|\n\n  <li|\n\n<ul class=\"icon-list\">\n  <li|g" "$TMP_README_PATH"
+
+# Postfix lists with </ul>
+perl -p0i -e "s|li>\n\n|li>\n</ul>\n\n|g" "$TMP_README_PATH"
+
+echo "Rewriting paths..."
 
 # Rewrite relative paths
 perl -pi -e "s|\(\.\./|(|g" "$TMP_README_PATH"

--- a/scripts/generate_readme
+++ b/scripts/generate_readme
@@ -29,9 +29,9 @@ fi
 
 JAZZY_VERSION=`jazzy --version`
 if [[ $? != 0 ]]; then
-	echo "Cannot find jazzy. jazzy is required to generate API links. To install try:"
-	echo "[sudo] gem install jazzy"
-	exit 1
+  echo "Cannot find jazzy. jazzy is required to generate API links. To install try:"
+  echo "[sudo] gem install jazzy"
+  exit 1
 fi
 
 # Generates a list of urls to APIs

--- a/scripts/generate_readme
+++ b/scripts/generate_readme
@@ -40,7 +40,13 @@ fi
 extract_apis_of_type() {
   type="$1"
   type_name="$2"
-  cat apidocs/search.json | tr , '\n' | grep "$type/" | grep -v "#" | while read line; do
+  cat apidocs/search.json | tr , '\n' \
+      | grep "^\"$type" \
+      | grep -v "$type\"$" \
+      | grep -v "(.*).*(.*)" \
+      | grep -v "@" \
+      | sort | uniq \
+      | while read line; do
     url=$(echo "$line" | cut -d'"' -f2)
     api=$(echo "$line" | cut -d'"' -f6)
     echo "* $type_name: [$api](${SITE_URL_BASE}${COMPONENT_SITE_PATH}/api-docs/$url)"
@@ -152,13 +158,13 @@ done
 echo "Generating pretty lists..."
 
 # Convert * spec urls to stylized lists
-perl -pi -e "s|\* \[(.+)\]\\((.+?)/go/design-(.+)\\)|  <li class=\"icon-list-item icon-list-item--spec\"><a href=\"\2/go/design-\3\">\1</a></li>|g" "$TMP_README_PATH"
+perl -pi -e "s|^\* \[(.+)\]\\((.+?)/go/design-(.+)\\)|  <li class=\"icon-list-item icon-list-item--spec\"><a href=\"\2/go/design-\3\">\1</a></li>|g" "$TMP_README_PATH"
 
 # Convert * list urls to stylized lists
-perl -pi -e "s|\* (.*)\[(.+)\]\\((.+)\\)|* \1<a href=\"\3\">\2</a>|g" "$TMP_README_PATH"
+perl -pi -e "s|^\* (.*)\[(.+)\]\\((.+)\\)|  <li class=\"icon-list-item icon-list-item--link\">\1<a href=\"\3\">\2</a></li>|g" "$TMP_README_PATH"
 
 # Convert * list text to stylized lists.
-perl -pi -e "s|\* (.+)$|  <li class=\"icon-list-item icon-list-item--link\">\1</li>|g" "$TMP_README_PATH"
+perl -pi -e "s|^\* (.+)$|  <li class=\"icon-list-item icon-list-item\">\1</li>|g" "$TMP_README_PATH"
 
 # Prefix lists with <ul>
 perl -p0i -e "s|\n\n  <li|\n\n<ul class=\"icon-list\">\n  <li|g" "$TMP_README_PATH"


### PR DESCRIPTION
./scripts/generate_readme will now generate the Design & API documentation section if desired.

Adding the following snippet to docs/README.md will result in the design & API links section being generated. This section is auto-generated from the jazzy API output and includes all classes, protocols, and enumerations. These links were a pain in the butt to add and maintain before, and now we don't have to 🎉.

```
<!-- design-and-api -->
```

Also updated the docs docs accordingly.

Also changed the order of operations so that articles are expanded inline and then pretty lists are generated. This will ensure that articles with pretty lists also get prettified.

---

## Example input (in ActivityIndicator)

```
<!-- design-and-api -->
```

## Example output

<ul class="icon-list">
  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/go/design-progress-indicators">Material Design guidelines: Progress & Activity</a></li>
  <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/progress-indicators/activity-indicators/api-docs/Classes/MDCActivityIndicator.html">MDCActivityIndicator</a></li>
  <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/progress-indicators/activity-indicators/api-docs/Classes/MDCActivityIndicatorTransition.html">MDCActivityIndicatorTransition</a></li>
  <li class="icon-list-item icon-list-item--link">Protocol: <a href="https://material.io/components/ios/catalog/progress-indicators/activity-indicators/api-docs/Protocols/MDCActivityIndicatorDelegate.html">MDCActivityIndicatorDelegate</a></li>
  <li class="icon-list-item icon-list-item--link">Enumeration: <a href="https://material.io/components/ios/catalog/progress-indicators/activity-indicators/api-docs/Enums/MDCActivityIndicatorMode.html">MDCActivityIndicatorMode</a></li>
</ul>
