### PR TITLE
[BottomSheet] Examples support accessible scrim

### DIFF
--- a/components/BottomSheet/examples/BottomSheetTableViewExample.swift
+++ b/components/BottomSheet/examples/BottomSheetTableViewExample.swift
@@ -64,6 +64,8 @@ class BottomSheetTableViewExample: UIViewController {
   @objc func didTapFloatingButton(_ sender : MDCFloatingButton) {
     let menu = BottomSheetTableViewMenu(style: .plain)
     let bottomSheet = MDCBottomSheetController(contentViewController: menu)
+    bottomSheet.isScrimAccessibilityElement = true
+    bottomSheet.scrimAccessibilityLabel = "Close"
     bottomSheet.trackingScrollView = menu.tableView
     present(bottomSheet, animated: true)
   }

--- a/components/BottomSheet/examples/BottomSheetTypicalUseExample.m
+++ b/components/BottomSheet/examples/BottomSheetTypicalUseExample.m
@@ -42,6 +42,8 @@
 
   MDCBottomSheetController *bottomSheet =
       [[MDCBottomSheetController alloc] initWithContentViewController:container];
+  bottomSheet.isScrimAccessibilityElement = YES;
+  bottomSheet.scrimAccessibilityLabel = @"Close";
   bottomSheet.trackingScrollView = viewController.collectionView;
   [self presentViewController:bottomSheet animated:YES completion:nil];
 }


### PR DESCRIPTION
The BottomSheet scrim (dimmed background overlay) can function as a button for
UIAccessibility features. This allows a discoverable close/dismiss function
for users. Turning this feature on by default in the catalog to showcase that
it is recommended.

Related to #4275
