### PR TITLE
[Pesto] Update minimum height so that it includes the safe area. 

### DIFF
--- a/demos/Pesto/Pesto/PestoCollectionViewController.h
+++ b/demos/Pesto/Pesto/PestoCollectionViewController.h
@@ -24,7 +24,7 @@
 
 @optional
 
-- (void)didSelectCell:(PestoCardCollectionViewCell *)cell completion:(void (^)())completionBlock;
+- (void)didSelectCell:(PestoCardCollectionViewCell *)cell completion:(void (^)(void))completionBlock;
 
 @end
 

--- a/demos/Pesto/Pesto/PestoCollectionViewController.m
+++ b/demos/Pesto/Pesto/PestoCollectionViewController.m
@@ -26,9 +26,9 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 static CGFloat kPestoCollectionViewControllerAnimationDuration = 0.33f;
 static CGFloat kPestoCollectionViewControllerCellHeight = 300.f;
-static CGFloat kPestoCollectionViewControllerDefaultHeaderHeight = 240.f;
+static CGFloat kPestoCollectionViewControllerDefaultHeaderHeight = 220.f;
 static CGFloat kPestoCollectionViewControllerInset = 5.f;
-static CGFloat kPestoCollectionViewControllerSmallHeaderHeight = 76.f;
+static CGFloat kPestoCollectionViewControllerSmallHeaderHeight = 56.f;
 
 @interface PestoCollectionViewController ()
 
@@ -207,6 +207,8 @@ static CGFloat kPestoCollectionViewControllerSmallHeaderHeight = 76.f;
   headerView.trackingScrollView = self.collectionView;
   headerView.maximumHeight = kPestoCollectionViewControllerDefaultHeaderHeight;
   headerView.minimumHeight = kPestoCollectionViewControllerSmallHeaderHeight;
+  headerView.minMaxHeightIncludesSafeArea = NO;
+
   [headerView addSubview:[self pestoHeaderView]];
 
   // Use a custom shadow under the flexible header.

--- a/demos/Pesto/Pesto/PestoViewController.m
+++ b/demos/Pesto/Pesto/PestoViewController.m
@@ -84,7 +84,7 @@ static CGFloat kPestoInset = 5.f;
 
 #pragma mark - PestoCollectionViewControllerDelegate
 
-- (void)didSelectCell:(PestoCardCollectionViewCell *)cell completion:(void (^)())completionBlock {
+- (void)didSelectCell:(PestoCardCollectionViewCell *)cell completion:(void (^)(void))completionBlock {
   self.zoomableView.frame = CGRectMake(
       cell.frame.origin.x, cell.frame.origin.y - self.collectionViewController.scrollOffsetY,
       cell.frame.size.width, cell.frame.size.height - 50.f);


### PR DESCRIPTION
### Thanks for starting a pull request on Material Components!

Fixes: https://github.com/material-components/material-components-ios/issues/4588

### Summary

<img width="646" alt="bugfix" src="https://user-images.githubusercontent.com/1971582/42869662-b27201c8-8ab0-11e8-8fbe-5c157381f24f.png">

### Justification

The functionality to account for the safe area already exists in the components (`minMaxHeightIncludesSafeArea`) so it can be fixed in the sample itself and does not seem to require a fix in the components themselves.

It is recommended, as per the documentation, to set this value to `NO` for clients:
https://github.com/material-components/material-components-ios/blob/f11269ad6b15cb50f9b137a4a0ff7512058166da/components/FlexibleHeader/src/MDCFlexibleHeaderView.h#L325

Also, the other sample `Shrine` sets the value to `NO` as well:
https://github.com/material-components/material-components-ios/blob/7d38b9a3ebe0d20a14794abce57f0e37b116e58c/demos/Shrine/Shrine/ShrineCollectionViewController.swift#L136

#### Don't forget:
- [x] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [x] Link to GitHub issues it solves. ```closes #1234```
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
pull request.
