### PR TITLE
 [Tabs] Fix alerts in examples

### DIFF
--- a/components/Tabs/examples/TabBarIconExample.m
+++ b/components/Tabs/examples/TabBarIconExample.m
@@ -106,6 +106,8 @@
       [UIAlertController alertControllerWithTitle:nil
                                           message:nil
                                    preferredStyle:UIAlertControllerStyleActionSheet];
+  sheet.popoverPresentationController.sourceView = self.alignmentButton;
+  sheet.popoverPresentationController.sourceRect = self.alignmentButton.bounds;
   [sheet addAction:[UIAlertAction actionWithTitle:@"Leading"
                                             style:UIAlertActionStyleDefault
                                           handler:^(UIAlertAction *_Nonnull action) {

--- a/components/Tabs/examples/TabBarIconExample.swift
+++ b/components/Tabs/examples/TabBarIconExample.swift
@@ -76,6 +76,8 @@ class TabBarIconSwiftExample: UIViewController {
 
   @objc func changeAlignmentDidTouch(sender: UIButton) {
     let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+    sheet.popoverPresentationController?.sourceView = self.alignmentButton
+    sheet.popoverPresentationController?.sourceRect = self.alignmentButton.bounds
     sheet.addAction(UIAlertAction(title: "Leading", style: .default, handler: { _ in
       self.alignment = .leading
     }))

--- a/components/Tabs/examples/TabBarIndicatorTemplateExample.swift
+++ b/components/Tabs/examples/TabBarIndicatorTemplateExample.swift
@@ -99,6 +99,8 @@ class TabBarIndicatorTemplateExample: UIViewController {
 
   @objc func changeAlignmentDidTouch(sender: UIButton) {
     let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+    sheet.popoverPresentationController?.sourceView = self.alignmentButton
+    sheet.popoverPresentationController?.sourceRect = self.alignmentButton.bounds
     sheet.addAction(UIAlertAction(title: "Leading", style: .default, handler: { _ in
       self.alignment = .leading
     }))
@@ -116,6 +118,8 @@ class TabBarIndicatorTemplateExample: UIViewController {
 
   @objc func changeAppearance(fromSender sender: UIButton) {
     let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+    sheet.popoverPresentationController?.sourceView = self.appearanceButton
+    sheet.popoverPresentationController?.sourceRect = self.appearanceButton.bounds
     sheet.addAction(UIAlertAction(title: "Titles", style: .default, handler: { _ in
       self.itemAppearance = .titles
     }))

--- a/components/Tabs/examples/TabBarInterfaceBuilderExample.m
+++ b/components/Tabs/examples/TabBarInterfaceBuilderExample.m
@@ -72,6 +72,8 @@
       [UIAlertController alertControllerWithTitle:nil
                                           message:nil
                                    preferredStyle:UIAlertControllerStyleActionSheet];
+  sheet.popoverPresentationController.sourceView = sender;
+  sheet.popoverPresentationController.sourceRect = sender.bounds;
   [sheet addAction:[UIAlertAction actionWithTitle:@"Leading"
                                             style:UIAlertActionStyleDefault
                                           handler:^(UIAlertAction *_Nonnull action) {

--- a/components/Tabs/examples/TabBarTextOnlyExample.m
+++ b/components/Tabs/examples/TabBarTextOnlyExample.m
@@ -81,6 +81,8 @@
       [UIAlertController alertControllerWithTitle:nil
                                           message:nil
                                    preferredStyle:UIAlertControllerStyleActionSheet];
+  sheet.popoverPresentationController.sourceView = (UICollectionViewCell *)sender;
+  sheet.popoverPresentationController.sourceRect = ((UICollectionViewCell *)sender).bounds;
   [sheet addAction:[UIAlertAction actionWithTitle:@"Leading"
                                             style:UIAlertActionStyleDefault
                                           handler:^(UIAlertAction *_Nonnull action) {
@@ -115,7 +117,7 @@
   [super collectionView:collectionView didSelectItemAtIndexPath:indexPath];
   switch (indexPath.row) {
     case 0:
-      [self changeAlignment:collectionView];
+      [self changeAlignment:[collectionView cellForItemAtIndexPath:indexPath]];
       break;
 
     case 1:

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
@@ -107,8 +107,6 @@
   [self.appBar addSubviewsToParent];
 
   self.appBar.navigationBar.tintColor = UIColor.whiteColor;
-
-  self.title = @"Tabs With Icons";
 }
 
 - (void)setupScrollView {
@@ -282,7 +280,7 @@
 @implementation TabBarIconExample (CatalogByConvention)
 
 + (NSArray *)catalogBreadcrumbs {
-  return @[ @"Tab Bar", @"Icons and Text" ];
+  return @[ @"Tab Bar", @"Tabs with Icons" ];
 }
 
 + (BOOL)catalogIsPrimaryDemo {

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
@@ -82,8 +82,6 @@ extension TabBarIconSwiftExample {
 
     self.navigationItem.rightBarButtonItem = badgeIncrementItem
 
-    self.title = "Tabs With Icons"
-
     setupScrollingContent()
   }
 
@@ -245,7 +243,7 @@ extension TabBarIconSwiftExample {
 // MARK: - Catalog by convention
 extension TabBarIconSwiftExample {
   @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Tab Bar", "Icons and Text (Swift)"]
+    return ["Tab Bar", "Tabs with Icons (Swift)"]
   }
 
   @objc class func catalogIsPrimaryDemo() -> Bool {


### PR DESCRIPTION
Several of the Tabs examples were using UIAlertControllers to present
multi-select options. Due to missing sourceView/sourceRect in the
popoverPresentationController, they would crash on iPads.  On iPhones,
they were shown as an action sheet and so did not require a source view.

## Sample screenshots
![simulator screen shot - ipad air 2 - 2018-07-06 at 14 14 28](https://user-images.githubusercontent.com/1753199/42394115-f90fd03a-8126-11e8-8471-b2d71e4b8b65.png)
![alignment-ipadair2-11 0 1](https://user-images.githubusercontent.com/1753199/42394116-f91d328e-8126-11e8-9a20-95e794145203.png)


Closes #3103
