### PR TITLE
[kokoro] Added an apidiff bot to our CI.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -230,6 +230,97 @@ generate_website() {
   fi
 }
 
+generate_apidiff() {
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    # Move into our cloned repo
+    cd github/repo
+
+    # Install sourcekitten, a dependency of the apidiff tool
+    brew install sourcekitten
+  fi
+
+  if [ -z "$GITHUB_API_TOKEN" ]; then
+    echo "GITHUB_API_TOKEN must be set to a github token with public_repo scope."
+    exit 1
+  fi
+
+  if [ -z "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
+    echo "KOKORO_GITHUB_PULL_REQUEST_NUMBER must be set to a github pull request number."
+    exit 1
+  fi
+
+  BUILDS_TMP_PATH=$(mktemp -d)
+  SEEN_XCODES_FILE_PATH="$BUILDS_TMP_PATH/seen_xcodes"
+  touch "$SEEN_XCODES_FILE_PATH"
+  xcodes=$(ls /Applications/ | grep "Xcode")
+  for xcode_path in $xcodes; do
+    xcode_version=$(cat /Applications/$xcode_path/Contents/version.plist \
+      | grep "CFBundleShortVersionString" -A1 \
+      | grep string \
+      | cut -d'>' -f2 \
+      | cut -d'<' -f1)
+    xcode_version_as_number="$(version_as_number $xcode_version)"
+
+    # Ignore duplicate Xcode installations
+    if grep -xq "$xcode_version_as_number" "$SEEN_XCODES_FILE_PATH"; then
+      continue
+    fi
+
+    echo "$xcode_version_as_number" >> "$SEEN_XCODES_FILE_PATH"
+
+    if [ "$xcode_version_as_number" -ne "$(version_as_number $XCODE_VERSION)" ]; then
+      continue
+    fi
+
+    sudo xcode-select --switch /Applications/$xcode_path/Contents/Developer
+    xcodebuild -version
+
+    # Resolves the following crash when switching Xcode versions:
+    # "Failed to locate a valid instance of CoreSimulatorService in the bootstrap"
+    launchctl remove com.apple.CoreSimulator.CoreSimulatorService || true
+  
+    base_sha=$(git merge-base origin/develop HEAD)
+
+    ./scripts/release apidiff "$base_sha" | tee "$BUILDS_TMP_PATH/api_diff"
+    changelog_path=$(cat "$BUILDS_TMP_PATH/api_diff" | grep "Changelog=" | cut -d'=' -f2)
+    error_path=$(cat "$BUILDS_TMP_PATH/api_diff" | grep "Errors=" | cut -d'=' -f2)
+    
+    pushd scripts/github-comment >> /dev/null
+    
+    if [ -f "$changelog_path" ]; then
+      echo "## API diff detected the following changes" > "$changelog_path.tmp"
+      cat "$changelog_path" >> "$changelog_path.tmp"
+
+      swift run github-comment \
+        --repo=material-components/material-components-ios \
+        --github_token="$GITHUB_API_TOKEN" \
+        --pull_request_number="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" \
+        --identifier=apidiff \
+        --comment_body="$changelog_path.tmp"
+
+    else
+      # No changelog, so delete any existing comment
+      swift run github-comment \
+        --repo=material-components/material-components-ios \
+        --github_token="$GITHUB_API_TOKEN" \
+        --pull_request_number="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" \
+        --identifier=apidiff \
+        --delete
+    fi
+
+    popd >> /dev/null
+
+    if [ -f "$error_path" ]; then
+      nested_error_path=$(cat "$error_path" | grep "stderr output is available in" | cut -d' ' -f6)
+      if [ -f "$nested_error_path" ]; then
+        echo
+        echo "Potential build errors:"
+        cat "$nested_error_path"
+      fi
+    fi
+  done
+}
+
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
   key="$1"
@@ -283,6 +374,7 @@ case "$DEPENDENCY_SYSTEM" in
   "cocoapods-podspec")  run_cocoapods ;;
   "website")    generate_website ;;
   "danger")     run_danger ;;
+  "apidiff")    generate_apidiff ;;
 
   *)            run_bazel ;;
 esac

--- a/.kokoro
+++ b/.kokoro
@@ -230,6 +230,16 @@ generate_website() {
   fi
 }
 
+# For local runs, you must set the following environment variables:
+#
+#   GITHUB_API_TOKEN -> Create a token here: https://github.com/settings/tokens.
+#                       Must have public_repo scope.
+#   KOKORO_GITHUB_PULL_REQUEST_NUMBER="###" -> The PR # you want to post the API diff results to.
+#
+# And you'll likely have to install sourcekitten:
+#
+#   brew install sourcekitten
+#
 generate_apidiff() {
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     # Move into our cloned repo

--- a/.kokoro
+++ b/.kokoro
@@ -230,6 +230,9 @@ generate_website() {
   fi
 }
 
+# Will generate an API diff between the current branch and the merge-base from develop.
+# The result will be posted to GitHub as a comment.
+#
 # For local runs, you must set the following environment variables:
 #
 #   GITHUB_API_TOKEN -> Create a token here: https://github.com/settings/tokens.
@@ -248,6 +251,19 @@ generate_apidiff() {
     # Install sourcekitten, a dependency of the apidiff tool
     brew install sourcekitten
   fi
+  
+  usage() {
+    echo "Usage: $0 -d apidiff"
+    echo
+    echo "Will generate an API diff between the current branch and the merge-base from develop."
+    echo "The result will be posted to GitHub as a comment."
+    echo
+    echo "Must set the following environment variables to run locally:"
+    echo
+    echo "GITHUB_API_TOKEN -> Create a token here: https://github.com/settings/tokens."
+    echo "                    Must have public_repo scope."
+    echo "KOKORO_GITHUB_PULL_REQUEST_NUMBER=\"###\" -> The PR # you want to post the API diff results to."
+  }
 
   if [ -z "$GITHUB_API_TOKEN" ]; then
     echo "GITHUB_API_TOKEN must be set to a github token with public_repo scope."

--- a/.kokoro
+++ b/.kokoro
@@ -251,7 +251,7 @@ generate_apidiff() {
     # Install sourcekitten, a dependency of the apidiff tool
     brew install sourcekitten
   fi
-  
+
   usage() {
     echo "Usage: $0 -d apidiff"
     echo
@@ -267,11 +267,13 @@ generate_apidiff() {
 
   if [ -z "$GITHUB_API_TOKEN" ]; then
     echo "GITHUB_API_TOKEN must be set to a github token with public_repo scope."
+    usage
     exit 1
   fi
 
   if [ -z "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
     echo "KOKORO_GITHUB_PULL_REQUEST_NUMBER must be set to a github pull request number."
+    usage
     exit 1
   fi
 

--- a/scripts/github-comment/.gitignore
+++ b/scripts/github-comment/.gitignore
@@ -1,0 +1,2 @@
+.build
+*.xcodeproj

--- a/scripts/github-comment/Package.resolved
+++ b/scripts/github-comment/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftPM",
+        "repositoryURL": "https://github.com/apple/swift-package-manager.git",
+        "state": {
+          "branch": null,
+          "revision": "63a01220e93271dc3bf204b9e13dd1aeb2beefee",
+          "version": "0.2.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/scripts/github-comment/Package.swift
+++ b/scripts/github-comment/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import PackageDescription
+
+let package = Package(
+  name: "github-comment",
+  products: [
+    .library(
+      name: "github-comment",
+      targets: ["github-comment"]),
+  ],
+  dependencies: [
+    .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0"),
+  ],
+  targets: [
+    .target(
+      name: "github-comment",
+      dependencies: ["Utility"]),
+  ]
+)
+

--- a/scripts/github-comment/Sources/github-comment/github/GitHub.swift
+++ b/scripts/github-comment/Sources/github-comment/github/GitHub.swift
@@ -25,3 +25,8 @@ class GitHub {
   }
   let token: String
 }
+
+protocol GitHubObject {
+  associatedtype JsonFormat
+  init(json: JsonFormat)
+}

--- a/scripts/github-comment/Sources/github-comment/github/GitHub.swift
+++ b/scripts/github-comment/Sources/github-comment/github/GitHub.swift
@@ -1,0 +1,27 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+/**
+ An instance of this object is able to make authenticated requests to the GitHub API.
+ */
+class GitHub {
+  init(token: String) {
+    self.token = token
+  }
+  let token: String
+}

--- a/scripts/github-comment/Sources/github-comment/github/GitHubAPI.swift
+++ b/scripts/github-comment/Sources/github-comment/github/GitHubAPI.swift
@@ -1,0 +1,158 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+private let apiUrlBase = "https://api.github.com/"
+
+// API methods for GitHub
+
+extension GitHub {
+  /**
+   Fetches all pages of a paginated query.
+
+   @param urlAsString An API url to request. Should be relative to https://api.github.com/
+   @param didSucceed Invoked with each page's data, parsed as json, as it returns.
+                     Return true to continue paginating.
+                     Return false to stop paginating.
+   */
+  func getAll(startingFrom urlAsString: String, didSucceed: (Any) -> Bool) {
+    var nextUrl = URL(string: apiUrlBase + urlAsString)
+    while let url = nextUrl {
+      var request = authenticated(request: URLRequest(url: url))
+
+      let results = synchronousRequestJson(with: request)
+      if results.response?.statusCode == 200 {
+        if let json = results.json {
+          if !didSucceed(json) {
+            break
+          }
+        }
+      } else {
+        if let error = results.error {
+          print("Error: \(error.localizedDescription)")
+        }
+        exit(1)
+      }
+
+      guard let links = results.response?.allHeaderFields["Link"] as? String,
+        let nextLink = links.components(separatedBy: ",").filter({ $0.contains("rel=\"next\"") }).first,
+        let nextUrlAsString = nextLink.components(separatedBy: ";").first?
+          .trimmingCharacters(in: .init(charactersIn: " "))
+          .trimmingCharacters(in: .init(charactersIn: "<>")) else {
+            break
+      }
+      nextUrl = URL(string: nextUrlAsString)
+    }
+  }
+
+  /**
+   Fetches a single object.
+
+   @param urlAsString An API url to request. Should be relative to https://api.github.com/
+   @param didSucceed Invoked with the response data parsed as json.
+   */
+  func get(from urlAsString: String, didSucceed: (Any) -> Void) {
+    guard let url = URL(string: apiUrlBase + urlAsString) else {
+      return
+    }
+    var request = authenticated(request: URLRequest(url: url))
+
+    let results = synchronousRequestJson(with: request)
+    if results.response?.statusCode == 200 {
+      if let json = results.json {
+        didSucceed(json)
+      }
+    } else {
+      if let error = results.error {
+        print("Error: \(error.localizedDescription)")
+      }
+      exit(1)
+    }
+  }
+
+  /**
+   Patches a single object.
+
+   @param urlAsString An API url to request. Should be relative to https://api.github.com/
+   @param json The json data to send.
+   @param didSucceed Invoked with the response data parsed as json.
+   */
+  func patch(to urlAsString: String, json: Any, didSucceed: (Any) -> Void) {
+    mutate(urlAsString: urlAsString, method: "PATCH", json: json, didSucceed: didSucceed)
+  }
+
+  /**
+   Posts a single object.
+
+   @param urlAsString An API url to request. Should be relative to https://api.github.com/
+   @param json The json data to send.
+   @param didSucceed Invoked with the response data parsed as json.
+   */
+  func post(to urlAsString: String, json: Any, didSucceed: (Any) -> Void) {
+    mutate(urlAsString: urlAsString, method: "POST", json: json, didSucceed: didSucceed)
+  }
+
+  /**
+   Deletes a single object.
+
+   @param urlAsString An API url to request. Should be relative to https://api.github.com/
+   @param didSucceed Invoked with the response data parsed as json.
+   */
+  func delete(at urlAsString: String, didSucceed: (Any) -> Void) {
+    mutate(urlAsString: urlAsString, method: "DELETE", json: nil, didSucceed: didSucceed)
+  }
+
+  private func mutate(urlAsString: String, method: String, json: Any?, didSucceed: (Any) -> Void) {
+    sleep(1) // Avoid hitting abuse rate limits
+    guard let url = URL(string: apiUrlBase + urlAsString) else {
+      return
+    }
+    var request = authenticated(request: URLRequest(url: url))
+    request.httpMethod = method
+    if let json = json {
+      request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+      do {
+        request.httpBody = try JSONSerialization.data(withJSONObject: json, options: [])
+      } catch {
+        print("Failed to encode json.")
+        exit(1)
+      }
+    }
+
+    let results = synchronousRequestJson(with: request)
+
+    if results.response?.statusCode == 200
+      || results.response?.statusCode == 201
+      || results.response?.statusCode == 204 {
+      if let json = results.json {
+        didSucceed(json)
+      }
+    } else {
+      if let error = results.error {
+        print("Error: \(error.localizedDescription)")
+      }
+      exit(1)
+    }
+  }
+
+  private func authenticated(request: URLRequest) -> URLRequest {
+    var request = request
+    request.addValue("token \(token)", forHTTPHeaderField: "Authorization")
+    return request
+  }
+}
+

--- a/scripts/github-comment/Sources/github-comment/github/GitHubComments.swift
+++ b/scripts/github-comment/Sources/github-comment/github/GitHubComments.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 extension GitHub {
-  struct Comment {
+  struct Comment: GitHubObject {
     typealias JsonFormat = [String: Any]
     init(json: JsonFormat) {
       self.json = json
@@ -36,7 +36,7 @@ extension GitHub {
     }
   }
 
-  struct CommentList {
+  struct CommentList: GitHubObject {
     typealias JsonFormat = [Comment.JsonFormat]
     init(json: JsonFormat) {
       self.json = json

--- a/scripts/github-comment/Sources/github-comment/github/GitHubComments.swift
+++ b/scripts/github-comment/Sources/github-comment/github/GitHubComments.swift
@@ -1,0 +1,52 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+extension GitHub {
+  struct Comment {
+    typealias JsonFormat = [String: Any]
+    init(json: JsonFormat) {
+      self.json = json
+    }
+    private let json: JsonFormat
+
+    var id: Int? { get { return json["id"] as? Int } }
+    var body: String? { get { return json["body"] as? String } }
+    var user: User? {
+      get {
+        guard let user = json["user"] as? User.JsonFormat else {
+          return nil
+        }
+        return User(json: user)
+      }
+    }
+  }
+
+  struct CommentList {
+    typealias JsonFormat = [Comment.JsonFormat]
+    init(json: JsonFormat) {
+      self.json = json
+    }
+    private let json: JsonFormat
+
+    var comments: [Comment]? {
+      get {
+        return json.map { Comment(json: $0) }
+      }
+    }
+  }
+}

--- a/scripts/github-comment/Sources/github-comment/github/GitHubUsers.swift
+++ b/scripts/github-comment/Sources/github-comment/github/GitHubUsers.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 extension GitHub {
-  struct User {
+  struct User: GitHubObject {
     typealias JsonFormat = [String: Any]
     init(json: JsonFormat) {
       self.json = json

--- a/scripts/github-comment/Sources/github-comment/github/GitHubUsers.swift
+++ b/scripts/github-comment/Sources/github-comment/github/GitHubUsers.swift
@@ -1,0 +1,31 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+extension GitHub {
+  struct User {
+    typealias JsonFormat = [String: Any]
+    init(json: JsonFormat) {
+      self.json = json
+    }
+    private let json: JsonFormat
+
+    var id: Int? { get { return json["id"] as? Int } }
+    var name: String? { get { return json["name"] as? String } }
+    var login: String? { get { return json["login"] as? String } }
+  }
+}

--- a/scripts/github-comment/Sources/github-comment/github/Networking.swift
+++ b/scripts/github-comment/Sources/github-comment/github/Networking.swift
@@ -1,0 +1,56 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+typealias RequestResult = (data: Data?, response: HTTPURLResponse?, error: Error?)
+typealias RequestJsonResult = (json: Any?, response: HTTPURLResponse?, error: Error?)
+
+/**
+ Makes a synchronous http request and returns the result as Data.
+ */
+func synchronousRequest(with request: URLRequest) -> RequestResult {
+  let semaphore = DispatchSemaphore(value: 0)
+  var result: RequestResult
+  let task = URLSession.shared.dataTask(with: request) { data, response, error in
+    result = (data, response as? HTTPURLResponse, error)
+    semaphore.signal()
+  }
+
+  task.resume()
+  _ = semaphore.wait(timeout: .distantFuture)
+
+  return result
+}
+
+/**
+ Makes a synchronous http request and returns the result parsed as JSON.
+ */
+func synchronousRequestJson(with request: URLRequest) -> RequestJsonResult {
+  let result = synchronousRequest(with: request)
+
+  guard let data = result.data else {
+    return (nil, result.response, result.error)
+  }
+
+  do {
+    let json = try JSONSerialization.jsonObject(with: data, options: [])
+    return (json, result.response, result.error)
+  } catch {
+    return (nil, result.response, result.error)
+  }
+}
+

--- a/scripts/github-comment/Sources/github-comment/main.swift
+++ b/scripts/github-comment/Sources/github-comment/main.swift
@@ -1,0 +1,153 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+import Utility
+
+// MARK: Argument parsing
+
+// The first argument is always the executable, drop it
+let arguments = Array(ProcessInfo.processInfo.arguments.dropFirst())
+
+let parser = ArgumentParser(usage: "<options>",
+                            overview: "A tool for managing comments on GitHub pull requests.")
+
+let repoArgument = parser.add(option: "--repo", kind: String.self, usage:
+  "[required]. The GitHub repository to synchronize with")
+let githubTokenArgument = parser.add(option: "--github_token", kind: String.self, usage:
+  "[required]. The token that should be used to issue GitHub API requests.")
+let prNumberArgument = parser.add(option: "--pull_request_number", kind: Int.self, usage:
+  "[required]. The pull request to which comments should be posted.")
+let identifierArgument = parser.add(option: "--identifier", kind: String.self, usage:
+  "[required]. An identifier that will be used to identify the comment.")
+
+let bodyArgument = parser.add(option: "--comment_body", kind: PathArgument.self, usage:
+  "[optional]. A path to a file containing the body of the comment.")
+let deleteArgument = parser.add(option: "--delete", kind: Bool.self, usage:
+  "[optional]. Will delete the comment.")
+
+let parsedArguments: ArgumentParser.Result
+do {
+  parsedArguments = try parser.parse(arguments)
+} catch let error as ArgumentParserError {
+  print(error.description)
+  exit(1)
+}
+catch let error {
+  print(error.localizedDescription)
+  exit(1)
+}
+
+guard let repo = parsedArguments.get(repoArgument) else {
+  print("--repo is required")
+  exit(1)
+}
+guard let githubToken = parsedArguments.get(githubTokenArgument) else {
+  print("--github_token is required")
+  exit(1)
+}
+guard let prNumber = parsedArguments.get(prNumberArgument) else {
+  print("--pull_request_number is required")
+  exit(1)
+}
+guard let identifier = parsedArguments.get(identifierArgument) else {
+  print("--identifier is required")
+  exit(1)
+}
+let bodyFilename = parsedArguments.get(bodyArgument)
+let shouldDelete = parsedArguments.get(deleteArgument) ?? false
+
+let commentIdentifier = "<!-- identifier: \(identifier) -->"
+
+// MARK: Load the comment body
+
+let github = GitHub(token: githubToken)
+
+var user: GitHub.User? = nil
+github.get(from: "user") { jsonResult in
+  guard let json = jsonResult as? GitHub.User.JsonFormat else {
+    return
+  }
+  user = GitHub.User(json: json)
+}
+
+guard let user = user, let userId = user.id else {
+  print("Failed to get authenticated user.")
+  exit(1)
+}
+
+var existingComment: GitHub.Comment? = nil
+github.getAll(startingFrom: "repos/\(repo)/issues/\(prNumber)/comments") { jsonResult in
+  guard let json = jsonResult as? GitHub.CommentList.JsonFormat else {
+    return false // Halt execution
+  }
+  let list = GitHub.CommentList(json: json)
+  guard let comments = list.comments else {
+    return false
+  }
+  for comment in comments {
+    guard let body = comment.body else {
+      continue
+    }
+    if comment.user?.id == user.id && body.contains(commentIdentifier) {
+      existingComment = comment
+      return false // Stop enumerating the comments
+    }
+  }
+  return true
+}
+
+func getCommentBody() throws -> String? {
+  if let bodyFilename = bodyFilename {
+    return try String.init(contentsOf: URL(fileURLWithPath: bodyFilename.path.asString))
+  }
+  return nil
+}
+
+if shouldDelete {
+  if let existingCommentId = existingComment?.id {
+    print("Deleting existing comment...")
+    github.delete(at: "repos/\(repo)/issues/comments/\(existingCommentId)") { jsonResult in
+      // Ignored.
+    }
+  }
+
+} else if let body = try getCommentBody() {
+  if let existingCommentId = existingComment?.id {
+    let desiredBody = body + "\n" + commentIdentifier
+
+    if existingComment?.body == desiredBody {
+      print("Nothing to do, comment matches desired body.")
+
+    } else {
+      print("Updating existing comment...")
+      github.patch(to: "repos/\(repo)/issues/comments/\(existingCommentId)", json: [
+        "body": desiredBody
+      ]) { jsonResult in
+        // Ignored.
+      }
+    }
+
+  } else {
+    print("Creating new comment...")
+    github.post(to: "repos/\(repo)/issues/\(prNumber)/comments", json: [
+      "body": body + "\n" + commentIdentifier
+    ]) { jsonResult in
+      // Ignored.
+    }
+  }
+}
+

--- a/scripts/github-comment/Sources/github-comment/main.swift
+++ b/scripts/github-comment/Sources/github-comment/main.swift
@@ -76,13 +76,7 @@ let commentIdentifier = "<!-- identifier: \(identifier) -->"
 
 let github = GitHub(token: githubToken)
 
-var user: GitHub.User? = nil
-github.get(from: "user") { jsonResult in
-  guard let json = jsonResult as? GitHub.User.JsonFormat else {
-    return
-  }
-  user = GitHub.User(json: json)
-}
+var user: GitHub.User? = github.get(from: "user")
 
 guard let user = user, let userId = user.id else {
   print("Failed to get authenticated user.")
@@ -120,9 +114,7 @@ func getCommentBody() throws -> String? {
 if shouldDelete {
   if let existingCommentId = existingComment?.id {
     print("Deleting existing comment...")
-    github.delete(at: "repos/\(repo)/issues/comments/\(existingCommentId)") { jsonResult in
-      // Ignored.
-    }
+    github.delete(at: "repos/\(repo)/issues/comments/\(existingCommentId)")
   }
 
 } else if let body = try getCommentBody() {
@@ -136,18 +128,14 @@ if shouldDelete {
       print("Updating existing comment...")
       github.patch(to: "repos/\(repo)/issues/comments/\(existingCommentId)", json: [
         "body": desiredBody
-      ]) { jsonResult in
-        // Ignored.
-      }
+      ])
     }
 
   } else {
     print("Creating new comment...")
     github.post(to: "repos/\(repo)/issues/\(prNumber)/comments", json: [
       "body": body + "\n" + commentIdentifier
-    ]) { jsonResult in
-      // Ignored.
-    }
+    ])
   }
 }
 

--- a/scripts/release
+++ b/scripts/release
@@ -429,7 +429,11 @@ generate_release_apidiff() {
   }
 
   # Verify commits
-  old_commit=$(git rev-list -n 1 origin/stable)
+  if [ -n "$1" ]; then
+    old_commit=$(git rev-list -n 1 $1)
+  else
+    old_commit=$(git rev-list -n 1 origin/stable)
+  fi
   new_commit=$(git rev-list -n 1 $(get_latest_branch))
 
   if [[ -z "$old_commit" || -z "$new_commit" ]]; then
@@ -476,7 +480,7 @@ generate_release_apidiff() {
   echo "Errors=$ALL_ERROR_LOG_PATH"
 
   # Run new pathdiff script on each umbrella header in array
-  for path_to_component in $(generate_release_components | grep -v "private"); do
+  for path_to_component in $(generate_release_components "$old_commit" | grep -v "private"); do
     component=$(basename $path_to_component)
 
     echo -n "Diffing $component..."
@@ -521,7 +525,12 @@ generate_release_authors() {
 }
 
 generate_release_components() {
-  git diff --name-only origin/stable..$(get_latest_branch) components/ \
+  if [ -n "$1" ]; then
+    old_commit="$1"
+  else
+    old_commit=origin/stable
+  fi
+  git diff --name-only "$old_commit"..$(get_latest_branch) components/ \
     | grep "src/" | cut -d'/' -f2- | rev | cut -d'/' -f3- | rev | sed 's|/src||' | sort | uniq
 }
 
@@ -642,9 +651,9 @@ case "$1" in
   publish)    publish_release ${@:2} ;;
   podspec)    publish_podspec ${@:2} ;;
 
-  apidiff)    generate_release_apidiff ${@:2} ;;
+  apidiff)    generate_release_apidiff ${@:2} ;; # args: [base sha]
   authors)    generate_release_authors ${@:2} ;;
-  components) generate_release_components ${@:2} ;;
+  components) generate_release_components ${@:2} ;; # args: [base sha]
   diff)       generate_release_diff ${@:2} ;;
   files)      generate_release_files ${@:2} ;;
   headers)    generate_release_headers ${@:2} ;;


### PR DESCRIPTION
Adds support for generating API diffs for PRs.

## How does it work?

There is a new job that runs alongside our PRs, `kokoro/pr/apidiff`. This job will run the `.kokoro` script with the `apidiff` environment. In this environment, we run our `scripts/release` API diff command and post the output as a comment to our pull request, if any API diff exists.

The intent of this bot is to allow us to quickly get an understanding of any API changes in a given PR. Most notably, if an API is being deleted without first being deprecated, this bot will give us a good opportunity to catch that before it lands in our release.

## Example output

<img width="792" alt="screen shot 2018-05-09 at 9 49 11 am" src="https://user-images.githubusercontent.com/45670/39818160-3e7839e6-536e-11e8-9897-e045343f0812.png">
