### PR TITLE
[BottomNavigation] Fix safe area insets on bottom nav example

### DIFF
--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -105,8 +105,8 @@
   self.view.backgroundColor = self.colorScheme.backgroundColor;
 }
 
-- (void)viewWillLayoutSubviews {
-  [super viewWillLayoutSubviews];
+- (void)viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
   [self layoutBottomNavBar];
 }
 


### PR DESCRIPTION
It seems the insets were broken in abae199d7135aaa8ea5ba2d1636e8fd767794285

Ensure the insets are correctly applied in the example by laying out after not before the safe area insets are applied.