### PR TITLE
[AppBar] Implement topLayoutGuideAdjustmentEnabled on the app bar container.

### DIFF
--- a/components/AppBar/examples/AppBarWrappingUITableViewControllerExample.m
+++ b/components/AppBar/examples/AppBarWrappingUITableViewControllerExample.m
@@ -47,6 +47,7 @@
   tableViewController.title = @"Wrapped table view";
   self.appBarContainerViewController =
       [[MDCAppBarContainerViewController alloc] initWithContentViewController:tableViewController];
+  self.appBarContainerViewController.topLayoutGuideAdjustmentEnabled = YES;
 
   tableViewController.tableView.dataSource = self;
   tableViewController.tableView.delegate =

--- a/components/AppBar/src/MDCAppBarContainerViewController.h
+++ b/components/AppBar/src/MDCAppBarContainerViewController.h
@@ -59,4 +59,30 @@
 /** The content view controller to be displayed behind the header. */
 @property(nonatomic, strong, nonnull, readonly) UIViewController *contentViewController;
 
+#pragma mark - Enabling top layout guide adjustment behavior
+
+/**
+ If enabled, the content view controller's top layout guide will be adjusted as the flexible
+ header's height changes and the content view controller view's frame will be set to the container
+ view controller's bounds.
+
+ This behavior is disabled by default, but it will be enabled by default in the future. Consider
+ enabling this behavior and making use of the topLayoutGuide in your view controller accordingly.
+
+ Example positioning a view using constraints:
+
+     [NSLayoutConstraint constraintWithItem:view
+                                  attribute:NSLayoutAttributeTop
+                                  relatedBy:NSLayoutRelationEqual
+                                     toItem:self.topLayoutGuide
+                                  attribute:NSLayoutAttributeBottom
+                                 multiplier:1
+                                   constant:32]
+
+ Example positioning a view without constraints:
+
+     frame.origin.y = self.topLayoutGuide.length + 32
+ */
+@property(nonatomic, getter=isTopLayoutGuideAdjustmentEnabled) BOOL topLayoutGuideAdjustmentEnabled;
+
 @end

--- a/components/AppBar/src/MDCAppBarContainerViewController.m
+++ b/components/AppBar/src/MDCAppBarContainerViewController.m
@@ -45,11 +45,16 @@
   [_appBar addSubviewsToParent];
 
   [_appBar.navigationBar observeNavigationItem:_contentViewController.navigationItem];
+
+  [self updateTopLayoutGuideBehavior];
 }
 
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
-  [_appBar.headerViewController updateTopLayoutGuide];
+
+  if (!self.topLayoutGuideAdjustmentEnabled) {
+    [_appBar.headerViewController updateTopLayoutGuide];
+  }
 }
 
 - (BOOL)prefersStatusBarHidden {
@@ -70,6 +75,40 @@
 
 - (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation {
   return self.contentViewController.preferredInterfaceOrientationForPresentation;
+}
+
+#pragma mark - Enabling top layout guide adjustment behavior
+
+- (void)updateTopLayoutGuideBehavior {
+  if (self.topLayoutGuideAdjustmentEnabled) {
+    if ([self isViewLoaded]) {
+      self.contentViewController.view.translatesAutoresizingMaskIntoConstraints = YES;
+      self.contentViewController.view.autoresizingMask = (UIViewAutoresizingFlexibleWidth
+                                                          | UIViewAutoresizingFlexibleHeight);
+      self.contentViewController.view.frame = self.view.bounds;
+    }
+
+    // The flexible header view controller, by default, will assume that it is a child view
+    // controller of the content view controller and modify its parent view controller's
+    // topLayoutGuide. With an App Bar container view controller, however, our flexible header's
+    // parent is the app bar container view controller instead. There does not appear to be a way to
+    // make two top layout guides constrain to one other
+    // (e.g. self.topLayoutGuide == self.contentViewController.topLayoutGuide) so instead we must
+    // tell the flexible header controller which view controller it should modify.
+    self.appBar.headerViewController.topLayoutGuideViewController = self.contentViewController;
+
+  } else {
+    self.appBar.headerViewController.topLayoutGuideViewController = nil;
+  }
+}
+
+- (void)setTopLayoutGuideAdjustmentEnabled:(BOOL)topLayoutGuideAdjustmentEnabled {
+  if (_topLayoutGuideAdjustmentEnabled == topLayoutGuideAdjustmentEnabled) {
+    return;
+  }
+  _topLayoutGuideAdjustmentEnabled = topLayoutGuideAdjustmentEnabled;
+
+  [self updateTopLayoutGuideBehavior];
 }
 
 @end

--- a/components/AppBar/tests/unit/AppBarWrappingLegacyTopLayoutGuideTests.swift
+++ b/components/AppBar/tests/unit/AppBarWrappingLegacyTopLayoutGuideTests.swift
@@ -1,0 +1,151 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents.MaterialAppBar
+import MaterialComponents.MaterialUIMetrics
+
+class AppBarWrappingLegacyTopLayoutGuideTests: XCTestCase {
+
+  // MARK: No scroll view
+
+  func testNoScrollViewTopLayoutGuideEqualsZero() {
+    // Given
+    let contentViewController = UIViewController()
+
+    let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.isTopLayoutGuideAdjustmentEnabled = false
+    container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+    container.appBar.headerViewController.headerView.minimumHeight = 50
+    container.appBar.headerViewController.headerView.maximumHeight = 100
+    let _ = container.view // Force the view to load.
+
+    // Then
+    XCTAssertEqual(contentViewController.topLayoutGuide.length, 0)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top, 0)
+    }
+    #endif
+  }
+
+  // MARK: Untracked table view
+
+  func testUntrackedTableViewTopLayoutGuideEqualsZero() {
+    // Given
+    let contentViewController = UITableViewController()
+
+    let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.isTopLayoutGuideAdjustmentEnabled = false
+    container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+    container.appBar.headerViewController.headerView.minimumHeight = 50
+    container.appBar.headerViewController.headerView.maximumHeight = 100
+    let _ = container.view // Force the view to load.
+
+    // Then
+    XCTAssertEqual(contentViewController.topLayoutGuide.length, 0)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top, 0)
+      XCTAssertEqual(contentViewController.tableView.adjustedContentInset.top, 0)
+    }
+    #endif
+  }
+
+  // MARK: Tracked table view
+
+  func testTrackedTableViewTopLayoutGuideEqualsZero() {
+    // Given
+    let contentViewController = UITableViewController()
+
+    let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.isTopLayoutGuideAdjustmentEnabled = false
+    container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+    container.appBar.headerViewController.headerView.minimumHeight = 50
+    container.appBar.headerViewController.headerView.maximumHeight = 100
+    let _ = container.view // Force the view to load.
+
+    container.appBar.headerViewController.headerView.trackingScrollView = contentViewController.tableView
+    container.appBar.headerViewController.headerView.trackingScrollDidScroll()
+
+    // Then
+    XCTAssertEqual(contentViewController.topLayoutGuide.length, 0)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top, 0)
+      XCTAssertEqual(contentViewController.tableView.adjustedContentInset.top,
+                     container.appBar.headerViewController.headerView.maximumHeight
+                      + MDCDeviceTopSafeAreaInset())
+    }
+    #endif
+  }
+
+  // MARK: Untracked collection view
+
+  func testUntrackedCollectionViewTopLayoutGuideEqualsZero() {
+    // Given
+    let flow = UICollectionViewFlowLayout()
+    let contentViewController = UICollectionViewController(collectionViewLayout: flow)
+
+    let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.isTopLayoutGuideAdjustmentEnabled = false
+    container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+    container.appBar.headerViewController.headerView.minimumHeight = 50
+    container.appBar.headerViewController.headerView.maximumHeight = 100
+    let _ = container.view // Force the view to load.
+
+    // Then
+    XCTAssertEqual(contentViewController.topLayoutGuide.length, 0)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top, 0)
+      XCTAssertEqual(contentViewController.collectionView!.adjustedContentInset.top, 0)
+    }
+    #endif
+  }
+
+  // MARK: Tracked collection view view
+
+  func testTrackedCollectionViewTopLayoutGuideEqualsZero() {
+    // Given
+    let flow = UICollectionViewFlowLayout()
+    let contentViewController = UICollectionViewController(collectionViewLayout: flow)
+
+    let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.isTopLayoutGuideAdjustmentEnabled = false
+    container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+    container.appBar.headerViewController.headerView.minimumHeight = 50
+    container.appBar.headerViewController.headerView.maximumHeight = 100
+    let _ = container.view // Force the view to load.
+
+    container.appBar.headerViewController.headerView.trackingScrollView =
+      contentViewController.collectionView
+    container.appBar.headerViewController.headerView.trackingScrollDidScroll()
+
+    // Then
+    XCTAssertEqual(contentViewController.topLayoutGuide.length, 0)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top, 0)
+      XCTAssertEqual(contentViewController.collectionView!.adjustedContentInset.top,
+                     container.appBar.headerViewController.headerView.maximumHeight
+                      + MDCDeviceTopSafeAreaInset())
+    }
+    #endif
+  }
+
+}
+

--- a/components/AppBar/tests/unit/AppBarWrappingLegacyTopLayoutGuideTests.swift
+++ b/components/AppBar/tests/unit/AppBarWrappingLegacyTopLayoutGuideTests.swift
@@ -34,6 +34,7 @@ class AppBarWrappingLegacyTopLayoutGuideTests: XCTestCase {
     let _ = container.view // Force the view to load.
 
     // Then
+    XCTAssertNil(container.appBar.headerViewController.topLayoutGuideViewController)
     XCTAssertEqual(contentViewController.topLayoutGuide.length, 0)
     #if swift(>=3.2)
     if #available(iOS 11.0, *) {
@@ -56,6 +57,7 @@ class AppBarWrappingLegacyTopLayoutGuideTests: XCTestCase {
     let _ = container.view // Force the view to load.
 
     // Then
+    XCTAssertNil(container.appBar.headerViewController.topLayoutGuideViewController)
     XCTAssertEqual(contentViewController.topLayoutGuide.length, 0)
     #if swift(>=3.2)
     if #available(iOS 11.0, *) {
@@ -82,6 +84,7 @@ class AppBarWrappingLegacyTopLayoutGuideTests: XCTestCase {
     container.appBar.headerViewController.headerView.trackingScrollDidScroll()
 
     // Then
+    XCTAssertNil(container.appBar.headerViewController.topLayoutGuideViewController)
     XCTAssertEqual(contentViewController.topLayoutGuide.length, 0)
     #if swift(>=3.2)
     if #available(iOS 11.0, *) {
@@ -108,6 +111,7 @@ class AppBarWrappingLegacyTopLayoutGuideTests: XCTestCase {
     let _ = container.view // Force the view to load.
 
     // Then
+    XCTAssertNil(container.appBar.headerViewController.topLayoutGuideViewController)
     XCTAssertEqual(contentViewController.topLayoutGuide.length, 0)
     #if swift(>=3.2)
     if #available(iOS 11.0, *) {
@@ -117,7 +121,7 @@ class AppBarWrappingLegacyTopLayoutGuideTests: XCTestCase {
     #endif
   }
 
-  // MARK: Tracked collection view view
+  // MARK: Tracked collection view
 
   func testTrackedCollectionViewTopLayoutGuideEqualsZero() {
     // Given
@@ -136,6 +140,7 @@ class AppBarWrappingLegacyTopLayoutGuideTests: XCTestCase {
     container.appBar.headerViewController.headerView.trackingScrollDidScroll()
 
     // Then
+    XCTAssertNil(container.appBar.headerViewController.topLayoutGuideViewController)
     XCTAssertEqual(contentViewController.topLayoutGuide.length, 0)
     #if swift(>=3.2)
     if #available(iOS 11.0, *) {

--- a/components/AppBar/tests/unit/AppBarWrappingTopLayoutGuideTests.swift
+++ b/components/AppBar/tests/unit/AppBarWrappingTopLayoutGuideTests.swift
@@ -1,0 +1,193 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents.MaterialAppBar
+import MaterialComponents.MaterialUIMetrics
+
+class AppBarWrappingTopLayoutGuideTests: XCTestCase {
+
+  // MARK: No scroll view
+
+  func testNoScrollViewTopLayoutGuideEqualsBottomEdgeOfHeaderView() {
+    // Given
+    let contentViewController = UIViewController()
+    let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.isTopLayoutGuideAdjustmentEnabled = true
+    container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+    container.appBar.headerViewController.headerView.minimumHeight = 50
+    container.appBar.headerViewController.headerView.maximumHeight = 100
+    let _ = container.view // Force the view to load.
+
+    // Then
+    XCTAssertEqual(contentViewController.view.autoresizingMask, [.flexibleWidth, .flexibleHeight])
+    XCTAssertEqual(contentViewController.view.frame, container.view.bounds)
+    XCTAssertEqual(contentViewController.topLayoutGuide.length,
+                   container.appBar.headerViewController.headerView.frame.maxY)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top,
+                     container.appBar.headerViewController.headerView.frame.maxY
+                      - MDCDeviceTopSafeAreaInset())
+    }
+    #endif
+  }
+
+  func testEarlyViewLoadStillAffectsTopLayoutGuide() {
+    // Given
+    let contentViewController = UIViewController()
+    let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.isTopLayoutGuideAdjustmentEnabled = true
+    container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+    container.appBar.headerViewController.headerView.minimumHeight = 50
+    container.appBar.headerViewController.headerView.maximumHeight = 100
+    let _ = container.view // Force the view to load.
+
+    // Then
+    XCTAssertEqual(contentViewController.view.autoresizingMask, [.flexibleWidth, .flexibleHeight])
+    XCTAssertEqual(contentViewController.view.frame, container.view.bounds)
+    XCTAssertEqual(contentViewController.topLayoutGuide.length,
+                   container.appBar.headerViewController.headerView.frame.maxY)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top,
+                     container.appBar.headerViewController.headerView.frame.maxY
+                      - MDCDeviceTopSafeAreaInset())
+    }
+    #endif
+  }
+
+  // MARK: Untracked table view
+
+  func testUntrackedTableViewTopLayoutGuideEqualsBottomEdgeOfHeaderView() {
+    // Given
+    let contentViewController = UITableViewController()
+    let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.isTopLayoutGuideAdjustmentEnabled = true
+    container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+    container.appBar.headerViewController.headerView.minimumHeight = 50
+    container.appBar.headerViewController.headerView.maximumHeight = 100
+    let _ = container.view // Force the view to load.
+
+    // Then
+    XCTAssertEqual(contentViewController.view.autoresizingMask, [.flexibleWidth, .flexibleHeight])
+    XCTAssertEqual(contentViewController.view.frame, container.view.bounds)
+    XCTAssertEqual(contentViewController.topLayoutGuide.length,
+                   container.appBar.headerViewController.headerView.frame.maxY)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top,
+                     container.appBar.headerViewController.headerView.frame.maxY
+                      - MDCDeviceTopSafeAreaInset())
+      XCTAssertEqual(contentViewController.tableView.adjustedContentInset.top, 0)
+    }
+    #endif
+  }
+
+  // MARK: Tracked table view
+
+  func testTrackedTableViewTopLayoutGuideEqualsBottomEdgeOfHeaderView() {
+    // Given
+    let contentViewController = UITableViewController()
+
+    let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.isTopLayoutGuideAdjustmentEnabled = true
+    container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+    container.appBar.headerViewController.headerView.minimumHeight = 50
+    container.appBar.headerViewController.headerView.maximumHeight = 100
+    let _ = container.view // Force the view to load.
+
+    container.appBar.headerViewController.headerView.trackingScrollView =
+        contentViewController.tableView
+    container.appBar.headerViewController.headerView.trackingScrollDidScroll()
+
+    // Then
+    XCTAssertEqual(contentViewController.topLayoutGuide.length,
+                   container.appBar.headerViewController.headerView.frame.maxY)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top, 0)
+      XCTAssertEqual(contentViewController.tableView.adjustedContentInset.top,
+                     container.appBar.headerViewController.headerView.maximumHeight
+                      + MDCDeviceTopSafeAreaInset())
+    }
+    #endif
+  }
+
+  // MARK: Untracked collection view
+
+  func testUntrackedCollectionViewTopLayoutGuideEqualsBottomEdgeOfHeaderView() {
+    // Given
+    let flow = UICollectionViewFlowLayout()
+    let contentViewController = UICollectionViewController(collectionViewLayout: flow)
+
+    let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.isTopLayoutGuideAdjustmentEnabled = true
+    container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+    container.appBar.headerViewController.headerView.minimumHeight = 50
+    container.appBar.headerViewController.headerView.maximumHeight = 100
+    let _ = container.view // Force the view to load.
+
+    // Then
+    XCTAssertEqual(contentViewController.view.autoresizingMask, [.flexibleWidth, .flexibleHeight])
+    XCTAssertEqual(contentViewController.view.frame, container.view.bounds)
+    XCTAssertEqual(contentViewController.topLayoutGuide.length,
+                   container.appBar.headerViewController.headerView.frame.maxY)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top,
+                     container.appBar.headerViewController.headerView.frame.maxY
+                      - MDCDeviceTopSafeAreaInset())
+      XCTAssertEqual(contentViewController.collectionView!.adjustedContentInset.top, 0)
+    }
+    #endif
+  }
+
+  // MARK: Tracked collection view view
+
+  func testTrackedCollectionViewTopLayoutGuideEqualsBottomEdgeOfHeaderView() {
+    // Given
+    let flow = UICollectionViewFlowLayout()
+    let contentViewController = UICollectionViewController(collectionViewLayout: flow)
+
+    let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.isTopLayoutGuideAdjustmentEnabled = true
+    container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+    container.appBar.headerViewController.headerView.minimumHeight = 50
+    container.appBar.headerViewController.headerView.maximumHeight = 100
+    let _ = container.view // Force the view to load.
+
+    container.appBar.headerViewController.headerView.trackingScrollView =
+      contentViewController.collectionView
+    container.appBar.headerViewController.headerView.trackingScrollDidScroll()
+
+    // Then
+    XCTAssertEqual(contentViewController.view.autoresizingMask, [.flexibleWidth, .flexibleHeight])
+    XCTAssertEqual(contentViewController.view.frame, container.view.bounds)
+    XCTAssertEqual(contentViewController.topLayoutGuide.length,
+                   container.appBar.headerViewController.headerView.frame.maxY)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top, 0)
+      XCTAssertEqual(contentViewController.collectionView!.adjustedContentInset.top,
+                     container.appBar.headerViewController.headerView.maximumHeight
+                      + MDCDeviceTopSafeAreaInset())
+    }
+    #endif
+  }
+
+}
+

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -288,17 +288,23 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
   CGFloat topInset = CGRectGetMaxY(_headerView.frame);
   self.topLayoutGuideConstraint.constant = topInset;
 
+    UIViewController *topLayoutGuideViewController = [self fhv_topLayoutGuideViewControllerWithFallback];
   // If there is a tracking scroll view then the flexible header will manage safe area insets via
   // the tracking scroll view's contentInsets. Some day - in the long distant future when we only
   // support iOS 11 and up - we can probably drop the content inset adjustment behavior in favor
   // of modifying additionalSafeAreaInsets instead.
   if (self.headerView.trackingScrollView != nil) {
+    // Reset the additional safe area insets if we are now tracking a scroll view.
+    if (topLayoutGuideViewController != nil) {
+      UIEdgeInsets additionalSafeAreaInsets = topLayoutGuideViewController.additionalSafeAreaInsets;
+      additionalSafeAreaInsets.top = 0;
+      topLayoutGuideViewController.additionalSafeAreaInsets = additionalSafeAreaInsets;
+    }
     return;
   }
 
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
-    UIViewController *topLayoutGuideViewController = [self fhv_topLayoutGuideViewControllerWithFallback];
     if (topLayoutGuideViewController != nil) {
       UIEdgeInsets additionalSafeAreaInsets = topLayoutGuideViewController.additionalSafeAreaInsets;
       if (self.headerView.statusBarHintCanOverlapHeader) {

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -294,12 +294,17 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
   // support iOS 11 and up - we can probably drop the content inset adjustment behavior in favor
   // of modifying additionalSafeAreaInsets instead.
   if (self.headerView.trackingScrollView != nil) {
-    // Reset the additional safe area insets if we are now tracking a scroll view.
-    if (topLayoutGuideViewController != nil) {
-      UIEdgeInsets additionalSafeAreaInsets = topLayoutGuideViewController.additionalSafeAreaInsets;
-      additionalSafeAreaInsets.top = 0;
-      topLayoutGuideViewController.additionalSafeAreaInsets = additionalSafeAreaInsets;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+    if (@available(iOS 11.0, *)) {
+      // Reset the additional safe area insets if we are now tracking a scroll view.
+      if (topLayoutGuideViewController != nil) {
+        UIEdgeInsets additionalSafeAreaInsets =
+            topLayoutGuideViewController.additionalSafeAreaInsets;
+        additionalSafeAreaInsets.top = 0;
+        topLayoutGuideViewController.additionalSafeAreaInsets = additionalSafeAreaInsets;
+      }
     }
+#endif
     return;
   }
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -288,14 +288,14 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
   CGFloat topInset = CGRectGetMaxY(_headerView.frame);
   self.topLayoutGuideConstraint.constant = topInset;
 
-    UIViewController *topLayoutGuideViewController = [self fhv_topLayoutGuideViewControllerWithFallback];
-  // If there is a tracking scroll view then the flexible header will manage safe area insets via
-  // the tracking scroll view's contentInsets. Some day - in the long distant future when we only
-  // support iOS 11 and up - we can probably drop the content inset adjustment behavior in favor
-  // of modifying additionalSafeAreaInsets instead.
-  if (self.headerView.trackingScrollView != nil) {
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
-    if (@available(iOS 11.0, *)) {
+  if (@available(iOS 11.0, *)) {
+    UIViewController *topLayoutGuideViewController = [self fhv_topLayoutGuideViewControllerWithFallback];
+    // If there is a tracking scroll view then the flexible header will manage safe area insets via
+    // the tracking scroll view's contentInsets. Some day - in the long distant future when we only
+    // support iOS 11 and up - we can probably drop the content inset adjustment behavior in favor
+    // of modifying additionalSafeAreaInsets instead.
+    if (self.headerView.trackingScrollView != nil) {
       // Reset the additional safe area insets if we are now tracking a scroll view.
       if (topLayoutGuideViewController != nil) {
         UIEdgeInsets additionalSafeAreaInsets =
@@ -303,14 +303,8 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
         additionalSafeAreaInsets.top = 0;
         topLayoutGuideViewController.additionalSafeAreaInsets = additionalSafeAreaInsets;
       }
-    }
-#endif
-    return;
-  }
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
-  if (@available(iOS 11.0, *)) {
-    if (topLayoutGuideViewController != nil) {
+    } else if (topLayoutGuideViewController != nil) {
       UIEdgeInsets additionalSafeAreaInsets = topLayoutGuideViewController.additionalSafeAreaInsets;
       if (self.headerView.statusBarHintCanOverlapHeader) {
         // safe area insets will likely already take into account the top safe area inset, so let's

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
@@ -77,6 +77,26 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
     #endif
   }
 
+  func testTrackingAnUntrackedTableViewTopLayoutGuideEqualsBottomEdgeOfHeaderView() {
+    // Given
+    let contentViewController = UITableViewController()
+    contentViewController.addChildViewController(fhvc)
+    contentViewController.view.addSubview(fhvc.view)
+    fhvc.didMove(toParentViewController: contentViewController)
+
+    fhvc.headerView.trackingScrollView = contentViewController.tableView
+
+    // Then
+    XCTAssertEqual(contentViewController.topLayoutGuide.length, fhvc.headerView.frame.maxY)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top, 0)
+      XCTAssertEqual(contentViewController.tableView.adjustedContentInset.top,
+                     fhvc.headerView.maximumHeight + MDCDeviceTopSafeAreaInset())
+    }
+    #endif
+  }
+
   // MARK: Tracked table view
 
   func testTrackedTableViewTopLayoutGuideEqualsBottomEdgeOfHeaderView() {

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
@@ -84,6 +84,17 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
     contentViewController.view.addSubview(fhvc.view)
     fhvc.didMove(toParentViewController: contentViewController)
 
+    // Then
+    XCTAssertEqual(contentViewController.topLayoutGuide.length, fhvc.headerView.frame.maxY)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top,
+                     fhvc.headerView.frame.maxY - MDCDeviceTopSafeAreaInset())
+      XCTAssertEqual(contentViewController.tableView.adjustedContentInset.top, 0)
+    }
+    #endif
+
+    // And then when
     fhvc.headerView.trackingScrollView = contentViewController.tableView
 
     // Then


### PR DESCRIPTION
This mimics the behavior of the flexible header container view controller introduced in 80fd217f766e0f5be6a3bc6bef5923f231721f9d. Notably, this allows content view controllers that are wrapped by an App Bar to make proper use of the top layout guide and additional safe area insets APIs.

Blocked by https://github.com/material-components/material-components-ios/pull/4354

Closes https://github.com/material-components/material-components-ios/issues/2540

## Screenshots

Before:

![before](https://user-images.githubusercontent.com/45670/41035558-0456d42c-695b-11e8-8071-62e174d8d90e.png)

After:

![after](https://user-images.githubusercontent.com/45670/41035560-06708b9a-695b-11e8-9231-f96ea34caea9.png)
