### PR TITLE
[FlexibleHeader] Fixes a layout bug with VoiceOver on that was introduced in v57.0.0 (5dc67c88c06f11761769de1d0bae34ff2c657046).

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1121,7 +1121,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   // Notably, UITableViewController's .view _is_ the tableView, so there is no way to add a flexible
   // header other than as a subview to the scroll view. This is the most common case to which the
   // following logic has been written.
-  if (self.superview == self.trackingScrollView) {
+  if (self.superview && self.superview == self.trackingScrollView) {
     if (self.superview.subviews.lastObject != self) {
       [self.superview bringSubviewToFront:self];
     }


### PR DESCRIPTION
Mirrored from [cl/207146446](http://cl/207146446) and fixes internal bug [b/111751034](http://b/111751034). This fixes a bug that was introduced in 5dc67c88c06f11761769de1d0bae34ff2c657046.

The bug behavior was that app bars were disappearing when voice over was enabled.

The logic for `self.superview == self.trackingScrollView` would be true if both self.superview and self.trackingScrollView were nil, resulting in the logic below being executed. We did not notice this before because the logic prior to 5dc67c88c06f11761769de1d0bae34ff2c657046 no-oped due to nil behavior. 5dc67c88c06f11761769de1d0bae34ff2c657046 introduced logic that did not no-op, however.

We are now guarding against entering this block of logic if self.superview == nil.