### PR TITLE
[BottomAppBar] Tint leading, trailing bar items.

### DIFF
--- a/components/BottomAppBar/BUILD
+++ b/components/BottomAppBar/BUILD
@@ -73,6 +73,7 @@ mdc_objc_library(
         ":BottomAppBar",
         ":ColorThemer",
         ":private",
+        "//components/NavigationBar",
     ],
     visibility = ["//visibility:private"],
 )

--- a/components/BottomAppBar/src/MDCBottomAppBarView.h
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.h
@@ -72,16 +72,6 @@ typedef NS_ENUM(NSInteger, MDCBottomAppBarFloatingButtonPosition) {
  */
 @property(nonatomic, copy, nullable) NSArray<UIBarButtonItem *> *trailingBarButtonItems;
 
-// Redeclaring to document the leading/trailing items' behavior.
-/**
- To tint the leading and trailing buttons, use @c leadingBarItemsTintColor or
- @c trailingBarItemsTintColor instead.
- */
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnullability"
-@property(null_resettable, nonatomic, strong) UIColor *tintColor NS_AVAILABLE_IOS(7_0);
-#pragma clang diagnostic pop
-
 /**
  Color of the background of the bottom app bar.
  */

--- a/components/BottomAppBar/src/MDCBottomAppBarView.h
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.h
@@ -79,6 +79,16 @@ typedef NS_ENUM(NSInteger, MDCBottomAppBarFloatingButtonPosition) {
 @property(nullable, nonatomic, strong) UIColor *barTintColor UI_APPEARANCE_SELECTOR;
 
 /**
+ The @c tintColor applied to the bar items on the leading side of the BottomAppBar.
+ */
+@property(nonnull, nonatomic, strong) UIColor *leadingBarItemsTintColor;
+
+/**
+ The @c tintColor applied to the bar items on the trailing side of the BottomAppBar.
+ */
+@property(nonnull, nonatomic, strong) UIColor *trailingBarItemsTintColor;
+
+/**
  To color the background of the view use -barTintColor instead.
  */
 @property(nullable, nonatomic, copy) UIColor *backgroundColor NS_UNAVAILABLE;

--- a/components/BottomAppBar/src/MDCBottomAppBarView.h
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.h
@@ -77,7 +77,10 @@ typedef NS_ENUM(NSInteger, MDCBottomAppBarFloatingButtonPosition) {
  To tint the leading and trailing buttons, use @c leadingBarItemsTintColor or
  @c trailingBarItemsTintColor instead.
  */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullability"
 @property(null_resettable, nonatomic, strong) UIColor *tintColor NS_AVAILABLE_IOS(7_0);
+#pragma clang diagnostic pop
 
 /**
  Color of the background of the bottom app bar.

--- a/components/BottomAppBar/src/MDCBottomAppBarView.h
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.h
@@ -72,6 +72,12 @@ typedef NS_ENUM(NSInteger, MDCBottomAppBarFloatingButtonPosition) {
  */
 @property(nonatomic, copy, nullable) NSArray<UIBarButtonItem *> *trailingBarButtonItems;
 
+// Redeclaring to document the leading/trailing items' behavior.
+/**
+ To tint the leading and trailing buttons, use @c leadingBarItemsTintColor or
+ @c trailingBarItemsTintColor instead.
+ */
+@property(null_resettable, nonatomic, strong) UIColor *tintColor NS_AVAILABLE_IOS(7_0);
 
 /**
  Color of the background of the bottom app bar.

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -96,6 +96,7 @@ static const int kMDCButtonAnimationDuration = 200;
   [self addSubview:_navBar];
 
   _navBar.backgroundColor = [UIColor clearColor];
+  _navBar.tintColor = [UIColor blackColor];
   _navBar.leadingBarItemsTintColor = UIColor.blackColor;
   _navBar.trailingBarItemsTintColor = UIColor.blackColor;
 }

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -96,7 +96,8 @@ static const int kMDCButtonAnimationDuration = 200;
   [self addSubview:_navBar];
 
   _navBar.backgroundColor = [UIColor clearColor];
-  _navBar.tintColor = [UIColor blackColor];
+  _navBar.leadingBarItemsTintColor = UIColor.blackColor;
+  _navBar.trailingBarItemsTintColor = UIColor.blackColor;
 }
 
 - (void)addBottomBarLayer {
@@ -382,6 +383,30 @@ static const int kMDCButtonAnimationDuration = 200;
 
 - (UIColor *)barTintColor {
   return [UIColor colorWithCGColor:_bottomBarLayer.fillColor];
+}
+
+- (void)setLeadingBarItemsTintColor:(UIColor *)leadingBarItemsTintColor {
+  NSParameterAssert(leadingBarItemsTintColor);
+  if (!leadingBarItemsTintColor) {
+    leadingBarItemsTintColor = UIColor.blackColor;
+  }
+  self.navBar.leadingBarItemsTintColor = leadingBarItemsTintColor;
+}
+
+- (UIColor *)leadingBarItemsTintColor {
+  return self.navBar.leadingBarItemsTintColor;
+}
+
+- (void)setTrailingBarItemsTintColor:(UIColor *)trailingBarItemsTintColor {
+  NSParameterAssert(trailingBarItemsTintColor);
+  if (!trailingBarItemsTintColor) {
+    trailingBarItemsTintColor = UIColor.blackColor;
+  }
+  self.navBar.trailingBarItemsTintColor = trailingBarItemsTintColor;
+}
+
+- (UIColor *)trailingBarItemsTintColor {
+  return self.navBar.trailingBarItemsTintColor;
 }
 
 - (void)setShadowColor:(UIColor *)shadowColor {

--- a/components/BottomAppBar/tests/unit/BottomAppBarTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarTests.m
@@ -1,0 +1,64 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialBottomAppBar.h"
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialNavigationBar.h"
+
+@interface MDCBottomAppBarView (Testing)
+@property(nonatomic, strong) MDCNavigationBar *navBar;
+@end
+
+@interface BottomAppBarTests : XCTestCase
+@property(nonatomic, strong) MDCBottomAppBarView *bottomAppBar;
+@end
+
+@implementation BottomAppBarTests
+
+- (void)setUp {
+  [super setUp];
+  self.bottomAppBar = [[MDCBottomAppBarView alloc] init];
+}
+
+#pragma mark - Color
+
+- (void)testLeadingBarItemTintColorDefault {
+  // Then
+  XCTAssertEqualObjects(self.bottomAppBar.leadingBarItemsTintColor, UIColor.blackColor);
+}
+
+- (void)testLeadingBarItemTintColorAppliesToNavigationBar {
+  // When
+  self.bottomAppBar.leadingBarItemsTintColor = UIColor.cyanColor;
+
+  // Then
+  XCTAssertEqualObjects(self.bottomAppBar.navBar.leadingBarItemsTintColor, UIColor.cyanColor);
+}
+
+- (void)testTrailingBarItemTintColorDefault {
+  // Then
+  XCTAssertEqualObjects(self.bottomAppBar.trailingBarItemsTintColor, UIColor.blackColor);
+}
+
+- (void)testTrailingBarItemTintColorAppliesToNavigationBar {
+  // When
+  self.bottomAppBar.trailingBarItemsTintColor = UIColor.purpleColor;
+
+  // Then
+  XCTAssertEqualObjects(self.bottomAppBar.navBar.trailingBarItemsTintColor, UIColor.purpleColor);
+}
+
+@end

--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -206,18 +206,6 @@ IB_DESIGNABLE
 @property(nullable, nonatomic, strong) UIColor *trailingBarItemsTintColor;
 
 /**
- The tint color applied to the bar items on the leading side of the BottomAppBar. If unset, then
- defaults to using this Navigation Bar's @c tintColor.
- */
-@property(nullable, nonatomic, strong) UIColor *leadingBarItemsTintColor;
-
-/**
- The tint color applied to the bar items on the trailing side of the BottomAppBar. If unset, then
- defaults to using this NavigationBar's @c tintColor.
- */
-@property(nullable, nonatomic, strong) UIColor *trailingBarItemsTintColor;
-
-/**
  Returns the color set for @c state that was set by setButtonsTitleColor:forState:.
 
  If no value has been set for a given state, the returned value will fall back to the value

--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -193,6 +193,19 @@ IB_DESIGNABLE
  */
 - (void)setButtonsTitleColor:(nullable UIColor *)color forState:(UIControlState)state;
 
+
+/**
+ The tint color applied to the bar items on the leading side of the BottomAppBar. If unset, then
+ defaults to using this Navigation Bar's @c tintColor.
+ */
+@property(nullable, nonatomic, strong) UIColor *leadingBarItemsTintColor;
+
+/**
+ The tint color applied to the bar items on the trailing side of the BottomAppBar. If unset, then
+ defaults to using this NavigationBar's @c tintColor.
+ */
+@property(nullable, nonatomic, strong) UIColor *trailingBarItemsTintColor;
+
 /**
  The tint color applied to the bar items on the leading side of the BottomAppBar. If unset, then
  defaults to using this Navigation Bar's @c tintColor.

--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -193,7 +193,6 @@ IB_DESIGNABLE
  */
 - (void)setButtonsTitleColor:(nullable UIColor *)color forState:(UIControlState)state;
 
-
 /**
  The tint color applied to the bar items on the leading side of the BottomAppBar. If unset, then
  defaults to using this Navigation Bar's @c tintColor.


### PR DESCRIPTION
The BottomAppBar should support different tint colors for the leading
and trailing items.

**Extreme Example**
<img width="371" alt="screen shot 2018-09-08 at 11 30 49 pm" src="https://user-images.githubusercontent.com/1753199/45260822-44407300-b3bf-11e8-85e0-a962ff969d97.png">


Part of #3928 
