### PR TITLE
[AppBar] Fix bug where initialization of nav controller with root view controller would not inject an App Bar.

### DIFF
--- a/components/AppBar/src/MDCAppBarNavigationController.h
+++ b/components/AppBar/src/MDCAppBarNavigationController.h
@@ -61,6 +61,10 @@
 
  To theme the injected App Bar, implement the delegate's
  -appBarNavigationController:willAddAppBar:asChildOfViewController: API.
+
+ @note If you use the initWithRootViewController: API you will not have been able to provide a
+ delegate yet. In this case, use the -appBarForViewController: API to retrieve the injected App Bar
+ for your root view controller and execute your delegate logic on the returned result, if any.
  */
 MDC_SUBCLASSING_RESTRICTED
 @interface MDCAppBarNavigationController : UINavigationController

--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -56,6 +56,14 @@
   return self;
 }
 
+- (instancetype)initWithRootViewController:(UIViewController *)rootViewController {
+  self = [super initWithRootViewController:rootViewController];
+  if (self) {
+    [self injectAppBarIntoViewController:rootViewController];
+  }
+  return self;
+}
+
 #pragma mark - UINavigationController overrides
 
 // Intercept status bar style inquiries and reroute them to our flexible header view controller.

--- a/components/AppBar/tests/unit/AppBarNavigationControllerTests.swift
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerTests.swift
@@ -26,6 +26,33 @@ class AppBarNavigationControllerTests: XCTestCase {
     navigationController = MDCAppBarNavigationController()
   }
 
+  func testInitializingWithRootViewControllerInjectsAnAppBar() {
+    // Given
+    let viewController = UIViewController()
+
+    // When
+    let navigationController = MDCAppBarNavigationController(rootViewController: viewController)
+
+    // Then
+    XCTAssertEqual(viewController.childViewControllers.count, 1,
+                   "Expected there to be exactly one child view controller added to the view"
+                    + " controller.")
+
+    XCTAssertEqual(navigationController.topViewController, viewController,
+                   "The navigation controller's top view controller is supposed to be the pushed"
+                    + " view controller, but it is \(viewController).")
+
+    XCTAssertTrue(viewController.childViewControllers.first is MDCFlexibleHeaderViewController,
+                  "The injected view controller is not a flexible header view controller, it is"
+                    + "\(String(describing: viewController.childViewControllers.first)) instead.")
+
+    if let headerViewController
+      = viewController.childViewControllers.first as? MDCFlexibleHeaderViewController {
+      XCTAssertEqual(headerViewController.headerView.frame.height,
+                     headerViewController.headerView.maximumHeight)
+    }
+  }
+
   func testPushingAViewControllerInjectsAnAppBar() {
     // Given
     let viewController = UIViewController()


### PR DESCRIPTION
Verified that the added test fails prior to this change and succeeds after.

Closes https://github.com/material-components/material-components-ios/issues/4688