### PR TITLE
[TextFields] Add accessibility docs for MDCTextField

### DIFF
--- a/components/TextFields/README.md
+++ b/components/TextFields/README.md
@@ -20,7 +20,7 @@ Text fields allow users to input text into your app. They are a direct connectio
   <img src="docs/assets/textfields.png" alt="Text Fields" width="375">
 </div>
 
-MDC's text fields come in several styles and have a great range of customization. Google's UX research has determined that Outlined and Filled (aka 'text box') styles perform the best by a large margin. So use  `MDCTextInputControllerFilled`, `MDCTextInputControllerOutlined`, and `MDCTextInputControllerOutlinedTextArea` if you can and set colors and fonts that match your company's branding.
+MDC's text fields come in several styles and have a great range of customization. Google's UX research has determined that Outlined and Filled (aka 'text box') styles perform the best by a large margin. So use `MDCTextInputControllerOutlinedField` , `MDCTextInputControllerTextFieldBox`, and `MDCTextInputControllerTextArea` if you can and set colors and fonts that match your company's branding.
 
 For more information on text field styles, and animated images of each style in action, see [Text Field Styles](./styling).
 
@@ -31,7 +31,6 @@ For more information on text field styles, and animated images of each style in 
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes.html#/c:objc(cs)MDCIntrinsicHeightTextView">MDCIntrinsicHeightTextView</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes.html#/c:objc(cs)MDCTextInputAllCharactersCounter">MDCTextInputAllCharactersCounter</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes.html#/c:objc(cs)MDCTextInputControllerFilled">MDCTextInputControllerFilled</a></li>
-  <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes.html#/c:objc(cs)MDCTextInputControllerFullWidth">MDCTextInputControllerFullWidth</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes.html#/c:objc(cs)MDCTextInputControllerLegacyDefault">MDCTextInputControllerLegacyDefault</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes.html#/c:objc(cs)MDCTextInputControllerLegacyFullWidth">MDCTextInputControllerLegacyFullWidth</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes.html#/c:objc(cs)MDCTextInputControllerOutlined">MDCTextInputControllerOutlined</a></li>
@@ -40,7 +39,9 @@ For more information on text field styles, and animated images of each style in 
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes/MDCMultilineTextField.html">MDCMultilineTextField</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes/MDCTextField.html">MDCTextField</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes/MDCTextInputControllerBase.html">MDCTextInputControllerBase</a></li>
+  <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes/MDCTextInputControllerFullWidth.html">MDCTextInputControllerFullWidth</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes/MDCTextInputUnderlineView.html">MDCTextInputUnderlineView</a></li>
+  <li class="icon-list-item icon-list-item--link">Protocol: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Protocols/MDCLeadingViewTextInput.html">MDCLeadingViewTextInput</a></li>
   <li class="icon-list-item icon-list-item--link">Protocol: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Protocols/MDCMultilineTextInput.html">MDCMultilineTextInput</a></li>
   <li class="icon-list-item icon-list-item--link">Protocol: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Protocols/MDCMultilineTextInputDelegate.html">MDCMultilineTextInputDelegate</a></li>
   <li class="icon-list-item icon-list-item--link">Protocol: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Protocols/MDCMultilineTextInputLayoutDelegate.html">MDCMultilineTextInputLayoutDelegate</a></li>
@@ -49,6 +50,7 @@ For more information on text field styles, and animated images of each style in 
   <li class="icon-list-item icon-list-item--link">Protocol: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Protocols/MDCTextInputController.html">MDCTextInputController</a></li>
   <li class="icon-list-item icon-list-item--link">Protocol: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Protocols/MDCTextInputControllerFloatingPlaceholder.html">MDCTextInputControllerFloatingPlaceholder</a></li>
   <li class="icon-list-item icon-list-item--link">Protocol: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Protocols/MDCTextInputPositioningDelegate.html">MDCTextInputPositioningDelegate</a></li>
+  <li class="icon-list-item icon-list-item--link">Enumeration: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Enums.html">Enumerations</a></li>
   <li class="icon-list-item icon-list-item--link">Enumeration: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Enums/MDCTextInputTextInsetsMode.html">MDCTextInputTextInsetsMode</a></li>
 </ul>
 
@@ -67,6 +69,8 @@ For more information on text field styles, and animated images of each style in 
 - [Extensions](#extensions)
   - [Text Fields Color Theming](#text-fields-color-theming)
   - [Text Fields Typography Theming](#text-fields-typography-theming)
+- [Accessibility](#accessibility)
+  - [MDCTextField Accessibility](#mdctextfield-accessibility)
 
 - - -
 
@@ -76,9 +80,9 @@ Text Fields provides both a single-line version based on `UITextField` and a mul
 
 The actual components (`MDCTextField` & `MDCMultilineTextField`) are 'dumb': they do not have styles, animations, or advanced features. They are designed to be controlled from the outside, via very liberal public API, with a text input controller.
 
-Most text input controllers included are based on `MDCTextInputControllerBase` which manipulates the exposed elements of the text field to make placeholders float.
+Most text input controllers included are based on `MDCTextInputControllerUnderline` which manipulates the exposed elements of the text field to make placeholders float.
 
-There is also a text input controller for full-width forms (`MDCTextInputControllerFullWidth`). Like `MDCTextInputControllerBase`d controllers, it also handles errors and character counting but has not been thoroughly tested with UX research. 
+There is also a text input controller for full-width forms (`MDCTextInputControllerFullWidth`). Like `MDCTextInputControllerUnderline`, it also handles errors and character counting.
 
 Customize the included text input controllers via their parameters or create your own to express your app's brand identity thru typography, color, and animation: if the placeholder should move, add constraints or change the frame. If the trailing label should display validation information, change the text and color it.
 
@@ -150,64 +154,32 @@ This is a multi-line text input. It's subclassed from `UIView` with an embedded 
   <li class="icon-list-item icon-list-item">Minimum number of lines</li>
 </ul>
 
-### Text Input Controller Classes: Recommended
+### Text Field Classes: The Controllers
 
-See [Text Field Styles](./styling) for images and details.
+#### Default Text Input Controller
 
-These are the controllers that have been optimized for discoverability and clickability thru rigorous research, design iterations, and user testing. Always try to use one of these first.
+This class holds all the 'magic' logic necessary to make the naturally 'dumb' text field and text view behave with:
 
-#### MDCTextInputControllerFilled
-
-Filled background with underline.
-
-#### MDCTextInputControllerOutlined
-
-Outlined background with no fill.
-
-#### MDCTextInputControllerOutlinedTextArea
-
-Nearly identical to `MDCTextInputControllerOutlined` but with two differences:
-
-- Intended only for multi-line text fields that remain expanded when empty
-- The floating placeholder does not cross the border but rather floats below it
-
-### Text Input Controller Classes: Cautioned
-
-See [Text Field Styles](./styling) for images and details.
-
-These are the controllers that have performed the worst in user testing or haven't been extensively user tested at all. Use them only if you have to or conduct your own A/B testing against one of the recommended controllers to see if they perform as expected in your application.
-
-#### MDCTextInputControllerFullWidth
-
-Optimized for full width forms like emails. While common in messaging apps, its design hasn't been rigorously tested with users. For now, the Material Design team suggests using this only when another design is impracticle. 
-
-#### MDCTextInputControllerUnderline
-
-'Classic' 2014 Material Design text field. This style is still found in many applications and sites but should be considered deprecated. It tested poorly in Material Research's user testing. Use `MDCTextInputControllerFilled` or `MDCTextInputControllerOutlined` instead.
-
-#### MDCTextInputControllerLegacyDefault && MDCTextInputControllerLegacyFullWidth
-
-Soon to be deprecated styles only created and included for backwards compatibility of the library. They have no visual distinction from the other full width and underline controllers but their layout behaves slightly differently.
-
-### Text Input Controller Classes: For Subclassing Only
-
-See [Text Field Styles](./styling) for images and details.
-
-#### MDCTextInputControllerBase
-
-__This class is meant to be subclassed and not used on its own.__ It's a full implementation of the `MDCTextInputControllerFloatingPlaceholder` protocol and holds all the 'magic' logic necessary to make:
-
-- Floating placeholder animations
+- Animations
+- Styles
 - Errors
 - Character counts
+
+- - -
+
+#### Full Width Text Input Controller
+
+Similar to the default text input controller but optimized for full width forms like emails.
+
 
 ## Usage
 
 <!-- Extracted from docs/usage.md -->
 
-A text field that conforms to `MDCTextInput` can be added to a view hierarchy the same way `UITextField` and `UIView` are. But to achieve the animations and presentations defined by the guidelines (floating placeholders, character counts), a controller that conforms to protocol `MDCTextInputController` must be initialized to manage the text field.
+A text field that conforms to MDCTextInput can be added to a view hierarchy the same way UITextField and UIView are. But to achieve the animations and presentations defined by the guidelines (floating placeholders, character counts), a controller that conforms to protocol `MDCTextInputController` must be initialized to manage the text field.
 
 **NOTE:** Expect to interact with _both the text field_ (for the traditional API) _and the controller_ (for changes affecting the presentation and state).
+
 
 <!-- Extracted from docs/examples.md -->
 
@@ -255,7 +227,7 @@ textFieldDefaultCharMax.placeholder = "Enter up to 50 characters"
 textFieldDefaultCharMax.textView.delegate = self
 
 // Second the controller is created to manage the text field
-textFieldControllerDefaultCharMax = MDCTextInputControllerUnderline(textInput: textFieldDefaultCharMax) // Hold on as a property
+textFieldControllerDefaultCharMax = MDCTextInputControllerUnderline(input: textFieldDefaultCharMax) // Hold on as a property
 textFieldControllerDefaultCharMax.characterCountMax = 50
 textFieldControllerDefaultCharMax.isFloatingEnabled = false
 ```
@@ -343,7 +315,7 @@ id<MDCColorScheming> colorScheme = [[MDCSemanticColorScheme alloc] init];
 
 ### Text Fields Typography Theming
 
-You can theme a text field with your app's typography scheme using the `TypographyThemer` extension.
+You can theme a text field with your app's typography scheme using the TypographyThemer extension.
 
 You must first add the Typography Themer extension to your project:
 
@@ -396,4 +368,40 @@ id<MDCTypographyScheming> typographyScheme = [[MDCTypographyScheme alloc] init];
                    toAllTextInputControllersOfClass:[MDCTextInputControllerUnderline class]];
 ```
 <!--</div>-->
+
+
+## Accessibility
+
+<!-- Extracted from docs/accessibility.md -->
+
+### MDCTextField Accessibility
+
+Like UITextFields, MDCTextFields are accessible by default. To best take advantage of their accessibility features
+please review the following recommendations.
+
+#### `-accessibilityValue` Behavior
+
+Similar to UITextFields, MDCTextFields are not accessibility elements themselves. Rather, they are accessibility
+containers whose subviews act as accessibility elements. Such subviews include the MDCTextField's placeholder
+label, the leading and trailing underline labels, and the clear button. The `accessibilityLabels` of these subviews
+contribute to the `accessibilityValue` of the MDCTextField as a whole, giving it a value consistent with that of a
+UITextField in a similar state. If the MDCTextField is empty, it will return a combination of any placeholderLabel text and
+leading underline text. If the MDCTextField is not empty, it will return a combination of the MDCTextField's current text
+and any leading underline text.
+
+#### Using `-accessibilityLabel`
+
+MDCTextField does not provide a custom implementation for `accessibilityLabel`. The client is free to set an
+appropriate `accessibilityLabel` following norms established by Apple if they wish. However, they should consider
+whether or not it it will provide information that is superfluous. A common scenario in which an
+`accessibilityLabel` might not be necessary would be an MDCTextField whose leading underline label (a view not
+present in UITextFields) conveys the information that an accessibility label might have otherwise conveyed. For
+example, if an MDCTextField is intended to hold a user's zip code, and the leading underline label's
+`accessibilityLabel` is already "Zip code", setting an `accessibilityLabel` of "Zip code" on the MDCTextField
+may lead to duplicate VoiceOver statements.
+
+#### Using `-accessibilityHint`
+
+In general, Apple advises designing your user interface in such a way that clarification in the form of  an
+`-accessibilityHint` is not needed. However, it is always an option.
 

--- a/components/TextFields/README.md
+++ b/components/TextFields/README.md
@@ -20,7 +20,7 @@ Text fields allow users to input text into your app. They are a direct connectio
   <img src="docs/assets/textfields.png" alt="Text Fields" width="375">
 </div>
 
-MDC's text fields come in several styles and have a great range of customization. Google's UX research has determined that Outlined and Filled (aka 'text box') styles perform the best by a large margin. So use `MDCTextInputControllerOutlinedField` , `MDCTextInputControllerTextFieldBox`, and `MDCTextInputControllerTextArea` if you can and set colors and fonts that match your company's branding.
+MDC's text fields come in several styles and have a great range of customization. Google's UX research has determined that Outlined and Filled (aka 'text box') styles perform the best by a large margin. So use  `MDCTextInputControllerFilled`, `MDCTextInputControllerOutlined`, and `MDCTextInputControllerOutlinedTextArea` if you can and set colors and fonts that match your company's branding.
 
 For more information on text field styles, and animated images of each style in action, see [Text Field Styles](./styling).
 
@@ -61,7 +61,9 @@ For more information on text field styles, and animated images of each style in 
   - [Installation with CocoaPods](#installation-with-cocoapods)
   - [Importing](#importing)
   - [Text Field Classes: The Inputs](#text-field-classes-the-inputs)
-  - [Text Field Classes: The Controllers](#text-field-classes-the-controllers)
+  - [Text Input Controller Classes: Recommended](#text-input-controller-classes-recommended)
+  - [Text Input Controller Classes: Cautioned](#text-input-controller-classes-cautioned)
+  - [Text Input Controller Classes: For Subclassing Only](#text-input-controller-classes-for-subclassing-only)
 - [Usage](#usage)
 - [Examples - Multi Line](#examples---multi-line)
   - [Text Field with Floating Placeholder](#text-field-with-floating-placeholder)
@@ -80,9 +82,9 @@ Text Fields provides both a single-line version based on `UITextField` and a mul
 
 The actual components (`MDCTextField` & `MDCMultilineTextField`) are 'dumb': they do not have styles, animations, or advanced features. They are designed to be controlled from the outside, via very liberal public API, with a text input controller.
 
-Most text input controllers included are based on `MDCTextInputControllerUnderline` which manipulates the exposed elements of the text field to make placeholders float.
+Most text input controllers included are based on `MDCTextInputControllerBase` which manipulates the exposed elements of the text field to make placeholders float.
 
-There is also a text input controller for full-width forms (`MDCTextInputControllerFullWidth`). Like `MDCTextInputControllerUnderline`, it also handles errors and character counting.
+There is also a text input controller for full-width forms (`MDCTextInputControllerFullWidth`). Like `MDCTextInputControllerBase`d controllers, it also handles errors and character counting but has not been thoroughly tested with UX research.
 
 Customize the included text input controllers via their parameters or create your own to express your app's brand identity thru typography, color, and animation: if the placeholder should move, add constraints or change the frame. If the trailing label should display validation information, change the text and color it.
 
@@ -151,32 +153,66 @@ as well as new features:
 This is a multi-line text input. It's subclassed from `UIView` with an embedded `UITextView`. It supports all the features of the single-line text field and `UITextView` plus:
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item">Minimum number of lines</li>
+<li class="icon-list-item icon-list-item">Minimum number of lines</li>
 </ul>
 
-### Text Field Classes: The Controllers
+### Text Input Controller Classes: Recommended
 
-#### Default Text Input Controller
+See [Text Field Styles](./styling) for images and details.
 
-This class holds all the 'magic' logic necessary to make the naturally 'dumb' text field and text view behave with:
+These are the controllers that have been optimized for discoverability and clickability thru rigorous research, design iterations, and user testing. Always try to use one of these first.
 
-- Animations
-- Styles
+#### MDCTextInputControllerFilled
+
+Filled background with underline.
+
+#### MDCTextInputControllerOutlined
+
+Outlined background with no fill.
+
+#### MDCTextInputControllerOutlinedTextArea
+
+Nearly identical to `MDCTextInputControllerOutlined` but with two differences:
+
+- Intended only for multi-line text fields that remain expanded when empty
+- The floating placeholder does not cross the border but rather floats below it
+
+### Text Input Controller Classes: Cautioned
+
+See [Text Field Styles](./styling) for images and details.
+
+These are the controllers that have performed the worst in user testing or haven't been extensively user tested at all. Use them only if you have to or conduct your own A/B testing against one of the recommended controllers to see if they perform as expected in your application.
+
+#### MDCTextInputControllerFullWidth
+
+Optimized for full width forms like emails. While common in messaging apps, its design hasn't been rigorously tested with users. For now, the Material Design team suggests using this only when another design is impracticle.
+
+#### MDCTextInputControllerUnderline
+
+'Classic' 2014 Material Design text field. This style is still found in many applications and sites but should be considered deprecated. It tested poorly in Material Research's user testing. Use `MDCTextInputControllerFilled` or `MDCTextInputControllerOutlined` instead.
+
+#### MDCTextInputControllerLegacyDefault && MDCTextInputControllerLegacyFullWidth
+
+Soon to be deprecated styles only created and included for backwards compatibility of the library. They have no visual distinction from the other full width and underline controllers but their layout behaves slightly differently.
+
+### Text Input Controller Classes: For Subclassing Only
+
+See [Text Field Styles](./styling) for images and details.
+
+#### MDCTextInputControllerBase
+
+__This class is meant to be subclassed and not used on its own.__ It's a full implementation of the `MDCTextInputControllerFloatingPlaceholder` protocol and holds all the 'magic' logic necessary to make:
+
+- Floating placeholder animations
 - Errors
 - Character counts
-
-- - -
-
-#### Full Width Text Input Controller
-
-Similar to the default text input controller but optimized for full width forms like emails.
 
 
 ## Usage
 
 <!-- Extracted from docs/usage.md -->
 
-A text field that conforms to MDCTextInput can be added to a view hierarchy the same way UITextField and UIView are. But to achieve the animations and presentations defined by the guidelines (floating placeholders, character counts), a controller that conforms to protocol `MDCTextInputController` must be initialized to manage the text field.
+A text field that conforms to `MDCTextInput` can be added to a view hierarchy the same way `UITextField` and `UIView` are. But to achieve the animations and presentations defined by the guidelines (floating placeholders, character counts), a controller that conforms to protocol `MDCTextInputController` must be initialized to manage the text field.
 
 **NOTE:** Expect to interact with _both the text field_ (for the traditional API) _and the controller_ (for changes affecting the presentation and state).
 
@@ -197,7 +233,7 @@ scrollView.addSubview(textFieldFloating)
 textFieldFloating.placeholder = "Full Name"
 textFieldFloating.textView.delegate = self
 
-textFieldControllerFloating = MDCTextInputControllerUnderline(input: textFieldFloating) // Hold on as a property
+textFieldControllerFloating = MDCTextInputControllerUnderline(textInput: textFieldFloating) // Hold on as a property
 ```
 
 #### Objective-C
@@ -227,7 +263,7 @@ textFieldDefaultCharMax.placeholder = "Enter up to 50 characters"
 textFieldDefaultCharMax.textView.delegate = self
 
 // Second the controller is created to manage the text field
-textFieldControllerDefaultCharMax = MDCTextInputControllerUnderline(input: textFieldDefaultCharMax) // Hold on as a property
+textFieldControllerDefaultCharMax = MDCTextInputControllerUnderline(textInput: textFieldDefaultCharMax) // Hold on as a property
 textFieldControllerDefaultCharMax.characterCountMax = 50
 textFieldControllerDefaultCharMax.isFloatingEnabled = false
 ```
@@ -315,7 +351,7 @@ id<MDCColorScheming> colorScheme = [[MDCSemanticColorScheme alloc] init];
 
 ### Text Fields Typography Theming
 
-You can theme a text field with your app's typography scheme using the TypographyThemer extension.
+You can theme a text field with your app's typography scheme using the `TypographyThemer` extension.
 
 You must first add the Typography Themer extension to your project:
 

--- a/components/TextFields/docs/README.md
+++ b/components/TextFields/docs/README.md
@@ -8,7 +8,7 @@ Text fields allow users to input text into your app. They are a direct connectio
   <img src="docs/assets/textfields.png" alt="Text Fields" width="375">
 </div>
 
-MDC's text fields come in several styles and have a great range of customization. Google's UX research has determined that Outlined and Filled (aka 'text box') styles perform the best by a large margin. So use `MDCTextInputControllerOutlinedField` , `MDCTextInputControllerTextFieldBox`, and `MDCTextInputControllerTextArea` if you can and set colors and fonts that match your company's branding.
+MDC's text fields come in several styles and have a great range of customization. Google's UX research has determined that Outlined and Filled (aka 'text box') styles perform the best by a large margin. So use  `MDCTextInputControllerFilled`, `MDCTextInputControllerOutlined`, and `MDCTextInputControllerOutlinedTextArea` if you can and set colors and fonts that match your company's branding.
 
 For more information on text field styles, and animated images of each style in action, see [Text Field Styles](./styling).
 
@@ -24,9 +24,9 @@ Text Fields provides both a single-line version based on `UITextField` and a mul
 
 The actual components (`MDCTextField` & `MDCMultilineTextField`) are 'dumb': they do not have styles, animations, or advanced features. They are designed to be controlled from the outside, via very liberal public API, with a text input controller.
 
-Most text input controllers included are based on `MDCTextInputControllerUnderline` which manipulates the exposed elements of the text field to make placeholders float.
+Most text input controllers included are based on `MDCTextInputControllerBase` which manipulates the exposed elements of the text field to make placeholders float.
 
-There is also a text input controller for full-width forms (`MDCTextInputControllerFullWidth`). Like `MDCTextInputControllerUnderline`, it also handles errors and character counting.
+There is also a text input controller for full-width forms (`MDCTextInputControllerFullWidth`). Like `MDCTextInputControllerBase`d controllers, it also handles errors and character counting but has not been thoroughly tested with UX research.
 
 Customize the included text input controllers via their parameters or create your own to express your app's brand identity thru typography, color, and animation: if the placeholder should move, add constraints or change the frame. If the trailing label should display validation information, change the text and color it.
 

--- a/components/TextFields/docs/README.md
+++ b/components/TextFields/docs/README.md
@@ -49,3 +49,7 @@ This pattern is not a delegation or data source-like relationship but rather a c
 - [Color Theming](color-theming.md)
 
 - [Typography Theming](typography-theming.md)
+
+## Accessibility
+
+- [Accessibility](accessibility.md)

--- a/components/TextFields/docs/accessibility.md
+++ b/components/TextFields/docs/accessibility.md
@@ -1,0 +1,30 @@
+### MDCTextField Accessibility
+
+Like UITextFields, MDCTextFields are accessible by default. To best take advantage of their accessibility features
+please review the following recommendations.
+
+#### `-accessibilityValue` Behavior
+
+Similar to UITextFields, MDCTextFields are not accessibility elements themselves. Rather, they are accessibility
+containers whose subviews act as accessibility elements. Such subviews include the MDCTextField's placeholder
+label, the leading and trailing underline labels, and the clear button. The `accessibilityLabels` of these subviews
+contribute to the `accessibilityValue` of the MDCTextField as a whole, giving it a value consistent with that of a
+UITextField in a similar state. If the MDCTextField is empty, it will return a combination of any placeholderLabel text and
+leading underline text. If the MDCTextField is not empty, it will return a combination of the MDCTextField's current text
+and any leading underline text.
+
+#### Using `-accessibilityLabel`
+
+MDCTextField does not provide a custom implementation for `accessibilityLabel`. The client is free to set an
+appropriate `accessibilityLabel` following norms established by Apple if they wish. However, they should consider
+whether or not it it will provide information that is superfluous. A common scenario in which an
+`accessibilityLabel` might not be necessary would be an MDCTextField whose leading underline label (a view not
+present in UITextFields) conveys the information that an accessibility label might have otherwise conveyed. For
+example, if an MDCTextField is intended to hold a user's zip code, and the leading underline label's
+`accessibilityLabel` is already "Zip code", setting an `accessibilityLabel` of "Zip code" on the MDCTextField
+may lead to duplicate VoiceOver statements.
+
+#### Using `-accessibilityHint`
+
+In general, Apple advises designing your user interface in such a way that clarification in the form of  an
+`-accessibilityHint` is not needed. However, it is always an option.

--- a/components/TextFields/docs/classes.md
+++ b/components/TextFields/docs/classes.md
@@ -21,21 +21,57 @@ as well as new features:
 
 This is a multi-line text input. It's subclassed from `UIView` with an embedded `UITextView`. It supports all the features of the single-line text field and `UITextView` plus:
 
-* Minimum number of lines
+<ul class="icon-list">
+<li class="icon-list-item icon-list-item">Minimum number of lines</li>
+</ul>
 
-### Text Field Classes: The Controllers
+### Text Input Controller Classes: Recommended
 
-#### Default Text Input Controller
+See [Text Field Styles](./styling) for images and details.
 
-This class holds all the 'magic' logic necessary to make the naturally 'dumb' text field and text view behave with:
+These are the controllers that have been optimized for discoverability and clickability thru rigorous research, design iterations, and user testing. Always try to use one of these first.
 
-- Animations
-- Styles
+#### MDCTextInputControllerFilled
+
+Filled background with underline.
+
+#### MDCTextInputControllerOutlined
+
+Outlined background with no fill.
+
+#### MDCTextInputControllerOutlinedTextArea
+
+Nearly identical to `MDCTextInputControllerOutlined` but with two differences:
+
+- Intended only for multi-line text fields that remain expanded when empty
+- The floating placeholder does not cross the border but rather floats below it
+
+### Text Input Controller Classes: Cautioned
+
+See [Text Field Styles](./styling) for images and details.
+
+These are the controllers that have performed the worst in user testing or haven't been extensively user tested at all. Use them only if you have to or conduct your own A/B testing against one of the recommended controllers to see if they perform as expected in your application.
+
+#### MDCTextInputControllerFullWidth
+
+Optimized for full width forms like emails. While common in messaging apps, its design hasn't been rigorously tested with users. For now, the Material Design team suggests using this only when another design is impracticle.
+
+#### MDCTextInputControllerUnderline
+
+'Classic' 2014 Material Design text field. This style is still found in many applications and sites but should be considered deprecated. It tested poorly in Material Research's user testing. Use `MDCTextInputControllerFilled` or `MDCTextInputControllerOutlined` instead.
+
+#### MDCTextInputControllerLegacyDefault && MDCTextInputControllerLegacyFullWidth
+
+Soon to be deprecated styles only created and included for backwards compatibility of the library. They have no visual distinction from the other full width and underline controllers but their layout behaves slightly differently.
+
+### Text Input Controller Classes: For Subclassing Only
+
+See [Text Field Styles](./styling) for images and details.
+
+#### MDCTextInputControllerBase
+
+__This class is meant to be subclassed and not used on its own.__ It's a full implementation of the `MDCTextInputControllerFloatingPlaceholder` protocol and holds all the 'magic' logic necessary to make:
+
+- Floating placeholder animations
 - Errors
 - Character counts
-
-- - -
-
-#### Full Width Text Input Controller
-
-Similar to the default text input controller but optimized for full width forms like emails.

--- a/components/TextFields/docs/examples.md
+++ b/components/TextFields/docs/examples.md
@@ -12,7 +12,7 @@ scrollView.addSubview(textFieldFloating)
 textFieldFloating.placeholder = "Full Name"
 textFieldFloating.textView.delegate = self
 
-textFieldControllerFloating = MDCTextInputControllerUnderline(input: textFieldFloating) // Hold on as a property
+textFieldControllerFloating = MDCTextInputControllerUnderline(textInput: textFieldFloating) // Hold on as a property
 ```
 
 #### Objective-C
@@ -42,7 +42,7 @@ textFieldDefaultCharMax.placeholder = "Enter up to 50 characters"
 textFieldDefaultCharMax.textView.delegate = self
 
 // Second the controller is created to manage the text field
-textFieldControllerDefaultCharMax = MDCTextInputControllerUnderline(input: textFieldDefaultCharMax) // Hold on as a property
+textFieldControllerDefaultCharMax = MDCTextInputControllerUnderline(textInput: textFieldDefaultCharMax) // Hold on as a property
 textFieldControllerDefaultCharMax.characterCountMax = 50
 textFieldControllerDefaultCharMax.isFloatingEnabled = false
 ```

--- a/components/TextFields/docs/typography-theming.md
+++ b/components/TextFields/docs/typography-theming.md
@@ -1,6 +1,6 @@
 ### Text Fields Typography Theming
 
-You can theme a text field with your app's typography scheme using the TypographyThemer extension.
+You can theme a text field with your app's typography scheme using the `TypographyThemer` extension.
 
 You must first add the Typography Themer extension to your project:
 

--- a/components/TextFields/docs/usage.md
+++ b/components/TextFields/docs/usage.md
@@ -1,3 +1,3 @@
-A text field that conforms to MDCTextInput can be added to a view hierarchy the same way UITextField and UIView are. But to achieve the animations and presentations defined by the guidelines (floating placeholders, character counts), a controller that conforms to protocol `MDCTextInputController` must be initialized to manage the text field.
+A text field that conforms to `MDCTextInput` can be added to a view hierarchy the same way `UITextField` and `UIView` are. But to achieve the animations and presentations defined by the guidelines (floating placeholders, character counts), a controller that conforms to protocol `MDCTextInputController` must be initialized to manage the text field.
 
 **NOTE:** Expect to interact with _both the text field_ (for the traditional API) _and the controller_ (for changes affecting the presentation and state).


### PR DESCRIPTION
Adds accessibility docs for MDCTextFields.
There are no code examples because my understanding is that the client doesn't actually have to do anything in most cases to achieve adequate accessibility with VoiceOver.
Closes #4325.

I'm a little concerned by how much was deleted from the component's readme when I ran the generate readme script.