### PR TITLE
Revert "[Dialogs] Remove use of MDCFlatButton for MDCButton and MDCTextButtonThemer (#4739)"

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -399,7 +399,6 @@ Pod::Spec.new do |mdc|
     component.resources = ["components/#{component.base_name}/src/Material#{component.base_name}.bundle"]
 
     component.dependency "MaterialComponents/Buttons"
-    component.dependency "MaterialComponents/Buttons+ButtonThemer"
     component.dependency "MaterialComponents/ShadowElevations"
     component.dependency "MaterialComponents/ShadowLayer"
     component.dependency "MaterialComponents/Typography"

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -30,7 +30,6 @@ mdc_public_objc_library(
     ],
     deps = [
         "//components/Buttons",
-        "//components/Buttons:ButtonThemer",
         "//components/ShadowElevations",
         "//components/ShadowLayer",
         "//components/Typography",

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.h
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.h
@@ -14,14 +14,14 @@
 
 #import <UIKit/UIKit.h>
 
-@class MDCButton;
+@class MDCFlatButton;
 
 @interface MDCAlertControllerView ()
 
 @property(nonatomic, nonnull, strong) UILabel *titleLabel;
 @property(nonatomic, nonnull, strong) UILabel *messageLabel;
 
-@property(nonatomic, nonnull, strong, readonly) NSArray<MDCButton *> *actionButtons;
+@property(nonatomic, nonnull, strong, readonly) NSArray<MDCFlatButton *> *actionButtons;
 
 - (nonnull MDCButton *)addActionButtonTitle:(NSString *_Nonnull)actionTitle
                              target:(nullable id)target

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.h
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.h
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialButtons.h"
+
 @class MDCFlatButton;
 
 @interface MDCAlertControllerView ()
@@ -24,8 +26,8 @@
 @property(nonatomic, nonnull, strong, readonly) NSArray<MDCFlatButton *> *actionButtons;
 
 - (nonnull MDCButton *)addActionButtonTitle:(NSString *_Nonnull)actionTitle
-                             target:(nullable id)target
-                           selector:(SEL _Nonnull)selector;
+                                     target:(nullable id)target
+                                   selector:(SEL _Nonnull)selector;
 
 - (CGSize)calculatePreferredContentSizeForBounds:(CGSize)boundsSize;
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -18,7 +18,6 @@
 #import <MDFInternationalization/MDFInternationalization.h>
 
 #import "MaterialButtons.h"
-#import "MaterialButtons+ButtonThemer.h"
 #import "MaterialTypography.h"
 
 // https://material.io/go/design-dialogs#dialogs-specs
@@ -48,9 +47,8 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 @end
 
 @implementation MDCAlertControllerView {
-    NSMutableArray<MDCButton *> *_actionButtons;
+    NSMutableArray<MDCFlatButton *> *_actionButtons;
     BOOL _mdc_adjustsFontForContentSizeCategory;
-    MDCButtonScheme *buttonScheme;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
@@ -88,7 +86,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     }
     self.messageLabel.textColor = [UIColor colorWithWhite:0.0f alpha:MDCDialogMessageOpacity];
     [self.contentScrollView addSubview:self.messageLabel];
-    buttonScheme = [[MDCButtonScheme alloc] init];
+
     _actionButtons = [[NSMutableArray alloc] init];
 
     [self setNeedsLayout];
@@ -116,8 +114,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 }
 
 - (MDCButton *)addActionButtonTitle:(NSString *)actionTitle target:(id)target selector:(SEL)selector {
-  MDCButton *actionButton = [[MDCButton alloc] initWithFrame:CGRectZero];
-  [MDCTextButtonThemer applyScheme:buttonScheme toButton:actionButton];
+  MDCFlatButton *actionButton = [[MDCFlatButton alloc] initWithFrame:CGRectZero];
   actionButton.mdc_adjustsFontForContentSizeCategory = self.mdc_adjustsFontForContentSizeCategory;
   [actionButton setTitle:actionTitle forState:UIControlStateNormal];
   if (_buttonColor) {
@@ -226,7 +223,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
         [finalButtonFont mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
                                 scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
   }
-  for (MDCButton *button in self.actionButtons) {
+  for (MDCFlatButton *button in self.actionButtons) {
     [button setTitleFont:finalButtonFont forState:UIControlStateNormal];
   }
 
@@ -244,7 +241,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)setButtonColor:(UIColor *)color {
   _buttonColor = color;
 
-  for (MDCButton *button in self.actionButtons) {
+  for (MDCFlatButton *button in self.actionButtons) {
     [button setTitleColor:_buttonColor forState:UIControlStateNormal];
   }
 }
@@ -524,7 +521,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {
   _mdc_adjustsFontForContentSizeCategory = adjusts;
 
-  for (MDCButton *button in _actionButtons) {
+  for (MDCFlatButton *button in _actionButtons) {
     button.mdc_adjustsFontForContentSizeCategory = adjusts;
   }
 


### PR DESCRIPTION
Revert "[Dialogs] Remove use of MDCFlatButton for MDCButton and MDCTextButtonThemer (#4739)"

This reverts commit 84d5dfbb83d0118ff26921318df8cc549d919809.

This commit resulted in undesired behavior for a client, this change reverts to the old desired behavior.
