### PR TITLE
[FlexibleHeader] Fix topLayoutGuide edge case behavior.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderContainerViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderContainerViewController.m
@@ -101,7 +101,7 @@
 
 - (void)updateTopLayoutGuideBehavior {
   if (_topLayoutGuideAdjustmentEnabled) {
-    if ([self isViewLoaded] && [self.contentViewController isViewLoaded]) {
+    if ([self isViewLoaded]) {
       self.contentViewController.view.translatesAutoresizingMaskIntoConstraints = YES;
       self.contentViewController.view.autoresizingMask = (UIViewAutoresizingFlexibleWidth
                                                           | UIViewAutoresizingFlexibleHeight);

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderContainerViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderContainerViewController.m
@@ -54,6 +54,8 @@
   self.headerViewController.view.frame = self.view.bounds;
   [self.view addSubview:self.headerViewController.view];
   [self.headerViewController didMoveToParentViewController:self];
+
+  [self updateTopLayoutGuideBehavior];
 }
 
 - (BOOL)prefersStatusBarHidden {
@@ -92,19 +94,12 @@
     }
   }
 
-  if (_topLayoutGuideAdjustmentEnabled) {
-    self.headerViewController.topLayoutGuideViewController = self.contentViewController;
-  }
+  [self updateTopLayoutGuideBehavior];
 }
 
 #pragma mark - Enabling top layout guide adjustment behavior
 
-- (void)setTopLayoutGuideAdjustmentEnabled:(BOOL)topLayoutGuideAdjustmentEnabled {
-  if (_topLayoutGuideAdjustmentEnabled == topLayoutGuideAdjustmentEnabled) {
-    return;
-  }
-  _topLayoutGuideAdjustmentEnabled = topLayoutGuideAdjustmentEnabled;
-
+- (void)updateTopLayoutGuideBehavior {
   if (_topLayoutGuideAdjustmentEnabled) {
     if ([self isViewLoaded] && [self.contentViewController isViewLoaded]) {
       self.contentViewController.view.translatesAutoresizingMaskIntoConstraints = YES;
@@ -125,6 +120,15 @@
   } else {
     self.headerViewController.topLayoutGuideViewController = nil;
   }
+}
+
+- (void)setTopLayoutGuideAdjustmentEnabled:(BOOL)topLayoutGuideAdjustmentEnabled {
+  if (_topLayoutGuideAdjustmentEnabled == topLayoutGuideAdjustmentEnabled) {
+    return;
+  }
+  _topLayoutGuideAdjustmentEnabled = topLayoutGuideAdjustmentEnabled;
+
+  [self updateTopLayoutGuideBehavior];
 }
 
 @end

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -286,6 +286,7 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
 
   if ([self isViewLoaded]) {
     [self extractTopLayoutGuideConstraint];
+    [self updateTopLayoutGuide];
   }
 }
 

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderWrappingTopLayoutGuideTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderWrappingTopLayoutGuideTests.swift
@@ -47,6 +47,28 @@ class FlexibleHeaderWrappingTopLayoutGuideTests: XCTestCase {
     let _ = container.view // Force the view to load.
 
     // Then
+    XCTAssertEqual(contentViewController.view.autoresizingMask, [.flexibleWidth, .flexibleHeight])
+    XCTAssertEqual(contentViewController.view.frame, container.view.bounds)
+    XCTAssertEqual(contentViewController.topLayoutGuide.length,
+                   container.headerViewController.headerView.frame.maxY)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top,
+                     container.headerViewController.headerView.frame.maxY
+                      - MDCDeviceTopSafeAreaInset())
+    }
+    #endif
+  }
+
+  func testEarlyViewLoadStillAffectsTopLayoutGuide() {
+    // Given
+    let contentViewController = UIViewController()
+    let _ = container.view // Force the view to load.
+    container.contentViewController = contentViewController
+
+    // Then
+    XCTAssertEqual(contentViewController.view.autoresizingMask, [.flexibleWidth, .flexibleHeight])
+    XCTAssertEqual(contentViewController.view.frame, container.view.bounds)
     XCTAssertEqual(contentViewController.topLayoutGuide.length,
                    container.headerViewController.headerView.frame.maxY)
     #if swift(>=3.2)
@@ -67,6 +89,8 @@ class FlexibleHeaderWrappingTopLayoutGuideTests: XCTestCase {
     let _ = container.view // Force the view to load.
 
     // Then
+    XCTAssertEqual(contentViewController.view.autoresizingMask, [.flexibleWidth, .flexibleHeight])
+    XCTAssertEqual(contentViewController.view.frame, container.view.bounds)
     XCTAssertEqual(contentViewController.topLayoutGuide.length,
                    container.headerViewController.headerView.frame.maxY)
     #if swift(>=3.2)
@@ -112,6 +136,8 @@ class FlexibleHeaderWrappingTopLayoutGuideTests: XCTestCase {
     let _ = container.view // Force the view to load.
 
     // Then
+    XCTAssertEqual(contentViewController.view.autoresizingMask, [.flexibleWidth, .flexibleHeight])
+    XCTAssertEqual(contentViewController.view.frame, container.view.bounds)
     XCTAssertEqual(contentViewController.topLayoutGuide.length,
                    container.headerViewController.headerView.frame.maxY)
     #if swift(>=3.2)
@@ -137,6 +163,8 @@ class FlexibleHeaderWrappingTopLayoutGuideTests: XCTestCase {
     container.headerViewController.headerView.trackingScrollDidScroll()
 
     // Then
+    XCTAssertEqual(contentViewController.view.autoresizingMask, [.flexibleWidth, .flexibleHeight])
+    XCTAssertEqual(contentViewController.view.frame, container.view.bounds)
     XCTAssertEqual(contentViewController.topLayoutGuide.length,
                    container.headerViewController.headerView.frame.maxY)
     #if swift(>=3.2)


### PR DESCRIPTION
When the container view controller's view is loaded before a content view controller is provided, it's possible for the top layout guide and autoresizing mask not to be set correctly on the content view controller.

This change ensures that even if the container view is loaded early that the content vc's top layout guide does get updated once the content vc is set.

Added tests accordingly.