### PR TITLE
[AppBar] Move more app bar logic back to the init phase.

### DIFF
--- a/components/AppBar/src/MDCAppBarViewController.m
+++ b/components/AppBar/src/MDCAppBarViewController.m
@@ -64,6 +64,12 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
     [(MDCShadowLayer *)shadowLayer setElevation:elevation];
   };
   [self.headerView setShadowLayer:[MDCShadowLayer layer] intensityDidChangeBlock:intensityBlock];
+
+  [self.headerView forwardTouchEventsForView:self.headerStackView];
+  [self.headerView forwardTouchEventsForView:self.navigationBar];
+
+  self.headerStackView.translatesAutoresizingMaskIntoConstraints = NO;
+  self.headerStackView.topBar = self.navigationBar;
 }
 
 - (MDCHeaderStackView *)headerStackView {
@@ -168,12 +174,6 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-
-  [self.headerView forwardTouchEventsForView:self.headerStackView];
-  [self.headerView forwardTouchEventsForView:self.navigationBar];
-
-  self.headerStackView.translatesAutoresizingMaskIntoConstraints = NO;
-  self.headerStackView.topBar = self.navigationBar;
 
   [self.view addSubview:self.headerStackView];
 

--- a/components/AppBar/tests/unit/AppBarViewControllerInitializationTests.swift
+++ b/components/AppBar/tests/unit/AppBarViewControllerInitializationTests.swift
@@ -1,0 +1,32 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents.MaterialAppBar
+
+class AppBarViewControllerInitializationTests: XCTestCase {
+
+  func testHeaderStackViewTopBarIsTheNavigationBarAfterInitialization() {
+    // Given
+    let appBarViewController = MDCAppBarViewController()
+
+    // Then
+    XCTAssertEqual(appBarViewController.headerStackView.topBar,
+                   appBarViewController.navigationBar,
+                   "Expected the app bar's top bar to be set to the navigation bar after"
+                    + " initialization.")
+  }
+}


### PR DESCRIPTION
2645cc539f6a17e8ecb729a1b5b7997be24f07fa changed the app bar initialization such that it would no longer touch self.view during initialization. This means that viewDidLoad now only gets called when the client adds the app bar view controller's view to the view hierarchy.

A client was depending on the header stack view's `topBar` property being set to the navigation bar immediately after initialization, so the above change broke this contract for them.

This change moves this logic into the app bar view controller's initialization phase so that the header stack view is fully configured upon initialization, renewing the contract that the client team expected.

Added a unit test to ensure that we maintain this contract into the future.