### PR TITLE
[TextFields] Post SetText notifications for attributed text

### DIFF
--- a/components/TextFields/examples/TextFieldKitchenSinkExample.swift
+++ b/components/TextFields/examples/TextFieldKitchenSinkExample.swift
@@ -93,6 +93,8 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
   lazy var clearModeButton: MDCButton = self.setupButton()
   lazy var underlineButton: MDCButton = self.setupButton()
 
+  let attributedString = NSAttributedString(string: "This uses attributed text.")
+
   deinit {
     NotificationCenter.default.removeObserver(self)
   }
@@ -121,7 +123,19 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
 
     let textFieldControllerFilledFloating = MDCTextInputControllerFilled(textInput: textFieldFilledFloating)
     textFieldControllerFilledFloating.placeholderText = "This is filled and floating"
-    return [textFieldControllerFilled, textFieldControllerFilledFloating]
+
+    let textFieldFilledFloatingAttributed = MDCTextField()
+    textFieldFilledFloatingAttributed.translatesAutoresizingMaskIntoConstraints = false
+    scrollView.addSubview(textFieldFilledFloatingAttributed)
+
+    textFieldFilledFloatingAttributed.delegate = self
+
+    let textFieldControllerFilledFloatingAttributed =
+        MDCTextInputControllerFilled(textInput: textFieldFilledFloatingAttributed)
+    textFieldControllerFilledFloatingAttributed.placeholderText = "This is filled and floating"
+    textFieldFilledFloatingAttributed.attributedText = attributedString
+    return [textFieldControllerFilled, textFieldControllerFilledFloating,
+            textFieldControllerFilledFloatingAttributed]
   }
 
   func setupFullWidthTextFields() -> [MDCTextInputControllerFullWidth] {
@@ -301,6 +315,22 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
     textFieldControllerUnderlineLeadingView.isFloatingEnabled = false
     textFieldControllerUnderlineLeadingView.placeholderText = "This has a leading view"
 
+    let textFieldLeadingViewAttributed = MDCTextField()
+    textFieldLeadingViewAttributed.leadingViewMode = .always
+    textFieldLeadingViewAttributed.leadingView = UIImageView(image:leadingViewImage)
+
+    textFieldLeadingViewAttributed.translatesAutoresizingMaskIntoConstraints = false
+    scrollView.addSubview(textFieldLeadingViewAttributed)
+
+    textFieldLeadingViewAttributed.delegate = self
+    textFieldLeadingViewAttributed.clearButtonMode = .whileEditing
+
+    let textFieldControllerUnderlineLeadingViewAttributed =
+      MDCTextInputControllerUnderline(textInput: textFieldLeadingViewAttributed)
+    textFieldControllerUnderlineLeadingViewAttributed.isFloatingEnabled = false
+    textFieldControllerUnderlineLeadingViewAttributed.placeholderText = "This has a leading view"
+    textFieldLeadingViewAttributed.attributedText = attributedString
+
     let textFieldLeadingViewFloating = MDCTextField()
     textFieldLeadingViewFloating.leadingViewMode = .always
     textFieldLeadingViewFloating.leadingView = UIImageView(image:leadingViewImage)
@@ -314,6 +344,22 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
     let textFieldControllerUnderlineLeadingViewFloating =
       MDCTextInputControllerUnderline(textInput: textFieldLeadingViewFloating)
     textFieldControllerUnderlineLeadingViewFloating.placeholderText = "This has a leading view and floats"
+
+    let textFieldLeadingViewFloatingAttributed = MDCTextField()
+    textFieldLeadingViewFloatingAttributed.leadingViewMode = .always
+    textFieldLeadingViewFloatingAttributed.leadingView = UIImageView(image:leadingViewImage)
+
+    textFieldLeadingViewFloatingAttributed.translatesAutoresizingMaskIntoConstraints = false
+    scrollView.addSubview(textFieldLeadingViewFloatingAttributed)
+
+    textFieldLeadingViewFloatingAttributed.delegate = self
+    textFieldLeadingViewFloatingAttributed.clearButtonMode = .whileEditing
+
+    let textFieldControllerUnderlineLeadingViewFloatingAttributed =
+      MDCTextInputControllerUnderline(textInput: textFieldLeadingViewFloatingAttributed)
+    textFieldControllerUnderlineLeadingViewFloatingAttributed.placeholderText =
+        "This has a leading view and floats"
+    textFieldLeadingViewFloatingAttributed.attributedText = attributedString
 
     let trailingViewImage = UIImage(named: "ic_done", in: bundle, compatibleWith: nil)!
 
@@ -405,8 +451,12 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
 
     return [textFieldControllerUnderlineDisabled,
             textFieldControllerUnderlineCustomFont, textFieldControllerUnderlineCustomFontFloating,
-            textFieldControllerUnderlineLeadingView, textFieldControllerUnderlineLeadingViewFloating,
-            textFieldControllerUnderlineTrailingView, textFieldControllerUnderlineTrailingViewFloating,
+            textFieldControllerUnderlineLeadingView,
+            textFieldControllerUnderlineLeadingViewAttributed,
+            textFieldControllerUnderlineLeadingViewFloating,
+            textFieldControllerUnderlineLeadingViewFloatingAttributed,
+            textFieldControllerUnderlineTrailingView,
+            textFieldControllerUnderlineTrailingViewFloating,
             textFieldControllerUnderlineLeadingTrailingView,
             textFieldControllerUnderlineLeadingTrailingViewFloating,
             textFieldControllerBase]
@@ -424,7 +474,18 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
     let textFieldControllerArea = MDCTextInputControllerOutlinedTextArea(textInput: textFieldArea)
     textFieldControllerArea.placeholderText = "This is a text area"
 
-    return [textFieldControllerArea]
+    let textFieldAreaAttributed = MDCMultilineTextField()
+    textFieldAreaAttributed.translatesAutoresizingMaskIntoConstraints = false
+    scrollView.addSubview(textFieldAreaAttributed)
+
+    textFieldAreaAttributed.textView?.delegate = self
+
+    let textFieldControllerAreaAttributed =
+        MDCTextInputControllerOutlinedTextArea(textInput: textFieldAreaAttributed)
+    textFieldControllerAreaAttributed.placeholderText = "This is a text area"
+    textFieldAreaAttributed.attributedText = attributedString
+
+    return [textFieldControllerArea, textFieldControllerAreaAttributed]
   }
 
   func setupUnderlineMultilineTextFields() -> [MDCTextInputControllerUnderline] {

--- a/components/TextFields/examples/TextFieldOutlinedExample.m
+++ b/components/TextFields/examples/TextFieldOutlinedExample.m
@@ -128,8 +128,8 @@
 
   self.messageController =
       [[MDCTextInputControllerOutlinedTextArea alloc] initWithTextInput:textFieldMessage];
-  textFieldMessage.text = @"This is where you could put a multi-line message like an email. It can"
-      "even handle new lines./n";
+  textFieldMessage.text = @"This is where you could put a multi-line message like an email.\nIt can"
+      " even handle new lines.";
   self.messageController.placeholderText = @"Message";
 
   NSDictionary *views = @{

--- a/components/TextFields/src/MDCMultilineTextField.m
+++ b/components/TextFields/src/MDCMultilineTextField.m
@@ -541,6 +541,8 @@ static NSString *const MDCMultilineTextFieldTrailingViewModeKey =
 - (void)setAttributedText:(NSAttributedString *)attributedText {
   self.textView.attributedText = attributedText;
   [self.fundament didSetText];
+  [[NSNotificationCenter defaultCenter] postNotificationName:MDCTextFieldTextDidSetTextNotification
+                                                      object:self];
 }
 
 - (UIBezierPath *)borderPath {

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -452,6 +452,17 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
   }
 }
 
+- (void)setAttributedText:(NSAttributedString *)attributedText {
+  [super setAttributedText:attributedText];
+  [_fundament didSetText];
+
+  if (!self.isFirstResponder) {
+    [[NSNotificationCenter defaultCenter]
+     postNotificationName:MDCTextFieldTextDidSetTextNotification
+     object:self];
+  }
+}
+
 #pragma mark - UITextField Overrides
 
 // This method doesn't have a positioning delegate mirror per se. But it uses the


### PR DESCRIPTION
TextFields were not always correctly posting notifications when attributed
text was set programmatically. This can cause the placeholder to remain in its
"empty" position and overlap the text.

Also added some examples to demonstrate the behavior and fixed a typo.

### Screenshots
|Style | Before | After |
|--|--|--|
| Filled | ![single-filled-before](https://user-images.githubusercontent.com/1753199/40553943-3e4efbca-6012-11e8-98bb-7762c5fb8a79.png) | ![single-filled-after](https://user-images.githubusercontent.com/1753199/40553947-43646942-6012-11e8-9829-9b1b5bab282e.png) 
| Underlined | ![single-underline-before](https://user-images.githubusercontent.com/1753199/40553951-480a67c6-6012-11e8-8b99-5d0c8099ad07.png) | ![single-underline-after](https://user-images.githubusercontent.com/1753199/40553955-4b9ad66e-6012-11e8-84ba-7bf9c371d4eb.png) |
| TextArea | ![textarea-before](https://user-images.githubusercontent.com/1753199/40554082-9decee16-6012-11e8-8005-11e092d38b99.png) | ![textarea-after](https://user-images.githubusercontent.com/1753199/40554085-a093e818-6012-11e8-953c-c61359120e8c.png) |


