### PR TITLE
[Catalog] Fix component list header section insets on iPhone X.

### DIFF
--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -115,7 +115,7 @@ class MDCNodeListViewController: CBCNodeListViewController {
   let estimadedAdditionalExamplesSectionHeight = CGFloat(50)
   let estimadedDemoRowHeight = CGFloat(60)
   let estimadedRowHeight = CGFloat(50)
-  let padding = CGFloat(20)
+  let padding = CGFloat(16)
   var componentDescription = ""
   var selectedNode: CBCNode? = nil
 
@@ -183,7 +183,7 @@ class MDCNodeListViewController: CBCNodeListViewController {
     super.viewDidLoad()
 
     mainSectionHeader = MainSectionHeader()
-    additionalExamplesSectionHeader = AdditionalExamplesSectionHeader()
+    additionalExamplesSectionHeader = createAdditionalExamplesSectionHeader()
     self.tableView.backgroundColor = UIColor.white
     self.tableView.separatorStyle = .none
     self.tableView.rowHeight = UITableViewAutomaticDimension
@@ -335,8 +335,7 @@ extension MDCNodeListViewController {
     return additionalExamplesSectionHeader
   }
 
-  func AdditionalExamplesSectionHeader() -> UIView {
-
+  func createAdditionalExamplesSectionHeader() -> UIView {
     let sectionView = UIView()
     sectionView.backgroundColor = UIColor.white
     let lineDivider = UIView()
@@ -399,23 +398,41 @@ extension MDCNodeListViewController {
       multiplier: 1.0,
       constant: -padding).isActive = true
 
+    let preiOS11Behavior = {
+      NSLayoutConstraint(
+        item: sectionView,
+        attribute: .leading,
+        relatedBy: .equal,
+        toItem: sectionTitleLabel,
+        attribute: .leading,
+        multiplier: 1.0,
+        constant: -self.padding).isActive = true
+      NSLayoutConstraint(
+        item: sectionView,
+        attribute: .trailing,
+        relatedBy: .equal,
+        toItem: sectionTitleLabel,
+        attribute: .trailing,
+        multiplier: 1.0,
+        constant: self.padding).isActive = true
+    }
     // Title Label to Section View
-    NSLayoutConstraint(
-      item: sectionView,
-      attribute: .leading,
-      relatedBy: .equal,
-      toItem: sectionTitleLabel,
-      attribute: .leading,
-      multiplier: 1.0,
-      constant: -padding).isActive = true
-    NSLayoutConstraint(
-      item: sectionView,
-      attribute: .trailing,
-      relatedBy: .equal,
-      toItem: sectionTitleLabel,
-      attribute: .trailing,
-      multiplier: 1.0,
-      constant: padding).isActive = true
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      // Align to the safe area insets.
+      sectionTitleLabel.leadingAnchor
+        .constraint(equalTo: sectionView.safeAreaLayoutGuide.leadingAnchor,
+                    constant: padding).isActive = true
+      sectionTitleLabel.trailingAnchor
+        .constraint(equalTo: sectionView.safeAreaLayoutGuide.trailingAnchor,
+                    constant: -padding).isActive = true
+    } else {
+      preiOS11Behavior()
+    }
+    #else
+    preiOS11Behavior()
+    #endif
+
      NSLayoutConstraint(
       item: sectionView,
       attribute: .bottom,
@@ -451,22 +468,40 @@ extension MDCNodeListViewController {
     sectionView.addSubview(descriptionLabel)
 
     // sectionTitleLabel to SectionView
-    NSLayoutConstraint(
-      item: sectionView,
-      attribute: .leading,
-      relatedBy: .equal,
-      toItem: sectionTitleLabel,
-      attribute: .leading,
-      multiplier: 1.0,
-      constant: -padding).isActive = true
-    NSLayoutConstraint(
-      item: sectionView,
-      attribute: .trailing,
-      relatedBy: .equal,
-      toItem: sectionTitleLabel,
-      attribute: .trailing,
-      multiplier: 1.0,
-      constant: padding).isActive = true
+    let preiOS11Behavior = {
+      NSLayoutConstraint(
+        item: sectionView,
+        attribute: .leading,
+        relatedBy: .equal,
+        toItem: sectionTitleLabel,
+        attribute: .leading,
+        multiplier: 1.0,
+        constant: -self.padding).isActive = true
+      NSLayoutConstraint(
+        item: sectionView,
+        attribute: .trailing,
+        relatedBy: .equal,
+        toItem: sectionTitleLabel,
+        attribute: .trailing,
+        multiplier: 1.0,
+        constant: self.padding).isActive = true
+    }
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      // Align to the safe area insets.
+      sectionTitleLabel.leadingAnchor
+        .constraint(equalTo: sectionView.safeAreaLayoutGuide.leadingAnchor,
+                    constant: padding).isActive = true
+      sectionTitleLabel.trailingAnchor
+        .constraint(equalTo: sectionView.safeAreaLayoutGuide.trailingAnchor,
+                    constant: -padding).isActive = true
+    } else {
+      preiOS11Behavior()
+    }
+    #else
+    preiOS11Behavior()
+    #endif
+
     NSLayoutConstraint(
       item: sectionView,
       attribute: .top,


### PR DESCRIPTION
Pivotal story: https://www.pivotaltracker.com/story/show/157292201
Closes: https://github.com/material-components/material-components-ios/issues/3681

## Screenshots

Before:
![simulator screen shot - iphone x - 2018-05-04 at 16 31 34](https://user-images.githubusercontent.com/45670/39651974-f5631b48-4fb9-11e8-94d8-3dd689f5ccba.png)

After:
![simulator screen shot - iphone x - 2018-05-04 at 16 31 10](https://user-images.githubusercontent.com/45670/39651978-f840eb56-4fb9-11e8-8600-09a307bc6676.png)
