### PR TITLE
[AppBar] Add new MDCAppBarNavigationController API. 

### DIFF
--- a/catalog/MDCCatalog/MDCMenuViewController.swift
+++ b/catalog/MDCCatalog/MDCMenuViewController.swift
@@ -90,12 +90,7 @@ class MDCMenuViewController: UITableViewController {
       })
     case 1:
       self.dismiss(animated: true, completion: {
-        let themeViewController = MDCThemePickerViewController()
-        let presentingViewController =
-          UINavigationController.embedExampleWithinAppBarContainer(using: themeViewController,
-                                                                   currentBounds: self.view.bounds,
-                                                                   named: "Themes")
-        navController.pushViewController(presentingViewController, animated: true)
+        navController.pushViewController(MDCThemePickerViewController(), animated: true)
       })
     default:
       self.dismiss(animated: true, completion: nil)

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -240,10 +240,6 @@ class MDCNodeListViewController: CBCNodeListViewController {
     self.navigationController?.setNavigationBarHidden(true, animated: animated)
   }
 
-  override var preferredStatusBarStyle: UIStatusBarStyle {
-    return .lightContent
-  }
-
   func themeDidChange(notification: NSNotification) {
     self.tableView.reloadData()
   }

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -148,7 +148,6 @@ class NodeViewTableViewPrimaryDemoCell: UITableViewCell {
 
 
 class MDCNodeListViewController: CBCNodeListViewController {
-  let appBar = MDCAppBar()
   var mainSectionHeader : UIView?
   var mainSectionHeaderTitleLabel : UILabel?
   var mainSectionHeaderDescriptionLabel : UILabel?
@@ -193,17 +192,6 @@ class MDCNodeListViewController: CBCNodeListViewController {
 
     componentDescription = childrenNodes.first?.exampleDescription() ?? ""
 
-    self.addChildViewController(appBar.headerViewController)
-
-    appBar.inferTopSafeAreaInsetFromViewController = true
-    appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = false
-
-    appBar.navigationBar.titleAlignment = .center
-    applyColorScheme(AppTheme.globalTheme.colorScheme)
-    MDCAppBarTypographyThemer.applyTypographyScheme(
-        AppTheme.globalTheme.typographyScheme,
-        to:appBar)
-
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(self.themeDidChange),
@@ -244,95 +232,20 @@ class MDCNodeListViewController: CBCNodeListViewController {
                             forCellReuseIdentifier: "NodeViewTableViewPrimaryDemoCell")
     self.tableView.register(NodeViewTableViewDemoCell.self,
                             forCellReuseIdentifier: "NodeViewTableViewDemoCell")
-    appBar.headerViewController.headerView.trackingScrollView = self.tableView
-
-    appBar.addSubviewsToParent()
   }
 
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
 
     self.navigationController?.setNavigationBarHidden(true, animated: animated)
-
-    applyColorScheme(AppTheme.globalTheme.colorScheme)
   }
 
-  override var childViewControllerForStatusBarStyle: UIViewController? {
-    return appBar.headerViewController
-  }
-
-  override var childViewControllerForStatusBarHidden: UIViewController? {
-    return appBar.headerViewController
+  override var preferredStatusBarStyle: UIStatusBarStyle {
+    return .lightContent
   }
 
   func themeDidChange(notification: NSNotification) {
-    guard let colorScheme = notification.userInfo?[AppTheme.globalThemeNotificationColorSchemeKey]
-          as? MDCColorScheming else {
-      return
-    }
-    applyColorScheme(colorScheme)
-    applyThemeToCurrentExample()
     self.tableView.reloadData()
-  }
-
-  private func applyColorScheme(_ colorScheme: MDCColorScheming) {
-    MDCAppBarColorThemer.applySemanticColorScheme(colorScheme, to: appBar)
-  }
-
-  func applyThemeToCurrentExample() {
-    // This is a short term solution of applying the theme instantly on the
-    // currently presented example. A better solution would be to re-theme the example's components
-    // and not reload the example entirely with a pop-push.
-    guard let navigationController = self.navigationController else {
-      return
-    }
-    guard let topVC = navigationController.topViewController,
-      topVC is MDCAppBarContainerViewController ||
-        topVC.self.responds(to: NSSelectorFromString("catalogBreadcrumbs")) else {
-          return
-    }
-    navigationController.popViewController(animated: false)
-    guard let selectedNode = selectedNode else {
-      return
-    }
-    let vc = createViewController(from: selectedNode)
-    self.navigationController?.pushViewController(vc, animated: false)
-  }
-}
-
-// MARK: UIScrollViewDelegate
-extension MDCNodeListViewController {
-
-  override func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    if scrollView == appBar.headerViewController.headerView.trackingScrollView {
-      appBar.headerViewController.headerView.trackingScrollDidScroll()
-    }
-  }
-
-  override func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-    if scrollView == appBar.headerViewController.headerView.trackingScrollView {
-      appBar.headerViewController.headerView.trackingScrollDidEndDecelerating()
-    }
-  }
-
-  override func scrollViewDidEndDragging(_ scrollView: UIScrollView,
-                                         willDecelerate decelerate: Bool) {
-    if scrollView == appBar.headerViewController.headerView.trackingScrollView {
-      let headerView = appBar.headerViewController.headerView
-      headerView.trackingScrollDidEndDraggingWillDecelerate(decelerate)
-    }
-  }
-
-  override func scrollViewWillEndDragging(_ scrollView: UIScrollView,
-                                          withVelocity velocity: CGPoint,
-                                          targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-    if scrollView == appBar.headerViewController.headerView.trackingScrollView {
-      let headerView = appBar.headerViewController.headerView
-      headerView.trackingScrollWillEndDragging(
-        withVelocity: velocity,
-        targetContentOffset: targetContentOffset
-      )
-    }
   }
 }
 
@@ -672,18 +585,10 @@ extension MDCNodeListViewController {
   }
 
   func createViewController(from node: CBCNode) -> UIViewController {
-    var vc: UIViewController
     let contentVC = node.createExampleViewController()
     themeExample(vc: contentVC)
-    if contentVC.responds(to: NSSelectorFromString("catalogShouldHideNavigation")) {
-      vc = contentVC
-    } else {
-      self.navigationController?.setMenuBarButton(for: contentVC)
-      vc = UINavigationController.embedExampleWithinAppBarContainer(using: contentVC,
-                                                                    currentBounds: view.bounds,
-                                                                    named: node.title)
-    }
-    return vc
+    self.navigationController?.setMenuBarButton(for: contentVC)
+    return contentVC
   }
 
   func themeExample(vc: UIViewController) {

--- a/components/AppBar/src/MDCAppBarNavigationController.h
+++ b/components/AppBar/src/MDCAppBarNavigationController.h
@@ -1,0 +1,83 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#ifndef MDC_SUBCLASSING_RESTRICTED
+#if defined(__has_attribute) && __has_attribute(objc_subclassing_restricted)
+#define MDC_SUBCLASSING_RESTRICTED __attribute__((objc_subclassing_restricted))
+#else
+#define MDC_SUBCLASSING_RESTRICTED
+#endif
+#endif  // #ifndef MDC_SUBCLASSING_RESTRICTED
+
+@class MDCAppBar;
+@class MDCAppBarNavigationController;
+
+/**
+ Defines the events that an MDCAppBarNavigationController may send to a delegate.
+ */
+@protocol MDCAppBarNavigationControllerDelegate <UINavigationControllerDelegate>
+@optional
+
+/**
+ Informs the receiver that the given App Bar will be added as a child of the given view controller.
+
+ This event is primarily intended to allow any configuration or theming of the App Bar to occur
+ before it becomes part of the view controller hierarchy.
+
+ By the time this event has fired, the navigation controller will already have attempted to infer
+ the tracking scroll view from the provided view controller.
+
+ @note This method will only be invoked if a new App Bar instance is about to be added to the view
+ controller. If a flexible header is already present in the view controller, this method will not
+ be invoked.
+ */
+- (void)appBarNavigationController:(nonnull MDCAppBarNavigationController *)navigationController
+                     willAddAppBar:(nonnull MDCAppBar *)appBar
+           asChildOfViewController:(nonnull UIViewController *)viewController;
+
+@end
+
+/**
+ A custom navigation controller instance that auto-injects App Bar instances into pushed view
+ controllers.
+
+ If a pushed view controller already has an App Bar or a Flexible Header then the navigation
+ controller will not inject a new App Bar.
+
+ To theme the injected App Bar, implement the delegate's
+ -appBarNavigationController:willAddAppBar:asChildOfViewController: API.
+ */
+MDC_SUBCLASSING_RESTRICTED
+@interface MDCAppBarNavigationController : UINavigationController
+
+#pragma mark - Reacting to state changes
+
+/**
+ An extension of the UINavigationController's delegate.
+ */
+@property(nonatomic, weak, nullable) id<MDCAppBarNavigationControllerDelegate> delegate;
+
+#pragma mark - Getting App Bar instances
+
+/**
+ Returns the injected App Bar for a given view controller, if an App Bar was injected.
+ */
+- (nullable MDCAppBar *)appBarForViewController:(nonnull UIViewController *)viewController;
+
+@end
+

--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -1,0 +1,133 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCAppBarNavigationController.h"
+
+#import "MDCAppBar.h"
+
+#import <objc/runtime.h>
+
+@implementation MDCAppBarNavigationController
+
+// We're overriding UINavigationController's delegate solely to change its type (we don't provide
+// a getter or setter implementation), thus the @dynamic.
+@dynamic delegate;
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+  self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+  if (self) {
+    // We always want the navigation bar to be hidden.
+    [self setNavigationBarHidden:YES animated:NO];
+  }
+  return self;
+}
+
+#pragma mark - UINavigationController overrides
+
+// Intercept status bar style inquiries and reroute them to our flexible header view controller.
+- (UIViewController *)childViewControllerForStatusBarStyle {
+  UIViewController *child = [super childViewControllerForStatusBarStyle];
+  MDCAppBar *appBar = [self appBarForViewController:child];
+  if (appBar) {
+    return appBar.headerViewController;
+  }
+  return child; // Fall back to using the child if we didn't knowingly inject an app bar.
+}
+
+// Inject an App Bar, if necessary, when a view controller is pushed.
+- (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated {
+  // We call this invoking super because super immediately queries the pushed view controller for
+  // things like status bar style, which we want to have rerouted to our flexible header view
+  // controller.
+  [self injectAppBarIntoViewController:viewController];
+
+  [super pushViewController:viewController animated:animated];
+}
+
+#pragma mark - Private
+
+- (void)injectAppBarIntoViewController:(UIViewController *)viewController {
+  if ([self appBarForViewController:viewController] != nil) {
+    return; // Already injected.
+  }
+
+  if ([self viewControllerHasFlexibleHeader:viewController]) {
+    return; // Already has a flexible header (not one we injected, but that's ok).
+  }
+
+  MDCAppBar *appBar = [[MDCAppBar alloc] init];
+  [self setAppBar:appBar forViewController:viewController];
+
+  // Ensures that the view controller's top layout guide / additional safe area insets are adjusted
+  // to take into consideration the flexible header's height.
+  appBar.headerViewController.topLayoutGuideViewController = viewController;
+  appBar.headerViewController.inferTopSafeAreaInsetFromViewController = YES;
+  appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = NO;
+  appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = YES;
+
+  // Attempt to infer the tracking scroll view.
+  appBar.headerViewController.headerView.trackingScrollView =
+      [self findFirstInstanceOfUIScrollViewInView:viewController.view];
+
+  if ([self.delegate respondsToSelector:
+       @selector(appBarNavigationController:willAddAppBar:asChildOfViewController:)]) {
+    [self.delegate appBarNavigationController:self
+                                willAddAppBar:appBar
+                      asChildOfViewController:viewController];
+  }
+
+  [viewController addChildViewController:appBar.headerViewController];
+
+  [appBar addSubviewsToParent];
+}
+
+- (BOOL)viewControllerHasFlexibleHeader:(UIViewController *)viewController {
+  // Searching the child view controllers covers both the contained case and the injected-as-a-child
+  // case. MDCFlexibleHeaderViewController can never be a top-level view controller.
+  for (UIViewController *childViewController in viewController.childViewControllers) {
+    if ([childViewController isKindOfClass:[MDCFlexibleHeaderViewController class]]) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
+- (UIScrollView *)findFirstInstanceOfUIScrollViewInView:(UIView *)view {
+  if ([view isKindOfClass:[UIScrollView class]]) {
+    return (UIScrollView *)view;
+  }
+  for (UIView *subview in view.subviews) {
+    UIScrollView *scrollView = [self findFirstInstanceOfUIScrollViewInView:subview];
+    if (scrollView != nil) {
+      return scrollView;
+    }
+  }
+  return nil;
+}
+
+- (MDCAppBar *)appBarForViewController:(UIViewController *)viewController {
+  return (MDCAppBar *)objc_getAssociatedObject(viewController, _cmd);
+}
+
+- (void)setAppBar:(MDCAppBar *)appBar forViewController:(UIViewController *)viewController {
+  objc_setAssociatedObject(viewController,
+                           @selector(appBarForViewController:),
+                           appBar,
+                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+@end
+

--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -70,8 +70,8 @@
 
 // Inject an App Bar, if necessary, when a view controller is pushed.
 - (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated {
-  // We call this invoking super because super immediately queries the pushed view controller for
-  // things like status bar style, which we want to have rerouted to our flexible header view
+  // We call this before invoking super because super immediately queries the pushed view controller
+  // for things like status bar style, which we want to have rerouted to our flexible header view
   // controller.
   [self injectAppBarIntoViewController:viewController];
 

--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -81,10 +81,6 @@
 #pragma mark - Private
 
 - (void)injectAppBarIntoViewController:(UIViewController *)viewController {
-  if ([self appBarForViewController:viewController] != nil) {
-    return; // Already injected.
-  }
-
   if ([self viewControllerHasFlexibleHeader:viewController]) {
     return; // Already has a flexible header (not one we injected, but that's ok).
   }

--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -78,6 +78,22 @@
   [super pushViewController:viewController animated:animated];
 }
 
+- (void)setNavigationBarHidden:(BOOL)navigationBarHidden {
+  // TODO: Consider using this API to hide the top view controller's flexible header.
+  NSAssert(navigationBarHidden, @"%@ requires that the system navigation bar remain hidden.",
+           NSStringFromClass([self class]));
+
+  [super setNavigationBarHidden:YES];
+}
+
+- (void)setNavigationBarHidden:(BOOL)navigationBarHidden animated:(BOOL)animated {
+  // TODO: Consider using this API to hide the top view controller's flexible header.
+  NSAssert(navigationBarHidden, @"%@ requires that the system navigation bar remain hidden.",
+           NSStringFromClass([self class]));
+
+  [super setNavigationBarHidden:YES animated:animated];
+}
+
 #pragma mark - Private
 
 - (void)injectAppBarIntoViewController:(UIViewController *)viewController {

--- a/components/AppBar/src/MaterialAppBar.h
+++ b/components/AppBar/src/MaterialAppBar.h
@@ -16,3 +16,4 @@
 
 #import "MDCAppBar.h"
 #import "MDCAppBarContainerViewController.h"
+#import "MDCAppBarNavigationController.h"

--- a/components/AppBar/tests/unit/AppBarNavigationControllerTests.swift
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerTests.swift
@@ -1,0 +1,109 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents.MaterialAppBar
+
+class AppBarNavigationControllerTests: XCTestCase {
+
+  var navigationController: MDCAppBarNavigationController!
+  override func setUp() {
+    super.setUp()
+
+    navigationController = MDCAppBarNavigationController()
+  }
+
+  func testPushingAViewControllerInjectsAnAppBar() {
+    // Given
+    let viewController = UIViewController()
+
+    // When
+    navigationController.pushViewController(viewController, animated: false)
+
+    // Then
+    XCTAssertEqual(viewController.childViewControllers.count, 1,
+                   "Expected there to be exactly one child view controller added to the view"
+                    + " controller.")
+
+    XCTAssertEqual(navigationController.topViewController, viewController,
+                   "The navigation controller's top view controller is supposed to be the pushed"
+                    + " view controller, but it is \(viewController).")
+
+    XCTAssertTrue(viewController.childViewControllers.first is MDCFlexibleHeaderViewController,
+                  "The injected view controller is not a flexible header view controller, it is"
+                    + "\(String(describing: viewController.childViewControllers.first)) instead.")
+
+    if let headerViewController
+        = viewController.childViewControllers.first as? MDCFlexibleHeaderViewController {
+      XCTAssertEqual(headerViewController.headerView.frame.height,
+                     headerViewController.headerView.maximumHeight)
+    }
+  }
+
+  func testPushingAnAppBarContainerViewControllerDoesNotInjectAnAppBar() {
+    // Given
+    let viewController = UIViewController()
+    let container = MDCAppBarContainerViewController(contentViewController: viewController)
+
+    // When
+    navigationController.pushViewController(container, animated: false)
+
+    // Then
+    XCTAssertEqual(container.childViewControllers.count, 2,
+                   "An App Bar container view controller should have exactly two child view"
+                    + " controllers. A failure of this assertion implies that the navigation"
+                    + " controller may have injected another App Bar.")
+  }
+
+  func testPushingAViewControllerWithAFlexibleHeaderDoesNotInjectAnAppBar() {
+    // Given
+    let viewController = UIViewController()
+    let fhvc = MDCFlexibleHeaderViewController()
+    viewController.addChildViewController(fhvc)
+    viewController.view.addSubview(fhvc.view)
+    fhvc.didMove(toParentViewController: viewController)
+
+    // When
+    navigationController.pushViewController(viewController, animated: false)
+
+    // Then
+    XCTAssertEqual(viewController.childViewControllers.count, 1,
+                   "The navigation controller may have injected another App Bar when it shouldn't"
+                    + " have.")
+  }
+
+  func testStatusBarStyleIsFetchedFromFlexibleHeaderViewController() {
+    // Given
+    let viewController = UIViewController()
+
+    // When
+    navigationController.pushViewController(viewController, animated: false)
+
+    // Then
+    let appBar = navigationController.appBar(for: viewController)
+
+    XCTAssertNotNil(appBar, "Could not retrieve the injected App Bar.")
+
+    if let appBar = appBar {
+      XCTAssertEqual(navigationController.childViewControllerForStatusBarStyle,
+                     appBar.headerViewController,
+                     "The navigation controller should be using the injected app bar's flexible"
+                      + "header view controller for status bar style updates.")
+    }
+  }
+}
+
+


### PR DESCRIPTION
This new API provides a dead-simple integration path for adding an App Bar to an app. I expect this API to be the dominant way for clients to integrate with the App Bar component.

The existing mechanisms of creating an App Bar (injection and wrapping with a container) are still feasible, and both methods can be used interchangeably with the navigation controller. If the navigation controller detects that a flexible header is already present in a pushed view controller it will not add an App Bar.

As part of this change I also explored simply providing a UINavigationControllerDelegate that responded to the willShow event. This approach had the following limitations:

- I did not see a clear path to properly supporting status bar styles. Properly supporting status bar styles requires that somebody, at some point in the hierarchy, is able to route status bar style queries to the flexible header view controller. A delegate lacks this facility.
- The willShow event is fired after the viewWillAppear: event fires, meaning we had to simulate the invocation of this on the injected view controllers. This required that we recursively traverse the App Bar's flexible header view controller and its children (in order to also notify the app bar's internal view controller of the viewWillAppear event). I was concerned that the requirement for this patch would lead to unexpected behavior down the road.

As a result of encountering the above limitations, I pivoted to providing a concrete UINavigationController subclass. I have been hesitant to provide this class for some time because of a very colorful history of supporting similar APIs over the last half decade. At this point, however, I feel that the number of behavioral APIs we've landed allow us to implement the navigation controller with minimal logic, keeping the implementation as simple as possible.

Notably, users of the new app bar navigation controller API will benefit from all injected App Bars having all of the most "modern" APIs enabled because this is a new API. This means that the scroll view's content offset is observed, it respects safe area insets based on the context, and the content view controller's top layout guide / safe area insets accurately reflect the space consumed by the flexible header.

Example usage:

```swift
let navigationController = MDCAppBarNavigationController()
navigationController.pushViewController(viewController, animated: true)
```

If you want to be able to theme the injected App Bar then you'll need to implement the navigation controller's delegate and respond to the willAdd events, like so:

```swift
// MARK: MDCAppBarNavigationControllerInjectorDelegate

func appBarNavigationController(_ navigationController: MDCAppBarNavigationController,
                                willAdd appBar: MDCAppBar,
                                asChildOf viewController: UIViewController) {
  MDCAppBarColorThemer.applySemanticColorScheme(AppTheme.globalTheme.colorScheme, to: appBar)
  MDCAppBarTypographyThemer.applyTypographyScheme(AppTheme.globalTheme.typographyScheme,
                                                  to: appBar)
}
```

Closes https://github.com/material-components/material-components-ios/issues/268