### PR TITLE
[Catalog] Make color pickers larger

### DIFF
--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -157,7 +157,7 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
                                           toItem: nil,
                                           attribute: .notAnAttribute,
                                           multiplier: 1,
-                                          constant:numberOfRows * (cellSize + (cellSpacing * 2))))
+                                          constant: numberOfRows * (cellSize + (cellSpacing * 2))))
     view.backgroundColor = .white
   }
 

--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -14,6 +14,7 @@
  limitations under the License.
  */
 
+import MDFTextAccessibility
 import MaterialComponents.MaterialIcons_ic_check
 import MaterialComponents.MaterialPalettes
 import MaterialComponents.MaterialThemes
@@ -66,7 +67,7 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
       colorScheme: { return createSchemeWithPalette(MDCPalette.orange) }
     )
   ]
-  private let cellSize : CGFloat = 33.0
+  private let cellSize : CGFloat = 48.0 // minimum touch target
   private let cellSpacing : CGFloat = 8.0
 
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
@@ -108,6 +109,10 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
     palettesCollectionView.backgroundColor = .white
     palettesCollectionView.contentInset = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 0)
     view.addSubview(palettesCollectionView)
+    let rowWidth = view.bounds.width - cellSpacing * 2
+    let cellsPerRow = floor(rowWidth / (cellSize + cellSpacing))
+    let numberOfCells = CGFloat(colorSchemeCells.count)
+    let numberOfRows = ceil(numberOfCells / cellsPerRow)
     view.addConstraint(NSLayoutConstraint(item: palettesCollectionView,
                                           attribute: .left,
                                           relatedBy: .equal,
@@ -135,7 +140,7 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
                                           toItem: nil,
                                           attribute: .notAnAttribute,
                                           multiplier: 1,
-                                          constant: cellSize + (cellSpacing * 2)))
+                                          constant:numberOfRows * (cellSize + (cellSpacing * 2))))
     view.backgroundColor = .white
   }
 

--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -128,7 +128,7 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
     view.addSubview(palettesCollectionView)
     let rowWidth = view.bounds.width - cellSpacing * 2
     let cellsPerRow = floor(rowWidth / (cellSize + cellSpacing))
-    let numberOfCells = CGFloat(colorSchemeCells.count)
+    let numberOfCells = CGFloat(colorSchemeConfigurations.count)
     let numberOfRows = ceil(numberOfCells / cellsPerRow)
     view.addConstraint(NSLayoutConstraint(item: palettesCollectionView,
                                           attribute: .left,


### PR DESCRIPTION
The color picker buttons were not large enough for a 48-point touch target.
Increasing their visual size also improves accessibility for users with
imperfect vision.

## Before

![catalog-picker-size-before](https://user-images.githubusercontent.com/1753199/42180700-3526780e-7e06-11e8-94a0-ce13e7191a57.png)

## After
| Portrait | Landscape|
|--|--|
| ![catalog-picker-size-after](https://user-images.githubusercontent.com/1753199/42180714-41f87c94-7e06-11e8-8afa-b26f93c6de95.png) |  ![catalog-picker-size-after-landscape](https://user-images.githubusercontent.com/1753199/42180717-45e94f2c-7e06-11e8-9067-6c269c360186.png) |
