### PR TITLE
[FeatureHighlight] Fix crash when backgrounding and re-opening app.

### DIFF
--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -168,27 +168,22 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = 1.5f;
 - (void)viewWillTransitionToSize:(CGSize)size
        withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
   [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-  UIViewController *presenter = self.presentingViewController;
-  UIViewController *presentedViewController = self;
-  [self dismissViewControllerAnimated:NO completion:nil];
-
-  [coordinator animateAlongsideTransition:nil
+  [coordinator animateAlongsideTransition:
+   ^(__unused id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+     [self resetHighlightPoint];
+   }
                                completion:
-      ^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
-        BOOL presentedIsNonNilDueToRaceCondition = presenter.presentedViewController;
-        void (^presentAgain)(void) = ^void(void) {
-          [presenter presentViewController:presentedViewController
-                                  animated:YES
-                                completion:nil];
-        };
-        if (presentedIsNonNilDueToRaceCondition) {
-          dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)),
-                         dispatch_get_main_queue(),
-                         presentAgain);
-        } else {
-          presentAgain();
-        }
-  }];
+   ^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+     [self resetHighlightPoint];
+   }];
+}
+
+- (void)resetHighlightPoint {
+  CGPoint point = [_highlightedView.superview convertPoint:_highlightedView.center
+                                                    toView:self.featureHighlightView];
+  self.featureHighlightView.highlightPoint = point;
+  [self.featureHighlightView layoutIfNeeded];
+  [self.featureHighlightView updateOuterHighlight];
 }
 
 - (void)setOuterHighlightColor:(UIColor *)outerHighlightColor {

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightAnimationController.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightAnimationController.m
@@ -14,7 +14,6 @@
  limitations under the License.
  */
 
-#import "MaterialApplication.h"
 #import "MDCFeatureHighlightAnimationController.h"
 
 #import "MDCFeatureHighlightView+Private.h"
@@ -67,38 +66,26 @@ const NSTimeInterval kMDCFeatureHighlightDismissalDuration = 0.2f;
         break;
     }
   }
-
-  BOOL presenting = self.presenting;
-  void (^animations)(void) = ^void(void) {
-    // We have to perform an animation on highlightView in this block or else UIKit
-    // will not know we are performing an animation and will call the completion block
-    // immediately, causing our CAAnimations to be cut short.
-    if (presenting) {
-      [highlightView layoutAppearing];
-    } else {
-      [highlightView layoutDisappearing];
-    }
-  };
-
-  void (^completion)(BOOL finished) = ^void(BOOL finished) {
-    // If we're dismissing, remove the highlight view from the hierarchy
-    if (!presenting) {
-      [fromView removeFromSuperview];
-    }
-    [transitionContext completeTransition:YES];
-  };
-
-  UIApplicationState applicationState = [UIApplication mdc_safeSharedApplication].applicationState;
-  if (applicationState == UIApplicationStateActive) {
-    [UIView animateWithDuration:transitionDuration
-                          delay:0.0
-                        options:UIViewAnimationOptionBeginFromCurrentState
-                     animations:animations
-                     completion:completion];
-  } else {
-    animations();
-    completion(YES);
-  }
+  [UIView animateWithDuration:transitionDuration
+      delay:0.0
+      options:UIViewAnimationOptionBeginFromCurrentState
+      animations:^{
+        // We have to perform an animation on highlightView in this block or else UIKit
+        // will not know we are performing an animation and will call the completion block
+        // immediately, causing our CAAnimations to be cut short.
+        if (self.presenting) {
+          [highlightView layoutAppearing];
+        } else {
+          [highlightView layoutDisappearing];
+        }
+      }
+      completion:^(__unused BOOL finished) {
+        // If we're dismissing, remove the highlight view from the hierarchy
+        if (!self.presenting) {
+          [fromView removeFromSuperview];
+        }
+        [transitionContext completeTransition:YES];
+      }];
 }
 
 @end

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightAnimationController.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightAnimationController.m
@@ -14,6 +14,7 @@
  limitations under the License.
  */
 
+#import "MaterialApplication.h"
 #import "MDCFeatureHighlightAnimationController.h"
 
 #import "MDCFeatureHighlightView+Private.h"
@@ -66,26 +67,38 @@ const NSTimeInterval kMDCFeatureHighlightDismissalDuration = 0.2f;
         break;
     }
   }
-  [UIView animateWithDuration:transitionDuration
-      delay:0.0
-      options:UIViewAnimationOptionBeginFromCurrentState
-      animations:^{
-        // We have to perform an animation on highlightView in this block or else UIKit
-        // will not know we are performing an animation and will call the completion block
-        // immediately, causing our CAAnimations to be cut short.
-        if (self.presenting) {
-          [highlightView layoutAppearing];
-        } else {
-          [highlightView layoutDisappearing];
-        }
-      }
-      completion:^(__unused BOOL finished) {
-        // If we're dismissing, remove the highlight view from the hierarchy
-        if (!self.presenting) {
-          [fromView removeFromSuperview];
-        }
-        [transitionContext completeTransition:YES];
-      }];
+
+  BOOL presenting = self.presenting;
+  void (^animations)(void) = ^void(void) {
+    // We have to perform an animation on highlightView in this block or else UIKit
+    // will not know we are performing an animation and will call the completion block
+    // immediately, causing our CAAnimations to be cut short.
+    if (presenting) {
+      [highlightView layoutAppearing];
+    } else {
+      [highlightView layoutDisappearing];
+    }
+  };
+
+  void (^completion)(BOOL finished) = ^void(BOOL finished) {
+    // If we're dismissing, remove the highlight view from the hierarchy
+    if (!presenting) {
+      [fromView removeFromSuperview];
+    }
+    [transitionContext completeTransition:YES];
+  };
+
+  UIApplicationState applicationState = [UIApplication mdc_safeSharedApplication].applicationState;
+  if (applicationState == UIApplicationStateActive) {
+    [UIView animateWithDuration:transitionDuration
+                          delay:0.0
+                        options:UIViewAnimationOptionBeginFromCurrentState
+                     animations:animations
+                     completion:completion];
+  } else {
+    animations();
+    completion(YES);
+  }
 }
 
 @end


### PR DESCRIPTION
Closes #4791 

This PR (#4796) closes issue #4791, which was related to a crash that resulted from a fix to an internal client bug where the layout of the feature highlight was incorrect after rotations.

The approach taken was to revert the change that resulted in the crash and add a safeguard against incorrect layout by applying the positioning code both in the animation block (which will be sufficient for most cases) as well as after (which will be sufficient for cases where the frames we rely on in the positioning code are incorrect during the animation.)