### PR TITLE
[Snackbar] API to set `accessibilityHint`.

### DIFF
--- a/components/Snackbar/BUILD
+++ b/components/Snackbar/BUILD
@@ -23,6 +23,7 @@ licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "Snackbar",
+    bundles = [":Bundle"],
     sdk_frameworks = [
         "CoreGraphics",
         "QuartzCore",
@@ -36,7 +37,20 @@ mdc_public_objc_library(
         "//components/private/Application",
         "//components/private/KeyboardWatcher",
         "//components/private/Overlay",
+        "@material_internationalization_ios//:MDFInternationalization",
     ],
+)
+
+filegroup(
+    name = "BundleFiles",
+    srcs = glob([
+        "src/MaterialSnackbar.bundle/**",
+    ]),
+)
+
+objc_bundle(
+    name = "Bundle",
+    bundle_imports = [":BundleFiles"],
 )
 
 mdc_objc_library(

--- a/components/Snackbar/BUILD
+++ b/components/Snackbar/BUILD
@@ -106,6 +106,8 @@ mdc_objc_library(
     srcs = native.glob([
         "tests/unit/*.m",
         "tests/unit/*.h",
+        "tests/unit/supplemental/*.m",
+        "tests/unit/supplemental/*.h",
     ]),
     sdk_frameworks = [
         "UIKit",

--- a/components/Snackbar/src/MDCSnackbarMessage.h
+++ b/components/Snackbar/src/MDCSnackbarMessage.h
@@ -139,6 +139,11 @@ extern NSString * __nonnull const MDCSnackbarMessageBoldAttributeName;
 @property(nonatomic, copy, nullable) NSString *accessibilityLabel;
 
 /**
+ Redeclaration from UIAccessibility to make clear that this class supports accessibility hints.
+ */
+@property(nonatomic, copy, nullable) NSString *accessibilityHint;
+
+/**
  Text that should be read when the message appears on screen and VoiceOver is enabled.
  */
 @property(nonatomic, readonly, nullable) NSString *voiceNotificationText;

--- a/components/Snackbar/src/MDCSnackbarMessage.m
+++ b/components/Snackbar/src/MDCSnackbarMessage.m
@@ -66,6 +66,7 @@ static BOOL _usesLegacySnackbar = YES;
   copy.duration = self.duration;
   copy.category = self.category;
   copy.accessibilityLabel = self.accessibilityLabel;
+  copy.accessibilityHint = self.accessibilityHint;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   copy.buttonTextColor = self.buttonTextColor;

--- a/components/Snackbar/src/MDCSnackbarMessageView.h
+++ b/components/Snackbar/src/MDCSnackbarMessageView.h
@@ -61,6 +61,16 @@
 @property(nonatomic, strong, nullable) NSMutableArray<MDCButton *> *actionButtons;
 
 /**
+ The @c accessibilityLabel to apply to the message of the Snackbar.
+ */
+@property(nullable, nonatomic, copy) NSString *accessibilityLabel;
+
+/**
+ The @c accessibilityHint to apply to the message of the Snackbar.
+ */
+@property(nullable, nonatomic, copy) NSString *accessibilityHint;
+
+/**
  Returns the button title color for a particular control state.
 
  Default for UIControlStateNormal is MDCRGBAColor(0xFF, 0xFF, 0xFF, 0.6f).

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -349,16 +349,19 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
                                            [[self class] bundle],
                                            @"Dismissal accessibility hint for Snackbar");
 
-    // For VoiceOver purposes, the label is the primary 'button' for dismissing the Snackbar, so
-    // we'll make sure the label looks like a button.
+    // For UIAccessibility purposes, the label is the primary 'button' for dismissing the Snackbar,
+    // so we'll make sure the label is treated like a button.
     _label.accessibilityTraits = UIAccessibilityTraitButton;
     _label.accessibilityIdentifier = MDCSnackbarMessageTitleAutomationIdentifier;
     _label.accessibilityHint = accessibilityHint;
 
-    // If an accessibility label was set on the message model object, use that instead of the text
-    // in the label.
+    // If an accessibility label or hint was set on the message model object, use that instead of
+    // the text in the label or the default hint.
     if ([message.accessibilityLabel length]) {
       _label.accessibilityLabel = message.accessibilityLabel;
+    }
+    if (message.accessibilityHint.length) {
+      _label.accessibilityHint = message.accessibilityHint;
     }
 
     _label.textColor = _messageTextColor;

--- a/components/Snackbar/tests/unit/MDCSnackbarManagerInstanceTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarManagerInstanceTests.m
@@ -15,20 +15,7 @@
 #import <XCTest/XCTest.h>
 
 #import "MaterialSnackbar.h"
-
-@interface FakeMDCSnackbarManagerDelegate : NSObject <MDCSnackbarManagerDelegate>
-
-- (void)willPresentSnackbarWithMessageView:(MDCSnackbarMessageView *)messageView;
-
-@end
-
-@implementation FakeMDCSnackbarManagerDelegate
-
-- (void)willPresentSnackbarWithMessageView:(__unused MDCSnackbarMessageView *)messageView {
-  // Nothing
-}
-
-@end
+#import "supplemental/MDCFakeMDCSnackbarManagerDelegate.h"
 
 @interface MDCSnackbarManagerInstanceTests : XCTestCase
 

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -19,6 +19,10 @@
 #import "MaterialSnackbar.h"
 #import "supplemental/MDCFakeMDCSnackbarManagerDelegate.h"
 
+@interface MDCSnackbarMessageView (Testing)
+@property(nonatomic, strong) UILabel *label;
+@end
+
 @interface MDCSnackbarMessageViewTests : XCTestCase
 @property(nonatomic, strong) MDCSnackbarManager *manager;
 @property(nonatomic, strong) FakeMDCSnackbarManagerDelegate *delegate;
@@ -29,6 +33,7 @@
 
 - (void)setUp {
   [super setUp];
+
   self.manager = [[MDCSnackbarManager alloc] init];
   self.delegate = [[FakeMDCSnackbarManagerDelegate alloc] init];
   self.manager.delegate = self.delegate;
@@ -54,35 +59,37 @@
   [self.manager showMessage:self.message];
 
   // Then
-  XCTAssertNil(self.delegate.presentedView.accessibilityLabel);
+  XCTAssertNil(self.delegate.presentedView.label.accessibilityLabel);
 }
 
 - (void)testAccessibilityLabelSetFromSnackbarMessageProperty {
   // When
   self.message.accessibilityLabel = @"not message text";
   [self.manager showMessage:self.message];
-  [NSRunLoop.mainRunLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
+  [NSRunLoop.mainRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1]];
 
   // Then
-  XCTAssertEqualObjects(self.delegate.presentedView.accessibilityLabel,
+  XCTAssertEqualObjects(self.delegate.presentedView.label.accessibilityLabel,
                         self.message.accessibilityLabel);
 }
 
 - (void)testAccessibilityHintDefaultIsNotNil {
   // When
   [self.manager showMessage:self.message];
+  [NSRunLoop.mainRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1]];
 
   // Then
-  XCTAssertNotNil(self.delegate.presentedView.accessibilityHint);
+  XCTAssertNotNil(self.delegate.presentedView.label.accessibilityHint);
 }
 
 - (void)testAccessibilityHintSetFromSnackbarMessageProperty {
   // When
   self.message.accessibilityHint = @"a hint";
   [self.manager showMessage:self.message];
+  [NSRunLoop.mainRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1]];
 
   // Then
-  XCTAssertEqualObjects(self.delegate.presentedView.accessibilityHint,
+  XCTAssertEqualObjects(self.delegate.presentedView.label.accessibilityHint,
                         self.message.accessibilityHint);
 }
 

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -17,12 +17,23 @@
 #import <XCTest/XCTest.h>
 
 #import "MaterialSnackbar.h"
+#import "supplemental/MDCFakeMDCSnackbarManagerDelegate.h"
 
 @interface MDCSnackbarMessageViewTests : XCTestCase
-
+@property(nonatomic, strong) MDCSnackbarManager *manager;
+@property(nonatomic, strong) FakeMDCSnackbarManagerDelegate *delegate;
+@property(nonatomic, strong) MDCSnackbarMessage *message;
 @end
 
 @implementation MDCSnackbarMessageViewTests
+
+- (void)setUp {
+  [super setUp];
+  self.manager = [[MDCSnackbarManager alloc] init];
+  self.delegate = [[FakeMDCSnackbarManagerDelegate alloc] init];
+  self.manager.delegate = self.delegate;
+  self.message = [MDCSnackbarMessage messageWithText:@"message text"];
+}
 
 - (void)testDefaultColors {
   // Given
@@ -36,6 +47,43 @@
                                         alpha:1]);
   XCTAssertEqualObjects(messageView.snackbarMessageViewShadowColor, UIColor.blackColor);
   XCTAssertEqualObjects(messageView.messageTextColor, UIColor.whiteColor);
+}
+
+- (void)testAccessibilityLabelDefaultIsNil {
+  // When
+  [self.manager showMessage:self.message];
+
+  // Then
+  XCTAssertNil(self.delegate.presentedView.accessibilityLabel);
+}
+
+- (void)testAccessibilityLabelSetFromSnackbarMessageProperty {
+  // When
+  self.message.accessibilityLabel = @"not message text";
+  [self.manager showMessage:self.message];
+  [NSRunLoop.mainRunLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
+
+  // Then
+  XCTAssertEqualObjects(self.delegate.presentedView.accessibilityLabel,
+                        self.message.accessibilityLabel);
+}
+
+- (void)testAccessibilityHintDefaultIsNotNil {
+  // When
+  [self.manager showMessage:self.message];
+
+  // Then
+  XCTAssertNotNil(self.delegate.presentedView.accessibilityHint);
+}
+
+- (void)testAccessibilityHintSetFromSnackbarMessageProperty {
+  // When
+  self.message.accessibilityHint = @"a hint";
+  [self.manager showMessage:self.message];
+
+  // Then
+  XCTAssertEqualObjects(self.delegate.presentedView.accessibilityHint,
+                        self.message.accessibilityHint);
 }
 
 @end

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -66,7 +66,7 @@
   // When
   self.message.accessibilityLabel = @"not message text";
   [self.manager showMessage:self.message];
-  [NSRunLoop.mainRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1]];
+  [NSRunLoop.mainRunLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
 
   // Then
   XCTAssertEqualObjects(self.delegate.presentedView.label.accessibilityLabel,
@@ -76,7 +76,7 @@
 - (void)testAccessibilityHintDefaultIsNotNil {
   // When
   [self.manager showMessage:self.message];
-  [NSRunLoop.mainRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1]];
+  [NSRunLoop.mainRunLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
 
   // Then
   XCTAssertNotNil(self.delegate.presentedView.label.accessibilityHint);
@@ -86,7 +86,7 @@
   // When
   self.message.accessibilityHint = @"a hint";
   [self.manager showMessage:self.message];
-  [NSRunLoop.mainRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1]];
+  [NSRunLoop.mainRunLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
 
   // Then
   XCTAssertEqualObjects(self.delegate.presentedView.label.accessibilityHint,

--- a/components/Snackbar/tests/unit/supplemental/MDCFakeMDCSnackbarManagerDelegate.h
+++ b/components/Snackbar/tests/unit/supplemental/MDCFakeMDCSnackbarManagerDelegate.h
@@ -1,0 +1,27 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialSnackbar.h"
+
+@interface FakeMDCSnackbarManagerDelegate : NSObject <MDCSnackbarManagerDelegate>
+
+@property(nonatomic, strong) MDCSnackbarMessageView *presentedView;
+
+- (void)willPresentSnackbarWithMessageView:(MDCSnackbarMessageView *)messageView;
+
+@end

--- a/components/Snackbar/tests/unit/supplemental/MDCFakeMDCSnackbarManagerDelegate.m
+++ b/components/Snackbar/tests/unit/supplemental/MDCFakeMDCSnackbarManagerDelegate.m
@@ -1,0 +1,23 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCFakeMDCSnackbarManagerDelegate.h"
+
+@implementation FakeMDCSnackbarManagerDelegate
+
+- (void)willPresentSnackbarWithMessageView:(MDCSnackbarMessageView *)messageView {
+  self.presentedView = messageView;
+}
+
+@end


### PR DESCRIPTION
Clients should be able to set/override the `accessibilityHint` value for
the Snackbar message label. There is already an API to set the
`accessibilityLabel`, but nothing for the hint.

Closes #4923