### PR TITLE
[BottomNavigation] Prevent delayed ink animations

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -400,13 +400,6 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
 
 #pragma mark - Touch handlers
 
-- (void)didTouchDownButton:(UIButton *)button {
-  MDCBottomNavigationItemView *itemView = (MDCBottomNavigationItemView *)button.superview;
-  CGPoint centerPoint = CGPointMake(CGRectGetMidX(itemView.inkView.bounds),
-                                    CGRectGetMidY(itemView.inkView.bounds));
-  [itemView.inkView startTouchBeganAnimationAtPoint:centerPoint completion:nil];
-}
-
 - (void)didTouchUpInsideButton:(UIButton *)button {
   for (NSUInteger i = 0; i < self.items.count; i++) {
     UITabBarItem *item = self.items[i];
@@ -500,9 +493,6 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
 #pragma clang diagnostic pop
 #endif
     itemView.selected = NO;
-    [itemView.button addTarget:self
-                        action:@selector(didTouchDownButton:)
-              forControlEvents:UIControlEventTouchDown];
     [itemView.button addTarget:self
                         action:@selector(didTouchUpInsideButton:)
               forControlEvents:UIControlEventTouchUpInside];

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -50,11 +50,12 @@ static const NSTimeInterval kMDCBottomNavigationItemViewTransitionDuration = 0.1
 static NSString *const kMaterialBottomNavigationBundle = @"MaterialBottomNavigation.bundle";
 static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 
-@interface MDCBottomNavigationItemView ()
+@interface MDCBottomNavigationItemView () <MDCInkViewDelegate>
 
 @property(nonatomic, strong) MDCBottomNavigationItemBadge *badge;
 @property(nonatomic, strong) UIImageView *iconImageView;
 @property(nonatomic, strong) UILabel *label;
+@property(nonatomic, assign) BOOL inkAnimationInProgress;
 
 @end
 
@@ -187,6 +188,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
     _inkView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     _inkView.usesLegacyInkRipple = NO;
     _inkView.clipsToBounds = NO;
+    _inkView.animationDelegate = self;
     [self addSubview:_inkView];
   }
 
@@ -198,6 +200,15 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
     _button.accessibilityValue = self.accessibilityValue;
     [self addSubview:_button];
   }
+}
+
+-(UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+  if ([self pointInside:point withEvent:event] && !self.inkAnimationInProgress) {
+    CGPoint centerPoint = CGPointMake(CGRectGetMidX(_inkView.bounds),
+                                      CGRectGetMidY(_inkView.bounds));
+    [self.inkView startTouchBeganAnimationAtPoint:centerPoint completion:nil];
+  }
+  return [super hitTest:point withEvent:event];
 }
 
 - (void)layoutSubviews {
@@ -430,6 +441,16 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 
 - (NSString *)accessibilityValue {
   return self.button.accessibilityValue;
+}
+
+#pragma mark - MDCInkViewDelegate
+
+-(void)inkAnimationDidEnd:(MDCInkView *)inkView {
+  self.inkAnimationInProgress = NO;
+}
+
+-(void)inkAnimationDidStart:(MDCInkView *)inkView {
+  self.inkAnimationInProgress = YES;
 }
 
 #pragma mark - Resource bundle


### PR DESCRIPTION
The MDCBottomNavigationItemView begins its ink animation with `UIControlEventTouchDown` and stops it on `UIControlEventTouchUpInside`. When the user taps the button these two events happen in quick succession and the ink effect seems pretty normal. Interestingly, when the user taps and holds the button it takes a very long time for the selector associated with `UIControlEventTouchDown` to be called. To make it happen faster and more reliably for both taps and long presses I’m triggering the ink animation in `-hitTest:withEvent:`. Other things I tried include using a gesture recognizer and putting it in `-touchesBegan:withEvent:`. This approach seems good though. 

Here's a gif with some long presses and taps:
![jul-19-2018 16-11-47](https://user-images.githubusercontent.com/8020010/42967684-0c062232-8b6f-11e8-81ae-5723c57256c4.gif)

Closes #4586