### PR TITLE
[Catalog] Add custom file header

### DIFF
--- a/catalog/MDCCatalog.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/catalog/MDCCatalog.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string> Copyright ___YEAR___-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.</string>
+</dict>
+</plist>


### PR DESCRIPTION
In Xcode 9+, custom file headers can be set for most file types. Using
this to generate our default copyright header for the project.

Tested with Xcode 9.4.1 and generates header files for Source and XCTest files. Multi-line comments (`/* ... */`) don't seem supported, so the template is using Single-line comment instead.
Tested with Xcode 8.3.3 and seems to have no (negative) effect.

## Sample screenshot
<img width="638" alt="screen shot 2018-07-06 at 11 03 17 am" src="https://user-images.githubusercontent.com/1753199/42386029-61209daa-810c-11e8-8959-114e08710620.png">


Closes #2747
