### PR TITLE
[TextFields] Fix text area placeholder

### DIFF
--- a/components/TextFields/examples/TextFieldFilledExample.swift
+++ b/components/TextFields/examples/TextFieldFilledExample.swift
@@ -155,6 +155,15 @@ final class TextFieldFilledSwiftExample: UIViewController {
     scrollView.addSubview(message)
     let messageController = MDCTextInputControllerFilled(textInput: message)
     message.textView?.delegate = self
+    #if swift(>=3.2)
+      message.text = """
+      This is where you could put a multi-line message like an email.
+
+      It can even handle new lines.
+      """
+    #else
+      message.text = "This is where you could put a multi-line message like an email. It can even handle new lines./n"
+    #endif
     messageController.placeholderText = "Message"
     allTextFieldControllers.append(messageController)
 

--- a/components/TextFields/examples/TextFieldOutlinedExample.m
+++ b/components/TextFields/examples/TextFieldOutlinedExample.m
@@ -128,6 +128,8 @@
 
   self.messageController =
       [[MDCTextInputControllerOutlinedTextArea alloc] initWithTextInput:textFieldMessage];
+  textFieldMessage.text = @"This is where you could put a multi-line message like an email. It can"
+      "even handle new lines./n";
   self.messageController.placeholderText = @"Message";
 
   NSDictionary *views = @{

--- a/components/TextFields/src/MDCTextInputControllerOutlinedTextArea.m
+++ b/components/TextFields/src/MDCTextInputControllerOutlinedTextArea.m
@@ -82,10 +82,6 @@ static UIRectCorner _roundedCornersDefault = UIRectCornerAllCorners;
 
 #pragma mark - MDCTextInputPositioningDelegate
 
-- (void)textInputDidLayoutSubviews {
-  [self updateBorder];
-}
-
 // clang-format off
 /**
  textInsets: is the source of truth for vertical layout. It's used to figure out the proper


### PR DESCRIPTION
The text area controller had not been updated when the other classes were. Its `textInputDidLayoutSubviews` only had a call to refresh the border. Other things need to happen so it's being deleted. The `super`'s implementation has all the correct functionality.

**Before:**
![simulator screen shot may 25 2018 at 9 17 57 am](https://user-images.githubusercontent.com/1271525/40546821-3d250a5a-5ffe-11e8-997e-090c837dd864.png)

**After:**
![simulator screen shot may 25 2018 at 9 28 59 am](https://user-images.githubusercontent.com/1271525/40546824-413a7940-5ffe-11e8-9ff5-edffb7677a2f.png)


Closes #4065
Closes #2121