### PR TITLE
[Slider] Notify VoiceOver of MDCSlider value changes

### DIFF
--- a/components/Slider/src/MDCSlider.m
+++ b/components/Slider/src/MDCSlider.m
@@ -488,6 +488,7 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
 
 - (void)thumbTrackValueChanged:(__unused MDCThumbTrack *)thumbTrack {
   [self sendActionsForControlEvents:UIControlEventValueChanged];
+  UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, self.accessibilityValue);
 }
 
 - (void)thumbTrackTouchDown:(__unused MDCThumbTrack *)thumbTrack {


### PR DESCRIPTION
This change makes it so that there is VoiceOver speech when the value of a slider changes. It's adding functionality to discrete sliders that was previously only there for non-discrete sliders. 

This closes https://github.com/material-components/material-components-ios/issues/4289.

Note: As it stands right now, this change also affects non-discrete sliders. It makes it so that if you choose to swipe horizontally instead of using the brief vertical thumb track swipes to change the value you hear the value as you swipe. There is a delay, so there is not an overwhelming barrage of messages. Rather, you drag your thumb, wait 1 second, and hear the new value. You drag it further along, wait another second, and you hear another new value. Honestly I think it's an improvement, but I thought I should make note!