### PR TITLE
Remove useFlexibleTopBottomInsets from MDCNavigationBar

### DIFF
--- a/components/AppBar/examples/AppBarPresentedExample.m
+++ b/components/AppBar/examples/AppBarPresentedExample.m
@@ -54,8 +54,6 @@
   _appBar.headerViewController.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorEnabled;
   [_appBar.headerViewController.headerView hideViewWhenShifted:_appBar.headerStackView];
 
-  _appBar.navigationBar.useFlexibleTopBottomInsets = YES;
-
   [MDCAppBarColorThemer applySemanticColorScheme:self.colorScheme
                                         toAppBar:_appBar];
   [MDCAppBarTypographyThemer applyTypographyScheme:self.typographyScheme

--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -288,23 +288,4 @@ IB_DESIGNABLE
 /** The text alignment of the navigation bar title. Defaults to NSTextAlignmentLeft. */
 @property(nonatomic) NSTextAlignment textAlignment __deprecated_msg("Use titleAlignment instead.");
 
-/**
- Makes the navigation bar use flexible top and bottom insets for buttons and titles, by vertically
- positioning them based on the height of the navigation bar.
-
- When set to NO, vertical insets do not allow the height of the navigation bar to be set to anything
- less than 56.0f, and titleView occupies the entire vertical space in MDCNavigationBar, regardless
- of the height and position of button bars.
-
- When set to YES, the titleView is aligned with the button bars and has the same height as them,
- regardless of the height of the navigation bar. This allows vertically aligning the content of the
- titleView with the buttons, by vertically centering the content of the titleView.
-
- Default is YES.
-
- NOTE: This property will be removed soon.
- */
-@property(nonatomic) BOOL useFlexibleTopBottomInsets
-    __deprecated_msg("Implement proper vertical alignment with the default YES behavior.");
-
 @end

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -29,8 +29,8 @@ static const NSUInteger kTitleFontSize = 20;
 static const CGFloat kNavigationBarDefaultHeight = 56;
 static const CGFloat kNavigationBarPadDefaultHeight = 64;
 static const CGFloat kNavigationBarMinHeight = 24;
-static const UIEdgeInsets kTextInsets = {16, 16, 16, 16};
-static const UIEdgeInsets kTextPadInsets = {20, 16, 20, 16};
+static const UIEdgeInsets kTextInsets = {0, 16, 0, 16};
+static const UIEdgeInsets kTextPadInsets = {0, 16, 0, 16};
 
 // KVO contexts
 static char *const kKVOContextMDCNavigationBar = "kKVOContextMDCNavigationBar";
@@ -141,7 +141,6 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
 - (void)commonMDCNavigationBarInit {
   _observedNavigationItemLock = [[NSObject alloc] init];
   _titleFont = [MDCTypography titleFont];
-  _useFlexibleTopBottomInsets = YES;
 
   _titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorFill;
   _titleLabel = [[UILabel alloc] init];
@@ -255,13 +254,6 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
   _trailingButtonBar.frame = trailingButtonBarFrame;
 
   UIEdgeInsets textInsets = [self usePadInsets] ? kTextPadInsets : kTextInsets;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  if (self.useFlexibleTopBottomInsets) {
-#pragma clang diagnostic pop
-    textInsets.top = 0;
-    textInsets.bottom = 0;
-  }
 
   // textFrame is used to determine layout of both TitleLabel and TitleView
   CGRect textFrame = UIEdgeInsetsInsetRect(self.bounds, textInsets);
@@ -325,18 +317,13 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
       break;
     }
   }
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  if (self.useFlexibleTopBottomInsets) {
-#pragma clang diagnostic pop
-    // No insets for the titleView, and a height that is the same as the button bars. Clients
-    // can vertically center their titleView subviews to align them with buttons.
-    titleViewFrame.origin.y = 0;
-    CGFloat maxHeight =
-        [self usePadInsets] ? kNavigationBarPadDefaultHeight : kNavigationBarDefaultHeight;
-    CGFloat minHeight = kNavigationBarMinHeight;
-    titleViewFrame.size.height = MIN(MAX(self.bounds.size.height, minHeight), maxHeight);
-  }
+  // No insets for the titleView, and a height that is the same as the button bars. Clients
+  // can vertically center their titleView subviews to align them with buttons.
+  titleViewFrame.origin.y = 0;
+  CGFloat maxHeight =
+      [self usePadInsets] ? kNavigationBarPadDefaultHeight : kNavigationBarDefaultHeight;
+  CGFloat minHeight = kNavigationBarMinHeight;
+  titleViewFrame.size.height = MIN(MAX(self.bounds.size.height, minHeight), maxHeight);
   self.titleView.frame = titleViewFrame;
 
   // Button and title label alignment
@@ -360,12 +347,7 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
 - (CGSize)sizeThatFits:(CGSize)size {
   CGFloat maxHeight =
       [self usePadInsets] ? kNavigationBarPadDefaultHeight : kNavigationBarDefaultHeight;
-  CGFloat minHeight = kNavigationBarMinHeight;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  CGFloat height =
-      self.useFlexibleTopBottomInsets ? MIN(MAX(size.height, minHeight), maxHeight) : maxHeight;
-#pragma clang diagnostic pop
+  CGFloat height = MIN(MAX(size.height, kNavigationBarMinHeight), maxHeight);
   return CGSizeMake(size.width, height);
 }
 
@@ -487,11 +469,7 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
       // the header regardless of the header's height.
       CGFloat maxHeight =
           [self usePadInsets] ? kNavigationBarPadDefaultHeight : kNavigationBarDefaultHeight;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      CGFloat height =
-          self.useFlexibleTopBottomInsets ? MIN(CGRectGetHeight(bounds), maxHeight) : maxHeight;
-#pragma clang diagnostic pop
+      CGFloat height = MIN(CGRectGetHeight(bounds), maxHeight);
       CGFloat navigationBarCenteredY = MDCFloor((height - CGRectGetHeight(frame)) / 2);
       navigationBarCenteredY = MAX(0, navigationBarCenteredY);
       return CGRectMake(CGRectGetMinX(frame), navigationBarCenteredY, CGRectGetWidth(frame),
@@ -515,13 +493,6 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
       MDCButtonBar *leftButtonBar = self.leadingButtonBar;
       MDCButtonBar *rightButtonBar = self.trailingButtonBar;
       UIEdgeInsets textInsets = [self usePadInsets] ? kTextPadInsets : kTextInsets;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      if (self.useFlexibleTopBottomInsets) {
-#pragma clang diagnostic pop
-        textInsets.top = 0;
-        textInsets.bottom = 0;
-      }
       CGFloat titleLeftInset = textInsets.left;
       CGFloat titleRightInset = textInsets.right;
 


### PR DESCRIPTION
Mainline the YES behavior for useFlexibleTopBottomInsets, and remove the already deprecated API.

Closes https://github.com/material-components/material-components-ios/issues/3924