### PR TITLE
[BottomNavigation] Fix shadow elevation value

### DIFF
--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -29,6 +29,7 @@ mdc_public_objc_library(
     ],
     deps = [
         "//components/Ink",
+        "//components/ShadowElevations",
         "//components/ShadowLayer",
         "//components/Typography",
         "//components/private/Math",

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -18,7 +18,6 @@
 
 #import "BottomNavigationTypicalUseSupplemental.h"
 
-#import "MaterialAppBar.h"
 #import "MaterialBottomNavigation.h"
 #import "MaterialPalettes.h"
 #import "MaterialBottomNavigation+ColorThemer.h"
@@ -27,7 +26,6 @@
 @interface BottomNavigationTypicalUseExample () <MDCBottomNavigationBarDelegate>
 
 @property(nonatomic, assign) int badgeCount;
-@property(nonatomic, strong) MDCAppBar *appBar;
 @property(nonatomic, strong) MDCBottomNavigationBar *bottomNavBar;
 @end
 
@@ -37,13 +35,11 @@
   self = [super init];
   if (self) {
     self.title = @"Bottom Navigation";
-    [self commonBottomNavigationTypicalUseExampleInit];
   }
   return self;
 }
 
-- (void)commonBottomNavigationTypicalUseExampleInit {
-  [self setupAppBar];
+- (void)commonBottomNavigationTypicalUseExampleViewDidLoad {
 
   _bottomNavBar = [[MDCBottomNavigationBar alloc] initWithFrame:CGRectZero];
   _bottomNavBar.titleVisibility = MDCBottomNavigationBarTitleVisibilitySelected;
@@ -98,12 +94,13 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  [self.appBar addSubviewsToParent];
+  [self commonBottomNavigationTypicalUseExampleViewDidLoad];
 
   [MDCBottomNavigationBarTypographyThemer applyTypographyScheme:self.typographyScheme
                                           toBottomNavigationBar:_bottomNavBar];
   [MDCBottomNavigationBarColorThemer applySemanticColorScheme:self.colorScheme
                                            toBottomNavigation:_bottomNavBar];
+  self.view.backgroundColor = self.colorScheme.backgroundColor;
 }
 
 - (void)viewWillLayoutSubviews {
@@ -122,8 +119,6 @@
 
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];
-  
-  [self.navigationController setNavigationBarHidden:YES animated:animated];
 }
 
 - (void)updateBadgeItemCount {
@@ -146,30 +141,6 @@
 - (void)bottomNavigationBar:(nonnull MDCBottomNavigationBar *)bottomNavigationBar
               didSelectItem:(nonnull UITabBarItem *)item {
   NSLog(@"Selected Item: %@", item.title);
-}
-
-#pragma mark - Configure MDCAppBar for navigation
-
-- (UIViewController *)childViewControllerForStatusBarHidden {
-  return self.appBar.headerViewController;
-}
-
-- (UIViewController *)childViewControllerForStatusBarStyle {
-  return self.appBar.headerViewController;
-}
-
-- (void)setupAppBar {
-  _appBar = [[MDCAppBar alloc] init];
-  [self addChildViewController:_appBar.headerViewController];
-  UIColor *color = [UIColor colorWithWhite:0.2f alpha:1];
-  _appBar.headerViewController.headerView.backgroundColor = color;
-  _appBar.headerViewController.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorEnabled;
-  [_appBar.headerViewController.headerView hideViewWhenShifted:_appBar.headerStackView];
-
-  _appBar.navigationBar.tintColor = [UIColor whiteColor];
-  _appBar.navigationBar.titleTextAttributes =
-      @{ NSForegroundColorAttributeName : [UIColor whiteColor] };
-  self.view.backgroundColor = [UIColor lightGrayColor];
 }
 
 @end

--- a/components/BottomNavigation/examples/supplemental/BottomNavigationTypicalUseSupplemental.m
+++ b/components/BottomNavigation/examples/supplemental/BottomNavigationTypicalUseSupplemental.m
@@ -32,10 +32,6 @@
   return YES;
 }
 
-- (BOOL)catalogShouldHideNavigation {
-  return NO;
-}
-
 + (BOOL)catalogIsPresentable {
   return YES;
 }

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -20,6 +20,7 @@
 
 #import <MDFInternationalization/MDFInternationalization.h>
 
+#import "MaterialShadowElevations.h"
 #import "MaterialShadowLayer.h"
 #import "MaterialTypography.h"
 #import "private/MaterialBottomNavigationStrings.h"
@@ -52,7 +53,6 @@ static NSString *const kMDCBottomNavigationBarBarTintColorKey =
 static const CGFloat kMDCBottomNavigationBarHeight = 56.f;
 static const CGFloat kMDCBottomNavigationBarHeightAdjacentTitles = 40.f;
 static const CGFloat kMDCBottomNavigationBarLandscapeContainerWidth = 320.f;
-static const MDCShadowElevation kMDCBottomNavigationBarElevation = 6.f;
 static NSString *const kMDCBottomNavigationBarBadgeColorString = @"badgeColor";
 static NSString *const kMDCBottomNavigationBarBadgeValueString = @"badgeValue";
 static NSString *const kMDCBottomNavigationBarImageString = @"image";
@@ -184,7 +184,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
                                      UIViewAutoresizingFlexibleRightMargin);
   _containerView.clipsToBounds = YES;
   [self addSubview:_containerView];
-  [self setElevation:kMDCBottomNavigationBarElevation];
+  [self setElevation:MDCShadowElevationBottomNavigationBar];
   _itemViews = [NSMutableArray array];
   _itemTitleFont = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleCaption];
 }

--- a/components/ShadowElevations/src/MDCShadowElevations.h
+++ b/components/ShadowElevations/src/MDCShadowElevations.h
@@ -35,6 +35,9 @@ typedef CGFloat MDCShadowElevation MDC_SHADOW_ELEVATION_TYPED_EXTENSIBLE_ENUM;
 /** The shadow elevation of the app bar. */
 FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationAppBar;
 
+/** The shadow elevation of the Bottom App Bar. */
+FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationBottomNavigationBar;
+
 /** The shadow elevation of a card in its picked up state. */
 FOUNDATION_EXPORT const MDCShadowElevation MDCShadowElevationCardPickedUp;
 


### PR DESCRIPTION
The Bottom Navigation should have an elevation of 8 dps instead of 6 based on
the latest design guidance.

**Before**
![bottomnav-ex-original](https://user-images.githubusercontent.com/1753199/40240442-92c9976e-5a86-11e8-9972-e5b6bfe07736.png)

**After**
![bottomnav-ex-after](https://user-images.githubusercontent.com/1753199/40240450-96201af0-5a86-11e8-9e1b-8a488cdc96c3.png)
