### PR TITLE
[kokoro] Add a stub apidiff command for the apidiff CI job.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -311,8 +311,6 @@ generate_apidiff() {
     changelog_path=$(cat "$BUILDS_TMP_PATH/api_diff" | grep "Changelog=" | cut -d'=' -f2)
     error_path=$(cat "$BUILDS_TMP_PATH/api_diff" | grep "Errors=" | cut -d'=' -f2)
 
-    pushd scripts/github-comment >> /dev/null
-
     # TODO: Post the results to a GitHub comment.
 
     if [ -f "$error_path" ]; then

--- a/.kokoro
+++ b/.kokoro
@@ -228,6 +228,104 @@ generate_website() {
   fi
 }
 
+# Will generate an API diff between the current branch and the merge-base from develop.
+# The result will be posted to GitHub as a comment.
+#
+# For local runs, you must set the following environment variables:
+#
+#   GITHUB_API_TOKEN -> Create a token here: https://github.com/settings/tokens.
+#                       Must have public_repo scope.
+#   KOKORO_GITHUB_PULL_REQUEST_NUMBER="###" -> The PR # you want to post the API diff results to.
+#
+# And you'll likely have to install sourcekitten:
+#
+#   brew install sourcekitten
+#
+generate_apidiff() {
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    # Move into our cloned repo
+    cd github/repo
+
+    # Install sourcekitten, a dependency of the apidiff tool
+    brew install sourcekitten
+  fi
+
+  usage() {
+    echo "Usage: $0 -d apidiff"
+    echo
+    echo "Will generate an API diff between the current branch and the merge-base from develop."
+    echo "The result will be posted to GitHub as a comment."
+    echo
+    echo "Must set the following environment variables to run locally:"
+    echo
+    echo "GITHUB_API_TOKEN -> Create a token here: https://github.com/settings/tokens."
+    echo "                    Must have public_repo scope."
+    echo "KOKORO_GITHUB_PULL_REQUEST_NUMBER=\"###\" -> The PR # you want to post the API diff results to."
+  }
+
+  if [ -z "$GITHUB_API_TOKEN" ]; then
+    echo "GITHUB_API_TOKEN must be set to a github token with public_repo scope."
+    usage
+    exit 1
+  fi
+
+  if [ -z "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
+    echo "KOKORO_GITHUB_PULL_REQUEST_NUMBER must be set to a github pull request number."
+    usage
+    exit 1
+  fi
+
+  BUILDS_TMP_PATH=$(mktemp -d)
+  SEEN_XCODES_FILE_PATH="$BUILDS_TMP_PATH/seen_xcodes"
+  touch "$SEEN_XCODES_FILE_PATH"
+  xcodes=$(ls /Applications/ | grep "Xcode")
+  for xcode_path in $xcodes; do
+    xcode_version=$(cat /Applications/$xcode_path/Contents/version.plist \
+      | grep "CFBundleShortVersionString" -A1 \
+      | grep string \
+      | cut -d'>' -f2 \
+      | cut -d'<' -f1)
+    xcode_version_as_number="$(version_as_number $xcode_version)"
+
+    # Ignore duplicate Xcode installations
+    if grep -xq "$xcode_version_as_number" "$SEEN_XCODES_FILE_PATH"; then
+      continue
+    fi
+
+    echo "$xcode_version_as_number" >> "$SEEN_XCODES_FILE_PATH"
+
+    if [ "$xcode_version_as_number" -ne "$(version_as_number $XCODE_VERSION)" ]; then
+      continue
+    fi
+
+    sudo xcode-select --switch /Applications/$xcode_path/Contents/Developer
+    xcodebuild -version
+
+    # Resolves the following crash when switching Xcode versions:
+    # "Failed to locate a valid instance of CoreSimulatorService in the bootstrap"
+    launchctl remove com.apple.CoreSimulator.CoreSimulatorService || true
+
+    base_sha=$(git merge-base origin/develop HEAD)
+
+    ./scripts/release apidiff "$base_sha" | tee "$BUILDS_TMP_PATH/api_diff"
+    changelog_path=$(cat "$BUILDS_TMP_PATH/api_diff" | grep "Changelog=" | cut -d'=' -f2)
+    error_path=$(cat "$BUILDS_TMP_PATH/api_diff" | grep "Errors=" | cut -d'=' -f2)
+
+    pushd scripts/github-comment >> /dev/null
+
+    # TODO: Post the results to a GitHub comment.
+
+    if [ -f "$error_path" ]; then
+      nested_error_path=$(cat "$error_path" | grep "stderr output is available in" | cut -d' ' -f6)
+      if [ -f "$nested_error_path" ]; then
+        echo
+        echo "Potential build errors:"
+        cat "$nested_error_path"
+      fi
+    fi
+  done
+}
+
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
   key="$1"
@@ -281,6 +379,7 @@ case "$DEPENDENCY_SYSTEM" in
   "cocoapods-podspec")  run_cocoapods ;;
   "website")    generate_website ;;
   "danger")     run_danger ;;
+  "apidiff")    generate_apidiff ;;
 
   *)            run_bazel ;;
 esac


### PR DESCRIPTION
This command will generate an API diff for the current pull request. In a follow-up PR it will also post the results of the API diff to the PR as a comment.

This is the first of two changes to the `apidiff` branch that will add support for API diff reporting to our PRs. The second PR will add the github comment reporting tool.