### PR TITLE
[FlexibleHeader] Fix bug where orientation changes would result in incorrect contentOffset.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -682,9 +682,9 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
     scrollView.contentInset = insets;
   }
 
-  BOOL statusBarIsHidden = [UIApplication mdc_safeSharedApplication].statusBarHidden;
+  BOOL statusBarIsHidden = [UIApplication mdc_safeSharedApplication].statusBarHidden ? YES : NO;
   if (_wasStatusBarHiddenIsValid && _wasStatusBarHidden != statusBarIsHidden
-      && !_isChangingStatusBarVisibility) {
+      && !_isChangingStatusBarVisibility && !self.inferTopSafeAreaInsetFromViewController) {
     // Our status bar state has changed without our knowledge. UIKit will have already adjusted our
     // content offset by now, so we want to counteract this. This logic is similar to that found in
     // statusBarShifterNeedsStatusBarAppearanceUpdate:


### PR DESCRIPTION
Closes https://github.com/material-components/material-components-ios/issues/4832

Repro steps:

1. Open MDCDragons.
2. Open the App Bar -> Wrapped Table View example.
3. Rotate from portrait to landscape.
4. Rotate from landscape to portrait.

Expected behavior: the content is still scrolled to the top.
Actual behavior, prior to this change: the content is partially scrolled.

The original logic added in 7e35618 solved a bug that caused the content offset to jump when the status bar visibility changed without our awareness. This logic does not appear to be necessary anymore when inferTopSafeAreaInsetFromViewController is enabled because we are more aggressively observing changes in the top content insets when this flag is enabled.

Tested on the following simulators:

- iPhone X 11.2
- iPhone SE 11.2
- iPhone SE 10.3.1
- iPhone 5s 8.1