### PR TITLE
[ButtonBar] Add a buttonBarDidInvalidateIntrinsicContentSize API to the delegate.

### DIFF
--- a/components/ButtonBar/src/MDCButtonBar.h
+++ b/components/ButtonBar/src/MDCButtonBar.h
@@ -59,7 +59,7 @@ IB_DESIGNABLE
 /**
  The delegate will be informed of events related to the layout of the button bar.
  */
-@property(nonatomic, weak) id<MDCButtonBarDelegate> delegate;
+@property(nonatomic, weak, nullable) id<MDCButtonBarDelegate> delegate;
 
 #pragma mark Button Items
 

--- a/components/ButtonBar/src/MDCButtonBar.h
+++ b/components/ButtonBar/src/MDCButtonBar.h
@@ -54,6 +54,13 @@ typedef NS_OPTIONS(NSUInteger, MDCButtonBarLayoutPosition) {
 IB_DESIGNABLE
 @interface MDCButtonBar : UIView
 
+#pragma mark Delegating
+
+/**
+ The delegate will be informed of events related to the layout of the button bar.
+ */
+@property(nonatomic, weak) id<MDCButtonBarDelegate> delegate;
+
 #pragma mark Button Items
 
 /**
@@ -196,6 +203,17 @@ typedef NS_OPTIONS(NSUInteger, MDCBarButtonItemLayoutHints) {
  */
 @protocol MDCButtonBarDelegate <NSObject>
 @optional
+
+/**
+ Informs the receiver that the button bar requires a layout pass.
+
+ The receiver is expected to call propagate this setNeedsLayout call to the view responsible for
+ setting the frame of the button bar so that the button bar can expand or contract as necessary.
+
+ This method is typically called as a result of a UIBarButtonItem property changing or as a result
+ of the items property being changed.
+ */
+- (void)buttonBarDidInvalidateIntrinsicContentSize:(nonnull MDCButtonBar *)buttonBar;
 
 /** Asks the receiver to return a view that represents the given bar button item. */
 - (nonnull UIView *)buttonBar:(nonnull MDCButtonBar *)buttonBar

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -103,6 +103,19 @@ static NSString *const kEnabledSelector = @"enabled";
 
   for (UIView *view in positionedButtonViews) {
     CGFloat width = view.frame.size.width;
+
+    // There's a finite number of buttons that can reasonably be shown in a button bar, so this
+    // linear-time lookup cost is minimal.
+    NSUInteger index = [_buttonViews indexOfObject:view];
+    if (index < [_items count]) {
+      UIBarButtonItem *item = _items[index];
+      if (item.width > 0) {
+        width = item.width;
+      } else {
+        width = [view sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)].width;
+      }
+    }
+
     switch (self.mdf_effectiveUserInterfaceLayoutDirection) {
       case UIUserInterfaceLayoutDirectionLeftToRight:
         break;
@@ -488,7 +501,6 @@ static NSString *const kEnabledSelector = @"enabled";
 - (void)setButtonTitleBaseline:(CGFloat)buttonTitleBaseline {
   _buttonTitleBaseline = buttonTitleBaseline;
 
-  [self invalidateIntrinsicContentSize];
   [self setNeedsLayout];
 }
 

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -139,6 +139,10 @@ static NSString *const kEnabledSelector = @"enabled";
   return [self sizeThatFits:size shouldLayout:NO];
 }
 
+- (CGSize)intrinsicContentSize {
+  return [self sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX) shouldLayout:NO];
+}
+
 - (void)layoutSubviews {
   [super layoutSubviews];
 
@@ -162,6 +166,14 @@ static NSString *const kEnabledSelector = @"enabled";
     return;
   } else {
     [self reloadButtonViews];
+  }
+}
+
+- (void)invalidateIntrinsicContentSize {
+  [super invalidateIntrinsicContentSize];
+
+  if ([self.delegate respondsToSelector:@selector(buttonBarDidInvalidateIntrinsicContentSize:)]) {
+    [self.delegate buttonBarDidInvalidateIntrinsicContentSize:self];
   }
 }
 
@@ -259,6 +271,7 @@ static NSString *const kEnabledSelector = @"enabled";
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(image))]) {
           [button setImage:newValue forState:UIControlStateNormal];
+          [self invalidateIntrinsicContentSize];
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(tag))]) {
           button.tag = [newValue integerValue];
@@ -268,6 +281,7 @@ static NSString *const kEnabledSelector = @"enabled";
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(title))]) {
           [button setTitle:newValue forState:UIControlStateNormal];
+          [self invalidateIntrinsicContentSize];
 
         } else {
           NSLog(@"Unknown key path notification received by %@ for %@.",
@@ -434,6 +448,7 @@ static NSString *const kEnabledSelector = @"enabled";
         }
         button.frame = frame;
 
+        [self invalidateIntrinsicContentSize];
         [self setNeedsLayout];
       }
     }
@@ -473,6 +488,7 @@ static NSString *const kEnabledSelector = @"enabled";
 - (void)setButtonTitleBaseline:(CGFloat)buttonTitleBaseline {
   _buttonTitleBaseline = buttonTitleBaseline;
 
+  [self invalidateIntrinsicContentSize];
   [self setNeedsLayout];
 }
 
@@ -491,6 +507,7 @@ static NSString *const kEnabledSelector = @"enabled";
   }
   _buttonViews = [self viewsForItems:_items];
 
+  [self invalidateIntrinsicContentSize];
   [self setNeedsLayout];
 }
 

--- a/components/ButtonBar/tests/unit/ButtonBarDelegateTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarDelegateTests.swift
@@ -29,6 +29,8 @@ class ButtonBarDelegateTests: XCTestCase {
   private var delegate: ButtonBarDelegate!
 
   override func setUp() {
+    super.setUp()
+
     buttonBar = MDCButtonBar()
     delegate = ButtonBarDelegate()
     buttonBar.delegate = delegate

--- a/components/ButtonBar/tests/unit/ButtonBarDelegateTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarDelegateTests.swift
@@ -1,0 +1,149 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents.MaterialButtonBar
+
+private class ButtonBarDelegate: NSObject, MDCButtonBarDelegate {
+  var didSetNeedsLayout = false
+  func buttonBarDidSetNeedsLayout(_ buttonBar: MDCButtonBar) {
+    didSetNeedsLayout = true
+  }
+}
+
+class ButtonBarDelegateTests: XCTestCase {
+  private var buttonBar: MDCButtonBar!
+  private var delegate: ButtonBarDelegate!
+
+  override func setUp() {
+    buttonBar = MDCButtonBar()
+    delegate = ButtonBarDelegate()
+    buttonBar.delegate = delegate
+  }
+
+  func testNotInvokedDuringInitialization() {
+    // Given setUp conditions
+
+    // Then
+    XCTAssertFalse(delegate.didSetNeedsLayout)
+  }
+
+  func testNotInvokedAfterItemsSetToEqualArrayOfItems() {
+    // Given
+    let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
+    buttonBar.items = [item]
+    // Forcefully clear the flag
+    delegate.didSetNeedsLayout = false
+
+    // When
+    buttonBar.items = [item]
+
+    // Then
+    XCTAssertFalse(delegate.didSetNeedsLayout)
+  }
+
+  func testInvokedAfterItemsSet() {
+    // Given
+    let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
+
+    // When
+    buttonBar.items = [item]
+
+    // Then
+    XCTAssertTrue(delegate.didSetNeedsLayout)
+  }
+
+  func testInvokedAfterItemsChange() {
+    // Given
+    let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
+    buttonBar.items = [item]
+    // Forcefully clear the flag
+    delegate.didSetNeedsLayout = false
+
+    // When
+    buttonBar.items = [UIBarButtonItem(title: "RIGHT", style: .plain, target: nil, action: nil)]
+
+    // Then
+    XCTAssertTrue(delegate.didSetNeedsLayout)
+  }
+
+  func testInvokedAfterTitleChanges() {
+    // Given
+    let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
+    buttonBar.items = [item]
+    // Forcefully clear the flag
+    delegate.didSetNeedsLayout = false
+
+    // When
+    item.title = "New title"
+
+    // Then
+    XCTAssertTrue(delegate.didSetNeedsLayout)
+  }
+
+  func testInvokedAfterImageChanges() {
+    // Given
+    let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
+    buttonBar.items = [item]
+    // Forcefully clear the flag
+    delegate.didSetNeedsLayout = false
+
+    // When
+    item.image = createImage(colored: .blue)
+
+    // Then
+    XCTAssertTrue(delegate.didSetNeedsLayout)
+  }
+
+  func testInvokedAfterTitleFontChanges() {
+    // Given
+    let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
+    buttonBar.items = [item]
+    // Forcefully clear the flag
+    delegate.didSetNeedsLayout = false
+
+    // When
+    buttonBar.setButtonsTitleFont(UIFont.systemFont(ofSize: 12), for: .normal)
+
+    // Then
+    XCTAssertTrue(delegate.didSetNeedsLayout)
+  }
+
+  func testInvokedAfterTitleBaselineChanges() {
+    // Given
+    let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
+    buttonBar.items = [item]
+    buttonBar.buttonTitleBaseline = 0
+    // Forcefully clear the flag
+    delegate.didSetNeedsLayout = false
+
+    // When
+    buttonBar.buttonTitleBaseline = 5
+
+    // Then
+    XCTAssertTrue(delegate.didSetNeedsLayout)
+  }
+
+  // Create a solid color image for testing purposes.
+  private func createImage(colored color: UIColor) -> UIImage {
+    UIGraphicsBeginImageContextWithOptions(CGSize(width: 64, height: 64), true, 1)
+    color.setFill()
+    UIRectFill(CGRect(x: 0, y: 0, width: 64, height: 64))
+    let image = UIGraphicsGetImageFromCurrentImageContext()
+    UIGraphicsEndImageContext()
+    return image!
+  }
+}

--- a/components/ButtonBar/tests/unit/ButtonBarDelegateTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarDelegateTests.swift
@@ -18,9 +18,9 @@ import XCTest
 import MaterialComponents.MaterialButtonBar
 
 private class ButtonBarDelegate: NSObject, MDCButtonBarDelegate {
-  var didSetNeedsLayout = false
-  @objc func buttonBarDidSetNeedsLayout(_ buttonBar: MDCButtonBar) {
-    didSetNeedsLayout = true
+  var didInvalidateIntrinsicContentSize = false
+  func buttonBarDidInvalidateIntrinsicContentSize(_ buttonBar: MDCButtonBar) {
+    didInvalidateIntrinsicContentSize = true
   }
 }
 
@@ -40,7 +40,7 @@ class ButtonBarDelegateTests: XCTestCase {
     // Given setUp conditions
 
     // Then
-    XCTAssertFalse(delegate.didSetNeedsLayout)
+    XCTAssertFalse(delegate.didInvalidateIntrinsicContentSize)
   }
 
   func testDelegateNotInvokedAfterItemsSetToEqualArrayOfItems() {
@@ -48,13 +48,13 @@ class ButtonBarDelegateTests: XCTestCase {
     let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
     buttonBar.items = [item]
     // Forcefully clear the flag
-    delegate.didSetNeedsLayout = false
+    delegate.didInvalidateIntrinsicContentSize = false
 
     // When
     buttonBar.items = [item]
 
     // Then
-    XCTAssertFalse(delegate.didSetNeedsLayout)
+    XCTAssertFalse(delegate.didInvalidateIntrinsicContentSize)
   }
 
   func testDelegateInvokedAfterItemsSet() {
@@ -65,7 +65,7 @@ class ButtonBarDelegateTests: XCTestCase {
     buttonBar.items = [item]
 
     // Then
-    XCTAssertTrue(delegate.didSetNeedsLayout)
+    XCTAssertTrue(delegate.didInvalidateIntrinsicContentSize)
   }
 
   func testDelegateInvokedAfterItemsChange() {
@@ -73,13 +73,13 @@ class ButtonBarDelegateTests: XCTestCase {
     let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
     buttonBar.items = [item]
     // Forcefully clear the flag
-    delegate.didSetNeedsLayout = false
+    delegate.didInvalidateIntrinsicContentSize = false
 
     // When
     buttonBar.items = [UIBarButtonItem(title: "RIGHT", style: .plain, target: nil, action: nil)]
 
     // Then
-    XCTAssertTrue(delegate.didSetNeedsLayout)
+    XCTAssertTrue(delegate.didInvalidateIntrinsicContentSize)
   }
 
   func testDelegateInvokedAfterTitleChanges() {
@@ -87,13 +87,13 @@ class ButtonBarDelegateTests: XCTestCase {
     let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
     buttonBar.items = [item]
     // Forcefully clear the flag
-    delegate.didSetNeedsLayout = false
+    delegate.didInvalidateIntrinsicContentSize = false
 
     // When
     item.title = "New title"
 
     // Then
-    XCTAssertTrue(delegate.didSetNeedsLayout)
+    XCTAssertTrue(delegate.didInvalidateIntrinsicContentSize)
   }
 
   func testDelegateInvokedAfterImageChanges() {
@@ -101,13 +101,13 @@ class ButtonBarDelegateTests: XCTestCase {
     let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
     buttonBar.items = [item]
     // Forcefully clear the flag
-    delegate.didSetNeedsLayout = false
+    delegate.didInvalidateIntrinsicContentSize = false
 
     // When
     item.image = createImage(colored: .blue)
 
     // Then
-    XCTAssertTrue(delegate.didSetNeedsLayout)
+    XCTAssertTrue(delegate.didInvalidateIntrinsicContentSize)
   }
 
   func testDelegateInvokedAfterTitleFontChanges() {
@@ -115,28 +115,28 @@ class ButtonBarDelegateTests: XCTestCase {
     let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
     buttonBar.items = [item]
     // Forcefully clear the flag
-    delegate.didSetNeedsLayout = false
+    delegate.didInvalidateIntrinsicContentSize = false
 
     // When
     buttonBar.setButtonsTitleFont(UIFont.systemFont(ofSize: 12), for: .normal)
 
     // Then
-    XCTAssertTrue(delegate.didSetNeedsLayout)
+    XCTAssertTrue(delegate.didInvalidateIntrinsicContentSize)
   }
 
-  func testDelegateInvokedAfterTitleBaselineChanges() {
+  func testDelegateNotInvokedAfterTitleBaselineChanges() {
     // Given
     let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
     buttonBar.items = [item]
     buttonBar.buttonTitleBaseline = 0
     // Forcefully clear the flag
-    delegate.didSetNeedsLayout = false
+    delegate.didInvalidateIntrinsicContentSize = false
 
     // When
     buttonBar.buttonTitleBaseline = 5
 
     // Then
-    XCTAssertTrue(delegate.didSetNeedsLayout)
+    XCTAssertFalse(delegate.didInvalidateIntrinsicContentSize)
   }
 
   // Create a solid color image for testing purposes.

--- a/components/ButtonBar/tests/unit/ButtonBarDelegateTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarDelegateTests.swift
@@ -19,7 +19,7 @@ import MaterialComponents.MaterialButtonBar
 
 private class ButtonBarDelegate: NSObject, MDCButtonBarDelegate {
   var didSetNeedsLayout = false
-  func buttonBarDidSetNeedsLayout(_ buttonBar: MDCButtonBar) {
+  @objc func buttonBarDidSetNeedsLayout(_ buttonBar: MDCButtonBar) {
     didSetNeedsLayout = true
   }
 }
@@ -36,14 +36,14 @@ class ButtonBarDelegateTests: XCTestCase {
     buttonBar.delegate = delegate
   }
 
-  func testNotInvokedDuringInitialization() {
+  func testDelegateNotInvokedDuringInitialization() {
     // Given setUp conditions
 
     // Then
     XCTAssertFalse(delegate.didSetNeedsLayout)
   }
 
-  func testNotInvokedAfterItemsSetToEqualArrayOfItems() {
+  func testDelegateNotInvokedAfterItemsSetToEqualArrayOfItems() {
     // Given
     let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
     buttonBar.items = [item]
@@ -57,7 +57,7 @@ class ButtonBarDelegateTests: XCTestCase {
     XCTAssertFalse(delegate.didSetNeedsLayout)
   }
 
-  func testInvokedAfterItemsSet() {
+  func testDelegateInvokedAfterItemsSet() {
     // Given
     let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
 
@@ -68,7 +68,7 @@ class ButtonBarDelegateTests: XCTestCase {
     XCTAssertTrue(delegate.didSetNeedsLayout)
   }
 
-  func testInvokedAfterItemsChange() {
+  func testDelegateInvokedAfterItemsChange() {
     // Given
     let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
     buttonBar.items = [item]
@@ -82,7 +82,7 @@ class ButtonBarDelegateTests: XCTestCase {
     XCTAssertTrue(delegate.didSetNeedsLayout)
   }
 
-  func testInvokedAfterTitleChanges() {
+  func testDelegateInvokedAfterTitleChanges() {
     // Given
     let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
     buttonBar.items = [item]
@@ -96,7 +96,7 @@ class ButtonBarDelegateTests: XCTestCase {
     XCTAssertTrue(delegate.didSetNeedsLayout)
   }
 
-  func testInvokedAfterImageChanges() {
+  func testDelegateInvokedAfterImageChanges() {
     // Given
     let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
     buttonBar.items = [item]
@@ -110,7 +110,7 @@ class ButtonBarDelegateTests: XCTestCase {
     XCTAssertTrue(delegate.didSetNeedsLayout)
   }
 
-  func testInvokedAfterTitleFontChanges() {
+  func testDelegateInvokedAfterTitleFontChanges() {
     // Given
     let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
     buttonBar.items = [item]
@@ -124,7 +124,7 @@ class ButtonBarDelegateTests: XCTestCase {
     XCTAssertTrue(delegate.didSetNeedsLayout)
   }
 
-  func testInvokedAfterTitleBaselineChanges() {
+  func testDelegateInvokedAfterTitleBaselineChanges() {
     // Given
     let item = UIBarButtonItem(title: "LEFT", style: .plain, target: nil, action: nil)
     buttonBar.items = [item]

--- a/components/ButtonBar/tests/unit/ButtonBarDelegateTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarDelegateTests.swift
@@ -1,18 +1,16 @@
-/*
- Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- */
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import XCTest
 import MaterialComponents.MaterialButtonBar


### PR DESCRIPTION
This will allow the owner of a button bar to react to changes in the button bar's intrinsic size.

We need to add this delegate because I'm not aware of an equivalent UIKit mechanism that works with views that aren't using auto layout (the MDCNavigationBar uses manual layout).

In a follow-up change, MDCNavigationBar will implement this delegate and update the layout of its left/right button bars as a result.

Part of https://github.com/material-components/material-components-ios/issues/1717