### PR TITLE
[BottomNavigation] Correct long title layout

### DIFF
--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -35,6 +35,8 @@
   self = [super init];
   if (self) {
     self.title = @"Bottom Navigation";
+    _colorScheme = [[MDCSemanticColorScheme alloc] init];
+    _typographyScheme = [[MDCTypographyScheme alloc] init];
   }
   return self;
 }

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -203,11 +203,11 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 - (void)layoutSubviews {
   [super layoutSubviews];
 
-  CGSize labelSize = [self.title boundingRectWithSize:self.bounds.size
-                                              options:NSStringDrawingUsesLineFragmentOrigin
-                                           attributes:@{ NSFontAttributeName:self.label.font }
-                                              context:nil].size;
-  self.label.frame = CGRectMake(0, 0, labelSize.width, labelSize.height);
+  [self.label sizeToFit];
+  CGSize labelSize = CGSizeMake(CGRectGetWidth(self.label.bounds),
+                                CGRectGetHeight(self.label.bounds));
+  CGFloat maxWidth = CGRectGetWidth(self.bounds);
+  self.label.frame = CGRectMake(0, 0, MIN(maxWidth, labelSize.width), labelSize.height);
   self.inkView.maxRippleRadius =
       (CGFloat)(MDCHypot(CGRectGetHeight(self.bounds), CGRectGetWidth(self.bounds)) / 2);
   [self centerLayoutAnimated:NO];


### PR DESCRIPTION
When title strings are very long (as may be common in localization to
non-default languages), MDCBottomNavigationBar was incorrectly computing the
expected height of the title label. Instead of querying the NSString for its
bounding rect, we can allow the UILabel to size itself and simply restrict
its width to the tab's width.

**Before (iPhone 4s/iOS 9.0)**
![bottomnav-long-title](https://user-images.githubusercontent.com/1753199/40679802-2f984c7e-6352-11e8-9123-82e92dea9c3f.png)

**After (iPhone 4s/iOS 9.0)**
![bottomnav-long-title-fixed](https://user-images.githubusercontent.com/1753199/40679814-394115bc-6352-11e8-9cbb-138ceba169fd.png)


Closes #4040
