### PR TITLE
Use objc_subclassing_restricted attributes directly instead of a macro

### DIFF
--- a/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.h
+++ b/components/ActivityIndicator/src/private/MDCActivityIndicatorMotionSpec.h
@@ -17,14 +17,6 @@
 #import <Foundation/Foundation.h>
 #import <MotionInterchange/MotionInterchange.h>
 
-#ifndef MDC_SUBCLASSING_RESTRICTED
-#if defined(__has_attribute) && __has_attribute(objc_subclassing_restricted)
-#define MDC_SUBCLASSING_RESTRICTED __attribute__((objc_subclassing_restricted))
-#else
-#define MDC_SUBCLASSING_RESTRICTED
-#endif
-#endif  // #ifndef MDC_SUBCLASSING_RESTRICTED
-
 typedef struct MDCActivityIndicatorMotionSpecIndeterminate {
   MDMMotionTiming outerRotation;
   MDMMotionTiming innerRotation;
@@ -46,7 +38,7 @@ typedef struct MDCActivityIndicatorMotionSpecProgress {
   MDMMotionTiming strokeEnd;
 } MDCActivityIndicatorMotionSpecProgress;
 
-MDC_SUBCLASSING_RESTRICTED
+__attribute__((objc_subclassing_restricted))
 @interface MDCActivityIndicatorMotionSpec: NSObject
 
 @property(nonatomic, class, readonly) NSTimeInterval pointCycleDuration;

--- a/components/AppBar/src/MDCAppBarNavigationController.h
+++ b/components/AppBar/src/MDCAppBarNavigationController.h
@@ -16,14 +16,6 @@
 
 #import <UIKit/UIKit.h>
 
-#ifndef MDC_SUBCLASSING_RESTRICTED
-#if defined(__has_attribute) && __has_attribute(objc_subclassing_restricted)
-#define MDC_SUBCLASSING_RESTRICTED __attribute__((objc_subclassing_restricted))
-#else
-#define MDC_SUBCLASSING_RESTRICTED
-#endif
-#endif  // #ifndef MDC_SUBCLASSING_RESTRICTED
-
 @class MDCAppBar;
 @class MDCAppBarViewController;
 @class MDCAppBarNavigationController;
@@ -90,7 +82,7 @@
  delegate yet. In this case, use the -appBarForViewController: API to retrieve the injected App Bar
  for your root view controller and execute your delegate logic on the returned result, if any.
  */
-MDC_SUBCLASSING_RESTRICTED
+__attribute__((objc_subclassing_restricted))
 @interface MDCAppBarNavigationController : UINavigationController
 
 #pragma mark - Reacting to state changes

--- a/components/LibraryInfo/src/MDCLibraryInfo.h
+++ b/components/LibraryInfo/src/MDCLibraryInfo.h
@@ -16,18 +16,10 @@
 
 #import <Foundation/Foundation.h>
 
-#ifndef MDC_SUBCLASSING_RESTRICTED
-#if defined(__has_attribute) && __has_attribute(objc_subclassing_restricted)
-#define MDC_SUBCLASSING_RESTRICTED __attribute__((objc_subclassing_restricted))
-#else
-#define MDC_SUBCLASSING_RESTRICTED
-#endif
-#endif  // #ifndef MDC_SUBCLASSING_RESTRICTED
-
 /**
  Information about the Material Components library.
  */
-MDC_SUBCLASSING_RESTRICTED
+__attribute__((objc_subclassing_restricted))
 @interface MDCLibraryInfo: NSObject
 
 /**


### PR DESCRIPTION
`__attribute__((objc_subclassing_restricted))` is supported as early as Xcode 8.3.3 so we do not require the macro checking for its availability.