### PR TITLE
[Catalog] Move to the new CbC standard

### DIFF
--- a/components/ActionSheet/examples/ActionSheetSwiftExample.swift
+++ b/components/ActionSheet/examples/ActionSheetSwiftExample.swift
@@ -92,13 +92,15 @@ class ActionSheetSwiftExample: UIViewController {
 
 // MARK: Catalog by Convensions
 extension ActionSheetSwiftExample {
-  class func catalogIsPrimaryDemo() -> Bool {
-    return false
+
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Action Sheet", "Action Sheet (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 
-  class func catalogBreadcrumbs() -> [String] {
-    return ["Action Sheet", "Action Sheet (Swift)"]
-  }
 }
 
 extension ActionSheetSwiftExample : UITableViewDelegate {

--- a/components/ActionSheet/examples/ActionSheetTypicalUse.m
+++ b/components/ActionSheet/examples/ActionSheetTypicalUse.m
@@ -91,16 +91,12 @@
 
 @implementation ActionSheetTypicalUse (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Action Sheet", @"Action Sheet"];
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Action Sheet", @"Action Sheet" ],
+    @"primaryDemo": @YES,
+    @"presentable": @YES
+  };
 }
 
 @end

--- a/components/ActivityIndicator/examples/ActivityIndicatorExample.swift
+++ b/components/ActivityIndicator/examples/ActivityIndicatorExample.swift
@@ -82,12 +82,13 @@ extension ActivityIndicatorSwiftController : MDCActivityIndicatorDelegate {
       return
    }
 
-   // MARK: Catalog by convention
-   @objc class func catalogBreadcrumbs() -> [String] {
-      return ["Activity Indicator", "Activity Indicator (Swift)"]
-   }
+  // MARK: Catalog by convention
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Activity Indicator", "Activity Indicator (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
+  }
 
-   @objc class func catalogIsPrimaryDemo() -> Bool {
-      return false
-   }
 }

--- a/components/ActivityIndicator/examples/ActivityIndicatorTransitionExample.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorTransitionExample.m
@@ -277,16 +277,12 @@ static const NSTimeInterval kActivityIndicatorExampleAnimationDuration = 2.0 / 3
 
 #pragma mark - Catalog by Convention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Activity Indicator", @"Activity Indicator Transition" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Activity Indicator", @"Activity Indicator Transition" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES
+  };
 }
 
 @end

--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleSupplemental.m
@@ -30,21 +30,14 @@ static NSString * const kCell = @"Cell";
 
 @implementation ActivityIndicatorExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Activity Indicator", @"Activity Indicator" ];
-}
-
-+ (NSString *)catalogDescription {
-  return @"Activity Indicator is a visual indication of an app loading content. It can display how "
-         @"long an operation will take or visualize an unspecified wait time.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Activity Indicator", @"Activity Indicator" ],
+    @"description": @"Activity Indicator is a visual indication of an app loading content. "
+    @"It can display how long an operation will take or visualize an unspecified wait time.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES
+  };
 }
 
 @end

--- a/components/AnimationTiming/examples/AnimationTimingExample.swift
+++ b/components/AnimationTiming/examples/AnimationTimingExample.swift
@@ -179,11 +179,12 @@ extension AnimationTimingExample {
       scrollView.addSubview(materialSharpView)
    }
 
-   @objc class func catalogBreadcrumbs() -> [String] {
-      return ["Animation Timing", "Animation Timing (Swift)"]
-   }
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Animation Timing", "Animation Timing (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
+  }
 
-   @objc class func catalogIsPrimaryDemo() -> Bool {
-      return false
-   }
 }

--- a/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
+++ b/components/AnimationTiming/examples/supplemental/AnimationTimingExampleSupplemental.m
@@ -27,21 +27,14 @@ static const CGSize kAnimationCircleSize = {48.f, 48.f};
 
 @implementation AnimationTimingExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Animation Timing", @"Animation Timing" ];
-}
-
-+ (NSString *)catalogDescription {
-  return @"Animation timing easing curves create smooth and consistent motion. Easing curves allow"
-          " elements to move between positions or states.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Animation Timing", @"Animation Timing" ],
+    @"description": @"Animation timing easing curves create smooth and consistent motion. "
+    @"Easing curves allow elements to move between positions or states.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES
+  };
 }
 
 @end

--- a/components/AppBar/examples/AppBarImageryExample.m
+++ b/components/AppBar/examples/AppBarImageryExample.m
@@ -110,19 +110,15 @@
 
 @implementation AppBarImageryExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"App Bar", @"Imagery" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"App Bar", @"Imagery" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
   return YES;
 }
 

--- a/components/AppBar/examples/AppBarImageryExample.swift
+++ b/components/AppBar/examples/AppBarImageryExample.swift
@@ -97,12 +97,13 @@ class AppBarImagerySwiftExample: UITableViewController {
 
 // MARK: Catalog by convention
 extension AppBarImagerySwiftExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["App Bar", "Imagery (Swift)"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["App Bar", "Imagery (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 
   func catalogShouldHideNavigation() -> Bool {

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.m
@@ -86,24 +86,17 @@
 
 @implementation AppBarInterfaceBuilderExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"App Bar", @"Interface Builder" ];
-}
-
-+ (NSString *)catalogStoryboardName {
-  return @"AppBarInterfaceBuilderExampleController";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"App Bar", @"Interface Builder" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+    @"storyboardName": @"AppBarInterfaceBuilderExampleController"
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
@@ -72,16 +72,14 @@ class AppBarInterfaceBuilderSwiftExample: UIViewController, UIScrollViewDelegate
 
 // MARK: Catalog by convention
 extension AppBarInterfaceBuilderSwiftExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["App Bar", "Interface Builder (Swift)"]
-  }
 
-  @objc class func catalogStoryboardName() -> String {
-    return "AppBarInterfaceBuilderSwiftExampleController"
-  }
-
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["App Bar", "Interface Builder (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+      "storyboardName": "AppBarInterfaceBuilderSwiftExampleController",
+    ]
   }
 
   func catalogShouldHideNavigation() -> Bool {

--- a/components/AppBar/examples/AppBarModalPresentationExample.m
+++ b/components/AppBar/examples/AppBarModalPresentationExample.m
@@ -183,20 +183,16 @@
 
 @implementation AppBarModalPresentationExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"App Bar", @"Modal Presentation" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"App Bar", @"Modal Presentation" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -154,12 +154,13 @@ class AppBarModalPresentationSwiftExample: UITableViewController {
 
 // MARK: Catalog by convention
 extension AppBarModalPresentationSwiftExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["App Bar", "Modal Presentation (Swift)"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["App Bar", "Modal Presentation (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 
   func catalogShouldHideNavigation() -> Bool {

--- a/components/AppBar/examples/AppBarPresentedExample.m
+++ b/components/AppBar/examples/AppBarPresentedExample.m
@@ -216,16 +216,12 @@
 
 @implementation AppBarPresentedExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"App Bar", @"Presented" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"App Bar", @"Presented" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/AppBar/examples/AppBarSectionHeadersExample.m
+++ b/components/AppBar/examples/AppBarSectionHeadersExample.m
@@ -99,19 +99,15 @@
 
 @implementation AppBarSectionHeadersExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"App Bar", @"UITableView with section headers" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"App Bar", @"UITableView with section headers" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
   return YES;
 }
 

--- a/components/AppBar/examples/AppBarTypicalCollectionViewExample.m
+++ b/components/AppBar/examples/AppBarTypicalCollectionViewExample.m
@@ -126,20 +126,12 @@
 
 @implementation AppBarTypicalCollectionViewExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"App Bar", @"Collection View with App bar" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-- (BOOL)catalogShouldHideNavigation {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"App Bar", @"Collection View with App bar" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/AppBar/examples/AppBarTypicalUseExample.m
+++ b/components/AppBar/examples/AppBarTypicalUseExample.m
@@ -108,23 +108,17 @@
 
 @implementation AppBarTypicalUseExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"App Bar", @"App Bar" ];
-}
-
-+ (NSString *)catalogDescription {
-  return @"The top app bar displays information and actions relating to the current view.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"App Bar", @"App Bar" ],
+    @"description": @"The top app bar displays information and actions relating to "
+    @"the current view.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
   return YES;
 }
 

--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -89,12 +89,13 @@ class AppBarTypicalUseSwiftExample: UITableViewController {
 
 // MARK: Catalog by convention
 extension AppBarTypicalUseSwiftExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["App Bar", "App Bar (Swift)"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["App Bar", "App Bar (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 
   func catalogShouldHideNavigation() -> Bool {

--- a/components/AppBar/examples/AppBarWKWebViewLargeContentExample.m
+++ b/components/AppBar/examples/AppBarWKWebViewLargeContentExample.m
@@ -142,20 +142,16 @@
 
 @implementation AppBarWKWebViewLargeContentExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"App Bar", @"WKWebView large content" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"App Bar", @"WKWebView large content" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/AppBar/examples/AppBarWKWebViewLargeContentNoBugExample.m
+++ b/components/AppBar/examples/AppBarWKWebViewLargeContentNoBugExample.m
@@ -106,20 +106,16 @@
 
 @implementation AppBarWKWebViewLargeContentNoBugExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"App Bar", @"WKWebView large content no bug" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"App Bar", @"WKWebView large content no bug" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/AppBar/examples/AppBarWKWebViewSmallContentBugExample.m
+++ b/components/AppBar/examples/AppBarWKWebViewSmallContentBugExample.m
@@ -104,20 +104,16 @@
 
 @implementation AppBarWKWebViewSmallContentBugExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"App Bar", @"WKWebView small content bug" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"App Bar", @"WKWebView small content bug" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/AppBar/examples/AppBarWKWebViewSmallContentExample.m
+++ b/components/AppBar/examples/AppBarWKWebViewSmallContentExample.m
@@ -137,20 +137,16 @@
 
 @implementation AppBarWKWebViewSmallContentExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"App Bar", @"WKWebView small content" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"App Bar", @"WKWebView small content" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/AppBar/examples/AppBarWithUITableViewController.swift
+++ b/components/AppBar/examples/AppBarWithUITableViewController.swift
@@ -107,16 +107,13 @@ class AppBarWithUITableViewController: UITableViewController {
 }
 
 extension AppBarWithUITableViewController {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["App Bar", "AppBar+UITableViewController"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return true
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["App Bar", "AppBar+UITableViewController"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 
   func catalogShouldHideNavigation() -> Bool {

--- a/components/AppBar/examples/AppBarWrappedExample.m
+++ b/components/AppBar/examples/AppBarWrappedExample.m
@@ -84,19 +84,15 @@
 
 @implementation AppBarWrappedExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"App Bar", @"Wrapped" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"App Bar", @"Wrapped" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
   return YES;
 }
 

--- a/components/AppBar/examples/AppBarWrappingUITableViewControllerExample.m
+++ b/components/AppBar/examples/AppBarWrappingUITableViewControllerExample.m
@@ -108,19 +108,15 @@
 
 @implementation AppBarWrappingUITableViewControllerExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"App Bar", @"Wrapped table view" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"App Bar", @"Wrapped table view" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
   return YES;
 }
 

--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
@@ -127,12 +127,13 @@ class BottomAppBarTypicalUseSwiftExample: UIViewController {
 
 // MARK: Catalog by convention
 extension BottomAppBarTypicalUseSwiftExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Bottom App Bar", "Bottom App Bar (Swift)"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Bottom App Bar", "Bottom App Bar (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 
   func catalogShouldHideNavigation() -> Bool {

--- a/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseSupplemental.m
+++ b/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseSupplemental.m
@@ -31,23 +31,17 @@ static NSString *const kCellIdentifier = @"cell";
 
 @implementation BottomAppBarTypicalUseExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Bottom App Bar", @"Bottom App Bar" ];
-}
-
-+ (NSString *)catalogDescription {
-  return @"A bottom app bar displays navigation and key actions at the bottom of the screen.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Bottom App Bar", @"Bottom App Bar" ],
+    @"description": @"A bottom app bar displays navigation and key actions at the "
+    @"bottom of the screen.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
   return YES;
 }
 

--- a/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
@@ -118,15 +118,12 @@ class BottomNavigationExplicitlySetColorExample: UIViewController {
 
 // MARK: Catalog by convention
 extension BottomNavigationExplicitlySetColorExample {
-  class func catalogBreadcrumbs() -> [String] {
-    return ["Bottom Navigation", "Bottom Navigation Set Color (Swift)"]
-  }
 
-  class func catalogIsPrimaryDemo() -> Bool {
-    return false
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Bottom Navigation", "Bottom Navigation Set Color (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }

--- a/components/BottomNavigation/examples/BottomNavigationNilBadges.swift
+++ b/components/BottomNavigation/examples/BottomNavigationNilBadges.swift
@@ -109,19 +109,16 @@ class BottomNavigationNilBadges : UIViewController {
 
 // MARK: Catalog by convention
 extension BottomNavigationNilBadges {
-  class func catalogBreadcrumbs() -> [String] {
-    return ["Bottom Navigation", "Badge Value Test"]
-  }
 
-  class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Bottom Navigation", "Badge Value Test"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 
   func catalogShouldHideNavigation() -> Bool {
     return true
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
   }
 }

--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -117,16 +117,13 @@ class BottomNavigationResetExample: UIViewController {
 
 // MARK: Catalog by convention
 extension BottomNavigationResetExample {
-  class func catalogBreadcrumbs() -> [String] {
-    return ["Bottom Navigation", "Bottom Navigation Reorder (Swift)"]
-  }
 
-  class func catalogIsPrimaryDemo() -> Bool {
-    return false
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Bottom Navigation", "Bottom Navigation Reorder (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 
   class func catalogShouldHideNavigation() -> Bool {

--- a/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
@@ -68,11 +68,12 @@ class BottomNavigationSelectedIconExample: UIViewController {
 
 // MARK: - Catalog by Conventions
 extension BottomNavigationSelectedIconExample {
-  class func catalogBreadcrumbs() -> [String] {
-    return ["Bottom Navigation", "Bottom Navigation Selected"]
-  }
 
-  class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Bottom Navigation", "Bottom Navigation Selected"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
@@ -86,11 +86,12 @@ class BottomNavigationTypicalUseSwiftExample: UIViewController {
 
 // MARK: Catalog by convention
 extension BottomNavigationTypicalUseSwiftExample {
-  class func catalogBreadcrumbs() -> [String] {
-    return ["Bottom Navigation", "Bottom Navigation (Swift)"]
-  }
 
-  class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Bottom Navigation", "Bottom Navigation (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }

--- a/components/BottomNavigation/examples/supplemental/BottomNavigationTypicalUseSupplemental.m
+++ b/components/BottomNavigation/examples/supplemental/BottomNavigationTypicalUseSupplemental.m
@@ -20,20 +20,14 @@
 
 @implementation BottomNavigationTypicalUseExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Bottom Navigation", @"Bottom Navigation" ];
-}
-
-+ (NSString *)catalogDescription {
-  return @"Bottom navigation bars allow movement between primary destinations in an app.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Bottom Navigation", @"Bottom Navigation" ],
+    @"description": @"Bottom navigation bars allow movement between primary destinations in "
+    @"an app.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/BottomSheet/examples/BottomSheetTableViewExample.swift
+++ b/components/BottomSheet/examples/BottomSheetTableViewExample.swift
@@ -110,15 +110,12 @@ private class BottomSheetTableViewMenu: UITableViewController {
 
 // MARK: Catalog by convention
 extension BottomSheetTableViewExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Bottom Sheet", "Table View Menu"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Bottom Sheet", "Table View Menu"],
+      "primaryDemo": false,
+      "presentable": true,
+    ]
   }
 }

--- a/components/BottomSheet/examples/supplemental/BottomSheetSupplemental.m
+++ b/components/BottomSheet/examples/supplemental/BottomSheetSupplemental.m
@@ -18,117 +18,86 @@
 
 @implementation BottomSheetAutolayoutExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Bottom Sheet", @"Autolayout Content" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Bottom Sheet", @"Autolayout Content" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end
 
 @implementation BottomSheetAutolayoutSafeAreaExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Bottom Sheet", @"Autolayout Safe Area Content" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Bottom Sheet", @"Autolayout Safe Area Content" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end
 
 @implementation BottomSheetShortCollectionExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Bottom Sheet", @"Collection View (Short)" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Bottom Sheet", @"Collection View (Short)" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end
 
 @implementation BottomSheetSimpleExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Bottom Sheet", @"Static Content" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Bottom Sheet", @"Static Content" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end
 
 @implementation BottomSheetTallExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Bottom Sheet", @"Preferred Content Size" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Bottom Sheet", @"Preferred Content Size" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end
 
 @implementation BottomSheetTypicalUseExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Bottom Sheet", @"Bottom Sheet" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (NSString *)catalogDescription {
-  return @"Bottom sheets are surfaces anchored to the bottom of the screen containing supplementary"
-          " content, actions, or navigation.";
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Bottom Sheet", @"Bottom Sheet" ],
+    @"description": @"Bottom sheets are surfaces anchored to the bottom of the screen "
+    @"containing supplementary content, actions, or navigation.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 @end
 
 @implementation BottomSheetShapedExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Bottom Sheet", @"Shaped Bottom Sheet" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Bottom Sheet", @"Shaped Bottom Sheet" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/ButtonBar/examples/ButtonBarCustomizedFontExample.m
+++ b/components/ButtonBar/examples/ButtonBarCustomizedFontExample.m
@@ -88,12 +88,12 @@
 
 @implementation ButtonBarCustomizedFontExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Button Bar", @"Button Bar (Customized)" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Button Bar", @"Button Bar (Customized)" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/ButtonBar/examples/ButtonBarIconExample.m
+++ b/components/ButtonBar/examples/ButtonBarIconExample.m
@@ -82,12 +82,12 @@
 
 @implementation ButtonBarIconExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Button Bar", @"Button Bar (Icons)" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Button Bar", @"Button Bar (Icons)" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.m
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.m
@@ -82,17 +82,14 @@
 
 @implementation ButtonBarTypicalUseExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Button Bar", @"Button Bar" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (NSString *)catalogDescription {
-  return @"The Button Bar is a view that represents a list of UIBarButtonItems as"
-          " horizontally-aligned buttons.";
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Button Bar", @"Button Bar" ],
+    @"description": @"The Button Bar is a view that represents a list of UIBarButtonItems as "
+    @"horizontally-aligned buttons.",
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
@@ -76,12 +76,13 @@ class ButtonBarTypicalUseSwiftExample: UIViewController {
 
 // MARK: Catalog by convention
 extension ButtonBarTypicalUseSwiftExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Button Bar", "Button Bar (Swift)"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Button Bar", "Button Bar (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }
 

--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -30,16 +30,13 @@
 
 #pragma mark - Catalog by Convention
 
-+ (NSArray<NSString *> *)catalogBreadcrumbs {
-  return @[ @"Buttons", @"Buttons (Content Edge Insets)" ];
-}
-
-+ (NSString *)catalogStoryboardName {
-  return @"ButtonsContentEdgeInsets";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Buttons", @"Buttons (Content Edge Insets)" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+    @"storyboardName": @"ButtonsContentEdgeInsets",
+  };
 }
 
 #pragma mark - UIViewController

--- a/components/Buttons/examples/ButtonsCustomFontViewController.swift
+++ b/components/Buttons/examples/ButtonsCustomFontViewController.swift
@@ -21,12 +21,12 @@ import MaterialComponents.MaterialButtons_ButtonThemer
 
 class ButtonsCustomFontViewController: UIViewController {
 
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Buttons", "Buttons (Custom Font)"]
-  }
-
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Buttons", "Buttons (Custom Font)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 
   override func viewDidLoad() {

--- a/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
+++ b/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
@@ -20,12 +20,12 @@ import MaterialComponents.MaterialButtons
 
 class ButtonsDynamicTypeViewController: UIViewController {
 
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Buttons", "Buttons (DynamicType)"]
-  }
-
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Buttons", "Buttons (DynamicType)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 
   override func viewDidLoad() {

--- a/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
+++ b/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
@@ -118,11 +118,12 @@ class ButtonsSimpleExampleSwiftViewController: UIViewController {
 }
 
 extension ButtonsSimpleExampleSwiftViewController {
-   @objc class func catalogBreadcrumbs() -> [String] {
-      return ["Buttons", "Buttons (Swift)"]
-   }
-   
-   @objc class func catalogIsPrimaryDemo() -> Bool {
-      return false
-   }
+
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Buttons", "Buttons (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
+  }
 }

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -205,15 +205,13 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
 }
 
 extension ButtonsSwiftAndStoryboardController {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Buttons", "Buttons (Swift and Storyboard)"]
-  }
 
-  @objc class func catalogStoryboardName() -> String {
-    return "ButtonsStoryboardAndProgrammatic"
-  }
-
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Buttons", "Buttons (Swift and Storyboard)"],
+      "primaryDemo": false,
+      "presentable": false,
+      "storyboardName": "ButtonsStoryboardAndProgrammatic",
+    ]
   }
 }

--- a/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
+++ b/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
@@ -110,12 +110,13 @@ class FloatingButtonExampleSwiftViewController: UIViewController {
 }
 
 extension FloatingButtonExampleSwiftViewController {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Buttons", "Floating Action Button (Swift)"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Buttons", "Floating Action Button (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }
 

--- a/components/Buttons/examples/FloatingButtonExampleViewController.m
+++ b/components/Buttons/examples/FloatingButtonExampleViewController.m
@@ -185,16 +185,12 @@ NSString *kMiniButtonLabel = @"Add";
 
 #pragma mark - Catalog by Convention
 
-+ (NSArray<NSString *> *)catalogBreadcrumbs {
-  return @[ @"Buttons", @"Floating Action Button" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Buttons", @"Floating Action Button" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
+++ b/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.m
@@ -30,21 +30,14 @@ static const CGFloat kViewOffsetToCenter = 20.0f;
 
 @implementation ButtonsTypicalUseExampleViewController (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Buttons", @"Buttons" ];
-}
-
-+ (NSString *)catalogDescription {
-  return @"Buttons allow users to take actions, and make choices, with a single tap.\nA floating"
-          " action button (FAB) represents the primary action of a screen.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Buttons", @"Buttons" ],
+    @"description": @"Buttons allow users to take actions, and make choices, with a single tap."
+    @"\nA floating action button (FAB) represents the primary action of a screen.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 @end
@@ -52,16 +45,12 @@ static const CGFloat kViewOffsetToCenter = 20.0f;
 
 @implementation ButtonsShapesExampleViewController (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Buttons", @"Shaped Buttons" ];
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
-}
-
-+ (BOOL)catalogIsDebug {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Buttons", @"Shaped Buttons" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/Cards/examples/CardExampleViewController.swift
+++ b/components/Cards/examples/CardExampleViewController.swift
@@ -60,24 +60,14 @@ class CardExampleViewController: UIViewController {
 }
 
 extension CardExampleViewController {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Cards", "Card (Swift)"]
-  }
 
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
-
-  @objc class func catalogIsDebug() -> Bool {
-    return false
-  }
-
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return true
-  }
-
-  @objc class func catalogDescription() -> String {
-    return "Cards contain content and actions about a single subject."
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Cards", "Card (Swift)"],
+      "description": "Cards contain content and actions about a single subject.",
+      "primaryDemo": true,
+      "presentable": true,
+    ]
   }
 }
 

--- a/components/Cards/examples/CardsCollectionExample.m
+++ b/components/Cards/examples/CardsCollectionExample.m
@@ -117,20 +117,12 @@ canMoveItemAtIndexPath:(NSIndexPath *)indexPath {
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Cards", @"Collection Card Cells" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
-}
-
-+ (BOOL)catalogIsDebug {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Cards", @"Collection Card Cells" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {

--- a/components/Cards/examples/CardsCollectionTintingExample.m
+++ b/components/Cards/examples/CardsCollectionTintingExample.m
@@ -107,24 +107,12 @@ minimumInteritemSpacingForSectionAtIndex:(NSInteger)section {
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Cards", @"Collection Card Tinting" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
-}
-
-+ (BOOL)catalogIsDebug {
-  return NO;
-}
-
-- (BOOL)catalogShouldHideNavigation {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Cards", @"Collection Card Tinting" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Cards/examples/EditReorderCollectionViewController.swift
+++ b/components/Cards/examples/EditReorderCollectionViewController.swift
@@ -244,19 +244,12 @@ class EditReorderCollectionViewController: UIViewController,
 }
 
 extension EditReorderCollectionViewController {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Cards", "Edit/Reorder"]
-  }
 
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
-
-  @objc class func catalogIsDebug() -> Bool {
-    return false
-  }
-
-  @objc class func catalogIsPrimaryExample() -> Bool {
-    return true
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Cards", "Edit/Reorder"],
+      "primaryDemo": false,
+      "presentable": true,
+    ]
   }
 }

--- a/components/Cards/examples/EditReorderShapedCollectionViewController.swift
+++ b/components/Cards/examples/EditReorderShapedCollectionViewController.swift
@@ -204,20 +204,13 @@ class EditReorderShapedCollectionViewController: UIViewController,
 }
 
 extension EditReorderShapedCollectionViewController {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Cards", "Shaped Edit/Reorder"]
-  }
 
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
-  }
-
-  @objc class func catalogIsDebug() -> Bool {
-    return false
-  }
-
-  @objc class func catalogIsPrimaryExample() -> Bool {
-    return true
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Cards", "Shaped Edit/Reorder"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }
 

--- a/components/Cards/examples/ShapedCardViewController.swift
+++ b/components/Cards/examples/ShapedCardViewController.swift
@@ -214,15 +214,12 @@ class ShapedCardViewController: UIViewController {
 
 @available(iOS 9.0, *)
 extension ShapedCardViewController {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Cards", "Shaped Card"]
-  }
 
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
-  }
-
-  @objc class func catalogIsDebug() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Cards", "Shaped Card"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.m
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.m
@@ -74,16 +74,12 @@ static UIButton *DeleteButton() {
 
 @implementation ChipsChoiceExampleViewController (Supplemental)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Chips", @"Choice" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Chips", @"Choice" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 @end
@@ -93,16 +89,12 @@ static UIButton *DeleteButton() {
 
 @implementation ChipsActionExampleViewController (Supplemental)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Chips", @"Action" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Chips", @"Action" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 @end
@@ -112,76 +104,60 @@ static UIButton *DeleteButton() {
 
 @implementation ChipsCollectionExampleViewController (Supplemental)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Chips", @"Collections" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Chips", @"Collections" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end
 
 @implementation ChipsCustomizedExampleViewController (Supplemental)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Chips", @"Customized" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Chips", @"Customized" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (UIImage *)doneImage {
   return DoneImage();
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end
 
 @implementation ChipsFilterExampleViewController (Supplemental)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Chips", @"Filter" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Chips", @"Filter" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 - (UIImage *)doneImage {
   return DoneImage();
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
 }
 
 @end
 
 @implementation ChipsFilterAnimatedExampleViewController (Supplemental)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Chips", @"Filter Animated" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Chips", @"Filter Animated" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (UIImage *)doneImage {
   return DoneImage();
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end
@@ -191,28 +167,24 @@ static UIButton *DeleteButton() {
 
 @implementation ChipsInputExampleViewController (Supplemental)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Chips", @"Input" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Chips", @"Input" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 @end
 
 @implementation ChipsSizingExampleViewController (Supplemental)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Chips", @"Sizing" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Chips", @"Sizing" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (UIImage *)faceImage {
@@ -221,46 +193,35 @@ static UIButton *DeleteButton() {
 
 - (UIButton *)deleteButton {
   return DeleteButton();
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end
 
 @implementation ChipsTypicalUseViewController (Supplemental)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Chips", @"Chips" ];
-}
-
-+ (NSString *)catalogDescription {
-  return @"Chips are compact elements that represent an input, attribute, or action.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Chips", @"Chips" ],
+    @"description": @"Chips are compact elements that represent an input, attribute, or action.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 - (UIImage *)doneImage {
   return DoneImage();
 }
 
-+ (BOOL)catalogIsPresentable {
-  return YES;
-}
-
 @end
 
 @implementation ChipsShapingExampleViewController (Supplemental)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Chips", @"Shaped Chip" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Chips", @"Shaped Chip" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (UIImage *)faceImage {
@@ -269,10 +230,6 @@ static UIButton *DeleteButton() {
 
 - (UIButton *)deleteButton {
   return DeleteButton();
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/CollectionCells/examples/CollectionCellsLayoutExample.m
+++ b/components/CollectionCells/examples/CollectionCellsLayoutExample.m
@@ -229,16 +229,12 @@ static NSString *const kExampleDetailText =
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collection Cells", @"Cell Layout Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collection Cells", @"Cell Layout Example" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/CollectionCells/examples/CollectionCellsTextExample.m
+++ b/components/CollectionCells/examples/CollectionCellsTextExample.m
@@ -107,22 +107,15 @@ static NSString *const kExampleDetailText =
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collection Cells", @"Cell Text Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (NSString *)catalogDescription {
-  return @"Material Collection Cells enables a native collection view cell to have Material "
-  "design layout and styling. It also provides editing and extensive customization "
-  "capabilities.";
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collection Cells", @"Cell Text Example" ],
+    @"description": @"Material Collection Cells enables a native collection view cell to have "
+    @"Material design layout and styling. It also provides editing and extensive customization "
+    @"capabilities.",
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/CollectionCells/examples/CollectionCellsTextWithImageController.m
+++ b/components/CollectionCells/examples/CollectionCellsTextWithImageController.m
@@ -73,16 +73,12 @@ static const NSUInteger kRowCount = 22;
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collection Cells", @"Cell Text with Image Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collection Cells", @"Cell Text with Image Example" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Collections/examples/CollectionsALaCarteExample.m
+++ b/components/Collections/examples/CollectionsALaCarteExample.m
@@ -125,16 +125,12 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Collections À la carte" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Collections À la carte" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Collections/examples/CollectionsAppearanceAnimationExample.m
+++ b/components/Collections/examples/CollectionsAppearanceAnimationExample.m
@@ -70,16 +70,12 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Appearance Animation Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Appearance Animation Example" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Collections/examples/CollectionsCellAccessoryExample.m
+++ b/components/Collections/examples/CollectionsCellAccessoryExample.m
@@ -111,16 +111,12 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Cell Accessory Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Cell Accessory Example" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Collections/examples/CollectionsCellColorExample.m
+++ b/components/Collections/examples/CollectionsCellColorExample.m
@@ -79,16 +79,12 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Cell Color Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Cell Color Example" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Collections/examples/CollectionsCellSeparatorExample.m
+++ b/components/Collections/examples/CollectionsCellSeparatorExample.m
@@ -123,16 +123,12 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Cell Separator Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Cell Separator Example" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Collections/examples/CollectionsContainerExample.m
+++ b/components/Collections/examples/CollectionsContainerExample.m
@@ -86,16 +86,12 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Collections in a Container" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Collections in a Container" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Collections/examples/CollectionsEditingExample.m
+++ b/components/Collections/examples/CollectionsEditingExample.m
@@ -166,16 +166,12 @@ static NSString *const HEADER_REUSE_IDENTIFIER = @"EditingExampleHeader";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Cell Editing Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Cell Editing Example" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Collections/examples/CollectionsEmptySections.m
+++ b/components/Collections/examples/CollectionsEmptySections.m
@@ -134,16 +134,12 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Empty Section Demo" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Empty Section Demo" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Collections/examples/CollectionsGridExample.m
+++ b/components/Collections/examples/CollectionsGridExample.m
@@ -149,16 +149,12 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Grid Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Grid Example" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Collections/examples/CollectionsHeaderFooterExample.m
+++ b/components/Collections/examples/CollectionsHeaderFooterExample.m
@@ -131,16 +131,12 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Header / Footer Demo" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Header / Footer Demo" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Collections/examples/CollectionsInkExample.m
+++ b/components/Collections/examples/CollectionsInkExample.m
@@ -80,16 +80,12 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Cell Ink Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Cell Ink Example" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Collections/examples/CollectionsInlayExample.m
+++ b/components/Collections/examples/CollectionsInlayExample.m
@@ -68,16 +68,12 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Cell Inlay Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Cell Inlay Example" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Collections/examples/CollectionsSimpleDemo.m
+++ b/components/Collections/examples/CollectionsSimpleDemo.m
@@ -70,22 +70,15 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Simple Demo" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (NSString *)catalogDescription {
-  return @"Material Collections enables a native collection view controller to have Material "
-          "design layout and styling. It also provides editing and extensive customization "
-          "capabilities.";
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Simple Demo" ],
+    @"description": @"Material Collections enables a native collection view controller to have "
+    @"Material design layout and styling. It also provides editing and extensive customization "
+    @"capabilities.",
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Collections/examples/CollectionsSimpleSwiftDemo.swift
+++ b/components/Collections/examples/CollectionsSimpleSwiftDemo.swift
@@ -55,15 +55,12 @@ class CollectionsSimpleSwiftDemo: MDCCollectionViewController {
 
 // MARK: Catalog by convention
 extension CollectionsSimpleSwiftDemo {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return [ "Collections", "Simple Swift Demo"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": [ "Collections", "Simple Swift Demo"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }

--- a/components/Collections/examples/CollectionsStoryboardExample.m
+++ b/components/Collections/examples/CollectionsStoryboardExample.m
@@ -70,20 +70,13 @@ static NSString *const kReusableIdentifierItem = @"customCell";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Storyboard Example" ];
-}
-
-+ (NSString *)catalogStoryboardName {
-  return @"CollectionsStoryboardExample";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Storyboard Example" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+    @"storyboardName": @"CollectionsStoryboardExample"
+  };
 }
 
 @end

--- a/components/Collections/examples/CollectionsSwipeToDismissRowExample.m
+++ b/components/Collections/examples/CollectionsSwipeToDismissRowExample.m
@@ -95,16 +95,12 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Swipe-To-Dismiss-Row Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Swipe-To-Dismiss-Row Example" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Collections/examples/CollectionsSwipeToDismissSectionExample.m
+++ b/components/Collections/examples/CollectionsSwipeToDismissSectionExample.m
@@ -94,16 +94,12 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Swipe-To-Dismiss-Section Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Swipe-To-Dismiss-Section Example" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Collections/examples/supplemental/CollectionsEditingManyCellsExampleSupplemental.m
+++ b/components/Collections/examples/supplemental/CollectionsEditingManyCellsExampleSupplemental.m
@@ -20,16 +20,12 @@
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Cell Editing Example (1000+)" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Cell Editing Example (1000+)" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 #pragma mark - <UICollectionViewDataSource>

--- a/components/Collections/examples/supplemental/CollectionsSectionInsetsExampleSupplemental.m
+++ b/components/Collections/examples/supplemental/CollectionsSectionInsetsExampleSupplemental.m
@@ -55,16 +55,12 @@
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Collections", @"Custom Section Insets" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Collections", @"Custom Section Insets" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Dialogs/examples/AlertComparison.swift
+++ b/components/Dialogs/examples/AlertComparison.swift
@@ -159,20 +159,12 @@ class DialogsAlertComparison: UIViewController {
 
 // MARK: Catalog by convention
 extension DialogsAlertComparison {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return [ "Dialogs", "Alert Comparison"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Dialogs", "Alert Comparison"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
-  }
-
-  @objc class func catalogIsDebug() -> Bool {
-    return false
-  }
-
 }

--- a/components/Dialogs/examples/DialogsCustomShadowViewController.swift
+++ b/components/Dialogs/examples/DialogsCustomShadowViewController.swift
@@ -104,15 +104,12 @@ class DialogsCustomShadowViewController: UIViewController {
   }
 
   // MARK: Catalog by convention
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return [ "Dialogs", "View with Corner Radius"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Dialogs", "View with Corner Radius"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }

--- a/components/Dialogs/examples/DialogsLongAlertViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertViewController.swift
@@ -77,11 +77,12 @@ class DialogsLongAlertViewController: UIViewController {
 
 // MARK: Catalog by convention
 extension DialogsLongAlertViewController {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return [ "Dialogs", "Swift Alert Demo"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Dialogs", "Swift Alert Demo"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }

--- a/components/Dialogs/examples/DialogsRoundedCornerViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerViewController.m
@@ -116,17 +116,14 @@
   [self presentViewController:viewController animated:YES completion:NULL];
 }
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Dialogs", @"Dialog with Rounded Corners" ];
-}
+#pragma mark - CatalogByConvention
 
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Dialogs", @"Dialog with Rounded Corners" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
-}
-
 
 @end

--- a/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerViewController.m
@@ -216,16 +216,12 @@
 
 @implementation DialogDismissalOverPresentedControllerViewController (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Dialogs", @"Dialog Over Presented View Controller on iPad" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Dialogs", @"Dialog Over Presented View Controller on iPad" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Dialogs/examples/supplemental/DialogsAlertViewControllerSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsAlertViewControllerSupplemental.m
@@ -54,16 +54,12 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
 @implementation DialogsAlertViewController (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Dialogs", @"AlertController" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Dialogs", @"AlertController" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/Dialogs/examples/supplemental/DialogsKeyboardViewControllerSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsKeyboardViewControllerSupplemental.m
@@ -51,16 +51,12 @@ static NSString * const kReusableIdentifierItem = @"cell";
 
 @implementation DialogsKeyboardViewController (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Dialogs", @"Dialog with an Input Field" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Dialogs", @"Dialog with an Input Field" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsTypicalUseSupplemental.m
@@ -56,21 +56,14 @@ static NSString * const kReusableIdentifierItem = @"cell";
 
 @implementation DialogsTypicalUseViewController (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Dialogs", @"Dialogs" ];
-}
-
-+ (NSString *)catalogDescription {
-  return @"Dialogs inform users about a task and can contain critical information, require"
-          " decisions, or involve multiple tasks.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Dialogs", @"Dialogs" ],
+    @"description": @"Dialogs inform users about a task and can contain critical information, "
+    @"require decisions, or involve multiple tasks.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/FeatureHighlight/examples/FeatureHightlightTypicalUseViewController.swift
+++ b/components/FeatureHighlight/examples/FeatureHightlightTypicalUseViewController.swift
@@ -67,11 +67,12 @@ class FeatureHighlightSwiftViewController: UIViewController {
 }
 
 extension FeatureHighlightSwiftViewController {
-  class func catalogBreadcrumbs() -> [String] {
-    return ["Feature Highlight", "Feature Highlight (Swift)"]
-  }
 
-  class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Feature Highlight", "Feature Highlight (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
@@ -95,21 +95,14 @@ static NSString *const reuseIdentifier = @"Cell";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Feature Highlight", @"Feature Highlight" ];
-}
-
-+ (NSString *)catalogDescription {
-  return @"The Feature Highlight component is used to introduce users to new features and"
-  " functionality at contextually relevant moments.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Feature Highlight", @"Feature Highlight" ],
+    @"description": @"The Feature Highlight component is used to introduce users to new features "
+    @"and functionality at contextually relevant moments.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 @end
@@ -160,16 +153,12 @@ static NSString *const reuseIdentifier = @"Cell";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Feature Highlight", @"Colors" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Feature Highlight", @"Colors" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end
@@ -195,12 +184,12 @@ static NSString *const reuseIdentifier = @"Cell";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Feature Highlight", @"Custom Fonts" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Feature Highlight", @"Custom Fonts" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end
@@ -255,16 +244,12 @@ static NSString *const reuseIdentifier = @"Cell";
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Feature Highlight", @"Shown Views" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Feature Highlight", @"Shown Views" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
@@ -27,20 +27,16 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
 
 @implementation FlexibleHeaderConfiguratorExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Flexible Header", @"Configurator" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Flexible Header", @"Configurator" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderFABSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderFABSupplemental.m
@@ -25,20 +25,16 @@
 
 @implementation FlexibleHeaderFABExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Flexible Header", @"Floating Action Button" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Flexible Header", @"Floating Action Button" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderHorizontalPagingSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderHorizontalPagingSupplemental.m
@@ -23,20 +23,16 @@
 
 @implementation FlexibleHeaderHorizontalPagingViewController (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Flexible Header", @"Horizontal Paging" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Flexible Header", @"Horizontal Paging" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderPageControlSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderPageControlSupplemental.m
@@ -25,20 +25,16 @@
 
 @implementation FlexibleHeaderPageControlExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Flexible Header", @"Page Control in Flexible Header" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Flexible Header", @"Page Control in Flexible Header" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTopLayoutGuideSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTopLayoutGuideSupplemental.m
@@ -26,20 +26,16 @@
 
 @implementation FlexibleHeaderTopLayoutGuideExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Flexible Header", @"Utilizing Top Layout Guide" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Flexible Header", @"Utilizing Top Layout Guide" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTypicalUseSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderTypicalUseSupplemental.m
@@ -23,25 +23,18 @@
 
 @implementation FlexibleHeaderTypicalUseViewController (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Flexible Header", @"Flexible Header" ];
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Flexible Header", @"Flexible Header" ],
+    @"description": @"The Flexible Header is a container view whose height and vertical offset "
+    @"react to UIScrollViewDelegate events.",
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (NSString *)catalogDescription {
-  return @"The Flexible Header is a container view whose height and vertical offset react to"
-          " UIScrollViewDelegate events.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderUINavigationBarSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderUINavigationBarSupplemental.m
@@ -25,20 +25,16 @@
 
 @implementation FlexibleHeaderUINavigationBarExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Flexible Header", @"Standard UINavigationBar" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Flexible Header", @"Standard UINavigationBar" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderWrappedSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderWrappedSupplemental.m
@@ -23,20 +23,16 @@
 
 @implementation FlexibleHeaderWrappedExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Flexible Header", @"Wrapped View Controller" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Flexible Header", @"Wrapped View Controller" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
+++ b/components/Ink/examples/supplemental/InkTypicalUseSupplemental.m
@@ -78,21 +78,14 @@
 
 @implementation InkTypicalUseViewController (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Ink", @"Ink" ];
-}
-
-+ (NSString *)catalogDescription {
-  return @"The Ink component provides a radial action in the form of a visual ripple of ink"
-          " expanding outward from the user's touch.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Ink", @"Ink" ],
+    @"description": @"The Ink component provides a radial action in the form of a visual ripple "
+    @" of ink expanding outward from the user's touch.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/List/examples/BaseCellExample.swift
+++ b/components/List/examples/BaseCellExample.swift
@@ -117,23 +117,13 @@ extension BaseCellExample: UICollectionViewDataSource {
 
 // MARK: Catalog By Convention
 extension BaseCellExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["List Items", "MDCBaseCell Example (Swift)"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return true
-  }
-
-  @objc class func catalogDescription() -> String {
-    return "MDCBaseCell Example (Swift)"
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
-
-  @objc class func catalogIsDebug() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["List Items", "MDCBaseCell Example (Swift)"],
+      "description": "MDCBaseCell Example (Swift)",
+      "primaryDemo": true,
+      "presentable": true,
+    ]
   }
 }

--- a/components/List/examples/CollectionListCellExampleTypicalUse.m
+++ b/components/List/examples/CollectionListCellExampleTypicalUse.m
@@ -168,24 +168,14 @@ static const CGFloat kSmallArbitraryCellWidth = 100.f;
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Lists", @"List Cell Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (NSString *)catalogDescription {
-  return @"Material Collection Lists are continuous, vertical indexes of text or images.";
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
-}
-
-+ (BOOL)catalogIsDebug {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Lists", @"List Cell Example" ],
+    @"description": @"Material Collection Lists are continuous, vertical indexes of text "
+    @"or images.",
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/List/examples/MDCBaseCellExample.m
+++ b/components/List/examples/MDCBaseCellExample.m
@@ -99,24 +99,13 @@
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"List Items", @"MDCBaseCell Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (NSString *)catalogDescription {
-  return @"MDCBaseCell Example";
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
-}
-
-+ (BOOL)catalogIsDebug {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"List Items", @"MDCBaseCell Example" ],
+    @"description": @"MDCBaseCell Example",
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/MaskedTransition/examples/supplemental/MaskedTransitionTypicalUseSupplemental.swift
+++ b/components/MaskedTransition/examples/supplemental/MaskedTransitionTypicalUseSupplemental.swift
@@ -24,19 +24,13 @@ extension MaskedTransitionTypicalUseSwiftExample {
 
   // MARK: - CatalogByConvention
 
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return [ "Masked Transition", "Masked Transition (Swift)" ]
-  }
-
-  @objc class func catalogDescription() -> String {
-    return "Examples of how the Floating Action Button can transition to other on-screen views."
-  }
-
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return true
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": [ "Masked Transition", "Masked Transition (Swift)" ],
+      "description": "Examples of how the Floating Action Button can transition to other "
+        + "on-screen views.",
+      "primaryDemo": true,
+      "presentable": true,
+    ]
   }
 }

--- a/components/NavigationBar/examples/NavigationBarIconsExample.m
+++ b/components/NavigationBar/examples/NavigationBarIconsExample.m
@@ -127,20 +127,16 @@
 
 @implementation NavigationBarIconsExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Navigation Bar", @"Navigation Bar With Icons" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Navigation Bar", @"Navigation Bar With Icons" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/NavigationBar/examples/NavigationBarLayoutExample.m
+++ b/components/NavigationBar/examples/NavigationBarLayoutExample.m
@@ -211,20 +211,16 @@
 
 @implementation NavigationBarLayoutExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Navigation Bar", @"Navigation Bar Item Layout" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Navigation Bar", @"Navigation Bar Item Layout" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/NavigationBar/examples/NavigationBarRTLIcons.m
+++ b/components/NavigationBar/examples/NavigationBarRTLIcons.m
@@ -112,20 +112,16 @@
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Navigation Bar", @"Navigation Bar TitleView RTL" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Navigation Bar", @"Navigation Bar TitleView RTL" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
+++ b/components/NavigationBar/examples/NavigationBarWithBarItemsExample.m
@@ -102,6 +102,17 @@
 
 @implementation NavigationBarWithBarItemsExample (CatalogByConvention)
 
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"App Bar", @"Modal Presentation" ],
+    @"description": @"Animation timing easing curves create smooth and consistent motion. "
+    @"Easing curves allow elements to move between positions or states.",
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+    @"storyboardName": @"AppBarInterfaceBuilderExampleController"
+  };
+}
+
 + (NSArray *)catalogBreadcrumbs {
   return @[ @"Navigation Bar", @"Navigation Bar with Items" ];
 }

--- a/components/NavigationBar/examples/NavigationbarWithCustomFont.m
+++ b/components/NavigationBar/examples/NavigationbarWithCustomFont.m
@@ -94,20 +94,16 @@
 
 @implementation NavigationBarWithCustomFontExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Navigation Bar", @"Navigation Bar with Custom Font" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Navigation Bar", @"Navigation Bar with Custom Font" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.m
+++ b/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.m
@@ -56,25 +56,18 @@
 
 @implementation NavigationBarTypicalUseExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Navigation Bar", @"Navigation Bar" ];
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Navigation Bar", @"Navigation Bar" ],
+    @"description": @"The Navigation Bar component is a view composed of a left and right Button "
+    @"Bar and either a title label or a custom title view.",
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (NSString *)catalogDescription {
-  return @"The Navigation Bar component is a view composed of a left and right Button Bar and"
-          " either a title label or a custom title view.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.swift
+++ b/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.swift
@@ -25,21 +25,15 @@ import MaterialComponents.MaterialNavigationBar
 extension NavigationBarTypicalUseSwiftExample {
 
   // (CatalogByConvention)
-
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return [ "Navigation Bar", "Navigation Bar (Swift)" ]
-  }
-
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Navigation Bar", "Navigation Bar (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 
   func catalogShouldHideNavigation() -> Bool {
     return true
   }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
-  }
-
 }

--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -86,20 +86,12 @@ class DrawerContentTableViewController: UITableViewController {
 
 extension BottomDrawerInfiniteScrollingExample {
 
-  @objc class func catalogDescription() -> String {
-    return "Navigation Drawer"
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Navigation Drawer", "Bottom Drawer Infinite Scrolling"],
+      "description": "Navigation Drawer",
+      "primaryDemo": true,
+      "presentable": true,
+    ]
   }
-
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return true
-  }
-
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Navigation Drawer", "Bottom Drawer Infinite Scrolling"]
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
-  }
-
 }

--- a/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
@@ -44,20 +44,12 @@ class BottomDrawerNoHeaderExample: UIViewController {
 
 extension BottomDrawerNoHeaderExample {
 
-  @objc class func catalogDescription() -> String {
-    return "Navigation Drawer"
-  }
-
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
-  }
-
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Navigation Drawer", "Bottom Drawer No Header"]
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Navigation Drawer", "Bottom Drawer No Header"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 
 }

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -42,20 +42,11 @@ class BottomDrawerWithHeaderExample: UIViewController {
 
 extension BottomDrawerWithHeaderExample {
 
-  @objc class func catalogDescription() -> String {
-    return "Navigation Drawer"
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Navigation Drawer", "Bottom Drawer"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
-
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return true
-  }
-
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Navigation Drawer", "Bottom Drawer"]
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
-  }
-
 }

--- a/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
@@ -106,20 +106,11 @@ class DrawerContentWithScrollViewController: UIViewController,
 
 extension BottomDrawerWithScrollableContentExample {
 
-  @objc class func catalogDescription() -> String {
-    return "Navigation Drawer "
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Navigation Drawer", "Bottom Drawer Scrollable Content"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
-
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return true
-  }
-
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Navigation Drawer", "Bottom Drawer Scrollable Content"]
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
-  }
-
 }

--- a/components/PageControl/examples/PageControlAnimationBlockExample.m
+++ b/components/PageControl/examples/PageControlAnimationBlockExample.m
@@ -192,16 +192,12 @@
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Page Control", @"Page Control with animation block" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Page Control", @"Page Control with animation block" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/PageControl/examples/PageControlButtonExample.m
+++ b/components/PageControl/examples/PageControlButtonExample.m
@@ -163,16 +163,12 @@
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Page Control", @"Page Control with Next Button" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Page Control", @"Page Control with Next Button" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/PageControl/examples/PageControlTypicalUseExample.m
+++ b/components/PageControl/examples/PageControlTypicalUseExample.m
@@ -138,21 +138,14 @@
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Page Control", @"Page Control" ];
-}
-
-+ (NSString *)catalogDescription {
-  return @"This control is designed to be a drop-in replacement for UIPageControl, with a user"
-  " experience influenced by Material Design.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Page Control", @"Page Control" ],
+    @"description": @"This control is designed to be a drop-in replacement for UIPageControl, "
+    @"with a user experience influenced by Material Design.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/PageControl/examples/PageControlTypicalUseExample.swift
+++ b/components/PageControl/examples/PageControlTypicalUseExample.swift
@@ -123,11 +123,11 @@ class PageControlSwiftExampleViewController: UIViewController, UIScrollViewDeleg
 
   // MARK: - CatalogByConvention
 
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return [ "Page Control", "Swift example"]
-  }
-
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Page Control", "Swift example"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }

--- a/components/Palettes/examples/PalettesExpandedExample.swift
+++ b/components/Palettes/examples/PalettesExpandedExample.swift
@@ -45,15 +45,12 @@ class PalettesGeneratedExampleViewController: PalettesExampleViewController {
 
 // MARK: - Catalog by convention
 extension PalettesGeneratedExampleViewController {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Palettes", "Generated Palettes"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Palettes", "Generated Palettes"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }

--- a/components/Palettes/examples/PalettesStandardExample.swift
+++ b/components/Palettes/examples/PalettesStandardExample.swift
@@ -45,19 +45,14 @@ class PalettesStandardExampleViewController: PalettesExampleViewController {
 
 // MARK: - Catalog by convention
 extension PalettesStandardExampleViewController {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Palettes", "Standard Palettes"]
-  }
 
-  @objc class func catalogDescription() -> String {
-    return "The Palettes component provides sets of reference colors that work well together."
-  }
-
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return true
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Palettes", "Standard Palettes"],
+      "description": "The Palettes component provides sets of reference colors that work "
+        + "well together.",
+      "primaryDemo": true,
+      "presentable": true,
+    ]
   }
 }

--- a/components/ProgressView/examples/ProgressViewExample.m
+++ b/components/ProgressView/examples/ProgressViewExample.m
@@ -290,21 +290,14 @@ static const CGFloat MDCProgressViewAnimationDuration = 1.f;
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Progress View", @"Progress View" ];
-}
-
-+ (NSString *)catalogDescription {
-  return @"Progress indicators display the length of a process or express an unspecified wait "
-          "time.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Progress View", @"Progress View" ],
+    @"description": @"Progress indicators display the length of a process or express an "
+    @"unspecified wait time.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.m
+++ b/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.m
@@ -131,16 +131,12 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27.0f;
 
 #pragma mark catalog by convention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Shadow", @"Shadow Elevations" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Shadow", @"Shadow Elevations" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.swift
+++ b/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.swift
@@ -86,12 +86,13 @@ class ShadowElevationsTypicalUseExample: UIViewController {
 
 // MARK: Catalog by convention
 extension ShadowElevationsTypicalUseExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Shadow", "Shadow Elevations (Swift)"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Shadow", "Shadow Elevations (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 
   func catalogShouldHideNavigation() -> Bool {

--- a/components/ShadowLayer/examples/ShadowCornerRadiusExample.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusExample.m
@@ -108,16 +108,12 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27.0f;
 
 #pragma mark catalog by convention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Shadow", @"Shadow Corner Radius" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Shadow", @"Shadow Corner Radius" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
+++ b/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
@@ -72,23 +72,14 @@ class ShadowDragSquareExampleViewController: UIViewController {
 
   // MARK: - CatalogByConvention
 
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return [ "Shadow", "Shadow Layer"]
-  }
-
-  @objc class func catalogStoryboardName() -> String {
-    return "ShadowDragSquareExample"
-  }
-
-  @objc class func catalogDescription() -> String {
-    return "Shadow Layer implements the Material Design specifications for elevation and shadows."
-  }
-
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return true
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": [ "Shadow", "Shadow Layer"],
+      "description": "Shadow Layer implements the Material Design specifications for "
+        + "elevation and shadows.",
+      "primaryDemo": true,
+      "presentable": true,
+      "storyboardName": "ShadowDragSquareExample",
+    ]
   }
 }

--- a/components/ShadowLayer/examples/ShapesShadows.swift
+++ b/components/ShadowLayer/examples/ShapesShadows.swift
@@ -68,16 +68,13 @@ class ShapesShadowsController: UIViewController {
 extension ShapesShadowsController {
   
   // MARK: Catalog by convention
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return [ "Shadow", "Shape & Shadow" ]
-  }
-  
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
-  }
 
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Shadow", "Shape & Shadow"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }
 

--- a/components/Slider/examples/SliderAutolayoutExampleViewController.m
+++ b/components/Slider/examples/SliderAutolayoutExampleViewController.m
@@ -74,16 +74,13 @@
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Slider", @"Slider Autolayout" ];
-}
-
-+ (NSString *)catalogStoryboardName {
-  return @"SliderAutolayoutExample";
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Slider", @"Slider Autolayout" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+    @"storyboardName": @"SliderAutolayoutExample"
+  };
 }
 
 @end

--- a/components/Slider/examples/SliderCompareExampleViewController.m
+++ b/components/Slider/examples/SliderCompareExampleViewController.m
@@ -102,16 +102,12 @@
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Slider", @"MDCSlider and UISlider Compared" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Slider", @"MDCSlider and UISlider Compared" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Slider/examples/supplemental/SliderCollectionSupplemental.m
+++ b/components/Slider/examples/supplemental/SliderCollectionSupplemental.m
@@ -23,20 +23,13 @@
 
 @implementation SliderCollectionViewController (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Slider", @"Slider" ];
-}
-
-+ (NSString *)catalogDescription {
-  return @"Sliders allow users to make selections from a range of values.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Slider", @"Slider" ],
+    @"description": @"Sliders allow users to make selections from a range of values.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
+++ b/components/Snackbar/examples/supplemental/SnackbarExampleSupplemental.m
@@ -56,60 +56,38 @@ static NSString * const kCellIdentifier = @"Cell";
 
 @implementation SnackbarSimpleExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Snackbar", @"Snackbar" ];
-}
-
-+ (NSString *)catalogDescription {
-  return @"Snackbars provide brief messages about app processes at the bottom of the screen.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
-}
-
-+ (BOOL)catalogIsDebug {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Snackbar", @"Snackbar" ],
+    @"description": @"Snackbars provide brief messages about app processes at the bottom of "
+    @"the screen.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 @end
 
 @implementation SnackbarOverlayViewExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Snackbar", @"Snackbar Overlay View" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Snackbar", @"Snackbar Overlay View" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 @end
 
 @implementation SnackbarInputAccessoryViewController (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Snackbar", @"Snackbar Input Accessory" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
-}
-
-+ (BOOL)catalogIsDebug {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Snackbar", @"Snackbar Input Accessory" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end
@@ -146,16 +124,12 @@ static NSString * const kCellIdentifier = @"Cell";
 
 @implementation SnackbarSuspensionExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Snackbar", @"Snackbar Suspension" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Snackbar", @"Snackbar Suspension" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/Tabs/examples/BottomNavigationBarExample.m
+++ b/components/Tabs/examples/BottomNavigationBarExample.m
@@ -118,16 +118,12 @@
 
 @implementation BottomNavigationBarExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Tab Bar", @"Bottom Navigation" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Tab Bar", @"Bottom Navigation" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Tabs/examples/TabBarInterfaceBuilderExample.m
+++ b/components/Tabs/examples/TabBarInterfaceBuilderExample.m
@@ -111,20 +111,13 @@
 
 @implementation TabBarInterfaceBuilderExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Tab Bar", @"Interface Builder" ];
-}
-
-+ (NSString *)catalogStoryboardName {
-  return @"TabBarInterfaceBuilderExample";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Tab Bar", @"Interface Builder" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+    @"storyboardName": @"TabBarInterfaceBuilderExample"
+  };
 }
 
 @end

--- a/components/Tabs/examples/TabBarViewControllerInterfaceBuilderExample.m
+++ b/components/Tabs/examples/TabBarViewControllerInterfaceBuilderExample.m
@@ -63,20 +63,13 @@
 
 @implementation TabBarViewControllerInterfaceBuilderExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Tab Bar", @"TabBarViewController Interface Builder" ];
-}
-
-+ (NSString *)catalogStoryboardName {
-  return @"TabBarViewControllerInterfaceBuilderExample";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Tab Bar", @"TabBarViewController Interface Builder" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+    @"storyboardName": @"TabBarViewControllerInterfaceBuilderExample"
+  };
 }
 
 @end

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
@@ -280,24 +280,14 @@
 
 @implementation TabBarIconExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Tab Bar", @"Tabs with Icons" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (NSString *)catalogDescription {
-  return @"Tabs organize content across different screens, data sets, and other interactions.";
-}
-
-- (BOOL)catalogShouldHideNavigation {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Tab Bar", @"Tabs with Icons" ],
+    @"description": @"Tabs organize content across different screens, data sets, and "
+    @"other interactions.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
@@ -248,12 +248,13 @@ extension TabBarIconSwiftExample {
 
 // MARK: - Catalog by convention
 extension TabBarIconSwiftExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Tab Bar", "Tabs with Icons (Swift)"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Tab Bar", "Tabs with Icons (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 
   func catalogShouldHideNavigation() -> Bool {

--- a/components/Tabs/examples/supplemental/TabBarIndicatorTemplateExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIndicatorTemplateExampleSupplemental.swift
@@ -126,19 +126,16 @@ extension TabBarIndicatorTemplateExample {
 
 // MARK: - Catalog by convention
 extension TabBarIndicatorTemplateExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Tab Bar", "Custom Selection Indicator"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Tab Bar", "Custom Selection Indicator"],
+      "primaryDemo": false,
+      "presentable": true,
+    ]
   }
 
   func catalogShouldHideNavigation() -> Bool {
-    return true
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
     return true
   }
 }

--- a/components/Tabs/examples/supplemental/TabBarTextOnlyExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarTextOnlyExampleSupplemental.m
@@ -126,20 +126,16 @@ static NSString * const kReusableIdentifierItem = @"Cell";
 
 @implementation TabBarTextOnlyExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Tab Bar", @"Text Tabs" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Tab Bar", @"Text Tabs" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
@@ -137,20 +137,16 @@
 
 @implementation TabBarViewControllerExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Tab Bar", @"TabBarViewController" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Tab Bar", @"TabBarViewController" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 - (BOOL)catalogShouldHideNavigation {
   return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
 }
 
 @end

--- a/components/TextFields/examples/MultilineTextFieldLegacyExample.m
+++ b/components/TextFields/examples/MultilineTextFieldLegacyExample.m
@@ -236,16 +236,12 @@
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Text Field", @"[Legacy] Multi-line" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Text Field", @"[Legacy] Multi-line" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 #pragma mark - Keyboard Handling

--- a/components/TextFields/examples/TextFieldCustomFontExample.m
+++ b/components/TextFields/examples/TextFieldCustomFontExample.m
@@ -409,16 +409,12 @@ replacementString:(NSString *)string {
 
 @implementation TextFieldCustomFontExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Text Field", @"Custom Fonts" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Text Field", @"Custom Fonts" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/TextFields/examples/TextFieldFilledExample.swift
+++ b/components/TextFields/examples/TextFieldFilledExample.swift
@@ -456,11 +456,12 @@ extension TextFieldFilledSwiftExample {
 }
 
 extension TextFieldFilledSwiftExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Text Field", "Filled Text Fields"]
-  }
 
-  @objc class func catalogIsPresentable() -> Bool {
-    return true
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Text Field", "Filled Text Fields"],
+      "primaryDemo": false,
+      "presentable": true,
+    ]
   }
 }

--- a/components/TextFields/examples/TextFieldLegacyExample.swift
+++ b/components/TextFields/examples/TextFieldLegacyExample.swift
@@ -416,7 +416,12 @@ extension TextFieldLegacySwiftExample {
 }
 
 extension TextFieldLegacySwiftExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Text Field", "[Legacy] Typical Use"]
+
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Text Field", "[Legacy] Typical Use"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }

--- a/components/TextFields/examples/TextFieldManualLayoutLegacyExample.m
+++ b/components/TextFields/examples/TextFieldManualLayoutLegacyExample.m
@@ -153,16 +153,12 @@
 
 @implementation TextFieldManualLayoutLegacyExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Text Field", @"[Legacy] Manual Layout" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Text Field", @"[Legacy] Manual Layout" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/TextFields/examples/TextFieldManualLayoutLegacyExample.swift
+++ b/components/TextFields/examples/TextFieldManualLayoutLegacyExample.swift
@@ -339,11 +339,12 @@ extension TextFieldManualLayoutLegacySwiftExample {
 
 // MARK: - CatalogByConvention
 extension TextFieldManualLayoutLegacySwiftExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Text Field", "[Legacy] Manual Layout (Swift)"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Text Field", "[Legacy] Manual Layout (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }

--- a/components/TextFields/examples/TextFieldOutlinedExample.m
+++ b/components/TextFields/examples/TextFieldOutlinedExample.m
@@ -438,16 +438,12 @@
 
 @implementation TextFieldOutlinedObjectiveCExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Text Field", @"Outlined text fields" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Text Field", @"Outlined text fields" ],
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/TextFields/examples/TextFieldOutlinedExample.swift
+++ b/components/TextFields/examples/TextFieldOutlinedExample.swift
@@ -431,7 +431,12 @@ extension TextFieldOutlinedSwiftExample {
 }
 
 extension TextFieldOutlinedSwiftExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Text Field", "Outlined Fields & Text Areas"]
+
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Text Field", "Outlined Fields & Text Areas"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }

--- a/components/TextFields/examples/TextFieldSemanticColorThemer.swift
+++ b/components/TextFields/examples/TextFieldSemanticColorThemer.swift
@@ -229,8 +229,12 @@ extension TextFieldSemanticColorThemer {
 // MARK: - Status Bar Style
 
 extension TextFieldSemanticColorThemer {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Text Field", "Theming Text Fields"]
-  }
 
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Text Field", "Theming Text Fields"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
+  }
 }

--- a/components/TextFields/examples/TextFieldStatesViewController.m
+++ b/components/TextFields/examples/TextFieldStatesViewController.m
@@ -249,12 +249,12 @@
 
 @implementation TextFieldStatesViewController (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Text Field", @"States" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Text Field", @"States" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/TextFields/examples/TextFieldUnderlineExample.swift
+++ b/components/TextFields/examples/TextFieldUnderlineExample.swift
@@ -439,21 +439,14 @@ extension TextFieldUnderlineSwiftExample {
 // MARK: - CatalogByConvention
 
 extension TextFieldUnderlineSwiftExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Text Field", "Underline Style"]
-  }
 
-  @objc class func catalogDescription() -> String {
-    // swiftlint:disable:next line_length
-    return "Text fields let users enter and edit text."
-  }
-
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Text Field", "Underline Style"],
+      "description": "Text fields let users enter and edit text.",
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }
 

--- a/components/TextFields/examples/TextFieldsTableViewExample.m
+++ b/components/TextFields/examples/TextFieldsTableViewExample.m
@@ -113,16 +113,12 @@ static NSString *const TSTTextFieldTableViewCellIdentifier = @"TSTTextFieldsTabl
 
 @implementation TextFieldsTableViewExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Text Field", @"Table View" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Text Field", @"Table View" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/TextFields/examples/supplemental/TextFieldControllerStylesExampleSupplemental.m
+++ b/components/TextFields/examples/supplemental/TextFieldControllerStylesExampleSupplemental.m
@@ -63,16 +63,12 @@
 
 @implementation TextFieldControllerStylesExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Text Field", @"Controller Styles" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Text Field", @"Controller Styles" ],
+    @"primaryDemo": @NO,
+    @"presentable": @YES,
+  };
 }
 
 @end

--- a/components/TextFields/examples/supplemental/TextFieldInterfaceBuilderExampleSupplemental.m
+++ b/components/TextFields/examples/supplemental/TextFieldInterfaceBuilderExampleSupplemental.m
@@ -26,20 +26,13 @@
 
 @implementation TextFieldInterfaceBuilderExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Text Field", @"Storyboard" ];
-}
-
-+ (NSString *)catalogStoryboardName {
-  return @"TextFieldInterfaceBuilderExample";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Text Field", @"Storyboard" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+    @"storyboardName": @"TextFieldInterfaceBuilderExample"
+  };
 }
 
 @end
@@ -54,20 +47,13 @@
 
 @implementation TextFieldInterfaceBuilderLegacyExample (CatalogByConvention)
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Text Field", @"[Legacy] Storyboard" ];
-}
-
-+ (NSString *)catalogStoryboardName {
-  return @"TextFieldInterfaceBuilderLegacyExample";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Text Field", @"[Legacy] Storyboard" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+    @"storyboardName": @"TextFieldInterfaceBuilderLegacyExample"
+  };
 }
 
 @end

--- a/components/TextFields/examples/supplemental/TextFieldKitchenSinkExampleSupplemental.swift
+++ b/components/TextFields/examples/supplemental/TextFieldKitchenSinkExampleSupplemental.swift
@@ -494,15 +494,12 @@ extension TextFieldKitchenSinkSwiftExample {
 }
 
 extension TextFieldKitchenSinkSwiftExample {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Text Field", "Kitchen Sink"]
-  }
 
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Text Field", "Kitchen Sink"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }

--- a/components/Typography/examples/TypographyCustomFontViewController.m
+++ b/components/Typography/examples/TypographyCustomFontViewController.m
@@ -150,16 +150,12 @@ static inline UIFont *customFont(MDCFontTextStyle style) {
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-   return @[ @"Typography and Fonts", @"Custom Font Example" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-   return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Typography and Fonts", @"Custom Font Example" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Typography/examples/TypographyFontListExample.swift
+++ b/components/Typography/examples/TypographyFontListExample.swift
@@ -146,20 +146,14 @@ class TypographyFontListExampleViewController: UITableViewController {
 
 // MARK: - CatalogByConvention
 extension TypographyFontListExampleViewController {
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["Typography and Fonts", "Typography"]
-  }
 
-  @objc class func catalogDescription() -> String {
-    return "The Typography component provides methods for displaying text using the type sizes and"
-      + " opacities from the Material Design specifications."
-  }
-
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return false
-  }
-
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Typography and Fonts", "Typography"],
+      "description": "The Typography component provides methods for displaying text using the "
+        + "type sizes and opacities from the Material Design specifications.",
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }

--- a/components/Typography/examples/TypographyMaterialStylesViewController.m
+++ b/components/Typography/examples/TypographyMaterialStylesViewController.m
@@ -194,16 +194,12 @@
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Typography and Fonts", @"Material Font Styles" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Typography and Fonts", @"Material Font Styles" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/Typography/examples/TypographySimpleExampleViewController.m
+++ b/components/Typography/examples/TypographySimpleExampleViewController.m
@@ -42,16 +42,12 @@
 
 #pragma mark - CatalogByConvention
 
-+ (NSArray *)catalogBreadcrumbs {
-  return @[ @"Typography and Fonts", @"Read Me Demo" ];
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return NO;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return NO;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Typography and Fonts", @"Read Me Demo" ],
+    @"primaryDemo": @NO,
+    @"presentable": @NO,
+  };
 }
 
 @end

--- a/components/private/Dragons/examples/ZShadow.swift
+++ b/components/private/Dragons/examples/ZShadow.swift
@@ -96,16 +96,13 @@ class ZShadowViewController: UIViewController {
 extension ZShadowViewController {
   
   // MARK: Catalog by convention
-  @objc class func catalogBreadcrumbs() -> [String] {
-    return ["ZShadow"]
-  }
-  
-  @objc class func catalogIsPrimaryDemo() -> Bool {
-    return true
-  }
 
-  @objc class func catalogIsPresentable() -> Bool {
-    return false
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["ZShadow"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
   }
 }
 

--- a/components/schemes/Typography/examples/MDCTypographySchemeFontListExampleViewController.m
+++ b/components/schemes/Typography/examples/MDCTypographySchemeFontListExampleViewController.m
@@ -187,21 +187,15 @@ static NSArray<UIFont *> *Fonts() {
 
 #pragma mark - Catalog by convention
 @implementation MDCTypographySchemeFontListExampleViewController (CatlogByConvention)
-+ (NSArray<NSString *> *)catalogBreadcrumbs {
-  return @[ @"Typography", @"TypographyScheme" ];
-}
 
-+ (NSString *)catalogDescription {
-  return @"The Typography component provides methods for displaying text using the type sizes and"
-          " opacities from the Material Design specifications.";
-}
-
-+ (BOOL)catalogIsPrimaryDemo {
-  return YES;
-}
-
-+ (BOOL)catalogIsPresentable {
-  return YES;
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs": @[ @"Typography", @"TypographyScheme" ],
+    @"description": @"The Typography component provides methods for displaying text using the "
+    @"type sizes and opacities from the Material Design specifications.",
+    @"primaryDemo": @YES,
+    @"presentable": @YES,
+  };
 }
 
 @end


### PR DESCRIPTION
Move to the new CbC standard released in CatalogByConvention v2.5.0. See PR: https://github.com/material-foundation/cocoapods-catalog-by-convention/pull/27 for more info on the change.