### PR TITLE
[Snackbar] Ensure that the bundle is loaded with CocoaPods.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -699,6 +699,7 @@ Pod::Spec.new do |mdc|
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"
     component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+    component.resources = ["components/#{component.base_name}/src/Material#{component.base_name}.bundle"]
 
     component.dependency "MaterialComponents/AnimationTiming"
     component.dependency "MaterialComponents/Buttons"


### PR DESCRIPTION
The bundle includes the snackbar "double-tap to dismiss" accessibility hint string.

Closes https://github.com/material-components/material-components-ios/issues/4685