### PR TITLE
[AppBar] Fix VoiceOver escape gesture bug.

### DIFF
--- a/components/AppBar/src/MDCAppBar.m
+++ b/components/AppBar/src/MDCAppBar.m
@@ -359,9 +359,18 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
 #endif
 }
 
+- (BOOL)accessibilityPerformEscape {
+  [self dismissSelf];
+  return YES;
+}
+
 #pragma mark User actions
 
 - (void)didTapBackButton:(__unused id)sender {
+  [self dismissSelf];
+}
+
+- (void)dismissSelf {
   UIViewController *pvc = self.flexibleHeaderParentViewController;
   if (pvc.navigationController && pvc.navigationController.viewControllers.count > 1) {
     [pvc.navigationController popViewControllerAnimated:YES];


### PR DESCRIPTION
Prior to this change, view controllers that were using an App Bar were not responding to the accessibility escape gesture in a UINavigationController. This is due to the fact that the UINavigationBar was hidden, disabling the default UIKit behavior.

After this change, the App Bar handles the accessibilityPerformEscape event by dismissing the app bar view controller.

Closes https://github.com/material-components/material-components-ios/issues/3656