### PR TITLE
[Catalog] make all example titles fit iPhone SE screen without clippi…

### DIFF
--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -578,6 +578,9 @@ extension MDCNodeListViewController {
       vc = MDCNodeListViewController(node: node)
     }
     self.navigationController?.pushViewController(vc, animated: true)
+    let MDCAppBarNavigationController = self.navigationController as? MDCAppBarNavigationController
+    let appBar = MDCAppBarNavigationController?.appBarViewController(for: vc)
+    appBar?.navigationBar.adjustsFontSizeToFitWidth = true
   }
 
   func createViewController(from node: CBCNode) -> UIViewController {

--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -225,6 +225,12 @@ IB_DESIGNABLE
  */
 @property(nonatomic) MDCNavigationBarTitleAlignment titleAlignment;
 
+
+/**
+ If YES, the title label will be ausized to fit a certain width. The default value is NO.
+ */
+@property(nonatomic) BOOL adjustsFontSizeToFitWidth;
+
 #pragma mark Observing UINavigationItem instances
 
 /**

--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -227,7 +227,7 @@ IB_DESIGNABLE
 
 
 /**
- If YES, the title label will be ausized to fit a certain width. The default value is NO.
+ If YES, the title label will be autosized to fit a certain width. The default value is NO.
  */
 @property(nonatomic) BOOL adjustsFontSizeToFitWidth;
 

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -717,6 +717,16 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
   _trailingButtonBar.inkColor = inkColor;
 }
 
+- (void)setAdjustsFontSizeToFitWidth:(BOOL)adjustsFontSizeToFitWidth {
+  if (_titleLabel.adjustsFontSizeToFitWidth != adjustsFontSizeToFitWidth) {
+    _titleLabel.adjustsFontSizeToFitWidth = adjustsFontSizeToFitWidth;
+  }
+}
+
+- (BOOL)adjustsFontSizeToFitWidth {
+  return _titleLabel.adjustsFontSizeToFitWidth;
+}
+
 - (void)setObservedNavigationItem:(UINavigationItem *)navigationItem {
   @synchronized(_observedNavigationItemLock) {
     if (navigationItem == _observedNavigationItem) {

--- a/components/Tabs/examples/supplemental/TabBarIndicatorTemplateExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIndicatorTemplateExampleSupplemental.swift
@@ -53,6 +53,8 @@ extension TabBarIndicatorTemplateExample {
 
     appBarViewController.headerStackView.bottomBar = self.tabBar
     appBarViewController.headerStackView.setNeedsLayout()
+
+    appBarViewController.navigationBar.adjustsFontSizeToFitWidth = true
     return appBarViewController
   }
 


### PR DESCRIPTION
…ng (#3835)

1. Fixed truncated titles in injected AppBars .
2. Fixed a truncated title in a non injected example manually (TabBarIndicatorTemplateExample). Since this was the only one truncated title in non injected instances, not sure if we should handle it at a higher level for now. We can probably do it after the refactoring of AppBar navigation controller is done.

closes #3835 