### PR TITLE
[NavigationDrawer] Fix Swift imports in examples.

### DIFF
--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -14,6 +14,7 @@
 
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
+import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerInfiniteScrollingExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()

--- a/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
@@ -14,6 +14,7 @@
 
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
+import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerNoHeaderExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -14,6 +14,7 @@
 
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
+import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerWithHeaderExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()

--- a/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
@@ -14,6 +14,7 @@
 
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
+import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerWithScrollableContentExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()

--- a/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
+++ b/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
@@ -14,6 +14,7 @@
 
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
+import MaterialComponents.MaterialColorScheme
 
 class DrawerContentViewController: UIViewController {
   var colorScheme = MDCSemanticColorScheme()


### PR DESCRIPTION
The Swift examples were not compiling internally because they were
missing many imports.