### PR TITLE
[Catalog] Improve Ink demo color contrast

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -261,6 +261,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
+  NSLog(@"Button (%p) touch area: %@", self, NSStringFromCGRect(UIEdgeInsetsInsetRect(CGRectStandardize(self.frame), self.hitAreaInsets)));
   // If there are custom hitAreaInsets, use those
   if (!UIEdgeInsetsEqualToEdgeInsets(self.hitAreaInsets, UIEdgeInsetsZero)) {
     return CGRectContainsPoint(

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -261,7 +261,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
-  NSLog(@"Button (%p) touch area: %@", self, NSStringFromCGRect(UIEdgeInsetsInsetRect(CGRectStandardize(self.frame), self.hitAreaInsets)));
   // If there are custom hitAreaInsets, use those
   if (!UIEdgeInsetsEqualToEdgeInsets(self.hitAreaInsets, UIEdgeInsetsZero)) {
     return CGRectContainsPoint(

--- a/components/Ink/examples/InkTypicalUse.m
+++ b/components/Ink/examples/InkTypicalUse.m
@@ -32,7 +32,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  UIColor *blueColor = [MDCPalette.bluePalette.tint500 colorWithAlphaComponent:0.5f];
+  UIColor *blueColor = MDCPalette.bluePalette.tint500;
   CGFloat spacing = 16;
   CGRect customFrame = CGRectMake(0, 0, 200, 200);
   CGRect legacyFrame = CGRectMake(spacing / 2, spacing / 2, CGRectGetWidth(customFrame) - spacing,

--- a/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
+++ b/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
@@ -21,6 +21,7 @@
 
 #import "InkTypicalUseSupplemental.h"
 
+#import "MaterialPalettes.h"
 #import "MaterialTypography.h"
 
 // A set of UILabels in an variety of shapes to tap on.
@@ -99,7 +100,7 @@
 @implementation InkTypicalUseViewController (Supplemental)
 
 - (void)setupExampleViews {
-  self.view.backgroundColor = [UIColor colorWithWhite:0.5f alpha:1];
+  self.view.backgroundColor = MDCPalette.greyPalette.tint800;
 
   CGRect boundedTitleLabelFrame =
       CGRectMake(0, CGRectGetHeight(self.shapes.frame), CGRectGetWidth(self.shapes.frame), 24);
@@ -107,7 +108,7 @@
   boundedTitleLabel.text = @"Ink";
   boundedTitleLabel.textAlignment = NSTextAlignmentCenter;
   boundedTitleLabel.font = [MDCTypography captionFont];
-  boundedTitleLabel.alpha = [MDCTypography captionFontOpacity];
+  boundedTitleLabel.textColor = UIColor.whiteColor;
   [self.shapes addSubview:boundedTitleLabel];
 
   self.legacyShape.autoresizingMask =
@@ -123,7 +124,7 @@
   legacyTitleLabel.text = @"Legacy Ink";
   legacyTitleLabel.textAlignment = NSTextAlignmentCenter;
   legacyTitleLabel.font = [MDCTypography captionFont];
-  legacyTitleLabel.alpha = [MDCTypography captionFontOpacity];
+  legacyTitleLabel.textColor = UIColor.whiteColor;
   [self.legacyShape addSubview:legacyTitleLabel];
 }
 

--- a/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
+++ b/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
@@ -39,7 +39,7 @@
     CGRect bigViewFrame =
         CGRectMake(padding, padding, CGRectGetWidth(frame) - 2 * padding, bigViewFrameHeight);
     UIView *bigView = [[UIView alloc] initWithFrame:bigViewFrame];
-    bigView.backgroundColor = [UIColor whiteColor];
+    bigView.backgroundColor = MDCPalette.greyPalette.tint800;
     [self addSubview:bigView];
 
     CGFloat buttonViewDim = 50;
@@ -49,7 +49,7 @@
         padding, padding + bigViewFrameHeight + fabPadding + padding,
         frame.size.width - 2 * padding - buttonViewDim - fabPadding * 3, pseudoButtonViewHeight);
     UIView *pseudoButtonView = [[UIView alloc] initWithFrame:pseudoButtonViewFrame];
-    pseudoButtonView.backgroundColor = [UIColor whiteColor];
+    pseudoButtonView.backgroundColor = MDCPalette.greyPalette.tint800;
     pseudoButtonView.layer.cornerRadius = 5;
     pseudoButtonView.clipsToBounds = YES;
     [self addSubview:pseudoButtonView];
@@ -60,7 +60,7 @@
         CGRectMake(pseudoFABViewFrameLeft, padding + bigViewFrameHeight + padding,
                    buttonViewDim + fabPadding, buttonViewDim + fabPadding);
     UIView *pseudoFABView = [[UIView alloc] initWithFrame:pseudoFABViewFrame];
-    pseudoFABView.backgroundColor = [UIColor whiteColor];
+    pseudoFABView.backgroundColor = MDCPalette.greyPalette.tint800;
     pseudoFABView.layer.cornerRadius = 28;
     pseudoFABView.clipsToBounds = YES;
     [self addSubview:pseudoFABView];
@@ -100,7 +100,7 @@
 @implementation InkTypicalUseViewController (Supplemental)
 
 - (void)setupExampleViews {
-  self.view.backgroundColor = MDCPalette.greyPalette.tint800;
+  self.view.backgroundColor = UIColor.whiteColor;
 
   CGRect boundedTitleLabelFrame =
       CGRectMake(0, CGRectGetHeight(self.shapes.frame), CGRectGetWidth(self.shapes.frame), 24);
@@ -108,13 +108,14 @@
   boundedTitleLabel.text = @"Ink";
   boundedTitleLabel.textAlignment = NSTextAlignmentCenter;
   boundedTitleLabel.font = [MDCTypography captionFont];
-  boundedTitleLabel.textColor = UIColor.whiteColor;
+  boundedTitleLabel.textColor = MDCPalette.greyPalette.tint800;
   [self.shapes addSubview:boundedTitleLabel];
 
   self.legacyShape.autoresizingMask =
       UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |
       UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleRightMargin;
-  self.legacyShape.backgroundColor = [UIColor whiteColor];
+
+  self.legacyShape.backgroundColor = MDCPalette.greyPalette.tint800;
 
   CGRect legacyTitleLabelFrame = CGRectMake(0,
                                             CGRectGetHeight(self.legacyShape.frame),
@@ -124,7 +125,7 @@
   legacyTitleLabel.text = @"Legacy Ink";
   legacyTitleLabel.textAlignment = NSTextAlignmentCenter;
   legacyTitleLabel.font = [MDCTypography captionFont];
-  legacyTitleLabel.textColor = UIColor.whiteColor;
+  legacyTitleLabel.textColor = MDCPalette.greyPalette.tint800;
   [self.legacyShape addSubview:legacyTitleLabel];
 }
 

--- a/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
+++ b/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
@@ -108,7 +108,7 @@
   boundedTitleLabel.text = @"Ink";
   boundedTitleLabel.textAlignment = NSTextAlignmentCenter;
   boundedTitleLabel.font = [MDCTypography captionFont];
-  boundedTitleLabel.textColor = MDCPalette.greyPalette.tint800;
+  boundedTitleLabel.alpha = [MDCTypography captionFontOpacity];
   [self.shapes addSubview:boundedTitleLabel];
 
   self.legacyShape.autoresizingMask =
@@ -125,7 +125,7 @@
   legacyTitleLabel.text = @"Legacy Ink";
   legacyTitleLabel.textAlignment = NSTextAlignmentCenter;
   legacyTitleLabel.font = [MDCTypography captionFont];
-  legacyTitleLabel.textColor = MDCPalette.greyPalette.tint800;
+  legacyTitleLabel.alpha = [MDCTypography captionFontOpacity];
   [self.legacyShape addSubview:legacyTitleLabel];
 }
 


### PR DESCRIPTION
The Ink example's color contrast ratios were too low to pass WCAG 2.1 AA-level
contrast requirements. Specifically the blue-on-white (Ink ripple effect) and
dark grey on light grey (text) were too low.  Switching to using the MDC
Palettes instead of custom colors.

**Before**
![ink-contrast-before](https://user-images.githubusercontent.com/1753199/43405864-dbf1d8d4-93e8-11e8-9342-466d466abb0a.png)

**After**
![ink-contrast-after](https://user-images.githubusercontent.com/1753199/43406137-978a6d9a-93e9-11e8-9b32-52632432a306.png)



Related to #4506
