### PR TITLE
[Chips] Adds support for reading contentHorizontalAlignment in MDCChipView.

### DIFF
--- a/components/Chips/examples/ChipsSizingExampleViewController.m
+++ b/components/Chips/examples/ChipsSizingExampleViewController.m
@@ -23,6 +23,7 @@
   MDCChipView *_chipView;
   MDCSlider *_widthSlider;
   MDCSlider *_heightSlider;
+  UISegmentedControl *_horizontalAlignmentControl;
 }
 
 - (void)viewDidLoad {
@@ -54,6 +55,13 @@
                     action:@selector(heightSliderChanged:)
           forControlEvents:UIControlEventValueChanged];
   [self.view addSubview:_heightSlider];
+
+  _horizontalAlignmentControl = [[UISegmentedControl alloc] initWithItems:@[ @"Default", @"Centered" ]];
+  _horizontalAlignmentControl.selectedSegmentIndex = 0;
+  [_horizontalAlignmentControl addTarget:self
+                                  action:@selector(horizontalAlignmentChanged:)
+                        forControlEvents:UIControlEventValueChanged];
+  [self.view addSubview:_horizontalAlignmentControl];
 }
 
 - (void)viewWillLayoutSubviews {
@@ -63,6 +71,8 @@
   _widthSlider.frame = CGRectMake(20, 140, self.view.bounds.size.width - 40, sliderSize.height);
   _heightSlider.frame =
       CGRectMake(20, 140 + sliderSize.height + 20, self.view.bounds.size.width - 40, sliderSize.height);
+  _horizontalAlignmentControl.frame =
+      CGRectMake(20, CGRectGetMaxY(_heightSlider.frame) + 20, self.view.bounds.size.width - 40, _horizontalAlignmentControl.frame.size.height);
 }
 
 - (void)widthSliderChanged:(MDCSlider *)slider {
@@ -76,6 +86,14 @@
   CGRect frame = _chipView.frame;
   frame.size.height = slider.value;
   _chipView.frame = frame;
+  [_chipView layoutIfNeeded];
+}
+
+- (void)horizontalAlignmentChanged:(UISegmentedControl *)segmentedControl {
+  UIControlContentHorizontalAlignment alignment = (segmentedControl.selectedSegmentIndex == 0)
+      ? UIControlContentHorizontalAlignmentFill
+      : UIControlContentHorizontalAlignmentCenter;
+  _chipView.contentHorizontalAlignment = alignment;
   [_chipView layoutIfNeeded];
 }
 

--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -29,6 +29,12 @@
 
  Chips contain an optional leading image, a title label and an optional trailing accessory view.
  They can also contain a leading image that appears only when the chip is selected.
+
+ Chips currently support two contentHorizontalAlignment styles: centered
+ (UIControlContentHorizontalAlignmentCenter) and default
+ (any other UIControlContentHorizontalAlignment value). In the default mode, the image and text will
+ be left-aligned, and the accessory view will be right aligned. In the centered mode, all three will
+ appear together in the center of the chip.
  */
 @interface MDCChipView : UIControl
 

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -41,6 +41,18 @@ static inline UIColor *MDCColorLighten(UIColor *color, CGFloat percent) {
   return MDCColorDarken(color, -percent);
 }
 
+static inline UIImage *TestImage(CGSize size) {
+  CGFloat scale = [UIScreen mainScreen].scale;
+  UIGraphicsBeginImageContextWithOptions(size, false, scale);
+  [UIColor.redColor setFill];
+  CGRect fillRect = CGRectZero;
+  fillRect.size = size;
+  UIRectFill(fillRect);
+  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+  return image;
+}
+
 @interface ChipsTests : XCTestCase
 
 @end
@@ -178,6 +190,49 @@ static inline UIColor *MDCColorLighten(UIColor *color, CGFloat percent) {
                              minimumDimension, 0.001);
   XCTAssertEqualWithAccuracy(chipWithMinimumHeightAndWidth.intrinsicContentSize.height,
                              minimumDimension, 0.001);
+}
+
+- (void)testLayoutWithHorizontalContentModeFill {
+  // Given
+  MDCChipView *chip = [[MDCChipView alloc] init];
+  chip.titleLabel.text = @"Chip";
+  chip.imageView.image = TestImage(CGSizeMake(24, 24));
+
+  // When
+  chip.frame = CGRectMake(0, 0, 1000, 500);
+  [chip layoutIfNeeded];
+
+  // Then
+  XCTAssertLessThan(CGRectGetMinX(chip.titleLabel.frame), CGRectGetMidX(chip.bounds));
+  XCTAssertLessThan(CGRectGetMinY(chip.titleLabel.frame), CGRectGetMidY(chip.bounds));
+  XCTAssertGreaterThan(CGRectGetMaxX(chip.titleLabel.frame), CGRectGetMidX(chip.bounds));
+  XCTAssertGreaterThan(CGRectGetMaxY(chip.titleLabel.frame), CGRectGetMidY(chip.bounds));
+  XCTAssertLessThan(CGRectGetMinX(chip.imageView.frame), CGRectGetMidX(chip.bounds));
+  XCTAssertLessThan(CGRectGetMinY(chip.imageView.frame), CGRectGetMidY(chip.bounds));
+  XCTAssertLessThan(CGRectGetMaxX(chip.imageView.frame), 100);
+  XCTAssertGreaterThan(CGRectGetMaxY(chip.imageView.frame), CGRectGetMidY(chip.bounds));
+}
+
+- (void)testLayoutWithHorizontalContentModeCenter {
+  // Given
+  MDCChipView *chip = [[MDCChipView alloc] init];
+  chip.contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
+  chip.titleLabel.text = @"Chip";
+  chip.imageView.image = TestImage(CGSizeMake(24, 24));
+
+  // When
+  chip.frame = CGRectMake(0, 0, 1000, 1000);
+  [chip layoutIfNeeded];
+
+  // Then
+  XCTAssertLessThan(CGRectGetMinX(chip.titleLabel.frame), CGRectGetMidX(chip.bounds));
+  XCTAssertLessThan(CGRectGetMinY(chip.titleLabel.frame), CGRectGetMidY(chip.bounds));
+  XCTAssertGreaterThan(CGRectGetMaxX(chip.titleLabel.frame), CGRectGetMidX(chip.bounds));
+  XCTAssertGreaterThan(CGRectGetMaxY(chip.titleLabel.frame), CGRectGetMidY(chip.bounds));
+  XCTAssertLessThan(CGRectGetMinX(chip.imageView.frame), CGRectGetMidX(chip.bounds));
+  XCTAssertLessThan(CGRectGetMinY(chip.imageView.frame), CGRectGetMidY(chip.bounds));
+  XCTAssertGreaterThan(CGRectGetMaxX(chip.imageView.frame), 100);
+  XCTAssertGreaterThan(CGRectGetMaxY(chip.imageView.frame), CGRectGetMidY(chip.bounds));
 }
 
 #pragma mark - Touch Target


### PR DESCRIPTION
The only supported values so far are Fill (the default now) and Center (the new value).

Also adds an example to the MDCDragon app:
![screen shot 2018-06-05 at 2 03 17 pm](https://user-images.githubusercontent.com/217786/41002659-3aac0714-68c9-11e8-947e-c35641f0a82b.png)


Closes #4277 