### PR TITLE
Disable codecov for now

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -197,8 +197,6 @@ run_cocoapods() {
       pod lib lint MaterialComponents.podspec
     fi
   done
-
-  bash <(curl -s https://codecov.io/bash)
 }
 
 # For local runs, you must set the following environment variables:


### PR DESCRIPTION
The generated codecov comments are mostly noise at this point and we're not measuring our public code coverage in any meaningful way at this point in time. Disabling the comments for now until we deem it to be an important enough tool to re-enable.