### PR TITLE
[MDCItemBar] Fix an issue where the protocol method `itemBar:shouldSelectItem:` does not behave correctly

### DIFF
--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -385,6 +385,10 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   [self configureCell:itemCell];
   [itemCell updateWithItem:item atIndex:indexPath.item count:_items.count];
 
+  BOOL shouldSelectItem = [self collectionView:collectionView
+                   shouldSelectItemAtIndexPath:indexPath];
+  itemCell.userInteractionEnabled = shouldSelectItem;
+
   return itemCell;
 }
 

--- a/components/Tabs/tests/unit/MDCItemBarTests.m
+++ b/components/Tabs/tests/unit/MDCItemBarTests.m
@@ -1,0 +1,105 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCItemBar.h"
+
+#import <XCTest/XCTest.h>
+
+// Exposing methods for testing
+@interface MDCItemBar (Testing)
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
+                  cellForItemAtIndexPath:(NSIndexPath *)indexPath;
+@end
+
+// Mock Delegate which returns NO for `shouldSelectItem:item`
+@interface MDCTabBarDelegateShouldSelectNO : NSObject <MDCItemBarDelegate>
+@end
+
+@implementation MDCTabBarDelegateShouldSelectNO
+
+- (BOOL)itemBar:(nonnull MDCItemBar *)itemBar shouldSelectItem:(nonnull UITabBarItem *)item {
+  return NO;
+}
+
+- (void)itemBar:(nonnull MDCItemBar *)itemBar didSelectItem:(nonnull UITabBarItem *)item {
+}
+
+@end
+
+// Mock Delegate which returns YES for `shouldSelectItem:item`
+@interface MDCTabBarDelegateShouldSelectYES : NSObject <MDCItemBarDelegate>
+@end
+
+@implementation MDCTabBarDelegateShouldSelectYES
+
+- (BOOL)itemBar:(nonnull MDCItemBar *)itemBar shouldSelectItem:(nonnull UITabBarItem *)item {
+  return YES;
+}
+
+- (void)itemBar:(nonnull MDCItemBar *)itemBar didSelectItem:(nonnull UITabBarItem *)item {
+}
+
+@end
+
+@interface MDCItemBarTests : XCTestCase
+
+@end
+
+@implementation MDCItemBarTests
+
+- (void)testItemBarCellWhenSelectDelegateNO {
+  // Given
+  id<MDCItemBarDelegate> delegate = [[MDCTabBarDelegateShouldSelectNO alloc] init];
+  MDCItemBar *itemBar = [[MDCItemBar alloc] init];
+  itemBar.delegate = delegate;
+
+  UICollectionView *collectionView = [itemBar valueForKey:@"_collectionView"];
+
+  UITabBarItem *_itemA = [[UITabBarItem alloc] initWithTitle:@"A" image:nil tag:0];
+
+  itemBar.items = @[ _itemA ];
+
+  // When
+  UICollectionViewCell *cell = [itemBar collectionView:collectionView
+                                cellForItemAtIndexPath:[NSIndexPath indexPathForItem:0
+                                                                           inSection:0]];
+
+  // Then
+  XCTAssertNotNil(cell);
+  XCTAssertFalse(cell.userInteractionEnabled);
+}
+
+- (void)testItemBarCellWhenSelectDelegateYES {
+  // Given
+  id<MDCItemBarDelegate> delegate = [[MDCTabBarDelegateShouldSelectYES alloc] init];
+  MDCItemBar *itemBar = [[MDCItemBar alloc] init];
+  itemBar.delegate = delegate;
+
+  UICollectionView *collectionView = [itemBar valueForKey:@"_collectionView"];
+
+  UITabBarItem *_itemA = [[UITabBarItem alloc] initWithTitle:@"A" image:nil tag:0];
+
+  itemBar.items = @[ _itemA ];
+
+  // When
+  UICollectionViewCell *cell = [itemBar collectionView:collectionView
+                                cellForItemAtIndexPath:[NSIndexPath indexPathForItem:0
+                                                                           inSection:0]];
+
+  // Then
+  XCTAssertNotNil(cell);
+  XCTAssertTrue(cell.userInteractionEnabled);
+}
+
+@end


### PR DESCRIPTION
Tapping on an item in an ItemBar with `itemBar:shouldSelectItem:` returning false, causes the item to give the UI feedback that it is enabled, in addition to that, it *removes* the highlight effect from the currently select item.

The pull request addresses this issue by setting the `userInteractionEnabled` of the cell to false if the item should not be selected

<img width="440" alt="screen shot 2018-09-09 at 12 52 28 pm" src="https://user-images.githubusercontent.com/5355138/45263747-f748b500-b42f-11e8-92c5-3445784aa51e.png">

This happens after selecting an item
<img width="444" alt="screen shot 2018-09-09 at 12 52 13 pm" src="https://user-images.githubusercontent.com/5355138/45263749-fca5ff80-b42f-11e8-8921-089de83656cf.png">