### PR TITLE
[scripts/github-comment] Remove duplicate target.

### DIFF
--- a/scripts/github-comment/Package.swift
+++ b/scripts/github-comment/Package.swift
@@ -20,11 +20,6 @@ import PackageDescription
 
 let package = Package(
   name: "github-comment",
-  products: [
-    .library(
-      name: "github-comment",
-      targets: ["github-comment"]),
-  ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0"),
   ],


### PR DESCRIPTION
This resolves a warning that was appearing when building/running the github-comment project:

```
warning: Ignoring duplicate product 'github-comment'
```

Tested by running:

```
cd scripts/github-comment/
swift run github-comment
```

And verifying that the above warning did not appear and that the command successfully built and executed.