### PR TITLE
[TextFields] Specify textRect origin according to UIUserInterfaceLayoutDirection

### DIFF
--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -484,7 +484,11 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1.f;
 
   // Standard textRect calculation
   UIEdgeInsets textInsets = self.textInsets;
-  textRect.origin.x += textInsets.left;
+  if (self.mdf_effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
+    textRect.origin.x += textInsets.right;
+  } else {
+    textRect.origin.x += textInsets.left;
+  }
   textRect.size.width -= textInsets.left + textInsets.right;
 
   // Adjustments for .leftView, .rightView


### PR DESCRIPTION
Closes #4959 

Before:
<img width="382" alt="screen shot 2018-08-30 at 4 45 34 pm" src="https://user-images.githubusercontent.com/8020010/44878173-2878f680-ac74-11e8-93cb-9f129c9b418f.png">

After:
<img width="378" alt="screen shot 2018-08-30 at 4 45 42 pm" src="https://user-images.githubusercontent.com/8020010/44878171-2878f680-ac74-11e8-93f3-5524d23dbe2d.png">
