### PR TITLE
[ButtonBar] Add uppercasesButtonTitles API for modifying title casing behavior.

### DIFF
--- a/components/ButtonBar/src/MDCButtonBar.h
+++ b/components/ButtonBar/src/MDCButtonBar.h
@@ -105,6 +105,15 @@ IB_DESIGNABLE
 @property(nonatomic) CGFloat buttonTitleBaseline;
 
 /**
+ If true, all button titles will be converted to uppercase.
+
+ Changing this property to NO will update the current title string for all buttons.
+
+ Default is YES.
+ */
+@property(nonatomic) BOOL uppercasesButtonTitles;
+
+/**
  Sets the title font for the given state for all buttons.
 
  @param font The font that should be displayed on text buttons for the given state.

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -43,6 +43,7 @@ static NSString *const kEnabledSelector = @"enabled";
 }
 
 - (void)commonMDCButtonBarInit {
+  _uppercasesButtonTitles = YES;
   _buttonItemsLock = [[NSObject alloc] init];
   _layoutPosition = MDCButtonBarLayoutPositionNone;
 
@@ -401,6 +402,18 @@ static NSString *const kEnabledSelector = @"enabled";
     }
 
     [self reloadButtonViews];
+  }
+}
+
+- (void)setUppercasesButtonTitles:(BOOL)uppercasesButtonTitles {
+  _uppercasesButtonTitles = uppercasesButtonTitles;
+
+  for (NSUInteger i = 0; i < [_buttonViews count]; ++i) {
+    UIView *viewObj = _buttonViews[i];
+    if ([viewObj isKindOfClass:[MDCButton class]]) {
+      MDCButton *button = (MDCButton *)viewObj;
+      button.uppercaseTitle = uppercasesButtonTitles;
+    }
   }
 }
 

--- a/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
+++ b/components/ButtonBar/src/private/MDCAppBarButtonBarBuilder.m
@@ -129,6 +129,7 @@ static const UIEdgeInsets kButtonInset = {0, 12.0f, 0, 12.0f};
 
   [MDCAppBarButtonBarBuilder configureButton:button fromButtonItem:buttonItem];
 
+  button.uppercaseTitle = buttonBar.uppercasesButtonTitles;
   [button setTitleColor:self.buttonTitleColor forState:UIControlStateNormal];
   [button setUnderlyingColorHint:self.buttonUnderlyingColor];
   for (NSNumber *state in _fonts) {

--- a/components/ButtonBar/tests/unit/ButtonBarButtonTitleCasingTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarButtonTitleCasingTests.swift
@@ -27,7 +27,7 @@ class ButtonBarButtonTitleCasingTests: XCTestCase {
   }
 
   func testDefaultCasingIsUppercase() {
-    // Given
+    // Then
     XCTAssertTrue(buttonBar.uppercasesButtonTitles)
   }
 

--- a/components/ButtonBar/tests/unit/ButtonBarButtonTitleCasingTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarButtonTitleCasingTests.swift
@@ -34,6 +34,8 @@ class ButtonBarButtonTitleCasingTests: XCTestCase {
   func testButtonTitlesAreUppercasedByDefault() {
     // Given
     let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+
+    // When
     buttonBar.items = items
 
     // Then
@@ -48,6 +50,8 @@ class ButtonBarButtonTitleCasingTests: XCTestCase {
   func testButtonTitlesAreNotUppercasedWhenFlagIsDisabledBeforeAssignment() {
     // Given
     let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+
+    // When
     buttonBar.uppercasesButtonTitles = false
     buttonBar.items = items
 
@@ -63,6 +67,8 @@ class ButtonBarButtonTitleCasingTests: XCTestCase {
     // Given
     let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
     buttonBar.items = items
+
+    // When
     buttonBar.uppercasesButtonTitles = false
 
     // Then

--- a/components/ButtonBar/tests/unit/ButtonBarButtonTitleCasingTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarButtonTitleCasingTests.swift
@@ -1,0 +1,75 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents.MaterialButtonBar
+import MaterialComponents.MaterialButtons
+
+class ButtonBarButtonTitleCasingTests: XCTestCase {
+
+  var buttonBar: MDCButtonBar!
+
+  override func setUp() {
+    buttonBar = MDCButtonBar()
+  }
+
+  func testDefaultCasingIsUppercase() {
+    // Given
+    XCTAssertTrue(buttonBar.uppercasesButtonTitles)
+  }
+
+  func testButtonTitlesAreUppercasedByDefault() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    buttonBar.items = items
+
+    // Then
+    XCTAssertTrue(buttonBar.uppercasesButtonTitles)
+    for view in buttonBar.subviews {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.title(for: .normal), "TEXT")
+      }
+    }
+  }
+
+  func testButtonTitlesAreNotUppercasedWhenFlagIsDisabledBeforeAssignment() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    buttonBar.uppercasesButtonTitles = false
+    buttonBar.items = items
+
+    // Then
+    for view in buttonBar.subviews {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.title(for: .normal), "Text")
+      }
+    }
+  }
+
+  func testButtonTitlesAreNotUppercasedWhenFlagIsDisabledAfterAssignment() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    buttonBar.items = items
+    buttonBar.uppercasesButtonTitles = false
+
+    // Then
+    for view in buttonBar.subviews {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.title(for: .normal), "Text")
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change enables us to expose a similar API in MDCNavigationBar that will enable configuration of title casing behaviors for navigation bar button bars.

Step 1/2 for https://github.com/material-components/material-components-ios/issues/2968