### PR TITLE
[FlexibleHeader] Fix a bug with WKWebView as a tracking scroll view.

### DIFF
--- a/components/AppBar/examples/AppBarWKWebViewLargeContentExample.m
+++ b/components/AppBar/examples/AppBarWKWebViewLargeContentExample.m
@@ -1,0 +1,165 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
+
+#import "MaterialAppBar.h"
+#import "MaterialAppBar+ColorThemer.h"
+#import "MaterialAppBar+TypographyThemer.h"
+
+// This demonstrates that a WKWebView with large content as the tracking scroll view is able to
+// scroll as expected, even with the useAdditionalSafeAreaInsetsForWebKitScrollViews flag enabled.
+
+@interface AppBarWKWebViewLargeContentExample : UIViewController
+
+@property(nonatomic, strong) MDCAppBar *appBar;
+@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
+
+@end
+
+@implementation AppBarWKWebViewLargeContentExample
+
+- (void)dealloc {
+  // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+  self.appBar.headerViewController.headerView.trackingScrollView = nil;
+}
+
+- (id)init {
+  self = [super init];
+  if (self) {
+    self.title = @"App Bar";
+
+    _appBar = [[MDCAppBar alloc] init];
+
+    // Behavioral flags.
+    _appBar.inferTopSafeAreaInsetFromViewController = YES;
+    _appBar.headerViewController.topLayoutGuideViewController = self;
+    _appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = NO;
+    _appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = YES;
+
+    _appBar.headerViewController.useAdditionalSafeAreaInsetsForWebKitScrollViews = YES;
+
+    [self addChildViewController:_appBar.headerViewController];
+
+    _appBar.navigationBar.inkColor = [UIColor colorWithWhite:0.9f alpha:0.1f];
+
+    self.colorScheme = [[MDCSemanticColorScheme alloc] init];
+    self.typographyScheme = [[MDCTypographyScheme alloc] init];
+  }
+  return self;
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  [MDCAppBarColorThemer applySemanticColorScheme:self.colorScheme toAppBar:_appBar];
+  [MDCAppBarTypographyThemer applyTypographyScheme:self.typographyScheme toAppBar:_appBar];
+
+  // Need to update the status bar style after applying the theme.
+  [self setNeedsStatusBarAppearanceUpdate];
+
+  WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+  WKWebView *webView = [[WKWebView alloc] initWithFrame:self.view.bounds configuration:config];
+  [self.view addSubview:webView];
+
+  NSMutableArray *content = [@[@"<html>\n<head></head><body>"] mutableCopy];
+  for (NSInteger ix = 0; ix < 500; ++ix) {
+    [content addObject:@"<p>Hello</p>"];
+  }
+  [content addObject:@"</body></html>"];
+  [webView loadHTMLString:[content componentsJoinedByString:@"\n"] baseURL:nil];
+
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    // No need to do anything - additionalSafeAreaInsets will inset our content.
+    webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+  } else {
+#endif
+  webView.translatesAutoresizingMaskIntoConstraints = NO;
+  [NSLayoutConstraint activateConstraints:
+   @[[NSLayoutConstraint constraintWithItem:webView
+                                  attribute:NSLayoutAttributeTop
+                                  relatedBy:NSLayoutRelationEqual
+                                     toItem:self.topLayoutGuide
+                                  attribute:NSLayoutAttributeBottom
+                                 multiplier:1.0
+                                   constant:0],
+     [NSLayoutConstraint constraintWithItem:webView
+                                  attribute:NSLayoutAttributeBottom
+                                  relatedBy:NSLayoutRelationEqual
+                                     toItem:self.view
+                                  attribute:NSLayoutAttributeBottom
+                                 multiplier:1.0
+                                   constant:0],
+     [NSLayoutConstraint constraintWithItem:webView
+                                  attribute:NSLayoutAttributeLeft
+                                  relatedBy:NSLayoutRelationEqual
+                                     toItem:self.view
+                                  attribute:NSLayoutAttributeLeft
+                                 multiplier:1.0
+                                   constant:0],
+     [NSLayoutConstraint constraintWithItem:webView
+                                  attribute:NSLayoutAttributeRight
+                                  relatedBy:NSLayoutRelationEqual
+                                     toItem:self.view
+                                  attribute:NSLayoutAttributeRight
+                                 multiplier:1.0
+                                   constant:0]
+     ]];
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  }
+#endif
+  self.appBar.headerViewController.headerView.trackingScrollView = webView.scrollView;
+  [self.appBar addSubviewsToParent];
+}
+
+- (UIViewController *)childViewControllerForStatusBarHidden {
+  return self.appBar.headerViewController;
+}
+
+- (UIViewController *)childViewControllerForStatusBarStyle {
+  return self.appBar.headerViewController;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+  [super viewWillAppear:animated];
+
+  [self.navigationController setNavigationBarHidden:YES animated:animated];
+}
+
+@end
+
+@implementation AppBarWKWebViewLargeContentExample (CatalogByConvention)
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"App Bar", @"WKWebView large content" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return YES;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return YES;
+}
+
++ (BOOL)catalogIsPresentable {
+  return NO;
+}
+
+@end

--- a/components/AppBar/examples/AppBarWKWebViewLargeContentNoBugExample.m
+++ b/components/AppBar/examples/AppBarWKWebViewLargeContentNoBugExample.m
@@ -1,0 +1,125 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
+
+#import "MaterialAppBar.h"
+#import "MaterialAppBar+ColorThemer.h"
+#import "MaterialAppBar+TypographyThemer.h"
+
+// This demonstrates that a WKWebView with large content as the tracking scroll view is able to
+// scroll as expected, even without the useAdditionalSafeAreaInsetsForWebKitScrollViews flag
+// enabled.
+
+@interface AppBarWKWebViewLargeContentNoBugExample : UIViewController
+
+@property(nonatomic, strong) MDCAppBar *appBar;
+@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
+
+@end
+
+@implementation AppBarWKWebViewLargeContentNoBugExample
+
+- (void)dealloc {
+  // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+  self.appBar.headerViewController.headerView.trackingScrollView = nil;
+}
+
+- (id)init {
+  self = [super init];
+  if (self) {
+    self.title = @"App Bar";
+
+    _appBar = [[MDCAppBar alloc] init];
+
+    // Behavioral flags.
+    _appBar.inferTopSafeAreaInsetFromViewController = YES;
+    _appBar.headerViewController.topLayoutGuideViewController = self;
+    _appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = NO;
+    _appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = YES;
+
+    [self addChildViewController:_appBar.headerViewController];
+
+    _appBar.navigationBar.inkColor = [UIColor colorWithWhite:0.9f alpha:0.1f];
+
+    self.colorScheme = [[MDCSemanticColorScheme alloc] init];
+    self.typographyScheme = [[MDCTypographyScheme alloc] init];
+  }
+  return self;
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  [MDCAppBarColorThemer applySemanticColorScheme:self.colorScheme toAppBar:_appBar];
+  [MDCAppBarTypographyThemer applyTypographyScheme:self.typographyScheme toAppBar:_appBar];
+
+  // Need to update the status bar style after applying the theme.
+  [self setNeedsStatusBarAppearanceUpdate];
+
+  WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+  WKWebView *webView = [[WKWebView alloc] initWithFrame:self.view.bounds configuration:config];
+  webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+  [self.view addSubview:webView];
+
+  NSMutableArray *content = [@[@"<html>\n<head></head><body>"] mutableCopy];
+  for (NSInteger ix = 0; ix < 500; ++ix) {
+    [content addObject:@"<p>Hello</p>"];
+  }
+  [content addObject:@"</body></html>"];
+  [webView loadHTMLString:[content componentsJoinedByString:@"\n"] baseURL:nil];
+
+  self.appBar.headerViewController.headerView.trackingScrollView = webView.scrollView;
+  [self.appBar addSubviewsToParent];
+}
+
+- (UIViewController *)childViewControllerForStatusBarHidden {
+  return self.appBar.headerViewController;
+}
+
+- (UIViewController *)childViewControllerForStatusBarStyle {
+  return self.appBar.headerViewController;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+  [super viewWillAppear:animated];
+
+  [self.navigationController setNavigationBarHidden:YES animated:animated];
+}
+
+@end
+
+@implementation AppBarWKWebViewLargeContentNoBugExample (CatalogByConvention)
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"App Bar", @"WKWebView large content no bug" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return YES;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return YES;
+}
+
++ (BOOL)catalogIsPresentable {
+  return NO;
+}
+
+@end

--- a/components/AppBar/examples/AppBarWKWebViewSmallContentBugExample.m
+++ b/components/AppBar/examples/AppBarWKWebViewSmallContentBugExample.m
@@ -1,0 +1,123 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
+
+#import "MaterialAppBar.h"
+#import "MaterialAppBar+ColorThemer.h"
+#import "MaterialAppBar+TypographyThemer.h"
+
+// This demonstrates a bug when WKWebView's scroll view is the tracking scroll view and the web
+// view's content is smaller than the screen. Note that the content is scrollable because the
+// contentSize.height is greater than the web view's bounds.height. This appears to stem from some
+// incorrect contentSize.height calculations in WKWebView.
+// See AppBarWKWebViewSmallContentExample for this same example, but with the bug fixed.
+
+@interface AppBarWKWebViewSmallContentBugExample : UIViewController
+
+@property(nonatomic, strong) MDCAppBar *appBar;
+@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
+
+@end
+
+@implementation AppBarWKWebViewSmallContentBugExample
+
+- (void)dealloc {
+  // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+  self.appBar.headerViewController.headerView.trackingScrollView = nil;
+}
+
+- (id)init {
+  self = [super init];
+  if (self) {
+    self.title = @"App Bar";
+
+    _appBar = [[MDCAppBar alloc] init];
+
+    // Behavioral flags.
+    _appBar.inferTopSafeAreaInsetFromViewController = YES;
+    _appBar.headerViewController.topLayoutGuideViewController = self;
+    _appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = NO;
+    _appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = YES;
+
+    [self addChildViewController:_appBar.headerViewController];
+
+    _appBar.navigationBar.inkColor = [UIColor colorWithWhite:0.9f alpha:0.1f];
+
+    self.colorScheme = [[MDCSemanticColorScheme alloc] init];
+    self.typographyScheme = [[MDCTypographyScheme alloc] init];
+  }
+  return self;
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  [MDCAppBarColorThemer applySemanticColorScheme:self.colorScheme toAppBar:_appBar];
+  [MDCAppBarTypographyThemer applyTypographyScheme:self.typographyScheme toAppBar:_appBar];
+
+  // Need to update the status bar style after applying the theme.
+  [self setNeedsStatusBarAppearanceUpdate];
+
+  WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+  WKWebView *webView = [[WKWebView alloc] initWithFrame:self.view.bounds configuration:config];
+  webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+  [self.view addSubview:webView];
+
+  [webView loadHTMLString:@"<html>\n<head></head><body>Hi</body></html>" baseURL:nil];
+
+  self.appBar.headerViewController.headerView.trackingScrollView = webView.scrollView;
+
+  [self.appBar addSubviewsToParent];
+}
+
+- (UIViewController *)childViewControllerForStatusBarHidden {
+  return self.appBar.headerViewController;
+}
+
+- (UIViewController *)childViewControllerForStatusBarStyle {
+  return self.appBar.headerViewController;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+  [super viewWillAppear:animated];
+
+  [self.navigationController setNavigationBarHidden:YES animated:animated];
+}
+
+@end
+
+@implementation AppBarWKWebViewSmallContentBugExample (CatalogByConvention)
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"App Bar", @"WKWebView small content bug" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return YES;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return YES;
+}
+
++ (BOOL)catalogIsPresentable {
+  return NO;
+}
+
+@end

--- a/components/AppBar/examples/AppBarWKWebViewSmallContentExample.m
+++ b/components/AppBar/examples/AppBarWKWebViewSmallContentExample.m
@@ -1,0 +1,160 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
+
+#import "MaterialAppBar.h"
+#import "MaterialAppBar+ColorThemer.h"
+#import "MaterialAppBar+TypographyThemer.h"
+
+// This demonstrates that a WKWebView with minimal content as the tracking scroll view is not able
+// to scroll as expected. This requires enabling useAdditionalSafeAreaInsetsForWebKitScrollViews
+// and adjusting the frame of the web view on pre-iOS 11 devices by using the topLayoutGuide.
+
+@interface AppBarWKWebViewSmallContentExample : UIViewController
+@property(nonatomic, strong) MDCAppBar *appBar;
+@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
+@end
+
+@implementation AppBarWKWebViewSmallContentExample
+
+- (void)dealloc {
+  // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+  self.appBar.headerViewController.headerView.trackingScrollView = nil;
+}
+
+- (id)init {
+  self = [super init];
+  if (self) {
+    self.title = @"App Bar";
+
+    _appBar = [[MDCAppBar alloc] init];
+
+    _appBar.inferTopSafeAreaInsetFromViewController = YES;
+    _appBar.headerViewController.topLayoutGuideViewController = self;
+    _appBar.headerViewController.headerView.minMaxHeightIncludesSafeArea = NO;
+    _appBar.headerViewController.headerView.observesTrackingScrollViewScrollEvents = YES;
+
+    // Fixes the WKWebView contentSize.height bug on iOS 11+.
+    _appBar.headerViewController.useAdditionalSafeAreaInsetsForWebKitScrollViews = YES;
+
+    [self addChildViewController:_appBar.headerViewController];
+
+    _appBar.navigationBar.inkColor = [UIColor colorWithWhite:0.9f alpha:0.1f];
+
+    self.colorScheme = [[MDCSemanticColorScheme alloc] init];
+    self.typographyScheme = [[MDCTypographyScheme alloc] init];
+  }
+  return self;
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  [MDCAppBarColorThemer applySemanticColorScheme:self.colorScheme toAppBar:_appBar];
+  [MDCAppBarTypographyThemer applyTypographyScheme:self.typographyScheme toAppBar:_appBar];
+
+  [self setNeedsStatusBarAppearanceUpdate];
+
+  WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+  WKWebView *webView = [[WKWebView alloc] initWithFrame:self.view.bounds configuration:config];
+  [self.view addSubview:webView];
+
+  [webView loadHTMLString:@"<html>\n<head></head><body>Hi</body></html>" baseURL:nil];
+
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    // No need to do anything - additionalSafeAreaInsets will inset our content.
+    webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+  } else {
+#endif
+  // Fixes the WKWebView contentSize.height bug pre-iOS 11.
+  webView.translatesAutoresizingMaskIntoConstraints = NO;
+  [NSLayoutConstraint activateConstraints:
+   @[[NSLayoutConstraint constraintWithItem:webView
+                                  attribute:NSLayoutAttributeTop
+                                  relatedBy:NSLayoutRelationEqual
+                                     toItem:self.topLayoutGuide
+                                  attribute:NSLayoutAttributeBottom
+                                 multiplier:1.0
+                                   constant:0],
+     [NSLayoutConstraint constraintWithItem:webView
+                                  attribute:NSLayoutAttributeBottom
+                                  relatedBy:NSLayoutRelationEqual
+                                     toItem:self.view
+                                  attribute:NSLayoutAttributeBottom
+                                 multiplier:1.0
+                                   constant:0],
+     [NSLayoutConstraint constraintWithItem:webView
+                                  attribute:NSLayoutAttributeLeft
+                                  relatedBy:NSLayoutRelationEqual
+                                     toItem:self.view
+                                  attribute:NSLayoutAttributeLeft
+                                 multiplier:1.0
+                                   constant:0],
+     [NSLayoutConstraint constraintWithItem:webView
+                                  attribute:NSLayoutAttributeRight
+                                  relatedBy:NSLayoutRelationEqual
+                                     toItem:self.view
+                                  attribute:NSLayoutAttributeRight
+                                 multiplier:1.0
+                                   constant:0]
+     ]];
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  }
+#endif
+
+  self.appBar.headerViewController.headerView.trackingScrollView = webView.scrollView;
+  [self.appBar addSubviewsToParent];
+}
+
+- (UIViewController *)childViewControllerForStatusBarHidden {
+  return self.appBar.headerViewController;
+}
+
+- (UIViewController *)childViewControllerForStatusBarStyle {
+  return self.appBar.headerViewController;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+  [super viewWillAppear:animated];
+
+  [self.navigationController setNavigationBarHidden:YES animated:animated];
+}
+
+@end
+
+@implementation AppBarWKWebViewSmallContentExample (CatalogByConvention)
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"App Bar", @"WKWebView small content" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return YES;
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return YES;
+}
+
++ (BOOL)catalogIsPresentable {
+  return NO;
+}
+
+@end

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -178,6 +178,8 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   // The block executed when shadow intensity changes.
   MDCFlexibleHeaderShadowIntensityChangeBlock _shadowIntensityChangeBlock;
 
+  Class _wkWebViewClass;
+
 #if DEBUG
   // Keeps track of whether the client called ...WillEndDraggingWithVelocity:...
   BOOL _didAdjustTargetContentOffset;
@@ -230,6 +232,8 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 }
 
 - (void)commonMDCFlexibleHeaderViewInit {
+  _wkWebViewClass = NSClassFromString(@"WKWebView");
+
   _statusBarShifter = [[MDCStatusBarShifter alloc] init];
   _statusBarShifter.delegate = self;
   _statusBarShifter.enabled = [self fhv_shouldAllowShifting];
@@ -547,6 +551,10 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   return _topSafeAreaGuide.frame.size.height;
 }
 
+- (BOOL)trackingScrollViewIsWebKit {
+  return [self.trackingScrollView.superview.class isSubclassOfClass:_wkWebViewClass];
+}
+
 #pragma mark - Private (fhv_ prefix)
 
 - (void)fhv_setContentOffset:(CGPoint)contentOffset {
@@ -630,7 +638,8 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 // This ensures that when our scroll view is scrolled to its top that our header is able to be fully
 // expanded.
 - (CGFloat)fhv_enforceInsetsForScrollView:(UIScrollView *)scrollView {
-  if (!scrollView) {
+  if (!scrollView || (self.useAdditionalSafeAreaInsetsForWebKitScrollViews
+                      && [self trackingScrollViewIsWebKit])) {
     return 0;
   }
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
@@ -102,6 +102,37 @@
  */
 @property(nonatomic) BOOL inferTopSafeAreaInsetFromViewController;
 
+/**
+ When a WKWebView's scroll view is the tracking scroll view, this behavioral flag affects whether
+ the flexible header uses additionalSafeAreaInsets or contentInset to adjust the tracking scroll
+ view's content.
+
+ Enabling this behavioral flag will fix a bug with small WKWebView content where the contentSize
+ would be improperly set, allowing the content to be scrolled when it shouldn't be.
+
+ This behavior will eventually be enabled by default.
+
+ Default is NO.
+
+ @note If you enable this flag you must also set a topLayoutGuideViewController. Failure to do so
+ will result in a runtime assertion failure.
+
+ @note If you support devices running an OS older than iOS 11 and you've enabled this flag, you
+ must also adjust the frame of your WKWebView to be positioned below the header using the
+ topLayoutGuide, like so:
+
+@code
+ [NSLayoutConstraint constraintWithItem:webView
+                              attribute:NSLayoutAttributeTop
+                              relatedBy:NSLayoutRelationEqual
+                                 toItem:self.topLayoutGuide
+                              attribute:NSLayoutAttributeBottom
+                             multiplier:1.0
+                               constant:0]
+@endcode
+ */
+@property(nonatomic) BOOL useAdditionalSafeAreaInsetsForWebKitScrollViews;
+
 #pragma mark UIViewController methods
 
 /**

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -442,6 +442,10 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 - (void)updateTopLayoutGuide {
   NSAssert([NSThread isMainThread],
            @"updateTopLayoutGuide must be called from the main thread.");
+  NSAssert(!self.useAdditionalSafeAreaInsetsForWebKitScrollViews
+           || (self.topLayoutGuideViewController != nil),
+           @"If useAdditionalSafeAreaInsetsForWebKitScrollViews is enabled you must also set a"
+           @"topLayoutGuideViewController.");
   // We observe (using KVO) the top layout guide's constant and re-invoke updateTopLayoutGuide
   // whenever it changes. We also change the constant in this method. So, to avoid a recursive
   // infinite loop we bail out early here if we're the ones that initiated the top layout guide
@@ -470,12 +474,18 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
+    BOOL alwaysUseAdditionalSafeAreaInsets = NO;
+    if (self.useAdditionalSafeAreaInsetsForWebKitScrollViews
+        && [self.headerView trackingScrollViewIsWebKit]) {
+      alwaysUseAdditionalSafeAreaInsets = YES;
+    }
+
     UIViewController *topLayoutGuideViewController = [self fhv_topLayoutGuideViewControllerWithFallback];
     // If there is a tracking scroll view then the flexible header will manage safe area insets via
     // the tracking scroll view's contentInsets. Some day - in the long distant future when we only
     // support iOS 11 and up - we can probably drop the content inset adjustment behavior in favor
     // of modifying additionalSafeAreaInsets instead.
-    if (self.headerView.trackingScrollView != nil) {
+    if (self.headerView.trackingScrollView != nil && !alwaysUseAdditionalSafeAreaInsets) {
       // Reset the additional safe area insets if we are now tracking a scroll view.
       if (topLayoutGuideViewController != nil) {
         UIEdgeInsets additionalSafeAreaInsets =
@@ -539,6 +549,16 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 
 - (BOOL)inferTopSafeAreaInsetFromViewController {
   return _headerView.inferTopSafeAreaInsetFromViewController;
+}
+
+- (void)setUseAdditionalSafeAreaInsetsForWebKitScrollViews:
+    (BOOL)useAdditionalSafeAreaInsetsForWebKitScrollViews {
+  _headerView.useAdditionalSafeAreaInsetsForWebKitScrollViews =
+      useAdditionalSafeAreaInsetsForWebKitScrollViews;
+}
+
+- (BOOL)useAdditionalSafeAreaInsetsForWebKitScrollViews {
+  return _headerView.useAdditionalSafeAreaInsetsForWebKitScrollViews;
 }
 
 #pragma mark - Top safe area inset extraction

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderView+Private.h
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderView+Private.h
@@ -41,4 +41,16 @@
  */
 @property(nonatomic, readonly) CGFloat topSafeAreaGuideHeight;
 
+#pragma mark - WebKit compatibility
+
+/**
+ Returns YES if the trackingScrollView is a scroll view of a WKWebView instance.
+ */
+- (BOOL)trackingScrollViewIsWebKit;
+
+/**
+ See MDCFlexibleHeaderViewController.h for documentation on this flag.
+ */
+@property(nonatomic) BOOL useAdditionalSafeAreaInsetsForWebKitScrollViews;
+
 @end


### PR DESCRIPTION
Repro case:
- Open MDCDragons.
- Open the App Bar -> WKWebView small content bug

Expected behavior: the web view does not allow the content to be scrolled up and down.
Actual behavior: the web view's scroll view's content size height appears to have extra padding, allowing the content to be scrolled.

---

This change introduces a runtime check for WKWebView. If the tracking scroll view is a scroll view of a WKWebView, we disable the content inset adjustment behavior in favor of using additionalSafeAreaInsets on iOS 11 and up. On older iOS devices, clients must instead rely on the topLayoutGuide and position their web view below the header accordingly. This is demonstrated in the two added examples.

This bug stems from the fact that UIKit's implementations of its various UIScrollView subclasses each have individual quirks. UITableView reacts differently to additionalSafeAreaInsets than WKWebView's scroll view, and a pure UIScrollView reacts differently from either of them. The most notable difference in behavior is how and when the contentOffset is adjusted in reaction to changes in the additionalSafeAreaInsets.

My original attempt at this fix included a public behavioral flag that would allow clients to opt in to using additionalSafeAreaInsets for any tracking scroll view, but the various quirks of UITableView and friends was expanding the scope of the fix too much. I would like to move the Flexible Header towards relying solely on additionalSafeAreaInsets in the future, but for now it is out of scope of this particular bug fix. As such, I've introduced a more focused behavioral flag that only enables itself if the tracking scroll view is a WKWebView's scroll view.

Closes https://github.com/material-components/material-components-ios/issues/4377