### PR TITLE
[BottomNavigation, Math] Fix `BOOL` types

### DIFF
--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -213,7 +213,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
   [self centerLayoutAnimated:NO];
 }
 
-- (void)centerLayoutAnimated:(bool)animated {
+- (void)centerLayoutAnimated:(BOOL)animated {
   if (self.titleBelowIcon) {
     CGPoint iconImageViewCenter =
         CGPointMake(CGRectGetMidX(self.bounds), CGRectGetHeight(self.iconImageView.bounds) / 2 +

--- a/components/private/Math/src/MDCMath.h
+++ b/components/private/Math/src/MDCMath.h
@@ -66,7 +66,7 @@ static inline CGFloat MDCDegreesToRadians(CGFloat degrees) {
 #endif
 }
 
-static inline bool MDCCGFloatEqual(CGFloat a, CGFloat b) {
+static inline BOOL MDCCGFloatEqual(CGFloat a, CGFloat b) {
   const CGFloat constantK = 3;
 #if CGFLOAT_IS_DOUBLE
   const CGFloat epsilon = DBL_EPSILON;


### PR DESCRIPTION
Two files were using C99 `bool` instead of Objective-C `BOOL` types. This
could lead to breakages in the future if the `BOOL` type were redefined by the
Objective-C headers.
