### PR TITLE
[NavigationBar] Add a flag that makes it possible to set any font size.

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -132,6 +132,20 @@ IB_DESIGNABLE
 @property(nonatomic, strong, null_resettable) UIFont *titleFont;
 
 /**
+ A behavioral flag that affects whether titleFont can be set to a font of any size or not.
+
+ If enabled, titleFont can be set to a font of any size.
+
+ If disabled, titleFont's size will be adjusted to 20 regardless of the provided font size.
+
+ We intend to enable this property by default in the future and to remote this flag entirely.
+ Consider enabling this flag on your navigation bar instances.
+
+ Default is NO.
+ */
+@property(nonatomic) BOOL allowAnyTitleFontSize;
+
+/**
  The title label's text color.
 
  Default is nil (text draws black).

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -174,7 +174,11 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
 }
 
 - (void)setTitleFont:(UIFont *)titleFont {
-  _titleFont = [UIFont fontWithDescriptor:titleFont.fontDescriptor size:kTitleFontSize];
+  if (self.allowAnyTitleFontSize) {
+    _titleFont = titleFont;
+  } else {
+    _titleFont = [UIFont fontWithDescriptor:titleFont.fontDescriptor size:kTitleFontSize];
+  }
   if (!_titleFont) {
     _titleFont = [MDCTypography titleFont];
   }

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -189,7 +189,7 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
   UIFont *resultFont = navBar.titleLabel.font;
   XCTAssertEqualObjects(resultFont.fontName, font.fontName);
-  XCTAssertEqualWithAccuracy(resultFont.pointSize, 20, 0.01);
+  XCTAssertEqualWithAccuracy(resultFont.pointSize, 24, 0.01);
 
   NSDictionary <NSString *, NSNumber *> *fontTraits =
       [[font fontDescriptor] objectForKey:UIFontDescriptorTraitsAttribute];

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -174,56 +174,61 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
                              kEpsilonAccuracy);
 }
 
-- (void)testTitleFontPropertyWithAllowAnyTitleFontSizeDisabled {
+- (void)testTitleFontProperty {
+  // Given
   MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-  navBar.frame = CGRectMake(0, 0, 300, 25);
   navBar.title = @"this is a Title";
-  navBar.titleAlignment = MDCNavigationBarTitleAlignmentCenter;
-  navBar.allowAnyTitleFontSize = NO;
-  [navBar layoutIfNeeded];
 
+  // Then
   XCTAssertNotNil(navBar.titleFont);
-  XCTAssertEqual(navBar.titleLabel.font, navBar.titleFont);
+  XCTAssertEqualObjects(navBar.titleLabel.font, navBar.titleFont);
 
+  // When
   UIFont *font = [UIFont systemFontOfSize:24];
   navBar.titleFont = font;
 
+  // Then
   UIFont *resultFont = navBar.titleLabel.font;
   XCTAssertEqualObjects(resultFont.fontName, font.fontName);
   XCTAssertEqualWithAccuracy(resultFont.pointSize, 20, 0.01);
 
+  // When
   NSDictionary <NSString *, NSNumber *> *fontTraits =
       [[font fontDescriptor] objectForKey:UIFontDescriptorTraitsAttribute];
   NSDictionary <NSString *, NSNumber *> *resultTraits =
       [[resultFont fontDescriptor] objectForKey:UIFontDescriptorTraitsAttribute];
 
-  XCTAssertEqual(fontTraits, resultTraits);
+  // Then
+  XCTAssertEqualObjects(fontTraits, resultTraits);
 }
 
 - (void)testTitleFontPropertyWithAllowAnyTitleFontSizeEnabled {
+  // Given
   MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-  navBar.frame = CGRectMake(0, 0, 300, 25);
   navBar.title = @"this is a Title";
-  navBar.titleAlignment = MDCNavigationBarTitleAlignmentCenter;
   navBar.allowAnyTitleFontSize = YES;
-  [navBar layoutIfNeeded];
 
+  // Then
   XCTAssertNotNil(navBar.titleFont);
-  XCTAssertEqual(navBar.titleLabel.font, navBar.titleFont);
+  XCTAssertEqualObjects(navBar.titleLabel.font, navBar.titleFont);
 
+  // When
   UIFont *font = [UIFont systemFontOfSize:24];
   navBar.titleFont = font;
 
+  // Then
   UIFont *resultFont = navBar.titleLabel.font;
   XCTAssertEqualObjects(resultFont.fontName, font.fontName);
   XCTAssertEqualWithAccuracy(resultFont.pointSize, 24, 0.01);
 
+  // When
   NSDictionary <NSString *, NSNumber *> *fontTraits =
       [[font fontDescriptor] objectForKey:UIFontDescriptorTraitsAttribute];
   NSDictionary <NSString *, NSNumber *> *resultTraits =
       [[resultFont fontDescriptor] objectForKey:UIFontDescriptorTraitsAttribute];
 
-  XCTAssertEqual(fontTraits, resultTraits);
+  // Then
+  XCTAssertEqualObjects(fontTraits, resultTraits);
 }
 
 #pragma mark - Accessibility

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -174,11 +174,38 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
                              kEpsilonAccuracy);
 }
 
-- (void)testTitleFontProperty {
+- (void)testTitleFontPropertyWithAllowAnyTitleFontSizeDisabled {
   MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
   navBar.frame = CGRectMake(0, 0, 300, 25);
   navBar.title = @"this is a Title";
   navBar.titleAlignment = MDCNavigationBarTitleAlignmentCenter;
+  navBar.allowAnyTitleFontSize = NO;
+  [navBar layoutIfNeeded];
+
+  XCTAssertNotNil(navBar.titleFont);
+  XCTAssertEqual(navBar.titleLabel.font, navBar.titleFont);
+
+  UIFont *font = [UIFont systemFontOfSize:24];
+  navBar.titleFont = font;
+
+  UIFont *resultFont = navBar.titleLabel.font;
+  XCTAssertEqualObjects(resultFont.fontName, font.fontName);
+  XCTAssertEqualWithAccuracy(resultFont.pointSize, 20, 0.01);
+
+  NSDictionary <NSString *, NSNumber *> *fontTraits =
+      [[font fontDescriptor] objectForKey:UIFontDescriptorTraitsAttribute];
+  NSDictionary <NSString *, NSNumber *> *resultTraits =
+      [[resultFont fontDescriptor] objectForKey:UIFontDescriptorTraitsAttribute];
+
+  XCTAssertEqual(fontTraits, resultTraits);
+}
+
+- (void)testTitleFontPropertyWithAllowAnyTitleFontSizeEnabled {
+  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
+  navBar.frame = CGRectMake(0, 0, 300, 25);
+  navBar.title = @"this is a Title";
+  navBar.titleAlignment = MDCNavigationBarTitleAlignmentCenter;
+  navBar.allowAnyTitleFontSize = YES;
   [navBar layoutIfNeeded];
 
   XCTAssertNotNil(navBar.titleFont);


### PR DESCRIPTION
This new flag allows a client to remove the 20pt font size restriction on MDCNavigationBar. This restriction was somewhat arbitrary and could cause problems with accessibility for certain font families.

Prior to this change, any font set on MDCNavigationBar would be restricted to 20pt size.

After this change, if the allowAnyTitleFontSize property is enabled on an MDCNavigationBar instance, then the font will be used directly and no sizes will be enforced.

This is required to support internal needs to set a navigation bar title font size of 18.