### PR TITLE
[Buttons] Fix button README

### DIFF
--- a/components/Buttons/README.md
+++ b/components/Buttons/README.md
@@ -49,7 +49,7 @@ many distinct button styles including text buttons, contained buttons, and float
   - [Theming](#theming)
   - [Color Theming](#color-theming)
   - [Typography Theming](#typography-theming)
-- [Accessibility {a11y}](#accessibility-{a11y})
+- [Accessibility](#accessibility)
   - [Set `-accessibilityLabel`](#set-`-accessibilitylabel`)
   - [Minimum touch size](#minimum-touch-size)
 
@@ -425,10 +425,9 @@ id<MDCTypographyScheming> typographyScheme = [[MDCTypographyScheme alloc] init];
 <!--</div>-->
 
 
-## Accessibility {#a11y}
 <!-- Extracted from docs/accessibility.md -->
 
-## Accessibility {a11y}
+## Accessibility
 
 To help ensure your buttons are accessible to as many users as possible, please
 be sure to review the following recommendations:

--- a/components/Buttons/docs/README.md
+++ b/components/Buttons/docs/README.md
@@ -36,5 +36,4 @@ elevation, Material Design ripples, and other stateful design APIs.
 - [Color Theming](color-theming.md)
 - [Typography Theming](typography-theming.md)
 
-## Accessibility {#a11y}
 - [Accessibility](accessibility.md)

--- a/components/Buttons/docs/accessibility.md
+++ b/components/Buttons/docs/accessibility.md
@@ -1,4 +1,4 @@
-## Accessibility {a11y}
+## Accessibility
 
 To help ensure your buttons are accessible to as many users as possible, please
 be sure to review the following recommendations:


### PR DESCRIPTION
Remove the duplicate heading for the accessibility section of the README and remove the {a11y} tag.
Closes #4545 
