### PR TITLE
[ActionSheet] Update test to guard against silent fail

### DIFF
--- a/components/ActionSheet/tests/unit/ActionSheetTest.swift
+++ b/components/ActionSheet/tests/unit/ActionSheetTest.swift
@@ -22,6 +22,8 @@ class ActionSheetTest: XCTestCase {
   var actionSheet: MDCActionSheetController!
 
   override func setUp() {
+    super.setUp()
+
     actionSheet = MDCActionSheetController()
   }
 
@@ -61,7 +63,6 @@ class ActionSheetTest: XCTestCase {
     actionSheet.addAction(action)
 
     // Then
-    XCTAssertEqual(actionSheet.view.subviews.count, 2)
     let tableView = actionSheet.view.subviews.flatMap{ $0 as? UITableView }.first
     if let table = tableView {
       XCTAssertEqual(table.numberOfRows(inSection: section), rowCount)
@@ -70,6 +71,8 @@ class ActionSheetTest: XCTestCase {
       } else {
         XCTFail("Cell wasn't loaded")
       }
+    } else {
+      XCTFail("No table was loaded")
     }
     
   }

--- a/components/ActionSheet/tests/unit/ActionSheetTest.swift
+++ b/components/ActionSheet/tests/unit/ActionSheetTest.swift
@@ -66,10 +66,12 @@ class ActionSheetTest: XCTestCase {
     let tableView = actionSheet.view.subviews.flatMap{ $0 as? UITableView }.first
     if let table = tableView {
       XCTAssertEqual(table.numberOfRows(inSection: section), rowCount)
-      if let cell = table.cellForRow(at: IndexPath(row: rowCount - 1, section: section)) {
+      if let dataSource = table.dataSource {
+        let cell = dataSource.tableView(table, cellForRowAt: IndexPath(row: rowCount - 1,
+                                                                       section: section))
         XCTAssertEqual(cell.accessibilityIdentifier, testIdentifier)
       } else {
-        XCTFail("Cell wasn't loaded")
+        XCTFail("No data source")
       }
     } else {
       XCTFail("No table was loaded")


### PR DESCRIPTION
Previously if there was no table the test would pass this addition now guards that if there is no table then the test should fail.