### PR TITLE
[ActivityIndicator] Default demo to .determinate

### DIFF
--- a/components/ActivityIndicator/examples/ActivityIndicatorExample.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorExample.m
@@ -53,28 +53,26 @@
   [MDCActivityIndicatorColorThemer applySemanticColorScheme:self.colorScheme
                                         toActivityIndicator:self.activityIndicator1];
   self.activityIndicator1.delegate = self;
-  self.activityIndicator1.progress = 0.6f;
   self.activityIndicator1.indicatorMode = MDCActivityIndicatorModeDeterminate;
   [self.activityIndicator1 sizeToFit];
-  [self.activityIndicator1 startAnimating];
 
   // Themed indeterminate activity indicator
   self.activityIndicator2 = [[MDCActivityIndicator alloc] init];
   self.activityIndicator2.delegate = self;
+  self.activityIndicator2.indicatorMode = MDCActivityIndicatorModeDeterminate;
   [MDCActivityIndicatorColorThemer applySemanticColorScheme:self.colorScheme
                                         toActivityIndicator:self.activityIndicator2];
   [self.activityIndicator2 sizeToFit];
-  [self.activityIndicator2 startAnimating];
 
   // Indeterminate activity indicator with custom colors.
   self.activityIndicator3 = [[MDCActivityIndicator alloc] init];
   self.activityIndicator3.delegate = self;
+  self.activityIndicator3.indicatorMode = MDCActivityIndicatorModeDeterminate;
   self.activityIndicator3.cycleColors =  @[ [MDCPalette bluePalette].tint500,
                                             [MDCPalette redPalette].tint500,
                                             [MDCPalette greenPalette].tint500,
                                             [MDCPalette yellowPalette].tint500 ];
   [self.activityIndicator3 sizeToFit];
-  [self.activityIndicator3 startAnimating];
 
   [self setupExampleViews];
 }

--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
@@ -78,6 +78,7 @@ static NSString * const kCell = @"Cell";
           forControlEvents:UIControlEventValueChanged];
 
   self.modeSwitch = [[UISwitch alloc] init];
+  [self.modeSwitch setOn:YES];
   [self.modeSwitch addTarget:self
                       action:@selector(didChangeModeSwitch:)
             forControlEvents:UIControlEventValueChanged];
@@ -89,8 +90,13 @@ static NSString * const kCell = @"Cell";
                   action:@selector(didChangeSliderValue:)
         forControlEvents:UIControlEventValueChanged];
 
+  self.activityIndicator1.progress = self.slider.value;
   self.activityIndicator2.progress = self.slider.value;
   self.activityIndicator3.progress = self.slider.value;
+
+  [self.activityIndicator1 startAnimating];
+  [self.activityIndicator2 startAnimating];
+  [self.activityIndicator3 startAnimating];
 
   self.tableView.layoutMargins = UIEdgeInsetsZero;
   self.tableView.separatorInset = UIEdgeInsetsZero;


### PR DESCRIPTION
In order to simplify Earl Grey automated testing, it is best to ensure there are no infinite animations taking place when the example view controllers load. Although there are ways to work around it, the behavior is more dependable and deterministic if we start from a known state.

|Before|After|
|--|--|
|![mdc-ai-before](https://user-images.githubusercontent.com/1753199/44377879-aac32700-a4cc-11e8-8da5-385c8eda45a4.gif)|![mdc-ai-after](https://user-images.githubusercontent.com/1753199/44377881-aeef4480-a4cc-11e8-94a9-5ffeed4303da.gif)|




Closes #4838 
