### PR TITLE
Add the Alpha pod as a dependency to the Examples podspec

### DIFF
--- a/MaterialComponentsExamples.podspec
+++ b/MaterialComponentsExamples.podspec
@@ -12,5 +12,6 @@ Pod::Spec.new do |s|
   s.source_files = 'components/*/examples/*.{h,m,swift}', 'components/*/examples/supplemental/*.{h,m,swift}', 'components/private/*/examples/*.{h,m,swift}', 'components/schemes/*/examples/*.{h,m,swift}', 'components/schemes/*/examples/supplemental/*.{h,m,swift}'
   s.resources = ['components/*/examples/resources/*', 'components/private/*/examples/resources/*', 'components/schemes/*/examples/resources/*']
   s.dependency 'MaterialComponents'
+  s.dependency 'MaterialComponentsAlpha'
   s.public_header_files = 'components/*/examples/*.h', 'components/*/examples/supplemental/*.h', 'components/private/*/examples/*.h', 'components/schemes/*/examples/*.h'
 end


### PR DESCRIPTION
Add the Alpha pod as a dependency to the Examples podspec, or otherwise the examples wouldn't be able to rely on alpha components.