### PR TITLE
[BottomAppBar] Fix example

### DIFF
--- a/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseSupplemental.m
+++ b/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseSupplemental.m
@@ -99,7 +99,6 @@ static NSString *const kCellIdentifier = @"cell";
   [MDCAppBarColorThemer applySemanticColorScheme:self.colorScheme toAppBar:_appBar];
   
   self.appBar.headerViewController.headerView.trackingScrollView = self.tableView;
-  self.tableView.delegate = self.appBar.headerViewController;
   
   [self.appBar addSubviewsToParent];
   
@@ -171,6 +170,28 @@ static NSString *const kCellIdentifier = @"cell";
     default:
       break;
   }
+}
+
+#pragma mark - UIScrollViewDelegate
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
+  [self.appBar.headerViewController scrollViewDidScroll:scrollView];
+}
+
+- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
+  [self.appBar.headerViewController scrollViewDidEndDecelerating:scrollView];
+}
+
+- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
+  [self.appBar.headerViewController scrollViewDidEndDragging:scrollView willDecelerate:decelerate];
+}
+
+- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
+                     withVelocity:(CGPoint)velocity
+              targetContentOffset:(inout CGPoint *)targetContentOffset {
+  [self.appBar.headerViewController scrollViewWillEndDragging:scrollView
+                                                 withVelocity:velocity
+                                          targetContentOffset:targetContentOffset];
 }
 
 @end

--- a/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseSupplemental.m
+++ b/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseSupplemental.m
@@ -175,23 +175,32 @@ static NSString *const kCellIdentifier = @"cell";
 #pragma mark - UIScrollViewDelegate
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-  [self.appBar.headerViewController scrollViewDidScroll:scrollView];
+  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
+    [self.appBar.headerViewController.headerView trackingScrollViewDidScroll];
+  }
 }
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
-  [self.appBar.headerViewController scrollViewDidEndDecelerating:scrollView];
+  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
+    [self.appBar.headerViewController.headerView trackingScrollViewDidEndDecelerating];
+  }
 }
 
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
-  [self.appBar.headerViewController scrollViewDidEndDragging:scrollView willDecelerate:decelerate];
+  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
+    [self.appBar.headerViewController.headerView
+     trackingScrollViewDidEndDraggingWillDecelerate:decelerate];
+  }
 }
 
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
                      withVelocity:(CGPoint)velocity
               targetContentOffset:(inout CGPoint *)targetContentOffset {
-  [self.appBar.headerViewController scrollViewWillEndDragging:scrollView
-                                                 withVelocity:velocity
-                                          targetContentOffset:targetContentOffset];
+  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
+    [self.appBar.headerViewController.headerView
+        trackingScrollViewWillEndDraggingWithVelocity:velocity
+                                  targetContentOffset:targetContentOffset];
+  }
 }
 
 @end


### PR DESCRIPTION
The example was not responding to taps to the table cells.  The AppBar needs
to be the `tableView`'s delegate, but so does the example view controller.
Forwarding the `UIScrollViewDelegate` methods to the flexible header view
controller to restore UITableView behavior.
