### PR TITLE
[bazel] Add an mdc_app_test_suite target API.

### DIFF
--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -3,6 +3,7 @@
 load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
 load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_ui_test")
 
 DEFAULT_IOS_RUNNER_TARGETS = [
     "//components/testing/runners:IPHONE_5_IN_8_1",
@@ -63,7 +64,7 @@ def mdc_unit_test_suite(
     visibility = ["//visibility:private"],
     size = "medium",
     **kwargs):
-  """Declare a MDC unit_test_suite using the ios_runners matrix."""
+  """Declare a MDC unit_test_suite using the DEFAULT_IOS_RUNNER_TARGETS matrix."""
   ios_unit_test_suite(
     name = name,
     deps = deps,
@@ -73,3 +74,26 @@ def mdc_unit_test_suite(
     size = size,
     **kwargs
   )
+
+def mdc_app_test_suite(
+    name = "app_tests",
+    deps = [],
+    minimum_os_version = "8.0",
+    visibility = ["//visibility:private"],
+    size = "medium",
+    **kwargs):
+  """Declare an MDC ui test using the DEFAULT_IOS_RUNNER_TARGETS matrix."""
+  # Note that there would ideally be an ios_ui_test_suite. Until such an API is added to bazel,
+  # we simulate a suite by create a separate test target for each runner.
+  # https://github.com/bazelbuild/rules_apple/issues/183
+  for runner in DEFAULT_IOS_RUNNER_TARGETS:
+    ios_ui_test(
+      name = name + runner.split(':')[1],
+      deps = deps,
+      minimum_os_version = minimum_os_version,
+      test_host = "@build_bazel_rules_apple//apple/testing/default_host/ios",
+      runner = runner,
+      visibility = visibility,
+      size = size,
+      **kwargs
+    )


### PR DESCRIPTION
This new API allows us to make UI tests that run alongside a hosted app in bazel.

The convention for app tests is:

```
components/
  Component/
    src/
    tests/
      app/   <- App tests go here.
      unit/
```

This new target addresses the build failures seen in https://github.com/material-components/material-components-ios/issues/3413 and https://github.com/material-components/material-components-ios/pull/3424.

## Example usage:

```python
mdc_objc_library(
    name = "app_test_sources",
    testonly = 1,
    srcs = glob(["tests/app/*.m"]),
    hdrs = glob(["tests/app/*.h"]),
    sdk_frameworks = [
        "UIKit",
        "XCTest",
    ],
    deps = [":BottomSheet"],
    visibility = ["//visibility:private"],
)

mdc_app_test_suite(
    deps = [":app_test_sources"],
)
```

## Verification

I've verified that this works in https://github.com/material-components/material-components-ios/pull/4182.