### PR TITLE
[AppBar] Enable inferTopSafeAreaInsetFromViewController on the App Bar in the navigation controller.

### DIFF
--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -123,7 +123,7 @@
 
   // Ensures that our App Bar's top layout guide reflects the current view controller hierarchy.
   // Most notably, this ensures we support iPad popovers and extensions.
-  appBar.headerViewController.inferTopSafeAreaInsetFromViewController = YES;
+  appBar.inferTopSafeAreaInsetFromViewController = YES;
 
   // We want our flexible header to calculate the safe area insets dynamically, rather than assume
   // we've pre-calculated them.


### PR DESCRIPTION

Repro case for the incorrect behavior:

- Open MDCCatalog in portrait on any iPhone.
- Open the Tabs component.
- Rotate to landscape.

Expected behavior: the App Bar's navigation bar collapses with the app bar's content.

Actual behavior: the App Bar's navigation bar still thinks that there is a status bar.

---

Prior to this change we were only enabling inferTopSafeAreaInsetFromViewController on the flexible header. This meant that the App Bar's layout constraints were not being updated with respect to the contextual top safe area insets.

After this change, we enable inferTopSafeAreaInsetFromViewController on the App Bar as well.

This bug only affects clients of the app bar navigation controller.