### PR TITLE
[kokoro] Add danger support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 bazel-*
 .kokoro-ios-runner
 
+node_modules/
+yarn.lock
+
 # MDC
 
 build_tests/CocoapodsObjCApp/CocoapodsObjCApp.xcworkspace

--- a/.kokoro
+++ b/.kokoro
@@ -174,6 +174,35 @@ run_cocoapods() {
   bash <(curl -s https://codecov.io/bash)
 }
 
+# For local runs, you must set the following environment variables:
+#
+#   DANGER_GITHUB_API_TOKEN -> Create a token here: https://github.com/settings/tokens.
+#                              Must have public_repo scope.
+#   DANGER_TEST_PR="###"    -> The PR # you want to test danger against.
+#
+# And you'll likely have to install danger:
+#
+#   yarn add danger
+#
+run_danger() {
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    # Move into our cloned repo
+    cd github/repo
+
+    export DANGER_TEST_PR="$KOKORO_GITHUB_PULL_REQUEST_NUMBER"
+
+    # Install danger
+    yarn add danger
+  fi
+
+  # We're not a supported CI, so we have to pretend to be one.
+  export DANGER_FAKE_CI="YEP"
+  export DANGER_TEST_REPO="material-components/material-components-ios"
+
+  # Run Danger
+  yarn danger ci
+}
+
 generate_website() {
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     # Move into our cloned repo
@@ -253,6 +282,7 @@ case "$DEPENDENCY_SYSTEM" in
   "cocoapods")  run_cocoapods ;;
   "cocoapods-podspec")  run_cocoapods ;;
   "website")    generate_website ;;
+  "danger")     run_danger ;;
 
   *)            run_bazel ;;
 esac

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -19,5 +19,8 @@ const {danger, warn, fail} = require('danger')
 // Danger.js documentation: http://danger.systems/js/
 
 if (!danger.github.pr.title.startsWith("[")) {
-  warn('This PR title does not include an affected component. For example: "[SomeComponent] Title.');
+  warn('This PR title does not include an affected component.'
+    + ' For example: "[SomeComponent] Title. If something is affecting multiple components and the'
+    + ' change can\'t be broken up into multiple PRs, then the common trait of the change could be'
+    + ' used in the PR title. E.g. `[documentation]`.');
 }

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,0 +1,23 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+const {danger, warn, fail} = require('danger')
+
+// Danger.js documentation: http://danger.systems/js/
+
+if (!danger.github.pr.title.startsWith("[")) {
+  warn('This PR title does not include an affected component. For example: "[SomeComponent] Title.');
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "danger": "^3.6.5"
+  }
+}


### PR DESCRIPTION
Adds support for running Danger checks against PRs.

## What is Danger?

[Danger](http://danger.systems/js/) is a tool built and maintained by @orta at Artsy. From the site docs:

> Danger runs during your CI process, and gives teams the chance to automate common code review chores.
> 
> This provides another logical step in your build, through this Danger can help lint your rote tasks in daily code review.
> 
> You can use Danger to codify your teams norms. Leaving humans to think about harder problems.
> 
> This happens by Danger leaving messages inside your PRs based on rules that you create with JavaScript or TypeScript.
> 
> Over time, as rules are adhered to, the message is amended to reflect the current state of the code review.

## Example output

<img width="804" alt="screen shot 2018-05-09 at 11 50 34 am" src="https://user-images.githubusercontent.com/45670/39825186-35a31a64-537f-11e8-96ae-dc4a520cf28e.png">

## How does it work?

Danger runs as part of our CI workflow. Danger has a dedicated job that runs in parallel with our other kokoro jobs. When the kokoro job runs, it invokes our `.kokoro` script with `danger` as the environment. The danger "logic" is found in Dangerfile.js. To start, our dangerfile simply checks whether a PR has a description that is longer than 10 characters. Over time, I hope that we can expand to more checks such as:

- Recommending that source changes be matched by test changes.
- Reminding to regenerate the component README.md if any of the doc articles change.
- Reminding that podspec and BUILD file changes often have to go hand-in-hand.
- Enforcing use of umbrella header imports over direct header imports.

## Can I run the danger checks locally?

Danger runs on PRs, so you won't be able to preview warnings before pushing your changes to GitHub. You technically can run the danger CI locally, but it will likely do the same work as the kokoro job (which starts running once you push the PR).

## What happens if danger gives a warning and I don't have any new changes to push?

For now, Danger is simply a warning, so it won't block any PRs from landing. But if you want to make sure that your PR is clean you can restart the job by clicking the Danger status bit in the PR and restarting the job for your PR.