### PR TITLE
[ButtonBar] Add support for pure Swift class button invocations.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -236,6 +236,7 @@ Pod::Spec.new do |mdc|
 
     component.dependency "MDFInternationalization"
     component.dependency "MaterialComponents/Buttons"
+    component.dependency "MaterialComponents/private/Application"
   end
 
   mdc.subspec "ButtonBar+ColorThemer" do |extension|

--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -29,6 +29,7 @@ mdc_public_objc_library(
     ],
     deps = [
         "//components/Buttons",
+        "//components/private/Application",
         "@material_internationalization_ios//:MDFInternationalization",
     ],
 )

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -18,6 +18,7 @@
 
 #import <MDFInternationalization/MDFInternationalization.h>
 
+#import "MaterialApplication.h"
 #import "MaterialButtons.h"
 #import "private/MDCAppBarButtonBarBuilder.h"
 
@@ -330,6 +331,14 @@ static NSString *const kEnabledSelector = @"enabled";
   }
 
   if (![target respondsToSelector:item.action]) {
+    return;
+  }
+
+  if (![target respondsToSelector:@selector(methodSignatureForSelector:)]) {
+    UIApplication *application = [UIApplication mdc_safeSharedApplication];
+    NSAssert(application != nil,
+             @"No UIApplication is available to send an event from; it will be lost.");
+    [application sendAction:item.action to:target from:item forEvent:event];
     return;
   }
 


### PR DESCRIPTION
Repro case:

Add the following code to a view controller with an App Bar:

```swift
class SomeObject {
  @objc func someEvent() {

  }
}

let object = SomeObject()

self.navigationItem.rightBarButtonItem =
  UIBarButtonItem(title: "Right", style: .done, target: object, action: #selector(SomeObject.someEvent))
```

Tap the button.

Expected behavior: the someEvent method is invoked.
Actual behavior: crash due to unrecognized selector `methodSignatureForSelector:`.

After this change the behavior works as expected, with the caveat being that we are not able to pass the button instance along as a third argument to pure Swift classes. The implication of this is that pure Swift classes will not be able to present popovers from the provided item instance. Supporting this case will require turning the pure Swift class into an Objective-C compatible class.

Closes https://github.com/material-components/material-components-ios/issues/2981