### PR TITLE
[Buttons] Fix `safeAreaInsets` availability check

### DIFF
--- a/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
+++ b/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
@@ -90,13 +90,9 @@
                  CGRectMinYEdge);
   };
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
-  if ([self.view respondsToSelector:@selector(safeAreaInsets)]) {
-    if (@available(iOS 11.0, *)) {
+  if (@available(iOS 11.0, *)) {
       UIEdgeInsets safeAreaInsets = self.view.safeAreaInsets;
       contentBounds = UIEdgeInsetsInsetRect(bounds, safeAreaInsets);
-    } else {
-      preiOS11Behavior();
-    }
   } else {
     preiOS11Behavior();
   }

--- a/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
+++ b/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
@@ -91,9 +91,12 @@
   };
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if ([self.view respondsToSelector:@selector(safeAreaInsets)]) {
-    UIEdgeInsets safeAreaInsets = self.view.safeAreaInsets;
-    contentBounds = UIEdgeInsetsInsetRect(bounds, safeAreaInsets);
-
+    if (@available(iOS 11.0, *)) {
+      UIEdgeInsets safeAreaInsets = self.view.safeAreaInsets;
+      contentBounds = UIEdgeInsetsInsetRect(bounds, safeAreaInsets);
+    } else {
+      preiOS11Behavior();
+    }
   } else {
     preiOS11Behavior();
   }


### PR DESCRIPTION
Only iOS 11+ has `safeAreaInsets` defined, so the compiler may complain when
we try to include without runtime guards available.
