### PR TITLE
[TextFields] Fix clearIcon drawing

### DIFF
--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -635,7 +635,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   CGFloat scale = [UIScreen mainScreen].scale;
   CGRect bounds = CGRectMake(0, 0, clearButtonSize.width * scale, clearButtonSize.height * scale);
   UIGraphicsBeginImageContextWithOptions(bounds.size, false, scale);
-  [color setFill];
+  [UIColor.grayColor setFill];
 
   [MDCPathForClearButtonImageFrame(bounds) fill];
   UIImage *image = UIGraphicsGetImageFromCurrentImageContext();

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -551,7 +551,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 - (void)updateClearButton {
   UIImage *image = self.clearButton.currentImage
                        ? self.clearButton.currentImage
-                       : [self drawnClearButtonImage:self.clearButton.tintColor];
+                       : [self drawnClearButtonImage];
 
   if (![self.clearButton imageForState:UIControlStateNormal]) {
     [self.clearButton setImage:image forState:UIControlStateNormal];
@@ -628,7 +628,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   return clearButtonAlpha;
 }
 
-- (UIImage *)drawnClearButtonImage:(UIColor *)color {
+- (UIImage *)drawnClearButtonImage {
   CGSize clearButtonSize = CGSizeMake(MDCTextInputClearButtonImageSquareWidthHeight,
                                       MDCTextInputClearButtonImageSquareWidthHeight);
 


### PR DESCRIPTION
The clear button's procedurally-drawn icon was using the button's `tintColor`,
which may be translucent. Instead, the icon should be drawn with an opaque
color so clients can assign any desired color from opaque to clear.

## Filled

**Before**
![filled-before](https://user-images.githubusercontent.com/1753199/42093536-b6cf4748-7b7a-11e8-9928-958db68a36ab.png)

**After**
![filled-after](https://user-images.githubusercontent.com/1753199/42093541-babb593c-7b7a-11e8-8bf8-621dcc1c03bd.png)


## Outlined

**Before**
![outlined-before](https://user-images.githubusercontent.com/1753199/42093551-c0ec129c-7b7a-11e8-8091-41f1559d4789.png)

**After**
![outlined-after](https://user-images.githubusercontent.com/1753199/42093555-c4c916b2-7b7a-11e8-80b3-019c217de182.png)
