### PR TITLE
[FlexibleHeader] Move all shift behavior APIs to their own header.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView+ShiftBehavior.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView+ShiftBehavior.h
@@ -1,0 +1,183 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCFlexibleHeaderView.h"
+
+#pragma mark - Shift behavior-specific APIs
+
+/**
+ The possible translation (shift) behaviors of a flexible header view.
+
+ Enabling shifting allows the header to enter the
+ @c MDCFlexibleHeaderScrollPhaseShifting scroll phase.
+ */
+typedef NS_ENUM(NSInteger, MDCFlexibleHeaderShiftBehavior) {
+
+  /** Header's y position never changes in reaction to scroll events. */
+  MDCFlexibleHeaderShiftBehaviorDisabled,
+
+  /** When fully-collapsed, the header translates vertically in reaction to scroll events. */
+  MDCFlexibleHeaderShiftBehaviorEnabled,
+
+  /**
+   When fully-collapsed, the header translates vertically in reaction to scroll events along with
+   the status bar.
+
+   If used with a vertically-paging scroll view, this behavior acts like
+   MDCFlexibleHeaderShiftBehaviorEnabled.
+   */
+  MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar,
+};
+
+/** The importance of content contained within the flexible header view. */
+typedef NS_ENUM(NSInteger, MDCFlexibleHeaderContentImportance) {
+
+  /**
+   Default behavior requires at most approximately a single swipe before the header re-appears.
+   */
+  MDCFlexibleHeaderContentImportanceDefault,
+
+  /**
+   Highly-important header content will re-appear faster than default importance.
+
+   Examples of important content:
+
+   - Search bar.
+   - Non-navigational actions.
+   */
+  MDCFlexibleHeaderContentImportanceHigh,
+};
+
+@interface MDCFlexibleHeaderView ()
+
+/**
+ The behavior of the header in response to the user interacting with the tracking scroll view.
+
+ @note If self.observesTrackingScrollViewScrollEvents is YES, then this property can only be
+ MDCFlexibleHeaderShiftBehaviorDisabled. Attempts to set shiftBehavior to any other value if
+ self.observesTrackingScrollViewScrollEvents is YES will result in an assertion being thrown.
+ */
+@property(nonatomic) MDCFlexibleHeaderShiftBehavior shiftBehavior;
+
+/**
+ If shiftBehavior is enabled, this property affects the manner in which the Header reappears when
+ pulling content down in the tracking scroll view.
+
+ Ignored if shiftBehavior == MDCFlexibleHeaderShiftBehaviorDisabled.
+
+ Default: MDCFlexibleHeaderContentImportanceDefault
+ */
+@property(nonatomic) MDCFlexibleHeaderContentImportance headerContentImportance;
+
+/**
+ When enabled, the header view will prioritize shifting off-screen and collapsing over shifting
+ on-screen and expanding.
+
+ This should only be enabled when the user is scrubbing the tracking scroll view, i.e. they're
+ able to jump large distances using a scrubber control.
+ */
+@property(nonatomic) BOOL trackingScrollViewIsBeingScrubbed;
+
+/**
+ Whether this header view's content is translucent/transparent. Provides a hint to status bar
+ rendering, to correctly display contents scrolling under the status bar as it shifts on/off screen.
+
+ Default: NO
+ */
+@property(nonatomic) BOOL contentIsTranslucent;
+
+/**
+ A hint stating whether or not the operating system's status bar frame can ever overlap the header's
+ frame.
+
+ This property is enabled by default with the expectation that the flexible header will primarily
+ be used in full-screen settings on the phone.
+
+ Disabling this property informs the flexible header that it should not concern itself with the
+ status bar in any manner. shiftBehavior .EnabledWithStatusBar will be treated simply as .Enabled
+ in this case.
+
+ Default: YES
+ */
+@property(nonatomic) BOOL statusBarHintCanOverlapHeader;
+
+/**
+ Hides the view by changing its alpha when the header shifts. Note that this only happens when the
+ header shifting behavior is set to MDCFlexibleHeaderShiftBehaviorEnabled.
+ */
+- (void)hideViewWhenShifted:(nonnull UIView *)view;
+
+/** Stops hiding the view when the header shifts. */
+- (void)stopHidingViewWhenShifted:(nonnull UIView *)view;
+
+#pragma mark Shifting the tracking scroll view on-screen
+
+/** Asks the receiver to bring the header on-screen if it's currently off-screen. */
+- (void)shiftHeaderOnScreenAnimated:(BOOL)animated;
+
+/** Asks the receiver to take the header off-screen if it's currently on-screen. */
+- (void)shiftHeaderOffScreenAnimated:(BOOL)animated;
+
+#pragma mark - UIScrollViewDelegate APIs required for shift behavior
+
+/**
+ Informs the receiver that the tracking scroll view has finished dragging.
+
+ Must be called from the trackingScrollView delegate's
+ UIScrollViewDelegate::scrollViewDidEndDragging:willDecelerate: implementor.
+
+ @note Do not invoke this method if self.observesTrackingScrollViewScrollEvents is YES.
+ */
+- (void)trackingScrollViewDidEndDraggingWillDecelerate:(BOOL)willDecelerate;
+
+/**
+ Informs the receiver that the tracking scroll view has finished decelerating.
+
+ Must be called from the trackingScrollView delegate's
+ UIScrollViewDelegate::scrollViewDidEndDecelerating: implementor.
+
+ @note Do not invoke this method if self.observesTrackingScrollViewScrollEvents is YES.
+ */
+- (void)trackingScrollViewDidEndDecelerating;
+
+/**
+ Potentially modifies the target content offset in order to ensure that the header view is either
+ visible or hidden depending on its current position.
+
+ Must be called from the trackingScrollView delegate's
+ -scrollViewWillEndDragging:withVelocity:targetContentOffset: implementor.
+
+ If your scroll view is vertically paging then this method will do nothing. You should also
+ disable hidesStatusBarWhenCollapsed.
+
+ @note Do not invoke this method if self.observesTrackingScrollViewScrollEvents is YES.
+
+ @return A Boolean value indicating whether the target content offset was modified.
+ */
+- (BOOL)trackingScrollViewWillEndDraggingWithVelocity:(CGPoint)velocity
+                                  targetContentOffset:(inout nonnull CGPoint *)targetContentOffset;
+
+@end
+
+// clang-format off
+@interface MDCFlexibleHeaderView ()
+
+/** @see shiftBehavior */
+@property(nonatomic) MDCFlexibleHeaderShiftBehavior behavior
+    __deprecated_msg("Use shiftBehavior instead.");
+
+@end
+// clang-format on

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -20,49 +20,6 @@ typedef void (^MDCFlexibleHeaderChangeContentInsetsBlock)(void);
 typedef void (^MDCFlexibleHeaderShadowIntensityChangeBlock)(CALayer *_Nonnull shadowLayer,
                                                             CGFloat intensity);
 
-/**
- The possible translation (shift) behaviors of a flexible header view.
-
- Enabling shifting allows the header to enter the
- @c MDCFlexibleHeaderScrollPhaseShifting scroll phase.
- */
-typedef NS_ENUM(NSInteger, MDCFlexibleHeaderShiftBehavior) {
-
-  /** Header's y position never changes in reaction to scroll events. */
-  MDCFlexibleHeaderShiftBehaviorDisabled,
-
-  /** When fully-collapsed, the header translates vertically in reaction to scroll events. */
-  MDCFlexibleHeaderShiftBehaviorEnabled,
-
-  /**
-   When fully-collapsed, the header translates vertically in reaction to scroll events along with
-   the status bar.
-
-   If used with a vertically-paging scroll view, this behavior acts like
-   MDCFlexibleHeaderShiftBehaviorEnabled.
-   */
-  MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar,
-};
-
-/** The importance of content contained within the flexible header view. */
-typedef NS_ENUM(NSInteger, MDCFlexibleHeaderContentImportance) {
-
-  /**
-   Default behavior requires at most approximately a single swipe before the header re-appears.
-   */
-  MDCFlexibleHeaderContentImportanceDefault,
-
-  /**
-   Highly-important header content will re-appear faster than default importance.
-
-   Examples of important content:
-
-   - Search bar.
-   - Non-navigational actions.
-   */
-  MDCFlexibleHeaderContentImportanceHigh,
-};
-
 /** Mutually exclusive phases that the flexible header view can be in. */
 typedef NS_ENUM(NSInteger, MDCFlexibleHeaderScrollPhase) {
 
@@ -127,43 +84,6 @@ IB_DESIGNABLE
  */
 - (void)trackingScrollViewDidScroll;
 
-/**
- Informs the receiver that the tracking scroll view has finished dragging.
-
- Must be called from the trackingScrollView delegate's
- UIScrollViewDelegate::scrollViewDidEndDragging:willDecelerate: implementor.
-
- @note Do not invoke this method if self.observesTrackingScrollViewScrollEvents is YES.
- */
-- (void)trackingScrollViewDidEndDraggingWillDecelerate:(BOOL)willDecelerate;
-
-/**
- Informs the receiver that the tracking scroll view has finished decelerating.
-
- Must be called from the trackingScrollView delegate's
- UIScrollViewDelegate::scrollViewDidEndDecelerating: implementor.
-
- @note Do not invoke this method if self.observesTrackingScrollViewScrollEvents is YES.
- */
-- (void)trackingScrollViewDidEndDecelerating;
-
-/**
- Potentially modifies the target content offset in order to ensure that the header view is either
- visible or hidden depending on its current position.
-
- Must be called from the trackingScrollView delegate's
- -scrollViewWillEndDragging:withVelocity:targetContentOffset: implementor.
-
- If your scroll view is vertically paging then this method will do nothing. You should also
- disable hidesStatusBarWhenCollapsed.
-
- @note Do not invoke this method if self.observesTrackingScrollViewScrollEvents is YES.
-
- @return A Boolean value indicating whether the target content offset was modified.
- */
-- (BOOL)trackingScrollViewWillEndDraggingWithVelocity:(CGPoint)velocity
-                                  targetContentOffset:(inout nonnull CGPoint *)targetContentOffset;
-
 #pragma mark Changing the tracking scroll view
 
 /**
@@ -171,14 +91,6 @@ IB_DESIGNABLE
  scroll view.
  */
 - (void)trackingScrollWillChangeToScrollView:(nullable UIScrollView *)scrollView;
-
-#pragma mark Shifting the tracking scroll view on-screen
-
-/** Asks the receiver to bring the header on-screen if it's currently off-screen. */
-- (void)shiftHeaderOnScreenAnimated:(BOOL)animated;
-
-/** Asks the receiver to take the header off-screen if it's currently on-screen. */
-- (void)shiftHeaderOffScreenAnimated:(BOOL)animated;
 
 #pragma mark UIKit Hooks
 
@@ -350,55 +262,12 @@ IB_DESIGNABLE
 #pragma mark Behaviors
 
 /**
- The behavior of the header in response to the user interacting with the tracking scroll view.
-
- @note If self.observesTrackingScrollViewScrollEvents is YES, then this property can only be
- MDCFlexibleHeaderShiftBehaviorDisabled. Attempts to set shiftBehavior to any other value if
- self.observesTrackingScrollViewScrollEvents is YES will result in an assertion being thrown.
- */
-@property(nonatomic) MDCFlexibleHeaderShiftBehavior shiftBehavior;
-
-/**
- Hides the view by changing its alpha when the header shifts. Note that this only happens when the
- header shifting behavior is set to MDCFlexibleHeaderShiftBehaviorEnabled.
- */
-- (void)hideViewWhenShifted:(nonnull UIView *)view;
-
-/** Stops hiding the view when the header shifts. */
-- (void)stopHidingViewWhenShifted:(nonnull UIView *)view;
-
-/**
- If shiftBehavior is enabled, this property affects the manner in which the Header reappears when
- pulling content down in the tracking scroll view.
-
- Ignored if shiftBehavior == MDCFlexibleHeaderShiftBehaviorDisabled.
-
- Default: MDCFlexibleHeaderContentImportanceDefault
- */
-@property(nonatomic) MDCFlexibleHeaderContentImportance headerContentImportance;
-
-/**
  Whether or not the header view is allowed to expand past its maximum height when the tracking
  scroll view has been dragged past its top edge.
 
  Default: YES
  */
 @property(nonatomic) BOOL canOverExtend;
-
-/**
- A hint stating whether or not the operating system's status bar frame can ever overlap the header's
- frame.
-
- This property is enabled by default with the expectation that the flexible header will primarily
- be used in full-screen settings on the phone.
-
- Disabling this property informs the flexible header that it should not concern itself with the
- status bar in any manner. shiftBehavior .EnabledWithStatusBar will be treated simply as .Enabled
- in this case.
-
- Default: YES
- */
-@property(nonatomic) BOOL statusBarHintCanOverlapHeader;
 
 @property(nonatomic) float visibleShadowOpacity;  ///< The visible shadow opacity. Default: 0.4
 
@@ -449,15 +318,6 @@ IB_DESIGNABLE
 @property(nonatomic) BOOL observesTrackingScrollViewScrollEvents;
 
 /**
- When enabled, the header view will prioritize shifting off-screen and collapsing over shifting
- on-screen and expanding.
-
- This should only be enabled when the user is scrubbing the tracking scroll view, i.e. they're
- able to jump large distances using a scrubber control.
- */
-@property(nonatomic) BOOL trackingScrollViewIsBeingScrubbed;
-
-/**
  Whether or not the header is floating in front of an infinite stream of content.
 
  Enabling this behavior will cause the header to always appear to be floating "in front of" the
@@ -475,16 +335,6 @@ IB_DESIGNABLE
  Default: NO
  */
 @property(nonatomic) BOOL sharedWithManyScrollViews;
-
-#pragma mark Configuring Status Bar Behaviors
-
-/**
- Whether this header view's content is translucent/transparent. Provides a hint to status bar
- rendering, to correctly display contents scrolling under the status bar as it shifts on/off screen.
-
- Default: NO
- */
-@property(nonatomic) BOOL contentIsTranslucent;
 
 #pragma mark Header View Delegate
 
@@ -521,10 +371,6 @@ IB_DESIGNABLE
 
 // clang-format off
 @interface MDCFlexibleHeaderView ()
-
-/** @see shiftBehavior */
-@property(nonatomic) MDCFlexibleHeaderShiftBehavior behavior
-__deprecated_msg("Use shiftBehavior instead.");
 
 #pragma mark Accessing the header's views
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -18,6 +18,7 @@
 
 #import "MaterialApplication.h"
 #import "MaterialUIMetrics.h"
+#import "MDCFlexibleHeaderView+ShiftBehavior.h"
 #import "private/MDCStatusBarShifter.h"
 #import "private/MDCFlexibleHeaderView+Private.h"
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -20,6 +20,7 @@
 #import "MaterialUIMetrics.h"
 #import "MDCFlexibleHeaderContainerViewController.h"
 #import "MDCFlexibleHeaderView.h"
+#import "MDCFlexibleHeaderView+ShiftBehavior.h"
 #import "private/MDCFlexibleHeaderView+Private.h"
 #import <MDFTextAccessibility/MDFTextAccessibility.h>
 

--- a/components/FlexibleHeader/src/MaterialFlexibleHeader.h
+++ b/components/FlexibleHeader/src/MaterialFlexibleHeader.h
@@ -16,4 +16,5 @@
 
 #import "MDCFlexibleHeaderContainerViewController.h"
 #import "MDCFlexibleHeaderView.h"
+#import "MDCFlexibleHeaderView+ShiftBehavior.h"
 #import "MDCFlexibleHeaderViewController.h"


### PR DESCRIPTION
This is being done in an effort to isolate the shift behavior logic. The goal is to better document the separations of concerns of the FlexibleHeader's individual features.