### PR TITLE
[BottomNavigation] Add support for custom text color on badge label - WIP

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -142,6 +142,10 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarAlignment) {
  */
 @property(nonatomic, assign) CGFloat itemsContentHorizontalMargin;
 
+@end
+
+@interface UITabBarItem ()
+
 /**
  Color of the text represented in the badge
  */

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -142,6 +142,11 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarAlignment) {
  */
 @property(nonatomic, assign) CGFloat itemsContentHorizontalMargin;
 
+/**
+ Color of the text represented in the badge
+ */
+@property(nonatomic, strong, nullable) UIColor *badgeTextColor;
+
 @end
 
 #pragma mark - MDCBottomNavigationBarDelegate

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -36,7 +36,6 @@ static const CGFloat kMDCBottomNavigationBarHeightAdjacentTitles = 40.f;
 static const CGFloat kMDCBottomNavigationBarLandscapeContainerWidth = 320.f;
 static const CGFloat kMDCBottomNavigationBarItemsHorizontalMargin = 12.f;
 static NSString *const kMDCBottomNavigationBarBadgeColorString = @"badgeColor";
-static NSString *const kMDCBottomNavigationBarBadgeTextColorString = @"badgeTextColor";
 static NSString *const kMDCBottomNavigationBarBadgeValueString = @"badgeValue";
 static NSString *const kMDCBottomNavigationBarAccessibilityValueString =
     @"accessibilityValue";
@@ -229,10 +228,6 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
               options:NSKeyValueObservingOptionNew
               context:nil];
     [item addObserver:self
-           forKeyPath:kMDCBottomNavigationBarBadgeTextColorString
-              options:NSKeyValueObservingOptionNew
-              context:nil];
-    [item addObserver:self
            forKeyPath:kMDCBottomNavigationBarBadgeValueString
               options:NSKeyValueObservingOptionNew
               context:nil];
@@ -263,7 +258,6 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
   for (UITabBarItem *item in self.items) {
     @try {
       [item removeObserver:self forKeyPath:kMDCBottomNavigationBarBadgeColorString];
-      [item removeObserver:self forKeyPath:kMDCBottomNavigationBarBadgeTextColorString];
       [item removeObserver:self forKeyPath:kMDCBottomNavigationBarBadgeValueString];
       [item removeObserver:self
                 forKeyPath:kMDCBottomNavigationBarAccessibilityValueString];
@@ -297,8 +291,6 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
     MDCBottomNavigationItemView *itemView = _itemViews[selectedItemNum];
     if ([keyPath isEqualToString:kMDCBottomNavigationBarBadgeColorString]) {
       itemView.badgeColor = change[kMDCBottomNavigationBarNewString];
-    } else if ([keyPath isEqualToString:kMDCBottomNavigationBarBadgeTextColorString]) {
-      itemView.badgeTextColor = change[kMDCBottomNavigationBarBadgeTextColorString];
     } else if ([keyPath
                 isEqualToString:kMDCBottomNavigationBarAccessibilityValueString]) {
       itemView.accessibilityValue = change[NSKeyValueChangeNewKey];
@@ -554,6 +546,15 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor {
   super.backgroundColor = backgroundColor;
+}
+
+- (void)setBadgeTextColor:(UIColor *)badgeTextColor {
+  if (_badgeTextColor != badgeTextColor) {
+    _badgeTextColor = badgeTextColor;
+    for (MDCBottomNavigationItemView *items in _itemViews) {
+      items.badgeTextColor = badgeTextColor;
+    }
+  }
 }
 
 - (UIColor *)backgroundColor {

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -36,6 +36,7 @@ static const CGFloat kMDCBottomNavigationBarHeightAdjacentTitles = 40.f;
 static const CGFloat kMDCBottomNavigationBarLandscapeContainerWidth = 320.f;
 static const CGFloat kMDCBottomNavigationBarItemsHorizontalMargin = 12.f;
 static NSString *const kMDCBottomNavigationBarBadgeColorString = @"badgeColor";
+static NSString *const kMDCBottomNavigationBarBadgeTextColorString = @"badgeTextColor";
 static NSString *const kMDCBottomNavigationBarBadgeValueString = @"badgeValue";
 static NSString *const kMDCBottomNavigationBarAccessibilityValueString =
     @"accessibilityValue";
@@ -228,6 +229,10 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
               options:NSKeyValueObservingOptionNew
               context:nil];
     [item addObserver:self
+           forKeyPath:kMDCBottomNavigationBarBadgeTextColorString
+              options:NSKeyValueObservingOptionNew
+              context:nil];
+    [item addObserver:self
            forKeyPath:kMDCBottomNavigationBarBadgeValueString
               options:NSKeyValueObservingOptionNew
               context:nil];
@@ -258,6 +263,7 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
   for (UITabBarItem *item in self.items) {
     @try {
       [item removeObserver:self forKeyPath:kMDCBottomNavigationBarBadgeColorString];
+      [item removeObserver:self forKeyPath:kMDCBottomNavigationBarBadgeTextColorString];
       [item removeObserver:self forKeyPath:kMDCBottomNavigationBarBadgeValueString];
       [item removeObserver:self
                 forKeyPath:kMDCBottomNavigationBarAccessibilityValueString];
@@ -291,6 +297,8 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
     MDCBottomNavigationItemView *itemView = _itemViews[selectedItemNum];
     if ([keyPath isEqualToString:kMDCBottomNavigationBarBadgeColorString]) {
       itemView.badgeColor = change[kMDCBottomNavigationBarNewString];
+    } else if ([keyPath isEqualToString:kMDCBottomNavigationBarBadgeTextColorString]) {
+      itemView.badgeTextColor = change[kMDCBottomNavigationBarBadgeTextColorString];
     } else if ([keyPath
                 isEqualToString:kMDCBottomNavigationBarAccessibilityValueString]) {
       itemView.accessibilityValue = change[NSKeyValueChangeNewKey];
@@ -393,6 +401,7 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
     itemView.contentInsets = self.itemsContentInsets;
     itemView.contentVerticalMargin = self.itemsContentVerticalMargin;
     itemView.contentHorizontalMargin = self.itemsContentHorizontalMargin;
+    itemView.badgeTextColor = self.badgeTextColor;
     MDCInkTouchController *controller = [[MDCInkTouchController alloc] initWithView:itemView];
     controller.delegate = self;
     [self.inkControllers addObject:controller];

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -36,6 +36,7 @@ static const CGFloat kMDCBottomNavigationBarHeightAdjacentTitles = 40.f;
 static const CGFloat kMDCBottomNavigationBarLandscapeContainerWidth = 320.f;
 static const CGFloat kMDCBottomNavigationBarItemsHorizontalMargin = 12.f;
 static NSString *const kMDCBottomNavigationBarBadgeColorString = @"badgeColor";
+static NSString *const kMDCBottomNavigationBarBadgeTextColorString = @"badgeTextColor";
 static NSString *const kMDCBottomNavigationBarBadgeValueString = @"badgeValue";
 static NSString *const kMDCBottomNavigationBarAccessibilityValueString =
     @"accessibilityValue";
@@ -228,6 +229,10 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
               options:NSKeyValueObservingOptionNew
               context:nil];
     [item addObserver:self
+           forKeyPath:kMDCBottomNavigationBarBadgeTextColorString
+              options:NSKeyValueObservingOptionNew
+              context:nil];
+    [item addObserver:self
            forKeyPath:kMDCBottomNavigationBarBadgeValueString
               options:NSKeyValueObservingOptionNew
               context:nil];
@@ -258,6 +263,7 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
   for (UITabBarItem *item in self.items) {
     @try {
       [item removeObserver:self forKeyPath:kMDCBottomNavigationBarBadgeColorString];
+      [item removeObserver:self forKeyPath:kMDCBottomNavigationBarBadgeTextColorString];
       [item removeObserver:self forKeyPath:kMDCBottomNavigationBarBadgeValueString];
       [item removeObserver:self
                 forKeyPath:kMDCBottomNavigationBarAccessibilityValueString];
@@ -291,6 +297,8 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
     MDCBottomNavigationItemView *itemView = _itemViews[selectedItemNum];
     if ([keyPath isEqualToString:kMDCBottomNavigationBarBadgeColorString]) {
       itemView.badgeColor = change[kMDCBottomNavigationBarNewString];
+    } else if ([keyPath isEqualToString:kMDCBottomNavigationBarBadgeTextColorString]) {
+      itemView.badgeTextColor = change[kMDCBottomNavigationBarBadgeTextColorString];
     } else if ([keyPath
                 isEqualToString:kMDCBottomNavigationBarAccessibilityValueString]) {
       itemView.accessibilityValue = change[NSKeyValueChangeNewKey];
@@ -393,7 +401,7 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
     itemView.contentInsets = self.itemsContentInsets;
     itemView.contentVerticalMargin = self.itemsContentVerticalMargin;
     itemView.contentHorizontalMargin = self.itemsContentHorizontalMargin;
-    itemView.badgeTextColor = self.badgeTextColor;
+    itemView.badgeTextColor = item.badgeTextColor;
     MDCInkTouchController *controller = [[MDCInkTouchController alloc] initWithView:itemView];
     controller.delegate = self;
     [self.inkControllers addObject:controller];
@@ -546,15 +554,6 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor {
   super.backgroundColor = backgroundColor;
-}
-
-- (void)setBadgeTextColor:(UIColor *)badgeTextColor {
-  if (_badgeTextColor != badgeTextColor) {
-    _badgeTextColor = badgeTextColor;
-    for (MDCBottomNavigationItemView *items in _itemViews) {
-      items.badgeTextColor = badgeTextColor;
-    }
-  }
 }
 
 - (UIColor *)backgroundColor {

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
@@ -35,6 +35,7 @@
 @property(nonatomic, strong) UIImage *selectedImage;
 
 @property(nonatomic, strong) UIColor *badgeColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong) UIColor *badgeTextColor;
 @property(nonatomic, strong) UIColor *selectedItemTintColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong) UIColor *unselectedItemTintColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong) UIColor *selectedItemTitleColor;

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
@@ -35,7 +35,7 @@
 @property(nonatomic, strong) UIImage *selectedImage;
 
 @property(nonatomic, strong) UIColor *badgeColor UI_APPEARANCE_SELECTOR;
-@property(nonatomic, strong) UIColor *badgeTextColor;
+@property(nonatomic, strong, null_resettable) UIColor *badgeTextColor;
 @property(nonatomic, strong) UIColor *selectedItemTintColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong) UIColor *unselectedItemTintColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong) UIColor *selectedItemTitleColor;

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -327,6 +327,13 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
   self.badge.badgeColor = badgeColor;
 }
 
+- (void)setBadgeTextColor:(UIColor *)badgeTextColor {
+  if (_badgeTextColor != badgeTextColor) {
+    _badgeTextColor = badgeTextColor;
+    self.badge.badgeValueLabel.textColor = badgeTextColor;
+  }
+}
+
 - (void)setBadgeValue:(NSString *)badgeValue {
   // Due to KVO, badgeValue may be of type NSNull.
   if ([badgeValue isKindOfClass:[NSNull class]]) {

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -329,9 +329,18 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 
 - (void)setBadgeTextColor:(UIColor *)badgeTextColor {
   if (_badgeTextColor != badgeTextColor) {
-    _badgeTextColor = badgeTextColor;
-    self.badge.badgeValueLabel.textColor = badgeTextColor;
+    if (badgeTextColor == nil) {
+      _badgeTextColor = [UIColor whiteColor];
+      self.badge.badgeValueLabel.textColor = [UIColor whiteColor];
+    } else {
+      _badgeTextColor = badgeTextColor;
+      self.badge.badgeValueLabel.textColor = badgeTextColor;
+    }
   }
+}
+
+- (UIColor *)badgeTextColor {
+  return self.badge.badgeValueLabel.textColor;
 }
 
 - (void)setBadgeValue:(NSString *)badgeValue {

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -328,12 +328,12 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 }
 
 - (void)setBadgeTextColor:(UIColor *)badgeTextColor {
-  if (_badgeTextColor != badgeTextColor) {
+  if (self.badgeTextColor != badgeTextColor) {
     if (badgeTextColor == nil) {
-      _badgeTextColor = [UIColor whiteColor];
+      self.badgeTextColor = [UIColor whiteColor];
       self.badge.badgeValueLabel.textColor = [UIColor whiteColor];
     } else {
-      _badgeTextColor = badgeTextColor;
+      self.badgeTextColor = badgeTextColor;
       self.badge.badgeValueLabel.textColor = badgeTextColor;
     }
   }


### PR DESCRIPTION
Add `badgeTextColor` property to bottom navigation to support custom badge text colors within the component. 

Potential make this only available in iOS 10+ to match the behavior of badgeColor.

This closes #2833 
