### PR TITLE
[BottomNavigation] Fix accessibilityValue for badgeValue updates

### DIFF
--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -347,7 +347,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
     badgeValue = nil;
   }
   self.badge.badgeValue = badgeValue;
-  if (self.accessibilityValue == nil || self.accessibilityValue.length == 0) {
+  if ([super accessibilityValue] == nil || [self accessibilityValue].length == 0) {
     self.button.accessibilityValue = badgeValue;
   }
   if (badgeValue == nil || badgeValue.length == 0) {
@@ -390,6 +390,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 }
 
 -(void)setAccessibilityValue:(NSString *)accessibilityValue {
+  [super setAccessibilityValue:accessibilityValue];
   self.button.accessibilityValue = accessibilityValue;
 }
 

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewAccessibilityTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewAccessibilityTests.m
@@ -1,0 +1,73 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MDCBottomNavigationItemView.h"
+
+@interface BottomNavigationItemViewAccessibilityTests : XCTestCase
+
+@end
+
+@implementation BottomNavigationItemViewAccessibilityTests
+
+- (void)testDefaultAccessiblityValue {
+  // Given
+  MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];
+
+  // When
+  itemView.badgeValue = @"777 apples";
+
+  // Then
+  XCTAssertEqualObjects(itemView.accessibilityValue, @"777 apples");
+}
+
+- (void)testDefaultAccessibilityValueUpdatesWhenBadgeValueChanges {
+  // Given
+  MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];
+
+  // When
+  itemView.badgeValue = @"777 apples";
+  itemView.badgeValue = @"65 blueberries";
+
+  // Then
+  XCTAssertEqualObjects(itemView.accessibilityValue, @"65 blueberries");
+}
+
+- (void)testCustomAccessibilityValueOverridesDefault {
+  // Given
+  MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];
+
+  // When
+  itemView.badgeValue = @"777 apples";
+  itemView.accessibilityValue = @"65 blueberries";
+
+  // Then
+  XCTAssertEqualObjects(itemView.accessibilityValue, @"65 blueberries");
+}
+
+- (void)testCustomAccessibilityValuePreventsBadgeValueFromOverriding {
+  // Given
+  MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];
+
+  // When
+  itemView.badgeValue = @"777 apples";
+  itemView.accessibilityValue = @"65 blueberries";
+  itemView.badgeValue = @"91 currants";
+
+  // Then
+  XCTAssertEqualObjects(itemView.accessibilityValue, @"65 blueberries");
+}
+
+@end


### PR DESCRIPTION
When the `badgeValue` property is updated, the `accessibilityValue` of the
item view should also be updated. However, recent changes to improve
accessibility resulted in the first badge value persisting forever as the
accessibilityValue (unless accessibilityValue was updated manually).

Fixes #4733
