### PR TITLE
[Dialogs] Add/update examples for dialog themer (Closed)

### DIFF
--- a/components/Dialogs/examples/AlertComparison.swift
+++ b/components/Dialogs/examples/AlertComparison.swift
@@ -16,13 +16,16 @@ import Foundation
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialDialogs
 
-
 /// This interface allows a user to present a UIKit Alert Controller and a Material Alert
 /// Controller.
 class DialogsAlertComparison: UIViewController {
 
-  let materialButton = MDCFlatButton()
-  let uikitButton = MDCFlatButton()
+  var colorScheme = MDCSemanticColorScheme()
+  var typographyScheme = MDCTypographyScheme()
+
+  private let materialButton = MDCFlatButton()
+  private let themedButton = MDCFlatButton()
+  private let uikitButton = MDCFlatButton()
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -38,21 +41,44 @@ class DialogsAlertComparison: UIViewController {
 
     NSLayoutConstraint.activate([
       NSLayoutConstraint(item:materialButton,
-                       attribute:.centerX,
-                       relatedBy:.equal,
-                       toItem:self.view,
-                       attribute:.centerX,
-                       multiplier:1.0,
+                       attribute: .centerX,
+                       relatedBy: .equal,
+                       toItem: self.view,
+                       attribute: .centerX,
+                       multiplier: 1.0,
                        constant: 0.0),
-      NSLayoutConstraint(item:materialButton,
-                       attribute:.centerY,
-                       relatedBy:.equal,
-                       toItem:self.view,
-                       attribute:.centerY,
-                       multiplier:1.0,
+      NSLayoutConstraint(item: materialButton,
+                       attribute: .centerY,
+                       relatedBy: .equal,
+                       toItem: self.view,
+                       attribute: .centerY,
+                       multiplier: 1.0,
                        constant: 0.0)
       ])
 
+    themedButton.translatesAutoresizingMaskIntoConstraints = false
+    themedButton.setTitle("Material Alert (Themed)", for: .normal)
+    themedButton.setTitleColor(UIColor(white: 0.1, alpha:1), for: .normal)
+    themedButton.sizeToFit()
+    themedButton.addTarget(self, action: #selector(tapThemed), for: .touchUpInside)
+    self.view.addSubview(themedButton)
+
+    NSLayoutConstraint.activate([
+      NSLayoutConstraint(item: themedButton,
+                         attribute: .centerX,
+                         relatedBy: .equal,
+                         toItem: self.view,
+                         attribute: .centerX,
+                         multiplier: 1.0,
+                         constant: 0.0),
+      NSLayoutConstraint(item:themedButton,
+                         attribute: .top,
+                         relatedBy: .equal,
+                         toItem: materialButton,
+                         attribute: .bottom,
+                         multiplier: 1.0,
+                         constant: 8.0)
+      ])
 
       uikitButton.translatesAutoresizingMaskIntoConstraints = false
       uikitButton.setTitle("UIKit Alert", for: UIControlState())
@@ -62,26 +88,48 @@ class DialogsAlertComparison: UIViewController {
       self.view.addSubview(uikitButton)
 
       NSLayoutConstraint.activate([
-        NSLayoutConstraint(item:uikitButton,
-                           attribute:.centerX,
-                           relatedBy:.equal,
-                           toItem:self.view,
-                           attribute:.centerX,
-                           multiplier:1.0,
+        NSLayoutConstraint(item: uikitButton,
+                           attribute: .centerX,
+                           relatedBy: .equal,
+                           toItem: self.view,
+                           attribute: .centerX,
+                           multiplier: 1.0,
                            constant: 0.0),
-        NSLayoutConstraint(item:uikitButton,
-                           attribute:.top,
-                           relatedBy:.equal,
-                           toItem:materialButton,
-                           attribute:.bottom,
-                           multiplier:1.0,
+        NSLayoutConstraint(item: uikitButton,
+                           attribute: .top,
+                           relatedBy: .equal,
+                           toItem: themedButton,
+                           attribute: .bottom,
+                           multiplier: 1.0,
                            constant: 8.0)
         ])
   }
 
   @objc func tapMaterial(_ sender: Any) {
-    let titleString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur"
-    let messageString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur " +
+    let alertController = createMDCAlertController()
+    self.present(alertController, animated: true, completion: nil)
+  }
+
+  @objc func tapThemed(_ sender: Any) {
+
+    let alertController = createMDCAlertController()
+
+    let scheme = MDCAlertScheme()
+    scheme.colorScheme = self.colorScheme
+    scheme.typographyScheme = self.typographyScheme
+
+    MDCAlertThemer.applyScheme(scheme, to: alertController)
+    self.present(alertController, animated: true, completion: nil)
+  }
+
+  @objc func tapUIKit(_ sender: Any) {
+    let alertController = createUIAlertController()
+    self.present(alertController, animated: true, completion: nil)
+  }
+
+  private var titleAndMessage: (title: String, message: String) {
+    return (title: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur",
+            message: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur " +
       "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
       "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +
       "quis eleifend nisi eros dictum mi. In finibus vulputate eros, in luctus diam auctor in. " +
@@ -100,8 +148,13 @@ class DialogsAlertComparison: UIViewController {
       "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
       "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +
       "quis eleifend nisi eros dictum mi. In finibus vulputate eros, in luctus diam auctor in. "
+    )
+  }
 
-    let alertController = MDCAlertController(title: titleString, message: messageString)
+  private func createMDCAlertController() -> MDCAlertController {
+
+    let texts = titleAndMessage
+    let alertController = MDCAlertController(title: texts.title, message: texts.message)
 
     let acceptAction = MDCAlertAction(title:"Accept") { (_) in print("Accept") }
     alertController.addAction(acceptAction)
@@ -112,33 +165,13 @@ class DialogsAlertComparison: UIViewController {
     let rejectAction = MDCAlertAction(title:"Reject") { (_) in print("Reject") }
     alertController.addAction(rejectAction)
 
-    self.present(alertController, animated: true, completion: nil)
+    return alertController
   }
 
-  @objc func tapUIKit(_ sender: Any) {
-    let titleString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur"
-    let messageString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur " +
-      "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
-      "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +
-      "quis eleifend nisi eros dictum mi. In finibus vulputate eros, in luctus diam auctor in. " +
-      "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
-      "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +
-      "quis eleifend nisi eros dictum mi. In finibus vulputate eros, in luctus diam auctor in. " +
-      "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
-      "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +
-      "quis eleifend nisi eros dictum mi. In finibus vulputate eros, in luctus diam auctor in. " +
-      "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
-      "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +
-      "quis eleifend nisi eros dictum mi. In finibus vulputate eros, in luctus diam auctor in. " +
-      "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
-      "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +
-      "quis eleifend nisi eros dictum mi. In finibus vulputate eros, in luctus diam auctor in. " +
-      "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
-      "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +
-      "quis eleifend nisi eros dictum mi. In finibus vulputate eros, in luctus diam auctor in. "
+  private func createUIAlertController() -> UIAlertController {
 
-    let alertController = UIAlertController(title: titleString,
-                                            message: messageString,
+    let texts = titleAndMessage
+    let alertController = UIAlertController(title: texts.title, message: texts.message,
                                             preferredStyle:.alert)
 
     let acceptAction = UIAlertAction(title:"Accept", style:.default) { (_) in print("Accept") }
@@ -151,7 +184,7 @@ class DialogsAlertComparison: UIViewController {
     let rejectAction = UIAlertAction(title:"Reject", style:.default) { (_) in print("Reject") }
     alertController.addAction(rejectAction)
 
-    self.present(alertController, animated: true, completion: nil)
+    return alertController
   }
 }
 

--- a/components/Dialogs/examples/DialogsAlertViewController.m
+++ b/components/Dialogs/examples/DialogsAlertViewController.m
@@ -15,8 +15,8 @@
 #import "supplemental/DialogsAlertViewControllerSupplemental.h"
 #import "MaterialButtons.h"
 #import "MaterialDialogs.h"
-#import "MaterialDialogs+ColorThemer.h"
-#import "MaterialDialogs+TypographyThemer.h"
+#import "MDCAlertScheme.h"
+#import "MDCAlertThemer.h"
 
 @implementation DialogsAlertViewController
 
@@ -70,9 +70,10 @@
 }
 
 - (void)themeAlertController:(MDCAlertController *)alertController {
-  [MDCAlertColorThemer applySemanticColorScheme:self.colorScheme toAlertController:alertController];
-  [MDCAlertTypographyThemer applyTypographyScheme:self.typographyScheme
-                                toAlertController:alertController];
+  MDCAlertScheme *alertScheme = [[MDCAlertScheme alloc] init];
+  alertScheme.colorScheme = self.colorScheme;
+  alertScheme.typographyScheme = self.typographyScheme;
+  [MDCAlertThemer applyScheme:alertScheme toAlertController:alertController];
 }
 
 - (IBAction)didTapShowAlert {
@@ -366,7 +367,6 @@
 
   MDCAlertController *materialAlertController =
       [MDCAlertController alertControllerWithTitle:titleString message:messageString];
-  [self themeAlertController:materialAlertController];
 
   MDCAlertAction *agreeAaction = [MDCAlertAction actionWithTitle:@"AGREE"
                                                          handler:^(MDCAlertAction *action) {

--- a/components/Dialogs/examples/DialogsLongAlertViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertViewController.swift
@@ -18,6 +18,9 @@ import MaterialComponents.MaterialDialogs
 
 class DialogsLongAlertViewController: UIViewController {
 
+  var colorScheme = MDCSemanticColorScheme()
+  var typographyScheme = MDCTypographyScheme()
+  
   let flatButton = MDCFlatButton()
 
   override func viewDidLoad() {
@@ -64,7 +67,10 @@ class DialogsLongAlertViewController: UIViewController {
     "euismod libero. Aliquam commodo urna vitae massa convallis aliquet."
 
     let materialAlertController = MDCAlertController(title: nil, message: messageString)
-    MDCAlertThemer.applyScheme(MDCAlertScheme(), to: materialAlertController)
+    let alertScheme = MDCAlertScheme()
+    alertScheme.colorScheme = self.colorScheme
+    alertScheme.typographyScheme = self.typographyScheme
+    MDCAlertThemer.applyScheme(alertScheme, to: materialAlertController)
 
     let action = MDCAlertAction(title:"OK") { (_) in print("OK") }
 

--- a/components/Dialogs/examples/DialogsLongAlertViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertViewController.swift
@@ -64,6 +64,7 @@ class DialogsLongAlertViewController: UIViewController {
     "euismod libero. Aliquam commodo urna vitae massa convallis aliquet."
 
     let materialAlertController = MDCAlertController(title: nil, message: messageString)
+    MDCAlertThemer.applyScheme(MDCAlertScheme(), to: materialAlertController)
 
     let action = MDCAlertAction(title:"OK") { (_) in print("OK") }
 

--- a/components/Dialogs/examples/DialogsRoundedCornerViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerViewController.m
@@ -16,6 +16,7 @@
 #import "MaterialButtons.h"
 #import "MaterialDialogs.h"
 #import "MaterialDialogs+DialogThemer.h"
+#import "MDCAlertScheme.h"
 #import "MDCAlertThemer.h"
 
 static const CGFloat kCornerRadius = 24.0f;
@@ -82,9 +83,21 @@ static const CGFloat kCornerRadius = 24.0f;
 @property(nonatomic, strong) MDCFlatButton *presentMDCButton;
 @property(nonatomic, strong) MDCDialogTransitionController *transitionController;
 
+@property(nonatomic, strong, nullable) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong, nullable) MDCTypographyScheme *typographyScheme;
+
 @end
 
 @implementation DialogsRoundedCornerViewController
+
+- (id)init {
+  self = [super init];
+  if (self) {
+    self.colorScheme = [[MDCSemanticColorScheme alloc] init];
+    self.typographyScheme = [[MDCTypographyScheme alloc] init];
+  }
+  return self;
+}
 
 - (void)viewDidLoad {
   [super viewDidLoad];
@@ -167,8 +180,10 @@ static const CGFloat kCornerRadius = 24.0f;
   MDCAlertController *mdcAlertController = [self createMDCAlertController];
 
   // Dialog Theming
-  MDCAlertScheme *scheme = [[MDCAlertScheme alloc] init];
-  [MDCAlertThemer applyScheme:scheme toAlertController:mdcAlertController];
+  MDCAlertScheme *alertScheme = [[MDCAlertScheme alloc] init];
+  alertScheme.colorScheme = self.colorScheme;
+  alertScheme.typographyScheme = self.typographyScheme;
+  [MDCAlertThemer applyScheme:alertScheme toAlertController:mdcAlertController];
   mdcAlertController.cornerRadius = kCornerRadius;
 
   [self presentViewController:mdcAlertController animated:YES completion:NULL];

--- a/components/Dialogs/examples/DialogsRoundedCornerViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerViewController.m
@@ -15,10 +15,16 @@
 #import "DialogsRoundedCornerViewController.h"
 #import "MaterialButtons.h"
 #import "MaterialDialogs.h"
+#import "MaterialDialogs+DialogThemer.h"
+#import "MDCAlertThemer.h"
+
+static const CGFloat kCornerRadius = 24.0f;
 
 @interface DialogsRoundedCornerSimpleController : UIViewController
 
 @property(nonatomic, strong) MDCFlatButton *dismissButton;
+
+@property(nonatomic, readwrite) CGFloat cornerRadius;
 
 @end
 
@@ -42,8 +48,6 @@
            forControlEvents:UIControlEventTouchUpInside];
 
   [self.view addSubview:_dismissButton];
-
-  self.view.layer.cornerRadius = 24.0;
 }
 
 - (void)viewWillLayoutSubviews {
@@ -61,12 +65,21 @@
   [self.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
 }
 
+- (CGFloat)cornerRadius {
+  return self.view.layer.cornerRadius;
+}
+
+- (void)setCornerRadius:(CGFloat)cornerRadius {
+  self.view.layer.cornerRadius = cornerRadius;
+}
+
 @end
 
 
 @interface DialogsRoundedCornerViewController ()
 
 @property(nonatomic, strong) MDCFlatButton *presentButton;
+@property(nonatomic, strong) MDCFlatButton *presentMDCButton;
 @property(nonatomic, strong) MDCDialogTransitionController *transitionController;
 
 @end
@@ -83,7 +96,7 @@
   self.view.backgroundColor = [UIColor whiteColor];
 
   _presentButton = [[MDCFlatButton alloc] initWithFrame:CGRectZero];
-  [_presentButton setTitle:@"Present" forState:UIControlStateNormal];
+  [_presentButton setTitle:@"UIKit Dialog" forState:UIControlStateNormal];
   [_presentButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
   _presentButton.autoresizingMask =
       UIViewAutoresizingFlexibleTopMargin |
@@ -95,6 +108,14 @@
            forControlEvents:UIControlEventTouchUpInside];
 
   [self.view addSubview:_presentButton];
+
+  _presentMDCButton = [[MDCFlatButton alloc] initWithFrame:CGRectZero];
+  [_presentMDCButton setTitle:@"Present Material Dialog" forState:UIControlStateNormal];
+  [_presentMDCButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
+  [_presentMDCButton addTarget:self
+                        action:@selector(didTapPresentMDCDialog:)
+              forControlEvents:UIControlEventTouchUpInside];
+  [self.view addSubview:_presentMDCButton];
 }
 
 - (void)viewWillLayoutSubviews {
@@ -102,16 +123,55 @@
   [_presentButton sizeToFit];
   _presentButton.center = CGPointMake(CGRectGetMidX(self.view.bounds),
                                       CGRectGetMidY(self.view.bounds));
+  [_presentMDCButton sizeToFit];
+  _presentMDCButton.center = CGPointMake(CGRectGetMidX(self.view.bounds),
+                                         _presentButton.center.y +
+                                         _presentButton.frame.size.height + 8.0);
+}
+
+- (MDCAlertController *)createMDCAlertController {
+
+  NSString *title = @"Using Material alert controller?";
+  NSString *message = @"Be careful with modal alerts as they can be annoying if over-used.";
+
+  MDCAlertController *mdcAlertController = [MDCAlertController alertControllerWithTitle:title message:message];
+  [mdcAlertController mdc_setAdjustsFontForContentSizeCategory:true];
+
+  MDCAlertAction *agreeAction = [MDCAlertAction actionWithTitle:@"OK" handler:^(MDCAlertAction * _Nonnull action) {
+    NSLog(@"OK pressed");
+  }];
+  [mdcAlertController addAction:agreeAction];
+
+  return mdcAlertController;
 }
 
 - (IBAction)didTapPresent:(id)sender {
-  UIViewController *viewController =
+  DialogsRoundedCornerSimpleController *viewController =
       [[DialogsRoundedCornerSimpleController alloc] initWithNibName:nil bundle:nil];
 
   viewController.modalPresentationStyle = UIModalPresentationCustom;
   viewController.transitioningDelegate = self.transitionController;
 
+  // sets the dialog's corner radius
+  viewController.cornerRadius = kCornerRadius;
+
+  // ensure shadow/tracking layer matches the dialog's corner radius
+  MDCDialogPresentationController *controller = viewController.mdc_dialogPresentationController;
+  controller.dialogCornerRadius = kCornerRadius;
+
   [self presentViewController:viewController animated:YES completion:NULL];
+}
+
+- (void)didTapPresentMDCDialog:(id)sender {
+
+  MDCAlertController *mdcAlertController = [self createMDCAlertController];
+
+  // Dialog Theming
+  MDCAlertScheme *scheme = [[MDCAlertScheme alloc] init];
+  [MDCAlertThemer applyScheme:scheme toAlertController:mdcAlertController];
+  mdcAlertController.cornerRadius = kCornerRadius;
+
+  [self presentViewController:mdcAlertController animated:YES completion:NULL];
 }
 
 #pragma mark - CatalogByConvention


### PR DESCRIPTION
Adding and updating existing examples that use the [new dialog themer (#5102)](https://github.com/material-components/material-components-ios/pull/5102).

Issue: b/113257098

BEFORE:
![dialog - before](https://user-images.githubusercontent.com/2329102/45421250-7a4d5380-b65a-11e8-80f4-d677dc5309c1.png)

AFTER (note the corner radius and themed color & font):
![dialog - after](https://user-images.githubusercontent.com/2329102/45421251-7a4d5380-b65a-11e8-8049-a7c3c9b9249b.png)

