### PR TITLE
[FlexibleHeader] Only extract the top layout guide if the view has loaded.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -246,7 +246,7 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
 - (void)fhv_extractTopLayoutGuideConstraint {
   UIViewController *topLayoutGuideViewController =
       [self fhv_topLayoutGuideViewControllerWithFallback];
-  if (!topLayoutGuideViewController) {
+  if (![topLayoutGuideViewController isViewLoaded]) {
     self.topLayoutGuideConstraint = nil;
     return;
   }

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -246,7 +246,7 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
 - (void)fhv_extractTopLayoutGuideConstraint {
   UIViewController *topLayoutGuideViewController =
       [self fhv_topLayoutGuideViewControllerWithFallback];
-  if (![topLayoutGuideViewController isViewLoaded]) {
+  if (!topLayoutGuideViewController.isViewLoaded) {
     self.topLayoutGuideConstraint = nil;
     return;
   }


### PR DESCRIPTION
This resolves the following runtime warning we were observing when the top layout guide was requested prior to the view controller being loaded:

    -[UIViewController topLayoutGuide]: guide not available before the view controller's view is loaded

This behavior is only visible when `topLayoutGuideAdjustmentEnabled` is YES.