### PR TITLE
[FlexibleHeader]! Make preferredStatusBarStyle settable.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
@@ -112,13 +112,25 @@
 - (BOOL)prefersStatusBarHidden;
 
 /**
- Calculates the status bar style based on the header view's background color.
-
- Light background colors use the default black status bar and dark background colors use the light
- status bar. If the header view's background color is not fully-opaque, then this returns
- UIStatusBarStyleDefault.
+ The status bar style that should be used for this view controller.
  */
-- (UIStatusBarStyle)preferredStatusBarStyle;
+@property(nonatomic) UIStatusBarStyle preferredStatusBarStyle;
+
+/**
+ Whether to calculate the preferredStatusBarStyle based on the view's background color.
+
+ If enabled, preferredStatusBarStyle will automatically return a status bar style that meets
+ accessibility contrast ratio guidelines. Light background colors use the default black status bar
+ and dark background colors use the light status bar. If the header view's background color is not
+ fully-opaque, then preferredStatusBarStyle will return UIStatusBarStyleDefault. Attempting to set
+ a value when this property is enabled will result in an assertion.
+
+ If disabled, preferredStatusBarStyle will act as a standard property - the value that you set will
+ be the value that is returned.
+
+ Default is YES.
+ */
+@property(nonatomic) BOOL inferPreferredStatusBarStyle;
 
 @end
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -89,6 +89,8 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 
 @implementation MDCFlexibleHeaderViewController
 
+@synthesize preferredStatusBarStyle = _preferredStatusBarStyle;
+
 - (void)dealloc {
   // Clear KVO observers
   self.topLayoutGuideConstraint = nil;
@@ -130,6 +132,8 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 }
 
 - (void)commonMDCFlexibleHeaderViewControllerInit {
+  _inferPreferredStatusBarStyle = YES;
+
   MDCFlexibleHeaderView *headerView =
       [[MDCFlexibleHeaderView alloc] initWithFrame:[UIScreen mainScreen].bounds];
   headerView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
@@ -220,11 +224,22 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-  UIColor *backgroundColor =
-      [MDCFlexibleHeaderView appearance].backgroundColor ?: _headerView.backgroundColor;
-  return (ShouldUseLightStatusBarOnBackgroundColor(backgroundColor)
-              ? UIStatusBarStyleLightContent
-              : UIStatusBarStyleDefault);
+  if (self.inferPreferredStatusBarStyle) {
+    UIColor *backgroundColor =
+        [MDCFlexibleHeaderView appearance].backgroundColor ?: _headerView.backgroundColor;
+    return (ShouldUseLightStatusBarOnBackgroundColor(backgroundColor)
+                ? UIStatusBarStyleLightContent
+                : UIStatusBarStyleDefault);
+  } else {
+    return _preferredStatusBarStyle;
+  }
+}
+
+- (void)setPreferredStatusBarStyle:(UIStatusBarStyle)preferredStatusBarStyle {
+  NSAssert(!self.inferPreferredStatusBarStyle,
+           @"You must disable inferPreferredStatusBarStyle prior to setting a status bar style.");
+
+  _preferredStatusBarStyle = preferredStatusBarStyle;
 }
 
 - (BOOL)prefersStatusBarHidden {

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderStatusBarTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderStatusBarTests.swift
@@ -24,20 +24,35 @@ class FlexibleHeaderStatusBarTests: XCTestCase {
     let controller = MDCFlexibleHeaderViewController()
     let view = controller.headerView
     view.backgroundColor = UIColor.black
-    XCTAssertEqual(controller.preferredStatusBarStyle(), UIStatusBarStyle.lightContent)
+    XCTAssertEqual(controller.preferredStatusBarStyle, UIStatusBarStyle.lightContent)
   }
 
   func testLightBackgroundColor() {
     let controller = MDCFlexibleHeaderViewController()
     let view = controller.headerView
     view.backgroundColor = UIColor.white
-    XCTAssertEqual(controller.preferredStatusBarStyle(), UIStatusBarStyle.default)
+    XCTAssertEqual(controller.preferredStatusBarStyle, UIStatusBarStyle.default)
   }
 
   func testNonOpaqueBackgroundColor() {
     let controller = MDCFlexibleHeaderViewController()
     let view = controller.headerView
     view.backgroundColor = UIColor.init(white: 0, alpha: 0)
-    XCTAssertEqual(controller.preferredStatusBarStyle(), UIStatusBarStyle.default)
+    XCTAssertEqual(controller.preferredStatusBarStyle, UIStatusBarStyle.default)
   }
+
+  func testExplicitStyleWhenDefault() {
+    let controller = MDCFlexibleHeaderViewController()
+    controller.inferPreferredStatusBarStyle = false
+    controller.preferredStatusBarStyle = .default
+    XCTAssertEqual(controller.preferredStatusBarStyle, .default)
+  }
+
+  func testExplicitStyleWhenLightContent() {
+    let controller = MDCFlexibleHeaderViewController()
+    controller.inferPreferredStatusBarStyle = false
+    controller.preferredStatusBarStyle = .lightContent
+    XCTAssertEqual(controller.preferredStatusBarStyle, .lightContent)
+  }
+
 }


### PR DESCRIPTION
In order to maintain existing contract of preferredStatusBarStyle being auto-calculated based on the header view's background color, preferredStatusBarStyle now changes its behavior based on the value of a new flag, inferPreferredStatusBarStyle.

By default, inferPreferredStatusBarStyle is true, meaning preferredStatusBarStyle will use the auto-calculation behavior.

When inferPreferredStatusBarStyle is disabled, preferredStatusBarStyle will instead act like a typical property.

Note that this is a breaking change for Swift clients because the API is changing from method to property syntax.

Closes https://github.com/material-components/material-components-ios/issues/4747