### PR TITLE
[Cards] 'Edit' button should show action, not state

### DIFF
--- a/components/Cards/examples/EditReorderCollectionViewController.swift
+++ b/components/Cards/examples/EditReorderCollectionViewController.swift
@@ -80,6 +80,8 @@ class EditReorderCollectionViewController: UIViewController,
       preiOS11Constraints()
     #endif
 
+    self.updateTitle()
+
   }
 
   func preiOS11Constraints() {
@@ -93,14 +95,23 @@ class EditReorderCollectionViewController: UIViewController,
                                                                  views: ["view": collectionView]));
   }
 
+  func updateTitle() {
+    if toggle == .edit {
+      navigationItem.rightBarButtonItem?.title = "Reorder"
+      self.title = "Cards (Edit)"
+    } else if toggle == .reorder {
+      navigationItem.rightBarButtonItem?.title = "Edit"
+      self.title = "Cards (Reorder)"
+    }
+  }
+
   func toggleModes() {
     if toggle == .edit {
       toggle = .reorder
-      navigationItem.rightBarButtonItem?.title = "Reorder"
     } else if toggle == .reorder {
       toggle = .edit
-      navigationItem.rightBarButtonItem?.title = "Edit"
     }
+    self.updateTitle()
     collectionView.reloadData()
   }
 

--- a/components/Cards/examples/EditReorderCollectionViewController.swift
+++ b/components/Cards/examples/EditReorderCollectionViewController.swift
@@ -81,7 +81,6 @@ class EditReorderCollectionViewController: UIViewController,
     #endif
 
     self.updateTitle()
-
   }
 
   func preiOS11Constraints() {


### PR DESCRIPTION
The Edit/Reorder example's appbar button for "Edit" or "Reorder" should show
the action that will take place, not the current state. The title should
reflect the current state.

Pivotal: https://www.pivotaltracker.com/story/show/157298528

**Before**
![simulator screen shot - iphone x - 2018-05-04 at 13 52 29](https://user-images.githubusercontent.com/1753199/39643331-706e01da-4fa2-11e8-9c35-9dbc93bf6038.png)

**After**
![simulator screen shot - iphone x - 2018-05-04 at 13 51 13](https://user-images.githubusercontent.com/1753199/39643274-40dc5caa-4fa2-11e8-9045-b075c348c1c1.png)


Known issue: 
#3731 - Button does not adjust size when the text changes