### PR TITLE
[Catalog] Fix VoiceOver ordering in Buttons demo

### DIFF
--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -160,6 +160,13 @@ const CGSize kMinimumAccessibleButtonSize = {64.0, 48.0};
   ];
 
   [self setupExampleViews];
+
+  NSMutableArray *accessibilityElements = [@[] mutableCopy];
+  for (NSUInteger index = 0; index < self.buttons.count; ++index) {
+    [accessibilityElements addObject:self.labels[index]];
+    [accessibilityElements addObject:self.buttons[index]];
+  }
+  self.view.accessibilityElements = [accessibilityElements copy];
 }
 
 - (void)setupExampleViews {


### PR DESCRIPTION
The Buttons main demo had its views "out of order" when using VoiceOver
because the buttons' frames were closer to the top of the screen
relative to their labels. Instead of relying on the view hierarchy to
find all of the elements, they can be manually returned in-order.

Closes #3654
