### PR TITLE
[FeatureHighlight] Fixing the issue with broken rotation placement for FeatureHighlight.

### DIFF
--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -168,16 +168,16 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
 - (void)viewWillTransitionToSize:(CGSize)size
        withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
   [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+  UIViewController *presenter = self.presentingViewController;
+  UIViewController *presentingViewController = self;
+  [self dismissViewControllerAnimated:NO completion:nil];
+
   [coordinator animateAlongsideTransition:^(__unused
                    id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
-    CGPoint point = [self->_highlightedView.superview convertPoint:self->_highlightedView.center
-                                                            toView:self.featureHighlightView];
-
-    self.featureHighlightView.highlightPoint = point;
-    [self.featureHighlightView layoutIfNeeded];
-    [self.featureHighlightView updateOuterHighlight];
   }
-                               completion:nil];
+                               completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+                                 [presenter presentViewController:presentingViewController animated:YES completion:nil];
+                               }];
 }
 
 - (void)setOuterHighlightColor:(UIColor *)outerHighlightColor {


### PR DESCRIPTION
When rotating a device on an item that changes position with animation coordinator inside `viewWillTransitionToSize:withTransitionCoordinator:`, there can be a possible race condition that causes FeatureHighlight to be placed in the wrong position.
The approach here is to dismiss and present FeatureHighlight from the new position to avoid such issue.

Close #4185 