### PR TITLE
[kokoro] Add a clang-format linter job.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -381,6 +381,160 @@ generate_apidiff() {
   fi
 }
 
+# Will run git clang-format on the branch's changes, reporting a failure if the linter generated any
+# stylistic changes.
+#
+# For local runs, you must set the following environment variables:
+#
+#   GITHUB_API_TOKEN -> Create a token here: https://github.com/settings/tokens.
+#                       Must have public_repo scope.
+#   KOKORO_GITHUB_PULL_REQUEST_NUMBER="###" -> The PR # you want to post the API diff results to.
+#   KOKORO_GITHUB_PULL_REQUEST_COMMIT="..." -> The PR commit you want to post to.
+#
+# And install the following tools:
+#
+# - clang-format
+# - git-clang-format
+lint_clang_format() {
+  usage() {
+    echo "Usage: $0 -d clang-format"
+    echo
+    echo "Will apply clang-format to changes made on the current branch from the merge-base of develop."
+    echo "The result will be posted to GitHub as a series of inline comments."
+    echo
+    echo "Must set the following environment variables to run locally:"
+    echo
+    echo "GITHUB_API_TOKEN -> Create a token here: https://github.com/settings/tokens."
+    echo "                    Must have public_repo scope."
+    echo "KOKORO_GITHUB_PULL_REQUEST_NUMBER=\"###\" -> The PR # you want to post the API diff results to."
+  }
+
+  if [ -z "$GITHUB_API_TOKEN" ]; then
+    echo "GITHUB_API_TOKEN must be set to a github token with public_repo scope."
+    usage
+    exit 1
+  fi
+
+  if [ -z "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
+    echo "KOKORO_GITHUB_PULL_REQUEST_NUMBER must be set to a github pull request number."
+    usage
+    exit 1
+  fi
+
+  if [ -z "$KOKORO_GITHUB_PULL_REQUEST_COMMIT" ]; then
+    echo "KOKORO_GITHUB_PULL_REQUEST_COMMIT must be set to a commit."
+    usage
+    exit 1
+  fi
+
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    select_xcode "$XCODE_VERSION"
+
+    mkdir bin
+    pushd bin >> /dev/null
+
+    # Install clang-format
+    echo "Downloading clang-format..."
+    CLANG_FORMAT_SHA="f2917c1235f32617e5819bb2a7ec0a4f163fbb82f305b5639c540fafa6622d12"
+    curl -Ls "https://github.com/material-foundation/clang-format/releases/download/r340070/clang-format" -o "clang-format"
+    if openssl sha -sha256 "clang-format" | grep -q "$CLANG_FORMAT_SHA"; then
+      echo "SHAs match. Proceeding."
+    else
+      echo "clang-format does not match sha. Aborting."
+      exit 1
+    fi
+    chmod +x "clang-format"
+
+    echo "Downloading git-clang-format..."
+    # Install git-clang-format
+    GIT_CLANG_FORMAT_SHA="1f6cfad79f90ea202dcf2d52a360186341a589cdbfdee05b0e7694f912aa9820"
+    curl -Ls https://raw.githubusercontent.com/llvm-mirror/clang/c510fac5695e904b43d5bf0feee31cc9550f110e/tools/clang-format/git-clang-format -o "git-clang-format"
+    if openssl sha -sha256 "git-clang-format" | grep -q "$GIT_CLANG_FORMAT_SHA"; then
+      echo "SHAs match. Proceeding."
+    else
+      echo "git-clang-format does not match sha. Aborting."
+      exit 1
+    fi
+    chmod +x "git-clang-format"
+
+    export PATH="$(pwd):$PATH"
+
+    popd >> /dev/null
+
+    # Move into our cloned repo
+    cd github/repo
+  fi
+
+  if ! git clang-format -h > /dev/null 2> /dev/null; then
+    echo
+    echo "git clang-format is not configured correctly."
+    echo "Please ensure that the git-clang-format command is in your PATH and that it is executable."
+    exit 1
+  fi
+
+  base_sha=$(git merge-base origin/develop HEAD)
+
+  echo "Running clang-format on changes from $base_sha to HEAD..."
+  git clang-format "$base_sha"
+  if ! git diff-index --quiet HEAD --; then
+    echo
+    echo "clang-format requires the following stylistic changes to be made:"
+    echo
+    git --no-pager diff
+
+    COMMENT_TMP_PATH=$(mktemp -d)
+    COMMENT_TMP_FILE="$COMMENT_TMP_PATH/comment"
+    DIFF_TMP_FILE="$COMMENT_TMP_PATH/diff"
+
+    echo "clang-format suggested the following change:" > "$COMMENT_TMP_FILE"
+    git --no-pager diff -U0 > "$DIFF_TMP_FILE"
+
+    echo "Posting results to GitHub..."
+
+    pushd scripts/github-comment >> /dev/null
+
+    swift run github-comment \
+      --repo=material-components/material-components-ios \
+      --github_token="$GITHUB_API_TOKEN" \
+      --pull_request_number="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" \
+      --commit="$KOKORO_GITHUB_PULL_REQUEST_COMMIT" \
+      --identifier=clang-format \
+      --comment_body="$COMMENT_TMP_FILE" \
+      --diff="$DIFF_TMP_FILE"
+
+    cat > "$COMMENT_TMP_FILE" <<EOL
+clang-format recommended changes.
+
+Consider installing [git-clang-format](https://github.com/llvm-mirror/clang/blob/master/tools/clang-format/git-clang-format) and running the following command:
+
+\`\`\`bash
+git clang-format \$(git merge-base origin/develop HEAD)
+\`\`\`
+EOL
+
+    swift run github-comment \
+      --repo=material-components/material-components-ios \
+      --github_token="$GITHUB_API_TOKEN" \
+      --pull_request_number="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" \
+      --identifier=clang-format \
+      --comment_body="$COMMENT_TMP_FILE"
+
+    popd >> /dev/null
+
+    exit 1
+  else
+    pushd scripts/github-comment >> /dev/null
+    # No recommended changes, so delete any existing comment
+    swift run github-comment \
+      --repo=material-components/material-components-ios \
+      --github_token="$GITHUB_API_TOKEN" \
+      --pull_request_number="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" \
+      --identifier=clang-format \
+      --delete
+    popd >> /dev/null
+  fi
+}
+
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
   key="$1"
@@ -430,6 +584,7 @@ popd
 
 case "$DEPENDENCY_SYSTEM" in
   "bazel")      run_bazel ;;
+  "clang-format")  lint_clang_format ;;
   "cocoapods")  run_cocoapods ;;
   "cocoapods-podspec")  run_cocoapods ;;
   "website")    generate_website ;;

--- a/scripts/github-comment/Sources/github-comment/DiffParser.swift
+++ b/scripts/github-comment/Sources/github-comment/DiffParser.swift
@@ -1,0 +1,113 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+struct Hunk {
+  let beforeRange: Range<Int>
+  let afterRange: Range<Int>
+  let contents: [String]
+}
+
+/**
+ Returns a pair of dictionaries of filenames to lists of hunks from a given diff format.
+
+ First dictionary are the "before" files.
+ Second dictionary are the "after" files.
+
+ // Before and after may match if no files were moved added or deleted.
+ */
+func hunksFromDiff(_ diffString: String) -> (before: [String: [Hunk]], after: [String: [Hunk]]) {
+  var beforeHunks: [String: [Hunk]] = [:]
+  var afterHunks: [String: [Hunk]] = [:]
+
+  var currentBeforeFile: String? = nil
+  var currentAfterFile: String? = nil
+  var currentBeforeRange: Range<Int>? = nil
+  var currentAfterRange: Range<Int>? = nil
+  var contents: [String] = []
+  let commitHunkIfPossible = {
+    guard let beforeFile = currentBeforeFile,
+        let afterFile = currentAfterFile,
+        let beforeRange = currentBeforeRange,
+        let afterRange = currentAfterRange else {
+      return
+    }
+
+    let hunk = Hunk(beforeRange: beforeRange, afterRange: afterRange, contents: contents)
+    beforeHunks[beforeFile, default: []].append(hunk)
+    afterHunks[afterFile, default: []].append(hunk)
+
+    currentBeforeRange = nil
+    currentAfterRange = nil
+    contents.removeAll()
+  }
+
+  diffString.enumerateLines { line, _ in
+    // Extract file
+    // Example:
+    // --- a/components/AppBar/src/MDCAppBarContainerViewController.m
+    if let fileParts = line.split(around: "diff --git a/").1 {
+      commitHunkIfPossible()
+
+      currentBeforeFile = fileParts.split(around: " ").0
+      currentAfterFile = fileParts.split(around: " b/").1
+      return
+    }
+
+    if currentBeforeFile == nil || currentAfterFile == nil {
+      return // Nothing to do until we find a file.
+    }
+
+    // Extract hunk line ranges
+    // Examples:
+    // @@ -19 +18,0 @@
+    // @@ -20,0 +20 @@
+    // @@ -31,3 +31 @@
+    if let lineNumberInfo = line.split(around: "@@ -").1 {
+      commitHunkIfPossible()
+
+      let parts = lineNumberInfo.split(separator: " ")
+      currentBeforeRange = rangeFromHunkString(String(parts[0]))
+      currentAfterRange = rangeFromHunkString(String(parts[1]))
+      return
+    }
+
+    // Extract contents
+    if currentBeforeRange != nil && currentAfterRange != nil {
+      contents.append(line)
+    }
+  }
+
+  // Commit the trailing hunk
+  commitHunkIfPossible()
+
+  return (before: beforeHunks, after: afterHunks)
+}
+
+private func rangeFromHunkString(_ hunkString: String) -> Range<Int>? {
+  let parts = hunkString.split(separator: ",")
+  if parts.count == 1,
+    let lineNumber = Int(parts[0]) {
+    return Range(uncheckedBounds: (lineNumber, lineNumber + 1))
+
+  } else if parts.count == 2,
+    let lineNumber = Int(parts[0]),
+    let numberOfLines = Int(parts[1]) {
+    return Range(uncheckedBounds: (lineNumber, lineNumber + max(1, numberOfLines)))
+  }
+  return nil
+}

--- a/scripts/github-comment/Sources/github-comment/HunkCorrelation.swift
+++ b/scripts/github-comment/Sources/github-comment/HunkCorrelation.swift
@@ -1,0 +1,68 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+/**
+ Returns a GitHub pull request comment "position" for a given hunk in a given list of hunks.
+
+ Context:
+ One might hope you could post comments to GitHub pull requests given a file and line range.
+ Alas, GitHub instead requires that you post comments to the pull request diff's hunks.
+ For example, if a pull request made changes to lines 20-50 on file A, and you want to post a
+ comment to line 25 of that file, you need to post a comment to "6" (line 20 is line "1" of the
+ hunk).
+
+ From the docs: https://developer.github.com/v3/pulls/comments/#create-a-comment
+ > The position value equals the number of lines down from the first "@@" hunk header in the
+ > file you want to add a comment. The line just below the "@@" line is position 1, the next
+ > line is position 2, and so on. The position in the diff continues to increase through lines
+ > of whitespace and additional hunks until the beginning of a new file.
+ */
+func githubPosition(for hunk: Hunk, in hunks: [Hunk]) -> Int? {
+  // Our hunk ranges line up like so:
+  // hunks.beforeRange = original code
+  // hunks.afterRange  = pull request changes
+  // hunk.beforeRange  = pull request changes
+  // hunk.afterRange   = after suggested changes
+  guard let index = hunks.index(where: { $0.afterRange.overlaps(hunk.beforeRange) }) else {
+    return nil
+  }
+
+  // Position is counted by number of lines in the hunk content, so we start by counting the number
+  // of lines in all of the preceeding hunks.
+  let numberOfPrecedingHunkLines = hunks[0..<index].map { $0.contents.count }.reduce(0, +)
+  // Each hunk's header (including the current one) has as an implicit line
+  let numberOfHunksHeaders = index + 1
+
+  // The position should be the last line of code we intend to change in the index'd hunk.
+  // First, count how many lines our hunk intends to change:
+  let linesChanged = hunk.contents.index(where: { !$0.starts(with: "-") }) ?? hunk.contents.count
+  let lastLineChanged = hunk.beforeRange.lowerBound + linesChanged
+
+  // We now know the line number. Now we need to calculate the position.
+  var numberOfLinesToCount = lastLineChanged - hunks[index].afterRange.lowerBound
+  for (hunkPosition, line) in hunks[index].contents.enumerated() {
+    if line.hasPrefix("-") { // Ignore removed lines
+      continue
+    }
+    numberOfLinesToCount = numberOfLinesToCount - 1
+    if numberOfLinesToCount == 0 {
+      return numberOfPrecedingHunkLines + numberOfHunksHeaders + hunkPosition
+    }
+  }
+  return nil
+}

--- a/scripts/github-comment/Sources/github-comment/github/GitHubAPI.swift
+++ b/scripts/github-comment/Sources/github-comment/github/GitHubAPI.swift
@@ -89,6 +89,35 @@ extension GitHub {
   }
 
   /**
+   Fetches a string.
+
+   @param urlAsString An API url to request. Should be relative to https://api.github.com/
+   @param additionalHeaders Optional additional request headers.
+   */
+  func get(from urlAsString: String, additionalHeaders: [String: String]? = nil) -> String? {
+    guard let url = URL(string: apiUrlBase + urlAsString) else {
+      return nil
+    }
+    var request = authenticated(request: URLRequest(url: url))
+    if let additionalHeaders = additionalHeaders {
+      for (field, value) in additionalHeaders {
+        request.addValue(value, forHTTPHeaderField: field)
+      }
+    }
+    let result = synchronousRequest(with: request)
+    if result.response?.statusCode == 200, let data = result.data {
+      return String(data: data, encoding: .utf8)
+
+    } else {
+      if let error = result.error {
+        print("Error: \(error.localizedDescription)")
+      }
+      exit(1)
+    }
+    return nil
+  }
+
+  /**
    Patches a single object.
 
    @param urlAsString An API url to request. Should be relative to https://api.github.com/

--- a/scripts/github-comment/Sources/github-comment/main.swift
+++ b/scripts/github-comment/Sources/github-comment/main.swift
@@ -34,10 +34,17 @@ let prNumberArgument = parser.add(option: "--pull_request_number", kind: Int.sel
 let identifierArgument = parser.add(option: "--identifier", kind: String.self, usage:
   "[required]. An identifier that will be used to identify the comment.")
 
+// Single comment feedback
 let bodyArgument = parser.add(option: "--comment_body", kind: PathArgument.self, usage:
   "[optional]. A path to a file containing the body of the comment.")
 let deleteArgument = parser.add(option: "--delete", kind: Bool.self, usage:
   "[optional]. Will delete the comment.")
+
+// Line-based feedback
+let diffArgument = parser.add(option: "--diff", kind: PathArgument.self, usage:
+  "[optional]. A diff that will be used to post line comments.")
+let commitArgument = parser.add(option: "--commit", kind: String.self, usage:
+  "[optional]. A commit that will be used to post line comments.")
 
 let parsedArguments: ArgumentParser.Result
 do {
@@ -69,6 +76,8 @@ guard let identifier = parsedArguments.get(identifierArgument) else {
 }
 let bodyFilename = parsedArguments.get(bodyArgument)
 let shouldDelete = parsedArguments.get(deleteArgument) ?? false
+let diffFilename = parsedArguments.get(diffArgument)
+let commit = parsedArguments.get(commitArgument)
 
 let commentIdentifier = "<!-- identifier: \(identifier) -->"
 
@@ -83,27 +92,6 @@ guard let user = user, let userId = user.id else {
   exit(1)
 }
 
-var existingComment: GitHub.Comment? = nil
-github.getAll(startingFrom: "repos/\(repo)/issues/\(prNumber)/comments") { jsonResult in
-  guard let json = jsonResult as? GitHub.CommentList.JsonFormat else {
-    return false // Halt execution
-  }
-  let list = GitHub.CommentList(json: json)
-  guard let comments = list.comments else {
-    return false
-  }
-  for comment in comments {
-    guard let body = comment.body else {
-      continue
-    }
-    if comment.user?.id == user.id && body.contains(commentIdentifier) {
-      existingComment = comment
-      return false // Stop enumerating the comments
-    }
-  }
-  return true
-}
-
 func getCommentBody() throws -> String? {
   if let bodyFilename = bodyFilename {
     return try String(contentsOf: URL(fileURLWithPath: bodyFilename.path.asString))
@@ -111,31 +99,141 @@ func getCommentBody() throws -> String? {
   return nil
 }
 
-if shouldDelete {
-  if let existingCommentId = existingComment?.id {
-    print("Deleting existing comment...")
-    github.delete(at: "repos/\(repo)/issues/comments/\(existingCommentId)")
+func getDiff() throws -> String? {
+  if let diffFilename = diffFilename {
+    return try String(contentsOf: URL(fileURLWithPath: diffFilename.path.asString))
   }
-
-} else if let body = try getCommentBody() {
-  if let existingCommentId = existingComment?.id {
-    let desiredBody = body + "\n" + commentIdentifier
-
-    if existingComment?.body == desiredBody {
-      print("Nothing to do, comment matches desired body.")
-
-    } else {
-      print("Updating existing comment...")
-      github.patch(to: "repos/\(repo)/issues/comments/\(existingCommentId)", json: [
-        "body": desiredBody
-      ])
-    }
-
-  } else {
-    print("Creating new comment...")
-    github.post(to: "repos/\(repo)/issues/\(prNumber)/comments", json: [
-      "body": body + "\n" + commentIdentifier
-    ])
-  }
+  return nil
 }
 
+if let diffFilename = diffFilename {
+  guard let body = try getCommentBody() else {
+    print("A comment body is required when posting comments.")
+    exit(1)
+  }
+
+  guard let commit = commit else {
+    print("A commit is required when posting comments.")
+    exit(1)
+  }
+
+  guard let diff = try getDiff() else {
+    print("No diff could be loaded from \(diffFilename).")
+    exit(1)
+  }
+
+  guard let pullRequestDiff = github.get(from: "repos/\(repo)/pulls/\(prNumber)",
+      additionalHeaders: ["Accept": "application/vnd.github.v3.diff"]) else {
+    print("Unable to fetch diff for pull request.")
+    exit(1)
+  }
+
+  // First build a set of comments that have already been posted.
+  var existingComments = Set<String>()
+  print("Building set of existing comments...")
+  github.getAll(startingFrom: "repos/\(repo)/pulls/\(prNumber)/comments") { jsonResult in
+    guard let json = jsonResult as? GitHub.CommentList.JsonFormat else {
+      return false // Halt execution
+    }
+    let list = GitHub.CommentList(json: json)
+    guard let comments = list.comments else {
+      return false
+    }
+    for comment in comments {
+      guard let body = comment.body else {
+        continue
+      }
+      existingComments.insert(body)
+    }
+    return true
+  }
+
+  print("Parsing pull request diff...")
+  let pullRequestHunks = hunksFromDiff(pullRequestDiff).after
+  print("Parsing desired diff...")
+  let diffHunks = hunksFromDiff(diff).before
+
+  print("Intersecting hunks...")
+  for (file, suggestedHunks) in diffHunks {
+    guard let fileHunks = pullRequestHunks[file] else {
+      continue // This file doesn't exist in the PR. Ignore it.
+    }
+
+    for suggestedHunk in suggestedHunks {
+      guard let position = githubPosition(for: suggestedHunk, in: fileHunks) else {
+        continue // Unable to find this hunk in the pull request diff.
+      }
+      let desiredBody = """
+\(body)
+
+```
+\(suggestedHunk.contents.joined(separator: "\n"))
+```
+
+\(commentIdentifier)
+<!-- Hunk: \(file) \(suggestedHunk.afterRange.lowerBound),\(suggestedHunk.afterRange.count) -->
+"""
+      if existingComments.contains(desiredBody) {
+        print("Already posted comment, skipping...")
+        continue // Don't repost this comment.
+      }
+      print("Posting comment...")
+      github.post(to: "repos/\(repo)/pulls/\(prNumber)/comments", json: [
+        "body": desiredBody,
+        "commit_id": commit,
+        "path": file,
+        "position": position
+      ])
+    }
+  }
+
+} else {
+  var existingComment: GitHub.Comment? = nil
+  github.getAll(startingFrom: "repos/\(repo)/issues/\(prNumber)/comments") { jsonResult in
+    guard let json = jsonResult as? GitHub.CommentList.JsonFormat else {
+      return false // Halt execution
+    }
+    let list = GitHub.CommentList(json: json)
+    guard let comments = list.comments else {
+      return false
+    }
+    for comment in comments {
+      guard let body = comment.body else {
+        continue
+      }
+      if comment.user?.id == user.id && body.contains(commentIdentifier) {
+        existingComment = comment
+        return false // Stop enumerating the comments
+      }
+    }
+    return true
+  }
+
+  if shouldDelete {
+    if let existingCommentId = existingComment?.id {
+      print("Deleting existing comment...")
+      github.delete(at: "repos/\(repo)/issues/comments/\(existingCommentId)")
+    }
+
+  } else if let body = try getCommentBody() {
+    if let existingCommentId = existingComment?.id {
+      let desiredBody = body + "\n" + commentIdentifier
+
+      if existingComment?.body == desiredBody {
+        print("Nothing to do, comment matches desired body.")
+
+      } else {
+        print("Updating existing comment...")
+        github.patch(to: "repos/\(repo)/issues/comments/\(existingCommentId)", json: [
+          "body": desiredBody
+        ])
+      }
+
+    } else {
+      print("Creating new comment...")
+      github.post(to: "repos/\(repo)/issues/\(prNumber)/comments", json: [
+        "body": body + "\n" + commentIdentifier
+      ])
+    }
+  }
+}


### PR DESCRIPTION
This job is our first official linter.

<img width="830" alt="screen shot 2018-08-30 at 5 12 35 pm" src="https://user-images.githubusercontent.com/45670/44880230-d8049780-ac79-11e8-926b-836b16c86f9f.png">

See https://github.com/material-components/material-components-ios/pull/4954 for an example thread in which I purposefully made some style regressions and let the tool post back to the PR until I resolved them.

This new job will apply clang-format *only* to the lines that have been changed by a given pull request. If any changes are suggested, the diff will be shown in the job's build logs and individual changes will be posted back to the PR at each suggested line.

The provided feedback can be addressed in multiple ways:

1. Manually, by copying the suggested changes into your code.
2. By running git-clang-format on your local branch. The tool will suggest this, including an ideal command line invocation to do so.

This job can be run locally, though it requires a fair amount of configuration to do so. See the job's documentation for more details on which environment variables are required.

---

This change also required modifications to the github-comment command line tool. Notably:

1. A very light-weight diff parser was added. This API takes a git diff [unified diff](https://www.gnu.org/software/diffutils/manual/html_node/Example-Unified.html#Example-Unified) file and parses it into individual [hunks](https://www.gnu.org/software/diffutils/manual/html_node/Hunks.html).
2. A hunk-correlator was added. This is the magic that translates clang-format's suggested diff into individual positions on a GitHub pull request.
3. A new GitHub API method for fetching a single file was added. We require this in order to fetch the pull request diff.
4. A new set of command line parameters was added to the github-comment tool. Use of these new parameters turn a suggested diff into a series of GitHub pull request line comments.

Before posting any new comments to the PR, the command enumerates all of the existing comments into a Set. If desired comment already exists in the set of comments then it will not be posted again. This is the mechanism by which we minimize noise generated from the job on subsequent updates to the PR.

---

The essential workflow for this tool is (on kokoro):

1. Install the clang-format version we're using internally by fetching it from our pre-built binary repository: https://github.com/material-foundation/clang-format
2. Install the git-clang-format tool.
3. Verify the checksums of both tools.
4. Run git-clang-format on the pull request.
5. If there have been no changes, exit with status 0 and post success back to the PR. Deletes any comment that had been made previously about style (this matches the apidiff behavior).
6. Otherwise, output the diff results and feed the diff to github-comment.
7. github-comment parses the pull request diff and the suggested diff, correlates the suggested hunks with the pull request hunks, and then posts individual line comments with the suggested changes.
8. If a summary comment hasn't already been posted to the PR, a summary comment is posted. Otherwise, we update the existing comment.
9. Post a failure status to the PR.

