### PR TITLE
[FlexibleHeader] Extract safe area logic to a separate object.

### DIFF
--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -49,6 +49,20 @@ mdc_objc_library(
 )
 
 mdc_objc_library(
+    name = "private",
+    hdrs = native.glob(["src/private/*.h"]),
+    includes = ["src/private"],
+    visibility = [":test_targets"],
+)
+
+package_group(
+    name = "test_targets",
+    packages = [
+        "//components/FlexibleHeader/...",
+    ],
+)
+
+mdc_objc_library(
     name = "CanAlwaysExpandToMaximumHeight",
     srcs = native.glob(["src/CanAlwaysExpandToMaximumHeight/*.m"]),
     hdrs = native.glob(["src/CanAlwaysExpandToMaximumHeight/*.h"]),
@@ -87,6 +101,7 @@ mdc_objc_library(
         "XCTest",
     ],
     deps = [
+        ":private",
         ":FlexibleHeader",
         ":ColorThemer",
         ":CanAlwaysExpandToMaximumHeight",

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -74,7 +74,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 }
 
 @interface MDCFlexibleHeaderView () <MDCStatusBarShifterDelegate,
-                                     MDCFlexibleHeaderSafeAreasDelegate>
+                                     MDCFlexibleHeaderSafeAreaDelegate>
 
 // The intensity strength of the shadow being displayed under the flexible header. Use this property
 // to check what the intensity of a custom shadow should be depending on a scroll position. Valid
@@ -445,9 +445,9 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   [_topSafeArea safeAreaInsetsDidChange];
 }
 
-#pragma mark MDCFlexibleHeaderSafeAreasDelegate
+#pragma mark MDCFlexibleHeaderSafeAreaDelegate
 
-- (void)flexibleHeaderSafeAreasTopSafeAreaInsetDidChange:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
+- (void)flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
   // If the min or max height have been explicitly set, don't adjust anything if the values
   // already include a Safe Area inset.
   BOOL hasSetMinOrMaxHeight = _hasExplicitlySetMinHeight || _hasExplicitlySetMaxHeight;
@@ -481,7 +481,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   }
 }
 
-- (BOOL)flexibleHeaderSafeAreasIsStatusBarShifted:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
+- (BOOL)flexibleHeaderSafeAreaIsStatusBarShifted:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
   return ([self fhv_canShiftOffscreen] &&
           _shiftBehavior == MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar &&
           _statusBarShifter.prefersStatusBarHidden);

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -487,6 +487,10 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
           _statusBarShifter.prefersStatusBarHidden);
 }
 
+- (CGFloat)flexibleHeaderSafeAreaDeviceTopSafeAreaInset:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
+  return MDCDeviceTopSafeAreaInset();
+}
+
 #pragma mark - Private (fhv_ prefix)
 
 - (void)fhv_setContentOffset:(CGPoint)contentOffset {

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -73,8 +73,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   return intendedShiftBehavior;
 }
 
-@interface MDCFlexibleHeaderView () <MDCStatusBarShifterDelegate,
-                                     MDCFlexibleHeaderSafeAreaDelegate>
+@interface MDCFlexibleHeaderView () <MDCStatusBarShifterDelegate, MDCFlexibleHeaderSafeAreaDelegate>
 
 // The intensity strength of the shadow being displayed under the flexible header. Use this property
 // to check what the intensity of a custom shadow should be depending on a scroll position. Valid
@@ -250,8 +249,10 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   _headerContentImportance = MDCFlexibleHeaderContentImportanceDefault;
   _statusBarHintCanOverlapHeader = YES;
 
+  const CGFloat topSafeAreaInset = [_topSafeArea topSafeAreaInset];
+
   _minMaxHeightIncludesSafeArea = YES;
-  _minimumHeight = kFlexibleHeaderDefaultHeight + [_topSafeArea topSafeAreaInset];
+  _minimumHeight = kFlexibleHeaderDefaultHeight + topSafeAreaInset;
   _maximumHeight = _minimumHeight;
 
   _visibleShadowOpacity = kDefaultVisibleShadowOpacity;
@@ -271,7 +272,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   [self.layer addSublayer:_customShadowLayer];
 
   _topSafeAreaGuide = [[UIView alloc] init];
-  _topSafeAreaGuide.frame = CGRectMake(0, 0, 0, [_topSafeArea topSafeAreaInset]);
+  _topSafeAreaGuide.frame = CGRectMake(0, 0, 0, topSafeAreaInset);
   [self addSubview:_topSafeAreaGuide];
 
   _contentView = [[UIView alloc] initWithFrame:self.bounds];
@@ -448,17 +449,18 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 #pragma mark MDCFlexibleHeaderSafeAreaDelegate
 
 - (void)flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
+  const CGFloat topSafeAreaInset = [_topSafeArea topSafeAreaInset];
+
   // If the min or max height have been explicitly set, don't adjust anything if the values
   // already include a Safe Area inset.
   BOOL hasSetMinOrMaxHeight = _hasExplicitlySetMinHeight || _hasExplicitlySetMaxHeight;
   if (!hasSetMinOrMaxHeight && _minMaxHeightIncludesSafeArea) {
     // If we're using the defaults we need to update them to account for the new Safe Area inset.
-    _minimumHeight = kFlexibleHeaderDefaultHeight + [_topSafeArea topSafeAreaInset];
+    _minimumHeight = kFlexibleHeaderDefaultHeight + topSafeAreaInset;
     _maximumHeight = _minimumHeight;
   }
 
-  _topSafeAreaGuide.frame =
-      CGRectMake(0, 0, self.bounds.size.width, [_topSafeArea topSafeAreaInset]);
+  _topSafeAreaGuide.frame = CGRectMake(0, 0, self.bounds.size.width, topSafeAreaInset);
 
   // Adjust the scroll view insets to account for the new Safe Area inset.
   [self fhv_enforceInsetsForScrollView:_trackingScrollView];

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -300,7 +300,7 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
       }
       if (self.inferTopSafeAreaInsetFromViewController
           && (object == self->_topSafeAreaConstraint || object == self->_topSafeAreaView)) {
-        [self->_headerView extractTopSafeAreaInset];
+        [self->_headerView topSafeAreaInsetDidChange];
       }
     };
 

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.h
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.h
@@ -17,7 +17,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-@protocol MDCFlexibleHeaderSafeAreasDelegate;
+@protocol MDCFlexibleHeaderSafeAreaDelegate;
 
 /**
  Extracts the top safe area for a given view controller.
@@ -72,26 +72,26 @@
 /**
  The delegate may react to changes in the top safe area inset.
  */
-@property(nonatomic, weak, nullable) id<MDCFlexibleHeaderSafeAreasDelegate> delegate;
+@property(nonatomic, weak, nullable) id<MDCFlexibleHeaderSafeAreaDelegate> delegate;
 
 @end
 
 /**
- The delegate protocol through which MDCFlexibleHeaderSafeAreas communicates changes in the top
+ The delegate protocol through which MDCFlexibleHeaderTopSafeArea communicates changes in the top
  safe area inset.
  */
-@protocol MDCFlexibleHeaderSafeAreasDelegate
+@protocol MDCFlexibleHeaderSafeAreaDelegate
 @required
 
 /**
  Informs the receiver that the topSafeAreaInset value has changed.
  */
-- (void)flexibleHeaderSafeAreasTopSafeAreaInsetDidChange:
+- (void)flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:
     (nonnull MDCFlexibleHeaderTopSafeArea *)safeAreas;
 
 /**
  Asks the receiver whether the status bar is likely shifted off-screen by the owner.
  */
-- (BOOL)flexibleHeaderSafeAreasIsStatusBarShifted:(nonnull MDCFlexibleHeaderTopSafeArea *)safeAreas;
+- (BOOL)flexibleHeaderSafeAreaIsStatusBarShifted:(nonnull MDCFlexibleHeaderTopSafeArea *)safeAreas;
 
 @end

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.h
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.h
@@ -1,0 +1,97 @@
+/*
+ Copyright 2015-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@protocol MDCFlexibleHeaderSafeAreasDelegate;
+
+/**
+ Extracts the top safe area for a given view controller.
+
+ @note This class implements legacy behavior gated behind the
+ inferTopSafeAreaInsetFromViewController flag. When this flag is disabled (currently the default),
+ we don't extract the top safe area from the given view controller - we extract it from
+ MDCDeviceTopSafeAreaInset. We hope to deprecate MDCDeviceTopSafeAreaInset, but this work is blocked
+ on all clients enabling inferTopSafeAreaInsetFromViewController on their flexible header view
+ controller.
+ */
+@interface MDCFlexibleHeaderTopSafeArea : NSObject
+
+#pragma mark Configuring the top safe area source
+
+/**
+ See MDCFlexibleHeaderViewController.h for detailed documentation.
+ */
+@property(nonatomic, weak, nullable) UIViewController *topSafeAreaSourceViewController;
+
+#pragma mark Querying the top safe area
+
+/**
+ Returns the top safe area inset value in a manner that depends on the
+ inferTopSafeAreaInsetFromViewController runtime flag.
+
+ If inferTopSafeAreaInsetFromViewController is enabled, returns the most recent top safe area inset
+ value we've extracted from the top safe area source view controller.
+
+ If inferTopSafeAreaInsetFromViewController is disabled, returns the device's top safe area insets.
+ */
+- (CGFloat)topSafeAreaInset;
+
+#pragma mark Informing the object of safe area inset changes
+
+/**
+ Informs the receiver that the safe area insets have changed.
+ */
+- (void)safeAreaInsetsDidChange;
+
+#pragma mark Migratory behavioral flags
+
+/**
+ See MDCFlexibleHeaderViewController.h for detailed documentation.
+
+ Defaults to NO, but we eventually want to default it to YES and remove this property altogether.
+ */
+@property(nonatomic) BOOL inferTopSafeAreaInsetFromViewController;
+
+#pragma mark Delegating changes in state
+
+/**
+ The delegate may react to changes in the top safe area inset.
+ */
+@property(nonatomic, weak, nullable) id<MDCFlexibleHeaderSafeAreasDelegate> delegate;
+
+@end
+
+/**
+ The delegate protocol through which MDCFlexibleHeaderSafeAreas communicates changes in the top
+ safe area inset.
+ */
+@protocol MDCFlexibleHeaderSafeAreasDelegate
+@required
+
+/**
+ Informs the receiver that the topSafeAreaInset value has changed.
+ */
+- (void)flexibleHeaderSafeAreasTopSafeAreaInsetDidChange:
+    (nonnull MDCFlexibleHeaderTopSafeArea *)safeAreas;
+
+/**
+ Asks the receiver whether the status bar is likely shifted off-screen by the owner.
+ */
+- (BOOL)flexibleHeaderSafeAreasIsStatusBarShifted:(nonnull MDCFlexibleHeaderTopSafeArea *)safeAreas;
+
+@end

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.h
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.h
@@ -94,4 +94,10 @@
  */
 - (BOOL)flexibleHeaderSafeAreaIsStatusBarShifted:(nonnull MDCFlexibleHeaderTopSafeArea *)safeAreas;
 
+/**
+ Asks the receiver to return the device's top safe area inset.
+ */
+- (CGFloat)flexibleHeaderSafeAreaDeviceTopSafeAreaInset:
+    (nonnull MDCFlexibleHeaderTopSafeArea *)safeAreas;
+
 @end

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.m
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.m
@@ -1,0 +1,136 @@
+/*
+ Copyright 2015-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDCFlexibleHeaderTopSafeArea.h"
+
+#import "MDCFlexibleHeaderView.h"
+
+#import "MaterialUIMetrics.h"
+
+// The default status bar height for non-X devices.
+static const CGFloat kNonXStatusBarHeight = 20;
+
+@interface MDCFlexibleHeaderTopSafeArea ()
+// We use this value to correctly handle top safe area insets on non-iPhone X devices.
+@property(nonatomic) CGFloat lastNonZeroTopSafeAreaInset;
+@property(nonatomic) CGFloat extractedTopSafeAreaInset;
+@end
+
+@implementation MDCFlexibleHeaderTopSafeArea
+
+@synthesize extractedTopSafeAreaInset = _extractedTopSafeAreaInset;
+
+#pragma mark - Public
+
+- (void)setTopSafeAreaSourceViewController:(UIViewController *)topSafeAreaSourceViewController {
+  _topSafeAreaSourceViewController = topSafeAreaSourceViewController;
+
+  if (self.inferTopSafeAreaInsetFromViewController) {
+    [self extractTopSafeAreaInset];
+  }
+}
+
+- (CGFloat)topSafeAreaInset {
+  if (self.inferTopSafeAreaInsetFromViewController) {
+    // Generally-speaking, we consider the top safe area inset to equate to the length of any
+    // "device-owned" pixels.
+    //
+    // On an iPhone X, the top safe area inset is a fixed hardware constant, varying only based on
+    // device orientation.
+    //
+    // On non-X devices, however, the top safe area inset is a flexible software value reflecting
+    // the status bar's current height. If the status bar is hidden, the top safe area inset is
+    // zero.
+    //
+    // This affects the flexible header mostly when the status bar shift behavior is enabled. The
+    // flexible header is able to hide the status bar interactively, meaning our top safe area inset
+    // can fluctuate between 0 and 20 on non-X devices as we show/hide the status bar. This can
+    // cause the tracking scroll view's content inset to "jump" because we make the scroll view's
+    // top content inset equal maximumHeight + topSafeAreaInset.
+    //
+    // Aside: If we only supported iOS 11 and up we'd likely be able to simplify a lot of this
+    // behavior by solely relying on additionalSafeAreaInsets. Alas, that will likely be sometime
+    // after 2020.
+    //
+    // So, to avoid the jumping behavior, we keep track of what the last non-zero top safe area
+    // inset was. If it was 20 and we know we've programmatically hidden the status bar, we continue
+    // to pretend that the top safe area inset is 20. Once the status bar is visible again we rely
+    // on the actual topSafeAreaInset value.
+    BOOL topSafeAreaInsetLikelyAffectedByStatusBarVisibility =
+        self.lastNonZeroTopSafeAreaInset == kNonXStatusBarHeight;
+    if (topSafeAreaInsetLikelyAffectedByStatusBarVisibility &&
+        [self.delegate flexibleHeaderSafeAreasIsStatusBarShifted:self]) {
+      return self.lastNonZeroTopSafeAreaInset;
+    } else {
+      return self.extractedTopSafeAreaInset;
+    }
+  } else {
+    return MDCDeviceTopSafeAreaInset();
+  }
+}
+
+- (void)safeAreaInsetsDidChange {
+  if (self.inferTopSafeAreaInsetFromViewController) {
+    [self extractTopSafeAreaInset];
+  } else {
+    // The device safe area insets may have changed, so we always fall back to calling the delegate.
+    [self.delegate flexibleHeaderSafeAreasTopSafeAreaInsetDidChange:self];
+  }
+}
+
+- (void)setInferTopSafeAreaInsetFromViewController:(BOOL)inferTopSafeAreaInsetFromViewController {
+  if (_inferTopSafeAreaInsetFromViewController == inferTopSafeAreaInsetFromViewController) {
+    return;
+  }
+  _inferTopSafeAreaInsetFromViewController = inferTopSafeAreaInsetFromViewController;
+
+  if (_inferTopSafeAreaInsetFromViewController) {
+    [self extractTopSafeAreaInset];
+  } else {
+    [self.delegate flexibleHeaderSafeAreasTopSafeAreaInsetDidChange:self];
+  }
+}
+
+#pragma mark - Private
+
+- (void)setExtractedTopSafeAreaInset:(CGFloat)extractedTopSafeAreaInset {
+  _extractedTopSafeAreaInset = extractedTopSafeAreaInset;
+
+  if (_extractedTopSafeAreaInset > 0) {
+    self.lastNonZeroTopSafeAreaInset = _extractedTopSafeAreaInset;
+  }
+
+  // No need to inform the delegate if this behavior is diabled.
+  if (self.inferTopSafeAreaInsetFromViewController) {
+    [self.delegate flexibleHeaderSafeAreasTopSafeAreaInsetDidChange:self];
+  }
+}
+
+- (void)extractTopSafeAreaInset {
+  UIViewController *viewController = self.topSafeAreaSourceViewController;
+  if (![viewController isViewLoaded]) {
+    self.extractedTopSafeAreaInset = 0;
+    return;
+  }
+
+  if (@available(iOS 11.0, *)) {
+    self.extractedTopSafeAreaInset = viewController.view.safeAreaInsets.top;
+  } else {
+    self.extractedTopSafeAreaInset = viewController.topLayoutGuide.length;
+  }
+}
+
+@end

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.m
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.m
@@ -72,7 +72,7 @@ static const CGFloat kNonXStatusBarHeight = 20;
     BOOL topSafeAreaInsetLikelyAffectedByStatusBarVisibility =
         self.lastNonZeroTopSafeAreaInset == kNonXStatusBarHeight;
     if (topSafeAreaInsetLikelyAffectedByStatusBarVisibility &&
-        [self.delegate flexibleHeaderSafeAreasIsStatusBarShifted:self]) {
+        [self.delegate flexibleHeaderSafeAreaIsStatusBarShifted:self]) {
       return self.lastNonZeroTopSafeAreaInset;
     } else {
       return self.extractedTopSafeAreaInset;
@@ -87,7 +87,7 @@ static const CGFloat kNonXStatusBarHeight = 20;
     [self extractTopSafeAreaInset];
   } else {
     // The device safe area insets may have changed, so we always fall back to calling the delegate.
-    [self.delegate flexibleHeaderSafeAreasTopSafeAreaInsetDidChange:self];
+    [self.delegate flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:self];
   }
 }
 
@@ -100,7 +100,7 @@ static const CGFloat kNonXStatusBarHeight = 20;
   if (_inferTopSafeAreaInsetFromViewController) {
     [self extractTopSafeAreaInset];
   } else {
-    [self.delegate flexibleHeaderSafeAreasTopSafeAreaInsetDidChange:self];
+    [self.delegate flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:self];
   }
 }
 
@@ -115,7 +115,7 @@ static const CGFloat kNonXStatusBarHeight = 20;
 
   // No need to inform the delegate if this behavior is diabled.
   if (self.inferTopSafeAreaInsetFromViewController) {
-    [self.delegate flexibleHeaderSafeAreasTopSafeAreaInsetDidChange:self];
+    [self.delegate flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:self];
   }
 }
 

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.m
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.m
@@ -18,8 +18,6 @@
 
 #import "MDCFlexibleHeaderView.h"
 
-#import "MaterialUIMetrics.h"
-
 // The default status bar height for non-X devices.
 static const CGFloat kNonXStatusBarHeight = 20;
 

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.m
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.m
@@ -78,7 +78,7 @@ static const CGFloat kNonXStatusBarHeight = 20;
       return self.extractedTopSafeAreaInset;
     }
   } else {
-    return MDCDeviceTopSafeAreaInset();
+    return [self.delegate flexibleHeaderSafeAreaDeviceTopSafeAreaInset:self];
   }
 }
 

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderView+Private.h
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderView+Private.h
@@ -32,7 +32,7 @@
  Forces an extraction of the top safe area inset. Intended to be called any time the top safe area
  inset is known to have changed.
  */
-- (void)extractTopSafeAreaInset;
+- (void)topSafeAreaInsetDidChange;
 
 /**
  The height of the top safe area guide.

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderTopSafeAreaTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderTopSafeAreaTests.m
@@ -20,7 +20,7 @@
 
 #import "../../src/private/MDCFlexibleHeaderTopSafeArea.h"
 
-#import "FlexibleHeaderTopSafeAreaTestsFakeViewController.h"
+#import "supplemental/FlexibleHeaderTopSafeAreaTestsFakeViewController.h"
 
 @interface FlexibleHeaderTopSafeAreaTests : XCTestCase
 @end

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderTopSafeAreaTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderTopSafeAreaTests.m
@@ -16,8 +16,11 @@
 
 #import <XCTest/XCTest.h>
 
-#import "../../src/private/MDCFlexibleHeaderTopSafeArea.h"
 #import "MaterialFlexibleHeader.h"
+
+#import "../../src/private/MDCFlexibleHeaderTopSafeArea.h"
+
+#import "FlexibleHeaderTopSafeAreaTestsFakeViewController.h"
 
 @interface FlexibleHeaderTopSafeAreaTests : XCTestCase
 @end
@@ -27,10 +30,6 @@
 @property(nonatomic) BOOL isStatusBarShifted;
 @property(nonatomic) BOOL topSafeAreaInsetDidChangeWasCalled;
 @property(nonatomic) CGFloat deviceTopSafeAreaInset;
-@end
-
-@interface FlexibleHeaderTopSafeAreaTestsFakeViewController : UIViewController
-@property(nonatomic) CGFloat topSafeAreaInset;
 @end
 
 @implementation FlexibleHeaderTopSafeAreaTests {
@@ -45,13 +44,6 @@
   _delegate = [[FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate alloc] init];
 }
 
-- (void)tearDown {
-  _topSafeArea = nil;
-  _delegate = nil;
-
-  [super tearDown];
-}
-
 #pragma mark - When inferTopSafeAreaInsetFromViewController is disabled
 
 - (void)testDeviceSafeAreaInsetIsDefaultTopSafeAreaInset {
@@ -62,9 +54,7 @@
 
   // Then
   XCTAssertNil(_topSafeArea.topSafeAreaSourceViewController);
-  XCTAssertEqualWithAccuracy(_topSafeArea.topSafeAreaInset,
-                             deviceTopSafeAreaInset,
-                             0.0001);
+  XCTAssertEqualWithAccuracy(_topSafeArea.topSafeAreaInset, deviceTopSafeAreaInset, 0.0001);
   XCTAssertFalse(_topSafeArea.inferTopSafeAreaInsetFromViewController);
 }
 
@@ -227,10 +217,11 @@
 
   // When
   _topSafeArea.topSafeAreaSourceViewController = nil;
+  viewController.topSafeAreaInset = 88;
   _topSafeArea.topSafeAreaSourceViewController = viewController;
 
   // Then
-  XCTAssertEqualWithAccuracy(_topSafeArea.topSafeAreaInset, 44, 0.0001);
+  XCTAssertEqualWithAccuracy(_topSafeArea.topSafeAreaInset, 88, 0.0001);
 }
 
 @end
@@ -251,80 +242,6 @@
 
 - (CGFloat)flexibleHeaderSafeAreaDeviceTopSafeAreaInset:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
   return self.deviceTopSafeAreaInset;
-}
-
-@end
-
-@interface FlexibleHeaderTopSafeAreaTestsFakeView : UIView
-@property(nonatomic) CGFloat topSafeAreaInset;
-@end
-
-@interface FlexibleHeaderTopSafeAreaTestsFakeLayoutGuide : NSObject <UILayoutSupport>
-@property(nonatomic) CGFloat topSafeAreaInset;
-@end
-
-@interface FlexibleHeaderTopSafeAreaTestsFakeViewController ()
-@property(nonatomic, strong) FlexibleHeaderTopSafeAreaTestsFakeView *view;
-@end
-
-@implementation FlexibleHeaderTopSafeAreaTestsFakeViewController {
-  FlexibleHeaderTopSafeAreaTestsFakeLayoutGuide *_topLayoutGuide;
-}
-
-@dynamic view;
-
-- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
-  self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
-  if (self) {
-    _topLayoutGuide = [[FlexibleHeaderTopSafeAreaTestsFakeLayoutGuide alloc] init];
-  }
-  return self;
-}
-
-- (void)loadView {
-  [super loadView];
-
-  self.view = [[FlexibleHeaderTopSafeAreaTestsFakeView alloc] initWithFrame:self.view.bounds];
-}
-
-- (id<UILayoutSupport>)topLayoutGuide {
-  return _topLayoutGuide;
-}
-
-- (FlexibleHeaderTopSafeAreaTestsFakeView *)view {
-  return (FlexibleHeaderTopSafeAreaTestsFakeView *)[super view];
-}
-
-- (void)setTopSafeAreaInset:(CGFloat)topSafeAreaInset {
-  self.view.topSafeAreaInset = topSafeAreaInset;
-  _topLayoutGuide.topSafeAreaInset = topSafeAreaInset;
-}
-
-- (CGFloat)topSafeAreaInset {
-  return self.view.topSafeAreaInset;
-}
-
-@end
-
-@implementation FlexibleHeaderTopSafeAreaTestsFakeLayoutGuide
-
-@synthesize bottomAnchor;
-@synthesize heightAnchor;
-@synthesize length;
-@synthesize topAnchor;
-
-- (CGFloat)length {
-  return self.topSafeAreaInset;
-}
-
-@end
-
-@implementation FlexibleHeaderTopSafeAreaTestsFakeView
-
-- (UIEdgeInsets)safeAreaInsets {
-  UIEdgeInsets safeAreaInsets = [super safeAreaInsets];
-  safeAreaInsets.top = self.topSafeAreaInset;
-  return safeAreaInsets;
 }
 
 @end

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderTopSafeAreaTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderTopSafeAreaTests.m
@@ -1,0 +1,314 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "../../src/private/MDCFlexibleHeaderTopSafeArea.h"
+#import "MaterialFlexibleHeader.h"
+
+@interface FlexibleHeaderTopSafeAreaTests : XCTestCase
+@end
+
+@interface FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate
+    : NSObject <MDCFlexibleHeaderSafeAreasDelegate>
+@property(nonatomic) BOOL isStatusBarShifted;
+@property(nonatomic) BOOL topSafeAreaInsetDidChangeWasCalled;
+@end
+
+@interface FlexibleHeaderTopSafeAreaTestsFakeViewController : UIViewController
+@property(nonatomic) CGFloat topSafeAreaInset;
+@end
+
+@implementation FlexibleHeaderTopSafeAreaTests {
+  MDCFlexibleHeaderTopSafeArea *_topSafeArea;
+  FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate *_delegate;
+}
+
+- (void)setUp {
+  [super setUp];
+
+  _topSafeArea = [[MDCFlexibleHeaderTopSafeArea alloc] init];
+  _delegate = [[FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate alloc] init];
+}
+
+- (void)tearDown {
+  _topSafeArea = nil;
+  _delegate = nil;
+
+  [super tearDown];
+}
+
+#pragma mark - inferTopSafeAreaInsetFromViewController disabled
+
+- (void)testDefaultConfiguration {
+  // Then
+  XCTAssertNil(_topSafeArea.topSafeAreaSourceViewController);
+  XCTAssertEqualWithAccuracy(_topSafeArea.topSafeAreaInset, 20, 0.0001);
+  XCTAssertFalse(_topSafeArea.inferTopSafeAreaInsetFromViewController);
+  XCTAssertNil(_topSafeArea.delegate);
+}
+
+- (void)testDidChangeInvokesDelegate {
+  // Given
+  _topSafeArea.delegate = _delegate;
+
+  // When
+  [_topSafeArea safeAreaInsetsDidChange];
+
+  // Then
+  XCTAssertTrue(_delegate.topSafeAreaInsetDidChangeWasCalled);
+}
+
+- (void)testSettingViewControllerDoesNotInvokeDelegate {
+  // Given
+  _topSafeArea.delegate = _delegate;
+  FlexibleHeaderTopSafeAreaTestsFakeViewController *viewController =
+      [[FlexibleHeaderTopSafeAreaTestsFakeViewController alloc] init];
+
+  // When
+  _topSafeArea.topSafeAreaSourceViewController = viewController;
+
+  // Then
+  XCTAssertFalse(_delegate.topSafeAreaInsetDidChangeWasCalled);
+}
+
+- (void)testIgnoresViewControllerTopSafeAreaInset {
+  // Given
+  FlexibleHeaderTopSafeAreaTestsFakeViewController *viewController =
+      [[FlexibleHeaderTopSafeAreaTestsFakeViewController alloc] init];
+  viewController.topSafeAreaInset = 44;
+
+  // When
+  _topSafeArea.topSafeAreaSourceViewController = viewController;
+
+  // Then
+  XCTAssertEqualWithAccuracy(_topSafeArea.topSafeAreaInset, 20, 0.0001);
+}
+
+#pragma mark - inferTopSafeAreaInsetFromViewController enabled
+
+- (void)testTopSafeAreaInsetIsZeroWithNilViewController {
+  // Given
+  _topSafeArea.inferTopSafeAreaInsetFromViewController = YES;
+
+  // Then
+  XCTAssertEqualWithAccuracy(_topSafeArea.topSafeAreaInset, 0, 0.0001);
+}
+
+- (void)testTopSafeAreaInsetMatchesViewController {
+  // Given
+  _topSafeArea.inferTopSafeAreaInsetFromViewController = YES;
+  FlexibleHeaderTopSafeAreaTestsFakeViewController *viewController =
+      [[FlexibleHeaderTopSafeAreaTestsFakeViewController alloc] init];
+  viewController.topSafeAreaInset = 44;
+
+  // When
+  _topSafeArea.topSafeAreaSourceViewController = viewController;
+
+  // Then
+  XCTAssertEqualWithAccuracy(_topSafeArea.topSafeAreaInset, 44, 0.0001);
+}
+
+- (void)testTopSafeAreaInsetNotUpdatedWithoutCallToSafeAreaInsetsDidChange {
+  // Given
+  _topSafeArea.inferTopSafeAreaInsetFromViewController = YES;
+  FlexibleHeaderTopSafeAreaTestsFakeViewController *viewController =
+      [[FlexibleHeaderTopSafeAreaTestsFakeViewController alloc] init];
+  _topSafeArea.topSafeAreaSourceViewController = viewController;
+
+  // When
+  viewController.topSafeAreaInset = 44;
+
+  // Then
+  XCTAssertEqualWithAccuracy(_topSafeArea.topSafeAreaInset, 0, 0.0001);
+}
+
+- (void)testTopSafeAreaInsetUpdatedAfterCallToSafeAreaInsetsDidChange {
+  // Given
+  _topSafeArea.inferTopSafeAreaInsetFromViewController = YES;
+  FlexibleHeaderTopSafeAreaTestsFakeViewController *viewController =
+      [[FlexibleHeaderTopSafeAreaTestsFakeViewController alloc] init];
+  _topSafeArea.topSafeAreaSourceViewController = viewController;
+
+  // When
+  viewController.topSafeAreaInset = 44;
+  [_topSafeArea safeAreaInsetsDidChange];
+
+  // Then
+  XCTAssertEqualWithAccuracy(_topSafeArea.topSafeAreaInset, 44, 0.0001);
+}
+
+// This test simulates a non-notch device hiding its status bar in reaction to the flexible header
+// shifting off-screen. In this case the top safe area inset should stay "pinned" to the previous
+// known value (of 20).
+- (void)testTopSafeAreaInsetDoesNotChangeWhileStatusBarIsShiftedWithNonNotchSafeAreaSize {
+  // Given
+  _topSafeArea.inferTopSafeAreaInsetFromViewController = YES;
+  _topSafeArea.delegate = _delegate;
+  FlexibleHeaderTopSafeAreaTestsFakeViewController *viewController =
+      [[FlexibleHeaderTopSafeAreaTestsFakeViewController alloc] init];
+  viewController.topSafeAreaInset = 20;
+  _topSafeArea.topSafeAreaSourceViewController = viewController;
+
+  // When
+  _delegate.isStatusBarShifted = YES;
+  viewController.topSafeAreaInset = 0;
+  [_topSafeArea safeAreaInsetsDidChange];
+
+  // Then
+  XCTAssertEqualWithAccuracy(_topSafeArea.topSafeAreaInset, 20, 0.0001);
+}
+
+- (void)testTopSafeAreaInsetDoesChangeWhileStatusBarIsShiftedWithAnyOtherSize {
+  // Given
+  _topSafeArea.inferTopSafeAreaInsetFromViewController = YES;
+  _topSafeArea.delegate = _delegate;
+  FlexibleHeaderTopSafeAreaTestsFakeViewController *viewController =
+      [[FlexibleHeaderTopSafeAreaTestsFakeViewController alloc] init];
+  viewController.topSafeAreaInset = 44;
+  _topSafeArea.topSafeAreaSourceViewController = viewController;
+
+  // When
+  _delegate.isStatusBarShifted = YES;
+  viewController.topSafeAreaInset = 0;
+  [_topSafeArea safeAreaInsetsDidChange];
+
+  // Then
+  XCTAssertEqualWithAccuracy(_topSafeArea.topSafeAreaInset, 0, 0.0001);
+}
+
+- (void)testTopSafeAreaInsetResetsToZeroWhenViewControllerIsSetToNil {
+  // Given
+  _topSafeArea.inferTopSafeAreaInsetFromViewController = YES;
+  FlexibleHeaderTopSafeAreaTestsFakeViewController *viewController =
+      [[FlexibleHeaderTopSafeAreaTestsFakeViewController alloc] init];
+  viewController.topSafeAreaInset = 44;
+  _topSafeArea.topSafeAreaSourceViewController = viewController;
+
+  // When
+  _topSafeArea.topSafeAreaSourceViewController = nil;
+
+  // Then
+  XCTAssertEqualWithAccuracy(_topSafeArea.topSafeAreaInset, 0, 0.0001);
+}
+
+- (void)testTopSafeAreaInsetResetsToViewControllerWhenViewControllerIsNilThenReSet {
+  // Given
+  _topSafeArea.inferTopSafeAreaInsetFromViewController = YES;
+  FlexibleHeaderTopSafeAreaTestsFakeViewController *viewController =
+      [[FlexibleHeaderTopSafeAreaTestsFakeViewController alloc] init];
+  viewController.topSafeAreaInset = 44;
+  _topSafeArea.topSafeAreaSourceViewController = viewController;
+
+  // When
+  _topSafeArea.topSafeAreaSourceViewController = nil;
+  _topSafeArea.topSafeAreaSourceViewController = viewController;
+
+  // Then
+  XCTAssertEqualWithAccuracy(_topSafeArea.topSafeAreaInset, 44, 0.0001);
+}
+
+@end
+
+#pragma mark - Fake implementations
+
+@implementation FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate
+
+#pragma mark MDCFlexibleHeaderTopSafeAreaDelegate
+
+- (BOOL)flexibleHeaderSafeAreasIsStatusBarShifted:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
+  return self.isStatusBarShifted;
+}
+
+- (void)flexibleHeaderSafeAreasTopSafeAreaInsetDidChange:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
+  self.topSafeAreaInsetDidChangeWasCalled = YES;
+}
+
+@end
+
+@interface FlexibleHeaderTopSafeAreaTestsFakeView : UIView
+@property(nonatomic) CGFloat topSafeAreaInset;
+@end
+
+@interface FlexibleHeaderTopSafeAreaTestsFakeLayoutGuide : NSObject <UILayoutSupport>
+@property(nonatomic) CGFloat topSafeAreaInset;
+@end
+
+@interface FlexibleHeaderTopSafeAreaTestsFakeViewController ()
+@property(nonatomic, strong) FlexibleHeaderTopSafeAreaTestsFakeView *view;
+@end
+
+@implementation FlexibleHeaderTopSafeAreaTestsFakeViewController {
+  FlexibleHeaderTopSafeAreaTestsFakeLayoutGuide *_topLayoutGuide;
+}
+
+@dynamic view;
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+  self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+  if (self) {
+    _topLayoutGuide = [[FlexibleHeaderTopSafeAreaTestsFakeLayoutGuide alloc] init];
+  }
+  return self;
+}
+
+- (void)loadView {
+  [super loadView];
+
+  self.view = [[FlexibleHeaderTopSafeAreaTestsFakeView alloc] initWithFrame:self.view.bounds];
+}
+
+- (id<UILayoutSupport>)topLayoutGuide {
+  return _topLayoutGuide;
+}
+
+- (FlexibleHeaderTopSafeAreaTestsFakeView *)view {
+  return (FlexibleHeaderTopSafeAreaTestsFakeView *)[super view];
+}
+
+- (void)setTopSafeAreaInset:(CGFloat)topSafeAreaInset {
+  self.view.topSafeAreaInset = topSafeAreaInset;
+  _topLayoutGuide.topSafeAreaInset = topSafeAreaInset;
+}
+
+- (CGFloat)topSafeAreaInset {
+  return self.view.topSafeAreaInset;
+}
+
+@end
+
+@implementation FlexibleHeaderTopSafeAreaTestsFakeLayoutGuide
+
+@synthesize bottomAnchor;
+@synthesize heightAnchor;
+@synthesize length;
+@synthesize topAnchor;
+
+- (CGFloat)length {
+  return self.topSafeAreaInset;
+}
+
+@end
+
+@implementation FlexibleHeaderTopSafeAreaTestsFakeView
+
+- (UIEdgeInsets)safeAreaInsets {
+  UIEdgeInsets safeAreaInsets = [super safeAreaInsets];
+  safeAreaInsets.top = self.topSafeAreaInset;
+  return safeAreaInsets;
+}
+
+@end

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderTopSafeAreaTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderTopSafeAreaTests.m
@@ -23,7 +23,7 @@
 @end
 
 @interface FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate
-    : NSObject <MDCFlexibleHeaderSafeAreasDelegate>
+    : NSObject <MDCFlexibleHeaderSafeAreaDelegate>
 @property(nonatomic) BOOL isStatusBarShifted;
 @property(nonatomic) BOOL topSafeAreaInsetDidChangeWasCalled;
 @end
@@ -229,11 +229,11 @@
 
 #pragma mark MDCFlexibleHeaderTopSafeAreaDelegate
 
-- (BOOL)flexibleHeaderSafeAreasIsStatusBarShifted:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
+- (BOOL)flexibleHeaderSafeAreaIsStatusBarShifted:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
   return self.isStatusBarShifted;
 }
 
-- (void)flexibleHeaderSafeAreasTopSafeAreaInsetDidChange:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
+- (void)flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
   self.topSafeAreaInsetDidChangeWasCalled = YES;
 }
 

--- a/components/FlexibleHeader/tests/unit/supplemental/FlexibleHeaderTopSafeAreaTestsFakeViewController.h
+++ b/components/FlexibleHeader/tests/unit/supplemental/FlexibleHeaderTopSafeAreaTestsFakeViewController.h
@@ -1,0 +1,19 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+@interface FlexibleHeaderTopSafeAreaTestsFakeViewController : UIViewController
+@property(nonatomic) CGFloat topSafeAreaInset;
+@end

--- a/components/FlexibleHeader/tests/unit/supplemental/FlexibleHeaderTopSafeAreaTestsFakeViewController.m
+++ b/components/FlexibleHeader/tests/unit/supplemental/FlexibleHeaderTopSafeAreaTestsFakeViewController.m
@@ -1,0 +1,89 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "FlexibleHeaderTopSafeAreaTestsFakeViewController.h"
+
+@interface FlexibleHeaderTopSafeAreaTestsFakeView : UIView
+@property(nonatomic) CGFloat topSafeAreaInset;
+@end
+
+@interface FlexibleHeaderTopSafeAreaTestsFakeLayoutGuide : NSObject <UILayoutSupport>
+@property(nonatomic) CGFloat topSafeAreaInset;
+@end
+
+@interface FlexibleHeaderTopSafeAreaTestsFakeViewController ()
+@property(nonatomic, strong) FlexibleHeaderTopSafeAreaTestsFakeView *view;
+@end
+
+@implementation FlexibleHeaderTopSafeAreaTestsFakeViewController {
+  FlexibleHeaderTopSafeAreaTestsFakeLayoutGuide *_topLayoutGuide;
+}
+
+@dynamic view;
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+  self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+  if (self) {
+    _topLayoutGuide = [[FlexibleHeaderTopSafeAreaTestsFakeLayoutGuide alloc] init];
+  }
+  return self;
+}
+
+- (void)loadView {
+  [super loadView];
+
+  self.view = [[FlexibleHeaderTopSafeAreaTestsFakeView alloc] initWithFrame:self.view.bounds];
+}
+
+- (id<UILayoutSupport>)topLayoutGuide {
+  return _topLayoutGuide;
+}
+
+- (FlexibleHeaderTopSafeAreaTestsFakeView *)view {
+  return (FlexibleHeaderTopSafeAreaTestsFakeView *)[super view];
+}
+
+- (void)setTopSafeAreaInset:(CGFloat)topSafeAreaInset {
+  self.view.topSafeAreaInset = topSafeAreaInset;
+  _topLayoutGuide.topSafeAreaInset = topSafeAreaInset;
+}
+
+- (CGFloat)topSafeAreaInset {
+  return self.view.topSafeAreaInset;
+}
+
+@end
+
+@implementation FlexibleHeaderTopSafeAreaTestsFakeLayoutGuide
+
+@synthesize bottomAnchor;
+@synthesize heightAnchor;
+@synthesize length;
+@synthesize topAnchor;
+
+- (CGFloat)length {
+  return self.topSafeAreaInset;
+}
+
+@end
+
+@implementation FlexibleHeaderTopSafeAreaTestsFakeView
+
+- (UIEdgeInsets)safeAreaInsets {
+  UIEdgeInsets safeAreaInsets = [super safeAreaInsets];
+  safeAreaInsets.top = self.topSafeAreaInset;
+  return safeAreaInsets;
+}
+
+@end

--- a/components/FlexibleHeader/tests/unit/supplemental/FlexibleHeaderTopSafeAreaTestsFakeViewController.m
+++ b/components/FlexibleHeader/tests/unit/supplemental/FlexibleHeaderTopSafeAreaTestsFakeViewController.m
@@ -67,10 +67,17 @@
 
 @implementation FlexibleHeaderTopSafeAreaTestsFakeLayoutGuide
 
-@synthesize bottomAnchor;
-@synthesize heightAnchor;
-@synthesize length;
-@synthesize topAnchor;
+- (NSLayoutYAxisAnchor *)bottomAnchor API_AVAILABLE(ios(9.0)) {
+  return nil;
+}
+
+- (NSLayoutDimension *)heightAnchor API_AVAILABLE(ios(9.0)) {
+  return nil;
+}
+
+- (NSLayoutYAxisAnchor *)topAnchor API_AVAILABLE(ios(9.0)) {
+  return nil;
+}
 
 - (CGFloat)length {
   return self.topSafeAreaInset;


### PR DESCRIPTION
There is a new private `MDCFlexibleHeaderTopSafeArea` object. This object contains all of the logic related to top safe area insets. As part of this extraction, many of the internal ivars from MDCFlexibleHeaderView have been moved to the new object.

This change does not intentionally introduce any functional or behavioral changes.

This change includes tests for this new object, along with updating the MDCFlexibleHeaderView.m logic to use the new object.

Part of https://github.com/material-components/material-components-ios/issues/5060