### PR TITLE
[NavigationBar] Add a titleViewLayoutBehavior API.

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -27,6 +27,24 @@ typedef NS_ENUM(NSInteger, MDCNavigationBarTitleAlignment) {
 };
 
 /**
+ Behaviors that affect the layout of an |MDCNavigationBar|'s titleView.
+ */
+typedef NS_ENUM(NSInteger, MDCNavigationBarTitleViewLayoutBehavior) {
+  /**
+   The title view's width will equal the navigation bar's width minus any space consumed by the
+   leading and trailing buttons.
+
+   The title view's center may not align with the navigation bar's center in this case.
+   */
+  MDCNavigationBarTitleViewLayoutBehaviorFill,
+
+  /**
+   Align the title view's center with the navigation bar's center, if possible.
+   */
+  MDCNavigationBarTitleViewLayoutBehaviorCenter
+};
+
+/**
  This protocol defines all of the properties on UINavigationItem that can be listened to by
  MDCNavigationBar.
  */
@@ -97,6 +115,13 @@ IB_DESIGNABLE
  requires it.
  */
 @property(nonatomic, strong, nullable) UIView *titleView;
+
+/**
+ The behavior that determines how to position the title view.
+
+ By default this is MDCNavigationBarTitleViewLayoutBehaviorFill.
+ */
+@property(nonatomic) MDCNavigationBarTitleViewLayoutBehavior titleViewLayoutBehavior;
 
 /**
  The font applied to the title of navigation bar.

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -155,6 +155,7 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   _titleFont = [MDCTypography titleFont];
   _useFlexibleTopBottomInsets = YES;
 
+  _titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorFill;
   _titleLabel = [[UILabel alloc] init];
   _titleLabel.font = _titleFont;
   _titleLabel.accessibilityTraits |= UIAccessibilityTraitHeader;
@@ -394,6 +395,26 @@ static NSString *const MDCNavigationBarTitleAlignmentKey = @"MDCNavigationBarTit
   }
 
   CGRect titleViewFrame = textFrame;
+  switch (self.titleViewLayoutBehavior) {
+    case MDCNavigationBarTitleViewLayoutBehaviorFill:
+      // Do nothing. The default textFrame calculation will fill the available space.
+      break;
+
+    case MDCNavigationBarTitleViewLayoutBehaviorCenter: {
+      CGFloat availableWidth = UIEdgeInsetsInsetRect(self.bounds, textInsets).size.width;
+      availableWidth -= MAX(_leadingButtonBar.frame.size.width,
+                            _trailingButtonBar.frame.size.width) * 2;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+      if (@available(iOS 11.0, *)) {
+        availableWidth -= self.safeAreaInsets.left + self.safeAreaInsets.right;
+      }
+#endif
+      titleViewFrame.size.width = availableWidth;
+      titleViewFrame = [self mdc_frameAlignedHorizontally:titleViewFrame
+                                                alignment:MDCNavigationBarTitleAlignmentCenter];
+      break;
+    }
+  }
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   if (self.useFlexibleTopBottomInsets) {

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -89,11 +89,12 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   XCTAssertEqual(alignment, MDCNavigationBarTitleAlignmentCenter);
 }
 
-- (void)testTitleViewIsCenteredWithNoButtons {
+- (void)testTitleViewIsCenteredWithNoButtonsAndFillBehavior {
   // Given
   MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
   navBar.frame = CGRectMake(0, 0, 300, 25);
   navBar.titleView = [[UIView alloc] init];
+  navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorFill;
 
   // When
   [navBar layoutIfNeeded];
@@ -103,11 +104,12 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
                              kEpsilonAccuracy);
 }
 
-- (void)testTitleViewShiftedRightWithLeadingButtons {
+- (void)testTitleViewShiftedRightWithLeadingButtonsAndFillBehavior {
   // Given
   MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
   navBar.frame = CGRectMake(0, 0, 300, 25);
   navBar.titleView = [[UIView alloc] init];
+  navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorFill;
   navBar.leadingBarButtonItems = @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
                                                                     style:UIBarButtonItemStylePlain
                                                                    target:nil action:nil]];
@@ -119,11 +121,12 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   XCTAssertGreaterThan(navBar.titleView.center.x, CGRectGetMidX(navBar.bounds));
 }
 
-- (void)testTitleViewShiftedLeftWithTrailingButtons {
+- (void)testTitleViewShiftedLeftWithTrailingButtonsAndFillBehavior {
   // Given
   MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
   navBar.frame = CGRectMake(0, 0, 300, 25);
   navBar.titleView = [[UIView alloc] init];
+  navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorFill;
   navBar.trailingBarButtonItems = @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
                                                                      style:UIBarButtonItemStylePlain
                                                                     target:nil action:nil]];

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -89,6 +89,88 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   XCTAssertEqual(alignment, MDCNavigationBarTitleAlignmentCenter);
 }
 
+- (void)testTitleViewIsCenteredWithNoButtons {
+  // Given
+  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
+  navBar.frame = CGRectMake(0, 0, 300, 25);
+  navBar.titleView = [[UIView alloc] init];
+
+  // When
+  [navBar layoutIfNeeded];
+
+  // Then
+  XCTAssertEqualWithAccuracy(navBar.titleView.center.x, CGRectGetMidX(navBar.bounds),
+                             kEpsilonAccuracy);
+}
+
+- (void)testTitleViewShiftedRightWithLeadingButtons {
+  // Given
+  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
+  navBar.frame = CGRectMake(0, 0, 300, 25);
+  navBar.titleView = [[UIView alloc] init];
+  navBar.leadingBarButtonItems = @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
+                                                                    style:UIBarButtonItemStylePlain
+                                                                   target:nil action:nil]];
+
+  // When
+  [navBar layoutIfNeeded];
+
+  // Then
+  XCTAssertGreaterThan(navBar.titleView.center.x, CGRectGetMidX(navBar.bounds));
+}
+
+- (void)testTitleViewShiftedLeftWithTrailingButtons {
+  // Given
+  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
+  navBar.frame = CGRectMake(0, 0, 300, 25);
+  navBar.titleView = [[UIView alloc] init];
+  navBar.trailingBarButtonItems = @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
+                                                                     style:UIBarButtonItemStylePlain
+                                                                    target:nil action:nil]];
+
+  // When
+  [navBar layoutIfNeeded];
+
+  // Then
+  XCTAssertLessThan(navBar.titleView.center.x, CGRectGetMidX(navBar.bounds));
+}
+
+- (void)testTitleViewCenteredWithLeadingButtonsAndCenterBehavior {
+  // Given
+  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
+  navBar.frame = CGRectMake(0, 0, 300, 25);
+  navBar.titleView = [[UIView alloc] init];
+  navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorCenter;
+  navBar.leadingBarButtonItems = @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
+                                                                    style:UIBarButtonItemStylePlain
+                                                                   target:nil action:nil]];
+
+  // When
+  [navBar layoutIfNeeded];
+
+  // Then
+  XCTAssertEqualWithAccuracy(navBar.titleView.center.x, CGRectGetMidX(navBar.bounds),
+                             kEpsilonAccuracy);
+}
+
+- (void)testTitleViewCenteredWithTrailingButtonsAndCenterBehavior {
+  // Given
+  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
+  navBar.frame = CGRectMake(0, 0, 300, 25);
+  navBar.titleView = [[UIView alloc] init];
+  navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorCenter;
+  navBar.trailingBarButtonItems = @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
+                                                                     style:UIBarButtonItemStylePlain
+                                                                    target:nil action:nil]];
+
+  // When
+  [navBar layoutIfNeeded];
+
+  // Then
+  XCTAssertEqualWithAccuracy(navBar.titleView.center.x, CGRectGetMidX(navBar.bounds),
+                             kEpsilonAccuracy);
+}
+
 - (void)testTitleFontProperty {
   MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
   navBar.frame = CGRectMake(0, 0, 300, 25);


### PR DESCRIPTION
This property allows a client to configure the title view layout behavior to be one of either "fill" or "center". The fill behavior is the default and existing behavior, which sets the title view's frame to fill the available navigation bar space. The center behavior will always attempt to center the title view within the navigation bar's bounds.

The center behavior is desired by teams in the simple cases of when they want their title view to be centered within the navigation bar as best as possible. This is also the default behavior of UINavigationBar.

Closes https://github.com/material-components/material-components-ios/issues/1650

### Screenshots

"Fill" behavior:

![simulator screen shot - iphone se - 2018-06-06 at 09 13 03](https://user-images.githubusercontent.com/45670/41040247-d71e762c-6969-11e8-8584-f86c0c6fe514.png)

"Center" behavior:

![simulator screen shot - iphone se - 2018-06-06 at 09 11 53](https://user-images.githubusercontent.com/45670/41040226-cb1bc244-6969-11e8-815b-145e2e40b98b.png)

"Center" behavior in RTL languages:

![simulator screen shot - iphone se - 2018-06-06 at 10 39 37](https://user-images.githubusercontent.com/45670/41045233-f9fc3948-6975-11e8-9e9d-48ca5ed7342c.png)
