### PR TITLE
[scripts/release] Don't include automated changes in the release notes.

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -583,7 +583,7 @@ generate_release_notes() {
         --pretty="* [%s](https://github.com/material-components/material-components-ios/commit/%H) (%an)" \
         --no-merges \
         origin/stable..$(get_latest_branch) \
-        $folder
+        $folder | grep -v "\[automated\]"
     }
 
     if [[ $(componentdiff) ]]; then


### PR DESCRIPTION
Any commit with `[automated]` in its title will be excluded from the release notes.

Closes https://github.com/material-components/material-components-ios/issues/5002