### PR TITLE
[BottomNavigation] Fix bug when `setItems` does not correctly set items

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -408,6 +408,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   if (_items == items) {
     return;
   }
+  
   // Remove existing item views from the bottom navigation so it can be repopulated with new items.
   for (MDCBottomNavigationItemView *itemView in self.itemViews) {
     [itemView removeFromSuperview];

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -275,7 +275,6 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   CGFloat navBarHeight = CGRectGetHeight(self.containerView.bounds);
   CGFloat itemWidth = navBarWidth / numItems;
   for (NSUInteger i = 0; i < self.itemViews.count; i++) {
-    NSLog(@"%lu", (unsigned long)self.itemViews.count);
     MDCBottomNavigationItemView *itemView = self.itemViews[i];
     if (layoutDirection == UIUserInterfaceLayoutDirectionLeftToRight) {
       itemView.frame = CGRectMake(i * itemWidth, 0, itemWidth, navBarHeight);
@@ -417,10 +416,8 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   [self removeObserversFromTabBarItems];
 
   _items = [items copy];
-  NSLog(@"We are working");
   for (NSUInteger i = 0; i < items.count; i++) {
     UITabBarItem *item = items[i];
-    // This could be it
     MDCBottomNavigationItemView *itemView =
         [[MDCBottomNavigationItemView alloc] initWithFrame:CGRectZero];
     itemView.title = item.title;
@@ -472,7 +469,6 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
                         action:@selector(didCancelTouchesForButton:)
               forControlEvents:UIControlEventTouchCancel];
     [self.itemViews addObject:itemView];
-    itemView.backgroundColor = [UIColor blueColor];
     [self.containerView addSubview:itemView];
   }
   [self addObserversToTabBarItems];

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -408,7 +408,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   if (_items == items) {
     return;
   }
-  
+
   // Remove existing item views from the bottom navigation so it can be repopulated with new items.
   for (MDCBottomNavigationItemView *itemView in self.itemViews) {
     [itemView removeFromSuperview];
@@ -417,6 +417,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   [self removeObserversFromTabBarItems];
 
   _items = [items copy];
+
   for (NSUInteger i = 0; i < items.count; i++) {
     UITabBarItem *item = items[i];
     MDCBottomNavigationItemView *itemView =

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -275,6 +275,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   CGFloat navBarHeight = CGRectGetHeight(self.containerView.bounds);
   CGFloat itemWidth = navBarWidth / numItems;
   for (NSUInteger i = 0; i < self.itemViews.count; i++) {
+    NSLog(@"%lu", (unsigned long)self.itemViews.count);
     MDCBottomNavigationItemView *itemView = self.itemViews[i];
     if (layoutDirection == UIUserInterfaceLayoutDirectionLeftToRight) {
       itemView.frame = CGRectMake(i * itemWidth, 0, itemWidth, navBarHeight);
@@ -408,17 +409,18 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   if (_items == items) {
     return;
   }
-
   // Remove existing item views from the bottom navigation so it can be repopulated with new items.
   for (MDCBottomNavigationItemView *itemView in self.itemViews) {
     [itemView removeFromSuperview];
   }
+  [self.itemViews removeAllObjects];
   [self removeObserversFromTabBarItems];
 
   _items = [items copy];
-
+  NSLog(@"We are working");
   for (NSUInteger i = 0; i < items.count; i++) {
     UITabBarItem *item = items[i];
+    // This could be it
     MDCBottomNavigationItemView *itemView =
         [[MDCBottomNavigationItemView alloc] initWithFrame:CGRectZero];
     itemView.title = item.title;
@@ -470,6 +472,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
                         action:@selector(didCancelTouchesForButton:)
               forControlEvents:UIControlEventTouchCancel];
     [self.itemViews addObject:itemView];
+    itemView.backgroundColor = [UIColor blueColor];
     [self.containerView addSubview:itemView];
   }
   [self addObserversToTabBarItems];

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -86,12 +86,14 @@
   // Given
   UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"1" image:nil tag:0];
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:0];
+  UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:0];
 
   // When
   self.bottomNavBar.items = @[item1, item2];
+  self.bottomNavBar.items = @[item1, item2, item3];
 
   // Then
-  XCTAssertEqual(self.bottomNavBar.itemViews.count, 2);
+  XCTAssertEqual(self.bottomNavBar.itemViews.count, 3);
 }
 
 @end

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -93,7 +93,7 @@
   self.bottomNavBar.items = @[item1, item2, item3];
 
   // Then
-  unsigned int tabsCount = 3;
+  NSUInteger tabsCount = 3;
   XCTAssertEqual(self.bottomNavBar.itemViews.count, tabsCount);
 }
 

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -93,7 +93,8 @@
   self.bottomNavBar.items = @[item1, item2, item3];
 
   // Then
-  XCTAssertEqual(self.bottomNavBar.itemViews.count, 3);
+  unsigned int tabsCount = 3;
+  XCTAssertEqual(self.bottomNavBar.itemViews.count, tabsCount);
 }
 
 @end

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -82,4 +82,16 @@
   }
 }
 
+-(void)testItemReset {
+  // Given
+  UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"1" image:nil tag:0];
+  UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:0];
+
+  // When
+  self.bottomNavBar.items = @[item1, item2];
+
+  // Then
+  XCTAssertEqual(self.bottomNavBar.itemViews.count, 2);
+}
+
 @end


### PR DESCRIPTION
 We might want to use [NSMutableArray array]; instead of `removeAllObjects`.

Closes #3177
