### PR TITLE
[TextFields] Fix outline text field clear button layout in RTL

### DIFF
--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -482,11 +482,7 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1.f;
 
   // Standard textRect calculation
   UIEdgeInsets textInsets = self.textInsets;
-  if (self.mdf_effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
-    textRect.origin.x += textInsets.right;
-  } else {
-    textRect.origin.x += textInsets.left;
-  }
+  textRect.origin.x += textInsets.left;
   textRect.size.width -= textInsets.left + textInsets.right;
 
   // Adjustments for .leftView, .rightView
@@ -534,7 +530,7 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1.f;
     // If there is a rightView, the clearButton will not be shown.
   } else {
     CGFloat clearButtonWidth = CGRectGetWidth(self.clearButton.bounds);
-    clearButtonWidth += 2 * MDCTextInputClearButtonImageBuiltInPadding;
+    clearButtonWidth += 2 * (MDCTextInputClearButtonImageBuiltInPadding * -1);
 
     // Clear buttons are only shown if there is entered text or programatically set text to clear.
     if (self.text.length > 0) {
@@ -585,15 +581,21 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1.f;
       CGFloat clearButtonWidth = CGRectGetWidth(self.clearButton.bounds);
 
       // The width is adjusted by the padding twice: once for the right side, once for left.
-      clearButtonWidth += 2 * MDCTextInputClearButtonImageBuiltInPadding;
+      CGFloat padding = 2 * (-1 * MDCTextInputClearButtonImageBuiltInPadding);
 
       // The clear button's width is already subtracted from the textRect.width if .always or
       // .unlessEditing.
       switch (self.clearButtonMode) {
         case UITextFieldViewModeUnlessEditing:
+          clearButtonWidth += padding;
           editingRect.size.width += clearButtonWidth;
           break;
         case UITextFieldViewModeWhileEditing:
+          if (self.effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
+            clearButtonWidth += padding;
+          } else {
+            clearButtonWidth -= padding;
+          }
           editingRect.size.width -= clearButtonWidth;
           break;
         default:

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -591,7 +591,8 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1.f;
           editingRect.size.width += clearButtonWidth;
           break;
         case UITextFieldViewModeWhileEditing:
-          if (self.effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
+          if (self.effectiveUserInterfaceLayoutDirection ==
+              UIUserInterfaceLayoutDirectionRightToLeft) {
             clearButtonWidth += padding;
           } else {
             clearButtonWidth -= padding;

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -530,7 +530,7 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1.f;
     // If there is a rightView, the clearButton will not be shown.
   } else {
     CGFloat clearButtonWidth = CGRectGetWidth(self.clearButton.bounds);
-    clearButtonWidth += 2 * (MDCTextInputClearButtonImageBuiltInPadding * -1);
+    clearButtonWidth += 2 * (-1 * MDCTextInputClearButtonImageBuiltInPadding);
 
     // Clear buttons are only shown if there is entered text or programatically set text to clear.
     if (self.text.length > 0) {

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -591,7 +591,7 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1.f;
           editingRect.size.width += clearButtonWidth;
           break;
         case UITextFieldViewModeWhileEditing:
-          if (self.effectiveUserInterfaceLayoutDirection ==
+          if (self.mdf_effectiveUserInterfaceLayoutDirection ==
               UIUserInterfaceLayoutDirectionRightToLeft) {
             clearButtonWidth += padding;
           } else {

--- a/components/TextFields/src/MDCTextInputControllerFilled.m
+++ b/components/TextFields/src/MDCTextInputControllerFilled.m
@@ -181,7 +181,7 @@ static CGFloat _underlineHeightNormalDefault =
 
   textInsets.bottom = [self beneathInputPadding] + [self underlineOffset];
 
-  if (self.textInput.effectiveUserInterfaceLayoutDirection ==
+  if (self.textInput.mdf_effectiveUserInterfaceLayoutDirection ==
       UIUserInterfaceLayoutDirectionRightToLeft) {
     textInsets.left = MDCTextInputControllerFilledHalfPadding;
     textInsets.right = MDCTextInputControllerFilledFullPadding;

--- a/components/TextFields/src/MDCTextInputControllerFilled.m
+++ b/components/TextFields/src/MDCTextInputControllerFilled.m
@@ -181,8 +181,14 @@ static CGFloat _underlineHeightNormalDefault =
 
   textInsets.bottom = [self beneathInputPadding] + [self underlineOffset];
 
-  textInsets.left = MDCTextInputControllerFilledFullPadding;
-  textInsets.right = MDCTextInputControllerFilledHalfPadding;
+  if (self.textInput.effectiveUserInterfaceLayoutDirection ==
+      UIUserInterfaceLayoutDirectionRightToLeft) {
+    textInsets.left = MDCTextInputControllerFilledHalfPadding;
+    textInsets.right = MDCTextInputControllerFilledFullPadding;
+  } else {
+    textInsets.left = MDCTextInputControllerFilledFullPadding;
+    textInsets.right = MDCTextInputControllerFilledHalfPadding;
+  }
 
   return textInsets;
 }


### PR DESCRIPTION
I previously issued https://github.com/material-components/material-components-ios/pull/4974, but it only fixed the issue for filled text fields.

I also created https://github.com/material-components/material-components-ios/issues/5128 to refactor RTL logic in TextFields, because it exists some places and not others, and where it does exist it could probably be made less confusing.

Here's are some screenshots:
RTL outlined:
![rtl_outlined](https://user-images.githubusercontent.com/8020010/45557677-284c2f80-b80c-11e8-919c-c46f837d23d6.png)
RTL filled:
![rtl_filled](https://user-images.githubusercontent.com/8020010/45557678-284c2f80-b80c-11e8-8d96-88e413baa7c1.png)
LTR outlined:
![ltr_outlined](https://user-images.githubusercontent.com/8020010/45557679-284c2f80-b80c-11e8-824e-407025ee68b0.png)
LTR filled:
![ltr_filled](https://user-images.githubusercontent.com/8020010/45557680-284c2f80-b80c-11e8-921a-86f7a122116c.png)
