### PR TITLE
[ButtonBar] Remove unnecessary ColorThemer dependency on NavigationBar.

### DIFF
--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -43,7 +43,6 @@ mdc_objc_library(
     ],
     deps = [
         ":ButtonBar",
-        "//components/NavigationBar",
         "//components/Themes",
     ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Closes https://github.com/material-components/material-components-ios/issues/3967