### PR TITLE
[BottomSheet] Use setter for sheet view height.

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -108,7 +108,7 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   [containerView addSubview:_dimmingView];
   [containerView addSubview:self.sheetView];
 
-  [self updatePreferredSheetHeight];
+  [self setPreferredSheetHeight:self.presentedViewController.preferredContentSize.height];
 
   // Add tap handler to dismiss the sheet.
   UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self
@@ -155,7 +155,7 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   [super preferredContentSizeDidChangeForChildContentContainer:container];
   self.sheetView.frame = [self frameOfPresentedViewInContainerView];
   [self.sheetView layoutIfNeeded];
-  [self updatePreferredSheetHeight];
+  [self setPreferredSheetHeight:self.presentedViewController.preferredContentSize.height];
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size
@@ -167,19 +167,24 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
           __unused id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
         self.sheetView.frame = [self frameOfPresentedViewInContainerView];
         [self.sheetView layoutIfNeeded];
-        [self updatePreferredSheetHeight];
+        [self setPreferredSheetHeight:self.presentedViewController.preferredContentSize.height];
       }
                       completion:nil];
 }
 
-- (void)updatePreferredSheetHeight {
-  CGFloat preferredContentHeight = self.presentedViewController.preferredContentSize.height;
+/**
+ Sets the new value of @c sheetView.preferredSheetHeight.
+ If @c preferredContentHeight is non-positive, it will set it to half of sheetView's
+ frame's height.
 
+ @param preferredSheetHeight If positive, the new value for @sheetView.preferredSheetHeight.
+ */
+- (void)setPreferredSheetHeight:(CGFloat) preferredSheetHeight {
   // If |preferredSheetHeight| has not been specified, use half of the current height.
-  if (MDCCGFloatEqual(preferredContentHeight, 0)) {
-    preferredContentHeight = MDCRound(CGRectGetHeight(self.sheetView.frame) / 2);
+  if (MDCCGFloatEqual(preferredSheetHeight, 0)) {
+    preferredSheetHeight = MDCRound(CGRectGetHeight(self.sheetView.frame) / 2);
   }
-  self.sheetView.preferredSheetHeight = preferredContentHeight;
+  self.sheetView.preferredSheetHeight = preferredSheetHeight;
 }
 
 - (void)dismissPresentedControllerIfNecessary:(UITapGestureRecognizer *)tapRecognizer {

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -179,7 +179,7 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
  @param preferredSheetHeight If positive, the new value for @sheetView.preferredSheetHeight.
  */
-- (void)setPreferredSheetHeight:(CGFloat) preferredSheetHeight {
+- (void)setPreferredSheetHeight:(CGFloat)preferredSheetHeight {
   // If |preferredSheetHeight| has not been specified, use half of the current height.
   if (MDCCGFloatEqual(preferredSheetHeight, 0)) {
     preferredSheetHeight = MDCRound(CGRectGetHeight(self.sheetView.frame) / 2);

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
@@ -79,7 +79,7 @@
   self.presentationController.sheetView = self.sheetView;
 }
 
-- (void)testSetPreferredSheetHeightWhenPresentedVCHasZeroPreferredContentSize {
+- (void)testSetPreferredSheetHeightZeroWhenSheetViewHasStandardizedFrame {
   // Given
   CGFloat sheetFrameHeight = 80;
   self.sheetView.frame = CGRectMake(0, 0, 75, sheetFrameHeight);
@@ -91,7 +91,7 @@
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, sheetFrameHeight / 2, 0.001);
 }
 
-- (void)testSetPreferredSheetHeightWhenPresentedVCHasZeroPreferredContentSizeUnstandardFrame {
+- (void)testSetPreferredSheetHeightZeroWhenSheetViewHasUnstandardizedFrame {
   // Given
   CGFloat sheetFrameHeight = -80;
   self.sheetView.frame = CGRectMake(75, 80, -75, sheetFrameHeight);
@@ -104,7 +104,7 @@
                              (CGFloat)fabs(sheetFrameHeight / 2), 0.001);
 }
 
-- (void)testSetPreferredSheetHeightWhenPresentedVCHasPositivePreferredContentSize {
+- (void)testSetPreferredSheetHeightPositiveValue {
   // Given
   CGFloat preferredSheetHeight = 120;
   self.sheetView.frame = CGRectMake(0, 0, 75, 80);
@@ -116,7 +116,7 @@
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, preferredSheetHeight, 0.001);
 }
 
-- (void)testSetPreferredSheetHeightWhenPresentedVCHasNegativePreferredContentSize {
+- (void)testSetPreferredSheetHeightNegativeValue {
   // Given
   CGFloat preferredSheetHeight = -120;
   self.sheetView.frame = CGRectMake(0, 0, 75, -80);

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
@@ -26,17 +26,18 @@
 @end
 
 /**
- A testing double for @c MDCSheetContainerView that allows inspecting the `preferredSheetHeight`
- property directly within the test.
+ A testing double for @c MDCSheetContainerView that allows setting an explicitly-nonstandardized
+ @c frame value.
+
+ @note Although it is possible to retrieve a non-standardized frame or bounds from a UIView object,
+       UIView will standardize the CGRect passed to @c setFrame:. To aid in testing, we turn
+       @c frame into a simple get/set property. We still call up to the super implementation of
+       @c setFrame: in case there are side-effects in UIView.
  */
 @interface FakeSheetView : MDCSheetContainerView
 @end
 
 @implementation FakeSheetView {
-  // Although it is possible to retrieve a non-standardized frame or bounds from a UIView object,
-  // UIView will standardize the CGRect passed to `setFrame`. To aid in testing, we turn `frame`
-  // into a simple get/set property. We still call up to the super implementation of `setFrame`
-  // in case there are side-effects in UIView.
   CGRect _frame;
 }
 
@@ -61,9 +62,9 @@
 - (void)setUp {
   [super setUp];
 
-  // The `_sheetView` is both an input and an output to `setPreferredSheetHeight:`. Its frame is
-  // used to guess the preferredContentHeight of the sheet. Once calculated, it receives an updated
-  // value for `preferredSheetHeight`.
+  // The `sheetView` property is both an input and an output to `setPreferredSheetHeight:`. Its
+  // frame may be used to guess the preferredContentHeight of the sheet. Once calculated, it
+  // receives an updated value for `preferredSheetHeight`.
   self.sheetView = [[FakeSheetView alloc] initWithFrame:CGRectZero
                                             contentView:[[UIView alloc] init]
                                              scrollView:[[UIScrollView alloc] init]];
@@ -72,10 +73,6 @@
   UIViewController *stubPresentingViewController = [[UIViewController alloc] init];
   UIViewController *stubPresentedViewController = [[UIViewController alloc] init];
 
-  // Although we are testing MDCBottomSheetPresentationController, we only care about the behavior
-  // of `-setPreferredSheetHeight` in this test. Because `_sheetView` is an iVar and not a
-  // property that can be exposed in a testing category, we have to write a subclass that employs
-  // KVC to allow setting the value of `_sheetView` to our test double.
   self.presentationController = [[MDCBottomSheetPresentationController alloc]
       initWithPresentedViewController:stubPresentedViewController
              presentingViewController:stubPresentingViewController];


### PR DESCRIPTION
The method `updateSheetViewHeight` had no inputs and no outputs. Since
its purpose it to assign a new value to
`sheetView.preferredSheetHeight`, it should accept a new value and use
fall-back/defaulting behavior if that value is 0.

Part of #4945