### PR TITLE
Introduce an Alpha program for MDC components.

### DIFF
--- a/MaterialComponentsAlpha.podspec
+++ b/MaterialComponentsAlpha.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |mdc|
+  mdc.name         = "MaterialComponentsAlpha"
+  mdc.version      = "60.2.0"
+  mdc.authors      = "The Material Components authors."
+  mdc.summary      = "A collection of stand-alone alpha UI libraries that are not yet guaranteed to be ready for general production use. Use with caution."
+  mdc.homepage     = "https://github.com/material-components/material-components-ios"
+  mdc.license      = "Apache 2.0"
+  mdc.source       = { :git => "https://github.com/material-components/material-components-ios.git", :tag => "v#{mdc.version}" }
+  mdc.platform     = :ios
+  mdc.requires_arc = true
+  mdc.ios.deployment_target = '8.0'
+
+  # See MaterialComponents.podspec for the subspec structure and template.
+
+  mdc.subspec "private" do |private_spec|
+    # CocoaPods requires at least one file to show up in a subspec, so we depend on the fake
+    # "Alpha" component as a baseline.
+    private_spec.subspec "Alpha" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/private/#{component.base_name}/src/*.h"
+      component.source_files = "components/private/#{component.base_name}/src/*.{h,m}"
+    end
+  end
+
+end

--- a/catalog/Podfile
+++ b/catalog/Podfile
@@ -6,6 +6,7 @@ target "MDCCatalog" do
   project 'MDCCatalog.xcodeproj'
   pod 'MaterialComponentsExamples', :path => '../'
   pod 'MaterialComponents', :path => '../'
+  pod 'MaterialComponentsAlpha', :path => '../'
   pod 'CatalogByConvention', "~> 2.5"
   pod 'MaterialCatalog', :path => 'MaterialCatalog/'
 
@@ -17,6 +18,7 @@ target "MDCUnitTests" do
   project 'MDCUnitTests.xcodeproj'
   pod 'MaterialComponentsUnitTests', :path => '../'
   pod 'MaterialComponents', :path => '../'
+  pod 'MaterialComponentsAlpha', :path => '../'
   pod 'CatalogByConvention', "~> 2.5"
   pod 'MaterialCatalog', :path => 'MaterialCatalog/'
 
@@ -28,6 +30,7 @@ target "MDCActionExtension" do
   project 'MDCCatalog.xcodeproj'
   pod 'MaterialComponentsExamples', :path => '../'
   pod 'MaterialComponents', :path => '../'
+  pod 'MaterialComponentsAlpha', :path => '../'
   pod 'CatalogByConvention', "~> 2.5"
   pod 'MaterialCatalog', :path => 'MaterialCatalog/'
 
@@ -39,6 +42,7 @@ target "MDCDragons" do
   project 'MDCDragons.xcodeproj'
   pod 'CatalogByConvention', "~> 2.5"
   pod 'MaterialComponents', :path => '../'
+  pod 'MaterialComponentsAlpha', :path => '../'
   pod 'MaterialComponentsExamples', :path => '../'
   use_frameworks!
 end

--- a/components/private/Alpha/src/MaterialAlphaComponent.h
+++ b/components/private/Alpha/src/MaterialAlphaComponent.h
@@ -1,0 +1,18 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+// This header's sole purpose is to provide a single file for the MaterialComponentsAlpha
+// podspec to pick up, in the event that we have no components presently in an Alpha state.

--- a/contributing/alpha_components.md
+++ b/contributing/alpha_components.md
@@ -1,0 +1,23 @@
+# Alpha program for components
+
+The intent of the Alpha program is to provide a place for component code to land that may not be
+fully ready for production, but for which we still want active collaboration with the team and
+potentially some early adoption with select clients.
+
+Any new component that we implement will first land in the `MaterialComponentsAlpha.podspec` as a
+subspec, similar to how components are defined in the `MaterialComponents.podspec`.
+
+Alpha components will appear in MDCCatalog and MDCDragons along with all of their examples and unit
+tests after a pod install. From the point of view of our catalogs, these components are just like
+any other.
+
+From the point of view of the public, Alpha components are not made available as part of our
+published pod. External clients that wish to use an Alpha component in their app will need to
+manually clone the repo and add the code to their project. This is by design.
+
+Alpha components are not subject to our deprecation policy and we will not provide behavioral flags
+for gradual migration of runtime behaviors.
+
+Once a component is ready for general production use, we will graduate the component to the
+`MaterialComponents.podspec`. At this point the component will be subject to all of the processes
+and expectations that any other production component.

--- a/contributing/alpha_components.md
+++ b/contributing/alpha_components.md
@@ -18,6 +18,8 @@ manually clone the repo and add the code to their project. This is by design.
 Alpha components are not subject to our deprecation policy and we will not provide behavioral flags
 for gradual migration of runtime behaviors.
 
+Changes to Alpha components will have **no** effect on our release version numbers.
+
 Once a component is ready for general production use, we will graduate the component to the
 `MaterialComponents.podspec`. At this point the component will be subject to all of the processes
 and expectations that any other production component.


### PR DESCRIPTION
The intent of the Alpha program is to provide a place for component code to land that may not be fully ready for production, but for which we still want active collaboration with the team and potentially some early adoption with select clients.

Any new component that we implement will first land in the MaterialComponentsAlpha.podspec as a subspec, similar to how components are defined in the MaterialComponents.podspec.

Alpha components will appear in MDCCatalog and MDCDragons along with all of their examples and unit tests after a `pod install`. From the point of view of our catalogs, these components are just like any other.

From the point of view of the public, Alpha components are not made available as part of our published pod. External clients that wish to use an Alpha component in their app will need to manually clone the repo and add the code to their project. This is by design.

Alpha components are not subject to our deprecation policy and we will not provide behavioral flags for gradual migration of runtime behaviors.

Changes to Alpha components will have **no** effect on our release version numbers.

Once a component is ready for general production use, we will graduate the component to the MaterialComponents.podspec. At this point the component will be subject to all of the processes and expectations that any other production component.