### PR TITLE
[TextFields] Get rid of "," separator in MDCTextField accessibilityValue

### DIFF
--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -797,8 +797,8 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1.f;
   if (self.leadingUnderlineLabel.accessibilityLabel.length > 0) {
     [accessibilityStrings addObject:self.leadingUnderlineLabel.accessibilityLabel];
   }
-  return accessibilityStrings.count > 0 ?
-      [accessibilityStrings componentsJoinedByString:@", "] : nil;
+  return accessibilityStrings.count > 0 ? [accessibilityStrings componentsJoinedByString:@" "]
+                                        : nil;
 }
 
 #pragma mark - Testing


### PR DESCRIPTION
Getting rid of comma separator in MDCTextField accessibilityValue because it is apparently being read aloud.

Closes #5097.