### PR TITLE
[kokoro] Fix import statement rewrite behavior.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -29,20 +29,18 @@ fix_bazel_imports() {
   fi
   
   rewrite_tests() {
-    find "${stashed_dir}${tests_dir_prefix}"components/private/*/tests/unit -type f -name '*.swift' -exec sed -i '' -E "$1" {} + || true
-    find "${stashed_dir}${tests_dir_prefix}"components/*/tests/unit -type f -name '*.swift' -exec sed -i '' -E "$1" {} + || true
+    find "${stashed_dir}${tests_dir_prefix}"components/private/*/tests/unit -type f -name '*.swift' -exec perl -pi -e "$1" {} + || true
+    find "${stashed_dir}${tests_dir_prefix}"components/*/tests/unit -type f -name '*.swift' -exec perl -pi -e "$1" {} + || true
   }
   rewrite_source() {
-    find "${stashed_dir}${tests_dir_prefix}"components/private/*/src -type f -name '*.h' -exec sed -i '' -E "$1" {} + || true
-    find "${stashed_dir}${tests_dir_prefix}"components/private/*/src -type f -name '*.m' -exec sed -i '' -E "$1" {} + || true
-    find "${stashed_dir}${tests_dir_prefix}"components/*/src -type f -name '*.h' -exec sed -i '' -E "$1" {} + || true
-    find "${stashed_dir}${tests_dir_prefix}"components/*/src -type f -name '*.m' -exec sed -i '' -E "$1" {} + || true
+    find "${stashed_dir}${tests_dir_prefix}"components/private/*/src -type f -name '*.h' -exec perl -pi -e "$1" {} + || true
+    find "${stashed_dir}${tests_dir_prefix}"components/private/*/src -type f -name '*.m' -exec perl -pi -e "$1" {} + || true
+    find "${stashed_dir}${tests_dir_prefix}"components/*/src -type f -name '*.h' -exec perl -pi -e "$1" {} + || true
+    find "${stashed_dir}${tests_dir_prefix}"components/*/src -type f -name '*.m' -exec perl -pi -e "$1" {} + || true
   }
 
   stashed_dir=""
   rewrite_tests "s/import MaterialComponents.Material(.+)_(.+)/import components_\1_\2/"
-  rewrite_tests "s/import MaterialComponents.MDC(.+)ColorThemer/import components_\1_ColorThemer/"
-  rewrite_tests "s/import MaterialComponents.MDC(.+)TypographyThemer/import components_\1_TypographyThemer/"
   rewrite_tests "s/import MaterialComponents.Material(.+)Scheme/import components_schemes_\1_\1/"
   rewrite_tests "s/import MaterialComponents.MaterialMath/import components_private_Math_Math/"
   rewrite_tests "s/import MaterialComponents.Material(.+)/import components_\1_\1/"
@@ -53,12 +51,10 @@ fix_bazel_imports() {
   stashed_dir="$(pwd)/"
   reset_imports() {
     # Undoes our source changes from above.
-    rewrite_tests "s/import components_(.+)_(.+)/import MaterialComponents.Material\1_\2/"
-    rewrite_tests "s/import components_(.+)_ColorThemer/import MaterialComponents.MDC\1ColorThemer/"
-    rewrite_tests "s/import components_(.+)_TypographyThemer/import MaterialComponents.MDC\1TypographyThemer/"
-    rewrite_tests "s/import components_private_Math_Math/import MaterialComponents.MaterialMath/"
     rewrite_tests "s/import components_schemes_(.+)_.+/import MaterialComponents.Material\1Scheme/"
-    rewrite_tests "s/import components_(.+)_.+/import MaterialComponents.Material\1/"
+    rewrite_tests "s/import components_private_Math_Math/import MaterialComponents.MaterialMath/"
+    rewrite_tests "s/import components_(.+)_\1/import MaterialComponents.Material\1/"
+    rewrite_tests "s/import components_(.+)_(.+)/import MaterialComponents.Material\1_\2/"
     rewrite_source "s/import \"Motion(.+)\.h\"/import <Motion\1\/Motion\1.h>/"
     rewrite_source "s/import \"MDF(.+)\.h\"/import <MDF\1\/MDF\1.h>/"
     rewrite_tests "s/import material_text_accessibility_ios_MDFTextAccessibility/import MDFTextAccessibility/"


### PR DESCRIPTION
Prior to this change, component imports were not being rewritten back to their original form after running kokoro with bazel. This was leaving the workspace in a modified state.

After this change, kokoro bazel runs will not leave the source in a modified state.

The root problem was due to the `components_<component>_<extension>` pattern. This pattern overlaps with the bazel `components_<component>_<component>` pattern, resulting in an incorrect import rewrite.

The fix was to add a backreference replacement for the `<component>_<component>` pattern and to rewrite those import statements before rewriting the extensions statements.

This change required that we use perl's regex replacement instead of sed's, because sed does not support backreferences in the search query.

Closes https://github.com/material-components/material-components-ios/issues/4146