### PR TITLE
[BottomNavigation] Update ripple color for unselected items.

### DIFF
--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -314,9 +314,10 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
   if (self.selected) {
     self.iconImageView.tintColor = self.selectedItemTintColor;
     self.label.textColor = self.selectedItemTitleColor;
-    self.inkView.inkColor =
-        [self.selectedItemTintColor colorWithAlphaComponent:MDCBottomNavigationItemViewInkOpacity];
   }
+  self.inkView.inkColor =
+      [self.selectedItemTintColor colorWithAlphaComponent:MDCBottomNavigationItemViewInkOpacity];
+
 }
 
 - (void)setUnselectedItemTintColor:(UIColor *)unselectedItemTintColor {
@@ -324,8 +325,6 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
   if (!self.selected) {
     self.iconImageView.tintColor = self.unselectedItemTintColor;
     self.label.textColor = self.unselectedItemTintColor;
-    self.inkView.inkColor =
-        [self.selectedItemTintColor colorWithAlphaComponent:MDCBottomNavigationItemViewInkOpacity];
   }
 }
 

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
@@ -112,4 +112,21 @@ static UIImage *fakeImage(void) {
                              0.001f);
 }
 
+- (void)testSetSelectedItemTintColorUpdatesInkColor {
+  // Given
+  MDCBottomNavigationItemView *item1 = [[MDCBottomNavigationItemView alloc] init];
+  MDCBottomNavigationItemView *item2 = [[MDCBottomNavigationItemView alloc] init];
+  item1.selected = YES;
+  UIColor *item1DefaultInkColor = item1.inkView.inkColor;
+  UIColor *item2DefaultInkColor = item2.inkView.inkColor;
+
+  // When
+  item1.selectedItemTintColor = UIColor.cyanColor;
+  item2.selectedItemTintColor = UIColor.cyanColor;
+
+  // Then
+  XCTAssertNotEqualObjects(item1.inkView.inkColor, item1DefaultInkColor);
+  XCTAssertNotEqualObjects(item2.inkView.inkColor, item2DefaultInkColor);
+}
+
 @end


### PR DESCRIPTION
All items should share the same (ink) ripple color, based on the
`selectedItemTintColor`. For currently-unselected items, the ripple color
would only be updated if the `unselectedItemTintColor` property was set.

The problem was caused by earlier behavior where the ripple color would be
derived from the current state of the button. If an unselected item were
pressed, its ripple color would be based on the `unselectedItemTintColor`.
That behavior was changed so that the `selectedItemTintColor` was used for the
ripple color in all states, but the logic was not moved outside of the
state-based conditional logic.

||Animated Screenshot|
|--|--|
|Before | ![bn-ink-before](https://user-images.githubusercontent.com/1753199/44802070-bd9ec100-ab88-11e8-86c9-48658f8adcc0.gif)|
|After | ![bn-ink-after](https://user-images.githubusercontent.com/1753199/44802075-c2fc0b80-ab88-11e8-872f-ad586408b928.gif)|



Closes #4937
