### PR TITLE
[Switch] Document the use of UISwitch

### DIFF
--- a/components/Switch/README.md
+++ b/components/Switch/README.md
@@ -1,4 +1,3 @@
 # Switch
 
-The [Switch component](https://material.io/go/design-switches) is yet to be completed, please follow the [tracking issue](https://www.pivotaltracker.com/epic/show/3954822) for more information.
-
+The [Switch component](https://material.io/go/design-switches) will not be implemented on iOS and [apps should use the native UISwitch instead](https://material.io/design/platform-guidance/cross-platform-adaptation.html).


### PR DESCRIPTION
iOS does not implement Material Switches because the iOS native UISwitch should be used instead. This is captured in the cross-platform adaptation guidelines.

Closes #3862
