### PR TITLE
[schemes] Fix docsite generation due to missing and malformed metadata.

### DIFF
--- a/components/schemes/Bidirectionality/README.md
+++ b/components/schemes/Bidirectionality/README.md
@@ -5,7 +5,6 @@ section: components
 excerpt: "Support and engineering guidance for bidirectional text."
 iconId: themes
 path: /catalog/theming/bidirectionality/
-api_doc_root: true
 -->
 
 # Bidirectionality

--- a/components/schemes/Color/.jazzy.yaml
+++ b/components/schemes/Color/.jazzy.yaml
@@ -1,0 +1,4 @@
+module: ColorScheme
+umbrella_header: src/MaterialColorScheme.h
+objc: true
+sdk: iphonesimulator

--- a/components/schemes/Typography/.jazzy.yaml
+++ b/components/schemes/Typography/.jazzy.yaml
@@ -1,0 +1,4 @@
+module: TypographyScheme
+umbrella_header: src/MaterialTypographyScheme.h
+objc: true
+sdk: iphonesimulator


### PR DESCRIPTION
Prior to this change, the docsite generator was failing to build our site because of missing jazzy config files and a component that was incorrectly marked as an api root.

After this change, the site builds successfully.