### PR TITLE
[Chips] Update example

### DIFF
--- a/components/Chips/examples/ChipsInputExampleViewController.m
+++ b/components/Chips/examples/ChipsInputExampleViewController.m
@@ -28,7 +28,8 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.colorScheme = [[MDCSemanticColorScheme alloc] init];
+    _colorScheme = [[MDCSemanticColorScheme alloc] init];
+    _typographyScheme = [[MDCTypographyScheme alloc] init];
   }
   return self;
 }
@@ -36,7 +37,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.view.backgroundColor = [UIColor lightGrayColor];
+  self.view.backgroundColor = self.colorScheme.backgroundColor;
   
   _chipField = [[MDCChipField alloc] initWithFrame:CGRectZero];
   _chipField.delegate = self;
@@ -49,6 +50,9 @@
   [super viewWillLayoutSubviews];
 
   CGRect frame = CGRectInset(self.view.bounds, 10, 10);
+  if (@available(iOS 11.0, *)) {
+    frame = UIEdgeInsetsInsetRect(frame, self.view.safeAreaInsets);
+  }
   frame.size = [_chipField sizeThatFits:frame.size];
   _chipField.frame = frame;
 }
@@ -60,6 +64,7 @@
 - (void)chipField:(MDCChipField *)chipField didAddChip:(MDCChipView *)chip {
   MDCChipViewScheme *scheme = [[MDCChipViewScheme alloc] init];
   scheme.colorScheme = self.colorScheme;
+  scheme.typographyScheme = self.typographyScheme;
   
   // Every other chip is stroked
   if (chipField.chips.count%2) {

--- a/components/Chips/examples/ChipsInputExampleViewController.m
+++ b/components/Chips/examples/ChipsInputExampleViewController.m
@@ -38,7 +38,7 @@
   [super viewDidLoad];
 
   self.view.backgroundColor = self.colorScheme.backgroundColor;
-  
+
   _chipField = [[MDCChipField alloc] initWithFrame:CGRectZero];
   _chipField.delegate = self;
   _chipField.textField.placeholderLabel.text = @"This is a chip field.";

--- a/components/Chips/examples/ChipsInputExampleViewController.m
+++ b/components/Chips/examples/ChipsInputExampleViewController.m
@@ -42,7 +42,7 @@
   _chipField = [[MDCChipField alloc] initWithFrame:CGRectZero];
   _chipField.delegate = self;
   _chipField.textField.placeholderLabel.text = @"This is a chip field.";
-  _chipField.backgroundColor = [UIColor whiteColor];
+  _chipField.backgroundColor = self.colorScheme.surfaceColor;
   [self.view addSubview:_chipField];
 }
 

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
@@ -66,6 +66,7 @@
 @end
 
 @interface ChipsInputExampleViewController : UIViewController
+@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
 @end
 


### PR DESCRIPTION
Previously the example didn't respect the safe area or use a typography scheme. This addresses both issues and cleans up some code. You previously couldn't see the chip field because it was hidden behind the app bar.

Closes #3708 

| Before | After |
| ------ | ------ |
|![simulator screen shot - iphone x - 2018-09-13 at 16 28 51](https://user-images.githubusercontent.com/7131294/45513977-259cfc00-b772-11e8-89c7-bcfb65825723.png)|![simulator screen shot - iphone x - 2018-09-13 at 16 27 17](https://user-images.githubusercontent.com/7131294/45513995-30579100-b772-11e8-877d-80c191b781e9.png)|
|![simulator screen shot - iphone x - 2018-09-13 at 16 28 57](https://user-images.githubusercontent.com/7131294/45514052-53824080-b772-11e8-969a-be99d248651e.png)|![simulator screen shot - iphone x - 2018-09-13 at 16 27 48](https://user-images.githubusercontent.com/7131294/45514058-5a10b800-b772-11e8-80fc-5abc602190d5.png)|



