### PR TITLE
[NavigationBar] Add uppercasesButtonTitles API for modifying title casing behavior.

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -160,6 +160,15 @@ IB_DESIGNABLE
 @property(nonatomic, strong, nullable) UIColor *inkColor;
 
 /**
+ If true, all button titles will be converted to uppercase.
+
+ Changing this property to NO will update the current title string for all buttons.
+
+ Default is YES.
+ */
+@property(nonatomic) BOOL uppercasesButtonTitles;
+
+/**
  Sets the title font for the given state for all buttons.
 
  @param font The font that should be displayed on text buttons for the given state.

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -137,6 +137,7 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
 }
 
 - (void)commonMDCNavigationBarInit {
+  _uppercasesButtonTitles = YES;
   _observedNavigationItemLock = [[NSObject alloc] init];
   _titleFont = [MDCTypography titleFont];
 
@@ -171,6 +172,13 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
     _trailingButtonBar.backgroundColor = nil;
   }
   return self;
+}
+
+- (void)setUppercasesButtonTitles:(BOOL)uppercasesButtonTitles {
+  _uppercasesButtonTitles = uppercasesButtonTitles;
+
+  _leadingButtonBar.uppercasesButtonTitles = uppercasesButtonTitles;
+  _trailingButtonBar.uppercasesButtonTitles = uppercasesButtonTitles;
 }
 
 - (void)setTitleFont:(UIFont *)titleFont {

--- a/components/NavigationBar/tests/unit/NavigationBarButtonTitleCasingTests.swift
+++ b/components/NavigationBar/tests/unit/NavigationBarButtonTitleCasingTests.swift
@@ -42,6 +42,8 @@ class NavigationBarButtonTitleCasingTests: XCTestCase {
   func testLeadingButtonTitlesAreUppercasedByDefault() {
     // Given
     let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+
+    // When
     navigationBar.leadingBarButtonItems = items
 
     // Then
@@ -56,6 +58,8 @@ class NavigationBarButtonTitleCasingTests: XCTestCase {
   func testLeadingButtonTitlesAreNotUppercasedWhenFlagIsDisabledBeforeAssignment() {
     // Given
     let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+
+    // When
     navigationBar.uppercasesButtonTitles = false
     navigationBar.leadingBarButtonItems = items
 
@@ -71,6 +75,8 @@ class NavigationBarButtonTitleCasingTests: XCTestCase {
     // Given
     let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
     navigationBar.leadingBarButtonItems = items
+
+    // When
     navigationBar.uppercasesButtonTitles = false
 
     // Then
@@ -98,6 +104,8 @@ class NavigationBarButtonTitleCasingTests: XCTestCase {
   func testTrailingButtonTitlesAreNotUppercasedWhenFlagIsDisabledBeforeAssignment() {
     // Given
     let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+
+    // When
     navigationBar.uppercasesButtonTitles = false
     navigationBar.trailingBarButtonItems = items
 
@@ -113,6 +121,8 @@ class NavigationBarButtonTitleCasingTests: XCTestCase {
     // Given
     let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
     navigationBar.trailingBarButtonItems = items
+
+    // When
     navigationBar.uppercasesButtonTitles = false
 
     // Then

--- a/components/NavigationBar/tests/unit/NavigationBarButtonTitleCasingTests.swift
+++ b/components/NavigationBar/tests/unit/NavigationBarButtonTitleCasingTests.swift
@@ -35,7 +35,7 @@ class NavigationBarButtonTitleCasingTests: XCTestCase {
   }
 
   func testDefaultCasingIsUppercase() {
-    // Given
+    // Then
     XCTAssertTrue(navigationBar.uppercasesButtonTitles)
   }
 

--- a/components/NavigationBar/tests/unit/NavigationBarButtonTitleCasingTests.swift
+++ b/components/NavigationBar/tests/unit/NavigationBarButtonTitleCasingTests.swift
@@ -1,0 +1,125 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MaterialComponents.MaterialNavigationBar
+import MaterialComponents.MaterialButtons
+
+class NavigationBarButtonTitleCasingTests: XCTestCase {
+
+  var navigationBar: MDCNavigationBar!
+
+  override func setUp() {
+    navigationBar = MDCNavigationBar()
+  }
+
+  private func recursiveSubviews(of superview: UIView) -> [UIView] {
+    var subviews = superview.subviews
+    for subview in superview.subviews {
+      subviews.append(contentsOf: recursiveSubviews(of: subview))
+    }
+    return subviews
+  }
+
+  func testDefaultCasingIsUppercase() {
+    // Given
+    XCTAssertTrue(navigationBar.uppercasesButtonTitles)
+  }
+
+  func testLeadingButtonTitlesAreUppercasedByDefault() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    navigationBar.leadingBarButtonItems = items
+
+    // Then
+    XCTAssertTrue(navigationBar.uppercasesButtonTitles)
+    for view in recursiveSubviews(of: navigationBar) {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.title(for: .normal), "TEXT")
+      }
+    }
+  }
+
+  func testLeadingButtonTitlesAreNotUppercasedWhenFlagIsDisabledBeforeAssignment() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    navigationBar.uppercasesButtonTitles = false
+    navigationBar.leadingBarButtonItems = items
+
+    // Then
+    for view in recursiveSubviews(of: navigationBar) {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.title(for: .normal), "Text")
+      }
+    }
+  }
+
+  func testLeadingButtonTitlesAreNotUppercasedWhenFlagIsDisabledAfterAssignment() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    navigationBar.leadingBarButtonItems = items
+    navigationBar.uppercasesButtonTitles = false
+
+    // Then
+    for view in recursiveSubviews(of: navigationBar) {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.title(for: .normal), "Text")
+      }
+    }
+  }
+
+  func testTrailingButtonTitlesAreUppercasedByDefault() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    navigationBar.trailingBarButtonItems = items
+
+    // Then
+    XCTAssertTrue(navigationBar.uppercasesButtonTitles)
+    for view in recursiveSubviews(of: navigationBar) {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.title(for: .normal), "TEXT")
+      }
+    }
+  }
+
+  func testTrailingButtonTitlesAreNotUppercasedWhenFlagIsDisabledBeforeAssignment() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    navigationBar.uppercasesButtonTitles = false
+    navigationBar.trailingBarButtonItems = items
+
+    // Then
+    for view in recursiveSubviews(of: navigationBar) {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.title(for: .normal), "Text")
+      }
+    }
+  }
+
+  func testTrailingButtonTitlesAreNotUppercasedWhenFlagIsDisabledAfterAssignment() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    navigationBar.trailingBarButtonItems = items
+    navigationBar.uppercasesButtonTitles = false
+
+    // Then
+    for view in recursiveSubviews(of: navigationBar) {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.title(for: .normal), "Text")
+      }
+    }
+  }
+}


### PR DESCRIPTION
This allows an owner of a navigation bar to configure the title casing behavior for both the leading and trailing button bars.

Closes https://github.com/material-components/material-components-ios/issues/2968