### PR TITLE
[TextFields] Make errorText span multiple lines on MDCTextField

### DIFF
--- a/components/TextFields/examples/TextFieldKitchenSinkExample.swift
+++ b/components/TextFields/examples/TextFieldKitchenSinkExample.swift
@@ -667,9 +667,13 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
   }
 
   @objc func errorSwitchDidChange(errorSwitch: UISwitch) {
-    allInputControllers.forEach { controller in
+    for (index, controller) in allInputControllers.enumerated() {
       if errorSwitch.isOn {
-        controller.setErrorText("Uh oh! Try something else.", errorAccessibilityValue: nil)
+        let shortError = "Uh oh! Try something else."
+        let longError = "Uh oh! Try something else. This is a long error message." +
+            " Such a long error message!"
+        let errorToUse = index % 2 == 0 ? shortError : longError
+        controller.setErrorText(errorToUse, errorAccessibilityValue: nil)
       } else {
         controller.setErrorText(nil, errorAccessibilityValue: nil)
       }

--- a/components/TextFields/examples/TextFieldKitchenSinkExample.swift
+++ b/components/TextFields/examples/TextFieldKitchenSinkExample.swift
@@ -669,9 +669,9 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
   @objc func errorSwitchDidChange(errorSwitch: UISwitch) {
     for (index, controller) in allInputControllers.enumerated() {
       if errorSwitch.isOn {
-        let shortError = "Uh oh! Try something else."
-        let longError = "Uh oh! Try something else. This is a long error message." +
-            " Such a long error message!"
+        let shortError = "Uh oh! Try something else. "
+        let longError = shortError + "This is a long error message. " +
+            "Such a long error message!"
         let errorToUse = index % 2 == 0 ? shortError : longError
         controller.setErrorText(errorToUse, errorAccessibilityValue: nil)
       } else {
@@ -681,8 +681,16 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
   }
 
   @objc func helperSwitchDidChange(helperSwitch: UISwitch) {
-    allInputControllers.forEach { controller in
-      controller.helperText = helperSwitch.isOn ? "This is helper text." : nil
+    for (index, controller) in allInputControllers.enumerated() {
+      if helperSwitch.isOn {
+        let shortHelper = "This is helper text. "
+        let longHelper = shortHelper + "This is some long helper text. " +
+            "Such long helper text!"
+        let helperTextToUse = index % 2 != 0 ? shortHelper : longHelper
+        controller.helperText = helperTextToUse
+      } else {
+        controller.helperText = nil
+      }
     }
   }
 

--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -1575,9 +1575,9 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
     }
   }
 
+  [self updateLayout];
   [self.textInput setNeedsLayout];
   [self.textInput layoutIfNeeded];
-  [self updateLayout];
 }
 
 -(void)setHelperText:(NSString *)helperText

--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -1373,11 +1373,8 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
                            (CGFloat)self.floatingPlaceholderScale.floatValue) +
                    MDCTextInputControllerBaseDefaultPadding;
 
-  CGFloat scale = UIScreen.mainScreen.scale;
-  CGFloat leadingOffset =
-      MDCCeil(self.textInput.leadingUnderlineLabel.font.lineHeight * scale) / scale;
-  CGFloat trailingOffset =
-      MDCCeil(self.textInput.trailingUnderlineLabel.font.lineHeight * scale) / scale;
+  CGFloat leadingOffset = self.textInput.leadingUnderlineLabel.intrinsicContentSize.height;
+  CGFloat trailingOffset = self.textInput.trailingUnderlineLabel.intrinsicContentSize.height;
 
   // The amount of space underneath the underline is variable. It could just be
   // MDCTextInputControllerBaseDefaultPadding or the biggest estimated underlineLabel height +

--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -999,6 +999,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   } else {
     if (![self.textInput.leadingUnderlineLabel.text isEqualToString:helperText]) {
       self.textInput.leadingUnderlineLabel.text = helperText;
+      [self.textInput layoutIfNeeded];
       [self updateLayout];
     }
   }
@@ -1573,6 +1574,10 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
       self.textInput.leadingUnderlineLabel.accessibilityLabel = nil;
     }
   }
+
+  [self.textInput setNeedsLayout];
+  [self.textInput layoutIfNeeded];
+  [self updateLayout];
 }
 
 -(void)setHelperText:(NSString *)helperText

--- a/components/TextFields/src/MDCTextInputControllerFilled.m
+++ b/components/TextFields/src/MDCTextInputControllerFilled.m
@@ -271,11 +271,8 @@ static CGFloat _underlineHeightNormalDefault =
   // The amount of space underneath the underline may depend on whether there is content in the
   // underline labels.
 
-  CGFloat scale = UIScreen.mainScreen.scale;
-  CGFloat leadingOffset =
-      MDCCeil(self.textInput.leadingUnderlineLabel.font.lineHeight * scale) / scale;
-  CGFloat trailingOffset =
-      MDCCeil(self.textInput.trailingUnderlineLabel.font.lineHeight * scale) / scale;
+  CGFloat leadingOffset = self.textInput.leadingUnderlineLabel.intrinsicContentSize.height;
+  CGFloat trailingOffset = self.textInput.trailingUnderlineLabel.intrinsicContentSize.height;
 
   CGFloat underlineOffset = 0;
   switch (self.textInput.textInsetsMode) {

--- a/components/TextFields/src/MDCTextInputControllerFullWidth.m
+++ b/components/TextFields/src/MDCTextInputControllerFullWidth.m
@@ -479,6 +479,7 @@ static UIFont *_trailingUnderlineLabelFontDefault;
   } else {
     if (![self.textInput.leadingUnderlineLabel.text isEqualToString:helperText]) {
       self.textInput.leadingUnderlineLabel.text = helperText;
+      [self.textInput layoutIfNeeded];
       [self updateLayout];
     }
   }
@@ -1163,6 +1164,9 @@ static UIFont *_trailingUnderlineLabelFontDefault;
       self.textInput.leadingUnderlineLabel.accessibilityLabel = nil;
     }
   }
+
+  [self.textInput layoutIfNeeded];
+  [self updateLayout];
 }
 
 - (void)setHelperText:(NSString *)helperText

--- a/components/TextFields/src/MDCTextInputControllerOutlinedTextArea.m
+++ b/components/TextFields/src/MDCTextInputControllerOutlinedTextArea.m
@@ -172,16 +172,14 @@ static UIRectCorner _roundedCornersDefault = UIRectCornerAllCorners;
   // The amount of space underneath the underline depends on whether there is content in the
   // underline labels.
   CGFloat underlineLabelsOffset = 0;
-  CGFloat scale = UIScreen.mainScreen.scale;
 
   if (self.textInput.leadingUnderlineLabel.text.length) {
-    underlineLabelsOffset =
-        MDCCeil(self.textInput.leadingUnderlineLabel.font.lineHeight * scale) / scale;
+    underlineLabelsOffset = self.textInput.leadingUnderlineLabel.intrinsicContentSize.height;
   }
   if (self.textInput.trailingUnderlineLabel.text.length || self.characterCountMax) {
     underlineLabelsOffset =
         MAX(underlineLabelsOffset,
-            MDCCeil(self.textInput.trailingUnderlineLabel.font.lineHeight * scale) / scale);
+            MDCCeil(self.textInput.trailingUnderlineLabel.intrinsicContentSize.height));
   }
 
   CGFloat underlineOffset = underlineLabelsOffset;

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -317,8 +317,6 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   _trailingUnderlineLabel.opaque = NO;
   [_textInput addSubview:_trailingUnderlineLabel];
 
-  UILayoutPriority defaultPriority = UILayoutPriorityDefaultHigh;
-
   _leadingUnderlineLeading = [NSLayoutConstraint constraintWithItem:_leadingUnderlineLabel
                                                           attribute:NSLayoutAttributeLeading
                                                           relatedBy:NSLayoutRelationEqual
@@ -326,7 +324,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                                           attribute:NSLayoutAttributeLeading
                                                          multiplier:1
                                                            constant:0];
-  _leadingUnderlineLeading.priority = defaultPriority;
+  _leadingUnderlineLeading.priority = UILayoutPriorityDefaultLow;
 
   _trailingUnderlineTrailing = [NSLayoutConstraint constraintWithItem:_trailingUnderlineLabel
                                                             attribute:NSLayoutAttributeTrailing
@@ -335,20 +333,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                                             attribute:NSLayoutAttributeTrailing
                                                            multiplier:1
                                                              constant:0];
-  _trailingUnderlineTrailing.priority = defaultPriority;
-
-  NSLayoutConstraint *labelSpacing =
-      [NSLayoutConstraint constraintWithItem:_leadingUnderlineLabel
-                                   attribute:NSLayoutAttributeTrailing
-                                   relatedBy:NSLayoutRelationEqual
-                                      toItem:_trailingUnderlineLabel
-                                   attribute:NSLayoutAttributeLeading
-                                  multiplier:1
-                                    constant:0];
-  labelSpacing.priority = defaultPriority;
-
-  [NSLayoutConstraint
-      activateConstraints:@[ labelSpacing, _leadingUnderlineLeading, _trailingUnderlineTrailing ]];
+  _trailingUnderlineTrailing.priority = UILayoutPriorityDefaultLow;
 
   NSLayoutConstraint *leadingTop =
   [NSLayoutConstraint constraintWithItem:_leadingUnderlineLabel
@@ -357,8 +342,8 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                   toItem:_underline
                                attribute:NSLayoutAttributeBottom
                               multiplier:1
-                                constant:5];
-  leadingTop.priority = defaultPriority;
+                                constant:MDCTextInputHalfPadding];
+  leadingTop.priority = UILayoutPriorityDefaultLow;
 
   NSLayoutConstraint *leadingBottom =
       [NSLayoutConstraint constraintWithItem:_textInput
@@ -367,8 +352,8 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                       toItem:_leadingUnderlineLabel
                                    attribute:NSLayoutAttributeBottom
                                   multiplier:1
-                                    constant:5];
-  leadingBottom.priority = defaultPriority;
+                                    constant:MDCTextInputHalfPadding];
+  leadingBottom.priority = UILayoutPriorityDefaultLow;
 
   NSLayoutConstraint *trailingBottom =
       [NSLayoutConstraint constraintWithItem:_trailingUnderlineLabel
@@ -378,15 +363,15 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                    attribute:NSLayoutAttributeBottom
                                   multiplier:1
                                     constant:0];
-  trailingBottom.priority = defaultPriority;
+  trailingBottom.priority = UILayoutPriorityDefaultLow;
 
-  [NSLayoutConstraint activateConstraints:@[ leadingTop, leadingBottom, trailingBottom ]];
+  NSArray *constraints = @[ _leadingUnderlineLeading, _trailingUnderlineTrailing, leadingBottom,
+      trailingBottom, leadingTop ];
+  [NSLayoutConstraint activateConstraints:constraints];
 
   // When push comes to shove, the leading label is more likely to expand than the trailing.
   [_leadingUnderlineLabel setContentHuggingPriority:UILayoutPriorityDefaultLow - 1
                                             forAxis:UILayoutConstraintAxisHorizontal];
-  [_leadingUnderlineLabel setContentCompressionResistancePriority:UILayoutPriorityDefaultLow
-                                                          forAxis:UILayoutConstraintAxisHorizontal];
 
   [_trailingUnderlineLabel
       setContentCompressionResistancePriority:UILayoutPriorityRequired
@@ -745,9 +730,8 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 
   textInsets.top = MDCTextInputFullPadding;
 
-  CGFloat scale = UIScreen.mainScreen.scale;
-  CGFloat leadingOffset = MDCCeil(self.leadingUnderlineLabel.font.lineHeight * scale) / scale;
-  CGFloat trailingOffset = MDCCeil(self.trailingUnderlineLabel.font.lineHeight * scale) / scale;
+  CGFloat leadingOffset = self.textInput.leadingUnderlineLabel.intrinsicContentSize.height;
+  CGFloat trailingOffset = self.textInput.trailingUnderlineLabel.intrinsicContentSize.height;
 
   // The amount of space underneath the underline is variable. It could just be
   // MDCTextInputHalfPadding or the biggest estimated underlineLabel height +
@@ -940,6 +924,8 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 
   self.leadingUnderlineLeading.constant = textInsets.left;
   self.trailingUnderlineTrailing.constant = -1 * textInsets.right;
+  _leadingUnderlineLabel.preferredMaxLayoutWidth = CGRectGetWidth(self.textInput.frame) -
+      CGRectGetWidth(self.trailingUnderlineLabel.frame) - textInsets.right - textInsets.left;
 }
 
 #pragma mark - Text Input Events

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -335,24 +335,37 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                                              constant:0];
   _trailingUnderlineTrailing.priority = UILayoutPriorityDefaultLow;
 
+  NSLayoutConstraint *labelSpacing =
+      [NSLayoutConstraint constraintWithItem:_leadingUnderlineLabel
+                                   attribute:NSLayoutAttributeTrailing
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:_trailingUnderlineLabel
+                                   attribute:NSLayoutAttributeLeading
+                                  multiplier:1
+                                    constant:0];
+  labelSpacing.priority = UILayoutPriorityDefaultLow;
+
+  [NSLayoutConstraint
+      activateConstraints:@[ labelSpacing, _leadingUnderlineLeading, _trailingUnderlineTrailing ]];
+
   NSLayoutConstraint *leadingTop =
-  [NSLayoutConstraint constraintWithItem:_leadingUnderlineLabel
-                               attribute:NSLayoutAttributeTop
-                               relatedBy:NSLayoutRelationGreaterThanOrEqual
-                                  toItem:_underline
+  [NSLayoutConstraint constraintWithItem:_underline
                                attribute:NSLayoutAttributeBottom
+                               relatedBy:NSLayoutRelationEqual
+                                  toItem:_leadingUnderlineLabel
+                               attribute:NSLayoutAttributeTop
                               multiplier:1
-                                constant:MDCTextInputHalfPadding];
+                                constant:-MDCTextInputHalfPadding];
   leadingTop.priority = UILayoutPriorityDefaultLow;
 
   NSLayoutConstraint *leadingBottom =
-      [NSLayoutConstraint constraintWithItem:_textInput
+      [NSLayoutConstraint constraintWithItem:_leadingUnderlineLabel
                                    attribute:NSLayoutAttributeBottom
                                    relatedBy:NSLayoutRelationGreaterThanOrEqual
-                                      toItem:_leadingUnderlineLabel
+                                      toItem:_textInput
                                    attribute:NSLayoutAttributeBottom
                                   multiplier:1
-                                    constant:MDCTextInputHalfPadding];
+                                    constant:-MDCTextInputHalfPadding];
   leadingBottom.priority = UILayoutPriorityDefaultLow;
 
   NSLayoutConstraint *trailingBottom =
@@ -365,9 +378,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                     constant:0];
   trailingBottom.priority = UILayoutPriorityDefaultLow;
 
-  NSArray *constraints = @[ _leadingUnderlineLeading, _trailingUnderlineTrailing, leadingBottom,
-      trailingBottom, leadingTop ];
-  [NSLayoutConstraint activateConstraints:constraints];
+  [NSLayoutConstraint activateConstraints:@[ leadingBottom, trailingBottom, leadingTop ]];
 
   // When push comes to shove, the leading label is more likely to expand than the trailing.
   [_leadingUnderlineLabel setContentHuggingPriority:UILayoutPriorityDefaultLow - 1

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -115,13 +115,15 @@ static inline UIColor *MDCTextInputUnderlineColor() {
     // TODO: (#4331) This needs to be converted to the new text scheme.
 
     // Initialize elements of UI
+    // setUpUnderlineView must come before setUpPlaceholderView because the latter depends on
+    // constraints set in the former
+    [self setupUnderlineView];
     [self setupPlaceholderLabel];
 
     // setupClearButton must come after setupPlaceholderLabel because it will setup constraints that
     // depend on the placeholderLabel
     [self setupClearButton];
     [self setupUnderlineLabels];
-    [self setupUnderlineView];
 
     [self updateTextColor];
     [self mdc_setAdjustsFontForContentSizeCategory:NO];
@@ -296,6 +298,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
     _leadingUnderlineLabel.textColor = MDCTextInputDefaultPlaceholderTextColor();
     _leadingUnderlineLabel.font = _textInput.font;
     _leadingUnderlineLabel.textAlignment = NSTextAlignmentNatural;
+    _leadingUnderlineLabel.numberOfLines = 0;
 
     [_leadingUnderlineLabel setTranslatesAutoresizingMaskIntoConstraints:NO];
   }
@@ -320,7 +323,6 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                                           attribute:NSLayoutAttributeLeading
                                                          multiplier:1
                                                            constant:0];
-  _leadingUnderlineLeading.priority = UILayoutPriorityDefaultLow;
 
   _trailingUnderlineTrailing = [NSLayoutConstraint constraintWithItem:_trailingUnderlineLabel
                                                             attribute:NSLayoutAttributeTrailing
@@ -329,7 +331,6 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                                             attribute:NSLayoutAttributeTrailing
                                                            multiplier:1
                                                              constant:0];
-  _trailingUnderlineTrailing.priority = UILayoutPriorityDefaultLow;
 
   NSLayoutConstraint *labelSpacing =
       [NSLayoutConstraint constraintWithItem:_leadingUnderlineLabel
@@ -339,19 +340,27 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                    attribute:NSLayoutAttributeLeading
                                   multiplier:1
                                     constant:0];
-  labelSpacing.priority = UILayoutPriorityDefaultLow;
 
   [NSLayoutConstraint
       activateConstraints:@[ labelSpacing, _leadingUnderlineLeading, _trailingUnderlineTrailing ]];
 
-  NSLayoutConstraint *leadingBottom = [NSLayoutConstraint constraintWithItem:_leadingUnderlineLabel
-                                                                   attribute:NSLayoutAttributeBottom
-                                                                   relatedBy:NSLayoutRelationEqual
-                                                                      toItem:_textInput
-                                                                   attribute:NSLayoutAttributeBottom
-                                                                  multiplier:1
-                                                                    constant:0];
-  leadingBottom.priority = UILayoutPriorityDefaultLow;
+  NSLayoutConstraint *leadingTop =
+  [NSLayoutConstraint constraintWithItem:_leadingUnderlineLabel
+                               attribute:NSLayoutAttributeTop
+                               relatedBy:NSLayoutRelationGreaterThanOrEqual
+                                  toItem:_underline
+                               attribute:NSLayoutAttributeBottom
+                              multiplier:1
+                                constant:5];
+
+  NSLayoutConstraint *leadingBottom =
+      [NSLayoutConstraint constraintWithItem:_textInput
+                                   attribute:NSLayoutAttributeBottom
+                                   relatedBy:NSLayoutRelationGreaterThanOrEqual
+                                      toItem:_leadingUnderlineLabel
+                                   attribute:NSLayoutAttributeBottom
+                                  multiplier:1
+                                    constant:5];
 
   NSLayoutConstraint *trailingBottom =
       [NSLayoutConstraint constraintWithItem:_trailingUnderlineLabel
@@ -363,7 +372,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                     constant:0];
   trailingBottom.priority = UILayoutPriorityDefaultLow;
 
-  [NSLayoutConstraint activateConstraints:@[ leadingBottom, trailingBottom ]];
+  [NSLayoutConstraint activateConstraints:@[ leadingTop, leadingBottom, trailingBottom ]];
 
   // When push comes to shove, the leading label is more likely to expand than the trailing.
   [_leadingUnderlineLabel setContentHuggingPriority:UILayoutPriorityDefaultLow - 1

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -368,17 +368,17 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                     constant:-MDCTextInputHalfPadding];
   leadingBottom.priority = UILayoutPriorityDefaultLow;
 
-  NSLayoutConstraint *trailingBottom =
-      [NSLayoutConstraint constraintWithItem:_trailingUnderlineLabel
-                                   attribute:NSLayoutAttributeBottom
-                                   relatedBy:NSLayoutRelationEqual
-                                      toItem:_textInput
-                                   attribute:NSLayoutAttributeBottom
-                                  multiplier:1
-                                    constant:0];
-  trailingBottom.priority = UILayoutPriorityDefaultLow;
+  NSLayoutConstraint *trailingTop =
+  [NSLayoutConstraint constraintWithItem:_underline
+                               attribute:NSLayoutAttributeBottom
+                               relatedBy:NSLayoutRelationEqual
+                                  toItem:_trailingUnderlineLabel
+                               attribute:NSLayoutAttributeTop
+                              multiplier:1
+                                constant:-MDCTextInputHalfPadding];
+  trailingTop.priority = UILayoutPriorityDefaultLow;
 
-  [NSLayoutConstraint activateConstraints:@[ leadingBottom, trailingBottom, leadingTop ]];
+  [NSLayoutConstraint activateConstraints:@[ leadingTop, leadingBottom, trailingTop ]];
 
   // When push comes to shove, the leading label is more likely to expand than the trailing.
   [_leadingUnderlineLabel setContentHuggingPriority:UILayoutPriorityDefaultLow - 1

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -385,6 +385,8 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   // When push comes to shove, the leading label is more likely to expand than the trailing.
   [_leadingUnderlineLabel setContentHuggingPriority:UILayoutPriorityDefaultLow - 1
                                             forAxis:UILayoutConstraintAxisHorizontal];
+  [_leadingUnderlineLabel setContentCompressionResistancePriority:UILayoutPriorityDefaultLow
+                                                          forAxis:UILayoutConstraintAxisHorizontal];
 
   [_trailingUnderlineLabel
       setContentCompressionResistancePriority:UILayoutPriorityRequired

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -298,7 +298,8 @@ static inline UIColor *MDCTextInputUnderlineColor() {
     _leadingUnderlineLabel.textColor = MDCTextInputDefaultPlaceholderTextColor();
     _leadingUnderlineLabel.font = _textInput.font;
     _leadingUnderlineLabel.textAlignment = NSTextAlignmentNatural;
-    _leadingUnderlineLabel.numberOfLines = 0;
+    _leadingUnderlineLabel.numberOfLines = 2;
+    _leadingUnderlineLabel.lineBreakMode = NSLineBreakByTruncatingTail;
 
     [_leadingUnderlineLabel setTranslatesAutoresizingMaskIntoConstraints:NO];
   }
@@ -316,6 +317,8 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   _trailingUnderlineLabel.opaque = NO;
   [_textInput addSubview:_trailingUnderlineLabel];
 
+  UILayoutPriority defaultPriority = UILayoutPriorityDefaultHigh;
+
   _leadingUnderlineLeading = [NSLayoutConstraint constraintWithItem:_leadingUnderlineLabel
                                                           attribute:NSLayoutAttributeLeading
                                                           relatedBy:NSLayoutRelationEqual
@@ -323,6 +326,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                                           attribute:NSLayoutAttributeLeading
                                                          multiplier:1
                                                            constant:0];
+  _leadingUnderlineLeading.priority = defaultPriority;
 
   _trailingUnderlineTrailing = [NSLayoutConstraint constraintWithItem:_trailingUnderlineLabel
                                                             attribute:NSLayoutAttributeTrailing
@@ -331,6 +335,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                                             attribute:NSLayoutAttributeTrailing
                                                            multiplier:1
                                                              constant:0];
+  _trailingUnderlineTrailing.priority = defaultPriority;
 
   NSLayoutConstraint *labelSpacing =
       [NSLayoutConstraint constraintWithItem:_leadingUnderlineLabel
@@ -340,6 +345,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                    attribute:NSLayoutAttributeLeading
                                   multiplier:1
                                     constant:0];
+  labelSpacing.priority = defaultPriority;
 
   [NSLayoutConstraint
       activateConstraints:@[ labelSpacing, _leadingUnderlineLeading, _trailingUnderlineTrailing ]];
@@ -352,6 +358,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                attribute:NSLayoutAttributeBottom
                               multiplier:1
                                 constant:5];
+  leadingTop.priority = defaultPriority;
 
   NSLayoutConstraint *leadingBottom =
       [NSLayoutConstraint constraintWithItem:_textInput
@@ -361,6 +368,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                    attribute:NSLayoutAttributeBottom
                                   multiplier:1
                                     constant:5];
+  leadingBottom.priority = defaultPriority;
 
   NSLayoutConstraint *trailingBottom =
       [NSLayoutConstraint constraintWithItem:_trailingUnderlineLabel
@@ -370,7 +378,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                    attribute:NSLayoutAttributeBottom
                                   multiplier:1
                                     constant:0];
-  trailingBottom.priority = UILayoutPriorityDefaultLow;
+  trailingBottom.priority = defaultPriority;
 
   [NSLayoutConstraint activateConstraints:@[ leadingTop, leadingBottom, trailingBottom ]];
 

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -366,7 +366,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                   toItem:_leadingUnderlineLabel
                                attribute:NSLayoutAttributeTop
                               multiplier:1
-                                constant:-MDCTextInputHalfPadding];
+                                constant:-1 * MDCTextInputHalfPadding];
   leadingTop.priority = UILayoutPriorityDefaultLow;
 
   NSLayoutConstraint *leadingBottom =
@@ -376,7 +376,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                       toItem:_textInput
                                    attribute:NSLayoutAttributeBottom
                                   multiplier:1
-                                    constant:-MDCTextInputHalfPadding];
+                                    constant:-1 * MDCTextInputHalfPadding];
   leadingBottom.priority = UILayoutPriorityDefaultLow;
 
   NSLayoutConstraint *trailingTop =
@@ -386,7 +386,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                   toItem:_trailingUnderlineLabel
                                attribute:NSLayoutAttributeTop
                               multiplier:1
-                                constant:-MDCTextInputHalfPadding];
+                                constant:-1 * MDCTextInputHalfPadding];
   trailingTop.priority = UILayoutPriorityDefaultLow;
 
   [NSLayoutConstraint activateConstraints:@[ leadingTop, leadingBottom, trailingTop ]];

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -67,6 +67,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 @property(nonatomic, strong) NSLayoutConstraint *clearButtonTrailing;
 @property(nonatomic, strong) NSLayoutConstraint *clearButtonWidth;
 @property(nonatomic, strong) NSLayoutConstraint *leadingUnderlineLeading;
+@property(nonatomic, strong) NSLayoutConstraint *leadingUnderlineWidth;
 @property(nonatomic, strong) NSLayoutConstraint *trailingUnderlineTrailing;
 @property(nonatomic, strong) NSLayoutConstraint *placeholderLeading;
 @property(nonatomic, strong) NSLayoutConstraint *placeholderLeadingLeadingViewTrailing;
@@ -298,7 +299,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
     _leadingUnderlineLabel.textColor = MDCTextInputDefaultPlaceholderTextColor();
     _leadingUnderlineLabel.font = _textInput.font;
     _leadingUnderlineLabel.textAlignment = NSTextAlignmentNatural;
-    _leadingUnderlineLabel.numberOfLines = 2;
+    _leadingUnderlineLabel.numberOfLines = 1;
     _leadingUnderlineLabel.lineBreakMode = NSLineBreakByTruncatingTail;
 
     [_leadingUnderlineLabel setTranslatesAutoresizingMaskIntoConstraints:NO];
@@ -326,6 +327,15 @@ static inline UIColor *MDCTextInputUnderlineColor() {
                                                            constant:0];
   _leadingUnderlineLeading.priority = UILayoutPriorityDefaultLow;
 
+  _leadingUnderlineWidth = [NSLayoutConstraint constraintWithItem:_leadingUnderlineLabel
+                                                          attribute:NSLayoutAttributeWidth
+                                                          relatedBy:NSLayoutRelationEqual
+                                                             toItem:nil
+                                                          attribute:NSLayoutAttributeNotAnAttribute
+                                                         multiplier:1
+                                                           constant:0];
+  _leadingUnderlineWidth.priority = UILayoutPriorityDefaultLow;
+
   _trailingUnderlineTrailing = [NSLayoutConstraint constraintWithItem:_trailingUnderlineLabel
                                                             attribute:NSLayoutAttributeTrailing
                                                             relatedBy:NSLayoutRelationEqual
@@ -346,7 +356,8 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   labelSpacing.priority = UILayoutPriorityDefaultLow;
 
   [NSLayoutConstraint
-      activateConstraints:@[ labelSpacing, _leadingUnderlineLeading, _trailingUnderlineTrailing ]];
+      activateConstraints:@[ labelSpacing, _leadingUnderlineLeading, _trailingUnderlineTrailing,
+      _leadingUnderlineWidth]];
 
   NSLayoutConstraint *leadingTop =
   [NSLayoutConstraint constraintWithItem:_underline
@@ -382,6 +393,8 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 
   // When push comes to shove, the leading label is more likely to expand than the trailing.
   [_leadingUnderlineLabel setContentHuggingPriority:UILayoutPriorityDefaultLow - 1
+                                            forAxis:UILayoutConstraintAxisHorizontal];
+  [_leadingUnderlineLabel setContentCompressionResistancePriority:UILayoutPriorityDefaultLow - 1
                                             forAxis:UILayoutConstraintAxisHorizontal];
 
   [_trailingUnderlineLabel
@@ -935,7 +948,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 
   self.leadingUnderlineLeading.constant = textInsets.left;
   self.trailingUnderlineTrailing.constant = -1 * textInsets.right;
-  _leadingUnderlineLabel.preferredMaxLayoutWidth = CGRectGetWidth(self.textInput.frame) -
+  _leadingUnderlineWidth.constant = CGRectGetWidth(self.textInput.frame) -
       CGRectGetWidth(self.trailingUnderlineLabel.frame) - textInsets.right - textInsets.left;
 }
 

--- a/components/TextFields/tests/unit/TextFieldTests.swift
+++ b/components/TextFields/tests/unit/TextFieldTests.swift
@@ -172,6 +172,31 @@ class TextFieldTests: XCTestCase {
     XCTAssertEqual(textField.textInsetsMode, .never)
   }
 
+  func testMultilineErrorMessages() {
+    let textField1 = MDCTextField(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+    textField1.translatesAutoresizingMaskIntoConstraints = false
+    let controller1 = MDCTextInputControllerFilled(textInput: textField1)
+    var errorMessage = "Error!"
+    controller1.setErrorText(errorMessage, errorAccessibilityValue: nil)
+    let textField1Height1 = textField1.intrinsicContentSize.height
+    errorMessage += ("\n" + errorMessage)
+    controller1.setErrorText(errorMessage, errorAccessibilityValue: nil)
+    let textField1Height2 = textField1.intrinsicContentSize.height
+
+    let textField2 = MDCMultilineTextField(frame: CGRect(x: 0, y: 0, width: 250, height: 250))
+    textField2.translatesAutoresizingMaskIntoConstraints = false
+    let controller2 = MDCTextInputControllerOutlinedTextArea(textInput: textField2)
+    errorMessage = "Error!"
+    controller2.setErrorText(errorMessage, errorAccessibilityValue: nil)
+    let textField2Height1 = textField2.intrinsicContentSize.height
+    errorMessage += ("\n" + errorMessage)
+    controller2.setErrorText(errorMessage, errorAccessibilityValue: nil)
+    let textField2Height2 = textField2.intrinsicContentSize.height
+
+    XCTAssert(textField1Height2 > textField1Height1 + textField1.leadingUnderlineLabel.font.lineHeight)
+    XCTAssert(textField2Height2 > textField2Height1 + textField2.leadingUnderlineLabel.font.lineHeight)
+  }
+
   func testUnderlineSetters() {
     let textField = MDCTextField()
 

--- a/components/TextFields/tests/unit/TextFieldTests.swift
+++ b/components/TextFields/tests/unit/TextFieldTests.swift
@@ -178,9 +178,13 @@ class TextFieldTests: XCTestCase {
     let controller1 = MDCTextInputControllerFilled(textInput: textField1)
     var errorMessage = "Error!"
     controller1.setErrorText(errorMessage, errorAccessibilityValue: nil)
+    textField1.setNeedsLayout()
+    textField1.layoutIfNeeded()
     let textField1Height1 = textField1.intrinsicContentSize.height
     errorMessage += ("\n" + errorMessage)
     controller1.setErrorText(errorMessage, errorAccessibilityValue: nil)
+    textField1.setNeedsLayout()
+    textField1.layoutIfNeeded()
     let textField1Height2 = textField1.intrinsicContentSize.height
 
     let textField2 = MDCMultilineTextField(frame: CGRect(x: 0, y: 0, width: 250, height: 250))
@@ -188,9 +192,13 @@ class TextFieldTests: XCTestCase {
     let controller2 = MDCTextInputControllerOutlinedTextArea(textInput: textField2)
     errorMessage = "Error!"
     controller2.setErrorText(errorMessage, errorAccessibilityValue: nil)
+    textField2.setNeedsLayout()
+    textField2.layoutIfNeeded()
     let textField2Height1 = textField2.intrinsicContentSize.height
     errorMessage += ("\n" + errorMessage)
     controller2.setErrorText(errorMessage, errorAccessibilityValue: nil)
+    textField2.setNeedsLayout()
+    textField2.layoutIfNeeded()
     let textField2Height2 = textField2.intrinsicContentSize.height
 
     XCTAssert(textField1Height2 > textField1Height1 + textField1.leadingUnderlineLabel.font.lineHeight)

--- a/components/TextFields/tests/unit/TextFieldTests.swift
+++ b/components/TextFields/tests/unit/TextFieldTests.swift
@@ -178,33 +178,15 @@ class TextFieldTests: XCTestCase {
     let controller1 = MDCTextInputControllerFilled(textInput: textField1)
     var errorMessage = "Error!"
     controller1.setErrorText(errorMessage, errorAccessibilityValue: nil)
-    let textField1Height1 = textField1.intrinsicContentSize.height
+    let labelIntrinsicHeight1 = textField1.leadingUnderlineLabel.intrinsicContentSize.height
+    let labelLineHeight = textField1.leadingUnderlineLabel.font.lineHeight
+    let labelNumberOfLinesBefore = round((labelIntrinsicHeight1 / labelLineHeight))
     errorMessage += ("\n" + errorMessage)
     controller1.setErrorText(errorMessage, errorAccessibilityValue: nil)
-    let textField1Height2 = textField1.intrinsicContentSize.height
-    let textField1labelLineHeight = textField1.leadingUnderlineLabel.font.lineHeight
-    XCTAssert(textField1Height2 > textField1Height1 + textField1labelLineHeight)
-
-    let textField2 = MDCMultilineTextField(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-    textField2.translatesAutoresizingMaskIntoConstraints = false
-    let controller2 = MDCTextInputControllerOutlinedTextArea(textInput: textField2)
-    textField2.text = "text\ntext\ntext\ntext\ntext\ntext\ntext\ntext\ntext\ntext\n"
-    NSLayoutConstraint(item: textField2,
-                       attribute: .width,
-                       relatedBy: .equal,
-                       toItem: nil,
-                       attribute: .notAnAttribute,
-                       multiplier: 1,
-                       constant: 100)
-      .isActive = true
-    errorMessage = "Error!"
-    controller2.setErrorText(errorMessage, errorAccessibilityValue: nil)
-    let textField2Height1 = textField2.intrinsicContentSize.height
-    errorMessage += ("\n" + errorMessage)
-    controller2.setErrorText(errorMessage, errorAccessibilityValue: nil)
-    let textField2Height2 = textField2.intrinsicContentSize.height
-    let textField2labelLineHeight = textField2.leadingUnderlineLabel.font.lineHeight
-    XCTAssert(textField2Height2 > textField2Height1 + textField2labelLineHeight)
+    let labelIntrinsicHeight2 = textField1.leadingUnderlineLabel.intrinsicContentSize.height
+    let labelNumberOfLinesAfter = round((labelIntrinsicHeight2 / labelLineHeight))
+    XCTAssert(labelNumberOfLinesBefore == 1)
+    XCTAssert(labelNumberOfLinesAfter == 2)
   }
 
   func testUnderlineSetters() {

--- a/components/TextFields/tests/unit/TextFieldTests.swift
+++ b/components/TextFields/tests/unit/TextFieldTests.swift
@@ -178,31 +178,33 @@ class TextFieldTests: XCTestCase {
     let controller1 = MDCTextInputControllerFilled(textInput: textField1)
     var errorMessage = "Error!"
     controller1.setErrorText(errorMessage, errorAccessibilityValue: nil)
-    textField1.setNeedsLayout()
-    textField1.layoutIfNeeded()
     let textField1Height1 = textField1.intrinsicContentSize.height
     errorMessage += ("\n" + errorMessage)
     controller1.setErrorText(errorMessage, errorAccessibilityValue: nil)
-    textField1.setNeedsLayout()
-    textField1.layoutIfNeeded()
     let textField1Height2 = textField1.intrinsicContentSize.height
+    let textField1labelLineHeight = textField1.leadingUnderlineLabel.font.lineHeight
+    XCTAssert(textField1Height2 > textField1Height1 + textField1labelLineHeight)
 
-    let textField2 = MDCMultilineTextField(frame: CGRect(x: 0, y: 0, width: 250, height: 250))
+    let textField2 = MDCMultilineTextField(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
     textField2.translatesAutoresizingMaskIntoConstraints = false
     let controller2 = MDCTextInputControllerOutlinedTextArea(textInput: textField2)
+    textField2.text = "text\ntext\ntext\ntext\ntext\ntext\ntext\ntext\ntext\ntext\n"
+    NSLayoutConstraint(item: textField2,
+                       attribute: .width,
+                       relatedBy: .equal,
+                       toItem: nil,
+                       attribute: .notAnAttribute,
+                       multiplier: 1,
+                       constant: 100)
+      .isActive = true
     errorMessage = "Error!"
     controller2.setErrorText(errorMessage, errorAccessibilityValue: nil)
-    textField2.setNeedsLayout()
-    textField2.layoutIfNeeded()
     let textField2Height1 = textField2.intrinsicContentSize.height
     errorMessage += ("\n" + errorMessage)
     controller2.setErrorText(errorMessage, errorAccessibilityValue: nil)
-    textField2.setNeedsLayout()
-    textField2.layoutIfNeeded()
     let textField2Height2 = textField2.intrinsicContentSize.height
-
-    XCTAssert(textField1Height2 > textField1Height1 + textField1.leadingUnderlineLabel.font.lineHeight)
-    XCTAssert(textField2Height2 > textField2Height1 + textField2.leadingUnderlineLabel.font.lineHeight)
+    let textField2labelLineHeight = textField2.leadingUnderlineLabel.font.lineHeight
+    XCTAssert(textField2Height2 > textField2Height1 + textField2labelLineHeight)
   }
 
   func testUnderlineSetters() {

--- a/components/TextFields/tests/unit/TextFieldTests.swift
+++ b/components/TextFields/tests/unit/TextFieldTests.swift
@@ -173,17 +173,18 @@ class TextFieldTests: XCTestCase {
   }
 
   func testMultilineErrorMessages() {
-    let textField1 = MDCTextField(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-    textField1.translatesAutoresizingMaskIntoConstraints = false
-    let controller1 = MDCTextInputControllerFilled(textInput: textField1)
+    let textField = MDCTextField(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+    textField.leadingUnderlineLabel.numberOfLines = 2
+    textField.translatesAutoresizingMaskIntoConstraints = false
+    let controller1 = MDCTextInputControllerFilled(textInput: textField)
     var errorMessage = "Error!"
     controller1.setErrorText(errorMessage, errorAccessibilityValue: nil)
-    let labelIntrinsicHeight1 = textField1.leadingUnderlineLabel.intrinsicContentSize.height
-    let labelLineHeight = textField1.leadingUnderlineLabel.font.lineHeight
+    let labelIntrinsicHeight1 = textField.leadingUnderlineLabel.intrinsicContentSize.height
+    let labelLineHeight = textField.leadingUnderlineLabel.font.lineHeight
     let labelNumberOfLinesBefore = round((labelIntrinsicHeight1 / labelLineHeight))
     errorMessage += ("\n" + errorMessage)
     controller1.setErrorText(errorMessage, errorAccessibilityValue: nil)
-    let labelIntrinsicHeight2 = textField1.leadingUnderlineLabel.intrinsicContentSize.height
+    let labelIntrinsicHeight2 = textField.leadingUnderlineLabel.intrinsicContentSize.height
     let labelNumberOfLinesAfter = round((labelIntrinsicHeight2 / labelLineHeight))
     XCTAssert(labelNumberOfLinesBefore == 1)
     XCTAssert(labelNumberOfLinesAfter == 2)


### PR DESCRIPTION
Before:
![simulator screen shot - iphone 8 plus - 2018-07-09 at 13 58 27](https://user-images.githubusercontent.com/8020010/42467530-2e5787d2-8380-11e8-8cd6-e15931232b37.png)

After:
![simulator screen shot - iphone 8 plus - 2018-07-09 at 13 48 31](https://user-images.githubusercontent.com/8020010/42467469-ff4fd106-837f-11e8-8381-c4927ee2ea26.png)

Closes https://github.com/material-components/material-components-ios/issues/4476 