### PR TITLE
[Tabs] Fix Tab Bar theming and background color issue

### DIFF
--- a/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
@@ -150,7 +150,7 @@
 }
 
 + (BOOL)catalogIsPresentable {
-  return YES;
+  return NO;
 }
 
 @end

--- a/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
@@ -52,11 +52,12 @@
 
 @implementation TBVCSampleViewController
 
+- (void)loadView {
+  self.view = [[TBVCSampleView alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
-
-  TBVCSampleView *sampleView = [[TBVCSampleView alloc] initWithFrame:self.view.bounds];
-  [self.view addSubview:sampleView];
 
   self.appBarViewController = [[MDCAppBarViewController alloc] init];
 

--- a/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
@@ -80,6 +80,10 @@
   [self.view setNeedsDisplay];
 }
 
+- (UIViewController *)childViewControllerForStatusBarStyle {
+  return self.appBarViewController;
+}
+
 + (nonnull instancetype)sampleWithTitle:(nonnull NSString *)title color:(nonnull UIColor *)color {
   return [self sampleWithTitle:title color:color icon:nil];
 }


### PR DESCRIPTION
This fixed two issues: (1) the status bar style color issue in tab bar view controller (2) the background color of the tab bar example was black, which was wrong.

Screenshot before the change:

![simulator screen shot - iphone x - 2018-08-20 at 12 30 02](https://user-images.githubusercontent.com/8836258/44353437-f1853280-a474-11e8-869e-57758a1eb1e2.png)

Screenshot After the change:
![simulator screen shot - iphone x - 2018-08-20 at 12 25 14](https://user-images.githubusercontent.com/8836258/44353242-7459bd80-a474-11e8-9e12-0bd8a0a49a50.png)


