### PR TITLE
[Catalog] Fix Snackbar crash after switching between LEGACY and NEW

### DIFF
--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -371,18 +371,18 @@ static const CGFloat kMaximumHeight = 80.0f;
       }
       [container addConstraint:_snackbarOnscreenConstraint];
 
-      if (MDCSnackbarMessage.usesLegacySnackbar) {
-        _snackbarOffscreenConstraint =
-            [NSLayoutConstraint constraintWithItem:snackbarView
-                                         attribute:NSLayoutAttributeTop
-                                         relatedBy:NSLayoutRelationEqual
-                                            toItem:container
-                                         attribute:NSLayoutAttributeBottom
-                                        multiplier:1.0
-                                          constant:-bottomMargin];
-        _snackbarOffscreenConstraint.active = YES;
-        [container addConstraint:_snackbarOffscreenConstraint];
+      _snackbarOffscreenConstraint = [NSLayoutConstraint constraintWithItem:snackbarView
+                                                                  attribute:NSLayoutAttributeTop
+                                                                  relatedBy:NSLayoutRelationEqual
+                                                                     toItem:container
+                                                                  attribute:NSLayoutAttributeBottom
+                                                                 multiplier:1.0
+                                                                   constant:-bottomMargin];
+      _snackbarOffscreenConstraint.active = MDCSnackbarMessage.usesLegacySnackbar;
+      if (!MDCSnackbarMessage.usesLegacySnackbar) {
+        _snackbarOffscreenConstraint.priority = UILayoutPriorityDefaultHigh;
       }
+      [container addConstraint:_snackbarOffscreenConstraint];
 
       // Always limit the height of the Snackbar.
       self.maximumHeightConstraint =

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -380,7 +380,7 @@ static const CGFloat kMaximumHeight = 80.0f;
                                                                    constant:-bottomMargin];
       _snackbarOffscreenConstraint.active = MDCSnackbarMessage.usesLegacySnackbar;
       if (!MDCSnackbarMessage.usesLegacySnackbar) {
-        _snackbarOffscreenConstraint.priority = UILayoutPriorityDefaultHigh;
+        _snackbarOffscreenConstraint.priority = UILayoutPriorityDefaultLow;
       }
       [container addConstraint:_snackbarOffscreenConstraint];
 


### PR DESCRIPTION
Showing "LEGACY" Snackbar while a "NEW" Snackbar is displaying makes app get crash.

EXC_BAD_ACCESS screen shoot

![][1]

## Reproduction steps

Steps to reproduce the behavior:

1. Open the Catalog → Snackbar → Start Demo
2. Tap on "Simple Snackbar" → Do below steps while Snackbar is showing
3. Tap on "LEGACY" 
4. Tap on "Simple Snackbar" 
5. Tap on "NEW" 
6. Tap on "Simple Snackbar" again

## Expected behavior

Current Snackbar is hidden and new Snackbar is displayed

## Actual behavior

App gets crash

## Platform (please complete the following information)

iPhone 8 Plus / iOS 11.4

  [1]: https://i.stack.imgur.com/6x4IA.png

Closes #3723