### PR TITLE
[AppBar] Add an inferTopSafeAreaInsetFromViewController behavior.

### DIFF
--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -195,6 +195,9 @@ class MDCNodeListViewController: CBCNodeListViewController {
 
     self.addChildViewController(appBar.headerViewController)
 
+    appBar.inferTopSafeAreaInsetFromViewController = true
+    appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+
     appBar.navigationBar.titleAlignment = .center
     applyColorScheme(AppTheme.globalTheme.colorScheme)
     MDCAppBarTypographyThemer.applyTypographyScheme(

--- a/components/AppBar/examples/AppBarImageryExample.m
+++ b/components/AppBar/examples/AppBarImageryExample.m
@@ -93,6 +93,10 @@
   if (self) {
     _appBar = [[MDCAppBar alloc] init];
 
+    // Behavioral flags.
+    _appBar.inferTopSafeAreaInsetFromViewController = YES;
+    _appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = NO;
+
     self.title = @"Imagery";
 
     [self addChildViewController:_appBar.headerViewController];

--- a/components/AppBar/examples/AppBarImageryExample.swift
+++ b/components/AppBar/examples/AppBarImageryExample.swift
@@ -76,6 +76,10 @@ class AppBarImagerySwiftExample: UITableViewController {
 
     self.title = "Imagery (Swift)"
 
+    // Behavioral flags.
+    appBar.inferTopSafeAreaInsetFromViewController = true
+    appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+
     self.addChildViewController(appBar.headerViewController)
   }
 

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
@@ -54,6 +54,11 @@
 
 - (void)commonAppBarInterfaceBuilderExampleSetup {
   self.appBar = [[MDCAppBar alloc] init];
+
+  // Behavioral flags.
+  self.appBar.inferTopSafeAreaInsetFromViewController = YES;
+  self.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = NO;
+
   self.colorScheme = [[MDCSemanticColorScheme alloc] init];
   [self addChildViewController:self.appBar.headerViewController];
 }

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
@@ -43,6 +43,10 @@ class AppBarInterfaceBuilderSwiftExample: UIViewController, UIScrollViewDelegate
   }
 
   func commonAppBarInterfaceBuilderSwiftExampleSetup() {
+    // Behavioral flags.
+    appBar.inferTopSafeAreaInsetFromViewController = true
+    appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+
     addChildViewController(appBar.headerViewController)
   }
 

--- a/components/AppBar/examples/AppBarModalPresentationExample.m
+++ b/components/AppBar/examples/AppBarModalPresentationExample.m
@@ -36,6 +36,11 @@
   if (self) {
     // Initialize the App Bar and add the headerViewController as a child.
     _appBar = [[MDCAppBar alloc] init];
+
+    // Behavioral flags.
+    _appBar.inferTopSafeAreaInsetFromViewController = YES;
+    _appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = NO;
+
     [self addChildViewController:_appBar.headerViewController];
 
     // Set presentation style

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -33,6 +33,10 @@ class AppBarModalPresentationSwiftExamplePresented: UITableViewController {
 
     self.title = "Modal Presentation (Swift)"
 
+    // Behavioral flags.
+    appBar.inferTopSafeAreaInsetFromViewController = true
+    appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+
     self.addChildViewController(appBar.headerViewController)
     self.modalPresentationStyle = .formSheet
     self.modalTransitionStyle = .coverVertical
@@ -121,9 +125,6 @@ class AppBarModalPresentationSwiftExample: UITableViewController {
     self.tableView.delegate = appBar.headerViewController
 
     appBar.addSubviewsToParent()
-
-    self.tableView.layoutMargins = UIEdgeInsets.zero
-    self.tableView.separatorInset = UIEdgeInsets.zero
 
     self.navigationItem.rightBarButtonItem =
       UIBarButtonItem(title: "Detail", style: .done, target: self, action: #selector(presentModal))

--- a/components/AppBar/examples/AppBarPresentedExample.m
+++ b/components/AppBar/examples/AppBarPresentedExample.m
@@ -45,6 +45,11 @@
     self.title = @"Presented App Bar";
 
     _appBar = [[MDCAppBar alloc] init];
+
+    // Behavioral flags.
+    _appBar.inferTopSafeAreaInsetFromViewController = YES;
+    _appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = NO;
+
     [self addChildViewController:_appBar.headerViewController];
 
     self.colorScheme = [[MDCSemanticColorScheme alloc] init];

--- a/components/AppBar/examples/AppBarSectionHeadersExample.m
+++ b/components/AppBar/examples/AppBarSectionHeadersExample.m
@@ -41,6 +41,11 @@
 
     // Step 2: Initialize the App Bar and add the headerViewController as a child.
     _appBar = [[MDCAppBar alloc] init];
+
+    // Behavioral flags.
+    _appBar.inferTopSafeAreaInsetFromViewController = YES;
+    _appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = NO;
+
     [self addChildViewController:_appBar.headerViewController];
 
     self.colorScheme = [[MDCSemanticColorScheme alloc] init];

--- a/components/AppBar/examples/AppBarTypicalCollectionViewExample.m
+++ b/components/AppBar/examples/AppBarTypicalCollectionViewExample.m
@@ -47,6 +47,11 @@
 
     // Step 2: Initialize the App Bar and add the headerViewController as a child.
     _appBar = [[MDCAppBar alloc] init];
+
+    // Behavioral flags.
+    _appBar.inferTopSafeAreaInsetFromViewController = YES;
+    _appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = NO;
+
     [self addChildViewController:_appBar.headerViewController];
     _appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = YES;
 

--- a/components/AppBar/examples/AppBarTypicalUseExample.m
+++ b/components/AppBar/examples/AppBarTypicalUseExample.m
@@ -43,6 +43,11 @@
 
     // Step 2: Initialize the App Bar and add the headerViewController as a child.
     _appBar = [[MDCAppBar alloc] init];
+
+    // Behavioral flags.
+    _appBar.inferTopSafeAreaInsetFromViewController = YES;
+    _appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = NO;
+
     [self addChildViewController:_appBar.headerViewController];
 
     _appBar.navigationBar.inkColor = [UIColor colorWithWhite:0.9f alpha:0.1f];

--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -36,6 +36,10 @@ class AppBarTypicalUseSwiftExample: UITableViewController {
 
     self.title = "App Bar (Swift)"
 
+    // Behavioral flags.
+    appBar.inferTopSafeAreaInsetFromViewController = true
+    appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+
     // Step 2: Add the headerViewController as a child.
     self.addChildViewController(appBar.headerViewController)
   }

--- a/components/AppBar/examples/AppBarWithUITableViewController.swift
+++ b/components/AppBar/examples/AppBarWithUITableViewController.swift
@@ -37,16 +37,25 @@ class AppBarWithUITableViewController: UITableViewController {
 
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-    self.addChildViewController(appBar.headerViewController)
+    commonInit()
   }
 
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
-    self.addChildViewController(appBar.headerViewController)
+    commonInit()
   }
 
   override init(style: UITableViewStyle) {
     super.init(style: style)
+    commonInit()
+  }
+
+  func commonInit() {
+
+    // Behavioral flags.
+    appBar.inferTopSafeAreaInsetFromViewController = true
+    appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
+
     self.addChildViewController(appBar.headerViewController)
   }
 

--- a/components/AppBar/examples/AppBarWrappedExample.m
+++ b/components/AppBar/examples/AppBarWrappedExample.m
@@ -59,6 +59,11 @@
   WrappedDemoViewController *demoVC = [[WrappedDemoViewController alloc] init];
   self.appBarContainerViewController =
       [[MDCAppBarContainerViewController alloc] initWithContentViewController:demoVC];
+
+  // Behavioral flags.
+  MDCAppBar *appBar = self.appBarContainerViewController.appBar;
+  appBar.inferTopSafeAreaInsetFromViewController = YES;
+  appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = NO;
   self.appBarContainerViewController.topLayoutGuideAdjustmentEnabled = YES;
 
   [MDCAppBarColorThemer applySemanticColorScheme:self.colorScheme

--- a/components/AppBar/examples/AppBarWrappingUITableViewControllerExample.m
+++ b/components/AppBar/examples/AppBarWrappingUITableViewControllerExample.m
@@ -53,6 +53,11 @@
   tableViewController.title = @"Wrapped table view";
   self.appBarContainerViewController =
       [[MDCAppBarContainerViewController alloc] initWithContentViewController:tableViewController];
+
+  // Behavioral flags.
+  MDCAppBar *appBar = self.appBarContainerViewController.appBar;
+  appBar.inferTopSafeAreaInsetFromViewController = YES;
+  appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = NO;
   self.appBarContainerViewController.topLayoutGuideAdjustmentEnabled = YES;
 
   tableViewController.tableView.dataSource = self;

--- a/components/AppBar/src/MDCAppBar.h
+++ b/components/AppBar/src/MDCAppBar.h
@@ -75,4 +75,30 @@
  */
 @property(nonatomic, strong, nonnull, readonly) MDCHeaderStackView *headerStackView;
 
+/**
+ Whether the App Bar should attempt to extract safe area insets from the view controller hierarchy
+ or not.
+
+ This behavior provides better support for App Bars on iPad, extensions, and anywhere else where the
+ view controller might not be directly behind the status bar / device safe area insets.
+
+ Enabling this behavior will do the following:
+
+ - Enable the same-named behavior on the headerViewController's headerView.
+ - Enable the headerViewController's topLayoutGuideAdjustmentEnabled behavior. Consider setting a
+   topLayoutGuideViewController to your content view controller if you want to use topLayoutGuide.
+ - The header stack view's frame will be inset by the flexible header view's topSafeAreaGuide rather
+   than the global device safe area insets.
+
+ Disabling this behavior will not disable headerViewController's topLayoutGuideAdjustmentEnabled
+ behavior.
+
+ This behavior will eventually be enabled by default.
+
+ See MDCFlexibleHeaderViewController's documentation for the API of the same name.
+
+ Default is NO.
+ */
+@property(nonatomic) BOOL inferTopSafeAreaInsetFromViewController;
+
 @end

--- a/components/AppBar/src/MDCAppBar.h
+++ b/components/AppBar/src/MDCAppBar.h
@@ -84,7 +84,7 @@
 
  Enabling this behavior will do the following:
 
- - Enable the same-named behavior on the headerViewController's headerView.
+ - Enable the same-named behavior on the headerViewController.
  - Enable the headerViewController's topLayoutGuideAdjustmentEnabled behavior. Consider setting a
    topLayoutGuideViewController to your content view controller if you want to use topLayoutGuide.
  - The header stack view's frame will be inset by the flexible header view's topSafeAreaGuide rather

--- a/components/AppBar/tests/unit/AppBarWrappingTopLayoutGuideTests.swift
+++ b/components/AppBar/tests/unit/AppBarWrappingTopLayoutGuideTests.swift
@@ -26,6 +26,7 @@ class AppBarWrappingTopLayoutGuideTests: XCTestCase {
     // Given
     let contentViewController = UIViewController()
     let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.appBar.inferTopSafeAreaInsetFromViewController = true
     container.isTopLayoutGuideAdjustmentEnabled = true
     container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
     container.appBar.headerViewController.headerView.minimumHeight = 50
@@ -50,6 +51,7 @@ class AppBarWrappingTopLayoutGuideTests: XCTestCase {
     // Given
     let contentViewController = UIViewController()
     let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.appBar.inferTopSafeAreaInsetFromViewController = true
     container.isTopLayoutGuideAdjustmentEnabled = true
     container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
     container.appBar.headerViewController.headerView.minimumHeight = 50
@@ -76,6 +78,7 @@ class AppBarWrappingTopLayoutGuideTests: XCTestCase {
     // Given
     let contentViewController = UITableViewController()
     let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.appBar.inferTopSafeAreaInsetFromViewController = true
     container.isTopLayoutGuideAdjustmentEnabled = true
     container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
     container.appBar.headerViewController.headerView.minimumHeight = 50
@@ -104,6 +107,7 @@ class AppBarWrappingTopLayoutGuideTests: XCTestCase {
     let contentViewController = UITableViewController()
 
     let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.appBar.inferTopSafeAreaInsetFromViewController = true
     container.isTopLayoutGuideAdjustmentEnabled = true
     container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
     container.appBar.headerViewController.headerView.minimumHeight = 50
@@ -121,8 +125,7 @@ class AppBarWrappingTopLayoutGuideTests: XCTestCase {
     if #available(iOS 11.0, *) {
       XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top, 0)
       XCTAssertEqual(contentViewController.tableView.adjustedContentInset.top,
-                     container.appBar.headerViewController.headerView.maximumHeight
-                      + MDCDeviceTopSafeAreaInset())
+                     container.appBar.headerViewController.headerView.maximumHeight)
     }
     #endif
   }
@@ -135,6 +138,7 @@ class AppBarWrappingTopLayoutGuideTests: XCTestCase {
     let contentViewController = UICollectionViewController(collectionViewLayout: flow)
 
     let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.appBar.inferTopSafeAreaInsetFromViewController = true
     container.isTopLayoutGuideAdjustmentEnabled = true
     container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
     container.appBar.headerViewController.headerView.minimumHeight = 50
@@ -164,6 +168,7 @@ class AppBarWrappingTopLayoutGuideTests: XCTestCase {
     let contentViewController = UICollectionViewController(collectionViewLayout: flow)
 
     let container = MDCAppBarContainerViewController(contentViewController: contentViewController)
+    container.appBar.inferTopSafeAreaInsetFromViewController = true
     container.isTopLayoutGuideAdjustmentEnabled = true
     container.appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
     container.appBar.headerViewController.headerView.minimumHeight = 50
@@ -183,8 +188,7 @@ class AppBarWrappingTopLayoutGuideTests: XCTestCase {
     if #available(iOS 11.0, *) {
       XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top, 0)
       XCTAssertEqual(contentViewController.collectionView!.adjustedContentInset.top,
-                     container.appBar.headerViewController.headerView.maximumHeight
-                      + MDCDeviceTopSafeAreaInset())
+                     container.appBar.headerViewController.headerView.maximumHeight)
     }
     #endif
   }


### PR DESCRIPTION
This behavior enables the similarly-named behavior added to the Flexible Header in bb245597d8895a78c346c76f7d0986d7a993ad12. In addition to allowing the flexible header's min/max height to use the contextual safe area insets, the App Bar will use the flexible header view's top safe area guide to position its header view (rather than using MDCDeviceSafeAreaInsets(), which we want to remove).

This change enables the new behavior in the App Bar examples and in the MDCCatalog node list view controller.

Closes https://github.com/material-components/material-components-ios/issues/4104