### PR TITLE
[List] Suggested Base List Cell API

### DIFF
--- a/components/List/src/MDCBaseCell/MDCBaseCell.h
+++ b/components/List/src/MDCBaseCell/MDCBaseCell.h
@@ -1,0 +1,25 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "MaterialShadowElevations.h"
+
+@interface MDCBaseCell : UICollectionViewCell
+
+/**
+ The shadow elevation for the cell.
+ */
+@property (nonatomic, assign) MDCShadowElevation elevation;
+
+@end

--- a/components/List/src/MDCBaseCell/MDCBaseCell.h
+++ b/components/List/src/MDCBaseCell/MDCBaseCell.h
@@ -18,8 +18,13 @@
 @interface MDCBaseCell : UICollectionViewCell
 
 /**
- The shadow elevation for the cell.
+ The current elevation of the cell.
  */
-@property (nonatomic, assign) MDCShadowElevation elevation;
+@property (nonatomic, assign) MDCShadowElevation currentElevation;
+
+/**
+ The current color of the cell’s underlying Ripple.
+ */
+@property (nonatomic, strong) UIColor *currentInkColor;
 
 @end


### PR DESCRIPTION
Since there are people interested in getting the base List cell ASAP and the subclass with UILabels and UIImageViews is still under discussion we're exploring releasing the base cell first. So this is the suggested API for that. It's really just a shadow property... The working implementation is [here](https://github.com/andrewoverton/material-components-ios/blob/01001208817f623c0c0b54eb2d3da05c8a6fc311/components/List/examples/Manual%20Layout%20List%203/MDCBaseCollectionViewCell.m) if you want to take a look. It adds an `MDCInkView`, that's pretty much it!