### PR TITLE
[FlexibleHeader] Fix infinite recursion when observesTrackingScrollViewScrollEvents is enabled.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -546,7 +546,11 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 #pragma mark - Private (fhv_ prefix)
 
 - (void)fhv_setContentOffset:(CGPoint)contentOffset {
-  _trackingScrollView.contentOffset = contentOffset;
+  // Avoid excessive writes. This can also cause infinite recursion if we're observing the content
+  // offset because of observesTrackingScrollViewScrollEvents.
+  if (!CGPointEqualToPoint(contentOffset, _trackingScrollView.contentOffset)) {
+    _trackingScrollView.contentOffset = contentOffset;
+  }
 
   // When we manually set our content offset it's because we're trying to avoid any sort of content
   // jumping behavior, so we ignore immediate content offset delta by resetting the shift


### PR DESCRIPTION
When observesTrackingScrollViewScrollEvents is enabled, we observe any setter event to the tracking scroll view, even if the setter is setting the same value that is already set. This means we can quickly and easily get into a situation where we're infinitely recursing on setting the contentOffset.

To reproduce this behavior:

1. Open MDCCatalog in portrait on an iPhone.
2. Open the Tabs component.
3. Rotate to landscape.

Expected behvaior: the app still works.
Actual behavior: infinite recursion.