### PR TITLE
[Dialogs] Fix button hit areas to match accessibility

### DIFF
--- a/components/Dialogs/examples/DialogsAlertViewController.m
+++ b/components/Dialogs/examples/DialogsAlertViewController.m
@@ -300,6 +300,24 @@
                                                     }];
   [materialAlertController addAction:action6];
 
+  MDCAlertAction *action7 = [MDCAlertAction actionWithTitle:@"OK - 7"
+                                                    handler:^(MDCAlertAction *action) {
+                                                      NSLog(@"%@", @"OK pressed");
+                                                    }];
+  [materialAlertController addAction:action7];
+
+  MDCAlertAction *action8 = [MDCAlertAction actionWithTitle:@"OK - 8"
+                                                    handler:^(MDCAlertAction *action) {
+                                                      NSLog(@"%@", @"OK pressed");
+                                                    }];
+  [materialAlertController addAction:action8];
+
+  MDCAlertAction *action9 = [MDCAlertAction actionWithTitle:@"OK - 9"
+                                                    handler:^(MDCAlertAction *action) {
+                                                      NSLog(@"%@", @"OK pressed");
+                                                    }];
+  [materialAlertController addAction:action9];
+
   [self presentViewController:materialAlertController animated:YES completion:NULL];
 }
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -355,7 +355,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)layoutSubviews {
   [super layoutSubviews];
 
-  for (MDCFlatButton *button in self.actionButtons) {
+  for (MDCButton *button in self.actionButtons) {
     [button sizeToFit];
     CGRect buttonFrame = button.frame;
     buttonFrame.size.width =

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -33,7 +33,7 @@ static const CGFloat MDCDialogContentVerticalPadding = 20.0;
 static const UIEdgeInsets MDCDialogActionsInsets = {8.0, 8.0, 8.0, 8.0};
 static const CGFloat MDCDialogActionsHorizontalPadding = 8.0;
 static const CGFloat MDCDialogActionsVerticalPadding = 8.0;
-static const CGFloat MDCDialogActionButtonHeight = 36.0;
+static const CGFloat MDCDialogActionButtonHeight = 48.0;
 static const CGFloat MDCDialogActionButtonMinimumWidth = 48.0;
 
 static const CGFloat MDCDialogMessageOpacity = 0.54f;
@@ -435,7 +435,8 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
       buttonOrigin.x -= buttonRect.size.width;
       buttonRect.origin = buttonOrigin;
-
+      buttonRect.size.width = MAX(CGRectGetWidth(buttonRect), MDCDialogActionButtonMinimumWidth);
+      buttonRect.size.height = MAX(CGRectGetHeight(buttonRect), MDCDialogActionButtonHeight);
       button.frame = buttonRect;
 
       if (button != [self.actionButtons lastObject]) {

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -35,7 +35,7 @@ static const CGFloat MDCDialogActionsHorizontalPadding = 8.0;
 static const CGFloat MDCDialogActionsVerticalPadding = 8.0;
 static const CGFloat MDCDialogActionButtonHeight = 36.0;
 static const CGFloat MDCDialogActionButtonMinimumWidth = 48.0;
-static const CGFloat MDCDialogActionButtonTouchTarget = 48.f;
+static const CGFloat MDCDialogActionMinTouchTarget = 48.f;
 
 static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
@@ -363,10 +363,8 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     buttonFrame.size.height =
         MAX(CGRectGetHeight(buttonFrame), MDCDialogActionButtonHeight);
     button.frame = buttonFrame;
-    CGFloat verticalInsets =
-        -(MDCDialogActionButtonTouchTarget - CGRectGetHeight(button.frame)) / 2;
-    CGFloat horizontalInsets =
-        -(MDCDialogActionButtonTouchTarget - CGRectGetWidth(button.frame)) / 2;
+    CGFloat verticalInsets = (CGRectGetHeight(button.frame) - MDCDialogActionMinTouchTarget) / 2;
+    CGFloat horizontalInsets = (CGRectGetWidth(button.frame) - MDCDialogActionMinTouchTarget) / 2;
     verticalInsets = MIN(0, verticalInsets);
     horizontalInsets = MIN(0, horizontalInsets);
     button.hitAreaInsets = UIEdgeInsetsMake(verticalInsets,

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -30,7 +30,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
 static const UIEdgeInsets MDCDialogContentInsets = {24.0, 24.0, 24.0, 24.0};
 static const CGFloat MDCDialogContentVerticalPadding = 20.0;
 
-static const UIEdgeInsets MDCDialogActionsInsets = {2.0, 8.0, 2.0, 8.0};
+static const UIEdgeInsets MDCDialogActionsInsets = {8.0, 8.0, 8.0, 8.0};
 static const CGFloat MDCDialogActionsHorizontalPadding = 8.0;
 static const CGFloat MDCDialogActionsVerticalPadding = 8.0;
 static const CGFloat MDCDialogActionButtonHeight = 48.0;

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -30,7 +30,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
 static const UIEdgeInsets MDCDialogContentInsets = {24.0, 24.0, 24.0, 24.0};
 static const CGFloat MDCDialogContentVerticalPadding = 20.0;
 
-static const UIEdgeInsets MDCDialogActionsInsets = {8.0, 8.0, 8.0, 8.0};
+static const UIEdgeInsets MDCDialogActionsInsets = {2.0, 8.0, 2.0, 8.0};
 static const CGFloat MDCDialogActionsHorizontalPadding = 8.0;
 static const CGFloat MDCDialogActionsVerticalPadding = 8.0;
 static const CGFloat MDCDialogActionButtonHeight = 48.0;
@@ -355,6 +355,10 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
   for (UIButton *button in self.actionButtons) {
     [button sizeToFit];
+    CGRect buttonFrame = button.frame;
+    buttonFrame.size.height = MAX(CGRectGetHeight(buttonFrame), MDCDialogActionButtonHeight);
+    buttonFrame.size.width = MAX(CGRectGetWidth(buttonFrame), MDCDialogActionButtonMinimumWidth);
+    button.frame = buttonFrame;
   }
 
   // Used to calculate the height of the scrolling content, so we limit the width.
@@ -435,8 +439,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
       buttonOrigin.x -= buttonRect.size.width;
       buttonRect.origin = buttonOrigin;
-      buttonRect.size.width = MAX(CGRectGetWidth(buttonRect), MDCDialogActionButtonMinimumWidth);
-      buttonRect.size.height = MAX(CGRectGetHeight(buttonRect), MDCDialogActionButtonHeight);
+
       button.frame = buttonRect;
 
       if (button != [self.actionButtons lastObject]) {

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -129,6 +129,12 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   buttonRect.size.height = MAX(buttonRect.size.height, MDCDialogActionButtonHeight);
   buttonRect.size.width = MAX(buttonRect.size.width, MDCDialogActionButtonMinimumWidth);
   actionButton.frame = buttonRect;
+  CGFloat verticalInset = MIN(0, -(48 - CGRectGetHeight(actionButton.bounds)) / 2);
+  CGFloat horizontalInset = MIN(0, -(48 - CGRectGetWidth(actionButton.bounds)) / 2);
+  actionButton.hitAreaInsets = UIEdgeInsetsMake(verticalInset,
+                                                horizontalInset,
+                                                verticalInset,
+                                                horizontalInset);
   [actionButton addTarget:target
                    action:selector
          forControlEvents:UIControlEventTouchUpInside];
@@ -273,6 +279,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     size.width = MDCDialogActionsInsets.left + MDCDialogActionsInsets.right;
     for (UIButton *button in self.actionButtons) {
       CGSize buttonSize = [button sizeThatFits:size];
+      buttonSize.height = MAX(buttonSize.height, MDCDialogActionButtonHeight);
       size.height += buttonSize.height;
       size.width = MAX(size.width, buttonSize.width);
       if (button != [self.actionButtons lastObject]) {
@@ -355,6 +362,12 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
   for (UIButton *button in self.actionButtons) {
     [button sizeToFit];
+    CGRect buttonFrame = button.frame;
+    buttonFrame.size.width =
+        MAX(CGRectGetWidth(buttonFrame), MDCDialogActionButtonMinimumWidth);
+    buttonFrame.size.height =
+        MAX(CGRectGetHeight(buttonFrame), MDCDialogActionButtonHeight);
+    button.frame = buttonFrame;
   }
 
   // Used to calculate the height of the scrolling content, so we limit the width.

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -32,7 +32,7 @@ static const CGFloat MDCDialogContentVerticalPadding = 20.0;
 
 static const UIEdgeInsets MDCDialogActionsInsets = {8.0, 8.0, 8.0, 8.0};
 static const CGFloat MDCDialogActionsHorizontalPadding = 8.0;
-static const CGFloat MDCDialogActionsVerticalPadding = 8.0;
+static const CGFloat MDCDialogActionsVerticalPadding = 12.0;
 static const CGFloat MDCDialogActionButtonHeight = 36.0;
 static const CGFloat MDCDialogActionButtonMinimumWidth = 48.0;
 static const CGFloat MDCDialogActionMinTouchTarget = 48.f;

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -230,6 +230,17 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   }
   for (MDCFlatButton *button in self.actionButtons) {
     [button setTitleFont:finalButtonFont forState:UIControlStateNormal];
+    [button sizeToFit];
+    CGRect buttonRect = button.frame;
+    buttonRect.size.height = MAX(CGRectGetHeight(buttonRect), MDCDialogActionButtonHeight);
+    buttonRect.size.width = MAX(CGRectGetWidth(buttonRect), MDCDialogActionButtonMinimumWidth);
+    button.frame = buttonRect;
+    CGFloat verticalInset = MIN(0, -(48 - CGRectGetHeight(button.bounds)) / 2);
+    CGFloat horizontalInset = MIN(0, -(48 - CGRectGetWidth(button.bounds)) / 2);
+    button.hitAreaInsets = UIEdgeInsetsMake(verticalInset,
+                                                  horizontalInset,
+                                                  verticalInset,
+                                                  horizontalInset);
   }
 
   [self setNeedsLayout];

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -33,7 +33,7 @@ static const CGFloat MDCDialogContentVerticalPadding = 20.0;
 static const UIEdgeInsets MDCDialogActionsInsets = {8.0, 8.0, 8.0, 8.0};
 static const CGFloat MDCDialogActionsHorizontalPadding = 8.0;
 static const CGFloat MDCDialogActionsVerticalPadding = 8.0;
-static const CGFloat MDCDialogActionButtonHeight = 48.0;
+static const CGFloat MDCDialogActionButtonHeight = 36.0;
 static const CGFloat MDCDialogActionButtonMinimumWidth = 48.0;
 
 static const CGFloat MDCDialogMessageOpacity = 0.54f;
@@ -355,10 +355,6 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
   for (UIButton *button in self.actionButtons) {
     [button sizeToFit];
-    CGRect buttonFrame = button.frame;
-    buttonFrame.size.height = MAX(CGRectGetHeight(buttonFrame), MDCDialogActionButtonHeight);
-    buttonFrame.size.width = MAX(CGRectGetWidth(buttonFrame), MDCDialogActionButtonMinimumWidth);
-    button.frame = buttonFrame;
   }
 
   // Used to calculate the height of the scrolling content, so we limit the width.

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -35,6 +35,7 @@ static const CGFloat MDCDialogActionsHorizontalPadding = 8.0;
 static const CGFloat MDCDialogActionsVerticalPadding = 8.0;
 static const CGFloat MDCDialogActionButtonHeight = 36.0;
 static const CGFloat MDCDialogActionButtonMinimumWidth = 48.0;
+static const CGFloat MDCDialogActionButtonTouchTarget = 48.f;
 
 static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
@@ -129,12 +130,6 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   buttonRect.size.height = MAX(buttonRect.size.height, MDCDialogActionButtonHeight);
   buttonRect.size.width = MAX(buttonRect.size.width, MDCDialogActionButtonMinimumWidth);
   actionButton.frame = buttonRect;
-  CGFloat verticalInset = MIN(0, -(48 - CGRectGetHeight(actionButton.bounds)) / 2);
-  CGFloat horizontalInset = MIN(0, -(48 - CGRectGetWidth(actionButton.bounds)) / 2);
-  actionButton.hitAreaInsets = UIEdgeInsetsMake(verticalInset,
-                                                horizontalInset,
-                                                verticalInset,
-                                                horizontalInset);
   [actionButton addTarget:target
                    action:selector
          forControlEvents:UIControlEventTouchUpInside];
@@ -230,17 +225,6 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   }
   for (MDCFlatButton *button in self.actionButtons) {
     [button setTitleFont:finalButtonFont forState:UIControlStateNormal];
-    [button sizeToFit];
-    CGRect buttonRect = button.frame;
-    buttonRect.size.height = MAX(CGRectGetHeight(buttonRect), MDCDialogActionButtonHeight);
-    buttonRect.size.width = MAX(CGRectGetWidth(buttonRect), MDCDialogActionButtonMinimumWidth);
-    button.frame = buttonRect;
-    CGFloat verticalInset = MIN(0, -(48 - CGRectGetHeight(button.bounds)) / 2);
-    CGFloat horizontalInset = MIN(0, -(48 - CGRectGetWidth(button.bounds)) / 2);
-    button.hitAreaInsets = UIEdgeInsetsMake(verticalInset,
-                                                  horizontalInset,
-                                                  verticalInset,
-                                                  horizontalInset);
   }
 
   [self setNeedsLayout];
@@ -371,7 +355,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)layoutSubviews {
   [super layoutSubviews];
 
-  for (UIButton *button in self.actionButtons) {
+  for (MDCFlatButton *button in self.actionButtons) {
     [button sizeToFit];
     CGRect buttonFrame = button.frame;
     buttonFrame.size.width =
@@ -379,6 +363,16 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     buttonFrame.size.height =
         MAX(CGRectGetHeight(buttonFrame), MDCDialogActionButtonHeight);
     button.frame = buttonFrame;
+    CGFloat verticalInsets =
+        -(MDCDialogActionButtonTouchTarget - CGRectGetHeight(button.frame)) / 2;
+    CGFloat horizontalInsets =
+        -(MDCDialogActionButtonTouchTarget - CGRectGetWidth(button.frame)) / 2;
+    verticalInsets = MIN(0, verticalInsets);
+    horizontalInsets = MIN(0, horizontalInsets);
+    button.hitAreaInsets = UIEdgeInsetsMake(verticalInsets,
+                                            horizontalInsets,
+                                            verticalInsets,
+                                            horizontalInsets);
   }
 
   // Used to calculate the height of the scrolling content, so we limit the width.


### PR DESCRIPTION
Update buttons within Dialog to have a minimum 48x48 touch area. 

Also, update example to make sure in an case where there is a large number of buttons, make sure that their is enough room in the scroll view. 

Closes #3664 
