### PR TITLE
[TextFields] Update placeholder and outline border color when enabling/disabling text fields with outline controllers

### DIFF
--- a/components/TextFields/src/MDCMultilineTextField.m
+++ b/components/TextFields/src/MDCMultilineTextField.m
@@ -571,8 +571,9 @@
 - (void)setEnabled:(BOOL)enabled {
   self.fundament.enabled = enabled;
   self.textView.editable = enabled;
-  [[NSNotificationCenter defaultCenter] postNotificationName:MDCTextInputDidToggleEnabled
-                                                      object:self];
+  [[NSNotificationCenter defaultCenter]
+      postNotificationName:MDCTextInputDidToggleEnabledNotification
+                    object:self];
 }
 
 - (void)setExpandsOnOverflow:(BOOL)expandsOnOverflow {

--- a/components/TextFields/src/MDCMultilineTextField.m
+++ b/components/TextFields/src/MDCMultilineTextField.m
@@ -571,6 +571,8 @@
 - (void)setEnabled:(BOOL)enabled {
   self.fundament.enabled = enabled;
   self.textView.editable = enabled;
+  [[NSNotificationCenter defaultCenter] postNotificationName:MDCTextInputDidToggleEnabled
+                                                      object:self];
 }
 
 - (void)setExpandsOnOverflow:(BOOL)expandsOnOverflow {

--- a/components/TextFields/src/MDCTextField.h
+++ b/components/TextFields/src/MDCTextField.h
@@ -21,6 +21,9 @@
 /** When text is manually set via .text or setText:, this notification fires. */
 extern NSString *_Nonnull const MDCTextFieldTextDidSetTextNotification;
 
+/** When the value of `enabled` changes on the text input, this notification fires. */
+extern NSString *_Nonnull const MDCTextInputDidToggleEnabled;
+
 /**
   Material Design compliant single-line text input.
   https://www.google.com/design/spec/components/text-fields.html#text-fields-single-line-text-field

--- a/components/TextFields/src/MDCTextField.h
+++ b/components/TextFields/src/MDCTextField.h
@@ -22,7 +22,7 @@
 extern NSString *_Nonnull const MDCTextFieldTextDidSetTextNotification;
 
 /** When the value of `enabled` changes on the text input, this notification fires. */
-extern NSString *_Nonnull const MDCTextInputDidToggleEnabled;
+extern NSString *_Nonnull const MDCTextInputDidToggleEnabledNotification;
 
 /**
   Material Design compliant single-line text input.

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -30,6 +30,7 @@
 #import "MaterialTypography.h"
 
 NSString *const MDCTextFieldTextDidSetTextNotification = @"MDCTextFieldTextDidSetTextNotification";
+NSString *const MDCTextInputDidToggleEnabled = @"MDCTextInputDidToggleEnabled";
 
 // The image we use for the clear button has a little too much air around it. So we have to shrink
 // by this amount on each side.
@@ -427,6 +428,8 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1.f;
 - (void)setEnabled:(BOOL)enabled {
   [super setEnabled:enabled];
   _fundament.enabled = enabled;
+  [[NSNotificationCenter defaultCenter] postNotificationName:MDCTextInputDidToggleEnabled
+                                                      object:self];
 }
 
 // In iOS 8, .leftView and .rightView are not swapped in RTL so we have to do that manually.

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -30,7 +30,8 @@
 #import "MaterialTypography.h"
 
 NSString *const MDCTextFieldTextDidSetTextNotification = @"MDCTextFieldTextDidSetTextNotification";
-NSString *const MDCTextInputDidToggleEnabled = @"MDCTextInputDidToggleEnabled";
+NSString *const MDCTextInputDidToggleEnabledNotification =
+    @"MDCTextInputDidToggleEnabledNotification";
 
 // The image we use for the clear button has a little too much air around it. So we have to shrink
 // by this amount on each side.
@@ -428,8 +429,9 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1.f;
 - (void)setEnabled:(BOOL)enabled {
   [super setEnabled:enabled];
   _fundament.enabled = enabled;
-  [[NSNotificationCenter defaultCenter] postNotificationName:MDCTextInputDidToggleEnabled
-                                                      object:self];
+  [[NSNotificationCenter defaultCenter]
+      postNotificationName:MDCTextInputDidToggleEnabledNotification
+                    object:self];
 }
 
 // In iOS 8, .leftView and .rightView are not swapped in RTL so we have to do that manually.

--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -280,7 +280,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
   [defaultCenter addObserver:self
                     selector:@selector(textInputDidToggleEnabled:)
-                        name:MDCTextInputDidToggleEnabled
+                        name:MDCTextInputDidToggleEnabledNotification
                       object:_textInput];
 
   if ([_textInput isKindOfClass:[UITextField class]]) {

--- a/components/TextFields/src/MDCTextInputControllerOutlined.m
+++ b/components/TextFields/src/MDCTextInputControllerOutlined.m
@@ -168,6 +168,10 @@ static UIRectCorner _roundedCornersDefault = UIRectCornerAllCorners;
   self.textInput.clipsToBounds = NO;
 }
 
+-(void)updateUnderline {
+  self.textInput.underline.hidden = YES;
+}
+
 - (void)updateBorder {
   [super updateBorder];
 
@@ -194,6 +198,9 @@ static UIRectCorner _roundedCornersDefault = UIRectCornerAllCorners;
   self.textInput.borderPath = path;
 
   UIColor *borderColor = self.textInput.isEditing ? self.activeColor : self.normalColor;
+  if (!self.textInput.isEnabled) {
+    borderColor = self.disabledColor;
+  }
   self.textInput.borderView.borderStrokeColor =
       (self.isDisplayingCharacterCountError || self.isDisplayingErrorText) ? self.errorColor
                                                                            : borderColor;

--- a/components/TextFields/tests/unit/OutlinedTextFieldColorThemerTests.m
+++ b/components/TextFields/tests/unit/OutlinedTextFieldColorThemerTests.m
@@ -47,7 +47,6 @@
                         controller.trailingUnderlineLabelTextColor);
   XCTAssertEqualObjects(controller.normalColor,
                         [colorScheme.onSurfaceColor colorWithAlphaComponent:0.6f]);
-  XCTAssertEqualObjects(textField.underline.color, controller.normalColor);
   XCTAssertEqualObjects(textField.borderView.borderStrokeColor, controller.normalColor);
   XCTAssertEqualObjects(controller.inlinePlaceholderColor,
                         [colorScheme.onSurfaceColor colorWithAlphaComponent:0.6f]);


### PR DESCRIPTION
Closes #4678.

It made sense to make the visual changes to the textfield desired by the client through the controller, because that's how it works with things like error text, through APIs on the controller like `-setErrorText:errorAccessibilityValue:`. However, `enabled` is a property on the TextField, not the controller, and there isn't _normally_ a line of communication _from_ the text field _to_ the controller. Occasionally there are delegates that allow for this, like `MDCTextFieldPositioningDelegate`. From what I could tell my options were either introduce another one, add a `weak id<MDCTextInputController>` property to `MDCTextField`, or bring KVO of the text field into the controller. I chose KVO...

Also, there was another bug where the underline was visible when a text field with an outline controller was disabled. That's not in the spec. Hiding the underline and not calling `super` in `updateUnderline` was the easiest approach to fixing it. I'm of two minds about it. It feels kind of hacky but it's by far the smallest change.

This gif is of the TextFieldOutlinedExample with the following added to the setup code:
```Objective-C
  self.zipController.normalColor = [UIColor blueColor];
  self.zipController.disabledColor = [UIColor greenColor];
  
  textFieldZip.placeholder = @"placeholder";
  textFieldZip.text = @"text";
  
  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
    textFieldZip.enabled = NO;
  });

  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(4 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
    textFieldZip.enabled = YES;
  });
```

![aug-13-2018 17-11-41](https://user-images.githubusercontent.com/8020010/44058405-02bc0398-9f1c-11e8-8259-2d6ce3518556.gif)

