### PR TITLE
[Buttons] Added a11y minimum touch target size to Accessibility section in readme.

### DIFF
--- a/components/Buttons/docs/README.md
+++ b/components/Buttons/docs/README.md
@@ -54,7 +54,7 @@ button.accessibilityLabel = @"Create";
 ### Minimum touch size
 
 #### Set the frame
-Make set your buttons to have a minium height. Touch guidelines recommends a height of 48 points.
+Set your buttons to have a minium size. [Material Touch guidelines](https://material.io/design/layout/spacing-methods.html#touch-click-targets) typically recommend a height and width of 48 points.
 ```
 button.minimumSize = CGSizeMake(48, 48);
 ```

--- a/components/Buttons/docs/README.md
+++ b/components/Buttons/docs/README.md
@@ -42,7 +42,7 @@ elevation, Material Design ripples, and other stateful design APIs.
 To help ensure your buttons are accessible to as many users as possible, please be sure to review
 the following recommendations:
 
-### Set an accessibilityLabel
+### Set `-accessibilityLabel`
 Set an appropriate
 [`accessibilityLabel`](https://developer.apple.com/documentation/uikit/uiaccessibilityelement/1619577-accessibilitylabel)
 value if your button does not have a title. This is often the case with `MDCFloatingButton`
@@ -61,19 +61,18 @@ button.minimumSize = CGSizeMake(48, 48);
 
 #### Set the touch size (alternative)
 
-An alternate approach is to set the hit areaInsets to a negative value to make the touch target
+An alternate approach is to set the `hitAreaInsets` to a negative value to make the touch target
 larger than the visual appearance of the button. When you do this you should be careful to make sure
-you pad the distance between the buttons so there is no overlap of the touch targets. This will
-allow your button to have a touch area that is larger than it is visually as show in the
-[layout section of the Material
-spec](https://material.io/design/layout/spacing-methods.html#touch-click-targets).
+you maintain an 8-point distance between the button touch targets. This will allow your button to
+have [a large enough touch
+target](https://material.io/design/layout/spacing-methods.html#touch-click-targets) while
+maintaining the desired visual appearance.
 
 ```
   CGFloat verticalInset = MIN(0, -(48 - button.frame.size.height) / 2);
   button .hitAreaInsets = UIEdgeInsetsMake(verticalInset, 0, verticalInset, 0);
 
 ```
-
-When you do this make sure to follow the rest of the layout guidence and pad buttons with extra
-space.
+When you do this make sure to follow the rest of the layout guidence and pad buttons with the
+recommended space.
 

--- a/components/Buttons/docs/README.md
+++ b/components/Buttons/docs/README.md
@@ -42,11 +42,38 @@ elevation, Material Design ripples, and other stateful design APIs.
 To help ensure your buttons are accessible to as many users as possible, please be sure to review
 the following recommendations:
 
-*  Set an appropriate
+### Set an accessibilityLabel
+Set an appropriate
 [`accessibilityLabel`](https://developer.apple.com/documentation/uikit/uiaccessibilityelement/1619577-accessibilitylabel)
 value if your button does not have a title. This is often the case with `MDCFloatingButton`
 instances which typically only have an icon.
-
 ```
 button.accessibilityLabel = @"Create";
 ```
+
+### Minimum touch size
+
+#### Set the frame
+Make set your buttons to have a minium height. Touch guidelines recommends a height of 48 points.
+```
+button.minimumSize = CGSizeMake(48, 48);
+```
+
+#### Set the touch size (alternative)
+
+An alternate approach is to set the hit areaInsets to a negative value to make the touch target
+larger than the visual appearance of the button. When you do this you should be careful to make sure
+you pad the distance between the buttons so there is no overlap of the touch targets. This will
+allow your button to have a touch area that is larger than it is visually as show in the
+[layout section of the Material
+spec](https://material.io/design/layout/spacing-methods.html#touch-click-targets).
+
+```
+  CGFloat verticalInset = MIN(0, -(48 - button.frame.size.height) / 2);
+  button .hitAreaInsets = UIEdgeInsetsMake(verticalInset, 0, verticalInset, 0);
+
+```
+
+When you do this make sure to follow the rest of the layout guidence and pad buttons with extra
+space.
+

--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -23,6 +23,8 @@
 
 #import "supplemental/ButtonsTypicalUseSupplemental.h"
 
+const CGFloat kAllyButtonHeight = 48.0;
+
 @interface ButtonsTypicalUseExampleViewController ()
 @property(nonatomic, strong) MDCFloatingButton *floatingButton;
 @end
@@ -47,12 +49,15 @@
   buttonScheme.colorScheme = self.colorScheme;
   buttonScheme.typographyScheme = self.typographyScheme;
 
+  CGFloat verticalInset;
   // Contained button
 
   MDCButton *containedButton = [[MDCButton alloc] init];
   [containedButton setTitle:@"Button" forState:UIControlStateNormal];
   [MDCContainedButtonThemer applyScheme:buttonScheme toButton:containedButton];
   [containedButton sizeToFit];
+  verticalInset = MIN(0, -(kAllyButtonHeight - containedButton.frame.size.height) / 2);
+  containedButton.hitAreaInsets = UIEdgeInsetsMake(verticalInset, 0, verticalInset, 0);
   [containedButton addTarget:self
                       action:@selector(didTap:)
             forControlEvents:UIControlEventTouchUpInside];
@@ -76,6 +81,8 @@
   [MDCTextButtonThemer applyScheme:buttonScheme toButton:textButton];
   [textButton setTitle:@"Button" forState:UIControlStateNormal];
   [textButton sizeToFit];
+  verticalInset = MIN(0, -(kAllyButtonHeight - textButton.frame.size.height) / 2);
+  textButton.hitAreaInsets = UIEdgeInsetsMake(verticalInset, 0, verticalInset, 0);
   [textButton addTarget:self
                  action:@selector(didTap:)
        forControlEvents:UIControlEventTouchUpInside];
@@ -99,6 +106,8 @@
   [outlinedButton setTitle:@"Button" forState:UIControlStateNormal];
   [MDCOutlinedButtonThemer applyScheme:buttonScheme toButton:outlinedButton];
   [outlinedButton sizeToFit];
+  verticalInset = MIN(0, -(kAllyButtonHeight - outlinedButton.frame.size.height) / 2);
+  outlinedButton.hitAreaInsets = UIEdgeInsetsMake(verticalInset, 0, verticalInset, 0);
   [outlinedButton addTarget:self
                     action:@selector(didTap:)
           forControlEvents:UIControlEventTouchUpInside];
@@ -128,6 +137,11 @@
       [[UIImage imageNamed:@"Plus"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   [self.floatingButton setImage:plusImage forState:UIControlStateNormal];
   [MDCFloatingActionButtonThemer applyScheme:buttonScheme toButton:self.floatingButton];
+  verticalInset = MIN(0, -(kAllyButtonHeight - self.floatingButton.frame.size.height) / 2);
+  UIEdgeInsets touchInsets = UIEdgeInsetsMake(verticalInset, 0, verticalInset, 0);
+  [self.floatingButton setHitAreaInsets:touchInsets
+                               forShape:MDCFloatingButtonShapeDefault
+                                 inMode:MDCFloatingButtonModeNormal];
   [self.view addSubview:self.floatingButton];
 
   self.buttons = @[

--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -23,7 +23,7 @@
 
 #import "supplemental/ButtonsTypicalUseSupplemental.h"
 
-const CGFloat kAllyButtonHeight = 48.0;
+const CGFloat kMinimumAccessibleButtonHeight = 48.0;
 
 @interface ButtonsTypicalUseExampleViewController ()
 @property(nonatomic, strong) MDCFloatingButton *floatingButton;
@@ -49,15 +49,16 @@ const CGFloat kAllyButtonHeight = 48.0;
   buttonScheme.colorScheme = self.colorScheme;
   buttonScheme.typographyScheme = self.typographyScheme;
 
-  CGFloat verticalInset;
   // Contained button
 
   MDCButton *containedButton = [[MDCButton alloc] init];
   [containedButton setTitle:@"Button" forState:UIControlStateNormal];
   [MDCContainedButtonThemer applyScheme:buttonScheme toButton:containedButton];
   [containedButton sizeToFit];
-  verticalInset = MIN(0, -(kAllyButtonHeight - containedButton.frame.size.height) / 2);
-  containedButton.hitAreaInsets = UIEdgeInsetsMake(verticalInset, 0, verticalInset, 0);
+  CGFloat containedButtonVerticalInset =
+      MIN(0, -(kMinimumAccessibleButtonHeight - CGRectGetHeight(containedButton.frame)) / 2);
+  containedButton.hitAreaInsets =
+      UIEdgeInsetsMake(containedButtonVerticalInset, 0, containedButtonVerticalInset, 0);
   [containedButton addTarget:self
                       action:@selector(didTap:)
             forControlEvents:UIControlEventTouchUpInside];
@@ -81,8 +82,9 @@ const CGFloat kAllyButtonHeight = 48.0;
   [MDCTextButtonThemer applyScheme:buttonScheme toButton:textButton];
   [textButton setTitle:@"Button" forState:UIControlStateNormal];
   [textButton sizeToFit];
-  verticalInset = MIN(0, -(kAllyButtonHeight - textButton.frame.size.height) / 2);
-  textButton.hitAreaInsets = UIEdgeInsetsMake(verticalInset, 0, verticalInset, 0);
+  CGFloat textButtonVerticalInset = MIN(0, -(kMinimumAccessibleButtonHeight - CGRectGetHeight(textButton.frame)) / 2);
+  textButton.hitAreaInsets =
+      UIEdgeInsetsMake(textButtonVerticalInset, 0, textButtonVerticalInset, 0);
   [textButton addTarget:self
                  action:@selector(didTap:)
        forControlEvents:UIControlEventTouchUpInside];
@@ -106,8 +108,10 @@ const CGFloat kAllyButtonHeight = 48.0;
   [outlinedButton setTitle:@"Button" forState:UIControlStateNormal];
   [MDCOutlinedButtonThemer applyScheme:buttonScheme toButton:outlinedButton];
   [outlinedButton sizeToFit];
-  verticalInset = MIN(0, -(kAllyButtonHeight - outlinedButton.frame.size.height) / 2);
-  outlinedButton.hitAreaInsets = UIEdgeInsetsMake(verticalInset, 0, verticalInset, 0);
+  CGFloat outlineButtonVerticalInset =
+      MIN(0, -(kMinimumAccessibleButtonHeight - CGRectGetHeight(outlinedButton.frame)) / 2);
+  outlinedButton.hitAreaInsets =
+      UIEdgeInsetsMake(outlineButtonVerticalInset, 0, outlineButtonVerticalInset, 0);
   [outlinedButton addTarget:self
                     action:@selector(didTap:)
           forControlEvents:UIControlEventTouchUpInside];
@@ -137,8 +141,10 @@ const CGFloat kAllyButtonHeight = 48.0;
       [[UIImage imageNamed:@"Plus"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   [self.floatingButton setImage:plusImage forState:UIControlStateNormal];
   [MDCFloatingActionButtonThemer applyScheme:buttonScheme toButton:self.floatingButton];
-  verticalInset = MIN(0, -(kAllyButtonHeight - self.floatingButton.frame.size.height) / 2);
-  UIEdgeInsets touchInsets = UIEdgeInsetsMake(verticalInset, 0, verticalInset, 0);
+  CGFloat floatingActionButtonVerticalInset =
+      MIN(0, -(kMinimumAccessibleButtonHeight - CGRectGetHeight(self.floatingButton.frame)) / 2);
+  UIEdgeInsets touchInsets =
+      UIEdgeInsetsMake(floatingActionButtonVerticalInset, 0, floatingActionButtonVerticalInset, 0);
   [self.floatingButton setHitAreaInsets:touchInsets
                                forShape:MDCFloatingButtonShapeDefault
                                  inMode:MDCFloatingButtonModeNormal];


### PR DESCRIPTION
Catalog: added minimum size a11y to button example.

https://github.com/material-components/material-components-ios/issues/3873