### PR TITLE
[TextFields] Tweak accessibility notification to prevent VoiceOver from cutting off

### DIFF
--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -1736,9 +1736,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
           errorText.length > 0 ? [NSString stringWithFormat:@"Error: %@", errorText] : @"Error.";
     }
 
-    // Simply sending a layout change notification does not seem to
-    UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcementString);
-
     NSString *valueString = @"";
 
     if (self.textInput.text.length > 0) {
@@ -1754,6 +1751,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
     self.textInput.leadingUnderlineLabel.accessibilityLabel =
         [NSString stringWithFormat:@"Error: %@.",
                                    leadingUnderlineLabelText ? leadingUnderlineLabelText : @""];
+    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self.textInput.leadingUnderlineLabel);
   } else {
     self.textInput.accessibilityValue = nil;
     self.textInput.leadingUnderlineLabel.accessibilityLabel = nil;


### PR DESCRIPTION
As the issue states, the VoiceOver message recited when the zip code text field is in an error state is cut off in the Catalog TextFields "Filled Text Field" example. @yarneo pointed out that maybe the element was prematurely losing focus. I noticed there was an `MDCChipField` method called `focusTextFieldForAccessibility`, which [posts](https://github.com/material-components/material-components-ios/blob/develop/components/Chips/src/MDCChipField.m#L667) a `UIAccessibilityLayoutChangedNotification` to force the Chip Field to be focused, and decided to try a similar approach here with the `textInput`'s `leadingUnderlineLabel`, which contains the text we want read.

Is this a valid fix? It feels funny to me, but I couldn't get anything else to work. If anyone else has any ideas I'd love to hear them. I should note that `leadingUnderlineLabel` is `nonnull`, so I think we can count on it at least being there... Huh.

Will close #4323 if merged.