### PR TITLE
[NavigationBar] Update layout when button bar sizes change.

### DIFF
--- a/components/AppBar/examples/AppBarTypicalUseExample.m
+++ b/components/AppBar/examples/AppBarTypicalUseExample.m
@@ -80,12 +80,8 @@
   self.navigationItem.rightBarButtonItem =
       [[UIBarButtonItem alloc] initWithTitle:@"Right"
                                        style:UIBarButtonItemStyleDone
-                                      target:self
-                                      action:@selector(didTap)];
-}
-
-- (void)didTap {
-  self.navigationItem.rightBarButtonItem.title = @"Left boo";
+                                      target:nil
+                                      action:nil];
 }
 
 // Optional step: If you allow the header view to hide the status bar you must implement this

--- a/components/AppBar/examples/AppBarTypicalUseExample.m
+++ b/components/AppBar/examples/AppBarTypicalUseExample.m
@@ -80,8 +80,12 @@
   self.navigationItem.rightBarButtonItem =
       [[UIBarButtonItem alloc] initWithTitle:@"Right"
                                        style:UIBarButtonItemStyleDone
-                                      target:nil
-                                      action:nil];
+                                      target:self
+                                      action:@selector(didTap)];
+}
+
+- (void)didTap {
+  self.navigationItem.rightBarButtonItem.title = @"Left boo";
 }
 
 // Optional step: If you allow the header view to hide the status bar you must implement this

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -103,7 +103,7 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
 @implementation MDCNavigationBarSandbagView
 @end
 
-@interface MDCNavigationBar (PrivateAPIs)
+@interface MDCNavigationBar (PrivateAPIs) <MDCButtonBarDelegate>
 
 /// titleLabel is hidden if there is a titleView. When not hidden, displays self.title.
 - (UILabel *)titleLabel;
@@ -146,8 +146,10 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
   _titleLabel.textAlignment = NSTextAlignmentCenter;
   _leadingButtonBar = [[MDCButtonBar alloc] init];
   _leadingButtonBar.layoutPosition = MDCButtonBarLayoutPositionLeading;
+  _leadingButtonBar.delegate = self;
   _trailingButtonBar = [[MDCButtonBar alloc] init];
   _trailingButtonBar.layoutPosition = MDCButtonBarLayoutPositionTrailing;
+  _trailingButtonBar.delegate = self;
 
   [self addSubview:_titleLabel];
   [self addSubview:_leadingButtonBar];
@@ -219,6 +221,12 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
 
 - (NSInteger)indexOfAccessibilityElement:(id)element {
   return [self.accessibilityElements indexOfObject:element];
+}
+
+#pragma mark - MDCButtonBarDelegate
+
+- (void)buttonBarDidInvalidateIntrinsicContentSize:(MDCButtonBar *)buttonBar {
+  [self setNeedsLayout];
 }
 
 #pragma mark UIView Overrides

--- a/components/NavigationBar/tests/unit/NavigationBarButtonLayoutTests.swift
+++ b/components/NavigationBar/tests/unit/NavigationBarButtonLayoutTests.swift
@@ -1,0 +1,104 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import MaterialComponents.MaterialNavigationBar
+import MaterialComponents.MaterialButtons
+
+class NavigationBarButtonLayoutTests: XCTestCase {
+
+  var navigationBar: MDCNavigationBar!
+
+  override func setUp() {
+    navigationBar = MDCNavigationBar()
+  }
+
+  private func recursiveSubviews(of superview: UIView) -> [UIView] {
+    var subviews = superview.subviews
+    for subview in superview.subviews {
+      subviews.append(contentsOf: recursiveSubviews(of: subview))
+    }
+    return subviews
+  }
+
+  func testInitialLayoutMatchesSizeThatFitsWidth() {
+    // Given
+    navigationBar.leadingBarButtonItems = [
+      UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)
+    ]
+    navigationBar.trailingBarButtonItems = [
+      UIBarButtonItem(title: "Text 2", style: .plain, target: nil, action: nil)
+    ]
+
+    // Then
+    for view in recursiveSubviews(of: navigationBar) {
+      if let button = view as? MDCButton {
+        let width = button.sizeThatFits(CGSize(width: CGFloat.infinity,
+                                               height: CGFloat.infinity)).width
+        XCTAssertEqual(width, button.bounds.width)
+      }
+    }
+  }
+
+  func testChangingTitleUpdatesLayoutToMatchSizeThatFitsWidth() {
+    // Given
+    navigationBar.leadingBarButtonItems = [
+      UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)
+    ]
+    navigationBar.trailingBarButtonItems = [
+      UIBarButtonItem(title: "Text 2", style: .plain, target: nil, action: nil)
+    ]
+
+    // When
+    navigationBar.leadingBarButtonItems?.forEach {
+      $0.title = "Longer title"
+    }
+    navigationBar.trailingBarButtonItems?.forEach {
+      $0.title = "Longer title"
+    }
+    navigationBar.layoutIfNeeded()
+
+    // Then
+    for view in recursiveSubviews(of: navigationBar) {
+      if let button = view as? MDCButton {
+        let width = button.sizeThatFits(CGSize(width: CGFloat.infinity,
+                                               height: CGFloat.infinity)).width
+        XCTAssertEqual(width, button.bounds.width)
+      }
+    }
+  }
+
+  func testChangingTitleFontUpdatesLayoutToMatchSizeThatFitsWidth() {
+    // Given
+    navigationBar.leadingBarButtonItems = [
+      UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)
+    ]
+    navigationBar.trailingBarButtonItems = [
+      UIBarButtonItem(title: "Text 2", style: .plain, target: nil, action: nil)
+    ]
+
+    // When
+    navigationBar.setButtonsTitleFont(UIFont.systemFont(ofSize: 20), for: .normal)
+    navigationBar.layoutIfNeeded()
+
+    // Then
+    for view in recursiveSubviews(of: navigationBar) {
+      if let button = view as? MDCButton {
+        let width = button.sizeThatFits(CGSize(width: CGFloat.infinity,
+                                               height: CGFloat.infinity)).width
+        XCTAssertEqual(width, button.bounds.width)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Prior to this change, changing the title of a button would often result in the button's label being clipped because the navigation bar was not updating its button bar frames when needed.

After this change, the navigation bar makes use of 471936b842e7473e51b5dc02df619a7e67a0c5b2 to react to changes in the intrinsic content size of the button bar.

## Before

| Before changing title | After changing title |
|:----------|:------------|
| ![simulator screen shot - iphone x - 2018-08-31 at 16 20 30](https://user-images.githubusercontent.com/45670/44934442-d51dab80-ad3a-11e8-9313-056e135de150.png) | ![simulator screen shot - iphone x - 2018-09-07 at 09 29 39](https://user-images.githubusercontent.com/45670/45221807-9d55bd00-b280-11e8-92c4-07e0bc409d64.png) |

## After

| Before changing title | After changing title |
|:----------|:------------|
| ![simulator screen shot - iphone x - 2018-08-31 at 16 20 30](https://user-images.githubusercontent.com/45670/44934442-d51dab80-ad3a-11e8-9313-056e135de150.png) | ![simulator screen shot - iphone x - 2018-08-31 at 16 20 32](https://user-images.githubusercontent.com/45670/44934447-d64ed880-ad3a-11e8-9c67-67e50995fce0.png) |

Closes https://github.com/material-components/material-components-ios/issues/1717