### PR TITLE
[Math] Fix CGFloat errors in tests.

### DIFF
--- a/components/private/Math/tests/unit/MDCMathTests.m
+++ b/components/private/Math/tests/unit/MDCMathTests.m
@@ -30,10 +30,11 @@
  */
 - (void)testMDCRectAlignScale {
   // Given
-  CGRect misalignedRect = CGRectMake(0.45, 0.78, 1.01, 5.98);
+  CGRect misalignedRect = CGRectMake(0.45f, 0.78f, 1.01f, 5.98f);
   CGRect alignedScale1Rect = CGRectMake(0, 0, 2, 7);
-  CGRect alignedScale2Rect = CGRectMake(0, 0.5, 1.5, 6.5);
-  CGRect alignedScale3Rect = CGRectMake(1.0 / 3.0, 2.0 / 3.0, 4.0 / 3.0, 19.0 / 3.0);
+  CGRect alignedScale2Rect = CGRectMake(0, 0.5f, 1.5f, 6.5f);
+  CGRect alignedScale3Rect = CGRectMake((CGFloat)(1.0 / 3.0), (CGFloat)(2.0 / 3.0),
+                                        (CGFloat)(4.0 / 3.0), (CGFloat)(19.0 / 3.0));
 
   // Then
   CGRect outputScale1Rect = MDCRectAlignToScale(misalignedRect, 1);
@@ -54,10 +55,10 @@
  */
 - (void)testMDCRectAlignScaleNegativeRectangle {
   // Given
-  CGRect misalignedRect = CGRectMake(-5.01, -0.399, 8.35, 2.65);
+  CGRect misalignedRect = CGRectMake(-5.01f, -0.399f, 8.35f, 2.65f);
   CGRect alignedScale1Rect = CGRectMake(-6, -1, 10, 4);
-  CGRect alignedScale2Rect = CGRectMake(-5.5, -0.5, 9, 3);
-  CGRect alignedScale3Rect = CGRectMake(-16.0 / 3.0, -2.0 / 3.0, 9, 3);
+  CGRect alignedScale2Rect = CGRectMake(-5.5f, -0.5f, 9, 3);
+  CGRect alignedScale3Rect = CGRectMake((CGFloat)(-16.0 / 3.0), (CGFloat)(-2.0 / 3.0), 9, 3);
 
   // Then
   CGRect outputScale1Rect = MDCRectAlignToScale(misalignedRect, 1);
@@ -78,11 +79,12 @@
  */
 - (void)testMDCRectAlignScaleNonStandardRectangle {
   // Given
-  CGRect misalignedRect = CGRectMake(17.9, -4.44, -10.10, -15.85);
+  CGRect misalignedRect = CGRectMake(17.9f, -4.44f, -10.10f, -15.85f);
   // Standardized: (7.80, -20.29), (10.10, 15.85)
   CGRect alignedScale1Rect = CGRectMake(7, -21, 11, 17);
-  CGRect alignedScale2Rect = CGRectMake(7.5, -20.5, 10.5, 16.5);
-  CGRect alignedScale3Rect = CGRectMake(23.0 / 3.0, -61.0 / 3.0, 31.0 / 3.0, 16);
+  CGRect alignedScale2Rect = CGRectMake(7.5f, -20.5f, 10.5f, 16.5f);
+  CGRect alignedScale3Rect = CGRectMake((CGFloat)(23.0 / 3.0), (CGFloat)(-61.0 / 3.0),
+                                        (CGFloat)(31.0 / 3.0), 16);
 
   // Then
   CGRect outputScale1Rect = MDCRectAlignToScale(misalignedRect, 1);
@@ -104,8 +106,9 @@
 - (void)testMDCRectAlignScaleAlreadyAligned {
   // Given
   CGRect alignedScale1Rect = CGRectMake(10, 15, 5, 10);
-  CGRect alignedScale2Rect = CGRectMake(10.5, 15.5, 5.5, 10.5);
-  CGRect alignedScale3Rect = CGRectMake(31.0 / 3.0, 47.0 / 3.0, 16.0 / 3.0, 32.0 / 3.0);
+  CGRect alignedScale2Rect = CGRectMake(10.5f, 15.5f, 5.5f, 10.5f);
+  CGRect alignedScale3Rect = CGRectMake((CGFloat)(31.0 / 3.0), (CGFloat)(47.0 / 3.0),
+                                        (CGFloat)(16.0 / 3.0), (CGFloat)(32.0 / 3.0));
 
   // Then
   CGRect outputScale1Rect = MDCRectAlignToScale(alignedScale1Rect, 1);
@@ -136,7 +139,7 @@
  */
 - (void)testMDCRectAlignScaleZeroScale {
   // Given
-  CGRect rectangle = CGRectMake(1.1, 2.2, 3.3, 4.4);
+  CGRect rectangle = CGRectMake(1.1f, 2.2f, 3.3f, 4.4f);
 
   // Then
   XCTAssertTrue(CGRectEqualToRect(MDCRectAlignToScale(rectangle, 0),
@@ -147,9 +150,9 @@
 
 - (void)testMDCPointRoundWithScale {
   // Given
-  CGPoint misalignedPoint = CGPointMake(0.7, -1.3);
-  CGPoint alignedScale1Point = CGPointMake(1.0, -1.0);
-  CGPoint alignedScale2Point = CGPointMake(0.5, -1.5);
+  CGPoint misalignedPoint = CGPointMake(0.7f, -1.3f);
+  CGPoint alignedScale1Point = CGPointMake(1, -1);
+  CGPoint alignedScale2Point = CGPointMake(0.5f, -1.5f);
   CGPoint alignedScale3Point = CGPointMake((CGFloat)(2.0 / 3.0), (CGFloat)(-4.0 / 3.0));
 
   // Then
@@ -163,17 +166,17 @@
 
 - (void)testMDCPointRoundScaleZeroScale {
   // Then
-  XCTAssertTrue(CGPointEqualToPoint(CGPointZero, MDCPointRoundWithScale(CGPointMake(5.5, 13), 0)));
+  XCTAssertTrue(CGPointEqualToPoint(CGPointZero, MDCPointRoundWithScale(CGPointMake(5.5f, 13), 0)));
 }
 
 #pragma mark - MDCCenter
 
 - (void)testMDCRoundCenterWithBoundsAndScale {
   // Given
-  CGPoint misalignedCenter = CGPointMake(0.7, -1.3);
+  CGPoint misalignedCenter = CGPointMake(0.7f, -1.3f);
   CGRect bounds = CGRectMake(0, 0, 20, 21);
-  CGPoint alignedScale1Center = CGPointMake(1, -1.5);
-  CGPoint alignedScale2Center = CGPointMake(0.5, -1.5);
+  CGPoint alignedScale1Center = CGPointMake(1, -1.5f);
+  CGPoint alignedScale2Center = CGPointMake(0.5f, -1.5f);
   CGPoint alignedScale3Center = CGPointMake((CGFloat)(2.0 / 3.0), (CGFloat)(-7.0 / 6.0));
 
   // Then
@@ -195,11 +198,11 @@
 #else
   const CGFloat acceptableRoundingError = 5E-7f;
 #endif
-  CGPoint misalignedCenter = CGPointMake(0.3, 9.99);
-  CGRect bounds = CGRectMake(0, 0, 20.1, 21.9);
+  CGPoint misalignedCenter = CGPointMake((CGFloat)0.3, (CGFloat)9.99);
+  CGRect bounds = CGRectMake(0, 0, (CGFloat)20.1, (CGFloat)21.9);
   CGPoint alignedScale1Center = CGPointMake((CGFloat)0.05, (CGFloat)9.95);
   CGPoint alignedScale2Center = CGPointMake((CGFloat)0.05, (CGFloat)9.95);
-  CGPoint alignedScale3Center = CGPointMake((CGFloat)(0.05 + 1.0 / 3.0), (CGFloat)(9.95));
+  CGPoint alignedScale3Center = CGPointMake((CGFloat)(0.05 + 1.0 / 3.0), (CGFloat)9.95);
 
   // Then
   CGPoint outputScale1Center = MDCRoundCenterWithBoundsAndScale(misalignedCenter, bounds, 1);


### PR DESCRIPTION
An internal build failed (once) when compiling the Math tests because
double-precision floating point
values were being implicitly cast to single-precision. Marking each of these
as either single-precision float or CGFloat (where convenient). Except for the
tests that measure rounding errors, single- and double-precision isn't
important for the test outputs.

Sample error:
```
material_components_ios/components/private/Math/tests/unit/MDCMathTests.m:33:38: error: implicit conversion loses floating-point precision: 'double' to 'CGFloat' (aka 'float') [-Werror,-Wconversion]
  CGRect misalignedRect = CGRectMake(0.45, 0.78, 1.01, 5.98);
                          ~~~~~~~~~~ ^~~~
```