### PR TITLE
[TextFields] Trigger layout pass to update borderView.borderLayer

### DIFF
--- a/components/TextFields/src/MDCTextInputControllerOutlined.m
+++ b/components/TextFields/src/MDCTextInputControllerOutlined.m
@@ -206,6 +206,8 @@ static UIRectCorner _roundedCornersDefault = UIRectCornerAllCorners;
                                                                            : borderColor;
   self.textInput.borderView.borderPath.lineWidth = self.textInput.isEditing ? 2 : 1;
 
+  [self.textInput.borderView setNeedsLayout];
+
   [self updatePlaceholder];
 }
 


### PR DESCRIPTION
Closes #4522.

According to the Material spec, the outlines on outlined textfields should be a little thicker when the textfield is in an editing state. Somewhere down the line that behavior was broken. This change fixes it. 

Before:
![simulator screen shot - iphone x - 2018-08-16 at 14 36 23](https://user-images.githubusercontent.com/8020010/44227892-cabbb900-a161-11e8-9d11-ccc348fb23e4.png)
After:
![simulator screen shot - iphone x - 2018-08-16 at 14 34 58](https://user-images.githubusercontent.com/8020010/44227831-a2cc5580-a161-11e8-9815-350d395ca530.png)

