### PR TITLE
[Dialogs] Remove use of MDCFlatButton for MDCButton and MDCTextButtonThemer

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -398,6 +398,7 @@ Pod::Spec.new do |mdc|
     component.resources = ["components/#{component.base_name}/src/Material#{component.base_name}.bundle"]
 
     component.dependency "MaterialComponents/Buttons"
+    component.dependency "MaterialComponents/Buttons+ButtonThemer"
     component.dependency "MaterialComponents/ShadowElevations"
     component.dependency "MaterialComponents/ShadowLayer"
     component.dependency "MaterialComponents/Typography"

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -30,7 +30,7 @@ mdc_public_objc_library(
     ],
     deps = [
         "//components/Buttons",
-        "//components/Buttons+ButtonThemer",
+        "//components/Buttons:ButtonThemer",
         "//components/ShadowElevations",
         "//components/ShadowLayer",
         "//components/Typography",

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -30,6 +30,7 @@ mdc_public_objc_library(
     ],
     deps = [
         "//components/Buttons",
+        "//components/Buttons+ButtonThemer",
         "//components/ShadowElevations",
         "//components/ShadowLayer",
         "//components/Typography",

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.h
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.h
@@ -16,14 +16,14 @@
 
 #import <UIKit/UIKit.h>
 
-@class MDCFlatButton;
+@class MDCButton;
 
 @interface MDCAlertControllerView ()
 
 @property(nonatomic, nonnull, strong) UILabel *titleLabel;
 @property(nonatomic, nonnull, strong) UILabel *messageLabel;
 
-@property(nonatomic, nonnull, strong, readonly) NSArray<MDCFlatButton *> *actionButtons;
+@property(nonatomic, nonnull, strong, readonly) NSArray<MDCButton *> *actionButtons;
 
 - (void)addActionButtonTitle:(NSString *_Nonnull)actionTitle
                       target:(nullable id)target

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -20,6 +20,7 @@
 #import <MDFInternationalization/MDFInternationalization.h>
 
 #import "MaterialButtons.h"
+#import "MaterialButtons+ButtonThemer.h"
 #import "MaterialTypography.h"
 
 // https://material.io/go/design-dialogs#dialogs-specs
@@ -49,8 +50,9 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 @end
 
 @implementation MDCAlertControllerView {
-    NSMutableArray<MDCFlatButton *> *_actionButtons;
+    NSMutableArray<MDCButton *> *_actionButtons;
     BOOL _mdc_adjustsFontForContentSizeCategory;
+    MDCButtonScheme *buttonScheme;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
@@ -88,7 +90,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     }
     self.messageLabel.textColor = [UIColor colorWithWhite:0.0f alpha:MDCDialogMessageOpacity];
     [self.contentScrollView addSubview:self.messageLabel];
-
+    buttonScheme = [[MDCButtonScheme alloc] init];
     _actionButtons = [[NSMutableArray alloc] init];
 
     [self setNeedsLayout];
@@ -116,7 +118,8 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 }
 
 - (void)addActionButtonTitle:(NSString *)actionTitle target:(id)target selector:(SEL)selector {
-  MDCFlatButton *actionButton = [[MDCFlatButton alloc] initWithFrame:CGRectZero];
+  MDCButton *actionButton = [[MDCButton alloc] initWithFrame:CGRectZero];
+  [MDCTextButtonThemer applyScheme:buttonScheme toButton:actionButton];
   actionButton.mdc_adjustsFontForContentSizeCategory = self.mdc_adjustsFontForContentSizeCategory;
   [actionButton setTitle:actionTitle forState:UIControlStateNormal];
   if (_buttonColor) {
@@ -223,7 +226,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
         [finalButtonFont mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
                                 scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
   }
-  for (MDCFlatButton *button in self.actionButtons) {
+  for (MDCButton *button in self.actionButtons) {
     [button setTitleFont:finalButtonFont forState:UIControlStateNormal];
   }
 
@@ -241,7 +244,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)setButtonColor:(UIColor *)color {
   _buttonColor = color;
 
-  for (MDCFlatButton *button in self.actionButtons) {
+  for (MDCButton *button in self.actionButtons) {
     [button setTitleColor:_buttonColor forState:UIControlStateNormal];
   }
 }
@@ -513,7 +516,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {
   _mdc_adjustsFontForContentSizeCategory = adjusts;
 
-  for (MDCFlatButton *button in _actionButtons) {
+  for (MDCButton *button in _actionButtons) {
     button.mdc_adjustsFontForContentSizeCategory = adjusts;
   }
 


### PR DESCRIPTION
Remove all instances of MDCFlatButton within [Dialogs] component
Replace with MDCTextButtonThemer and MDCButton

MDCFlatButton is the old API and MDCTextButtonThemer/MDCButton are the modern APIs.


Closes #3914