### PR TITLE
[BottomSheet] Allow for custom height when initially opened

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -65,6 +65,11 @@
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;
 
 /**
+ This is used to set a custom height on the sheet view.
+ */
+@property(nonatomic) CGFloat preferredSheetHeight;
+
+/**
  If @c YES, then the dimmed scrim view will act as an accessibility element for dismissing the
  bottom sheet.
 

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -104,7 +104,6 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
   [containerView addSubview:_dimmingView];
   [containerView addSubview:_sheetView];
-
   [self updatePreferredSheetHeight];
 
   // Add tap handler to dismiss the sheet.
@@ -168,7 +167,12 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 }
 
 - (void)updatePreferredSheetHeight {
-  CGFloat preferredContentHeight = self.presentedViewController.preferredContentSize.height;
+  CGFloat preferredContentHeight;
+  if (self.preferredSheetHeight == 0.f) {
+    preferredContentHeight = self.presentedViewController.preferredContentSize.height;
+  } else {
+    preferredContentHeight = self.preferredSheetHeight;
+  }
 
   // If |preferredSheetHeight| has not been specified, use half of the current height.
   if (MDCCGFloatEqual(preferredContentHeight, 0)) {
@@ -232,6 +236,11 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
 - (UIAccessibilityTraits)scrimAccessibilityTraits {
   return _scrimAccessibilityTraits;
+}
+
+- (void)setPreferredSheetHeight:(CGFloat)preferredSheetHeight {
+  _preferredSheetHeight = preferredSheetHeight;
+  [self updatePreferredSheetHeight];
 }
 
 #pragma mark - MDCSheetContainerViewDelegate

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.h
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.h
@@ -45,6 +45,11 @@
  */
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;
 
+/**
+ The height of the content view.
+ */
+@property(nonatomic) CGFloat preferredSheetHeight;
+
 @end
 
 @interface MDCBottomSheetTransitionController (ScrimAccessibility)

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.m
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.m
@@ -48,6 +48,7 @@ static const NSTimeInterval MDCBottomSheetTransitionDuration = 0.25;
   presentationController.isScrimAccessibilityElement = _isScrimAccessibilityElement;
   presentationController.scrimAccessibilityHint = _scrimAccessibilityHint;
   presentationController.scrimAccessibilityLabel = _scrimAccessibilityLabel;
+  presentationController.preferredSheetHeight = _preferredSheetHeight;
   return presentationController;
 }
 


### PR DESCRIPTION
This will allow clients and other components that to open to a custom height instead of half the screen height or the content height.

Part of #4945 