### PR TITLE
Removed outdated link to hotfixing.md

### DIFF
--- a/contributing/README.md
+++ b/contributing/README.md
@@ -46,10 +46,6 @@ Since PRs on github permanently stay in the `Changes requested` state it is hard
 
 See [deprecation_policy.md](deprecation_policy.md) for details.
 
-### Hotfixing
-
-Occasionally it is necessary to hotfix the framework. See [hotfixing.md](hotfixing.md) for details.
-
 ## Finding an issue to work on
 
 MDC-iOS uses GitHub to file and track issues.


### PR DESCRIPTION
This fixes the website generator.

9f222f9a330a3fa39a7c91faef814d4de8966b0f removed the hotfixing.md file but did not update links to that file. Our website generator ensures links within our repo do not 404. I did not look at the presubmit results when I merged that PR, forgetting the fact that our website generator validates links.