### PR TITLE
[AppBar] Increase likelihood that we detect existing App Bars when auto-injecting.

### DIFF
--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -97,13 +97,17 @@
 #pragma mark - Private
 
 - (void)injectAppBarIntoViewController:(UIViewController *)viewController {
+  // Force the view to load immediately in case the view controller is using viewDidLoad to manage
+  // its child view controllers (potentially injecting an App Bar as a result).
+  UIView *viewControllerView = viewController.view;
+
   if ([self viewControllerHasFlexibleHeader:viewController]) {
     return; // Already has a flexible header (not one we injected, but that's ok).
   }
 
   // Attempt to infer the tracking scroll view.
   UIScrollView *trackingScrollView =
-      [self findFirstInstanceOfUIScrollViewInView:viewController.view];
+      [self findFirstInstanceOfUIScrollViewInView:viewControllerView];
 
   MDCAppBar *appBar = [[MDCAppBar alloc] init];
 
@@ -152,6 +156,10 @@
   // case. MDCFlexibleHeaderViewController can never be a top-level view controller.
   for (UIViewController *childViewController in viewController.childViewControllers) {
     if ([childViewController isKindOfClass:[MDCFlexibleHeaderViewController class]]) {
+      return YES;
+    }
+    // Recurse in case the flexible header is nested within a container.
+    if ([self viewControllerHasFlexibleHeader:childViewController]) {
       return YES;
     }
   }

--- a/components/AppBar/tests/unit/AppBarNavigationControllerTests.swift
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerTests.swift
@@ -68,6 +68,24 @@ class AppBarNavigationControllerTests: XCTestCase {
                     + " controller may have injected another App Bar.")
   }
 
+  func testPushingAContainedAppBarContainerViewControllerDoesNotInjectAnAppBar() {
+    // Given
+    let viewController = UIViewController()
+    let container = MDCAppBarContainerViewController(contentViewController: viewController)
+    let nestedContainer = UIViewController()
+    nestedContainer.addChildViewController(container)
+    nestedContainer.view.addSubview(container.view)
+    container.didMove(toParentViewController: nestedContainer)
+
+    // When
+    navigationController.pushViewController(nestedContainer, animated: false)
+
+    // Then
+    XCTAssertEqual(nestedContainer.childViewControllers.count, 1,
+                   "The view controller hierarchy already has one app bar view controller, but it"
+                    + " appears to have possibly added another.")
+  }
+
   func testPushingAViewControllerWithAFlexibleHeaderDoesNotInjectAnAppBar() {
     // Given
     let viewController = UIViewController()


### PR DESCRIPTION
This includes two changes that increase the likelihood of us detecting existing App Bars in a pushed view controller:

1. Some clients manage view controllers in viewDidLoad. We're already accessing .view in the injection logic, but we were not doing so until after the check for an App Bar. We now fetch the view before we check the view controller hierarchy, giving the pushed view controller an opportunity to configure itself before we check for an existing App Bar.
2. There are cases within our own catalog where we have a "nested dolls" of view controllers, i.e. an App Bar in a container inside another view controller. We were not recursing our pre-existing flexible header view controller check, meaning we would miss these deeply-nested view controller cases. This change adds a recursive step to the view controller check.

I verified that the added test fails prior to this change and succeeds after this change.

## Screenshots

Before: 
![simulator screen shot - iphone se - 2018-08-01 at 20 17 06](https://user-images.githubusercontent.com/45670/43597573-730c4e48-9650-11e8-8399-065e1e8b7503.png)

After:
![simulator screen shot - iphone se - 2018-08-01 at 20 16 00](https://user-images.githubusercontent.com/45670/43597576-757cb686-9650-11e8-9205-2fa563110797.png)
