### PR TITLE
[alpha_components] Add README.md note

### DIFF
--- a/contributing/alpha_components.md
+++ b/contributing/alpha_components.md
@@ -24,4 +24,20 @@ Once a component is ready for general production use, we will graduate the compo
 `MaterialComponents.podspec`. At this point the component will be subject to all of the processes
 and expectations that any other production component.
 
-All of your Swift example or test files must import `MaterialComponentsAlpha.ComponentName`.
+## Import statements
+
+Swift import statements for alpha components follow the pattern `MaterialComponentsAlpha.<#ComponentName#>`.
+
+## Component README.md
+
+The component's README.md should include the following near the top of the document:
+
+```
+## Alpha component
+
+This component is an [alpha component](../../contributing/alpha_components.md). This means the API is
+subject to change without notice. To use this component, you must manually clone the
+material-components-ios repo and add the following to your Podfile:
+
+    pod 'MaterialComponentsAlpha', :path => 'path/to/material-components-ios'
+```

--- a/contributing/alpha_components.md
+++ b/contributing/alpha_components.md
@@ -36,8 +36,8 @@ The component's README.md should include the following near the top of the docum
 ## Alpha component
 
 This component is an [alpha component](../../contributing/alpha_components.md). This means the API is
-subject to change without notice. To use this component, you must manually clone the
-material-components-ios repo and add the following to your Podfile:
+subject to change without notice and without incrementing major/minor version numbers. To use this
+component, you must manually clone the material-components-ios repo and add the following to your Podfile:
 
     pod 'MaterialComponentsAlpha', :path => 'path/to/material-components-ios'
 ```


### PR DESCRIPTION
Added a section to the alpha components documentation inspired by https://github.com/material-components/material-components-ios/pull/5134. This section encourages alpha components to include a section calling out the fact that the component is an alpha component and how to install it.