### PR TITLE
[GitHub] Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Platform (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -4,27 +4,30 @@ about: Create a report to help us improve
 
 ---
 
-For usage questions: ask on [Stack  Overflow](https://stackoverflow.com/questions/tagged/material-components+ios).
+> For usage questions: ask on [Stack  Overflow](https://stackoverflow.com/questions/tagged/material-components+ios).
 
-**Describe the bug**
 A clear and concise description of what the bug is.
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+## Reproduction steps
 
-**Expected behavior**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Tap on '....'
+
+## Expected behavior
+
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+## Actual behavior
 
-**Platform (please complete the following information):**
+A clear and concise description of what actually happened. Include screenshots or gifs where possible.
+
+## Platform (please complete the following information)
+
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
 
-**Additional context**
+## Additional context
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -4,6 +4,8 @@ about: Create a report to help us improve
 
 ---
 
+For usage questions: ask on [Stack  Overflow](https://stackoverflow.com/questions/tagged/material-components+ios).
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -4,14 +4,10 @@ about: Suggest an idea for MDC iOS
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+## Feature Request/Suggestion
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+## Additional context
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
-**Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for MDC iOS
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
GitHub launched support for [multiple issue and pull request templates](https://blog.github.com/2018-01-25-multiple-issue-and-pull-request-templates/) earlier this year. This PR adds a couple templates for issues.