### PR TITLE
[FlexibleHeader] Allow additionalSafeAreaInsets to respect contextual top insets.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -543,7 +543,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   return _topSafeAreaGuide;
 }
 
-- (CGFloat)topSafeAreaGuideLength {
+- (CGFloat)topSafeAreaGuideHeight {
   return _topSafeAreaGuide.frame.size.height;
 }
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -543,6 +543,10 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   return _topSafeAreaGuide;
 }
 
+- (CGFloat)topSafeAreaGuideLength {
+  return _topSafeAreaGuide.frame.size.height;
+}
+
 #pragma mark - Private (fhv_ prefix)
 
 - (void)fhv_setContentOffset:(CGPoint)contentOffset {

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -488,12 +488,8 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
       UIEdgeInsets additionalSafeAreaInsets = topLayoutGuideViewController.additionalSafeAreaInsets;
       // We need to avoid double-counting any top safe area amount because this will already be
       // taken into account as part of additionalSafeAreaInsets.
-      topInset -= self.headerView.topSafeAreaGuideLength;
-      if (self.headerView.minMaxHeightIncludesSafeArea) {
-        topInset = MIN(self.headerView.maximumHeight - MDCDeviceTopSafeAreaInset(), topInset);
-      } else {
-        topInset = MIN(self.headerView.maximumHeight, topInset);
-      }
+      topInset = MIN(self.headerView.maximumHeight,
+                     topInset - self.headerView.topSafeAreaGuideLength);
       additionalSafeAreaInsets.top = topInset;
       topLayoutGuideViewController.additionalSafeAreaInsets = additionalSafeAreaInsets;
     }

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -486,14 +486,15 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 
     } else if (topLayoutGuideViewController != nil) {
       UIEdgeInsets additionalSafeAreaInsets = topLayoutGuideViewController.additionalSafeAreaInsets;
-      if (self.headerView.statusBarHintCanOverlapHeader) {
-        // safe area insets will likely already take into account the top safe area inset, so let's
-        // avoid double-counting that here.
-        additionalSafeAreaInsets.top = topInset - MDCDeviceTopSafeAreaInset();
-
+      // We need to avoid double-counting any top safe area amount because this will already be
+      // taken into account as part of additionalSafeAreaInsets.
+      topInset -= self.headerView.topSafeAreaGuideLength;
+      if (self.headerView.minMaxHeightIncludesSafeArea) {
+        topInset = MIN(self.headerView.maximumHeight - MDCDeviceTopSafeAreaInset(), topInset);
       } else {
-        additionalSafeAreaInsets.top = topInset;
+        topInset = MIN(self.headerView.maximumHeight, topInset);
       }
+      additionalSafeAreaInsets.top = topInset;
       topLayoutGuideViewController.additionalSafeAreaInsets = additionalSafeAreaInsets;
     }
   }

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -488,8 +488,12 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
       UIEdgeInsets additionalSafeAreaInsets = topLayoutGuideViewController.additionalSafeAreaInsets;
       // We need to avoid double-counting any top safe area amount because this will already be
       // taken into account as part of additionalSafeAreaInsets.
-      topInset = MIN(self.headerView.maximumHeight,
-                     topInset - self.headerView.topSafeAreaGuideLength);
+      topInset -= self.headerView.topSafeAreaGuideLength;
+      if (self.headerView.minMaxHeightIncludesSafeArea) {
+        topInset = MIN(self.headerView.maximumHeight - MDCDeviceTopSafeAreaInset(), topInset);
+      } else {
+        topInset = MIN(self.headerView.maximumHeight, topInset);
+      }
       additionalSafeAreaInsets.top = topInset;
       topLayoutGuideViewController.additionalSafeAreaInsets = additionalSafeAreaInsets;
     }

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -488,7 +488,7 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
       UIEdgeInsets additionalSafeAreaInsets = topLayoutGuideViewController.additionalSafeAreaInsets;
       // We need to avoid double-counting any top safe area amount because this will already be
       // taken into account as part of additionalSafeAreaInsets.
-      topInset -= self.headerView.topSafeAreaGuideLength;
+      topInset -= self.headerView.topSafeAreaGuideHeight;
       if (self.headerView.minMaxHeightIncludesSafeArea) {
         topInset = MIN(self.headerView.maximumHeight - MDCDeviceTopSafeAreaInset(), topInset);
       } else {

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderView+Private.h
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderView+Private.h
@@ -36,4 +36,9 @@
  */
 - (void)extractTopSafeAreaInset;
 
+/**
+ The length of the top safe area guide.
+ */
+@property(nonatomic, readonly) CGFloat topSafeAreaGuideLength;
+
 @end

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderView+Private.h
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderView+Private.h
@@ -37,8 +37,8 @@
 - (void)extractTopSafeAreaInset;
 
 /**
- The length of the top safe area guide.
+ The height of the top safe area guide.
  */
-@property(nonatomic, readonly) CGFloat topSafeAreaGuideLength;
+@property(nonatomic, readonly) CGFloat topSafeAreaGuideHeight;
 
 @end

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderWrappingTopLayoutGuideTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderWrappingTopLayoutGuideTests.swift
@@ -16,7 +16,6 @@
 
 import XCTest
 import MaterialComponents.MaterialFlexibleHeader
-import MaterialComponents.MaterialUIMetrics
 
 class FlexibleHeaderWrappingTopLayoutGuideTests: XCTestCase {
 
@@ -54,8 +53,7 @@ class FlexibleHeaderWrappingTopLayoutGuideTests: XCTestCase {
     #if swift(>=3.2)
     if #available(iOS 11.0, *) {
       XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top,
-                     container.headerViewController.headerView.frame.maxY
-                      - MDCDeviceTopSafeAreaInset())
+                     container.headerViewController.headerView.frame.maxY)
     }
     #endif
   }
@@ -74,8 +72,7 @@ class FlexibleHeaderWrappingTopLayoutGuideTests: XCTestCase {
     #if swift(>=3.2)
     if #available(iOS 11.0, *) {
       XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top,
-                     container.headerViewController.headerView.frame.maxY
-                      - MDCDeviceTopSafeAreaInset())
+                     container.headerViewController.headerView.frame.maxY)
     }
     #endif
   }
@@ -96,8 +93,7 @@ class FlexibleHeaderWrappingTopLayoutGuideTests: XCTestCase {
     #if swift(>=3.2)
     if #available(iOS 11.0, *) {
       XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top,
-                     container.headerViewController.headerView.frame.maxY
-                      - MDCDeviceTopSafeAreaInset())
+                     container.headerViewController.headerView.frame.maxY)
       XCTAssertEqual(contentViewController.tableView.adjustedContentInset.top, 0)
     }
     #endif
@@ -142,8 +138,7 @@ class FlexibleHeaderWrappingTopLayoutGuideTests: XCTestCase {
     #if swift(>=3.2)
     if #available(iOS 11.0, *) {
       XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top,
-                     container.headerViewController.headerView.frame.maxY
-                      - MDCDeviceTopSafeAreaInset())
+                     container.headerViewController.headerView.frame.maxY)
       XCTAssertEqual(contentViewController.collectionView!.adjustedContentInset.top, 0)
     }
     #endif


### PR DESCRIPTION
Prior to this change, the additionalSafeAreaInsets logic was relying on MDCDeviceSafeAreaInsets to remove any system-provided insets from the additional safe area insets. This removal is necessary to avoid double-counting of the safe area insets. Unfortunately, this means that this logic isn't aware of the contextual safe area insets and results in over-counting in cases where the flexible header is not, in fact, behind a status bar.

After this change, the additionalSafeAreaInsets logic will use the flexible header's top safe area guide to subtract any additional safe area insets instead. This ties the additionalSafeAreaInsets logic in to the rest of the contextual safe area insets logic, enabling proper calculation of additionalSafeAreaInsets in cases where the flexible header is not behind a status bar.