### PR TITLE
[Docs] Add badges to all components.

### DIFF
--- a/components/ActivityIndicator/README.md
+++ b/components/ActivityIndicator/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Circular progress & activity indicator
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BActivityIndicator%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BActivityIndicator%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 Material Design progress indicators display the length of a process or express an unspecified wait
 time. There are two styles of progress indicators: linear and circular.

--- a/components/ActivityIndicator/README.md
+++ b/components/ActivityIndicator/README.md
@@ -12,6 +12,8 @@ api_doc_root: true
 
 # Circular progress & activity indicator
 
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BActivityIndicator%255D&query=%24.total_count)
+
 Material Design progress indicators display the length of a process or express an unspecified wait
 time. There are two styles of progress indicators: linear and circular.
 

--- a/components/ActivityIndicator/docs/README.md
+++ b/components/ActivityIndicator/docs/README.md
@@ -1,5 +1,7 @@
 # Circular progress & activity indicator
 
+<!-- badges -->
+
 Material Design progress indicators display the length of a process or express an unspecified wait
 time. There are two styles of progress indicators: linear and circular.
 

--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # App bars: top
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BAppBar%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BAppBar%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BAppBar%5D)
 
 The Material Design top app bar displays information and actions relating to the current view.
 

--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -12,6 +12,8 @@ api_doc_root: true
 
 # App bars: top
 
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BAppBar%255D&query=%24.total_count)
+
 The Material Design top app bar displays information and actions relating to the current view.
 
 <div class="article__asset article__asset--screenshot">

--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # App bars: top
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BAppBar%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BAppBar%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 The Material Design top app bar displays information and actions relating to the current view.
 

--- a/components/AppBar/docs/README.md
+++ b/components/AppBar/docs/README.md
@@ -1,5 +1,7 @@
 # App bars: top
 
+<!-- badges -->
+
 The Material Design top app bar displays information and actions relating to the current view.
 
 <div class="article__asset article__asset--screenshot">

--- a/components/BottomAppBar/README.md
+++ b/components/BottomAppBar/README.md
@@ -12,6 +12,8 @@ api_doc_root: true
 
 # App bars: bottom
 
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BBottomAppBar%255D&query=%24.total_count)
+
 A bottom app bar displays navigation and key actions at the bottom of the screen. Bottom app bars
 work like [navigation bars](../NavigationBar), but with the additional option to show a
 [floating action button](../Buttons).

--- a/components/BottomAppBar/README.md
+++ b/components/BottomAppBar/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # App bars: bottom
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BBottomAppBar%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BBottomAppBar%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 A bottom app bar displays navigation and key actions at the bottom of the screen. Bottom app bars
 work like [navigation bars](../NavigationBar), but with the additional option to show a

--- a/components/BottomAppBar/README.md
+++ b/components/BottomAppBar/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # App bars: bottom
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BBottomAppBar%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BBottomAppBar%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BBottomAppBar%5D)
 
 A bottom app bar displays navigation and key actions at the bottom of the screen. Bottom app bars
 work like [navigation bars](../NavigationBar), but with the additional option to show a

--- a/components/BottomAppBar/docs/README.md
+++ b/components/BottomAppBar/docs/README.md
@@ -1,5 +1,7 @@
 # App bars: bottom
 
+<!-- badges -->
+
 A bottom app bar displays navigation and key actions at the bottom of the screen. Bottom app bars
 work like [navigation bars](../../NavigationBar), but with the additional option to show a
 [floating action button](../../Buttons).

--- a/components/BottomNavigation/README.md
+++ b/components/BottomNavigation/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Bottom navigation
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BBottomNavigation%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BBottomNavigation%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BBottomNavigation%5D)
 
 Bottom navigation bars allow movement between primary destinations in an app. Tapping on a bottom
 navigation icon takes you directly to the associated view or refreshes the currently active view.

--- a/components/BottomNavigation/README.md
+++ b/components/BottomNavigation/README.md
@@ -12,6 +12,8 @@ api_doc_root: true
 
 # Bottom navigation
 
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BBottomNavigation%255D&query=%24.total_count)
+
 Bottom navigation bars allow movement between primary destinations in an app. Tapping on a bottom
 navigation icon takes you directly to the associated view or refreshes the currently active view.
 

--- a/components/BottomNavigation/README.md
+++ b/components/BottomNavigation/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Bottom navigation
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BBottomNavigation%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BBottomNavigation%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 Bottom navigation bars allow movement between primary destinations in an app. Tapping on a bottom
 navigation icon takes you directly to the associated view or refreshes the currently active view.

--- a/components/BottomNavigation/docs/README.md
+++ b/components/BottomNavigation/docs/README.md
@@ -1,5 +1,7 @@
 # Bottom navigation
 
+<!-- badges -->
+
 Bottom navigation bars allow movement between primary destinations in an app. Tapping on a bottom
 navigation icon takes you directly to the associated view or refreshes the currently active view.
 

--- a/components/ButtonBar/README.md
+++ b/components/ButtonBar/README.md
@@ -2,7 +2,7 @@
 
 # Button bar
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BButtonBar%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BButtonBar%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BButtonBar%5D)
 
 <div class="article__asset article__asset--screenshot">
   <img src="docs/assets/button_bar.png" alt="Button Bar" width="375">

--- a/components/ButtonBar/README.md
+++ b/components/ButtonBar/README.md
@@ -1,6 +1,8 @@
 <!-- This file was auto-generated using ./scripts/generate_readme ButtonBar -->
 
-# Button Bar
+# Button bar
+
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BButtonBar%255D&query=%24.total_count)
 
 <div class="article__asset article__asset--screenshot">
   <img src="docs/assets/button_bar.png" alt="Button Bar" width="375">

--- a/components/ButtonBar/README.md
+++ b/components/ButtonBar/README.md
@@ -2,7 +2,7 @@
 
 # Button bar
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BButtonBar%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BButtonBar%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 <div class="article__asset article__asset--screenshot">
   <img src="docs/assets/button_bar.png" alt="Button Bar" width="375">

--- a/components/ButtonBar/docs/README.md
+++ b/components/ButtonBar/docs/README.md
@@ -1,5 +1,7 @@
 # Button bar
 
+<!-- badges -->
+
 <div class="article__asset article__asset--screenshot">
   <img src="docs/assets/button_bar.png" alt="Button Bar" width="375">
 </div>

--- a/components/Buttons/README.md
+++ b/components/Buttons/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Buttons
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BButtons%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BButtons%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BButtons%5D)
 
 Material design buttons allow users to take actions, and make choices, with a single tap. There are
 many distinct button styles including text buttons, contained buttons, and floating action buttons.

--- a/components/Buttons/README.md
+++ b/components/Buttons/README.md
@@ -12,6 +12,8 @@ api_doc_root: true
 
 # Buttons
 
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BButtons%255D&query=%24.total_count)
+
 Material design buttons allow users to take actions, and make choices, with a single tap. There are
 many distinct button styles including text buttons, contained buttons, and floating action buttons.
 

--- a/components/Buttons/README.md
+++ b/components/Buttons/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Buttons
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BButtons%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BButtons%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 Material design buttons allow users to take actions, and make choices, with a single tap. There are
 many distinct button styles including text buttons, contained buttons, and floating action buttons.

--- a/components/Buttons/docs/README.md
+++ b/components/Buttons/docs/README.md
@@ -1,5 +1,7 @@
 # Buttons
 
+<!-- badges -->
+
 Material design buttons allow users to take actions, and make choices, with a single tap. There are
 many distinct button styles including text buttons, contained buttons, and floating action buttons.
 

--- a/components/Cards/README.md
+++ b/components/Cards/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Cards
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BCards%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BCards%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BCards%5D)
 
 Cards contain content and actions about a single subject. They can be used standalone, or as part
 of a list. Cards are meant to be interactive, and aren't meant to be be used solely for style

--- a/components/Cards/README.md
+++ b/components/Cards/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Cards
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BCards%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BCards%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 Cards contain content and actions about a single subject. They can be used standalone, or as part
 of a list. Cards are meant to be interactive, and aren't meant to be be used solely for style

--- a/components/Cards/README.md
+++ b/components/Cards/README.md
@@ -12,6 +12,8 @@ api_doc_root: true
 
 # Cards
 
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BCards%255D&query=%24.total_count)
+
 Cards contain content and actions about a single subject. They can be used standalone, or as part
 of a list. Cards are meant to be interactive, and aren't meant to be be used solely for style
 purposes.

--- a/components/Cards/docs/README.md
+++ b/components/Cards/docs/README.md
@@ -1,5 +1,7 @@
 # Cards
 
+<!-- badges -->
+
 Cards contain content and actions about a single subject. They can be used standalone, or as part
 of a list. Cards are meant to be interactive, and aren't meant to be be used solely for style
 purposes.

--- a/components/Chips/README.md
+++ b/components/Chips/README.md
@@ -12,6 +12,8 @@ api_doc_root: true
 
 # Chips
 
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BChips%255D&query=%24.total_count)
+
 Chips are compact elements that represent an input, attribute, or action.
 
 ## Design & API documentation

--- a/components/Chips/README.md
+++ b/components/Chips/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Chips
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BChips%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BChips%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BChips%5D)
 
 Chips are compact elements that represent an input, attribute, or action.
 

--- a/components/Chips/README.md
+++ b/components/Chips/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Chips
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BChips%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BChips%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 Chips are compact elements that represent an input, attribute, or action.
 

--- a/components/Chips/docs/README.md
+++ b/components/Chips/docs/README.md
@@ -1,5 +1,7 @@
 # Chips
 
+<!-- badges -->
+
 Chips are compact elements that represent an input, attribute, or action.
 
 <!-- design-and-api -->

--- a/components/Dialogs/README.md
+++ b/components/Dialogs/README.md
@@ -12,6 +12,8 @@ api_doc_root: true
 
 # Dialogs
 
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BDialogs%255D&query=%24.total_count)
+
 Dialogs inform users about a task and can contain critical information, require decisions, or
 involve multiple tasks.
 

--- a/components/Dialogs/README.md
+++ b/components/Dialogs/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Dialogs
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BDialogs%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BDialogs%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 Dialogs inform users about a task and can contain critical information, require decisions, or
 involve multiple tasks.

--- a/components/Dialogs/README.md
+++ b/components/Dialogs/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Dialogs
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BDialogs%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BDialogs%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BDialogs%5D)
 
 Dialogs inform users about a task and can contain critical information, require decisions, or
 involve multiple tasks.

--- a/components/Dialogs/docs/README.md
+++ b/components/Dialogs/docs/README.md
@@ -1,5 +1,7 @@
 # Dialogs
 
+<!-- badges -->
+
 Dialogs inform users about a task and can contain critical information, require decisions, or
 involve multiple tasks.
 

--- a/components/FeatureHighlight/README.md
+++ b/components/FeatureHighlight/README.md
@@ -12,11 +12,13 @@ api_doc_root: true
 
 # Feature highlight
 
-The Feature Highlight component is a way to visually highlight a part of the screen in order to introduce users to new features and functionality.
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BFeatureHighlight%255D&query=%24.total_count)
 
 <div class="article__asset article__asset--screenshot">
   <img src="docs/assets/feature_highlight.png" alt="Feature Highlight" width="375">
 </div>
+
+The Feature Highlight component is a way to visually highlight a part of the screen in order to introduce users to new features and functionality.
 
 ## Design & API documentation
 

--- a/components/FeatureHighlight/README.md
+++ b/components/FeatureHighlight/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Feature highlight
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BFeatureHighlight%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BFeatureHighlight%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BFeatureHighlight%5D)
 
 <div class="article__asset article__asset--screenshot">
   <img src="docs/assets/feature_highlight.png" alt="Feature Highlight" width="375">

--- a/components/FeatureHighlight/README.md
+++ b/components/FeatureHighlight/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Feature highlight
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BFeatureHighlight%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BFeatureHighlight%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 <div class="article__asset article__asset--screenshot">
   <img src="docs/assets/feature_highlight.png" alt="Feature Highlight" width="375">

--- a/components/FeatureHighlight/docs/README.md
+++ b/components/FeatureHighlight/docs/README.md
@@ -1,5 +1,7 @@
 # Feature highlight
 
+<!-- badges -->
+
 <div class="article__asset article__asset--screenshot">
   <img src="docs/assets/feature_highlight.png" alt="Feature Highlight" width="375">
 </div>

--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Flexible header
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BFlexibleHeader%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BFlexibleHeader%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BFlexibleHeader%5D)
 
 A flexible header is a container view whose height and vertical offset react to
 UIScrollViewDelegate events.

--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -12,6 +12,8 @@ api_doc_root: true
 
 # Flexible header
 
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BFlexibleHeader%255D&query=%24.total_count)
+
 A flexible header is a container view whose height and vertical offset react to
 UIScrollViewDelegate events.
 

--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Flexible header
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BFlexibleHeader%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BFlexibleHeader%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 A flexible header is a container view whose height and vertical offset react to
 UIScrollViewDelegate events.

--- a/components/FlexibleHeader/docs/README.md
+++ b/components/FlexibleHeader/docs/README.md
@@ -1,5 +1,7 @@
 # Flexible header
 
+<!-- badges -->
+
 A flexible header is a container view whose height and vertical offset react to
 UIScrollViewDelegate events.
 

--- a/components/NavigationBar/README.md
+++ b/components/NavigationBar/README.md
@@ -12,6 +12,8 @@ api_doc_root: true
 
 # Navigation bar
 
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BNavigationBar%255D&query=%24.total_count)
+
 A navigation bar is a view composed of leading and trailing buttons and either a title label or a
 custom title view.
 

--- a/components/NavigationBar/README.md
+++ b/components/NavigationBar/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Navigation bar
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BNavigationBar%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BNavigationBar%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BNavigationBar%5D)
 
 A navigation bar is a view composed of leading and trailing buttons and either a title label or a
 custom title view.

--- a/components/NavigationBar/README.md
+++ b/components/NavigationBar/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Navigation bar
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BNavigationBar%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BNavigationBar%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 A navigation bar is a view composed of leading and trailing buttons and either a title label or a
 custom title view.

--- a/components/NavigationBar/docs/README.md
+++ b/components/NavigationBar/docs/README.md
@@ -1,5 +1,7 @@
 # Navigation bar
 
+<!-- badges -->
+
 A navigation bar is a view composed of leading and trailing buttons and either a title label or a
 custom title view.
 

--- a/components/PageControl/README.md
+++ b/components/PageControl/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Page control
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BPageControl%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BPageControl%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BPageControl%5D)
 
 This control is designed to be a drop-in replacement for `UIPageControl`, with a user experience
 influenced by Material Design specifications for animation and layout. The API methods are the

--- a/components/PageControl/README.md
+++ b/components/PageControl/README.md
@@ -12,6 +12,8 @@ api_doc_root: true
 
 # Page control
 
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BPageControl%255D&query=%24.total_count)
+
 This control is designed to be a drop-in replacement for `UIPageControl`, with a user experience
 influenced by Material Design specifications for animation and layout. The API methods are the
 same as a `UIPageControl`, with the addition of a few key methods required to achieve the

--- a/components/PageControl/README.md
+++ b/components/PageControl/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Page control
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BPageControl%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BPageControl%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 This control is designed to be a drop-in replacement for `UIPageControl`, with a user experience
 influenced by Material Design specifications for animation and layout. The API methods are the

--- a/components/PageControl/docs/README.md
+++ b/components/PageControl/docs/README.md
@@ -1,5 +1,7 @@
 # Page control
 
+<!-- badges -->
+
 This control is designed to be a drop-in replacement for `UIPageControl`, with a user experience
 influenced by Material Design specifications for animation and layout. The API methods are the
 same as a `UIPageControl`, with the addition of a few key methods required to achieve the

--- a/components/ProgressView/README.md
+++ b/components/ProgressView/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Progress view
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BProgressView%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BProgressView%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BProgressView%5D)
 
 Progress view is a linear progress indicator that implements Material Design animation and layout.
 

--- a/components/ProgressView/README.md
+++ b/components/ProgressView/README.md
@@ -12,6 +12,8 @@ api_doc_root: true
 
 # Progress view
 
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BProgressView%255D&query=%24.total_count)
+
 Progress view is a linear progress indicator that implements Material Design animation and layout.
 
 <div class="article__asset article__asset--screenshot">

--- a/components/ProgressView/README.md
+++ b/components/ProgressView/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Progress view
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BProgressView%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BProgressView%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 Progress view is a linear progress indicator that implements Material Design animation and layout.
 

--- a/components/ProgressView/docs/README.md
+++ b/components/ProgressView/docs/README.md
@@ -1,5 +1,7 @@
 # Progress view
 
+<!-- badges -->
+
 Progress view is a linear progress indicator that implements Material Design animation and layout.
 
 <div class="article__asset article__asset--screenshot">

--- a/components/Slider/README.md
+++ b/components/Slider/README.md
@@ -12,6 +12,8 @@ api_doc_root: true
 
 # Slider
 
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BSlider%255D&query=%24.total_count)
+
 The `MDCSlider` object is a Material Design control used to select a value from a continuous range
 or discrete set of values.
 

--- a/components/Slider/README.md
+++ b/components/Slider/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Slider
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BSlider%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BSlider%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BSlider%5D)
 
 The `MDCSlider` object is a Material Design control used to select a value from a continuous range
 or discrete set of values.

--- a/components/Slider/README.md
+++ b/components/Slider/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Slider
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BSlider%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BSlider%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 The `MDCSlider` object is a Material Design control used to select a value from a continuous range
 or discrete set of values.

--- a/components/Slider/docs/README.md
+++ b/components/Slider/docs/README.md
@@ -1,5 +1,7 @@
 # Slider
 
+<!-- badges -->
+
 The `MDCSlider` object is a Material Design control used to select a value from a continuous range
 or discrete set of values.
 

--- a/components/Snackbar/README.md
+++ b/components/Snackbar/README.md
@@ -12,6 +12,8 @@ api_doc_root: true
 
 # Snackbar
 
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BSnackbar%255D&query=%24.total_count)
+
 Snackbars provide brief feedback about an operation through a message at the bottom of the screen.
 Snackbars contain up to two lines of text directly related to the operation performed. They may
 contain a text action, but no icons.
@@ -29,6 +31,8 @@ contain a text action, but no icons.
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/snackbars/api-docs/Classes/MDCSnackbarMessageAction.html">MDCSnackbarMessageAction</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/snackbars/api-docs/Classes/MDCSnackbarMessageView.html">MDCSnackbarMessageView</a></li>
   <li class="icon-list-item icon-list-item--link">Protocol: <a href="https://material.io/components/ios/catalog/snackbars/api-docs/Protocols.html#/c:objc(pl)MDCSnackbarSuspensionToken">MDCSnackbarSuspensionToken</a></li>
+  <li class="icon-list-item icon-list-item--link">Protocol: <a href="https://material.io/components/ios/catalog/snackbars/api-docs/Protocols/MDCSnackbarManagerDelegate.html">MDCSnackbarManagerDelegate</a></li>
+  <li class="icon-list-item icon-list-item--link">Enumeration: <a href="https://material.io/components/ios/catalog/snackbars/api-docs/Enums/MDCSnackbarAlignment.html">MDCSnackbarAlignment</a></li>
 </ul>
 
 ## Related components

--- a/components/Snackbar/README.md
+++ b/components/Snackbar/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Snackbar
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BSnackbar%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BSnackbar%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 Snackbars provide brief feedback about an operation through a message at the bottom of the screen.
 Snackbars contain up to two lines of text directly related to the operation performed. They may

--- a/components/Snackbar/README.md
+++ b/components/Snackbar/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Snackbar
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BSnackbar%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BSnackbar%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BSnackbar%5D)
 
 Snackbars provide brief feedback about an operation through a message at the bottom of the screen.
 Snackbars contain up to two lines of text directly related to the operation performed. They may

--- a/components/Snackbar/docs/README.md
+++ b/components/Snackbar/docs/README.md
@@ -1,5 +1,7 @@
 # Snackbar
 
+<!-- badges -->
+
 Snackbars provide brief feedback about an operation through a message at the bottom of the screen.
 Snackbars contain up to two lines of text directly related to the operation performed. They may
 contain a text action, but no icons.

--- a/components/Tabs/README.md
+++ b/components/Tabs/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Tabs
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BTabs%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BTabs%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BTabs%5D)
 
 Tabs are bars of buttons used to navigate between groups of content.
 

--- a/components/Tabs/README.md
+++ b/components/Tabs/README.md
@@ -12,6 +12,8 @@ api_doc_root: true
 
 # Tabs
 
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BTabs%255D&query=%24.total_count)
+
 Tabs are bars of buttons used to navigate between groups of content.
 
 <div class="article__asset article__asset--screenshot">

--- a/components/Tabs/README.md
+++ b/components/Tabs/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Tabs
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BTabs%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BTabs%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 Tabs are bars of buttons used to navigate between groups of content.
 

--- a/components/Tabs/docs/README.md
+++ b/components/Tabs/docs/README.md
@@ -1,5 +1,7 @@
 # Tabs
 
+<!-- badges -->
+
 Tabs are bars of buttons used to navigate between groups of content.
 
 <div class="article__asset article__asset--screenshot">

--- a/components/TextFields/README.md
+++ b/components/TextFields/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Text fields
 
-[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BTextFields%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BTextFields%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BTextFields%5D)
 
 Text fields allow users to input text into your app. They are a direct connection to your users' thoughts and intentions via on-screen, or physical, keyboard. The Material Design Text Fields take the familiar element to new levels by adding useful animations, character counts, helper text, error states, and styles.
 

--- a/components/TextFields/README.md
+++ b/components/TextFields/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Text fields
 
-![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BTextFields%255D&query=%24.total_count)
+[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BTextFields%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)
 
 Text fields allow users to input text into your app. They are a direct connection to your users' thoughts and intentions via on-screen, or physical, keyboard. The Material Design Text Fields take the familiar element to new levels by adding useful animations, character counts, helper text, error states, and styles.
 

--- a/components/TextFields/README.md
+++ b/components/TextFields/README.md
@@ -12,6 +12,8 @@ api_doc_root: true
 
 # Text fields
 
+![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255BTextFields%255D&query=%24.total_count)
+
 Text fields allow users to input text into your app. They are a direct connection to your users' thoughts and intentions via on-screen, or physical, keyboard. The Material Design Text Fields take the familiar element to new levels by adding useful animations, character counts, helper text, error states, and styles.
 
 <div class="article__asset article__asset--screenshot">

--- a/components/TextFields/docs/README.md
+++ b/components/TextFields/docs/README.md
@@ -1,5 +1,7 @@
 # Text fields
 
+<!-- badges -->
+
 Text fields allow users to input text into your app. They are a direct connection to your users' thoughts and intentions via on-screen, or physical, keyboard. The Material Design Text Fields take the familiar element to new levels by adding useful animations, character counts, helper text, error states, and styles.
 
 <div class="article__asset article__asset--screenshot">

--- a/contributing/documentation.md
+++ b/contributing/documentation.md
@@ -59,6 +59,14 @@ guidelines_title=
 If a variable is not provided and a template requires it, then the template will be generated with
 the missing variables shown as placeholders still.
 
+### Badges
+
+To generate badges for a component, use the following snippet.
+
+```markdown
+<!-- badges -->
+```
+
 ### Design & API links
 
 To generate design and API links, use the following snippet. Note that this requires that you've

--- a/scripts/generate_all_readmes
+++ b/scripts/generate_all_readmes
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+#
+# Copyright 2018-present The Material Components for iOS Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+usage() {
+  echo "Usage: $0"
+  echo
+  echo "Generates all root readmes for every public component."
+  echo
+  echo "Example usage: $0"
+}
+
+find components -type d | cut -d'/' -f1-2 | sort | uniq | grep / | while read line; do
+  component=$(echo "$line" | cut -d'/' -f2)
+  if [ ! -f "$line/docs/README.md" ]; then
+    continue
+  fi
+
+  echo "Generating readme for $component..."
+
+  ./scripts/generate_readme $component
+done

--- a/scripts/generate_readme
+++ b/scripts/generate_readme
@@ -153,7 +153,7 @@ cat "$TMP_EXPANDED_README_PATH" | while read line; do
       echo "$indent [$text](#$url)" >> "$TMP_README_PATH"
     done
   elif [ "$line" = "$BADGES_STRING" ]; then
-    echo "[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255B${COMPONENT}%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)" >> "$TMP_README_PATH"
+    echo "[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255B${COMPONENT}%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5B${COMPONENT}%5D)" >> "$TMP_README_PATH"
   else
     echo "$line" >> "$TMP_README_PATH"
   fi

--- a/scripts/generate_readme
+++ b/scripts/generate_readme
@@ -67,6 +67,7 @@ TMP_EXPANDED_README_PATH="$TMP_PATH/README.md.expanded"
 TMP_TOC_PATH="$TMP_PATH/toc.md"
 TOC_STRING="<!-- toc -->"
 DESIGN_AND_API_STRING="<!-- design-and-api -->"
+BADGES_STRING="<!-- badges -->"
 VARS_PATH="$COMPONENT_PATH/.vars"
 SITE_URL_BASE="https://material.io/components/ios"
 
@@ -151,6 +152,8 @@ cat "$TMP_EXPANDED_README_PATH" | while read line; do
       url=${url// /-} # Turn spaces into dashes
       echo "$indent [$text](#$url)" >> "$TMP_README_PATH"
     done
+  elif [ "$line" = "$BADGES_STRING" ]; then
+    echo "![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255B${COMPONENT}%255D&query=%24.total_count)" >> "$TMP_README_PATH"
   else
     echo "$line" >> "$TMP_README_PATH"
   fi

--- a/scripts/generate_readme
+++ b/scripts/generate_readme
@@ -153,7 +153,7 @@ cat "$TMP_EXPANDED_README_PATH" | while read line; do
       echo "$indent [$text](#$url)" >> "$TMP_README_PATH"
     done
   elif [ "$line" = "$BADGES_STRING" ]; then
-    echo "![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255B${COMPONENT}%255D&query=%24.total_count)" >> "$TMP_README_PATH"
+    echo "[![Open bugs badge](https://img.shields.io/badge/dynamic/json.svg?label=open%20bugs&url=https%3A%2F%2Fapi.github.com%2Fsearch%2Fissues%3Fq%3Dis%253Aopen%2Blabel%253Atype%253ABug%2Blabel%253A%255B${COMPONENT}%255D&query=%24.total_count)](https://github.com/material-components/material-components-ios/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3ABug+label%3A%5BActivityIndicator%5D)" >> "$TMP_README_PATH"
   else
     echo "$line" >> "$TMP_README_PATH"
   fi


### PR DESCRIPTION
As part of our readme generator, components can now opt in to displaying badges in their readme.

The badges are generated from https://shields.io/ and are focused on an individual component. We're currently generating the following badges:

- Open bug count.