### PR TITLE
[AppBar] Implement setViewControllers on MDCAppBarNavigationController.

### DIFF
--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -86,6 +86,17 @@
   [super pushViewController:viewController animated:animated];
 }
 
+- (void)setViewControllers:(NSArray<UIViewController *> *)viewControllers animated:(BOOL)animated {
+  for (UIViewController *viewController in viewControllers) {
+    // We call this before invoking super because super immediately queries the pushed view controller
+    // for things like status bar style, which we want to have rerouted to our flexible header view
+    // controller.
+    [self injectAppBarIntoViewController:viewController];
+  }
+
+  [super setViewControllers:viewControllers animated:animated];
+}
+
 - (void)setNavigationBarHidden:(BOOL)navigationBarHidden {
   // TODO: Consider using this API to hide the top view controller's flexible header.
   NSAssert(navigationBarHidden, @"%@ requires that the system navigation bar remain hidden.",

--- a/components/AppBar/tests/unit/AppBarNavigationControllerTests.swift
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerTests.swift
@@ -80,6 +80,60 @@ class AppBarNavigationControllerTests: XCTestCase {
     }
   }
 
+  func testSettingAViewControllerInjectsAnAppBar() {
+    // Given
+    let viewController = UIViewController()
+
+    // When
+    navigationController.viewControllers = [viewController]
+
+    // Then
+    XCTAssertEqual(viewController.childViewControllers.count, 1,
+                   "Expected there to be exactly one child view controller added to the view"
+                    + " controller.")
+
+    XCTAssertEqual(navigationController.topViewController, viewController,
+                   "The navigation controller's top view controller is supposed to be the pushed"
+                    + " view controller, but it is \(viewController).")
+
+    XCTAssertTrue(viewController.childViewControllers.first is MDCFlexibleHeaderViewController,
+                  "The injected view controller is not a flexible header view controller, it is"
+                    + "\(String(describing: viewController.childViewControllers.first)) instead.")
+
+    if let headerViewController
+      = viewController.childViewControllers.first as? MDCFlexibleHeaderViewController {
+      XCTAssertEqual(headerViewController.headerView.frame.height,
+                     headerViewController.headerView.maximumHeight)
+    }
+  }
+
+  func testSettingAViewControllerAnimatedInjectsAnAppBar() {
+    // Given
+    let viewController = UIViewController()
+
+    // When
+    navigationController.setViewControllers([viewController], animated: false)
+
+    // Then
+    XCTAssertEqual(viewController.childViewControllers.count, 1,
+                   "Expected there to be exactly one child view controller added to the view"
+                    + " controller.")
+
+    XCTAssertEqual(navigationController.topViewController, viewController,
+                   "The navigation controller's top view controller is supposed to be the pushed"
+                    + " view controller, but it is \(viewController).")
+
+    XCTAssertTrue(viewController.childViewControllers.first is MDCFlexibleHeaderViewController,
+                  "The injected view controller is not a flexible header view controller, it is"
+                    + "\(String(describing: viewController.childViewControllers.first)) instead.")
+
+    if let headerViewController
+      = viewController.childViewControllers.first as? MDCFlexibleHeaderViewController {
+      XCTAssertEqual(headerViewController.headerView.frame.height,
+                     headerViewController.headerView.maximumHeight)
+    }
+  }
+
   func testPushingAnAppBarContainerViewControllerDoesNotInjectAnAppBar() {
     // Given
     let viewController = UIViewController()


### PR DESCRIPTION
Prior to this change, view controllers that were provided to an MDCAppBarNavigationController via the setViewControllers:animated: API would not have an app bar injected.

After this change, MDCAppBarNavigationController will properly inject an app bar into the set view controllers, as expected.

Closes https://github.com/material-components/material-components-ios/issues/4735