### PR TITLE
[Snackbar] Added switch control support for Snackbar

### DIFF
--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -303,7 +303,7 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
 #pragma mark - Helper methods
 
 - (BOOL)isSnackbarTransient:(MDCSnackbarMessageView *)snackbarView {
-  if (UIAccessibilityIsVoiceOverRunning()) {
+  if (UIAccessibilityIsVoiceOverRunning() || UIAccessibilityIsSwitchControlRunning()) {
     return ![snackbarView shouldWaitForDismissalDuringVoiceover];
   }
 


### PR DESCRIPTION
What this new change does is now switch control users are focused on the Snackbar when it is presented if it has an action in it, and interact with its action. This also makes the Snackbar stay on the screen until it is dealt with, same as for Voiceover.

The reason Switch Control didn't have access to the Snackbar prior to this change is because we were setting `snackbarView.accessibilityElementsHidden = YES;` as it seemed to be transient being that we were only checking for `UIAccessibilityIsVoiceOverRunning` and not `UIAccessibilityIsSwitchControlRunning` as well.

This new behavior allows us to imitate VO behavior.

If we don't seek to change focus to the Snackbar for Switch Control users and have the behavior be partially different from VO users, we can have a new case for Switch Control users where `UIAccessibilityAnnouncementNotification` isn't posted but rather `UIAccessibilityLayoutChangedNotification` without setting `accessibilityElementsHidden` to `YES`.


