### PR TITLE
[Catalog] Make Component tiles accessibility elements

### DIFF
--- a/catalog/MDCCatalog/MDCCatalogCollectionViewCell.swift
+++ b/catalog/MDCCatalog/MDCCatalogCollectionViewCell.swift
@@ -39,6 +39,8 @@ class MDCCatalogCollectionViewCell: UICollectionViewCell {
     contentView.addSubview(label)
     contentView.clipsToBounds = true
     contentView.addSubview(tile)
+    self.isAccessibilityElement = true
+    self.accessibilityTraits |= UIAccessibilityTraitButton
   }
 
   @available(*, unavailable)
@@ -76,5 +78,14 @@ class MDCCatalogCollectionViewCell: UICollectionViewCell {
     label.text = componentName
     tile.componentName = componentName
     accessibilityIdentifier = componentName
+  }
+
+  override public var accessibilityLabel: String? {
+    get {
+      return self.label.accessibilityLabel
+    }
+    set {
+      self.label.accessibilityLabel = newValue
+    }
   }
 }


### PR DESCRIPTION
Instead of selecting (or scrubbing to find) the labels within the main
Component tiles list, each tile should be its own accessibility element.

## Accessibility Inspector Screenshot
<img width="627" alt="screen shot 2018-07-06 at 2 56 23 pm" src="https://user-images.githubusercontent.com/1753199/42395793-27f90b18-812d-11e8-9443-9aa7fbe042e8.png">


Closes #3877