### PR TITLE
[Contributing] Update Alpha doc

### DIFF
--- a/contributing/alpha_components.md
+++ b/contributing/alpha_components.md
@@ -24,4 +24,4 @@ Once a component is ready for general production use, we will graduate the compo
 `MaterialComponents.podspec`. At this point the component will be subject to all of the processes
 and expectations that any other production component.
 
-All of your Swift example or test files must import `MaterialComponentsAlpha.$ComponentName`.
+All of your Swift example or test files must import `MaterialComponentsAlpha.ComponentName`.

--- a/contributing/alpha_components.md
+++ b/contributing/alpha_components.md
@@ -23,3 +23,5 @@ Changes to Alpha components will have **no** effect on our release version numbe
 Once a component is ready for general production use, we will graduate the component to the
 `MaterialComponents.podspec`. At this point the component will be subject to all of the processes
 and expectations that any other production component.
+
+All of your Swift example or test files must import `MaterialComponentsAlpha.$ComponentName`.


### PR DESCRIPTION
Update alpha_components.md so that future contributors don't get stuck on imports. The import statements can't follow the standard convention if they are in the MaterialComponentsAlpha phase then a component will need to import `MaterialComponentsAlpha` instead of `MaterialComponents`.