### PR TITLE
[BottomSheet] Add property so clients can set a custom height for bottom sheet

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -67,9 +67,12 @@
 /**
  This is used to set a custom height on the sheet view.
 
- @note This will override setting the preferredContentSize if a positive value is passed.
- @note If a non-positive value is passed then the sheet will open up to either half the screen
- height or the size of the contentViewController whatever value is smaller.
+ @note If a positive value is passed then the sheet view will be that height even if
+ perferredContentSize has been set. Otherwise the sheet will open up to half the screen height or
+ the size of the presentedViewController's preferredContentSize whatever value is smaller.
+ @note The preferredSheetHeight can never be taller than the height of the content, if the content
+ is smaller than the value passed to preferredSheetHeight then the sheet view will be the size of
+ the content height.
  */
 @property(nonatomic, assign) CGFloat preferredSheetHeight;
 

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -65,6 +65,15 @@
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;
 
 /**
+ This is used to set a custom height on the sheet view.
+
+ @note This will override setting the preferredContentSize if a positive value is passed.
+ @note If a non-positive value is passed then the sheet will open up to either half the screen
+ height or the size of the contentViewController whatever value is smaller.
+ */
+@property(nonatomic, assign) CGFloat preferredSheetHeight;
+
+/**
  If @c YES, then the dimmed scrim view will act as an accessibility element for dismissing the
  bottom sheet.
 

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -108,7 +108,7 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   [containerView addSubview:_dimmingView];
   [containerView addSubview:self.sheetView];
 
-  [self updatePreferredSheetHeight:self.presentedViewController.preferredContentSize.height];
+  [self updatePreferredSheetHeight];
 
   // Add tap handler to dismiss the sheet.
   UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self
@@ -155,7 +155,7 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   [super preferredContentSizeDidChangeForChildContentContainer:container];
   self.sheetView.frame = [self frameOfPresentedViewInContainerView];
   [self.sheetView layoutIfNeeded];
-  [self updatePreferredSheetHeight:self.presentedViewController.preferredContentSize.height];
+  [self updatePreferredSheetHeight];
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size
@@ -167,7 +167,7 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
           __unused id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
         self.sheetView.frame = [self frameOfPresentedViewInContainerView];
         [self.sheetView layoutIfNeeded];
-        [self updatePreferredSheetHeight:self.presentedViewController.preferredContentSize.height];
+        [self updatePreferredSheetHeight];
       }
                       completion:nil];
 }
@@ -176,14 +176,17 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
  Sets the new value of @c sheetView.preferredSheetHeight.
  If @c preferredContentHeight is non-positive, it will set it to half of sheetView's
  frame's height.
-
- @param preferredSheetHeight If positive, the new value for @sheetView.preferredSheetHeight.
  */
-- (void)updatePreferredSheetHeight:(CGFloat)preferredSheetHeight {
+- (void)updatePreferredSheetHeight {
   // If |preferredSheetHeight| has not been specified, use half of the current height.
+  CGFloat preferredSheetHeight;
   if (self.preferredSheetHeight > 0.f) {
     preferredSheetHeight = self.preferredSheetHeight;
-  } else if (MDCCGFloatEqual(preferredSheetHeight, 0)) {
+  } else {
+    preferredSheetHeight = self.presentedViewController.preferredContentSize.height;
+  }
+
+  if (MDCCGFloatEqual(preferredSheetHeight, 0)) {
     preferredSheetHeight = MDCRound(CGRectGetHeight(self.sheetView.frame) / 2);
   }
   self.sheetView.preferredSheetHeight = preferredSheetHeight;
@@ -248,9 +251,7 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
 - (void)setPreferredSheetHeight:(CGFloat)preferredSheetHeight {
   _preferredSheetHeight = preferredSheetHeight;
-  if (preferredSheetHeight > 0.f) {
-    [self updatePreferredSheetHeight:preferredSheetHeight];
-  }
+  [self updatePreferredSheetHeight];
 }
 
 #pragma mark - MDCSheetContainerViewDelegate

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -108,7 +108,7 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   [containerView addSubview:_dimmingView];
   [containerView addSubview:self.sheetView];
 
-  [self setPreferredSheetHeight:self.presentedViewController.preferredContentSize.height];
+  [self updatePreferredSheetHeight:self.presentedViewController.preferredContentSize.height];
 
   // Add tap handler to dismiss the sheet.
   UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self
@@ -155,7 +155,7 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   [super preferredContentSizeDidChangeForChildContentContainer:container];
   self.sheetView.frame = [self frameOfPresentedViewInContainerView];
   [self.sheetView layoutIfNeeded];
-  [self setPreferredSheetHeight:self.presentedViewController.preferredContentSize.height];
+  [self updatePreferredSheetHeight:self.presentedViewController.preferredContentSize.height];
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size
@@ -167,7 +167,7 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
           __unused id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
         self.sheetView.frame = [self frameOfPresentedViewInContainerView];
         [self.sheetView layoutIfNeeded];
-        [self setPreferredSheetHeight:self.presentedViewController.preferredContentSize.height];
+        [self updatePreferredSheetHeight:self.presentedViewController.preferredContentSize.height];
       }
                       completion:nil];
 }
@@ -179,9 +179,11 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
  @param preferredSheetHeight If positive, the new value for @sheetView.preferredSheetHeight.
  */
-- (void)setPreferredSheetHeight:(CGFloat)preferredSheetHeight {
+- (void)updatePreferredSheetHeight:(CGFloat)preferredSheetHeight {
   // If |preferredSheetHeight| has not been specified, use half of the current height.
-  if (MDCCGFloatEqual(preferredSheetHeight, 0)) {
+  if (self.preferredSheetHeight > 0.f) {
+    preferredSheetHeight = self.preferredSheetHeight;
+  } else if (MDCCGFloatEqual(preferredSheetHeight, 0)) {
     preferredSheetHeight = MDCRound(CGRectGetHeight(self.sheetView.frame) / 2);
   }
   self.sheetView.preferredSheetHeight = preferredSheetHeight;
@@ -242,6 +244,13 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
 - (UIAccessibilityTraits)scrimAccessibilityTraits {
   return _scrimAccessibilityTraits;
+}
+
+- (void)setPreferredSheetHeight:(CGFloat)preferredSheetHeight {
+  _preferredSheetHeight = preferredSheetHeight;
+  if (preferredSheetHeight > 0.f) {
+    [self updatePreferredSheetHeight:preferredSheetHeight];
+  }
 }
 
 #pragma mark - MDCSheetContainerViewDelegate

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.h
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.h
@@ -49,9 +49,12 @@
  This is used to set a custom height on the sheet view. This is can be used to set the initial
  height when the ViewController is presented.
 
- @note This will override setting the preferredContentSize if a positive value is passed.
- @note If a non-positive value is passed then the sheet will open up to either half the screen
- height or the size of the contentViewController whatever value is smaller.
+ @note If a positive value is passed then the sheet view will be that height even if
+ perferredContentSize has been set. Otherwise the sheet will open up to half the screen height or
+ the size of the presentedViewController's preferredContentSize whatever value is smaller.
+ @note The preferredSheetHeight can never be taller than the height of the content, if the content
+ is smaller than the value passed to preferredSheetHeight then the sheet view will be the size of
+ the content height.
  */
 @property(nonatomic, assign) CGFloat preferredSheetHeight;
 

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.h
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.h
@@ -45,6 +45,16 @@
  */
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;
 
+/**
+ This is used to set a custom height on the sheet view. This is can be used to set the initial
+ height when the ViewController is presented.
+
+ @note This will override setting the preferredContentSize if a positive value is passed.
+ @note If a non-positive value is passed then the sheet will open up to either half the screen
+ height or the size of the contentViewController whatever value is smaller.
+ */
+@property(nonatomic, assign) CGFloat preferredSheetHeight;
+
 @end
 
 @interface MDCBottomSheetTransitionController (ScrimAccessibility)

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.m
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.m
@@ -48,6 +48,7 @@ static const NSTimeInterval MDCBottomSheetTransitionDuration = 0.25;
   presentationController.isScrimAccessibilityElement = _isScrimAccessibilityElement;
   presentationController.scrimAccessibilityHint = _scrimAccessibilityHint;
   presentationController.scrimAccessibilityLabel = _scrimAccessibilityLabel;
+  presentationController.preferredSheetHeight = _preferredSheetHeight;
   return presentationController;
 }
 

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
@@ -22,7 +22,7 @@
 // Exposing internal methods for unit testing
 @interface MDCBottomSheetPresentationController (Testing)
 @property(nonatomic, strong) MDCSheetContainerView *sheetView;
-- (void)updatePreferredSheetHeight:(CGFloat)preferredSheetHeight;
+- (void)updatePreferredSheetHeight;
 @end
 
 /**
@@ -85,7 +85,7 @@
   self.sheetView.frame = CGRectMake(0, 0, 75, sheetFrameHeight);
 
   // When
-  [self.presentationController updatePreferredSheetHeight:0];
+  [self.presentationController updatePreferredSheetHeight];
 
   // Then
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, sheetFrameHeight / 2, 0.001);
@@ -97,7 +97,7 @@
   self.sheetView.frame = CGRectMake(75, 80, -75, sheetFrameHeight);
 
   // When
-  [self.presentationController updatePreferredSheetHeight:0];
+  [self.presentationController updatePreferredSheetHeight];
 
   // Then
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight,
@@ -107,10 +107,12 @@
 - (void)testSetPreferredSheetHeightPositiveValue {
   // Given
   CGFloat preferredSheetHeight = 120;
+  self.presentationController.presentedViewController.preferredContentSize =
+      CGSizeMake(100, preferredSheetHeight);
   self.sheetView.frame = CGRectMake(0, 0, 75, 80);
 
   // When
-  [self.presentationController updatePreferredSheetHeight:preferredSheetHeight];
+  [self.presentationController updatePreferredSheetHeight];
 
   // Then
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, preferredSheetHeight, 0.001);
@@ -119,10 +121,12 @@
 - (void)testSetPreferredSheetHeightNegativeValue {
   // Given
   CGFloat preferredSheetHeight = -120;
+  self.presentationController.presentedViewController.preferredContentSize =
+      CGSizeMake(0, preferredSheetHeight);
   self.sheetView.frame = CGRectMake(0, 0, 75, -80);
 
   // When
-  [self.presentationController updatePreferredSheetHeight:preferredSheetHeight];
+  [self.presentationController updatePreferredSheetHeight];
 
   // Then
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, preferredSheetHeight, 0.001);
@@ -132,10 +136,9 @@
   // Given
   CGFloat preferredSheetHeight = 100;
   self.presentationController.preferredSheetHeight = preferredSheetHeight;
-  CGFloat fakeValue = 200;
 
   // When
-  [self.presentationController updatePreferredSheetHeight:fakeValue];
+  [self.presentationController updatePreferredSheetHeight];
 
   // Then
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, preferredSheetHeight, 0.001);
@@ -149,7 +152,7 @@
   self.sheetView.frame = CGRectMake(0, 0, 75, sheetHeight);
 
   // When
-  [self.presentationController updatePreferredSheetHeight:0];
+  [self.presentationController updatePreferredSheetHeight];
 
   // Then
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, (CGFloat)(sheetHeight / 2),
@@ -164,9 +167,7 @@
   self.presentationController.preferredSheetHeight = preferredSheetHeight;
 
   // When
-  [self.presentationController
-      updatePreferredSheetHeight:self.presentationController.presentedViewController
-                                     .preferredContentSize.height];
+  [self.presentationController updatePreferredSheetHeight];
 
   // Then
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, preferredSheetHeight, 0.001);
@@ -180,9 +181,7 @@
   self.presentationController.preferredSheetHeight = preferredSheetHeight;
 
   // When
-  [self.presentationController
-      updatePreferredSheetHeight:self.presentationController.presentedViewController
-                                     .preferredContentSize.height];
+  [self.presentationController updatePreferredSheetHeight];
 
   // Then
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, preferredContentSize.height,
@@ -197,11 +196,9 @@
   self.sheetView.frame = CGRectMake(0, 0, 200, sheetHeight);
 
   // When
-  [self.presentationController
-      updatePreferredSheetHeight:self.presentationController.preferredSheetHeight];
+  [self.presentationController updatePreferredSheetHeight];
   self.presentationController.preferredSheetHeight = 0;
-  [self.presentationController
-      updatePreferredSheetHeight:self.presentationController.preferredSheetHeight];
+  [self.presentationController updatePreferredSheetHeight];
 
   // Then
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, (CGFloat)(sheetHeight / 2),

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
@@ -205,35 +205,25 @@
                              0.001);
 }
 
-- (void)testVeryLargePreferredSheetHeight {
+- (void)testVeryLargePreferredSheetHeightAndSmallContent {
   // Given
-  CGRect standardFrame = CGRectMake(0, 0, 200, 300);
-  UIScrollView *scrollView = [[UIScrollView alloc] initWithFrame:standardFrame];
-  scrollView.contentSize = standardFrame.size;
+  CGFloat scrollViewHeight = 100;
+  CGRect smallFrame = CGRectMake(0, 0, 200, scrollViewHeight);
+  UIScrollView *scrollView = [[UIScrollView alloc] initWithFrame:smallFrame];
   FakeSheetView *sheetView =
-      [[FakeSheetView alloc] initWithFrame:standardFrame
-                               contentView:[[UIView alloc] initWithFrame:standardFrame]
+      [[FakeSheetView alloc] initWithFrame:smallFrame
+                               contentView:[[UIView alloc] initWithFrame:smallFrame]
                                 scrollView:scrollView];
 
-  UIViewController *stubPresentingViewController = [[UIViewController alloc] init];
-  stubPresentingViewController.view.frame = standardFrame;
-  UIViewController *stubPresentedViewController = [[UIViewController alloc] init];
-  stubPresentedViewController.view.frame = standardFrame;
-
-  MDCBottomSheetPresentationController *presentationController =
-      [[MDCBottomSheetPresentationController alloc]
-                                 initWithPresentedViewController:stubPresentedViewController
-                                 presentingViewController:stubPresentingViewController];
-  presentationController.sheetView = sheetView;
-  presentationController.preferredSheetHeight = 5000;
+  self.presentationController.sheetView = sheetView;
+  self.presentationController.preferredSheetHeight = 5000;
 
 
   // When
-  [presentationController updatePreferredSheetHeight];
+  [self.presentationController updatePreferredSheetHeight];
 
   // Then
-  CGFloat expectedHeight = CGRectGetHeight(standardFrame) / 2;
-  XCTAssertEqualWithAccuracy(sheetView.preferredSheetHeight, expectedHeight, 0.001);
+  XCTAssertEqualWithAccuracy(CGRectGetHeight(sheetView.frame), CGRectGetHeight(smallFrame), 0.001);
 }
 
 @end

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
@@ -164,7 +164,9 @@
   self.presentationController.preferredSheetHeight = preferredSheetHeight;
 
   // When
-  [self.presentationController updatePreferredSheetHeight:self.presentationController.presentedViewController.preferredContentSize.height];
+  [self.presentationController
+      updatePreferredSheetHeight:self.presentationController.presentedViewController
+                                     .preferredContentSize.height];
 
   // Then
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, preferredSheetHeight, 0.001);
@@ -178,7 +180,9 @@
   self.presentationController.preferredSheetHeight = preferredSheetHeight;
 
   // When
-  [self.presentationController updatePreferredSheetHeight:self.presentationController.presentedViewController.preferredContentSize.height];
+  [self.presentationController
+      updatePreferredSheetHeight:self.presentationController.presentedViewController
+                                     .preferredContentSize.height];
 
   // Then
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, preferredContentSize.height,

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
@@ -207,20 +207,18 @@
 
 - (void)testVeryLargePreferredSheetHeight {
   // Given
-  CGRect sheetFrame = CGRectMake(0, 0, 200, 300);
-  CGRect contentViewFrame = CGRectMake(0, 0, 200, 300);
-  CGRect scrollViewFrame = CGRectMake(0, 0, 200, 300);
-  UIScrollView *scrollView = [[UIScrollView alloc] initWithFrame:scrollViewFrame];
-  scrollView.contentSize = CGSizeMake(200, 300);
+  CGRect standardFrame = CGRectMake(0, 0, 200, 300);
+  UIScrollView *scrollView = [[UIScrollView alloc] initWithFrame:standardFrame];
+  scrollView.contentSize = standardFrame.size;
   FakeSheetView *sheetView =
-      [[FakeSheetView alloc] initWithFrame:sheetFrame
-                               contentView:[[UIView alloc] initWithFrame:contentViewFrame]
+      [[FakeSheetView alloc] initWithFrame:standardFrame
+                               contentView:[[UIView alloc] initWithFrame:standardFrame]
                                 scrollView:scrollView];
 
   UIViewController *stubPresentingViewController = [[UIViewController alloc] init];
-  stubPresentingViewController.view.frame = CGRectMake(0, 0, 200, 300);
+  stubPresentingViewController.view.frame = standardFrame;
   UIViewController *stubPresentedViewController = [[UIViewController alloc] init];
-  stubPresentedViewController.view.frame = CGRectMake(0, 0, 200, 300);
+  stubPresentedViewController.view.frame = standardFrame;
 
   MDCBottomSheetPresentationController *presentationController =
       [[MDCBottomSheetPresentationController alloc]
@@ -234,7 +232,8 @@
   [presentationController updatePreferredSheetHeight];
 
   // Then
-  XCTAssertEqualWithAccuracy(sheetView.preferredSheetHeight, (CGFloat)(150), 0.001);
+  CGFloat expectedHeight = CGRectGetHeight(standardFrame) / 2;
+  XCTAssertEqualWithAccuracy(sheetView.preferredSheetHeight, expectedHeight, 0.001);
 }
 
 @end

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
@@ -79,7 +79,7 @@
   self.presentationController.sheetView = self.sheetView;
 }
 
-- (void)testSetPreferredSheetHeightZeroWhenSheetViewHasStandardizedFrame {
+- (void)testUpdatePreferredSheetHeightZeroWhenSheetViewHasStandardizedFrame {
   // Given
   CGFloat sheetFrameHeight = 80;
   self.sheetView.frame = CGRectMake(0, 0, 75, sheetFrameHeight);
@@ -91,7 +91,7 @@
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, sheetFrameHeight / 2, 0.001);
 }
 
-- (void)testSetPreferredSheetHeightZeroWhenSheetViewHasUnstandardizedFrame {
+- (void)testUpdatePreferredSheetHeightZeroWhenSheetViewHasUnstandardizedFrame {
   // Given
   CGFloat sheetFrameHeight = -80;
   self.sheetView.frame = CGRectMake(75, 80, -75, sheetFrameHeight);
@@ -104,7 +104,7 @@
                              (CGFloat)fabs(sheetFrameHeight / 2), 0.001);
 }
 
-- (void)testSetPreferredSheetHeightPositiveValue {
+- (void)testUpdatePreferredSheetHeightPositiveValue {
   // Given
   CGFloat preferredSheetHeight = 120;
   self.presentationController.presentedViewController.preferredContentSize =
@@ -118,7 +118,7 @@
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, preferredSheetHeight, 0.001);
 }
 
-- (void)testSetPreferredSheetHeightNegativeValue {
+- (void)testUpdatePreferredSheetHeightNegativeValue {
   // Given
   CGFloat preferredSheetHeight = -120;
   self.presentationController.presentedViewController.preferredContentSize =
@@ -132,7 +132,7 @@
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, preferredSheetHeight, 0.001);
 }
 
-- (void)testSetPreferredSheetHeight {
+- (void)testUpdatePreferredSheetHeight {
   // Given
   CGFloat preferredSheetHeight = 100;
   self.presentationController.preferredSheetHeight = preferredSheetHeight;
@@ -144,7 +144,7 @@
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, preferredSheetHeight, 0.001);
 }
 
-- (void)testSetNegativePreferredSheetHeight {
+- (void)testUpdateNegativePreferredSheetHeight {
   // Given
   CGFloat preferrredSheetHeight = -100;
   self.presentationController.preferredSheetHeight = preferrredSheetHeight;
@@ -159,7 +159,7 @@
                              0.001);
 }
 
-- (void)testSetPreferredSheetHeightAndPreferredContentSize {
+- (void)testUpdatePreferredSheetHeightAndPreferredContentSize {
   // Given
   CGSize preferredContentSize = CGSizeMake(100, 100);
   CGFloat preferredSheetHeight = 200;

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
@@ -189,4 +189,23 @@
                              0.001);
 }
 
+- (void)testPreferredSheetHeightNonZeroThenZero {
+  // Given
+  CGFloat preferredSheetHeight = 200;
+  self.presentationController.preferredSheetHeight = preferredSheetHeight;
+  CGFloat sheetHeight = 300;
+  self.sheetView.frame = CGRectMake(0, 0, 200, sheetHeight);
+
+  // When
+  [self.presentationController
+      updatePreferredSheetHeight:self.presentationController.preferredSheetHeight];
+  self.presentationController.preferredSheetHeight = 0;
+  [self.presentationController
+      updatePreferredSheetHeight:self.presentationController.preferredSheetHeight];
+
+  // Then
+  XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, (CGFloat)(sheetHeight / 2),
+                             0.001);
+}
+
 @end

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
@@ -205,4 +205,36 @@
                              0.001);
 }
 
+- (void)testVeryLargePreferredSheetHeight {
+  // Given
+  CGRect sheetFrame = CGRectMake(0, 0, 200, 300);
+  CGRect contentViewFrame = CGRectMake(0, 0, 200, 300);
+  CGRect scrollViewFrame = CGRectMake(0, 0, 200, 300);
+  UIScrollView *scrollView = [[UIScrollView alloc] initWithFrame:scrollViewFrame];
+  scrollView.contentSize = CGSizeMake(200, 300);
+  FakeSheetView *sheetView =
+      [[FakeSheetView alloc] initWithFrame:sheetFrame
+                               contentView:[[UIView alloc] initWithFrame:contentViewFrame]
+                                scrollView:scrollView];
+
+  UIViewController *stubPresentingViewController = [[UIViewController alloc] init];
+  stubPresentingViewController.view.frame = CGRectMake(0, 0, 200, 300);
+  UIViewController *stubPresentedViewController = [[UIViewController alloc] init];
+  stubPresentedViewController.view.frame = CGRectMake(0, 0, 200, 300);
+
+  MDCBottomSheetPresentationController *presentationController =
+      [[MDCBottomSheetPresentationController alloc]
+                                 initWithPresentedViewController:stubPresentedViewController
+                                 presentingViewController:stubPresentingViewController];
+  presentationController.sheetView = sheetView;
+  presentationController.preferredSheetHeight = 5000;
+
+
+  // When
+  [presentationController updatePreferredSheetHeight];
+
+  // Then
+  XCTAssertEqualWithAccuracy(sheetView.preferredSheetHeight, (CGFloat)(150), 0.001);
+}
+
 @end

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
@@ -22,7 +22,7 @@
 // Exposing internal methods for unit testing
 @interface MDCBottomSheetPresentationController (Testing)
 @property(nonatomic, strong) MDCSheetContainerView *sheetView;
-- (void)setPreferredSheetHeight:(CGFloat)preferredSheetHeight;
+- (void)updatePreferredSheetHeight:(CGFloat)preferredSheetHeight;
 @end
 
 /**
@@ -85,7 +85,7 @@
   self.sheetView.frame = CGRectMake(0, 0, 75, sheetFrameHeight);
 
   // When
-  [self.presentationController setPreferredSheetHeight:0];
+  [self.presentationController updatePreferredSheetHeight:0];
 
   // Then
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, sheetFrameHeight / 2, 0.001);
@@ -97,7 +97,7 @@
   self.sheetView.frame = CGRectMake(75, 80, -75, sheetFrameHeight);
 
   // When
-  [self.presentationController setPreferredSheetHeight:0];
+  [self.presentationController updatePreferredSheetHeight:0];
 
   // Then
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight,
@@ -110,7 +110,7 @@
   self.sheetView.frame = CGRectMake(0, 0, 75, 80);
 
   // When
-  [self.presentationController setPreferredSheetHeight:preferredSheetHeight];
+  [self.presentationController updatePreferredSheetHeight:preferredSheetHeight];
 
   // Then
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, preferredSheetHeight, 0.001);
@@ -122,10 +122,67 @@
   self.sheetView.frame = CGRectMake(0, 0, 75, -80);
 
   // When
-  [self.presentationController setPreferredSheetHeight:preferredSheetHeight];
+  [self.presentationController updatePreferredSheetHeight:preferredSheetHeight];
 
   // Then
   XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, preferredSheetHeight, 0.001);
+}
+
+- (void)testSetPreferredSheetHeight {
+  // Given
+  CGFloat preferredSheetHeight = 100;
+  self.presentationController.preferredSheetHeight = preferredSheetHeight;
+  CGFloat fakeValue = 200;
+
+  // When
+  [self.presentationController updatePreferredSheetHeight:fakeValue];
+
+  // Then
+  XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, preferredSheetHeight, 0.001);
+}
+
+- (void)testSetNegativePreferredSheetHeight {
+  // Given
+  CGFloat preferrredSheetHeight = -100;
+  self.presentationController.preferredSheetHeight = preferrredSheetHeight;
+  CGFloat sheetHeight = 250;
+  self.sheetView.frame = CGRectMake(0, 0, 75, sheetHeight);
+
+  // When
+  [self.presentationController updatePreferredSheetHeight:0];
+
+  // Then
+  XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, (CGFloat)(sheetHeight / 2),
+                             0.001);
+}
+
+- (void)testSetPreferredSheetHeightAndPreferredContentSize {
+  // Given
+  CGSize preferredContentSize = CGSizeMake(100, 100);
+  CGFloat preferredSheetHeight = 200;
+  self.presentationController.presentedViewController.preferredContentSize = preferredContentSize;
+  self.presentationController.preferredSheetHeight = preferredSheetHeight;
+
+  // When
+  [self.presentationController updatePreferredSheetHeight:self.presentationController.presentedViewController.preferredContentSize.height];
+
+  // Then
+  XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, preferredSheetHeight, 0.001);
+}
+
+- (void)testPreferredSheetHeightNegativeAndPreferredContentSizePositive {
+  // Given
+  CGSize preferredContentSize = CGSizeMake(100, 100);
+  CGFloat preferredSheetHeight = -200;
+  self.presentationController.presentedViewController.preferredContentSize = preferredContentSize;
+  self.presentationController.preferredSheetHeight = preferredSheetHeight;
+
+  // When
+  [self.presentationController updatePreferredSheetHeight:self.presentationController.presentedViewController.preferredContentSize.height];
+
+  // Then
+  XCTAssertEqualWithAccuracy(self.sheetView.preferredSheetHeight, preferredContentSize.height,
+                             0.001);
 }
 
 @end

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
@@ -218,7 +218,6 @@
   self.presentationController.sheetView = sheetView;
   self.presentationController.preferredSheetHeight = 5000;
 
-
   // When
   [self.presentationController updatePreferredSheetHeight];
 


### PR DESCRIPTION
Previously clients could only set a custom height for bottom sheet by setting the `preferredContentSize` this adds a property so clients can set a specific height and not touch `preferredContentSize`.

Related to #4945 