### PR TITLE
[TextFields] Change MDCTextField accessibilityValue logic

### DIFF
--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -808,12 +808,11 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1.f;
   NSMutableArray *accessibilityStrings = [[NSMutableArray alloc] init];
   if ([super accessibilityValue].length > 0) {
     [accessibilityStrings addObject:[super accessibilityValue]];
+  } else if (self.placeholderLabel.accessibilityLabel.length > 0) {
+    [accessibilityStrings addObject:self.placeholderLabel.accessibilityLabel];
   }
   if (self.leadingUnderlineLabel.accessibilityLabel.length > 0) {
     [accessibilityStrings addObject:self.leadingUnderlineLabel.accessibilityLabel];
-  }
-  if (self.placeholderLabel.accessibilityLabel.length > 0) {
-    [accessibilityStrings addObject:self.placeholderLabel.accessibilityLabel];
   }
   return accessibilityStrings.count > 0 ?
       [accessibilityStrings componentsJoinedByString:@", "] : nil;


### PR DESCRIPTION
The original fix (https://github.com/material-components/material-components-ios/pull/4319) for issue https://github.com/material-components/material-components-ios/issues/4315 got complaints, so this PR tweaks the logic a bit. With these changes the placeholder is only included in the accessibilityValue if the TextField is empty.

Closes #4315