### PR TITLE
[BottomAppBar] Make FAB visibility a switch

### DIFF
--- a/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseSupplemental.m
+++ b/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseSupplemental.m
@@ -16,6 +16,8 @@
 
 #import "BottomAppBarTypicalUseSupplemental.h"
 
+static NSString *const kCellIdentifier = @"cell";
+
 @interface BottomAppBarExampleTableViewController ()
 @property(nonatomic, strong) UISwitch *fabVisibilitySwitch;
 @end
@@ -76,12 +78,6 @@
   return self;
 }
 
-- (void)dealloc {
-  [self.fabVisibilitySwitch removeTarget:self
-                                  action:@selector(didTapFABVisibilitySwitch:)
-                        forControlEvents:UIControlEventAllEvents];
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -92,7 +88,7 @@
                      forControlEvents:UIControlEventValueChanged];
 
 
-  [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:@"cell"];
+  [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:kCellIdentifier];
   self.tableView.layoutMargins = UIEdgeInsetsZero;
   self.tableView.separatorInset = UIEdgeInsetsZero;
 }
@@ -109,7 +105,7 @@
 
 - (UITableViewCell *)tableView:(UITableView *)tableView
          cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell"];
+  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kCellIdentifier];
   cell.layoutMargins = UIEdgeInsetsZero;
   cell.textLabel.text = self.listItems[indexPath.item];
   [self.fabVisibilitySwitch removeFromSuperview];
@@ -148,6 +144,8 @@
                                             animated:YES];
       break;
     case 5:
+      [self.fabVisibilitySwitch setOn:!self.fabVisibilitySwitch.isOn animated:YES];
+      [self didTapFABVisibilitySwitch:self.fabVisibilitySwitch];
       break;
     default:
       break;

--- a/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseSupplemental.m
+++ b/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseSupplemental.m
@@ -87,7 +87,6 @@ static NSString *const kCellIdentifier = @"cell";
                                action:@selector(didTapFABVisibilitySwitch:)
                      forControlEvents:UIControlEventValueChanged];
 
-
   [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:kCellIdentifier];
   self.tableView.layoutMargins = UIEdgeInsetsZero;
   self.tableView.separatorInset = UIEdgeInsetsZero;

--- a/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseSupplemental.m
+++ b/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseSupplemental.m
@@ -16,6 +16,10 @@
 
 #import "BottomAppBarTypicalUseSupplemental.h"
 
+@interface BottomAppBarExampleTableViewController ()
+@property(nonatomic, strong) UISwitch *fabVisibilitySwitch;
+@end
+
 @implementation BottomAppBarTypicalUseExample (CatalogByConvention)
 
 + (NSArray *)catalogBreadcrumbs {
@@ -66,15 +70,29 @@
                                         @"Trailing Floating Button",
                                         @"Primary Elevation Floating Button",
                                         @"Secondary Elevation Floating Button",
-                                        @"Toggle Floating Button Visibility" ];
+                                        @"Visible FAB" ];
     _listItems = listItems;
   }
   return self;
 }
 
+- (void)dealloc {
+  [self.fabVisibilitySwitch removeTarget:self
+                                  action:@selector(didTapFABVisibilitySwitch:)
+                        forControlEvents:UIControlEventAllEvents];
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
 
+  self.fabVisibilitySwitch = [[UISwitch alloc] init];
+  self.fabVisibilitySwitch.on = !self.bottomBarView.floatingButtonHidden;
+  [self.fabVisibilitySwitch addTarget:self
+                               action:@selector(didTapFABVisibilitySwitch:)
+                     forControlEvents:UIControlEventValueChanged];
+
+
+  [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:@"cell"];
   self.tableView.layoutMargins = UIEdgeInsetsZero;
   self.tableView.separatorInset = UIEdgeInsetsZero;
 }
@@ -92,13 +110,19 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView
          cellForRowAtIndexPath:(NSIndexPath *)indexPath {
   UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell"];
-  if (!cell) {
-    cell =
-        [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"cell"];
-  }
   cell.layoutMargins = UIEdgeInsetsZero;
   cell.textLabel.text = self.listItems[indexPath.item];
+  [self.fabVisibilitySwitch removeFromSuperview];
+  if (indexPath.row == (NSInteger)(self.listItems.count - 1)) {
+    cell.accessoryView = self.fabVisibilitySwitch;
+  } else {
+    cell.accessoryView = nil;
+  }
   return cell;
+}
+
+- (void)didTapFABVisibilitySwitch:(UISwitch *)sender {
+  [self.bottomBarView setFloatingButtonHidden:!sender.isOn animated:YES];
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
@@ -124,8 +148,6 @@
                                             animated:YES];
       break;
     case 5:
-      [self.bottomBarView setFloatingButtonHidden:!self.bottomBarView.floatingButtonHidden
-                                         animated:YES];
       break;
     default:
       break;


### PR DESCRIPTION
The BottomAppBar example should use a switch for toggling visiblity instead of
a "toggle cell".

Pivotal: https://www.pivotaltracker.com/story/show/157298385

**Before**
![simulator screen shot - iphone 4s - 2018-05-04 at 14 13 16](https://user-images.githubusercontent.com/1753199/39645140-527a0ea0-4fa5-11e8-9e49-49f5d3c41db2.png)

**After**
![simulator screen shot - iphone 4s - 2018-05-04 at 14 10 44](https://user-images.githubusercontent.com/1753199/39645149-5776d53c-4fa5-11e8-8b9c-a74ff3cfb226.png)

![simulator screen shot - iphone 4s - 2018-05-04 at 14 10 46](https://user-images.githubusercontent.com/1753199/39645157-5af443f2-4fa5-11e8-87c3-0b734d2ecadd.png)
