### PR TITLE
[NavigationBar] Deprecate useFlexibleTopBottomInsets

### DIFF
--- a/components/AppBar/examples/AppBarTypicalUseExample.m
+++ b/components/AppBar/examples/AppBarTypicalUseExample.m
@@ -45,8 +45,6 @@
 
     _appBar.navigationBar.inkColor = [UIColor colorWithWhite:0.9f alpha:0.1f];
 
-    _appBar.navigationBar.useFlexibleTopBottomInsets = YES;
-
     self.colorScheme = [[MDCSemanticColorScheme alloc] init];
     self.typographyScheme = [[MDCTypographyScheme alloc] init];
   }

--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -242,24 +242,6 @@ IB_DESIGNABLE
 #pragma mark - To be deprecated
 
 /**
- Makes the navigation bar use flexible top and bottom insets for buttons and titles, by vertically
- positioning them based on the height of the navigation bar. Default insets do not allow the height
- of the navigation bar to be set to anything less than 56.0f, so this property has to be set to YES
- in that case.
- 
- When this is set to YES, the custom titleView is aligned with the button bars and has the same
- height as them, regardless of the height of the navigation bar. This allows vertically aligning the
- content of the titleView with the buttons, by vertically centering the content of the titleView.
- 
- Default is NO.
- 
- NOTE: This property will be deprecated and the YES behavior will replace the current behavior.
- All clients who rely on the titleView should set this to YES and implement proper alignment before
- deprecation.
- */
-@property(nonatomic) BOOL useFlexibleTopBottomInsets;
-
-/**
  Display attributes for the titleView's title text.
 
  Font attribute will take precedence over titleFont property.
@@ -280,5 +262,24 @@ IB_DESIGNABLE
 
 /** The text alignment of the navigation bar title. Defaults to NSTextAlignmentLeft. */
 @property(nonatomic) NSTextAlignment textAlignment __deprecated_msg("Use titleAlignment instead.");
+
+/**
+ Makes the navigation bar use flexible top and bottom insets for buttons and titles, by vertically
+ positioning them based on the height of the navigation bar.
+
+ When set to NO, vertical insets do not allow the height of the navigation bar to be set to anything
+ less than 56.0f, and titleView occupies the entire vertical space in MDCNavigationBar, regardless
+ of the height and position of button bars.
+
+ When set to YES, the titleView is aligned with the button bars and has the same height as them,
+ regardless of the height of the navigation bar. This allows vertically aligning the content of the
+ titleView with the buttons, by vertically centering the content of the titleView.
+
+ Default is YES.
+
+ NOTE: This property will be removed soon.
+ */
+@property(nonatomic) BOOL useFlexibleTopBottomInsets
+    __deprecated_msg("Implement proper vertical alignment with the default YES behavior.");
 
 @end

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -344,7 +344,10 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   _trailingButtonBar.frame = trailingButtonBarFrame;
 
   UIEdgeInsets textInsets = [self usePadInsets] ? kTextPadInsets : kTextInsets;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   if (self.useFlexibleTopBottomInsets) {
+#pragma clang diagnostic pop
     textInsets.top = 0;
     textInsets.bottom = 0;
   }
@@ -391,7 +394,10 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   }
 
   CGRect titleViewFrame = textFrame;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   if (self.useFlexibleTopBottomInsets) {
+#pragma clang diagnostic pop
     // No insets for the titleView, and a height that is the same as the button bars. Clients
     // can vertically center their titleView subviews to align them with buttons.
     titleViewFrame.origin.y = 0;
@@ -424,8 +430,11 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   CGFloat maxHeight =
       [self usePadInsets] ? kNavigationBarPadDefaultHeight : kNavigationBarDefaultHeight;
   CGFloat minHeight = kNavigationBarMinHeight;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   CGFloat height =
       self.useFlexibleTopBottomInsets ? MIN(MAX(size.height, minHeight), maxHeight) : maxHeight;
+#pragma clang diagnostic pop
   return CGSizeMake(size.width, height);
 }
 
@@ -547,8 +556,11 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
       // the header regardless of the header's height.
       CGFloat maxHeight =
           [self usePadInsets] ? kNavigationBarPadDefaultHeight : kNavigationBarDefaultHeight;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
       CGFloat height =
           self.useFlexibleTopBottomInsets ? MIN(CGRectGetHeight(bounds), maxHeight) : maxHeight;
+#pragma clang diagnostic pop
       CGFloat navigationBarCenteredY = MDCFloor((height - CGRectGetHeight(frame)) / 2);
       navigationBarCenteredY = MAX(0, navigationBarCenteredY);
       return CGRectMake(CGRectGetMinX(frame), navigationBarCenteredY, CGRectGetWidth(frame),
@@ -572,7 +584,10 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
       MDCButtonBar *leftButtonBar = self.leadingButtonBar;
       MDCButtonBar *rightButtonBar = self.trailingButtonBar;
       UIEdgeInsets textInsets = [self usePadInsets] ? kTextPadInsets : kTextInsets;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
       if (self.useFlexibleTopBottomInsets) {
+#pragma clang diagnostic pop
         textInsets.top = 0;
         textInsets.bottom = 0;
       }

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -153,6 +153,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
 - (void)commonMDCNavigationBarInit {
   _observedNavigationItemLock = [[NSObject alloc] init];
   _titleFont = [MDCTypography titleFont];
+  _useFlexibleTopBottomInsets = YES;
 
   _titleLabel = [[UILabel alloc] init];
   _titleLabel.font = _titleFont;


### PR DESCRIPTION
Deprecate useFlexibleTopBottomInsets and change the default behavior to YES.