### PR TITLE
[Buttons] Fix updateTitles to prevent crash

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -527,9 +527,10 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 - (void)updateTitleCase {
   // This calls setTitle or setAttributedTitle for every title value we have stored. In each
   // respective setter the title is upcased if _uppercaseTitle is YES.
-  for (NSNumber *key in _nontransformedTitles.keyEnumerator) {
+  NSDictionary<NSNumber *, NSString *> *nontransformedTitles = [_nontransformedTitles copy];
+  for (NSNumber *key in nontransformedTitles.keyEnumerator) {
     UIControlState state = key.unsignedIntegerValue;
-    NSString *title = _nontransformedTitles[key];
+    NSString *title = nontransformedTitles[key];
     if ([title isKindOfClass:[NSAttributedString class]]) {
       [self setAttributedTitle:(NSAttributedString *)title forState:state];
     } else {

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -154,6 +154,8 @@ static NSString *controlStateDescription(UIControlState controlState) {
   // When
   button.uppercaseTitle = NO;
   [button setTitle:originalTitle forState:UIControlStateNormal];
+  [button setTitle:originalTitle forState:UIControlStateHighlighted];
+  [button setTitle:originalTitle forState:UIControlStateDisabled];
   button.uppercaseTitle = YES;
 
   // Then
@@ -169,6 +171,8 @@ static NSString *controlStateDescription(UIControlState controlState) {
   // When
   button.uppercaseTitle = YES;
   [button setTitle:originalTitle forState:UIControlStateNormal];
+  [button setTitle:originalTitle forState:UIControlStateHighlighted];
+  [button setTitle:originalTitle forState:UIControlStateDisabled];
   button.uppercaseTitle = NO;
 
   // Then


### PR DESCRIPTION
When a button had more than one title-for-state value, changing the property
`-uppercaseTitle` would cause a crash on iOS 10 and below. This was because
the code was both enumerating and mutating the same `_nontransformedTitles`
dictionary.

Closes #4152
