### PR TITLE
[TextFields] {BreakingChange} Remove unused `backgroundColor` property

### DIFF
--- a/components/TextFields/src/ColorThemer/MDCFilledTextFieldColorThemer.m
+++ b/components/TextFields/src/ColorThemer/MDCFilledTextFieldColorThemer.m
@@ -26,7 +26,6 @@ static CGFloat const kFilledTextFieldIndicatorLineAlpha = 0.42f;
 
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
      toTextInputControllerFilled:(nonnull MDCTextInputControllerFilled *)textInputControllerFilled {
-  textInputControllerFilled.backgroundColor = colorScheme.surfaceColor;
   textInputControllerFilled.borderFillColor =
       [colorScheme.onSurfaceColor colorWithAlphaComponent:kFilledTextFieldSurfaceOverlayAlpha];
   textInputControllerFilled.normalColor =

--- a/components/TextFields/src/ColorThemer/MDCTextFieldColorThemer.m
+++ b/components/TextFields/src/ColorThemer/MDCTextFieldColorThemer.m
@@ -63,7 +63,6 @@
   textInputController.inlinePlaceholderColor = onSurface60Opacity;
   textInputController.trailingUnderlineLabelTextColor = onSurface60Opacity;
   textInputController.leadingUnderlineLabelTextColor = onSurface60Opacity;
-  textInputController.backgroundColor = colorScheme.surfaceColor;
 
   if ([textInputController
           conformsToProtocol:@protocol(MDCTextInputControllerFloatingPlaceholder)]) {

--- a/components/TextFields/src/MDCTextInputController.h
+++ b/components/TextFields/src/MDCTextInputController.h
@@ -37,19 +37,6 @@
 @property(class, nonatomic, null_resettable, strong) UIColor *activeColorDefault;
 
 /**
- Color for background for the various views making up a text field.
-
- Default is backgroundColorDefault.
- */
-@property(nonatomic, null_resettable, strong) UIColor *backgroundColor;
-
-/**
- Default value for backgroundColor.
- */
-@property(class, nonatomic, null_resettable, strong) UIColor *backgroundColorDefault;
-
-
-/**
  The character counter. Override to use a custom character counter.
 
  Default is an internal instance MDCTextInputAllCharactersCounter. Setting this property to null

--- a/components/TextFields/src/MDCTextInputControllerBase.h
+++ b/components/TextFields/src/MDCTextInputControllerBase.h
@@ -60,13 +60,6 @@ extern const CGFloat MDCTextInputControllerBaseDefaultBorderRadius;
 @interface MDCTextInputControllerBase : NSObject <MDCTextInputControllerFloatingPlaceholder>
 
 /**
- Color for background for the various views making up a text field.
-
- Default is backgroundColorDefault.
- */
-@property(nonatomic, null_resettable, strong) UIColor *backgroundColor;
-
-/**
  The color behind the input and label that defines the preferred tap zone.
 
  Default is borderFillColorDefault.

--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -45,8 +45,6 @@ static const NSTimeInterval
 
 static NSString *const MDCTextInputControllerBaseActiveColorKey =
     @"MDCTextInputControllerBaseActiveColorKey";
-static NSString *const MDCTextInputControllerBaseBackgroundColorKey =
-    @"MDCTextInputControllerBaseBackgroundColorKey";
 static NSString *const MDCTextInputControllerBaseBorderFillColorKey =
     @"MDCTextInputControllerBaseBorderFillColorKey";
 static NSString *const MDCTextInputControllerBaseCharacterCounterKey =
@@ -129,7 +127,6 @@ static CGFloat _underlineHeightActiveDefault = 0;
 static CGFloat _underlineHeightNormalDefault = 0;
 
 static UIColor *_activeColorDefault;
-static UIColor *_backgroundColorDefault;
 static UIColor *_borderFillColorDefault;
 static UIColor *_disabledColorDefault;
 static UIColor *_errorColorDefault;
@@ -157,7 +154,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   NSNumber *_floatingPlaceholderScale;
 
   UIColor *_activeColor;
-  UIColor *_backgroundColor;
   UIColor *_borderFillColor;
   UIColor *_disabledColor;
   UIColor *_errorColor;
@@ -192,7 +188,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
 @implementation MDCTextInputControllerBase
 
-@synthesize backgroundColor = _backgroundColor;
 @synthesize characterCountMax = _characterCountMax;
 @synthesize characterCountViewMode = _characterCountViewMode;
 @synthesize floatingEnabled = _floatingEnabled;
@@ -222,8 +217,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   if (self) {
     _activeColor = [aDecoder decodeObjectOfClass:[UIColor class]
                                           forKey:MDCTextInputControllerBaseActiveColorKey];
-    _backgroundColor = [aDecoder decodeObjectOfClass:[UIColor class]
-                                              forKey:MDCTextInputControllerBaseBackgroundColorKey];
     _borderFillColor = [aDecoder decodeObjectOfClass:[UIColor class]
                                               forKey:MDCTextInputControllerBaseBorderFillColorKey];
     _characterCounter =
@@ -322,7 +315,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
   [aCoder encodeObject:self.activeColor forKey:MDCTextInputControllerBaseActiveColorKey];
-  [aCoder encodeObject:self.backgroundColor forKey:MDCTextInputControllerBaseBackgroundColorKey];
   [aCoder encodeObject:self.borderFillColor forKey:MDCTextInputControllerBaseBorderFillColorKey];
   if ([self.characterCounter conformsToProtocol:@protocol(NSSecureCoding)]) {
     [aCoder encodeObject:self.characterCounter
@@ -376,7 +368,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   MDCTextInputControllerBase *copy = [[[self class] alloc] init];
 
   copy.activeColor = self.activeColor;
-  copy.backgroundColor = self.backgroundColor;
   copy.borderFillColor = self.borderFillColor;
   copy.characterCounter = self.characterCounter;  // Just a pointer value copy
   copy.characterCountViewMode = self.characterCountViewMode;
@@ -959,30 +950,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 + (void)setActiveColorDefault:(UIColor *)activeColorDefault {
   _activeColorDefault = activeColorDefault ? activeColorDefault
                                            : MDCTextInputControllerBaseDefaultActiveColorDefault();
-}
-
-- (UIColor *)backgroundColor {
-  if (!_backgroundColor) {
-    _backgroundColor = [self class].backgroundColorDefault;
-  }
-  return _backgroundColor;
-}
-
-- (void)setBackgroundColor:(UIColor *)backgroundColor {
-  if (_backgroundColor != backgroundColor) {
-    _backgroundColor = backgroundColor ?: [self class].backgroundColorDefault;
-  }
-}
-
-+ (UIColor *)backgroundColorDefault {
-  if (!_backgroundColorDefault) {
-    _backgroundColorDefault = [UIColor clearColor];
-  }
-  return _backgroundColorDefault;
-}
-
-+ (void)setBackgroundColorDefault:(UIColor *)backgroundColorDefault {
-  _backgroundColorDefault = backgroundColorDefault ?: [UIColor clearColor];
 }
 
 - (UIColor *)borderFillColor {

--- a/components/TextFields/src/MDCTextInputControllerFullWidth.h
+++ b/components/TextFields/src/MDCTextInputControllerFullWidth.h
@@ -63,4 +63,9 @@
  */
 @property(nonatomic, null_resettable, strong) UIColor *backgroundColor;
 
+/**
+ Default value for backgroundColor.
+ */
+@property(class, nonatomic, null_resettable, strong) UIColor *backgroundColorDefault;
+
 @end

--- a/components/TextFields/src/MDCTextInputControllerFullWidth.h
+++ b/components/TextFields/src/MDCTextInputControllerFullWidth.h
@@ -56,4 +56,11 @@
  */
 @interface MDCTextInputControllerFullWidth : NSObject <MDCTextInputController>
 
+/**
+ Color for background for the various views making up a text field.
+
+ Default is backgroundColorDefault.
+ */
+@property(nonatomic, null_resettable, strong) UIColor *backgroundColor;
+
 @end


### PR DESCRIPTION
Only MDCTextInputControllerFullWidth is using `backgroundColor` in any
meaningful way. For MDCTextInputControllerBase, the property wasn't used
anywhere in the input controller.

Reduces the scope of #3357