### PR TITLE
[Cards] Fix example IBOutlet

### DIFF
--- a/components/Cards/examples/CardExampleViewController.swift
+++ b/components/Cards/examples/CardExampleViewController.swift
@@ -18,7 +18,6 @@ import UIKit
 import MaterialComponents.MaterialButtons_ButtonThemer
 
 class CardExampleViewController: UIViewController {
-  @IBOutlet var contentView: UIView!
   @IBOutlet weak var imageView: CardImageView!
   @IBOutlet weak var card: MDCCard!
   @IBOutlet weak var button: MDCButton!
@@ -33,8 +32,7 @@ class CardExampleViewController: UIViewController {
     // License details: https://unsplash.com/license
     let bundle = Bundle(for: CardExampleViewController.self)
     bundle.loadNibNamed("CardExampleViewController", owner: self, options: nil)
-    contentView.frame = self.view.bounds
-    self.view.addSubview(contentView)
+    view.frame = self.view.bounds
 
     let buttonScheme = MDCButtonScheme();
     buttonScheme.colorScheme = colorScheme

--- a/components/Cards/examples/resources/CardExampleViewController.xib
+++ b/components/Cards/examples/resources/CardExampleViewController.xib
@@ -15,8 +15,8 @@
             <connections>
                 <outlet property="button" destination="NWQ-Eq-COf" id="tUV-oY-3Ia"/>
                 <outlet property="card" destination="BAQ-GJ-1pn" id="kH3-zF-uH0"/>
-                <outlet property="contentView" destination="i5M-Pr-FkT" id="Hkq-gw-WEg"/>
                 <outlet property="imageView" destination="ldt-3r-Agk" id="rFC-QD-GJJ"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="Ht4-oZ-f2i"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -135,6 +135,6 @@
         </view>
     </objects>
     <resources>
-        <image name="sample-image" width="4824" height="3229"/>
+        <image name="sample-image" width="920" height="615"/>
     </resources>
 </document>


### PR DESCRIPTION
When running internally, the `view` property didn't have an IBOutlet binding.
This caused a crash.

|Before|After|
|--|--|
|![card-iboutlet-before](https://user-images.githubusercontent.com/1753199/44282685-dd012a00-a229-11e8-8163-c3bb7fe10a3e.png)|![card-iboutlet-after](https://user-images.githubusercontent.com/1753199/44282698-e38fa180-a229-11e8-9cdb-083fa5ce688f.png)|
