### PR TITLE
[Dialogs] {WIP}

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -462,6 +462,16 @@ Pod::Spec.new do |mdc|
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 
+  mdc.subspec "Dialogs+DialogThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/Dialogs+ColorThemer"
+    extension.dependency "MaterialComponents/Dialogs+TypographyThemer"
+  end
+
   # FeatureHighlight
 
   mdc.subspec "FeatureHighlight" do |component|

--- a/components/Dialogs/examples/AlertComparison.swift
+++ b/components/Dialogs/examples/AlertComparison.swift
@@ -16,13 +16,13 @@ import Foundation
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialDialogs
 
-
 /// This interface allows a user to present a UIKit Alert Controller and a Material Alert
 /// Controller.
 class DialogsAlertComparison: UIViewController {
 
-  let materialButton = MDCFlatButton()
-  let uikitButton = MDCFlatButton()
+  private let materialButton = MDCFlatButton()
+  private let themedButton = MDCFlatButton()
+  private let uikitButton = MDCFlatButton()
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -38,21 +38,44 @@ class DialogsAlertComparison: UIViewController {
 
     NSLayoutConstraint.activate([
       NSLayoutConstraint(item:materialButton,
-                       attribute:.centerX,
-                       relatedBy:.equal,
-                       toItem:self.view,
-                       attribute:.centerX,
-                       multiplier:1.0,
+                       attribute: .centerX,
+                       relatedBy: .equal,
+                       toItem: self.view,
+                       attribute: .centerX,
+                       multiplier: 1.0,
                        constant: 0.0),
-      NSLayoutConstraint(item:materialButton,
-                       attribute:.centerY,
-                       relatedBy:.equal,
-                       toItem:self.view,
-                       attribute:.centerY,
-                       multiplier:1.0,
+      NSLayoutConstraint(item: materialButton,
+                       attribute: .centerY,
+                       relatedBy: .equal,
+                       toItem: self.view,
+                       attribute: .centerY,
+                       multiplier: 1.0,
                        constant: 0.0)
       ])
 
+    themedButton.translatesAutoresizingMaskIntoConstraints = false
+    themedButton.setTitle("Material Alert (Themed)", for: .normal)
+    themedButton.setTitleColor(UIColor(white: 0.1, alpha:1), for: .normal)
+    themedButton.sizeToFit()
+    themedButton.addTarget(self, action: #selector(tapThemed), for: .touchUpInside)
+    self.view.addSubview(themedButton)
+
+    NSLayoutConstraint.activate([
+      NSLayoutConstraint(item: themedButton,
+                         attribute: .centerX,
+                         relatedBy: .equal,
+                         toItem: self.view,
+                         attribute: .centerX,
+                         multiplier: 1.0,
+                         constant: 0.0),
+      NSLayoutConstraint(item:themedButton,
+                         attribute: .top,
+                         relatedBy: .equal,
+                         toItem: materialButton,
+                         attribute: .bottom,
+                         multiplier: 1.0,
+                         constant: 8.0)
+      ])
 
       uikitButton.translatesAutoresizingMaskIntoConstraints = false
       uikitButton.setTitle("UIKit Alert", for: UIControlState())
@@ -62,24 +85,41 @@ class DialogsAlertComparison: UIViewController {
       self.view.addSubview(uikitButton)
 
       NSLayoutConstraint.activate([
-        NSLayoutConstraint(item:uikitButton,
-                           attribute:.centerX,
-                           relatedBy:.equal,
-                           toItem:self.view,
-                           attribute:.centerX,
-                           multiplier:1.0,
+        NSLayoutConstraint(item: uikitButton,
+                           attribute: .centerX,
+                           relatedBy: .equal,
+                           toItem: self.view,
+                           attribute: .centerX,
+                           multiplier: 1.0,
                            constant: 0.0),
-        NSLayoutConstraint(item:uikitButton,
-                           attribute:.top,
-                           relatedBy:.equal,
-                           toItem:materialButton,
-                           attribute:.bottom,
-                           multiplier:1.0,
+        NSLayoutConstraint(item: uikitButton,
+                           attribute: .top,
+                           relatedBy: .equal,
+                           toItem: themedButton,
+                           attribute: .bottom,
+                           multiplier: 1.0,
                            constant: 8.0)
         ])
   }
 
   @objc func tapMaterial(_ sender: Any) {
+    let alertController = createMDCAlertController()
+    self.present(alertController, animated: true, completion: nil)
+  }
+
+  @objc func tapThemed(_ sender: Any) {
+    let alertController = createMDCAlertController()
+    let scheme = MDCAlertScheme()
+    MDCAlertThemer.applyScheme(scheme, to: alertController)
+    self.present(alertController, animated: true, completion: nil)
+  }
+
+  @objc func tapUIKit(_ sender: Any) {
+    let alertController = createUIAlertController()
+    self.present(alertController, animated: true, completion: nil)
+  }
+
+  private func createMDCAlertController() -> MDCAlertController {
     let titleString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur"
     let messageString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur " +
       "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
@@ -112,10 +152,11 @@ class DialogsAlertComparison: UIViewController {
     let rejectAction = MDCAlertAction(title:"Reject") { (_) in print("Reject") }
     alertController.addAction(rejectAction)
 
-    self.present(alertController, animated: true, completion: nil)
+    return alertController
   }
 
-  @objc func tapUIKit(_ sender: Any) {
+  private func createUIAlertController() -> UIAlertController {
+
     let titleString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur"
     let messageString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur " +
       "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
@@ -151,7 +192,7 @@ class DialogsAlertComparison: UIViewController {
     let rejectAction = UIAlertAction(title:"Reject", style:.default) { (_) in print("Reject") }
     alertController.addAction(rejectAction)
 
-    self.present(alertController, animated: true, completion: nil)
+    return alertController
   }
 }
 

--- a/components/Dialogs/examples/AlertComparison.swift
+++ b/components/Dialogs/examples/AlertComparison.swift
@@ -20,6 +20,9 @@ import MaterialComponents.MaterialDialogs
 /// Controller.
 class DialogsAlertComparison: UIViewController {
 
+  var colorScheme = MDCSemanticColorScheme()
+  var typographyScheme = MDCTypographyScheme()
+
   private let materialButton = MDCFlatButton()
   private let themedButton = MDCFlatButton()
   private let uikitButton = MDCFlatButton()
@@ -108,8 +111,13 @@ class DialogsAlertComparison: UIViewController {
   }
 
   @objc func tapThemed(_ sender: Any) {
+
     let alertController = createMDCAlertController()
+
     let scheme = MDCAlertScheme()
+    scheme.colorScheme = self.colorScheme
+    scheme.typographyScheme = self.typographyScheme
+
     MDCAlertThemer.applyScheme(scheme, to: alertController)
     self.present(alertController, animated: true, completion: nil)
   }
@@ -119,9 +127,9 @@ class DialogsAlertComparison: UIViewController {
     self.present(alertController, animated: true, completion: nil)
   }
 
-  private func createMDCAlertController() -> MDCAlertController {
-    let titleString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur"
-    let messageString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur " +
+  private var titleAndMessage: (title: String, message: String) {
+    return (title: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur",
+            message: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur " +
       "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
       "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +
       "quis eleifend nisi eros dictum mi. In finibus vulputate eros, in luctus diam auctor in. " +
@@ -140,8 +148,13 @@ class DialogsAlertComparison: UIViewController {
       "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
       "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +
       "quis eleifend nisi eros dictum mi. In finibus vulputate eros, in luctus diam auctor in. "
+    )
+  }
 
-    let alertController = MDCAlertController(title: titleString, message: messageString)
+  private func createMDCAlertController() -> MDCAlertController {
+
+    let texts = titleAndMessage
+    let alertController = MDCAlertController(title: texts.title, message: texts.message)
 
     let acceptAction = MDCAlertAction(title:"Accept") { (_) in print("Accept") }
     alertController.addAction(acceptAction)
@@ -157,29 +170,8 @@ class DialogsAlertComparison: UIViewController {
 
   private func createUIAlertController() -> UIAlertController {
 
-    let titleString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur"
-    let messageString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur " +
-      "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
-      "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +
-      "quis eleifend nisi eros dictum mi. In finibus vulputate eros, in luctus diam auctor in. " +
-      "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
-      "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +
-      "quis eleifend nisi eros dictum mi. In finibus vulputate eros, in luctus diam auctor in. " +
-      "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
-      "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +
-      "quis eleifend nisi eros dictum mi. In finibus vulputate eros, in luctus diam auctor in. " +
-      "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
-      "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +
-      "quis eleifend nisi eros dictum mi. In finibus vulputate eros, in luctus diam auctor in. " +
-      "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
-      "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +
-      "quis eleifend nisi eros dictum mi. In finibus vulputate eros, in luctus diam auctor in. " +
-      "ultricies diam libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risus " +
-      "maximus tempus. Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, " +
-      "quis eleifend nisi eros dictum mi. In finibus vulputate eros, in luctus diam auctor in. "
-
-    let alertController = UIAlertController(title: titleString,
-                                            message: messageString,
+    let texts = titleAndMessage
+    let alertController = UIAlertController(title: texts.title, message: texts.message,
                                             preferredStyle:.alert)
 
     let acceptAction = UIAlertAction(title:"Accept", style:.default) { (_) in print("Accept") }

--- a/components/Dialogs/examples/DialogsAlertViewController.m
+++ b/components/Dialogs/examples/DialogsAlertViewController.m
@@ -70,7 +70,9 @@
 }
 
 - (void)themeAlertController:(MDCAlertController *)alertController {
-  MDCAlertScheme *alertScheme = [MDCAlertScheme new];
+  MDCAlertScheme *alertScheme = [[MDCAlertScheme alloc] init];
+  alertScheme.colorScheme = self.colorScheme;
+  alertScheme.typographyScheme = self.typographyScheme;
   [MDCAlertThemer applyScheme:alertScheme toAlertController:alertController];
 }
 

--- a/components/Dialogs/examples/DialogsAlertViewController.m
+++ b/components/Dialogs/examples/DialogsAlertViewController.m
@@ -15,8 +15,8 @@
 #import "supplemental/DialogsAlertViewControllerSupplemental.h"
 #import "MaterialButtons.h"
 #import "MaterialDialogs.h"
-#import "MaterialDialogs+ColorThemer.h"
-#import "MaterialDialogs+TypographyThemer.h"
+#import "MDCAlertScheme.h"
+#import "MDCAlertThemer.h"
 
 @implementation DialogsAlertViewController
 
@@ -70,9 +70,8 @@
 }
 
 - (void)themeAlertController:(MDCAlertController *)alertController {
-  [MDCAlertColorThemer applySemanticColorScheme:self.colorScheme toAlertController:alertController];
-  [MDCAlertTypographyThemer applyTypographyScheme:self.typographyScheme
-                                toAlertController:alertController];
+  MDCAlertScheme *alertScheme = [MDCAlertScheme new];
+  [MDCAlertThemer applyScheme:alertScheme toAlertController:alertController];
 }
 
 - (IBAction)didTapShowAlert {
@@ -366,7 +365,6 @@
 
   MDCAlertController *materialAlertController =
       [MDCAlertController alertControllerWithTitle:titleString message:messageString];
-  [self themeAlertController:materialAlertController];
 
   MDCAlertAction *agreeAaction = [MDCAlertAction actionWithTitle:@"AGREE"
                                                          handler:^(MDCAlertAction *action) {

--- a/components/Dialogs/examples/DialogsLongAlertViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertViewController.swift
@@ -64,6 +64,7 @@ class DialogsLongAlertViewController: UIViewController {
     "euismod libero. Aliquam commodo urna vitae massa convallis aliquet."
 
     let materialAlertController = MDCAlertController(title: nil, message: messageString)
+    MDCAlertThemer.applyScheme(MDCAlertScheme(), to: materialAlertController)
 
     let action = MDCAlertAction(title:"OK") { (_) in print("OK") }
 

--- a/components/Dialogs/examples/DialogsRoundedCornerViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerViewController.m
@@ -15,10 +15,16 @@
 #import "DialogsRoundedCornerViewController.h"
 #import "MaterialButtons.h"
 #import "MaterialDialogs.h"
+#import "MaterialDialogs+DialogThemer.h"
+#import "MDCAlertThemer.h"
+
+static const CGFloat kCornerRadius = 24.0f;
 
 @interface DialogsRoundedCornerSimpleController : UIViewController
 
 @property(nonatomic, strong) MDCFlatButton *dismissButton;
+
+@property(nonatomic, readwrite) CGFloat cornerRadius;
 
 @end
 
@@ -42,8 +48,6 @@
            forControlEvents:UIControlEventTouchUpInside];
 
   [self.view addSubview:_dismissButton];
-
-  self.view.layer.cornerRadius = 24.0;
 }
 
 - (void)viewWillLayoutSubviews {
@@ -61,12 +65,21 @@
   [self.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
 }
 
+- (CGFloat)cornerRadius {
+  return self.view.layer.cornerRadius;
+}
+
+- (void)setCornerRadius:(CGFloat)cornerRadius {
+  self.view.layer.cornerRadius = cornerRadius;
+}
+
 @end
 
 
 @interface DialogsRoundedCornerViewController ()
 
 @property(nonatomic, strong) MDCFlatButton *presentButton;
+@property(nonatomic, strong) MDCFlatButton *presentMDCButton;
 @property(nonatomic, strong) MDCDialogTransitionController *transitionController;
 
 @end
@@ -83,7 +96,7 @@
   self.view.backgroundColor = [UIColor whiteColor];
 
   _presentButton = [[MDCFlatButton alloc] initWithFrame:CGRectZero];
-  [_presentButton setTitle:@"Present" forState:UIControlStateNormal];
+  [_presentButton setTitle:@"UIKit Dialog" forState:UIControlStateNormal];
   [_presentButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
   _presentButton.autoresizingMask =
       UIViewAutoresizingFlexibleTopMargin |
@@ -95,6 +108,14 @@
            forControlEvents:UIControlEventTouchUpInside];
 
   [self.view addSubview:_presentButton];
+
+  _presentMDCButton = [[MDCFlatButton alloc] initWithFrame:CGRectZero];
+  [_presentMDCButton setTitle:@"Present Material Dialog" forState:UIControlStateNormal];
+  [_presentMDCButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
+  [_presentMDCButton addTarget:self
+                        action:@selector(didTapPresentMDCDialog:)
+              forControlEvents:UIControlEventTouchUpInside];
+  [self.view addSubview:_presentMDCButton];
 }
 
 - (void)viewWillLayoutSubviews {
@@ -102,16 +123,55 @@
   [_presentButton sizeToFit];
   _presentButton.center = CGPointMake(CGRectGetMidX(self.view.bounds),
                                       CGRectGetMidY(self.view.bounds));
+  [_presentMDCButton sizeToFit];
+  _presentMDCButton.center = CGPointMake(CGRectGetMidX(self.view.bounds),
+                                         _presentButton.center.y +
+                                         _presentButton.frame.size.height + 8.0);
+}
+
+- (MDCAlertController *)createMDCAlertController {
+
+  NSString *title = @"Using Material alert controller?";
+  NSString *message = @"Be careful with modal alerts as they can be annoying if over-used.";
+
+  MDCAlertController *mdcAlertController = [MDCAlertController alertControllerWithTitle:title message:message];
+  [mdcAlertController mdc_setAdjustsFontForContentSizeCategory:true];
+
+  MDCAlertAction *agreeAction = [MDCAlertAction actionWithTitle:@"OK" handler:^(MDCAlertAction * _Nonnull action) {
+    NSLog(@"OK pressed");
+  }];
+  [mdcAlertController addAction:agreeAction];
+
+  return mdcAlertController;
 }
 
 - (IBAction)didTapPresent:(id)sender {
-  UIViewController *viewController =
+  DialogsRoundedCornerSimpleController *viewController =
       [[DialogsRoundedCornerSimpleController alloc] initWithNibName:nil bundle:nil];
 
   viewController.modalPresentationStyle = UIModalPresentationCustom;
   viewController.transitioningDelegate = self.transitionController;
 
+  // sets the dialog's corner radius
+  viewController.cornerRadius = kCornerRadius;
+
+  // ensure shadow/tracking layer matches the dialog's corner radius
+  MDCDialogPresentationController *controller = viewController.mdc_dialogPresentationController;
+  controller.dialogCornerRadius = kCornerRadius;
+
   [self presentViewController:viewController animated:YES completion:NULL];
+}
+
+- (void)didTapPresentMDCDialog:(id)sender {
+
+  MDCAlertController *mdcAlertController = [self createMDCAlertController];
+
+  // Dialog Theming
+  MDCAlertScheme *scheme = [MDCAlertScheme new];
+  [MDCAlertThemer applyScheme:scheme toAlertController:mdcAlertController];
+  mdcAlertController.cornerRadius = kCornerRadius;
+
+  [self presentViewController:mdcAlertController animated:YES completion:NULL];
 }
 
 #pragma mark - CatalogByConvention

--- a/components/Dialogs/examples/DialogsRoundedCornerViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerViewController.m
@@ -167,7 +167,7 @@ static const CGFloat kCornerRadius = 24.0f;
   MDCAlertController *mdcAlertController = [self createMDCAlertController];
 
   // Dialog Theming
-  MDCAlertScheme *scheme = [MDCAlertScheme new];
+  MDCAlertScheme *scheme = [[MDCAlertScheme alloc] init];
   [MDCAlertThemer applyScheme:scheme toAlertController:mdcAlertController];
   mdcAlertController.cornerRadius = kCornerRadius;
 

--- a/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
+++ b/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #import <Foundation/Foundation.h>
+
 #import "MaterialColorScheme.h"
-#import "MaterialShapeScheme.h"
 #import "MaterialTypographyScheme.h"
 
 /** Defines a readonly immutable interface for component style data to be applied by a themer. */

--- a/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
+++ b/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
@@ -1,0 +1,47 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import "MaterialColorScheme.h"
+#import "MaterialShapeScheme.h"
+#import "MaterialTypographyScheme.h"
+
+/** Defines a readonly immutable interface for component style data to be applied by a themer. */
+@protocol MDCAlertScheming
+
+/** The color scheme to apply to Dialog. */
+@property(nonnull, readonly, nonatomic) id<MDCColorScheming> colorScheme;
+
+/** The typography scheme to apply to Dialog. */
+@property(nonnull, readonly, nonatomic) id<MDCTypographyScheming> typographyScheme;
+
+/** The corner radius to apply to Dialog. */
+@property(readonly, nonatomic) CGFloat cornerRadius;
+
+@end
+
+/**  A simple implementation of @c MDCAlertScheming that provides default color,
+ typography and shape schemes, from which customizations can be made. */
+@interface MDCAlertScheme : NSObject <MDCAlertScheming>
+
+/** The color scheme to apply to Dialog. */
+@property(nonnull, readwrite, nonatomic) id<MDCColorScheming> colorScheme;
+
+/** The typography scheme to apply to Dialog. */
+@property(nonnull, readwrite, nonatomic) id<MDCTypographyScheming> typographyScheme;
+
+/** The corner radius to apply to Dialog. */
+@property(readwrite, nonatomic) CGFloat cornerRadius;
+
+@end

--- a/components/Dialogs/src/DialogThemer/MDCAlertScheme.m
+++ b/components/Dialogs/src/DialogThemer/MDCAlertScheme.m
@@ -1,0 +1,30 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCAlertScheme.h"
+
+static const CGFloat kCornerRadius = 4.0f;
+
+@implementation MDCAlertScheme
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _colorScheme = [MDCSemanticColorScheme new];
+    _typographyScheme = [MDCTypographyScheme new];
+    _cornerRadius = kCornerRadius;
+  }
+  return self;
+}
+@end

--- a/components/Dialogs/src/DialogThemer/MDCAlertScheme.m
+++ b/components/Dialogs/src/DialogThemer/MDCAlertScheme.m
@@ -21,8 +21,8 @@ static const CGFloat kCornerRadius = 4.0f;
 - (instancetype)init {
   self = [super init];
   if (self) {
-    _colorScheme = [MDCSemanticColorScheme new];
-    _typographyScheme = [MDCTypographyScheme new];
+    _colorScheme = [[MDCSemanticColorScheme alloc] init];
+    _typographyScheme = [[MDCTypographyScheme alloc] init];
     _cornerRadius = kCornerRadius;
   }
   return self;

--- a/components/Dialogs/src/DialogThemer/MDCAlertThemer.h
+++ b/components/Dialogs/src/DialogThemer/MDCAlertThemer.h
@@ -1,0 +1,30 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import "MDCAlertController.h"
+#import "MDCAlertScheme.h"
+
+@interface MDCAlertThemer : NSObject
+
+/**
+ Applies a component scheme's properties to an MDCAlertController.
+
+ @param dialogScheme The component scheme to apply to the alert dialog instance.
+ @param alertController An alert dialog instance to which the component scheme should be applied.
+ */
++ (void)applyScheme:(nonnull id<MDCAlertScheming>)dialogScheme
+    toAlertController:(nonnull MDCAlertController *)alertController;
+
+@end

--- a/components/Dialogs/src/DialogThemer/MDCAlertThemer.h
+++ b/components/Dialogs/src/DialogThemer/MDCAlertThemer.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import <Foundation/Foundation.h>
+
 #import "MDCAlertController.h"
 #import "MDCAlertScheme.h"
 
@@ -21,10 +22,10 @@
 /**
  Applies a component scheme's properties to an MDCAlertController.
 
- @param dialogScheme The component scheme to apply to the alert dialog instance.
+ @param alertScheme The component scheme to apply to the alert dialog instance.
  @param alertController An alert dialog instance to which the component scheme should be applied.
  */
-+ (void)applyScheme:(nonnull id<MDCAlertScheming>)dialogScheme
++ (void)applyScheme:(nonnull id<MDCAlertScheming>)alertScheme
     toAlertController:(nonnull MDCAlertController *)alertController;
 
 @end

--- a/components/Dialogs/src/DialogThemer/MDCAlertThemer.m
+++ b/components/Dialogs/src/DialogThemer/MDCAlertThemer.m
@@ -18,15 +18,15 @@
 
 @implementation MDCAlertThemer
 
-+ (void)applyScheme:(nonnull id<MDCAlertScheming>)dialogSchem
++ (void)applyScheme:(nonnull id<MDCAlertScheming>)alertScheme
     toAlertController:(nonnull MDCAlertController *)alertController {
-  [MDCAlertColorThemer applySemanticColorScheme:dialogSchem.colorScheme
+  [MDCAlertColorThemer applySemanticColorScheme:alertScheme.colorScheme
                               toAlertController:alertController];
 
-  [MDCAlertTypographyThemer applyTypographyScheme:dialogSchem.typographyScheme
+  [MDCAlertTypographyThemer applyTypographyScheme:alertScheme.typographyScheme
                                 toAlertController:alertController];
 
-  alertController.cornerRadius = dialogSchem.cornerRadius;
+  alertController.cornerRadius = alertScheme.cornerRadius;
 }
 
 @end

--- a/components/Dialogs/src/DialogThemer/MDCAlertThemer.m
+++ b/components/Dialogs/src/DialogThemer/MDCAlertThemer.m
@@ -1,0 +1,32 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCAlertThemer.h"
+#import "MDCAlertColorThemer.h"
+#import "MDCAlertTypographyThemer.h"
+
+@implementation MDCAlertThemer
+
++ (void)applyScheme:(nonnull id<MDCAlertScheming>)dialogSchem
+    toAlertController:(nonnull MDCAlertController *)alertController {
+  [MDCAlertColorThemer applySemanticColorScheme:dialogSchem.colorScheme
+                              toAlertController:alertController];
+
+  [MDCAlertTypographyThemer applyTypographyScheme:dialogSchem.typographyScheme
+                                toAlertController:alertController];
+
+  alertController.cornerRadius = dialogSchem.cornerRadius;
+}
+
+@end

--- a/components/Dialogs/src/DialogThemer/MaterialDialogs+DialogThemer.h
+++ b/components/Dialogs/src/DialogThemer/MaterialDialogs+DialogThemer.h
@@ -1,0 +1,15 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCAlertThemer.h"

--- a/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
+++ b/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
@@ -20,9 +20,16 @@ import MaterialComponents.MDCAlertThemer
 class MDCAlertControllerAlertThemerTests: XCTestCase {
 
   let defaultCornerRadius: CGFloat = 4.0
+  var alertScheme: MDCAlertScheme = MDCAlertScheme()
+
+  override func setUp() {
+    super.setUp()
+
+    alertScheme = MDCAlertScheme()
+  }
 
   func testDefaultAlertScheme() {
-    // Given
+    // When
     let alertScheme = MDCAlertScheme()
 
     // Then
@@ -33,15 +40,15 @@ class MDCAlertControllerAlertThemerTests: XCTestCase {
 
   func testApplyingAlertSchemeWithCustomColor() {
     // Given
-    let alertScheme = MDCAlertScheme()
     let colorScheme = MDCSemanticColorScheme()
+
     let alert = MDCAlertController(title: "Title", message: "Message")
     let alertView = alert.view as! MDCAlertControllerView
 
-    // When
     colorScheme.onSurfaceColor = .orange
     alertScheme.colorScheme = colorScheme
 
+    // When
     MDCAlertThemer.applyScheme(alertScheme, to: alert)
 
     // Then
@@ -54,16 +61,15 @@ class MDCAlertControllerAlertThemerTests: XCTestCase {
     
   func testApplyingAlertSchemeWithCustomTypography() {
     // Given
-    let alertScheme = MDCAlertScheme()
     let typographyScheme = MDCTypographyScheme()
     let alert = MDCAlertController(title: "Title", message: "Message")
     let alertView = alert.view as! MDCAlertControllerView
 
-    // When
     let testFont = UIFont.boldSystemFont(ofSize: 55.0)
     typographyScheme.headline6 = testFont
     alertScheme.typographyScheme = typographyScheme
 
+    // When
     MDCAlertThemer.applyScheme(alertScheme, to: alert)
 
     // Then
@@ -75,13 +81,13 @@ class MDCAlertControllerAlertThemerTests: XCTestCase {
 
   func testApplyingAlertSchemeWithCustomShape() {
     // Given
-    let alertScheme = MDCAlertScheme()
     let cornerRadius: CGFloat = 33.3
     let alert = MDCAlertController(title: "Title", message: "Message")
     let alertView = alert.view as! MDCAlertControllerView
 
-    // When
     alertScheme.cornerRadius = cornerRadius
+
+    // When
     MDCAlertThemer.applyScheme(alertScheme, to: alert)
 
     // Then

--- a/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
+++ b/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
@@ -1,0 +1,91 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import MaterialComponents.MDCAlertScheme
+import MaterialComponents.MDCAlertThemer
+
+class MDCAlertControllerAlertThemerTests: XCTestCase {
+
+  let defaultCornerRadius: CGFloat = 4.0
+
+  func testDefaultAlertScheme() {
+    // Given
+    let alertScheme = MDCAlertScheme()
+
+    // Then
+    XCTAssertEqual(alertScheme.colorScheme.primaryColor, MDCSemanticColorScheme().primaryColor)
+    XCTAssertEqual(alertScheme.typographyScheme.body1, MDCTypographyScheme().body1)
+    XCTAssertEqual(alertScheme.cornerRadius, defaultCornerRadius)
+  }
+
+  func testApplyingAlertSchemeWithCustomColor() {
+    // Given
+    let alertScheme = MDCAlertScheme()
+    let colorScheme = MDCSemanticColorScheme()
+    let alert = MDCAlertController(title: "Title", message: "Message")
+    let alertView = alert.view as! MDCAlertControllerView
+
+    // When
+    colorScheme.onSurfaceColor = .orange
+    alertScheme.colorScheme = colorScheme
+
+    MDCAlertThemer.applyScheme(alertScheme, to: alert)
+
+    // Then
+    XCTAssertEqual(alertScheme.colorScheme.onSurfaceColor, colorScheme.onSurfaceColor)
+    XCTAssertEqual(alertView.titleColor,
+                   alertScheme.colorScheme.onSurfaceColor.withAlphaComponent(0.87))
+    XCTAssertNotEqual(alertView.titleColor,
+                   MDCSemanticColorScheme().onSurfaceColor.withAlphaComponent(0.87))
+  }
+    
+  func testApplyingAlertSchemeWithCustomTypography() {
+    // Given
+    let alertScheme = MDCAlertScheme()
+    let typographyScheme = MDCTypographyScheme()
+    let alert = MDCAlertController(title: "Title", message: "Message")
+    let alertView = alert.view as! MDCAlertControllerView
+
+    // When
+    let testFont = UIFont.boldSystemFont(ofSize: 55.0)
+    typographyScheme.headline6 = testFont
+    alertScheme.typographyScheme = typographyScheme
+
+    MDCAlertThemer.applyScheme(alertScheme, to: alert)
+
+    // Then
+    XCTAssertEqual(alertScheme.typographyScheme.headline6, typographyScheme.headline6)
+    XCTAssertEqual(alertView.titleFont, alertScheme.typographyScheme.headline6)
+    XCTAssertNotEqual(alertView.titleFont, MDCTypographyScheme().headline6)
+    XCTAssertEqual(alertView.titleFont, testFont)
+  }
+
+  func testApplyingAlertSchemeWithCustomShape() {
+    // Given
+    let alertScheme = MDCAlertScheme()
+    let cornerRadius: CGFloat = 33.3
+    let alert = MDCAlertController(title: "Title", message: "Message")
+    let alertView = alert.view as! MDCAlertControllerView
+
+    // When
+    alertScheme.cornerRadius = cornerRadius
+    MDCAlertThemer.applyScheme(alertScheme, to: alert)
+
+    // Then
+    XCTAssertEqual(alertScheme.cornerRadius, cornerRadius, accuracy: 0.0)
+    XCTAssertEqual(alertView.cornerRadius, cornerRadius, accuracy: 0.0)
+    XCTAssertNotEqual(alertScheme.cornerRadius, defaultCornerRadius, accuracy: 0.0)
+  }
+}

--- a/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
+++ b/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import XCTest
+
 import MaterialComponents.MDCAlertScheme
 import MaterialComponents.MDCAlertThemer
 


### PR DESCRIPTION
Adding and updating existing examples that use the [new dialog themer (#5102)](https://github.com/material-components/material-components-ios/pull/5102).

Issue: b/113257098

BEFORE:
![dialog - before](https://user-images.githubusercontent.com/2329102/45421250-7a4d5380-b65a-11e8-80f4-d677dc5309c1.png)

AFTER (note the corner radius and themed color & font):
![dialog - after](https://user-images.githubusercontent.com/2329102/45421251-7a4d5380-b65a-11e8-8049-a7c3c9b9249b.png)
