### PR TITLE
[Buttons] Rename MDCFloatingButton category to MDCButton

### DIFF
--- a/components/Buttons/examples/FloatingButtonExampleViewController.m
+++ b/components/Buttons/examples/FloatingButtonExampleViewController.m
@@ -24,9 +24,9 @@ NSString *kMiniButtonLabel = @"Add";
 
 @interface FloatingButtonExampleViewController : UIViewController
 @property(nonatomic, strong) UILabel *iPadLabel;
-@property(nonatomic, strong) MDCButton *miniFloatingButton;
-@property(nonatomic, strong) MDCButton *defaultFloatingButton;
-@property(nonatomic, strong) MDCButton *largeIconFloatingButton;
+@property(nonatomic, strong) MDCFloatingButton *miniFloatingButton;
+@property(nonatomic, strong) MDCFloatingButton *defaultFloatingButton;
+@property(nonatomic, strong) MDCFloatingButton *largeIconFloatingButton;
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
 @end
 
@@ -55,14 +55,14 @@ NSString *kMiniButtonLabel = @"Add";
   self.iPadLabel = [[UILabel alloc] init];
   self.iPadLabel.text = @"Try me on an iPad!";
 
-  self.miniButton = [[MDCButton alloc] initWithFrame:CGRectZero
+  self.miniFloatingButton = [[MDCFloatingButton alloc] initWithFrame:CGRectZero
                                                                shape:MDCFloatingButtonShapeMini];
-  self.miniButton.translatesAutoresizingMaskIntoConstraints = NO;
-  [self.miniButton setImage:plusImage forState:UIControlStateNormal];
-  self.miniButton.accessibilityLabel = kMiniButtonLabel;
-  [self.miniButton setMinimumSize:CGSizeMake(96, 40)
-                         forShape:MDCFloatingButtonShapeMini
-                           inMode:MDCFloatingButtonModeExpanded];
+  self.miniFloatingButton.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.miniFloatingButton setImage:plusImage forState:UIControlStateNormal];
+  self.miniFloatingButton.accessibilityLabel = kMiniButtonLabel;
+  [self.miniFloatingButton setMinimumSize:CGSizeMake(96, 40)
+                                 forShape:MDCFloatingButtonShapeMini
+                                   inMode:MDCFloatingButtonModeExpanded];
   [MDCFloatingButtonColorThemer applySemanticColorScheme:self.colorScheme
                                                 toButton:self.miniFloatingButton];
 

--- a/components/Buttons/examples/FloatingButtonExampleViewController.m
+++ b/components/Buttons/examples/FloatingButtonExampleViewController.m
@@ -24,9 +24,9 @@ NSString *kMiniButtonLabel = @"Add";
 
 @interface FloatingButtonExampleViewController : UIViewController
 @property(nonatomic, strong) UILabel *iPadLabel;
-@property(nonatomic, strong) MDCFloatingButton *miniFloatingButton;
-@property(nonatomic, strong) MDCFloatingButton *defaultFloatingButton;
-@property(nonatomic, strong) MDCFloatingButton *largeIconFloatingButton;
+@property(nonatomic, strong) MDCButton *miniFloatingButton;
+@property(nonatomic, strong) MDCButton *defaultFloatingButton;
+@property(nonatomic, strong) MDCButton *largeIconFloatingButton;
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
 @end
 
@@ -55,14 +55,14 @@ NSString *kMiniButtonLabel = @"Add";
   self.iPadLabel = [[UILabel alloc] init];
   self.iPadLabel.text = @"Try me on an iPad!";
 
-  self.miniFloatingButton = [[MDCFloatingButton alloc] initWithFrame:CGRectZero
+  self.miniButton = [[MDCButton alloc] initWithFrame:CGRectZero
                                                                shape:MDCFloatingButtonShapeMini];
-  self.miniFloatingButton.translatesAutoresizingMaskIntoConstraints = NO;
-  [self.miniFloatingButton setImage:plusImage forState:UIControlStateNormal];
-  self.miniFloatingButton.accessibilityLabel = kMiniButtonLabel;
-  [self.miniFloatingButton setMinimumSize:CGSizeMake(96, 40)
-                                 forShape:MDCFloatingButtonShapeMini
-                                   inMode:MDCFloatingButtonModeExpanded];
+  self.miniButton.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.miniButton setImage:plusImage forState:UIControlStateNormal];
+  self.miniButton.accessibilityLabel = kMiniButtonLabel;
+  [self.miniButton setMinimumSize:CGSizeMake(96, 40)
+                         forShape:MDCFloatingButtonShapeMini
+                           inMode:MDCFloatingButtonModeExpanded];
   [MDCFloatingButtonColorThemer applySemanticColorScheme:self.colorScheme
                                                 toButton:self.miniFloatingButton];
 

--- a/components/Buttons/src/MDCButton+Animation.h
+++ b/components/Buttons/src/MDCButton+Animation.h
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-#import "MDCFloatingButton.h"
+#import "MDCButton.h"
 
 @interface MDCButton (Animation)
 

--- a/components/Buttons/src/MDCButton+Animation.h
+++ b/components/Buttons/src/MDCButton+Animation.h
@@ -16,7 +16,7 @@
 
 #import "MDCFloatingButton.h"
 
-@interface MDCFloatingButton (Animation)
+@interface MDCButton (Animation)
 
 /**
  Expand this button to its unscaled (normal) size.

--- a/components/Buttons/src/MDCButton+Animation.m
+++ b/components/Buttons/src/MDCButton+Animation.m
@@ -14,39 +14,39 @@
  limitations under the License.
  */
 
-#import "MDCFloatingButton+Animation.h"
+#import "MDCButton+Animation.h"
 
 #if TARGET_IPHONE_SIMULATOR
 float UIAnimationDragCoefficient(void);  // Private API for simulator animation speed
 #endif
 
-static NSString *const kMDCFloatingButtonTransformKey = @"kMDCFloatingButtonTransformKey";
-static NSString *const kMDCFloatingButtonOpacityKey = @"kMDCFloatingButtonOpacityKey";
+static NSString *const kMDCButtonTransformKey = @"kMDCButtonTransformKey";
+static NSString *const kMDCButtonOpacityKey = @"kMDCButtonOpacityKey";
 
 // By using a power of 2 (2^-12), we can reduce rounding errors during transform multiplication
-static const CGFloat kMDCFloatingButtonTransformScale = (CGFloat)0.000244140625;
+static const CGFloat kMDCButtonTransformScale = (CGFloat)0.000244140625;
 
-static const NSTimeInterval kMDCFloatingButtonEnterDuration = 0.270f;
-static const NSTimeInterval kMDCFloatingButtonExitDuration = 0.180f;
+static const NSTimeInterval kMDCButtonEnterDuration = 0.270f;
+static const NSTimeInterval kMDCButtonExitDuration = 0.180f;
 
-static const NSTimeInterval kMDCFloatingButtonEnterIconDuration = 0.180f;
-static const NSTimeInterval kMDCFloatingButtonEnterIconOffset = 0.090f;
-static const NSTimeInterval kMDCFloatingButtonExitIconDuration = 0.135f;
-static const NSTimeInterval kMDCFloatingButtonExitIconOffset = 0.000f;
+static const NSTimeInterval kMDCButtonEnterIconDuration = 0.180f;
+static const NSTimeInterval kMDCButtonEnterIconOffset = 0.090f;
+static const NSTimeInterval kMDCButtonExitIconDuration = 0.135f;
+static const NSTimeInterval kMDCButtonExitIconOffset = 0.000f;
 
-static const NSTimeInterval kMDCFloatingButtonOpacityDuration = 0.015f;
-static const NSTimeInterval kMDCFloatingButtonOpacityEnterOffset = 0.030f;
-static const NSTimeInterval kMDCFloatingButtonOpacityExitOffset = 0.150f;
+static const NSTimeInterval kMDCButtonOpacityDuration = 0.015f;
+static const NSTimeInterval kMDCButtonOpacityEnterOffset = 0.030f;
+static const NSTimeInterval kMDCButtonOpacityExitOffset = 0.150f;
 
-@implementation MDCFloatingButton (Animation)
+@implementation MDCButton (Animation)
 
 + (CATransform3D)collapseTransform {
-  return CATransform3DMakeScale(kMDCFloatingButtonTransformScale, kMDCFloatingButtonTransformScale,
+  return CATransform3DMakeScale(kMDCButtonTransformScale, kMDCButtonTransformScale,
                                 1);
 }
 
 + (CATransform3D)expandTransform {
-  return CATransform3DInvert([MDCFloatingButton collapseTransform]);
+  return CATransform3DInvert([MDCButton collapseTransform]);
 }
 
 + (CABasicAnimation *)animationWithKeypath:(nonnull NSString *)keyPath
@@ -92,7 +92,7 @@ static const NSTimeInterval kMDCFloatingButtonOpacityExitOffset = 0.150f;
 - (void)expand:(BOOL)animated completion:(void (^_Nullable)(void))completion {
   void (^expandActions)(void) = ^{
     self.layer.transform =
-        CATransform3DConcat(self.layer.transform, [MDCFloatingButton expandTransform]);
+        CATransform3DConcat(self.layer.transform, [MDCButton expandTransform]);
     self.layer.opacity = 1;
     self.imageView.layer.transform =
         CATransform3DConcat(self.imageView.layer.transform, [MDCFloatingButton expandTransform]);
@@ -163,10 +163,10 @@ static const NSTimeInterval kMDCFloatingButtonOpacityExitOffset = 0.150f;
 - (void)collapse:(BOOL)animated completion:(void (^_Nullable)(void))completion {
   void (^collapseActions)(void) = ^{
     self.layer.transform =
-        CATransform3DConcat(self.layer.transform, [MDCFloatingButton collapseTransform]);
+        CATransform3DConcat(self.layer.transform, [MDCButton collapseTransform]);
     self.layer.opacity = 0;
     self.imageView.layer.transform =
-        CATransform3DConcat(self.imageView.layer.transform, [MDCFloatingButton collapseTransform]);
+        CATransform3DConcat(self.imageView.layer.transform, [MDCButton collapseTransform]);
     [self.layer removeAnimationForKey:kMDCFloatingButtonTransformKey];
     [self.layer removeAnimationForKey:kMDCFloatingButtonOpacityKey];
     [self.imageView.layer removeAnimationForKey:kMDCFloatingButtonTransformKey];

--- a/components/Buttons/src/MDCButton+Animation.m
+++ b/components/Buttons/src/MDCButton+Animation.m
@@ -95,10 +95,10 @@ static const NSTimeInterval kMDCButtonOpacityExitOffset = 0.150f;
         CATransform3DConcat(self.layer.transform, [MDCButton expandTransform]);
     self.layer.opacity = 1;
     self.imageView.layer.transform =
-        CATransform3DConcat(self.imageView.layer.transform, [MDCFloatingButton expandTransform]);
-    [self.layer removeAnimationForKey:kMDCFloatingButtonTransformKey];
-    [self.layer removeAnimationForKey:kMDCFloatingButtonOpacityKey];
-    [self.imageView.layer removeAnimationForKey:kMDCFloatingButtonTransformKey];
+        CATransform3DConcat(self.imageView.layer.transform, [MDCButton expandTransform]);
+    [self.layer removeAnimationForKey:kMDCButtonTransformKey];
+    [self.layer removeAnimationForKey:kMDCButtonOpacityKey];
+    [self.imageView.layer removeAnimationForKey:kMDCButtonTransformKey];
     if (completion) {
       completion();
     }
@@ -109,19 +109,19 @@ static const NSTimeInterval kMDCButtonOpacityExitOffset = 0.150f;
     [CATransaction setDisableActions:YES];
     [CATransaction setCompletionBlock:expandActions];
 
-    CABasicAnimation *overallScaleAnimation = [MDCFloatingButton
+    CABasicAnimation *overallScaleAnimation = [MDCButton
         animationWithKeypath:@"transform"
                      toValue:[NSValue
                                  valueWithCATransform3D:CATransform3DConcat(
                                                             self.layer.transform,
-                                                            [MDCFloatingButton expandTransform])]
+                                                            [MDCButton expandTransform])]
                    fromValue:nil
               timingFunction:[[CAMediaTimingFunction alloc]
                                  initWithControlPoints:0.0f:0.0f:0.2f:1.0f]
                     fillMode:kCAFillModeForwards
-                    duration:kMDCFloatingButtonEnterDuration
+                    duration:kMDCButtonEnterDuration
                  beginOffset:0];
-    [self.layer addAnimation:overallScaleAnimation forKey:kMDCFloatingButtonTransformKey];
+    [self.layer addAnimation:overallScaleAnimation forKey:kMDCButtonTransformKey];
 
     CALayer *iconPresentationLayer = self.imageView.layer.presentationLayer;
     if (iconPresentationLayer) {
@@ -132,27 +132,27 @@ static const NSTimeInterval kMDCButtonOpacityExitOffset = 0.150f;
                                                                   presentationLayer.transform,
                                                                   CATransform3DMakeScale(0, 0, 1))]
                             : nil;
-      CABasicAnimation *iconScaleAnimation = [MDCFloatingButton
+      CABasicAnimation *iconScaleAnimation = [MDCButton
           animationWithKeypath:@"transform"
                        toValue:[NSValue valueWithCATransform3D:iconPresentationLayer.transform]
                      fromValue:fromValue
                 timingFunction:[[CAMediaTimingFunction alloc]
                                    initWithControlPoints:0.0f:0.0f:0.2f:1.0f]
                       fillMode:kCAFillModeBoth
-                      duration:kMDCFloatingButtonEnterIconDuration
-                   beginOffset:kMDCFloatingButtonEnterIconOffset];
-      [self.imageView.layer addAnimation:iconScaleAnimation forKey:kMDCFloatingButtonTransformKey];
+                      duration:kMDCButtonEnterIconDuration
+                   beginOffset:kMDCButtonEnterIconOffset];
+      [self.imageView.layer addAnimation:iconScaleAnimation forKey:kMDCButtonTransformKey];
     }
 
-    CABasicAnimation *opacityAnimation = [MDCFloatingButton
+    CABasicAnimation *opacityAnimation = [MDCButton
         animationWithKeypath:@"opacity"
                      toValue:[NSNumber numberWithInt:1]
                    fromValue:nil
               timingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear]
                     fillMode:kCAFillModeForwards
-                    duration:kMDCFloatingButtonOpacityDuration
-                 beginOffset:kMDCFloatingButtonOpacityEnterOffset];
-    [self.layer addAnimation:opacityAnimation forKey:kMDCFloatingButtonOpacityKey];
+                    duration:kMDCButtonOpacityDuration
+                 beginOffset:kMDCButtonOpacityEnterOffset];
+    [self.layer addAnimation:opacityAnimation forKey:kMDCButtonOpacityKey];
 
     [CATransaction commit];
   } else {
@@ -167,9 +167,9 @@ static const NSTimeInterval kMDCButtonOpacityExitOffset = 0.150f;
     self.layer.opacity = 0;
     self.imageView.layer.transform =
         CATransform3DConcat(self.imageView.layer.transform, [MDCButton collapseTransform]);
-    [self.layer removeAnimationForKey:kMDCFloatingButtonTransformKey];
-    [self.layer removeAnimationForKey:kMDCFloatingButtonOpacityKey];
-    [self.imageView.layer removeAnimationForKey:kMDCFloatingButtonTransformKey];
+    [self.layer removeAnimationForKey:kMDCButtonTransformKey];
+    [self.layer removeAnimationForKey:kMDCButtonOpacityKey];
+    [self.imageView.layer removeAnimationForKey:kMDCButtonTransformKey];
     if (completion) {
       completion();
     }
@@ -180,43 +180,43 @@ static const NSTimeInterval kMDCButtonOpacityExitOffset = 0.150f;
     [CATransaction setDisableActions:YES];
     [CATransaction setCompletionBlock:collapseActions];
 
-    CABasicAnimation *overallScaleAnimation = [MDCFloatingButton
+    CABasicAnimation *overallScaleAnimation = [MDCButton
         animationWithKeypath:@"transform"
                      toValue:[NSValue
                                  valueWithCATransform3D:CATransform3DConcat(
                                                             self.layer.transform,
-                                                            [MDCFloatingButton collapseTransform])]
+                                                            [MDCButton collapseTransform])]
                    fromValue:nil
               timingFunction:[[CAMediaTimingFunction alloc]
                                  initWithControlPoints:0.4f:0.0f:1.0f:1.0f]
                     fillMode:kCAFillModeForwards
-                    duration:kMDCFloatingButtonExitDuration
+                    duration:kMDCButtonExitDuration
                  beginOffset:0];
-    [self.layer addAnimation:overallScaleAnimation forKey:kMDCFloatingButtonTransformKey];
+    [self.layer addAnimation:overallScaleAnimation forKey:kMDCButtonTransformKey];
 
-    CABasicAnimation *iconScaleAnimation = [MDCFloatingButton
+    CABasicAnimation *iconScaleAnimation = [MDCButton
         animationWithKeypath:@"transform"
                      toValue:[NSValue
                                  valueWithCATransform3D:CATransform3DConcat(
                                                             self.imageView.layer.transform,
-                                                            [MDCFloatingButton collapseTransform])]
+                                                            [MDCButton collapseTransform])]
                    fromValue:nil
               timingFunction:[[CAMediaTimingFunction alloc]
                                  initWithControlPoints:0.4f:0.0f:1.0f:1.0f]
                     fillMode:kCAFillModeForwards
-                    duration:kMDCFloatingButtonExitIconDuration
-                 beginOffset:kMDCFloatingButtonExitIconOffset];
-    [self.imageView.layer addAnimation:iconScaleAnimation forKey:kMDCFloatingButtonTransformKey];
+                    duration:kMDCButtonExitIconDuration
+                 beginOffset:kMDCButtonExitIconOffset];
+    [self.imageView.layer addAnimation:iconScaleAnimation forKey:kMDCButtonTransformKey];
 
-    CABasicAnimation *opacityAnimation = [MDCFloatingButton
+    CABasicAnimation *opacityAnimation = [MDCButton
         animationWithKeypath:@"opacity"
                      toValue:[NSNumber numberWithFloat:0]
                    fromValue:nil
               timingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear]
                     fillMode:kCAFillModeForwards
-                    duration:kMDCFloatingButtonOpacityDuration
-                 beginOffset:kMDCFloatingButtonOpacityExitOffset];
-    [self.layer addAnimation:opacityAnimation forKey:kMDCFloatingButtonOpacityKey];
+                    duration:kMDCButtonOpacityDuration
+                 beginOffset:kMDCButtonOpacityExitOffset];
+    [self.layer addAnimation:opacityAnimation forKey:kMDCButtonOpacityKey];
 
     [CATransaction commit];
   } else {

--- a/components/Buttons/src/MaterialButtons.h
+++ b/components/Buttons/src/MaterialButtons.h
@@ -17,5 +17,5 @@
 #import "MDCButton.h"
 #import "MDCFlatButton.h"
 #import "MDCFloatingButton.h"
-#import "MDCFloatingButton+Animation.h"
+#import "MDCButton+Animation.h"
 #import "MDCRaisedButton.h"


### PR DESCRIPTION
In order to take a step towards deprecation of MDCFloatingButton we need to rename this category. This should allow client teams to still use floating buttons animations as before. This change just enables the animations to occur on ANY MDCButton instead of only MDCFloatingButtons.
