### PR TITLE
[FlexibleHeader] Explicitly hide status bar when header view wants it

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -347,8 +347,8 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
 #pragma mark MDCFlexibleHeaderViewDelegate
 
 - (void)flexibleHeaderViewNeedsStatusBarAppearanceUpdate:
-    (__unused MDCFlexibleHeaderView *)headerView {
-  [self setNeedsStatusBarAppearanceUpdate];
+    (MDCFlexibleHeaderView *)headerView {
+  [[UIApplication mdc_safeSharedApplication] setStatusBarHidden:headerView.prefersStatusBarHidden];
 }
 
 - (void)flexibleHeaderViewFrameDidChange:(MDCFlexibleHeaderView *)headerView {


### PR DESCRIPTION
This PR replaces a call to `-[UIViewController setNeedsStatusBarAppearanceUpdate]` with a call to `-[UIApplication setStatusBarHidden]` in the `MDCFlexibleHeaderViewController`.
Someone who knows the FlexibleHeader better than me (or even someone who doesn’t) can tell me if this is likely to break stuff.

FWIW, I noticed that changing `UIViewControllerBasedStatusBarAppearance` to `true` in the Dragons Info.plist makes this change unnecessary, because then the view controllers are all asked about their status bar appearance/hidden preferences.

Closes #4094