### PR TITLE
[ProgressView] Add 'animate' button to example.

### DIFF
--- a/components/ProgressView/examples/ProgressViewExample.m
+++ b/components/ProgressView/examples/ProgressViewExample.m
@@ -98,6 +98,13 @@ static const CGFloat MDCProgressViewAnimationDuration = 1.f;
   [self setupProgressViews];
   [self setupLabels];
   [self setupConstraints];
+
+  self.navigationItem.rightBarButtonItem =
+      [[UIBarButtonItem alloc] initWithTitle:@"Animate"
+                                       style:UIBarButtonItemStylePlain
+                                      target:self
+                                      action:@selector(didPressAnimateButton:)];
+  self.navigationItem.rightBarButtonItem.accessibilityIdentifier = @"animate_button";
 }
 
 - (void)setupLabels {
@@ -191,13 +198,16 @@ static const CGFloat MDCProgressViewAnimationDuration = 1.f;
   [self.view addConstraints:horizontalConstraints];
 }
 
-- (void)viewDidAppear:(BOOL)animated {
-  [super viewDidAppear:animated];
+- (void)didPressAnimateButton:(UIButton *)sender {
+  sender.enabled = NO;
   [self animateStep1:_stockProgressView];
   [self animateStep1:_tintedProgressView];
   [self animateStep1:_fullyColoredProgressView];
-  [self animateBackwardProgressResetView];
-  [self animateBackwardProgressAnimateView];
+  [self animateBackwardProgressResetViewWithCountdown:4];
+  [self animateBackwardProgressAnimateViewWithCountdown:4 completion:^(BOOL ignored) {
+    sender.enabled = YES;
+  }];
+
 }
 
 - (void)animateStep1:(MDCProgressView *)progressView {
@@ -227,40 +237,38 @@ static const CGFloat MDCProgressViewAnimationDuration = 1.f;
 }
 
 - (void)animateStep4:(MDCProgressView *)progressView {
-  __weak MDCProgressView *weakProgressView = progressView;
   [progressView setHidden:YES
                  animated:YES
-               completion:^(BOOL finished) {
-                 [self performSelector:@selector(animateStep1:)
-                            withObject:weakProgressView
-                            afterDelay:MDCProgressViewAnimationDuration];
-               }];
+               completion:nil];
 }
 
-- (void)animateBackwardProgressResetView {
+- (void)animateBackwardProgressResetViewWithCountdown:(NSInteger)remainingCounts {
+  --remainingCounts;
   __weak ProgressViewExample *weakSelf = self;
 
   [_backwardProgressResetView setProgress:1 - _backwardProgressResetView.progress
                                  animated:YES
-                               completion:^(BOOL finished) {
-                                 [weakSelf
-                                     performSelector:@selector(animateBackwardProgressResetView)
-                                          withObject:nil
-                                          afterDelay:MDCProgressViewAnimationDuration];
-                               }];
+                               completion:nil];
+  if (remainingCounts > 0) {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(MDCProgressViewAnimationDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      [weakSelf animateBackwardProgressResetViewWithCountdown:remainingCounts];
+    });
+  }
 }
 
-- (void)animateBackwardProgressAnimateView {
+- (void)animateBackwardProgressAnimateViewWithCountdown:(NSInteger)remainingCounts
+                                             completion:(void (^)(BOOL))completion {
+  --remainingCounts;
   __weak ProgressViewExample *weakSelf = self;
 
-  [_backwardProgressAnimateView setProgress:1 - _backwardProgressResetView.progress
+  [_backwardProgressAnimateView setProgress:1 - _backwardProgressAnimateView.progress
                                    animated:YES
-                                 completion:^(BOOL finished) {
-                                   [weakSelf
-                                       performSelector:@selector(animateBackwardProgressAnimateView)
-                                            withObject:nil
-                                            afterDelay:MDCProgressViewAnimationDuration];
-                                 }];
+                                 completion:remainingCounts == 0 ? completion : nil];
+  if (remainingCounts) {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(MDCProgressViewAnimationDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      [weakSelf animateBackwardProgressAnimateViewWithCountdown:remainingCounts completion:completion];
+    });
+  }
 }
 
 #pragma mark - CatalogByConvention

--- a/components/ProgressView/examples/ProgressViewExample.m
+++ b/components/ProgressView/examples/ProgressViewExample.m
@@ -250,7 +250,9 @@ static const CGFloat MDCProgressViewAnimationDuration = 1.f;
                                  animated:YES
                                completion:nil];
   if (remainingCounts > 0) {
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(MDCProgressViewAnimationDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                 (int64_t)(MDCProgressViewAnimationDuration * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
       [weakSelf animateBackwardProgressResetViewWithCountdown:remainingCounts];
     });
   }
@@ -265,8 +267,11 @@ static const CGFloat MDCProgressViewAnimationDuration = 1.f;
                                    animated:YES
                                  completion:remainingCounts == 0 ? completion : nil];
   if (remainingCounts) {
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(MDCProgressViewAnimationDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-      [weakSelf animateBackwardProgressAnimateViewWithCountdown:remainingCounts completion:completion];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                 (int64_t)(MDCProgressViewAnimationDuration * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+      [weakSelf animateBackwardProgressAnimateViewWithCountdown:remainingCounts
+                                                     completion:completion];
     });
   }
 }


### PR DESCRIPTION
The ProgressView example had infinite animation loops. This causes problems
when working with Earl Grey, which tries to wait for the main loop to stop
executing animations before interacting. By adding a manual "Animate" button
we allow Earl Grey tests to execute and still allow users to see how a
ProgressView will act when placed on-screen.

|Before|After|
|--|--|
|![mdc-pv-before](https://user-images.githubusercontent.com/1753199/44406891-c1986680-a52a-11e8-8442-a3db7c287c36.gif)|![mdc-pv-button](https://user-images.githubusercontent.com/1753199/44406901-c52bed80-a52a-11e8-80d2-081e8b481eb5.gif)|

Closes #4835
