### PR TITLE
[BottomAppBar] enable customizing the vertical position of FAB  

### DIFF
--- a/components/BottomAppBar/src/MDCBottomAppBarView.h
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.h
@@ -61,6 +61,11 @@ typedef NS_ENUM(NSInteger, MDCBottomAppBarFloatingButtonPosition) {
 @property(nonatomic, strong, nonnull, readonly) MDCFloatingButton *floatingButton;
 
 /**
+ The offset from the center of the floating button to the top edge of the navigation bar
+ */
+@property(nonatomic, assign) CGFloat floatingButtonCenterToNavigationBarTopOffset;
+
+/**
  Navigation bar items that precede the floating action button. There is no limit to the number of
  buttons that can be added, but button bar width overflow is not handled.
  */

--- a/components/BottomAppBar/src/MDCBottomAppBarView.h
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.h
@@ -63,7 +63,7 @@ typedef NS_ENUM(NSInteger, MDCBottomAppBarFloatingButtonPosition) {
 /**
  The offset from the center of the floating button to the top edge of the navigation bar
  */
-@property(nonatomic, assign) CGFloat floatingButtonCenterToNavigationBarTopOffset;
+@property(nonatomic, assign) CGFloat floatingButtonVerticalOffset;
 
 /**
  Navigation bar items that precede the floating action button. There is no limit to the number of

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -74,7 +74,7 @@ static const int kMDCButtonAnimationDuration = 200;
 
 - (void)commonMDCBottomAppBarViewInit {
   self.cutView = [[MDCBottomAppBarCutView alloc] initWithFrame:self.bounds];
-  self.floatingButtonCenterToNavigationBarTopOffset =
+  self.floatingButtonVerticalOffset =
       kMDCBottomAppBarViewFloatingButtonCenterToNavigationBarTopOffset;
   [self addSubview:self.cutView];
 
@@ -128,7 +128,7 @@ static const int kMDCButtonAnimationDuration = 200;
   CGFloat midX = appBarWidth / 2;
 
   floatingButtonPoint.y =
-      MAX(0.0f, navigationBarTopEdgeYOffset - self.floatingButtonCenterToNavigationBarTopOffset);
+      MAX(0.0f, navigationBarTopEdgeYOffset - self.floatingButtonVerticalOffset);
   switch (self.floatingButtonPosition) {
     case MDCBottomAppBarFloatingButtonPositionLeading: {
       if (self.layoutDirection == UIUserInterfaceLayoutDirectionLeftToRight) {

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -25,6 +25,7 @@
 static NSString *kMDCBottomAppBarViewAnimKeyString = @"AnimKey";
 static NSString *kMDCBottomAppBarViewPathString = @"path";
 static NSString *kMDCBottomAppBarViewPositionString = @"position";
+static const CGFloat kMDCBottomAppBarViewFloatingButtonCenterToNavigationBarTopOffset = 0.f;
 static const CGFloat kMDCBottomAppBarViewFloatingButtonElevationPrimary = 6.f;
 static const CGFloat kMDCBottomAppBarViewFloatingButtonElevationSecondary = 4.f;
 static const int kMDCButtonAnimationDuration = 200;
@@ -73,11 +74,15 @@ static const int kMDCButtonAnimationDuration = 200;
 
 - (void)commonMDCBottomAppBarViewInit {
   self.cutView = [[MDCBottomAppBarCutView alloc] initWithFrame:self.bounds];
+  self.floatingButtonCenterToNavigationBarTopOffset =
+      kMDCBottomAppBarViewFloatingButtonCenterToNavigationBarTopOffset;
   [self addSubview:self.cutView];
+
   self.autoresizingMask = (UIViewAutoresizingFlexibleWidth |
                            UIViewAutoresizingFlexibleLeftMargin |
                            UIViewAutoresizingFlexibleRightMargin);
   self.layoutDirection = self.mdf_effectiveUserInterfaceLayoutDirection;
+
   [self addFloatingButton];
   [self addBottomBarLayer];
   [self addNavBar];
@@ -117,38 +122,38 @@ static const int kMDCButtonAnimationDuration = 200;
   }
 }
 
-- (CGPoint)getFloatingButtonCenterPositionForWidth:(CGFloat)width {
+- (CGPoint)getFloatingButtonCenterPositionForAppBarWidth:(CGFloat)appBarWidth {
   CGPoint floatingButtonPoint = CGPointZero;
-  CGFloat halfDefaultDimension = CGRectGetMidX(self.floatingButton.bounds);
-  CGFloat midX = width / 2;
+  CGFloat navigationBarTopEdgeYOffset = CGRectGetMinY(self.navBar.frame);
+  CGFloat midX = appBarWidth / 2;
+
+  floatingButtonPoint.y =
+      MAX(0.0f, navigationBarTopEdgeYOffset - self.floatingButtonCenterToNavigationBarTopOffset);
   switch (self.floatingButtonPosition) {
     case MDCBottomAppBarFloatingButtonPositionLeading: {
       if (self.layoutDirection == UIUserInterfaceLayoutDirectionLeftToRight) {
-        floatingButtonPoint = CGPointMake(kMDCBottomAppBarFloatingButtonPositionX,
-                                          halfDefaultDimension);
+        floatingButtonPoint.x = kMDCBottomAppBarFloatingButtonPositionX;
       } else {
-        floatingButtonPoint = CGPointMake(width - kMDCBottomAppBarFloatingButtonPositionX,
-                                          halfDefaultDimension);
+        floatingButtonPoint.x = appBarWidth - kMDCBottomAppBarFloatingButtonPositionX;
       }
       break;
     }
     case MDCBottomAppBarFloatingButtonPositionCenter: {
-      floatingButtonPoint = CGPointMake(midX, halfDefaultDimension);
+      floatingButtonPoint.x = midX;
       break;
     }
     case MDCBottomAppBarFloatingButtonPositionTrailing: {
       if (self.layoutDirection == UIUserInterfaceLayoutDirectionLeftToRight) {
-        floatingButtonPoint = CGPointMake(width - kMDCBottomAppBarFloatingButtonPositionX,
-                                          halfDefaultDimension);
+        floatingButtonPoint.x = appBarWidth - kMDCBottomAppBarFloatingButtonPositionX;
       } else {
-        floatingButtonPoint = CGPointMake(kMDCBottomAppBarFloatingButtonPositionX,
-                                          halfDefaultDimension);
+        floatingButtonPoint.x = kMDCBottomAppBarFloatingButtonPositionX;
       }
       break;
     }
     default:
       break;
   }
+
   return floatingButtonPoint;
 }
 
@@ -197,7 +202,8 @@ static const int kMDCButtonAnimationDuration = 200;
 }
 
 - (void)moveFloatingButtonCenterAnimated:(BOOL)animated {
-  CGPoint endPoint = [self getFloatingButtonCenterPositionForWidth:CGRectGetWidth(self.bounds)];
+  CGPoint endPoint =
+      [self getFloatingButtonCenterPositionForAppBarWidth:CGRectGetWidth(self.bounds)];
   if (animated) {
     CABasicAnimation *animation =
         [CABasicAnimation animationWithKeyPath:kMDCBottomAppBarViewPositionString];
@@ -238,7 +244,7 @@ static const int kMDCButtonAnimationDuration = 200;
 - (void)layoutSubviews {
   [super layoutSubviews];
   self.floatingButton.center =
-      [self getFloatingButtonCenterPositionForWidth:CGRectGetWidth(self.bounds)];
+      [self getFloatingButtonCenterPositionForAppBarWidth:CGRectGetWidth(self.bounds)];
   [self renderPathBasedOnFloatingButtonVisibitlityAnimated:NO];
 
   CGRect navBarFrame =

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -243,14 +243,15 @@ static const int kMDCButtonAnimationDuration = 200;
 
 - (void)layoutSubviews {
   [super layoutSubviews];
-  self.floatingButton.center =
-      [self getFloatingButtonCenterPositionForAppBarWidth:CGRectGetWidth(self.bounds)];
-  [self renderPathBasedOnFloatingButtonVisibitlityAnimated:NO];
 
   CGRect navBarFrame =
       CGRectMake(0, kMDCBottomAppBarNavigationViewYOffset, CGRectGetWidth(self.bounds),
                  kMDCBottomAppBarHeight - kMDCBottomAppBarNavigationViewYOffset);
   self.navBar.frame = navBarFrame;
+
+  self.floatingButton.center =
+      [self getFloatingButtonCenterPositionForAppBarWidth:CGRectGetWidth(self.bounds)];
+  [self renderPathBasedOnFloatingButtonVisibitlityAnimated:NO];
 }
 
 - (UIEdgeInsets)mdc_safeAreaInsets {

--- a/components/BottomAppBar/tests/unit/BottomAppBarTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarTests.m
@@ -61,4 +61,16 @@
   XCTAssertEqualObjects(self.bottomAppBar.navBar.trailingBarItemsTintColor, UIColor.purpleColor);
 }
 
+#pragma mark - Floating Button
+
+- (void)testCustomizedFloatingButtonVerticalHeight {
+  CGFloat veriticalOffset = 5.0f;
+  self.bottomAppBar.floatingButtonVerticalOffset = veriticalOffset;
+  [self.bottomAppBar layoutSubviews];
+  CGPoint floatingButtonPosition = self.bottomAppBar.floatingButton.center;
+  CGPoint navigationBarPosition = self.bottomAppBar.navBar.frame.origin;
+  XCTAssertEqualWithAccuracy(floatingButtonPosition.y + veriticalOffset, navigationBarPosition.y,
+                             0.001f);
+}
+
 @end


### PR DESCRIPTION
This change provides a `floatingButtonCenterToNavigationBarTopOffset` property in `MDCBottomAppBarView` to customize the vertical position of FAB. You can use it on an `MDCBottomAppBarView` instance once it is initialized. 

Example:
```
MDCBottomAppBarView *appBarView = [[MDCBottomAppBarView alloc] init];
appBarView.floatingButtonCenterToNavigationBarTopOffset = 20.0f
```


closes #5011 and #5012

Before the change:
![simulator screen shot - iphone x - 2018-09-14 at 17 06 10](https://user-images.githubusercontent.com/8836258/45575161-7e3aca80-b840-11e8-9b40-31f1b7e8de68.png)


After the change:
![pc3](https://user-images.githubusercontent.com/8836258/45640281-31ddcd80-ba80-11e8-818d-eb02ecea3c02.gif)
