### PR TITLE
[Tabs] "Add" button shows when needed

### DIFF
--- a/components/Tabs/examples/TabBarIconExample.m
+++ b/components/Tabs/examples/TabBarIconExample.m
@@ -21,6 +21,10 @@
 #import "MaterialTabs.h"
 #import "MaterialTabs+ColorThemer.h"
 
+@interface TabBarIconExample ()
+@property(nonatomic, strong)UIBarButtonItem *addStarButtonItem;
+@end
+
 @implementation TabBarIconExample
 
 - (void)viewDidLoad {
@@ -29,6 +33,12 @@
   [self setupExampleViews];
 
   [self loadTabBar];
+
+
+  self.addStarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Add"
+                                                            style:UIBarButtonItemStylePlain
+                                                           target:self
+                                                           action:@selector(incrementDidTouch:)];
 }
 
 #pragma mark - Action
@@ -123,6 +133,11 @@
 
   [self.scrollView setContentOffset:CGPointMake(index * CGRectGetWidth(self.view.bounds), 0)
                            animated:YES];
+  if (index == 0) {
+    self.navigationItem.rightBarButtonItem = nil;
+  } else {
+    self.navigationItem.rightBarButtonItem = self.addStarButtonItem;
+  }
 }
 
 @end

--- a/components/Tabs/examples/TabBarIconExample.m
+++ b/components/Tabs/examples/TabBarIconExample.m
@@ -34,7 +34,6 @@
 
   [self loadTabBar];
 
-
   self.addStarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Add"
                                                             style:UIBarButtonItemStylePlain
                                                            target:self

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
@@ -106,13 +106,6 @@
 
   [self.appBar addSubviewsToParent];
 
-  UIBarButtonItem *badgeIncrementItem =
-      [[UIBarButtonItem alloc] initWithTitle:@"Add"
-                                       style:UIBarButtonItemStylePlain
-                                      target:self
-                                      action:@selector(incrementDidTouch:)];
-
-  self.navigationItem.rightBarButtonItem = badgeIncrementItem;
   self.appBar.navigationBar.tintColor = UIColor.whiteColor;
 
   self.title = @"Tabs With Icons";


### PR DESCRIPTION
The Tabs Icon example has an "Add" button in the App Bar that adds a star to
one of the two views. The Add button should only be visible if that view is
visible.

Pivotal: https://www.pivotaltracker.com/story/show/157298200

**Before:**
![simulator screen shot - iphone 4s - 2018-05-04 at 15 26 48](https://user-images.githubusercontent.com/1753199/39648186-9bb02e88-4faf-11e8-84bb-148d3a4c0efc.png)
![simulator screen shot - iphone 4s - 2018-05-04 at 15 26 53](https://user-images.githubusercontent.com/1753199/39648190-9e117b28-4faf-11e8-9304-e6e8ae04ac99.png)


**After:**
![simulator screen shot - iphone 4s - 2018-05-04 at 15 24 06](https://user-images.githubusercontent.com/1753199/39648197-a4a1ee6e-4faf-11e8-9cbf-fd4ba9fd14e4.png)
![simulator screen shot - iphone 4s - 2018-05-04 at 15 24 07](https://user-images.githubusercontent.com/1753199/39648199-a6aa61fa-4faf-11e8-9d2d-1794cafd3c28.png)
