### PR TITLE
[schemes/Color] Formally mark all to-be-deprecated APIs as "ToBeDeprecated".

### DIFF
--- a/components/ActivityIndicator/src/ColorThemer/MDCActivityIndicatorColorThemer.h
+++ b/components/ActivityIndicator/src/ColorThemer/MDCActivityIndicatorColorThemer.h
@@ -33,13 +33,16 @@
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
              toActivityIndicator:(nonnull MDCActivityIndicator *)activityIndicator;
 
-#pragma mark - Soon to be deprecated
+@end
+
+@interface MDCActivityIndicatorColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme's properties to an MDCActivityIndicator.
 
  @warning This method will soon be deprecated. Consider using
- @c +applySemanticColorScheme:toActivityIndicator: instead.
+ @c +applySemanticColorScheme:toActivityIndicator: instead. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to the component instance.
  @param activityIndicator A component instance to which the color scheme should be applied.

--- a/components/AppBar/src/ColorThemer/MDCAppBarColorThemer.h
+++ b/components/AppBar/src/ColorThemer/MDCAppBarColorThemer.h
@@ -46,8 +46,6 @@
 + (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                     toAppBarViewController:(nonnull MDCAppBarViewController *)appBarViewController;
 
-#pragma mark - To be deprecated
-
 /**
  Applies a color scheme's properties to an MDCAppBar using the primary mapping.
 
@@ -70,11 +68,15 @@
 + (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                                   toAppBar:(nonnull MDCAppBar *)appBar;
 
+@end
+
+@interface MDCAppBarColorThemer (ToBeDeprecated)
+
 /**
  Applies a color scheme's properties to an MDCAppBar.
 
  @warning This method will soon be deprecated. Consider using @c +applySemanticColorScheme:toAppBar:
- instead.
+ instead. Learn more at components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to the component instance.
  @param appBar A component instance to which the color scheme should be applied.

--- a/components/BottomAppBar/src/ColorThemer/MDCBottomAppBarColorThemer.h
+++ b/components/BottomAppBar/src/ColorThemer/MDCBottomAppBarColorThemer.h
@@ -27,13 +27,15 @@
  */
 @interface MDCBottomAppBarColorThemer : NSObject
 
-#pragma mark - Soon to be deprecated
+@end
+
+@interface MDCBottomAppBarColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme to theme a MDCBottomAppBarView.
 
  @warning This method will soon be deprecated. There is no replacement yet.
- @seealso https://www.pivotaltracker.com/story/show/157095394
+ Learn more at components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to the component instance.
  @param bottomAppBarView A component instance to which the color scheme should be applied.

--- a/components/BottomNavigation/src/ColorThemer/MDCBottomNavigationBarColorThemer.h
+++ b/components/BottomNavigation/src/ColorThemer/MDCBottomNavigationBarColorThemer.h
@@ -31,13 +31,16 @@
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
               toBottomNavigation:(nonnull MDCBottomNavigationBar *)bottomNavigation;
 
-#pragma mark - Soon to be deprecated
+@end
+
+@interface MDCBottomNavigationBarColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme to theme a MDCBottomNavigationBar.
 
  @warning This method will soon be deprecated. Consider using
- @c +applySemanticColorScheme:toBottomNavigation: instead.
+ @c +applySemanticColorScheme:toBottomNavigation: instead. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to MDCBottomNavigationBar.
  @param bottomNavigationBar A MDCBottomNavigationBar instance to apply a color scheme.

--- a/components/ButtonBar/src/ColorThemer/MDCButtonBarColorThemer.h
+++ b/components/ButtonBar/src/ColorThemer/MDCButtonBarColorThemer.h
@@ -31,13 +31,16 @@
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                      toButtonBar:(nonnull MDCButtonBar *)buttonBar;
 
-#pragma mark - Soon to be deprecated
+@end
+
+@interface MDCButtonBarColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme's properties to an MDCButtonBar.
 
  @warning This method will soon be deprecated. Consider using
- @c +applySemanticColorScheme:toButtonBar: instead.
+ @c +applySemanticColorScheme:toButtonBar: instead. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to the component instance.
  @param buttonBar A component instance to which the color scheme should be applied.

--- a/components/Buttons/src/ColorThemer/MDCButtonColorThemer.h
+++ b/components/Buttons/src/ColorThemer/MDCButtonColorThemer.h
@@ -25,15 +25,21 @@
  Color themers for instances of MDCButton and MDCFloatingButton.
 
  @warning This class will soon be deprecated. Please consider using one of the more specific
- @c MDC*ButtonColorThemer classes instead.
+ @c MDC*ButtonColorThemer classes instead. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
  */
 @interface MDCButtonColorThemer : NSObject
+
+@end
+
+@interface MDCButtonColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme's properties to an MDCButton.
 
  @warning This method will soon be deprecated. There is no direct replacement. Consider using one of
- the more specific  @c MDC*ButtonColorThemer classes instead.
+ the more specific  @c MDC*ButtonColorThemer classes instead. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to the component instance.
  @param button A component instance to which the color scheme should be applied.
@@ -45,6 +51,7 @@
  Applies a color scheme's properties to an MDCButton using the flat button style.
 
  @warning This method will soon be deprecated. Consider using @c MDCTextButtonColorThemer instead.
+ Learn more at components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to the component instance.
  @param flatButton A component instance to which the color scheme should be applied.
@@ -56,7 +63,7 @@
  Applies a color scheme's properties to an MDCButton using the raised button style.
 
  @warning This method will soon be deprecated. Consider using @c MDCContainedButtonColorThemer
- instead.
+ instead. Learn more at components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to the component instance.
  @param raisedButton A component instance to which the color scheme should be applied.
@@ -68,7 +75,7 @@
  Applies a color scheme's properties to an MDCFloatingButton using the floating button style.
 
  @warning This method will soon be deprecated. Consider using @c MDCFloatingButtonColorThemer
- instead.
+ instead. Learn more at components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to the component instance.
  @param floatingButton A component instance to which the color scheme should be applied.
@@ -80,7 +87,8 @@
  Applies a color scheme's properties to an MDCButton.
 
  @warning This method will soon be deprecated. There is no direct replacement. Consider using one of
- the more specific  @c MDC*ButtonColorThemer classes instead.
+ the more specific  @c MDC*ButtonColorThemer classes instead. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to the component instance.
  @param button A component instance to which the color scheme should be applied.

--- a/components/Chips/src/ColorThemer/MDCChipViewColorThemer.h
+++ b/components/Chips/src/ColorThemer/MDCChipViewColorThemer.h
@@ -42,7 +42,9 @@
 + (void)applyOutlinedVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                                  toChipView:(nonnull MDCChipView *)chipView;
 
-#pragma mark - Soon to be deprecated
+@end
+
+@interface MDCChipViewColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme's properties to a stroked MDCChipView.

--- a/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.h
+++ b/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.h
@@ -33,13 +33,16 @@
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                toAlertController:(nonnull MDCAlertController *)alertController;
 
-#pragma mark - Soon to be deprecated
+@end
+
+@interface MDCAlertColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme to theme to all MDCAlertController alert dialogs.
 
  @warning This method will soon be deprecated. There is no direct replacement. Consider using
- @c applySemanticColorScheme:toAlertController: instead.
+ @c applySemanticColorScheme:toAlertController: instead. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to all MDCAlertController alert dialogs.
  */

--- a/components/FeatureHighlight/src/ColorThemer/MDCFeatureHighlightColorThemer.h
+++ b/components/FeatureHighlight/src/ColorThemer/MDCFeatureHighlightColorThemer.h
@@ -35,13 +35,16 @@
     toFeatureHighlightViewController:
         (nonnull MDCFeatureHighlightViewController *)featureHighlightViewController;
 
-#pragma mark - Soon to be deprecated
+@end
+
+@interface MDCFeatureHighlightColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme to theme to a MDCFeatureHighlightView.
 
  @warning This method will soon be deprecated. Consider using
- @c applySemanticColorScheme:toFeatureHighlightViewController: instead.
+ @c applySemanticColorScheme:toFeatureHighlightViewController: instead. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to MDCFeatureHighlightView. 
  @param featureHighlightView A MDCFeatureHighlightView instance to apply a color scheme.

--- a/components/FlexibleHeader/src/ColorThemer/MDCFlexibleHeaderColorThemer.h
+++ b/components/FlexibleHeader/src/ColorThemer/MDCFlexibleHeaderColorThemer.h
@@ -46,13 +46,16 @@
 + (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                       toFlexibleHeaderView:(nonnull MDCFlexibleHeaderView *)flexibleHeaderView;
 
-#pragma mark - Soon to be deprecated
+@end
+
+@interface MDCFlexibleHeaderColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme to theme a MDCFlexibleHeaderView.
 
  @warning This method will soon be deprecated. Consider using
- @c +applySemanticColorScheme:toFlexibleHeaderView: instead.
+ @c +applySemanticColorScheme:toFlexibleHeaderView: instead. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to MDCFlexibleHeaderView.
  @param flexibleHeaderView A MDCFlexibleHeaderView instance to apply a color scheme.
@@ -64,7 +67,8 @@
  Applies a color scheme to theme a MDCFlexibleHeaderViewController.
 
  @warning This method will soon be deprecated. Consider using
- @c +applySemanticColorScheme:toFlexibleHeaderView: instead.
+ @c +applySemanticColorScheme:toFlexibleHeaderView: instead. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to MDCFlexibleHeaderView.
  @param flexibleHeaderController A MDCFlexibleHeaderViewController instance to apply a color scheme.

--- a/components/HeaderStackView/src/ColorThemer/MDCHeaderStackViewColorThemer.h
+++ b/components/HeaderStackView/src/ColorThemer/MDCHeaderStackViewColorThemer.h
@@ -25,12 +25,21 @@
  A color themer for instances of MDCHeaderStackView.
 
  @warning This class will soon be deprecated. There will be no replacement API. Consider theming
- your flexible header view or app bar instead.
+ your flexible header view or app bar instead. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
  */
 @interface MDCHeaderStackViewColorThemer : NSObject
 
+@end
+
+@interface MDCHeaderStackViewColorThemer (ToBeDeprecated)
+
 /**
  Applies a color scheme's properties to an MDCHeaderStackView.
+
+ @warning This class will soon be deprecated. There will be no replacement API. Consider theming
+ your flexible header view or app bar instead. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to the component instance.
  @param headerStackView A component instance to which the color scheme should be applied.

--- a/components/Ink/src/ColorThemer/MDCInkColorThemer.h
+++ b/components/Ink/src/ColorThemer/MDCInkColorThemer.h
@@ -28,11 +28,15 @@
  set by the owning component in a context-specific manner.
  */
 @interface MDCInkColorThemer : NSObject
+@end
+
+@interface MDCInkColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme to theme a MDCInkView.
 
- @warning This API will soon be deprecated. There is no direct replacement.
+ @warning This API will soon be deprecated. There is no direct replacement. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to MDCInkView.
  @param inkView A MDCInkView instance to apply a color scheme.
@@ -41,3 +45,4 @@
                toInkView:(nonnull MDCInkView *)inkView;
 
 @end
+

--- a/components/NavigationBar/src/ColorThemer/MDCNavigationBarColorThemer.h
+++ b/components/NavigationBar/src/ColorThemer/MDCNavigationBarColorThemer.h
@@ -46,13 +46,16 @@
 + (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                            toNavigationBar:(nonnull MDCNavigationBar *)navigationBar;
 
-#pragma mark - Soon to be deprecated
+@end
+
+@interface MDCNavigationBarColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme to theme a MDCNavigationBar.
 
  @warning This method will soon be deprecated. Consider using
- @c +applySemanticColorScheme:toNavigationBar: instead.
+ @c +applySemanticColorScheme:toNavigationBar: instead. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to MDCNavigationBar.
  @param navigationBar A MDCNavigationBar instance to apply a color scheme.

--- a/components/PageControl/src/ColorThemer/MDCPageControlColorThemer.h
+++ b/components/PageControl/src/ColorThemer/MDCPageControlColorThemer.h
@@ -22,18 +22,18 @@
 /**
  Used to apply a color scheme to theme MDCPageControl. This API does not yet implement the Material
  Design color system.
-
- @seealso https://www.pivotaltracker.com/story/show/157072365
  */
 @interface MDCPageControlColorThemer : NSObject
 
-#pragma mark - Soon to be deprecated
+@end
+
+@interface MDCPageControlColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme to theme a MDCPageControl.
 
- @warning This method will soon be deprecated. There is no replacement yet.
- @seealso https://www.pivotaltracker.com/story/show/157072365
+ @warning This method will soon be deprecated. There is no replacement yet. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to the component instance.
  @param pageControl A component instance to which the color scheme should be applied.

--- a/components/ProgressView/src/ColorThemer/MDCProgressViewColorThemer.h
+++ b/components/ProgressView/src/ColorThemer/MDCProgressViewColorThemer.h
@@ -22,18 +22,17 @@
 /**
  Used to apply a color scheme to theme MDCProgressView. This API does not yet implement the Material
  Design color system.
-
- @seealso https://www.pivotaltracker.com/story/show/157095443
  */
 @interface MDCProgressViewColorThemer : NSObject
+@end
 
-#pragma mark - Soon to be deprecated
+@interface MDCProgressViewColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme to theme a MDCProgressView.
 
- @warning This method will soon be deprecated. There is no replacement yet.
- @seealso https://www.pivotaltracker.com/story/show/157095443
+ @warning This method will soon be deprecated. There is no replacement yet. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to the component instance.
  @param progressView A component instance to which the color scheme should be applied.

--- a/components/Slider/src/ColorThemer/MDCSliderColorThemer.h
+++ b/components/Slider/src/ColorThemer/MDCSliderColorThemer.h
@@ -33,13 +33,15 @@
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                         toSlider:(nonnull MDCSlider *)slider;
 
-#pragma mark - Soon to be deprecated
+@end
+
+@interface MDCSliderColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme to theme a MDCSlider.
 
  @warning This method will soon be deprecated. Consider using @c +applySemanticColorScheme:toSlider:
- instead.
+ instead. Learn more at components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to MDCSlider.
  @param slider A MDCSlider instance to apply a color scheme.
@@ -52,6 +54,7 @@
  the primary light and primary dark are gray.
 
  @warning This method will soon be deprecated. Consider using MDCSemanticColorScheme instead.
+ Learn more at components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
  */
 + (nonnull MDCBasicColorScheme *)defaultSliderLightColorScheme;
 
@@ -60,6 +63,7 @@
  the primary light and primary dark are white.
 
  @warning This method will soon be deprecated. Consider using MDCSemanticColorScheme instead.
+ Learn more at components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
  */
 + (nonnull MDCBasicColorScheme *)defaultSliderDarkColorScheme;
 

--- a/components/Snackbar/src/ColorThemer/MDCSnackbarColorThemer.h
+++ b/components/Snackbar/src/ColorThemer/MDCSnackbarColorThemer.h
@@ -31,12 +31,15 @@
  */
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme;
 
-#pragma mark - Deprecated
+@end
+
+@interface MDCSnackbarColorThemer (Deprecated)
 
 /**
  Applies a color scheme to theme to a MDCSnackbarMessageView.
 
- @warning This method is deprecated. Consider using applySemanticColorScheme:colorScheme.
+ @warning This method is deprecated. Consider using applySemanticColorScheme:colorScheme. Learn more
+ at components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to MDCSnackbarMessageView.
  @param snackbarMessageView A MDCSnackbarMessageView instance to apply a color scheme.
@@ -44,4 +47,5 @@
 + (void)applyColorScheme:(nonnull id<MDCColorScheme>)colorScheme
    toSnackbarMessageView:(nonnull MDCSnackbarMessageView *)snackbarMessageView
        __deprecated_msg("use applySemanticColorScheme: instead.");
+
 @end

--- a/components/Snackbar/src/ColorThemer/MDCSnackbarColorThemer.m
+++ b/components/Snackbar/src/ColorThemer/MDCSnackbarColorThemer.m
@@ -31,7 +31,7 @@
 }
 
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 + (void)applyColorScheme:(nonnull id<MDCColorScheme>)colorScheme
    toSnackbarMessageView:(nonnull MDCSnackbarMessageView *)snackbarMessageView {
 }

--- a/components/Snackbar/src/ColorThemer/MDCSnackbarColorThemer.m
+++ b/components/Snackbar/src/ColorThemer/MDCSnackbarColorThemer.m
@@ -30,8 +30,11 @@
                                  forState:UIControlStateHighlighted];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (void)applyColorScheme:(nonnull id<MDCColorScheme>)colorScheme
    toSnackbarMessageView:(nonnull MDCSnackbarMessageView *)snackbarMessageView {
 }
+#pragma clang diagnostic pop
 
 @end

--- a/components/Tabs/src/ColorThemer/MDCTabBarColorThemer.h
+++ b/components/Tabs/src/ColorThemer/MDCTabBarColorThemer.h
@@ -44,13 +44,15 @@
 + (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                                     toTabs:(nonnull MDCTabBar *)tabBar;
 
-#pragma mark - Soon to be deprecated
+@end
+
+@interface MDCTabBarColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme to theme a MDCTabBar.
 
  @warning This method will soon be deprecated. Consider using @c +applySemanticColorScheme:toTabs:
- instead.
+ instead. Learn more at components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply to MDCTabBar.
  @param tabBar A MDCTabBar instance to apply a color scheme. 

--- a/components/TextFields/src/ColorThemer/MDCTextFieldColorThemer.h
+++ b/components/TextFields/src/ColorThemer/MDCTextFieldColorThemer.h
@@ -53,13 +53,16 @@
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                      toTextInput:(nonnull id<MDCTextInput>)textInput;
 
-#pragma mark - Soon to be deprecated
+@end
+
+@interface MDCTextFieldColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme to theme MDCTextField in MDCTextInputController.
 
  @warning This method will soon be deprecated. Consider using
- +applySemanticColorScheme:toTextInputController: instead.
+ +applySemanticColorScheme:toTextInputController: instead. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply.
  @param textInputController A MDCTextInputController instance to apply a color scheme.
@@ -72,7 +75,8 @@
  using the default color class properties.
 
  @warning This method will soon be deprecated. Consider using
- +applySemanticColorScheme:toAllTextInputControllersOfClass: instead.
+ +applySemanticColorScheme:toAllTextInputControllersOfClass: instead. Learn more at
+ components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
 
  @param colorScheme The color scheme to apply.
  @param textInputControllerClass A Class that conforms to MDCTextInputController (at least.)


### PR DESCRIPTION
This change further formalizes our pattern of annotating APIs that will be or are deprecated using class categories. Moving an API into such a category has the benefit of being picked up by the API diff toolchain and elevated into our release notes as a result.