### PR TITLE
[ProgressView] Don't post accessibility notification on -setHidden:

### DIFF
--- a/components/ProgressView/src/MDCProgressView.m
+++ b/components/ProgressView/src/MDCProgressView.m
@@ -146,11 +146,6 @@ static const NSTimeInterval MDCProgressViewAnimationDuration = 0.25;
                    completion:userCompletion];
 }
 
-- (void)setHidden:(BOOL)hidden {
-  [super setHidden:hidden];
-  UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, hidden ? nil : self);
-}
-
 - (void)setHidden:(BOOL)hidden
          animated:(BOOL)animated
        completion:(void (^__nullable)(BOOL finished))userCompletion {


### PR DESCRIPTION
MDCProgressView posts accessibility notifications in two scenarios: when it's `progress` property changes and when `-setHidden:` is called. UIProgressView only posts one when `progress` changes, not when it's hidden/unhidden. I spoke with Sid and he recommended making the two more similar by getting rid of the `-setHidden:` announcement. 

Closes #4307 