### PR TITLE
[FlexibleHeader] Add new canAlwaysExpandToMaximumHeight behavior.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -486,6 +486,14 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/UIMetrics"
   end
 
+  mdc.subspec "FlexibleHeader+CanAlwaysExpandToMaximumHeight" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
+  end
+
   mdc.subspec "FlexibleHeader+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
     extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"

--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -48,12 +48,27 @@ mdc_objc_library(
     visibility = ["//visibility:public"],
 )
 
+mdc_objc_library(
+    name = "CanAlwaysExpandToMaximumHeight",
+    srcs = native.glob(["src/CanAlwaysExpandToMaximumHeight/*.m"]),
+    hdrs = native.glob(["src/CanAlwaysExpandToMaximumHeight/*.h"]),
+    includes = ["src/CanAlwaysExpandToMaximumHeight"],
+    sdk_frameworks = [
+        "UIKit",
+    ],
+    deps = [
+        ":FlexibleHeader",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
     deps = [
         ":FlexibleHeader",
         ":ColorThemer",
+        ":CanAlwaysExpandToMaximumHeight",
     ],
     visibility = ["//visibility:private"],
 )
@@ -70,6 +85,7 @@ mdc_objc_library(
     deps = [
         ":FlexibleHeader",
         ":ColorThemer",
+        ":CanAlwaysExpandToMaximumHeight",
     ],
     visibility = ["//visibility:private"],
 )

--- a/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
@@ -17,8 +17,9 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialFlexibleHeader.h"
-#import "MaterialFlexibleHeader+CanAlwaysExpandToMaximumHeight.h"
 #import "supplemental/FlexibleHeaderConfiguratorSupplemental.h"
+
+#import "MaterialFlexibleHeader+CanAlwaysExpandToMaximumHeight.h"
 
 @interface FlexibleHeaderConfiguratorExample ()
 @property(nonatomic) BOOL overrideStatusBarHidden;

--- a/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
@@ -17,6 +17,7 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialFlexibleHeader.h"
+#import "MaterialFlexibleHeader+CanAlwaysExpandToMaximumHeight.h"
 #import "supplemental/FlexibleHeaderConfiguratorSupplemental.h"
 
 @interface FlexibleHeaderConfiguratorExample ()
@@ -97,6 +98,10 @@
 
     case FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea:
       headerView.minMaxHeightIncludesSafeArea = [value boolValue];
+      break;
+
+    case FlexibleHeaderConfiguratorFieldCanAlwaysExpandToMaximumHeight:
+      headerView.canAlwaysExpandToMaximumHeight = [value boolValue];
       break;
   }
 }
@@ -192,8 +197,12 @@ static const CGFloat kHeightScalar = 300;
 
     case FlexibleHeaderConfiguratorFieldMaximumHeight:
       return @([self normalizedHeight:self.fhvc.headerView.maximumHeight]);
+
     case FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea:
       return @(self.fhvc.headerView.minMaxHeightIncludesSafeArea);
+
+    case FlexibleHeaderConfiguratorFieldCanAlwaysExpandToMaximumHeight:
+      return @(self.fhvc.headerView.canAlwaysExpandToMaximumHeight);
   }
 }
 

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.h
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.h
@@ -35,6 +35,7 @@ typedef enum : NSUInteger {
   FlexibleHeaderConfiguratorFieldMinimumHeight,
   FlexibleHeaderConfiguratorFieldMaximumHeight,
   FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea,
+  FlexibleHeaderConfiguratorFieldCanAlwaysExpandToMaximumHeight,
 } FlexibleHeaderConfiguratorField;
 
 @interface FlexibleHeaderConfiguratorExample : UITableViewController

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
@@ -173,7 +173,9 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
     sliderItem(@"Minimum", FlexibleHeaderConfiguratorFieldMinimumHeight),
     sliderItem(@"Maximum", FlexibleHeaderConfiguratorFieldMaximumHeight),
     switchItem(@"Min / max height includes Safe Area",
-               FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea)
+               FlexibleHeaderConfiguratorFieldMinMaxHeightIncludeSafeArea),
+    switchItem(@"Can always expand to maximum height",
+               FlexibleHeaderConfiguratorFieldCanAlwaysExpandToMaximumHeight)
   ]);
 
   NSMutableArray *fillerItems = [NSMutableArray array];

--- a/components/FlexibleHeader/src/CanAlwaysExpandToMaximumHeight/MDCFlexibleHeaderView+canAlwaysExpandToMaximumHeight.h
+++ b/components/FlexibleHeader/src/CanAlwaysExpandToMaximumHeight/MDCFlexibleHeaderView+canAlwaysExpandToMaximumHeight.h
@@ -1,0 +1,38 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MaterialFlexibleHeader.h"
+
+@interface MDCFlexibleHeaderView ()
+
+/**
+ Whether the flexible header is able to expand to its maximum height even when the target scroll
+ view content offset is not at the top of the content.
+
+ When enabled, the flexible header will be able to expand to its maximum height even when scrolled
+ within the content of the tracking scroll view.
+
+ When disabled, the flexible header will only expand to its maximum height once the scroll view
+ reaches the top of its content.
+
+ @note This is an experimental feature. Please do not enable it without first consulting the MDC
+ team about your intended use case.
+
+ Default is NO.
+ */
+@property(nonatomic) BOOL canAlwaysExpandToMaximumHeight;
+
+@end

--- a/components/FlexibleHeader/src/CanAlwaysExpandToMaximumHeight/MaterialFlexibleHeader+CanAlwaysExpandToMaximumHeight.h
+++ b/components/FlexibleHeader/src/CanAlwaysExpandToMaximumHeight/MaterialFlexibleHeader+CanAlwaysExpandToMaximumHeight.h
@@ -1,0 +1,17 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCFlexibleHeaderView+canAlwaysExpandToMaximumHeight.h"

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -94,6 +94,9 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 // This property is ignored if inferTopSafeAreaInsetFromViewController is NO.
 @property(nonatomic) CGFloat topSafeAreaInset;
 
+// Exposed via the FlexibleHeader+CanAlwaysExpandToMaximumHeight target.
+@property(nonatomic) BOOL canAlwaysExpandToMaximumHeight;
+
 @end
 
 // All injections into the content and scroll indicator insets are tracked here. It's super
@@ -139,8 +142,11 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
   // Prevents delta calculations on first update pass.
   BOOL _shiftAccumulatorLastContentOffsetIsValid;
-  // When the header can slide off-screen, this tracks how off-screen the header is.
+  // When the header can slide off-screen, a positive value indicates how off-screen the header is.
   // Essentially: view's top edge = -_shiftAccumulator
+  // When canAlwaysExpandToMaximumHeight is enabled, a negative value indicates how expanded the
+  // header is.
+  // Essentially: view's height += -_shiftAccumulator
   CGFloat _shiftAccumulator;
   CGPoint _shiftAccumulatorLastContentOffset;  // Stores our last delta'd content offset.
   CGFloat _shiftAccumulatorDeltaY;
@@ -754,6 +760,11 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
           _shiftAccumulator < [self fhv_accumulatorMax]);
 }
 
+- (BOOL)fhv_isPartiallyExpanded {
+  return ([self fhv_isDetachedFromTopOfContent] && _shiftAccumulator < 0 &&
+          _shiftAccumulator > -(self.maximumHeight - self.minimumHeight));
+}
+
 // The flexible header is "in front of" the content.
 - (BOOL)fhv_isDetachedFromTopOfContent {
   // Epsilon here is somewhat large in order to be visually-forgiving for sub-point situations.
@@ -855,7 +866,17 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   // Erase any scrollback that was injected into the accumulator by capping it back down.
   _shiftAccumulator = MIN([self fhv_accumulatorMax], _shiftAccumulator);
 
-  CGFloat destination = _wantsToBeHidden ? [self fhv_accumulatorMax] : 0;
+  CGFloat destination;
+  if (_shiftAccumulator > 0) {  // Shifted
+    destination = _wantsToBeHidden ? [self fhv_accumulatorMax] : 0;
+
+  } else if (_shiftAccumulator < 0) {  // Expanded
+    destination = _wantsToBeHidden ? 0 : [self fhv_accumulatorMin];
+
+  } else {
+    destination = 0;
+  }
+
   CGFloat distanceToDestination = destination - _shiftAccumulator;
 
   NSTimeInterval duration = displayLink.duration;
@@ -866,7 +887,8 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
   // This is a simple "force" that's stronger the further we are from the destination.
   _shiftAccumulator += kAttachmentCoefficient * distanceToDestination * duration;
-  _shiftAccumulator = MAX(0, MIN([self fhv_accumulatorMax], _shiftAccumulator));
+  _shiftAccumulator =
+      MAX([self fhv_accumulatorMin], MIN([self fhv_accumulatorMax], _shiftAccumulator));
 
   [_statusBarShifter setOffset:_shiftAccumulator];
 
@@ -893,7 +915,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
   CGFloat frameBottomEdge = [self fhv_projectedHeaderBottomEdge];
   frameBottomEdge = MAX(0, MIN(kShadowScaleLength, frameBottomEdge));
-  CGFloat boundedAccumulator = MIN([self fhv_accumulatorMax], _shiftAccumulator);
+  CGFloat boundedAccumulator = MAX(0, MIN([self fhv_accumulatorMax], _shiftAccumulator));
 
   CGFloat shadowIntensity;
   if (self.hidesStatusBarWhenCollapsed) {
@@ -954,6 +976,30 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
 #pragma mark Layout
 
+- (CGFloat)fhv_accumulatorMin {
+  CGFloat offsetWithoutInset = [self fhv_contentOffsetWithoutInjectedTopInset];
+  CGFloat headerHeight = -offsetWithoutInset;
+
+  CGFloat lowerBound;
+
+  if (self.canAlwaysExpandToMaximumHeight) {
+    CGFloat maxExpansion;
+    if (headerHeight < self.computedMinimumHeight) {
+      // The header is detached from the content and able to fully expand.
+      maxExpansion = self.minimumHeight - self.maximumHeight;
+    } else {
+      // We're now attached to the content and need to constrain our possible expansion.
+      maxExpansion = self.computedMaximumHeight - headerHeight;
+    }
+    // Expansion is tracked via negative accumulation.
+    lowerBound = MIN(0, -maxExpansion);
+  } else {
+    lowerBound = 0;
+  }
+
+  return lowerBound;
+}
+
 - (void)fhv_updateLayout {
   if (!_trackingScrollView) {
     return;
@@ -1003,15 +1049,16 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
     }
 
     if (![self fhv_isOverExtendingBottom] && !_shiftAccumulatorDisplayLink) {
-      // When we're not allowed to shift offscreen, only allow the header to shift further
-      // on-screen in case it was previously off-screen due to a behavior change.
-      if (![self fhv_canShiftOffscreen]) {
-        deltaY = MIN(0, deltaY);
-      }
-
       // When scrubbing we only allow the header to shrink and shift off-screen.
       if (self.trackingScrollViewIsBeingScrubbed) {
         deltaY = MAX(0, deltaY);
+      }
+
+      if (self.canAlwaysExpandToMaximumHeight) {
+        // When still attached to the top content, don't accumulate negatively.
+        if (headerHeight >= self.computedMinimumHeight) {
+          deltaY = MAX(0, deltaY);
+        }
       }
 
       // Check if our delta y will cause us to cross the boundary from shrinking to shifting and,
@@ -1037,7 +1084,10 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
       CGFloat upperBound;
 
-      if (headerHeight < 0) {
+      if (![self fhv_canShiftOffscreen]) {
+        // Don't allow any shifting.
+        upperBound = 0;
+      } else if (headerHeight < 0) {
         // Header is shifting while detached from content.
         upperBound = [self fhv_accumulatorMax] + [self fhv_anchorLength];
       } else if (headerHeight < self.computedMinimumHeight) {
@@ -1048,26 +1098,16 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
         upperBound = 0;
       }
 
+      CGFloat lowerBound = [self fhv_accumulatorMin];
+
       // Ensure that we don't lose any deltaY by first capping the accumulator within its valid
       // range.
       _shiftAccumulator = MIN(upperBound, _shiftAccumulator);
 
       // Accumulate the deltaY.
-      _shiftAccumulator = MAX(0, MIN(upperBound, _shiftAccumulator + deltaY));
+      _shiftAccumulator = MAX(lowerBound, MIN(upperBound, _shiftAccumulator + deltaY));
     }
   }
-
-  CGRect bounds = self.bounds;
-
-  if (_canOverExtend && !UIAccessibilityIsVoiceOverRunning()) {
-    bounds.size.height = MAX(self.computedMinimumHeight, headerHeight);
-
-  } else {
-    bounds.size.height = MAX(self.computedMinimumHeight,
-                             MIN(self.computedMaximumHeight, headerHeight));
-  }
-
-  self.bounds = bounds;
 
   [self fhv_commitAccumulatorToFrame];
 
@@ -1087,8 +1127,29 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
 // Commit the current shiftOffscreenAccumulator value to the view's position.
 - (void)fhv_commitAccumulatorToFrame {
+  CGFloat offsetWithoutInset = [self fhv_contentOffsetWithoutInjectedTopInset];
+  CGFloat headerHeight = -offsetWithoutInset;
+
+  CGRect bounds = self.bounds;
+
+  CGFloat additionalHeightInjection = MAX(0, -_shiftAccumulator);
+
+  if (_canOverExtend && !UIAccessibilityIsVoiceOverRunning()) {
+    bounds.size.height = MAX(self.computedMinimumHeight, headerHeight) + additionalHeightInjection;
+  } else {
+    bounds.size.height =
+        (MAX(self.computedMinimumHeight, MIN(self.computedMaximumHeight, headerHeight))
+         + additionalHeightInjection);
+  }
+
+  // Avoid excessive writes - the default behavior of the flexible header has minimal height
+  // adjustment behavior (basically only when over-extending).
+  if (!CGRectEqualToRect(self.bounds, bounds)) {
+    self.bounds = bounds;
+  }
+
   CGPoint position = self.center;
-  CGFloat shiftOffset = MIN([self fhv_accumulatorMax], _shiftAccumulator);
+  CGFloat shiftOffset = MAX(0, MIN([self fhv_accumulatorMax], _shiftAccumulator));
   // Offset the frame.
   position.y = -shiftOffset;
   position.y += self.bounds.size.height / 2;
@@ -1107,7 +1168,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
     view.alpha = 1 - percentShiftedAlongThreshold;
   }
 
-  [_statusBarShifter setOffset:_shiftAccumulator];
+  [_statusBarShifter setOffset:shiftOffset];
 
   [self.delegate flexibleHeaderViewFrameDidChange:self];
 }
@@ -1368,10 +1429,10 @@ static BOOL isRunningiOS10_3OrAbove() {
            @"Do not manually forward tracking scroll view events when"
            @" observesTrackingScrollViewScrollEvents is enabled.");
 
-  if (![self fhv_canShiftOffscreen]) {
+  if (![self fhv_canShiftOffscreen] && [self fhv_isPartiallyShifted]) {
     _wantsToBeHidden = NO;
   }
-  if (!willDecelerate && [self fhv_isPartiallyShifted]) {
+  if (!willDecelerate && ([self fhv_isPartiallyShifted] || [self fhv_isPartiallyExpanded])) {
     [self fhv_startDisplayLink];
   }
   _didDecelerate = willDecelerate;
@@ -1395,6 +1456,10 @@ static BOOL isRunningiOS10_3OrAbove() {
   if ([self fhv_isPartiallyShifted]) {
     _wantsToBeHidden =
         (_shiftAccumulator >= (1 - kMinimumVisibleProportion) * [self fhv_accumulatorMax]);
+    [self fhv_startDisplayLink];
+  } else if ([self fhv_isPartiallyExpanded]) {
+    _wantsToBeHidden =
+        (_shiftAccumulator >= (1 - kMinimumVisibleProportion) * [self fhv_accumulatorMin]);
     [self fhv_startDisplayLink];
   }
 }
@@ -1639,6 +1704,18 @@ static BOOL isRunningiOS10_3OrAbove() {
       *targetContentOffset = target;
       return YES;
     }
+  }
+  if (self.canAlwaysExpandToMaximumHeight && [self fhv_isPartiallyExpanded]) {
+    CGPoint target = *targetContentOffset;
+
+    // Don't allow the header to be partially expanded.
+    if (_wantsToBeHidden) {
+      target.y -= _shiftAccumulator;
+    } else {
+      target.y += ([self fhv_accumulatorMin] - _shiftAccumulator);
+    }
+    *targetContentOffset = target;
+    return YES;
   }
 
   return NO;

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -892,14 +892,15 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
   // This is a simple "force" that's stronger the further we are from the destination.
   _shiftAccumulator += kAttachmentCoefficient * distanceToDestination * duration;
+
   if (self.canAlwaysExpandToMaximumHeight) {
     _shiftAccumulator =
         MAX([self fhv_accumulatorMin], MIN([self fhv_accumulatorMax], _shiftAccumulator));
+    [_statusBarShifter setOffset:MAX(0, _shiftAccumulator)];
   } else {
     _shiftAccumulator = MAX(0, MIN([self fhv_accumulatorMax], _shiftAccumulator));
+    [_statusBarShifter setOffset:_shiftAccumulator];
   }
-
-  [_statusBarShifter setOffset:_shiftAccumulator];
 
   // Have we reached our destination?
   if (fabs(destination - _shiftAccumulator) <= kShiftEpsilon) {
@@ -1119,14 +1120,13 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
         upperBound = 0;
       }
 
-      CGFloat lowerBound = [self fhv_accumulatorMin];
-
       // Ensure that we don't lose any deltaY by first capping the accumulator within its valid
       // range.
       _shiftAccumulator = MIN(upperBound, _shiftAccumulator);
 
       // Accumulate the deltaY.
       if (self.canAlwaysExpandToMaximumHeight) {
+        CGFloat lowerBound = [self fhv_accumulatorMin];
         _shiftAccumulator = MAX(lowerBound, MIN(upperBound, _shiftAccumulator + deltaY));
       } else {
         _shiftAccumulator = MAX(0, MIN(upperBound, _shiftAccumulator + deltaY));

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -991,8 +991,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 #pragma mark Layout
 
 - (CGFloat)fhv_accumulatorMin {
-  CGFloat offsetWithoutInset = [self fhv_contentOffsetWithoutInjectedTopInset];
-  CGFloat headerHeight = -offsetWithoutInset;
+  CGFloat headerHeight = -[self fhv_contentOffsetWithoutInjectedTopInset];
 
   CGFloat lowerBound;
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1139,8 +1139,8 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
     if (_canOverExtend && !UIAccessibilityIsVoiceOverRunning()) {
       bounds.size.height = MAX(self.computedMinimumHeight, headerHeight);
     } else {
-      bounds.size.height = MAX(self.computedMinimumHeight,
-                               MIN(self.computedMaximumHeight, headerHeight));
+      bounds.size.height =
+          MAX(self.computedMinimumHeight, MIN(self.computedMaximumHeight, headerHeight));
     }
     self.bounds = bounds;
   }
@@ -1171,11 +1171,12 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
     CGFloat additionalHeightInjection = MAX(0, -_shiftAccumulator);
 
     if (_canOverExtend && !UIAccessibilityIsVoiceOverRunning()) {
-      bounds.size.height = MAX(self.computedMinimumHeight, headerHeight) + additionalHeightInjection;
+      bounds.size.height =
+          MAX(self.computedMinimumHeight, headerHeight) + additionalHeightInjection;
     } else {
       bounds.size.height =
-      (MAX(self.computedMinimumHeight, MIN(self.computedMaximumHeight, headerHeight))
-       + additionalHeightInjection);
+          (MAX(self.computedMinimumHeight, MIN(self.computedMaximumHeight, headerHeight)) +
+           additionalHeightInjection);
     }
 
     // Avoid excessive writes - the default behavior of the flexible header has minimal height

--- a/components/FlexibleHeader/src/private/MDCStatusBarShifter.m
+++ b/components/FlexibleHeader/src/private/MDCStatusBarShifter.m
@@ -235,7 +235,7 @@ typedef NS_ENUM(NSInteger, MDCStatusBarShifterState) {
   }
 
   // Bound the status bar range to [0..._originalStatusBarHeight].
-  CGFloat statusOffsetY = MIN(_originalStatusBarHeight, offset);
+  CGFloat statusOffsetY = MAX(0, MIN(_originalStatusBarHeight, offset));
 
   // Adjust the frame of the status bar.
   if (statusOffsetY > 0) {

--- a/components/FlexibleHeader/src/private/MDCStatusBarShifter.m
+++ b/components/FlexibleHeader/src/private/MDCStatusBarShifter.m
@@ -235,7 +235,7 @@ typedef NS_ENUM(NSInteger, MDCStatusBarShifterState) {
   }
 
   // Bound the status bar range to [0..._originalStatusBarHeight].
-  CGFloat statusOffsetY = MAX(0, MIN(_originalStatusBarHeight, offset));
+  CGFloat statusOffsetY = MIN(_originalStatusBarHeight, offset);
 
   // Adjust the frame of the status bar.
   if (statusOffsetY > 0) {


### PR DESCRIPTION
This rolls forward #4794 which was rolled back in v62.0.0.

All runtime logic introduced by #4794 has bee gated behind the new behavioral flag in an effort to maintain existing functionality.

Closes https://github.com/material-components/material-components-ios/issues/4393