### PR TITLE
[BottomSheet] Allow for custom height when initially opened

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -66,8 +66,12 @@
 
 /**
  This is used to set a custom height on the sheet view.
+
+ @note This will override setting the preferredContentSize if a positive value is passed.
+ @note If a non-positive value is passed then the sheet will open up to either half the screen
+ height or the size of the contentViewController whatever value is smaller.
  */
-@property(nonatomic) CGFloat preferredSheetHeight;
+@property(nonatomic, assign) CGFloat preferredSheetHeight;
 
 /**
  If @c YES, then the dimmed scrim view will act as an accessibility element for dismissing the

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -65,6 +65,11 @@
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;
 
 /**
+ This is used to set a custom height on the sheet view.
+ */
+@property(nonatomic) CGFloat preferredSheetHeight;
+
+/**
  If @c YES, then the dimmed scrim view will act as an accessibility element for dismissing the
  bottom sheet.
 

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -169,10 +169,10 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
 - (void)updatePreferredSheetHeight {
   CGFloat preferredContentHeight;
-  if (self.preferredSheetHeight == 0.f) {
-    preferredContentHeight = self.presentedViewController.preferredContentSize.height;
-  } else {
+  if (self.preferredSheetHeight > 0.f) {
     preferredContentHeight = self.preferredSheetHeight;
+  } else {
+    preferredContentHeight = self.presentedViewController.preferredContentSize.height;
   }
 
   // If |preferredSheetHeight| has not been specified, use half of the current height.

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -168,7 +168,12 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 }
 
 - (void)updatePreferredSheetHeight {
-  CGFloat preferredContentHeight = self.presentedViewController.preferredContentSize.height;
+  CGFloat preferredContentHeight;
+  if (self.preferredSheetHeight == 0.f) {
+    preferredContentHeight = self.presentedViewController.preferredContentSize.height;
+  } else {
+    preferredContentHeight = self.preferredSheetHeight;
+  }
 
   // If |preferredSheetHeight| has not been specified, use half of the current height.
   if (MDCCGFloatEqual(preferredContentHeight, 0)) {
@@ -232,6 +237,11 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
 - (UIAccessibilityTraits)scrimAccessibilityTraits {
   return _scrimAccessibilityTraits;
+}
+
+- (void)setPreferredSheetHeight:(CGFloat)preferredSheetHeight {
+  _preferredSheetHeight = preferredSheetHeight;
+  [self updatePreferredSheetHeight];
 }
 
 #pragma mark - MDCSheetContainerViewDelegate

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.h
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.h
@@ -46,9 +46,14 @@
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;
 
 /**
- The height of the content view.
+ This is used to set a custom height on the sheet view. This is can be used to set the initial
+ height when the ViewController is presented.
+
+ @note This will override setting the preferredContentSize if a positive value is passed.
+ @note If a non-positive value is passed then the sheet will open up to either half the screen
+ height or the size of the contentViewController whatever value is smaller.
  */
-@property(nonatomic) CGFloat preferredSheetHeight;
+@property(nonatomic, assign) CGFloat preferredSheetHeight;
 
 @end
 

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.h
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.h
@@ -45,6 +45,11 @@
  */
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;
 
+/**
+ The height of the content view.
+ */
+@property(nonatomic) CGFloat preferredSheetHeight;
+
 @end
 
 @interface MDCBottomSheetTransitionController (ScrimAccessibility)

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.m
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.m
@@ -48,6 +48,7 @@ static const NSTimeInterval MDCBottomSheetTransitionDuration = 0.25;
   presentationController.isScrimAccessibilityElement = _isScrimAccessibilityElement;
   presentationController.scrimAccessibilityHint = _scrimAccessibilityHint;
   presentationController.scrimAccessibilityLabel = _scrimAccessibilityLabel;
+  presentationController.preferredSheetHeight = _preferredSheetHeight;
   return presentationController;
 }
 

--- a/components/BottomSheet/tests/unit/BottomSheetPresentationTest.swift
+++ b/components/BottomSheet/tests/unit/BottomSheetPresentationTest.swift
@@ -1,0 +1,66 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+import MaterialComponents.MaterialBottomSheet
+
+class BottomSheetPresentationTest: XCTestCase {
+  var presentationController: MDCBottomSheetPresentationController!
+
+  override func setUp() {
+    super.setUp()
+
+    let mockPresented = UIViewController()
+    let mockPresenting = UIViewController()
+    presentationController =
+        MDCBottomSheetPresentationController(presentedViewController: mockPresented,
+                                             presenting: mockPresenting)
+  }
+
+  func testSetPreferredSheetHeight() {
+    // Given
+    let preferredSheetHeight: CGFloat = 150.0
+
+    // When
+    presentationController.preferredSheetHeight = preferredSheetHeight
+
+    // Then
+    let sheetView = getSheetView()
+    XCTAssertEqual(sheetView.frame.height, preferredSheetHeight)
+  }
+
+  func testSetPreferredContentSizeThenSheetHeight() {
+    // Given
+    let preferredContentSize: CGSize = CGSize(width: 100, height: 100)
+    let preferredSheetHeight: CGFloat = 150.0
+
+    // When
+    presentationController.presentingViewController.preferredContentSize = preferredContentSize
+    presentationController.preferredSheetHeight = preferredSheetHeight
+
+    // Then
+    let sheetView = getSheetView()
+    XCTAssertEqual(sheetView.frame.height, preferredSheetHeight)
+  }
+
+  private func getSheetView() -> UIView {
+    if let sheetView = presentationController.presentedView {
+      return sheetView
+    } else {
+      XCTFail("No sheet view was created")
+      return UIView()
+    }
+  }
+}

--- a/components/BottomSheet/tests/unit/BottomSheetPresentationTest.swift
+++ b/components/BottomSheet/tests/unit/BottomSheetPresentationTest.swift
@@ -31,14 +31,17 @@ class BottomSheetPresentationTest: XCTestCase {
 
   func testSetPreferredSheetHeight() {
     // Given
-    let preferredSheetHeight: CGFloat = 150.0
+    let preferredSheetHeight: CGFloat = 125.0
 
     // When
     presentationController.preferredSheetHeight = preferredSheetHeight
+    presentationController.presentedViewController.view.setNeedsLayout()
+    presentationController.presentedViewController.view.layoutIfNeeded()
+    print(presentationController.frameOfPresentedViewInContainerView)
 
     // Then
     let sheetView = getSheetView()
-    XCTAssertEqual(sheetView.frame.height, preferredSheetHeight)
+    XCTAssertEqual(sheetView.bounds.height, preferredSheetHeight)
   }
 
   func testSetPreferredContentSizeThenSheetHeight() {
@@ -47,12 +50,12 @@ class BottomSheetPresentationTest: XCTestCase {
     let preferredSheetHeight: CGFloat = 150.0
 
     // When
-    presentationController.presentingViewController.preferredContentSize = preferredContentSize
+    presentationController.presentedViewController.preferredContentSize = preferredContentSize
     presentationController.preferredSheetHeight = preferredSheetHeight
 
     // Then
     let sheetView = getSheetView()
-    XCTAssertEqual(sheetView.frame.height, preferredSheetHeight)
+    XCTAssertEqual(sheetView.bounds.height, preferredSheetHeight)
   }
 
   private func getSheetView() -> UIView {


### PR DESCRIPTION
This will allow clients and other components that to open to a custom height instead of half the screen height or the content height.


**Test are WIP** Everything else you can review. **Test are WIP**

Part of #4945

| Before | After |
| ------- | ----- |
|![simulator screen shot - iphone 8 - 2018-09-05 at 13 03 38](https://user-images.githubusercontent.com/7131294/45109081-76767a00-b10c-11e8-999a-9ae471ff19ab.png)|![simulator screen shot - iphone 8 - 2018-09-05 at 13 04 42](https://user-images.githubusercontent.com/7131294/45109094-7bd3c480-b10c-11e8-84a0-b18c844941d8.png)|