### PR TITLE
[FlexibleHeader] Enforce top layout guide adjustment on pre-iOS 11 devices.

### DIFF
--- a/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
+++ b/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
@@ -54,13 +54,53 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
   self.title = @"Animation Timing";
 
   self.scrollView = [[UIScrollView alloc] initWithFrame:self.view.bounds];
-  self.scrollView.autoresizingMask =
-      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
   self.scrollView.contentSize = CGSizeMake(CGRectGetWidth(self.view.frame),
                                            CGRectGetHeight(self.view.frame) + kTopMargin);
   self.scrollView.clipsToBounds = YES;
   [self.view addSubview:self.scrollView];
+
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    // No need to do anything - additionalSafeAreaInsets will inset our content.
+    self.scrollView.autoresizingMask =
+        UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  } else {
+#endif
+    self.scrollView.translatesAutoresizingMaskIntoConstraints = NO;
+    [NSLayoutConstraint activateConstraints:
+     @[[NSLayoutConstraint constraintWithItem:self.scrollView
+                                    attribute:NSLayoutAttributeTop
+                                    relatedBy:NSLayoutRelationEqual
+                                       toItem:self.topLayoutGuide
+                                    attribute:NSLayoutAttributeBottom
+                                   multiplier:1.0
+                                     constant:0],
+       [NSLayoutConstraint constraintWithItem:self.scrollView
+                                    attribute:NSLayoutAttributeBottom
+                                    relatedBy:NSLayoutRelationEqual
+                                       toItem:self.view
+                                    attribute:NSLayoutAttributeBottom
+                                   multiplier:1.0
+                                     constant:0],
+       [NSLayoutConstraint constraintWithItem:self.scrollView
+                                    attribute:NSLayoutAttributeLeft
+                                    relatedBy:NSLayoutRelationEqual
+                                       toItem:self.view
+                                    attribute:NSLayoutAttributeLeft
+                                   multiplier:1.0
+                                     constant:0],
+       [NSLayoutConstraint constraintWithItem:self.scrollView
+                                    attribute:NSLayoutAttributeRight
+                                    relatedBy:NSLayoutRelationEqual
+                                       toItem:self.view
+                                    attribute:NSLayoutAttributeRight
+                                   multiplier:1.0
+                                     constant:0]
+       ]];
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  }
+#endif
 
   CGFloat lineSpace = (CGRectGetHeight(self.view.frame) - 50.f) / 5.f;
   UILabel *linearLabel = [AnimationTimingExample curveLabelWithTitle:@"Linear"];

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -39,6 +39,10 @@ static NSString *const MDCFlexibleHeaderViewControllerHeaderViewKey =
 static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
     @"MDCFlexibleHeaderViewControllerLayoutDelegateKey";
 
+// KVO contexts
+static char *const kKVOContextMDCFlexibleHeaderViewController =
+    "kKVOContextMDCFlexibleHeaderViewController";
+
 @interface MDCFlexibleHeaderViewController () <MDCFlexibleHeaderViewDelegate>
 
 /**
@@ -51,13 +55,20 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
 
 /**
  The NSLayoutConstraint attached to the flexible header view controller's parentViewController's
- topLayoutGuide.
+ topLayoutGuide. We need to strongly hold it in order to de-register KVO events.
 */
-@property(nonatomic, weak) NSLayoutConstraint *topLayoutGuideConstraint;
+@property(nonatomic, strong) NSLayoutConstraint *topLayoutGuideConstraint;
+
+// For avoiding re-entrant recursion while modifying the top layout guide.
+@property(nonatomic) BOOL isUpdatingTopLayoutGuide;
 
 @end
 
 @implementation MDCFlexibleHeaderViewController
+
+- (void)dealloc {
+  self.topLayoutGuideConstraint = nil; // Clear KVO observers
+}
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
   self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
@@ -226,6 +237,33 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
   }
 }
 
+#pragma mark KVO
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary *)change
+                       context:(void *)context {
+  if (context == kKVOContextMDCFlexibleHeaderViewController) {
+    void (^mainThreadWork)(void) = ^{
+      if (object != self->_topLayoutGuideConstraint) {
+        return;
+      }
+
+      [self updateTopLayoutGuide];
+    };
+
+    // Ensure that UIKit modifications occur on the main thread.
+    if ([NSThread isMainThread]) {
+      mainThreadWork();
+    } else {
+      [[NSOperationQueue mainQueue] addOperationWithBlock:mainThreadWork];
+    }
+
+  } else {
+    [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+  }
+}
+
 #pragma mark - Top layout guide support
 
 /*
@@ -242,6 +280,9 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
  undocumented side effect of also updating the topLayoutGuide's length.
  This approach is discussed here:
  https://stackoverflow.com/questions/19588171/how-to-set-toplayoutguide-position-for-child-view-controller
+
+ Also see this open radar feature request for a mutable top layout guide:
+ http://www.openradar.me/19984939
  */
 - (void)fhv_extractTopLayoutGuideConstraint {
   UIViewController *topLayoutGuideViewController =
@@ -264,6 +305,44 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
   }
 }
 
+- (void)setTopLayoutGuideConstraint:(NSLayoutConstraint *)topLayoutGuideConstraint {
+  if (_topLayoutGuideConstraint == topLayoutGuideConstraint) {
+    return;
+  }
+
+  /*
+   On pre-iOS 11 devices, the top layout guide's constant gets set by UIKit multiple times on
+   call stacks that we have no influence over, meaning it's easy for our custom top layout guide
+   value to be lost (being reset to UIKit's default of "20" usually). We want to have final say on
+   the value though, so we KVO the property and re-apply our calculated top layout guide any time
+   the top layout guide is modified.
+
+   We only do this on pre-iOS 11 devices because iOS 11 and above are less aggressive about setting
+   the top layout guide constant (and clients should be relying on additionalSafeAreaInsets anyway).
+   */
+  BOOL shouldObserveLayoutGuideConstant = YES;
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    shouldObserveLayoutGuideConstant = NO;
+  }
+#endif
+
+  if (shouldObserveLayoutGuideConstant) {
+    [_topLayoutGuideConstraint removeObserver:self
+                                   forKeyPath:NSStringFromSelector(@selector(constant))
+                                      context:kKVOContextMDCFlexibleHeaderViewController];
+  }
+
+  _topLayoutGuideConstraint = topLayoutGuideConstraint;
+
+  if (shouldObserveLayoutGuideConstant) {
+    [_topLayoutGuideConstraint addObserver:self
+                                forKeyPath:NSStringFromSelector(@selector(constant))
+                                   options:NSKeyValueObservingOptionNew
+                                   context:kKVOContextMDCFlexibleHeaderViewController];
+  }
+}
+
 - (UIViewController *)fhv_topLayoutGuideViewControllerWithFallback {
   UIViewController *topLayoutGuideViewController = self.topLayoutGuideViewController;
   if (!topLayoutGuideViewController) {
@@ -273,6 +352,14 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
 }
 
 - (void)updateTopLayoutGuide {
+  // We observe (using KVO) the top layout guide's constant and re-invoke updateTopLayoutGuide
+  // whenever it changes. We also change the constant in this method. So, to avoid a recursive
+  // infinite loop we bail out early here if we're the ones that initiated the top layout guide
+  // constant change.
+  if (self.isUpdatingTopLayoutGuide) {
+    return;
+  }
+
   if (!self.topLayoutGuideAdjustmentEnabled) {
     // Legacy behavior
     [self.topLayoutGuideConstraint setConstant:self.flexibleHeaderViewControllerHeightOffset];
@@ -286,7 +373,12 @@ static NSString *const MDCFlexibleHeaderViewControllerLayoutDelegateKey =
     [self fhv_extractTopLayoutGuideConstraint];
   }
   CGFloat topInset = CGRectGetMaxY(_headerView.frame);
-  self.topLayoutGuideConstraint.constant = topInset;
+  // Avoid excessive re-calculations.
+  if (self.topLayoutGuideConstraint.constant != topInset) {
+    self.isUpdatingTopLayoutGuide = YES;
+    self.topLayoutGuideConstraint.constant = topInset;
+    self.isUpdatingTopLayoutGuide = NO;
+  }
 
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -353,7 +353,7 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 
 - (void)fhv_setTopLayoutGuideConstraintConstant:(CGFloat)constant {
   self.isUpdatingTopLayoutGuide = YES;
-  self.topLayoutGuideConstraint.constant = self.flexibleHeaderViewControllerHeightOffset;
+  self.topLayoutGuideConstraint.constant = constant;
   self.isUpdatingTopLayoutGuide = NO;
 }
 
@@ -383,7 +383,7 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
   CGFloat topInset = CGRectGetMaxY(_headerView.frame);
   // Avoid excessive re-calculations.
   if (self.topLayoutGuideConstraint.constant != topInset) {
-    [self fhv_setTopLayoutGuideConstraintConstant:self.flexibleHeaderViewControllerHeightOffset];
+    [self fhv_setTopLayoutGuideConstraintConstant:topInset];
   }
 
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -364,7 +364,9 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 
   if (!self.topLayoutGuideAdjustmentEnabled) {
     // Legacy behavior
+    self.isUpdatingTopLayoutGuide = YES;
     [self.topLayoutGuideConstraint setConstant:self.flexibleHeaderViewControllerHeightOffset];
+    self.isUpdatingTopLayoutGuide = NO;
     return;
   }
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -351,6 +351,12 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
   return topLayoutGuideViewController;
 }
 
+- (void)fhv_setTopLayoutGuideConstraintConstant:(CGFloat)constant {
+  self.isUpdatingTopLayoutGuide = YES;
+  self.topLayoutGuideConstraint.constant = self.flexibleHeaderViewControllerHeightOffset;
+  self.isUpdatingTopLayoutGuide = NO;
+}
+
 - (void)updateTopLayoutGuide {
   NSAssert([NSThread isMainThread],
            @"updateTopLayoutGuide must be called from the main thread.");
@@ -364,9 +370,7 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 
   if (!self.topLayoutGuideAdjustmentEnabled) {
     // Legacy behavior
-    self.isUpdatingTopLayoutGuide = YES;
-    [self.topLayoutGuideConstraint setConstant:self.flexibleHeaderViewControllerHeightOffset];
-    self.isUpdatingTopLayoutGuide = NO;
+    [self fhv_setTopLayoutGuideConstraintConstant:self.flexibleHeaderViewControllerHeightOffset];
     return;
   }
 
@@ -379,9 +383,7 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
   CGFloat topInset = CGRectGetMaxY(_headerView.frame);
   // Avoid excessive re-calculations.
   if (self.topLayoutGuideConstraint.constant != topInset) {
-    self.isUpdatingTopLayoutGuide = YES;
-    self.topLayoutGuideConstraint.constant = topInset;
-    self.isUpdatingTopLayoutGuide = NO;
+    [self fhv_setTopLayoutGuideConstraintConstant:self.flexibleHeaderViewControllerHeightOffset];
   }
 
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
@@ -458,7 +460,7 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 
     // We must change the constant of the constraint attached to our parentViewController's
     // topLayoutGuide to trigger the re-layout of its subviews
-    [self.topLayoutGuideConstraint setConstant:self.flexibleHeaderViewControllerHeightOffset];
+    [self fhv_setTopLayoutGuideConstraintConstant:self.flexibleHeaderViewControllerHeightOffset];
   }
 
   [self.layoutDelegate flexibleHeaderViewController:self

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -352,6 +352,8 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 }
 
 - (void)updateTopLayoutGuide {
+  NSAssert([NSThread isMainThread],
+           @"updateTopLayoutGuide must be called from the main thread.");
   // We observe (using KVO) the top layout guide's constant and re-invoke updateTopLayoutGuide
   // whenever it changes. We also change the constant in this method. So, to avoid a recursive
   // infinite loop we bail out early here if we're the ones that initiated the top layout guide


### PR DESCRIPTION
Prior to iOS 11, UIKit will aggressively reset the top layout guide's value to a system default (usually of "20" if there's a status bar). This behavior was overriding our attempts to modify the top layout guide's constant such that it would include the flexible header's height.

Prior to this change - and only on pre-iOS 11 devices - the top layout guide was not being adjusted to include the flexible header's height. This meant that view controllers that relied on the top layout guide would lay out correctly on iOS 11 and above, but incorrectly on pre-iOS 11 devices.

This incorrect behavior can be seen in the AnimationTiming example. Note that the content is being positioned with the top layout guide in mind, but it is still behind the status bar.

![simulator screen shot - iphone 6 - 2018-07-16 at 14 18 00](https://user-images.githubusercontent.com/45670/42777952-9ced2952-8909-11e8-8ed5-a47efb328bad.png)

After this change - and only on pre-iOS 11 devices - the flexible header will observe any changes made to the top layout guide constant and re-set the value to the calculated top layout guide inset. This ensures that the top layout guide adjustment behavior is consistent across our supported iOS versions. This was tested on an iOS 8.1 and iOS 10.3.1 simulator.

After this change, the AnimationTiming example correctly positions its content on pre-iOS 11 devices:

![simulator screen shot - iphone 6 - 2018-07-16 at 14 19 58](https://user-images.githubusercontent.com/45670/42777995-b9929b50-8909-11e8-984e-2b491154cff8.png)
