### PR TITLE
[Dragons] Allow view controllers to determine status bar visibility/style.

### DIFF
--- a/catalog/MDCDragons/Info.plist
+++ b/catalog/MDCDragons/Info.plist
@@ -40,6 +40,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
This is required for examples that intentionally change the status bar visibility, such as the flexible header configurator.