### PR TITLE
[Dialogs] Make "modal" dialog "non-dismissable"

### DIFF
--- a/components/Dialogs/examples/DialogsTypicalUseViewController.m
+++ b/components/Dialogs/examples/DialogsTypicalUseViewController.m
@@ -28,7 +28,8 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  [self loadCollectionView:@[@"Dismissable Programmatic", @"Dismissable Storyboard", @"Non-dismissable Programmatic", @"Open URL"]];
+  [self loadCollectionView:@[@"Dismissable Programmatic", @"Dismissable Storyboard",
+                             @"Non-dismissable Programmatic", @"Open URL"]];
   // We must create and store a strong reference to the transitionController.
   // A presented view controller will set this object as its transitioning delegate.
   self.transitionController = [[MDCDialogTransitionController alloc] init];

--- a/components/Dialogs/examples/DialogsTypicalUseViewController.m
+++ b/components/Dialogs/examples/DialogsTypicalUseViewController.m
@@ -28,7 +28,7 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  [self loadCollectionView:@[@"Programmatic", @"Storyboard", @"Modal", @"Open URL"]];
+  [self loadCollectionView:@[@"Dismissable Programmatic", @"Dismissable Storyboard", @"Non-dismissable Programmatic", @"Open URL"]];
   // We must create and store a strong reference to the transitionController.
   // A presented view controller will set this object as its transitioning delegate.
   self.transitionController = [[MDCDialogTransitionController alloc] init];


### PR DESCRIPTION
"Modal" dialogs simply meant that they were non-dismissable. Fixing the
wording in the example to communicate the differences.

Pivotal: https://www.pivotaltracker.com/story/show/157298804

**Before**
![simulator screen shot - iphone 4s - 2018-05-04 at 14 22 38](https://user-images.githubusercontent.com/1753199/39645669-1a47964a-4fa7-11e8-87e9-240f3faf3194.png)

**After**
![simulator screen shot - iphone 4s - 2018-05-04 at 14 20 57](https://user-images.githubusercontent.com/1753199/39645674-1d296c80-4fa7-11e8-87a2-8ce4c5588b52.png)
