### PR TITLE
[Buttons] Updated accessibility documentation and examples

### DIFF
--- a/components/Buttons/docs/README.md
+++ b/components/Buttons/docs/README.md
@@ -48,13 +48,13 @@ Set an appropriate
 value if your button does not have a title. This is often the case with Floating
 Action Button instances which typically only have an icon.
 
-####Objective-C
+#### Objective-C
 
 ```objc
 button.accessibilityLabel = @"Create";
 ```
 
-####Swift
+#### Swift
 
 ```swift
 button.accessibilityLabel = "Create"
@@ -79,7 +79,7 @@ while maintaining the desired visual appearance. For more see the [layout
 guidance](https://guidelines.googleplex.com/googlematerial/layout/#principles)
 in the spec.
 
-#####Objective-C
+##### Objective-C
 
 ```objc
   CGFloat verticalInset = MIN(0, -(48 - CGRectGetHeight(button.bounds)) / 2);
@@ -87,7 +87,7 @@ in the spec.
   button.hitAreaInsets = UIEdgeInsetsMake(verticalInset, horizontalInset, verticalInset, horizontalInset);
 ```
 
-#####Swift
+##### Swift
 
 ```swift
 let buttonVerticalInset =
@@ -106,13 +106,13 @@ guidelines](https://guidelines.googleplex.com/googlematerial/components/buttons.
 typically recommend [a minimum height of 36 points and a minimum width of 64
 points](https://material.io/design/components/buttons.html#specs).
 
-#####Objective-C
+##### Objective-C
 
 ```objc
 button.minimumSize = CGSizeMake(64, 36);
 ```
 
-#####Swift
+##### Swift
 
 ```swift
 button.minimumSize = CGSize(width: 64, height: 48)

--- a/components/Buttons/docs/README.md
+++ b/components/Buttons/docs/README.md
@@ -36,43 +36,109 @@ elevation, Material Design ripples, and other stateful design APIs.
 - [Color Theming](color-theming.md)
 - [Typography Theming](typography-theming.md)
 
+## Accessibility {#a11y}
 
-## Accessibility
-
-To help ensure your buttons are accessible to as many users as possible, please be sure to review
-the following recommendations:
+To help ensure your buttons are accessible to as many users as possible, please
+be sure to review the following recommendations:
 
 ### Set `-accessibilityLabel`
+
 Set an appropriate
 [`accessibilityLabel`](https://developer.apple.com/documentation/uikit/uiaccessibilityelement/1619577-accessibilitylabel)
-value if your button does not have a title. This is often the case with `MDCFloatingButton`
-instances which typically only have an icon.
-```
+value if your button does not have a title. This is often the case with Floating
+Action Button instances which typically only have an icon.
+
+####Objective-C
+
+```objc
 button.accessibilityLabel = @"Create";
+```
+
+####Swift
+
+```swift
+button.accessibilityLabel = "Create"
 ```
 
 ### Minimum touch size
 
-#### Set the frame
-Set your buttons to have a minium size. [Material Touch guidelines](https://material.io/design/layout/spacing-methods.html#touch-click-targets) typically recommend a height and width of 48 points.
+Make sure that your buttons have a minimum touch area. The Google Material spec
+for buttons calls for buttons that have a [visual height of
+36](https://guidelines.googleplex.com/googlematerial/components/buttons.html#style)
+and that [touch areas should be at least 48 points high and 64
+wide](https://material.io/design/layout/spacing-methods.html#touch-click-targets).
+
+#### Set the touch size
+
+To keep a button's visual sizes small with larger touchable areas, set the
+`hitAreaInsets` to a negative value. Be careful to maintain sufficient distance
+between the button touch targets. This will allow your button to have [a large
+enough touch
+target](https://material.io/design/layout/spacing-methods.html#touch-click-targets)
+while maintaining the desired visual appearance. For more see the [layout
+guidance](https://guidelines.googleplex.com/googlematerial/layout/#principles)
+in the spec.
+
+#####Objective-C
+
+```objc
+  CGFloat verticalInset = MIN(0, -(48 - CGRectGetHeight(button.bounds)) / 2);
+  CGFloat horizontalInset = MIN(0, -(48 - CGRectGetWidth(button.bounds)) / 2);
+  button.hitAreaInsets = UIEdgeInsetsMake(verticalInset, horizontalInset, verticalInset, horizontalInset);
 ```
-button.minimumSize = CGSizeMake(48, 48);
+
+#####Swift
+
+```swift
+let buttonVerticalInset =
+  min(0, -(kMinimumAccessibleButtonSize.height - button.bounds.height) / 2);
+let buttonHorizontalInset =
+  min(0, -(kMinimumAccessibleButtonSize.width - button.bounds.width) / 2);
+button.hitAreaInsets =
+  UIEdgeInsetsMake(buttonVerticalInset, buttonHorizontalInset,
+                   buttonVerticalInset, buttonHorizontalInset);
 ```
 
-#### Set the touch size (alternative)
+#### Set the minimum visual size of the button
 
-An alternate approach is to set the `hitAreaInsets` to a negative value to make the touch target
-larger than the visual appearance of the button. When you do this you should be careful to make sure
-you maintain an 8-point distance between the button touch targets. This will allow your button to
-have [a large enough touch
-target](https://material.io/design/layout/spacing-methods.html#touch-click-targets) while
-maintaining the desired visual appearance.
+Set your buttons to have a minimum size. [Google Material Buttons
+guidelines](https://guidelines.googleplex.com/googlematerial/components/buttons.html#style)
+typically recommend [a minimum height of 36 points and a minimum width of 64
+points](https://material.io/design/components/buttons.html#specs).
 
+#####Objective-C
+
+```objc
+button.minimumSize = CGSizeMake(64, 36);
 ```
-  CGFloat verticalInset = MIN(0, -(48 - button.frame.size.height) / 2);
-  button .hitAreaInsets = UIEdgeInsetsMake(verticalInset, 0, verticalInset, 0);
 
+#####Swift
+
+```swift
+button.minimumSize = CGSize(width: 64, height: 48)
 ```
-When you do this make sure to follow the rest of the layout guidence and pad buttons with the
-recommended space.
 
+##### Exceptions
+
+However there are
+[some](https://material.io/design/components/buttons.html#toggle-button) clear
+[exceptions](https://material.io/design/components/app-bars-bottom.html#specs)
+for these rules. Please adjust your buttons sizes accordingly.
+
+#### Using `accessibilityHint`
+
+Apple rarely recommends using the `accessibilityHint` because the label should
+already be clear enough to indicate what will happen. Before you consider
+setting an `-accessibilityHint` consider if you need it or if the rest of your
+UI could be adjusted to make it more contextually clear.
+
+A well-crafted, thoughtful user interface can remove the need for
+`accessibilityHint` in most situations. Examples for a selection dialog to
+choose one or more days of the week for a repeating calendar event:
+
+*   (Good) The dialog includes a header above the list of days reading, "Event
+    repeats weekly on the following day(s)." The list items do not need
+    `accessibilityHint` values.
+*   (Bad) The dialog has no header above the list of days. Each list item
+    (representing a day of the week) has the `accessibilityHint` value, "Toggles
+    this day."

--- a/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
+++ b/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
@@ -22,6 +22,7 @@ import MaterialComponents.MaterialButtons
 class ButtonsSimpleExampleSwiftViewController: UIViewController {
 
   let floatingButtonPlusDimension = CGFloat(24)
+  let kMinimumAccessibleButtonSize = CGSize(width: 64, height: 48)
   
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -29,23 +30,37 @@ class ButtonsSimpleExampleSwiftViewController: UIViewController {
     view.backgroundColor = UIColor(white: 0.9, alpha: 1.0)
     //let titleColor = UIColor.white
     let backgroundColor = UIColor(white: 0.1, alpha: 1.0)
+    let buttonScheme = MDCButtonScheme()
+    
+    let containedButton = MDCButton()
+    MDCContainedButtonThemer.applyScheme(buttonScheme, to: containedButton)
+    containedButton.setTitle("Tap Me Too", for: UIControlState())
+    containedButton.sizeToFit()
+    let containedButtonVerticalInset =
+      min(0, -(kMinimumAccessibleButtonSize.height - containedButton.bounds.height) / 2);
+    let containedButtonHorizontalInset =
+      min(0, -(kMinimumAccessibleButtonSize.width - containedButton.bounds.width) / 2);
+    containedButton.hitAreaInsets =
+      UIEdgeInsetsMake(containedButtonVerticalInset, containedButtonHorizontalInset,
+                       containedButtonVerticalInset, containedButtonHorizontalInset);
+    containedButton.translatesAutoresizingMaskIntoConstraints = false
+    containedButton.addTarget(self, action: #selector(tap), for: .touchUpInside)
+    view.addSubview(containedButton)
 
-    let raisedButton = MDCRaisedButton()
-    raisedButton.setBackgroundColor(backgroundColor, for: .normal)
-    raisedButton.setElevation(.raisedButtonResting, for: UIControlState())
-    raisedButton.setTitle("Tap Me Too", for: UIControlState())
-    raisedButton.sizeToFit()
-    raisedButton.translatesAutoresizingMaskIntoConstraints = false
-    raisedButton.addTarget(self, action: #selector(tap), for: .touchUpInside)
-    view.addSubview(raisedButton)
-
-    let flatButton = MDCFlatButton()
-    flatButton.setTitleColor(.gray, for: .normal)
-    flatButton.setTitle("Touch me", for: UIControlState())
-    flatButton.sizeToFit()
-    flatButton.translatesAutoresizingMaskIntoConstraints = false
-    flatButton.addTarget(self, action: #selector(tap), for: .touchUpInside)
-    view.addSubview(flatButton)
+    let textButton = MDCButton()
+    MDCTextButtonThemer.applyScheme(buttonScheme, to: textButton)
+    textButton.setTitle("Touch me", for: UIControlState())
+    textButton.sizeToFit()
+    let textButtonVerticalInset =
+      min(0, -(kMinimumAccessibleButtonSize.height - textButton.bounds.height) / 2);
+    let textButtonHorizontalInset =
+      min(0, -(kMinimumAccessibleButtonSize.width - textButton.bounds.width) / 2);
+    textButton.hitAreaInsets =
+      UIEdgeInsetsMake(textButtonVerticalInset, textButtonHorizontalInset,
+                       textButtonVerticalInset, textButtonHorizontalInset);
+    textButton.translatesAutoresizingMaskIntoConstraints = false
+    textButton.addTarget(self, action: #selector(tap), for: .touchUpInside)
+    view.addSubview(textButton)
 
     let floatingButton = MDCFloatingButton()
     floatingButton.backgroundColor = backgroundColor
@@ -55,19 +70,20 @@ class ButtonsSimpleExampleSwiftViewController: UIViewController {
 
     let plusShapeLayer = ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton)
     floatingButton.layer.addSublayer(plusShapeLayer)
+    floatingButton.accessibilityLabel = "Create"
 
     view.addSubview(floatingButton)
 
     let views = [
-      "raised": raisedButton,
-      "flat": flatButton,
+      "contained": containedButton,
+      "text": textButton,
       "floating": floatingButton
     ]
 
-    centerView(view: flatButton, onView: self.view)
+    centerView(view: textButton, onView: self.view)
 
     view.addConstraints(
-      NSLayoutConstraint.constraints(withVisualFormat: "V:[raised]-40-[flat]-40-[floating]",
+      NSLayoutConstraint.constraints(withVisualFormat: "V:[contained]-40-[text]-40-[floating]",
         options: .alignAllCenterX,
         metrics: nil,
         views: views))

--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -23,7 +23,7 @@
 
 #import "supplemental/ButtonsTypicalUseSupplemental.h"
 
-const CGFloat kMinimumAccessibleButtonHeight = 48.0;
+const CGSize kMinimumAccessibleButtonSize = {64.0, 48.0};
 
 @interface ButtonsTypicalUseExampleViewController ()
 @property(nonatomic, strong) MDCFloatingButton *floatingButton;
@@ -56,9 +56,12 @@ const CGFloat kMinimumAccessibleButtonHeight = 48.0;
   [MDCContainedButtonThemer applyScheme:buttonScheme toButton:containedButton];
   [containedButton sizeToFit];
   CGFloat containedButtonVerticalInset =
-      MIN(0, -(kMinimumAccessibleButtonHeight - CGRectGetHeight(containedButton.frame)) / 2);
+      MIN(0, -(kMinimumAccessibleButtonSize.height - CGRectGetHeight(containedButton.bounds)) / 2);
+  CGFloat containedButtonHorizontalInset =
+      MIN(0, -(kMinimumAccessibleButtonSize.width - CGRectGetWidth(containedButton.bounds)) / 2);
   containedButton.hitAreaInsets =
-      UIEdgeInsetsMake(containedButtonVerticalInset, 0, containedButtonVerticalInset, 0);
+      UIEdgeInsetsMake(containedButtonVerticalInset, containedButtonHorizontalInset,
+                       containedButtonVerticalInset, containedButtonHorizontalInset);
   [containedButton addTarget:self
                       action:@selector(didTap:)
             forControlEvents:UIControlEventTouchUpInside];
@@ -82,9 +85,13 @@ const CGFloat kMinimumAccessibleButtonHeight = 48.0;
   [MDCTextButtonThemer applyScheme:buttonScheme toButton:textButton];
   [textButton setTitle:@"Button" forState:UIControlStateNormal];
   [textButton sizeToFit];
-  CGFloat textButtonVerticalInset = MIN(0, -(kMinimumAccessibleButtonHeight - CGRectGetHeight(textButton.frame)) / 2);
+  CGFloat textButtonVerticalInset =
+      MIN(0, -(kMinimumAccessibleButtonSize.height - CGRectGetHeight(textButton.bounds)) / 2);
+  CGFloat textButtonHorizontalInset =
+      MIN(0, -(kMinimumAccessibleButtonSize.width - CGRectGetWidth(textButton.bounds)) / 2);
   textButton.hitAreaInsets =
-      UIEdgeInsetsMake(textButtonVerticalInset, 0, textButtonVerticalInset, 0);
+      UIEdgeInsetsMake(textButtonVerticalInset, textButtonHorizontalInset,
+                       textButtonVerticalInset, textButtonHorizontalInset);
   [textButton addTarget:self
                  action:@selector(didTap:)
        forControlEvents:UIControlEventTouchUpInside];
@@ -109,9 +116,12 @@ const CGFloat kMinimumAccessibleButtonHeight = 48.0;
   [MDCOutlinedButtonThemer applyScheme:buttonScheme toButton:outlinedButton];
   [outlinedButton sizeToFit];
   CGFloat outlineButtonVerticalInset =
-      MIN(0, -(kMinimumAccessibleButtonHeight - CGRectGetHeight(outlinedButton.frame)) / 2);
+      MIN(0, -(kMinimumAccessibleButtonSize.height - CGRectGetHeight(outlinedButton.frame)) / 2);
+  CGFloat outlineButtonHorizontalInset =
+      MIN(0, -(kMinimumAccessibleButtonSize.width - CGRectGetWidth(outlinedButton.frame)) / 2);
   outlinedButton.hitAreaInsets =
-      UIEdgeInsetsMake(outlineButtonVerticalInset, 0, outlineButtonVerticalInset, 0);
+      UIEdgeInsetsMake(outlineButtonVerticalInset, outlineButtonHorizontalInset,
+                       outlineButtonVerticalInset, outlineButtonHorizontalInset);
   [outlinedButton addTarget:self
                     action:@selector(didTap:)
           forControlEvents:UIControlEventTouchUpInside];
@@ -141,13 +151,7 @@ const CGFloat kMinimumAccessibleButtonHeight = 48.0;
       [[UIImage imageNamed:@"Plus"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   [self.floatingButton setImage:plusImage forState:UIControlStateNormal];
   [MDCFloatingActionButtonThemer applyScheme:buttonScheme toButton:self.floatingButton];
-  CGFloat floatingActionButtonVerticalInset =
-      MIN(0, -(kMinimumAccessibleButtonHeight - CGRectGetHeight(self.floatingButton.frame)) / 2);
-  UIEdgeInsets touchInsets =
-      UIEdgeInsetsMake(floatingActionButtonVerticalInset, 0, floatingActionButtonVerticalInset, 0);
-  [self.floatingButton setHitAreaInsets:touchInsets
-                               forShape:MDCFloatingButtonShapeDefault
-                                 inMode:MDCFloatingButtonModeNormal];
+  self.floatingButton.accessibilityLabel = @"Create";
   [self.view addSubview:self.floatingButton];
 
   self.buttons = @[

--- a/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
+++ b/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
@@ -35,14 +35,17 @@ class FloatingButtonExampleSwiftViewController: UIViewController {
     miniFloatingButton.translatesAutoresizingMaskIntoConstraints = false
     miniFloatingButton.setMinimumSize(CGSize(width: 96, height: 40), for: .mini, in: .expanded)
     miniFloatingButton.setImage(plusImage, for: .normal)
+    miniFloatingButton.accessibilityLabel = "Create"
 
     defaultFloatingButton.sizeToFit()
     defaultFloatingButton.translatesAutoresizingMaskIntoConstraints = false
     defaultFloatingButton.setImage(plusImage, for: .normal)
+    defaultFloatingButton.accessibilityLabel = "Create"
 
     largeIconFloatingButton.sizeToFit()
     largeIconFloatingButton.translatesAutoresizingMaskIntoConstraints = false
     largeIconFloatingButton.setImage(plusImage36, for: .normal)
+    largeIconFloatingButton.accessibilityLabel = "Create"
     largeIconFloatingButton.setContentEdgeInsets(UIEdgeInsetsMake(-6, -6, -6, 0), for: .default,
                                                  in: .expanded)
 


### PR DESCRIPTION
Made copyedit improvements to the accessibility documentation.
Applied those instructions to the button examples.

Fixes: https://github.com/material-components/material-components-ios/issues/3874 and https://github.com/material-components/material-components-ios/issues/3873