### PR TITLE
[FlexibleHeader] Improved height consistency when horizontally paging.

### DIFF
--- a/components/FlexibleHeader/examples/FlexibleHeaderHorizontalPagingExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderHorizontalPagingExample.m
@@ -151,6 +151,7 @@ static const NSUInteger kNumberOfPages = 10;
 - (void)commonMDCFlexibleHeaderViewControllerInit {
   self.fhvc = [[MDCFlexibleHeaderViewController alloc] initWithNibName:nil bundle:nil];
   self.fhvc.headerView.sharedWithManyScrollViews = YES;
+  self.fhvc.headerView.maximumHeight = 200;
   [self addChildViewController:_fhvc];
 }
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1412,6 +1412,14 @@ static BOOL isRunningiOS10_3OrAbove() {
     CGPoint offset = scrollView.contentOffset;
     offset.y = self.trackingScrollView.contentOffset.y;
     scrollView.contentOffset = offset;
+
+  } else if (self.trackingScrollView.contentOffset.y > scrollView.contentOffset.y
+             && scrollView.contentOffset.y < 0) { // Destination is showing an expanded header.
+    // Our header is possibly smaller now than it will be when we move to the new content.
+    // Scroll the new content such that we collapse the header to the current height.
+    CGPoint offset = scrollView.contentOffset;
+    offset.y = MIN(self.trackingScrollView.contentOffset.y, 0);
+    scrollView.contentOffset = offset;
   }
 }
 


### PR DESCRIPTION
This change only affects flexible headers that are being used in a horizontally-paging setting.

Repro steps:
- Open MDCDragons.
- Open the Flexible Header horizontal paging example.
- Scroll the first page down until the header is collapsed.
- Swipe to the next page.

Prior to this changew, the flexible header's height would increase after moving to the new page.
After this change, the flexible header's height will stay collapsed after moving to the new page.

Related to https://github.com/material-components/material-components-ios/issues/3130

### Videos

#### Before

![before](https://user-images.githubusercontent.com/45670/43005764-ced0b02e-8c01-11e8-979f-476e6d465617.gif)

#### After

Note: the video loops, so the header appears to "jump" when the loop restarts:

![after](https://user-images.githubusercontent.com/45670/43005540-31fdc958-8c01-11e8-845a-be9cfa67c0c7.gif)
