### PR TITLE
[ShapeLibrary] Make the new CornerTreatment initializers use concrete types

### DIFF
--- a/components/BottomSheet/tests/unit/BottomSheetShapeThemerTests.swift
+++ b/components/BottomSheet/tests/unit/BottomSheetShapeThemerTests.swift
@@ -46,11 +46,10 @@ class BottomSheetShapeThemerTests: XCTestCase {
 
   func testBottomSheetShapeThemerPreferred() {
     // Given
-    let bottomSheetCollapsedBaselineShapeValue = NSNumber(value: 24)
+    let collapsedBaselineShapeValue = CGFloat(24)
     let shapeScheme = MDCShapeScheme()
     let bottomSheet = MDCBottomSheetController(contentViewController: UIViewController())
-    let generatedCorner = MDCRoundedCornerTreatment(cornerType: .rounded,
-                                                    andSize: bottomSheetCollapsedBaselineShapeValue)
+    let generatedCorner = MDCCornerTreatment.corner(withRadius: collapsedBaselineShapeValue)
     shapeScheme.largeSurfaceShape = MDCShapeCategory(cornersWith: .angled, andSize: 10)
     bottomSheet.setShapeGenerator(MDCRectangleShapeGenerator(), for: .preferred)
 

--- a/components/private/ShapeLibrary/src/MDCCornerTreatment+CornerTypeInitalizer.h
+++ b/components/private/ShapeLibrary/src/MDCCornerTreatment+CornerTypeInitalizer.h
@@ -14,14 +14,30 @@
 
 #import "MaterialShapes.h"
 
-typedef NS_ENUM(NSInteger, MDCCornerType) {
-  MDCCornerTypeCurved,
-  MDCCornerTypeCut,
-  MDCCornerTypeRounded
-};
-
 @interface MDCCornerTreatment (CornerTypeInitalizer)
 
-- (instancetype)initWithCornerType:(MDCCornerType)cornerType andSize:(NSNumber *)size;
+/**
+ Initialize and return an MDCCornerTreatment as an MDCRoundedCornerTreatment.
+
+ @param value The radius to set the rounded corner to.
+ @return an MDCRoundedCornerTreatment.
+ */
++ (MDCCornerTreatment *)cornerWithRadius:(CGFloat)value;
+
+/**
+ Initialize and return an MDCCornerTreatment as an MDCCutCornerTreatment.
+
+ @param value The cut to set the cut corner to.
+ @return an MDCCutCornerTreatment.
+ */
++ (MDCCornerTreatment *)cornerWithCut:(CGFloat)value;
+
+/**
+ Initialize and return an MDCCornerTreatment as an MDCCurvedCornerTreatment.
+
+ @param value The size to set the curved corner to.
+ @return an MDCCurvedCornerTreatment.
+ */
++ (MDCCornerTreatment *)cornerWithCurve:(CGSize)value;
 
 @end

--- a/components/private/ShapeLibrary/src/MDCCornerTreatment+CornerTypeInitalizer.h
+++ b/components/private/ShapeLibrary/src/MDCCornerTreatment+CornerTypeInitalizer.h
@@ -14,6 +14,10 @@
 
 #import "MaterialShapes.h"
 
+#import "MDCCurvedCornerTreatment.h"
+#import "MDCCutCornerTreatment.h"
+#import "MDCRoundedCornerTreatment.h"
+
 @interface MDCCornerTreatment (CornerTypeInitalizer)
 
 /**
@@ -22,7 +26,7 @@
  @param value The radius to set the rounded corner to.
  @return an MDCRoundedCornerTreatment.
  */
-+ (MDCCornerTreatment *)cornerWithRadius:(CGFloat)value;
++ (MDCRoundedCornerTreatment *)cornerWithRadius:(CGFloat)value;
 
 /**
  Initialize and return an MDCCornerTreatment as an MDCCutCornerTreatment.
@@ -30,7 +34,7 @@
  @param value The cut to set the cut corner to.
  @return an MDCCutCornerTreatment.
  */
-+ (MDCCornerTreatment *)cornerWithCut:(CGFloat)value;
++ (MDCCutCornerTreatment *)cornerWithCut:(CGFloat)value;
 
 /**
  Initialize and return an MDCCornerTreatment as an MDCCurvedCornerTreatment.
@@ -38,6 +42,6 @@
  @param value The size to set the curved corner to.
  @return an MDCCurvedCornerTreatment.
  */
-+ (MDCCornerTreatment *)cornerWithCurve:(CGSize)value;
++ (MDCCurvedCornerTreatment *)cornerWithCurve:(CGSize)value;
 
 @end

--- a/components/private/ShapeLibrary/src/MDCCornerTreatment+CornerTypeInitalizer.m
+++ b/components/private/ShapeLibrary/src/MDCCornerTreatment+CornerTypeInitalizer.m
@@ -20,26 +20,16 @@
 
 @implementation MDCCornerTreatment (CornerTypeInitalizer)
 
-- (instancetype)initWithCornerType:(MDCCornerType)cornerType andSize:(NSNumber *)size {
-  self = [self init];
-  switch (cornerType) {
-    case MDCCornerTypeCurved: {
-      CGSize curvedSize = [size CGSizeValue];
-      self = [[MDCCurvedCornerTreatment alloc] initWithSize:curvedSize];
-      break;
-    }
-    case MDCCornerTypeCut: {
-      CGFloat cutSize = [size floatValue];
-      self = [[MDCCutCornerTreatment alloc] initWithCut:cutSize];
-      break;
-    }
-    case MDCCornerTypeRounded: {
-      CGFloat radiusSize = [size floatValue];
-      self = [[MDCRoundedCornerTreatment alloc] initWithRadius:radiusSize];
-      break;
-    }
-  }
-  return self;
++ (MDCCornerTreatment *)cornerWithRadius:(CGFloat)value {
+  return [[MDCRoundedCornerTreatment alloc] initWithRadius:value];
+}
+
++ (MDCCornerTreatment *)cornerWithCut:(CGFloat)value {
+  return [[MDCCutCornerTreatment alloc] initWithCut:value];
+}
+
++ (MDCCornerTreatment *)cornerWithCurve:(CGSize)value {
+  return [[MDCCurvedCornerTreatment alloc] initWithSize:value];
 }
 
 @end

--- a/components/private/ShapeLibrary/src/MDCCornerTreatment+CornerTypeInitalizer.m
+++ b/components/private/ShapeLibrary/src/MDCCornerTreatment+CornerTypeInitalizer.m
@@ -14,21 +14,17 @@
 
 #import "MDCCornerTreatment+CornerTypeInitalizer.h"
 
-#import "MDCCurvedCornerTreatment.h"
-#import "MDCCutCornerTreatment.h"
-#import "MDCRoundedCornerTreatment.h"
-
 @implementation MDCCornerTreatment (CornerTypeInitalizer)
 
-+ (MDCCornerTreatment *)cornerWithRadius:(CGFloat)value {
++ (MDCRoundedCornerTreatment *)cornerWithRadius:(CGFloat)value {
   return [[MDCRoundedCornerTreatment alloc] initWithRadius:value];
 }
 
-+ (MDCCornerTreatment *)cornerWithCut:(CGFloat)value {
++ (MDCCutCornerTreatment *)cornerWithCut:(CGFloat)value {
   return [[MDCCutCornerTreatment alloc] initWithCut:value];
 }
 
-+ (MDCCornerTreatment *)cornerWithCurve:(CGSize)value {
++ (MDCCurvedCornerTreatment *)cornerWithCurve:(CGSize)value {
   return [[MDCCurvedCornerTreatment alloc] initWithSize:value];
 }
 

--- a/components/private/ShapeLibrary/tests/unit/ShapeLibraryTests.m
+++ b/components/private/ShapeLibrary/tests/unit/ShapeLibraryTests.m
@@ -35,9 +35,7 @@
       [[MDCCurvedCornerTreatment alloc] initWithSize:CGSizeMake(2, 5)];
   MDCCurvedCornerTreatment *curvedCorner2 =
       [[MDCCurvedCornerTreatment alloc] initWithSize:CGSizeMake(1, 3)];
-  NSNumber *value = (NSNumber *)[NSValue valueWithCGSize:CGSizeMake(2, 5)];
-  MDCCornerTreatment *cornerTreatment =
-      [[MDCCornerTreatment alloc] initWithCornerType:MDCCornerTypeCurved andSize:value];
+  MDCCornerTreatment *cornerTreatment = [MDCCornerTreatment cornerWithCurve:CGSizeMake(2, 5)];
 
   // When
   XCTAssertNotEqualObjects(curvedCorner, curvedCorner2);
@@ -55,9 +53,7 @@
       [[MDCRoundedCornerTreatment alloc] initWithRadius:3.2f];
   MDCRoundedCornerTreatment *roundedCorner2 =
       [[MDCRoundedCornerTreatment alloc] initWithRadius:4.3f];
-  NSNumber *value = @(3.2f);
-  MDCCornerTreatment *cornerTreatment =
-      [[MDCCornerTreatment alloc] initWithCornerType:MDCCornerTypeRounded andSize:value];
+  MDCCornerTreatment *cornerTreatment = [MDCCornerTreatment cornerWithRadius:3.2f];
 
   // When
   XCTAssertNotEqualObjects(roundedCorner, roundedCorner2);
@@ -73,9 +69,7 @@
   // Given
   MDCCutCornerTreatment *cutCorner = [[MDCCutCornerTreatment alloc] initWithCut:3.2f];
   MDCCutCornerTreatment *cutCorner2 = [[MDCCutCornerTreatment alloc] initWithCut:4.3f];
-  NSNumber *value = @(3.2f);
-  MDCCornerTreatment *cornerTreatment =
-      [[MDCCornerTreatment alloc] initWithCornerType:MDCCornerTypeCut andSize:value];
+  MDCCornerTreatment *cornerTreatment = [MDCCornerTreatment cornerWithCut:3.2f];
 
   // When
   XCTAssertNotEqualObjects(cutCorner, cutCorner2);

--- a/components/schemes/Shape/src/MDCShapeCorner.m
+++ b/components/schemes/Shape/src/MDCShapeCorner.m
@@ -57,15 +57,12 @@
 
 - (MDCCornerTreatment *)cornerTreatmentSizeWithNormalizedShapeSize:(CGFloat)shapeSize {
   MDCCornerTreatment *cornerTreatment;
-  NSNumber *size = @(shapeSize);
   switch (_family) {
     case MDCShapeCornerFamilyAngled:
-      cornerTreatment = [[MDCCornerTreatment alloc] initWithCornerType:MDCCornerTypeCut
-                                                               andSize:size];
+      cornerTreatment = [MDCCornerTreatment cornerWithCut:shapeSize];
       break;
     case MDCShapeCornerFamilyRounded:
-      cornerTreatment = [[MDCCornerTreatment alloc] initWithCornerType:MDCCornerTypeRounded
-                                                               andSize:size];
+      cornerTreatment = [MDCCornerTreatment cornerWithRadius:shapeSize];
       break;
   }
   return cornerTreatment;


### PR DESCRIPTION
This PR changes the recent addition of convenience initializers of MDCCornerTreatments to become a certain instance subclass to use concrete types rather than a generic NSNumber with parsing. This resolves #5063 