### PR TITLE
[FlexibleHeaderView] Make FexibleHeaderView respect contentInsetAdjustmentBehavior (#4970)

### DIFF
--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -138,6 +138,11 @@
   info.trackingScrollView = trackingScrollView;
   [self setInfo:info forViewController:viewController];
 
+  if (@available(iOS 11.0, *)) {
+    appBar.appBarViewController.headerView
+        .disableContentInsetAdjustmentWhenContentInsetAdjustmentBehaviorIsNever = YES;
+  }
+
   // Ensures that the view controller's top layout guide / additional safe area insets are adjusted
   // to take into consideration the flexible header's height.
   appBar.appBarViewController.topLayoutGuideViewController = viewController;

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -338,7 +338,7 @@ IB_DESIGNABLE
 @property(nonatomic) BOOL sharedWithManyScrollViews;
 
 /**
- If the flag is set YES, the trackingScrollView doesn't adjust the content inset when its
+ If enabled, the trackingScrollView doesn't adjust the content inset when its
  contentInsetAdjustmentBehavior is set to be UIScrollViewContentInsetAdjustmentNever.
 
  Default: NO

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -337,6 +337,16 @@ IB_DESIGNABLE
  */
 @property(nonatomic) BOOL sharedWithManyScrollViews;
 
+/**
+ If the flag is set YES, the trackingScrollView doesn't adjust the content inset when its
+ contentInsetAdjustmentBehavior is set to be UIScrollViewContentInsetAdjustmentNever.
+
+ Default: NO
+ */
+@property(nonatomic)
+    BOOL disableContentInsetAdjustmentWhenContentInsetAdjustmentBehaviorIsNever API_AVAILABLE(
+        ios(11.0), tvos(11.0));
+
 #pragma mark Header View Delegate
 
 /** The delegate for this header view. */

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -635,6 +635,13 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
                       && [self trackingScrollViewIsWebKit])) {
     return 0;
   }
+  if (@available(iOS 11.0, *)) {
+    // Don't adjust the contentInset if scrollView's behavior doesn't want it.
+    // Compatible to iOS 11 and above
+    if (scrollView.contentInsetAdjustmentBehavior == UIScrollViewContentInsetAdjustmentNever) {
+      return 0;
+    }
+  }
 
   MDCFlexibleHeaderScrollViewInfo *info = [_trackedScrollViews objectForKey:scrollView];
   if (!info) {

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -638,7 +638,8 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   if (@available(iOS 11.0, *)) {
     // Don't adjust the contentInset if scrollView's behavior doesn't want it.
     // Compatible to iOS 11 and above
-    if (scrollView.contentInsetAdjustmentBehavior == UIScrollViewContentInsetAdjustmentNever) {
+    if (self.disableContentInsetAdjustmentWhenContentInsetAdjustmentBehaviorIsNever &&
+        scrollView.contentInsetAdjustmentBehavior == UIScrollViewContentInsetAdjustmentNever) {
       return 0;
     }
   }

--- a/components/PageControl/examples/PageControlTypicalUseExample.m
+++ b/components/PageControl/examples/PageControlTypicalUseExample.m
@@ -40,6 +40,9 @@
 
   // Scroll view configuration
   _scrollView = [[UIScrollView alloc] initWithFrame:self.view.bounds];
+  if (@available(iOS 11.0, *)) {
+    _scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+  }
   _scrollView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   _scrollView.delegate = self;
   _scrollView.pagingEnabled = YES;


### PR DESCRIPTION
This fix is compatible for iOS 11 and above. For pre iOS11 version, FlexibleHeaderView still insets the contentInset. To fix it, we need to use a deprecated API automaticallyAdjustsScrollViewInsets from a view controller, which is not supported by the current FlexibleHeaderView architecture. Suggestions are welcomed.

Before the Change:
![pc2](https://user-images.githubusercontent.com/8836258/45308459-8072f100-b4ef-11e8-9642-7afedfc17010.gif)

After the Change:
![pc1](https://user-images.githubusercontent.com/8836258/45308287-1f4b1d80-b4ef-11e8-8359-08b079af40e5.gif)
