### PR TITLE
[BottomSheet] Dismiss BottomSheet with UIAccessibility

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetController.h
+++ b/components/BottomSheet/src/MDCBottomSheetController.h
@@ -63,14 +63,14 @@
 
  Defaults to @c nil.
  */
-@property(nonatomic, copy) NSString *scrimAccessibilityLabel;
+@property(nullable, nonatomic, copy) NSString *scrimAccessibilityLabel;
 
 /**
  The @c accessibilityHint value of the dimmed scrim view.
 
  Defaults to @c nil.
  */
-@property(nonatomic, copy) NSString *scrimAccessibilityHint;
+@property(nullable, nonatomic, copy) NSString *scrimAccessibilityHint;
 
 /**
  The @c accessibilityTraits of the dimmed scrim view.

--- a/components/BottomSheet/src/MDCBottomSheetController.h
+++ b/components/BottomSheet/src/MDCBottomSheetController.h
@@ -51,6 +51,35 @@
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;
 
 /**
+ If @c YES, then the dimmed scrim view will act as an accessibility element for dismissing the
+ bottom sheet.
+
+ Defaults to @c NO.
+ */
+@property(nonatomic, assign) BOOL isScrimAccessibilityElement;
+
+/**
+ The @c accessibilityLabel value of the dimmed scrim view.
+
+ Defaults to @c nil.
+ */
+@property(nonatomic, copy) NSString *scrimAccessibilityLabel;
+
+/**
+ The @c accessibilityHint value of the dimmed scrim view.
+
+ Defaults to @c nil.
+ */
+@property(nonatomic, copy) NSString *scrimAccessibilityHint;
+
+/**
+ The @c accessibilityTraits of the dimmed scrim view.
+
+ Defaults to @c UIAccessibilityTraitButton.
+ */
+@property(nonatomic, assign) UIAccessibilityTraits scrimAccessibilityTraits;
+
+/**
  The bottom sheet delegate.
  */
 @property(nonatomic, weak, nullable) id<MDCBottomSheetControllerDelegate> delegate;

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -125,6 +125,38 @@
   return;
 }
 
+- (void)setIsScrimAccessibilityElement:(BOOL)isScrimAccessibilityElement {
+  _transitionController.isScrimAccessibilityElement = isScrimAccessibilityElement;
+}
+
+- (BOOL)isScrimAccessibilityElement {
+  return _transitionController.isScrimAccessibilityElement;
+}
+
+- (void)setScrimAccessibilityLabel:(NSString *)scrimAccessibilityLabel {
+  _transitionController.scrimAccessibilityLabel = scrimAccessibilityLabel;
+}
+
+- (NSString *)scrimAccessibilityLabel {
+  return _transitionController.scrimAccessibilityLabel;
+}
+
+- (void)setScrimAccessibilityHint:(NSString *)scrimAccessibilityHint {
+  _transitionController.scrimAccessibilityHint = scrimAccessibilityHint;
+}
+
+- (NSString *)scrimAccessibilityHint {
+  return _transitionController.scrimAccessibilityHint;
+}
+
+- (void)setScrimAccessibilityTraits:(UIAccessibilityTraits)scrimAccessibilityTraits {
+  _transitionController.scrimAccessibilityTraits = scrimAccessibilityTraits;
+}
+
+- (UIAccessibilityTraits)scrimAccessibilityTraits {
+  return _transitionController.scrimAccessibilityTraits;
+}
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)bottomSheetPresentationControllerDidDismissBottomSheet:

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -76,14 +76,14 @@
 
  Defaults to @c nil.
  */
-@property(nonatomic, copy) NSString *scrimAccessibilityLabel;
+@property(nullable, nonatomic, copy) NSString *scrimAccessibilityLabel;
 
 /**
  The @c accessibilityHint value of the dimmed scrim view.
 
  Defaults to @c nil.
  */
-@property(nonatomic, copy) NSString *scrimAccessibilityHint;
+@property(nullable, nonatomic, copy) NSString *scrimAccessibilityHint;
 
 /**
  The @c accessibilityTraits of the dimmed scrim view.

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -64,6 +64,35 @@
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;
 
 /**
+ If @c YES, then the dimmed scrim view will act as an accessibility element for dismissing the
+ bottom sheet.
+
+ Defaults to @c NO.
+ */
+@property(nonatomic, assign) BOOL isScrimAccessibilityElement;
+
+/**
+ The @c accessibilityLabel value of the dimmed scrim view.
+
+ Defaults to @c nil.
+ */
+@property(nonatomic, copy) NSString *scrimAccessibilityLabel;
+
+/**
+ The @c accessibilityHint value of the dimmed scrim view.
+
+ Defaults to @c nil.
+ */
+@property(nonatomic, copy) NSString *scrimAccessibilityHint;
+
+/**
+ The @c accessibilityTraits of the dimmed scrim view.
+
+ Defaults to @c UIAccessibilityTraitButton.
+ */
+@property(nonatomic, assign) UIAccessibilityTraits scrimAccessibilityTraits;
+
+/**
  Delegate to tell the presenter when to dismiss.
  */
 @property(nonatomic, weak, nullable) id<MDCBottomSheetPresentationControllerDelegate> delegate;

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -50,6 +50,10 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 @implementation MDCBottomSheetPresentationController {
   UIView *_dimmingView;
   MDCSheetContainerView *_sheetView;
+  @private BOOL _scrimIsAccessibilityElement;
+  @private NSString *_scrimAccessibilityLabel;
+  @private NSString *_scrimAccessibilityHint;
+  @private UIAccessibilityTraits _scrimAccessibilityTraits;
 }
 
 @synthesize delegate;
@@ -86,6 +90,11 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   _dimmingView.translatesAutoresizingMaskIntoConstraints = NO;
   _dimmingView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  _dimmingView.accessibilityTraits |= UIAccessibilityTraitButton;
+  _dimmingView.isAccessibilityElement = _scrimIsAccessibilityElement;
+  _dimmingView.accessibilityTraits = _scrimAccessibilityTraits;
+  _dimmingView.accessibilityLabel = _scrimAccessibilityLabel;
+  _dimmingView.accessibilityHint = _scrimAccessibilityHint;
 
   UIScrollView *scrollView = self.trackingScrollView;
   if (scrollView == nil) {
@@ -190,6 +199,44 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
        @selector(bottomSheetPresentationControllerDidDismissBottomSheet:)]) {
     [strongDelegate bottomSheetPresentationControllerDidDismissBottomSheet:self];
   }
+}
+
+#pragma mark - Properties
+
+- (void)setIsScrimAccessibilityElement:(BOOL)isScrimAccessibilityElement {
+  _scrimIsAccessibilityElement = isScrimAccessibilityElement;
+  _dimmingView.isAccessibilityElement = isScrimAccessibilityElement;
+}
+
+- (BOOL)isScrimAccessibilityElement {
+  return _scrimIsAccessibilityElement;
+}
+
+- (void)setScrimAccessibilityLabel:(NSString *)scrimAccessibilityLabel {
+  _scrimAccessibilityLabel = scrimAccessibilityLabel;
+  _dimmingView.accessibilityLabel = scrimAccessibilityLabel;
+}
+
+- (NSString *)scrimAccessibilityLabel {
+  return _scrimAccessibilityLabel;
+}
+
+- (void)setScrimAccessibilityHint:(NSString *)scrimAccessibilityHint {
+  _scrimAccessibilityHint = scrimAccessibilityHint;
+  _dimmingView.accessibilityHint = scrimAccessibilityHint;
+}
+
+- (NSString *)scrimAccessibilityHint {
+  return _scrimAccessibilityHint;
+}
+
+- (void)setScrimAccessibilityTraits:(UIAccessibilityTraits)scrimAccessibilityTraits {
+  _scrimAccessibilityTraits = scrimAccessibilityTraits;
+  _dimmingView.accessibilityTraits = scrimAccessibilityTraits;
+}
+
+- (UIAccessibilityTraits)scrimAccessibilityTraits {
+  return _scrimAccessibilityTraits;
 }
 
 #pragma mark - MDCSheetContainerViewDelegate

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.h
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.h
@@ -48,3 +48,36 @@
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;
 
 @end
+
+@interface MDCBottomSheetTransitionController (ScrimAccessibility)
+
+/**
+ If @c YES, then the dimmed scrim view will act as an accessibility element for dismissing the
+ bottom sheet.
+
+ Defaults to @c NO.
+ */
+@property(nonatomic, assign) BOOL isScrimAccessibilityElement;
+
+/**
+ The @c accessibilityLabel value of the dimmed scrim view.
+
+ Defaults to @c nil.
+ */
+@property(nonatomic, copy) NSString *scrimAccessibilityLabel;
+
+/**
+ The @c accessibilityHint value of the dimmed scrim view.
+
+ Defaults to @c nil.
+ */
+@property(nonatomic, copy) NSString *scrimAccessibilityHint;
+
+/**
+ The @c accessibilityTraits of the dimmed scrim view.
+
+ Defaults to @c UIAccessibilityTraitButton.
+ */
+@property(nonatomic, assign) UIAccessibilityTraits scrimAccessibilityTraits;
+
+@end

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.h
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.h
@@ -64,14 +64,14 @@
 
  Defaults to @c nil.
  */
-@property(nonatomic, copy) NSString *scrimAccessibilityLabel;
+@property(nullable, nonatomic, copy) NSString *scrimAccessibilityLabel;
 
 /**
  The @c accessibilityHint value of the dimmed scrim view.
 
  Defaults to @c nil.
  */
-@property(nonatomic, copy) NSString *scrimAccessibilityHint;
+@property(nullable, nonatomic, copy) NSString *scrimAccessibilityHint;
 
 /**
  The @c accessibilityTraits of the dimmed scrim view.

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.m
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.m
@@ -20,9 +20,22 @@
 
 static const NSTimeInterval MDCBottomSheetTransitionDuration = 0.25;
 
-@implementation MDCBottomSheetTransitionController
+@implementation MDCBottomSheetTransitionController {
+  @protected BOOL _isScrimAccessibilityElement;
+  @protected NSString *_scrimAccessibilityLabel;
+  @protected NSString *_scrimAccessibilityHint;
+  @protected UIAccessibilityTraits _scrimAccessibilityTraits;
+}
 
 #pragma mark - UIViewControllerTransitioningDelegate
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _scrimAccessibilityTraits = UIAccessibilityTraitButton;
+  }
+  return self;
+}
 
 - (UIPresentationController *)
     presentationControllerForPresentedViewController:(UIViewController *)presented
@@ -33,6 +46,10 @@ static const NSTimeInterval MDCBottomSheetTransitionDuration = 0.25;
                                                            presentingViewController:presenting];
   presentationController.trackingScrollView = self.trackingScrollView;
   presentationController.dismissOnBackgroundTap = self.dismissOnBackgroundTap;
+  presentationController.scrimAccessibilityTraits = _scrimAccessibilityTraits;
+  presentationController.isScrimAccessibilityElement = _isScrimAccessibilityElement;
+  presentationController.scrimAccessibilityHint = _scrimAccessibilityHint;
+  presentationController.scrimAccessibilityLabel = _scrimAccessibilityLabel;
   return presentationController;
 }
 
@@ -129,6 +146,38 @@ static const NSTimeInterval MDCBottomSheetTransitionDuration = 0.25;
   } else {
     return containerView.frame;
   }
+}
+
+- (void)setIsScrimAccessibilityElement:(BOOL)isScrimAccessibilityElement {
+  _isScrimAccessibilityElement = isScrimAccessibilityElement;
+}
+
+- (BOOL)isScrimAccessibilityElement {
+  return _isScrimAccessibilityElement;
+}
+
+- (void)setScrimAccessibilityLabel:(NSString *)scrimAccessibilityLabel {
+  _scrimAccessibilityLabel = scrimAccessibilityLabel;
+}
+
+- (NSString *)scrimAccessibilityLabel {
+  return _scrimAccessibilityLabel;
+}
+
+- (void)setScrimAccessibilityHint:(NSString *)scrimAccessibilityHint {
+  _scrimAccessibilityHint = scrimAccessibilityHint;
+}
+
+- (NSString *)scrimAccessibilityHint {
+  return _scrimAccessibilityHint;
+}
+
+- (void)setScrimAccessibilityTraits:(UIAccessibilityTraits)scrimAccessibilityTraits {
+  _scrimAccessibilityTraits = scrimAccessibilityTraits;
+}
+
+- (UIAccessibilityTraits)scrimAccessibilityTraits {
+  return _scrimAccessibilityTraits;
 }
 
 @end


### PR DESCRIPTION
VoiceOver and switch device users currently have to use the accessibility
escape gesture to dismiss a Bottom Sheet. Optionally, the BottomSheet can use
the dimmed "scrim" area (which can be tappable) to dismiss the bottom sheet
using accessibility technologies.

Obsoletes and closes #4275
