### PR TITLE
[TextFields] Fix clear button render scale

### DIFF
--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -641,7 +641,6 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   UIGraphicsEndImageContext();
 
   image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-  NSLog(@"%@", NSStringFromCGSize(image.size));
   return image;
 }
 

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -632,9 +632,8 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   CGSize clearButtonSize = CGSizeMake(MDCTextInputClearButtonImageSquareWidthHeight,
                                       MDCTextInputClearButtonImageSquareWidthHeight);
 
-  CGFloat scale = [UIScreen mainScreen].scale;
-  CGRect bounds = CGRectMake(0, 0, clearButtonSize.width * scale, clearButtonSize.height * scale);
-  UIGraphicsBeginImageContextWithOptions(bounds.size, false, scale);
+  CGRect bounds = CGRectMake(0, 0, clearButtonSize.width, clearButtonSize.height);
+  UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0);
   [UIColor.grayColor setFill];
 
   [MDCPathForClearButtonImageFrame(bounds) fill];
@@ -642,6 +641,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   UIGraphicsEndImageContext();
 
   image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+  NSLog(@"%@", NSStringFromCGSize(image.size));
   return image;
 }
 


### PR DESCRIPTION
The clear button rendering code accidentally used the screen scale when
calculating a graphics context size. Instead, it should simply set the scale
of the graphics context and request the size in points.

**Original (iPad Mini 4)**
![mdc-underline-original](https://user-images.githubusercontent.com/1753199/42652448-70c88960-85e0-11e8-8bb0-20dfc1503596.png)

**Fixed (iPad Mini 4)**
![mdc-underline-scalefix](https://user-images.githubusercontent.com/1753199/42652465-7f51e102-85e0-11e8-9017-35e7de9e4f1f.png)

Closes #4538