### PR TITLE
[BottomSheet] Fix layout issues with bottom sheets containing scroll views

### DIFF
--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -234,11 +234,17 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
   self.sheet.frame = sheetRect;
 
   CGRect contentFrame = self.sheet.bounds;
-  contentFrame.size.height -= kSheetBounceBuffer;
   if (!self.sheet.scrollView) {
     // If the content doesn't scroll then we have to set its frame to the size we are making
     // visible. This ensures content using autolayout lays out correctly.
     contentFrame.size.height = [self truncatedPreferredSheetHeight];
+  } else if (self.sheet.scrollView.contentSize.height > 0) {
+    // If the content does scroll and has contentSize set, make it the
+    // larger of the contentSize height and the preferred height (if
+    // we don't set the frame at all, it has whatever random size
+    // UIKit assigned to it).
+    contentFrame.size.height =
+        MAX(self.sheet.scrollView.contentSize.height, [self truncatedPreferredSheetHeight]);
   }
   self.contentView.frame = contentFrame;
 }


### PR DESCRIPTION
This PR was forked from https://github.com/material-components/material-components-ios/pull/3413. This PR removes the UI tests that were originally included in that PR because the UI tests do not run on our infrastructure without increasing flakiness (this is due to bazel problems, not the PR).

@bhamiltoncx's original description:

> MDCBottomSheetController had a few subtle issues when the content view controller contained a scroll view.
>
> Contained scroll views always had their height set to the maximum height of the `MDCSheetContainerView`, which might be larger than the contained scroll view's content size.
>
> With this PR, we ensure we make the contained scroll view height the larger of the content height and the preferred height (if we don't set the frame at all, it has whatever random size UIKit assigned to it).