### PR TITLE
[Catalog] Make theme colors accessible

### DIFF
--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -89,10 +89,10 @@ extension UINavigationController {
       appBarFont = UIFont(descriptor: descriptor, size: 16)
     }
     let container = MDCAppBarContainerViewController(contentViewController: viewController)
+    MDCAppBarColorThemer.applySemanticColorScheme(AppTheme.globalTheme.colorScheme,
+                                                  to: container.appBar);
     container.appBar.navigationBar.titleAlignment = .center
-    container.appBar.navigationBar.tintColor = UIColor.white
-    container.appBar.navigationBar.titleTextAttributes =
-      [ NSForegroundColorAttributeName: UIColor.white, NSFontAttributeName: appBarFont ]
+    container.appBar.navigationBar.titleTextAttributes = [ NSFontAttributeName: appBarFont ]
     MDCAppBarColorThemer.applySemanticColorScheme(AppTheme.globalTheme.colorScheme,
                                                   to: container.appBar)
     // TODO(featherless): Remove once

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -62,7 +62,6 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
     let dotsImage = MDCIcons.imageFor_ic_more_horiz()?.withRenderingMode(.alwaysTemplate)
     button.setImage(dotsImage, for: .normal)
     button.adjustsImageWhenHighlighted = false
-    button.tintColor = .white
     return button
   }()
 
@@ -122,6 +121,8 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
     MDCFlexibleHeaderColorThemer.applySemanticColorScheme(colorScheme,
                                                           to: headerViewController.headerView)
 
+    titleLabel.textColor = colorScheme.onPrimaryColor
+    menuButton.tintColor = colorScheme.onPrimaryColor
     collectionView?.collectionViewLayout.invalidateLayout()
     collectionView?.reloadData()
   }
@@ -174,7 +175,7 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
     menuButton.addTarget(self.navigationController,
                          action: #selector(navigationController?.presentMenu),
                          for: .touchUpInside)
-
+    menuButton.tintColor = colorScheme.onPrimaryColor
     containerView.addSubview(menuButton)
 
     setupFlexibleHeaderContentConstraints()

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -272,8 +272,6 @@ class MDCNodeListViewController: CBCNodeListViewController {
 
   private func applyColorScheme(_ colorScheme: MDCColorScheming) {
     MDCAppBarColorThemer.applySemanticColorScheme(colorScheme, to: appBar)
-
-    appBar.navigationBar.tintColor = UIColor.white
   }
 
   func applyThemeToCurrentExample() {

--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -14,6 +14,7 @@
  limitations under the License.
  */
 
+import MDFTextAccessibility
 import MaterialComponents.MaterialIcons_ic_check
 import MaterialComponents.MaterialPalettes
 import MaterialComponents.MaterialThemes
@@ -24,6 +25,22 @@ private func createSchemeWithPalette(_ palette: MDCPalette) -> MDCSemanticColorS
   scheme.primaryColor = palette.tint500
   scheme.primaryColorVariant = palette.tint900
   scheme.secondaryColor = scheme.primaryColor
+  if let onPrimaryColor = MDFTextAccessibility.textColor(fromChoices: [MDCPalette.grey.tint100,
+                                                                      MDCPalette.grey.tint900,
+                                                                      UIColor.black,
+                                                                      UIColor.white],
+                                                        onBackgroundColor: scheme.primaryColor,
+                                                        options: .preferLighter) {
+    scheme.onPrimaryColor = onPrimaryColor
+  }
+  if let onSecondaryColor = MDFTextAccessibility.textColor(fromChoices: [MDCPalette.grey.tint100,
+                                                                         MDCPalette.grey.tint900,
+                                                                         UIColor.black,
+                                                                         UIColor.white],
+                                                           onBackgroundColor: scheme.secondaryColor,
+                                                           options: .preferLighter) {
+    scheme.onSecondaryColor = onSecondaryColor
+  }
   return scheme
 }
 


### PR DESCRIPTION
Improving the contrast ratios of the catalog color themes.

## Before

| | Main Screen | Component Example List| Theme Picker | 
|--|--|--|--|
| Before | ![catalog-contrast-main-before](https://user-images.githubusercontent.com/1753199/42179426-f1276d88-7e01-11e8-986f-3c63302531ff.PNG) | ![catalog-contrast-detail-before](https://user-images.githubusercontent.com/1753199/42179526-521051aa-7e02-11e8-92bc-5f10ff94ed34.png) | ![catalog-contrast-picker-before](https://user-images.githubusercontent.com/1753199/42180301-bf77defa-7e04-11e8-9a36-a9f474783724.png) |
| After | ![catalog-contrast-main-after](https://user-images.githubusercontent.com/1753199/42179495-3b33ce76-7e02-11e8-9d14-ddd1d7516991.PNG) | ![catalog-contrast-detail-after](https://user-images.githubusercontent.com/1753199/42179509-440ebb8c-7e02-11e8-8fd5-e7bd776271e9.png) | ![catalog-contrast-picker-after](https://user-images.githubusercontent.com/1753199/42180314-c4f00510-7e04-11e8-9810-0ec78a7aa87f.png) |