### PR TITLE
[TextFields] Add placeholderLabel accessibilityLabel to textField accessibilityValue

### DIFF
--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -702,7 +702,7 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
 }
 
 - (NSString *)accessibilityValue {
-  NSMutableArray *accessibilityStrings = [NSMutableArray new];
+  NSMutableArray *accessibilityStrings = [[NSMutableArray alloc] init];
   if ([super accessibilityValue].length > 0) {
     [accessibilityStrings addObject:[super accessibilityValue]];
   }
@@ -713,7 +713,7 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
     [accessibilityStrings addObject:self.placeholderLabel.accessibilityLabel];
   }
   return accessibilityStrings.count > 0 ?
-      [accessibilityStrings componentsJoinedByString:@" "] : nil;
+      [accessibilityStrings componentsJoinedByString:@", "] : nil;
 }
 
 #pragma mark - Testing

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -702,12 +702,18 @@ static const CGFloat MDCTextInputEditingRectRightViewPaddingCorrection = -2.f;
 }
 
 - (NSString *)accessibilityValue {
-  if (self.leadingUnderlineLabel.text.length > 0) {
-    return [NSString stringWithFormat:@"%@ %@", [super accessibilityValue],
-                                      self.leadingUnderlineLabel.accessibilityLabel];
+  NSMutableArray *accessibilityStrings = [NSMutableArray new];
+  if ([super accessibilityValue].length > 0) {
+    [accessibilityStrings addObject:[super accessibilityValue]];
   }
-
-  return [super accessibilityValue];
+  if (self.leadingUnderlineLabel.accessibilityLabel.length > 0) {
+    [accessibilityStrings addObject:self.leadingUnderlineLabel.accessibilityLabel];
+  }
+  if (self.placeholderLabel.accessibilityLabel.length > 0) {
+    [accessibilityStrings addObject:self.placeholderLabel.accessibilityLabel];
+  }
+  return accessibilityStrings.count > 0 ?
+      [accessibilityStrings componentsJoinedByString:@" "] : nil;
 }
 
 #pragma mark - Testing


### PR DESCRIPTION
It's a `Chips` issue, but since `MDCChipField` uses an `MDCTextField` I think adding the functionality described in the issue to the textfield will address it.

Will resolve https://github.com/material-components/material-components-ios/issues/4315
