### PR TITLE
[List] Initial List PR Feedback

### DIFF
--- a/components/List/examples/Manual Layout List 2/ManualLayoutListBaseCell2.h
+++ b/components/List/examples/Manual Layout List 2/ManualLayoutListBaseCell2.h
@@ -20,61 +20,11 @@
 
 @class MDCInkView;
 
-/**
- The cell can be in a Normal, a Highlighted, or a Selected state.
- The Highlighted and Selected states map to the properties of the UICollectionViewCell that
- share the same names.
- */
-typedef NS_ENUM(NSInteger, MDCListBaseCellState) {
-  /** The visual state when the cell is in its normal state. */
-  MDCListBaseCellStateNormal = 0,
-
-  /** The visual state when the cell is in its highlighted state. */
-  MDCListBaseCellStateHighlighted,
-
-  /** The visual state when the cell is in its selected state. */
-  MDCListBaseCellStateSelected,
-};
-
 @interface ManualLayoutListBaseCell2 : UICollectionViewCell
 
 /**
- Sets the shadow elevation for an UIControlState state
-
- @param shadowElevation The shadow elevation
- @param state UIControlState the card state
+ The shadow elevation for the cell.
  */
-- (void)setShadowElevation:(MDCShadowElevation)shadowElevation forState:(MDCListBaseCellState)state;
-
-/**
- Returns the shadow elevation for an UIControlState state
-
- If no elevation has been set for a state, the value for UIControlStateNormal will be returned.
- Default value for UIControlStateNormal is 1
- Default value for UIControlStateHighlighted is 8
-
- @param state UIControlState the card state
- @return The shadow elevation for the requested state.
- */
-- (MDCShadowElevation)shadowElevationForState:(MDCListBaseCellState)state;
-
-/**
- Sets the shadow color for an UIControlState state
-
- @param shadowColor The shadow color
- @param state UIControlState the card state
- */
-- (void)setShadowColor:(nullable UIColor *)shadowColor forState:(MDCListBaseCellState)state;
-
-/**
- Returns the shadow color for an UIControlState state
-
- If no color has been set for a state, the value for MDCCardViewStateNormal will be returned.
- Default value for UIControlStateNormal is blackColor
-
- @param state UIControlState the card state
- @return The shadow color for the requested state.
- */
-- (nullable UIColor *)shadowColorForState:(MDCListBaseCellState)state;
+@property (nonatomic, assign) MDCShadowElevation elevation;
 
 @end

--- a/components/List/examples/Manual Layout List 2/ManualLayoutListCellExample2.m
+++ b/components/List/examples/Manual Layout List 2/ManualLayoutListCellExample2.m
@@ -22,8 +22,7 @@
 
 static NSString *const kManualLayoutListItemCell2ReuseIdentifier = @"kManualLayoutListItemCell2ReuseIdentifier";
 
-static const CGFloat kSmallestCellHeight = 40.f;
-static const CGFloat kSmallArbitraryCellWidth = 200.f;
+static const CGFloat kArbitraryCellHeight = 40.f;
 
 @interface ManualLayoutListCellExample2 ()
 
@@ -38,7 +37,6 @@ static const CGFloat kSmallArbitraryCellWidth = 200.f;
   flowLayout.minimumInteritemSpacing = 0;
   flowLayout.minimumLineSpacing = 1;
   flowLayout.scrollDirection = UICollectionViewScrollDirectionVertical;
-  flowLayout.estimatedItemSize = CGSizeMake(kSmallArbitraryCellWidth, kSmallestCellHeight);
   return [self initWithCollectionViewLayout:flowLayout];
 }
 
@@ -59,9 +57,11 @@ static const CGFloat kSmallArbitraryCellWidth = 200.f;
   self.collectionView.alwaysBounceVertical = YES;
   self.automaticallyAdjustsScrollViewInsets = NO;
   self.parentViewController.automaticallyAdjustsScrollViewInsets = NO;
+  ((UICollectionViewFlowLayout *)self.collectionView.collectionViewLayout).estimatedItemSize =
+      CGSizeMake(self.view.bounds.size.width, kArbitraryCellHeight);
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
-    self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
+    self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
   }
 #endif
   // Register cell class.
@@ -93,24 +93,13 @@ static const CGFloat kSmallArbitraryCellWidth = 200.f;
                                             forIndexPath:indexPath];
 
   CGFloat cellWidth = CGRectGetWidth(self.collectionView.bounds);
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
-  if (@available(iOS 11.0, *)) {
-    cellWidth -=
-    (collectionView.adjustedContentInset.left + collectionView.adjustedContentInset.right);
-  }
-#endif
   cell.cellWidth = cellWidth;
 
-  cell.typographyScheme = _typographyScheme;
   cell.mdc_adjustsFontForContentSizeCategory = YES;
 
   if (indexPath.item % 2 == 0) {
     UIImage *image2 = [UIImage imageNamed:@"Cake"];
     cell.trailingImage = image2;
-  }
-
-  if (indexPath.item == 36) {
-    NSLog(@"32");
   }
 
   NSArray *array = @[@"Sed ut perspiciatis unde omnis iste natus error",
@@ -163,10 +152,12 @@ static const CGFloat kSmallArbitraryCellWidth = 200.f;
        withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
   [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 
-  [self.collectionView.collectionViewLayout invalidateLayout];
+  ((UICollectionViewFlowLayout *)self.collectionView.collectionViewLayout).estimatedItemSize =
+  CGSizeMake(size.width, kArbitraryCellHeight);
 
   [coordinator animateAlongsideTransition:nil completion:^(__unused id context) {
     [self.collectionView.collectionViewLayout invalidateLayout];
+    [self.collectionView reloadData];
   }];
 }
 

--- a/components/List/examples/Manual Layout List 2/ManualLayoutListItemCell2.h
+++ b/components/List/examples/Manual Layout List 2/ManualLayoutListItemCell2.h
@@ -32,24 +32,44 @@
 @property (nonatomic, assign) CGFloat cellWidth;
 
 /**
- The label used to display title text, which is the most prominent text in the cell.
- */
-@property (strong, nonatomic, readonly, nonnull) UILabel *titleLabel;
-
-/**
  A convenience accessor for the title text.
  */
 @property (nonatomic, copy, nullable) NSString *titleText;
 
 /**
- The label used to display detail text, below the title text.
+ A convenience accessor for the title text color.
  */
-@property (strong, nonatomic, readonly, nonnull) UILabel *detailLabel;
+@property (nonatomic, strong, nullable) UIColor *titleLabelTextColor;
+
+/**
+ A convenience accessor for the title text font.
+ */
+@property (nonatomic, strong, nullable) UIFont *titleLabelFont;
+
+/**
+ A convenience accessor for the title text font.
+ */
+@property (nonatomic, assign) NSTextAlignment titleLabelTextAlignment;
 
 /**
  A convenience accessor for the detail text.
  */
 @property (nonatomic, copy, nullable) NSString *detailText;
+
+/**
+ A convenience accessor for the detail text color.
+ */
+@property (nonatomic, strong, nullable) UIColor *detailLabelTextColor;
+
+/**
+ A convenience accessor for the detail text font.
+ */
+@property (nonatomic, strong, nullable) UIFont *detailLabelFont;
+
+/**
+ A convenience accessor for the detail text font.
+ */
+@property (nonatomic, assign) NSTextAlignment detailLabelTextAlignment;
 
 /**
  The UIImageview used to display the leading image.
@@ -62,9 +82,9 @@
 @property (strong, nonatomic, nullable) UIImage *leadingImage;
 
 /**
- The UIImageview used to display the trailing image.
+ A convenience accessor for the leading image corner radius.
  */
-@property (strong, nonatomic, nonnull, readonly) UIImageView *trailingImageView;
+@property (nonatomic, assign) UIImage *leadingImageCornerRadius;
 
 /**
  A convenience accessor for the trailing image.
@@ -72,9 +92,9 @@
 @property (strong, nonatomic, nullable) UIImage *trailingImage;
 
 /**
- The typography scheme of the cell.
+ A convenience accessor for the trailing image corner radius.
  */
-@property (strong, nonatomic, nonnull) id<MDCTypographyScheming> typographyScheme;
+@property (nonatomic, assign) UIImage *trailingImageCornerRadius;
 
 /**
  Indicates whether the view's contents should automatically update their font when the device’s

--- a/components/List/examples/Manual Layout List 2/ManualLayoutListItemCell2.m
+++ b/components/List/examples/Manual Layout List 2/ManualLayoutListItemCell2.m
@@ -101,10 +101,12 @@ static const CGFloat kDetailColorOpacity = 0.6f;
 
   self.titleLabel = [[UILabel alloc] init];
   self.titleLabel.textColor = [UIColor colorWithWhite:0 alpha:kTitleColorOpacity];
+  self.titleLabel.font = [self defaultTitleLabelFont];
   [self.textContainer addSubview:self.titleLabel];
 
   self.detailLabel = [[UILabel alloc] init];
   self.detailLabel.textColor = [UIColor colorWithWhite:0 alpha:kDetailColorOpacity];
+  self.detailLabel.font = [self defaultDetailLabelFont];
   [self.textContainer addSubview:self.detailLabel];
 }
 
@@ -125,10 +127,15 @@ static const CGFloat kDetailColorOpacity = 0.6f;
 -(void)prepareForReuse {
   [super prepareForReuse];
   self.titleText = nil;
+  self.titleLabelTextColor = self.defaultTitleLabelTextColor;
+  self.titleLabelFont = self.defaultTitleLabelFont;
+  self.titleLabelTextAlignment = NSTextAlignmentLeft;
   self.detailText = nil;
+  self.detailLabelTextColor = self.defaultDetailLabelTextColor;
+  self.detailLabelFont = self.defaultDetailLabelFont;
+  self.detailLabelTextAlignment = NSTextAlignmentLeft;
   self.leadingImage = nil;
   self.trailingImage = nil;
-  self.typographyScheme = self.defaultTypographyScheme;
 }
 
 #pragma mark Accessors
@@ -144,6 +151,39 @@ static const CGFloat kDetailColorOpacity = 0.6f;
   return self.titleLabel.text;
 }
 
+-(void)setTitleLabelTextColor:(UIColor *)titleLabelTextColor {
+  if ([titleLabelTextColor isEqual:self.titleLabel.textColor]) {
+    return;
+  }
+  self.titleLabel.textColor = titleLabelTextColor;
+}
+
+-(UIColor *)titleLabelTextColor {
+  return self.titleLabel.textColor;
+}
+
+-(void)setTitleLabelFont:(UIFont *)titleLabelFont {
+  if ([titleLabelFont isEqual:self.titleLabel.font]) {
+    return;
+  }
+  self.titleLabel.font = titleLabelFont;
+}
+
+-(UIFont *)titleLabelFont {
+  return self.titleLabel.font;
+}
+
+-(void)setTitleLabelTextAlignment:(NSTextAlignment)titleLabelTextAlignment {
+  if (titleLabelTextAlignment == self.titleLabel.textAlignment) {
+    return;
+  }
+  self.titleLabel.textAlignment = titleLabelTextAlignment;
+}
+
+-(NSTextAlignment)titleLabelTextAlignment {
+  return self.titleLabel.textAlignment;
+}
+
 -(void)setDetailText:(NSString *)detailText {
   if ([detailText isEqualToString:self.detailLabel.text]) {
     return;
@@ -153,6 +193,39 @@ static const CGFloat kDetailColorOpacity = 0.6f;
 
 -(NSString *)detailText {
   return self.detailLabel.text;
+}
+
+-(void)setDetailLabelTextColor:(UIColor *)detailLabelTextColor {
+  if ([detailLabelTextColor isEqual:self.detailLabel.textColor]) {
+    return;
+  }
+  self.detailLabel.textColor = detailLabelTextColor;
+}
+
+-(UIColor *)detailLabelTextColor {
+  return self.detailLabel.textColor;
+}
+
+-(void)setDetailLabelFont:(UIFont *)detailLabelFont {
+  if ([detailLabelFont isEqual:self.detailLabel.font]) {
+    return;
+  }
+  self.detailLabel.font = detailLabelFont;
+}
+
+-(UIFont *)detailLabelFont {
+  return self.detailLabel.font;
+}
+
+-(void)setDetailLabelTextAlignment:(NSTextAlignment)detailLabelTextAlignment {
+  if (detailLabelTextAlignment == self.detailLabel.textAlignment) {
+    return;
+  }
+  self.detailLabel.textAlignment = detailLabelTextAlignment;
+}
+
+-(NSTextAlignment)detailLabelTextAlignment {
+  return self.detailLabel.textAlignment;
 }
 
 - (void)setLeadingImage:(UIImage *)leadingImage {
@@ -399,13 +472,6 @@ static const CGFloat kDetailColorOpacity = 0.6f;
   return [MDCTypographyScheme new];
 }
 
--(void)setTypographyScheme:(MDCTypographyScheme *)typographyScheme {
-  _typographyScheme = typographyScheme;
-  self.titleLabel.font = _typographyScheme.body1 ?: self.titleLabel.font;
-  self.detailLabel.font = _typographyScheme.body2 ?: self.detailLabel.font;
-  [self adjustFontsForContentSizeCategory];
-}
-
 - (BOOL)mdc_adjustsFontForContentSizeCategory {
   return _mdc_adjustsFontForContentSizeCategory;
 }
@@ -433,8 +499,8 @@ static const CGFloat kDetailColorOpacity = 0.6f;
 }
 
 - (void)adjustFontsForContentSizeCategory {
-  UIFont *titleFont = self.titleLabel.font ?: self.typographyScheme.headline1;
-  UIFont *detailFont = self.detailLabel.font ?: self.typographyScheme.subtitle1;
+  UIFont *titleFont = self.titleLabel.font ?: self.defaultTitleLabelFont;
+  UIFont *detailFont = self.detailLabel.font ?: self.defaultDetailLabelFont;
 //  if (_mdc_adjustsFontForContentSizeCategory) {
 //    titleFont =
 //    [titleFont mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleHeadline
@@ -446,6 +512,22 @@ static const CGFloat kDetailColorOpacity = 0.6f;
   self.titleLabel.font = titleFont;
   self.detailLabel.font = detailFont;
   [self assignFrames];
+}
+
+- (UIFont *)defaultTitleLabelFont {
+  return [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleTitle];
+}
+
+- (UIFont *)defaultDetailLabelFont {
+  return [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleCaption];
+}
+
+- (UIColor *)defaultTitleLabelTextColor {
+  return [UIColor colorWithWhite:0 alpha:kTitleColorOpacity];
+}
+
+- (UIColor *)defaultDetailLabelTextColor {
+  return [UIColor colorWithWhite:0 alpha:kDetailColorOpacity];
 }
 
 @end

--- a/components/List/examples/Manual Layout List 2/ManualLayoutListItemCell2.m
+++ b/components/List/examples/Manual Layout List 2/ManualLayoutListItemCell2.m
@@ -288,7 +288,7 @@ static const CGFloat kDetailColorOpacity = 0.6f;
   CGFloat leadingPadding = 0;
   CGFloat topPadding = 0;
   if (!CGSizeEqualToSize(size, CGSizeZero)) {
-    leadingPadding = kDefaultHorizontalMargin;
+    leadingPadding = self.layoutMargins.left + kDefaultHorizontalMargin;
     topPadding = [self verticalMarginForImageViewOfSize:size];
   }
   CGPoint origin = CGPointMake(leadingPadding, topPadding);
@@ -306,7 +306,7 @@ static const CGFloat kDetailColorOpacity = 0.6f;
   CGFloat trailingPadding = 0;
   CGFloat topPadding = 0;
   if (!CGSizeEqualToSize(size, CGSizeZero)) {
-    trailingPadding = kDefaultHorizontalMargin;
+    trailingPadding = self.layoutMargins.right + kDefaultHorizontalMargin;
     topPadding = [self verticalMarginForImageViewOfSize:size];
   }
   CGFloat originX = self.cellWidth - trailingPadding - size.width;
@@ -335,7 +335,7 @@ static const CGFloat kDetailColorOpacity = 0.6f;
 //  CGFloat textContainerMinX = leadingImageViewMaxX + kDefaultHorizontalMargin;
   CGFloat textContainerMinX = [self dynamicTextOffset];
   CGFloat trailingImageViewMinX = self.trailingImage ?
-      CGRectGetMinX(self.trailingImageView.frame) : self.cellWidth;
+      CGRectGetMinX(self.trailingImageView.frame) : self.cellWidth - self.layoutMargins.right;
   CGFloat textContainerMaxX = trailingImageViewMinX - kDefaultHorizontalMargin;
   CGFloat textContainerMinY = kDefaultVerticalMarginMax;
   CGFloat textContainerWidth = textContainerMaxX - textContainerMinX;
@@ -408,13 +408,21 @@ static const CGFloat kDetailColorOpacity = 0.6f;
 }
 
 - (CGFloat)dynamicTextOffset {
-  if (!self.leadingImage) {
-    return kTextLeadingMarginMin;
-  } else if (CGRectGetHeight(self.leadingImageView.frame) <= kImageSideLengthMedium) {
-    return kTextLeadingMarginMedium;
+  CGFloat startingOffset = 0;
+  if (self.mdf_effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
+    startingOffset = self.layoutMargins.right;
   } else {
-    return kTextLeadingMarginMax;
+    startingOffset = self.layoutMargins.left;
   }
+  CGFloat additionalOffset = 0;
+  if (!self.leadingImage) {
+    additionalOffset = kTextLeadingMarginMin;
+  } else if (CGRectGetHeight(self.leadingImageView.frame) <= kImageSideLengthMedium) {
+    additionalOffset = kTextLeadingMarginMedium;
+  } else {
+    additionalOffset = kTextLeadingMarginMax;
+  }
+  return startingOffset + additionalOffset;
 }
 
 - (CGFloat)dynamicInterLabelVerticalPadding {
@@ -501,14 +509,14 @@ static const CGFloat kDetailColorOpacity = 0.6f;
 - (void)adjustFontsForContentSizeCategory {
   UIFont *titleFont = self.titleLabel.font ?: self.defaultTitleLabelFont;
   UIFont *detailFont = self.detailLabel.font ?: self.defaultDetailLabelFont;
-//  if (_mdc_adjustsFontForContentSizeCategory) {
-//    titleFont =
-//    [titleFont mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleHeadline
-//                            scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
-//    detailFont =
-//    [detailFont mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleSubheadline
-//                             scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
-//  }
+  if (_mdc_adjustsFontForContentSizeCategory) {
+    titleFont =
+    [titleFont mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleTitle
+                            scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
+    detailFont =
+    [detailFont mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleCaption
+                             scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
+  }
   self.titleLabel.font = titleFont;
   self.detailLabel.font = detailFont;
   [self assignFrames];


### PR DESCRIPTION
I met with @ianegordon last Friday and we took passes through both the APIs and implementations of the list cell classes I’ve been working on.

He suggested I make the following changes to the stuff introduced in https://github.com/material-components/material-components-ios/pull/4382:

- Get rid of the `MDCListBaseCellState ` enum
- Replace state dependent elevation mechanism with an elevation property that works on the underlying shadow layer
- Make the ink spread across the entire screen in the `ManualLayoutListItemCell2.m` example, outside the safe area insets.
- Replace readonly view properties with pass-through accessors for:
  -  UILabels, specifically textColor, font, alignment, and text
  -  UIImageViews, specifically image and cornerRadius
- Remove `MDCTypographyScheme`—use `MDCFontTextStyles` instead
- See if you can avoid setting frames in `preferredLayoutAttributesFittingAttributes:`—do it in `layoutSubviews` instead (I still need to do this.)

It's not complete yet--I'm still working on making it more solid and addressing some iOS 8 bugs, etc. But this is the general idea.

A PR with _just_ the suggested API is coming soon.