### PR TITLE
[Dialogs] Update trackingView's `clipsToBounds` properly

### DIFF
--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -75,6 +75,7 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
     [_dimmingView addGestureRecognizer:_dismissGestureRecognizer];
 
     _trackingView = [[MDCDialogShadowedView alloc] init];
+    _trackingView.clipsToBounds = YES;
 
     [self registerKeyboardNotifications];
   }


### PR DESCRIPTION
When presenting a view with rounded corners, trackingView's corners are visible since clipsToBounds is set to NO by default.

Internal change 198049099.

<img width="825" alt="screen shot 2018-05-29 at 4 54 07 pm" src="https://user-images.githubusercontent.com/742162/40685022-1736e726-6361-11e8-9f8f-6371487c6775.png">
