### PR TITLE
[Dialogs] Add a dialog themer

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -462,6 +462,16 @@ Pod::Spec.new do |mdc|
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 
+  mdc.subspec "Dialogs+DialogThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/Dialogs+ColorThemer"
+    extension.dependency "MaterialComponents/Dialogs+TypographyThemer"
+  end
+
   # FeatureHighlight
 
   mdc.subspec "FeatureHighlight" do |component|

--- a/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.h
+++ b/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.h
@@ -1,0 +1,31 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import "MDCAlertController.h"
+#import "MDCAlertScheme.h"
+
+@interface MDCAlertControllerThemer : NSObject
+
+/**
+ Applies a component scheme's properties to an MDCAlertController.
+
+ @param alertScheme The component scheme to apply to the alert dialog instance.
+ @param alertController An alert dialog instance to which the component scheme should be applied.
+ */
++ (void)applyScheme:(nonnull id<MDCAlertScheming>)alertScheme
+    toAlertController:(nonnull MDCAlertController *)alertController;
+
+@end

--- a/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.m
+++ b/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.m
@@ -1,0 +1,32 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCAlertControllerThemer.h"
+#import "MDCAlertColorThemer.h"
+#import "MDCAlertTypographyThemer.h"
+
+@implementation MDCAlertControllerThemer
+
++ (void)applyScheme:(nonnull id<MDCAlertScheming>)alertScheme
+    toAlertController:(nonnull MDCAlertController *)alertController {
+  [MDCAlertColorThemer applySemanticColorScheme:alertScheme.colorScheme
+                              toAlertController:alertController];
+
+  [MDCAlertTypographyThemer applyTypographyScheme:alertScheme.typographyScheme
+                                toAlertController:alertController];
+
+  alertController.cornerRadius = alertScheme.cornerRadius;
+}
+
+@end

--- a/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
+++ b/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
@@ -1,0 +1,47 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import "MaterialColorScheme.h"
+#import "MaterialTypographyScheme.h"
+
+/** Defines a readonly immutable interface for component style data to be applied by a themer. */
+@protocol MDCAlertScheming
+
+/** The color scheme to apply to Dialog. */
+@property(nonnull, readonly, nonatomic) id<MDCColorScheming> colorScheme;
+
+/** The typography scheme to apply to Dialog. */
+@property(nonnull, readonly, nonatomic) id<MDCTypographyScheming> typographyScheme;
+
+/** The corner radius to apply to Dialog. */
+@property(readonly, nonatomic) CGFloat cornerRadius;
+
+@end
+
+/**  A simple implementation of @c MDCAlertScheming that provides default color,
+ typography and shape schemes, from which customizations can be made. */
+@interface MDCAlertScheme : NSObject <MDCAlertScheming>
+
+/** The color scheme to apply to Dialog. */
+@property(nonnull, readwrite, nonatomic) id<MDCColorScheming> colorScheme;
+
+/** The typography scheme to apply to Dialog. */
+@property(nonnull, readwrite, nonatomic) id<MDCTypographyScheming> typographyScheme;
+
+/** The corner radius to apply to Dialog. */
+@property(readwrite, nonatomic) CGFloat cornerRadius;
+
+@end

--- a/components/Dialogs/src/DialogThemer/MDCAlertScheme.m
+++ b/components/Dialogs/src/DialogThemer/MDCAlertScheme.m
@@ -1,0 +1,30 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCAlertScheme.h"
+
+static const CGFloat kCornerRadius = 4.0f;
+
+@implementation MDCAlertScheme
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _colorScheme = [[MDCSemanticColorScheme alloc] init];
+    _typographyScheme = [[MDCTypographyScheme alloc] init];
+    _cornerRadius = kCornerRadius;
+  }
+  return self;
+}
+@end

--- a/components/Dialogs/src/DialogThemer/MaterialDialogs+DialogThemer.h
+++ b/components/Dialogs/src/DialogThemer/MaterialDialogs+DialogThemer.h
@@ -1,0 +1,15 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCAlertControllerThemer.h"

--- a/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
+++ b/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
@@ -1,0 +1,98 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+import MaterialComponents.MDCAlertScheme
+import MaterialComponents.MDCAlertControllerThemer
+
+class MDCAlertControllerAlertThemerTests: XCTestCase {
+
+  let defaultCornerRadius: CGFloat = 4.0
+  var alertScheme: MDCAlertScheme = MDCAlertScheme()
+
+  override func setUp() {
+    super.setUp()
+
+    alertScheme = MDCAlertScheme()
+  }
+
+  func testDefaultAlertScheme() {
+    // When
+    let alertScheme = MDCAlertScheme()
+
+    // Then
+    XCTAssertEqual(alertScheme.colorScheme.primaryColor, MDCSemanticColorScheme().primaryColor)
+    XCTAssertEqual(alertScheme.typographyScheme.body1, MDCTypographyScheme().body1)
+    XCTAssertEqual(alertScheme.cornerRadius, defaultCornerRadius)
+  }
+
+  func testApplyingAlertSchemeWithCustomColor() {
+    // Given
+    let colorScheme = MDCSemanticColorScheme()
+
+    let alert = MDCAlertController(title: "Title", message: "Message")
+    let alertView = alert.view as! MDCAlertControllerView
+
+    colorScheme.onSurfaceColor = .orange
+    alertScheme.colorScheme = colorScheme
+
+    // When
+    MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
+
+    // Then
+    XCTAssertEqual(alertScheme.colorScheme.onSurfaceColor, colorScheme.onSurfaceColor)
+    XCTAssertEqual(alertView.titleColor,
+                   alertScheme.colorScheme.onSurfaceColor.withAlphaComponent(0.87))
+    XCTAssertNotEqual(alertView.titleColor,
+                   MDCSemanticColorScheme().onSurfaceColor.withAlphaComponent(0.87))
+  }
+    
+  func testApplyingAlertSchemeWithCustomTypography() {
+    // Given
+    let typographyScheme = MDCTypographyScheme()
+    let alert = MDCAlertController(title: "Title", message: "Message")
+    let alertView = alert.view as! MDCAlertControllerView
+
+    let testFont = UIFont.boldSystemFont(ofSize: 55.0)
+    typographyScheme.headline6 = testFont
+    alertScheme.typographyScheme = typographyScheme
+
+    // When
+    MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
+
+    // Then
+    XCTAssertEqual(alertScheme.typographyScheme.headline6, typographyScheme.headline6)
+    XCTAssertEqual(alertView.titleFont, alertScheme.typographyScheme.headline6)
+    XCTAssertNotEqual(alertView.titleFont, MDCTypographyScheme().headline6)
+    XCTAssertEqual(alertView.titleFont, testFont)
+  }
+
+  func testApplyingAlertSchemeWithCustomShape() {
+    // Given
+    let cornerRadius: CGFloat = 33.3
+    let alert = MDCAlertController(title: "Title", message: "Message")
+    let alertView = alert.view as! MDCAlertControllerView
+
+    alertScheme.cornerRadius = cornerRadius
+
+    // When
+    MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
+
+    // Then
+    XCTAssertEqual(alertScheme.cornerRadius, cornerRadius, accuracy: 0.0)
+    XCTAssertEqual(alertView.cornerRadius, cornerRadius, accuracy: 0.0)
+    XCTAssertNotEqual(alertScheme.cornerRadius, defaultCornerRadius, accuracy: 0.0)
+  }
+}


### PR DESCRIPTION
A new Dialog Themer that applies a dialogScheme to a dialog.

The dialogScheme includes the color and typography schemes, plus the [dialog's new corner radius property](https://github.com/material-components/material-components-ios/pull/4988) (no themer yet for shapes, so  this property is directly modified by the themer).

Issue: b/113257098

Note: See examples using the new themer/scheme in a [followup PR #5158](https://github.com/material-components/material-components-ios/pull/5158).

BEFORE:
![dialog - before](https://user-images.githubusercontent.com/2329102/45421250-7a4d5380-b65a-11e8-80f4-d677dc5309c1.png)

AFTER (note the corner radius and themed color & font):
![dialog - after](https://user-images.githubusercontent.com/2329102/45421251-7a4d5380-b65a-11e8-8049-a7c3c9b9249b.png)
