### PR TITLE
[TextFields] Fix notification parameter type

### DIFF
--- a/components/TextFields/src/MDCMultilineTextField.m
+++ b/components/TextFields/src/MDCMultilineTextField.m
@@ -736,12 +736,12 @@ static NSString *const MDCMultilineTextFieldTrailingViewModeKey =
 
 #pragma mark - UITextView Notification Observation
 
-- (void)textViewDidBeginEditing:(__unused UITextView *)textView {
+- (void)textViewDidBeginEditing:(__unused NSNotification *)note {
   self.editing = YES;
   [self.fundament didBeginEditing];
 }
 
-- (void)textViewDidChange:(__unused UITextView *)textView {
+- (void)textViewDidChange:(__unused NSNotification *)note {
   [self.fundament didChange];
   CGSize currentSize = self.bounds.size;
   CGSize requiredSize = [self sizeThatFits:CGSizeMake(currentSize.width, CGFLOAT_MAX)];
@@ -754,7 +754,7 @@ static NSString *const MDCMultilineTextFieldTrailingViewModeKey =
   }
 }
 
-- (void)textViewDidEndEditing:(__unused UITextView *)textView {
+- (void)textViewDidEndEditing:(__unused NSNotification *)note {
   self.editing = NO;
   [self.fundament didEndEditing];
 }


### PR DESCRIPTION
When receiving notification callbacks, the invoked method had the wrong
parameter type. Since these are currently unused, there were no
problems. However, if the code is edited to use these arguments, a crash
is likely.
