### PR TITLE
Remove "+Extensions" pod installation instructions from component rea…

### DIFF
--- a/components/HeaderStackView/README.md
+++ b/components/HeaderStackView/README.md
@@ -37,11 +37,6 @@ pod 'MaterialComponents/HeaderStackView'
 ```
 <!--{: .code-renderer.code-renderer--install }-->
 
-To add this component along with its themer and other related extensions, please add the following instead:
-```bash
-pod 'MaterialComponents/HeaderStackView+Extensions'
-```
-
 Then, run the following command:
 
 ```bash

--- a/components/Ink/README.md
+++ b/components/Ink/README.md
@@ -37,11 +37,6 @@ pod 'MaterialComponents/Ink'
 ```
 <!--{: .code-renderer.code-renderer--install }-->
 
-To add this component along with its themer and other related extensions, please add the following instead:
-```bash
-pod 'MaterialComponents/Ink+Extensions'
-```
-
 Then, run the following command:
 
 ```bash


### PR DESCRIPTION
Several Readmes were not updated to reflect the removal of the "+Extensions" subspecs in MaterialComponents.podspec. This PR removes them.

Closes #5067