### PR TITLE
[Cards] Added interactability toggle to Cards

### DIFF
--- a/components/Cards/examples/CardExampleViewController.swift
+++ b/components/Cards/examples/CardExampleViewController.swift
@@ -19,7 +19,7 @@ import MaterialComponents.MaterialButtons_ButtonThemer
 
 class CardExampleViewController: UIViewController {
   @IBOutlet var contentView: UIView!
-  @IBOutlet weak var imageView: UIImageView!
+  @IBOutlet weak var imageView: CardImageView!
   @IBOutlet weak var card: MDCCard!
   @IBOutlet weak var button: MDCButton!
 
@@ -36,15 +36,6 @@ class CardExampleViewController: UIViewController {
     contentView.frame = self.view.bounds
     self.view.addSubview(contentView)
 
-    let bezierPath = UIBezierPath(roundedRect: imageView.bounds,
-                                  byRoundingCorners: [.topLeft, .topRight],
-                                  cornerRadii: CGSize(width: card.cornerRadius,
-                                                      height: card.cornerRadius))
-    let shapeLayer = CAShapeLayer()
-    shapeLayer.frame = imageView.bounds
-    shapeLayer.path = bezierPath.cgPath
-    imageView.layer.mask = shapeLayer
-
     let buttonScheme = MDCButtonScheme();
     buttonScheme.colorScheme = colorScheme
     buttonScheme.typographyScheme = typographyScheme
@@ -53,11 +44,7 @@ class CardExampleViewController: UIViewController {
     let cardScheme = MDCCardScheme();
     cardScheme.colorScheme = colorScheme
     MDCCardThemer.applyScheme(cardScheme, to: card)
-  }
-
-  override func didReceiveMemoryWarning() {
-      super.didReceiveMemoryWarning()
-      // Dispose of any resources that can be recreated.
+    card.isInteractable = false
   }
 
   override public var traitCollection: UITraitCollection {
@@ -90,4 +77,33 @@ extension CardExampleViewController {
   @objc class func catalogDescription() -> String {
     return "Cards contain content and actions about a single subject."
   }
+}
+
+class CardImageView: UIImageView {
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    self.curveImageToCorners()
+  }
+
+  func curveImageToCorners() {
+    // The main image from the xib is taken from: https://unsplash.com/photos/wMzx2nBdeng
+    // License details: https://unsplash.com/license
+    var roundingCorners = UIRectCorner.topLeft
+    if (UIDevice.current.orientation == .portrait ||
+      UIDevice.current.orientation == .portraitUpsideDown) {
+      roundingCorners.formUnion(.topRight)
+    } else {
+      roundingCorners.formUnion(.bottomLeft)
+    }
+
+    let bezierPath = UIBezierPath(roundedRect: self.bounds,
+                                  byRoundingCorners: roundingCorners,
+                                  cornerRadii: CGSize(width: 4,
+                                                      height: 4))
+    let shapeLayer = CAShapeLayer()
+    shapeLayer.frame = self.bounds
+    shapeLayer.path = bezierPath.cgPath
+    self.layer.mask = shapeLayer
+  }
+
 }

--- a/components/Cards/examples/resources/CardExampleViewController.xib
+++ b/components/Cards/examples/resources/CardExampleViewController.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
+    <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -21,33 +21,35 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BAQ-GJ-1pn" customClass="MDCCard">
-                    <rect key="frame" x="30" y="94" width="315" height="479"/>
+                    <rect key="frame" x="26" y="150.33333333333334" width="323" height="511.33333333333326"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sample-image" translatesAutoresizingMaskIntoConstraints="NO" id="ldt-3r-Agk" customClass="CardImageView" customModule="MaterialComponentsExamples" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="0.0" width="315" height="315"/>
+                            <rect key="frame" x="0.0" y="0.0" width="323" height="322.66666666666669"/>
                             <constraints>
                                 <constraint firstAttribute="width" secondItem="ldt-3r-Agk" secondAttribute="height" multiplier="15:15" id="OUj-9G-eou"/>
                             </constraints>
                         </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mpO-dS-0yd">
-                            <rect key="frame" x="8" y="325" width="299" height="20.5"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Title Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mpO-dS-0yd">
+                            <rect key="frame" x="8" y="332.66666666666663" width="307" height="20.333333333333314"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" verticalCompressionResistancePriority="749" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tmz-Bt-Hco">
-                            <rect key="frame" x="8" y="353.5" width="299" height="75.5"/>
-                            <string key="text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</string>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tmz-Bt-Hco">
+                            <rect key="frame" x="8" y="361" width="307" height="100.33333333333331"/>
+                            <string key="text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</string>
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                             <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NWQ-Eq-COf" customClass="MDCButton">
-                            <rect key="frame" x="102.5" y="437" width="110" height="34"/>
-                            <state key="normal" title="Action Button"/>
+                        <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NWQ-Eq-COf" customClass="MDCButton">
+                            <rect key="frame" x="106.66666666666666" y="469.33333333333326" width="110" height="34"/>
+                            <state key="normal" title="Action Button">
+                                <color key="titleColor" red="0.0" green="0.47058823529999999" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                            </state>
                         </button>
                     </subviews>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -59,7 +61,6 @@
                         <constraint firstAttribute="trailing" secondItem="mpO-dS-0yd" secondAttribute="trailing" constant="8" id="MFB-Nj-dQU"/>
                         <constraint firstItem="mpO-dS-0yd" firstAttribute="leading" secondItem="BAQ-GJ-1pn" secondAttribute="leading" constant="8" id="WJn-vb-ReP"/>
                         <constraint firstItem="mpO-dS-0yd" firstAttribute="top" secondItem="ldt-3r-Agk" secondAttribute="bottom" constant="10" id="Y9S-sz-I8f"/>
-                        <constraint firstItem="NWQ-Eq-COf" firstAttribute="centerX" secondItem="BAQ-GJ-1pn" secondAttribute="centerX" id="YBt-vK-89V"/>
                         <constraint firstItem="Tmz-Bt-Hco" firstAttribute="top" secondItem="mpO-dS-0yd" secondAttribute="bottom" constant="8" id="bRb-kf-lM3"/>
                         <constraint firstItem="ldt-3r-Agk" firstAttribute="trailing" secondItem="Tmz-Bt-Hco" secondAttribute="leading" constant="-8" id="bjC-5v-fyc"/>
                         <constraint firstAttribute="trailing" secondItem="ldt-3r-Agk" secondAttribute="trailing" id="bzX-OZ-rhy"/>
@@ -68,6 +69,7 @@
                         <constraint firstItem="Tmz-Bt-Hco" firstAttribute="leading" secondItem="BAQ-GJ-1pn" secondAttribute="leading" constant="8" id="hBu-ah-26L"/>
                         <constraint firstItem="ldt-3r-Agk" firstAttribute="leading" secondItem="BAQ-GJ-1pn" secondAttribute="leading" id="laW-HO-JiJ"/>
                         <constraint firstAttribute="trailing" secondItem="Tmz-Bt-Hco" secondAttribute="trailing" constant="8" id="qQK-f0-FLE"/>
+                        <constraint firstItem="NWQ-Eq-COf" firstAttribute="centerX" secondItem="Tmz-Bt-Hco" secondAttribute="centerX" id="yhl-7M-gxu"/>
                     </constraints>
                     <variation key="default">
                         <mask key="constraints">
@@ -107,10 +109,14 @@
                     </variation>
                     <variation key="heightClass=regular-widthClass=regular">
                         <mask key="constraints">
-                            <include reference="0CE-xb-4pW"/>
-                            <include reference="6nf-mh-lPb"/>
-                            <include reference="bjC-5v-fyc"/>
-                            <include reference="DhK-tR-doL"/>
+                            <exclude reference="0CE-xb-4pW"/>
+                            <exclude reference="6nf-mh-lPb"/>
+                            <exclude reference="bjC-5v-fyc"/>
+                            <include reference="bzX-OZ-rhy"/>
+                            <exclude reference="DhK-tR-doL"/>
+                            <include reference="WJn-vb-ReP"/>
+                            <include reference="Y9S-sz-I8f"/>
+                            <include reference="hBu-ah-26L"/>
                         </mask>
                     </variation>
                 </view>
@@ -119,10 +125,10 @@
             <constraints>
                 <constraint firstItem="BAQ-GJ-1pn" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" id="57T-Xi-SQb"/>
                 <constraint firstItem="BAQ-GJ-1pn" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="Yc8-Tp-Oxg"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="BAQ-GJ-1pn" secondAttribute="trailing" constant="30" id="bdn-MZ-eeg"/>
-                <constraint firstItem="BAQ-GJ-1pn" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="30" id="qTV-9a-RUO"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="BAQ-GJ-1pn" secondAttribute="bottom" constant="30" id="rBD-rT-QRT"/>
-                <constraint firstItem="BAQ-GJ-1pn" firstAttribute="top" relation="greaterThanOrEqual" secondItem="i5M-Pr-FkT" secondAttribute="topMargin" constant="30" id="tgZ-0g-Sb2"/>
+                <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="BAQ-GJ-1pn" secondAttribute="trailing" constant="10" id="bdn-MZ-eeg"/>
+                <constraint firstItem="BAQ-GJ-1pn" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="i5M-Pr-FkT" secondAttribute="leadingMargin" constant="10" id="qTV-9a-RUO"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="BAQ-GJ-1pn" secondAttribute="bottom" constant="20" id="rBD-rT-QRT"/>
+                <constraint firstItem="BAQ-GJ-1pn" firstAttribute="top" relation="greaterThanOrEqual" secondItem="i5M-Pr-FkT" secondAttribute="topMargin" constant="20" id="tgZ-0g-Sb2"/>
             </constraints>
             <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
             <point key="canvasLocation" x="34.5" y="54.5"/>

--- a/components/Cards/examples/resources/CardExampleViewController.xib
+++ b/components/Cards/examples/resources/CardExampleViewController.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13770" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13770"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -27,7 +27,7 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BAQ-GJ-1pn" customClass="MDCCard">
                     <rect key="frame" x="30" y="94" width="315" height="479"/>
                     <subviews>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sample-image" translatesAutoresizingMaskIntoConstraints="NO" id="ldt-3r-Agk">
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sample-image" translatesAutoresizingMaskIntoConstraints="NO" id="ldt-3r-Agk" customClass="CardImageView" customModule="MaterialComponentsExamples" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="315" height="315"/>
                             <constraints>
                                 <constraint firstAttribute="width" secondItem="ldt-3r-Agk" secondAttribute="height" multiplier="15:15" id="OUj-9G-eou"/>

--- a/components/Cards/examples/supplemental/CardTintExampleCell.m
+++ b/components/Cards/examples/supplemental/CardTintExampleCell.m
@@ -33,6 +33,7 @@
 
     [self setImageTintColor:[UIColor blueColor] forState:MDCCardCellStateNormal];
     [self setImageTintColor:[UIColor blueColor] forState:MDCCardCellStateSelected];
+    [self setIsInteractable:NO];
   }
   return self;
 }

--- a/components/Cards/examples/supplemental/CardTintExampleCell.m
+++ b/components/Cards/examples/supplemental/CardTintExampleCell.m
@@ -33,7 +33,7 @@
 
     [self setImageTintColor:[UIColor blueColor] forState:MDCCardCellStateNormal];
     [self setImageTintColor:[UIColor blueColor] forState:MDCCardCellStateSelected];
-    [self setIsInteractable:NO];
+    [self setInteractable:NO];
   }
   return self;
 }

--- a/components/Cards/src/CardThemer/MDCCardThemer.m
+++ b/components/Cards/src/CardThemer/MDCCardThemer.m
@@ -29,7 +29,7 @@ static const CGFloat kBorderWidth = 1.f;
              toCard:(nonnull MDCCard *)card {
   [card setShadowElevation:kNormalElevation forState:UIControlStateNormal];
   [card setShadowElevation:kHighlightedElevation forState:UIControlStateHighlighted];
-  [card setIsInteractable:YES];
+  [card setInteractable:YES];
   [MDCCardsColorThemer applySemanticColorScheme:scheme.colorScheme toCard:card];
 }
 
@@ -38,7 +38,7 @@ static const CGFloat kBorderWidth = 1.f;
   [cardCell setShadowElevation:kNormalElevation forState:MDCCardCellStateNormal];
   [cardCell setShadowElevation:kHighlightedElevation forState:MDCCardCellStateHighlighted];
   [cardCell setShadowElevation:kSelectedElevation forState:MDCCardCellStateSelected];
-  [cardCell setIsInteractable:YES];
+  [cardCell setInteractable:YES];
   [MDCCardsColorThemer applySemanticColorScheme:scheme.colorScheme toCardCell:cardCell];
 }
 

--- a/components/Cards/src/CardThemer/MDCCardThemer.m
+++ b/components/Cards/src/CardThemer/MDCCardThemer.m
@@ -29,7 +29,7 @@ static const CGFloat kBorderWidth = 1.f;
              toCard:(nonnull MDCCard *)card {
   [card setShadowElevation:kNormalElevation forState:UIControlStateNormal];
   [card setShadowElevation:kHighlightedElevation forState:UIControlStateHighlighted];
-  [card setInteractable:YES];
+  card.interactable = YES;
   [MDCCardsColorThemer applySemanticColorScheme:scheme.colorScheme toCard:card];
 }
 
@@ -38,7 +38,7 @@ static const CGFloat kBorderWidth = 1.f;
   [cardCell setShadowElevation:kNormalElevation forState:MDCCardCellStateNormal];
   [cardCell setShadowElevation:kHighlightedElevation forState:MDCCardCellStateHighlighted];
   [cardCell setShadowElevation:kSelectedElevation forState:MDCCardCellStateSelected];
-  [cardCell setInteractable:YES];
+  cardCell.interactable = YES;
   [MDCCardsColorThemer applySemanticColorScheme:scheme.colorScheme toCardCell:cardCell];
 }
 

--- a/components/Cards/src/CardThemer/MDCCardThemer.m
+++ b/components/Cards/src/CardThemer/MDCCardThemer.m
@@ -29,7 +29,7 @@ static const CGFloat kBorderWidth = 1.f;
              toCard:(nonnull MDCCard *)card {
   [card setShadowElevation:kNormalElevation forState:UIControlStateNormal];
   [card setShadowElevation:kHighlightedElevation forState:UIControlStateHighlighted];
-
+  [card setIsInteractable:YES];
   [MDCCardsColorThemer applySemanticColorScheme:scheme.colorScheme toCard:card];
 }
 
@@ -38,7 +38,7 @@ static const CGFloat kBorderWidth = 1.f;
   [cardCell setShadowElevation:kNormalElevation forState:MDCCardCellStateNormal];
   [cardCell setShadowElevation:kHighlightedElevation forState:MDCCardCellStateHighlighted];
   [cardCell setShadowElevation:kSelectedElevation forState:MDCCardCellStateSelected];
-
+  [cardCell setIsInteractable:YES];
   [MDCCardsColorThemer applySemanticColorScheme:scheme.colorScheme toCardCell:cardCell];
 }
 

--- a/components/Cards/src/MDCCard.h
+++ b/components/Cards/src/MDCCard.h
@@ -33,6 +33,18 @@
  */
 @property(nonatomic, readonly, strong, nonnull) MDCInkView *inkView;
 
+/**
+ This property defines if a card as a whole should be interactable or not.
+ What this means is that when isInteractable is set to NO, there will be no ink ripple and
+ no change in shadow elevation when tapped or selected.
+
+ Default is set to YES.
+
+ Important: Our specification for cards explicitly define a card as being an interactable component.
+ Therefore, this property should be set to NO *only if* there are other interactable items within
+ the card's content, such as buttons or other tappable controls.
+ */
+@property(nonatomic, assign) BOOL isInteractable;
 
 /**
  Sets the shadow elevation for an UIControlState state

--- a/components/Cards/src/MDCCard.h
+++ b/components/Cards/src/MDCCard.h
@@ -45,7 +45,7 @@
  Therefore, this property should be set to NO *only if* there are other interactable items within
  the card's content, such as buttons or other tappable controls.
  */
-@property (nonatomic, getter=isInteractable) BOOL interactable;
+@property (nonatomic, getter=isInteractable) IBInspectable BOOL interactable;
 
 /**
  Sets the shadow elevation for an UIControlState state

--- a/components/Cards/src/MDCCard.h
+++ b/components/Cards/src/MDCCard.h
@@ -45,7 +45,7 @@
  Therefore, this property should be set to NO *only if* there are other interactable items within
  the card's content, such as buttons or other tappable controls.
  */
-@property(nonatomic, assign) BOOL isInteractable;
+@property (nonatomic, getter=isInteractable) BOOL interactable;
 
 /**
  Sets the shadow elevation for an UIControlState state

--- a/components/Cards/src/MDCCard.h
+++ b/components/Cards/src/MDCCard.h
@@ -36,7 +36,8 @@
 /**
  This property defines if a card as a whole should be interactable or not.
  What this means is that when isInteractable is set to NO, there will be no ink ripple and
- no change in shadow elevation when tapped or selected.
+ no change in shadow elevation when tapped or selected. Also the card container itself will not be
+ tappable, but any of its subviews will still be tappable.
 
  Default is set to YES.
 

--- a/components/Cards/src/MDCCard.m
+++ b/components/Cards/src/MDCCard.m
@@ -75,9 +75,9 @@ static const BOOL MDCCardIsInteractableDefault = YES;
                                                                forKey:MDCCardBackgroundColorsKey]];
     }
     if ([coder containsValueForKey:MDCCardIsInteractableKey]) {
-      self.isInteractable = [coder decodeBoolForKey:MDCCardIsInteractableKey];
+      self.interactable = [coder decodeBoolForKey:MDCCardIsInteractableKey];
     } else {
-      self.isInteractable = MDCCardIsInteractableDefault;
+      self.interactable = MDCCardIsInteractableDefault;
     }
     [self commonMDCCardInit];
   }
@@ -328,8 +328,8 @@ static const BOOL MDCCardIsInteractableDefault = YES;
   self.layer.shapedBackgroundColor = _backgroundColor;
 }
 
-- (void)setIsInteractable:(BOOL)isInteractable {
-  _isInteractable = isInteractable;
+- (void)setInteractable:(BOOL)interactable {
+  _isInteractable = interactable;
 }
 
 - (BOOL)isInteractable {

--- a/components/Cards/src/MDCCard.m
+++ b/components/Cards/src/MDCCard.m
@@ -26,11 +26,12 @@ static NSString *const MDCCardCornerRadiusKey = @"MDCCardCornerRadiusKey";
 static NSString *const MDCCardInkViewKey = @"MDCCardInkViewKey";
 static NSString *const MDCCardShadowColorsKey = @"MDCCardShadowColorsKey";
 static NSString *const MDCCardShadowElevationsKey = @"MDCCardShadowElevationsKey";
+static NSString *const MDCCardIsInteractableKey = @"MDCCardIsInteractableKey";
 
 static const CGFloat MDCCardShadowElevationNormal = 1.f;
 static const CGFloat MDCCardShadowElevationHighlighted = 8.f;
 static const CGFloat MDCCardCornerRadiusDefault = 4.f;
-
+static const BOOL MDCCardIsInteractableDefault = YES;
 
 @interface MDCCard ()
 @property(nonatomic, readonly, strong) MDCShapedShadowLayer *layer;
@@ -43,6 +44,7 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
   NSMutableDictionary<NSNumber *, UIColor *> *_borderColors;
   UIColor *_backgroundColor;
   CGPoint _lastTouch;
+  BOOL _isInteractable;
 }
 
 @dynamic layer;
@@ -72,6 +74,11 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
       [self.layer setShapedBackgroundColor:[coder decodeObjectOfClass:[UIColor class]
                                                                forKey:MDCCardBackgroundColorsKey]];
     }
+    if ([coder containsValueForKey:MDCCardIsInteractableKey]) {
+      self.isInteractable = [coder decodeBoolForKey:MDCCardIsInteractableKey];
+    } else {
+      self.isInteractable = MDCCardIsInteractableDefault;
+    }
     [self commonMDCCardInit];
   }
   return self;
@@ -81,6 +88,7 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
   self = [super initWithFrame:frame];
   if (self) {
     self.layer.cornerRadius = MDCCardCornerRadiusDefault;
+    _isInteractable = MDCCardIsInteractableDefault;
     [self commonMDCCardInit];
   }
   return self;
@@ -124,6 +132,7 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
   [self updateBorderWidth];
   [self updateBorderColor];
   [self updateBackgroundColor];
+  [self updateIsInteractable];
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
@@ -135,6 +144,7 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
   [coder encodeObject:_inkView forKey:MDCCardInkViewKey];
   [coder encodeDouble:self.layer.cornerRadius forKey:MDCCardCornerRadiusKey];
   [coder encodeObject:self.layer.shapedBackgroundColor forKey:MDCCardBackgroundColorsKey];
+  [coder encodeBool:_isInteractable forKey:MDCCardIsInteractableKey];
 }
 
 - (void)layoutSubviews {
@@ -250,6 +260,9 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
 }
 
 - (void)setHighlighted:(BOOL)highlighted {
+  if (!_isInteractable) {
+    return;
+  }
   if (highlighted && !self.highlighted) {
     [self.inkView startTouchBeganAnimationAtPoint:_lastTouch completion:nil];
   } else if (!highlighted && self.highlighted) {
@@ -315,6 +328,19 @@ static const CGFloat MDCCardCornerRadiusDefault = 4.f;
 
 - (void)updateBackgroundColor {
   self.layer.shapedBackgroundColor = _backgroundColor;
+}
+
+- (void)setIsInteractable:(BOOL)isInteractable {
+  _isInteractable = isInteractable;
+  [self updateIsInteractable];
+}
+
+- (BOOL)isInteractable {
+  return _isInteractable;
+}
+
+- (void)updateIsInteractable {
+  self.inkView.hidden = !_isInteractable;
 }
 
 @end

--- a/components/Cards/src/MDCCard.m
+++ b/components/Cards/src/MDCCard.m
@@ -44,7 +44,6 @@ static const BOOL MDCCardIsInteractableDefault = YES;
   NSMutableDictionary<NSNumber *, UIColor *> *_borderColors;
   UIColor *_backgroundColor;
   CGPoint _lastTouch;
-  BOOL _isInteractable;
 }
 
 @dynamic layer;
@@ -75,9 +74,9 @@ static const BOOL MDCCardIsInteractableDefault = YES;
                                                                forKey:MDCCardBackgroundColorsKey]];
     }
     if ([coder containsValueForKey:MDCCardIsInteractableKey]) {
-      self.interactable = [coder decodeBoolForKey:MDCCardIsInteractableKey];
+      _interactable = [coder decodeBoolForKey:MDCCardIsInteractableKey];
     } else {
-      self.interactable = MDCCardIsInteractableDefault;
+      _interactable = MDCCardIsInteractableDefault;
     }
     [self commonMDCCardInit];
   }
@@ -88,7 +87,7 @@ static const BOOL MDCCardIsInteractableDefault = YES;
   self = [super initWithFrame:frame];
   if (self) {
     self.layer.cornerRadius = MDCCardCornerRadiusDefault;
-    _isInteractable = MDCCardIsInteractableDefault;
+    _interactable = MDCCardIsInteractableDefault;
     [self commonMDCCardInit];
   }
   return self;
@@ -143,7 +142,7 @@ static const BOOL MDCCardIsInteractableDefault = YES;
   [coder encodeObject:_inkView forKey:MDCCardInkViewKey];
   [coder encodeDouble:self.layer.cornerRadius forKey:MDCCardCornerRadiusKey];
   [coder encodeObject:self.layer.shapedBackgroundColor forKey:MDCCardBackgroundColorsKey];
-  [coder encodeBool:_isInteractable forKey:MDCCardIsInteractableKey];
+  [coder encodeBool:_interactable forKey:MDCCardIsInteractableKey];
 }
 
 - (void)layoutSubviews {
@@ -280,7 +279,7 @@ static const BOOL MDCCardIsInteractableDefault = YES;
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
   UIView *result = [super hitTest:point withEvent:event];
-  if (!_isInteractable && result == self) {
+  if (!_interactable && result == self) {
     return nil;
   }
   if (self.layer.shapeGenerator) {
@@ -326,14 +325,6 @@ static const BOOL MDCCardIsInteractableDefault = YES;
 
 - (void)updateBackgroundColor {
   self.layer.shapedBackgroundColor = _backgroundColor;
-}
-
-- (void)setInteractable:(BOOL)interactable {
-  _isInteractable = interactable;
-}
-
-- (BOOL)isInteractable {
-  return _isInteractable;
 }
 
 @end

--- a/components/Cards/src/MDCCard.m
+++ b/components/Cards/src/MDCCard.m
@@ -132,7 +132,6 @@ static const BOOL MDCCardIsInteractableDefault = YES;
   [self updateBorderWidth];
   [self updateBorderColor];
   [self updateBackgroundColor];
-  [self updateIsInteractable];
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
@@ -260,9 +259,6 @@ static const BOOL MDCCardIsInteractableDefault = YES;
 }
 
 - (void)setHighlighted:(BOOL)highlighted {
-  if (!_isInteractable) {
-    return;
-  }
   if (highlighted && !self.highlighted) {
     [self.inkView startTouchBeganAnimationAtPoint:_lastTouch completion:nil];
   } else if (!highlighted && self.highlighted) {
@@ -283,14 +279,16 @@ static const BOOL MDCCardIsInteractableDefault = YES;
 }
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+  UIView *result = [super hitTest:point withEvent:event];
+  if (!_isInteractable && result == self) {
+    return nil;
+  }
   if (self.layer.shapeGenerator) {
-    if (CGPathContainsPoint(self.layer.shapeLayer.path, nil, point, true)) {
-      return self;
-    } else {
+    if (!CGPathContainsPoint(self.layer.shapeLayer.path, nil, point, true)) {
       return nil;
     }
   }
-  return [super hitTest:point withEvent:event];
+  return result;
 }
 
 - (void)setShapeGenerator:(id<MDCShapeGenerating>)shapeGenerator {
@@ -332,15 +330,10 @@ static const BOOL MDCCardIsInteractableDefault = YES;
 
 - (void)setIsInteractable:(BOOL)isInteractable {
   _isInteractable = isInteractable;
-  [self updateIsInteractable];
 }
 
 - (BOOL)isInteractable {
   return _isInteractable;
-}
-
-- (void)updateIsInteractable {
-  self.inkView.hidden = !_isInteractable;
 }
 
 @end

--- a/components/Cards/src/MDCCardCollectionCell.h
+++ b/components/Cards/src/MDCCardCollectionCell.h
@@ -102,7 +102,7 @@ typedef NS_ENUM(NSInteger, MDCCardCellVerticalImageAlignment) {
  Therefore, this property should be set to NO *only if* there are other interactable items within
  the card's content, such as buttons or other tappable controls.
  */
-@property(nonatomic, assign) BOOL isInteractable;
+@property (nonatomic, getter=isInteractable) BOOL interactable;
 
 /*
  The shape generator used to define the card cell's shape.

--- a/components/Cards/src/MDCCardCollectionCell.h
+++ b/components/Cards/src/MDCCardCollectionCell.h
@@ -93,7 +93,8 @@ typedef NS_ENUM(NSInteger, MDCCardCellVerticalImageAlignment) {
 /**
  This property defines if a card as a whole should be interactable or not.
  What this means is that when isInteractable is set to NO, there will be no ink ripple and
- no change in shadow elevation when tapped or selected.
+ no change in shadow elevation when tapped or selected. Also the card container itself will not be
+ tappable, but any of its subviews will still be tappable.
 
  Default is set to YES.
 

--- a/components/Cards/src/MDCCardCollectionCell.h
+++ b/components/Cards/src/MDCCardCollectionCell.h
@@ -102,7 +102,7 @@ typedef NS_ENUM(NSInteger, MDCCardCellVerticalImageAlignment) {
  Therefore, this property should be set to NO *only if* there are other interactable items within
  the card's content, such as buttons or other tappable controls.
  */
-@property (nonatomic, getter=isInteractable) BOOL interactable;
+@property (nonatomic, getter=isInteractable) IBInspectable BOOL interactable;
 
 /*
  The shape generator used to define the card cell's shape.

--- a/components/Cards/src/MDCCardCollectionCell.h
+++ b/components/Cards/src/MDCCardCollectionCell.h
@@ -90,6 +90,19 @@ typedef NS_ENUM(NSInteger, MDCCardCellVerticalImageAlignment) {
  */
 @property(nonatomic, readonly, strong, nonnull) MDCInkView *inkView;
 
+/**
+ This property defines if a card as a whole should be interactable or not.
+ What this means is that when isInteractable is set to NO, there will be no ink ripple and
+ no change in shadow elevation when tapped or selected.
+
+ Default is set to YES.
+
+ Important: Our specification for cards explicitly define a card as being an interactable component.
+ Therefore, this property should be set to NO *only if* there are other interactable items within
+ the card's content, such as buttons or other tappable controls.
+ */
+@property(nonatomic, assign) BOOL isInteractable;
+
 /*
  The shape generator used to define the card cell's shape.
  When set, layer properties such as cornerRadius and other layer properties are nullified/zeroed.

--- a/components/Cards/src/MDCCardCollectionCell.m
+++ b/components/Cards/src/MDCCardCollectionCell.m
@@ -118,7 +118,7 @@ static const BOOL MDCCardCellIsInteractableDefault = YES;
   self = [super initWithFrame:frame];
   if (self) {
     self.layer.cornerRadius = MDCCardCellCornerRadiusDefault;
-    _interactable = YES;
+    _interactable = MDCCardCellIsInteractableDefault;
     [self commonMDCCardCollectionCellInit];
   }
   return self;

--- a/components/Cards/src/MDCCardCollectionCell.m
+++ b/components/Cards/src/MDCCardCollectionCell.m
@@ -36,13 +36,14 @@ static NSString *const MDCCardCellShadowColorsKey = @"MDCCardCellShadowColorsKey
 static NSString *const MDCCardCellStateKey = @"MDCCardCellStateKey";
 static NSString *const MDCCardCellVerticalImageAlignmentsKey =
     @"MDCCardCellVerticalImageAlignmentsKey";
+static NSString *const MDCCardCellIsInteractableKey = @"MDCCardCellIsInteractableKey";
 
 static const CGFloat MDCCardCellCornerRadiusDefault = 4.f;
 static const CGFloat MDCCardCellSelectedImagePadding = 8;
 static const CGFloat MDCCardCellShadowElevationHighlighted = 8.f;
 static const CGFloat MDCCardCellShadowElevationNormal = 1.f;
 static const CGFloat MDCCardCellShadowElevationSelected = 8.f;
-
+static const BOOL MDCCardCellIsInteractableDefault = YES;
 
 @interface MDCCardCollectionCell ()
 @property(nonatomic, strong, nullable) UIImageView *selectedImageView;
@@ -60,6 +61,7 @@ static const CGFloat MDCCardCellShadowElevationSelected = 8.f;
   NSMutableDictionary<NSNumber *, UIColor *> *_imageTintColors;
   UIColor *_backgroundColor;
   CGPoint _lastTouch;
+  BOOL _isInteractable;
 }
 
 @dynamic layer;
@@ -103,6 +105,11 @@ static const CGFloat MDCCardCellShadowElevationSelected = 8.f;
           [coder decodeObjectOfClass:[UIColor class]
                               forKey:MDCCardCellBackgroundColorsKey]];
     }
+    if ([coder containsValueForKey:MDCCardCellIsInteractableKey]) {
+      self.isInteractable = [coder decodeBoolForKey:MDCCardCellIsInteractableKey];
+    } else {
+      self.isInteractable = MDCCardCellIsInteractableDefault;
+    }
     [self commonMDCCardCollectionCellInit];
   }
   return self;
@@ -112,6 +119,7 @@ static const CGFloat MDCCardCellShadowElevationSelected = 8.f;
   self = [super initWithFrame:frame];
   if (self) {
     self.layer.cornerRadius = MDCCardCellCornerRadiusDefault;
+    _isInteractable = YES;
     [self commonMDCCardCollectionCellInit];
   }
   return self;
@@ -189,6 +197,7 @@ static const CGFloat MDCCardCellShadowElevationSelected = 8.f;
   [self updateImage];
   [self updateImageTintColor];
   [self updateBackgroundColor];
+  [self updateIsInteractable];
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
@@ -207,6 +216,7 @@ static const CGFloat MDCCardCellShadowElevationSelected = 8.f;
   [coder encodeObject:_verticalImageAlignments forKey:MDCCardCellVerticalImageAlignmentsKey];
   [coder encodeObject:_imageTintColors forKey:MDCCardCellImageTintColorsKey];
   [coder encodeObject:self.layer.shapedBackgroundColor forKey:MDCCardCellBackgroundColorsKey];
+  [coder encodeBool:_isInteractable forKey:MDCCardCellIsInteractableKey];
 }
 
 - (void)layoutSubviews {
@@ -227,6 +237,10 @@ static const CGFloat MDCCardCellShadowElevationSelected = 8.f;
 }
 
 - (void)setState:(MDCCardCellState)state animated:(BOOL)animated {
+  if (!_isInteractable) {
+    return;
+  }
+
   switch (state) {
     case MDCCardCellStateSelected: {
       if (_state != MDCCardCellStateHighlighted) {
@@ -533,6 +547,19 @@ static const CGFloat MDCCardCellShadowElevationSelected = 8.f;
 
 - (void)updateBackgroundColor {
   self.layer.shapedBackgroundColor = _backgroundColor;
+}
+
+- (void)setIsInteractable:(BOOL)isInteractable {
+  _isInteractable = isInteractable;
+  [self updateIsInteractable];
+}
+
+- (BOOL)isInteractable {
+  return _isInteractable;
+}
+
+- (void)updateIsInteractable {
+  self.inkView.hidden = !_isInteractable;
 }
 
 #pragma mark - UIResponder

--- a/components/Cards/src/MDCCardCollectionCell.m
+++ b/components/Cards/src/MDCCardCollectionCell.m
@@ -61,7 +61,6 @@ static const BOOL MDCCardCellIsInteractableDefault = YES;
   NSMutableDictionary<NSNumber *, UIColor *> *_imageTintColors;
   UIColor *_backgroundColor;
   CGPoint _lastTouch;
-  BOOL _isInteractable;
 }
 
 @dynamic layer;
@@ -106,9 +105,9 @@ static const BOOL MDCCardCellIsInteractableDefault = YES;
                               forKey:MDCCardCellBackgroundColorsKey]];
     }
     if ([coder containsValueForKey:MDCCardCellIsInteractableKey]) {
-      self.interactable = [coder decodeBoolForKey:MDCCardCellIsInteractableKey];
+      _interactable = [coder decodeBoolForKey:MDCCardCellIsInteractableKey];
     } else {
-      self.interactable = MDCCardCellIsInteractableDefault;
+      _interactable = MDCCardCellIsInteractableDefault;
     }
     [self commonMDCCardCollectionCellInit];
   }
@@ -119,7 +118,7 @@ static const BOOL MDCCardCellIsInteractableDefault = YES;
   self = [super initWithFrame:frame];
   if (self) {
     self.layer.cornerRadius = MDCCardCellCornerRadiusDefault;
-    _isInteractable = YES;
+    _interactable = YES;
     [self commonMDCCardCollectionCellInit];
   }
   return self;
@@ -215,7 +214,7 @@ static const BOOL MDCCardCellIsInteractableDefault = YES;
   [coder encodeObject:_verticalImageAlignments forKey:MDCCardCellVerticalImageAlignmentsKey];
   [coder encodeObject:_imageTintColors forKey:MDCCardCellImageTintColorsKey];
   [coder encodeObject:self.layer.shapedBackgroundColor forKey:MDCCardCellBackgroundColorsKey];
-  [coder encodeBool:_isInteractable forKey:MDCCardCellIsInteractableKey];
+  [coder encodeBool:_interactable forKey:MDCCardCellIsInteractableKey];
 }
 
 - (void)layoutSubviews {
@@ -544,19 +543,11 @@ static const BOOL MDCCardCellIsInteractableDefault = YES;
   self.layer.shapedBackgroundColor = _backgroundColor;
 }
 
-- (void)setInteractable:(BOOL)interactable {
-  _isInteractable = interactable;
-}
-
-- (BOOL)isInteractable {
-  return _isInteractable;
-}
-
 #pragma mark - UIResponder
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
   UIView *result = [super hitTest:point withEvent:event];
-  if (!_isInteractable && (result == self.contentView || result == self)) {
+  if (!_interactable && (result == self.contentView || result == self)) {
     return nil;
   }
   return result;

--- a/components/Cards/src/MDCCardCollectionCell.m
+++ b/components/Cards/src/MDCCardCollectionCell.m
@@ -556,7 +556,7 @@ static const BOOL MDCCardCellIsInteractableDefault = YES;
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
   UIView *result = [super hitTest:point withEvent:event];
-  if (!_isInteractable && result == self.contentView) {
+  if (!_isInteractable && (result == self.contentView || result == self)) {
     return nil;
   }
   return result;

--- a/components/Cards/src/MDCCardCollectionCell.m
+++ b/components/Cards/src/MDCCardCollectionCell.m
@@ -106,9 +106,9 @@ static const BOOL MDCCardCellIsInteractableDefault = YES;
                               forKey:MDCCardCellBackgroundColorsKey]];
     }
     if ([coder containsValueForKey:MDCCardCellIsInteractableKey]) {
-      self.isInteractable = [coder decodeBoolForKey:MDCCardCellIsInteractableKey];
+      self.interactable = [coder decodeBoolForKey:MDCCardCellIsInteractableKey];
     } else {
-      self.isInteractable = MDCCardCellIsInteractableDefault;
+      self.interactable = MDCCardCellIsInteractableDefault;
     }
     [self commonMDCCardCollectionCellInit];
   }
@@ -544,8 +544,8 @@ static const BOOL MDCCardCellIsInteractableDefault = YES;
   self.layer.shapedBackgroundColor = _backgroundColor;
 }
 
-- (void)setIsInteractable:(BOOL)isInteractable {
-  _isInteractable = isInteractable;
+- (void)setInteractable:(BOOL)interactable {
+  _isInteractable = interactable;
 }
 
 - (BOOL)isInteractable {
@@ -556,7 +556,7 @@ static const BOOL MDCCardCellIsInteractableDefault = YES;
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
   UIView *result = [super hitTest:point withEvent:event];
-  if (!_isInteractable && result == self) {
+  if (!_isInteractable && result == self.contentView) {
     return nil;
   }
   return result;

--- a/components/Cards/src/MDCCardCollectionCell.m
+++ b/components/Cards/src/MDCCardCollectionCell.m
@@ -197,7 +197,6 @@ static const BOOL MDCCardCellIsInteractableDefault = YES;
   [self updateImage];
   [self updateImageTintColor];
   [self updateBackgroundColor];
-  [self updateIsInteractable];
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
@@ -237,10 +236,6 @@ static const BOOL MDCCardCellIsInteractableDefault = YES;
 }
 
 - (void)setState:(MDCCardCellState)state animated:(BOOL)animated {
-  if (!_isInteractable) {
-    return;
-  }
-
   switch (state) {
     case MDCCardCellStateSelected: {
       if (_state != MDCCardCellStateHighlighted) {
@@ -551,18 +546,21 @@ static const BOOL MDCCardCellIsInteractableDefault = YES;
 
 - (void)setIsInteractable:(BOOL)isInteractable {
   _isInteractable = isInteractable;
-  [self updateIsInteractable];
 }
 
 - (BOOL)isInteractable {
   return _isInteractable;
 }
 
-- (void)updateIsInteractable {
-  self.inkView.hidden = !_isInteractable;
-}
-
 #pragma mark - UIResponder
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+  UIView *result = [super hitTest:point withEvent:event];
+  if (!_isInteractable && result == self) {
+    return nil;
+  }
+  return result;
+}
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
   [super touchesBegan:touches withEvent:event];

--- a/components/Cards/tests/unit/MDCCardTests.m
+++ b/components/Cards/tests/unit/MDCCardTests.m
@@ -103,6 +103,19 @@
   XCTAssertEqual(self.card.inkView.layer.sublayers.count, 2U);
 }
 
+- (void)testCardInteractabilityToggle {
+  self.card.isInteractable = NO;
+  XCTAssertEqual(self.card.inkView.hidden, YES);
+  self.card.highlighted = YES;
+  XCTAssertEqual(((MDCShadowLayer *)self.card.layer).elevation, 1.f);
+  self.card.highlighted = NO;
+  self.card.isInteractable = YES;
+  XCTAssertEqual(self.card.inkView.hidden, NO);
+  self.card.highlighted = YES;
+  XCTAssertEqual(((MDCShadowLayer *)self.card.layer).elevation, 8.f);
+  self.card.highlighted = NO;
+}
+
 - (void)testCardEncoding {
   self.card.cornerRadius = 7.5f;
   self.card.bounds = CGRectMake(1, 2, 3, 4);
@@ -114,6 +127,7 @@
   [self.card setShadowColor:[UIColor greenColor] forState:UIControlStateHighlighted];
   [self.card setBorderColor:[UIColor redColor] forState:UIControlStateNormal];
   [self.card setBorderColor:[UIColor greenColor] forState:UIControlStateHighlighted];
+  self.card.isInteractable = NO;
 
   NSData *archivedData = [NSKeyedArchiver archivedDataWithRootObject:self.card];
   MDCCard *unarchivedCard = [NSKeyedUnarchiver unarchiveObjectWithData:archivedData];
@@ -146,6 +160,7 @@
                  [self.card borderWidthForState:UIControlStateHighlighted]);
   XCTAssertNotNil(unarchivedCard.inkView);
   XCTAssertEqual(unarchivedCard.subviews.count, self.card.subviews.count);
+  XCTAssertEqual(unarchivedCard.isInteractable, NO);
 }
 
 - (void)testCellSelectAndUnselect {
@@ -175,6 +190,23 @@
   XCTAssertEqual(((MDCShadowLayer *)self.cell.layer).elevation, 1.f);
   XCTAssertEqual(self.cell.cornerRadius, 4.f);
   XCTAssertEqual(self.cell.inkView.layer.sublayers.count, 1U);
+}
+
+- (void)testCellInteractabilityToggle {
+  self.cell.isInteractable = NO;
+  XCTAssertEqual(self.cell.inkView.hidden, YES);
+  self.cell.selectable = YES;
+  self.cell.selected = YES;
+  XCTAssertEqual(((MDCShadowLayer *)self.cell.layer).elevation, 1.f);
+  self.cell.selectable = YES;
+  self.cell.selected = YES;
+  self.cell.isInteractable = YES;
+  XCTAssertEqual(self.cell.inkView.hidden, NO);
+  self.cell.selectable = YES;
+  self.cell.selected = YES;
+  XCTAssertEqual(((MDCShadowLayer *)self.cell.layer).elevation, 8.f);
+  self.cell.selectable = YES;
+  self.cell.selected = YES;
 }
 
 - (void)testCellLongPress {
@@ -411,6 +443,7 @@ static UIImage *FakeImage(void) {
   [self.cell setBorderColor:[UIColor redColor] forState:MDCCardCellStateNormal];
   [self.cell setBorderColor:[UIColor greenColor] forState:MDCCardCellStateHighlighted];
   [self.cell setBorderColor:[UIColor blueColor] forState:MDCCardCellStateSelected];
+  self.cell.isInteractable = NO;
 
   NSData *archivedData = [NSKeyedArchiver archivedDataWithRootObject:self.cell];
   MDCCardCollectionCell *unarchivedCell = [NSKeyedUnarchiver unarchiveObjectWithData:archivedData];
@@ -481,6 +514,7 @@ static UIImage *FakeImage(void) {
                  [self.cell verticalImageAlignmentForState:MDCCardCellStateHighlighted]);
   XCTAssertEqual([unarchivedCell verticalImageAlignmentForState:MDCCardCellStateSelected],
                  [self.cell verticalImageAlignmentForState:MDCCardCellStateSelected]);
+  XCTAssertEqual(unarchivedCell.isInteractable, NO);
 }
 
 @end

--- a/components/Cards/tests/unit/MDCCardTests.m
+++ b/components/Cards/tests/unit/MDCCardTests.m
@@ -104,7 +104,7 @@
 }
 
 - (void)testCardInteractabilityToggle {
-  self.card.isInteractable = NO;
+  self.card.interactable = NO;
   self.card.frame = CGRectMake(0, 0, 1000, 1000);
   NSMutableArray *touchArray = [NSMutableArray new];
   [touchArray addObject:[UITouch new]];
@@ -126,7 +126,7 @@
   [self.card setShadowColor:[UIColor greenColor] forState:UIControlStateHighlighted];
   [self.card setBorderColor:[UIColor redColor] forState:UIControlStateNormal];
   [self.card setBorderColor:[UIColor greenColor] forState:UIControlStateHighlighted];
-  self.card.isInteractable = NO;
+  self.card.interactable = NO;
 
   NSData *archivedData = [NSKeyedArchiver archivedDataWithRootObject:self.card];
   MDCCard *unarchivedCard = [NSKeyedUnarchiver unarchiveObjectWithData:archivedData];
@@ -192,7 +192,7 @@
 }
 
 - (void)testCellInteractabilityToggle {
-  self.cell.isInteractable = NO;
+  self.cell.interactable = NO;
   self.cell.frame = CGRectMake(0, 0, 1000, 1000);
   NSMutableArray *touchArray = [NSMutableArray new];
   [touchArray addObject:[UITouch new]];
@@ -437,7 +437,7 @@ static UIImage *FakeImage(void) {
   [self.cell setBorderColor:[UIColor redColor] forState:MDCCardCellStateNormal];
   [self.cell setBorderColor:[UIColor greenColor] forState:MDCCardCellStateHighlighted];
   [self.cell setBorderColor:[UIColor blueColor] forState:MDCCardCellStateSelected];
-  self.cell.isInteractable = NO;
+  self.cell.interactable = NO;
 
   NSData *archivedData = [NSKeyedArchiver archivedDataWithRootObject:self.cell];
   MDCCardCollectionCell *unarchivedCell = [NSKeyedUnarchiver unarchiveObjectWithData:archivedData];

--- a/components/Cards/tests/unit/MDCCardTests.m
+++ b/components/Cards/tests/unit/MDCCardTests.m
@@ -105,15 +105,14 @@
 
 - (void)testCardInteractabilityToggle {
   self.card.isInteractable = NO;
-  XCTAssertEqual(self.card.inkView.hidden, YES);
-  self.card.highlighted = YES;
-  XCTAssertEqual(((MDCShadowLayer *)self.card.layer).elevation, 1.f);
-  self.card.highlighted = NO;
-  self.card.isInteractable = YES;
-  XCTAssertEqual(self.card.inkView.hidden, NO);
-  self.card.highlighted = YES;
-  XCTAssertEqual(((MDCShadowLayer *)self.card.layer).elevation, 8.f);
-  self.card.highlighted = NO;
+  self.card.frame = CGRectMake(0, 0, 1000, 1000);
+  NSMutableArray *touchArray = [NSMutableArray new];
+  [touchArray addObject:[UITouch new]];
+  NSSet *touches = [[NSSet alloc] init];
+  [touches setByAddingObjectsFromArray:touchArray];
+  UIEvent *event = [[UIEvent alloc] init];
+  UIView *view = [self.card hitTest:self.card.center withEvent:event];
+  XCTAssertNil(view);
 }
 
 - (void)testCardEncoding {
@@ -194,19 +193,14 @@
 
 - (void)testCellInteractabilityToggle {
   self.cell.isInteractable = NO;
-  XCTAssertEqual(self.cell.inkView.hidden, YES);
-  self.cell.selectable = YES;
-  self.cell.selected = YES;
-  XCTAssertEqual(((MDCShadowLayer *)self.cell.layer).elevation, 1.f);
-  self.cell.selectable = YES;
-  self.cell.selected = YES;
-  self.cell.isInteractable = YES;
-  XCTAssertEqual(self.cell.inkView.hidden, NO);
-  self.cell.selectable = YES;
-  self.cell.selected = YES;
-  XCTAssertEqual(((MDCShadowLayer *)self.cell.layer).elevation, 8.f);
-  self.cell.selectable = YES;
-  self.cell.selected = YES;
+  self.cell.frame = CGRectMake(0, 0, 1000, 1000);
+  NSMutableArray *touchArray = [NSMutableArray new];
+  [touchArray addObject:[UITouch new]];
+  NSSet *touches = [[NSSet alloc] init];
+  [touches setByAddingObjectsFromArray:touchArray];
+  UIEvent *event = [[UIEvent alloc] init];
+  UIView *view = [self.cell hitTest:self.cell.center withEvent:event];
+  XCTAssertNil(view);
 }
 
 - (void)testCellLongPress {


### PR DESCRIPTION
After a discussion with design we have concluded that a card as a whole doesn't need to be interactable as long as there are other interactable components in its content. As an example, a card that has a button can remove its interactability and allow the button to operate as the interactable entity.

This PR includes:
* addition of the `isInteractable` boolean for MDCCard and MDCCardCollectionCell.
* Update to our Card examples to show this change.
* Update unit tests for Cards to test the new property.
* Small fix to the card example.

This unblocks #4261 

GIF demonstrating a card that its `isInteractable` is set to `NO`.
![2018-06-18 17_10_24](https://user-images.githubusercontent.com/4066863/41563062-83b5c79e-731c-11e8-99e8-2f248d04bbf0.gif)
