### PR TITLE
[AppBar] Mark MDCAppBarTextColorAccessibilityMutator as deprecated.

### DIFF
--- a/components/AppBar/src/MDCAppBarViewController.h
+++ b/components/AppBar/src/MDCAppBarViewController.h
@@ -120,13 +120,14 @@
 
  @note This API will be deprecated with no replacement.
  */
-
+__deprecated_msg("Use themers and MDFTextAccessibility directly instead.")
 @interface MDCAppBarTextColorAccessibilityMutator : NSObject
 
 /**
  Mutates title text color and navigation items' tint colors based on background color of
  app bar's navigation bar or header view background color.
  */
-- (void)mutate:(nonnull MDCAppBar *)appBar;
+- (void)mutate:(nonnull MDCAppBar *)appBar
+__deprecated_msg("Use themers and MDFTextAccessibility instead.");
 
 @end

--- a/components/AppBar/src/MDCAppBarViewController.m
+++ b/components/AppBar/src/MDCAppBarViewController.m
@@ -329,6 +329,8 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
 
 @end
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation MDCAppBarTextColorAccessibilityMutator
 
 - (void)mutate:(nonnull MDCAppBar *)appBar {
@@ -362,3 +364,4 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
 }
 
 @end
+#pragma clang diagnostic pop


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/4806