### PR TITLE
[Catalog] Make theme picker available to VoiceOver

### DIFF
--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -28,9 +28,10 @@ private func createSchemeWithPalette(_ palette: MDCPalette) -> MDCSemanticColorS
 }
 
 class MDCColorThemeCellConfiguration {
-  var name: String
-  var mainColor: UIColor
-  var colorScheme: MDCColorScheming
+  let name: String
+  let mainColor: UIColor
+  let colorScheme: MDCColorScheming
+
   init(name: String, mainColor: UIColor, colorScheme: MDCColorScheming) {
     self.name = name
     self.mainColor = mainColor
@@ -50,32 +51,25 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
   private let colorSchemeConfigurations = [
     MDCColorThemeCellConfiguration(name: "Default",
                                    mainColor: AppTheme.defaultTheme.colorScheme.primaryColor,
-                                   colorScheme: { return AppTheme.defaultTheme.colorScheme }()
-    ),
+                                   colorScheme: AppTheme.defaultTheme.colorScheme),
     MDCColorThemeCellConfiguration(name: "Blue",
                                    mainColor: MDCPalette.blue.tint500,
-                                   colorScheme: { return createSchemeWithPalette(MDCPalette.blue) }()
-    ),
+                                   colorScheme: createSchemeWithPalette(MDCPalette.blue)),
     MDCColorThemeCellConfiguration(name: "Red",
                                    mainColor: MDCPalette.red.tint500,
-                                   colorScheme: { return createSchemeWithPalette(MDCPalette.red) }()
-    ),
+                                   colorScheme: createSchemeWithPalette(MDCPalette.red)),
     MDCColorThemeCellConfiguration(name: "Green",
                                    mainColor: MDCPalette.green.tint500,
-                                   colorScheme: { return createSchemeWithPalette(MDCPalette.green) }()
-    ),
+                                   colorScheme: createSchemeWithPalette(MDCPalette.green)),
     MDCColorThemeCellConfiguration(name: "Amber",
                                    mainColor: MDCPalette.amber.tint500,
-                                   colorScheme: { return createSchemeWithPalette(MDCPalette.amber) }()
-    ),
+                                   colorScheme: createSchemeWithPalette(MDCPalette.amber)),
     MDCColorThemeCellConfiguration(name: "Pink",
                                    mainColor: MDCPalette.pink.tint500,
-                                   colorScheme: { return createSchemeWithPalette(MDCPalette.pink) }()
-    ),
+                                   colorScheme: createSchemeWithPalette(MDCPalette.pink)),
     MDCColorThemeCellConfiguration(name: "Orange",
                                    mainColor: MDCPalette.orange.tint500,
-                                   colorScheme: { return createSchemeWithPalette(MDCPalette.orange) }()
-    )
+                                   colorScheme: createSchemeWithPalette(MDCPalette.orange))
   ]
 
   private let cellSize : CGFloat = 33.0

--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -27,6 +27,17 @@ private func createSchemeWithPalette(_ palette: MDCPalette) -> MDCSemanticColorS
   return scheme
 }
 
+class MDCColorThemeCellConfiguration {
+  var name: String
+  var mainColor: UIColor
+  var colorScheme: MDCColorScheming
+  init(name: String, mainColor: UIColor, colorScheme: MDCColorScheming) {
+    self.name = name
+    self.mainColor = mainColor
+    self.colorScheme = colorScheme
+  }
+}
+
 class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource,
   UICollectionViewDelegateFlowLayout {
 
@@ -36,36 +47,37 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
   let titleColor = AppTheme.globalTheme.colorScheme.onSurfaceColor.withAlphaComponent(0.5)
   let titleFont = AppTheme.globalTheme.typographyScheme.button
   private let cellReuseIdentifier = "cell"
-  private let colorSchemeCells = [
-    (
-      mainColor: AppTheme.defaultTheme.colorScheme.primaryColor,
-      colorScheme: { return AppTheme.defaultTheme.colorScheme }
+  private let colorSchemeConfigurations = [
+    MDCColorThemeCellConfiguration(name: "Default",
+                                   mainColor: AppTheme.defaultTheme.colorScheme.primaryColor,
+                                   colorScheme: { return AppTheme.defaultTheme.colorScheme }()
     ),
-    (
-      mainColor: MDCPalette.blue.tint500,
-      colorScheme: { return createSchemeWithPalette(MDCPalette.blue) }
+    MDCColorThemeCellConfiguration(name: "Blue",
+                                   mainColor: MDCPalette.blue.tint500,
+                                   colorScheme: { return createSchemeWithPalette(MDCPalette.blue) }()
     ),
-    (
-      mainColor: MDCPalette.red.tint500,
-      colorScheme: { return createSchemeWithPalette(MDCPalette.red) }
+    MDCColorThemeCellConfiguration(name: "Red",
+                                   mainColor: MDCPalette.red.tint500,
+                                   colorScheme: { return createSchemeWithPalette(MDCPalette.red) }()
     ),
-    (
-      mainColor: MDCPalette.green.tint500,
-      colorScheme: { return createSchemeWithPalette(MDCPalette.green) }
+    MDCColorThemeCellConfiguration(name: "Green",
+                                   mainColor: MDCPalette.green.tint500,
+                                   colorScheme: { return createSchemeWithPalette(MDCPalette.green) }()
     ),
-    (
-      mainColor: MDCPalette.amber.tint500,
-      colorScheme: { return createSchemeWithPalette(MDCPalette.amber) }
+    MDCColorThemeCellConfiguration(name: "Amber",
+                                   mainColor: MDCPalette.amber.tint500,
+                                   colorScheme: { return createSchemeWithPalette(MDCPalette.amber) }()
     ),
-    (
-      mainColor: MDCPalette.pink.tint500,
-      colorScheme: { return createSchemeWithPalette(MDCPalette.pink) }
+    MDCColorThemeCellConfiguration(name: "Pink",
+                                   mainColor: MDCPalette.pink.tint500,
+                                   colorScheme: { return createSchemeWithPalette(MDCPalette.pink) }()
     ),
-    (
-      mainColor: MDCPalette.orange.tint500,
-      colorScheme: { return createSchemeWithPalette(MDCPalette.orange) }
+    MDCColorThemeCellConfiguration(name: "Orange",
+                                   mainColor: MDCPalette.orange.tint500,
+                                   colorScheme: { return createSchemeWithPalette(MDCPalette.orange) }()
     )
   ]
+
   private let cellSize : CGFloat = 33.0
   private let cellSpacing : CGFloat = 8.0
 
@@ -80,7 +92,7 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    paletteTitle.text = "Material Palette"
+    paletteTitle.text = "Material Palette-based themes"
     paletteTitle.font = titleFont
     paletteTitle.textColor = titleColor
     paletteTitle.translatesAutoresizingMaskIntoConstraints = false
@@ -143,17 +155,22 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
                       cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellReuseIdentifier,
                                                   for: indexPath) as! PaletteCell
-    cell.contentView.backgroundColor = colorSchemeCells[indexPath.item].mainColor
+    cell.contentView.backgroundColor = colorSchemeConfigurations[indexPath.item].mainColor
     cell.contentView.layer.cornerRadius = cellSize / 2
     cell.contentView.layer.borderWidth = 1
     cell.contentView.layer.borderColor =
       AppTheme.globalTheme.colorScheme.onSurfaceColor.withAlphaComponent(0.05).cgColor
     if AppTheme.globalTheme.colorScheme.primaryColor
-      == colorSchemeCells[indexPath.item].mainColor {
+      == colorSchemeConfigurations[indexPath.item].mainColor {
       cell.imageView.isHidden = false
+      cell.isSelected = true
     } else {
       cell.imageView.isHidden = true
+      cell.isSelected = false
     }
+    cell.isAccessibilityElement = true
+    cell.accessibilityLabel = colorSchemeConfigurations[indexPath.row].name
+    cell.accessibilityHint = "Changes the catalog color theme."
     return cell
   }
 
@@ -190,13 +207,13 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
 
   func collectionView(_ collectionView: UICollectionView,
                       numberOfItemsInSection section: Int) -> Int {
-    return colorSchemeCells.count
+    return colorSchemeConfigurations.count
   }
 
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    let colorScheme = colorSchemeCells[indexPath.item].colorScheme
+    let colorScheme = colorSchemeConfigurations[indexPath.item].colorScheme
     navigationController?.popViewController(animated: true)
-    AppTheme.globalTheme = AppTheme(colorScheme: colorScheme(),
+    AppTheme.globalTheme = AppTheme(colorScheme: colorScheme,
                                     typographyScheme: AppTheme.globalTheme.typographyScheme)
   }
 

--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -27,12 +27,12 @@ private func createSchemeWithPalette(_ palette: MDCPalette) -> MDCSemanticColorS
   return scheme
 }
 
-class MDCColorThemeCellConfiguration {
+private struct MDCColorThemeCellConfiguration {
   let name: String
   let mainColor: UIColor
-  let colorScheme: MDCColorScheming
+  let colorScheme: () -> MDCColorScheming
 
-  init(name: String, mainColor: UIColor, colorScheme: MDCColorScheming) {
+  init(name: String, mainColor: UIColor, colorScheme: @escaping () -> MDCColorScheming) {
     self.name = name
     self.mainColor = mainColor
     self.colorScheme = colorScheme
@@ -51,25 +51,37 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
   private let colorSchemeConfigurations = [
     MDCColorThemeCellConfiguration(name: "Default",
                                    mainColor: AppTheme.defaultTheme.colorScheme.primaryColor,
-                                   colorScheme: AppTheme.defaultTheme.colorScheme),
+                                   colorScheme: { return AppTheme.defaultTheme.colorScheme }),
     MDCColorThemeCellConfiguration(name: "Blue",
                                    mainColor: MDCPalette.blue.tint500,
-                                   colorScheme: createSchemeWithPalette(MDCPalette.blue)),
+                                   colorScheme: {
+                                    return createSchemeWithPalette(MDCPalette.blue)
+    }),
     MDCColorThemeCellConfiguration(name: "Red",
                                    mainColor: MDCPalette.red.tint500,
-                                   colorScheme: createSchemeWithPalette(MDCPalette.red)),
+                                   colorScheme: {
+                                    return createSchemeWithPalette(MDCPalette.red)
+    }),
     MDCColorThemeCellConfiguration(name: "Green",
                                    mainColor: MDCPalette.green.tint500,
-                                   colorScheme: createSchemeWithPalette(MDCPalette.green)),
+                                   colorScheme: {
+                                    return createSchemeWithPalette(MDCPalette.green)
+    }),
     MDCColorThemeCellConfiguration(name: "Amber",
                                    mainColor: MDCPalette.amber.tint500,
-                                   colorScheme: createSchemeWithPalette(MDCPalette.amber)),
+                                   colorScheme: {
+                                    return createSchemeWithPalette(MDCPalette.amber)
+    }),
     MDCColorThemeCellConfiguration(name: "Pink",
                                    mainColor: MDCPalette.pink.tint500,
-                                   colorScheme: createSchemeWithPalette(MDCPalette.pink)),
+                                   colorScheme: {
+                                    return createSchemeWithPalette(MDCPalette.pink)
+    }),
     MDCColorThemeCellConfiguration(name: "Orange",
                                    mainColor: MDCPalette.orange.tint500,
-                                   colorScheme: createSchemeWithPalette(MDCPalette.orange))
+                                   colorScheme: {
+                                    return createSchemeWithPalette(MDCPalette.orange)
+    })
   ]
 
   private let cellSize : CGFloat = 33.0
@@ -205,7 +217,7 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
   }
 
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    let colorScheme = colorSchemeConfigurations[indexPath.item].colorScheme
+    let colorScheme = colorSchemeConfigurations[indexPath.item].colorScheme()
     navigationController?.popViewController(animated: true)
     AppTheme.globalTheme = AppTheme(colorScheme: colorScheme,
                                     typographyScheme: AppTheme.globalTheme.typographyScheme)


### PR DESCRIPTION
The Theme picker was not accessible to VoiceOver due to a few missing
properties. Adding those properties and enhancing the text a bit to clarify
what the screen does.

Closes #3652
