### PR TITLE
[BottomNavigation] Remove UI Appearance selectors. **Breaking change**

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -66,14 +66,13 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarAlignment) {
  Configures when item titles should be displayed.
  Default is MDCBottomNavigationBarTitleVisibilitySelected.
  */
-@property(nonatomic, assign) MDCBottomNavigationBarTitleVisibility titleVisibility
-    UI_APPEARANCE_SELECTOR;
+@property(nonatomic, assign) MDCBottomNavigationBarTitleVisibility titleVisibility;
 
 /**
  Configures item space distribution and title orientation in landscape mode.
  Default is MDCBottomNavigationBarDistributionEqual.
  */
-@property(nonatomic, assign) MDCBottomNavigationBarAlignment alignment UI_APPEARANCE_SELECTOR;
+@property(nonatomic, assign) MDCBottomNavigationBarAlignment alignment;
 
 /**
  An array of UITabBarItems that is used to populate bottom navigation bar content. It is strongly
@@ -92,14 +91,13 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarAlignment) {
  Display font used for item titles.
  Default is system font.
  */
-@property(nonatomic, strong, nonnull) UIFont *itemTitleFont UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, nonnull) UIFont *itemTitleFont;
 
 /**
  Color of selected item. Applies color to items' icons and text. If set also sets
  selectedItemTitleColor. Default color is black.
  */
-@property (nonatomic, strong, readwrite, nonnull) UIColor *selectedItemTintColor
-    UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong, readwrite, nonnull) UIColor *selectedItemTintColor;
 
 /**
  Color of the selected item's title text. Default color is black.
@@ -110,18 +108,17 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarAlignment) {
  Color of unselected items. Applies color to items' icons. Text is not displayed in unselected mode.
  Default color is dark gray.
  */
-@property (nonatomic, strong, readwrite, nonnull) UIColor *unselectedItemTintColor
-    UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong, readwrite, nonnull) UIColor *unselectedItemTintColor;
 
 /**
  Color of the background of bottom navigation bar and the bar items.
  */
-@property(nonatomic, strong, nullable) UIColor *barTintColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, nullable) UIColor *barTintColor;
 
 /**
  To color the background of the view use -barTintColor instead.
  */
-@property(nullable, nonatomic,copy) UIColor *backgroundColor UI_APPEARANCE_SELECTOR;
+@property(nullable, nonatomic,copy) UIColor *backgroundColor;
 
 @end
 

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemBadge.h
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemBadge.h
@@ -25,7 +25,7 @@
 @property(nonatomic, assign) CGFloat yPadding;
 
 @property(nonatomic, copy) NSString *badgeValue;
-@property(nonatomic, strong) UIColor *badgeColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong) UIColor *badgeColor;
 @property(nonatomic, strong, readonly) UILabel *badgeValueLabel;
 
 @end

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
@@ -28,14 +28,14 @@
 
 @property(nonatomic, copy) NSString *badgeValue;
 @property(nonatomic, copy) NSString *title;
-@property(nonatomic, strong) UIFont *itemTitleFont UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong) UIFont *itemTitleFont;
 
 @property(nonatomic, strong) UIButton *button;
 @property(nonatomic, strong) UIImage *image;
 
-@property(nonatomic, strong) UIColor *badgeColor UI_APPEARANCE_SELECTOR;
-@property(nonatomic, strong) UIColor *selectedItemTintColor UI_APPEARANCE_SELECTOR;
-@property(nonatomic, strong) UIColor *unselectedItemTintColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong) UIColor *badgeColor;
+@property(nonatomic, strong) UIColor *selectedItemTintColor;
+@property(nonatomic, strong) UIColor *unselectedItemTintColor;
 @property(nonatomic, strong) UIColor *selectedItemTitleColor;
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated;


### PR DESCRIPTION
Removes all selectors from BottomNavigationBar and its components

This addresses the issue #3016 as we discussed.
