### PR TITLE
[HeaderStackView] Allow flexible topBar in MDCHeaderStackView

### DIFF
--- a/components/HeaderStackView/src/MDCHeaderStackView.m
+++ b/components/HeaderStackView/src/MDCHeaderStackView.m
@@ -61,10 +61,10 @@ static NSString *const MDCHeaderStackViewBottomBarKey = @"MDCHeaderStackViewBott
 
   CGSize boundsSize = self.bounds.size;
 
-  CGSize topBarSize = [_topBar sizeThatFits:boundsSize];
   CGSize bottomBarSize = [_bottomBar sizeThatFits:boundsSize];
-
-  CGFloat remainingHeight = boundsSize.height - topBarSize.height - bottomBarSize.height;
+  CGFloat remainingHeight = boundsSize.height - bottomBarSize.height;
+  CGSize topBarSize = [_topBar sizeThatFits:CGSizeMake(boundsSize.width, remainingHeight)];
+  remainingHeight -= topBarSize.height;
 
   CGRect topBarFrame = CGRectMake(0, 0, topBarSize.width, topBarSize.height);
   CGRect bottomBarFrame = CGRectMake(0, 0, bottomBarSize.width, bottomBarSize.height);


### PR DESCRIPTION
Change the layout behavior in MDCHeaderStackView to accommodate a topBar with flexible height.

Internal testing of this PR is done in cl/198879834, and there is some discussion on b/79893968.

Closes https://github.com/material-components/material-components-ios/issues/4356