### PR TITLE
[Buttons] Disable FAB animation for VoiceOver

### DIFF
--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -186,28 +186,30 @@ const CGSize kMinimumAccessibleButtonSize = {64.0, 48.0};
 
 - (void)didTap:(id)sender {
   NSLog(@"%@ was tapped.", NSStringFromClass([sender class]));
-  if (sender == self.floatingButton) {
-    [self.floatingButton
-          collapse:YES
-        completion:^{
-          dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)),
-                         dispatch_get_main_queue(), ^{
-                           [self.floatingButton expand:YES completion:nil];
-                         });
-        }];
+  if (!UIAccessibilityIsVoiceOverRunning()) {
+    if (sender == self.floatingButton) {
+      [self.floatingButton
+            collapse:YES
+          completion:^{
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)),
+                           dispatch_get_main_queue(), ^{
+                             [self.floatingButton expand:YES completion:nil];
+                           });
+          }];
+    }
   }
 }
 
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];
-  if (animated) {
+  if (animated && !UIAccessibilityIsVoiceOverRunning()) {
     [self.floatingButton collapse:NO completion:nil];
   }
 }
 
 - (void)viewDidAppear:(BOOL)animated {
   [super viewDidAppear:animated];
-  if (animated) {
+  if (animated && !UIAccessibilityIsVoiceOverRunning()) {
     [self.floatingButton expand:YES completion:nil];
   }
 }


### PR DESCRIPTION
When VoiceOver is running and the FAB animations for expanding/collapsing are
triggered, sometimes VoiceOver won't detect the FAB. It can still detect the
FAB if the user "scrubs" their finger to discover it, but it's a big problem
if they don't know they're missing a button.  The effect seems intermittent
and this is the best work-around.
