### PR TITLE
[Snackbar] Allow Snackbars to have leading alignment on iPads

### DIFF
--- a/components/Snackbar/src/MDCSnackbarAlignment.h
+++ b/components/Snackbar/src/MDCSnackbarAlignment.h
@@ -1,0 +1,28 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/**
+ States used to configure snackbar alignment.
+ */
+typedef NS_ENUM(NSInteger, MDCSnackbarAlignment) {
+
+  // Snackbar is positioned in the center of the screen. This is the default setting
+  // and only permitted setting for iPhone.
+  MDCSnackbarAlignmentCenter = 0,
+
+  // Snackbar is positioned near the leading margin.
+  MDCSnackbarAlignmentLeading = 1,
+};

--- a/components/Snackbar/src/MDCSnackbarAlignment.h
+++ b/components/Snackbar/src/MDCSnackbarAlignment.h
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  States used to configure snackbar alignment.
  */

--- a/components/Snackbar/src/MDCSnackbarAlignment.h
+++ b/components/Snackbar/src/MDCSnackbarAlignment.h
@@ -17,12 +17,11 @@
 #import <Foundation/Foundation.h>
 
 /**
- States used to configure snackbar alignment.
+ States used to configure Snackbar alignment.
  */
 typedef NS_ENUM(NSInteger, MDCSnackbarAlignment) {
   /**
-   Snackbar is positioned in the center of the screen. This is the default setting
-   and only permitted setting for iPhone.
+   Snackbar is positioned in the center of the screen.
    */
   MDCSnackbarAlignmentCenter = 0,
 

--- a/components/Snackbar/src/MDCSnackbarAlignment.h
+++ b/components/Snackbar/src/MDCSnackbarAlignment.h
@@ -20,11 +20,14 @@
  States used to configure snackbar alignment.
  */
 typedef NS_ENUM(NSInteger, MDCSnackbarAlignment) {
-
-  // Snackbar is positioned in the center of the screen. This is the default setting
-  // and only permitted setting for iPhone.
+  /**
+   Snackbar is positioned in the center of the screen. This is the default setting
+   and only permitted setting for iPhone.
+   */
   MDCSnackbarAlignmentCenter = 0,
 
-  // Snackbar is positioned near the leading margin.
+  /**
+   Snackbar is positioned near the leading margin.
+   */
   MDCSnackbarAlignmentLeading = 1,
 };

--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -44,7 +44,7 @@
 
  @note The setter must be called from the main thread.
  */
-@property (class, nonatomic) MDCSnackbarAlignment alignment;
+@property (class, nonatomic, assign) MDCSnackbarAlignment alignment;
 
 /**
  Shows @c message to the user, in a style consistent with the data contained in @c message.

--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -79,13 +79,11 @@
 + (void)setBottomOffset:(CGFloat)offset;
 
 /**
- Determines whether the snackbar is presented in the center of the of the screen or (on iPad only)
- from the leading edge of the screen.
+ Determines the snackbar alignment to the screen.
 
  If called within an animation block, the change will be animated.
 
  @note This method must be called from the main thread.
- @warning On non-iPad devices this setter will be a no-op.
  */
 + (void)setAlignment:(MDCSnackbarAlignment)alignment;
 

--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -15,6 +15,7 @@
  */
 
 #import <UIKit/UIKit.h>
+#import "MDCSnackbarAlignment.h"
 
 @class MDCSnackbarMessage;
 @protocol MDCSnackbarSuspensionToken;
@@ -76,6 +77,17 @@
  move and should not be obscured.
  */
 + (void)setBottomOffset:(CGFloat)offset;
+
+/**
+ Determines whether the snackbar is presented in the center of the of the screen or (on iPad only)
+ from the leading edge of the screen.
+
+ If called within an animation block, the change will be animated.
+
+ @note This method must be called from the main thread.
+ @warning On non-iPad devices this setter will be a no-op.
+ */
++ (void)setAlignment:(MDCSnackbarAlignment)alignment;
 
 #pragma mark Suspending
 

--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -34,6 +34,19 @@
 @interface MDCSnackbarManager : NSObject
 
 /**
+ Determines the Snackbar alignment to the screen.
+
+ If called within an animation block, the change will be animated.
+
+ @note This setting is only used when both the horizontal and vertical size classes of the presenting
+ window are @c UIUserInterfaceSizeClassRegular. Otherwise @c MDCSnackbarAlignmentCenter
+ will be used.
+
+ @note The setter must be called from the main thread.
+ */
+@property (class, nonatomic) MDCSnackbarAlignment alignment;
+
+/**
  Shows @c message to the user, in a style consistent with the data contained in @c message.
 
  For messages with the same category, the firing of completion blocks has a guaranteed FIFO
@@ -45,7 +58,7 @@
 /**
  MDCSnackbarManager will display the messages in this view.
 
- Call this method to choose where in the view hierarchy snackbar messages will be presented. It is
+ Call this method to choose where in the view hierarchy Snackbar messages will be presented. It is
  only necessary to provide a host view if the default behavior is unable to find one on it's own,
  most commonly when using MDCSnackbarManager inside an application extension. By default, if you use
  MDCSnackbarManager without calling @c setPresentationHostView, the manager will attempt to find a
@@ -77,15 +90,6 @@
  move and should not be obscured.
  */
 + (void)setBottomOffset:(CGFloat)offset;
-
-/**
- Determines the snackbar alignment to the screen.
-
- If called within an animation block, the change will be animated.
-
- @note This method must be called from the main thread.
- */
-+ (void)setAlignment:(MDCSnackbarAlignment)alignment;
 
 #pragma mark Suspending
 
@@ -126,34 +130,34 @@
 #pragma mark Styling
 
 /**
- The color for the background of the snackbar message view.
+ The color for the background of the Snackbar message view.
  */
 @property(class, nonatomic, strong, nullable) UIColor *snackbarMessageViewBackgroundColor;
 
 /**
- The color for the shadow color for the snackbar message view.
+ The color for the shadow color for the Snackbar message view.
  */
 @property(class, nonatomic, strong, nullable) UIColor *snackbarMessageViewShadowColor;
 
 /**
- The color for the message text in the snackbar message view.
+ The color for the message text in the Snackbar message view.
  */
 @property(class, nonatomic, strong, nullable) UIColor *messageTextColor;
 
 /**
- The font for the message text in the snackbar message view.
+ The font for the message text in the Snackbar message view.
  */
 @property(class, nonatomic, strong, nullable) UIFont *messageFont;
 
 /**
- The font for the button text in the snackbar message view.
+ The font for the button text in the Snackbar message view.
  */
 @property(class, nonatomic, strong, nullable) UIFont *buttonFont;
 
 
 /**
  If enabled, modifications of class styling properties will be applied immediately
- to the currently presented snackbar.
+ to the currently presented Snackbar.
 
  Default is set to NO.
  */
@@ -176,7 +180,7 @@
 + (void)setButtonTitleColor:(nullable UIColor *)titleColor forState:(UIControlState)state;
 
 /**
- Indicates whether the snackbar should automatically update its font when the device’s
+ Indicates whether the Snackbar should automatically update its font when the device’s
  UIContentSizeCategory is changed.
 
  This property is modeled after the adjustsFontForContentSizeCategory property in the
@@ -193,7 +197,7 @@
 @end
 
 /**
- A suspension token is returned when messages are suspended by the snackbar manager.
+ A suspension token is returned when messages are suspended by the Snackbar manager.
 
  Messages are suppressed while a suspension token is kept in memory. Messages will resume being
  displayed when the suspension token is released or when the suspension token is passed to

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -534,6 +534,13 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
   manager.overlayView.bottomOffset = offset;
 }
 
++ (void)setAlignment:(MDCSnackbarAlignment)alignment {
+  NSAssert([NSThread isMainThread], @"setAlignment must be called on main thread.");
+
+  MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
+  manager.overlayView.alignment = alignment;
+}
+
 #pragma mark - Suspension
 
 + (id<MDCSnackbarSuspensionToken>)suspendMessagesWithCategory:(NSString *)category {

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -42,7 +42,7 @@ static BOOL UIViewHasFocusedAccessibilityElement(UIView *view) {
 static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
 
 /**
- The 'actual' snackbar manager which will take care of showing/hiding snackbar messages.
+ The 'actual' Snackbar manager which will take care of showing/hiding Snackbar messages.
  */
 @interface MDCSnackbarManagerInternal : NSObject
 
@@ -60,7 +60,7 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
 @property(nonatomic) NSMutableDictionary<NSString *, NSMutableSet<NSUUID *> *> *suspensionTokens;
 
 /**
- The view which will host our snackbar messages.
+ The view which will host our Snackbar messages.
  */
 @property(nonatomic) MDCSnackbarOverlayView *overlayView;
 
@@ -70,7 +70,7 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
 @property(nonatomic) UIView *presentationHostView;
 
 /**
- The currently-showing snackbar.
+ The currently-showing Snackbar.
  */
 @property(nonatomic) MDCSnackbarMessageView *currentSnackbar;
 
@@ -130,7 +130,7 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
 #pragma mark - Message Displaying
 
 /**
- Determines whether or not a message is eligible to be shown based on the snackbar manager's current
+ Determines whether or not a message is eligible to be shown based on the Snackbar manager's current
  configuration.
 
  @note This method should ensure that messages in the same category are not shown out of order.
@@ -208,9 +208,9 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
   __block BOOL shouldDismiss = YES;
   MDCSnackbarMessageDismissHandler dismissHandler =
       ^(BOOL userInitiated, MDCSnackbarMessageAction *action) {
-        // Because we start a timer to dismiss the snackbar once it is on screen, there exists the
-        // potential to try and dismiss the snackbar view multiple times, say if the user taps on
-        // the snackbar (dismissal one) and then the timer fires (dismissal two). This check ensures
+        // Because we start a timer to dismiss the Snackbar once it is on screen, there exists the
+        // potential to try and dismiss the Snackbar view multiple times, say if the user taps on
+        // the Snackbar (dismissal one) and then the timer fires (dismissal two). This check ensures
         // that the dismissal logic will only fire one time for a given Snackbar view.
         if (shouldDismiss) {
           shouldDismiss = NO;
@@ -252,7 +252,7 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
                   BOOL hasVoiceOverFocus = UIAccessibilityIsVoiceOverRunning() &&
                                            UIViewHasFocusedAccessibilityElement(strongSnackbarView);
                   if (strongSnackbarView && !hasVoiceOverFocus) {
-                    // Mimic the user tapping on the snackbar.
+                    // Mimic the user tapping on the Snackbar.
                     [strongSnackbarView dismissWithAction:nil userInitiated:NO];
                   }
                 });
@@ -266,7 +266,7 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
   // Ensure that this method is called on the main thread.
   NSAssert([NSThread isMainThread], @"Method is not called on main thread.");
 
-  // Mark the snackbar as being in the process of dismissal.
+  // Mark the Snackbar as being in the process of dismissal.
   snackbarView.dismissing = YES;
 
   MDCSnackbarMessage *message = snackbarView.message;
@@ -284,7 +284,7 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
                                        [self deactivateOverlay:self.overlayView];
 
                                        // If VoiceOver had been enabled and the snackbarView was
-                                       // transient, the snackbar was just announced (layout was not
+                                       // transient, the Snackbar was just announced (layout was not
                                        // reported as changed) so there is no need to post a layout
                                        // change here.
                                        if (![self isSnackbarTransient:snackbarView]) {
@@ -294,7 +294,7 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
 
                                        self.currentSnackbar = nil;
 
-                                       // Now that the snackbar view is offscreen, we can allow more
+                                       // Now that the snackbarView is offscreen, we can allow more
                                        // messages to be shown.
                                        self.showingMessage = NO;
                                        [self showNextMessageIfNecessaryMainThread];
@@ -399,7 +399,7 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
   // Ensure that this method is called on the main thread.
   NSAssert([NSThread isMainThread], @"Method is not called on main thread.");
 
-  // Make sure that if there is a snackbar on screen, it does not belong to the current category.
+  // Make sure that if there is a Snackbar on screen, it does not belong to the current category.
   if (self.currentSnackbar != nil && !self.currentSnackbar.dismissing) {
     MDCSnackbarMessage *currentMessage = self.currentSnackbar.message;
 
@@ -412,7 +412,7 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
     }
   }
 
-  // Now that we've ensured that the currently showing snackbar has been taken care of, we can go
+  // Now that we've ensured that the currently showing Snackbar has been taken care of, we can go
   // through pending messages and fire off their completion blocks as we remove them from the
   // queue.
   NSMutableIndexSet *indexesToRemove = [NSMutableIndexSet indexSet];
@@ -424,7 +424,7 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
           // Mark the message for removal from the pending messages list.
           [indexesToRemove addIndex:idx];
 
-          // Notify the outside world that this snackbar has been completed.
+          // Notify the outside world that this Snackbar has been completed.
           [pendingMessage executeCompletionHandlerWithUserInteraction:NO completion:nil];
         }
       }];
@@ -539,6 +539,11 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
 
   MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
   manager.overlayView.alignment = alignment;
+}
+
++ (MDCSnackbarAlignment)alignment {
+  MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
+  return manager.overlayView.alignment;
 }
 
 #pragma mark - Suspension

--- a/components/Snackbar/src/MDCSnackbarMessage.h
+++ b/components/Snackbar/src/MDCSnackbarMessage.h
@@ -24,7 +24,7 @@
 typedef void (^MDCSnackbarMessageCompletionHandler)(BOOL userInitiated);
 
 /**
- Called when the button in the snackbar is tapped.
+ Called when the button in the Snackbar is tapped.
  */
 typedef void (^MDCSnackbarMessageActionHandler)(void);
 
@@ -47,7 +47,7 @@ extern NSString * __nonnull const MDCSnackbarMessageBoldAttributeName;
 /**
  Represents a message to unobtrusively show to the user.
 
- A snackbar message provides brief feedback about an operation. Messages are passed to the snackbar
+ A Snackbar message provides brief feedback about an operation. Messages are passed to the Snackbar
  manager to be displayed.
 
  Snackbars prefer an application's main window is a subclass of @c MDCOverlayWindow. When a standard
@@ -72,7 +72,7 @@ extern NSString * __nonnull const MDCSnackbarMessageBoldAttributeName;
 + (nonnull instancetype)messageWithAttributedText:(nonnull NSAttributedString *)attributedText;
 
 /**
- Use the older legacy version of snackbar. Default is YES.
+ Use the older legacy version of Snackbar. Default is YES.
  */
 @property(class, nonatomic, assign) BOOL usesLegacySnackbar;
 
@@ -87,20 +87,20 @@ extern NSString * __nonnull const MDCSnackbarMessageBoldAttributeName;
  The primary text of the message with styling.
 
  Any attributes supported by UIKit may be set, though font and color will be overridden by the
- snackbar. Either @c text or @c attributedText must be set.
+ Snackbar. Either @c text or @c attributedText must be set.
  */
 @property(nonatomic, copy, nullable) NSAttributedString *attributedText;
 
 /**
  Optional button to show along with the rest of the message.
 
- A MDCSnackbarMessageAction is displayed as a button on the snackbar. If no action is set no button
+ A MDCSnackbarMessageAction is displayed as a button on the Snackbar. If no action is set no button
  will appear on the Snackbar.
  */
 @property(nonatomic, strong, nullable) MDCSnackbarMessageAction *action;
 
 /**
-  The color used for button text on the snackbar in normal state.
+  The color used for button text on the Snackbar in normal state.
 
   Default is nil, but MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f) will be set as the default color
   and is taken from MDCSnackbarMessageView's buttonTitleColorForState:
@@ -129,7 +129,7 @@ extern NSString * __nonnull const MDCSnackbarMessageBoldAttributeName;
 
  Default is nil. If set, only the last message of this category will be shown, any currently
  showing or pending messages in this category will be dismissed as if the user had directly tapped
- the snackbar.
+ the Snackbar.
  */
 @property(nonatomic, copy, nullable) NSString *category;
 
@@ -156,7 +156,7 @@ extern NSString * __nonnull const MDCSnackbarMessageBoldAttributeName;
 @property(nonatomic, copy, nullable) NSString *title;
 
 /**
- Called when the button in the snackbar is tapped.
+ Called when the button in the Snackbar is tapped.
 
  Always called on the main thread.
  */

--- a/components/Snackbar/src/MDCSnackbarMessageView.h
+++ b/components/Snackbar/src/MDCSnackbarMessageView.h
@@ -15,6 +15,7 @@
  */
 
 #import <UIKit/UIKit.h>
+#import "MDCSnackbarAlignment.h"
 
 /**
  Class which provides the default implementation of a snackbar.

--- a/components/Snackbar/src/MDCSnackbarMessageView.h
+++ b/components/Snackbar/src/MDCSnackbarMessageView.h
@@ -15,7 +15,6 @@
  */
 
 #import <UIKit/UIKit.h>
-#import "MDCSnackbarAlignment.h"
 
 /**
  Class which provides the default implementation of a snackbar.

--- a/components/Snackbar/src/MDCSnackbarMessageView.h
+++ b/components/Snackbar/src/MDCSnackbarMessageView.h
@@ -17,12 +17,12 @@
 #import <UIKit/UIKit.h>
 
 /**
- Class which provides the default implementation of a snackbar.
+ Class which provides the default implementation of a Snackbar.
  */
 @interface MDCSnackbarMessageView : UIView
 
 /**
- The color for the background of the snackbar message view.
+ The color for the background of the Snackbar message view.
 
  The default color is a dark gray color.
  */
@@ -30,7 +30,7 @@
     UIColor *snackbarMessageViewBackgroundColor UI_APPEARANCE_SELECTOR;
 
 /**
- The color for the shadow color for the snackbar message view.
+ The color for the shadow color for the Snackbar message view.
 
  The default color is @c blackColor.
  */
@@ -38,19 +38,19 @@
     UIColor *snackbarMessageViewShadowColor UI_APPEARANCE_SELECTOR;
 
 /**
- The color for the message text in the snackbar message view.
+ The color for the message text in the Snackbar message view.
 
  The default color is @c whiteColor.
  */
 @property(nonatomic, strong, nullable) UIColor *messageTextColor UI_APPEARANCE_SELECTOR;
 
 /**
- The font for the message text in the snackbar message view.
+ The font for the message text in the Snackbar message view.
  */
 @property(nonatomic, strong, nullable) UIFont *messageFont UI_APPEARANCE_SELECTOR;
 
 /**
- The font for the button text in the snackbar message view.
+ The font for the button text in the Snackbar message view.
  */
 @property(nonatomic, strong, nullable) UIFont *buttonFont UI_APPEARANCE_SELECTOR;
 
@@ -76,7 +76,7 @@ UI_APPEARANCE_SELECTOR;
 
 
 /**
- Indicates whether the snackbar should automatically update its font when the device’s
+ Indicates whether the Snackbar should automatically update its font when the device’s
  UIContentSizeCategory is changed.
 
  This property is modeled after the adjustsFontForContentSizeCategory property in the

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -924,23 +924,6 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
   return constraints;
 }
 
-- (void)activateConstraintsForAlignment:(MDCSnackbarAlignment)alignment {
-  switch (alignment) {
-    case MDCSnackbarAlignmentCenter:
-      self.leadingConstraint.active = NO;
-      self.centerConstraint.active = YES;
-      break;
-    case MDCSnackbarAlignmentLeading:
-      self.leadingConstraint.active = YES;
-      self.centerConstraint.active = NO;
-      break;
-    default:
-      self.leadingConstraint.active = NO;
-      self.centerConstraint.active = YES;
-      break;
-  }
-}
-
 - (void)layoutSubviews {
   [super layoutSubviews];
 

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -39,7 +39,7 @@ static inline UIColor *MDCRGBAColor(uint8_t r, uint8_t g, uint8_t b, float a) {
 }
 
 /**
- The thickness of the snackbar border.
+ The thickness of the Snackbar border.
  */
 static const CGFloat kBorderWidth = 0;
 
@@ -61,7 +61,7 @@ static const CGFloat kCornerRadius = 4;
 static const CGFloat kLegacyCornerRadius = 0;
 
 /**
- Padding between the edges of the snackbar and any content.
+ Padding between the edges of the Snackbar and any content.
  */
 static UIEdgeInsets kContentMargin = (UIEdgeInsets){16.0, 16.0, 16.0, 8.0};
 static UIEdgeInsets kLegacyContentMargin = (UIEdgeInsets){18.0, 24.0, 18.0, 24.0};
@@ -84,12 +84,12 @@ static const CGFloat kButtonPadding = 8.0f;
 
 
 /**
- Minimum padding for the vertical padding of the buttons to the snackbar
+ Minimum padding for the vertical padding of the buttons to the Snackbar
  */
 static const CGFloat kMinVerticalButtonPadding = 6.0f;
 
 /**
- The width of the snackbar.
+ The width of the Snackbar.
  */
 static const CGFloat kMinimumViewWidth_iPad = 288.0f;
 static const CGFloat kMaximumViewWidth_iPad = 568.0f;
@@ -97,7 +97,7 @@ static const CGFloat kMinimumViewWidth_iPhone = 320.0f;
 static const CGFloat kMaximumViewWidth_iPhone = 320.0f;
 
 /**
- The minimum height of the snackbar.
+ The minimum height of the Snackbar.
  */
 static const CGFloat kMinimumHeight = 48.0f;
 
@@ -157,7 +157,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
 @property(nonatomic, strong) UIView *contentView;
 
 /**
- Holds onto the dismissal handler, called when the snackbar should dismiss due to user interaction.
+ Holds onto the dismissal handler, called when the Snackbar should dismiss due to user interaction.
  */
 @property(nonatomic, copy) MDCSnackbarMessageDismissHandler dismissalHandler;
 
@@ -329,7 +329,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
                                            [[self class] bundle],
                                            @"Dismissal accessibility hint for Snackbar");
 
-    // For VoiceOver purposes, the label is the primary 'button' for dismissing the snackbar, so
+    // For VoiceOver purposes, the label is the primary 'button' for dismissing the Snackbar, so
     // we'll make sure the label looks like a button.
     _label.accessibilityTraits = UIAccessibilityTraitButton;
     _label.accessibilityIdentifier = MDCSnackbarMessageTitleAutomationIdentifier;
@@ -664,7 +664,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
 }
 
 /**
- Provides constraints to pin the container view to the size of the snackbar, inset by
+ Provides constraints to pin the container view to the size of the Snackbar, inset by
  @c kBorderWidth. Also positions the content view and button view inside of the container view.
  */
 - (NSArray *)containerViewConstraints {
@@ -690,14 +690,14 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
   NSString *formatString = nil;  // Scratch variable.
   NSMutableArray *constraints = [NSMutableArray array];
 
-  // Pin the left and right edges of the container view to the snackbar.
+  // Pin the left and right edges of the container view to the Snackbar.
   formatString = @"H:|-(==kBorderMargin)-[container]-(==kBorderMargin)-|";
   [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:formatString
                                                                            options:0
                                                                            metrics:metrics
                                                                              views:views]];
 
-  // Pin the top and bottom edges of the container view to the snackbar.
+  // Pin the top and bottom edges of the container view to the Snackbar.
   formatString = @"V:|-(==kBorderMargin)-[container]-(==kContentSafeBottomInset)-|";
   [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:formatString
                                                                            options:0
@@ -874,7 +874,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
       views[@"previousButton"] = previousButton;
     }
 
-    // In a horizontal layout, the button takes on the height of the snackbar.
+    // In a horizontal layout, the button takes on the height of the Snackbar.
     [constraints
         addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[buttonContainer]|"
                                                                     options:0
@@ -935,7 +935,8 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
       self.centerConstraint.active = NO;
       break;
     default:
-      NSAssert(NO, @"`alignment` should be a valid MDCSnackbarAlignment value");
+      self.leadingConstraint.active = NO;
+      self.centerConstraint.active = YES;
       break;
   }
 }
@@ -969,7 +970,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
 }
 
 - (CGFloat)contentSafeBottomInset {
-  // If a bottom offset has been set to raise the HUD, e.g. above a tab bar, we should ignore
+  // If a bottom offset has been set to raise the HUD/Snackbar, e.g. above a tab bar, we should ignore
   // any safeAreaInsets, since it is no longer 'anchored' to the bottom of the screen. This is set
   // by the MDCSnackbarOverlayView whenever the bottomOffset is non-zero.
   if (!self.anchoredToScreenBottom || !MDCSnackbarMessage.usesLegacySnackbar) {

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -238,7 +238,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
       self.layer.shadowRadius = kShadowSpread;
     }
 
-    _anchoredToScreenEdge = YES;
+    _anchoredToScreenBottom = YES;
 
     // Borders are drawn inside of the bounds of a layer. Because our border is translucent, we need
     // to have a view with transparent background and border only (@c self). Inside will be a
@@ -635,8 +635,8 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
 
 #pragma mark - Constraints and layout
 
-- (void)setAnchoredToScreenEdge:(BOOL)anchoredToScreenEdge {
-  _anchoredToScreenEdge = anchoredToScreenEdge;
+- (void)setAnchoredToScreenBottom:(BOOL)anchoredToScreenBottom {
+  _anchoredToScreenBottom = anchoredToScreenBottom;
   [self invalidateIntrinsicContentSize];
 
   if (self.viewConstraints) {
@@ -924,6 +924,22 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
   return constraints;
 }
 
+- (void)activateConstraintsForAlignment:(MDCSnackbarAlignment)alignment {
+  switch (alignment) {
+    case MDCSnackbarAlignmentCenter:
+      self.leadingConstraint.active = NO;
+      self.centerConstraint.active = YES;
+      break;
+    case MDCSnackbarAlignmentLeading:
+      self.leadingConstraint.active = YES;
+      self.centerConstraint.active = NO;
+      break;
+    default:
+      NSAssert(NO, @"`alignment` should be a valid MDCSnackbarAlignment value");
+      break;
+  }
+}
+
 - (void)layoutSubviews {
   [super layoutSubviews];
 
@@ -956,7 +972,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
   // If a bottom offset has been set to raise the HUD, e.g. above a tab bar, we should ignore
   // any safeAreaInsets, since it is no longer 'anchored' to the bottom of the screen. This is set
   // by the MDCSnackbarOverlayView whenever the bottomOffset is non-zero.
-  if (!self.anchoredToScreenEdge || !MDCSnackbarMessage.usesLegacySnackbar) {
+  if (!self.anchoredToScreenBottom || !MDCSnackbarMessage.usesLegacySnackbar) {
     return 0;
   }
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)

--- a/components/Snackbar/src/MaterialSnackbar.h
+++ b/components/Snackbar/src/MaterialSnackbar.h
@@ -14,6 +14,7 @@
  limitations under the License.
  */
 
+#import "MDCSnackbarAlignment.h"
 #import "MDCSnackbarManager.h"
 #import "MDCSnackbarMessage.h"
 #import "MDCSnackbarMessageView.h"

--- a/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
+++ b/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
@@ -53,7 +53,19 @@ typedef void (^MDCSnackbarMessageDismissHandler)(BOOL userInitiated,
 /**
  If the snackbar view should be anchored to the bottom of the screen. Default is YES.
  */
-@property(nonatomic) BOOL anchoredToScreenEdge;
+@property(nonatomic) BOOL anchoredToScreenBottom;
+
+/**
+ The layout constraint which determines how far the snackbar is from the leading edge of the screen.
+ It is active when the alignment of the parent overlay view is MDCAlignmentLeading.
+ */
+@property(nonatomic) NSLayoutConstraint *leadingConstraint;
+
+/**
+ The layout constraint used to center the snackbar.
+ It is active when the alignment of the parent overlay view is MDCAlignmentCenter.
+ */
+@property(nonatomic) NSLayoutConstraint *centerConstraint;
 
 /**
  Creates a snackbar view to display @c message.
@@ -114,5 +126,14 @@ typedef void (^MDCSnackbarMessageDismissHandler)(BOOL userInitiated,
  */
 - (CABasicAnimation *_Nullable)animateSnackbarScaleFrom:(CGFloat)fromScale
                                                 toScale:(CGFloat)toScale;
+
+/**
+ Activate the appropriate constraints for the given alignment.
+ If the alignment is leading, the leading constraint is activated and the center constraint is deactivated.
+ If the alignment is center, the center constraint is activated and the leading constraint is deactivated.
+
+ @param alignment the alignment.
+ */
+- (void)activateConstraintsForAlignment:(MDCSnackbarAlignment)alignment;
 
 @end

--- a/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
+++ b/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
@@ -56,18 +56,6 @@ typedef void (^MDCSnackbarMessageDismissHandler)(BOOL userInitiated,
 @property(nonatomic) BOOL anchoredToScreenBottom;
 
 /**
- The layout constraint which determines how far the Snackbar is from the leading edge of the screen.
- It is active when the alignment of the parent overlay view is MDCSnackbarAlignmentLeading.
- */
-@property(nonatomic, nullable) NSLayoutConstraint *leadingConstraint;
-
-/**
- The layout constraint used to center the Snackbar.
- It is active when the alignment of the parent overlay view is MDCSnackbarAlignmentCenter.
- */
-@property(nonatomic, nullable) NSLayoutConstraint *centerConstraint;
-
-/**
  Creates a Snackbar view to display @c message.
 
  The view will call @c handler when the user has interacted with the Snackbar view in such a way
@@ -126,14 +114,5 @@ typedef void (^MDCSnackbarMessageDismissHandler)(BOOL userInitiated,
  */
 - (CABasicAnimation *_Nullable)animateSnackbarScaleFrom:(CGFloat)fromScale
                                                 toScale:(CGFloat)toScale;
-
-/**
- Activate the appropriate constraints for the given alignment.
- If the alignment is leading, the leading constraint is activated and the center constraint is deactivated.
- If the alignment is center, the center constraint is activated and the leading constraint is deactivated.
-
- @param alignment the alignment.
- */
-- (void)activateConstraintsForAlignment:(MDCSnackbarAlignment)alignment;
 
 @end

--- a/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
+++ b/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
@@ -59,13 +59,13 @@ typedef void (^MDCSnackbarMessageDismissHandler)(BOOL userInitiated,
  The layout constraint which determines how far the snackbar is from the leading edge of the screen.
  It is active when the alignment of the parent overlay view is MDCAlignmentLeading.
  */
-@property(nonatomic) NSLayoutConstraint *leadingConstraint;
+@property(nonatomic, nullable) NSLayoutConstraint *leadingConstraint;
 
 /**
  The layout constraint used to center the snackbar.
  It is active when the alignment of the parent overlay view is MDCAlignmentCenter.
  */
-@property(nonatomic) NSLayoutConstraint *centerConstraint;
+@property(nonatomic, nullable) NSLayoutConstraint *centerConstraint;
 
 /**
  Creates a snackbar view to display @c message.

--- a/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
+++ b/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
@@ -20,7 +20,7 @@
 @class MDCSnackbarMessageAction;
 
 /**
- Called by the snackbar message view when the user interacts with the snackbar view.
+ Called by the Snackbar message view when the user interacts with the Snackbar view.
 
  @c userInitiated indicates whether or not the handler is being called due to direct user
  interaction. @c action, if non-nil, indicates that the user chose to execute a specific action.
@@ -31,17 +31,17 @@ typedef void (^MDCSnackbarMessageDismissHandler)(BOOL userInitiated,
 @interface MDCSnackbarMessageView ()
 
 /**
- If the user has tapped on the snackbar or if @c dismissWithAction:userInitiated: has been called.
+ If the user has tapped on the Snackbar or if @c dismissWithAction:userInitiated: has been called.
  */
 @property(nonatomic, getter=isDismissing) BOOL dismissing;
 
 /**
- The minimum width of the snackbar.
+ The minimum width of the Snackbar.
  */
 @property(nonatomic, readonly) CGFloat minimumWidth;
 
 /**
- The maximum width of the snackbar.
+ The maximum width of the Snackbar.
  */
 @property(nonatomic, readonly) CGFloat maximumWidth;
 
@@ -51,26 +51,26 @@ typedef void (^MDCSnackbarMessageDismissHandler)(BOOL userInitiated,
 @property(nonatomic, nullable, readonly, strong) MDCSnackbarMessage *message;
 
 /**
- If the snackbar view should be anchored to the bottom of the screen. Default is YES.
+ If the Snackbar view should be anchored to the bottom of the screen. Default is YES.
  */
 @property(nonatomic) BOOL anchoredToScreenBottom;
 
 /**
- The layout constraint which determines how far the snackbar is from the leading edge of the screen.
- It is active when the alignment of the parent overlay view is MDCAlignmentLeading.
+ The layout constraint which determines how far the Snackbar is from the leading edge of the screen.
+ It is active when the alignment of the parent overlay view is MDCSnackbarAlignmentLeading.
  */
 @property(nonatomic, nullable) NSLayoutConstraint *leadingConstraint;
 
 /**
- The layout constraint used to center the snackbar.
- It is active when the alignment of the parent overlay view is MDCAlignmentCenter.
+ The layout constraint used to center the Snackbar.
+ It is active when the alignment of the parent overlay view is MDCSnackbarAlignmentCenter.
  */
 @property(nonatomic, nullable) NSLayoutConstraint *centerConstraint;
 
 /**
- Creates a snackbar view to display @c message.
+ Creates a Snackbar view to display @c message.
 
- The view will call @c handler when the user has interacted with the snackbar view in such a way
+ The view will call @c handler when the user has interacted with the Snackbar view in such a way
  that it needs to be dismissed prior to its timer-based dismissal time.
  */
 - (_Nonnull instancetype)initWithMessage:(MDCSnackbarMessage *_Nullable)message
@@ -107,7 +107,7 @@ typedef void (^MDCSnackbarMessageDismissHandler)(BOOL userInitiated,
 
 
 /**
- Animate the opacity of the snackbar view.
+ Animate the opacity of the Snackbar view.
 
  @param fromOpacity initial opacity to start animation.
  @param toOpacity opacity to finish animation.
@@ -118,7 +118,7 @@ typedef void (^MDCSnackbarMessageDismissHandler)(BOOL userInitiated,
 
 
 /**
- Animate the scale of the snackbar view.
+ Animate the scale of the Snackbar view.
 
  @param fromScale initial scale to start animation.
  @param toScale scale to finish animation.

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.h
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.h
@@ -19,14 +19,14 @@
 
 @class MDCSnackbarMessageView;
 
-/** The identifier reported for the snackbar. */
+/** The identifier reported for the Snackbar. */
 OBJC_EXTERN NSString *const MDCSnackbarOverlayIdentifier;
 
-/** The time it takes to show or hide the snackbar. */
+/** The time it takes to show or hide the Snackbar. */
 OBJC_EXTERN NSTimeInterval const MDCSnackbarLegacyTransitionDuration;
 
 /**
- Custom overlay view for displaying snackbars.
+ Custom overlay view for displaying Snackbars.
  */
 @interface MDCSnackbarOverlayView : UIView
 
@@ -38,9 +38,9 @@ OBJC_EXTERN NSTimeInterval const MDCSnackbarLegacyTransitionDuration;
 - (instancetype)initWithFrame:(CGRect)frame;
 
 /**
- Shows the snackbar view with the most appropriate animation.
+ Shows the Snackbar view with the most appropriate animation.
 
- @param snackbarView The snackbar view to display.
+ @param snackbarView The Snackbar view to display.
  @param animated Whether or not the show should be animated.
  @param completion A block to execute when the presentation is finished.
  */
@@ -49,7 +49,7 @@ OBJC_EXTERN NSTimeInterval const MDCSnackbarLegacyTransitionDuration;
               completion:(void (^)(void))completion;
 
 /**
- Dismisses the currently showing snackbar view.
+ Dismisses the currently showing Snackbar view.
 
  @param animated Whether or not the dismiss should be animated.
  @param completion A block to execute when the dismissal is finished.
@@ -57,14 +57,14 @@ OBJC_EXTERN NSTimeInterval const MDCSnackbarLegacyTransitionDuration;
 - (void)dismissSnackbarViewAnimated:(BOOL)animated completion:(void (^)(void))completion;
 
 /**
- How far from the bottom of the screen should snackbars be presented.
+ How far from the bottom of the screen should Snackbars be presented.
 
  If set inside of an animation block, the change will animate.
  */
 @property(nonatomic) CGFloat bottomOffset;
 
 /**
- Determines whether the snackbar is presented in the center of the of the screen or (on iPad only)
+ Determines whether the Snackbar is presented in the center of the of the screen or (on iPad only)
  the leading edge of the screen.
 
  If called within an animation block, the change will be animated.

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.h
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.h
@@ -70,7 +70,6 @@ OBJC_EXTERN NSTimeInterval const MDCSnackbarLegacyTransitionDuration;
  If called within an animation block, the change will be animated.
 
  @note This method must be called from the main thread.
- @warning On non-iPad devices this setter will be a no-op.
 */
 @property(nonatomic) MDCSnackbarAlignment alignment;
 

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.h
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.h
@@ -15,6 +15,7 @@
  */
 
 #import <UIKit/UIKit.h>
+#import "MDCSnackbarAlignment.h"
 
 @class MDCSnackbarMessageView;
 
@@ -61,5 +62,16 @@ OBJC_EXTERN NSTimeInterval const MDCSnackbarLegacyTransitionDuration;
  If set inside of an animation block, the change will animate.
  */
 @property(nonatomic) CGFloat bottomOffset;
+
+/**
+ Determines whether the snackbar is presented in the center of the of the screen or (on iPad only)
+ the leading edge of the screen.
+
+ If called within an animation block, the change will be animated.
+
+ @note This method must be called from the main thread.
+ @warning On non-iPad devices this setter will be a no-op.
+*/
+@property(nonatomic) MDCSnackbarAlignment alignment;
 
 @end

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -14,9 +14,11 @@
  limitations under the License.
  */
 
+#import "MDCSnackbarOverlayView.h"
+
 #import <Foundation/Foundation.h>
 
-#import "MDCSnackbarOverlayView.h"
+#import <MDFInternationalization/MDFInternationalization.h>
 
 #import "../MDCSnackbarMessage.h"
 #import "MDCSnackbarMessageViewInternal.h"
@@ -27,26 +29,26 @@
 
 NSString *const MDCSnackbarOverlayIdentifier = @"MDCSnackbar";
 
-// The time it takes to show or hide the snackbar.
+// The time it takes to show or hide the Snackbar.
 NSTimeInterval const MDCSnackbarEnterTransitionDuration = 0.15f;
 NSTimeInterval const MDCSnackbarExitTransitionDuration = 0.075f;
 NSTimeInterval const MDCSnackbarLegacyTransitionDuration = 0.5f;
 
-// The scaling starting point for presenting the new snackbar.
+// The scaling starting point for presenting the new Snackbar.
 static const CGFloat MDCSnackbarEnterStartingScale = 0.8f;
 
-// How far from the bottom of the screen should the snackbar be.
+// How far from the bottom of the screen should the Snackbar be.
 static const CGFloat MDCSnackbarBottomMargin_iPhone = 8.f;
 static const CGFloat MDCSnackbarBottomMargin_iPad = 24.f;
 static const CGFloat MDCSnackbarLegacyBottomMargin_iPhone = 0.f;
 static const CGFloat MDCSnackbarLegacyBottomMargin_iPad = 0.f;
 
-// How far from the sides of the screen should the snackbar be.
-static const CGFloat MDCSnackbarSideMargin_iPhone = 8.f;
-static const CGFloat MDCSnackbarLegacySideMargin_iPhone = 0.f;
-static const CGFloat MDCSnackbarSideMargin_iPad = 24.0f;
+// How far from the sides of the screen should the Snackbar be.
+static const CGFloat MDCSnackbarSideMargin_CompactWidth = 8.f;
+static const CGFloat MDCSnackbarLegacySideMargin_CompactWidth = 0.f;
+static const CGFloat MDCSnackbarSideMargin_RegularWidth = 24.0f;
 
-// The maximum height of the snackbar.
+// The maximum height of the Snackbar.
 static const CGFloat kMaximumHeight = 80.0f;
 
 #if defined(__IPHONE_10_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0)
@@ -57,7 +59,7 @@ static const CGFloat kMaximumHeight = 80.0f;
 @interface MDCSnackbarOverlayView ()
 
 /**
- The snackbar view to show. Setting this property simply puts the snackbar view into the window
+ The Snackbar view to show. Setting this property simply puts the Snackbar view into the window
  hierarchy and installs constraints which will keep it pinned to the bottom of the screen.
  */
 @property(nonatomic) MDCSnackbarMessageView *snackbarView;
@@ -69,17 +71,17 @@ static const CGFloat kMaximumHeight = 80.0f;
 
 /**
  The layout constraint which determines the bottom of the containing view. Setting the constant
- to a negative value will cause snackbars to appear from a point above the bottom of the screen.
+ to a negative value will cause Snackbars to appear from a point above the bottom of the screen.
  */
 @property(nonatomic) NSLayoutConstraint *bottomConstraint;
 
 /**
- The layout constraint which determines the maximum height of the snackbar .
+ The layout constraint which determines the maximum height of the Snackbar .
  */
 @property(nonatomic) NSLayoutConstraint *maximumHeightConstraint;
 
 /**
- The view which actually houses the snackbar. This view is sized to be the same width and height as
+ The view which actually houses the Snackbar. This view is sized to be the same width and height as
  ourselves, except offset from the bottom, based on the keyboard height as well as any user-set
  content offsets.
  */
@@ -87,7 +89,7 @@ static const CGFloat kMaximumHeight = 80.0f;
 
 /**
  Whether or not we are triggering a layout change ourselves. This is to distinguish when our bounds
- are changing due to rotation rather than us adding/removing a snackbar.
+ are changing due to rotation rather than us adding/removing a Snackbar.
  */
 @property(nonatomic) BOOL manualLayoutChange;
 
@@ -97,12 +99,12 @@ static const CGFloat kMaximumHeight = 80.0f;
 @property(nonatomic) NSTimeInterval rotationDuration;
 
 /**
- The constraint used to pin the bottom of the snackbar to the bottom of the screen.
+ The constraint used to pin the bottom of the Snackbar to the bottom of the screen.
  */
 @property(nonatomic) NSLayoutConstraint *snackbarOnscreenConstraint;
 
 /**
- The constraint used to pin the top of the snackbar to the bottom of the screen.
+ The constraint used to pin the top of the Snackbar to the bottom of the screen.
  */
 @property(nonatomic) NSLayoutConstraint *snackbarOffscreenConstraint;
 
@@ -159,7 +161,7 @@ static const CGFloat kMaximumHeight = 80.0f;
  Installs constraints for the ever-present container view.
 
  @note These constraints remain installed for the life of the overlay view, whereas the
-       constraints installed in @c setsnackbarView: come and go with the current snackbar.
+       constraints installed in @c setSnackbarView: come and go with the current Snackbar.
  */
 - (void)setupContainerConstraints {
   [self addConstraint:[NSLayoutConstraint constraintWithItem:_containingView
@@ -232,11 +234,13 @@ static const CGFloat kMaximumHeight = 80.0f;
 
 - (CGFloat)sideMargin {
   if (MDCSnackbarMessage.usesLegacySnackbar) {
-    return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? MDCSnackbarSideMargin_iPad
-                                                                : MDCSnackbarLegacySideMargin_iPhone;
+    return self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular ?
+        MDCSnackbarSideMargin_RegularWidth :
+        MDCSnackbarLegacySideMargin_CompactWidth;
   }
-  return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? MDCSnackbarSideMargin_iPad
-                                                              : MDCSnackbarSideMargin_iPhone;
+  return self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular ?
+      MDCSnackbarSideMargin_RegularWidth :
+      MDCSnackbarSideMargin_CompactWidth;
 }
 
 - (void)setSnackbarView:(MDCSnackbarMessageView *)snackbarView {
@@ -254,64 +258,74 @@ static const CGFloat kMaximumHeight = 80.0f;
     if (snackbarView) {
       [container addSubview:snackbarView];
 
-      // Pin the snackbar to the bottom of the screen.
+      // Pin the Snackbar to the bottom of the screen.
       [snackbarView setTranslatesAutoresizingMaskIntoConstraints:NO];
 
-      BOOL isRegularWidth = self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular;
-      BOOL isRegularHeight = self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassRegular;
+      BOOL isRegularWidth =
+          self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular;
+      BOOL isRegularHeight =
+          self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassRegular;
       if (isRegularWidth && isRegularHeight) {
-        snackbarView.centerConstraint  = [NSLayoutConstraint constraintWithItem:snackbarView
-                                                                      attribute:NSLayoutAttributeCenterX
-                                                                      relatedBy:NSLayoutRelationEqual
-                                                                         toItem:container
-                                                                      attribute:NSLayoutAttributeCenterX
-                                                                     multiplier:1.0
-                                                                       constant:0];
+        snackbarView.centerConstraint =
+            [NSLayoutConstraint constraintWithItem:snackbarView
+                                         attribute:NSLayoutAttributeCenterX
+                                         relatedBy:NSLayoutRelationEqual
+                                            toItem:container
+                                         attribute:NSLayoutAttributeCenterX
+                                        multiplier:1.0
+                                          constant:0];
         snackbarView.centerConstraint.active = self.alignment == MDCSnackbarAlignmentCenter;
 
-        snackbarView.leadingConstraint  = [NSLayoutConstraint constraintWithItem:snackbarView
-                                                                       attribute:NSLayoutAttributeLeading
-                                                                       relatedBy:NSLayoutRelationEqual
-                                                                          toItem:container
-                                                                       attribute:NSLayoutAttributeLeading
-                                                                      multiplier:1.0
-                                                                        constant:sideMargin];
+        snackbarView.leadingConstraint =
+            [NSLayoutConstraint constraintWithItem:snackbarView
+                                         attribute:NSLayoutAttributeLeading
+                                         relatedBy:NSLayoutRelationEqual
+                                            toItem:container
+                                         attribute:NSLayoutAttributeLeading
+                                        multiplier:1.0
+                                          constant:sideMargin];
         snackbarView.leadingConstraint.active = self.alignment == MDCSnackbarAlignmentLeading;
 
         // If not full width, ensure that it doesn't get any larger than our own width.
         [container
-         addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
-                                                    attribute:NSLayoutAttributeWidth
-                                                    relatedBy:NSLayoutRelationLessThanOrEqual
-                                                       toItem:container
-                                                    attribute:NSLayoutAttributeWidth
-                                                   multiplier:1.0
-                                                     constant:-2 * sideMargin]];
+            addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
+                                                       attribute:NSLayoutAttributeWidth
+                                                       relatedBy:NSLayoutRelationLessThanOrEqual
+                                                          toItem:container
+                                                       attribute:NSLayoutAttributeWidth
+                                                      multiplier:1.0
+                                                        constant:-2 * sideMargin]];
 
         // Also ensure that it doesn't get any smaller than its own minimum width.
         [container
-         addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
-                                                    attribute:NSLayoutAttributeWidth
-                                                    relatedBy:NSLayoutRelationGreaterThanOrEqual
-                                                       toItem:nil
-                                                    attribute:NSLayoutAttributeNotAnAttribute
-                                                   multiplier:1.0
-                                                     constant:[snackbarView minimumWidth]]];
+            addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
+                                                       attribute:NSLayoutAttributeWidth
+                                                       relatedBy:NSLayoutRelationGreaterThanOrEqual
+                                                          toItem:nil
+                                                       attribute:NSLayoutAttributeNotAnAttribute
+                                                      multiplier:1.0
+                                                        constant:[snackbarView minimumWidth]]];
 
         // Also ensure that it doesn't get any larger than its own maximum width.
         [container
-         addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
-                                                    attribute:NSLayoutAttributeWidth
-                                                    relatedBy:NSLayoutRelationLessThanOrEqual
-                                                       toItem:nil
-                                                    attribute:NSLayoutAttributeNotAnAttribute
-                                                   multiplier:1.0
-                                                     constant:[snackbarView maximumWidth]]];
+            addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
+                                                       attribute:NSLayoutAttributeWidth
+                                                       relatedBy:NSLayoutRelationLessThanOrEqual
+                                                          toItem:nil
+                                                       attribute:NSLayoutAttributeNotAnAttribute
+                                                      multiplier:1.0
+                                                        constant:[snackbarView maximumWidth]]];
       } else {
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
         if (@available(iOS 11.0, *)) {
-          leftMargin += self.safeAreaInsets.left;
-          rightMargin += self.safeAreaInsets.right;
+          if (self.mdf_effectiveUserInterfaceLayoutDirection ==
+              UIUserInterfaceLayoutDirectionLeftToRight) {
+            leftMargin += self.mdc_safeAreaInsets.left;
+            rightMargin += self.mdc_safeAreaInsets.right;
+          } else {
+            leftMargin += self.mdc_safeAreaInsets.right;
+            rightMargin += self.mdc_safeAreaInsets.left;
+          }
         }
 #endif
 
@@ -346,18 +360,19 @@ static const CGFloat kMaximumHeight = 80.0f;
       [container addConstraint:_snackbarOnscreenConstraint];
 
       if (MDCSnackbarMessage.usesLegacySnackbar) {
-        _snackbarOffscreenConstraint = [NSLayoutConstraint constraintWithItem:snackbarView
-                                                                    attribute:NSLayoutAttributeTop
-                                                                    relatedBy:NSLayoutRelationEqual
-                                                                       toItem:container
-                                                                    attribute:NSLayoutAttributeBottom
-                                                                   multiplier:1.0
-                                                                     constant:-bottomMargin];
+        _snackbarOffscreenConstraint =
+            [NSLayoutConstraint constraintWithItem:snackbarView
+                                         attribute:NSLayoutAttributeTop
+                                         relatedBy:NSLayoutRelationEqual
+                                            toItem:container
+                                         attribute:NSLayoutAttributeBottom
+                                        multiplier:1.0
+                                          constant:-bottomMargin];
         _snackbarOffscreenConstraint.active = YES;
         [container addConstraint:_snackbarOffscreenConstraint];
       }
 
-      // Always limit the height of the snackbar.
+      // Always limit the height of the Snackbar.
       self.maximumHeightConstraint =
           [NSLayoutConstraint constraintWithItem:snackbarView
                                        attribute:NSLayoutAttributeHeight
@@ -372,8 +387,8 @@ static const CGFloat kMaximumHeight = 80.0f;
   }
 }
 
-// All we care about is whether or not we tapped on the snackbar view. Everything else should pass
-// through to other windows. Only ask the snackbar view if the given point belongs, and ignore all
+// All we care about is whether or not we tapped on the Snackbar view. Everything else should pass
+// through to other windows. Only ask the Snackbar view if the given point belongs, and ignore all
 // other touches.
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
   BOOL result = NO;
@@ -431,12 +446,23 @@ static const CGFloat kMaximumHeight = 80.0f;
   [self triggerSnackbarLayoutChange];
 }
 
+- (UIEdgeInsets)mdc_safeAreaInsets {
+  UIEdgeInsets insets = UIEdgeInsetsZero;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    // Accommodate insets for iPhone X.
+    insets = self.safeAreaInsets;
+  }
+#endif
+  return insets;
+}
+
 #pragma mark - Presentation/Dismissal
 
 - (void)showSnackbarView:(MDCSnackbarMessageView *)snackbarView
                 animated:(BOOL)animated
               completion:(void (^)(void))completion {
-  self.snackbarView = snackbarView;  // Install the snackbar.
+  self.snackbarView = snackbarView;  // Install the Snackbar.
   self.bottomConstraint.constant = -self.dynamicBottomMargin;
 
   if (animated) {
@@ -452,7 +478,7 @@ static const CGFloat kMaximumHeight = 80.0f;
   if (animated) {
     [self slideOutMessageView:self.snackbarView
                    completion:^{
-                     self.snackbarView = nil;  // Uninstall the snackbar
+                     self.snackbarView = nil;  // Uninstall the Snackbar
 
                      if (completion) {
                        completion();
@@ -473,7 +499,7 @@ static const CGFloat kMaximumHeight = 80.0f;
       fromContentOpacity:(CGFloat)fromContentOpacity
         toContentOpacity:(CGFloat)toContentOpacity
               completion:(void (^)(void))completion {
-  // Prepare to move the snackbar.
+  // Prepare to move the Snackbar.
   NSTimeInterval duration = MDCSnackbarLegacyTransitionDuration;
   if (!MDCSnackbarMessage.usesLegacySnackbar) {
     duration = onscreen ? MDCSnackbarEnterTransitionDuration : MDCSnackbarExitTransitionDuration;
@@ -497,7 +523,7 @@ static const CGFloat kMaximumHeight = 80.0f;
                           delay:0
                         options:0
                      animations:^{
-                       // Trigger snackbar animation.
+                       // Trigger Snackbar animation.
                        [self->_containingView layoutIfNeeded];
                      }
                      completion:nil];
@@ -521,7 +547,7 @@ static const CGFloat kMaximumHeight = 80.0f;
   [CATransaction commit];
 
   // To support the MDCOverlayObserver seeing frame changes, we need to update the frame of the
-  // new snackbar for the observer, as now it doesn't change frame but rather change opacity.
+  // new Snackbar for the observer, as now it doesn't change frame but rather change opacity.
   // In future we should add support for opacity to our MDCOverlayObserver and not only frame.
   CGRect snackbarRect = [self snackbarRectInScreenCoordinates];
   if (!MDCSnackbarMessage.usesLegacySnackbar && !onscreen) {
@@ -537,7 +563,7 @@ static const CGFloat kMaximumHeight = 80.0f;
 
 - (void)slideInMessageView:(MDCSnackbarMessageView *)snackbarView
                 completion:(void (^)(void))completion {
-  // Make sure that the snackbar has been properly sized to calculate the translation value.
+  // Make sure that the Snackbar has been properly sized to calculate the translation value.
   [self triggerSnackbarLayoutChange];
 
   [self slideMessageView:snackbarView
@@ -549,7 +575,7 @@ static const CGFloat kMaximumHeight = 80.0f;
 
 - (void)slideOutMessageView:(MDCSnackbarMessageView *)snackbarView
                  completion:(void (^)(void))completion {
-  // Make sure that the snackbar has been properly sized to calculate the translation value.
+  // Make sure that the Snackbar has been properly sized to calculate the translation value.
   [self triggerSnackbarLayoutChange];
 
   [self slideMessageView:snackbarView
@@ -562,7 +588,7 @@ static const CGFloat kMaximumHeight = 80.0f;
 #pragma mark - Keyboard Notifications
 
 - (void)updatesnackbarPositionWithKeyboardUserInfo:(NSDictionary *)userInfo {
-  // Always set the bottom constraint, even if there isn't a snackbar currently displayed.
+  // Always set the bottom constraint, even if there isn't a Snackbar currently displayed.
   void (^updateBlock)(void) = ^{
     self.bottomConstraint.constant = -[self dynamicBottomMargin];
     [self triggerSnackbarLayoutChange];
@@ -612,7 +638,7 @@ static const CGFloat kMaximumHeight = 80.0f;
     self.bottomConstraint.constant = -self.dynamicBottomMargin;
     [self triggerSnackbarLayoutChange];
 
-    // If there is no snackbar the following method returns CGRectNull, but we still need to notify
+    // If there is no Snackbar the following method returns CGRectNull, but we still need to notify
     // observers of bottom offset changes.
     CGRect frame = [self snackbarRectInScreenCoordinates];
     if (CGRectIsNull(frame)) {
@@ -634,7 +660,7 @@ static const CGFloat kMaximumHeight = 80.0f;
 
     [self triggerSnackbarLayoutChange];
 
-    // If there is no snackbar the following method returns CGRectNull, but we still need to notify
+    // If there is no Snackbar the following method returns CGRectNull, but we still need to notify
     // observers of bottom offset changes.
     CGRect frame = [self snackbarRectInScreenCoordinates];
     if (CGRectIsNull(frame)) {

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -257,85 +257,79 @@ static const CGFloat kMaximumHeight = 80.0f;
       // Pin the snackbar to the bottom of the screen.
       [snackbarView setTranslatesAutoresizingMaskIntoConstraints:NO];
 
-      switch (self.traitCollection.horizontalSizeClass) {
-        case UIUserInterfaceSizeClassUnspecified:
-        case UIUserInterfaceSizeClassCompact:
+      BOOL isRegularWidth = self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular;
+      BOOL isRegularHeight = self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassRegular;
+      if (isRegularWidth && isRegularHeight) {
+        snackbarView.centerConstraint  = [NSLayoutConstraint constraintWithItem:snackbarView
+                                                                      attribute:NSLayoutAttributeCenterX
+                                                                      relatedBy:NSLayoutRelationEqual
+                                                                         toItem:container
+                                                                      attribute:NSLayoutAttributeCenterX
+                                                                     multiplier:1.0
+                                                                       constant:0];
+        snackbarView.centerConstraint.active = self.alignment == MDCSnackbarAlignmentCenter;
 
+        snackbarView.leadingConstraint  = [NSLayoutConstraint constraintWithItem:snackbarView
+                                                                       attribute:NSLayoutAttributeLeading
+                                                                       relatedBy:NSLayoutRelationEqual
+                                                                          toItem:container
+                                                                       attribute:NSLayoutAttributeLeading
+                                                                      multiplier:1.0
+                                                                        constant:sideMargin];
+        snackbarView.leadingConstraint.active = self.alignment == MDCSnackbarAlignmentLeading;
+
+        // If not full width, ensure that it doesn't get any larger than our own width.
+        [container
+         addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
+                                                    attribute:NSLayoutAttributeWidth
+                                                    relatedBy:NSLayoutRelationLessThanOrEqual
+                                                       toItem:container
+                                                    attribute:NSLayoutAttributeWidth
+                                                   multiplier:1.0
+                                                     constant:-2 * sideMargin]];
+
+        // Also ensure that it doesn't get any smaller than its own minimum width.
+        [container
+         addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
+                                                    attribute:NSLayoutAttributeWidth
+                                                    relatedBy:NSLayoutRelationGreaterThanOrEqual
+                                                       toItem:nil
+                                                    attribute:NSLayoutAttributeNotAnAttribute
+                                                   multiplier:1.0
+                                                     constant:[snackbarView minimumWidth]]];
+
+        // Also ensure that it doesn't get any larger than its own maximum width.
+        [container
+         addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
+                                                    attribute:NSLayoutAttributeWidth
+                                                    relatedBy:NSLayoutRelationLessThanOrEqual
+                                                       toItem:nil
+                                                    attribute:NSLayoutAttributeNotAnAttribute
+                                                   multiplier:1.0
+                                                     constant:[snackbarView maximumWidth]]];
+      } else {
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
-          if (@available(iOS 11.0, *)) {
-            leftMargin += self.safeAreaInsets.left;
-            rightMargin += self.safeAreaInsets.right;
-          }
+        if (@available(iOS 11.0, *)) {
+          leftMargin += self.safeAreaInsets.left;
+          rightMargin += self.safeAreaInsets.right;
+        }
 #endif
 
-          [container addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
-                                                                attribute:NSLayoutAttributeLeading
-                                                                relatedBy:NSLayoutRelationEqual
-                                                                   toItem:container
-                                                                attribute:NSLayoutAttributeLeading
-                                                               multiplier:1.0
-                                                                 constant:leftMargin]];
+        [container addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
+                                                              attribute:NSLayoutAttributeLeading
+                                                              relatedBy:NSLayoutRelationEqual
+                                                                 toItem:container
+                                                              attribute:NSLayoutAttributeLeading
+                                                             multiplier:1.0
+                                                               constant:leftMargin]];
 
-          [container addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
-                                                                attribute:NSLayoutAttributeTrailing
-                                                                relatedBy:NSLayoutRelationEqual
-                                                                   toItem:container
-                                                                attribute:NSLayoutAttributeTrailing
-                                                               multiplier:1.0
-                                                                 constant:-1 * rightMargin]];
-          break;
-        case UIUserInterfaceSizeClassRegular:
-          snackbarView.centerConstraint  = [NSLayoutConstraint constraintWithItem:snackbarView
-                                                                        attribute:NSLayoutAttributeCenterX
-                                                                        relatedBy:NSLayoutRelationEqual
-                                                                           toItem:container
-                                                                        attribute:NSLayoutAttributeCenterX
-                                                                       multiplier:1.0
-                                                                         constant:0];
-          snackbarView.centerConstraint.active = self.alignment == MDCSnackbarAlignmentCenter;
-
-          snackbarView.leadingConstraint  = [NSLayoutConstraint constraintWithItem:snackbarView
-                                                                         attribute:NSLayoutAttributeLeading
-                                                                         relatedBy:NSLayoutRelationEqual
-                                                                            toItem:container
-                                                                         attribute:NSLayoutAttributeLeading
-                                                                        multiplier:1.0
-                                                                          constant:sideMargin];
-          snackbarView.leadingConstraint.active = self.alignment == MDCSnackbarAlignmentLeading;
-
-          // If not full width, ensure that it doesn't get any larger than our own width.
-          [container
-           addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
-                                                      attribute:NSLayoutAttributeWidth
-                                                      relatedBy:NSLayoutRelationLessThanOrEqual
-                                                         toItem:container
-                                                      attribute:NSLayoutAttributeWidth
-                                                     multiplier:1.0
-                                                       constant:-2 * sideMargin]];
-
-          // Also ensure that it doesn't get any smaller than its own minimum width.
-          [container
-           addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
-                                                      attribute:NSLayoutAttributeWidth
-                                                      relatedBy:NSLayoutRelationGreaterThanOrEqual
-                                                         toItem:nil
-                                                      attribute:NSLayoutAttributeNotAnAttribute
-                                                     multiplier:1.0
-                                                       constant:[snackbarView minimumWidth]]];
-
-          // Also ensure that it doesn't get any larger than its own maximum width.
-          [container
-           addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
-                                                      attribute:NSLayoutAttributeWidth
-                                                      relatedBy:NSLayoutRelationLessThanOrEqual
-                                                         toItem:nil
-                                                      attribute:NSLayoutAttributeNotAnAttribute
-                                                     multiplier:1.0
-                                                       constant:[snackbarView maximumWidth]]];
-          break;
-        default:
-          NSAssert(NO, @"Unknown size class");
-          break;
+        [container addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
+                                                              attribute:NSLayoutAttributeTrailing
+                                                              relatedBy:NSLayoutRelationEqual
+                                                                 toItem:container
+                                                              attribute:NSLayoutAttributeTrailing
+                                                             multiplier:1.0
+                                                               constant:-1 * rightMargin]];
       }
 
       _snackbarOnscreenConstraint = [NSLayoutConstraint constraintWithItem:snackbarView

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -65,6 +65,18 @@ static const CGFloat kMaximumHeight = 80.0f;
 @property(nonatomic) MDCSnackbarMessageView *snackbarView;
 
 /**
+ The layout constraint which determines how far the Snackbar is from the leading edge of the screen.
+ It is active when the alignment of the parent overlay view is MDCSnackbarAlignmentLeading.
+ */
+@property(nonatomic) NSLayoutConstraint *snackbarViewLeadingConstraint;
+
+/**
+ The layout constraint used to center the Snackbar.
+ It is active when the alignment of the parent overlay view is MDCSnackbarAlignmentCenter.
+ */
+@property(nonatomic) NSLayoutConstraint *snackbarViewCenterConstraint;
+
+/**
  The object which will notify us of changes in the keyboard position.
  */
 @property(nonatomic) MDCKeyboardWatcher *watcher;
@@ -266,7 +278,7 @@ static const CGFloat kMaximumHeight = 80.0f;
       BOOL isRegularHeight =
           self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassRegular;
       if (isRegularWidth && isRegularHeight) {
-        snackbarView.centerConstraint =
+        self.snackbarViewCenterConstraint =
             [NSLayoutConstraint constraintWithItem:snackbarView
                                          attribute:NSLayoutAttributeCenterX
                                          relatedBy:NSLayoutRelationEqual
@@ -274,9 +286,9 @@ static const CGFloat kMaximumHeight = 80.0f;
                                          attribute:NSLayoutAttributeCenterX
                                         multiplier:1.0
                                           constant:0];
-        snackbarView.centerConstraint.active = self.alignment == MDCSnackbarAlignmentCenter;
+        self.snackbarViewCenterConstraint.active = self.alignment == MDCSnackbarAlignmentCenter;
 
-        snackbarView.leadingConstraint =
+        self.snackbarViewLeadingConstraint =
             [NSLayoutConstraint constraintWithItem:snackbarView
                                          attribute:NSLayoutAttributeLeading
                                          relatedBy:NSLayoutRelationEqual
@@ -284,7 +296,7 @@ static const CGFloat kMaximumHeight = 80.0f;
                                          attribute:NSLayoutAttributeLeading
                                         multiplier:1.0
                                           constant:sideMargin];
-        snackbarView.leadingConstraint.active = self.alignment == MDCSnackbarAlignmentLeading;
+        self.snackbarViewLeadingConstraint.active = self.alignment == MDCSnackbarAlignmentLeading;
 
         // If not full width, ensure that it doesn't get any larger than our own width.
         [container
@@ -628,7 +640,7 @@ static const CGFloat kMaximumHeight = 80.0f;
   [self updatesnackbarPositionWithKeyboardUserInfo:[notification userInfo]];
 }
 
-#pragma mark - Bottom Offset
+#pragma mark - Bottom And Side Margins
 
 - (void)setBottomOffset:(CGFloat)bottomOffset {
   if (_bottomOffset != bottomOffset) {
@@ -656,7 +668,7 @@ static const CGFloat kMaximumHeight = 80.0f;
   if (_alignment != alignment) {
     _alignment = alignment;
 
-    [self.snackbarView activateConstraintsForAlignment:alignment];
+    [self activateSnackbarViewConstraintsForAlignment:alignment];
 
     [self triggerSnackbarLayoutChange];
 
@@ -674,6 +686,22 @@ static const CGFloat kMaximumHeight = 80.0f;
   }
 }
 
+- (void)activateSnackbarViewConstraintsForAlignment:(MDCSnackbarAlignment)alignment {
+  switch (alignment) {
+    case MDCSnackbarAlignmentCenter:
+      self.snackbarViewLeadingConstraint.active = NO;
+      self.snackbarViewCenterConstraint.active = YES;
+      break;
+    case MDCSnackbarAlignmentLeading:
+      self.snackbarViewLeadingConstraint.active = YES;
+      self.snackbarViewCenterConstraint.active = NO;
+      break;
+    default:
+      self.snackbarViewLeadingConstraint.active = NO;
+      self.snackbarViewCenterConstraint.active = YES;
+      break;
+  }
+}
 
 #pragma mark - Rotation
 


### PR DESCRIPTION
Snackbars are allowed to have leading alignment on iPads, but until now no implementations have been suggested. Here's an idea for how it could be done using an alignment enum.

If merged this will close issue #2830 and resolve pivotal ticket [156805088](https://www.pivotaltracker.com/n/projects/2150420/stories/156805088).

Here's a screenshot:
![simulator screen shot - ipad air 2 - 2018-05-14 at 13 26 01](https://user-images.githubusercontent.com/8020010/40019940-b510d4e0-578e-11e8-8b6f-4adda8ffadb3.png)
