### PR TITLE
[BottomSheet] Example unit tests for updatePreferredSheetHeight - WIP

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -66,8 +66,12 @@
 
 /**
  This is used to set a custom height on the sheet view.
+
+ @note This will override setting the preferredContentSize if a positive value is passed.
+ @note If a non-positive value is passed then the sheet will open up to either half the screen
+ height or the size of the contentViewController whatever value is smaller.
  */
-@property(nonatomic) CGFloat preferredSheetHeight;
+@property(nonatomic, assign) CGFloat preferredSheetHeight;
 
 /**
  If @c YES, then the dimmed scrim view will act as an accessibility element for dismissing the

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -65,6 +65,11 @@
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;
 
 /**
+ This is used to set a custom height on the sheet view.
+ */
+@property(nonatomic) CGFloat preferredSheetHeight;
+
+/**
  If @c YES, then the dimmed scrim view will act as an accessibility element for dismissing the
  bottom sheet.
 

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -169,10 +169,10 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
 - (void)updatePreferredSheetHeight {
   CGFloat preferredContentHeight;
-  if (self.preferredSheetHeight == 0.f) {
-    preferredContentHeight = self.presentedViewController.preferredContentSize.height;
-  } else {
+  if (self.preferredSheetHeight > 0.f) {
     preferredContentHeight = self.preferredSheetHeight;
+  } else {
+    preferredContentHeight = self.presentedViewController.preferredContentSize.height;
   }
 
   // If |preferredSheetHeight| has not been specified, use half of the current height.

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -168,7 +168,12 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 }
 
 - (void)updatePreferredSheetHeight {
-  CGFloat preferredContentHeight = self.presentedViewController.preferredContentSize.height;
+  CGFloat preferredContentHeight;
+  if (self.preferredSheetHeight == 0.f) {
+    preferredContentHeight = self.presentedViewController.preferredContentSize.height;
+  } else {
+    preferredContentHeight = self.preferredSheetHeight;
+  }
 
   // If |preferredSheetHeight| has not been specified, use half of the current height.
   if (MDCCGFloatEqual(preferredContentHeight, 0)) {
@@ -232,6 +237,11 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
 - (UIAccessibilityTraits)scrimAccessibilityTraits {
   return _scrimAccessibilityTraits;
+}
+
+- (void)setPreferredSheetHeight:(CGFloat)preferredSheetHeight {
+  _preferredSheetHeight = preferredSheetHeight;
+  [self updatePreferredSheetHeight];
 }
 
 #pragma mark - MDCSheetContainerViewDelegate

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.h
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.h
@@ -46,9 +46,14 @@
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;
 
 /**
- The height of the content view.
+ This is used to set a custom height on the sheet view. This is can be used to set the initial
+ height when the ViewController is presented.
+
+ @note This will override setting the preferredContentSize if a positive value is passed.
+ @note If a non-positive value is passed then the sheet will open up to either half the screen
+ height or the size of the contentViewController whatever value is smaller.
  */
-@property(nonatomic) CGFloat preferredSheetHeight;
+@property(nonatomic, assign) CGFloat preferredSheetHeight;
 
 @end
 

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.h
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.h
@@ -45,6 +45,11 @@
  */
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;
 
+/**
+ The height of the content view.
+ */
+@property(nonatomic) CGFloat preferredSheetHeight;
+
 @end
 
 @interface MDCBottomSheetTransitionController (ScrimAccessibility)

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.m
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.m
@@ -48,6 +48,7 @@ static const NSTimeInterval MDCBottomSheetTransitionDuration = 0.25;
   presentationController.isScrimAccessibilityElement = _isScrimAccessibilityElement;
   presentationController.scrimAccessibilityHint = _scrimAccessibilityHint;
   presentationController.scrimAccessibilityLabel = _scrimAccessibilityLabel;
+  presentationController.preferredSheetHeight = _preferredSheetHeight;
   return presentationController;
 }
 

--- a/components/BottomSheet/tests/unit/BottomSheetPresentationTest.swift
+++ b/components/BottomSheet/tests/unit/BottomSheetPresentationTest.swift
@@ -1,0 +1,66 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+import MaterialComponents.MaterialBottomSheet
+
+class BottomSheetPresentationTest: XCTestCase {
+  var presentationController: MDCBottomSheetPresentationController!
+
+  override func setUp() {
+    super.setUp()
+
+    let mockPresented = UIViewController()
+    let mockPresenting = UIViewController()
+    presentationController =
+        MDCBottomSheetPresentationController(presentedViewController: mockPresented,
+                                             presenting: mockPresenting)
+  }
+
+  func testSetPreferredSheetHeight() {
+    // Given
+    let preferredSheetHeight: CGFloat = 150.0
+
+    // When
+    presentationController.preferredSheetHeight = preferredSheetHeight
+
+    // Then
+    let sheetView = getSheetView()
+    XCTAssertEqual(sheetView.frame.height, preferredSheetHeight)
+  }
+
+  func testSetPreferredContentSizeThenSheetHeight() {
+    // Given
+    let preferredContentSize: CGSize = CGSize(width: 100, height: 100)
+    let preferredSheetHeight: CGFloat = 150.0
+
+    // When
+    presentationController.presentingViewController.preferredContentSize = preferredContentSize
+    presentationController.preferredSheetHeight = preferredSheetHeight
+
+    // Then
+    let sheetView = getSheetView()
+    XCTAssertEqual(sheetView.frame.height, preferredSheetHeight)
+  }
+
+  private func getSheetView() -> UIView {
+    if let sheetView = presentationController.presentedView {
+      return sheetView
+    } else {
+      XCTFail("No sheet view was created")
+      return UIView()
+    }
+  }
+}

--- a/components/BottomSheet/tests/unit/BottomSheetPresentationTest.swift
+++ b/components/BottomSheet/tests/unit/BottomSheetPresentationTest.swift
@@ -31,14 +31,17 @@ class BottomSheetPresentationTest: XCTestCase {
 
   func testSetPreferredSheetHeight() {
     // Given
-    let preferredSheetHeight: CGFloat = 150.0
+    let preferredSheetHeight: CGFloat = 125.0
 
     // When
     presentationController.preferredSheetHeight = preferredSheetHeight
+    presentationController.presentedViewController.view.setNeedsLayout()
+    presentationController.presentedViewController.view.layoutIfNeeded()
+    print(presentationController.frameOfPresentedViewInContainerView)
 
     // Then
     let sheetView = getSheetView()
-    XCTAssertEqual(sheetView.frame.height, preferredSheetHeight)
+    XCTAssertEqual(sheetView.bounds.height, preferredSheetHeight)
   }
 
   func testSetPreferredContentSizeThenSheetHeight() {
@@ -47,12 +50,12 @@ class BottomSheetPresentationTest: XCTestCase {
     let preferredSheetHeight: CGFloat = 150.0
 
     // When
-    presentationController.presentingViewController.preferredContentSize = preferredContentSize
+    presentationController.presentedViewController.preferredContentSize = preferredContentSize
     presentationController.preferredSheetHeight = preferredSheetHeight
 
     // Then
     let sheetView = getSheetView()
-    XCTAssertEqual(sheetView.frame.height, preferredSheetHeight)
+    XCTAssertEqual(sheetView.bounds.height, preferredSheetHeight)
   }
 
   private func getSheetView() -> UIView {

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerTests.m
@@ -40,15 +40,10 @@
 @end
 
 @interface MDCFakeBottomSheetPresentationController : MDCBottomSheetPresentationController
-@property(nonatomic, strong) UIViewController *test_PresentedViewController;
 @property(nonatomic, strong) UIView *test_sheetView;
 @end
 
 @implementation MDCFakeBottomSheetPresentationController
-
-- (UIViewController *)presentedViewController {
-  return self.test_PresentedViewController;
-}
 
 - (void)setTest_sheetView:(UIView *)test_sheetView {
   [self setValue:test_sheetView forKey:@"_sheetView"];
@@ -65,22 +60,26 @@
 @end
 
 @implementation MDCBottomSheetPresentationControllerTests
-/*
-- (void)updatePreferredSheetHeight {
-  CGFloat preferredContentHeight;
-  if (self.preferredSheetHeight > 0.f) {
-    preferredContentHeight = self.preferredSheetHeight;
-  } else {
-    preferredContentHeight = self.presentedViewController.preferredContentSize.height;
-  }
 
-  // If |preferredSheetHeight| has not been specified, use half of the current height.
-  if (MDCCGFloatEqual(preferredContentHeight, 0)) {
-    preferredContentHeight = MDCRound(_sheetView.frame.size.height / 2);
-  }
-  _sheetView.preferredSheetHeight = preferredContentHeight;
+- (void)testPreferredSheetHeightWhenPreferredSheetHeightNonZero {
+  // Given
+  FakeSheetView *sheetView = [[FakeSheetView alloc] init];
+  UIViewController *presentingViewController = [[UIViewController alloc] init];
+  MDCFakePresentedViewController *presentedViewController = [[MDCFakePresentedViewController alloc] init];
+  MDCFakeBottomSheetPresentationController *presentationController =
+  [[MDCFakeBottomSheetPresentationController alloc]
+   initWithPresentedViewController:presentedViewController
+   presentingViewController:presentingViewController];
+  presentationController.preferredSheetHeight = 99;
+  presentationController.test_sheetView = sheetView;
+  presentedViewController.test_preferredContentSize = CGSizeMake(50, 60);
+
+  // When
+  [presentationController updatePreferredSheetHeight];
+
+  // Then
+  XCTAssertEqualWithAccuracy(sheetView.preferredSheetHeight, 99, 0.001);
 }
-*/
 
 - (void)testPreferredSheetHeightWhenPreferredContentSizeNonZero {
   // Given
@@ -91,7 +90,6 @@
       [[MDCFakeBottomSheetPresentationController alloc]
           initWithPresentedViewController:presentedViewController
           presentingViewController:presentingViewController];
-  presentationController.test_PresentedViewController = presentedViewController;
   presentationController.test_sheetView = sheetView;
   presentedViewController.test_preferredContentSize = CGSizeMake(50, 60);
 

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerTests.m
@@ -1,0 +1,124 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialBottomSheet.h"
+
+@interface MDCBottomSheetPresentationController (Testing)
+- (void)updatePreferredSheetHeight;
+@end
+
+@interface MDCFakePresentedViewController : UIViewController
+@property(nonatomic, assign) CGSize test_preferredContentSize;
+@end
+
+@implementation MDCFakePresentedViewController
+
+- (CGSize)preferredContentSize {
+  return self.test_preferredContentSize;
+}
+
+@end
+
+@interface FakeSheetView : UIView
+@property(nonatomic, assign) CGFloat preferredSheetHeight;
+@end
+
+@implementation FakeSheetView
+@end
+
+@interface MDCFakeBottomSheetPresentationController : MDCBottomSheetPresentationController
+@property(nonatomic, strong) UIViewController *test_PresentedViewController;
+@property(nonatomic, strong) UIView *test_sheetView;
+@end
+
+@implementation MDCFakeBottomSheetPresentationController
+
+- (UIViewController *)presentedViewController {
+  return self.test_PresentedViewController;
+}
+
+- (void)setTest_sheetView:(UIView *)test_sheetView {
+  [self setValue:test_sheetView forKey:@"_sheetView"];
+}
+
+- (UIView *)test_sheetView {
+  return [self valueForKey:@"_sheetView"];
+}
+
+@end
+
+@interface MDCBottomSheetPresentationControllerTests : XCTestCase
+
+@end
+
+@implementation MDCBottomSheetPresentationControllerTests
+/*
+- (void)updatePreferredSheetHeight {
+  CGFloat preferredContentHeight;
+  if (self.preferredSheetHeight > 0.f) {
+    preferredContentHeight = self.preferredSheetHeight;
+  } else {
+    preferredContentHeight = self.presentedViewController.preferredContentSize.height;
+  }
+
+  // If |preferredSheetHeight| has not been specified, use half of the current height.
+  if (MDCCGFloatEqual(preferredContentHeight, 0)) {
+    preferredContentHeight = MDCRound(_sheetView.frame.size.height / 2);
+  }
+  _sheetView.preferredSheetHeight = preferredContentHeight;
+}
+*/
+
+- (void)testPreferredSheetHeightWhenPreferredContentSizeNonZero {
+  // Given
+  FakeSheetView *sheetView = [[FakeSheetView alloc] init];
+  UIViewController *presentingViewController = [[UIViewController alloc] init];
+  MDCFakePresentedViewController *presentedViewController = [[MDCFakePresentedViewController alloc] init];
+  MDCFakeBottomSheetPresentationController *presentationController =
+      [[MDCFakeBottomSheetPresentationController alloc]
+          initWithPresentedViewController:presentedViewController
+          presentingViewController:presentingViewController];
+  presentationController.test_PresentedViewController = presentedViewController;
+  presentationController.test_sheetView = sheetView;
+  presentedViewController.test_preferredContentSize = CGSizeMake(50, 60);
+
+  // When
+  [presentationController updatePreferredSheetHeight];
+
+  // Then
+  XCTAssertEqualWithAccuracy(sheetView.preferredSheetHeight, 60, 0.001);
+}
+
+- (void)testPreferredSheetHeightWhenPreferredContentSizeIsZero {
+  // Given
+  FakeSheetView *sheetView = [[FakeSheetView alloc] init];
+  UIViewController *presentingViewController = [[UIViewController alloc] init];
+  MDCFakePresentedViewController *presentedViewController = [[MDCFakePresentedViewController alloc] init];
+  MDCFakeBottomSheetPresentationController *presentationController =
+  [[MDCFakeBottomSheetPresentationController alloc]
+   initWithPresentedViewController:presentedViewController
+   presentingViewController:presentingViewController];
+  presentationController.test_sheetView = sheetView;
+  sheetView.bounds = CGRectMake(0, 0, 100, 80);
+
+  // When
+  [presentationController updatePreferredSheetHeight];
+
+  // Then
+  XCTAssertEqualWithAccuracy(sheetView.preferredSheetHeight, 40, 0.001);
+}
+
+@end


### PR DESCRIPTION
A couple of basic unit tests to verify the logic flows inside `updatePreferredSheetHeight`. They could definitely benefit from some refactoring within MDCBottomSheetPresentationController, but given the current code structure these seem to be the simplest way to exercise the new code independently.

Marked "WIP" so nobody tries to merge this as it's just an example to illustrate my thoughts on #5023 