### PR TITLE
 [BottomNavigation] Button for badge increment.

### DIFF
--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -81,7 +81,12 @@
 #endif
   _bottomNavBar.items = @[ tabBarItem1, tabBarItem2, tabBarItem3, tabBarItem4, tabBarItem5 ];
   _bottomNavBar.selectedItem = tabBarItem2;
-  [self updateBadgeItemCount];
+
+  self.navigationItem.rightBarButtonItem =
+      [[UIBarButtonItem alloc] initWithTitle:@"+Message"
+                                       style:UIBarButtonItemStylePlain
+                                      target:self
+                                      action:@selector(updateBadgeItemCount)];
 }
 
 - (void)layoutBottomNavBar {
@@ -131,11 +136,6 @@
   }
   self.badgeCount++;
   self.bottomNavBar.items[1].badgeValue = [NSNumber numberWithInt:self.badgeCount].stringValue;
-
-  __weak BottomNavigationTypicalUseExample *weakSelf = self;
-  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-    [weakSelf updateBadgeItemCount];
-  });
 }
 
 #pragma mark - MDCBottomNavigationBarDelegate

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -87,6 +87,10 @@
                                        style:UIBarButtonItemStylePlain
                                       target:self
                                       action:@selector(updateBadgeItemCount)];
+  self.navigationItem.rightBarButtonItem.accessibilityLabel = @"Add a message";
+  self.navigationItem.rightBarButtonItem.accessibilityHint =
+      @"Increases the badge on the \"Messages\" tab.";
+  self.navigationItem.rightBarButtonItem.accessibilityIdentifier = @"messages-increment-badge";
 }
 
 - (void)layoutBottomNavBar {


### PR DESCRIPTION
The BottomNavigation main demo has an infinite loop of badgeValue
updates, making EarlGrey testing difficult. Instead, we can use the
AppBar's rightBarButton to provide a button for incrementing the badge
value manually.

|Before|After|
|--|--|
|![mdc-bn-before](https://user-images.githubusercontent.com/1753199/44378402-1d350680-a4cf-11e8-891d-b70d8fc395b4.gif)|![mdc-bn-after](https://user-images.githubusercontent.com/1753199/44378408-21612400-a4cf-11e8-88c9-6d6dde20b7aa.gif)|



Closes #4836 
