### PR TITLE
[scripts] Add a squash-and-merge Chrome extension.

### DIFF
--- a/scripts/github-squash-and-merge/README.md
+++ b/scripts/github-squash-and-merge/README.md
@@ -1,0 +1,20 @@
+# GitHub PR Descriptions in Squash and Merge
+
+This is a Chrome extension that will automatically populate a squash-and-merge commit message with
+the PR's description.
+
+## Installation
+
+1. Visit [chrome://extensions/](chrome://extensions/).
+2. Enable Developer Mode.
+3. Click "Load unpacked".
+4. Select this folder.
+5. Refresh any tabs with GitHub open.
+
+Clicking the "squash and merge" button on pull requests will now populate the commit description
+with the PR description instead of the git commit messages.
+
+## Uninstallation
+
+1. Visit [chrome://extensions/](chrome://extensions/).
+2. Disable or remove the extension.

--- a/scripts/github-squash-and-merge/main.js
+++ b/scripts/github-squash-and-merge/main.js
@@ -41,6 +41,8 @@
     }
 
     squashButton.addEventListener('click', function() {
+      // GitHub populates the commit message with a bit of a delay, so we also need to delay our
+      // population of the message.
       setTimeout(function() {
         var mergeMessageField = document.getElementById('merge_message_field');
         var prTextarea = document.getElementsByClassName('comment-form-textarea')[0];

--- a/scripts/github-squash-and-merge/main.js
+++ b/scripts/github-squash-and-merge/main.js
@@ -19,9 +19,7 @@
  event firing after the initial load. This means if you open the pull requests page and then
  click a pull request, this js file is only executed when you load the initial pull requests page.
  Because the DOM is changing dynamically and we don't have a way to register live events to DOM
- elements as they're created, we need to poll the page for any squash-and-merge buttons. We do this
- on a 500ms interval in order to maximize the likelihood of us adding the event before someone
- clicks the button.
+ elements as they're created, we need to poll the page for any squash-and-merge buttons.
  */
 (function() {
   /*

--- a/scripts/github-squash-and-merge/main.js
+++ b/scripts/github-squash-and-merge/main.js
@@ -1,0 +1,67 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/**
+ GitHub loads its webpages using pjax, meaning we never really get a full document-did-load
+ event firing after the initial load. This means if you open the pull requests page and then
+ click a pull request, this js file is only executed when you load the initial pull requests page.
+ Because the DOM is changing dynamically and we don't have a way to register live events to DOM
+ elements as they're created, we need to poll the page for any squash-and-merge buttons. We do this
+ on a 500ms interval in order to maximize the likelihood of us adding the event before someone
+ clicks the button.
+ */
+(function() {
+  /*
+   On PR pages, finds a "Squash and Merge" button and adds a click event listener that replaces
+   the commit description with the PR description.
+   */
+  function scanForSquashAndMergeButtons() {
+    if (document.location.href.indexOf('/pull/') === -1) {
+      return;
+    }
+    var squashContainer = document.getElementsByClassName('btn-group-squash')[0];
+    if (!squashContainer) {
+      return;
+    }
+    var squashButton = squashContainer.querySelector('button[type="submit"]');
+  
+    if (squashButton.getAttribute('squashmerge')) {
+      return;
+    }
+
+    squashButton.addEventListener('click', function() {
+      setTimeout(function() {
+        var mergeMessageField = document.getElementById('merge_message_field');
+        var prTextarea = document.getElementsByClassName('comment-form-textarea')[0];
+        mergeMessageField.value = prTextarea.value;
+      }, 50);
+    });
+    squashButton.setAttribute('squashmerge', 'true');
+  }
+
+  const pollInterval = 1000; // Milliseconds
+
+  /*
+   Polls the current page for a squash and merge button.
+   */
+  function poll() {
+    scanForSquashAndMergeButtons();
+
+    setTimeout(poll, pollInterval);
+  }
+
+  setTimeout(poll, pollInterval);
+})();

--- a/scripts/github-squash-and-merge/manifest.json
+++ b/scripts/github-squash-and-merge/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "GitHub PR Descriptions in Squash and Merge",
+  "version": "1.0",
+  "description": "Sets squash-and-merge commit messages to the PR description.",
+  "manifest_version": 2,
+	"content_scripts": [{
+		"matches": ["https://github.com/*"],
+		"js": ["main.js"],
+		"run_at": "document_end",
+		"all_frames": true
+	}]
+}


### PR DESCRIPTION
This extension will automatically populate the suggested squash-and-merge description with the pull request's description.

## Before

![before](https://user-images.githubusercontent.com/45670/40694806-1cd8d65a-638c-11e8-97ed-0aacc5949bd4.gif)

## After

![after](https://user-images.githubusercontent.com/45670/40694816-371ae7b0-638c-11e8-9a1b-961dee011410.gif)

