### PR TITLE
[Snackbar] Make examples accessible to Switch Control

### DIFF
--- a/components/Snackbar/examples/SnackbarSuspensionExample.m
+++ b/components/Snackbar/examples/SnackbarSuspensionExample.m
@@ -111,6 +111,51 @@ static NSString *const kCategoryB = @"CategoryB";
     case 2:
       [self showMessageWithPrefix:@"No Category Message" category:nil];
       break;
+    case 3: {
+      UICollectionViewCell *cell = [collectionView cellForItemAtIndexPath:indexPath];
+      if ([cell isKindOfClass:[MDCCollectionViewTextCell class]]) {
+        MDCCollectionViewTextCell *mdcCell = (MDCCollectionViewTextCell *)cell;
+        UIView *accessoryView = mdcCell.accessoryView;
+        if ([accessoryView isKindOfClass:[UISwitch class]]) {
+          UISwitch *theSwitch = (UISwitch *)accessoryView;
+          [theSwitch setOn:!theSwitch.isOn animated:YES];
+          cell.accessibilityValue = theSwitch.isOn ? @"on" : @"off";
+          cell.accessibilityLabel = mdcCell.textLabel.text;
+          [self setSuspendedGroupA:theSwitch.isOn];
+        }
+      }
+      break;
+    }
+    case 4: {
+      UICollectionViewCell *cell = [collectionView cellForItemAtIndexPath:indexPath];
+      if ([cell isKindOfClass:[MDCCollectionViewTextCell class]]) {
+        MDCCollectionViewTextCell *mdcCell = (MDCCollectionViewTextCell *)cell;
+        UIView *accessoryView = mdcCell.accessoryView;
+        if ([accessoryView isKindOfClass:[UISwitch class]]) {
+          UISwitch *theSwitch = (UISwitch *)accessoryView;
+          [theSwitch setOn:!theSwitch.isOn animated:YES];
+          cell.accessibilityValue = theSwitch.isOn ? @"on" : @"off";
+          cell.accessibilityLabel = mdcCell.textLabel.text;
+          [self setSuspendedGroupB:theSwitch.isOn];
+        }
+      }
+      break;
+    }
+    case 5: {
+      UICollectionViewCell *cell = [collectionView cellForItemAtIndexPath:indexPath];
+      if ([cell isKindOfClass:[MDCCollectionViewTextCell class]]) {
+        MDCCollectionViewTextCell *mdcCell = (MDCCollectionViewTextCell *)cell;
+        UIView *accessoryView = mdcCell.accessoryView;
+        if ([accessoryView isKindOfClass:[UISwitch class]]) {
+          UISwitch *theSwitch = (UISwitch *)accessoryView;
+          [theSwitch setOn:!theSwitch.isOn animated:YES];
+          cell.accessibilityValue = theSwitch.isOn ? @"on" : @"off";
+          cell.accessibilityLabel = mdcCell.textLabel.text;
+          [self setSuspendedAllMessages:theSwitch.isOn];
+        }
+      }
+      break;
+    }
     default:
       break;
   }

--- a/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
+++ b/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
@@ -45,8 +45,10 @@ static NSString * const kCellIdentifier = @"Cell";
       [collectionView dequeueReusableCellWithReuseIdentifier:kCellIdentifier
                                                 forIndexPath:indexPath];
   cell.textLabel.text = self.choices[indexPath.row];
-
+  cell.accessibilityTraits = cell.accessibilityTraits | UIAccessibilityTraitButton;
+  cell.isAccessibilityElement = YES;
   cell.accessibilityIdentifier = cell.textLabel.text;
+  cell.accessibilityLabel = cell.textLabel.text;
   return cell;
 }
 
@@ -121,6 +123,9 @@ static NSString * const kCellIdentifier = @"Cell";
                                             forIndexPath:indexPath];
 
   cell.textLabel.text = self.choices[indexPath.row];
+  cell.isAccessibilityElement = YES;
+  cell.accessibilityTraits = cell.accessibilityTraits | UIAccessibilityTraitButton;
+  cell.accessibilityLabel = cell.textLabel.text;
   if (indexPath.row > 2) {
     UISwitch *editingSwitch = [[UISwitch alloc] initWithFrame:CGRectZero];
     [editingSwitch setTag:indexPath.row];
@@ -128,8 +133,10 @@ static NSString * const kCellIdentifier = @"Cell";
                       action:@selector(handleSuspendStateChanged:)
             forControlEvents:UIControlEventValueChanged];
     cell.accessoryView = editingSwitch;
+    cell.accessibilityValue = editingSwitch.isOn ? @"on" : @"off";
   } else {
     cell.accessoryView = nil;
+    cell.accessibilityValue = nil;
   }
 
   return cell;


### PR DESCRIPTION
Users of Switch Control could not access the cells needed to make Snackbars
appear. For VoiceOver, the accessibilityLabel, accessibilityValue, and
accessibilityHint for the cells in the Message Suspension example were not
integrated with the cells themselves.

Closes #4712
