### PR TITLE
[Chips] Allow clients to set `accessibilityLabel` on MDCChipView

### DIFF
--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -513,7 +513,15 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 }
 
 - (NSString *)accessibilityLabel {
-  return self.titleLabel.accessibilityLabel ?: self.titleLabel.text;
+  NSString *accessibilityLabel = [super accessibilityLabel];
+  if (accessibilityLabel.length > 0) {
+    return accessibilityLabel;
+  }
+  accessibilityLabel = self.titleLabel.accessibilityLabel;
+  if (accessibilityLabel.length > 0) {
+    return accessibilityLabel;
+  }
+  return self.titleLabel.text;
 }
 
 - (void)updateState {

--- a/components/Chips/tests/unit/ChipAccessibilityTests.m
+++ b/components/Chips/tests/unit/ChipAccessibilityTests.m
@@ -86,4 +86,21 @@
   XCTAssertNotEqual(chip.accessibilityTraits & UIAccessibilityTraitSelected, UIAccessibilityTraitSelected, @"Chip accessibility should be de-selected when disabled & highlighted");
 }
 
+- (void)testAccessibilityLabel_default {
+  chip.titleLabel.text = @"Title";
+  XCTAssertEqualObjects(chip.accessibilityLabel, @"Title");
+}
+
+- (void)testAccessibilityLabel_setTitleLabelAccessibilityLabel {
+  chip.titleLabel.text = @"Title";
+  chip.titleLabel.accessibilityLabel = @"Accessibility Title";
+  XCTAssertEqualObjects(chip.accessibilityLabel, @"Accessibility Title");
+}
+
+- (void)testAccessibilityLabel_setAccessibilityLabel {
+  chip.titleLabel.text = @"Title";
+  chip.accessibilityLabel = @"Accessibility Title";
+  XCTAssertEqualObjects(chip.accessibilityLabel, @"Accessibility Title");
+}
+
 @end

--- a/components/Chips/tests/unit/ChipAccessibilityTests.m
+++ b/components/Chips/tests/unit/ChipAccessibilityTests.m
@@ -87,19 +87,29 @@
 }
 
 - (void)testAccessibilityLabel_default {
+  // When
   chip.titleLabel.text = @"Title";
+
+  // Then
   XCTAssertEqualObjects(chip.accessibilityLabel, @"Title");
 }
 
 - (void)testAccessibilityLabel_setTitleLabelAccessibilityLabel {
+  // When
   chip.titleLabel.text = @"Title";
   chip.titleLabel.accessibilityLabel = @"Accessibility Title";
+
+  // Then
   XCTAssertEqualObjects(chip.accessibilityLabel, @"Accessibility Title");
 }
 
 - (void)testAccessibilityLabel_setAccessibilityLabel {
+  // When
   chip.titleLabel.text = @"Title";
+  chip.titleLabel.accessibilityLabel = @"Label accessibility title";
   chip.accessibilityLabel = @"Accessibility Title";
+
+  // Then
   XCTAssertEqualObjects(chip.accessibilityLabel, @"Accessibility Title");
 }
 


### PR DESCRIPTION
Allow clients to set `accessibilityLabel` on MDCChipView, instead of ignoring any value they set.

This was broken by: #4399