### PR TITLE
[Dialogs] Add accessibilityIdentifier to Actions.

### DIFF
--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -133,7 +133,7 @@ typedef void (^MDCActionHandler)(MDCAlertAction *_Nonnull action);
 /**
  MDCAlertAction is passed to an MDCAlertController to add a button to the alert dialog.
  */
-@interface MDCAlertAction : NSObject <NSCopying>
+@interface MDCAlertAction : NSObject <NSCopying, UIAccessibilityIdentification>
 
 /**
  Action alerts control the buttons that will be displayed on the bottom of an alert controller.
@@ -156,5 +156,10 @@ typedef void (^MDCActionHandler)(MDCAlertAction *_Nonnull action);
 @property(nonatomic, nullable, readonly) NSString *title;
 
 // TODO(iangordon): Add support for enabled property to match UIAlertAction
+
+/**
+ The @c accessibilityIdentifier for the view associated with this action.
+ */
+@property(nonatomic, nullable, copy) NSString *accessibilityIdentifier;
 
 @end

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -56,6 +56,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 
 - (id)copyWithZone:(__unused NSZone *)zone {
   MDCAlertAction *action = [[self class] actionWithTitle:self.title handler:self.completionHandler];
+  action.accessibilityIdentifier = self.accessibilityIdentifier;
 
   return action;
 }
@@ -161,9 +162,10 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 
 - (void)addActionToAlertView:(MDCAlertAction *)action {
   if (self.alertView) {
-    [self.alertView addActionButtonTitle:action.title
-                                  target:self
-                                selector:@selector(actionButtonPressed:)];
+    MDCButton *addedAction = [self.alertView addActionButtonTitle:action.title
+                                                           target:self
+                                                         selector:@selector(actionButtonPressed:)];
+    addedAction.accessibilityIdentifier = action.accessibilityIdentifier;
     self.preferredContentSize =
         [self.alertView calculatePreferredContentSizeForBounds:CGRectInfinite.size];
     [self.alertView setNeedsLayout];

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.h
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.h
@@ -25,7 +25,7 @@
 
 @property(nonatomic, nonnull, strong, readonly) NSArray<MDCButton *> *actionButtons;
 
-- (MDCButton *)addActionButtonTitle:(NSString *_Nonnull)actionTitle
+- (nonnull MDCButton *)addActionButtonTitle:(NSString *_Nonnull)actionTitle
                              target:(nullable id)target
                            selector:(SEL _Nonnull)selector;
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.h
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.h
@@ -25,9 +25,9 @@
 
 @property(nonatomic, nonnull, strong, readonly) NSArray<MDCButton *> *actionButtons;
 
-- (void)addActionButtonTitle:(NSString *_Nonnull)actionTitle
-                      target:(nullable id)target
-                    selector:(SEL _Nonnull)selector;
+- (MDCButton *)addActionButtonTitle:(NSString *_Nonnull)actionTitle
+                             target:(nullable id)target
+                           selector:(SEL _Nonnull)selector;
 
 - (CGSize)calculatePreferredContentSizeForBounds:(CGSize)boundsSize;
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -117,7 +117,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   [self setNeedsLayout];
 }
 
-- (void)addActionButtonTitle:(NSString *)actionTitle target:(id)target selector:(SEL)selector {
+- (MDCButton *)addActionButtonTitle:(NSString *)actionTitle target:(id)target selector:(SEL)selector {
   MDCButton *actionButton = [[MDCButton alloc] initWithFrame:CGRectZero];
   [MDCTextButtonThemer applyScheme:buttonScheme toButton:actionButton];
   actionButton.mdc_adjustsFontForContentSizeCategory = self.mdc_adjustsFontForContentSizeCategory;
@@ -140,6 +140,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   [self.actionsScrollView addSubview:actionButton];
 
   [_actionButtons addObject:actionButton];
+  return actionButton;
 }
 
 - (void)setTitleFont:(UIFont *)font {

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -243,7 +243,8 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
 
 - (void)testAccessibilityIdentifiersAppliesToAlertControllerViewButtons {
   // Given
-  MDCAlertController *alertController = [MDCAlertController alertControllerWithTitle:@"Title" message:@"message"];
+  MDCAlertController *alertController = [MDCAlertController alertControllerWithTitle:@"Title"
+                                                                             message:@"message"];
   MDCAlertAction *action1 = [MDCAlertAction actionWithTitle:@"button1" handler:nil];
   action1.accessibilityIdentifier = @"1";
   MDCAlertAction *action2 = [MDCAlertAction actionWithTitle:@"buttonA" handler:nil];
@@ -252,6 +253,7 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   // When
   [alertController addAction:action1];
   [alertController addAction:action2];
+  
   // Force the view to load
   if (@available(iOS 9.0, *)) {
     [alertController loadViewIfNeeded];

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -24,6 +24,10 @@
 
 static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertControllerSubclassValueKey";
 
+@interface MDCAlertController (Testing)
+@property(nonatomic, nullable, weak) MDCAlertControllerView *alertView;
+@end
+
 @interface MDCAlertControllerSubclass : MDCAlertController
 @property(nonatomic, assign) NSInteger value;
 @end
@@ -235,6 +239,38 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
                                            handler:^(MDCAlertAction * _Nonnull action) {
                                            }]];
   XCTAssertFalse(alert.isViewLoaded);
+}
+
+- (void)testAccessibilityIdentifiersAppliesToAlertControllerViewButtons {
+  // Given
+  MDCAlertController *alertController = [MDCAlertController alertControllerWithTitle:@"Title" message:@"message"];
+  MDCAlertAction *action1 = [MDCAlertAction actionWithTitle:@"button1" handler:nil];
+  action1.accessibilityIdentifier = @"1";
+  MDCAlertAction *action2 = [MDCAlertAction actionWithTitle:@"buttonA" handler:nil];
+  action2.accessibilityIdentifier = @"A";
+
+  // When
+  [alertController addAction:action1];
+  [alertController addAction:action2];
+  // Force the view to load
+  if (@available(iOS 9.0, *)) {
+    [alertController loadViewIfNeeded];
+  } else {
+    (void)alertController.view;
+  }
+
+  // Then
+  NSArray<UIButton *> *buttons = alertController.alertView.actionButtons;
+  XCTAssertEqual(buttons.count, 2U);
+  UIButton *button1 = buttons.firstObject;
+  UIButton *button2 = buttons.lastObject;
+
+  if (![[button1.titleLabel.text lowercaseString] isEqualToString:action1.title]) {
+    button1 = buttons.lastObject;
+    button2 = buttons.firstObject;
+  }
+  XCTAssertEqualObjects(button1.accessibilityIdentifier, @"1");
+  XCTAssertEqualObjects(button2.accessibilityIdentifier, @"A");
 }
 
 @end


### PR DESCRIPTION
To improve support for UI testing, `accessibilityIdentifier` values
should be attached to the action buttons of MDCAlertController views.
Instead of exposing the views and the buttons, an
`accessibilityIdentifier` property can be assigned to the MDCAlertAction
directly using the UIAccessibilityIdentification protocol.

Closes #4916