### PR TITLE
[NavigationBar] Tint leading, trailing button bars.

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -193,6 +193,19 @@ IB_DESIGNABLE
  */
 - (void)setButtonsTitleColor:(nullable UIColor *)color forState:(UIControlState)state;
 
+
+/**
+ The tint color applied to the bar items on the leading side of the BottomAppBar. If unset, then
+ defaults to using this Navigation Bar's @c tintColor.
+ */
+@property(nullable, nonatomic, strong) UIColor *leadingBarItemsTintColor;
+
+/**
+ The tint color applied to the bar items on the trailing side of the BottomAppBar. If unset, then
+ defaults to using this NavigationBar's @c tintColor.
+ */
+@property(nullable, nonatomic, strong) UIColor *trailingBarItemsTintColor;
+
 /**
  Returns the color set for @c state that was set by setButtonsTitleColor:forState:.
 

--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -193,7 +193,6 @@ IB_DESIGNABLE
  */
 - (void)setButtonsTitleColor:(nullable UIColor *)color forState:(UIControlState)state;
 
-
 /**
  The tint color applied to the bar items on the leading side of the BottomAppBar. If unset, then
  defaults to using this Navigation Bar's @c tintColor.

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -542,8 +542,8 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
   [super tintColorDidChange];
 
   // Tint color should only modify interactive elements
-  _leadingButtonBar.tintColor = self.tintColor;
-  _trailingButtonBar.tintColor = self.tintColor;
+  _leadingButtonBar.tintColor = self.leadingBarItemsTintColor ?: self.tintColor;
+  _trailingButtonBar.tintColor = self.trailingBarItemsTintColor ?: self.tintColor;
 }
 
 #pragma mark Public
@@ -631,6 +631,16 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
 
 - (UIColor *)buttonsTitleColorForState:(UIControlState)state {
   return [_leadingButtonBar buttonsTitleColorForState:state];
+}
+
+- (void)setLeadingBarItemsTintColor:(UIColor *)leadingBarItemsTintColor {
+  _leadingBarItemsTintColor = leadingBarItemsTintColor;
+  self.leadingButtonBar.tintColor = leadingBarItemsTintColor;
+}
+
+- (void)setTrailingBarItemsTintColor:(UIColor *)trailingBarItemsTintColor {
+  _trailingBarItemsTintColor = trailingBarItemsTintColor;
+  self.trailingButtonBar.tintColor = trailingBarItemsTintColor;
 }
 
 - (void)setLeadingBarButtonItems:(NSArray<UIBarButtonItem *> *)leadingBarButtonItems {

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -111,7 +111,8 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   self.navBar.leadingBarButtonItems =
       @[ [[UIBarButtonItem alloc] initWithTitle:@"Button"
                                           style:UIBarButtonItemStylePlain
-                                         target:nil action:nil] ];
+                                         target:nil
+                                         action:nil] ];
 
   // When
   [self.navBar layoutIfNeeded];
@@ -128,7 +129,8 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   self.navBar.trailingBarButtonItems =
       @[ [[UIBarButtonItem alloc] initWithTitle:@"Button"
                                           style:UIBarButtonItemStylePlain
-                                         target:nil action:nil] ];
+                                         target:nil
+                                         action:nil] ];
 
   // When
   [self.navBar layoutIfNeeded];
@@ -145,7 +147,8 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   self.navBar.leadingBarButtonItems =
       @[ [[UIBarButtonItem alloc] initWithTitle:@"Button"
                                           style:UIBarButtonItemStylePlain
-                                         target:nil action:nil] ];
+                                         target:nil
+                                         action:nil] ];
 
   // When
   [self.navBar layoutIfNeeded];
@@ -163,7 +166,8 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   self.navBar.trailingBarButtonItems =
       @[ [[UIBarButtonItem alloc] initWithTitle:@"Button"
                                           style:UIBarButtonItemStylePlain
-                                         target:nil action:nil] ];
+                                         target:nil
+                                         action:nil] ];
 
   // When
   [self.navBar layoutIfNeeded];

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -109,9 +109,9 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   self.navBar.titleView = [[UIView alloc] init];
   self.navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorFill;
   self.navBar.leadingBarButtonItems =
-      @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
-                                         style:UIBarButtonItemStylePlain
-                                        target:nil action:nil]];
+      @[ [[UIBarButtonItem alloc] initWithTitle:@"Button"
+                                          style:UIBarButtonItemStylePlain
+                                         target:nil action:nil] ];
 
   // When
   [self.navBar layoutIfNeeded];
@@ -126,9 +126,9 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   self.navBar.titleView = [[UIView alloc] init];
   self.navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorFill;
   self.navBar.trailingBarButtonItems =
-      @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
-                                         style:UIBarButtonItemStylePlain
-                                        target:nil action:nil]];
+      @[ [[UIBarButtonItem alloc] initWithTitle:@"Button"
+                                          style:UIBarButtonItemStylePlain
+                                         target:nil action:nil] ];
 
   // When
   [self.navBar layoutIfNeeded];
@@ -143,9 +143,9 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   self.navBar.titleView = [[UIView alloc] init];
   self.navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorCenter;
   self.navBar.leadingBarButtonItems =
-      @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
-                                         style:UIBarButtonItemStylePlain
-                                        target:nil action:nil]];
+      @[ [[UIBarButtonItem alloc] initWithTitle:@"Button"
+                                          style:UIBarButtonItemStylePlain
+                                         target:nil action:nil] ];
 
   // When
   [self.navBar layoutIfNeeded];
@@ -161,9 +161,9 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   self.navBar.titleView = [[UIView alloc] init];
   self.navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorCenter;
   self.navBar.trailingBarButtonItems =
-      @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
-                                         style:UIBarButtonItemStylePlain
-                                        target:nil action:nil]];
+      @[ [[UIBarButtonItem alloc] initWithTitle:@"Button"
+                                          style:UIBarButtonItemStylePlain
+                                         target:nil action:nil] ];
 
   // When
   [self.navBar layoutIfNeeded];
@@ -282,7 +282,7 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
   // When
   self.navBar.leadingBarButtonItem = leadingItem;
-  self.navBar.trailingBarButtonItems = @[leadingItem, trailingItem];
+  self.navBar.trailingBarButtonItems = @[ leadingItem, trailingItem ];
 
   // Then
   NSArray *elements = self.navBar.accessibilityElements;
@@ -313,7 +313,7 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   // When
   self.navBar.titleView = [[UIView alloc] init];
   self.navBar.leadingBarButtonItem = leadingItem;
-  self.navBar.trailingBarButtonItems = @[leadingItem, trailingItem];
+  self.navBar.trailingBarButtonItems = @[ leadingItem, trailingItem ];
 
   // Then
   NSArray *elements = self.navBar.accessibilityElements;
@@ -387,7 +387,7 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   self.navBar.leadingBarItemsTintColor = UIColor.orangeColor;
 
   // Then
-  XCTAssertEqualObjects([self.navBar leadingButtonBar].tintColor , UIColor.orangeColor);
+  XCTAssertEqualObjects([self.navBar leadingButtonBar].tintColor, UIColor.orangeColor);
 }
 
 - (void)testSetLeadingButtonBarItemsTintColorToNilRevertsToTintColor {
@@ -399,7 +399,7 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
   self.navBar.leadingBarItemsTintColor = nil;
 
   // Then
-  XCTAssertEqualObjects([self.navBar leadingButtonBar].tintColor , UIColor.purpleColor);
+  XCTAssertEqualObjects([self.navBar leadingButtonBar].tintColor, UIColor.purpleColor);
 }
 
 - (void)testTrailingButtonBarItemsTintColorDefaultsToNil {

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -22,66 +22,68 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
 @interface MDCNavigationBar (Testing)
 @property(nonatomic) UILabel *titleLabel;
+- (MDCButtonBar *)leadingButtonBar;
+- (MDCButtonBar *)trailingButtonBar;
 @end
 
 @interface NavigationBarTests : XCTestCase
+@property(nonatomic) MDCNavigationBar *navBar;
 @end
 
 @implementation NavigationBarTests
 
+- (void)setUp {
+  [super setUp];
+  self.navBar = [[MDCNavigationBar alloc] init];
+}
+
 - (void)testSettingTextAlignmentToCenterMustCenterTheTitleLabel {
   // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-  navBar.frame = CGRectMake(0, 0, 300, 25);
-  navBar.title = @"this is a Title";
+  self.navBar.frame = CGRectMake(0, 0, 300, 25);
+  self.navBar.title = @"this is a Title";
 
   // When
-  navBar.titleAlignment = MDCNavigationBarTitleAlignmentCenter;
-  [navBar layoutIfNeeded];
+  self.navBar.titleAlignment = MDCNavigationBarTitleAlignmentCenter;
+  [self.navBar layoutIfNeeded];
 
   // Then
-  XCTAssertEqualWithAccuracy(navBar.titleLabel.center.x, CGRectGetMidX(navBar.bounds),
+  XCTAssertEqualWithAccuracy(self.navBar.titleLabel.center.x, CGRectGetMidX(self.navBar.bounds),
                              kEpsilonAccuracy);
 }
 
 - (void)testChangingTextOfACenterTextAlignmentMustCenterTheTitleLabel {
   // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-  navBar.frame = CGRectMake(0, 0, 300, 25);
-  navBar.title = @"this is a Title";
-  navBar.titleAlignment = MDCNavigationBarTitleAlignmentCenter;
+  self.navBar.frame = CGRectMake(0, 0, 300, 25);
+  self.navBar.title = @"this is a Title";
+  self.navBar.titleAlignment = MDCNavigationBarTitleAlignmentCenter;
 
   // When
-  navBar.title = @"..";
-  [navBar layoutIfNeeded];
+  self.navBar.title = @"..";
+  [self.navBar layoutIfNeeded];
 
   // Then
-  XCTAssertEqualWithAccuracy(navBar.titleLabel.center.x, CGRectGetMidX(navBar.bounds),
+  XCTAssertEqualWithAccuracy(self.navBar.titleLabel.center.x, CGRectGetMidX(self.navBar.bounds),
                              kEpsilonAccuracy);
 }
 
 - (void)testSettingTextAlignmentToLeftMustLeftAlignTheTitleLabel {
   // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-  navBar.frame = CGRectMake(0, 0, 200, 25);
-  navBar.title = @"this is a Title";
-  navBar.titleAlignment = MDCNavigationBarTitleAlignmentCenter;
-  [navBar layoutIfNeeded];
+  self.navBar.frame = CGRectMake(0, 0, 200, 25);
+  self.navBar.title = @"this is a Title";
+  self.navBar.titleAlignment = MDCNavigationBarTitleAlignmentCenter;
+  [self.navBar layoutIfNeeded];
 
   // When
-  navBar.titleAlignment = MDCNavigationBarTitleAlignmentLeading;
-  [navBar layoutIfNeeded];
+  self.navBar.titleAlignment = MDCNavigationBarTitleAlignmentLeading;
+  [self.navBar layoutIfNeeded];
 
   // Then
-  XCTAssertLessThan(navBar.titleLabel.center.x, CGRectGetMidX(navBar.bounds));
+  XCTAssertLessThan(self.navBar.titleLabel.center.x, CGRectGetMidX(self.navBar.bounds));
 }
 
 - (void)testDefaultTextAlignment {
-  // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-
   // When
-  MDCNavigationBarTitleAlignment alignment = navBar.titleAlignment;
+  MDCNavigationBarTitleAlignment alignment = self.navBar.titleAlignment;
 
   // Then
   XCTAssertEqual(alignment, MDCNavigationBarTitleAlignmentCenter);
@@ -89,104 +91,102 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
 - (void)testTitleViewIsCenteredWithNoButtonsAndFillBehavior {
   // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-  navBar.frame = CGRectMake(0, 0, 300, 25);
-  navBar.titleView = [[UIView alloc] init];
-  navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorFill;
+  self.navBar.frame = CGRectMake(0, 0, 300, 25);
+  self.navBar.titleView = [[UIView alloc] init];
+  self.navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorFill;
 
   // When
-  [navBar layoutIfNeeded];
+  [self.navBar layoutIfNeeded];
 
   // Then
-  XCTAssertEqualWithAccuracy(navBar.titleView.center.x, CGRectGetMidX(navBar.bounds),
+  XCTAssertEqualWithAccuracy(self.navBar.titleView.center.x, CGRectGetMidX(self.navBar.bounds),
                              kEpsilonAccuracy);
 }
 
 - (void)testTitleViewShiftedRightWithLeadingButtonsAndFillBehavior {
   // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-  navBar.frame = CGRectMake(0, 0, 300, 25);
-  navBar.titleView = [[UIView alloc] init];
-  navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorFill;
-  navBar.leadingBarButtonItems = @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
-                                                                    style:UIBarButtonItemStylePlain
-                                                                   target:nil action:nil]];
+  self.navBar.frame = CGRectMake(0, 0, 300, 25);
+  self.navBar.titleView = [[UIView alloc] init];
+  self.navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorFill;
+  self.navBar.leadingBarButtonItems =
+      @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
+                                         style:UIBarButtonItemStylePlain
+                                        target:nil action:nil]];
 
   // When
-  [navBar layoutIfNeeded];
+  [self.navBar layoutIfNeeded];
 
   // Then
-  XCTAssertGreaterThan(navBar.titleView.center.x, CGRectGetMidX(navBar.bounds));
+  XCTAssertGreaterThan(self.navBar.titleView.center.x, CGRectGetMidX(self.navBar.bounds));
 }
 
 - (void)testTitleViewShiftedLeftWithTrailingButtonsAndFillBehavior {
   // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-  navBar.frame = CGRectMake(0, 0, 300, 25);
-  navBar.titleView = [[UIView alloc] init];
-  navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorFill;
-  navBar.trailingBarButtonItems = @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
-                                                                     style:UIBarButtonItemStylePlain
-                                                                    target:nil action:nil]];
+  self.navBar.frame = CGRectMake(0, 0, 300, 25);
+  self.navBar.titleView = [[UIView alloc] init];
+  self.navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorFill;
+  self.navBar.trailingBarButtonItems =
+      @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
+                                         style:UIBarButtonItemStylePlain
+                                        target:nil action:nil]];
 
   // When
-  [navBar layoutIfNeeded];
+  [self.navBar layoutIfNeeded];
 
   // Then
-  XCTAssertLessThan(navBar.titleView.center.x, CGRectGetMidX(navBar.bounds));
+  XCTAssertLessThan(self.navBar.titleView.center.x, CGRectGetMidX(self.navBar.bounds));
 }
 
 - (void)testTitleViewCenteredWithLeadingButtonsAndCenterBehavior {
   // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-  navBar.frame = CGRectMake(0, 0, 300, 25);
-  navBar.titleView = [[UIView alloc] init];
-  navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorCenter;
-  navBar.leadingBarButtonItems = @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
-                                                                    style:UIBarButtonItemStylePlain
-                                                                   target:nil action:nil]];
+  self.navBar.frame = CGRectMake(0, 0, 300, 25);
+  self.navBar.titleView = [[UIView alloc] init];
+  self.navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorCenter;
+  self.navBar.leadingBarButtonItems =
+      @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
+                                         style:UIBarButtonItemStylePlain
+                                        target:nil action:nil]];
 
   // When
-  [navBar layoutIfNeeded];
+  [self.navBar layoutIfNeeded];
 
   // Then
-  XCTAssertEqualWithAccuracy(navBar.titleView.center.x, CGRectGetMidX(navBar.bounds),
+  XCTAssertEqualWithAccuracy(self.navBar.titleView.center.x, CGRectGetMidX(self.navBar.bounds),
                              kEpsilonAccuracy);
 }
 
 - (void)testTitleViewCenteredWithTrailingButtonsAndCenterBehavior {
   // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-  navBar.frame = CGRectMake(0, 0, 300, 25);
-  navBar.titleView = [[UIView alloc] init];
-  navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorCenter;
-  navBar.trailingBarButtonItems = @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
-                                                                     style:UIBarButtonItemStylePlain
-                                                                    target:nil action:nil]];
+  self.navBar.frame = CGRectMake(0, 0, 300, 25);
+  self.navBar.titleView = [[UIView alloc] init];
+  self.navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorCenter;
+  self.navBar.trailingBarButtonItems =
+      @[[[UIBarButtonItem alloc] initWithTitle:@"Button"
+                                         style:UIBarButtonItemStylePlain
+                                        target:nil action:nil]];
 
   // When
-  [navBar layoutIfNeeded];
+  [self.navBar layoutIfNeeded];
 
   // Then
-  XCTAssertEqualWithAccuracy(navBar.titleView.center.x, CGRectGetMidX(navBar.bounds),
+  XCTAssertEqualWithAccuracy(self.navBar.titleView.center.x, CGRectGetMidX(self.navBar.bounds),
                              kEpsilonAccuracy);
 }
 
 - (void)testTitleFontProperty {
   // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-  navBar.title = @"this is a Title";
+  self.navBar.title = @"this is a Title";
 
   // Then
-  XCTAssertNotNil(navBar.titleFont);
-  XCTAssertEqualObjects(navBar.titleLabel.font, navBar.titleFont);
+  XCTAssertNotNil(self.navBar.titleFont);
+  XCTAssertEqualObjects(self.navBar.titleLabel.font, self.navBar.titleFont);
 
   // When
   UIFont *font = [UIFont systemFontOfSize:24];
-  navBar.titleFont = font;
+  self.navBar.titleFont = font;
 
   // Then
-  UIFont *resultFont = navBar.titleLabel.font;
+  UIFont *resultFont = self.navBar.titleLabel.font;
   XCTAssertEqualObjects(resultFont.fontName, font.fontName);
   XCTAssertEqualWithAccuracy(resultFont.pointSize, 20, 0.01);
 
@@ -202,20 +202,19 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
 - (void)testTitleFontPropertyWithAllowAnyTitleFontSizeEnabled {
   // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-  navBar.title = @"this is a Title";
-  navBar.allowAnyTitleFontSize = YES;
+  self.navBar.title = @"this is a Title";
+  self.navBar.allowAnyTitleFontSize = YES;
 
   // Then
-  XCTAssertNotNil(navBar.titleFont);
-  XCTAssertEqualObjects(navBar.titleLabel.font, navBar.titleFont);
+  XCTAssertNotNil(self.navBar.titleFont);
+  XCTAssertEqualObjects(self.navBar.titleLabel.font, self.navBar.titleFont);
 
   // When
   UIFont *font = [UIFont systemFontOfSize:24];
-  navBar.titleFont = font;
+  self.navBar.titleFont = font;
 
   // Then
-  UIFont *resultFont = navBar.titleLabel.font;
+  UIFont *resultFont = self.navBar.titleLabel.font;
   XCTAssertEqualObjects(resultFont.fontName, font.fontName);
   XCTAssertEqualWithAccuracy(resultFont.pointSize, 24, 0.01);
 
@@ -232,79 +231,61 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 #pragma mark - Accessibility
 
 - (void)testNavigationBarIsNotAccessibilityElement {
-  // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-
   // Then
-  XCTAssertFalse(navBar.isAccessibilityElement);
+  XCTAssertFalse(self.navBar.isAccessibilityElement);
 }
 
 - (void)testAccessibilityItemsCountWithNoTitle {
-  // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-
   // Then
   const NSInteger elementsCount = 3; // Leading bar, titleLabel, trailing bar
-  XCTAssertEqual(elementsCount, navBar.accessibilityElementCount);
+  XCTAssertEqual(elementsCount, self.navBar.accessibilityElementCount);
 }
 
 - (void)testAccessibilityItemsCountWithTitleView {
-  // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-
   // When
-  navBar.titleView = [[UIView alloc] init];
+  self.navBar.titleView = [[UIView alloc] init];
 
   // Then
   const NSInteger elementsCount = 3; // Leading bar, titleView, trailing bar
-  XCTAssertEqual(elementsCount, navBar.accessibilityElementCount);
+  XCTAssertEqual(elementsCount, self.navBar.accessibilityElementCount);
 }
 
 - (void)testAccessibilityItemAtIndexDefault {
-  // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-
   // Then
-  XCTAssertTrue([[navBar accessibilityElementAtIndex:0] isKindOfClass:[MDCButtonBar class]]);
-  XCTAssertEqual(navBar.titleLabel, [navBar accessibilityElementAtIndex:1]);
-  XCTAssertTrue([[navBar accessibilityElementAtIndex:2] isKindOfClass:[MDCButtonBar class]]);
+  XCTAssertTrue([[self.navBar accessibilityElementAtIndex:0] isKindOfClass:[MDCButtonBar class]]);
+  XCTAssertEqual(self.navBar.titleLabel, [self.navBar accessibilityElementAtIndex:1]);
+  XCTAssertTrue([[self.navBar accessibilityElementAtIndex:2] isKindOfClass:[MDCButtonBar class]]);
 }
 
 - (void)testIndexOfAccessibilityElementDefault {
-  // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-
   // Then
-  XCTAssertEqual(1, [navBar indexOfAccessibilityElement:navBar.titleLabel]);
-  XCTAssertEqual(NSNotFound, [navBar indexOfAccessibilityElement:navBar.leftBarButtonItem]);
+  XCTAssertEqual(1, [self.navBar indexOfAccessibilityElement:self.navBar.titleLabel]);
+  XCTAssertEqual(NSNotFound,
+                 [self.navBar indexOfAccessibilityElement:self.navBar.leftBarButtonItem]);
 }
 
 - (void)testIndexOfAccessibilityElementWithTitleView {
-  // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
-
   // When
-  navBar.titleView = [[UIView alloc] init];
+  self.navBar.titleView = [[UIView alloc] init];
 
   // Then
-  XCTAssertEqual(1, [navBar indexOfAccessibilityElement:navBar.titleView]);
-  XCTAssertEqual(NSNotFound, [navBar indexOfAccessibilityElement:navBar.titleLabel]);
+  XCTAssertEqual(1, [self.navBar indexOfAccessibilityElement:self.navBar.titleView]);
+  XCTAssertEqual(NSNotFound, [self.navBar indexOfAccessibilityElement:self.navBar.titleLabel]);
 }
 
 - (void)testAccessibilityElementsWithNoTitle {
   // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
   UIBarButtonItem *leadingItem = [[UIBarButtonItem alloc] init];
   leadingItem.title = @"Leading";
   UIBarButtonItem *trailingItem = [[UIBarButtonItem alloc] init];
   trailingItem.title = @"Trailing";
 
   // When
-  navBar.leadingBarButtonItem = leadingItem;
-  navBar.trailingBarButtonItems = @[leadingItem, trailingItem];
+  self.navBar.leadingBarButtonItem = leadingItem;
+  self.navBar.trailingBarButtonItems = @[leadingItem, trailingItem];
 
   // Then
-  NSArray *elements = navBar.accessibilityElements;
+  NSArray *elements = self.navBar.accessibilityElements;
   XCTAssertNotNil(elements);
   XCTAssertEqual(3U, elements.count);
   id firstItem = elements[0];
@@ -313,7 +294,7 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
     MDCButtonBar *leadingButtonBar = (MDCButtonBar *)firstItem;
     XCTAssertEqual(1U, leadingButtonBar.subviews.count);
   }
-  XCTAssertEqualObjects(navBar.titleLabel, elements[1]);
+  XCTAssertEqualObjects(self.navBar.titleLabel, elements[1]);
   id secondItem = elements[2];
   XCTAssertTrue([secondItem isKindOfClass:[MDCButtonBar class]]);
   if ([secondItem isKindOfClass:[MDCButtonBar class]]) {
@@ -324,19 +305,18 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
 - (void)testAccessibilityElementsWithTitleView {
   // Given
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
   UIBarButtonItem *leadingItem = [[UIBarButtonItem alloc] init];
   leadingItem.title = @"Leading";
   UIBarButtonItem *trailingItem = [[UIBarButtonItem alloc] init];
   trailingItem.title = @"Trailing";
 
   // When
-  navBar.titleView = [[UIView alloc] init];
-  navBar.leadingBarButtonItem = leadingItem;
-  navBar.trailingBarButtonItems = @[leadingItem, trailingItem];
+  self.navBar.titleView = [[UIView alloc] init];
+  self.navBar.leadingBarButtonItem = leadingItem;
+  self.navBar.trailingBarButtonItems = @[leadingItem, trailingItem];
 
   // Then
-  NSArray *elements = navBar.accessibilityElements;
+  NSArray *elements = self.navBar.accessibilityElements;
   XCTAssertNotNil(elements);
   XCTAssertEqual(3U, elements.count);
   id firstItem = elements[0];
@@ -345,7 +325,7 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
     MDCButtonBar *leadingButtonBar = (MDCButtonBar *)firstItem;
     XCTAssertEqual(1U, leadingButtonBar.subviews.count);
   }
-  XCTAssertEqualObjects(navBar.titleView, elements[1]);
+  XCTAssertEqualObjects(self.navBar.titleView, elements[1]);
   id secondItem = elements[2];
   XCTAssertTrue([secondItem isKindOfClass:[MDCButtonBar class]]);
   if ([secondItem isKindOfClass:[MDCButtonBar class]]) {
@@ -357,14 +337,13 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 #pragma mark - Typography
 
 - (void)testTypographyThemer {
-  MDCNavigationBar *navBar = [[MDCNavigationBar alloc] init];
   MDCTypographyScheme *scheme = [[MDCTypographyScheme alloc] init];
-  [MDCNavigationBarTypographyThemer applyTypographyScheme:scheme toNavigationBar:navBar];
+  [MDCNavigationBarTypographyThemer applyTypographyScheme:scheme toNavigationBar:self.navBar];
 
   // To enforce 20 point size we are using fontWithName:size: and for some reason even though the
   // printout looks idential comparing the fonts returns false. (Using fontWithSize: did not work
   // for system font medium, instead it returned a regular font).
-  UIFont *titleFont = navBar.titleLabel.font;
+  UIFont *titleFont = self.navBar.titleLabel.font;
   XCTAssertEqualObjects(titleFont.fontName, scheme.headline6.fontName);
   XCTAssertEqual(titleFont.pointSize, scheme.headline6.pointSize);
 
@@ -393,6 +372,60 @@ static const CGFloat kEpsilonAccuracy = 0.001f;
 
   return weight;
 
+}
+
+#pragma mark - Color
+
+- (void)testLeadingButtonBarItemsTintColorDefaultsToNil {
+  // Then
+  XCTAssertNil(self.navBar.leadingBarItemsTintColor);
+}
+
+- (void)testLeadingButtonBarItemsTintColorOverridesButtonBarTintColor {
+  // When
+  self.navBar.tintColor = UIColor.purpleColor;
+  self.navBar.leadingBarItemsTintColor = UIColor.orangeColor;
+
+  // Then
+  XCTAssertEqualObjects([self.navBar leadingButtonBar].tintColor , UIColor.orangeColor);
+}
+
+- (void)testSetLeadingButtonBarItemsTintColorToNilRevertsToTintColor {
+  // Given
+  self.navBar.tintColor = UIColor.purpleColor;
+  self.navBar.leadingBarItemsTintColor = UIColor.orangeColor;
+
+  // When
+  self.navBar.leadingBarItemsTintColor = nil;
+
+  // Then
+  XCTAssertEqualObjects([self.navBar leadingButtonBar].tintColor , UIColor.purpleColor);
+}
+
+- (void)testTrailingButtonBarItemsTintColorDefaultsToNil {
+  // Then
+  XCTAssertNil(self.navBar.trailingBarItemsTintColor);
+}
+
+- (void)testTrailingButtonBarItemsTintColorOverridesButtonBarTintColor {
+  // When
+  self.navBar.tintColor = UIColor.cyanColor;
+  self.navBar.trailingBarItemsTintColor = UIColor.greenColor;
+
+  // Then
+  XCTAssertEqualObjects([self.navBar trailingButtonBar].tintColor, UIColor.greenColor);
+}
+
+- (void)testSetTrailingButtonBarItemsTintColorToNilRevertsToTintColor {
+  // Given
+  self.navBar.tintColor = UIColor.cyanColor;
+  self.navBar.trailingBarItemsTintColor = UIColor.greenColor;
+
+  // When
+  self.navBar.trailingBarItemsTintColor = nil;
+
+  // then
+  XCTAssertEqualObjects([self.navBar trailingButtonBar].tintColor, UIColor.cyanColor);
 }
 
 @end


### PR DESCRIPTION
To prepare for tinting the leading and trailing button bar items in the
Bottom App Bar, the MDCNavigationBar should support an API that allows
separate tint colors for the leading and trailing button bar items.

**Extreme Example**

<img width="374" alt="screen shot 2018-09-07 at 11 23 02 pm" src="https://user-images.githubusercontent.com/1753199/45249812-024afa80-b2f5-11e8-920b-c32dccd8d3a5.png">

Part of #3928
