### PR TITLE
[AppBar] Make migration links be actual links

### DIFF
--- a/components/AppBar/src/MDCAppBarContainerViewController.h
+++ b/components/AppBar/src/MDCAppBarContainerViewController.h
@@ -94,7 +94,7 @@
  The App Bar views that will be presented in front of the contentViewController's view.
 
  @warning This API will eventually be deprecated. Use appBarViewController instead. Learn more at
- components/AppBar/docs/migration-guide-appbar-appbarviewcontroller.md
+ https://github.com/material-components/material-components-ios/blob/develop/components/AppBar/docs/migration-guide-appbar-appbarviewcontroller.md
  */
 @property(nonatomic, strong, nonnull, readonly) MDCAppBar *appBar;
 

--- a/components/AppBar/src/MDCAppBarNavigationController.h
+++ b/components/AppBar/src/MDCAppBarNavigationController.h
@@ -68,7 +68,7 @@
 
  @warning This method will soon be deprecated. Please use
  -appBarNavigationController:willAddAppBarViewController:asChildOfViewController: instead. Learn
- more at components/AppBar/docs/migration-guide-appbar-appbarviewcontroller.md
+ more at https://github.com/material-components/material-components-ios/blob/develop/components/AppBar/docs/migration-guide-appbar-appbarviewcontroller.md
  */
 - (void)appBarNavigationController:(nonnull MDCAppBarNavigationController *)navigationController
                      willAddAppBar:(nonnull MDCAppBar *)appBar
@@ -117,7 +117,7 @@ MDC_SUBCLASSING_RESTRICTED
  Returns the injected App Bar for a given view controller, if an App Bar was injected.
 
  @warning This method will eventually be deprecated. Use -appBarViewControllerForViewController:
- instead. Learn more at components/AppBar/docs/migration-guide-appbar-appbarviewcontroller.md
+ instead. Learn more at https://github.com/material-components/material-components-ios/blob/develop/components/AppBar/docs/migration-guide-appbar-appbarviewcontroller.md
  */
 - (nullable MDCAppBar *)appBarForViewController:(nonnull UIViewController *)viewController;
 

--- a/components/AppBar/src/MDCAppBarViewController.h
+++ b/components/AppBar/src/MDCAppBarViewController.h
@@ -56,7 +56,8 @@
 
  AppBar depends on the FlexibleHeader, HeaderStackView, and NavigationBar Material Components.
 
- @note This API will be deprecated in favor of MDCAppBarViewController.
+ @warning This API will be deprecated in favor of MDCAppBarViewController. Learn more at
+ components/AppBar/docs/migration-guide-appbar-appbarviewcontroller.md
  */
 @interface MDCAppBar : NSObject
 

--- a/components/AppBar/src/MDCAppBarViewController.h
+++ b/components/AppBar/src/MDCAppBarViewController.h
@@ -57,7 +57,7 @@
  AppBar depends on the FlexibleHeader, HeaderStackView, and NavigationBar Material Components.
 
  @warning This API will be deprecated in favor of MDCAppBarViewController. Learn more at
- components/AppBar/docs/migration-guide-appbar-appbarviewcontroller.md
+ https://github.com/material-components/material-components-ios/blob/develop/components/AppBar/docs/migration-guide-appbar-appbarviewcontroller.md
  */
 @interface MDCAppBar : NSObject
 


### PR DESCRIPTION
Also adds a missing link to the MDCAppBar class.