### PR TITLE
[FlexibleHeader] Fix iPhone X status bar bug when changing orientation.

### DIFF
--- a/components/FlexibleHeader/src/private/MDCStatusBarShifter.m
+++ b/components/FlexibleHeader/src/private/MDCStatusBarShifter.m
@@ -153,8 +153,9 @@ typedef NS_ENUM(NSInteger, MDCStatusBarShifterState) {
   }
 
   // Invalidate the snapshot if our replica view is currently hidden and we're attempting to take
-  // a new snapshot. This handles the case where are on an iPhone X in landscape, shift the status
-  // bar off-screen, then rotate to portrait and drag back down.
+  // a new snapshot. This handles the case where you're running on an iPhone X in landscape, you
+  // hide the header, and then rotate back to portrait. It is at this point that we want to
+  // invalidate the snapshot.
   if (_isChangingInterfaceOrientation && snapshotState == MDCStatusBarShifterStateIsSnapshot) {
     snapshotState = MDCStatusBarShifterStateInvalidSnapshot;
   }

--- a/components/FlexibleHeader/src/private/MDCStatusBarShifter.m
+++ b/components/FlexibleHeader/src/private/MDCStatusBarShifter.m
@@ -53,6 +53,8 @@ typedef NS_ENUM(NSInteger, MDCStatusBarShifterState) {
   // While our snapshot is invalid we have slightly different status bar visibility.
   BOOL _prefersStatusBarHiddenWhileInvalid;
 
+  BOOL _isChangingInterfaceOrientation;
+
   BOOL _prefersStatusBarHidden;
   MDCStatusBarShifterState _snapshotState;
 
@@ -147,6 +149,13 @@ typedef NS_ENUM(NSInteger, MDCStatusBarShifterState) {
   // state.
   if (!_snapshottingEnabled && _snapshotState == MDCStatusBarShifterStateRealStatusBar &&
       snapshotState == MDCStatusBarShifterStateIsSnapshot) {
+    snapshotState = MDCStatusBarShifterStateInvalidSnapshot;
+  }
+
+  // Invalidate the snapshot if our replica view is currently hidden and we're attempting to take
+  // a new snapshot. This handles the case where are on an iPhone X in landscape, shift the status
+  // bar off-screen, then rotate to portrait and drag back down.
+  if (_isChangingInterfaceOrientation && snapshotState == MDCStatusBarShifterStateIsSnapshot) {
     snapshotState = MDCStatusBarShifterStateInvalidSnapshot;
   }
 
@@ -273,10 +282,12 @@ typedef NS_ENUM(NSInteger, MDCStatusBarShifterState) {
 
 - (void)interfaceOrientationWillChange {
   _statusBarReplicaView.hidden = YES;
+  _isChangingInterfaceOrientation = YES;
 }
 
 - (void)interfaceOrientationDidChange {
   _statusBarReplicaView.hidden = NO;
+  _isChangingInterfaceOrientation = NO;
 }
 
 - (void)didMoveToWindow {


### PR DESCRIPTION
Repro steps for the specific behavior:

1. Open MDCDragons in portrait on an iPhone X.
2. Open the Flexible Header -> Configurator demo.
3. Enable status bar shifting.
4. Rotate to landscape.
5. Shift the header off-screen.
6. Rotate back to portrait.
7. Scroll the header back on-screen.

Expected behavior: the status bar shifts back on screen with the flexible header.

Prior to this change, the actual behavior was a buggy screenshot being shown in place of the status bar until the status bar actually became visible again.

After this change, the behavior works as expected.

## Screenshots

Before:

![before](https://user-images.githubusercontent.com/45670/42890182-2d7fd926-8a7a-11e8-86ee-46aebf881f33.gif)

After:

![after](https://user-images.githubusercontent.com/45670/42890665-624f3448-8a7b-11e8-99c3-268996d70b3f.gif)
