### PR TITLE
[FlexibleHeader] Always update opacity for views that hide when shifted.

### DIFF
--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
@@ -99,6 +99,8 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleBottomMargin;
   [self.fhvc.headerView addSubview:titleLabel];
 
+  [self.fhvc.headerView hideViewWhenShifted:titleLabel];
+
   self.fhvc.headerView.minimumHeight = CGRectGetMaxY(titleLabel.frame);
 
   id (^switchItem)(NSString *, FlexibleHeaderConfiguratorField) = ^(

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -30,9 +30,8 @@ static const CGFloat kFlexibleHeaderDefaultHeight = 56;
 // The maximum default opacity of the shadow.
 static const float kDefaultVisibleShadowOpacity = 0.4f;
 
-// The threshold in which the _viewsToHideWhenShifted should be fully hidden. 0.5 means the views
-// are completely hidden when the header has shifted half of its content height upwards. This should
-// never be 0.
+// The percentage shifted threshold at which point the _viewsToHideWhenShifted should be fully
+// hidden.
 static const float kContentHidingThreshold = 0.5f;
 
 // This length defines the moment at which the shadow will be fully visible as the header shifts
@@ -841,15 +840,6 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
   frameBottomEdge = MAX(0, MIN(kShadowScaleLength, frameBottomEdge));
   CGFloat boundedAccumulator = MIN([self fhv_accumulatorMax], _shiftAccumulator);
 
-  if (_shiftBehavior != MDCFlexibleHeaderShiftBehaviorDisabled) {
-    CGFloat contentHeight = self.computedMinimumHeight - MDCDeviceTopSafeAreaInset();
-    CGFloat hideThreshold = kContentHidingThreshold;
-    CGFloat alpha = MAX(contentHeight - boundedAccumulator / hideThreshold, 0) / contentHeight;
-    for (UIView *view in _viewsToHideWhenShifted) {
-      view.alpha = alpha;
-    }
-  }
-
   CGFloat shadowIntensity;
   if (self.hidesStatusBarWhenCollapsed) {
     // Calculate the desired shadow strength for the offset & accumulator and then take the
@@ -1051,6 +1041,15 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 
   [self fhv_accumulatorDidChange];
   [self fhv_recalculatePhase];
+
+  // Update opacity of _viewsToHideWhenShifted
+  CGFloat contentHeight = self.computedMinimumHeight - MDCDeviceTopSafeAreaInset();
+  CGFloat hideThreshold = kContentHidingThreshold;
+  CGFloat boundedAccumulator = MIN([self fhv_accumulatorMax], _shiftAccumulator);
+  CGFloat alpha = MAX(contentHeight - boundedAccumulator / hideThreshold, 0) / contentHeight;
+  for (UIView *view in _viewsToHideWhenShifted) {
+    view.alpha = alpha;
+  }
 
   [_statusBarShifter setOffset:_shiftAccumulator];
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1045,7 +1045,7 @@ static NSString *const MDCFlexibleHeaderDelegateKey = @"MDCFlexibleHeaderDelegat
 
   CGFloat opacityShiftThreshold = [self fhv_accumulatorMax] * kContentHidingThreshold;
   // 0% means not shifted at all, 100% means shifted up to our threshold amount.
-  CGFloat percentShiftedAlongThreshold = MIN(1, MAX(shiftOffset / opacityShiftThreshold, 0));
+  CGFloat percentShiftedAlongThreshold = MIN(1, MAX(0, shiftOffset / opacityShiftThreshold));
   for (UIView *view in _viewsToHideWhenShifted) {
     // When not shifted at all, we want to be fully visible. We invert the percentage to get our
     // desired alpha.


### PR DESCRIPTION
Before this change, views that hide when shifted would only change their visibility if shifting was enabled. This resulted in a bug where if shifting was disabled then views would not become visible again once the header shifted back on screen.

After this change, views that hide when shifted will always change their visibility when the header's frame changes.

Closes https://github.com/material-components/material-components-ios/issues/3559

## Screenshots

### Before
![before](https://user-images.githubusercontent.com/45670/40084375-ed43551e-5864-11e8-95a8-8761e1f7a3be.gif)

### After

![after](https://user-images.githubusercontent.com/45670/40084112-11c69906-5864-11e8-946b-b7957ace1a83.gif)
