### PR TITLE
[Catalog] set cell selection style to none in several examples (#3870)

### DIFF
--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
@@ -144,6 +144,7 @@ static NSString * const kCell = @"Cell";
   UITableViewCell *cell =
       [tableView dequeueReusableCellWithIdentifier:kCell forIndexPath:indexPath];
   cell.textLabel.text = @"";
+  cell.selectionStyle = UITableViewCellSelectionStyleNone;
   switch (indexPath.row) {
     case 0:
       cell.accessoryView = nil;

--- a/components/AppBar/examples/AppBarImageryExample.m
+++ b/components/AppBar/examples/AppBarImageryExample.m
@@ -149,6 +149,7 @@
     cell =
         [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"cell"];
   }
+  cell.selectionStyle = UITableViewCellSelectionStyleNone;
   return cell;
 }
 

--- a/components/AppBar/examples/AppBarImageryExample.swift
+++ b/components/AppBar/examples/AppBarImageryExample.swift
@@ -126,6 +126,7 @@ extension AppBarImagerySwiftExample {
       if cell == nil {
         cell = UITableViewCell(style: .default, reuseIdentifier: "cell")
       }
+      cell!.selectionStyle = UITableViewCellSelectionStyle.none
       return cell!
   }
 }

--- a/components/AppBar/examples/AppBarImageryExample.swift
+++ b/components/AppBar/examples/AppBarImageryExample.swift
@@ -126,7 +126,7 @@ extension AppBarImagerySwiftExample {
       if cell == nil {
         cell = UITableViewCell(style: .default, reuseIdentifier: "cell")
       }
-      cell!.selectionStyle = UITableViewCellSelectionStyle.none
+      cell!.selectionStyle = .none
       return cell!
   }
 }

--- a/components/AppBar/examples/AppBarSectionHeadersExample.m
+++ b/components/AppBar/examples/AppBarSectionHeadersExample.m
@@ -129,6 +129,7 @@
     [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"cell"];
   }
   cell.textLabel.text = indexPath.section == 0 ? @"Demo" : @"Example";
+  cell.selectionStyle = UITableViewCellSelectionStyleNone;
   return cell;
 }
 

--- a/components/AppBar/examples/AppBarTypicalUseExample.m
+++ b/components/AppBar/examples/AppBarTypicalUseExample.m
@@ -146,6 +146,7 @@
         [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"cell"];
   }
   cell.layoutMargins = UIEdgeInsetsZero;
+  cell.selectionStyle = UITableViewCellSelectionStyleNone;
   return cell;
 }
 

--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -119,7 +119,7 @@ extension AppBarTypicalUseSwiftExample {
         cell = UITableViewCell(style: .default, reuseIdentifier: "cell")
       }
       cell!.layoutMargins = UIEdgeInsets.zero
-      cell!.selectionStyle = UITableViewCellSelectionStyle.none
+      cell!.selectionStyle = .none
       return cell!
   }
 

--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -119,6 +119,7 @@ extension AppBarTypicalUseSwiftExample {
         cell = UITableViewCell(style: .default, reuseIdentifier: "cell")
       }
       cell!.layoutMargins = UIEdgeInsets.zero
+      cell!.selectionStyle = UITableViewCellSelectionStyle.none
       return cell!
   }
 


### PR DESCRIPTION
set cell selection style to none in following examples:
Activity Indicator Demo
App Bar Demo
AppBarSectionHeaderExample
AppBarImageryExample

closes #3870 