### PR TITLE
[NavigationBar] Remove restriction for 20pt fonts.

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -25,7 +25,6 @@
 #import "MaterialTypography.h"
 
 
-static const NSUInteger kTitleFontSize = 20;
 static const CGFloat kNavigationBarDefaultHeight = 56;
 static const CGFloat kNavigationBarPadDefaultHeight = 64;
 static const CGFloat kNavigationBarMinHeight = 24;
@@ -176,7 +175,7 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
 }
 
 - (void)setTitleFont:(UIFont *)titleFont {
-  _titleFont = [UIFont fontWithDescriptor:titleFont.fontDescriptor size:kTitleFontSize];
+  _titleFont = titleFont;
   if (!_titleFont) {
     _titleFont = [MDCTypography titleFont];
   }

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -189,7 +189,7 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
   UIFont *resultFont = navBar.titleLabel.font;
   XCTAssertEqualObjects(resultFont.fontName, font.fontName);
-  XCTAssertEqualWithAccuracy(resultFont.pointSize, 20, 0.01);
+  XCTAssertEqualWithAccuracy(resultFont.pointSize, 24, 0.01);
 
   NSDictionary <NSString *, NSNumber *> *fontTraits =
       [[font fontDescriptor] objectForKey:UIFontDescriptorTraitsAttribute];


### PR DESCRIPTION
This restriction is somewhat arbitrary and could cause problems with accessibility for certain font families.

Prior to this change, any font set on MDCNavigationBar would be restricted to 20pt size.

After this change, the font will be used directly and no sizes will be enforced.

This is required to support internal needs to set a navigation bar title font size of 18.