### PR TITLE
{kokoro} Symlink DerivedData to tmpfs.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -96,7 +96,9 @@ move_derived_data_to_tmp() {
 run_bazel() {
   echo "Running bazel builds..."
 
-  move_derived_data_to_tmp
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    move_derived_data_to_tmp
+  fi
 
   fix_bazel_imports
 
@@ -131,7 +133,9 @@ run_bazel() {
 run_cocoapods() {
   echo "Running cocoapods builds..."
 
-  move_derived_data_to_tmp
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    move_derived_data_to_tmp
+  fi
 
   xcode_min_version_as_number="$(version_as_number $XCODE_MINIMUM_VERSION)"
 

--- a/.kokoro
+++ b/.kokoro
@@ -96,8 +96,6 @@ move_derived_data_to_tmp() {
 run_bazel() {
   echo "Running bazel builds..."
 
-  move
-
   move_derived_data_to_tmp
 
   fix_bazel_imports

--- a/.kokoro
+++ b/.kokoro
@@ -85,8 +85,20 @@ version_as_number() {
   echo "${padded_version//.}"
 }
 
+move_derived_data_to_tmp() {
+  targetDir="${HOME}/Library/Developer/Xcode/DerivedData"
+  if [[ -d "$targetDir" ]]; then
+    mv "$targetDir" /tmpfs/
+    ln -sf /tmpfs/DerivedData "$targetDir"
+  fi
+}
+
 run_bazel() {
   echo "Running bazel builds..."
+
+  move
+
+  move_derived_data_to_tmp
 
   fix_bazel_imports
 
@@ -120,6 +132,8 @@ run_bazel() {
 
 run_cocoapods() {
   echo "Running cocoapods builds..."
+
+  move_derived_data_to_tmp
 
   xcode_min_version_as_number="$(version_as_number $XCODE_MINIMUM_VERSION)"
 


### PR DESCRIPTION
When compiling on kokoro, we often run out of disk space. This is because
their executors limit the main partition to 4-5 GB. To gain access to more
disk space, we can symlink the DerivedData directory to a temporary directory.
