### PR TITLE
[BottomNavigation] Test cases when we reset the bottom navigation items array

### DIFF
--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -26,9 +26,10 @@ class BottomNavigationResetExample: UIViewController {
   // The tabs that will be reordered later
   let tabBarItem1 = UITabBarItem(title: "Home", image: UIImage(named: "Home"), tag: 0)
   let tabBarItem2 =
-    UITabBarItem(title: "Messages", image: UIImage(named: "Email"), tag: 0)
+    UITabBarItem(title: "Messages", image: UIImage(named: "Email"), tag: 1)
   let tabBarItem3 =
-    UITabBarItem(title: "Favorites", image: UIImage(named: "Favorite"), tag: 0)
+    UITabBarItem(title: "Favorites", image: UIImage(named: "Favorite"), tag: 2)
+  let tabBarItem4 = UITabBarItem(title: "Cake", image: UIImage(named: "Cake"), tag: 3)
 
   let buttonOne = MDCButton()
   let buttonTwo = MDCButton()
@@ -107,7 +108,8 @@ class BottomNavigationResetExample: UIViewController {
   }
 
   @objc func reorderTwo(_ button: UIButton) {
-    bottomNavBar.items = [tabBarItem3, tabBarItem1, tabBarItem2]
+    bottomNavBar.items = [tabBarItem3, tabBarItem1, tabBarItem2, tabBarItem4]
+    bottomNavBar.selectedItem = tabBarItem3
   }
 }
 

--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -69,7 +69,7 @@ class BottomNavigationResetExample: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    view.backgroundColor = MDCPalette.grey.tint100
+    view.backgroundColor = colorScheme.backgroundColor
     view.addSubview(bottomNavBar)
 
     bottomNavBar.alignment = .centered

--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -104,12 +104,10 @@ class BottomNavigationResetExample: UIViewController {
 
   @objc func reorderOne(_ button: UIButton) {
     bottomNavBar.items = [tabBarItem2, tabBarItem3, tabBarItem1]
-    
   }
 
   @objc func reorderTwo(_ button: UIButton) {
     bottomNavBar.items = [tabBarItem3, tabBarItem1, tabBarItem2]
-    bottomNavBar.selectedItem = tabBarItem2
   }
 }
 

--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -1,0 +1,129 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+import MaterialComponents
+
+class BottomNavigationResetExample: UIViewController {
+
+  var colorScheme = MDCSemanticColorScheme()
+
+  let bottomNavBar = MDCBottomNavigationBar()
+
+  // The tabs that will be reordered later
+  let tabBarItem1 = UITabBarItem(title: "Home", image: UIImage(named: "Home"), tag: 0)
+  let tabBarItem2 =
+    UITabBarItem(title: "Messages", image: UIImage(named: "Email"), tag: 0)
+  let tabBarItem3 =
+    UITabBarItem(title: "Favorites", image: UIImage(named: "Favorite"), tag: 0)
+
+  let buttonOne = MDCButton()
+  let buttonTwo = MDCButton()
+
+  init() {
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  @available(*, unavailable)
+  required init?(coder aDecoder: NSCoder) {
+    super.init(coder: aDecoder)
+  }
+
+  func layoutBottomNavBar() {
+    let size = bottomNavBar.sizeThatFits(view.bounds.size)
+    let bottomNavBarFrame = CGRect(x: 0,
+                                   y: view.bounds.height - size.height,
+                                   width: size.width,
+                                   height: size.height)
+    bottomNavBar.frame = bottomNavBarFrame
+  }
+
+  override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+    layoutBottomNavBar()
+  }
+
+  #if swift(>=3.2)
+  @available(iOS 11, *)
+  override func viewSafeAreaInsetsDidChange() {
+    super.viewSafeAreaInsetsDidChange()
+    layoutBottomNavBar()
+  }
+  #endif
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    view.backgroundColor = .lightGray
+    view.addSubview(bottomNavBar)
+
+    bottomNavBar.alignment = .centered
+
+    // Add items to the bottom navigation bar.
+    bottomNavBar.items = [ tabBarItem1, tabBarItem2, tabBarItem3 ]
+
+    // Select a bottom navigation bar item.
+    bottomNavBar.selectedItem = tabBarItem2
+
+    // Layout buttons
+    buttonOne.setTitle("Reorder One", for: .normal)
+    buttonOne.sizeToFit()
+    buttonOne.frame.origin = CGPoint(x: view.center.x - (buttonOne.frame.width / 2),
+                                     y: view.center.y - (buttonOne.frame.height + 16))
+    buttonOne.addTarget(self, action: #selector(reorderOne), for: .touchUpInside)
+    view.addSubview(buttonOne)
+
+    buttonTwo.setTitle("Reorder Two", for: .normal)
+    buttonTwo.sizeToFit()
+    buttonTwo.frame.origin = CGPoint(x: view.center.x - (buttonTwo.frame.width / 2),
+                                      y: view.center.y + 16)
+    buttonTwo.addTarget(self, action: #selector(reorderTwo), for: .touchUpInside)
+    view.addSubview(buttonTwo)
+
+    MDCBottomNavigationBarColorThemer.applySemanticColorScheme(colorScheme,
+                                                               toBottomNavigation: bottomNavBar)
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    self.navigationController?.setNavigationBarHidden(true, animated: animated)
+  }
+
+  @objc func reorderOne(_ button: UIButton) {
+    bottomNavBar.items = [tabBarItem2, tabBarItem3, tabBarItem1]
+    
+  }
+
+  @objc func reorderTwo(_ button: UIButton) {
+    bottomNavBar.items = [tabBarItem3, tabBarItem1, tabBarItem2]
+    bottomNavBar.selectedItem = tabBarItem2
+  }
+}
+
+// MARK: Catalog by convention
+extension BottomNavigationResetExample {
+  class func catalogBreadcrumbs() -> [String] {
+    return ["Bottom Navigation", "Bottom Navigation Reset (Swift)"]
+  }
+
+  class func catalogIsPrimaryDemo() -> Bool {
+    return false
+  }
+
+  @objc class func catalogIsPresentable() -> Bool {
+    return false
+  }
+}

--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -17,9 +17,11 @@
 import Foundation
 import MaterialComponents
 
+/// Example to showcase a reorder of the tabs from an user action
 class BottomNavigationResetExample: UIViewController {
 
   var colorScheme = MDCSemanticColorScheme()
+  var typographyScheme = MDCTypographyScheme()
 
   let bottomNavBar = MDCBottomNavigationBar()
 
@@ -67,8 +69,7 @@ class BottomNavigationResetExample: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-
-    view.backgroundColor = .lightGray
+    view.backgroundColor = MDCPalette.grey.tint100
     view.addSubview(bottomNavBar)
 
     bottomNavBar.alignment = .centered
@@ -84,30 +85,27 @@ class BottomNavigationResetExample: UIViewController {
     buttonOne.sizeToFit()
     buttonOne.frame.origin = CGPoint(x: view.center.x - (buttonOne.frame.width / 2),
                                      y: view.center.y - (buttonOne.frame.height + 16))
-    buttonOne.addTarget(self, action: #selector(reorderOne), for: .touchUpInside)
+    buttonOne.addTarget(self, action: #selector(reorderItems), for: .touchUpInside)
     view.addSubview(buttonOne)
 
     buttonTwo.setTitle("Reorder Two", for: .normal)
     buttonTwo.sizeToFit()
     buttonTwo.frame.origin = CGPoint(x: view.center.x - (buttonTwo.frame.width / 2),
                                       y: view.center.y + 16)
-    buttonTwo.addTarget(self, action: #selector(reorderTwo), for: .touchUpInside)
+    buttonTwo.addTarget(self, action: #selector(reorderItemsAndSetSelected), for: .touchUpInside)
     view.addSubview(buttonTwo)
 
     MDCBottomNavigationBarColorThemer.applySemanticColorScheme(colorScheme,
                                                                toBottomNavigation: bottomNavBar)
+    MDCBottomNavigationBarTypographyThemer.applyTypographyScheme(typographyScheme,
+                                                                 to: bottomNavBar)
   }
 
-  override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-    self.navigationController?.setNavigationBarHidden(true, animated: animated)
-  }
-
-  @objc func reorderOne(_ button: UIButton) {
+  @objc func reorderItems(_ button: UIButton) {
     bottomNavBar.items = [tabBarItem2, tabBarItem3, tabBarItem1]
   }
 
-  @objc func reorderTwo(_ button: UIButton) {
+  @objc func reorderItemsAndSetSelected(_ button: UIButton) {
     bottomNavBar.items = [tabBarItem3, tabBarItem1, tabBarItem2, tabBarItem4]
     bottomNavBar.selectedItem = tabBarItem3
   }
@@ -116,7 +114,7 @@ class BottomNavigationResetExample: UIViewController {
 // MARK: Catalog by convention
 extension BottomNavigationResetExample {
   class func catalogBreadcrumbs() -> [String] {
-    return ["Bottom Navigation", "Bottom Navigation Reset (Swift)"]
+    return ["Bottom Navigation", "Bottom Navigation Reorder (Swift)"]
   }
 
   class func catalogIsPrimaryDemo() -> Bool {
@@ -125,5 +123,9 @@ extension BottomNavigationResetExample {
 
   @objc class func catalogIsPresentable() -> Bool {
     return false
+  }
+
+  class func catalogShouldHideNavigation() -> Bool {
+    return true
   }
 }

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -405,7 +405,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
 #pragma mark - Setters
 
 - (void)setItems:(NSArray<UITabBarItem *> *)items {
-  if ([_items isEqual:items]) {
+  if ([_items isEqual:items] || _items == items) {
     return;
   }
 

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -405,7 +405,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
 #pragma mark - Setters
 
 - (void)setItems:(NSArray<UITabBarItem *> *)items {
-  if (_items == items) {
+  if ([_items isEqual:items]) {
     return;
   }
 
@@ -475,6 +475,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
   }
   self.selectedItem = self.items[0];
   [self addObserversToTabBarItems];
+  self.selectedItem = NULL;
   [self setNeedsLayout];
   [self setNeedsDisplay];
 }

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -473,7 +473,10 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
     [self.itemViews addObject:itemView];
     [self.containerView addSubview:itemView];
   }
+  self.selectedItem = self.items[0];
   [self addObserversToTabBarItems];
+  [self setNeedsLayout];
+  [self setNeedsDisplay];
 }
 
 - (void)setSelectedItem:(UITabBarItem *)selectedItem {

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -405,6 +405,7 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
 #pragma mark - Setters
 
 - (void)setItems:(NSArray<UITabBarItem *> *)items {
+  NSAssert(items.count > 1, @"Items should always have 2 or more tabs");
   if ([_items isEqual:items] || _items == items) {
     return;
   }
@@ -473,9 +474,12 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
     [self.itemViews addObject:itemView];
     [self.containerView addSubview:itemView];
   }
-  self.selectedItem = self.items[0];
+  if (items.count >= 1) {
+    self.selectedItem = self.items[0];
+  } else {
+    self.selectedItem = nil;
+  }
   [self addObserversToTabBarItems];
-  self.selectedItem = NULL;
   [self setNeedsLayout];
   [self setNeedsDisplay];
 }

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -405,7 +405,6 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
 #pragma mark - Setters
 
 - (void)setItems:(NSArray<UITabBarItem *> *)items {
-  NSAssert(items.count > 1, @"Items should always have 2 or more tabs");
   if ([_items isEqual:items] || _items == items) {
     return;
   }
@@ -474,14 +473,9 @@ static NSString *const kMDCBottomNavigationBarTitleString = @"title";
     [self.itemViews addObject:itemView];
     [self.containerView addSubview:itemView];
   }
-  if (items.count >= 1) {
-    self.selectedItem = self.items[0];
-  } else {
-    self.selectedItem = nil;
-  }
+  self.selectedItem = nil;
   [self addObserversToTabBarItems];
   [self setNeedsLayout];
-  [self setNeedsDisplay];
 }
 
 - (void)setSelectedItem:(UITabBarItem *)selectedItem {

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -97,4 +97,31 @@
   XCTAssertEqual(self.bottomNavBar.itemViews.count, tabsCount);
 }
 
+-(void)testItemFrameAfterReset {
+  // Given
+  UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"1" image:nil tag:0];
+  UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:0];
+  UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:0];
+
+  // When
+  self.bottomNavBar.items = @[item1, item2];
+  self.bottomNavBar.items = @[item1, item2, item3];
+
+  // Then
+  XCTAssertFalse(CGRectEqualToRect(self.bottomNavBar.itemViews[0].frame, CGRectZero));
+}
+
+-(void)testSelectedItemAfterReset {
+  // Given
+  UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"1" image:nil tag:0];
+  UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:0];
+  UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:0];
+
+  // When
+  self.bottomNavBar.items = @[item1, item2];
+  self.bottomNavBar.items = @[item1, item2, item3];
+
+  XCTAssertNil(self.bottomNavBar.selectedItem);
+}
+
 @end

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -97,6 +97,24 @@
   XCTAssertEqual(self.bottomNavBar.itemViews.count, tabsCount);
 }
 
+-(void)testFramesAfterReset {
+  // Given
+  UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"1" image:nil tag:0];
+  UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:1];
+  UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:2];
+  [self.bottomNavBar setNeedsLayout];
+  [self.bottomNavBar layoutIfNeeded];
+  [self.bottomNavBar setNeedsDisplay];
+  [self.bottomNavBar sizeToFit];
+  self.bottomNavBar.frame = CGRectMake(0, 0, 320, 56);
+
+  // When
+  self.bottomNavBar.items = @[item1, item2];
+  self.bottomNavBar.items = @[item1, item2, item3];
+
+  XCTAssertNil(self.bottomNavBar.selectedItem);
+}
+
 -(void)testSelectedItemAfterReset {
   // Given
   UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"1" image:nil tag:0];

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -97,24 +97,6 @@
   XCTAssertEqual(self.bottomNavBar.itemViews.count, tabsCount);
 }
 
--(void)testItemFrameAfterReset {
-
-  MDCBottomNavigationBar *bar =
-      [[MDCBottomNavigationBar alloc] initWithFrame:CGRectMake(0, 0, 320, 80)];
-  // Given
-  UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"1" image:nil tag:0];
-  UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:0];
-  UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:0];
-
-  // When
-  bar.items = @[item1, item2];
-  bar.items = @[item1, item2, item3];
-
-
-  // Then
-  XCTAssertFalse(!CGRectEqualToRect(bar.itemViews[0].frame, CGRectZero));
-}
-
 -(void)testSelectedItemAfterReset {
   // Given
   UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"1" image:nil tag:0];

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -98,17 +98,21 @@
 }
 
 -(void)testItemFrameAfterReset {
+
+  MDCBottomNavigationBar *bar =
+      [[MDCBottomNavigationBar alloc] initWithFrame:CGRectMake(0, 0, 320, 80)];
   // Given
   UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"1" image:nil tag:0];
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:0];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:0];
 
   // When
-  self.bottomNavBar.items = @[item1, item2];
-  self.bottomNavBar.items = @[item1, item2, item3];
+  bar.items = @[item1, item2];
+  bar.items = @[item1, item2, item3];
+
 
   // Then
-  XCTAssertFalse(CGRectEqualToRect(self.bottomNavBar.itemViews[0].frame, CGRectZero));
+  XCTAssertFalse(!CGRectEqualToRect(bar.itemViews[0].frame, CGRectZero));
 }
 
 -(void)testSelectedItemAfterReset {

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -102,17 +102,16 @@
   UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"1" image:nil tag:0];
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:1];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:2];
-  [self.bottomNavBar setNeedsLayout];
-  [self.bottomNavBar layoutIfNeeded];
-  [self.bottomNavBar setNeedsDisplay];
   [self.bottomNavBar sizeToFit];
   self.bottomNavBar.frame = CGRectMake(0, 0, 320, 56);
+  [self.bottomNavBar setNeedsLayout];
 
   // When
   self.bottomNavBar.items = @[item1, item2];
   self.bottomNavBar.items = @[item1, item2, item3];
+  [self.bottomNavBar layoutIfNeeded];
 
-  XCTAssertNil(self.bottomNavBar.selectedItem);
+  XCTAssertFalse(CGRectEqualToRect(self.bottomNavBar.itemViews[0].frame, CGRectZero));
 }
 
 -(void)testSelectedItemAfterReset {

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -104,13 +104,13 @@
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:2];
   [self.bottomNavBar sizeToFit];
   self.bottomNavBar.frame = CGRectMake(0, 0, 320, 56);
-  [self.bottomNavBar setNeedsLayout];
 
   // When
   self.bottomNavBar.items = @[item1, item2];
   self.bottomNavBar.items = @[item1, item2, item3];
   [self.bottomNavBar layoutIfNeeded];
 
+  // Then
   XCTAssertFalse(CGRectEqualToRect(self.bottomNavBar.itemViews[0].frame, CGRectZero));
 }
 
@@ -124,6 +124,7 @@
   self.bottomNavBar.items = @[item1, item2];
   self.bottomNavBar.items = @[item1, item2, item3];
 
+  // Then
   XCTAssertNil(self.bottomNavBar.selectedItem);
 }
 


### PR DESCRIPTION
Added an example to showcase when items are reset to an new array.

Fixed the bug when we reset items and they don't layout correctly.

After a reset, set the selected tab to Null to mirror UITabBar
https://developer.apple.com/documentation/uikit/uitabbar/1623453-selecteditem?language=objc

Added two test to check for selection being Null after a reset and frames not being zero after a reset.

Closes #4429 