### PR TITLE
[Catalog] Finish menu functionality and placement

### DIFF
--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -39,6 +39,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     let rootNodeViewController = MDCCatalogComponentsController(node: tree)
     let navigationController = UINavigationController(rootViewController: rootNodeViewController)
+
     // In the event that an example view controller hides the navigation bar we generally want to
     // ensure that the edge-swipe pop gesture can still take effect. This may be overly-assumptive
     // but we'll explore other alternatives when we have a concrete example of this approach causing

--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -39,7 +39,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     let rootNodeViewController = MDCCatalogComponentsController(node: tree)
     let navigationController = UINavigationController(rootViewController: rootNodeViewController)
-
     // In the event that an example view controller hides the navigation bar we generally want to
     // ensure that the edge-swipe pop gesture can still take effect. This may be overly-assumptive
     // but we'll explore other alternatives when we have a concrete example of this approach causing

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -32,10 +32,11 @@ import UIKit
 class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchControllerDelegate {
 
   fileprivate struct Constants {
-    static let headerScrollThreshold: CGFloat = 20
+    static let headerScrollThreshold: CGFloat = 30
     static let inset: CGFloat = 16
-    static let logoTitleVerticalSpacing: CGFloat = 32
-    static let logoWidthHeight: CGFloat = 40
+    static let logoTitleVerticalSpacing: CGFloat = 30
+    static let logoWidthHeight: CGFloat = 30
+    static let menuButtonWidthHeight: CGFloat = 24
     static let spacing: CGFloat = 1
   }
 
@@ -55,6 +56,17 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
     return imageView
   }()
 
+  private lazy var menuButton: UIButton = {
+    let button = UIButton()
+    button.translatesAutoresizingMaskIntoConstraints = false
+    let dotsImage = MDCIcons.imageFor_ic_more_horiz()?.withRenderingMode(.alwaysTemplate)
+    button.setImage(dotsImage, for: .normal)
+    button.adjustsImageWhenHighlighted = false
+    button.tintColor = .white
+    return button
+  }()
+
+
   private let node: CBCNode
   private lazy var titleLabel: UILabel = {
     let titleLabel = UILabel()
@@ -63,6 +75,7 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
   }()
 
   private var titleLabelLeadingConstraint: NSLayoutConstraint?
+  private var titleLabelTrailingConstraint: NSLayoutConstraint?
   private var titleLabelBottomConstraint: NSLayoutConstraint?
   private var titleLabelHeightConstraint: NSLayoutConstraint?
 
@@ -80,7 +93,7 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
 
     super.init(collectionViewLayout: layout)
 
-    title = "Material Components for iOS v\(MDCLibraryInfo.versionString)"
+    title = "Material Components for iOS"
 
     addChildViewController(headerViewController)
 
@@ -131,6 +144,7 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
 
     titleLabel.text = title!
     titleLabel.textColor = UIColor(white: 1, alpha: 1)
+    titleLabel.textAlignment = .center
     titleLabel.font = UIFont.mdc_preferredFont(forMaterialTextStyle: .title)
     if #available(iOS 9.0, *) {
         titleLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 20, weight: UIFontWeightRegular)
@@ -172,35 +186,13 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
                              colorScheme)
     logo.image = image
 
-    NSLayoutConstraint(item: logo,
-                       attribute: .bottom,
-                       relatedBy: .equal,
-                       toItem: titleLabel,
-                       attribute: .top,
-                       multiplier: 1,
-                       constant: -1 * Constants.logoTitleVerticalSpacing).isActive = true
-    NSLayoutConstraint(item: logo,
-                       attribute: .leading,
-                       relatedBy: .equal,
-                       toItem: titleLabel,
-                       attribute: .leading,
-                       multiplier: 1,
-                       constant: 0).isActive = true
+    menuButton.addTarget(self.navigationController,
+                         action: #selector(navigationController?.presentMenu),
+                         for: .touchUpInside)
 
-    NSLayoutConstraint(item: logo,
-                       attribute: .width,
-                       relatedBy: .equal,
-                       toItem: logo,
-                       attribute: .height,
-                       multiplier: 1,
-                       constant: 0).isActive = true
-    NSLayoutConstraint(item: logo,
-                       attribute: .width,
-                       relatedBy: .equal,
-                       toItem: nil,
-                       attribute: .notAnAttribute,
-                       multiplier: 1,
-                       constant: Constants.logoWidthHeight).isActive = true
+    headerViewController.headerView.addSubview(menuButton)
+
+    setupFlexibleHeaderContentConstraints()
 
     MDCFlexibleHeaderColorThemer.applySemanticColorScheme(colorScheme,
                                                           to: headerViewController.headerView)
@@ -260,6 +252,68 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
                    height: titleLabel.bounds.height)
   }
 #endif
+
+  func setupFlexibleHeaderContentConstraints() {
+    NSLayoutConstraint(item: logo,
+                       attribute: .bottom,
+                       relatedBy: .equal,
+                       toItem: titleLabel,
+                       attribute: .top,
+                       multiplier: 1,
+                       constant: -1 * Constants.logoTitleVerticalSpacing).isActive = true
+    NSLayoutConstraint(item: logo,
+                       attribute: .leading,
+                       relatedBy: .equal,
+                       toItem: titleLabel,
+                       attribute: .leading,
+                       multiplier: 1,
+                       constant: 0).isActive = true
+
+    NSLayoutConstraint(item: logo,
+                       attribute: .width,
+                       relatedBy: .equal,
+                       toItem: logo,
+                       attribute: .height,
+                       multiplier: 1,
+                       constant: 0).isActive = true
+    NSLayoutConstraint(item: logo,
+                       attribute: .width,
+                       relatedBy: .equal,
+                       toItem: nil,
+                       attribute: .notAnAttribute,
+                       multiplier: 1,
+                       constant: Constants.logoWidthHeight).isActive = true
+
+    NSLayoutConstraint(item: menuButton,
+                       attribute: .centerY,
+                       relatedBy: .equal,
+                       toItem: logo,
+                       attribute: .centerY,
+                       multiplier: 1,
+                       constant: 0).isActive = true
+    NSLayoutConstraint(item: menuButton,
+                       attribute: .trailing,
+                       relatedBy: .equal,
+                       toItem: headerViewController.headerView,
+                       attribute: .trailing,
+                       multiplier: 1,
+                       constant: -1 * Constants.inset).isActive = true
+
+    NSLayoutConstraint(item: menuButton,
+                       attribute: .width,
+                       relatedBy: .equal,
+                       toItem: menuButton,
+                       attribute: .height,
+                       multiplier: 1,
+                       constant: 0).isActive = true
+    NSLayoutConstraint(item: menuButton,
+                       attribute: .width,
+                       relatedBy: .equal,
+                       toItem: nil,
+                       attribute: .notAnAttribute,
+                       multiplier: 1,
+                       constant: Constants.menuButtonWidthHeight).isActive = true
+  }
 
   // MARK: UICollectionViewDataSource
 
@@ -372,14 +426,19 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
       titleLabelLeadingConstraint!.isActive = true
     }
 
-    _ = NSLayoutConstraint(
-      item: label,
-      attribute: .trailing,
-      relatedBy: .equal,
-      toItem: containerView,
-      attribute: .trailing,
-      multiplier: 1.0,
-      constant: 0).isActive = true
+    if let constraint = titleLabelTrailingConstraint {
+      constraint.constant = -insets.right
+    } else {
+      titleLabelTrailingConstraint = NSLayoutConstraint(
+        item: label,
+        attribute: .trailing,
+        relatedBy: .equal,
+        toItem: containerView,
+        attribute: .trailing,
+        multiplier: 1.0,
+        constant: -insets.right)
+      titleLabelTrailingConstraint!.isActive = true
+    }
 
     if let constraint = titleLabelBottomConstraint {
       constraint.constant = -insets.bottom
@@ -420,8 +479,9 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
     }
 #endif
     let relativeOffset = inset + offset
-
-    logo.alpha = 1 - (relativeOffset / Constants.headerScrollThreshold)
+    let buttonsAlpha = 1 - (relativeOffset / Constants.headerScrollThreshold)
+    logo.alpha = buttonsAlpha
+    menuButton.alpha = buttonsAlpha
   }
 }
 

--- a/catalog/MDCCatalog/MDCCatalogDebugAlert.swift
+++ b/catalog/MDCCatalog/MDCCatalogDebugAlert.swift
@@ -58,7 +58,6 @@ class MDCCatalogDebugAlert: UICollectionViewController {
 
     layout.minimumLineSpacing = 0
     layout.minimumInteritemSpacing = 0
-    layout.itemSize = CGSize(width: 400, height: 44)
 
     super.init(collectionViewLayout: layout)
 

--- a/catalog/MDCCatalog/MDCCatalogWindow.swift
+++ b/catalog/MDCCatalog/MDCCatalogWindow.swift
@@ -25,7 +25,6 @@ import MaterialComponents.MaterialDialogs
  Triple tapping anywhere will toggle the visible touches.
  */
 class MDCCatalogWindow: MDCOverlayWindow {
-  var debugUIEnabled = true
   var showTouches = false
 
   fileprivate let fadeDuration: TimeInterval = 0.2
@@ -61,12 +60,7 @@ class MDCCatalogWindow: MDCOverlayWindow {
           continue
         case .stationary:
           continue
-        case .ended:
-          if touch.tapCount == 3 && debugUIEnabled {
-            showDebugSettings()
-          }
-          fallthrough
-        case .cancelled:
+        case .cancelled, .ended:
           endDisplayingTouch(touch)
           continue
         }
@@ -76,7 +70,7 @@ class MDCCatalogWindow: MDCOverlayWindow {
     super.sendEvent(event)
   }
 
-  fileprivate func showDebugSettings() {
+  func showDebugSettings() {
     let touches = MDCCatalogDebugSetting(title: "Show touches")
     touches.getter = { self.showTouches }
     touches.setter = { newValue in self.showTouches = newValue }
@@ -85,11 +79,7 @@ class MDCCatalogWindow: MDCOverlayWindow {
     safeAreaInsets.getter = { self.showSafeAreaEdgeInsets }
     safeAreaInsets.setter = { newValue in self.showSafeAreaEdgeInsets = newValue }
 
-    let dontShow = MDCCatalogDebugSetting(title: "Don't show this again")
-    dontShow.getter = { !self.debugUIEnabled }
-    dontShow.setter = { newValue in self.debugUIEnabled = !newValue }
-
-    let debugUI = MDCCatalogDebugAlert(settings: [touches, safeAreaInsets, dontShow])
+    let debugUI = MDCCatalogDebugAlert(settings: [touches, safeAreaInsets])
     rootViewController?.present(debugUI, animated: true, completion: nil)
   }
 

--- a/catalog/MDCCatalog/MDCMenuViewController.swift
+++ b/catalog/MDCCatalog/MDCMenuViewController.swift
@@ -25,7 +25,8 @@ class MDCMenuViewController: UITableViewController {
   let tableData =
     [(title: "Settings", icon: MDCIcons.imageFor_ic_settings()?.withRenderingMode(.alwaysTemplate)),
      (title: "Themes", icon: MDCIcons.imageFor_ic_color_lens()?.withRenderingMode(.alwaysTemplate)),
-     (title: "Help", icon: MDCIcons.imageFor_ic_help_outline()?.withRenderingMode(.alwaysTemplate))]
+     (title:  "v\(MDCLibraryInfo.versionString)",
+      icon: MDCIcons.imageFor_ic_help_outline()?.withRenderingMode(.alwaysTemplate))]
   let cellIdentifier = "MenuCell"
   let iconColor = AppTheme.globalTheme.colorScheme.onSurfaceColor.withAlphaComponent(0.61)
 
@@ -59,7 +60,15 @@ class MDCMenuViewController: UITableViewController {
     guard let navController = self.presentingViewController as? UINavigationController else {
       return
     }
-    if (indexPath.item == 1) {
+    switch indexPath.item {
+    case 0:
+      self.dismiss(animated: true, completion: {
+        if let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+          let window = appDelegate.window as? MDCCatalogWindow {
+          window.showDebugSettings()
+        }
+      })
+    case 1:
       self.dismiss(animated: true, completion: {
         let themeViewController = MDCThemePickerViewController()
         let presentingViewController =
@@ -68,11 +77,9 @@ class MDCMenuViewController: UITableViewController {
                                                                    named: "Themes")
         navController.pushViewController(presentingViewController, animated: true)
       })
-    } else {
+    default:
       self.dismiss(animated: true, completion: nil)
     }
-
   }
-
 }
 


### PR DESCRIPTION
Pivotals: https://www.pivotaltracker.com/story/show/156998143 (settings) - closes story
https://www.pivotaltracker.com/story/show/157165663 (menu accessible from main screen) - closes story
https://www.pivotaltracker.com/story/show/157022469 (red lines)

In this PR these are the changes:

* Added menu button to main screen
* Updated the main screens flexible header redlines after adding the button so the layout will look good
* Removed the versioning from the title in the main screen as per designs
* Added a setting menu that was previously shown by tapping the app 3 times
* Remove the 3 tap trigger for the settings menu
* Removed the "do not show this again" in the settings menu as now we can't trigger it mistakenly with a triple tap.
* Added the version number instead of where the help was in the menu dialog so we can remove it from the main screen title and be able to also access it anywhere in the app.

![2018-05-07 16_33_17](https://user-images.githubusercontent.com/4066863/39724272-50a9fb80-5216-11e8-80a0-6cf0f01f459c.gif)
![simulator screen shot - iphone x - 2018-05-07 at 16 29 30](https://user-images.githubusercontent.com/4066863/39724273-50b78b4c-5216-11e8-843a-81afd4636630.png)
![simulator screen shot - iphone x - 2018-05-07 at 16 29 24](https://user-images.githubusercontent.com/4066863/39724274-50c64c04-5216-11e8-8912-9f118a1f3eab.png)
![simulator screen shot - iphone x - 2018-05-07 at 16 29 20](https://user-images.githubusercontent.com/4066863/39724275-50d40560-5216-11e8-8b54-1c0db9332102.png)
