### PR TITLE
[Catalog] Enable AppBar's isTopLayoutGuideAdjustmentEnabled in all examples.

### DIFF
--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -94,6 +94,7 @@ extension UINavigationController {
                                                   to: container.appBar);
     container.appBar.navigationBar.titleAlignment = .center
     container.appBar.navigationBar.titleTextAttributes = [ NSFontAttributeName: appBarFont ]
+    container.isTopLayoutGuideAdjustmentEnabled = true
     MDCAppBarColorThemer.applySemanticColorScheme(AppTheme.globalTheme.colorScheme,
                                                   to: container.appBar)
     // TODO(featherless): Remove once
@@ -104,13 +105,6 @@ extension UINavigationController {
       headerView.trackingScrollView = collectionVC.collectionView
     } else if let scrollView = viewController.view as? UIScrollView {
       headerView.trackingScrollView = scrollView
-    } else {
-      // TODO(chuga): This is bad. We should be adjusting for Safe Area changes.
-      var contentFrame = container.contentViewController.view.frame
-      let headerSize = headerView.sizeThatFits(container.contentViewController.view.frame.size)
-      contentFrame.origin.y = headerSize.height
-      contentFrame.size.height = currentBounds.height - headerSize.height
-      container.contentViewController.view.frame = contentFrame
     }
     return container
   }

--- a/catalog/MDCDragons/MDCDragonsController.swift
+++ b/catalog/MDCDragons/MDCDragonsController.swift
@@ -247,6 +247,7 @@ class MDCDragonsController: UIViewController,
       container.appBar.navigationBar.titleTextAttributes =
         [ NSForegroundColorAttributeName: UIColor.white,
           NSFontAttributeName: UIFont.systemFont(ofSize: 16) ]
+      container.isTopLayoutGuideAdjustmentEnabled = true
       vc.title = nodeData.node.title
       
       let headerView = container.appBar.headerViewController.headerView
@@ -254,12 +255,6 @@ class MDCDragonsController: UIViewController,
         headerView.trackingScrollView = collectionVC.collectionView
       } else if let scrollView = vc.view as? UIScrollView {
         headerView.trackingScrollView = scrollView
-      } else {
-        var contentFrame = container.contentViewController.view.frame
-        let headerSize = headerView.sizeThatFits(container.contentViewController.view.frame.size)
-        contentFrame.origin.y = headerSize.height
-        contentFrame.size.height = self.view.bounds.height - headerSize.height
-        container.contentViewController.view.frame = contentFrame
       }
       vc = container
     }

--- a/components/AppBar/examples/AppBarWrappedExample.m
+++ b/components/AppBar/examples/AppBarWrappedExample.m
@@ -59,6 +59,7 @@
   WrappedDemoViewController *demoVC = [[WrappedDemoViewController alloc] init];
   self.appBarContainerViewController =
       [[MDCAppBarContainerViewController alloc] initWithContentViewController:demoVC];
+  self.appBarContainerViewController.topLayoutGuideAdjustmentEnabled = YES;
 
   [MDCAppBarColorThemer applySemanticColorScheme:self.colorScheme
                                         toAppBar:self.appBarContainerViewController.appBar];

--- a/components/BottomSheet/examples/BottomSheetShapedExample.m
+++ b/components/BottomSheet/examples/BottomSheetShapedExample.m
@@ -38,6 +38,7 @@
   container.preferredContentSize = CGSizeMake(500, 200);
   container.appBar.headerViewController.headerView.trackingScrollView =
       viewController.collectionView;
+  container.topLayoutGuideAdjustmentEnabled = YES;
 
   [MDCAppBarColorThemer applySemanticColorScheme:self.colorScheme toAppBar:container.appBar];
   [MDCAppBarTypographyThemer applyTypographyScheme:self.typographyScheme toAppBar:container.appBar];

--- a/components/BottomSheet/examples/BottomSheetTypicalUseExample.m
+++ b/components/BottomSheet/examples/BottomSheetTypicalUseExample.m
@@ -35,6 +35,7 @@
   container.preferredContentSize = CGSizeMake(500, 200);
   container.appBar.headerViewController.headerView.trackingScrollView =
       viewController.collectionView;
+  container.topLayoutGuideAdjustmentEnabled = YES;
 
   [MDCAppBarColorThemer applySemanticColorScheme:self.colorScheme toAppBar:container.appBar];
   [MDCAppBarTypographyThemer applyTypographyScheme:self.typographyScheme toAppBar:container.appBar];


### PR DESCRIPTION
This enables the new FlexibleHeader/AppBar behavior that correctly updates the content view controller's safe area insets/top layout guide to match the flexible header's height and sets the frame of the content view controller to match the bounds of the container view controller.

This is a continuation of the work initiated in 9707aec0fd0bb5e0fe667439d6246e0d6e5824ce.

As part of this change, we were able to remove the Catalog logic that would manually adjust the frame of examples that did not have a scroll view. Examples are now expected to adjust their content according to the top layout guide / safe area insets, as can be seen in the ButtonsTypicalUse example.

Examples that *do* have a scroll view will also now make use of the correct top layout guide / safe area insets behavior. This behavioral change can most notably be seen in the ActivityIndicator example, which no longer has a 20 point "dead zone" above the table view. Note in the following screenshots that the highlighted frame matches the full bounds in the "after" screenshot, but that it is shifted down in the "before" screenshot.

Before:

<img width="673" alt="screen shot 2018-07-12 at 2 06 57 pm" src="https://user-images.githubusercontent.com/45670/42651305-089180e8-85dd-11e8-9b94-5f9ec289317d.png">

After:

<img width="662" alt="screen shot 2018-07-12 at 2 06 23 pm" src="https://user-images.githubusercontent.com/45670/42651290-fe41864c-85dc-11e8-9078-8f38641fe064.png">
