### PR TITLE
[ActionSheet] Show first action

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -151,6 +151,7 @@ static NSString *const ReuseIdentifier = @"BaseCell";
   }
 #endif
   _tableView.contentInset = insets;
+  _tableView.contentOffset = CGPointMake(0, -size.height);
 }
 
 - (void)viewWillAppear:(BOOL)animated {


### PR DESCRIPTION
This makes it so that if there are too many actions to show on screen when the ActionSheet is presented then always show the first one. Previously the first couple actions would be hidden behind the header.

Closes #4948 

| Before  |   After  |
| ------- | ------- |
|![simulator screen shot - iphone x - 2018-08-30 at 10 24 51](https://user-images.githubusercontent.com/7131294/44858531-36ad1f80-ac40-11e8-93bb-abcdb7107f0a.png)| ![simulator screen shot - iphone x - 2018-08-30 at 10 25 19](https://user-images.githubusercontent.com/7131294/44858564-4c224980-ac40-11e8-8c56-b98c2f73a86f.png)|
