### PR TITLE
[BottomSheet] Make `sheetView` a property.

### DIFF
--- a/components/BottomSheet/BUILD
+++ b/components/BottomSheet/BUILD
@@ -35,6 +35,13 @@ mdc_public_objc_library(
 )
 
 mdc_objc_library(
+    name = "privateHeaders",
+    hdrs = glob(["src/private/*.h"]),
+    visibility = ["//visibility:private"],
+    deps = [":BottomSheet"],
+)
+
+mdc_objc_library(
     name = "ShapeThemer",
     srcs = native.glob(["src/ShapeThemer/*.m"]),
     hdrs = native.glob(["src/ShapeThemer/*.h"]),
@@ -60,6 +67,7 @@ mdc_objc_library(
     ],
     deps = [
         ":BottomSheet",
+        ":privateHeaders",
     ],
     visibility = ["//visibility:private"],
 )

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -164,11 +164,12 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
   [coordinator
       animateAlongsideTransition:^(
-          __unused id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+          __unused id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
         self.sheetView.frame = [self frameOfPresentedViewInContainerView];
         [self.sheetView layoutIfNeeded];
         [self updatePreferredSheetHeight];
-      }               completion:nil];
+      }
+                      completion:nil];
 }
 
 - (void)updatePreferredSheetHeight {

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -42,9 +42,12 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 @interface MDCBottomSheetPresentationController () <MDCSheetContainerViewDelegate>
 @end
 
+@interface MDCBottomSheetPresentationController ()
+@property(nonatomic, strong) MDCSheetContainerView *sheetView;
+@end
+
 @implementation MDCBottomSheetPresentationController {
   UIView *_dimmingView;
-  MDCSheetContainerView *_sheetView;
   @private BOOL _scrimIsAccessibilityElement;
   @private NSString *_scrimAccessibilityLabel;
   @private NSString *_scrimAccessibilityHint;
@@ -54,7 +57,7 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 @synthesize delegate;
 
 - (UIView *)presentedView {
-  return _sheetView;
+  return self.sheetView;
 }
 
 - (CGRect)frameOfPresentedViewInContainerView {
@@ -96,14 +99,14 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
     scrollView = MDCBottomSheetGetPrimaryScrollView(self.presentedViewController);
   }
   CGRect sheetFrame = [self frameOfPresentedViewInContainerView];
-  _sheetView = [[MDCSheetContainerView alloc] initWithFrame:sheetFrame
+  self.sheetView = [[MDCSheetContainerView alloc] initWithFrame:sheetFrame
                                                 contentView:self.presentedViewController.view
                                                  scrollView:scrollView];
-  _sheetView.delegate = self;
-  _sheetView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
+  self.sheetView.delegate = self;
+  self.sheetView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
 
   [containerView addSubview:_dimmingView];
-  [containerView addSubview:_sheetView];
+  [containerView addSubview:self.sheetView];
 
   [self updatePreferredSheetHeight];
 
@@ -150,8 +153,8 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
 - (void)preferredContentSizeDidChangeForChildContentContainer:(id<UIContentContainer>)container {
   [super preferredContentSizeDidChangeForChildContentContainer:container];
-  _sheetView.frame = [self frameOfPresentedViewInContainerView];
-  [_sheetView layoutIfNeeded];
+  self.sheetView.frame = [self frameOfPresentedViewInContainerView];
+  [self.sheetView layoutIfNeeded];
   [self updatePreferredSheetHeight];
 }
 
@@ -161,8 +164,8 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
   [coordinator animateAlongsideTransition:
       ^(__unused id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
-        self->_sheetView.frame = [self frameOfPresentedViewInContainerView];
-        [self->_sheetView layoutIfNeeded];
+        self.sheetView.frame = [self frameOfPresentedViewInContainerView];
+        [self.sheetView layoutIfNeeded];
         [self updatePreferredSheetHeight];
       }                        completion:nil];
 }
@@ -172,9 +175,9 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
   // If |preferredSheetHeight| has not been specified, use half of the current height.
   if (MDCCGFloatEqual(preferredContentHeight, 0)) {
-    preferredContentHeight = MDCRound(CGRectGetHeight(_sheetView.frame) / 2);
+    preferredContentHeight = MDCRound(CGRectGetHeight(self.sheetView.frame) / 2);
   }
-  _sheetView.preferredSheetHeight = preferredContentHeight;
+  self.sheetView.preferredSheetHeight = preferredContentHeight;
 }
 
 - (void)dismissPresentedControllerIfNecessary:(UITapGestureRecognizer *)tapRecognizer {

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -100,8 +100,8 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   }
   CGRect sheetFrame = [self frameOfPresentedViewInContainerView];
   self.sheetView = [[MDCSheetContainerView alloc] initWithFrame:sheetFrame
-                                                contentView:self.presentedViewController.view
-                                                 scrollView:scrollView];
+                                                    contentView:self.presentedViewController.view
+                                                     scrollView:scrollView];
   self.sheetView.delegate = self;
   self.sheetView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
 
@@ -162,12 +162,13 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
        withTransitionCoordinator:(id <UIViewControllerTransitionCoordinator>)coordinator {
   [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 
-  [coordinator animateAlongsideTransition:
-      ^(__unused id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+  [coordinator
+      animateAlongsideTransition:^(
+          __unused id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
         self.sheetView.frame = [self frameOfPresentedViewInContainerView];
         [self.sheetView layoutIfNeeded];
         [self updatePreferredSheetHeight];
-      }                        completion:nil];
+      }               completion:nil];
 }
 
 - (void)updatePreferredSheetHeight {


### PR DESCRIPTION
To make testing a bit easier, sheetView can become a property declared
in a class extension.

Part of #4945
