### PR TITLE
[Shapes] Bug fix for getting the wrong backgroundColor when shapeGenerator is set.

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -536,6 +536,10 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [self updateBackgroundColor];
 }
 
+- (UIColor *)backgroundColor {
+  return self.layer.shapedBackgroundColor;
+}
+
 - (UIColor *)backgroundColorForState:(UIControlState)state {
   return _backgroundColors[@(state)];
 }

--- a/components/Buttons/tests/unit/ButtonsShapeThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsShapeThemerTests.m
@@ -14,7 +14,6 @@
 
 #import <XCTest/XCTest.h>
 
-#import "MaterialButtons+ButtonThemer.h"
 #import "MaterialButtons+ShapeThemer.h"
 #import "MaterialButtons.h"
 #import "MaterialShapeLibrary.h"
@@ -58,9 +57,15 @@
 }
 
 - (void)testBackgroundColorAfterButtonTheming {
-  MDCButtonScheme *scheme = [[MDCButtonScheme alloc] init];
-  [MDCTextButtonThemer applyScheme:scheme toButton:self.button];
-  XCTAssertEqualObjects([UIColor clearColor], self.button.backgroundColor);
+  // Given
+  UIColor *bgColor = [UIColor blueColor];
+  self.button.backgroundColor = bgColor;
+
+  // When
+  [MDCButtonShapeThemer applyShapeScheme:self.shapeScheme toButton:self.button];
+
+  // Then
+  XCTAssertEqualObjects(bgColor, self.button.backgroundColor);
 }
 
 @end

--- a/components/Buttons/tests/unit/ButtonsShapeThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsShapeThemerTests.m
@@ -14,6 +14,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import "MaterialButtons+ButtonThemer.h"
 #import "MaterialButtons+ShapeThemer.h"
 #import "MaterialButtons.h"
 #import "MaterialShapeLibrary.h"
@@ -54,6 +55,12 @@
   XCTAssertEqualObjects(rect.bottomLeftCorner, self.shapeScheme.smallSurfaceShape.bottomLeftCorner);
   XCTAssertEqualObjects(rect.bottomRightCorner,
                         self.shapeScheme.smallSurfaceShape.bottomRightCorner);
+}
+
+- (void)testBackgroundColorAfterButtonTheming {
+  MDCButtonScheme *scheme = [[MDCButtonScheme alloc] init];
+  [MDCTextButtonThemer applyScheme:scheme toButton:self.button];
+  XCTAssertEqualObjects([UIColor clearColor], self.button.backgroundColor);
 }
 
 @end

--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -126,6 +126,7 @@ mdc_objc_library(
     ],
     deps = [
         ":Chips",
+        ":ChipThemer",
         ":ColorThemer",
         ":FontThemer",
         ":ShapeThemer",

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -315,6 +315,10 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
   [self updateBackgroundColor];
 }
 
+- (UIColor *)backgroundColor {
+  return self.layer.shapedBackgroundColor;
+}
+
 - (void)updateBackgroundColor {
   self.layer.shapedBackgroundColor = [self backgroundColorForState:self.state];
 }

--- a/components/Chips/tests/unit/ChipViewColorThemerTests.m
+++ b/components/Chips/tests/unit/ChipViewColorThemerTests.m
@@ -103,4 +103,11 @@
                         [textColor colorWithAlphaComponent:0.38f]);
 }
 
+- (void)testBackgroundColorAfterColorTheming {
+  self.colorScheme.surfaceColor = [UIColor blueColor];
+  [MDCChipViewColorThemer applyOutlinedVariantWithColorScheme:self.colorScheme
+                                                   toChipView:self.chip];
+  XCTAssertEqualObjects(self.colorScheme.surfaceColor, self.chip.backgroundColor);
+}
+
 @end

--- a/components/Chips/tests/unit/ChipViewShapeThemerTests.m
+++ b/components/Chips/tests/unit/ChipViewShapeThemerTests.m
@@ -14,6 +14,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import "MaterialChips+ChipThemer.h"
 #import "MaterialChips+ShapeThemer.h"
 #import "MaterialChips.h"
 
@@ -53,6 +54,12 @@
   XCTAssertEqualObjects(rect.topRightCorner, corner);
   XCTAssertEqualObjects(rect.bottomLeftCorner, corner);
   XCTAssertEqualObjects(rect.bottomRightCorner, corner);
+}
+
+- (void)testBackgroundColorAfterChipTheming {
+  MDCChipViewScheme *scheme = [[MDCChipViewScheme alloc] init];
+  [MDCChipViewThemer applyOutlinedVariantWithScheme:scheme toChipView:self.chip];
+  XCTAssertEqualObjects(scheme.colorScheme.surfaceColor, self.chip.backgroundColor);
 }
 
 @end


### PR DESCRIPTION
This bug fix resolves issue #5126 

Quoting issue:
"Shape-able components such as Buttons and Chips rely on an `MDCShapedShadowLayer` as their main layer class underlying the view. Due to that, there is new logic for setting and getting the `backgroundColor` and is done through `self.layer.shapedBackgroundColor`. There exists logic in these components for setting the `shapedBackgroundColor` when calling the `backgroundColor` setter. However, when fetching `backgroundColor`, then Button and Chips don't have a getter to fetch `shapedBackgroundColor`. This means that when those components do have a custom shape active, then when fetching the background color, it will not return the correct one."