### PR TITLE
[BottomNavigation] Parameterize top padding and vertical margin

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -123,6 +123,25 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarAlignment) {
  */
 @property(nullable, nonatomic,copy) UIColor *backgroundColor UI_APPEARANCE_SELECTOR;
 
+/**
+ The inset applied to each items bounds to determine the rect in which the items' contents will be
+ centered. The contents are centered in this rect, but not compressed, so they may still extend
+ beyond these bounds. Defaults to {0, 0, 0, 0}. The inset is flipped for RTL.
+ */
+@property(nonatomic, assign) UIEdgeInsets itemsContentInsets;
+
+/**
+ The margin between the item's icon and title when alignment is either Justified or Centered.
+ Defaults to 0.
+ */
+@property(nonatomic, assign) CGFloat itemsContentVerticalMargin;
+
+/**
+ The margin between the item's icon and title when alignment is JustifiedAdjacentTitles. Defaults to
+ 12.
+ */
+@property(nonatomic, assign) CGFloat itemsContentHorizontalMargin;
+
 @end
 
 #pragma mark - MDCBottomNavigationBarDelegate

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -20,6 +20,7 @@
 
 #import <MDFInternationalization/MDFInternationalization.h>
 
+#import "MaterialMath.h"
 #import "MaterialShadowElevations.h"
 #import "MaterialShadowLayer.h"
 #import "MaterialTypography.h"
@@ -53,6 +54,7 @@ static NSString *const kMDCBottomNavigationBarBarTintColorKey =
 static const CGFloat kMDCBottomNavigationBarHeight = 56.f;
 static const CGFloat kMDCBottomNavigationBarHeightAdjacentTitles = 40.f;
 static const CGFloat kMDCBottomNavigationBarLandscapeContainerWidth = 320.f;
+static const CGFloat kMDCBottomNavigationBarItemsHorizontalMargin = 12.f;
 static NSString *const kMDCBottomNavigationBarBadgeColorString = @"badgeColor";
 static NSString *const kMDCBottomNavigationBarBadgeValueString = @"badgeValue";
 static NSString *const kMDCBottomNavigationBarAccessibilityValueString =
@@ -168,6 +170,7 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
 }
 
 - (void)commonMDCBottomNavigationBarInit {
+  _itemsContentHorizontalMargin = kMDCBottomNavigationBarItemsHorizontalMargin;
   _selectedItemTintColor = [UIColor blackColor];
   _unselectedItemTintColor = [UIColor grayColor];
   _selectedItemTitleColor = _selectedItemTintColor;
@@ -454,6 +457,9 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
     itemView.titleVisibility = self.titleVisibility;
     itemView.titleBelowIcon = self.titleBelowItem;
     itemView.accessibilityValue = item.accessibilityValue;
+    itemView.contentInsets = self.itemsContentInsets;
+    itemView.contentVerticalMargin = self.itemsContentVerticalMargin;
+    itemView.contentHorizontalMargin = self.itemsContentHorizontalMargin;
 
     NSString *key =
         kMaterialBottomNavigationStringTable[kStr_MaterialBottomNavigationItemCountAccessibilityHint];
@@ -524,6 +530,42 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
       [itemView setSelected:NO animated:animated];
     }
   }
+}
+
+- (void)setItemsContentInsets:(UIEdgeInsets)itemsContentInsets {
+  if (UIEdgeInsetsEqualToEdgeInsets(_itemsContentInsets, itemsContentInsets)) {
+    return;
+  }
+  _itemsContentInsets = itemsContentInsets;
+  for (NSUInteger i = 0; i < self.items.count; i++) {
+    MDCBottomNavigationItemView *itemView = self.itemViews[i];
+    itemView.contentInsets = itemsContentInsets;
+  }
+  [self setNeedsLayout];
+}
+
+- (void)setItemsContentVerticalMargin:(CGFloat)itemsContentsVerticalMargin {
+  if (MDCCGFloatEqual(_itemsContentVerticalMargin, itemsContentsVerticalMargin)) {
+    return;
+  }
+  _itemsContentVerticalMargin = itemsContentsVerticalMargin;
+  for (NSUInteger i = 0; i < self.items.count; i++) {
+    MDCBottomNavigationItemView *itemView = self.itemViews[i];
+    itemView.contentVerticalMargin = itemsContentsVerticalMargin;
+  }
+  [self setNeedsLayout];
+}
+
+- (void)setItemsContentHorizontalMargin:(CGFloat)itemsContentHorizontalMargin {
+  if (MDCCGFloatEqual(_itemsContentHorizontalMargin, itemsContentHorizontalMargin)) {
+    return;
+  }
+  _itemsContentHorizontalMargin = itemsContentHorizontalMargin;
+  for (NSUInteger i = 0; i < self.items.count; i++) {
+    MDCBottomNavigationItemView *itemView = self.itemViews[i];
+    itemView.contentHorizontalMargin = itemsContentHorizontalMargin;
+  }
+  [self setNeedsLayout];
 }
 
 - (void)setTitleBelowItem:(BOOL)titleBelowItem {

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
@@ -39,6 +39,11 @@
 @property(nonatomic, strong) UIColor *unselectedItemTintColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong) UIColor *selectedItemTitleColor;
 
+@property(nonatomic, assign) UIEdgeInsets contentInsets;
+
+@property(nonatomic, assign) CGFloat contentVerticalMargin;
+@property(nonatomic, assign) CGFloat contentHorizontalMargin;
+
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated;
 
 @end

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewCodingTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewCodingTests.m
@@ -30,6 +30,11 @@ static UIImage *fakeImage(void) {
   return image;
 }
 
+@interface MDCBottomNavigationItemView (Testing)
+@property(nonatomic, strong) UIImageView *iconImageView;
+@property(nonatomic, strong) UILabel *label;
+@end
+
 @interface BottomNavigationItemViewCodingTests : XCTestCase
 
 @end
@@ -87,6 +92,77 @@ static UIImage *fakeImage(void) {
 
   // Then
   XCTAssertEqual(view.subviews.count, unarchivedView.subviews.count);
+}
+
+- (void)testVerticalMarginLayout {
+  // Given
+  MDCBottomNavigationItemView *view = [[MDCBottomNavigationItemView alloc] init];
+  view.title = @"Test Content";
+  view.image = fakeImage();
+  view.bounds = CGRectMake(0, 0, 100, 100);
+  view.contentVerticalMargin = 20;
+  view.contentHorizontalMargin = 20;
+  view.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+
+  // When
+  view.titleBelowIcon = YES;
+  [view layoutSubviews];
+
+  // Then
+  CGFloat contentHeight =
+      CGRectGetHeight(view.label.bounds) + CGRectGetHeight(view.iconImageView.bounds);
+  CGFloat expectedDistance = contentHeight / 2 + view.contentVerticalMargin;
+  XCTAssertEqualWithAccuracy(view.label.center.y - view.iconImageView.center.y,
+                             expectedDistance,
+                             0.001f);
+}
+
+- (void)testHorizontalMarginLayout {
+  // Given
+  MDCBottomNavigationItemView *view = [[MDCBottomNavigationItemView alloc] init];
+  view.title = @"Test Content";
+  view.image = fakeImage();
+  view.bounds = CGRectMake(0, 0, 100, 100);
+  view.contentVerticalMargin = 20;
+  view.contentHorizontalMargin = 20;
+  view.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+
+  // When
+  view.titleBelowIcon = NO;
+  [view layoutSubviews];
+
+  // Then
+  CGFloat contentWidth =
+      CGRectGetWidth(view.label.bounds) + CGRectGetWidth(view.iconImageView.bounds);
+  CGFloat expectedDistance = contentWidth / 2 + view.contentHorizontalMargin;
+  XCTAssertEqualWithAccuracy(view.label.center.x - view.iconImageView.center.x,
+                             expectedDistance,
+                             0.001f);
+}
+
+- (void)testContentInsetLayout {
+  // Given
+  MDCBottomNavigationItemView *view = [[MDCBottomNavigationItemView alloc] init];
+  view.title = @"Test Content";
+  view.image = fakeImage();
+  view.bounds = CGRectMake(0, 0, 100, 100);
+  view.contentVerticalMargin = 20;
+  view.contentHorizontalMargin = 20;
+  view.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+
+  // When
+  view.titleBelowIcon = YES;
+  view.contentInsets = UIEdgeInsetsMake(10, 10, 5, 5);
+  [view layoutSubviews];
+
+  // Then
+  CGRect contentRect = UIEdgeInsetsInsetRect(view.bounds, view.contentInsets);
+  XCTAssert(view.label.center.x == CGRectGetMidX(contentRect));
+  XCTAssert(view.iconImageView.center.x == CGRectGetMidX(contentRect));
+  CGFloat contentSpan = CGRectGetMaxY(view.label.frame) - CGRectGetMinY(view.iconImageView.frame);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(view.iconImageView.frame) + contentSpan / 2,
+                             CGRectGetMidY(contentRect),
+                             0.001f);
 }
 
 @end


### PR DESCRIPTION
Expose parameters for the top padding of the nav bar items and the vertical spacing between the icon and title. 

Before:
![simulator screen shot - iphone x - 2018-06-22 at 17 17 13](https://user-images.githubusercontent.com/1418389/41799614-269ce57a-7640-11e8-9f75-8c4c057101ed.png)

After:
![simulator screen shot - iphone x - 2018-06-22 at 17 16 33](https://user-images.githubusercontent.com/1418389/41799621-2b13c7ea-7640-11e8-88f1-30ae38220b05.png)

Closes #4042