### PR TITLE
[github-comment] When posting diff comments, use only the file to unique the comment.

### DIFF
--- a/scripts/github-comment/Sources/github-comment/main.swift
+++ b/scripts/github-comment/Sources/github-comment/main.swift
@@ -171,7 +171,7 @@ if let diffFilename = diffFilename {
 ```
 
 \(commentIdentifier)
-<!-- Hunk: \(file) \(suggestedHunk.afterRange.lowerBound),\(suggestedHunk.afterRange.count) -->
+<!-- File: \(file) -->
 """
       if existingComments.contains(desiredBody) {
         print("Already posted comment, skipping...")


### PR DESCRIPTION
This ensures that if a piece of feedback moves around within a given file (e.g. because lines were added or removed above this feedback) that we won't erroneously post the same comment again.