### PR TITLE
[BottomNavigation] Layout Bottom Navigation with Size Classes Instead of Orientation

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -193,7 +193,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   [super layoutSubviews];
 
   CGSize size = self.bounds.size;
-  if (UIDeviceOrientationIsLandscape([UIDevice currentDevice].orientation)) {
+  if (self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
     [self layoutLandscapeModeWithBottomNavSize:size
                                 containerWidth:self.maxLandscapeClusterContainerWidth];
   } else {
@@ -208,7 +208,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   UIEdgeInsets insets = self.mdc_safeAreaInsets;
   CGFloat heightWithInset = kMDCBottomNavigationBarHeight + insets.bottom;
   if (self.alignment == MDCBottomNavigationBarAlignmentJustifiedAdjacentTitles &&
-      UIDeviceOrientationIsLandscape([UIDevice currentDevice].orientation)) {
+      self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
     heightWithInset = kMDCBottomNavigationBarHeightAdjacentTitles + insets.bottom;
   }
   CGSize insetSize = CGSizeMake(size.width, heightWithInset);
@@ -252,7 +252,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
                            containerWidth:(CGFloat)containerWidth {
   CGFloat barHeight = kMDCBottomNavigationBarHeight;
   if (self.alignment == MDCBottomNavigationBarAlignmentJustifiedAdjacentTitles &&
-      UIDeviceOrientationIsLandscape([UIDevice currentDevice].orientation)) {
+      self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
     barHeight = kMDCBottomNavigationBarHeightAdjacentTitles;
   }
   if (itemsDistributed) {


### PR DESCRIPTION
Closes #3044.

Before:
![simulator screen shot - ipad air 2 - 2018-06-21 at 13 17 36](https://user-images.githubusercontent.com/8020010/41734813-110950ee-7556-11e8-9286-f443e071f323.png)

After:
![simulator screen shot - ipad air 2 - 2018-06-21 at 13 18 25](https://user-images.githubusercontent.com/8020010/41734812-10f8319c-7556-11e8-8b05-920865bd68d3.png)


