### PR TITLE
[Chips] Example respects safe area

### DIFF
--- a/components/Chips/examples/ChipsTypicalUseViewController.m
+++ b/components/Chips/examples/ChipsTypicalUseViewController.m
@@ -47,13 +47,13 @@
 
   [MDCChipViewTypographyThemer applyTypographyScheme:self.typographyScheme
                                           toChipView:_sizingChip];
-    
+
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
-    if (@available(iOS 11.0, *)) {
-        self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
-    }
+  if (@available(iOS 11.0, *)) {
+    self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
+  }
 #endif
-  
+
   self.collectionView.backgroundColor = [UIColor whiteColor];
   self.collectionView.delaysContentTouches = NO;
   self.collectionView.contentInset = UIEdgeInsetsMake(20, 20, 20, 20);

--- a/components/Chips/examples/ChipsTypicalUseViewController.m
+++ b/components/Chips/examples/ChipsTypicalUseViewController.m
@@ -47,6 +47,12 @@
 
   [MDCChipViewTypographyThemer applyTypographyScheme:self.typographyScheme
                                           toChipView:_sizingChip];
+    
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+    if (@available(iOS 11.0, *)) {
+        self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
+    }
+#endif
   
   self.collectionView.backgroundColor = [UIColor whiteColor];
   self.collectionView.delaysContentTouches = NO;


### PR DESCRIPTION
Update: ChipsTypicalUseViewController.m to respect safe area in landscape. Closes issue #3704.

iPhone X / iOS 11.4