### PR TITLE
[ButtonBar] Annotate MDCButtonBarDelegate's only API as deprecated.

### DIFF
--- a/components/ButtonBar/src/MDCButtonBar.h
+++ b/components/ButtonBar/src/MDCButtonBar.h
@@ -188,11 +188,12 @@ typedef NS_OPTIONS(NSUInteger, MDCBarButtonItemLayoutHints) {
  @seealso MDCBarButtonItemLayoutHints
  */
 @protocol MDCButtonBarDelegate <NSObject>
-@required
+@optional
 
 /** Asks the receiver to return a view that represents the given bar button item. */
 - (nonnull UIView *)buttonBar:(nonnull MDCButtonBar *)buttonBar
                   viewForItem:(nonnull UIBarButtonItem *)barButtonItem
-                  layoutHints:(MDCBarButtonItemLayoutHints)layoutHints;
+                  layoutHints:(MDCBarButtonItemLayoutHints)layoutHints
+    __deprecated_msg("There will be no replacement for this API.");
 
 @end

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -190,7 +190,6 @@ static NSString *const kEnabledSelector = @"enabled";
   if (![barButtonItems count]) {
     return nil;
   }
-  id<MDCButtonBarDelegate> delegate = _defaultBuilder;
 
   NSMutableArray<UIView *> *views = [NSMutableArray array];
   [barButtonItems enumerateObjectsUsingBlock:^(UIBarButtonItem *item,
@@ -203,7 +202,7 @@ static NSString *const kEnabledSelector = @"enabled";
     if (idx == [barButtonItems count] - 1) {
       hints |= MDCBarButtonItemLayoutHintsIsLastButton;
     }
-    UIView *view = [delegate buttonBar:self viewForItem:item layoutHints:hints];
+    UIView *view = [self->_defaultBuilder buttonBar:self viewForItem:item layoutHints:hints];
     if (!view) {
       return;
     }

--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.h
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.h
@@ -17,7 +17,14 @@
 #import "MDCButtonBar.h"
 
 /** MDCBarButtonItemBuilder is an implementation of a Material button item factory. */
-@interface MDCAppBarButtonBarBuilder : NSObject <MDCButtonBarDelegate>
+@interface MDCAppBarButtonBarBuilder : NSObject
+
+/**
+ Returns a view that represents the given bar button item.
+ */
+- (nonnull UIView *)buttonBar:(nonnull MDCButtonBar *)buttonBar
+                  viewForItem:(nonnull UIBarButtonItem *)barButtonItem
+                  layoutHints:(MDCBarButtonItemLayoutHints)layoutHints;
 
 /** The title color for the bar button items. */
 @property(nonatomic, strong) UIColor *buttonTitleColor;

--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.h
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.h
@@ -22,9 +22,9 @@
 /**
  Returns a view that represents the given bar button item.
  */
-- (nonnull UIView *)buttonBar:(nonnull MDCButtonBar *)buttonBar
-                  viewForItem:(nonnull UIBarButtonItem *)barButtonItem
-                  layoutHints:(MDCBarButtonItemLayoutHints)layoutHints;
+- (UIView *)buttonBar:(MDCButtonBar *)buttonBar
+          viewForItem:(UIBarButtonItem *)barButtonItem
+          layoutHints:(MDCBarButtonItemLayoutHints)layoutHints;
 
 /** The title color for the bar button items. */
 @property(nonatomic, strong) UIColor *buttonTitleColor;


### PR DESCRIPTION
This API is only used internally and is a layer of indirection that is not necessary.

The API has no internal usage or reasonable mechanism for use publicly, so we are marking it deprecated immediately.

Closes https://github.com/material-components/material-components-ios/issues/2943