### PR TITLE
[FlexibleHeader]! Update top layout behavior to match documentation.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -345,7 +345,7 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 
 - (UIViewController *)fhv_topLayoutGuideViewControllerWithFallback {
   UIViewController *topLayoutGuideViewController = self.topLayoutGuideViewController;
-  if (!topLayoutGuideViewController) {
+  if (!topLayoutGuideViewController && !self.topLayoutGuideAdjustmentEnabled) {
     topLayoutGuideViewController = self.parentViewController;
   }
   return topLayoutGuideViewController;

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
@@ -37,6 +37,26 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
     super.tearDown()
   }
 
+  // MARK: No top layout guide view controller
+
+  func testTopLayoutGuideIsUnaffactedWithNoTopLayoutGuideViewController() {
+    // Given
+    let contentViewController = UIViewController()
+    contentViewController.addChildViewController(fhvc)
+    contentViewController.view.addSubview(fhvc.view)
+    fhvc.isTopLayoutGuideAdjustmentEnabled = true
+    fhvc.topLayoutGuideViewController = nil
+    fhvc.didMove(toParentViewController: contentViewController)
+
+    // Then
+    XCTAssertEqual(contentViewController.topLayoutGuide.length, 0)
+    #if swift(>=3.2)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top, 0)
+    }
+    #endif
+  }
+
   // MARK: No scroll view
 
   func testNoScrollViewTopLayoutGuideEqualsBottomEdgeOfHeaderView() {

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
@@ -26,7 +26,6 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
     super.setUp()
 
     fhvc = MDCFlexibleHeaderViewController()
-    fhvc.isTopLayoutGuideAdjustmentEnabled = true
     fhvc.headerView.minMaxHeightIncludesSafeArea = false
     fhvc.headerView.minimumHeight = 50
     fhvc.headerView.maximumHeight = 100
@@ -45,6 +44,7 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
     let contentViewController = UIViewController()
     contentViewController.addChildViewController(fhvc)
     contentViewController.view.addSubview(fhvc.view)
+    fhvc.topLayoutGuideViewController = contentViewController
     fhvc.didMove(toParentViewController: contentViewController)
 
     // Then
@@ -64,6 +64,7 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
     let contentViewController = UITableViewController()
     contentViewController.addChildViewController(fhvc)
     contentViewController.view.addSubview(fhvc.view)
+    fhvc.topLayoutGuideViewController = contentViewController
     fhvc.didMove(toParentViewController: contentViewController)
 
     // Then
@@ -82,6 +83,7 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
     let contentViewController = UITableViewController()
     contentViewController.addChildViewController(fhvc)
     contentViewController.view.addSubview(fhvc.view)
+    fhvc.topLayoutGuideViewController = contentViewController
     fhvc.didMove(toParentViewController: contentViewController)
 
     // Then
@@ -116,6 +118,7 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
     fhvc.headerView.trackingScrollView = contentViewController.tableView
     contentViewController.addChildViewController(fhvc)
     contentViewController.view.addSubview(fhvc.view)
+    fhvc.topLayoutGuideViewController = contentViewController
     fhvc.didMove(toParentViewController: contentViewController)
     fhvc.headerView.trackingScrollDidScroll()
 
@@ -139,6 +142,7 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
     fhvc.headerView.trackingScrollView = contentViewController.tableView
     contentViewController.addChildViewController(fhvc)
     contentViewController.view.addSubview(fhvc.view)
+    fhvc.topLayoutGuideViewController = contentViewController
     fhvc.didMove(toParentViewController: contentViewController)
     fhvc.headerView.trackingScrollDidScroll()
     contentViewController.tableView.contentOffset =
@@ -165,6 +169,7 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
     let contentViewController = UICollectionViewController(collectionViewLayout: flow)
     contentViewController.addChildViewController(fhvc)
     contentViewController.view.addSubview(fhvc.view)
+    fhvc.topLayoutGuideViewController = contentViewController
     fhvc.didMove(toParentViewController: contentViewController)
 
     // Then
@@ -187,6 +192,7 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
     fhvc.headerView.trackingScrollView = contentViewController.collectionView
     contentViewController.addChildViewController(fhvc)
     contentViewController.view.addSubview(fhvc.view)
+    fhvc.topLayoutGuideViewController = contentViewController
     fhvc.didMove(toParentViewController: contentViewController)
     fhvc.headerView.trackingScrollDidScroll()
 
@@ -211,6 +217,7 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
     fhvc.headerView.trackingScrollView = contentViewController.collectionView!
     contentViewController.addChildViewController(fhvc)
     contentViewController.view.addSubview(fhvc.view)
+    fhvc.topLayoutGuideViewController = contentViewController
     fhvc.didMove(toParentViewController: contentViewController)
     fhvc.headerView.trackingScrollDidScroll()
     contentViewController.collectionView!.contentOffset =


### PR DESCRIPTION
The documentation for topLayoutGuideAdjustmentEnabled indicates that if the property is enabled and topLayoutGuideViewController is nil, then no view controller layout guide will be modified.

Prior to this change, this was not the case. If topLayoutGuideAdjustmentEnabled was enabled and topLayoutGuideViewController set to nil, the parent view controller of the flexible header view controller was being inferred as the top layout guide view controller.

After this change, when topLayoutGuideAdjustmentEnabled and topLayoutGuideViewController is nil, no view controller's top layout guide will be adjusted.

Breaking behavior
-----------------

This is a breaking behavioral change for clients that had enabled topLayoutGuideAdjustmentEnabled on MDCFlexibleHeaderViewController. To address the breakage, clients must explicitly set a topLayoutGuideViewController.