### PR TITLE
[FlexibleHeader] Add support for observing the tracking scroll view.

### DIFF
--- a/components/AppBar/examples/AppBarImageryExample.m
+++ b/components/AppBar/examples/AppBarImageryExample.m
@@ -26,6 +26,11 @@
 
 @implementation AppBarImageryExample
 
+- (void)dealloc {
+  // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+  self.appBar.headerViewController.headerView.trackingScrollView = nil;
+}
+
 - (id)init {
   self = [super init];
   if (self) {
@@ -65,18 +70,13 @@
   // Allow the header to show more of the image.
   self.appBar.headerViewController.headerView.maximumHeight = 300;
 
+  // Allows us to avoid forwarding events, but means we can't enable shift behaviors.
+  self.appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = YES;
+
   // Typical use
   self.appBar.headerViewController.headerView.trackingScrollView = self.tableView;
 
-  // Choice: If you do not need to implement any delegate methods and you are not using a
-  //         collection view, you can use the headerViewController as the delegate.
-  // Alternative: See AppBarTypicalUseExample.
-  self.tableView.delegate = self.appBar.headerViewController;
-
   [self.appBar addSubviewsToParent];
-
-  self.tableView.layoutMargins = UIEdgeInsetsZero;
-  self.tableView.separatorInset = UIEdgeInsetsZero;
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
@@ -143,7 +143,6 @@
     cell =
         [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"cell"];
   }
-  cell.layoutMargins = UIEdgeInsetsZero;
   return cell;
 }
 

--- a/components/AppBar/examples/AppBarImageryExample.swift
+++ b/components/AppBar/examples/AppBarImageryExample.swift
@@ -22,6 +22,11 @@ class AppBarImagerySwiftExample: UITableViewController {
   let appBar = MDCAppBar()
   var colorScheme = MDCSemanticColorScheme()
 
+  deinit {
+    // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+    appBar.headerViewController.headerView.trackingScrollView = nil
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -51,8 +56,10 @@ class AppBarImagerySwiftExample: UITableViewController {
     // Allow the header to show more of the image.
     headerView.maximumHeight = 200
 
+    // Allows us to avoid forwarding events, but means we can't enable shift behaviors.
+    headerView.observesTrackingScrollViewScrollEvents = true
+
     headerView.trackingScrollView = self.tableView
-    self.tableView.delegate = appBar.headerViewController
 
     appBar.addSubviewsToParent()
   }
@@ -114,7 +121,6 @@ extension AppBarImagerySwiftExample {
       if cell == nil {
         cell = UITableViewCell(style: .default, reuseIdentifier: "cell")
       }
-      cell!.layoutMargins = UIEdgeInsets.zero
       return cell!
   }
 }

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
@@ -29,6 +29,11 @@
 
 @implementation AppBarInterfaceBuilderExample
 
+- (void)dealloc {
+  // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+  self.appBar.headerViewController.headerView.trackingScrollView = nil;
+}
+
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
   self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
   if (self) {
@@ -57,13 +62,11 @@
   [super viewDidLoad];
 
   [MDCAppBarColorThemer applySemanticColorScheme:self.colorScheme toAppBar:_appBar];
-  
-  self.appBar.headerViewController.headerView.trackingScrollView = self.scrollView;
 
-  // Choice: If you do not need to implement any delegate methods and you are not using a
-  //         collection view, you can use the headerViewController as the delegate.
-  // Alternative: See AppBarTypicalUseExample.
-  self.scrollView.delegate = self.appBar.headerViewController;
+  // Allows us to avoid forwarding events, but means we can't enable shift behaviors.
+  self.appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = YES;
+
+  self.appBar.headerViewController.headerView.trackingScrollView = self.scrollView;
 
   [self.appBar addSubviewsToParent];
 }

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
@@ -23,6 +23,11 @@ class AppBarInterfaceBuilderSwiftExample: UIViewController, UIScrollViewDelegate
   let appBar = MDCAppBar()
   var colorScheme = MDCSemanticColorScheme()
 
+  deinit {
+    // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+    appBar.headerViewController.headerView.trackingScrollView = nil
+  }
+
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     commonAppBarInterfaceBuilderSwiftExampleSetup()
@@ -45,10 +50,11 @@ class AppBarInterfaceBuilderSwiftExample: UIViewController, UIScrollViewDelegate
     super.viewDidLoad()
 
     MDCAppBarColorThemer.applySemanticColorScheme(colorScheme, to: appBar)
-    
-    appBar.headerViewController.headerView.trackingScrollView = scrollView
 
-    scrollView.delegate = appBar.headerViewController
+    // Allows us to avoid forwarding events, but means we can't enable shift behaviors.
+    appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = true
+
+    appBar.headerViewController.headerView.trackingScrollView = scrollView
 
     appBar.addSubviewsToParent()
   }

--- a/components/AppBar/examples/AppBarModalPresentationExample.m
+++ b/components/AppBar/examples/AppBarModalPresentationExample.m
@@ -26,6 +26,11 @@
 
 @implementation AppBarModalPresentationExamplePresented
 
+- (void)dealloc {
+  // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+  self.appBar.headerViewController.headerView.trackingScrollView = nil;
+}
+
 - (instancetype)init {
   self = [super init];
   if (self) {
@@ -50,15 +55,11 @@
 
   [MDCAppBarColorThemer applySemanticColorScheme:self.colorScheme toAppBar:_appBar];
 
-  // UITableViewController's tableView.delegate is self by default. We're setting it here for
-  // emphasis.
-  self.tableView.delegate = self;
+  // Allows us to avoid forwarding events, but means we can't enable shift behaviors.
+  self.appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = YES;
 
   self.appBar.headerViewController.headerView.trackingScrollView = self.tableView;
   [self.appBar addSubviewsToParent];
-
-  self.tableView.layoutMargins = UIEdgeInsetsZero;
-  self.tableView.separatorInset = UIEdgeInsetsZero;
 
   // Add optional navigation items
   self.navigationItem.leftBarButtonItem =
@@ -76,40 +77,6 @@
 
 - (void)dismissSelf {
   [self dismissViewControllerAnimated:YES completion:nil];
-}
-
-#pragma mark - UIScrollViewDelegate
-
-// The following four methods must be forwarded to the tracking scroll view in order to implement
-// the Flexible Header's behavior.
-
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-    [self.appBar.headerViewController.headerView trackingScrollViewDidScroll];
-  }
-}
-
-- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
-  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-    [self.appBar.headerViewController.headerView trackingScrollViewDidEndDecelerating];
-  }
-}
-
-- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
-  if (scrollView == headerView.trackingScrollView) {
-    [headerView trackingScrollViewDidEndDraggingWillDecelerate:decelerate];
-  }
-}
-
-- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
-                     withVelocity:(CGPoint)velocity
-              targetContentOffset:(inout CGPoint *)targetContentOffset {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
-  if (scrollView == headerView.trackingScrollView) {
-    [headerView trackingScrollViewWillEndDraggingWithVelocity:velocity
-                                          targetContentOffset:targetContentOffset];
-  }
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -23,6 +23,11 @@ class AppBarModalPresentationSwiftExamplePresented: UITableViewController {
   let appBar = MDCAppBar()
   var colorScheme = MDCSemanticColorScheme()
 
+  deinit {
+    // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+    appBar.headerViewController.headerView.trackingScrollView = nil
+  }
+
   init() {
     super.init(nibName: nil, bundle: nil)
 
@@ -42,13 +47,12 @@ class AppBarModalPresentationSwiftExamplePresented: UITableViewController {
 
     MDCAppBarColorThemer.applySemanticColorScheme(colorScheme, to: appBar)
 
+    // Allows us to avoid forwarding events, but means we can't enable shift behaviors.
+    appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = true
+
     appBar.headerViewController.headerView.trackingScrollView = self.tableView
-    self.tableView.delegate = appBar.headerViewController
 
     appBar.addSubviewsToParent()
-
-    self.tableView.layoutMargins = UIEdgeInsets.zero
-    self.tableView.separatorInset = UIEdgeInsets.zero
 
     self.navigationItem.rightBarButtonItem =
       UIBarButtonItem(title: "Touch", style: .done, target: nil, action: nil)

--- a/components/AppBar/examples/AppBarPresentedExample.m
+++ b/components/AppBar/examples/AppBarPresentedExample.m
@@ -30,6 +30,11 @@
 
 @implementation PresentedDemoViewController
 
+- (void)dealloc {
+  // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+  self.appBar.headerViewController.headerView.trackingScrollView = nil;
+}
+
 - (id)init {
   UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
   layout.minimumInteritemSpacing = 10.0f;
@@ -51,8 +56,8 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  _appBar.headerViewController.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorEnabled;
-  [_appBar.headerViewController.headerView hideViewWhenShifted:_appBar.headerStackView];
+  // Allows us to avoid forwarding events, but means we can't enable shift behaviors.
+  self.appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = YES;
 
   [MDCAppBarColorThemer applySemanticColorScheme:self.colorScheme
                                         toAppBar:_appBar];
@@ -113,37 +118,6 @@
   sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
   CGRect collectionViewFrame = collectionView.frame;
   return CGSizeMake(collectionViewFrame.size.width/2.f - 14.f, 40.f);
-}
-
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
-  if (scrollView == headerView.trackingScrollView) {
-    [headerView trackingScrollViewDidScroll];
-  }
-}
-
-- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
-  if (scrollView == headerView.trackingScrollView) {
-    [headerView trackingScrollViewDidEndDraggingWillDecelerate:decelerate];
-  }
-}
-
-- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
-  if (scrollView == headerView.trackingScrollView) {
-    [headerView trackingScrollViewDidEndDecelerating];
-  }
-}
-
-- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
-                     withVelocity:(CGPoint)velocity
-              targetContentOffset:(inout CGPoint *)targetContentOffset {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
-  if (scrollView == headerView.trackingScrollView) {
-    [headerView trackingScrollViewWillEndDraggingWithVelocity:velocity
-                                          targetContentOffset:targetContentOffset];
-  }
 }
 
 @end

--- a/components/AppBar/examples/AppBarSectionHeadersExample.m
+++ b/components/AppBar/examples/AppBarSectionHeadersExample.m
@@ -29,6 +29,11 @@
 
 @implementation AppBarSectionHeadersExample
 
+- (void)dealloc {
+  // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+  self.appBar.headerViewController.headerView.trackingScrollView = nil;
+}
+
 - (id)init {
   self = [super init];
   if (self) {
@@ -59,13 +64,11 @@
   // Step 3: Register the App Bar views.
   [self.appBar addSubviewsToParent];
 
-  self.tableView.layoutMargins = UIEdgeInsetsZero;
-
   self.navigationItem.rightBarButtonItem =
-  [[UIBarButtonItem alloc] initWithTitle:@"Right"
-                                   style:UIBarButtonItemStyleDone
-                                  target:nil
-                                  action:nil];
+      [[UIBarButtonItem alloc] initWithTitle:@"Right"
+                                       style:UIBarButtonItemStyleDone
+                                      target:nil
+                                      action:nil];
 }
 
 // Optional step: If you allow the header view to hide the status bar you must implement this
@@ -119,7 +122,6 @@
     cell =
     [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"cell"];
   }
-  cell.layoutMargins = UIEdgeInsetsZero;
   cell.textLabel.text = indexPath.section == 0 ? @"Demo" : @"Example";
   return cell;
 }

--- a/components/AppBar/examples/AppBarTypicalCollectionViewExample.m
+++ b/components/AppBar/examples/AppBarTypicalCollectionViewExample.m
@@ -31,6 +31,11 @@
 @end
 @implementation AppBarTypicalCollectionViewExample
 
+- (void)dealloc {
+  // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+  self.appBar.headerViewController.headerView.trackingScrollView = nil;
+}
+
 - (id)init {
   UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
   layout.minimumInteritemSpacing = 10.0f;
@@ -43,6 +48,7 @@
     // Step 2: Initialize the App Bar and add the headerViewController as a child.
     _appBar = [[MDCAppBar alloc] init];
     [self addChildViewController:_appBar.headerViewController];
+    _appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = YES;
 
     self.colorScheme = [[MDCSemanticColorScheme alloc] init];
     self.typographyScheme = [[MDCTypographyScheme alloc] init];
@@ -103,38 +109,6 @@
   sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
   CGRect collectionViewFrame = collectionView.frame;
   return CGSizeMake(collectionViewFrame.size.width/2.f - 14.f, 40.f);
-}
-
-#pragma mark - UIScrollViewDelegate
-
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
-  if (scrollView == headerView.trackingScrollView) {
-    [headerView trackingScrollViewDidScroll];
-  }
-}
-
-- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
-  if (scrollView == headerView.trackingScrollView) {
-    [headerView trackingScrollViewDidEndDraggingWillDecelerate:decelerate];
-  }
-}
-
-- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
-  if (scrollView == headerView.trackingScrollView) {
-    [headerView trackingScrollViewDidEndDecelerating];
-  }
-}
-- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
-                     withVelocity:(CGPoint)velocity
-              targetContentOffset:(inout CGPoint *)targetContentOffset {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
-  if (scrollView == headerView.trackingScrollView) {
-    [headerView trackingScrollViewWillEndDraggingWithVelocity:velocity
-                                          targetContentOffset:targetContentOffset];
-  }
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {

--- a/components/AppBar/examples/AppBarTypicalUseExample.m
+++ b/components/AppBar/examples/AppBarTypicalUseExample.m
@@ -31,6 +31,11 @@
 
 @implementation AppBarTypicalUseExample
 
+- (void)dealloc {
+  // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+  self.appBar.headerViewController.headerView.trackingScrollView = nil;
+}
+
 - (id)init {
   self = [super init];
   if (self) {
@@ -39,9 +44,6 @@
     // Step 2: Initialize the App Bar and add the headerViewController as a child.
     _appBar = [[MDCAppBar alloc] init];
     [self addChildViewController:_appBar.headerViewController];
-
-    _appBar.headerViewController.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorEnabled;
-    [_appBar.headerViewController.headerView hideViewWhenShifted:_appBar.headerStackView];
 
     _appBar.navigationBar.inkColor = [UIColor colorWithWhite:0.9f alpha:0.1f];
 
@@ -59,15 +61,15 @@
 
   // Need to update the status bar style after applying the theme.
   [self setNeedsStatusBarAppearanceUpdate];
-  
+
+  // Allows us to avoid forwarding events, but means we can't enable shift behaviors.
+  self.appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = YES;
+
   // Recommended step: Set the tracking scroll view.
   self.appBar.headerViewController.headerView.trackingScrollView = self.tableView;
 
   // Step 3: Register the App Bar views.
   [self.appBar addSubviewsToParent];
-
-  self.tableView.layoutMargins = UIEdgeInsetsZero;
-  self.tableView.separatorInset = UIEdgeInsetsZero;
 
   self.navigationItem.rightBarButtonItem =
       [[UIBarButtonItem alloc] initWithTitle:@"Right"
@@ -92,38 +94,6 @@
   [super viewWillAppear:animated];
 
   [self.navigationController setNavigationBarHidden:YES animated:animated];
-}
-
-#pragma mark - UIScrollViewDelegate
-
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
-  if (scrollView == headerView.trackingScrollView) {
-    [headerView trackingScrollViewDidScroll];
-  }
-}
-
-- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
-  if (scrollView == headerView.trackingScrollView) {
-    [headerView trackingScrollViewDidEndDraggingWillDecelerate:decelerate];
-  }
-}
-
-- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
-  if (scrollView == headerView.trackingScrollView) {
-    [headerView trackingScrollViewDidEndDecelerating];
-  }
-}
-- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
-                     withVelocity:(CGPoint)velocity
-              targetContentOffset:(inout CGPoint *)targetContentOffset {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
-  if (scrollView == headerView.trackingScrollView) {
-    [headerView trackingScrollViewWillEndDraggingWithVelocity:velocity
-                                          targetContentOffset:targetContentOffset];
-  }
 }
 
 @end

--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -26,6 +26,11 @@ class AppBarTypicalUseSwiftExample: UITableViewController {
   var colorScheme = MDCSemanticColorScheme()
   var typographyScheme = MDCTypographyScheme()
 
+  deinit {
+    // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+    appBar.headerViewController.headerView.trackingScrollView = nil
+  }
+
   init() {
     super.init(nibName: nil, bundle: nil)
 
@@ -44,15 +49,15 @@ class AppBarTypicalUseSwiftExample: UITableViewController {
 
     MDCAppBarColorThemer.applySemanticColorScheme(colorScheme, to: appBar)
     MDCAppBarTypographyThemer.applyTypographyScheme(typographyScheme, to: appBar)
-    
+
+    // Allows us to avoid forwarding events, but means we can't enable shift behaviors.
+    appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = true
+
     // Recommended step: Set the tracking scroll view.
     appBar.headerViewController.headerView.trackingScrollView = self.tableView
 
     // Step 2: Register the App Bar views.
     appBar.addSubviewsToParent()
-
-    self.tableView.layoutMargins = UIEdgeInsets.zero
-    self.tableView.separatorInset = UIEdgeInsets.zero
 
     self.navigationItem.rightBarButtonItem =
       UIBarButtonItem(title: "Right", style: .done, target: nil, action: nil)
@@ -75,33 +80,6 @@ class AppBarTypicalUseSwiftExample: UITableViewController {
 
     self.navigationController?.setNavigationBarHidden(true, animated: animated)
   }
-
-  override func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    if scrollView == appBar.headerViewController.headerView.trackingScrollView {
-      appBar.headerViewController.headerView.trackingScrollDidScroll()
-    }
-  }
-
-  override func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-    if scrollView == appBar.headerViewController.headerView.trackingScrollView {
-      appBar.headerViewController.headerView.trackingScrollDidEndDecelerating()
-    }
-  }
-
-  override func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-    let headerView = appBar.headerViewController.headerView
-    if scrollView == headerView.trackingScrollView {
-      headerView.trackingScrollDidEndDraggingWillDecelerate(decelerate)
-    }
-  }
-
-  override func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-    let headerView = appBar.headerViewController.headerView
-    if scrollView == headerView.trackingScrollView {
-      headerView.trackingScrollWillEndDragging(withVelocity: velocity, targetContentOffset: targetContentOffset)
-    }
-  }
-
 }
 
 // MARK: Catalog by convention

--- a/components/AppBar/examples/AppBarWithUITableViewController.swift
+++ b/components/AppBar/examples/AppBarWithUITableViewController.swift
@@ -30,6 +30,11 @@ class AppBarWithUITableViewController: UITableViewController {
   var numberOfRows = 50
   var colorScheme = MDCSemanticColorScheme()
 
+  deinit {
+    // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+    appBar.headerViewController.headerView.trackingScrollView = nil
+  }
+
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     self.addChildViewController(appBar.headerViewController)
@@ -47,7 +52,10 @@ class AppBarWithUITableViewController: UITableViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    
+
+    // Allows us to avoid forwarding events, but means we can't enable shift behaviors.
+    appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = true
+
     appBar.addSubviewsToParent()
 
     MDCAppBarColorThemer.applySemanticColorScheme(colorScheme, to: appBar)
@@ -86,35 +94,6 @@ class AppBarWithUITableViewController: UITableViewController {
     numberOfRows += 1
     tableView.endUpdates()
   }
-
-  // MARK: UIScrollViewDelegate
-
-  override func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    if scrollView == appBar.headerViewController.headerView.trackingScrollView {
-      appBar.headerViewController.headerView.trackingScrollDidScroll()
-    }
-  }
-
-  override func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-    if scrollView == appBar.headerViewController.headerView.trackingScrollView {
-      appBar.headerViewController.headerView.trackingScrollDidEndDecelerating()
-    }
-  }
-
-  override func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-    let headerView = appBar.headerViewController.headerView
-    if scrollView == headerView.trackingScrollView {
-      headerView.trackingScrollDidEndDraggingWillDecelerate(decelerate)
-    }
-  }
-
-  override func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-    let headerView = appBar.headerViewController.headerView
-    if scrollView == headerView.trackingScrollView {
-      headerView.trackingScrollWillEndDragging(withVelocity: velocity, targetContentOffset: targetContentOffset)
-    }
-  }
-
 }
 
 extension AppBarWithUITableViewController {

--- a/components/AppBar/examples/AppBarWrappingUITableViewControllerExample.m
+++ b/components/AppBar/examples/AppBarWrappingUITableViewControllerExample.m
@@ -30,6 +30,12 @@
 
 @implementation AppBarWrappingUITableViewControllerExample
 
+- (void)dealloc {
+  // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+  self.appBarContainerViewController.appBar.headerViewController.headerView.trackingScrollView
+      = nil;
+}
+
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
   self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
   if (self) {
@@ -50,13 +56,16 @@
   self.appBarContainerViewController.topLayoutGuideAdjustmentEnabled = YES;
 
   tableViewController.tableView.dataSource = self;
-  tableViewController.tableView.delegate =
-      self.appBarContainerViewController.appBar.headerViewController;
   [tableViewController.tableView registerClass:[UITableViewCell class]
                         forCellReuseIdentifier:@"cell"];
 
-  self.appBarContainerViewController.appBar.headerViewController.headerView.trackingScrollView =
-      tableViewController.tableView;
+  MDCFlexibleHeaderView *headerView =
+      self.appBarContainerViewController.appBar.headerViewController.headerView;
+
+  // Allows us to avoid forwarding events, but means we can't enable shift behaviors.
+  headerView.observesTrackingScrollViewScrollEvents = YES;
+
+  headerView.trackingScrollView = tableViewController.tableView;
 
   [MDCAppBarColorThemer applySemanticColorScheme:self.colorScheme
                                         toAppBar:self.appBarContainerViewController.appBar];

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -122,6 +122,8 @@ IB_DESIGNABLE
 
  Must be called from the trackingScrollView delegate's UIScrollViewDelegate::scrollViewDidScroll:
  implementor.
+
+ @note Do not invoke this method if self.observesTrackingScrollViewScrollEvents is YES.
  */
 - (void)trackingScrollViewDidScroll;
 
@@ -130,6 +132,8 @@ IB_DESIGNABLE
 
  Must be called from the trackingScrollView delegate's
  UIScrollViewDelegate::scrollViewDidEndDragging:willDecelerate: implementor.
+
+ @note Do not invoke this method if self.observesTrackingScrollViewScrollEvents is YES.
  */
 - (void)trackingScrollViewDidEndDraggingWillDecelerate:(BOOL)willDecelerate;
 
@@ -138,6 +142,8 @@ IB_DESIGNABLE
 
  Must be called from the trackingScrollView delegate's
  UIScrollViewDelegate::scrollViewDidEndDecelerating: implementor.
+
+ @note Do not invoke this method if self.observesTrackingScrollViewScrollEvents is YES.
  */
 - (void)trackingScrollViewDidEndDecelerating;
 
@@ -150,6 +156,8 @@ IB_DESIGNABLE
 
  If your scroll view is vertically paging then this method will do nothing. You should also
  disable hidesStatusBarWhenCollapsed.
+
+ @note Do not invoke this method if self.observesTrackingScrollViewScrollEvents is YES.
 
  @return A Boolean value indicating whether the target content offset was modified.
  */
@@ -341,7 +349,13 @@ IB_DESIGNABLE
 
 #pragma mark Behaviors
 
-/** The behavior of the header in response to the user interacting with the tracking scroll view. */
+/**
+ The behavior of the header in response to the user interacting with the tracking scroll view.
+
+ @note If self.observesTrackingScrollViewScrollEvents is YES, then this property can only be
+ MDCFlexibleHeaderShiftBehaviorDisabled. Attempts to set shiftBehavior to any other value if
+ self.observesTrackingScrollViewScrollEvents is YES will result in an assertion being thrown.
+ */
 @property(nonatomic) MDCFlexibleHeaderShiftBehavior shiftBehavior;
 
 /**
@@ -408,6 +422,31 @@ IB_DESIGNABLE
  delegate points to a dead object.
  */
 @property(nonatomic, weak, nullable) UIScrollView *trackingScrollView;
+
+/**
+ Whether to automatically observe the trackingScrollView's content offset changes.
+
+ When enabled, the header view will observe the contentOffset property of the tracking scroll view
+ and react to changes accordingly.
+
+ You must not forward any scroll view events to the header view if this property is enabled. Any
+ attempts to do so will result in an assertion.
+
+ If you attempt to enable this property when shiftBehavior is set to anything other than
+ MDCFlexibleHeaderShiftBehaviorDisabled, an assertion will be thrown. If you intend to use any
+ shifting behavior you must manually forward the necessary scroll view events.
+
+ @note If you enable this property and you support iOS 10.3 or below, you are responsible for
+ explicitly nilling out the tracking scroll view before it is deallocated. This is not required if
+ your minimum OS is iOS 11 or above. Failure to nil out the tracking scroll view may lead to runtime
+ crashes due to dangling observers on the tracking scroll view. Most commonly, the tracking scroll
+ view can be nil'd out in the view controller's dealloc method. An example of the error you might
+ see is: "An instance of class UITableView was deallocated while key value observers were still
+ registered with it."
+
+ Default: NO
+ */
+@property(nonatomic) BOOL observesTrackingScrollViewScrollEvents;
 
 /**
  When enabled, the header view will prioritize shifting off-screen and collapsing over shifting

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -166,7 +166,7 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
   // If there is no tracking scroll view then we have to poke the header into sizing itself.
   if (!_headerView.trackingScrollView) {
     [_headerView sizeToFit];
-  } else {
+  } else if (!_headerView.observesTrackingScrollViewScrollEvents) {
     [_headerView trackingScrollViewDidScroll];
   }
 

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderScrollViewObservationTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderScrollViewObservationTests.swift
@@ -1,0 +1,89 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents.MaterialFlexibleHeader
+
+class FlexibleHeaderScrollViewObservationTests: XCTestCase {
+
+  var fhvc: MDCFlexibleHeaderViewController!
+
+  override func setUp() {
+    super.setUp()
+
+    fhvc = MDCFlexibleHeaderViewController()
+
+    // The behavior we're testing
+    fhvc.headerView.observesTrackingScrollViewScrollEvents = true
+  }
+
+  override func tearDown() {
+    fhvc = nil
+
+    super.tearDown()
+  }
+
+  // MARK: Tracked table view
+
+  func testTrackedTableViewTopContentOffsetIsObserved() {
+    // Given
+    let contentViewController = UITableViewController()
+    contentViewController.tableView.contentSize =
+      CGSize(width: contentViewController.tableView.bounds.width,
+             height: contentViewController.tableView.bounds.height * 2)
+    fhvc.headerView.trackingScrollView = contentViewController.tableView
+    contentViewController.addChildViewController(fhvc)
+    contentViewController.view.addSubview(fhvc.view)
+    fhvc.didMove(toParentViewController: contentViewController)
+
+    // When
+    let overshoot: CGFloat = 10
+    contentViewController.tableView.contentOffset =
+      CGPoint(x: 0, y: -contentViewController.tableView.contentInset.top - overshoot)
+
+    // Then
+    XCTAssertEqual(fhvc.headerView.frame.size.height, fhvc.headerView.maximumHeight + overshoot)
+
+    // Required teardown when observation is enabled on pre-iOS 11 devices
+    fhvc.headerView.trackingScrollView = nil
+  }
+
+  func testTrackedTableViewTopContentOffsetCausesShadowLayerOpacityChange() {
+    // Given
+    let contentViewController = UITableViewController()
+    contentViewController.tableView.contentSize =
+      CGSize(width: contentViewController.tableView.bounds.width,
+             height: contentViewController.tableView.bounds.height * 2)
+    fhvc.headerView.trackingScrollView = contentViewController.tableView
+    contentViewController.addChildViewController(fhvc)
+    contentViewController.view.addSubview(fhvc.view)
+    fhvc.didMove(toParentViewController: contentViewController)
+
+    // When
+    let scrollAmount: CGFloat = fhvc.headerView.maximumHeight
+    contentViewController.tableView.contentOffset =
+      CGPoint(x: 0, y: -contentViewController.tableView.contentInset.top + scrollAmount)
+
+    // Then
+    XCTAssertGreaterThan(fhvc.headerView.layer.shadowOpacity, 0,
+                         "Shadow opacity was expected to be non-zero due to scrolling amount.")
+
+    // Required teardown when observation is enabled on pre-iOS 11 devices
+    fhvc.headerView.trackingScrollView = nil
+  }
+
+}
+


### PR DESCRIPTION
This new opt-in behavior allows a client to more easily integrate the Flexible Header (and relatedly, the App Bar) when they do not require shifting behavior (which is most of the time).

The new behavior can be enabled by setting `observesTrackingScrollViewScrollEvents` to true on the flexible header view instance.

When this property is enabled, the flexible header will no longer allow tracking scroll view events to be manually forwarded, and it will also enforce the shift behavior being set to a disabled state. The intent of this enforcement is to encourage unambiguous usage of the flexible header (you're either allowing it to observe events, or you're forwarding events, but not both).

I've rolled this new behavior out to all of the App Bar examples to demonstrate how much code it removes. I expect this to be a large win for client teams that are integrating with the App Bar.

The underlying implementation of this new behavior relies on KVO of the scroll view's contentOffset property. We manage registration of KVO events through the fhv_startObservingContentOffset and fhv_stopObservingContentOffset APIs.

Prior to iOS 11, the KVO implementation of observers required that you deregister any observers from an object before it is deallocated. As such, if a client wishes to use this behavior and they also support iOS 10.* or below, they must also explicitly nil out the tracking scroll view before it is deallocated. This is required because we keep a weak reference to the tracking scroll view (for a variety of important reasons, namely: avoiding retain cycles and ensuring we don't keep the tracking scroll view alive longer than its owning controller). Because of the weak reference, we can't rely on our own dealloc method being invoked before the tracking scroll view is deallocated. As such, only the client who provided us with a tracking scroll view is capable of making an informed decision as to when to nil out the tracking scroll view. In essence, this behavior comes with a KVO contract (a cost) while providing a much easier integration experience (the benefit).

If a client supports iOS 11 and up, they can simply enable this behavior with no additional code.

Closes https://github.com/material-components/material-components-ios/issues/347