### PR TITLE
[Dialogs] make accessibilityPerformEscape honor MDCDialogPresentationController…

### DIFF
--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -22,6 +22,8 @@
 #import "MaterialButtons.h"
 #import "MaterialTypography.h"
 #import "MDCAlertControllerView.h"
+#import "UIViewController+MaterialDialogs.h"
+#import "MDCDialogPresentationController.h"
 #import "private/MDCAlertControllerView+Private.h"
 #import "private/MaterialDialogsStrings.h"
 #import "private/MaterialDialogsStrings_table.h"
@@ -385,8 +387,13 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 #pragma mark - UIAccessibilityAction
 
 - (BOOL)accessibilityPerformEscape {
-  [self.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
-  return YES;
+  MDCDialogPresentationController *dialogPresentationController =
+      self.mdc_dialogPresentationController;
+  if (dialogPresentationController.dismissOnBackgroundTap) {
+    [self.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
+    return YES;
+  }
+  return NO;
 }
 
 @end


### PR DESCRIPTION
One thing I'm not clear on--is it okay to assume that the MDCAlertController's presentationController will always be an MDCDialogPresentationController? This solution only works when it is one

Closes #4259.
Closes #3661.