### PR TITLE
[Catalog] Adding IDEWorkspaceChecks.plist to our source control

### DIFF
--- a/catalog/MDCCatalog.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/catalog/MDCCatalog.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Since Xcode 9.3 this started showing up in `git status` as untracked and looks like this should be added to our source control.

context:
"Xcode 9.3 adds a new IDEWorkspaceChecks.plist file to a workspace's shared data, to store the state of necessary workspace checks. Committing this file to source control will prevent unnecessary rerunning of those checks for each user opening the workspace. (37293167)"

( https://developer.apple.com/library/archive/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html )
