### PR TITLE
[AppBar] Expose MDCAppBarViewController as a replacement for MDCAppBar.

### DIFF
--- a/components/AppBar/src/ColorThemer/MDCAppBarColorThemer.h
+++ b/components/AppBar/src/ColorThemer/MDCAppBarColorThemer.h
@@ -23,6 +23,32 @@
 @interface MDCAppBarColorThemer : NSObject
 
 /**
+ Applies a color scheme's properties to an MDCAppBarViewController instance using the primary
+ mapping.
+
+ Uses the primary color as the most important color for the component.
+
+ @param colorScheme The color scheme to apply to the component instance.
+ @param appBarViewController A component instance to which the color scheme should be applied.
+ */
++ (void)applyColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+  toAppBarViewController:(nonnull MDCAppBarViewController *)appBarViewController;
+
+/**
+ Applies a color scheme's properties to an MDCAppBarViewController instance using the surface
+ mapping.
+
+ Uses the surface color as the most important color for the component.
+
+ @param colorScheme The color scheme to apply to the component instance.
+ @param appBarViewController A component instance to which the color scheme should be applied.
+ */
++ (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+                    toAppBarViewController:(nonnull MDCAppBarViewController *)appBarViewController;
+
+#pragma mark - To be deprecated
+
+/**
  Applies a color scheme's properties to an MDCAppBar using the primary mapping.
 
  Uses the primary color as the most important color for the component.
@@ -43,8 +69,6 @@
  */
 + (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                                   toAppBar:(nonnull MDCAppBar *)appBar;
-
-#pragma mark - Soon to be deprecated
 
 /**
  Applies a color scheme's properties to an MDCAppBar.

--- a/components/AppBar/src/ColorThemer/MDCAppBarColorThemer.m
+++ b/components/AppBar/src/ColorThemer/MDCAppBarColorThemer.m
@@ -21,6 +21,25 @@
 
 @implementation MDCAppBarColorThemer
 
++ (void)applyColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+  toAppBarViewController:(nonnull MDCAppBarViewController *)appBarViewController {
+  [MDCFlexibleHeaderColorThemer applySemanticColorScheme:colorScheme
+                                    toFlexibleHeaderView:appBarViewController.headerView];
+  [MDCNavigationBarColorThemer applySemanticColorScheme:colorScheme
+                                        toNavigationBar:appBarViewController.navigationBar];
+}
+
++ (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+                    toAppBarViewController:(nonnull MDCAppBarViewController *)appBarViewController {
+  [MDCFlexibleHeaderColorThemer applySurfaceVariantWithColorScheme:colorScheme
+                                              toFlexibleHeaderView:appBarViewController.headerView];
+  [MDCNavigationBarColorThemer applySurfaceVariantWithColorScheme:colorScheme
+                                                  toNavigationBar:
+      appBarViewController.navigationBar];
+}
+
+#pragma mark - To be deprecated
+
 + (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
                         toAppBar:(MDCAppBar *)appBar {
   [MDCFlexibleHeaderColorThemer applySemanticColorScheme:colorScheme

--- a/components/AppBar/src/ColorThemer/MaterialAppBar+ColorThemer.h
+++ b/components/AppBar/src/ColorThemer/MaterialAppBar+ColorThemer.h
@@ -15,3 +15,4 @@
  */
 
 #import "MDCAppBarColorThemer.h"
+

--- a/components/AppBar/src/MDCAppBar.h
+++ b/components/AppBar/src/MDCAppBar.h
@@ -18,27 +18,29 @@
 #import "MaterialHeaderStackView.h"
 #import "MaterialNavigationBar.h"
 
-@class MDCAppBar;
+@class MDCAppBarViewController;
 
 /**
- The MDCAppBarTextColorAccessibilityMutator class creates an external object with which to work on
- an instance of a Material App Bar to activate and ensure accessibility on its title and buttons.
-
- ### Dependencies
-
- Material AppBarTextColorAccessibilityMutator depends on the AppBar material component and
- MDFTextAccessibility Framework.
+ MDCAppBarViewController is a flexible header view controller that manages a navigation bar and
+ header stack view in order to provide the Material Top App Bar user interface.
  */
-
-@interface MDCAppBarTextColorAccessibilityMutator : NSObject
+@interface MDCAppBarViewController : MDCFlexibleHeaderViewController
 
 /**
- Mutates title text color and navigation items' tint colors based on background color of
- app bar's navigation bar or header view background color.
+ The navigation bar often represents the information stored in a view controller's navigationItem
+ propoerty, but it can also be directly configured.
  */
-- (void)mutate:(nonnull MDCAppBar *)appBar;
+@property(nonatomic, strong, nonnull) MDCNavigationBar *navigationBar;
+
+/**
+ The header stack view owns the navigationBar (as the top bar) and an optional bottom bar (typically
+ a tab bar).
+ */
+@property(nonatomic, strong, nonnull) MDCHeaderStackView *headerStackView;
 
 @end
+
+#pragma mark - To be deprecated
 
 /**
  The MDCAppBar class creates and configures the constellation of components required to represent a
@@ -53,8 +55,9 @@
  ### Dependencies
 
  AppBar depends on the FlexibleHeader, HeaderStackView, and NavigationBar Material Components.
+
+ @note This API will be deprecated in favor of MDCAppBarViewController.
  */
-//TODO: (#3012) Re-add NSSecureCoding
 @interface MDCAppBar : NSObject
 
 /**
@@ -66,6 +69,9 @@
 /** The header view controller instance manages the App Bar's flexible header view behavior. */
 @property(nonatomic, strong, nonnull, readonly)
     MDCFlexibleHeaderViewController *headerViewController;
+
+/** The App Bar view controller instance manages the App Bar's flexible header view behavior. */
+@property(nonatomic, strong, nonnull, readonly) MDCAppBarViewController *appBarViewController;
 
 /** The navigation bar. */
 @property(nonatomic, strong, nonnull, readonly) MDCNavigationBar *navigationBar;
@@ -100,5 +106,27 @@
  Default is NO.
  */
 @property(nonatomic) BOOL inferTopSafeAreaInsetFromViewController;
+
+@end
+
+/**
+ The MDCAppBarTextColorAccessibilityMutator class creates an external object with which to work on
+ an instance of a Material App Bar to activate and ensure accessibility on its title and buttons.
+
+ ### Dependencies
+
+ Material AppBarTextColorAccessibilityMutator depends on the AppBar material component and
+ MDFTextAccessibility Framework.
+
+ @note This API will be deprecated with no replacement.
+ */
+
+@interface MDCAppBarTextColorAccessibilityMutator : NSObject
+
+/**
+ Mutates title text color and navigation items' tint colors based on background color of
+ app bar's navigation bar or header view background color.
+ */
+- (void)mutate:(nonnull MDCAppBar *)appBar;
 
 @end

--- a/components/AppBar/src/MDCAppBarContainerViewController.h
+++ b/components/AppBar/src/MDCAppBarContainerViewController.h
@@ -17,6 +17,7 @@
 #import <UIKit/UIKit.h>
 
 @class MDCAppBar;
+@class MDCAppBarViewController;
 
 /**
  The MDCAppBarContainerViewController controller provides an interface for placing a
@@ -53,8 +54,10 @@
 - (nonnull instancetype)initWithCoder:(nonnull NSCoder *)aDecoder NS_UNAVAILABLE;
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
-/** The App Bar views that will be presented in front of the contentViewController's view. */
-@property(nonatomic, strong, nonnull, readonly) MDCAppBar *appBar;
+/**
+ The App Bar view controller that will be a sibling to the contentViewController.
+ */
+@property(nonatomic, strong, nonnull, readonly) MDCAppBarViewController *appBarViewController;
 
 /** The content view controller to be displayed behind the header. */
 @property(nonatomic, strong, nonnull, readonly) UIViewController *contentViewController;
@@ -84,5 +87,14 @@
      frame.origin.y = self.topLayoutGuide.length + 32
  */
 @property(nonatomic, getter=isTopLayoutGuideAdjustmentEnabled) BOOL topLayoutGuideAdjustmentEnabled;
+
+#pragma mark - To be deprecated
+
+/**
+ The App Bar views that will be presented in front of the contentViewController's view.
+
+ This API will eventually be deprecated. Use appBarViewController instead.
+ */
+@property(nonatomic, strong, nonnull, readonly) MDCAppBar *appBar;
 
 @end

--- a/components/AppBar/src/MDCAppBarContainerViewController.m
+++ b/components/AppBar/src/MDCAppBarContainerViewController.m
@@ -28,7 +28,7 @@
   if (self) {
     _appBar = [[MDCAppBar alloc] init];
 
-    [self addChildViewController:_appBar.headerViewController];
+    [self addChildViewController:_appBar.appBarViewController];
 
     _contentViewController = contentViewController;
     [self addChildViewController:contentViewController];
@@ -53,16 +53,16 @@
   [super viewWillLayoutSubviews];
 
   if (!self.topLayoutGuideAdjustmentEnabled) {
-    [_appBar.headerViewController updateTopLayoutGuide];
+    [_appBar.appBarViewController updateTopLayoutGuide];
   }
 }
 
 - (BOOL)prefersStatusBarHidden {
-  return self.appBar.headerViewController.prefersStatusBarHidden;
+  return self.appBar.appBarViewController.prefersStatusBarHidden;
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-  return self.appBar.headerViewController.preferredStatusBarStyle;
+  return self.appBar.appBarViewController.preferredStatusBarStyle;
 }
 
 - (BOOL)shouldAutorotate {
@@ -99,10 +99,10 @@
     // make two top layout guides constrain to one other
     // (e.g. self.topLayoutGuide == self.contentViewController.topLayoutGuide) so instead we must
     // tell the flexible header controller which view controller it should modify.
-    self.appBar.headerViewController.topLayoutGuideViewController = self.contentViewController;
+    self.appBar.appBarViewController.topLayoutGuideViewController = self.contentViewController;
 
   } else {
-    self.appBar.headerViewController.topLayoutGuideViewController = nil;
+    self.appBar.appBarViewController.topLayoutGuideViewController = nil;
   }
 }
 

--- a/components/AppBar/src/MDCAppBarContainerViewController.m
+++ b/components/AppBar/src/MDCAppBarContainerViewController.m
@@ -77,6 +77,10 @@
   return self.contentViewController.preferredInterfaceOrientationForPresentation;
 }
 
+- (MDCAppBarViewController *)appBarViewController {
+  return _appBar.appBarViewController;
+}
+
 #pragma mark - Enabling top layout guide adjustment behavior
 
 - (void)updateTopLayoutGuideBehavior {

--- a/components/AppBar/src/MDCAppBarNavigationController.h
+++ b/components/AppBar/src/MDCAppBarNavigationController.h
@@ -25,6 +25,7 @@
 #endif  // #ifndef MDC_SUBCLASSING_RESTRICTED
 
 @class MDCAppBar;
+@class MDCAppBarViewController;
 @class MDCAppBarNavigationController;
 
 /**
@@ -45,6 +46,28 @@
  @note This method will only be invoked if a new App Bar instance is about to be added to the view
  controller. If a flexible header is already present in the view controller, this method will not
  be invoked.
+ */
+- (void)appBarNavigationController:(nonnull MDCAppBarNavigationController *)navigationController
+       willAddAppBarViewController:(nonnull MDCAppBarViewController *)appBarViewController
+           asChildOfViewController:(nonnull UIViewController *)viewController;
+
+#pragma mark - Will be deprecated
+
+/**
+ Informs the receiver that the given App Bar will be added as a child of the given view controller.
+
+ This event is primarily intended to allow any configuration or theming of the App Bar to occur
+ before it becomes part of the view controller hierarchy.
+
+ By the time this event has fired, the navigation controller will already have attempted to infer
+ the tracking scroll view from the provided view controller.
+
+ @note This method will only be invoked if a new App Bar instance is about to be added to the view
+ controller. If a flexible header is already present in the view controller, this method will not
+ be invoked.
+
+ This method will soon be deprecated. Please use
+ -appBarNavigationController:willAddAppBarViewController:asChildOfViewController: instead.
  */
 - (void)appBarNavigationController:(nonnull MDCAppBarNavigationController *)navigationController
                      willAddAppBar:(nonnull MDCAppBar *)appBar
@@ -76,10 +99,21 @@ MDC_SUBCLASSING_RESTRICTED
  */
 @property(nonatomic, weak, nullable) id<MDCAppBarNavigationControllerDelegate> delegate;
 
-#pragma mark - Getting App Bar instances
+#pragma mark - Getting App Bar view controller instances
+
+/**
+ Returns the injected App Bar view controller for a given view controller, if an App Bar was
+ injected.
+ */
+- (nullable MDCAppBarViewController *)appBarViewControllerForViewController:
+    (nonnull UIViewController *)viewController;
+
+#pragma mark - To be deprecated
 
 /**
  Returns the injected App Bar for a given view controller, if an App Bar was injected.
+
+ This method will eventually be deprecated. Use -appBarViewControllerForViewController: instead.
  */
 - (nullable MDCAppBar *)appBarForViewController:(nonnull UIViewController *)viewController;
 

--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -36,7 +36,7 @@
 - (void)dealloc {
   // On pre-iOS 11 devices we need to manually clear out the trackingScrollView because we've
   // enabled the observesTrackingScrollViewScrollEvents behavior on the flexible header.
-  self.appBar.headerViewController.headerView.trackingScrollView = nil;
+  self.appBar.appBarViewController.headerView.trackingScrollView = nil;
 }
 
 @end
@@ -71,7 +71,7 @@
   UIViewController *child = [super childViewControllerForStatusBarStyle];
   MDCAppBar *appBar = [self appBarForViewController:child];
   if (appBar) {
-    return appBar.headerViewController;
+    return appBar.appBarViewController;
   }
   return child; // Fall back to using the child if we didn't knowingly inject an app bar.
 }
@@ -131,22 +131,22 @@
 
   // Ensures that the view controller's top layout guide / additional safe area insets are adjusted
   // to take into consideration the flexible header's height.
-  appBar.headerViewController.topLayoutGuideViewController = viewController;
+  appBar.appBarViewController.topLayoutGuideViewController = viewController;
 
   // Ensures that our App Bar's top layout guide reflects the current view controller hierarchy.
   // Most notably, this ensures we support iPad popovers and extensions.
-  appBar.inferTopSafeAreaInsetFromViewController = YES;
+  appBar.appBarViewController.inferTopSafeAreaInsetFromViewController = YES;
 
   // We want our flexible header to calculate the safe area insets dynamically, rather than assume
   // we've pre-calculated them.
-  appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = NO;
+  appBar.appBarViewController.headerView.minMaxHeightIncludesSafeArea = NO;
 
   // This is the magic that allows us to avoid having to explicitly forward any scroll view events
   // to the flexible header. Enabling this means we cannot enable the shiftBehavior on the
   // flexible header. In those cases the client is expected to create their own App Bar.
-  appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = YES;
+  appBar.appBarViewController.headerView.observesTrackingScrollViewScrollEvents = YES;
 
-  appBar.headerViewController.headerView.trackingScrollView = trackingScrollView;
+  appBar.appBarViewController.headerView.trackingScrollView = trackingScrollView;
 
   if ([self.delegate respondsToSelector:
        @selector(appBarNavigationController:willAddAppBar:asChildOfViewController:)]) {
@@ -155,7 +155,14 @@
                       asChildOfViewController:viewController];
   }
 
-  [viewController addChildViewController:appBar.headerViewController];
+  if ([self.delegate respondsToSelector:
+       @selector(appBarNavigationController:willAddAppBarViewController:asChildOfViewController:)]) {
+    [self.delegate appBarNavigationController:self
+                  willAddAppBarViewController:appBar.appBarViewController
+                      asChildOfViewController:viewController];
+  }
+
+  [viewController addChildViewController:appBar.appBarViewController];
   [appBar addSubviewsToParent];
 }
 
@@ -203,6 +210,11 @@
 
 - (MDCAppBar *)appBarForViewController:(UIViewController *)viewController {
   return [self infoForViewController:viewController].appBar;
+}
+
+- (MDCAppBarViewController *)
+    appBarViewControllerForViewController:(UIViewController *)viewController {
+  return [self infoForViewController:viewController].appBar.appBarViewController;
 }
 
 @end

--- a/components/AppBar/src/TypographyThemer/MDCAppBarTypographyThemer.h
+++ b/components/AppBar/src/TypographyThemer/MDCAppBarTypographyThemer.h
@@ -26,6 +26,17 @@
  Applies a typography scheme's properties to an MDCAppBar.
 
  @param typographyScheme The typography scheme to apply to the component instance.
+ @param appBarViewController A component instance to which the typography scheme should be applied.
+ */
++ (void)applyTypographyScheme:(nonnull id<MDCTypographyScheming>)typographyScheme
+       toAppBarViewController:(nonnull MDCAppBarViewController *)appBarViewController;
+
+#pragma mark - To be deprecated
+
+/**
+ Applies a typography scheme's properties to an MDCAppBar.
+
+ @param typographyScheme The typography scheme to apply to the component instance.
  @param appBar A component instance to which the typography scheme should be applied.
  */
 + (void)applyTypographyScheme:(nonnull id<MDCTypographyScheming>)typographyScheme

--- a/components/AppBar/src/TypographyThemer/MDCAppBarTypographyThemer.m
+++ b/components/AppBar/src/TypographyThemer/MDCAppBarTypographyThemer.m
@@ -20,6 +20,14 @@
 
 @implementation MDCAppBarTypographyThemer
 
++ (void)applyTypographyScheme:(nonnull id<MDCTypographyScheming>)typographyScheme
+       toAppBarViewController:(nonnull MDCAppBarViewController *)appBarViewController {
+  [MDCNavigationBarTypographyThemer applyTypographyScheme:typographyScheme
+                                          toNavigationBar:appBarViewController.navigationBar];
+}
+
+#pragma mark - To be deprecated
+
 + (void)applyTypographyScheme:(id<MDCTypographyScheming>)typographyScheme
                      toAppBar:(MDCAppBar *)appBar {
   [MDCNavigationBarTypographyThemer applyTypographyScheme:typographyScheme


### PR DESCRIPTION
This change introduces the following changes:

- MDCAppBarViewController is a new public API.
- MDCAppBarViewController is now a subclass of MDCFlexibleHeaderViewController.
- MDCAppBar and friends are marked as to be deprecated.
- MDCAppBar is now a simple shell for MDCAppBarViewController and it forwards all messages to the view controller accordingly.
- MDCAppBarNavigationController exposes new APIs related to the app bar view controller. The old MDCAppBar APIs have been marked as "to be deprecated".
- Themers all have new APIs for the new view controller. The App Bar-specific APIs have been marked as "to be deprecated".
- All internal implementation details make use of the view controller where possible instead of an app bar.
- The app bar view controller is now a flexible header view controller, rather than a child of it. If any clients were depending on the private previous behavior for any reason then this change will break them.

There is a follow-up change to this that will update the catalog to the new APIs. I have split that out to a separate change due to its size.

This API change will ease client integrations, giving them a clearer conceptual understanding of "App Bar as a sub-type of Flexible Header", vs the previous "model" pattern which bound the App Bar's views to a flexible header view controller instance.

## Typical client migration

```swift
// Step 1
-  let appBar = MDCAppBar()
+  let appBarViewController = MDCAppBarViewController()

// Step 2
-    self.addChildViewController(appBar.headerViewController)
+    self.addChildViewController(appBarViewController)

// Step 3
-    appBar.addSubviewsToParent()
+    view.addSubview(appBarViewController.view)
+    appBarViewController.didMove(toParentViewController: self)
```