### PR TITLE
[Chips] Add client the ability to delete chips in a chip field

### DIFF
--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -54,6 +54,13 @@ mdc_objc_library(
 )
 
 mdc_objc_library(
+    name = "privateHeaders",
+    hdrs = glob(["src/*.h"]),
+    visibility = ["//visibility:private"],
+    deps = [":Chips"],
+)
+
+mdc_objc_library(
     name = "FontThemer",
     srcs = native.glob(["src/FontThemer/*.m"]),
     hdrs = native.glob(["src/FontThemer/*.h"]),
@@ -130,6 +137,7 @@ mdc_objc_library(
         ":ShapeThemer",
         ":TypographyThemer",
         ":private",
+        ":privateHeaders",
         "//components/TextFields:private",
         "//components/private/ShapeLibrary",
     ],

--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -92,7 +92,6 @@ mdc_objc_library(
     visibility = ["//visibility:public"],
 )
 
-
 mdc_objc_library(
     name = "TypographyThemer",
     srcs = native.glob(["src/TypographyThemer/*.m"]),
@@ -131,18 +130,10 @@ mdc_objc_library(
         ":ShapeThemer",
         ":TypographyThemer",
         ":private",
-        ":privateImplemenation",
         "//components/TextFields:private",
         "//components/private/ShapeLibrary",
     ],
     visibility = ["//visibility:private"],
-)
-
-mdc_objc_library(
-    name = "privateImplemenation",
-    srcs = glob(["src/*.m"]),
-    visibility = ["//visibility:private"],
-    deps = [":Chips"],
 )
 
 mdc_unit_test_suite(

--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -131,10 +131,18 @@ mdc_objc_library(
         ":ShapeThemer",
         ":TypographyThemer",
         ":private",
+        ":privateImplemenation",
         "//components/TextFields:private",
         "//components/private/ShapeLibrary",
     ],
     visibility = ["//visibility:private"],
+)
+
+mdc_objc_library(
+    name = "privateImplemenation",
+    srcs = glob(["src/*.m"]),
+    visibility = ["//visibility:private"],
+    deps = [":Chips"],
 )
 
 mdc_unit_test_suite(

--- a/components/Chips/README.md
+++ b/components/Chips/README.md
@@ -307,13 +307,13 @@ Enabling this flag will add 24x24 touch targets within the chip view. This goes 
 #### Swift
 ```swift
 let chipField = MDCChipField()
-chipField.enableChipsThatDelete = true
+chipField.showChipsDeleteButton = true
 ```
 
 #### Objective-C
 ```objc
 MDCChipField *chipField = [[MDCChipField alloc] init];
-chipField.enableChipsThatDelete = YES;
+chipField.showChipsDeleteButton = YES;
 ```
 <!--</div>-->
 

--- a/components/Chips/README.md
+++ b/components/Chips/README.md
@@ -44,6 +44,8 @@ Chips are compact elements that represent an input, attribute, or action.
   - [Stateful properties](#stateful-properties)
   - [Selected Image View](#selected-image-view)
   - [Padding](#padding)
+- [Behavioral flags](#behavioral-flags)
+  - [Accessibility](#accessibility)
 - [Examples](#examples)
   - [Create a single Chip](#create-a-single-chip)
 - [Extensions](#extensions)
@@ -287,6 +289,33 @@ ensure your chips look correct whether or not they have an image and/or accessor
 uses these property to determine `intrinsicContentSize` and `sizeThatFits`.
 
 - - -
+
+
+## Behavioral flags
+
+<!-- Extracted from docs/enable-chips-that-delete.md -->
+
+If within your `MDCChipField` you want chips that can be deleted follow these steps.
+
+### Accessibility
+
+Enabling this flag will add 24x24 touch targets within the chip view. This goes against Google's recommended 
+48x48 touch targets. We recommend if you enable this behavior your associate it with a `MDCSnackbar` or 
+`MDCDialog` to confirm allow the user to confirm their behavior.
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+let chipField = MDCChipField()
+chipField.enableChipsThatDelete = true
+```
+
+#### Objective-C
+```objc
+MDCChipField *chipField = [[MDCChipField alloc] init];
+chipField.enableChipsThatDelete = YES;
+```
+<!--</div>-->
 
 
 ## Examples

--- a/components/Chips/docs/README.md
+++ b/components/Chips/docs/README.md
@@ -22,6 +22,10 @@ Chips are compact elements that represent an input, attribute, or action.
 
 - [Tips](tips.md)
 
+## Behavioral flags
+
+- [Enable chips that delete](enable-chips-that-delete.md)
+
 ## Examples
 
 - [Examples](Examples.md)

--- a/components/Chips/docs/enable-chips-that-delete.md
+++ b/components/Chips/docs/enable-chips-that-delete.md
@@ -1,0 +1,21 @@
+If within your `MDCChipField` you want chips that can be deleted follow these steps.
+
+### Accessibility
+
+Enabling this flag will add 24x24 touch targets within the chip view. This goes against Google's recommended 
+48x48 touch targets. We recommend if you enable this behavior your associate it with a `MDCSnackbar` or 
+`MDCDialog` to confirm allow the user to confirm their behavior.
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+let chipField = MDCChipField()
+chipField.enableChipsThatDelete = true
+```
+
+#### Objective-C
+```objc
+MDCChipField *chipField = [[MDCChipField alloc] init];
+chipField.enableChipsThatDelete = YES;
+```
+<!--</div>-->

--- a/components/Chips/docs/enable-chips-that-delete.md
+++ b/components/Chips/docs/enable-chips-that-delete.md
@@ -10,12 +10,12 @@ Enabling this flag will add 24x24 touch targets within the chip view. This goes 
 #### Swift
 ```swift
 let chipField = MDCChipField()
-chipField.enableChipsThatDelete = true
+chipField.showChipsDeleteButton = true
 ```
 
 #### Objective-C
 ```objc
 MDCChipField *chipField = [[MDCChipField alloc] init];
-chipField.enableChipsThatDelete = YES;
+chipField.showChipsDeleteButton = YES;
 ```
 <!--</div>-->

--- a/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
+++ b/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
@@ -40,7 +40,7 @@ class ChipsFieldDeleteEnabledViewController : UIViewController, MDCChipFieldDele
     chipField.delegate = self
     chipField.textField.placeholderLabel.text = "This is a chip field."
     chipField.backgroundColor = colorScheme.surfaceColor
-    chipField.enableChipsThatDelete = true
+    chipField.showChipsDeleteButton = true
     view.addSubview(chipField)
   }
 

--- a/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
+++ b/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
@@ -1,0 +1,81 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+import MaterialComponents.MaterialChips
+import MaterialComponents.MaterialChips_ChipThemer
+import MaterialComponents.MaterialTextFields
+
+class ChipsFieldDeleteEnabledViewController : UIViewController, MDCChipFieldDelegate {
+  var colorScheme = MDCSemanticColorScheme()
+  var typographyScheme = MDCTypographyScheme()
+  var chipField = MDCChipField()
+
+  init() {
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  @available(*, unavailable)
+  required init?(coder aDecoder: NSCoder) {
+    super.init(coder: aDecoder)
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    view.backgroundColor = colorScheme.backgroundColor
+    chipField.frame = .zero
+    chipField.delegate = self
+    chipField.textField.placeholderLabel.text = "This is a chip field."
+    chipField.backgroundColor = colorScheme.surfaceColor
+    chipField.enableChipsThatDelete = true
+    view.addSubview(chipField)
+  }
+
+  override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+
+    var frame = view.bounds
+    if #available(iOS 11.0, *) {
+      frame = UIEdgeInsetsInsetRect(frame, view.safeAreaInsets)
+    }
+    frame.size = chipField.sizeThatFits(frame.size)
+    chipField.frame = frame
+  }
+
+  func chipFieldHeightDidChange(_ chipField: MDCChipField) {
+    view.layoutIfNeeded()
+  }
+
+  func chipField(_ chipField: MDCChipField, didAddChip chip: MDCChipView) {
+    let scheme = MDCChipViewScheme()
+    scheme.colorScheme = colorScheme
+    scheme.typographyScheme = typographyScheme
+    MDCChipViewThemer.applyScheme(scheme, to: chip)
+    chip.sizeToFit()
+    let chipVerticalInset = min(0, chip.bounds.height - 48 / 2)
+    chip.hitAreaInsets = UIEdgeInsetsMake(chipVerticalInset, 0, chipVerticalInset, 0)
+  }
+}
+// MARK - Catalog by Convention
+extension ChipsFieldDeleteEnabledViewController {
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs" : ["Chips", "Chips Input Delete Enabled (Swift)"],
+      "primaryDemo" : false,
+      "presentable" : false,
+    ]
+  }
+}

--- a/components/Chips/src/MDCChipField.h
+++ b/components/Chips/src/MDCChipField.h
@@ -116,6 +116,15 @@ typedef NS_OPTIONS(NSUInteger, MDCChipFieldDelimiter) {
 @property(nonatomic, assign) UIEdgeInsets contentEdgeInsets;
 
 /**
+ Enabling this property allows chips to be deleted by tapping on them.
+ 
+ @note This does not support the 48x48 touch targets that Google recommends. We recommend if this
+ behavior is enabled that a snackbar or dialog are used as well to allow the user to confirm if they
+ want to delete the chip.
+ */
+@property(nonatomic) BOOL enableChipsThatDelete;
+
+/**
  Adds a chip to the chip field.
 
  @param chip The chip to add to the field.

--- a/components/Chips/src/MDCChipField.h
+++ b/components/Chips/src/MDCChipField.h
@@ -86,6 +86,15 @@ typedef NS_OPTIONS(NSUInteger, MDCChipFieldDelimiter) {
 @property(nonatomic, assign) BOOL showPlaceholderWithChips;
 
 /**
+ Enabling this property allows chips to be deleted by tapping on them.
+
+ @note This does not support the 48x48 touch targets that Google recommends. We recommend if this
+ behavior is enabled that a snackbar or dialog are used as well to allow the user to confirm if they
+ want to delete the chip.
+ */
+@property(nonatomic) BOOL showChipsDeleteButton;
+
+/**
  The delimiter used to create chips in the text field. Uses default value
  MDCChipFieldDelimiterDefault if no delimiter is set.
  */
@@ -114,15 +123,6 @@ typedef NS_OPTIONS(NSUInteger, MDCChipFieldDelimiter) {
  Default is |kMDCChipFieldDefaultContentEdgeInsets|.
  */
 @property(nonatomic, assign) UIEdgeInsets contentEdgeInsets;
-
-/**
- Enabling this property allows chips to be deleted by tapping on them.
-
- @note This does not support the 48x48 touch targets that Google recommends. We recommend if this
- behavior is enabled that a snackbar or dialog are used as well to allow the user to confirm if they
- want to delete the chip.
- */
-@property(nonatomic) BOOL enableChipsThatDelete;
 
 /**
  Adds a chip to the chip field.

--- a/components/Chips/src/MDCChipField.h
+++ b/components/Chips/src/MDCChipField.h
@@ -117,7 +117,7 @@ typedef NS_OPTIONS(NSUInteger, MDCChipFieldDelimiter) {
 
 /**
  Enabling this property allows chips to be deleted by tapping on them.
- 
+
  @note This does not support the 48x48 touch targets that Google recommends. We recommend if this
  behavior is enabled that a snackbar or dialog are used as well to allow the user to confirm if they
  want to delete the chip.

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -452,78 +452,78 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
                                   MDCFloor((frame.size.height - 2) * 0.90909f + 0.5f));
   UIBezierPath *ic_clear_path = [UIBezierPath bezierPath];
   [ic_clear_path
-      moveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50000f * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)];
+    moveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50000f * innerBounds.size.width,
+                            CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)];
   [ic_clear_path
-      addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 1.00000f * innerBounds.size.width,
-                                  CGRectGetMinY(innerBounds) + 0.50000f * innerBounds.size.height)
-      controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 0.77600f * innerBounds.size.width,
-                                CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)
-      controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 1.00000f * innerBounds.size.width,
-                                CGRectGetMinY(innerBounds) + 0.22400f * innerBounds.size.height)];
+    addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 1.00000f * innerBounds.size.width,
+                                CGRectGetMinY(innerBounds) + 0.50000f * innerBounds.size.height)
+    controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 0.77600f * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)
+    controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 1.00000f * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + 0.22400f * innerBounds.size.height)];
   [ic_clear_path
-      addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50000f * innerBounds.size.width,
-                                  CGRectGetMinY(innerBounds) + 1.00000f * innerBounds.size.height)
-      controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 1.00000f * innerBounds.size.width,
-                                CGRectGetMinY(innerBounds) + 0.77600f * innerBounds.size.height)
-      controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 0.77600f * innerBounds.size.width,
-                                CGRectGetMinY(innerBounds) + 1.00000f * innerBounds.size.height)];
-  [ic_clear_path
-      addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.00000f * innerBounds.size.width,
-                                  CGRectGetMinY(innerBounds) + 0.50000f * innerBounds.size.height)
-      controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 0.22400f * innerBounds.size.width,
+    addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50000f * innerBounds.size.width,
                                 CGRectGetMinY(innerBounds) + 1.00000f * innerBounds.size.height)
-      controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 0.00000f * innerBounds.size.width,
-                                CGRectGetMinY(innerBounds) + 0.77600f * innerBounds.size.height)];
+    controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 1.00000f * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + 0.77600f * innerBounds.size.height)
+    controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 0.77600f * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + 1.00000f * innerBounds.size.height)];
   [ic_clear_path
-      addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50000f * innerBounds.size.width,
-                                  CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)
-      controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 0.00000f * innerBounds.size.width,
-                                CGRectGetMinY(innerBounds) + 0.22400f * innerBounds.size.height)
-      controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 0.22400f * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)];
+    addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.00000f * innerBounds.size.width,
+                                CGRectGetMinY(innerBounds) + 0.50000f * innerBounds.size.height)
+    controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 0.22400f * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + 1.00000f * innerBounds.size.height)
+    controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 0.00000f * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + 0.77600f * innerBounds.size.height)];
+  [ic_clear_path
+    addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50000f * innerBounds.size.width,
+                                CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)
+    controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 0.00000f * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + 0.22400f * innerBounds.size.height)
+    controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 0.22400f * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)];
   [ic_clear_path closePath];
   [ic_clear_path
-      moveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.73417f * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + 0.31467f * innerBounds.size.height)];
+    moveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.73417f * innerBounds.size.width,
+                            CGRectGetMinY(innerBounds) + 0.31467f * innerBounds.size.height)];
   [ic_clear_path
-      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.68700f * innerBounds.size.width,
-                                 CGRectGetMinY(innerBounds) + 0.26750f * innerBounds.size.height)];
+    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.68700f * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + 0.26750f * innerBounds.size.height)];
   [ic_clear_path
-      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50083f * innerBounds.size.width,
-                                 CGRectGetMinY(innerBounds) + 0.45367f * innerBounds.size.height)];
+    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50083f * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + 0.45367f * innerBounds.size.height)];
   [ic_clear_path
-      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.31467f * innerBounds.size.width,
-                                 CGRectGetMinY(innerBounds) + 0.26750f * innerBounds.size.height)];
+    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.31467f * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + 0.26750f * innerBounds.size.height)];
   [ic_clear_path
-      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.26750f * innerBounds.size.width,
-                                 CGRectGetMinY(innerBounds) + 0.31467f * innerBounds.size.height)];
+    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.26750f * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + 0.31467f * innerBounds.size.height)];
   [ic_clear_path
-      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.45367f * innerBounds.size.width,
-                                 CGRectGetMinY(innerBounds) + 0.50083f * innerBounds.size.height)];
+    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.45367f * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + 0.50083f * innerBounds.size.height)];
   [ic_clear_path
-      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.26750f * innerBounds.size.width,
-                                 CGRectGetMinY(innerBounds) + 0.68700f * innerBounds.size.height)];
+    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.26750f * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + 0.68700f * innerBounds.size.height)];
   [ic_clear_path
-      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.31467f * innerBounds.size.width,
-                                 CGRectGetMinY(innerBounds) + 0.73417f * innerBounds.size.height)];
+    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.31467f * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + 0.73417f * innerBounds.size.height)];
   [ic_clear_path
-      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50083f * innerBounds.size.width,
-                                 CGRectGetMinY(innerBounds) + 0.54800f * innerBounds.size.height)];
+    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50083f * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + 0.54800f * innerBounds.size.height)];
   [ic_clear_path
-      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.68700f * innerBounds.size.width,
-                                 CGRectGetMinY(innerBounds) + 0.73417f * innerBounds.size.height)];
+    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.68700f * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + 0.73417f * innerBounds.size.height)];
   [ic_clear_path
-      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.73417f * innerBounds.size.width,
-                                 CGRectGetMinY(innerBounds) + 0.68700f * innerBounds.size.height)];
+    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.73417f * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + 0.68700f * innerBounds.size.height)];
   [ic_clear_path
-      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.54800f * innerBounds.size.width,
-                                 CGRectGetMinY(innerBounds) + 0.50083f * innerBounds.size.height)];
+    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.54800f * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + 0.50083f * innerBounds.size.height)];
   [ic_clear_path
-      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.73417f * innerBounds.size.width,
-                                 CGRectGetMinY(innerBounds) + 0.31467f * innerBounds.size.height)];
+    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.73417f * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + 0.31467f * innerBounds.size.height)];
   [ic_clear_path closePath];
-  
+
   return ic_clear_path;
 }
 

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -434,8 +434,8 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
 }
 
 - (UIImage *)drawClearButton {
-  CGSize clearButtonSize = CGSizeMake(MDCChipFieldClearImageSquareWidthHeight,
-                                      MDCChipFieldClearImageSquareWidthHeight);
+  CGSize clearButtonSize =
+      CGSizeMake(MDCChipFieldClearImageSquareWidthHeight, MDCChipFieldClearImageSquareWidthHeight);
 
   CGRect bounds = CGRectMake(0, 0, clearButtonSize.width, clearButtonSize.height);
   UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0);

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -398,7 +398,7 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
   if (strippedTitle.length > 0) {
     MDCChipView *chip = [[MDCChipView alloc] init];
     chip.titleLabel.text = strippedTitle;
-    if (self.enableChipsThatDelete) {
+    if (self.showChipsDeleteButton) {
       [self addClearButtonToChip:chip];
     }
     BOOL shouldAddChip = YES;

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -16,6 +16,7 @@
 
 #import <MDFInternationalization/MDFInternationalization.h>
 
+#import "MaterialMath.h"
 #import "MaterialTextFields.h"
 
 static NSString *const MDCChipFieldTextFieldKey = @"textField";
@@ -35,6 +36,7 @@ static const CGFloat MDCChipFieldVerticalInset = 8.f;
 static const CGFloat MDCChipFieldIndent = 4.f;
 static const CGFloat MDCChipFieldHorizontalMargin = 4.f;
 static const CGFloat MDCChipFieldVerticalMargin = 5.f;
+static const CGFloat MDCChipFieldClearButtonImageSquareWidthHeight = 24.f;
 static const UIKeyboardType MDCChipFieldDefaultKeyboardType = UIKeyboardTypeEmailAddress;
 
 const CGFloat MDCChipFieldDefaultMinTextFieldWidth = 60.f;
@@ -396,6 +398,9 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
   if (strippedTitle.length > 0) {
     MDCChipView *chip = [[MDCChipView alloc] init];
     chip.titleLabel.text = strippedTitle;
+    if (self.enableChipsThatDelete) {
+      [self addClearButtonToChip:chip];
+    }
     BOOL shouldAddChip = YES;
     if ([self.delegate respondsToSelector:@selector(chipField:shouldAddChip:)]) {
       shouldAddChip = [self.delegate chipField:self shouldAddChip:chip];
@@ -407,6 +412,126 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
   } else {
     [self clearTextInput];
   }
+}
+
+- (void)addClearButtonToChip:(MDCChipView *)chip {
+  UIControl *clearButton = [[UIControl alloc] init];
+  CGFloat widthAndHeight = MDCChipFieldClearButtonImageSquareWidthHeight;
+  clearButton.frame = CGRectMake(0, 0, widthAndHeight, widthAndHeight);
+  clearButton.layer.cornerRadius = widthAndHeight / 2;
+  UIImageView *clearImageView = [[UIImageView alloc] initWithImage:[self drawClearButton]];
+  clearImageView.frame = clearButton.frame;
+  clearButton.tintColor = [UIColor.blackColor colorWithAlphaComponent:0.6f];
+  [clearButton addSubview:clearImageView];
+  chip.accessoryView = clearButton;
+  [clearButton addTarget:self
+                  action:@selector(deleteChip:)
+        forControlEvents:UIControlEventTouchUpInside];
+}
+
+- (UIImage *)drawClearButton {
+  CGSize clearButtonSize = CGSizeMake(MDCChipFieldClearButtonImageSquareWidthHeight,
+                                      MDCChipFieldClearButtonImageSquareWidthHeight);
+
+  CGRect bounds = CGRectMake(0, 0, clearButtonSize.width, clearButtonSize.height);
+  UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0);
+  [UIColor.grayColor setFill];
+  [MDCPathForClearButtonImageFrame(bounds) fill];
+  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+
+  image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+  return image;
+}
+
+static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
+  // GENERATED CODE
+
+  CGRect innerBounds = CGRectMake(CGRectGetMinX(frame) + 2, CGRectGetMinY(frame) + 2,
+                                  MDCFloor((frame.size.width - 2) * 0.90909f + 0.5f),
+                                  MDCFloor((frame.size.height - 2) * 0.90909f + 0.5f));
+  UIBezierPath *ic_clear_path = [UIBezierPath bezierPath];
+  [ic_clear_path
+      moveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50000f * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)];
+  [ic_clear_path
+      addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 1.00000f * innerBounds.size.width,
+                                  CGRectGetMinY(innerBounds) + 0.50000f * innerBounds.size.height)
+      controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 0.77600f * innerBounds.size.width,
+                                CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)
+      controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 1.00000f * innerBounds.size.width,
+                                CGRectGetMinY(innerBounds) + 0.22400f * innerBounds.size.height)];
+  [ic_clear_path
+      addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50000f * innerBounds.size.width,
+                                  CGRectGetMinY(innerBounds) + 1.00000f * innerBounds.size.height)
+      controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 1.00000f * innerBounds.size.width,
+                                CGRectGetMinY(innerBounds) + 0.77600f * innerBounds.size.height)
+      controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 0.77600f * innerBounds.size.width,
+                                CGRectGetMinY(innerBounds) + 1.00000f * innerBounds.size.height)];
+  [ic_clear_path
+      addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.00000f * innerBounds.size.width,
+                                  CGRectGetMinY(innerBounds) + 0.50000f * innerBounds.size.height)
+      controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 0.22400f * innerBounds.size.width,
+                                CGRectGetMinY(innerBounds) + 1.00000f * innerBounds.size.height)
+      controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 0.00000f * innerBounds.size.width,
+                                CGRectGetMinY(innerBounds) + 0.77600f * innerBounds.size.height)];
+  [ic_clear_path
+      addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50000f * innerBounds.size.width,
+                                  CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)
+      controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 0.00000f * innerBounds.size.width,
+                                CGRectGetMinY(innerBounds) + 0.22400f * innerBounds.size.height)
+      controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 0.22400f * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)];
+  [ic_clear_path closePath];
+  [ic_clear_path
+      moveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.73417f * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + 0.31467f * innerBounds.size.height)];
+  [ic_clear_path
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.68700f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.26750f * innerBounds.size.height)];
+  [ic_clear_path
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50083f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.45367f * innerBounds.size.height)];
+  [ic_clear_path
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.31467f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.26750f * innerBounds.size.height)];
+  [ic_clear_path
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.26750f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.31467f * innerBounds.size.height)];
+  [ic_clear_path
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.45367f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.50083f * innerBounds.size.height)];
+  [ic_clear_path
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.26750f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.68700f * innerBounds.size.height)];
+  [ic_clear_path
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.31467f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.73417f * innerBounds.size.height)];
+  [ic_clear_path
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50083f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.54800f * innerBounds.size.height)];
+  [ic_clear_path
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.68700f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.73417f * innerBounds.size.height)];
+  [ic_clear_path
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.73417f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.68700f * innerBounds.size.height)];
+  [ic_clear_path
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.54800f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.50083f * innerBounds.size.height)];
+  [ic_clear_path
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.73417f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.31467f * innerBounds.size.height)];
+  [ic_clear_path closePath];
+  
+  return ic_clear_path;
+}
+
+- (void)deleteChip:(id)sender {
+  UIControl *deleteButton = (UIControl *)sender;
+  MDCChipView *chip = (MDCChipView *)deleteButton.superview;
+  [self removeChip:chip];
+  [self clearTextInput];
 }
 
 - (void)notifyDelegateIfSizeNeedsToBeUpdated {

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -452,76 +452,76 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
                                   MDCFloor((frame.size.height - 2) * 0.90909f + 0.5f));
   UIBezierPath *ic_clear_path = [UIBezierPath bezierPath];
   [ic_clear_path
-    moveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50000f * innerBounds.size.width,
-                            CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)];
-  [ic_clear_path
-    addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 1.00000f * innerBounds.size.width,
-                                CGRectGetMinY(innerBounds) + 0.50000f * innerBounds.size.height)
-    controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 0.77600f * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)
-    controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 1.00000f * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + 0.22400f * innerBounds.size.height)];
-  [ic_clear_path
-    addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50000f * innerBounds.size.width,
-                                CGRectGetMinY(innerBounds) + 1.00000f * innerBounds.size.height)
-    controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 1.00000f * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + 0.77600f * innerBounds.size.height)
-    controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 0.77600f * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + 1.00000f * innerBounds.size.height)];
-  [ic_clear_path
-    addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.00000f * innerBounds.size.width,
-                                CGRectGetMinY(innerBounds) + 0.50000f * innerBounds.size.height)
-    controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 0.22400f * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + 1.00000f * innerBounds.size.height)
-    controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 0.00000f * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + 0.77600f * innerBounds.size.height)];
-  [ic_clear_path
-    addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50000f * innerBounds.size.width,
-                                CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)
-    controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 0.00000f * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + 0.22400f * innerBounds.size.height)
-    controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 0.22400f * innerBounds.size.width,
+      moveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50000f * innerBounds.size.width,
                               CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)];
+  [ic_clear_path
+      addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 1.00000f * innerBounds.size.width,
+                                  CGRectGetMinY(innerBounds) + 0.50000f * innerBounds.size.height)
+        controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 0.77600f * innerBounds.size.width,
+                                  CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)
+        controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 1.00000f * innerBounds.size.width,
+                                  CGRectGetMinY(innerBounds) + 0.22400f * innerBounds.size.height)];
+  [ic_clear_path
+      addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50000f * innerBounds.size.width,
+                                  CGRectGetMinY(innerBounds) + 1.00000f * innerBounds.size.height)
+        controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 1.00000f * innerBounds.size.width,
+                                  CGRectGetMinY(innerBounds) + 0.77600f * innerBounds.size.height)
+        controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 0.77600f * innerBounds.size.width,
+                                  CGRectGetMinY(innerBounds) + 1.00000f * innerBounds.size.height)];
+  [ic_clear_path
+      addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.00000f * innerBounds.size.width,
+                                  CGRectGetMinY(innerBounds) + 0.50000f * innerBounds.size.height)
+        controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 0.22400f * innerBounds.size.width,
+                                  CGRectGetMinY(innerBounds) + 1.00000f * innerBounds.size.height)
+        controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 0.00000f * innerBounds.size.width,
+                                  CGRectGetMinY(innerBounds) + 0.77600f * innerBounds.size.height)];
+  [ic_clear_path
+      addCurveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50000f * innerBounds.size.width,
+                                  CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)
+        controlPoint1:CGPointMake(CGRectGetMinX(innerBounds) + 0.00000f * innerBounds.size.width,
+                                  CGRectGetMinY(innerBounds) + 0.22400f * innerBounds.size.height)
+        controlPoint2:CGPointMake(CGRectGetMinX(innerBounds) + 0.22400f * innerBounds.size.width,
+                                  CGRectGetMinY(innerBounds) + 0.00000f * innerBounds.size.height)];
   [ic_clear_path closePath];
   [ic_clear_path
-    moveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.73417f * innerBounds.size.width,
-                            CGRectGetMinY(innerBounds) + 0.31467f * innerBounds.size.height)];
+      moveToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.73417f * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + 0.31467f * innerBounds.size.height)];
   [ic_clear_path
-    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.68700f * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + 0.26750f * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.68700f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.26750f * innerBounds.size.height)];
   [ic_clear_path
-    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50083f * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + 0.45367f * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50083f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.45367f * innerBounds.size.height)];
   [ic_clear_path
-    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.31467f * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + 0.26750f * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.31467f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.26750f * innerBounds.size.height)];
   [ic_clear_path
-    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.26750f * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + 0.31467f * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.26750f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.31467f * innerBounds.size.height)];
   [ic_clear_path
-    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.45367f * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + 0.50083f * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.45367f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.50083f * innerBounds.size.height)];
   [ic_clear_path
-    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.26750f * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + 0.68700f * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.26750f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.68700f * innerBounds.size.height)];
   [ic_clear_path
-    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.31467f * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + 0.73417f * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.31467f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.73417f * innerBounds.size.height)];
   [ic_clear_path
-    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50083f * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + 0.54800f * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.50083f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.54800f * innerBounds.size.height)];
   [ic_clear_path
-    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.68700f * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + 0.73417f * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.68700f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.73417f * innerBounds.size.height)];
   [ic_clear_path
-    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.73417f * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + 0.68700f * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.73417f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.68700f * innerBounds.size.height)];
   [ic_clear_path
-    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.54800f * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + 0.50083f * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.54800f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.50083f * innerBounds.size.height)];
   [ic_clear_path
-    addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.73417f * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + 0.31467f * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(CGRectGetMinX(innerBounds) + 0.73417f * innerBounds.size.width,
+                                 CGRectGetMinY(innerBounds) + 0.31467f * innerBounds.size.height)];
   [ic_clear_path closePath];
 
   return ic_clear_path;

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -36,7 +36,8 @@ static const CGFloat MDCChipFieldVerticalInset = 8.f;
 static const CGFloat MDCChipFieldIndent = 4.f;
 static const CGFloat MDCChipFieldHorizontalMargin = 4.f;
 static const CGFloat MDCChipFieldVerticalMargin = 5.f;
-static const CGFloat MDCChipFieldClearButtonImageSquareWidthHeight = 24.f;
+static const CGFloat MDCChipFieldClearButtonSquareWidthHeight = 24.f;
+static const CGFloat MDCChipFieldClearImageSquareWidthHeight = 18.f;
 static const UIKeyboardType MDCChipFieldDefaultKeyboardType = UIKeyboardTypeEmailAddress;
 
 const CGFloat MDCChipFieldDefaultMinTextFieldWidth = 60.f;
@@ -416,11 +417,14 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
 
 - (void)addClearButtonToChip:(MDCChipView *)chip {
   UIControl *clearButton = [[UIControl alloc] init];
-  CGFloat widthAndHeight = MDCChipFieldClearButtonImageSquareWidthHeight;
-  clearButton.frame = CGRectMake(0, 0, widthAndHeight, widthAndHeight);
-  clearButton.layer.cornerRadius = widthAndHeight / 2;
+  CGFloat clearButtonWidthAndHeight = MDCChipFieldClearButtonSquareWidthHeight;
+  clearButton.frame = CGRectMake(0, 0, clearButtonWidthAndHeight, clearButtonWidthAndHeight);
+  clearButton.layer.cornerRadius = clearButtonWidthAndHeight / 2;
   UIImageView *clearImageView = [[UIImageView alloc] initWithImage:[self drawClearButton]];
-  clearImageView.frame = clearButton.frame;
+  CGFloat widthAndHeight = MDCChipFieldClearImageSquareWidthHeight;
+  CGFloat padding =
+      (MDCChipFieldClearButtonSquareWidthHeight - MDCChipFieldClearImageSquareWidthHeight) / 2;
+  clearImageView.frame = CGRectMake(padding, padding, widthAndHeight, widthAndHeight);
   clearButton.tintColor = [UIColor.blackColor colorWithAlphaComponent:0.6f];
   [clearButton addSubview:clearImageView];
   chip.accessoryView = clearButton;
@@ -430,8 +434,8 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
 }
 
 - (UIImage *)drawClearButton {
-  CGSize clearButtonSize = CGSizeMake(MDCChipFieldClearButtonImageSquareWidthHeight,
-                                      MDCChipFieldClearButtonImageSquareWidthHeight);
+  CGSize clearButtonSize = CGSizeMake(MDCChipFieldClearImageSquareWidthHeight,
+                                      MDCChipFieldClearImageSquareWidthHeight);
 
   CGRect bounds = CGRectMake(0, 0, clearButtonSize.width, clearButtonSize.height);
   UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0);

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -318,7 +318,7 @@ static inline UIImage *TestImage(CGSize size) {
 - (void)testChipsWithDeleteEnabled {
   // Given
   MDCChipField *field = [[MDCChipField alloc] init];
-  field.enableChipsThatDelete = YES;
+  field.showChipsDeleteButton = YES;
   field.textField.text = @"Test";
 
   // When

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -304,7 +304,7 @@ static inline UIImage *TestImage(CGSize size) {
   NSUInteger chipCount = field.chips.count;
 
   // Then
-  XCTAssertEqual(chipCount, 1);
+  XCTAssertEqual(chipCount, (NSUInteger)1);
 
   // Given
   NSUInteger controlViewCount = 0;
@@ -318,7 +318,7 @@ static inline UIImage *TestImage(CGSize size) {
   }
 
   // Then
-  XCTAssertEqual(controlViewCount, 0);
+  XCTAssertEqual(controlViewCount, (NSUInteger)0);
 }
 
 - (void)testChipsWithDeleteEnabled {
@@ -332,7 +332,7 @@ static inline UIImage *TestImage(CGSize size) {
   NSUInteger chipCount = field.chips.count;
 
   // Then
-  XCTAssertEqual(chipCount, 1);
+  XCTAssertEqual(chipCount, (NSUInteger)1);
 
   // Given
   NSUInteger controlViewCount = 0;
@@ -346,7 +346,7 @@ static inline UIImage *TestImage(CGSize size) {
   }
 
   // Then
-  XCTAssertEqual(controlViewCount, 1);
+  XCTAssertEqual(controlViewCount, (NSUInteger)1);
 }
 
 @end

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -301,9 +301,11 @@ static inline UIImage *TestImage(CGSize size) {
   XCTAssertEqual(chipCount, 1);
 
 
-  // When
+  // Given
   NSUInteger controlViewCount = 0;
   MDCChipView *chip = field.chips[0];
+
+  // When
   for (UIView *subview in chip.subviews) {
     if ([subview isKindOfClass:[UIControl class]]) {
       controlViewCount += 1;
@@ -327,9 +329,11 @@ static inline UIImage *TestImage(CGSize size) {
   // Then
   XCTAssertEqual(chipCount, 1);
 
-  // When
+  // Given
   NSUInteger controlViewCount = 0;
   MDCChipView *chip = field.chips[0];
+
+  // When
   for (UIView *subview in chip.subviews) {
     if ([subview isKindOfClass:[UIControl class]]) {
       controlViewCount += 1;

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -300,7 +300,6 @@ static inline UIImage *TestImage(CGSize size) {
   // Then
   XCTAssertEqual(chipCount, 1);
 
-
   // Given
   NSUInteger controlViewCount = 0;
   MDCChipView *chip = field.chips[0];

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -12,10 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialChips.h"
+
 #import <XCTest/XCTest.h>
 
-#import "../../src/MDCChipField.m"
-#import "MaterialChips.h"
+#import "../../src/MDCChipField.h"
+
+// Expose internal methods for testing
+@interface MDCChipField (Testing)
+- (void)createNewChipFromInput;
+@end
 
 static inline UIColor *MDCColorFromRGB(uint32_t rgbValue) {
   return [UIColor colorWithRed:((CGFloat)((rgbValue & 0xFF0000) >> 16)) / 255

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -14,8 +14,8 @@
 
 #import <XCTest/XCTest.h>
 
-#import "MaterialChips.h"
 #import "../../src/MDCChipField.m"
+#import "MaterialChips.h"
 
 static inline UIColor *MDCColorFromRGB(uint32_t rgbValue) {
   return [UIColor colorWithRed:((CGFloat)((rgbValue & 0xFF0000) >> 16)) / 255

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -15,6 +15,7 @@
 #import <XCTest/XCTest.h>
 
 #import "MaterialChips.h"
+#import "../../src/MDCChipField.m"
 
 static inline UIColor *MDCColorFromRGB(uint32_t rgbValue) {
   return [UIColor colorWithRed:((CGFloat)((rgbValue & 0xFF0000) >> 16)) / 255
@@ -285,6 +286,58 @@ static inline UIImage *TestImage(CGSize size) {
   XCTAssertFalse([chip pointInside:CGPointMake(CGRectGetMaxX(chipBounds) - hitAreaInsets.right,
                                                CGRectGetMaxY(chipBounds) - hitAreaInsets.bottom)
                         withEvent:nil]);
+}
+
+- (void)testChipsWithoutDeleteEnabled {
+  // Given
+  MDCChipField *field = [[MDCChipField alloc] init];
+  field.textField.text = @"Test";
+
+  // When
+  [field createNewChipFromInput];
+  NSUInteger chipCount = field.chips.count;
+
+  // Then
+  XCTAssertEqual(chipCount, 1);
+
+
+  // When
+  NSUInteger controlViewCount = 0;
+  MDCChipView *chip = field.chips[0];
+  for (UIView *subview in chip.subviews) {
+    if ([subview isKindOfClass:[UIControl class]]) {
+      controlViewCount += 1;
+    }
+  }
+
+  // Then
+  XCTAssertEqual(controlViewCount, 0);
+}
+
+- (void)testChipsWithDeleteEnabled {
+  // Given
+  MDCChipField *field = [[MDCChipField alloc] init];
+  field.enableChipsThatDelete = YES;
+  field.textField.text = @"Test";
+
+  // When
+  [field createNewChipFromInput];
+  NSUInteger chipCount = field.chips.count;
+
+  // Then
+  XCTAssertEqual(chipCount, 1);
+
+  // When
+  NSUInteger controlViewCount = 0;
+  MDCChipView *chip = field.chips[0];
+  for (UIView *subview in chip.subviews) {
+    if ([subview isKindOfClass:[UIControl class]]) {
+      controlViewCount += 1;
+    }
+  }
+
+  // Then
+  XCTAssertEqual(controlViewCount, 1);
 }
 
 @end


### PR DESCRIPTION
This adds the ability for clients to delete chips within a chip field. 

Within the unit test I couldn't simulate touchUpInside so I felt this was the best option. A client cannot get this behavior unless if they set the flag `showChipsDeleteButton`.

Closes #4787 