### PR TITLE
[Tabs] Fix an example bug

### DIFF
--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
@@ -74,7 +74,7 @@ extension TabBarIconSwiftExample {
   }
 
   func setupExampleViews() {
-    view.backgroundColor = colorScheme.backgroundColor
+    view.backgroundColor = UIColor.white
 
     view.addSubview(appBarViewController.view)
     appBarViewController.didMove(toParentViewController: self)

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
@@ -18,6 +18,8 @@
 import UIKit
 
 import MaterialComponents.MaterialAppBar
+import MaterialComponents.MaterialAppBar_ColorThemer
+import MaterialComponents.MaterialAppBar_TypographyThemer
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialButtons_ButtonThemer
 import MaterialComponents.MaterialPalettes
@@ -60,10 +62,11 @@ extension TabBarIconSwiftExample {
     let appBarViewController = MDCAppBarViewController()
 
     self.addChildViewController(appBarViewController)
-    appBarViewController.headerView.backgroundColor = UIColor.white
     appBarViewController.headerView.minMaxHeightIncludesSafeArea = false
     appBarViewController.headerView.minimumHeight = 56 + 72
     appBarViewController.headerView.tintColor = MDCPalette.blue.tint500
+    MDCAppBarColorThemer.applyColorScheme(colorScheme, to: appBarViewController)
+    MDCAppBarTypographyThemer.applyTypographyScheme(typographyScheme, to: appBarViewController)
 
     appBarViewController.headerStackView.bottomBar = self.tabBar
     appBarViewController.headerStackView.setNeedsLayout()
@@ -71,7 +74,7 @@ extension TabBarIconSwiftExample {
   }
 
   func setupExampleViews() {
-    view.backgroundColor = UIColor.white
+    view.backgroundColor = colorScheme.backgroundColor
 
     view.addSubview(appBarViewController.view)
     appBarViewController.didMove(toParentViewController: self)


### PR DESCRIPTION
This changes adds a `MDCAppBarColorThemer` and `MDCAppBarTypographyThemer` to the example. Previously there was a bug where the app bar wasn't the same color as the tab bar this addresses that.

Related to #2408  

| Before | After |
| ------- | ------- |
|![simulator screen shot - iphone x - 2018-09-12 at 11 07 36](https://user-images.githubusercontent.com/7131294/45434318-23f10c80-b67c-11e8-8345-079a4a87b4c8.png)|![simulator screen shot - iphone x - 2018-09-12 at 10 53 44](https://user-images.githubusercontent.com/7131294/45434323-281d2a00-b67c-11e8-9aba-6d6c3734680c.png)|

