### PR TITLE
[scripts] Add back the clang-format installer logic.

### DIFF
--- a/scripts/install/install_clang_format
+++ b/scripts/install/install_clang_format
@@ -25,7 +25,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -o errexit
 
 if ! clang-format -version >/dev/null 2>&1; then
-  echo "Fixing permissions in brew's install directory."
+  echo "Installing clang-format..."
   sudo chown -R $(whoami) /usr/local/share /usr/local/bin
   brew install clang-format
 fi

--- a/scripts/install/install_clang_format
+++ b/scripts/install/install_clang_format
@@ -24,6 +24,12 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 set -o errexit
 
+if ! clang-format -version >/dev/null 2>&1; then
+  echo "Fixing permissions in brew's install directory."
+  sudo chown -R $(whoami) /usr/local/share /usr/local/bin
+  brew install clang-format
+fi
+
 # Respect existing installs first.
 if ! git clang-format -h >/dev/null 2>&1; then
   echo "git clang-format not available..."

--- a/scripts/install/install_clang_format
+++ b/scripts/install/install_clang_format
@@ -25,8 +25,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -o errexit
 
 if ! clang-format -version >/dev/null 2>&1; then
-  echo "Installing clang-format..."
+  echo "Fixing permissions for brew install..."
   sudo chown -R $(whoami) /usr/local/share /usr/local/bin
+  echo "Installing clang-format..."
   brew install clang-format
 fi
 


### PR DESCRIPTION
This was accidentally removed in 7e31e36e410077b9860c49a23036d08213d1ef38.