### PR TITLE
[Snackbar] Add a +hasMessagesShowingOrQueued class method

### DIFF
--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -58,6 +58,13 @@
 + (void)setPresentationHostView:(nullable UIView *)hostView;
 
 /**
+ Checks if there is any message showing or queued. Does not consider suspended messages.
+
+ @note This method must be called from the main thread.
+ */
++ (BOOL)hasMessagesShowingOrQueued;
+
+/**
  Bypasses showing the messages of the given @c category.
 
  Completion blocks are called, but the UI won't show any queued messages and will dismiss any

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -516,6 +516,14 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
   manager.presentationHostView = hostView;
 }
 
++ (BOOL)hasMessagesShowingOrQueued {
+  NSAssert([NSThread isMainThread], @"hasMessagesShowingOrQueued must be called on main thread.");
+
+  MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
+
+  return (manager.showingMessage || manager.pendingMessages.count != 0);
+}
+
 + (void)dismissAndCallCompletionBlocksWithCategory:(NSString *)category {
   // Snag a copy now, we'll use that internally.
   NSString *categoryToDismiss = [category copy];

--- a/components/Snackbar/tests/unit/SnackbarManagerSwiftTests.swift
+++ b/components/Snackbar/tests/unit/SnackbarManagerSwiftTests.swift
@@ -19,6 +19,11 @@ import MaterialComponents.MaterialSnackbar
 
 class SnackbarManagerSwiftTests: XCTestCase {
 
+  override func tearDown() {
+    MDCSnackbarManager.dismissAndCallCompletionBlocks(withCategory: nil)
+    super.tearDown()
+  }
+
   func testMessagesResumedWhenTokenIsDeallocated() {
     // Given
     let expectation = self.expectation(description: "completion")
@@ -41,6 +46,23 @@ class SnackbarManagerSwiftTests: XCTestCase {
 
     // Then
     // Swift unit tests are sometimes slower, need to wait a little longer
+    self.waitForExpectations(timeout: 3.0, handler: nil)
+  }
+
+  func testHasMessagesShowingOrQueued() {
+    let message = MDCSnackbarMessage(text: "foo1")
+    message.duration = 10;
+    MDCSnackbarManager.show(message)
+
+    let expectation = self.expectation(description: "has_shown_message")
+
+    // We need to dispatch_async in order to assure that the assertion happens after showMessage:
+    // actually displays the message.
+    DispatchQueue.main.async {
+      XCTAssertTrue(MDCSnackbarManager.hasMessagesShowingOrQueued())
+      expectation.fulfill()
+    }
+
     self.waitForExpectations(timeout: 3.0, handler: nil)
   }
 }

--- a/components/Snackbar/tests/unit/SnackbarManagerTests.m
+++ b/components/Snackbar/tests/unit/SnackbarManagerTests.m
@@ -23,6 +23,11 @@
 
 @implementation SnackbarManagerTests
 
+- (void)tearDown {
+  [MDCSnackbarManager dismissAndCallCompletionBlocksWithCategory:nil];
+  [super tearDown];
+}
+
 // Disabled due to flakiness in CI.
 - (void)disabled_testMessagesResumedWhenTokenIsDeallocated {
   // Given
@@ -44,6 +49,23 @@
 
   // Then
   [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+- (void)testHasMessagesShowingOrQueued {
+  MDCSnackbarMessage *message = [MDCSnackbarMessage messageWithText:@"foo1"];
+  message.duration = 10;
+  [MDCSnackbarManager showMessage:message];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"has_shown_message"];
+
+  // We need to dispatch_async in order to assure that the assertion happens after showMessage:
+  // actually displays the message.
+  dispatch_async(dispatch_get_main_queue(), ^{
+    XCTAssertTrue([MDCSnackbarManager hasMessagesShowingOrQueued]);
+    [expectation fulfill];
+  });
+
+  [self waitForExpectationsWithTimeout:3.0 handler:nil];
 }
 
 @end


### PR DESCRIPTION
Add a +hasMessagesShowingOrQueued class method to check if there are any Snackbar messages being shown or queued. 

This is code contribution from g3, the CL has been reviewed and approved by me and randallli.