### PR TITLE
[FlexibleHeader] Fix additionalSafeAreaInsets bug when topLayoutGuideAdjustmentEnabled is enabled.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -288,17 +288,23 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
   CGFloat topInset = CGRectGetMaxY(_headerView.frame);
   self.topLayoutGuideConstraint.constant = topInset;
 
+    UIViewController *topLayoutGuideViewController = [self fhv_topLayoutGuideViewControllerWithFallback];
   // If there is a tracking scroll view then the flexible header will manage safe area insets via
   // the tracking scroll view's contentInsets. Some day - in the long distant future when we only
   // support iOS 11 and up - we can probably drop the content inset adjustment behavior in favor
   // of modifying additionalSafeAreaInsets instead.
   if (self.headerView.trackingScrollView != nil) {
+    // Reset the additional safe area insets if we are now tracking a scroll view.
+    if (topLayoutGuideViewController != nil) {
+      UIEdgeInsets additionalSafeAreaInsets = topLayoutGuideViewController.additionalSafeAreaInsets;
+      additionalSafeAreaInsets.top = 0;
+      topLayoutGuideViewController.additionalSafeAreaInsets = additionalSafeAreaInsets;
+    }
     return;
   }
 
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
-    UIViewController *topLayoutGuideViewController = [self fhv_topLayoutGuideViewControllerWithFallback];
     if (topLayoutGuideViewController != nil) {
       UIEdgeInsets additionalSafeAreaInsets = topLayoutGuideViewController.additionalSafeAreaInsets;
       if (self.headerView.statusBarHintCanOverlapHeader) {

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -294,12 +294,17 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
   // support iOS 11 and up - we can probably drop the content inset adjustment behavior in favor
   // of modifying additionalSafeAreaInsets instead.
   if (self.headerView.trackingScrollView != nil) {
-    // Reset the additional safe area insets if we are now tracking a scroll view.
-    if (topLayoutGuideViewController != nil) {
-      UIEdgeInsets additionalSafeAreaInsets = topLayoutGuideViewController.additionalSafeAreaInsets;
-      additionalSafeAreaInsets.top = 0;
-      topLayoutGuideViewController.additionalSafeAreaInsets = additionalSafeAreaInsets;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+    if (@available(iOS 11.0, *)) {
+      // Reset the additional safe area insets if we are now tracking a scroll view.
+      if (topLayoutGuideViewController != nil) {
+        UIEdgeInsets additionalSafeAreaInsets =
+            topLayoutGuideViewController.additionalSafeAreaInsets;
+        additionalSafeAreaInsets.top = 0;
+        topLayoutGuideViewController.additionalSafeAreaInsets = additionalSafeAreaInsets;
+      }
     }
+#endif
     return;
   }
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -288,14 +288,14 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
   CGFloat topInset = CGRectGetMaxY(_headerView.frame);
   self.topLayoutGuideConstraint.constant = topInset;
 
-    UIViewController *topLayoutGuideViewController = [self fhv_topLayoutGuideViewControllerWithFallback];
-  // If there is a tracking scroll view then the flexible header will manage safe area insets via
-  // the tracking scroll view's contentInsets. Some day - in the long distant future when we only
-  // support iOS 11 and up - we can probably drop the content inset adjustment behavior in favor
-  // of modifying additionalSafeAreaInsets instead.
-  if (self.headerView.trackingScrollView != nil) {
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
-    if (@available(iOS 11.0, *)) {
+  if (@available(iOS 11.0, *)) {
+    UIViewController *topLayoutGuideViewController = [self fhv_topLayoutGuideViewControllerWithFallback];
+    // If there is a tracking scroll view then the flexible header will manage safe area insets via
+    // the tracking scroll view's contentInsets. Some day - in the long distant future when we only
+    // support iOS 11 and up - we can probably drop the content inset adjustment behavior in favor
+    // of modifying additionalSafeAreaInsets instead.
+    if (self.headerView.trackingScrollView != nil) {
       // Reset the additional safe area insets if we are now tracking a scroll view.
       if (topLayoutGuideViewController != nil) {
         UIEdgeInsets additionalSafeAreaInsets =
@@ -303,14 +303,8 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
         additionalSafeAreaInsets.top = 0;
         topLayoutGuideViewController.additionalSafeAreaInsets = additionalSafeAreaInsets;
       }
-    }
-#endif
-    return;
-  }
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
-  if (@available(iOS 11.0, *)) {
-    if (topLayoutGuideViewController != nil) {
+    } else if (topLayoutGuideViewController != nil) {
       UIEdgeInsets additionalSafeAreaInsets = topLayoutGuideViewController.additionalSafeAreaInsets;
       if (self.headerView.statusBarHintCanOverlapHeader) {
         // safe area insets will likely already take into account the top safe area inset, so let's

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
@@ -77,6 +77,26 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
     #endif
   }
 
+  func testTrackingAnUntrackedTableViewTopLayoutGuideEqualsBottomEdgeOfHeaderView() {
+    // Given
+    let contentViewController = UITableViewController()
+    contentViewController.addChildViewController(fhvc)
+    contentViewController.view.addSubview(fhvc.view)
+    fhvc.didMove(toParentViewController: contentViewController)
+
+    fhvc.headerView.trackingScrollView = contentViewController.tableView
+
+    // Then
+    XCTAssertEqual(contentViewController.topLayoutGuide.length, fhvc.headerView.frame.maxY)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top, 0)
+      XCTAssertEqual(contentViewController.tableView.adjustedContentInset.top,
+                     fhvc.headerView.maximumHeight + MDCDeviceTopSafeAreaInset())
+    }
+    #endif
+  }
+
   // MARK: Tracked table view
 
   func testTrackedTableViewTopLayoutGuideEqualsBottomEdgeOfHeaderView() {

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
@@ -84,6 +84,17 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
     contentViewController.view.addSubview(fhvc.view)
     fhvc.didMove(toParentViewController: contentViewController)
 
+    // Then
+    XCTAssertEqual(contentViewController.topLayoutGuide.length, fhvc.headerView.frame.maxY)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top,
+                     fhvc.headerView.frame.maxY - MDCDeviceTopSafeAreaInset())
+      XCTAssertEqual(contentViewController.tableView.adjustedContentInset.top, 0)
+    }
+    #endif
+
+    // And then when
     fhvc.headerView.trackingScrollView = contentViewController.tableView
 
     // Then


### PR DESCRIPTION
Prior to this change:

When self.topLayoutGuideAdjustmentEnabled was enabled before a tracking scroll view is set, the top layout guide behavior was adjusting the additionalSafeAreaInsets. If a tracking scroll view was then set, the additionalSafeAreaInsets were never reset, resulting in the additional safe area insets being incorrect on the topLayoutGuideViewController.

After this change:

If no tracking scroll view is set when self.topLayoutGuideAdjustmentEnabled is enabled, the topLayoutGuideViewController's additionalSafeAreaInsets is reset to 0.