### PR TITLE
[TextFields] Migrate textInputClearButtonTintColor to MDCTextInputController, tests

### DIFF
--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -808,12 +808,11 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1.f;
   NSMutableArray *accessibilityStrings = [[NSMutableArray alloc] init];
   if ([super accessibilityValue].length > 0) {
     [accessibilityStrings addObject:[super accessibilityValue]];
+  } else if (self.placeholderLabel.accessibilityLabel.length > 0) {
+    [accessibilityStrings addObject:self.placeholderLabel.accessibilityLabel];
   }
   if (self.leadingUnderlineLabel.accessibilityLabel.length > 0) {
     [accessibilityStrings addObject:self.leadingUnderlineLabel.accessibilityLabel];
-  }
-  if (self.placeholderLabel.accessibilityLabel.length > 0) {
-    [accessibilityStrings addObject:self.placeholderLabel.accessibilityLabel];
   }
   return accessibilityStrings.count > 0 ?
       [accessibilityStrings componentsJoinedByString:@", "] : nil;

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -808,11 +808,12 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1.f;
   NSMutableArray *accessibilityStrings = [[NSMutableArray alloc] init];
   if ([super accessibilityValue].length > 0) {
     [accessibilityStrings addObject:[super accessibilityValue]];
-  } else if (self.placeholderLabel.accessibilityLabel.length > 0) {
-    [accessibilityStrings addObject:self.placeholderLabel.accessibilityLabel];
   }
   if (self.leadingUnderlineLabel.accessibilityLabel.length > 0) {
     [accessibilityStrings addObject:self.leadingUnderlineLabel.accessibilityLabel];
+  }
+  if (self.placeholderLabel.accessibilityLabel.length > 0) {
+    [accessibilityStrings addObject:self.placeholderLabel.accessibilityLabel];
   }
   return accessibilityStrings.count > 0 ?
       [accessibilityStrings componentsJoinedByString:@", "] : nil;

--- a/components/TextFields/src/MDCTextInputController.h
+++ b/components/TextFields/src/MDCTextInputController.h
@@ -196,6 +196,16 @@
 @property(nonatomic, nullable, strong) UIView<MDCTextInput> *textInput;
 
 /**
+ The tintColor applied to the textInput's clear button.
+ See @c UIImageView.tintColor for additional details.
+ */
+@property(nonatomic, null_resettable, strong) UIColor *textInputClearButtonTintColor;
+
+/**
+ Default value for @c textInputClearButtonTintColor. */
+@property(class, nonatomic, nullable, strong) UIColor *textInputClearButtonTintColorDefault;
+
+/**
  The font applied to the trailing side underline label.
 
  Default is trailingUnderlineLabelFontDefault.

--- a/components/TextFields/src/MDCTextInputControllerBase.h
+++ b/components/TextFields/src/MDCTextInputControllerBase.h
@@ -97,15 +97,4 @@ extern const CGFloat MDCTextInputControllerBaseDefaultBorderRadius;
  */
 @property(nonatomic, assign) NSUInteger minimumLines;
 
-/**
- The tintColor applied to the textInput's clear button.
-
- See @c UIImageView.tintColor for additional details.
- */
-@property(nonatomic, null_resettable, strong) UIColor *textInputClearButtonTintColor;
-
-/**
- Default value for @c textInputClearButtonTintColor. */
-@property(class, nonatomic, nullable, strong) UIColor *textInputClearButtonTintColorDefault;
-
 @end

--- a/components/TextFields/src/MDCTextInputControllerFullWidth.m
+++ b/components/TextFields/src/MDCTextInputControllerFullWidth.m
@@ -78,6 +78,7 @@ static UIColor *_trailingUnderlineLabelTextColorDefault;
 
 static UIFont *_inlinePlaceholderFontDefault;
 static UIFont *_textInputFontDefault;
+static UIColor *_textInputClearButtonTintColorDefault;
 static UIFont *_trailingUnderlineLabelFontDefault;
 
 @interface MDCTextInputControllerFullWidth () {
@@ -92,6 +93,7 @@ static UIFont *_trailingUnderlineLabelFontDefault;
 
   UIFont *_inlinePlaceholderFont;
   UIFont *_textInputFont;
+  UIColor *_textInputClearButtonTintColor;
   UIFont *_trailingUnderlineLabelFont;
 }
 
@@ -258,6 +260,7 @@ static UIFont *_trailingUnderlineLabelFontDefault;
 
   [self subscribeForNotifications];
   _textInput.underline.color = [UIColor clearColor];
+  _textInput.clearButton.tintColor = self.textInputClearButtonTintColor;
   [self updateLayout];
 }
 
@@ -734,6 +737,26 @@ static UIFont *_trailingUnderlineLabelFontDefault;
 
 + (void)setTextInputFontDefault:(UIFont *)textInputFontDefault {
   _textInputFontDefault = textInputFontDefault;
+}
+
+- (UIColor *)textInputClearButtonTintColor {
+    if (_textInputClearButtonTintColor) {
+        return _textInputClearButtonTintColor;
+    }
+    return [self class].textInputClearButtonTintColorDefault ?: self.textInput.clearButton.tintColor;
+}
+
+- (void)setTextInputClearButtonTintColor:(UIColor *)textInputClearButtonTintColor {
+    _textInputClearButtonTintColor = textInputClearButtonTintColor;
+    _textInput.clearButton.tintColor = _textInputClearButtonTintColor;
+}
+
++ (UIColor *)textInputClearButtonTintColorDefault {
+    return _textInputClearButtonTintColorDefault;
+}
+
++ (void)setTextInputClearButtonTintColorDefault:(UIColor *)textInputClearButtonTintColorDefault {
+    _textInputClearButtonTintColorDefault = textInputClearButtonTintColorDefault;
 }
 
 - (UIFont *)trailingUnderlineLabelFont {

--- a/components/TextFields/tests/unit/TextFieldControllerClassPropertiesLegacyTests.swift
+++ b/components/TextFields/tests/unit/TextFieldControllerClassPropertiesLegacyTests.swift
@@ -42,6 +42,7 @@ class TextFieldControllerClassPropertiesLegacyTests: XCTestCase {
     MDCTextInputControllerLegacyDefault.floatingPlaceholderNormalColorDefault = nil
     MDCTextInputControllerLegacyDefault.floatingPlaceholderScaleDefault = 0.75
     MDCTextInputControllerLegacyDefault.isFloatingEnabledDefault = true
+    MDCTextInputControllerLegacyDefault.textInputClearButtonTintColorDefault = nil
 
     MDCTextInputControllerLegacyFullWidth.errorColorDefault = nil
     MDCTextInputControllerLegacyFullWidth.inlinePlaceholderColorDefault = nil
@@ -56,6 +57,8 @@ class TextFieldControllerClassPropertiesLegacyTests: XCTestCase {
     MDCTextInputControllerLegacyFullWidth.inlinePlaceholderFontDefault = nil
     MDCTextInputControllerLegacyFullWidth.leadingUnderlineLabelFontDefault = nil
     MDCTextInputControllerLegacyFullWidth.trailingUnderlineLabelFontDefault = nil
+    
+    MDCTextInputControllerLegacyFullWidth.textInputClearButtonTintColorDefault = nil
   }
 
   func testLegacyDefault() {
@@ -92,6 +95,8 @@ class TextFieldControllerClassPropertiesLegacyTests: XCTestCase {
                    UIColor(white: 0, alpha: CGFloat(Float(0.54))))
     XCTAssertEqual(Float(MDCTextInputControllerLegacyDefault.floatingPlaceholderScaleDefault), 0.75)
     XCTAssertEqual(MDCTextInputControllerLegacyDefault.isFloatingEnabledDefault, true)
+    
+    XCTAssertNil(MDCTextInputControllerLegacyDefault.textInputClearButtonTintColorDefault)
 
     // Test the use of the class properties.
     let textField = MDCTextField()
@@ -244,6 +249,8 @@ class TextFieldControllerClassPropertiesLegacyTests: XCTestCase {
                    MDCTextInputControllerLegacyFullWidth.trailingUnderlineLabelFontDefault)
     XCTAssertEqual(MDCTextInputControllerLegacyFullWidth.leadingUnderlineLabelFontDefault,
                    UIFont.mdc_standardFont(forMaterialTextStyle: .caption))
+    
+    XCTAssertNil(MDCTextInputControllerLegacyFullWidth.textInputClearButtonTintColorDefault)
 
     // Test the use of the class properties.
     let textField = MDCTextField()
@@ -356,4 +363,83 @@ class TextFieldControllerClassPropertiesLegacyTests: XCTestCase {
     XCTAssertEqual(controller.trailingUnderlineLabelFont,
                    MDCTextInputControllerLegacyFullWidth.trailingUnderlineLabelFontDefault)
   }
+  
+  func testLegacyDefaultTextInputClearButtonTintColorUsesDefault() {
+    // Given
+    MDCTextInputControllerLegacyDefault.textInputClearButtonTintColorDefault = .orange
+    
+    // When
+    let textInput = MDCTextField()
+    let controllerLegacyDefault = MDCTextInputControllerLegacyDefault(textInput: textInput)
+    
+    // Then
+    XCTAssertEqual(controllerLegacyDefault.textInputClearButtonTintColor,
+                   MDCTextInputControllerLegacyDefault.textInputClearButtonTintColorDefault)
+  }
+  
+  func testLegacyDefaultTextInputClearButtonTintColorDefaultAppliesToTextField() {
+    // Given
+    MDCTextInputControllerLegacyDefault.textInputClearButtonTintColorDefault = .orange
+    
+    // When
+    let textInputLegacyDefault = MDCTextField()
+    let _ = MDCTextInputControllerLegacyDefault(textInput: textInputLegacyDefault)
+    
+    // Then
+    XCTAssertEqual(textInputLegacyDefault.clearButton.tintColor,
+                   MDCTextInputControllerLegacyDefault.textInputClearButtonTintColorDefault)
+  }
+  
+  func testLegacyDefaultTextInputClearButtonTintColorAppliesToTextField() {
+    // Given
+    let textInputLegacyDefault = MDCTextField()
+    let controllerLegacyDefault = MDCTextInputControllerLegacyDefault(textInput: textInputLegacyDefault)
+    
+    // When
+    controllerLegacyDefault.textInputClearButtonTintColor = .black
+    
+    // Then
+    XCTAssertEqual(textInputLegacyDefault.clearButton.tintColor,
+                   controllerLegacyDefault.textInputClearButtonTintColor)
+  }
+  
+  func testLegacyFullWidthTextInputClearButtonTintColorUsesDefault() {
+    // Given
+    MDCTextInputControllerLegacyFullWidth.textInputClearButtonTintColorDefault = .orange
+    
+    // When
+    let textInput = MDCTextField()
+    let controllerLegacyFullWidth = MDCTextInputControllerLegacyFullWidth(textInput: textInput)
+    
+    // Then
+    XCTAssertEqual(controllerLegacyFullWidth.textInputClearButtonTintColor,
+                   MDCTextInputControllerLegacyFullWidth.textInputClearButtonTintColorDefault)
+  }
+  
+  func testLegacyFullWidthTextinputClearButtonTintColorDefaultAppliesToTextField() {
+    // Given
+    MDCTextInputControllerLegacyFullWidth.textInputClearButtonTintColorDefault = .orange
+    
+    // When
+    let textInputLegacyFullWidth = MDCTextField()
+    let _ = MDCTextInputControllerLegacyFullWidth(textInput: textInputLegacyFullWidth)
+    
+    // Then
+    XCTAssertEqual(textInputLegacyFullWidth.clearButton.tintColor,
+                   MDCTextInputControllerLegacyFullWidth.textInputClearButtonTintColorDefault)
+  }
+  
+  func testLegacyFullWidthTextInputClearButtonTintColorAppliesToTextField() {
+    // Given
+    let textInputLegacyFullWidth = MDCTextField()
+    let controllerLegacyFullWidth  = MDCTextInputControllerLegacyDefault(textInput: textInputLegacyFullWidth)
+    
+    // When
+    controllerLegacyFullWidth.textInputClearButtonTintColor = .black
+    
+    // Then
+    XCTAssertEqual(textInputLegacyFullWidth.clearButton.tintColor,
+                   controllerLegacyFullWidth.textInputClearButtonTintColor)
+  }
+  
 }

--- a/components/TextFields/tests/unit/TextFieldControllerClassPropertiesLegacyTests.swift
+++ b/components/TextFields/tests/unit/TextFieldControllerClassPropertiesLegacyTests.swift
@@ -432,7 +432,7 @@ class TextFieldControllerClassPropertiesLegacyTests: XCTestCase {
   func testLegacyFullWidthTextInputClearButtonTintColorAppliesToTextField() {
     // Given
     let textInputLegacyFullWidth = MDCTextField()
-    let controllerLegacyFullWidth  = MDCTextInputControllerLegacyDefault(textInput: textInputLegacyFullWidth)
+    let controllerLegacyFullWidth  = MDCTextInputControllerLegacyFullWidth(textInput: textInputLegacyFullWidth)
     
     // When
     controllerLegacyFullWidth.textInputClearButtonTintColor = .black

--- a/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
+++ b/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
@@ -89,6 +89,7 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
     MDCTextInputControllerUnderline.floatingPlaceholderNormalColorDefault = nil
     MDCTextInputControllerUnderline.floatingPlaceholderScaleDefault = 0.75
     MDCTextInputControllerUnderline.isFloatingEnabledDefault = true
+    MDCTextInputControllerUnderline.textInputClearButtonTintColorDefault = nil;
 
     MDCTextInputControllerFullWidth.errorColorDefault = nil
     MDCTextInputControllerFullWidth.inlinePlaceholderColorDefault = nil
@@ -104,6 +105,8 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
     MDCTextInputControllerFullWidth.inlinePlaceholderFontDefault = nil
     MDCTextInputControllerFullWidth.leadingUnderlineLabelFontDefault = nil
     MDCTextInputControllerFullWidth.trailingUnderlineLabelFontDefault = nil
+    
+    MDCTextInputControllerFullWidth.textInputClearButtonTintColorDefault = nil;
   }
 
   func testFilled() {
@@ -325,6 +328,8 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
     XCTAssertEqual(Float(MDCTextInputControllerOutlined.floatingPlaceholderScaleDefault), 0.75)
     XCTAssertEqual(MDCTextInputControllerOutlined.isFloatingEnabledDefault, true)
     XCTAssertEqual(MDCTextInputControllerOutlined.roundedCornersDefault, [])
+    
+    XCTAssertNil(MDCTextInputControllerOutlined.textInputClearButtonTintColorDefault)
 
     // Test the use of the class properties.
     let textField = MDCTextField()
@@ -504,6 +509,8 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
     XCTAssertEqual(Float(MDCTextInputControllerUnderline.floatingPlaceholderScaleDefault), 0.75)
     XCTAssertEqual(MDCTextInputControllerUnderline.isFloatingEnabledDefault, true)
     XCTAssertEqual(MDCTextInputControllerUnderline.roundedCornersDefault, [])
+    
+    XCTAssertNil(MDCTextInputControllerUnderline.textInputClearButtonTintColorDefault)
 
     // Test the use of the class properties.
     let textField = MDCTextField()
@@ -670,6 +677,8 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
                    MDCTextInputControllerFullWidth.trailingUnderlineLabelFontDefault)
     XCTAssertEqual(MDCTextInputControllerFullWidth.leadingUnderlineLabelFontDefault,
                    UIFont.mdc_standardFont(forMaterialTextStyle: .caption))
+    
+    XCTAssertNil(MDCTextInputControllerFilled.textInputClearButtonTintColorDefault)
 
     // Test the use of the class properties.
     let textField = MDCTextField()
@@ -860,5 +869,82 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
     // Then
     XCTAssertEqual(textInputOutlined.clearButton.tintColor,
                    controllerOutlined.textInputClearButtonTintColor)
+  }
+  
+  func testUnderlineTextInputClearButtonTintColorUsesDefault() {
+    // Given
+    MDCTextInputControllerUnderline.textInputClearButtonTintColorDefault = .orange
+    
+    // When
+    let textInput = MDCTextField()
+    let controllerUnderline = MDCTextInputControllerUnderline(textInput: textInput)
+    
+    // Then
+    XCTAssertEqual(controllerUnderline.textInputClearButtonTintColor,
+                   MDCTextInputControllerUnderline.textInputClearButtonTintColorDefault)
+  }
+  
+  func testUnderlineTextInputClearButtonTintColorDefaultAppliesToTextField() {
+    // Given
+    MDCTextInputControllerUnderline.textInputClearButtonTintColorDefault = .orange
+    
+    // When
+    let textInputUnderline = MDCTextField()
+    let _ = MDCTextInputControllerUnderline(textInput: textInputUnderline)
+    
+    // Then
+    XCTAssertEqual(textInputUnderline.clearButton.tintColor,
+                   MDCTextInputControllerUnderline.textInputClearButtonTintColorDefault)
+  }
+  
+  func testUnderlineTextInputClearButtonTintColorAppliesToTextField() {
+    // Given
+    let textInputUnderline = MDCTextField()
+    let controllerUnderline = MDCTextInputControllerUnderline(textInput: textInputUnderline)
+    
+    // When
+    controllerUnderline.textInputClearButtonTintColor = .black
+    
+    // Then
+    XCTAssertEqual(textInputUnderline.clearButton.tintColor,
+                   controllerUnderline.textInputClearButtonTintColor)
+  }
+  
+  func testFullWidthTextInputClearButtonTintColorUsesDefault() {
+    // Given
+    MDCTextInputControllerFullWidth.textInputClearButtonTintColorDefault = .orange
+    
+    // When
+    let textInput = MDCTextField()
+    let controllerFullWidth = MDCTextInputControllerFullWidth(textInput: textInput)
+    
+    // Then
+    XCTAssertEqual(controllerFullWidth.textInputClearButtonTintColor, MDCTextInputControllerFullWidth.textInputClearButtonTintColorDefault)
+  }
+  
+  func testFullWidthTextInputClearButtonTintColorDefaultAppliesToTextField() {
+    // Given
+    MDCTextInputControllerFullWidth.textInputClearButtonTintColorDefault = .orange
+    
+    // When
+    let textInputFullWidth = MDCTextField()
+    let _ = MDCTextInputControllerFullWidth(textInput: textInputFullWidth)
+    
+    // Then
+    XCTAssertEqual(textInputFullWidth.clearButton.tintColor,
+                   MDCTextInputControllerFullWidth.textInputClearButtonTintColorDefault)
+  }
+  
+  func testFullWidthTextInputClearButtonTintColorAppliesToTextField() {
+    // Given
+    let textInputFullWidth = MDCTextField()
+    let controllerFullWidth = MDCTextInputControllerFullWidth(textInput: textInputFullWidth)
+    
+    // When
+    controllerFullWidth.textInputClearButtonTintColor = .black
+    
+    // Then
+    XCTAssertEqual(textInputFullWidth.clearButton.tintColor,
+                   controllerFullWidth.textInputClearButtonTintColor)
   }
 }

--- a/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
+++ b/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
@@ -106,7 +106,7 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
     MDCTextInputControllerFullWidth.leadingUnderlineLabelFontDefault = nil
     MDCTextInputControllerFullWidth.trailingUnderlineLabelFontDefault = nil
     
-    MDCTextInputControllerFullWidth.textInputClearButtonTintColorDefault = nil;
+    MDCTextInputControllerFullWidth.textInputClearButtonTintColorDefault = nil
   }
 
   func testFilled() {

--- a/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
+++ b/components/TextFields/tests/unit/TextFieldControllerClassPropertiesTests.swift
@@ -919,7 +919,8 @@ class TextFieldControllerClassPropertiesTests: XCTestCase {
     let controllerFullWidth = MDCTextInputControllerFullWidth(textInput: textInput)
     
     // Then
-    XCTAssertEqual(controllerFullWidth.textInputClearButtonTintColor, MDCTextInputControllerFullWidth.textInputClearButtonTintColorDefault)
+    XCTAssertEqual(controllerFullWidth.textInputClearButtonTintColor,
+                   MDCTextInputControllerFullWidth.textInputClearButtonTintColorDefault)
   }
   
   func testFullWidthTextInputClearButtonTintColorDefaultAppliesToTextField() {


### PR DESCRIPTION
Adding support for theming the clear button tint color in MDCTextInputController. Allows for theming the clear button tint color in legacy, full-width, and underline text fields.

Closes #4453. 