### PR TITLE
[Catalog] DO NOT MERGE : Test new MDFI18n release

### DIFF
--- a/catalog/Podfile
+++ b/catalog/Podfile
@@ -4,6 +4,7 @@ project 'MDCCatalog.xcodeproj'
 target "MDCCatalog" do
   platform :ios, '8.0'
   project 'MDCCatalog.xcodeproj'
+  pod 'MDFInternationalization', :git => 'https://github.com/material-foundation/material-internationalization-ios', :branch => 'release-candidate'
   pod 'MaterialComponentsExamples', :path => '../'
   pod 'MaterialComponents', :path => '../'
   pod 'CatalogByConvention', "~> 2.5"


### PR DESCRIPTION
Catalog appears to be working as expected when MDC-iOS/stable is pointed at MDFI18n/release-candidate.

Note back arrow in upper left and mirrored layout of the alert.

![simulator screen shot - iphone x - 2018-08-03 at 16 54 18](https://user-images.githubusercontent.com/1121006/43665410-077a4cea-973e-11e8-8d1c-934da138bce5.png)
