### PR TITLE
[PageControl] Make MDCPageControl minimum height adhere to accessibility requirements

### DIFF
--- a/components/PageControl/src/MDCPageControl.m
+++ b/components/PageControl/src/MDCPageControl.m
@@ -30,7 +30,7 @@ static NSString *const kMaterialPageControlBundle = @"MaterialPageControl.bundle
 static NSString *const kMaterialPageControlScrollViewContentOffset = @"bounds.origin";
 
 // Matches native UIPageControl minimum height.
-static const CGFloat kPageControlMinimumHeight = 37.0f;
+static const CGFloat kPageControlMinimumHeight = 48.0f;
 
 // Matches native UIPageControl indicator radius.
 static const CGFloat kPageControlIndicatorRadius = 3.5f;

--- a/components/PageControl/tests/unit/PageControlExampleTests.m
+++ b/components/PageControl/tests/unit/PageControlExampleTests.m
@@ -81,21 +81,27 @@
   [pageControl sizeToFit];
   nativePageControl.numberOfPages = 1;
   [nativePageControl sizeToFit];
-  XCTAssertTrue(CGRectEqualToRect(CGRectIntegral(pageControl.frame), nativePageControl.frame));
+  CGRect frame = CGRectIntegral(pageControl.frame);
+  XCTAssertEqual(frame.size.height, 48.0);
+  XCTAssertEqual(frame.size.width, nativePageControl.frame.size.width);
 
   // Test both controls with 4 pages.
   pageControl.numberOfPages = 4;
   [pageControl sizeToFit];
   nativePageControl.numberOfPages = 4;
   [nativePageControl sizeToFit];
-  XCTAssertTrue(CGRectEqualToRect(CGRectIntegral(pageControl.frame), nativePageControl.frame));
+  frame = CGRectIntegral(pageControl.frame);
+  XCTAssertEqual(frame.size.height, 48.0);
+  XCTAssertEqual(frame.size.width, nativePageControl.frame.size.width);
 
   // Test with different number of pages for each control.
   pageControl.numberOfPages = 4;
   [pageControl sizeToFit];
   nativePageControl.numberOfPages = 2;
   [nativePageControl sizeToFit];
-  XCTAssertFalse(CGRectEqualToRect(CGRectIntegral(pageControl.frame), nativePageControl.frame));
+  frame = CGRectIntegral(pageControl.frame);
+  XCTAssertEqual(frame.size.height, 48.0);
+  XCTAssertNotEqual(frame.size.width, nativePageControl.frame.size.width);
 }
 
 - (void)testScrollOffsetOutOfBoundsOfNumberOfPages {


### PR DESCRIPTION
This change increases the minimum page control height 48 to adhere to accessibility standards.

Closes https://github.com/material-components/material-components-ios/issues/4287.