### PR TITLE
[FlexibleHeader] Add buttons to the configurator demo for shifting the header on/off-screen.

### DIFF
--- a/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
@@ -95,7 +95,7 @@
       break;
     }
 
-    // Header height
+      // Header height
 
     case FlexibleHeaderConfiguratorFieldMinimumHeight:
       headerView.minimumHeight = [self heightDenormalized:[value floatValue]];

--- a/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
@@ -85,6 +85,16 @@
                              : MDCFlexibleHeaderContentImportanceDefault);
       break;
 
+    case FlexibleHeaderConfiguratorFieldShiftOffscreen: {
+      [headerView shiftHeaderOffScreenAnimated:YES];
+      break;
+    }
+
+    case FlexibleHeaderConfiguratorFieldShiftOnscreen: {
+      [headerView shiftHeaderOnScreenAnimated:YES];
+      break;
+    }
+
     // Header height
 
     case FlexibleHeaderConfiguratorFieldMinimumHeight:
@@ -183,6 +193,11 @@ static const CGFloat kHeightScalar = 300;
       BOOL enabled = (behavior == MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar);
       return @(enabled);
     }
+
+    // Buttons have no value
+    case FlexibleHeaderConfiguratorFieldShiftOffscreen:
+    case FlexibleHeaderConfiguratorFieldShiftOnscreen:
+      return nil;
 
     case FlexibleHeaderConfiguratorFieldInFrontOfInfiniteContent:
       return @(self.fhvc.headerView.inFrontOfInfiniteContent);

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorControlItem.h
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorControlItem.h
@@ -22,6 +22,7 @@
 #import <Foundation/Foundation.h>
 
 typedef enum : NSUInteger {
+  FlexibleHeaderConfiguratorControlTypeButton,
   FlexibleHeaderConfiguratorControlTypeSwitch,
   FlexibleHeaderConfiguratorControlTypeSlider
 } FlexibleHeaderConfiguratorControlType;

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.h
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.h
@@ -31,6 +31,8 @@ typedef enum : NSUInteger {
   FlexibleHeaderConfiguratorFieldContentImportance,
   FlexibleHeaderConfiguratorFieldShiftBehaviorEnabled,
   FlexibleHeaderConfiguratorFieldShiftBehaviorEnabledWithStatusBar,
+  FlexibleHeaderConfiguratorFieldShiftOffscreen,
+  FlexibleHeaderConfiguratorFieldShiftOnscreen,
 
   FlexibleHeaderConfiguratorFieldMinimumHeight,
   FlexibleHeaderConfiguratorFieldMaximumHeight,

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
@@ -281,7 +281,7 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
   id item = self.sections[indexPath.section][indexPath.row];
   if ([item isKindOfClass:[FlexibleHeaderConfiguratorControlItem class]]) {
     FlexibleHeaderConfiguratorControlItem *fieldItem =
-    (FlexibleHeaderConfiguratorControlItem *)item;
+        (FlexibleHeaderConfiguratorControlItem *)item;
     if (fieldItem.controlType == FlexibleHeaderConfiguratorControlTypeButton) {
       [self field:(FlexibleHeaderConfiguratorField)fieldItem.field didChangeValue:nil];
       [tableView deselectRowAtIndexPath:indexPath animated:YES];
@@ -293,7 +293,7 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
   id item = self.sections[indexPath.section][indexPath.row];
   if ([item isKindOfClass:[FlexibleHeaderConfiguratorControlItem class]]) {
     FlexibleHeaderConfiguratorControlItem *fieldItem =
-    (FlexibleHeaderConfiguratorControlItem *)item;
+        (FlexibleHeaderConfiguratorControlItem *)item;
     if (fieldItem.controlType == FlexibleHeaderConfiguratorControlTypeButton) {
       return YES;
     }

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
@@ -133,6 +133,11 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
 
   [self.fhvc.headerView hideViewWhenShifted:self.titleLabel];
 
+  id (^buttonItem)(NSString *, FlexibleHeaderConfiguratorField) = ^(
+      NSString *title, FlexibleHeaderConfiguratorField field) {
+    FlexibleHeaderConfiguratorControlType type = FlexibleHeaderConfiguratorControlTypeButton;
+    return [FlexibleHeaderConfiguratorControlItem itemWithTitle:title controlType:type field:field];
+  };
   id (^switchItem)(NSString *, FlexibleHeaderConfiguratorField) = ^(
       NSString *title, FlexibleHeaderConfiguratorField field) {
     FlexibleHeaderConfiguratorControlType type = FlexibleHeaderConfiguratorControlTypeSwitch;
@@ -166,7 +171,9 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
     switchItem(@"Enabled", FlexibleHeaderConfiguratorFieldShiftBehaviorEnabled),
     switchItem(@"Enabled with status bar",
                FlexibleHeaderConfiguratorFieldShiftBehaviorEnabledWithStatusBar),
-    switchItem(@"Header content is important", FlexibleHeaderConfiguratorFieldContentImportance)
+    switchItem(@"Header content is important", FlexibleHeaderConfiguratorFieldContentImportance),
+    buttonItem(@"Shift header off-screen", FlexibleHeaderConfiguratorFieldShiftOffscreen),
+    buttonItem(@"Shift header on-screen", FlexibleHeaderConfiguratorFieldShiftOnscreen)
   ]);
 
   createSection(@"Header height", @[
@@ -190,6 +197,9 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
 
 - (UIControl *)controlForControlType:(FlexibleHeaderConfiguratorControlType)controlType {
   switch (controlType) {
+    case FlexibleHeaderConfiguratorControlTypeButton:
+      return nil;
+
     case FlexibleHeaderConfiguratorControlTypeSwitch:
       return [[UISwitch alloc] init];
 
@@ -267,7 +277,27 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
   return cell;
 }
 
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+  id item = self.sections[indexPath.section][indexPath.row];
+  if ([item isKindOfClass:[FlexibleHeaderConfiguratorControlItem class]]) {
+    FlexibleHeaderConfiguratorControlItem *fieldItem =
+    (FlexibleHeaderConfiguratorControlItem *)item;
+    if (fieldItem.controlType == FlexibleHeaderConfiguratorControlTypeButton) {
+      [self field:(FlexibleHeaderConfiguratorField)fieldItem.field didChangeValue:nil];
+      [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    }
+  }
+}
+
 - (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
+  id item = self.sections[indexPath.section][indexPath.row];
+  if ([item isKindOfClass:[FlexibleHeaderConfiguratorControlItem class]]) {
+    FlexibleHeaderConfiguratorControlItem *fieldItem =
+    (FlexibleHeaderConfiguratorControlItem *)item;
+    if (fieldItem.controlType == FlexibleHeaderConfiguratorControlTypeButton) {
+      return YES;
+    }
+  }
   return NO;
 }
 


### PR DESCRIPTION
Screenshot:

![simulator screen shot - iphone x - 2018-08-31 at 09 13 25](https://user-images.githubusercontent.com/45670/44914406-25c2e380-acfe-11e8-8c79-8d583b5b75a6.png)
