### PR TITLE
[Tabs] fix TabBarViewControllerExample to respect safe area

### DIFF
--- a/components/Tabs/examples/TabBarViewControllerExample.m
+++ b/components/Tabs/examples/TabBarViewControllerExample.m
@@ -16,8 +16,6 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialButtons.h"
-#import "MaterialButtons+ButtonThemer.h"
 #import "MaterialColorScheme.h"
 #import "MaterialSlider.h"
 #import "MaterialTabs.h"
@@ -42,54 +40,12 @@
   [self loadTabBar];
 }
 
-#pragma mark - Action
-
-- (void)toggleTabBar {
-  [self setTabBarHidden:!self.tabBarHidden animated:YES];
-}
-
-- (void)pushHidesNavigation {
-  TBVCSampleViewController *vc =
-      [TBVCSampleViewController sampleWithTitle:@"Push&Hide" color:UIColor.grayColor];
-  vc.colorScheme = self.colorScheme;
-  vc.typographyScheme = self.typographyScheme;
-  [self.navigationController pushViewController:vc animated:YES];
-}
-
 #pragma mark - Private
 
 - (void)loadTabBar {
   NSArray *viewControllers = [self constructExampleViewControllers];
   self.viewControllers = viewControllers;
-  UIViewController *child0 = viewControllers[0];
-  self.selectedViewController = child0;
-  UIViewController *child1 = viewControllers[1];
-
-  MDCButtonScheme *buttonScheme = [[MDCButtonScheme alloc] init];
-  buttonScheme.colorScheme = self.colorScheme;
-  buttonScheme.typographyScheme = self.typographyScheme;
-
-  // Put the button under the header.
-  MDCButton *button = [[MDCButton alloc] initWithFrame:CGRectMake(10, 120, 300, 40)];
-  [MDCContainedButtonThemer applyScheme:buttonScheme toButton:button];
-  [button setTitle:@"Push and Hide Tab" forState:UIControlStateNormal];
-  [button sizeToFit];
-  [child1.view addSubview:button];
-  [button addTarget:self
-                action:@selector(pushHidesNavigation)
-      forControlEvents:UIControlEventTouchUpInside];
-
-  UIViewController *child2 = viewControllers[2];
-  // Put the button under the header.
-  button = [[MDCButton alloc] initWithFrame:CGRectMake(10, 120, 300, 40)];
-  [MDCContainedButtonThemer applyScheme:buttonScheme toButton:button];
-  [button setTitle:@"Toggle Tab Bar" forState:UIControlStateNormal];
-  [button sizeToFit];
-  [child2.view addSubview:button];
-  [button addTarget:self
-                action:@selector(toggleTabBar)
-      forControlEvents:UIControlEventTouchUpInside];
-  
+  self.selectedViewController = [self.viewControllers firstObject];
   [MDCTabBarColorThemer applySemanticColorScheme:self.colorScheme toTabs:self.tabBar];
 }
 

--- a/components/Tabs/examples/TabBarViewControllerExample.m
+++ b/components/Tabs/examples/TabBarViewControllerExample.m
@@ -45,7 +45,7 @@
 - (void)loadTabBar {
   NSArray *viewControllers = [self constructExampleViewControllers];
   self.viewControllers = viewControllers;
-  self.selectedViewController = [self.viewControllers firstObject];
+  self.selectedViewController = self.viewControllers.firstObject;
   [MDCTabBarColorThemer applySemanticColorScheme:self.colorScheme toTabs:self.tabBar];
 }
 

--- a/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.h
+++ b/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.h
@@ -47,9 +47,8 @@ typedef void (^MDCButtonActionBlock)(void);
 
 + (nonnull instancetype)sampleWithTitle:(nonnull NSString *)title color:(nonnull UIColor *)color;
 
-- (void)addMDCButtonWithFrame:(CGRect)frame
-                 buttonScheme:(id<MDCButtonScheming>)buttonScheme
-                        title:(NSString *)title
-                  actionBlock:(MDCButtonActionBlock)actionBlock;
-
+- (void)setMDCButtonWithFrame:(CGRect)frame
+                 buttonScheme:(nonnull id<MDCButtonScheming>)buttonScheme
+                        title:(nonnull NSString *)title
+                  actionBlock:(nullable MDCButtonActionBlock)actionBlock;
 @end

--- a/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.h
+++ b/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.h
@@ -20,9 +20,12 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialButtons+ButtonThemer.h"
 #import "MaterialColorScheme.h"
 #import "MaterialTypographyScheme.h"
 #import "MaterialTabs.h"
+
+typedef void (^MDCButtonActionBlock)(void);
 
 @interface TabBarViewControllerExample : MDCTabBarViewController
 @property(nonatomic, strong, nullable) MDCSemanticColorScheme *colorScheme;
@@ -38,7 +41,15 @@
 @end
 
 @interface TBVCSampleViewController : UIViewController
-+ (nonnull instancetype)sampleWithTitle:(nonnull NSString *)title color:(nonnull UIColor *)color;
+
 @property(nonatomic, nullable) MDCSemanticColorScheme *colorScheme;
 @property(nonatomic, nullable) MDCTypographyScheme *typographyScheme;
+
++ (nonnull instancetype)sampleWithTitle:(nonnull NSString *)title color:(nonnull UIColor *)color;
+
+- (void)addMDCButtonWithFrame:(CGRect)frame
+                 buttonScheme:(id<MDCButtonScheming>)buttonScheme
+                        title:(NSString *)title
+                  actionBlock:(MDCButtonActionBlock)actionBlock;
+
 @end

--- a/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
@@ -23,6 +23,7 @@
 #import "MaterialAppBar.h"
 #import "MaterialAppBar+ColorThemer.h"
 #import "MaterialAppBar+TypographyThemer.h"
+#import "MaterialButtons.h"
 #import "MaterialPalettes.h"
 
 @interface TBVCSampleView : UIView
@@ -46,8 +47,13 @@
 @end
 
 @interface TBVCSampleViewController ()
+
 @property(nonatomic) MDCAppBarViewController *appBarViewController;
 @property(nonatomic) UILabel *titleLabel;
+@property(nonatomic) CGRect buttonFrame;
+@property(nonatomic) UIButton *button;
+@property(nonatomic, copy) MDCButtonActionBlock buttonActionBlock;
+
 @end
 
 @implementation TBVCSampleViewController
@@ -78,6 +84,17 @@
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
   _titleLabel.center = self.view.center;
+  UIEdgeInsets edgeInsets = UIEdgeInsetsZero;
+  if (@available(iOS 11.0, *)) {
+    edgeInsets = self.view.safeAreaInsets;
+  }
+  CGRect buttonFrame = self.buttonFrame;
+  self.button.frame = CGRectMake(buttonFrame.origin.x + edgeInsets.left,
+                                 buttonFrame.origin.y + edgeInsets.top,
+                                 buttonFrame.size.width,
+                                 buttonFrame.size.height);
+  [self.button sizeToFit];
+
   [self.view setNeedsDisplay];
 }
 
@@ -106,6 +123,28 @@
   return sample;
 }
 
+- (void)addMDCButtonWithFrame:(CGRect)frame
+                 buttonScheme:(id<MDCButtonScheming>)buttonScheme
+                        title:(NSString *)title
+                  actionBlock:(MDCButtonActionBlock)actionBlock {
+  MDCButton *button = [[MDCButton alloc] initWithFrame:CGRectZero];
+  [button setTitle:title forState:UIControlStateNormal];
+  [MDCContainedButtonThemer applyScheme:buttonScheme toButton:button];
+  [self.view addSubview:button];
+  self.button = button;
+  self.buttonFrame = frame;
+  self.buttonActionBlock = actionBlock;
+  [button addTarget:self
+             action:@selector(triggerButtonActionHandler)
+   forControlEvents:UIControlEventTouchUpInside];
+}
+
+- (void)triggerButtonActionHandler {
+  if (self.buttonActionBlock) {
+    self.buttonActionBlock();
+  }
+}
+
 @end
 
 @implementation TabBarViewControllerExample (Supplemental)
@@ -117,14 +156,40 @@
 
 - (nonnull NSArray *)constructExampleViewControllers {
   NSBundle *bundle = [NSBundle bundleForClass:[TabBarViewControllerExample class]];
+  MDCButtonScheme *buttonScheme = [[MDCButtonScheme alloc] init];
+  buttonScheme.colorScheme = self.colorScheme;
+  buttonScheme.typographyScheme = self.typographyScheme;
+
   TBVCSampleViewController *child1 =
       [TBVCSampleViewController sampleWithTitle:@"One" color:UIColor.redColor];
+
   UIColor *blue = [UIColor colorWithRed:0x3A / 255.f green:0x56 / 255.f blue:0xFF / 255.f alpha:1];
   TBVCSampleViewController *child2 = [TBVCSampleViewController sampleWithTitle:@"Two" color:blue];
+  __weak TabBarViewControllerExample *weakSelf = self;
+  [child2 addMDCButtonWithFrame:CGRectMake(10, 120, 300, 40)
+                   buttonScheme:buttonScheme
+                          title:@"Push and Hide Tab"
+                    actionBlock:^{
+                      TabBarViewControllerExample *strongSelf = weakSelf;
+                      TBVCSampleViewController *vc =
+                      [TBVCSampleViewController sampleWithTitle:@"Push&Hide" color:UIColor.grayColor];
+                      vc.colorScheme = self.colorScheme;
+                      vc.typographyScheme = self.typographyScheme;
+                      [strongSelf.navigationController pushViewController:vc animated:YES];
+                    }];
+
   UIImage *starImage =
       [UIImage imageNamed:@"TabBarDemo_ic_star" inBundle:bundle compatibleWithTraitCollection:nil];
   TBVCSampleViewController *child3 =
       [TBVCSampleViewController sampleWithTitle:@"Three" color:UIColor.blueColor icon:starImage];
+  [child3 addMDCButtonWithFrame:CGRectMake(10, 120, 300, 40)
+                   buttonScheme:buttonScheme
+                          title:@"Toggle Tab Bar"
+                    actionBlock:^{
+                      TabBarViewControllerExample *strongSelf = weakSelf;
+                      [strongSelf setTabBarHidden:!strongSelf.tabBarHidden animated:YES];
+                    }];
+
   NSArray *viewControllers = @[ child1, child2, child3 ];
   for (TBVCSampleViewController *vc in viewControllers) {
     vc.colorScheme = self.colorScheme;

--- a/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
@@ -50,8 +50,8 @@
 
 @property(nonatomic) MDCAppBarViewController *appBarViewController;
 @property(nonatomic) UILabel *titleLabel;
-@property(nonatomic) CGRect buttonFrame;
-@property(nonatomic) UIButton *button;
+@property(nonatomic) CGRect buttonFrame; // The desired frame of the button
+@property(nonatomic) MDCButton *button;
 @property(nonatomic, copy) MDCButtonActionBlock buttonActionBlock;
 
 @end
@@ -84,15 +84,12 @@
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
   _titleLabel.center = self.view.center;
-  UIEdgeInsets edgeInsets = UIEdgeInsetsZero;
+  UIEdgeInsets safeAreaInsets = UIEdgeInsetsZero;
   if (@available(iOS 11.0, *)) {
-    edgeInsets = self.view.safeAreaInsets;
+    safeAreaInsets = self.view.safeAreaInsets;
   }
   CGRect buttonFrame = self.buttonFrame;
-  self.button.frame = CGRectMake(buttonFrame.origin.x + edgeInsets.left,
-                                 buttonFrame.origin.y + edgeInsets.top,
-                                 buttonFrame.size.width,
-                                 buttonFrame.size.height);
+  self.button.frame = CGRectOffset(buttonFrame, safeAreaInsets.left, safeAreaInsets.top);
   [self.button sizeToFit];
 
   [self.view setNeedsDisplay];
@@ -123,16 +120,16 @@
   return sample;
 }
 
-- (void)addMDCButtonWithFrame:(CGRect)frame
-                 buttonScheme:(id<MDCButtonScheming>)buttonScheme
-                        title:(NSString *)title
-                  actionBlock:(MDCButtonActionBlock)actionBlock {
+- (void)setMDCButtonWithFrame:(CGRect)frame
+                 buttonScheme:(nonnull id<MDCButtonScheming>)buttonScheme
+                        title:(nonnull NSString *)title
+                  actionBlock:(nullable MDCButtonActionBlock)actionBlock {
   MDCButton *button = [[MDCButton alloc] initWithFrame:CGRectZero];
   [button setTitle:title forState:UIControlStateNormal];
   [MDCContainedButtonThemer applyScheme:buttonScheme toButton:button];
   [self.view addSubview:button];
   self.button = button;
-  self.buttonFrame = frame;
+  self.buttonFrame = CGRectStandardize(frame);
   self.buttonActionBlock = actionBlock;
   [button addTarget:self
              action:@selector(triggerButtonActionHandler)
@@ -166,15 +163,15 @@
   UIColor *blue = [UIColor colorWithRed:0x3A / 255.f green:0x56 / 255.f blue:0xFF / 255.f alpha:1];
   TBVCSampleViewController *child2 = [TBVCSampleViewController sampleWithTitle:@"Two" color:blue];
   __weak TabBarViewControllerExample *weakSelf = self;
-  [child2 addMDCButtonWithFrame:CGRectMake(10, 120, 300, 40)
+  [child2 setMDCButtonWithFrame:CGRectMake(10, 120, 300, 40)
                    buttonScheme:buttonScheme
                           title:@"Push and Hide Tab"
                     actionBlock:^{
                       TabBarViewControllerExample *strongSelf = weakSelf;
                       TBVCSampleViewController *vc =
                       [TBVCSampleViewController sampleWithTitle:@"Push&Hide" color:UIColor.grayColor];
-                      vc.colorScheme = self.colorScheme;
-                      vc.typographyScheme = self.typographyScheme;
+                      vc.colorScheme = strongSelf.colorScheme;
+                      vc.typographyScheme = strongSelf.typographyScheme;
                       [strongSelf.navigationController pushViewController:vc animated:YES];
                     }];
 
@@ -182,7 +179,7 @@
       [UIImage imageNamed:@"TabBarDemo_ic_star" inBundle:bundle compatibleWithTraitCollection:nil];
   TBVCSampleViewController *child3 =
       [TBVCSampleViewController sampleWithTitle:@"Three" color:UIColor.blueColor icon:starImage];
-  [child3 addMDCButtonWithFrame:CGRectMake(10, 120, 300, 40)
+  [child3 setMDCButtonWithFrame:CGRectMake(10, 120, 300, 40)
                    buttonScheme:buttonScheme
                           title:@"Toggle Tab Bar"
                     actionBlock:^{


### PR DESCRIPTION
closes #3728 

### Before

![b1](https://user-images.githubusercontent.com/8836258/44799553-351d2200-ab82-11e8-9548-f0eb54cf2769.png)

### After:

![a1](https://user-images.githubusercontent.com/8836258/44799555-364e4f00-ab82-11e8-8aec-6b6316374f9b.png)