### PR TITLE
[Snackbar] Create explicit singleton

### DIFF
--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -52,6 +52,11 @@
 @interface MDCSnackbarManager : NSObject
 
 /**
+ An instance of MDCSnackbarManager.
+ */
+@property(class, nonnull, nonatomic, readonly, strong) MDCSnackbarManager *defaultManager;
+
+/**
  Determines the Snackbar alignment to the screen.
 
  If called within an animation block, the change will be animated.
@@ -62,7 +67,7 @@
 
  @note The setter must be called from the main thread.
  */
-@property (class, nonatomic, assign) MDCSnackbarAlignment alignment;
+@property(nonatomic, assign) MDCSnackbarAlignment alignment;
 
 /**
  Shows @c message to the user, in a style consistent with the data contained in @c message.
@@ -71,7 +76,7 @@
  ordering. Ordering between completion blocks of different categories is not guaranteed. This method
  is safe to call from any thread.
  */
-+ (void)showMessage:(nullable MDCSnackbarMessage *)message;
+- (void)showMessage:(nullable MDCSnackbarMessage *)message;
 
 /**
  MDCSnackbarManager will display the messages in this view.
@@ -87,14 +92,14 @@
  @note This method must be called from the main thread.
  @note Calling setPresentationHostView will not change the parent of the currently visible message.
  */
-+ (void)setPresentationHostView:(nullable UIView *)hostView;
+- (void)setPresentationHostView:(nullable UIView *)hostView;
 
 /**
  Checks if there is any message showing or queued. Does not consider suspended messages.
 
  @note This method must be called from the main thread.
  */
-+ (BOOL)hasMessagesShowingOrQueued;
+- (BOOL)hasMessagesShowingOrQueued;
 
 /**
  Bypasses showing the messages of the given @c category.
@@ -103,7 +108,7 @@
  messages for the @c category. Calling this method with @c nil will dismiss all messages. This
  method is safe to call from any thread.
  */
-+ (void)dismissAndCallCompletionBlocksWithCategory:(nullable NSString *)category;
+- (void)dismissAndCallCompletionBlocksWithCategory:(nullable NSString *)category;
 
 /**
  How far from the bottom of the screen messages are displayed.
@@ -114,7 +119,7 @@
  @note This is meant for apps which have a navigation element such as a tab bar, which cannot
  move and should not be obscured.
  */
-+ (void)setBottomOffset:(CGFloat)offset;
+- (void)setBottomOffset:(CGFloat)offset;
 
 #pragma mark Suspending
 
@@ -127,7 +132,7 @@
  @return A token suitable for use in {@c +[MDCSnackbarManager resumeWithToken:]}. Letting this
  object deallocate is equivalent to calling {@c +[MDCSnackbarManager resumeMessagesWithToken:]}.
  */
-+ (nullable id <MDCSnackbarSuspensionToken>)suspendAllMessages;
+- (nullable id <MDCSnackbarSuspensionToken>)suspendAllMessages;
 
 /**
  Suspends the display of all messages in a given category.
@@ -140,7 +145,7 @@
  Letting this object dealloc is equivalent to calling
  {@c +[MDCSnackbarManager resumeMessagesWithToken:]}.
  */
-+ (nullable id <MDCSnackbarSuspensionToken>)
+- (nullable id <MDCSnackbarSuspensionToken>)
     suspendMessagesWithCategory:(nullable NSString *)category;
 
 /**
@@ -150,34 +155,34 @@
 
  @param token The suspension token to invalidate.
  */
-+ (void)resumeMessagesWithToken:(nullable id <MDCSnackbarSuspensionToken>)token;
+- (void)resumeMessagesWithToken:(nullable id <MDCSnackbarSuspensionToken>)token;
 
 #pragma mark Styling
 
 /**
  The color for the background of the Snackbar message view.
  */
-@property(class, nonatomic, strong, nullable) UIColor *snackbarMessageViewBackgroundColor;
+@property(nonatomic, strong, nullable) UIColor *snackbarMessageViewBackgroundColor;
 
 /**
  The color for the shadow color for the Snackbar message view.
  */
-@property(class, nonatomic, strong, nullable) UIColor *snackbarMessageViewShadowColor;
+@property(nonatomic, strong, nullable) UIColor *snackbarMessageViewShadowColor;
 
 /**
  The color for the message text in the Snackbar message view.
  */
-@property(class, nonatomic, strong, nullable) UIColor *messageTextColor;
+@property(nonatomic, strong, nullable) UIColor *messageTextColor;
 
 /**
  The font for the message text in the Snackbar message view.
  */
-@property(class, nonatomic, strong, nullable) UIFont *messageFont;
+@property(nonatomic, strong, nullable) UIFont *messageFont;
 
 /**
  The font for the button text in the Snackbar message view.
  */
-@property(class, nonatomic, strong, nullable) UIFont *buttonFont;
+@property(nonatomic, strong, nullable) UIFont *buttonFont;
 
 /**
  If enabled, modifications of class styling properties will be applied immediately
@@ -185,7 +190,7 @@
 
  Default is set to NO.
  */
-@property(class, nonatomic, assign) BOOL shouldApplyStyleChangesToVisibleSnackbars;
+@property(nonatomic, assign) BOOL shouldApplyStyleChangesToVisibleSnackbars;
 
 /**
  Returns the button title color for a particular control state.
@@ -193,7 +198,7 @@
  @param state The control state.
  @return The button title color for the requested state.
  */
-+ (nullable UIColor *)buttonTitleColorForState:(UIControlState)state;
+- (nullable UIColor *)buttonTitleColorForState:(UIControlState)state;
 
 /**
  Sets the button title color for a particular control state.
@@ -201,7 +206,7 @@
  @param titleColor The title color.
  @param state The control state.
  */
-+ (void)setButtonTitleColor:(nullable UIColor *)titleColor forState:(UIControlState)state;
+- (void)setButtonTitleColor:(nullable UIColor *)titleColor forState:(UIControlState)state;
 
 /**
  Indicates whether the Snackbar should automatically update its font when the device’s
@@ -215,14 +220,14 @@
 
  Default is set to NO.
  */
-@property(class, nonatomic, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
+@property(nonatomic, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
     BOOL mdc_adjustsFontForContentSizeCategory;
 
 
 /**
  The delegate for MDCSnackbarManager through which it may inform of snackbar presentation updates.
  */
-@property(class, nonatomic, weak, nullable) id<MDCSnackbarManagerDelegate> delegate;
+@property(nonatomic, weak, nullable) id<MDCSnackbarManagerDelegate> delegate;
 
 @end
 
@@ -234,4 +239,107 @@
  @c resumeMessagesWithToken.
  */
 @protocol MDCSnackbarSuspensionToken <NSObject>
+@end
+
+#pragma mark - To be deprecated
+
+@interface MDCSnackbarManager (LegacyAPI)
+
+/**
+ The @c alignment property of the @c defaultManager instance.
+ */
+@property(class, nonatomic, assign) MDCSnackbarAlignment alignment;
+
+/**
+ Calls @c -showMessage: on the @c defaultManager instance.
+ */
++ (void)showMessage:(nullable MDCSnackbarMessage *)message;
+
+/**
+ Calls @c -setPresentationHostView: on the @c defaultManager instance.
+ */
++ (void)setPresentationHostView:(nullable UIView *)hostView;
+
+/**
+ Calls @c -hasMessagesShowingORQueued on the @c defaultManager instance.
+ */
++ (BOOL)hasMessagesShowingOrQueued;
+
+/**
+ Calls @c -dismissAndCallCompletionBlocksWithCategory: on the @c defaultManager instance.
+ */
++ (void)dismissAndCallCompletionBlocksWithCategory:(nullable NSString *)category;
+
+/**
+ Calls -setBottomOffset: on the @c defaultManager instance.
+ */
++ (void)setBottomOffset:(CGFloat)offset;
+
+/**
+ Calls @c -suspendAllMessages on the @c defaultManager instance.
+ */
++ (nullable id <MDCSnackbarSuspensionToken>)suspendAllMessages;
+
+/**
+ Calls @c -suspendMessagesWithCategory: on the @c defaultManager instance.
+ */
++ (nullable id <MDCSnackbarSuspensionToken>)
+    suspendMessagesWithCategory:(nullable NSString *)category;
+
+/**
+ Calls @c -resumeMessagesWithToken: on the @c defaultManager instance.
+ */
++ (void)resumeMessagesWithToken:(nullable id <MDCSnackbarSuspensionToken>)token;
+
+/**
+ Bound to @c snackbarMessageViewBackgroundColor on the @c defaultManager instance.
+ */
+@property(class, nonatomic, strong, nullable) UIColor *snackbarMessageViewBackgroundColor;
+
+/**
+ Bound to @c snackbarMessageViewShadowColor on the @c defaultManager instance.
+ */
+@property(class, nonatomic, strong, nullable) UIColor *snackbarMessageViewShadowColor;
+
+/**
+ Bound to @c messageTextColor on the @c defaultManager instance.
+ */
+@property(class, nonatomic, strong, nullable) UIColor *messageTextColor;
+
+/**
+ Bound to @c messageFont on the @c defaultManager instance.
+ */
+@property(class, nonatomic, strong, nullable) UIFont *messageFont;
+
+/**
+ Bound to @c buttonFont on the @c defaultManager instance.
+ */
+@property(class, nonatomic, strong, nullable) UIFont *buttonFont;
+
+/**
+ Bound to @c shouldApplyStyleChangesToVisibleSnackbars on the @c defaultManager instance.
+ */
+@property(class, nonatomic, assign) BOOL shouldApplyStyleChangesToVisibleSnackbars;
+
+/**
+ Calls @c -buttonTitleColorForState: on the @c defaultManager instance.
+ */
++ (nullable UIColor *)buttonTitleColorForState:(UIControlState)state;
+
+/**
+ Calls @c -setButtonTitleColor:forState: on the @c defaultManager instance.
+ */
++ (void)setButtonTitleColor:(nullable UIColor *)titleColor forState:(UIControlState)state;
+
+/**
+ Bound to @c mdc_adjustsFontForContentSizeCategory on the @c defaultManager instance.
+ */
+@property(class, nonatomic, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
+    BOOL mdc_adjustsFontForContentSizeCategory;
+
+/**
+ Bound to @c delegate on the @c defaultManager instance.
+ */
+@property(class, nonatomic, weak, nullable) id<MDCSnackbarManagerDelegate> delegate;
+
 @end

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -47,6 +47,12 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
 @interface MDCSnackbarManagerInternal : NSObject
 
 /**
+ The instance of MDCSnackbarManager that "owns" this internal manager.  Used to get theming
+ properties. Can be refactored away in the future.
+ */
+@property(nonatomic, weak) MDCSnackbarManager *manager;
+
+/**
  The list of messages waiting to be displayed.
  */
 @property(nonatomic) NSMutableArray *pendingMessages;
@@ -84,6 +90,8 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
  */
 @property(nonatomic, weak) id<MDCSnackbarManagerDelegate> delegate;
 
+- (instancetype)initWithSnackbarManager:(__weak MDCSnackbarManager *)manager;
+
 @end
 
 @interface MDCSnackbarManagerSuspensionToken : NSObject <MDCSnackbarSuspensionToken>
@@ -98,33 +106,16 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
  */
 @property(nonatomic) NSString *category;
 
+- (instancetype)initWithManager:(nonnull MDCSnackbarManager *)manager;
+
 @end
 
 @implementation MDCSnackbarManagerInternal
 
-static UIColor *_snackbarMessageViewBackgroundColor;
-static UIColor *_snackbarMessageViewShadowColor;
-static UIColor *_messageTextColor;
-static UIFont *_messageFont;
-static UIFont *_buttonFont;
-static NSMutableDictionary<NSNumber *, UIColor *> *_buttonTitleColors;
-static BOOL _mdc_adjustsFontForContentSizeCategory;
-static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
-
-+ (MDCSnackbarManagerInternal *)sharedInstance {
-  static MDCSnackbarManagerInternal *manager = nil;
-  static dispatch_once_t onceToken;
-
-  dispatch_once(&onceToken, ^{
-    manager = [[MDCSnackbarManagerInternal alloc] init];
-  });
-
-  return manager;
-}
-
-- (instancetype)init {
+- (instancetype)initWithSnackbarManager:(MDCSnackbarManager *__weak)manager {
   self = [super init];
   if (self) {
+    _manager = manager;
     _pendingMessages = [[NSMutableArray alloc] init];
     _suspensionTokens = [NSMutableDictionary dictionary];
     _overlayView = [[MDCSnackbarOverlayView alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
@@ -226,7 +217,9 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
       };
 
   Class viewClass = [message viewClass];
-  snackbarView = [[viewClass alloc] initWithMessage:message dismissHandler:dismissHandler];
+  snackbarView = [[viewClass alloc] initWithMessage:message
+                                     dismissHandler:dismissHandler
+                                    snackbarManager:self.manager];
   [self.delegate willPresentSnackbarWithMessageView:snackbarView];
   self.currentSnackbar = snackbarView;
   self.overlayView.accessibilityViewIsModal = ![self isSnackbarTransient:snackbarView];
@@ -498,19 +491,48 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
 
 #pragma mark - Public API
 
-@implementation MDCSnackbarManager
+@interface MDCSnackbarManager ()
+@property(nonnull, nonatomic, strong) MDCSnackbarManagerInternal *internalManager;
+@end
 
-+ (void)setDelegate:(id<MDCSnackbarManagerDelegate>)delegate {
-  MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-  manager.delegate = delegate;
+@implementation MDCSnackbarManager {
+  UIColor *_snackbarMessageViewBackgroundColor;
+  UIColor *_snackbarMessageViewShadowColor;
+  UIColor *_messageTextColor;
+  UIFont *_messageFont;
+  UIFont *_buttonFont;
+  NSMutableDictionary<NSNumber *, UIColor *> *_buttonTitleColors;
+  BOOL _mdc_adjustsFontForContentSizeCategory;
+  BOOL _shouldApplyStyleChangesToVisibleSnackbars;
 }
 
-+ (id<MDCSnackbarManagerDelegate>)delegate {
-  MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-  return manager.delegate;
+
++ (instancetype)defaultManager {
+  static MDCSnackbarManager *defaultManager;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    defaultManager = [[MDCSnackbarManager alloc] init];
+  });
+  return defaultManager;
 }
 
-+ (void)showMessage:(MDCSnackbarMessage *)inputMessage {
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _internalManager = [[MDCSnackbarManagerInternal alloc] initWithSnackbarManager:self];
+  }
+  return self;
+}
+
+- (void)setDelegate:(id<MDCSnackbarManagerDelegate>)delegate {
+  self.internalManager.delegate = delegate;
+}
+
+- (id<MDCSnackbarManagerDelegate>)delegate {
+  return self.internalManager.delegate;
+}
+
+- (void)showMessage:(MDCSnackbarMessage *)inputMessage {
   if (!inputMessage) {
     return;
   }
@@ -520,84 +542,76 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
 
   // Ensure that all of our work happens on the main thread.
   dispatch_async(dispatch_get_main_queue(), ^{
-    MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-    [manager showMessageMainThread:message];
+    [self.internalManager showMessageMainThread:message];
   });
 }
 
-+ (void)setPresentationHostView:(UIView *)hostView {
+- (void)setPresentationHostView:(UIView *)hostView {
   NSAssert([NSThread isMainThread], @"setPresentationHostView must be called on main thread.");
 
-  MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-  manager.presentationHostView = hostView;
+  self.internalManager.presentationHostView = hostView;
 }
 
-+ (BOOL)hasMessagesShowingOrQueued {
+- (BOOL)hasMessagesShowingOrQueued {
   NSAssert([NSThread isMainThread], @"hasMessagesShowingOrQueued must be called on main thread.");
 
-  MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-
-  return (manager.showingMessage || manager.pendingMessages.count != 0);
+  return (self.internalManager.showingMessage || self.internalManager.pendingMessages.count != 0);
 }
 
-+ (void)dismissAndCallCompletionBlocksWithCategory:(NSString *)category {
+- (void)dismissAndCallCompletionBlocksWithCategory:(NSString *)category {
   // Snag a copy now, we'll use that internally.
   NSString *categoryToDismiss = [category copy];
 
   // Ensure that all of our work happens on the main thread.
   dispatch_async(dispatch_get_main_queue(), ^{
-    MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-    [manager dismissAndCallCompletionBlocksOnMainThreadWithCategory:categoryToDismiss];
+    [self.internalManager dismissAndCallCompletionBlocksOnMainThreadWithCategory:categoryToDismiss];
   });
 }
 
-+ (void)setBottomOffset:(CGFloat)offset {
+- (void)setBottomOffset:(CGFloat)offset {
   NSAssert([NSThread isMainThread], @"setBottomOffset must be called on main thread.");
 
-  MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-  manager.overlayView.bottomOffset = offset;
+  self.internalManager.overlayView.bottomOffset = offset;
 }
 
-+ (void)setAlignment:(MDCSnackbarAlignment)alignment {
+- (void)setAlignment:(MDCSnackbarAlignment)alignment {
   NSAssert([NSThread isMainThread], @"setAlignment must be called on main thread.");
 
-  MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-  manager.overlayView.alignment = alignment;
+  self.internalManager.overlayView.alignment = alignment;
 }
 
-+ (MDCSnackbarAlignment)alignment {
-  MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-  return manager.overlayView.alignment;
+- (MDCSnackbarAlignment)alignment {
+  return self.internalManager.overlayView.alignment;
 }
 
 #pragma mark - Suspension
 
-+ (id<MDCSnackbarSuspensionToken>)suspendMessagesWithCategory:(NSString *)category {
-  MDCSnackbarManagerSuspensionToken *token = [[MDCSnackbarManagerSuspensionToken alloc] init];
+- (id<MDCSnackbarSuspensionToken>)suspendMessagesWithCategory:(NSString *)category {
+  MDCSnackbarManagerSuspensionToken *token =
+      [[MDCSnackbarManagerSuspensionToken alloc] initWithManager:self];
   token.category = category;
 
   // Ensure that all of our work happens on the main thread.
   dispatch_async(dispatch_get_main_queue(), ^{
-    MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-    [manager addSuspensionIdentifierMainThread:token.identifier forCategory:token.category];
+    [self.internalManager addSuspensionIdentifierMainThread:token.identifier
+                                                forCategory:token.category];
   });
 
   return token;
 }
 
-+ (id<MDCSnackbarSuspensionToken>)suspendAllMessages {
+- (id<MDCSnackbarSuspensionToken>)suspendAllMessages {
   return [self suspendMessagesWithCategory:kAllMessagesCategory];
 }
 
-+ (void)handleInvalidatedIdentifier:(NSUUID *)identifier forCategory:(NSString *)category {
+- (void)handleInvalidatedIdentifier:(NSUUID *)identifier forCategory:(NSString *)category {
   // Ensure that all of our work happens on the main thread.
   dispatch_async(dispatch_get_main_queue(), ^{
-    MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-    [manager removeSuspensionIdentifierMainThread:identifier forCategory:category];
+    [self.internalManager removeSuspensionIdentifierMainThread:identifier forCategory:category];
   });
 }
 
-+ (void)resumeMessagesWithToken:(id<MDCSnackbarSuspensionToken>)inToken {
+- (void)resumeMessagesWithToken:(id<MDCSnackbarSuspensionToken>)inToken {
   if (![inToken isKindOfClass:[MDCSnackbarManagerSuspensionToken class]]) {
     return;
   }
@@ -608,7 +622,7 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
 
 #pragma mark - Styling
 
-+ (void)runSnackbarUpdatesOnMainThread:(void (^)(void))block {
+- (void)runSnackbarUpdatesOnMainThread:(void (^)(void))block {
   if (_shouldApplyStyleChangesToVisibleSnackbars) {
     if ([NSThread isMainThread]) {
       block();
@@ -618,132 +632,252 @@ static BOOL _shouldApplyStyleChangesToVisibleSnackbars;
   }
 }
 
-+ (void)setSnackbarMessageViewBackgroundColor:(UIColor *)snackbarMessageViewBackgroundColor {
+- (void)setSnackbarMessageViewBackgroundColor:(UIColor *)snackbarMessageViewBackgroundColor {
   if (snackbarMessageViewBackgroundColor != _snackbarMessageViewBackgroundColor) {
     _snackbarMessageViewBackgroundColor = snackbarMessageViewBackgroundColor;
     [self runSnackbarUpdatesOnMainThread:^{
-      MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-      [manager.currentSnackbar
+      [self.internalManager.currentSnackbar
           setSnackbarMessageViewBackgroundColor:snackbarMessageViewBackgroundColor];
     }];
   }
 }
 
-+ (UIColor *)snackbarMessageViewBackgroundColor {
+- (UIColor *)snackbarMessageViewBackgroundColor {
   return _snackbarMessageViewBackgroundColor;
 }
 
-+ (void)setSnackbarMessageViewShadowColor:(UIColor *)snackbarMessageViewShadowColor {
+- (void)setSnackbarMessageViewShadowColor:(UIColor *)snackbarMessageViewShadowColor {
   if (snackbarMessageViewShadowColor != _snackbarMessageViewShadowColor) {
     _snackbarMessageViewShadowColor = snackbarMessageViewShadowColor;
     [self runSnackbarUpdatesOnMainThread:^{
-      MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-      [manager.currentSnackbar setSnackbarMessageViewShadowColor:snackbarMessageViewShadowColor];
+      [self.internalManager.currentSnackbar
+          setSnackbarMessageViewShadowColor:snackbarMessageViewShadowColor];
     }];
   }
 }
 
-+ (UIColor *)snackbarMessageViewShadowColor {
+- (UIColor *)snackbarMessageViewShadowColor {
   return _snackbarMessageViewShadowColor;
 }
 
-+ (void)setMessageTextColor:(UIColor *)messageTextColor {
+- (void)setMessageTextColor:(UIColor *)messageTextColor {
   if (messageTextColor != _messageTextColor) {
     _messageTextColor = messageTextColor;
     [self runSnackbarUpdatesOnMainThread:^{
-      MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-      [manager.currentSnackbar setMessageTextColor:messageTextColor];
+      [self.internalManager.currentSnackbar setMessageTextColor:messageTextColor];
     }];
   }
 }
 
-+ (UIColor *)messageTextColor {
+- (UIColor *)messageTextColor {
   return _messageTextColor;
 }
 
-+ (void)setMessageFont:(UIFont *)messageFont {
+- (void)setMessageFont:(UIFont *)messageFont {
   if (messageFont != _messageFont) {
     _messageFont = messageFont;
     [self runSnackbarUpdatesOnMainThread:^{
-      MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-      [manager.currentSnackbar setMessageFont:messageFont];
+      [self.internalManager.currentSnackbar setMessageFont:messageFont];
     }];
   }
 }
 
-+ (UIFont *)messageFont {
+- (UIFont *)messageFont {
   return _messageFont;
 }
 
-+ (void)setButtonFont:(UIFont *)buttonFont {
+- (void)setButtonFont:(UIFont *)buttonFont {
   if (buttonFont != _buttonFont) {
     _buttonFont = buttonFont;
     [self runSnackbarUpdatesOnMainThread:^{
-      MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-      [manager.currentSnackbar setButtonFont:buttonFont];
+      [self.internalManager.currentSnackbar setButtonFont:buttonFont];
     }];
   }
 }
 
-+ (UIFont *)buttonFont {
+- (UIFont *)buttonFont {
   return _buttonFont;
 }
 
-+ (void)setButtonTitleColor:(UIColor *)titleColor forState:(UIControlState)state {
+- (void)setButtonTitleColor:(UIColor *)titleColor forState:(UIControlState)state {
   if (_buttonTitleColors == nil) {
     _buttonTitleColors = [NSMutableDictionary dictionary];
   }
   if (titleColor != _buttonTitleColors[@(state)]) {
     _buttonTitleColors[@(state)] = titleColor;
     [self runSnackbarUpdatesOnMainThread:^{
-      MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-      [manager.currentSnackbar setButtonTitleColor:titleColor forState:state];
+      [self.internalManager.currentSnackbar setButtonTitleColor:titleColor forState:state];
     }];
   }
 }
 
-+ (UIColor *)buttonTitleColorForState:(UIControlState)state {
+- (UIColor *)buttonTitleColorForState:(UIControlState)state {
   return _buttonTitleColors[@(state)];
 }
 
-+ (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)mdc_adjustsFontForContentSizeCategory {
+- (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)mdc_adjustsFontForContentSizeCategory {
   if (mdc_adjustsFontForContentSizeCategory != _mdc_adjustsFontForContentSizeCategory) {
     _mdc_adjustsFontForContentSizeCategory = mdc_adjustsFontForContentSizeCategory;
     [self runSnackbarUpdatesOnMainThread:^{
-      MDCSnackbarManagerInternal *manager = [MDCSnackbarManagerInternal sharedInstance];
-      [manager.currentSnackbar
+      [self.internalManager.currentSnackbar
           mdc_setAdjustsFontForContentSizeCategory:mdc_adjustsFontForContentSizeCategory];
     }];
   }
 }
 
-+ (BOOL)mdc_adjustsFontForContentSizeCategory {
+- (BOOL)mdc_adjustsFontForContentSizeCategory {
   return _mdc_adjustsFontForContentSizeCategory;
 }
 
-+ (void)setShouldApplyStyleChangesToVisibleSnackbars:
+- (void)setShouldApplyStyleChangesToVisibleSnackbars:
     (BOOL)shouldApplyStyleChangesToVisibleSnackbars {
   _shouldApplyStyleChangesToVisibleSnackbars = shouldApplyStyleChangesToVisibleSnackbars;
 }
 
-+ (BOOL)shouldApplyStyleChangesToVisibleSnackbars {
+- (BOOL)shouldApplyStyleChangesToVisibleSnackbars {
   return _shouldApplyStyleChangesToVisibleSnackbars;
 }
 
 @end
 
+@interface MDCSnackbarManagerSuspensionToken ()
+@property(nonatomic, weak) MDCSnackbarManager *manager;
+@end
+
 @implementation MDCSnackbarManagerSuspensionToken
 
-- (instancetype)init {
+- (instancetype)initWithManager:(MDCSnackbarManager *)manager {
   self = [super init];
   if (self != nil) {
     _identifier = [NSUUID UUID];
+    _manager = manager;
   }
   return self;
 }
 
 - (void)dealloc {
-  [MDCSnackbarManager resumeMessagesWithToken:self];
+  [_manager resumeMessagesWithToken:self];
+}
+
+@end
+
+@implementation MDCSnackbarManager (LegacyAPI)
+
++ (MDCSnackbarAlignment)alignment {
+  return MDCSnackbarManager.defaultManager.alignment;
+}
+
++ (void)setAlignment:(MDCSnackbarAlignment)alignment {
+  MDCSnackbarManager.defaultManager.alignment = alignment;
+}
+
++ (void)showMessage:(nullable MDCSnackbarMessage *)message {
+  [MDCSnackbarManager.defaultManager showMessage:message];
+}
+
++ (void)setPresentationHostView:(nullable UIView *)hostView {
+  [MDCSnackbarManager.defaultManager setPresentationHostView:hostView];
+}
+
++ (BOOL)hasMessagesShowingOrQueued {
+  return MDCSnackbarManager.defaultManager.hasMessagesShowingOrQueued;
+}
+
++ (void)dismissAndCallCompletionBlocksWithCategory:(nullable NSString *)category {
+  [MDCSnackbarManager.defaultManager dismissAndCallCompletionBlocksWithCategory:category];
+}
+
++ (void)setBottomOffset:(CGFloat)offset {
+  [MDCSnackbarManager.defaultManager setBottomOffset:offset];
+}
+
++ (nullable id <MDCSnackbarSuspensionToken>)suspendAllMessages {
+  return MDCSnackbarManager.defaultManager.suspendAllMessages;
+}
+
++ (nullable id <MDCSnackbarSuspensionToken>)
+    suspendMessagesWithCategory:(nullable NSString *)category {
+  return [MDCSnackbarManager.defaultManager suspendMessagesWithCategory:category];
+}
+
++ (void)resumeMessagesWithToken:(nullable id <MDCSnackbarSuspensionToken>)token {
+  [MDCSnackbarManager.defaultManager resumeMessagesWithToken:token];
+}
+
++ (UIColor *)snackbarMessageViewBackgroundColor {
+  return MDCSnackbarManager.defaultManager.snackbarMessageViewBackgroundColor;
+}
+
++ (void)setSnackbarMessageViewBackgroundColor:(UIColor *)snackbarMessageViewBackgroundColor {
+  MDCSnackbarManager.defaultManager.snackbarMessageViewBackgroundColor =
+      snackbarMessageViewBackgroundColor;
+}
+
++ (UIColor *)snackbarMessageViewShadowColor {
+  return MDCSnackbarManager.defaultManager.snackbarMessageViewShadowColor;
+}
+
++ (void)setSnackbarMessageViewShadowColor:(UIColor *)snackbarMessageViewShadowColor {
+  MDCSnackbarManager.defaultManager.snackbarMessageViewShadowColor = snackbarMessageViewShadowColor;
+}
+
++ (UIColor *)messageTextColor {
+  return MDCSnackbarManager.defaultManager.messageTextColor;
+}
+
++ (void)setMessageTextColor:(UIColor *)messageTextColor {
+  MDCSnackbarManager.defaultManager.messageTextColor = messageTextColor;
+}
+
++ (UIFont *)messageFont {
+  return MDCSnackbarManager.defaultManager.messageFont;
+}
+
++ (void)setMessageFont:(UIFont *)messageFont {
+  MDCSnackbarManager.defaultManager.messageFont = messageFont;
+}
+
++ (UIFont *)buttonFont {
+  return MDCSnackbarManager.defaultManager.buttonFont;
+}
+
++ (void)setButtonFont:(UIFont *)buttonFont {
+  MDCSnackbarManager.defaultManager.buttonFont = buttonFont;
+}
+
++ (BOOL)shouldApplyStyleChangesToVisibleSnackbars {
+  return MDCSnackbarManager.defaultManager.shouldApplyStyleChangesToVisibleSnackbars;
+}
+
++ (void)setShouldApplyStyleChangesToVisibleSnackbars:(BOOL)shouldApplyStyleChangesToVisibleSnackbars
+    {
+  MDCSnackbarManager.defaultManager.shouldApplyStyleChangesToVisibleSnackbars =
+      shouldApplyStyleChangesToVisibleSnackbars;
+}
+
++ (UIColor *)buttonTitleColorForState:(UIControlState)state {
+  return [MDCSnackbarManager.defaultManager buttonTitleColorForState:state];
+}
+
++ (void)setButtonTitleColor:(nullable UIColor *)titleColor forState:(UIControlState)state {
+  [MDCSnackbarManager.defaultManager setButtonTitleColor:titleColor forState:state];
+}
+
++ (BOOL)mdc_adjustsFontForContentSizeCategory {
+  return MDCSnackbarManager.defaultManager.mdc_adjustsFontForContentSizeCategory;
+}
+
++ (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)mdc_adjustsFontForContentSizeCategory {
+  [MDCSnackbarManager.defaultManager
+      mdc_setAdjustsFontForContentSizeCategory:mdc_adjustsFontForContentSizeCategory];
+}
+
++ (id<MDCSnackbarManagerDelegate>)delegate {
+  return MDCSnackbarManager.defaultManager.delegate;
+}
+
++ (void)setDelegate:(id<MDCSnackbarManagerDelegate>)delegate {
+  MDCSnackbarManager.defaultManager.delegate = delegate;
 }
 
 @end

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -214,35 +214,34 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
-  self = [super initWithFrame:frame];
-
-  if (self) {
-    _snackbarMessageViewShadowColor =
-        MDCSnackbarManager.snackbarMessageViewShadowColor ?: UIColor.blackColor;
-    _snackbarMessageViewBackgroundColor =
-        MDCSnackbarManager.snackbarMessageViewBackgroundColor ?: MDCRGBAColor(0x32, 0x32, 0x32, 1);
-    _messageTextColor =
-        MDCSnackbarManager.messageTextColor ?: UIColor.whiteColor;
-    _buttonTitleColors = [NSMutableDictionary dictionary];
-    _buttonTitleColors[@(UIControlStateNormal)] =
-        [MDCSnackbarManager buttonTitleColorForState:UIControlStateNormal] ?:
-            MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f);
-    _buttonTitleColors[@(UIControlStateHighlighted)] =
-        [MDCSnackbarManager buttonTitleColorForState:UIControlStateHighlighted] ?:
-            UIColor.whiteColor;
-    _mdc_adjustsFontForContentSizeCategory =
-        MDCSnackbarManager.mdc_adjustsFontForContentSizeCategory;
-    _messageFont = MDCSnackbarManager.messageFont;
-    _buttonFont = MDCSnackbarManager.buttonFont;
-  }
-
-  return self;
+  return [self initWithMessage:nil
+                dismissHandler:nil
+               snackbarManager:MDCSnackbarManager.defaultManager];
 }
 
 - (instancetype)initWithMessage:(MDCSnackbarMessage *)message
-                 dismissHandler:(MDCSnackbarMessageDismissHandler)handler {
-  self = [super init];
+                 dismissHandler:(MDCSnackbarMessageDismissHandler)handler
+                snackbarManager:(MDCSnackbarManager *)manager {
+  self = [super initWithFrame:CGRectZero];
+
   if (self) {
+    _snackbarMessageViewShadowColor =
+        manager.snackbarMessageViewShadowColor ?: UIColor.blackColor;
+    _snackbarMessageViewBackgroundColor =
+        manager.snackbarMessageViewBackgroundColor ?: MDCRGBAColor(0x32, 0x32, 0x32, 1);
+    _messageTextColor =
+        manager.messageTextColor ?: UIColor.whiteColor;
+    _buttonTitleColors = [NSMutableDictionary dictionary];
+    _buttonTitleColors[@(UIControlStateNormal)] =
+        [manager buttonTitleColorForState:UIControlStateNormal] ?:
+        MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f);
+    _buttonTitleColors[@(UIControlStateHighlighted)] =
+        [manager buttonTitleColorForState:UIControlStateHighlighted] ?:
+        UIColor.whiteColor;
+    _mdc_adjustsFontForContentSizeCategory =
+        manager.mdc_adjustsFontForContentSizeCategory;
+    _messageFont = manager.messageFont;
+    _buttonFont = manager.buttonFont;
     _message = message;
     _dismissalHandler = [handler copy];
 

--- a/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
+++ b/components/Snackbar/src/private/MDCSnackbarMessageViewInternal.h
@@ -16,6 +16,7 @@
 
 #import "../MDCSnackbarMessageView.h"
 
+@class MDCSnackbarManager;
 @class MDCSnackbarMessage;
 @class MDCSnackbarMessageAction;
 
@@ -62,7 +63,8 @@ typedef void (^MDCSnackbarMessageDismissHandler)(BOOL userInitiated,
  that it needs to be dismissed prior to its timer-based dismissal time.
  */
 - (_Nonnull instancetype)initWithMessage:(MDCSnackbarMessage *_Nullable)message
-                          dismissHandler:(MDCSnackbarMessageDismissHandler _Nullable)handler;
+                          dismissHandler:(MDCSnackbarMessageDismissHandler _Nullable)handler
+                         snackbarManager:(MDCSnackbarManager *_Nonnull)manager;
 
 /**
  Dismisses the message view.

--- a/components/Snackbar/tests/unit/MDCSnackbarManagerInstanceTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarManagerInstanceTests.m
@@ -1,0 +1,177 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialSnackbar.h"
+
+@interface FakeMDCSnackbarManagerDelegate : NSObject <MDCSnackbarManagerDelegate>
+
+- (void)willPresentSnackbarWithMessageView:(MDCSnackbarMessageView *)messageView;
+
+@end
+
+@implementation FakeMDCSnackbarManagerDelegate
+
+- (void)willPresentSnackbarWithMessageView:(__unused MDCSnackbarMessageView *)messageView {
+  // Nothing
+}
+
+@end
+
+@interface MDCSnackbarManagerInstanceTests : XCTestCase
+
+@property(nonatomic, strong) UIColor *messageTextColor;
+@property(nonatomic, strong) UIColor *snackbarMessageViewShadowColor;
+@property(nonatomic, strong) UIColor *snackbarMessageViewBackgroundColor;
+@property(nonatomic, strong) NSMutableDictionary *titleColorForState;
+
+@end
+
+@implementation MDCSnackbarManagerInstanceTests
+
+// The fact that MDCSnackbarManager.defaultInstance is a singelton means it's incredibly hard to
+// test correctly. The -setUp and -tearDown methods below attempt to save/restore the
+// defaultManager's tested state as well as possible. If either these tests or any of the "default"
+// styling tests begin to flake/fail, it's probably best to remove these methods as well as
+// -testClassPropertiesAssignToDefaultInstance .
+
+- (void)setUp {
+  [super setUp];
+
+  self.messageTextColor = MDCSnackbarManager.messageTextColor;
+  self.snackbarMessageViewShadowColor = MDCSnackbarManager.snackbarMessageViewShadowColor;
+  self.snackbarMessageViewShadowColor = MDCSnackbarManager.snackbarMessageViewBackgroundColor;
+  self.titleColorForState = [@{} mutableCopy];
+  NSUInteger maxState = UIControlStateNormal | UIControlStateDisabled | UIControlStateSelected
+    | UIControlStateHighlighted;
+  for (NSUInteger state = 0; state < maxState; ++state) {
+    self.titleColorForState[@(state)] = [MDCSnackbarManager buttonTitleColorForState:state];
+  }
+}
+
+- (void)tearDown {
+  MDCSnackbarManager.messageTextColor = self.messageTextColor;
+  MDCSnackbarManager.snackbarMessageViewShadowColor = self.snackbarMessageViewShadowColor;
+  MDCSnackbarManager.snackbarMessageViewBackgroundColor = self.snackbarMessageViewBackgroundColor;
+  for (NSNumber *state in self.titleColorForState.allKeys) {
+    if (self.titleColorForState[state] != nil) {
+      [MDCSnackbarManager setButtonTitleColor:self.titleColorForState[state]
+                                     forState:state.unsignedIntegerValue];
+    }
+  }
+  [self.titleColorForState removeAllObjects];
+  [super tearDown];
+}
+
+- (void)testTwoInitializationsProvideTwoObjects {
+  // When
+  MDCSnackbarManager *manager1 = [[MDCSnackbarManager alloc] init];
+  MDCSnackbarManager *manager2 = [[MDCSnackbarManager alloc] init];
+
+  // Then
+  XCTAssertNotEqual(manager1, manager2);
+}
+
+- (void)testDefaultInstanceIsTheSame {
+  // Given
+  MDCSnackbarManager *manager = MDCSnackbarManager.defaultManager;
+
+  // Then
+  XCTAssertEqual(MDCSnackbarManager.defaultManager, manager);
+}
+
+- (void)testClassPropertiesAssignToDefaultInstance {
+  // Given
+  MDCSnackbarManager *manager = MDCSnackbarManager.defaultManager;
+  FakeMDCSnackbarManagerDelegate *delegate = [[FakeMDCSnackbarManagerDelegate alloc] init];
+
+  // When
+  MDCSnackbarManager.alignment = MDCSnackbarAlignmentLeading;
+  MDCSnackbarManager.buttonFont = [UIFont systemFontOfSize:72];
+  MDCSnackbarManager.delegate = delegate;
+  [MDCSnackbarManager mdc_setAdjustsFontForContentSizeCategory:YES];
+  MDCSnackbarManager.messageFont = [UIFont systemFontOfSize:66];
+  MDCSnackbarManager.messageTextColor = UIColor.orangeColor;
+  MDCSnackbarManager.shouldApplyStyleChangesToVisibleSnackbars = YES;
+  MDCSnackbarManager.snackbarMessageViewBackgroundColor = UIColor.brownColor;
+  MDCSnackbarManager.snackbarMessageViewShadowColor = UIColor.purpleColor;
+  [MDCSnackbarManager setButtonTitleColor:UIColor.greenColor forState:UIControlStateDisabled];
+
+  // Then
+  XCTAssertEqual(manager.alignment, MDCSnackbarManager.alignment);
+  XCTAssertEqual(manager.buttonFont, MDCSnackbarManager.buttonFont);
+  XCTAssertEqual(manager.delegate, MDCSnackbarManager.delegate);
+  XCTAssertEqual(manager.mdc_adjustsFontForContentSizeCategory,
+                 MDCSnackbarManager.mdc_adjustsFontForContentSizeCategory);
+  XCTAssertEqual(manager.messageFont, MDCSnackbarManager.messageFont);
+  XCTAssertEqual(manager.messageTextColor, MDCSnackbarManager.messageTextColor);
+  XCTAssertEqual(manager.shouldApplyStyleChangesToVisibleSnackbars,
+                 MDCSnackbarManager.shouldApplyStyleChangesToVisibleSnackbars);
+  XCTAssertEqual(manager.snackbarMessageViewBackgroundColor,
+                 MDCSnackbarManager.snackbarMessageViewBackgroundColor);
+  XCTAssertEqual(manager.snackbarMessageViewShadowColor,
+                 MDCSnackbarManager.snackbarMessageViewShadowColor);
+  XCTAssertEqual([manager buttonTitleColorForState:UIControlStateDisabled],
+                 [MDCSnackbarManager buttonTitleColorForState:UIControlStateDisabled]);
+}
+
+- (void)testInstancesDoNotSharePropertyStorage {
+  // Given
+  MDCSnackbarManager *manager1 = [[MDCSnackbarManager alloc] init];
+  MDCSnackbarManager *manager2 = [[MDCSnackbarManager alloc] init];
+  FakeMDCSnackbarManagerDelegate *delegate1 = [[FakeMDCSnackbarManagerDelegate alloc] init];
+  FakeMDCSnackbarManagerDelegate *delegate2 = [[FakeMDCSnackbarManagerDelegate alloc] init];
+
+  // When
+  manager1.alignment = MDCSnackbarAlignmentLeading;
+  manager2.alignment = MDCSnackbarAlignmentCenter;
+  manager1.buttonFont = [UIFont systemFontOfSize:72];
+  manager2.buttonFont = [UIFont systemFontOfSize:41];
+  manager1.delegate = delegate1;
+  manager2.delegate = delegate2;
+  manager1.mdc_adjustsFontForContentSizeCategory = YES;
+  manager2.mdc_adjustsFontForContentSizeCategory = NO;
+  manager1.messageFont = [UIFont systemFontOfSize:66];
+  manager2.messageFont = [UIFont systemFontOfSize:33];
+  manager1.messageTextColor = UIColor.orangeColor;
+  manager2.messageTextColor = UIColor.blueColor;
+  manager1.shouldApplyStyleChangesToVisibleSnackbars = YES;
+  manager2.shouldApplyStyleChangesToVisibleSnackbars = NO;
+  manager1.snackbarMessageViewBackgroundColor = UIColor.brownColor;
+  manager2.snackbarMessageViewBackgroundColor = UIColor.yellowColor;
+  manager1.snackbarMessageViewShadowColor = UIColor.purpleColor;
+  manager2.snackbarMessageViewShadowColor = UIColor.cyanColor;
+  [manager1 setButtonTitleColor:UIColor.greenColor forState:UIControlStateDisabled];
+  [manager2 setButtonTitleColor:UIColor.magentaColor forState:UIControlStateDisabled];
+
+  // Then
+  XCTAssertNotEqual(manager1.alignment, manager2.alignment);
+  XCTAssertNotEqual(manager1.buttonFont, manager2.buttonFont);
+  XCTAssertNotEqual(manager1.delegate, manager2.delegate);
+  XCTAssertNotEqual(manager1.mdc_adjustsFontForContentSizeCategory,
+                    manager2.mdc_adjustsFontForContentSizeCategory);
+  XCTAssertNotEqual(manager1.messageFont, manager2.messageFont);
+  XCTAssertNotEqual(manager1.messageTextColor, manager2.messageTextColor);
+  XCTAssertNotEqual(manager1.shouldApplyStyleChangesToVisibleSnackbars,
+                    manager2.shouldApplyStyleChangesToVisibleSnackbars);
+  XCTAssertNotEqual(manager1.snackbarMessageViewBackgroundColor,
+                    manager2.snackbarMessageViewBackgroundColor);
+  XCTAssertNotEqual(manager1.snackbarMessageViewShadowColor,
+                    manager2.snackbarMessageViewShadowColor);
+  XCTAssertNotEqual([manager1 buttonTitleColorForState:UIControlStateDisabled],
+                    [manager2 buttonTitleColorForState:UIControlStateDisabled]);
+}
+
+@end


### PR DESCRIPTION
Creating an explicit singleton for the MDCSnackbarManager so that clients can
use their own instances (perhaps one per screen in the future) or configure
instances for testing.

Unblocks internal issue b/77900596

This is a roll-forward of #4556
Closes #4686
