### PR TITLE
[Catalog] Improve "Settings" UIAccessibility support

### DIFF
--- a/catalog/MDCCatalog/MDCCatalogDebugAlert.swift
+++ b/catalog/MDCCatalog/MDCCatalogDebugAlert.swift
@@ -196,6 +196,9 @@ class MDCCatalogDebugDismissCell: UICollectionViewCell {
     super.init(frame: frame)
     label.text = "DISMISS"
     label.textAlignment = .center
+    isAccessibilityElement = true
+    accessibilityTraits = UIAccessibilityTraitButton
+    accessibilityLabel = label.text
     contentView.addSubview(label)
   }
 


### PR DESCRIPTION
The Settings menu's "Dismiss" button was completely inaccessible for Switch
Control users. Because it was not an accessibility element, Switch Control
would not navigate to it. Also adding the `.button` trait to the "Dismiss"
button so that VoiceOver will correctly read it as a button.

Closes #4743
