### PR TITLE
[Snackbar] VoiceOver users can exit the snackbar

### DIFF
--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -222,7 +222,6 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
                                     snackbarManager:self.manager];
   [self.delegate willPresentSnackbarWithMessageView:snackbarView];
   self.currentSnackbar = snackbarView;
-  self.overlayView.accessibilityViewIsModal = ![self isSnackbarTransient:snackbarView];
   self.overlayView.hidden = NO;
   [self activateOverlay:self.overlayView];
 


### PR DESCRIPTION
When a Snackbar message with an action (button) appears, the focus is changed
for UIAccessibility. Instead of forcing the user to take an action (either the
button or the label to dismiss), the user should be able to navigate away from
the Snackbar message and leave it on-screen if they desire.

Clients should be dismissing the Snackbar message programmatically once the
user takes "an action" within the app. UIAccessibility navigation does not
count as an "action" but normal UIVC navigation does.

Closes #4798