### PR TITLE
[ActionSheet] Add background color

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -138,6 +138,9 @@ __attribute__((objc_subclassing_restricted))
  */
 @property(nonatomic, nullable, strong) UIFont *actionFont;
 
+/**
+ The color applied to the sheet view of the action sheet controller.
+ */
 @property(nonatomic, nonnull, strong) UIColor *backgroundColor;
 
 @property(nonatomic, strong, readonly, nonnull)

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -71,7 +71,6 @@ static NSString *const ReuseIdentifier = @"BaseCell";
 }
 
 @synthesize mdc_adjustsFontForContentSizeCategory = _mdc_adjustsFontForContentSizeCategory;
-@synthesize backgroundColor = _backgroundColor;
 
 + (instancetype)actionSheetControllerWithTitle:(NSString *)title message:(NSString *)message {
   return [[MDCActionSheetController alloc] initWithTitle:title message:message];
@@ -306,10 +305,6 @@ static NSString *const ReuseIdentifier = @"BaseCell";
   self.view.backgroundColor = backgroundColor;
   _tableView.backgroundColor = backgroundColor;
   _header.backgroundColor = backgroundColor;
-}
-
-- (UIColor *)backgroundColor {
-  return _backgroundColor;
 }
 
 #pragma mark - Dynamic Type

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -135,7 +135,7 @@ static NSString *const ReuseIdentifier = @"BaseCell";
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.view.backgroundColor = _backgroundColor;
+  self.view.backgroundColor = self.backgroundColor;
   _tableView.frame = self.view.bounds;
   [self.view addSubview:_tableView];
   [self.view addSubview:_header];

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -135,6 +135,7 @@ static NSString *const ReuseIdentifier = @"BaseCell";
 - (void)viewDidLoad {
   [super viewDidLoad];
 
+  self.view.backgroundColor = _backgroundColor;
   _tableView.frame = self.view.bounds;
   [self.view addSubview:_tableView];
   [self.view addSubview:_header];

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -71,6 +71,7 @@ static NSString *const ReuseIdentifier = @"BaseCell";
 }
 
 @synthesize mdc_adjustsFontForContentSizeCategory = _mdc_adjustsFontForContentSizeCategory;
+@synthesize backgroundColor = _backgroundColor;
 
 + (instancetype)actionSheetControllerWithTitle:(NSString *)title message:(NSString *)message {
   return [[MDCActionSheetController alloc] initWithTitle:title message:message];
@@ -111,7 +112,9 @@ static NSString *const ReuseIdentifier = @"BaseCell";
     _header = [[MDCActionSheetHeaderView alloc] initWithFrame:CGRectZero];
     _header.title = [title copy];
     _header.message = [message copy];
-    self.backgroundColor = [UIColor whiteColor];
+    _backgroundColor = UIColor.whiteColor;
+    _header.backgroundColor = UIColor.whiteColor;
+    _tableView.backgroundColor = UIColor.whiteColor;
   }
 
   return self;
@@ -299,13 +302,14 @@ static NSString *const ReuseIdentifier = @"BaseCell";
 }
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor {
+  _backgroundColor = backgroundColor;
   self.view.backgroundColor = backgroundColor;
   _tableView.backgroundColor = backgroundColor;
   _header.backgroundColor = backgroundColor;
 }
 
 - (UIColor *)backgroundColor {
-  return self.view.backgroundColor;
+  return _backgroundColor;
 }
 
 #pragma mark - Dynamic Type

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -113,8 +113,8 @@ static NSString *const ReuseIdentifier = @"BaseCell";
     _header.title = [title copy];
     _header.message = [message copy];
     _backgroundColor = UIColor.whiteColor;
-    _header.backgroundColor = UIColor.whiteColor;
-    _tableView.backgroundColor = UIColor.whiteColor;
+    _header.backgroundColor = _backgroundColor;
+    _tableView.backgroundColor = _backgroundColor;
   }
 
   return self;

--- a/components/ActionSheet/tests/unit/ActionSheetTest.swift
+++ b/components/ActionSheet/tests/unit/ActionSheetTest.swift
@@ -78,8 +78,12 @@ class ActionSheetTest: XCTestCase {
   }
 
   func testDefaultBackgroundColor() {
+    // When
+    let _ = actionSheet.view
+    
     // Then
     XCTAssertEqual(actionSheet.backgroundColor, .white)
+    XCTAssertEqual(actionSheet.view.backgroundColor, .white)
     let subviewsArray = actionSheet.view.subviews
     for view in subviewsArray {
       XCTAssertEqual(view.backgroundColor, .white)

--- a/components/ActionSheet/tests/unit/ActionSheetTest.swift
+++ b/components/ActionSheet/tests/unit/ActionSheetTest.swift
@@ -80,6 +80,10 @@ class ActionSheetTest: XCTestCase {
   func testDefaultBackgroundColor() {
     // Then
     XCTAssertEqual(actionSheet.backgroundColor, .white)
+    let subviewsArray = actionSheet.view.subviews
+    for view in subviewsArray {
+      XCTAssertEqual(view.backgroundColor, .white)
+    }
   }
 
   func testSetBackgroundColor() {

--- a/components/ActionSheet/tests/unit/ActionSheetTest.swift
+++ b/components/ActionSheet/tests/unit/ActionSheetTest.swift
@@ -76,4 +76,20 @@ class ActionSheetTest: XCTestCase {
     }
     
   }
+
+  func testDefaultBackgroundColor() {
+    // Then
+    XCTAssertEqual(actionSheet.backgroundColor, .white)
+  }
+
+  func testSetBackgroundColor() {
+    // Given
+    let newBackgroundColor: UIColor = .green
+
+    // When
+    actionSheet.backgroundColor = newBackgroundColor
+
+    // Then
+    XCTAssertEqual(actionSheet.backgroundColor, newBackgroundColor)
+  }
 }

--- a/components/ActionSheet/tests/unit/ActionSheetTest.swift
+++ b/components/ActionSheet/tests/unit/ActionSheetTest.swift
@@ -92,4 +92,17 @@ class ActionSheetTest: XCTestCase {
     // Then
     XCTAssertEqual(actionSheet.backgroundColor, newBackgroundColor)
   }
+
+  func testBackgroundColorMatchesViewBackgroundColor() {
+    // Given
+    let newBackgroundColor: UIColor = .green
+    actionSheet.backgroundColor = newBackgroundColor
+
+    // When
+    let _ = actionSheet.view
+
+    // Then
+    XCTAssertEqual(actionSheet.view.backgroundColor, actionSheet.backgroundColor)
+    XCTAssertEqual(actionSheet.view.backgroundColor, newBackgroundColor)
+  }
 }


### PR DESCRIPTION
Add the ability for clients to set the background color on an ActionSheet.

Previously this was missing test and documentation. 

Also previously this used self inside of initialization when self isn't guaranteed.

Previous PRs related to this.
#4957 & #4984 

This partially closes #4903 

| Before | After |
| ------ | ------ |
|![simulator screen shot - iphone x - 2018-09-10 at 22 13 58](https://user-images.githubusercontent.com/7131294/45334003-d8891200-b546-11e8-92eb-b1b98e169d41.png)|![simulator screen shot - iphone x - 2018-09-10 at 22 08 51](https://user-images.githubusercontent.com/7131294/45334005-dcb52f80-b546-11e8-98df-0599a1b8da32.png)|

