### PR TITLE
[AnimationTiming] Add button to start animation.

### DIFF
--- a/components/AnimationTiming/examples/AnimationTimingExample.m
+++ b/components/AnimationTiming/examples/AnimationTimingExample.m
@@ -37,7 +37,11 @@ const NSTimeInterval kAnimationTimeDelay = 0.5f;
   [super viewDidLoad];
   [self setupExampleViews];
 
-  self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Animate" style:UIBarButtonItemStylePlain target:self action:@selector(didTapAnimateButton:)];
+  self.navigationItem.rightBarButtonItem =
+      [[UIBarButtonItem alloc] initWithTitle:@"Animate"
+                                       style:UIBarButtonItemStylePlain
+                                      target:self
+                                      action:@selector(didTapAnimateButton:)];
 }
 
 - (void)playAnimations:(void (^)(BOOL))completion {
@@ -47,19 +51,27 @@ const NSTimeInterval kAnimationTimeDelay = 0.5f;
 
   CAMediaTimingFunction *materialStandardCurve =
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionStandard];
-  [self applyAnimationToView:_materialStandardView withTimingFunction:materialStandardCurve completion:nil];
+  [self applyAnimationToView:_materialStandardView
+          withTimingFunction:materialStandardCurve
+                  completion:nil];
 
   CAMediaTimingFunction *materialDecelerationCurve =
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionDeceleration];
-  [self applyAnimationToView:_materialDecelerationView withTimingFunction:materialDecelerationCurve completion:nil];
+  [self applyAnimationToView:_materialDecelerationView
+          withTimingFunction:materialDecelerationCurve
+                  completion:nil];
 
   CAMediaTimingFunction *materialAccelerationCurve =
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionAcceleration];
-  [self applyAnimationToView:_materialAccelerationView withTimingFunction:materialAccelerationCurve completion:nil];
+  [self applyAnimationToView:_materialAccelerationView
+          withTimingFunction:materialAccelerationCurve
+                  completion:nil];
    
   CAMediaTimingFunction *materialSharpCurve =
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionSharp];
-   [self applyAnimationToView:_materialSharpView withTimingFunction:materialSharpCurve completion:completion];
+   [self applyAnimationToView:_materialSharpView
+           withTimingFunction:materialSharpCurve
+                   completion:completion];
 }
 
 - (void)applyAnimationToView:(UIView *)view

--- a/components/AnimationTiming/examples/AnimationTimingExample.m
+++ b/components/AnimationTiming/examples/AnimationTimingExample.m
@@ -26,47 +26,45 @@ const NSTimeInterval kAnimationTimeDelay = 0.5f;
 
 @implementation AnimationTimingExample
 
+- (void)didTapAnimateButton:(UIButton *)sender {
+  sender.enabled = NO;
+  [self playAnimations:^(BOOL ignored) {
+    sender.enabled = YES;
+  }];
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
   [self setupExampleViews];
+
+  self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Animate" style:UIBarButtonItemStylePlain target:self action:@selector(didTapAnimateButton:)];
 }
 
-- (void)viewDidAppear:(BOOL)animated {
-  [super viewDidAppear:animated];
-  NSTimeInterval timeInterval = 2 * (kAnimationTimeInterval + kAnimationTimeDelay);
-  [_animationLoop invalidate];
-  _animationLoop = [NSTimer scheduledTimerWithTimeInterval:timeInterval
-                                                    target:self
-                                                  selector:@selector(playAnimations:)
-                                                  userInfo:nil
-                                                   repeats:YES];
-  [self playAnimations:nil];
-}
-
-- (void)playAnimations:(NSTimer *)timer {
+- (void)playAnimations:(void (^)(BOOL))completion {
   CAMediaTimingFunction *linearTimingCurve =
       [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
-  [self applyAnimationToView:_linearView withTimingFunction:linearTimingCurve];
+  [self applyAnimationToView:_linearView withTimingFunction:linearTimingCurve completion:nil];
 
   CAMediaTimingFunction *materialStandardCurve =
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionStandard];
-  [self applyAnimationToView:_materialStandardView withTimingFunction:materialStandardCurve];
+  [self applyAnimationToView:_materialStandardView withTimingFunction:materialStandardCurve completion:nil];
 
   CAMediaTimingFunction *materialDecelerationCurve =
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionDeceleration];
-  [self applyAnimationToView:_materialDecelerationView withTimingFunction:materialDecelerationCurve];
+  [self applyAnimationToView:_materialDecelerationView withTimingFunction:materialDecelerationCurve completion:nil];
 
   CAMediaTimingFunction *materialAccelerationCurve =
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionAcceleration];
-  [self applyAnimationToView:_materialAccelerationView withTimingFunction:materialAccelerationCurve];
+  [self applyAnimationToView:_materialAccelerationView withTimingFunction:materialAccelerationCurve completion:nil];
    
   CAMediaTimingFunction *materialSharpCurve =
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionSharp];
-   [self applyAnimationToView:_materialSharpView withTimingFunction:materialSharpCurve];
+   [self applyAnimationToView:_materialSharpView withTimingFunction:materialSharpCurve completion:completion];
 }
 
 - (void)applyAnimationToView:(UIView *)view
-          withTimingFunction:(CAMediaTimingFunction *)timingFunction {
+          withTimingFunction:(CAMediaTimingFunction *)timingFunction
+                  completion:(void (^)(BOOL))completion {
   CGFloat animWidth = self.view.frame.size.width - view.frame.size.width - 32.f;
   CGAffineTransform transform = CGAffineTransformMakeTranslation(animWidth, 0);
   [UIView mdc_animateWithTimingFunction:timingFunction
@@ -84,7 +82,7 @@ const NSTimeInterval kAnimationTimeDelay = 0.5f;
                                    animations:^{
                                      view.transform = CGAffineTransformIdentity;
                                    }
-                                   completion:nil];
+                                   completion:completion];
       }];
 }
 

--- a/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
+++ b/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
@@ -44,7 +44,6 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
   return YES;
 }
 
-
 @end
 
 @implementation AnimationTimingExample (Supplemental)


### PR DESCRIPTION
Uses a button to trigger the timing animation instead of having it run
in an infinite loop.

|Before|After|
|--|--|
|![simulator screen shot - iphone 7 - 2018-08-20 at 16 34 24](https://user-images.githubusercontent.com/1753199/44365146-ed6a0c80-a496-11e8-9b16-962c49bb8a91.png)|![simulator screen shot - iphone 7 - 2018-08-20 at 16 26 51](https://user-images.githubusercontent.com/1753199/44364848-1342e180-a496-11e8-9016-d4e131605e3e.png)|

Closes #4837 
