### PR TITLE
[BottomNavigation] Expose UIView for a given UITabBarItem.

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -140,6 +140,13 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarAlignment) {
  */
 @property(nonatomic, assign) CGFloat itemsContentHorizontalMargin;
 
+/**
+ Returns the navigation bar subview associated with the specific item.
+
+ @param item A UITabBarItem
+ */
+- (nullable UIView *)viewForItem:(nonnull UITabBarItem *)item;
+
 @end
 
 #pragma mark - MDCBottomNavigationBarDelegate

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -320,6 +320,18 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
   return insets;
 }
 
+- (UIView *)viewForItem:(UITabBarItem *)item {
+  NSUInteger itemIndex = [_items indexOfObject:item];
+  if (itemIndex == NSNotFound) {
+    return nil;
+  }
+  if (itemIndex >= _itemViews.count) {
+    NSAssert(NO, @"Item index should not be out of item view bounds");
+    return nil;
+  }
+  return _itemViews[itemIndex];
+}
+
 #pragma mark - Touch handlers
 
 - (void)didTouchDownButton:(UIButton *)button {

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -163,19 +163,35 @@
   XCTAssert(self.bottomNavBar.itemViews.lastObject.label.isHidden);
 }
 
--(void)testViewForItem {
+-(void)testViewForItemFound {
+  // Given
+  UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"1" image:nil tag:0];
+  UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:0];
+
+  // When
+  self.bottomNavBar.items = @[item1, item2];
+
+  // Then
+  MDCBottomNavigationItemView *viewForItem1 =
+      (MDCBottomNavigationItemView *)[self.bottomNavBar viewForItem:item1];
+  MDCBottomNavigationItemView *viewForItem2 =
+      (MDCBottomNavigationItemView *)[self.bottomNavBar viewForItem:item2];
+  XCTAssertNotEqual(viewForItem1, viewForItem2);
+  XCTAssertTrue([self.bottomNavBar.itemViews containsObject:viewForItem1], @"BottomNavBar.itemViews did not contain the view (%@) returned for UITabBarItem (%@)", viewForItem1, item1);
+  XCTAssertTrue([self.bottomNavBar.itemViews containsObject:viewForItem2], @"BottomNavBar.itemViews did not contain the view (%@) returned for UITabBarItem (%@)", viewForItem2, item2);
+}
+
+-(void)testViewForItemNotFound {
+  // Given
   UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"1" image:nil tag:0];
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:0];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"3" image:nil tag:0];
-  self.bottomNavBar.items = @[item1, item2, item3];
 
-  XCTAssertEqual([self.bottomNavBar viewForItem:item1], self.bottomNavBar.itemViews[0]);
-  XCTAssertEqual([self.bottomNavBar viewForItem:item2], self.bottomNavBar.itemViews[1]);
-  XCTAssertEqual([self.bottomNavBar viewForItem:item3], self.bottomNavBar.itemViews[2]);
+  // When
+  self.bottomNavBar.items = @[item1, item2];
 
-  // Test when tab bar item is not in navigation bar
-  UITabBarItem *item4 = [[UITabBarItem alloc] initWithTitle:@"4" image:nil tag:0];
-  XCTAssert([self.bottomNavBar viewForItem:item4] == nil);
+  // Then
+  XCTAssert([self.bottomNavBar viewForItem:item3] == nil);
 }
 
 @end

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -163,13 +163,13 @@
   XCTAssert(self.bottomNavBar.itemViews.lastObject.label.isHidden);
 }
 
--(void)testViewForItemFound {
+- (void)testViewForItemFound {
   // Given
   UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"1" image:nil tag:0];
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:0];
 
   // When
-  self.bottomNavBar.items = @[item1, item2];
+  self.bottomNavBar.items = @[ item1, item2 ];
 
   // Then
   MDCBottomNavigationItemView *viewForItem1 =
@@ -177,18 +177,24 @@
   MDCBottomNavigationItemView *viewForItem2 =
       (MDCBottomNavigationItemView *)[self.bottomNavBar viewForItem:item2];
   XCTAssertNotEqual(viewForItem1, viewForItem2);
-  XCTAssertTrue([self.bottomNavBar.itemViews containsObject:viewForItem1], @"BottomNavBar.itemViews did not contain the view (%@) returned for UITabBarItem (%@)", viewForItem1, item1);
-  XCTAssertTrue([self.bottomNavBar.itemViews containsObject:viewForItem2], @"BottomNavBar.itemViews did not contain the view (%@) returned for UITabBarItem (%@)", viewForItem2, item2);
+  XCTAssertTrue(
+      [self.bottomNavBar.itemViews containsObject:viewForItem1],
+      @"BottomNavBar.itemViews did not contain the view (%@) returned for UITabBarItem (%@)",
+      viewForItem1, item1);
+  XCTAssertTrue(
+      [self.bottomNavBar.itemViews containsObject:viewForItem2],
+      @"BottomNavBar.itemViews did not contain the view (%@) returned for UITabBarItem (%@)",
+      viewForItem2, item2);
 }
 
--(void)testViewForItemNotFound {
+- (void)testViewForItemNotFound {
   // Given
   UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"1" image:nil tag:0];
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:0];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"3" image:nil tag:0];
 
   // When
-  self.bottomNavBar.items = @[item1, item2];
+  self.bottomNavBar.items = @[ item1, item2 ];
 
   // Then
   XCTAssert([self.bottomNavBar viewForItem:item3] == nil);

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -163,4 +163,19 @@
   XCTAssert(self.bottomNavBar.itemViews.lastObject.label.isHidden);
 }
 
+-(void)testViewForItem {
+  UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"1" image:nil tag:0];
+  UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"2" image:nil tag:0];
+  UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"3" image:nil tag:0];
+  self.bottomNavBar.items = @[item1, item2, item3];
+
+  XCTAssertEqual([self.bottomNavBar viewForItem:item1], self.bottomNavBar.itemViews[0]);
+  XCTAssertEqual([self.bottomNavBar viewForItem:item2], self.bottomNavBar.itemViews[1]);
+  XCTAssertEqual([self.bottomNavBar viewForItem:item3], self.bottomNavBar.itemViews[2]);
+
+  // Test when tab bar item is not in navigation bar
+  UITabBarItem *item4 = [[UITabBarItem alloc] initWithTitle:@"4" image:nil tag:0];
+  XCTAssert([self.bottomNavBar viewForItem:item4] == nil);
+}
+
 @end


### PR DESCRIPTION
This will allow MDCBottomNavigationBar to work with popover / tooltip libraries which require an anchor view for positioning (i.e, if we want to display a tooltip over one of the tabs).

Closes [#4824](https://github.com/material-components/material-components-ios/issues/4824)
