### PR TITLE
[Catalog] Launch main demo using Magic Tap

### DIFF
--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -630,7 +630,7 @@ extension MDCNodeListViewController {
   }
 
   override func accessibilityPerformMagicTap() -> Bool {
-    self.primaryDemoButtonClicked()
+    primaryDemoButtonClicked()
     return true
   }
 

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -629,6 +629,11 @@ extension MDCNodeListViewController {
     return cell!
   }
 
+  override func accessibilityPerformMagicTap() -> Bool {
+    self.primaryDemoButtonClicked()
+    return true
+  }
+
   func primaryDemoButtonClicked () {
     let indexPath = IndexPath(row: 0, section: Section.description.rawValue)
     self.tableView(self.tableView, didSelectRowAt: indexPath)


### PR DESCRIPTION
When Voice Over users activate the Magic Tap gesture (2-finger
double-tap) on a component examples list view, it should open the
Primary Demo.