### PR TITLE
Revert "Update releasing.md (#4423)"

### DIFF
--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -231,6 +231,9 @@ synchronization within Google.
 
     git push origin stable develop
 
+You can now sync to the desired stable release. [go/mdc-releasing#re-run-the-import-script-against-githubstable](http://go/mdc-releasing#re-run-the-import-script-against-githubstable). Once you've submitted
+the internal CL, continue below to tag and publish the release.
+
 ## Publish the official release
 
 > Have all release-blocking clients given the go-ahead? **Do not create the official release
@@ -240,8 +243,6 @@ synchronization within Google.
 You can now publish the release to GitHub:
 
     scripts/release publish <version>
-
-- Google: You can now sync the internal cl to the tagged stable release. [go/mdc-releasing#re-run-the-import-script-against-githubstable](http://go/mdc-releasing#re-run-the-import-script-against-githubstable). The release must be tagged in GitHub before you sync internally.
 
 ## Publish to Cocoapods
 


### PR DESCRIPTION
This reverts commit 44624188b4fadc0ffefa719265e18f1882142848.

In order to decrease the risk of a published version deviating from what we're able to submit internally, the release engineer is expected to submit the CL after the merge command, not after the publish command.