### PR TITLE
[FlexibleHeader] Fix bug where header disappears when using voiceover

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -984,8 +984,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
       // incorrect scrolling as the scrollview attempts to resolve to a position that will place
       // the header in the center of the scroll. Punting to the next loop prevents this.
       dispatch_async(dispatch_get_main_queue(), ^{
-        self.transform =
-            CGAffineTransformMakeTranslation(0, self.trackingScrollView.contentOffset.y);
+        self.transform = CGAffineTransformMakeTranslation(0, offset.y);
         [self fhv_updateLayout];
       });
     } else {


### PR DESCRIPTION
When using voiceover, we observe that the origin.y value of the header view was set to a negative value, which causes the header view to be placed out of bounds of the screen. We believe that the content offset of self.trackingScrollView was overridden before the block that sets the translation is called. This fix resolves this issue by using the content offset computed outside of the block when setting a translation.
