### PR TITLE
[Ink] Fix demo being clipped by safe area issue (#384)

### DIFF
--- a/components/Ink/examples/InkTypicalUse.m
+++ b/components/Ink/examples/InkTypicalUse.m
@@ -32,6 +32,10 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
+  UIView *containerView = [[UIView alloc] initWithFrame:self.view.frame];
+  [self.view addSubview:containerView];
+  self.containerView = containerView;
+
   UIColor *blueColor = MDCPalette.bluePalette.tint500;
   CGFloat spacing = 16;
   CGRect customFrame = CGRectMake(0, 0, 200, 200);
@@ -54,7 +58,7 @@
     [inkTouchController addInkView];
     [_inkTouchControllers addObject:inkTouchController];
   }
-  [self.view addSubview:self.shapes];
+  [containerView addSubview:self.shapes];
 
   MDCInkTouchController *inkTouchController =
       [[MDCInkTouchController alloc] initWithView:self.legacyShape];
@@ -62,7 +66,7 @@
   inkTouchController.defaultInkView.inkColor = blueColor;
   [inkTouchController addInkView];
   [_inkTouchControllers addObject:inkTouchController];
-  [self.view addSubview:self.legacyShape];
+  [containerView addSubview:self.legacyShape];
 }
 
 #pragma mark - Private

--- a/components/Ink/examples/supplemental/InkTypicalUseSupplemental.h
+++ b/components/Ink/examples/supplemental/InkTypicalUseSupplemental.h
@@ -31,6 +31,7 @@
 
 @property(nonatomic, strong) ExampleShapes *shapes;
 @property(nonatomic, strong) UIView *legacyShape;
+@property(nonatomic, weak) UIView *containerView;
 
 @end
 

--- a/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
+++ b/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
@@ -130,19 +130,36 @@
 }
 
 - (void)viewWillLayoutSubviews {
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 11.0, *)) {
+    UIEdgeInsets safeAreaInsets = self.view.safeAreaInsets;
+    self.containerView.frame = CGRectMake(safeAreaInsets.left,
+                                          safeAreaInsets.top,
+                                          CGRectGetWidth(self.view.frame) - safeAreaInsets.left - safeAreaInsets.right,
+                                          CGRectGetHeight(self.view.frame) - safeAreaInsets.top - safeAreaInsets.bottom);
+  } else {
+#endif
+    self.containerView.frame = CGRectMake(0,
+                                          self.topLayoutGuide.length,
+                                          CGRectGetWidth(self.view.frame),
+                                          CGRectGetHeight(self.view.frame) - self.topLayoutGuide.length);
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  }
+#endif
+
   CGFloat offset = 8;
   CGFloat shapeDimension = 200;
   CGFloat spacing = 16;
-  if (CGRectGetHeight(self.view.frame) > CGRectGetWidth(self.view.frame)) {
+  if (CGRectGetHeight(self.containerView.frame) > CGRectGetWidth(self.containerView.frame)) {
     self.shapes.center =
-        CGPointMake(self.view.center.x, self.view.center.y - shapeDimension - offset);
+        CGPointMake(self.containerView.center.x, self.containerView.center.y - shapeDimension - offset);
     self.legacyShape.center =
-        CGPointMake(self.view.center.x, self.view.center.y + spacing * 2 + offset);
+        CGPointMake(self.containerView.center.x, self.containerView.center.y + spacing * 2 + offset);
   } else {
-    self.shapes.center = CGPointMake(self.view.center.x - shapeDimension / 2 - spacing * 2,
-                                     self.view.center.y / 2 + spacing * 2);
-    self.legacyShape.center = CGPointMake(self.view.center.x + shapeDimension / 2 + spacing * 2,
-                                          self.view.center.y / 2 + spacing * 2);
+    self.shapes.center = CGPointMake(self.containerView.center.x - shapeDimension / 2 - spacing * 2,
+                                     self.containerView.center.y / 2 + spacing * 2);
+    self.legacyShape.center = CGPointMake(self.containerView.center.x + shapeDimension / 2 + spacing * 2,
+                                          self.containerView.center.y / 2 + spacing * 2);
   }
 }
 

--- a/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
+++ b/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
@@ -130,7 +130,6 @@
 }
 
 - (void)viewWillLayoutSubviews {
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     UIEdgeInsets safeAreaInsets = self.view.safeAreaInsets;
     self.containerView.frame = CGRectMake(safeAreaInsets.left,
@@ -138,14 +137,11 @@
                                           CGRectGetWidth(self.view.frame) - safeAreaInsets.left - safeAreaInsets.right,
                                           CGRectGetHeight(self.view.frame) - safeAreaInsets.top - safeAreaInsets.bottom);
   } else {
-#endif
     self.containerView.frame = CGRectMake(0,
                                           self.topLayoutGuide.length,
                                           CGRectGetWidth(self.view.frame),
                                           CGRectGetHeight(self.view.frame) - self.topLayoutGuide.length);
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   }
-#endif
 
   CGFloat offset = 8;
   CGFloat shapeDimension = 200;


### PR DESCRIPTION
closes #384.

Changes:
Add a container subview to make the layout easier and aware of the safeArea.

Before:
![simulator screen shot - iphone 5 - 2018-08-27 at 12 14 13](https://user-images.githubusercontent.com/8836258/44671175-c8bfe880-a9f2-11e8-863e-d5f7eda14ddd.png)
![simulator screen shot - iphone 5 - 2018-08-27 at 12 14 15](https://user-images.githubusercontent.com/8836258/44671176-c8bfe880-a9f2-11e8-81db-0b1c173d75e8.png)

After:
![simulator screen shot - iphone 5 - 2018-08-27 at 12 07 07](https://user-images.githubusercontent.com/8836258/44671179-cd849c80-a9f2-11e8-8bfe-51ed60de3913.png)
![simulator screen shot - iphone 5 - 2018-08-27 at 12 07 08](https://user-images.githubusercontent.com/8836258/44671180-cd849c80-a9f2-11e8-9ceb-7590218e9d65.png)
