### PR TITLE
[FlexibleHeader] Fix infinite recursion when VoiceOver is enabled.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1140,7 +1140,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
       // focusing.
       CGPoint offset = self.trackingScrollView.contentOffset;
       offset.y = MAX(offset.y, -self.maximumHeight);
-      self.trackingScrollView.contentOffset = offset;
+      [self fhv_setContentOffset:offset];
       // Setting the transform on the same run loop as the accessibility scroll can cause additional
       // incorrect scrolling as the scrollview attempts to resolve to a position that will place
       // the header in the center of the scroll. Punting to the next loop prevents this.


### PR DESCRIPTION
The recursion was happening when both VoiceOver and observesTrackingScrollViewScrollEvents were enabled.

After this change, the VoiceOver fix added by 5dc67c88c06f11761769de1d0bae34ff2c657046 will use fhv_setContentOffset instead of directly setting the contentOffset so that we don't create an infinite KVO recursion.

I tested this fix on an iPhone SE running iOS 12. I verified that the crash existed before this change, and that it no longer crashed after this fix.

Closes https://github.com/material-components/material-components-ios/issues/4744