### PR TITLE
[ShadowLayer] Mark shadowPath invalid on cornerRadius change

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -679,6 +679,7 @@ Pod::Spec.new do |mdc|
     component.source_files = "components/#{component.base_name}/src/*.{h,m}"
 
     component.dependency "MaterialComponents/ShadowElevations"
+    component.dependency "MaterialComponents/private/Math"
   end
 
   # Slider

--- a/components/ShadowLayer/BUILD
+++ b/components/ShadowLayer/BUILD
@@ -29,6 +29,7 @@ mdc_public_objc_library(
     ],
     deps = [
         "//components/ShadowElevations",
+        "//components/private/Math",
     ],
 )
 

--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -16,6 +16,8 @@
 
 #import "MDCShadowLayer.h"
 
+#import "MDCMath.h"
+
 static const CGFloat kShadowElevationDialog = 24.0;
 static const float kKeyShadowOpacity = 0.26f;
 static const float kAmbientShadowOpacity = 0.08f;
@@ -297,6 +299,17 @@ static const float kAmbientShadowOpacity = 0.08f;
   _bottomShadow.shadowOffset = shadowMetrics.bottomShadowOffset;
   _bottomShadow.shadowRadius = shadowMetrics.bottomShadowRadius;
   _bottomShadow.shadowOpacity = shadowMetrics.bottomShadowOpacity;
+}
+
+- (void)setCornerRadius:(CGFloat)cornerRadius {
+  BOOL radiusChanged = !MDCCGFloatEqual(self.cornerRadius, cornerRadius);
+  [super setCornerRadius:cornerRadius];
+  // We MUST check if we are changing the value before we invalidate the shadowPath to
+  // avoid and endless loop
+  if (radiusChanged) {
+    _shadowPathIsInvalid = YES;
+    [self setNeedsLayout];
+  }
 }
 
 #pragma mark - CALayerDelegate

--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -305,7 +305,7 @@ static const float kAmbientShadowOpacity = 0.08f;
   BOOL radiusChanged = !MDCCGFloatEqual(self.cornerRadius, cornerRadius);
   [super setCornerRadius:cornerRadius];
   // We MUST check if we are changing the value before we invalidate the shadowPath to
-  // avoid and endless loop
+  // avoid an endless loop
   if (radiusChanged) {
     _shadowPathIsInvalid = YES;
     [self setNeedsLayout];


### PR DESCRIPTION
Note the cornerRadius changes are not getting reflected in the before version.

| Before | After |
|--|--|
|![shadowradius-broken](https://user-images.githubusercontent.com/1121006/44730113-367d1a80-aaae-11e8-9b55-024f97b797e0.gif)|![shadowradius-fixed](https://user-images.githubusercontent.com/1121006/44730119-3d0b9200-aaae-11e8-8798-98ae8100f671.gif)|

