### PR TITLE
Remove all __IPHONE_11_0 checks now that we no longer support Xcode 8.

### DIFF
--- a/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
+++ b/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
@@ -59,13 +59,11 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
   self.scrollView.clipsToBounds = YES;
   [self.view addSubview:self.scrollView];
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     // No need to do anything - additionalSafeAreaInsets will inset our content.
     self.scrollView.autoresizingMask =
         UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   } else {
-#endif
     self.scrollView.translatesAutoresizingMaskIntoConstraints = NO;
     [NSLayoutConstraint activateConstraints:
      @[[NSLayoutConstraint constraintWithItem:self.scrollView
@@ -97,9 +95,7 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
                                    multiplier:1.0
                                      constant:0]
        ]];
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   }
-#endif
 
   CGFloat lineSpace = (CGRectGetHeight(self.view.frame) - 50.f) / 5.f;
   UILabel *linearLabel = [AnimationTimingExample curveLabelWithTitle:@"Linear"];

--- a/components/AppBar/examples/AppBarPresentedExample.m
+++ b/components/AppBar/examples/AppBarPresentedExample.m
@@ -197,11 +197,9 @@
 
 - (void)presentDemoPopover {
   CGRect rect = CGRectMake(self.view.bounds.size.width / 2, self.topLayoutGuide.length, 1, 1);
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     rect = CGRectMake(self.view.bounds.size.width / 2, self.view.safeAreaInsets.top, 1, 1);
   }
-#endif
   
   self.demoViewController.modalPresentationStyle = UIModalPresentationPopover;
   self.demoViewController.popoverPresentationController.sourceView = self.view;

--- a/components/AppBar/examples/AppBarWKWebViewLargeContentExample.m
+++ b/components/AppBar/examples/AppBarWKWebViewLargeContentExample.m
@@ -84,12 +84,10 @@
   [content addObject:@"</body></html>"];
   [webView loadHTMLString:[content componentsJoinedByString:@"\n"] baseURL:nil];
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     // No need to do anything - additionalSafeAreaInsets will inset our content.
     webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
   } else {
-#endif
   webView.translatesAutoresizingMaskIntoConstraints = NO;
   [NSLayoutConstraint activateConstraints:
    @[[NSLayoutConstraint constraintWithItem:webView
@@ -121,9 +119,7 @@
                                  multiplier:1.0
                                    constant:0]
      ]];
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   }
-#endif
   self.appBar.headerViewController.headerView.trackingScrollView = webView.scrollView;
   [self.appBar addSubviewsToParent];
 }

--- a/components/AppBar/examples/AppBarWKWebViewSmallContentExample.m
+++ b/components/AppBar/examples/AppBarWKWebViewSmallContentExample.m
@@ -77,12 +77,10 @@
 
   [webView loadHTMLString:@"<html>\n<head></head><body>Hi</body></html>" baseURL:nil];
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     // No need to do anything - additionalSafeAreaInsets will inset our content.
     webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
   } else {
-#endif
   // Fixes the WKWebView contentSize.height bug pre-iOS 11.
   webView.translatesAutoresizingMaskIntoConstraints = NO;
   [NSLayoutConstraint activateConstraints:
@@ -115,9 +113,7 @@
                                  multiplier:1.0
                                    constant:0]
      ]];
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   }
-#endif
 
   self.appBar.headerViewController.headerView.trackingScrollView = webView.scrollView;
   [self.appBar addSubviewsToParent];

--- a/components/AppBar/src/MDCAppBarViewController.m
+++ b/components/AppBar/src/MDCAppBarViewController.m
@@ -237,13 +237,11 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     // We only update the top inset on iOS 11 because previously we were not adjusting the header
     // height to make it smaller when the status bar is hidden.
     _verticalConstraint.constant = MDCDeviceTopSafeAreaInset();
   }
-#endif
 }
 
 - (void)didMoveToParentViewController:(UIViewController *)parent {

--- a/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseViewController.m
+++ b/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseViewController.m
@@ -49,14 +49,12 @@
   [self layoutBottomAppBar];
 }
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
 - (void)viewSafeAreaInsetsDidChange {
   if (@available(iOS 11.0, *)) {
     [super viewSafeAreaInsetsDidChange];
   }
   [self layoutBottomAppBar];
 }
-#endif
 
 #pragma mark - Setters
 

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -250,13 +250,11 @@ static const int kMDCButtonAnimationDuration = 200;
 
 - (UIEdgeInsets)mdc_safeAreaInsets {
   UIEdgeInsets insets = UIEdgeInsetsZero;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
 
     // Accommodate insets for iPhone X.
     insets = self.safeAreaInsets;
   }
-#endif
   return insets;
 }
 

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -119,14 +119,12 @@
   [self layoutBottomNavBar];
 }
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
 - (void)viewSafeAreaInsetsDidChange {
   if (@available(iOS 11.0, *)) {
     [super viewSafeAreaInsetsDidChange];
   }
   [self layoutBottomNavBar];
 }
-#endif
 
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -315,12 +315,10 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
 
 - (UIEdgeInsets)mdc_safeAreaInsets {
   UIEdgeInsets insets = UIEdgeInsetsZero;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     // Accommodate insets for iPhone X.
     insets = self.safeAreaInsets;
   }
-#endif
   return insets;
 }
 

--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -104,11 +104,9 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
 
     // Since we handle the SafeAreaInsets ourselves through the contentInset property, we disable
     // the adjustment behavior to prevent accounting for it twice.
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
     if (@available(iOS 11.0, *)) {
       scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
     }
-#endif
   }
   return self;
 }
@@ -155,7 +153,6 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
 }
 
 - (void)safeAreaInsetsDidChange {
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [super safeAreaInsetsDidChange];
 
@@ -170,7 +167,6 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
                                       CGRectGetHeight(self.frame) - self.safeAreaInsets.top);
     self.sheet.scrollView.frame = scrollViewFrame;
   }
-#endif
 }
 
 #pragma mark - KVO
@@ -204,11 +200,9 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
   self.originalPreferredSheetHeight = preferredSheetHeight;
 
   CGFloat adjustedPreferredSheetHeight = self.originalPreferredSheetHeight;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     adjustedPreferredSheetHeight += self.safeAreaInsets.bottom;
   }
-#endif
 
   if (_preferredSheetHeight == adjustedPreferredSheetHeight) {
     return;
@@ -263,11 +257,9 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
 // Returns the maximum allowable height that the sheet can be dragged to.
 - (CGFloat)maximumSheetHeight {
   CGFloat boundsHeight = CGRectGetHeight(self.bounds);
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     boundsHeight -= self.safeAreaInsets.top;
   }
-#endif
   CGFloat scrollViewContentHeight = self.sheet.scrollView.contentInset.top +
       self.sheet.scrollView.contentSize.height + self.sheet.scrollView.contentInset.bottom;
 

--- a/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
+++ b/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
@@ -98,7 +98,6 @@ static const CGFloat kViewOffsetToCenter = 20.0f;
     preiOS11Behavior();
   }
 
-
   return contentBounds;
 }
 

--- a/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
+++ b/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
@@ -91,16 +91,13 @@ static const CGFloat kViewOffsetToCenter = 20.0f;
                  self.topLayoutGuide.length,
                  CGRectMinYEdge);
   };
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
       UIEdgeInsets safeAreaInsets = self.view.safeAreaInsets;
       contentBounds = UIEdgeInsetsInsetRect(bounds, safeAreaInsets);
   } else {
     preiOS11Behavior();
   }
-#else
-  preiOS11Behavior();
-#endif
+
 
   return contentBounds;
 }

--- a/components/Chips/examples/ChipsTypicalUseViewController.m
+++ b/components/Chips/examples/ChipsTypicalUseViewController.m
@@ -48,11 +48,9 @@
   [MDCChipViewTypographyThemer applyTypographyScheme:self.typographyScheme
                                           toChipView:_sizingChip];
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
   }
-#endif
 
   self.collectionView.backgroundColor = [UIColor whiteColor];
   self.collectionView.delaysContentTouches = NO;

--- a/components/Collections/examples/CollectionsALaCarteExample.m
+++ b/components/Collections/examples/CollectionsALaCarteExample.m
@@ -60,11 +60,9 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
                                                  collectionViewLayout:self.collectionViewLayout];
   self.collectionView = _customCollectionView;
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     _customCollectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
   }
-#endif
 
   // Register cell class.
   [self.collectionView registerClass:[MDCCollectionViewTextCell class]

--- a/components/Collections/src/MDCCollectionViewController.m
+++ b/components/Collections/src/MDCCollectionViewController.m
@@ -85,11 +85,9 @@ NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFoote
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
   }
-#endif
 
   [self.collectionView setCollectionViewLayout:self.collectionViewLayout];
   self.collectionView.backgroundColor = [UIColor whiteColor];
@@ -124,14 +122,12 @@ NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFoote
   // scroll view indicator (with a zPosition of 0) would be placed behind supplementary views.
   // We know that iOS keeps the scroll indicator as the top-most view in the hierarchy as a subview,
   // so we grab it and give it a better zPosition ourselves.
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     UIView *maybeScrollViewIndicator = self.collectionView.subviews.lastObject;
     if ([maybeScrollViewIndicator isKindOfClass:[UIImageView class]]) {
       maybeScrollViewIndicator.layer.zPosition = 2;
     }
   }
-#endif
 }
 
 - (void)setCollectionView:(__kindof UICollectionView *)collectionView {
@@ -239,11 +235,9 @@ NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFoote
                     collectionView:(UICollectionView *)collectionView {
   UIEdgeInsets contentInset = collectionView.contentInset;
 // On the iPhone X, we need to use the offset which might take into account the safe area.
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     contentInset = collectionView.adjustedContentInset;
   }
-#endif
 
   CGFloat bounds = CGRectGetWidth(UIEdgeInsetsInsetRect(collectionView.bounds, contentInset));
   UIEdgeInsets sectionInsets = [self collectionView:collectionView
@@ -272,7 +266,6 @@ NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFoote
   if (isCardStyle) {
     insets.left = inset;
     insets.right = inset;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
     if (@available(iOS 11.0, *)) {
       if (collectionView.contentInsetAdjustmentBehavior
           == UIScrollViewContentInsetAdjustmentAlways) {
@@ -281,7 +274,6 @@ NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFoote
         insets.right = MAX(0, insets.right - collectionView.safeAreaInsets.right);
       }
     }
-#endif
   }
   // Set top/bottom insets.
   if (isCardStyle || isGroupedStyle) {
@@ -352,11 +344,9 @@ NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFoote
 - (CGFloat)cellWidthAtSectionIndex:(NSInteger)section {
   UIEdgeInsets contentInset = self.collectionView.contentInset;
   // On the iPhone X, we need to use the offset which might take into account the safe area.
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     contentInset = self.collectionView.adjustedContentInset;
   }
-#endif
   CGFloat bounds = CGRectGetWidth(
       UIEdgeInsetsInsetRect(self.collectionView.bounds, contentInset));
   UIEdgeInsets sectionInsets = [self collectionView:self.collectionView

--- a/components/Collections/src/MDCCollectionViewFlowLayout.m
+++ b/components/Collections/src/MDCCollectionViewFlowLayout.m
@@ -182,21 +182,17 @@ static const NSInteger kSupplementaryViewZIndex = 99;
       attr.size = CGSizeMake(CGRectGetWidth(currentBounds), MDCCollectionInfoBarHeaderHeight);
       // Allow header to move upwards with scroll, but prevent from moving downwards with scroll.
       CGFloat insetTop = self.collectionView.contentInset.top;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
       if (@available(iOS 11.0, *)) {
         insetTop = self.collectionView.adjustedContentInset.top;
       }
-#endif
       CGFloat boundsY = currentBounds.origin.y;
       CGFloat maxOffsetY = MAX(boundsY + insetTop, 0);
       offsetY = boundsY + (attr.size.height / 2) + insetTop - maxOffsetY;
     } else if ([kind isEqualToString:MDCCollectionInfoBarKindFooter]) {
       CGFloat height = MDCCollectionInfoBarFooterHeight;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
       if (@available(iOS 11.0, *)) {
         height += self.collectionView.safeAreaInsets.bottom;
       }
-#endif
       attr.size = CGSizeMake(CGRectGetWidth(currentBounds), height);
       offsetY = currentBounds.origin.y + currentBounds.size.height - (attr.size.height / 2);
     }

--- a/components/Collections/src/private/MDCCollectionInfoBarView.m
+++ b/components/Collections/src/private/MDCCollectionInfoBarView.m
@@ -91,13 +91,11 @@ static inline UIColor *CollectionInfoBarRedColor(void) {
   [super layoutSubviews];
 
   UIEdgeInsets collectionViewSafeAreaInsets = UIEdgeInsetsZero;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
     if (@available(iOS 11.0, *)) {
       if (self.superview) {
         collectionViewSafeAreaInsets = self.superview.safeAreaInsets;
       }
     }
-#endif
   CGFloat leftInset = MAX(MDCCollectionInfoBarLabelHorizontalPadding,
                           collectionViewSafeAreaInsets.left);
   CGFloat rightInset = MAX(MDCCollectionInfoBarLabelHorizontalPadding,

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -91,11 +91,9 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
 
   // For pre iOS 11 devices, we are assuming a safeAreaInset of UIEdgeInsetsZero
   UIEdgeInsets containerSafeAreaInsets = UIEdgeInsetsZero;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     containerSafeAreaInsets = self.containerView.safeAreaInsets;
   }
-#endif
 
   // Take the larger of the Safe Area insets and the Material specified insets.
   containerSafeAreaInsets.top = MAX(containerSafeAreaInsets.top, MDCDialogEdgeInsets.top);

--- a/components/FlexibleHeader/examples/FlexibleHeaderHorizontalPagingExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderHorizontalPagingExample.m
@@ -40,11 +40,9 @@ static const NSUInteger kNumberOfPages = 10;
   _pagingScrollView = [[UIScrollView alloc] initWithFrame:self.view.bounds];
   _pagingScrollView.pagingEnabled = YES;
   _pagingScrollView.delegate = self;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     _pagingScrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
   }
-#endif
   _pagingScrollView.autoresizingMask =
       (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
   _pagingScrollView.scrollsToTop = NO;

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -393,7 +393,6 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
     } else {
       self.topSafeAreaInset = viewController.topLayoutGuide.length;
     }
-
   }
 }
 
@@ -621,7 +620,6 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
     existingContentInsetAdjustment = (scrollView.adjustedContentInset.top
                                       - scrollView.contentInset.top);
   }
-
 
   return existingContentInsetAdjustment;
 }

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -388,15 +388,12 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   if (![viewController isViewLoaded]) {
     self.topSafeAreaInset = 0;
   } else {
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
     if (@available(iOS 11.0, *)) {
       self.topSafeAreaInset = viewController.view.safeAreaInsets.top;
     } else {
       self.topSafeAreaInset = viewController.topLayoutGuide.length;
     }
-#else
-    self.topSafeAreaInset = viewController.topLayoutGuide.length;
-#endif
+
   }
 }
 
@@ -436,7 +433,6 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 }
 
 - (void)safeAreaInsetsDidChange {
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [super safeAreaInsetsDidChange];
 
@@ -448,7 +444,6 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
       [self fhv_topSafeAreaInsetDidChange];
     }
   }
-#endif
 }
 
 #pragma mark - Top Safe Area Inset
@@ -586,11 +581,9 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   // the scroll view's been created, but not in any further runloops.
   if (CGPointEqualToPoint(offsetPriorToInsetAdjustment, _trackingScrollView.contentOffset)) {
     CGFloat scrollViewAdjustedContentInsetTop = _trackingScrollView.contentInset.top;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
     if (@available(iOS 11.0, *)) {
       scrollViewAdjustedContentInsetTop = _trackingScrollView.adjustedContentInset.top;
     }
-#endif
     offsetPriorToInsetAdjustment.y = MAX(offsetPriorToInsetAdjustment.y,
                                          -scrollViewAdjustedContentInsetTop);
     [self fhv_setContentOffset:offsetPriorToInsetAdjustment];
@@ -624,14 +617,11 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 - (CGFloat)fhv_existingContentInsetAdjustmentForScrollView:(UIScrollView *)scrollView {
   CGFloat existingContentInsetAdjustment = 0;
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     existingContentInsetAdjustment = (scrollView.adjustedContentInset.top
                                       - scrollView.contentInset.top);
   }
-#else
-  (void)scrollView; // To silence unused variable warnings.
-#endif
+
 
   return existingContentInsetAdjustment;
 }

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -150,7 +150,6 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
   [super willMoveToParentViewController:parent];
 
   BOOL shouldDisableAutomaticInsetting = YES;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   // Prior to iOS 11 there was no way to know whether UIKit had injected insets into our
   // UIScrollView, so we disable automatic insetting on these devices. iOS 11 provides
   // the adjustedContentInset API which allows us to respond to changes in the safe area
@@ -158,7 +157,6 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
   if (@available(iOS 11.0, *)) {
     shouldDisableAutomaticInsetting = NO;
   }
-#endif
   if (shouldDisableAutomaticInsetting) {
     parent.automaticallyAdjustsScrollViewInsets = NO;
   }
@@ -385,11 +383,9 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
    the top layout guide constant (and clients should be relying on additionalSafeAreaInsets anyway).
    */
   BOOL shouldObserveLayoutGuideConstant = YES;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     shouldObserveLayoutGuideConstant = NO;
   }
-#endif
 
   if (shouldObserveLayoutGuideConstant) {
     [_topLayoutGuideConstraint removeObserver:self
@@ -488,7 +484,6 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
     [self fhv_setTopLayoutGuideConstraintConstant:topInset];
   }
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     BOOL alwaysUseAdditionalSafeAreaInsets = NO;
     if (self.useAdditionalSafeAreaInsetsForWebKitScrollViews
@@ -524,7 +519,6 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
       topLayoutGuideViewController.additionalSafeAreaInsets = additionalSafeAreaInsets;
     }
   }
-#endif
 }
 
 - (CGFloat)headerViewControllerHeight {
@@ -637,11 +631,9 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
     _headerView.topSafeAreaSourceViewController = ancestor;
 
     BOOL shouldObserveLayoutGuide = YES;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
     if (@available(iOS 11.0, *)) {
       shouldObserveLayoutGuide = NO;
     }
-#endif
     if (shouldObserveLayoutGuide) {
       self.topSafeAreaConstraint = [self fhv_topLayoutGuideConstraintForViewController:ancestor];
     } else {

--- a/components/List/examples/CollectionListCellExampleTypicalUse.m
+++ b/components/List/examples/CollectionListCellExampleTypicalUse.m
@@ -58,11 +58,9 @@ static const CGFloat kSmallArbitraryCellWidth = 100.f;
   self.collectionView.alwaysBounceVertical = YES;
   self.automaticallyAdjustsScrollViewInsets = NO;
   self.parentViewController.automaticallyAdjustsScrollViewInsets = NO;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
   }
-#endif
   // Register cell class.
   [self.collectionView registerClass:[CollectionViewListCell class]
           forCellWithReuseIdentifier:kReusableIdentifierItem];
@@ -136,12 +134,10 @@ static const CGFloat kSmallArbitraryCellWidth = 100.f;
   [cell applyTypographyScheme:_typographyScheme];
   cell.mdc_adjustsFontForContentSizeCategory = YES;
   CGFloat cellWidth = CGRectGetWidth(collectionView.bounds);
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     cellWidth -=
         (collectionView.adjustedContentInset.left + collectionView.adjustedContentInset.right);
   }
-#endif
   [cell setCellWidth:cellWidth];
   cell.titleLabel.text = _content[indexPath.item][0];
   cell.titleLabel.textAlignment = [_content[indexPath.item][1] integerValue];

--- a/components/List/examples/MDCBaseCellExample.m
+++ b/components/List/examples/MDCBaseCellExample.m
@@ -51,14 +51,12 @@
   CGFloat originY = self.view.bounds.origin.y;
   CGFloat width = self.view.bounds.size.width;
   CGFloat height = self.view.bounds.size.height;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     originX += self.view.safeAreaInsets.left;
     originY += self.view.safeAreaInsets.top;
     width -= (self.view.safeAreaInsets.left + self.view.safeAreaInsets.right);
     height -= (self.view.safeAreaInsets.top + self.view.safeAreaInsets.bottom);
   }
-#endif
   CGRect frame = CGRectMake(originX, originY, width, height);
   self.collectionView.frame = frame;
   self.collectionViewLayout.estimatedItemSize =

--- a/components/NavigationBar/examples/NavigationBarIconsExample.m
+++ b/components/NavigationBar/examples/NavigationBarIconsExample.m
@@ -89,11 +89,9 @@
   self.navigationItem.rightBarButtonItem = trailingButtonItem;
   self.navigationItem.backBarButtonItem = backButtonItem;
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [self.view.safeAreaLayoutGuide.topAnchor constraintEqualToAnchor:self.navigationBar.topAnchor].active = YES;
   } else {
-#endif
     [NSLayoutConstraint constraintWithItem:self.topLayoutGuide
                                  attribute:NSLayoutAttributeBottom
                                  relatedBy:NSLayoutRelationEqual
@@ -101,9 +99,7 @@
                                  attribute:NSLayoutAttributeTop
                                 multiplier:1.0
                                   constant:0].active = YES;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   }
-#endif
   NSDictionary *viewsBindings = NSDictionaryOfVariableBindings(_navigationBar);
 
   [NSLayoutConstraint

--- a/components/NavigationBar/examples/NavigationBarLayoutExample.m
+++ b/components/NavigationBar/examples/NavigationBarLayoutExample.m
@@ -98,11 +98,9 @@
   [self.view addSubview:self.trailingItemField];
   [self.view addSubview:self.titleField];
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [self.view.safeAreaLayoutGuide.topAnchor constraintEqualToAnchor:self.navigationBar.topAnchor].active = YES;
   } else {
-#endif
     [NSLayoutConstraint constraintWithItem:self.topLayoutGuide
                                  attribute:NSLayoutAttributeBottom
                                  relatedBy:NSLayoutRelationEqual
@@ -110,9 +108,7 @@
                                  attribute:NSLayoutAttributeTop
                                 multiplier:1.0
                                   constant:0].active = YES;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   }
-#endif
   [NSLayoutConstraint constraintWithItem:self.navigationBar
                                attribute:NSLayoutAttributeBottom
                                relatedBy:NSLayoutRelationEqual

--- a/components/NavigationBar/examples/NavigationBarRTLIcons.m
+++ b/components/NavigationBar/examples/NavigationBarRTLIcons.m
@@ -76,11 +76,9 @@
   self.navigationBar.tintColor = UIColor.whiteColor;
   self.navigationItem.rightBarButtonItems = @[ infoButtonItem, reorderButtonItem, checkCircleButtonItem];
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [self.view.safeAreaLayoutGuide.topAnchor constraintEqualToAnchor:self.navigationBar.topAnchor].active = YES;
   } else {
-#endif
     [NSLayoutConstraint constraintWithItem:self.topLayoutGuide
                                  attribute:NSLayoutAttributeBottom
                                  relatedBy:NSLayoutRelationEqual
@@ -88,9 +86,7 @@
                                  attribute:NSLayoutAttributeTop
                                 multiplier:1.0
                                   constant:0].active = YES;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   }
-#endif
   NSDictionary *viewsBindings = NSDictionaryOfVariableBindings(_navigationBar);
 
   [NSLayoutConstraint

--- a/components/NavigationBar/examples/NavigationBarTypicalUseExample.m
+++ b/components/NavigationBar/examples/NavigationBarTypicalUseExample.m
@@ -54,11 +54,9 @@
 
   self.navBar.translatesAutoresizingMaskIntoConstraints = NO;
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [self.view.safeAreaLayoutGuide.topAnchor constraintEqualToAnchor:self.navBar.topAnchor].active = YES;
   } else {
-#endif
     [NSLayoutConstraint constraintWithItem:self.topLayoutGuide
                                  attribute:NSLayoutAttributeBottom
                                  relatedBy:NSLayoutRelationEqual
@@ -66,9 +64,7 @@
                                  attribute:NSLayoutAttributeTop
                                 multiplier:1.0
                                   constant:0].active = YES;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   }
-#endif
   
   NSDictionary *viewsBindings = NSDictionaryOfVariableBindings(_navBar);
 

--- a/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
+++ b/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
@@ -64,11 +64,9 @@
 
   self.navBar.translatesAutoresizingMaskIntoConstraints = NO;
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [self.view.safeAreaLayoutGuide.topAnchor constraintEqualToAnchor:self.navBar.topAnchor].active = YES;
   } else {
-#endif
     [NSLayoutConstraint constraintWithItem:self.topLayoutGuide
                                  attribute:NSLayoutAttributeBottom
                                  relatedBy:NSLayoutRelationEqual
@@ -76,9 +74,7 @@
                                  attribute:NSLayoutAttributeTop
                                 multiplier:1.0
                                   constant:0].active = YES;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   }
-#endif
 
   NSDictionary *viewsBindings = @{@"navBar": self.navBar};
 

--- a/components/NavigationBar/examples/NavigationbarWithCustomFont.m
+++ b/components/NavigationBar/examples/NavigationbarWithCustomFont.m
@@ -41,11 +41,7 @@
 
   UIFont *font = [UIFont fontWithName:@"Zapfino" size:18.0];
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   NSDictionary<NSAttributedStringKey,id> *titleTextAttributes = @{ NSFontAttributeName : font };
-#else
-  NSDictionary<NSString *,id> *titleTextAttributes = @{ NSFontAttributeName : font };
-#endif
 
   [self.navBar setTitleTextAttributes:titleTextAttributes];
 
@@ -60,11 +56,9 @@
 
   self.navBar.translatesAutoresizingMaskIntoConstraints = NO;
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [self.view.safeAreaLayoutGuide.topAnchor constraintEqualToAnchor:self.navBar.topAnchor].active = YES;
   } else {
-#endif
     [NSLayoutConstraint constraintWithItem:self.topLayoutGuide
                                  attribute:NSLayoutAttributeBottom
                                  relatedBy:NSLayoutRelationEqual
@@ -72,9 +66,7 @@
                                  attribute:NSLayoutAttributeTop
                                 multiplier:1.0
                                   constant:0].active = YES;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   }
-#endif
 
   NSDictionary *viewsBindings = @{@"navBar": self.navBar};
 

--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -289,13 +289,8 @@ IB_DESIGNABLE
 
  Note: this property will be deprecated in future, please use titleFont and titleTextColor instead.
  */
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
 @property(nonatomic, copy, nullable)
     NSDictionary<NSAttributedStringKey, id> *titleTextAttributes UI_APPEARANCE_SELECTOR;
-#else
-@property(nonatomic, copy, nullable)
-    NSDictionary<NSString *, id> *titleTextAttributes UI_APPEARANCE_SELECTOR;
-#endif
 
 #pragma mark - Deprecated
 

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -223,7 +223,6 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
   // For pre iOS 11 devices, it's safe to assume that the Safe Area insets' left and right
   // values are zero. DO NOT use this to get the top or bottom Safe Area insets.
   UIEdgeInsets RTLFriendlySafeAreaInsets = UIEdgeInsetsZero;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     RTLFriendlySafeAreaInsets =
         MDFInsetsMakeWithLayoutDirection(self.safeAreaInsets.top,
@@ -232,7 +231,6 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
                                          self.safeAreaInsets.right,
                                          self.mdf_effectiveUserInterfaceLayoutDirection);
   }
-#endif
 
   CGSize leadingButtonBarSize = [_leadingButtonBar sizeThatFits:self.bounds.size];
   CGRect leadingButtonBarFrame = CGRectMake(RTLFriendlySafeAreaInsets.left,
@@ -261,12 +259,10 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
   CGRect textFrame = UIEdgeInsetsInsetRect(self.bounds, textInsets);
   textFrame.origin.x += _leadingButtonBar.frame.size.width;
   textFrame.size.width -= _leadingButtonBar.frame.size.width + _trailingButtonBar.frame.size.width;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     textFrame.origin.x += self.safeAreaInsets.left;
     textFrame.size.width -= self.safeAreaInsets.left + self.safeAreaInsets.right;
   }
-#endif
 
   // Layout TitleLabel
   NSMutableParagraphStyle *paraStyle = [[NSMutableParagraphStyle alloc] init];
@@ -308,11 +304,9 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
       CGFloat availableWidth = UIEdgeInsetsInsetRect(self.bounds, textInsets).size.width;
       availableWidth -= MAX(_leadingButtonBar.frame.size.width,
                             _trailingButtonBar.frame.size.width) * 2;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
       if (@available(iOS 11.0, *)) {
         availableWidth -= self.safeAreaInsets.left + self.safeAreaInsets.right;
       }
-#endif
       titleViewFrame.size.width = availableWidth;
       titleViewFrame = [self mdc_frameAlignedHorizontally:titleViewFrame
                                                 alignment:MDCNavigationBarTitleAlignmentCenter];

--- a/components/PageControl/examples/PageControlAnimationBlockExample.m
+++ b/components/PageControl/examples/PageControlAnimationBlockExample.m
@@ -128,12 +128,10 @@
   CGRect standardizedFrame = CGRectStandardize(self.view.frame);
   [_pageControl sizeThatFits:standardizedFrame.size];
   UIEdgeInsets edgeInsets = UIEdgeInsetsZero;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     // Accommodate insets for iPhone X.
     edgeInsets = self.view.safeAreaInsets;
   }
-#endif
   CGFloat yOffset =
       CGRectGetHeight(self.view.frame) - CGRectGetHeight(_pageControl.frame) - edgeInsets.bottom;
   _pageControl.frame =

--- a/components/PageControl/examples/PageControlButtonExample.m
+++ b/components/PageControl/examples/PageControlButtonExample.m
@@ -116,12 +116,10 @@
   CGRect standardizedFrame = CGRectStandardize(self.view.frame);
   [_pageControl sizeThatFits:standardizedFrame.size];
   UIEdgeInsets edgeInsets = UIEdgeInsetsZero;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     // Accommodate insets for iPhone X.
     edgeInsets = self.view.safeAreaInsets;
   }
-#endif
   CGFloat yOffset =
       CGRectGetHeight(self.view.frame) - CGRectGetHeight(_pageControl.frame) - edgeInsets.bottom;
   _pageControl.frame =

--- a/components/PageControl/examples/PageControlTypicalUseExample.m
+++ b/components/PageControl/examples/PageControlTypicalUseExample.m
@@ -103,12 +103,10 @@
 
   // We want the page control to hug the bottom of the screen.
   UIEdgeInsets edgeInsets = UIEdgeInsetsZero;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     // Accommodate insets for iPhone X.
     edgeInsets = self.view.safeAreaInsets;
   }
-#endif
   [_pageControl sizeToFit];
   CGFloat yOffset =
       CGRectGetHeight(self.view.frame) - CGRectGetHeight(_pageControl.frame) - edgeInsets.bottom;

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -943,11 +943,9 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
   if (!self.anchoredToScreenBottom || !MDCSnackbarMessage.usesLegacySnackbar) {
     return 0;
   }
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     return self.window.safeAreaInsets.bottom;
   }
-#endif
   return 0;
 }
 
@@ -956,11 +954,9 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
       MDCSnackbarMessage.usesLegacySnackbar ? kLegacyContentMargin : kContentMargin;
 
   UIEdgeInsets safeAreaInsets = UIEdgeInsetsZero;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     safeAreaInsets = self.window.safeAreaInsets;
   }
-#endif
 
   // We only take the left and right safeAreaInsets in to account because the bottom is
   // handled by contentSafeBottomInset and we will never overlap the top inset.

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -222,11 +222,9 @@ static const CGFloat kMaximumHeight = 80.0f;
   CGFloat keyboardHeight = self.watcher.visibleKeyboardHeight;
   CGFloat userHeight = self.bottomOffset;
   if (!MDCSnackbarMessage.usesLegacySnackbar) {
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
     if (@available(iOS 11.0, *)) {
       userHeight = MAX(userHeight, self.safeAreaInsets.bottom);
     }
-#endif
   }
 
   return MAX(keyboardHeight, userHeight);
@@ -328,7 +326,6 @@ static const CGFloat kMaximumHeight = 80.0f;
                                                       multiplier:1.0
                                                         constant:[snackbarView maximumWidth]]];
       } else {
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
         if (@available(iOS 11.0, *)) {
           if (self.mdf_effectiveUserInterfaceLayoutDirection ==
               UIUserInterfaceLayoutDirectionLeftToRight) {
@@ -339,7 +336,6 @@ static const CGFloat kMaximumHeight = 80.0f;
             rightMargin += self.mdc_safeAreaInsets.left;
           }
         }
-#endif
 
         [container addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
                                                               attribute:NSLayoutAttributeLeading
@@ -437,13 +433,11 @@ static const CGFloat kMaximumHeight = 80.0f;
 - (CGFloat)maximumHeight {
   // Maximum height must be extended to include the bottom content safe area.
   CGFloat maximumHeight = kMaximumHeight;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (self.anchoredToScreenBottom && MDCSnackbarMessage.usesLegacySnackbar) {
     if (@available(iOS 11.0, *)) {
       maximumHeight += self.safeAreaInsets.bottom;
     }
   }
-#endif
   return maximumHeight;
 }
 
@@ -460,12 +454,10 @@ static const CGFloat kMaximumHeight = 80.0f;
 
 - (UIEdgeInsets)mdc_safeAreaInsets {
   UIEdgeInsets insets = UIEdgeInsetsZero;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     // Accommodate insets for iPhone X.
     insets = self.safeAreaInsets;
   }
-#endif
   return insets;
 }
 

--- a/components/Tabs/src/MDCTabBarViewController.m
+++ b/components/Tabs/src/MDCTabBarViewController.m
@@ -316,11 +316,9 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = 0.3f;
   CGRect bounds = self.view.bounds;
   CGFloat tabBarHeight = [[_tabBar class] defaultHeightForBarPosition:UIBarPositionBottom
                                                        itemAppearance:_tabBar.itemAppearance];
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     tabBarHeight += self.view.safeAreaInsets.bottom;
   }
-#endif
 
   CGRect currentViewFrame = bounds;
   CGRect tabBarFrame = CGRectMake(bounds.origin.x, bounds.origin.y + bounds.size.height,

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -115,12 +115,10 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   collectionView.showsHorizontalScrollIndicator = NO;
   collectionView.showsVerticalScrollIndicator = NO;
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     collectionView.contentInsetAdjustmentBehavior =
         UIScrollViewContentInsetAdjustmentScrollableAxes;
   }
-#endif
 
   collectionView.dataSource = self;
   collectionView.delegate = self;
@@ -306,11 +304,9 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 }
 
 - (void)safeAreaInsetsDidChange {
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [super safeAreaInsetsDidChange];
   }
-#endif
   [self setNeedsLayout];
 }
 
@@ -434,12 +430,10 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 #pragma mark - Private
 
 - (CGFloat)adjustedCollectionViewWidth {
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     return CGRectGetWidth(UIEdgeInsetsInsetRect(_collectionView.bounds,
                                                 _collectionView.adjustedContentInset));
   }
-#endif
   return CGRectGetWidth(_collectionView.bounds);
 }
 
@@ -679,13 +673,11 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   const BOOL isRegular = (sizeClass == UIUserInterfaceSizeClassRegular);
   CGFloat inset = isRegular ? kRegularInset : kCompactInset;
   // If the collection view has Safe Area insets, we don't want to add an extra horizontal inset.
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     if (_collectionView.safeAreaInsets.left > 0 || _collectionView.safeAreaInsets.right > 0) {
       inset = 0;
     }
   }
-#endif
   return UIEdgeInsetsMake(0.0f, inset, 0.0f, inset);
 }
 
@@ -984,12 +976,10 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 }
 
 - (CGRect)adjustedCollectionViewBounds {
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     return UIEdgeInsetsInsetRect(self.collectionView.bounds,
                                  self.collectionView.adjustedContentInset);
   }
-#endif
   return self.collectionView.bounds;
 }
 

--- a/components/TextFields/examples/MultilineTextFieldLegacyExample.m
+++ b/components/TextFields/examples/MultilineTextFieldLegacyExample.m
@@ -161,7 +161,6 @@
                                                       @"charMax" : multilineTextFieldCharMaxDefault
                                                     }]];
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [NSLayoutConstraint activateConstraints:@[
       [NSLayoutConstraint constraintWithItem:multilineTextFieldUnstyled
@@ -197,24 +196,7 @@
                                     constant:-20]
     ]];
   }
-#else
-  [NSLayoutConstraint activateConstraints:@[
-    [NSLayoutConstraint constraintWithItem:multilineTextFieldUnstyled
-                                 attribute:NSLayoutAttributeTop
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:self.scrollView
-                                 attribute:NSLayoutAttributeTop
-                                multiplier:1
-                                  constant:20],
-    [NSLayoutConstraint constraintWithItem:multilineTextFieldCharMaxFullWidth
-                                 attribute:NSLayoutAttributeBottom
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:self.scrollView
-                                 attribute:NSLayoutAttributeBottomMargin
-                                multiplier:1
-                                  constant:-20]
-  ]];
-#endif
+
 
   [NSLayoutConstraint constraintWithItem:multilineTextFieldCharMaxFullWidth
                                attribute:NSLayoutAttributeLeading

--- a/components/TextFields/examples/MultilineTextFieldLegacyExample.m
+++ b/components/TextFields/examples/MultilineTextFieldLegacyExample.m
@@ -197,7 +197,6 @@
     ]];
   }
 
-
   [NSLayoutConstraint constraintWithItem:multilineTextFieldCharMaxFullWidth
                                attribute:NSLayoutAttributeLeading
                                relatedBy:NSLayoutRelationEqual

--- a/components/TextFields/examples/TextFieldControllerStylesExample.m
+++ b/components/TextFields/examples/TextFieldControllerStylesExample.m
@@ -183,7 +183,6 @@
                                 constant:0]
       .active = YES;
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [NSLayoutConstraint constraintWithItem:textFieldOutlined
                                  attribute:NSLayoutAttributeTop
@@ -219,26 +218,6 @@
                                   constant:-20]
     .active = YES;
   }
-#else
-  [NSLayoutConstraint constraintWithItem:textFieldOutlined
-                               attribute:NSLayoutAttributeTop
-                               relatedBy:NSLayoutRelationEqual
-                                  toItem:self.scrollView
-                               attribute:NSLayoutAttributeTop
-                              multiplier:1
-                                constant:20]
-      .active = YES;
-
-  [NSLayoutConstraint constraintWithItem:textFieldOutlined
-                               attribute:NSLayoutAttributeBottom
-                               relatedBy:NSLayoutRelationLessThanOrEqual
-                                  toItem:self.scrollView
-                               attribute:NSLayoutAttributeTop
-                              multiplier:1
-                                constant:-20]
-  .active = YES;
-#endif
-
 }
 
 #pragma mark - UITextFieldDelegate

--- a/components/TextFields/examples/TextFieldCustomFontExample.m
+++ b/components/TextFields/examples/TextFieldCustomFontExample.m
@@ -102,7 +102,6 @@
                                                       attribute:NSLayoutAttributeTrailingMargin
                                                      multiplier:1
                                                        constant:0]];
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [NSLayoutConstraint activateConstraints:@[
                                               [NSLayoutConstraint constraintWithItem:systemFontTextField
@@ -138,24 +137,7 @@
                                                                             constant:-20]
                                               ]];
   }
-#else
-  [NSLayoutConstraint activateConstraints:@[
-                                            [NSLayoutConstraint constraintWithItem:systemFontTextField
-                                                                         attribute:NSLayoutAttributeTop
-                                                                         relatedBy:NSLayoutRelationEqual
-                                                                            toItem:self.scrollView
-                                                                         attribute:NSLayoutAttributeTop
-                                                                        multiplier:1
-                                                                          constant:20],
-                                            [NSLayoutConstraint constraintWithItem:systemFontTextField
-                                                                         attribute:NSLayoutAttributeBottom
-                                                                         relatedBy:NSLayoutRelationEqual
-                                                                            toItem:self.scrollView
-                                                                         attribute:NSLayoutAttributeBottomMargin
-                                                                        multiplier:1
-                                                                          constant:-20]
-                                            ]];
-#endif
+
 
   [NSLayoutConstraint activateConstraints:constraints];
 }

--- a/components/TextFields/examples/TextFieldCustomFontExample.m
+++ b/components/TextFields/examples/TextFieldCustomFontExample.m
@@ -138,7 +138,6 @@
                                               ]];
   }
 
-
   [NSLayoutConstraint activateConstraints:constraints];
 }
 

--- a/components/TextFields/examples/TextFieldOutlinedExample.m
+++ b/components/TextFields/examples/TextFieldOutlinedExample.m
@@ -210,7 +210,6 @@
                                                       attribute:NSLayoutAttributeTrailingMargin
                                                      multiplier:1
                                                        constant:0]];
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [NSLayoutConstraint activateConstraints:@[
       [NSLayoutConstraint constraintWithItem:textFieldName
@@ -246,24 +245,7 @@
                                     constant:-20]
     ]];
   }
-#else
-  [NSLayoutConstraint activateConstraints:@[
-    [NSLayoutConstraint constraintWithItem:textFieldName
-                                 attribute:NSLayoutAttributeTop
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:self.scrollView
-                                 attribute:NSLayoutAttributeTop
-                                multiplier:1
-                                  constant:20],
-    [NSLayoutConstraint constraintWithItem:textFieldMessage
-                                 attribute:NSLayoutAttributeBottom
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:self.scrollView
-                                 attribute:NSLayoutAttributeBottomMargin
-                                multiplier:1
-                                  constant:-20]
-  ]];
-#endif
+
 
   [constraints
       addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[state(80)]-[zip]|"

--- a/components/TextFields/examples/TextFieldOutlinedExample.m
+++ b/components/TextFields/examples/TextFieldOutlinedExample.m
@@ -246,7 +246,6 @@
     ]];
   }
 
-
   [constraints
       addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[state(80)]-[zip]|"
                                                                   options:0

--- a/components/TextFields/examples/TextFieldStatesViewController.m
+++ b/components/TextFields/examples/TextFieldStatesViewController.m
@@ -114,7 +114,6 @@
                                   metrics:nil
                                     views:views]];
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [NSLayoutConstraint constraintWithItem:self.enabled
                                  attribute:NSLayoutAttributeTop
@@ -151,24 +150,7 @@
                                   constant:-20]
         .active = YES;
   }
-#else
-  [NSLayoutConstraint constraintWithItem:self.enabled
-                               attribute:NSLayoutAttributeTop
-                               relatedBy:NSLayoutRelationEqual
-                                  toItem:self.scrollView
-                               attribute:NSLayoutAttributeTop
-                              multiplier:1
-                                constant:20]
-      .active = YES;
-  [NSLayoutConstraint constraintWithItem:self.erroredDisabled
-                               attribute:NSLayoutAttributeBottom
-                               relatedBy:NSLayoutRelationEqual
-                                  toItem:self.scrollView
-                               attribute:NSLayoutAttributeBottomMargin
-                              multiplier:1
-                                constant:-20]
-      .active = YES;
-#endif
+
 }
 
 - (void)setupControllers {

--- a/components/TextFields/examples/TextFieldStatesViewController.m
+++ b/components/TextFields/examples/TextFieldStatesViewController.m
@@ -150,7 +150,6 @@
                                   constant:-20]
         .active = YES;
   }
-
 }
 
 - (void)setupControllers {

--- a/components/TextFields/examples/TextFieldsTableViewExample.m
+++ b/components/TextFields/examples/TextFieldsTableViewExample.m
@@ -49,15 +49,12 @@ static NSString *const TSTTextFieldTableViewCellIdentifier = @"TSTTextFieldsTabl
   [self.tableView setContentInset:UIEdgeInsetsMake(20, 0, 0, -20)];
   [self.tableView setSeparatorStyle:UITableViewCellSeparatorStyleNone];
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     [self.tableView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
   } else {
     [self.tableView.topAnchor constraintEqualToAnchor:self.topLayoutGuide.bottomAnchor].active = YES;
   }
-#else
-  [self.tableView.topAnchor constraintEqualToAnchor:self.topLayoutGuide.bottomAnchor].active = YES;
-#endif
+
 
   [self.tableView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor].active = YES;
 

--- a/components/Typography/src/UIFontDescriptor+MaterialTypography.m
+++ b/components/Typography/src/UIFontDescriptor+MaterialTypography.m
@@ -72,10 +72,8 @@
   // If we are within an application, query the preferredContentSizeCategory.
   if ([UIApplication mdc_safeSharedApplication]) {
     sizeCategory = [UIApplication mdc_safeSharedApplication].preferredContentSizeCategory;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   } else if (@available(iOS 10.0, *)) {
     sizeCategory = UIScreen.mainScreen.traitCollection.preferredContentSizeCategory;
-#endif
   }
 
   return [UIFontDescriptor mdc_fontDescriptorForMaterialTextStyle:style sizeCategory:sizeCategory];

--- a/components/private/UIMetrics/src/MDCLayoutMetrics.m
+++ b/components/private/UIMetrics/src/MDCLayoutMetrics.m
@@ -20,7 +20,6 @@
 
 static const CGFloat kFixedStatusBarHeightOnPreiPhoneXDevices = 20;
 
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
 static BOOL HasHardwareSafeAreas(void) {
   static BOOL hasHardwareSafeAreas = NO;
   if (@available(iOS 11.0, *)) {
@@ -40,11 +39,9 @@ static BOOL HasHardwareSafeAreas(void) {
   }
   return hasHardwareSafeAreas;
 }
-#endif
 
 CGFloat MDCDeviceTopSafeAreaInset(void) {
   CGFloat topInset = kFixedStatusBarHeightOnPreiPhoneXDevices;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     // Devices with hardware safe area insets have fixed insets that depend on the device
     // orientation. On such devices, we aren't interested in the status bar's height because the
@@ -57,6 +54,5 @@ CGFloat MDCDeviceTopSafeAreaInset(void) {
       topInset = insets.top;
     }
   }
-#endif
   return topInset;
 }


### PR DESCRIPTION
We can now make use of @available throughout our codebase.

We support Xcode 9 and up, which includes the iOS 11 SDK. This means we can remove any guards for SDKs prior to iOS 11.

This was cleaned up by running a global find-and-replace with the following regular expression:

```
Find:#if defined\(__IPHONE_11_0\) && \(__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0\)\n(.+if \(@available\(iOS 11.0, \*\)\) \{(?:.|\n)*?)(?:#else(?:.|\n)*?)?\n#endif
Replace:$1
```

With some additional cleanup for stragglers that didn't match this pattern. Note that else clauses were intentionally dropped.

Closes https://github.com/material-components/material-components-ios/issues/4909