### PR TITLE
[CODEOWNERS] Determine if .github/ path is required

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,45 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+**       @ianegordon
+
+# Order is important. The last matching pattern has the most precedence.
+# So if a pull request only touches javascript files, only these owners
+# will be requested to review.
+# *.js    @octocat @github/js
+
+# You can also use email addresses if you prefer.
+/components/ActivityIndicator/    @jmdetloff
+/components/AnimationTiming/      @yarneo
+/components/AppBar/               @jverkoey
+/components/BottomAppBar/         @jmdetloff
+/components/BottomNavigation/     @romoore
+/components/BottomSheet/          @jmdetloff
+/components/ButtonBar/            @romoore
+/components/Buttons/              @randallli
+/components/Cards/                @yarneo
+/components/Chips/                @romoore
+/components/CollectionCells/      @yarneo
+/components/CollectionLayoutAttributes/ @ianegordon
+/components/Collections/          @ianegordon
+/components/Dialogs/              @ianegordon
+/components/FeatureHighlight/     @mohammadcazig
+/components/FlexibleHeader/       @jverkoey
+/components/HeaderStackView/      @jverkoey
+/components/Ink/                  @yarneo
+/components/LibraryInfo/          @ajsecord
+/components/MaskedTransition/     @jverkoey
+/components/NavigationBar/        @yarneo, @jverkoey
+/components/OverlayWindow/        @yarneo
+/components/PageControl/          @randallli
+/components/Palettes/             @ajsecord
+/components/ProgressView/         @romoore
+/components/ShadowElevations/     @ianegordon
+/components/ShadowLayer/          @ianegordon
+/components/Slider/               @romoore
+/components/Snackbar/             @yarneo
+/components/Tabs/                 @mohammadcazig, @brianjmoore
+/components/TextFields/           @willlarche
+/components/Themes/               @jgunaratne
+/components/Typography/           @randallli


### PR DESCRIPTION
Perhaps there is an unwritten requirement? I've seen in placed in this
directory in some other repositories where the owners claim it works.

### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [ ] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [ ] Link to GitHub issues it solves. ```closes #1234```
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
pull request.
