### PR TITLE
[Catalog] Fix Swift example imports

### DIFF
--- a/components/AnimationTiming/examples/AnimationTimingExample.swift
+++ b/components/AnimationTiming/examples/AnimationTimingExample.swift
@@ -18,6 +18,7 @@
 
 import UIKit
 import MaterialComponents.MaterialAnimationTiming
+import MaterialComponents.MaterialTypography
 
 struct Constants {
    struct AnimationTime {

--- a/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
@@ -15,7 +15,9 @@
  */
 
 import Foundation
-import MaterialComponents
+import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialPalettes
+import MaterialComponents.MaterialBottomNavigation_ColorThemer
 
 class BottomNavigationExplicitlySetColorExample: UIViewController {
 

--- a/components/BottomNavigation/examples/BottomNavigationNilBadges.swift
+++ b/components/BottomNavigation/examples/BottomNavigationNilBadges.swift
@@ -15,7 +15,8 @@
 */
 
 import Foundation
-import MaterialComponents
+import MaterialComponents.MaterialAppBar
+import MaterialComponents.MaterialBottomNavigation_ColorThemer
 
 class BottomNavigationNilBadges : UIViewController {
 

--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -15,7 +15,11 @@
  */
 
 import Foundation
-import MaterialComponents
+import MaterialComponents.MaterialBottomNavigation_ColorThemer
+import MaterialComponents.MaterialBottomNavigation_TypographyThemer
+import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialTypographyScheme
 
 /// Example to showcase a reorder of the tabs from an user action
 class BottomNavigationResetExample: UIViewController {

--- a/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
@@ -15,7 +15,8 @@
  */
 
 import Foundation
-import MaterialComponents
+import MaterialComponents.MaterialBottomNavigation_ColorThemer
+import MaterialComponents.MaterialTypographyScheme
 
 // Example to show different icons for selected and unselected states
 class BottomNavigationSelectedIconExample: UIViewController {

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
@@ -15,7 +15,8 @@
 */
 
 import Foundation
-import MaterialComponents
+import MaterialComponents.MaterialBottomNavigation_ColorThemer
+import MaterialComponents.MaterialColorScheme
 
 class BottomNavigationTypicalUseSwiftExample: UIViewController {
 

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import Foundation
-import MaterialComponents
+import MaterialComponents.MaterialButtonBar_ColorThemer
 
 class ButtonBarTypicalUseSwiftExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()

--- a/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
+++ b/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
@@ -17,7 +17,7 @@
 import Foundation
 import UIKit
 
-import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialButtons_ButtonThemer
 
 class ButtonsSimpleExampleSwiftViewController: UIViewController {
 

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -17,7 +17,7 @@
 import Foundation
 import UIKit
 
-import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialButtons_ButtonThemer
 
 class ButtonsSwiftAndStoryboardController: UIViewController {
 

--- a/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
+++ b/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
@@ -16,6 +16,8 @@
 
 import UIKit
 
+import MaterialComponents.MaterialButtons
+
 class FloatingButtonExampleSwiftViewController: UIViewController {
 
   let miniFloatingButton = MDCFloatingButton(frame: .zero, shape: .mini)

--- a/components/Dialogs/examples/AlertComparison.swift
+++ b/components/Dialogs/examples/AlertComparison.swift
@@ -15,7 +15,8 @@
  */
 
 import Foundation
-import MaterialComponents
+import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialDialogs
 
 
 /// This interface allows a user to present a UIKit Alert Controller and a Material Alert

--- a/components/Dialogs/examples/DialogsCustomShadowViewController.swift
+++ b/components/Dialogs/examples/DialogsCustomShadowViewController.swift
@@ -15,7 +15,8 @@
  */
 
 import Foundation
-import MaterialComponents
+import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialDialogs
 
 class CustomShadowViewController: UIViewController {
 

--- a/components/Dialogs/examples/DialogsLongAlertViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertViewController.swift
@@ -15,7 +15,8 @@
  */
 
 import Foundation
-import MaterialComponents
+import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialDialogs
 
 class DialogsLongAlertViewController: UIViewController {
 

--- a/components/FeatureHighlight/examples/FeatureHightlightTypicalUseViewController.swift
+++ b/components/FeatureHighlight/examples/FeatureHightlightTypicalUseViewController.swift
@@ -14,7 +14,9 @@
  limitations under the License.
  */
 
-import MaterialComponents
+import MaterialComponents.MaterialFeatureHighlight_ColorThemer
+import MaterialComponents.MaterialFeatureHighlight_TypographyThemer
+import MaterialComponents.MaterialButtons_ButtonThemer
 
 /// Example to show how to use a feature highlight
 class FeatureHighlightSwiftViewController: UIViewController {

--- a/components/HeaderStackView/examples/HeaderStackViewTypicalUse.swift
+++ b/components/HeaderStackView/examples/HeaderStackViewTypicalUse.swift
@@ -14,8 +14,8 @@
  limitations under the License.
  */
 
-import Foundation
-import MaterialComponents
+import UIKit
+import MaterialComponents.MaterialHeaderStackView
 
 open class HeaderStackViewTypicalUseSwiftExample: HeaderStackViewTypicalUse {
 

--- a/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.swift
+++ b/components/HeaderStackView/examples/supplemental/HeaderStackViewTypicalUseSupplemental.swift
@@ -18,7 +18,7 @@
  */
 
 import Foundation
-import MaterialComponents
+import MaterialComponents.MaterialHeaderStackView
 
 extension HeaderStackViewTypicalUseSwiftExample {
 

--- a/components/NavigationBar/examples/NavigationBarTypicalUseExample.swift
+++ b/components/NavigationBar/examples/NavigationBarTypicalUseExample.swift
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import UIKit
-import MaterialComponents.MaterialNavigationBar
+import MaterialComponents.MaterialNavigationBar_ColorThemer
 
 open class NavigationBarTypicalUseSwiftExample: NavigationBarTypicalUseExample {
 

--- a/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.swift
+++ b/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.swift
@@ -19,8 +19,8 @@ This file contains supplemental code used to populate the examples with dummy da
 instructions. It is not necessary to import this file to use Material Components for iOS.
 */
 
-import Foundation
-import MaterialComponents
+import UIKit
+import MaterialComponents.MaterialNavigationBar
 
 extension NavigationBarTypicalUseSwiftExample {
 

--- a/components/PageControl/examples/PageControlTypicalUseExample.swift
+++ b/components/PageControl/examples/PageControlTypicalUseExample.swift
@@ -17,6 +17,7 @@ limitations under the License.
 import Foundation
 
 import MaterialComponents.MaterialPageControl
+import MaterialComponents.MaterialPalettes
 
 class PageControlSwiftExampleViewController: UIViewController, UIScrollViewDelegate {
 

--- a/components/Palettes/examples/PalettesExpandedExample.swift
+++ b/components/Palettes/examples/PalettesExpandedExample.swift
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import MaterialComponents
+import MaterialComponents.MaterialPalettes
 
 private func randomFloat() -> CGFloat {
   return CGFloat(arc4random()) / CGFloat(UInt32.max)

--- a/components/Palettes/examples/PalettesStandardExample.swift
+++ b/components/Palettes/examples/PalettesStandardExample.swift
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import MaterialComponents
+import MaterialComponents.MaterialPalettes
 
 class PalettesStandardExampleViewController: PalettesExampleViewController {
   convenience init() {

--- a/components/Palettes/examples/supplemental/PalettesExampleViewController.swift
+++ b/components/Palettes/examples/supplemental/PalettesExampleViewController.swift
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import MaterialComponents.MaterialPalettes
-import MDFTextAccessibility.MDFTextAccessibility
+import MDFTextAccessibility
 
 /**
  Returns a high-contrast color for text against @c backgroundColor. If no such color can be found,

--- a/components/Palettes/examples/supplemental/PalettesExampleViewController.swift
+++ b/components/Palettes/examples/supplemental/PalettesExampleViewController.swift
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import MaterialComponents
+import MaterialComponents.MaterialPalettes
+import MDFTextAccessibility.MDFTextAccessibility
 
 /**
  Returns a high-contrast color for text against @c backgroundColor. If no such color can be found,

--- a/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.swift
+++ b/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.swift
@@ -14,8 +14,10 @@
  limitations under the License.
  */
 
+import UIKit
 import Foundation
-import MaterialComponents
+import MaterialComponents.MaterialShadowElevations
+import MaterialComponents.MaterialAppBar
 
 class ShadowElevationsTypicalUseExample: UIViewController {
 

--- a/components/Tabs/examples/TabBarIconExample.swift
+++ b/components/Tabs/examples/TabBarIconExample.swift
@@ -17,7 +17,9 @@
 import UIKit
 
 import MaterialComponents.MaterialAppBar
+import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialPalettes
 import MaterialComponents.MaterialTabs
 import MaterialComponents.MaterialTabs_ColorThemer
 import MaterialComponents.MaterialTypographyScheme

--- a/components/Tabs/examples/TabBarIndicatorTemplateExample.swift
+++ b/components/Tabs/examples/TabBarIndicatorTemplateExample.swift
@@ -17,8 +17,11 @@
 import UIKit
 import CoreGraphics
 
-import MaterialComponents.MaterialAppBar
+import MaterialComponents.MaterialAppBar_ColorThemer
+import MaterialComponents.MaterialAppBar_TypographyThemer
+import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialTypographyScheme
 import MaterialComponents.MaterialTabs
 import MaterialComponents.MaterialTabs_ColorThemer
 

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
@@ -19,8 +19,10 @@
 
 import UIKit
 
+import MaterialComponents.MaterialAppBar
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialButtons_ButtonThemer
+import MaterialComponents.MaterialPalettes
 
 extension TabBarIconSwiftExample {
 

--- a/components/Tabs/examples/supplemental/TabBarIndicatorTemplateExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIndicatorTemplateExampleSupplemental.swift
@@ -16,6 +16,7 @@
 
 import UIKit
 
+import MaterialComponents.MaterialAppBar
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialButtons_ButtonThemer
 

--- a/components/TextFields/examples/TextFieldFilledExample.swift
+++ b/components/TextFields/examples/TextFieldFilledExample.swift
@@ -16,7 +16,8 @@
 
 // swiftlint:disable function_body_length
 
-import MaterialComponents.MaterialTextFields
+import MaterialComponents.MaterialTextFields_ColorThemer
+import MaterialComponents.MaterialTextFields_TypographyThemer
 
 final class TextFieldFilledSwiftExample: UIViewController {
 

--- a/components/TextFields/examples/TextFieldKitchenSinkExample.swift
+++ b/components/TextFields/examples/TextFieldKitchenSinkExample.swift
@@ -204,7 +204,7 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
     baselineTestLabel.font = textFieldFloatingCharMax.font
     self.scrollView.addSubview(baselineTestLabel)
 
-    if #available(iOSApplicationExtension 9.0, *) {
+    if #available(iOSApplicationExtension 9.0, *), #available(iOS 9.0, *) {
       baselineTestLabel.trailingAnchor.constraint(equalTo: textFieldFloatingCharMax.trailingAnchor,
                                                  constant: 0).isActive = true
 

--- a/components/TextFields/examples/TextFieldOutlinedExample.swift
+++ b/components/TextFields/examples/TextFieldOutlinedExample.swift
@@ -16,7 +16,8 @@
 
 // swiftlint:disable function_body_length
 
-import MaterialComponents.MaterialTextFields
+import MaterialComponents.MaterialTextFields_ColorThemer
+import MaterialComponents.MaterialTextFields_TypographyThemer
 
 final class TextFieldOutlinedSwiftExample: UIViewController {
 

--- a/components/TextFields/examples/TextFieldSemanticColorThemer.swift
+++ b/components/TextFields/examples/TextFieldSemanticColorThemer.swift
@@ -16,7 +16,8 @@
 
 // swiftlint:disable function_body_length
 
-import MaterialComponents.MaterialTextFields
+import MaterialComponents.MaterialTextFields_ColorThemer
+import MaterialComponents.MaterialTextFields_TypographyThemer
 
 final class TextFieldSemanticColorThemer: UIViewController {
 


### PR DESCRIPTION
Many of our Swift examples are either missing imports or are importing all of
MaterialComponents. Both of these will cause failures during internal builds.
