### PR TITLE
[ShadowElevations] Expose BottomNavigationBar elevation

### DIFF
--- a/components/ShadowElevations/src/MDCShadowElevations.h
+++ b/components/ShadowElevations/src/MDCShadowElevations.h
@@ -35,6 +35,9 @@ typedef CGFloat MDCShadowElevation MDC_SHADOW_ELEVATION_TYPED_EXTENSIBLE_ENUM;
 /** The shadow elevation of the app bar. */
 FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationAppBar;
 
+/** The shadow elevation of the Bottom App Bar. */
+FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationBottomNavigationBar;
+
 /** The shadow elevation of a card in its picked up state. */
 FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationCardPickedUp;
 


### PR DESCRIPTION
There was a defined elevation for BottomNavigation bar but it was not public.
