### PR TITLE
[TextFields] Don't set non-floating placeholder color to active color while editing

### DIFF
--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -437,7 +437,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
                            ? self.errorColor
                            : nonErrorColor;
   } else {
-    placeholderColor = self.textInput.isEditing ? self.activeColor : self.inlinePlaceholderColor;
+    placeholderColor = self.inlinePlaceholderColor;
   }
   if (!self.textInput.isEnabled) {
     placeholderColor = self.disabledColor;


### PR DESCRIPTION
Closes #4844.

Previously, non-floating placeholder text color changed to `activeColor` while editing. An internal client sensed something incorrect about this, and Phil confirmed that it should stay set the value of `inlinePlaceholderColor`.

Before:
![simulator screen shot - iphone x - 2018-08-20 at 15 56 25](https://user-images.githubusercontent.com/8020010/44364338-b2ff7000-a494-11e8-95ec-a638ae7e9669.png)

After:
![simulator screen shot - iphone x - 2018-08-20 at 15 56 00](https://user-images.githubusercontent.com/8020010/44364339-b2ff7000-a494-11e8-82cf-7f580ae972a8.png)
