### PR TITLE
[CollectionCells] Support more than three lines in MDCCollectionViewTextCell?

### DIFF
--- a/components/CollectionCells/src/MDCCollectionViewTextCell.m
+++ b/components/CollectionCells/src/MDCCollectionViewTextCell.m
@@ -225,7 +225,7 @@ static inline CGRect AlignRectToUpperPixel(CGRect rect) {
       detailFrame.origin.y = (boundsHeight / 2) - (detailFrame.size.height / 2);
     }
 
-  } else if (numberOfAllVisibleTextLines == 3) {
+  } else if (numberOfAllVisibleTextLines >= 3) {
     if (!CGRectIsEmpty(textFrame) && !CGRectIsEmpty(detailFrame)) {
       // Alignment for three lines.
       textFrame.origin.y =


### PR DESCRIPTION
The issue is that our internal client was setting numberOfLines to 0 on both title and detail labels in the MDCCollectionViewTextCell, which resulted in there being more than 3 lines of text, which the cell currently cannot handle. When the number of visible lines isn't equal to 1, 2, or 3, it just doesn't update the Y origins of the labels. The change I'm suggesting will make it so that in scenarios where there are more than 3 lines of text the Y origins of these labels are updated. I am alerting the internal client that a change to their codebase _may_ be necessary as well. 

Closes #4037 