### PR TITLE
[ActionSheet] Add color properties to header labels

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -140,6 +140,15 @@ __attribute__((objc_subclassing_restricted))
 
 @property(nonatomic, nonnull, strong) UIColor *backgroundColor;
 
+/**
+ The color applied to the title of the action sheet controller.
+ */
+@property(nonatomic, strong, nullable) UIColor *titleTextColor;
+/**
+ The color applied to the message of the action sheet controller.
+ */
+@property(nonatomic, strong, nullable) UIColor *messageTextColor;
+
 @property(nonatomic, strong, readonly, nonnull)
     MDCBottomSheetTransitionController *transitionController;
 

--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -144,6 +144,7 @@ __attribute__((objc_subclassing_restricted))
  The color applied to the title of the action sheet controller.
  */
 @property(nonatomic, strong, nullable) UIColor *titleTextColor;
+
 /**
  The color applied to the message of the action sheet controller.
  */

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -308,6 +308,22 @@ static NSString *const ReuseIdentifier = @"BaseCell";
   return self.view.backgroundColor;
 }
 
+- (void)setTitleTextColor:(UIColor *)titleTextColor {
+  _header.titleTextColor = titleTextColor;
+}
+
+- (UIColor *)titleTextColor {
+  return _header.titleTextColor;
+}
+
+- (void)setMessageTextColor:(UIColor *)messageTextColor {
+  _header.messageTextColor = messageTextColor;
+}
+
+- (UIColor *)messageTextColor {
+  return _header.messageTextColor;
+}
+
 #pragma mark - Dynamic Type
 
 - (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {

--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.h
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.h
@@ -32,4 +32,8 @@
 
 @property (nonatomic, strong, nonnull) UIFont *messageFont;
 
+@property(nonatomic, strong, nullable) UIColor *titleTextColor;
+
+@property(nonatomic, strong, nullable) UIColor *messageTextColor;
+
 @end

--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
@@ -111,6 +111,7 @@ static const CGFloat MiddlePadding = 8.f;
 
 - (void)setTitle:(NSString *)title {
   _titleLabel.text = title;
+  [self styleTitleAndMessage];
   [self setNeedsLayout];
 }
 
@@ -120,18 +121,24 @@ static const CGFloat MiddlePadding = 8.f;
 
 - (void)setMessage:(NSString *)message {
   _messageLabel.text = message;
-  // If message is empty or nil then the title label's alpha value should be lighter, if there is both
-  // then the title label's alpha should be darker.
-  if (self.message && ![self.message isEqualToString:@""]) {
-    _titleLabel.alpha = TitleLabelAlpha;
-  } else {
-    _titleLabel.alpha = MessageLabelAlpha;
-  }
+  [self styleTitleAndMessage];
   [self setNeedsLayout];
 }
 
 - (NSString *)message {
   return _messageLabel.text;
+}
+
+- (void)styleTitleAndMessage {
+  // If message is empty or nil then the title label's alpha value should be lighter and primary
+  // color, if there is both then the title label's alpha should be darker secondary color.
+  if (self.message && ![self.message isEqualToString:@""]) {
+    _titleLabel.alpha = TitleLabelAlpha;
+  } else {
+    _titleLabel.alpha = MessageLabelAlpha;
+  }
+  _messageLabel.textColor = self.messageTextColor;
+  _titleLabel.textColor = self.titleTextColor;
 }
 
 - (void)setTitleFont:(UIFont *)titleFont {
@@ -197,6 +204,15 @@ static const CGFloat MiddlePadding = 8.f;
                                                     object:nil];
   }
   [self updateFonts];
+}
+
+- (void)setTitleTextColor:(UIColor *)titleTextColor {
+  _titleTextColor = titleTextColor;
+  _titleLabel.textColor = titleTextColor;
+}
+- (void)setMessageTextColor:(UIColor *)messageTextColor {
+  _messageTextColor = messageTextColor;
+  _messageLabel.textColor = messageTextColor;
 }
 
 @end

--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
@@ -210,6 +210,7 @@ static const CGFloat MiddlePadding = 8.f;
   _titleTextColor = titleTextColor;
   _titleLabel.textColor = titleTextColor;
 }
+
 - (void)setMessageTextColor:(UIColor *)messageTextColor {
   _messageTextColor = messageTextColor;
   _messageLabel.textColor = messageTextColor;

--- a/components/ActionSheet/tests/unit/ActionSheetTest.swift
+++ b/components/ActionSheet/tests/unit/ActionSheetTest.swift
@@ -25,6 +25,33 @@ class ActionSheetTest: XCTestCase {
     actionSheet = MDCActionSheetController()
   }
 
+  private func getLabel(with text: String) -> UILabel? {
+    let subviewsArray = actionSheet.view.subviews.filter { !($0 is UITableView) }
+    if let header = subviewsArray.first {
+      var labels: [UILabel] = header.subviews.flatMap { $0 as? UILabel }
+      labels = labels.filter { $0.text == text }
+      if let label = labels.first {
+        return label
+      } else {
+        return nil
+      }
+    } else {
+      return nil
+    }
+  }
+
+  private func setupTitle() -> String {
+    let testTitleString: String = "Title test"
+    actionSheet.title = testTitleString
+    return testTitleString
+  }
+
+  private func setupMessage() -> String {
+    let testMessageString: String = "Message test"
+    actionSheet.message = testMessageString
+    return testMessageString
+  }
+
   func testNumberOfActions() {
     // Then
     XCTAssertEqual(actionSheet.actions.count, 0)
@@ -75,5 +102,81 @@ class ActionSheetTest: XCTestCase {
       XCTFail("No table was loaded")
     }
     
+  }
+
+  func testDefaultHeaderTitleColor() {
+    // When
+    let titleString = setupTitle()
+    let titleLabel = getLabel(with: titleString)
+
+    // Then
+    XCTAssertNotNil(titleLabel)
+    XCTAssertEqual(titleLabel?.textColor, .black)
+  }
+
+  func testDefaultHeaderMessageColor() {
+    // When
+    let messageString = setupMessage()
+    let messageLabel = getLabel(with: messageString)
+
+    // Then
+    XCTAssertNotNil(messageLabel)
+    XCTAssertEqual(messageLabel?.textColor, .black)
+  }
+
+  func testSetHeaderTitleColor() {
+    // Given
+    let titleString = setupTitle()
+    var titleColor: UIColor = .blue
+
+    // When
+    actionSheet.titleTextColor = titleColor
+    var titleLabel = getLabel(with: titleString)
+
+    // Then
+    XCTAssertNotNil(titleLabel)
+    XCTAssertEqual(titleLabel?.textColor, actionSheet.titleTextColor)
+
+    // Given
+    actionSheet.title = nil
+    titleColor = .green
+    let newTitle = "Test"
+
+    // When
+    actionSheet.titleTextColor = titleColor
+    actionSheet.title = newTitle
+    titleLabel = getLabel(with: newTitle)
+
+    // Then
+    XCTAssertNotNil(titleLabel)
+    XCTAssertEqual(titleLabel?.textColor, titleColor)
+  }
+
+  func testSetHeaderMessageColor() {
+    // Given
+    let messageString = setupMessage()
+    var messageColor: UIColor = .blue
+
+    // When
+    actionSheet.messageTextColor = messageColor
+    var messageLabel = getLabel(with: messageString)
+
+    // Then
+    XCTAssertNotNil(messageLabel)
+    XCTAssertEqual(messageLabel?.textColor, actionSheet.messageTextColor)
+
+    // Given
+    actionSheet.message = nil
+    messageColor = .green
+    let newMessage = "Test"
+
+    // When
+    actionSheet.messageTextColor = messageColor
+    actionSheet.message = newMessage
+    messageLabel = getLabel(with: newMessage)
+
+    // Then
+    XCTAssertNotNil(messageLabel)
+    XCTAssertEqual(messageLabel?.textColor, messageColor)
   }
 }


### PR DESCRIPTION
Previously clients had no way of setting custom colors to the `title` and `message` labels. This adds the functionality. The `titleLabel` and `messageLabel` are both `ivars` on the `header` which is an `ivar` on the `MDCActionSheetController` that is why `getLabel` is needed and so verbose. The `setupTitle` and `setupMessage` functions are just helps to reduce repetition of code if later test are added.

Previous discussions were had at #4993 #4984 #4968 
Related to #5039 #4903 

| Before | After |
| ------- | ------- |
|![simulator screen shot - iphone x - 2018-09-10 at 22 13 58](https://user-images.githubusercontent.com/7131294/45335650-674d5d00-b54e-11e8-9e6e-34ae5bac051c.png)|![simulator screen shot - iphone x - 2018-09-10 at 22 41 43](https://user-images.githubusercontent.com/7131294/45335652-6c121100-b54e-11e8-9fca-50e0a44d099e.png)|

