### PR TITLE
[ActionSheet] Labels use text color instead of alpha

### DIFF
--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
@@ -49,7 +49,7 @@ static const CGFloat MiddlePadding = 8.f;
     _messageLabel.font = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleBody1];
     _messageLabel.numberOfLines = 2;
     _messageLabel.lineBreakMode = NSLineBreakByWordWrapping;
-    _messageLabel.alpha = MessageLabelAlpha;
+    _messageLabel.textColor = [UIColor.blackColor colorWithAlphaComponent:MessageLabelAlpha];
   }
   return self;
 }
@@ -125,9 +125,9 @@ static const CGFloat MiddlePadding = 8.f;
   // If message is empty or nil then the title label's alpha value should be lighter, if there is both
   // then the title label's alpha should be darker.
   if (self.message && ![self.message isEqualToString:@""]) {
-    self.titleLabel.alpha = TitleLabelAlpha;
+    _titleLabel.textColor = [UIColor.blackColor colorWithAlphaComponent:TitleLabelAlpha];
   } else {
-    self.titleLabel.alpha = MessageLabelAlpha;
+    _titleLabel.textColor = [UIColor.blackColor colorWithAlphaComponent:MessageLabelAlpha];
   }
   [self setNeedsLayout];
 }

--- a/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
+++ b/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
@@ -56,7 +56,7 @@ static const CGFloat ActionItemTitleVerticalPadding = 18.f;
   [_textLabel sizeToFit];
   _textLabel.font = [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleSubheadline];
   _textLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
-  _textLabel.alpha = LabelAlpha;
+  _textLabel.textColor = [UIColor.blackColor colorWithAlphaComponent:LabelAlpha];
   CGFloat leadingConstant;
   if (_itemAction.image) {
     leadingConstant = TitleLeadingPadding;

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -44,8 +44,9 @@
   self.actionSheet.title = @"Test";
 
   // Then
-  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor,
-                        [UIColor.blackColor colorWithAlphaComponent:0.6f]);
+  UIColor *expectedColor = [UIColor.blackColor colorWithAlphaComponent:0.6f];
+  UIColor *titleColor = self.actionSheet.header.titleLabel.textColor;
+  XCTAssertEqualObjects(titleColor, expectedColor);
 }
 
 - (void)testMessageColor {
@@ -53,8 +54,9 @@
   self.actionSheet.message = @"Test";
 
   // Then
-  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor,
-                        [UIColor.blackColor colorWithAlphaComponent:0.6f]);
+  UIColor *expectedColor = [UIColor.blackColor colorWithAlphaComponent:0.6f];
+  UIColor *messageColor = self.actionSheet.header.messageLabel.textColor;
+  XCTAssertEqualObjects(messageColor, expectedColor);
 }
 
 - (void)testTitleAndMessageColor {
@@ -63,10 +65,13 @@
   self.actionSheet.message = @"Test message";
 
   // Then
-  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor,
-                        [UIColor.blackColor colorWithAlphaComponent:0.87f]);
-  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor,
-                        [UIColor.blackColor colorWithAlphaComponent:0.6f]);
+  UIColor *expectedTitleColor = [UIColor.blackColor colorWithAlphaComponent:0.87f];
+  UIColor *titleColor = self.actionSheet.header.titleLabel.textColor;
+  XCTAssertEqualObjects(titleColor, expectedTitleColor);
+
+  UIColor *expectedMessageColor = [UIColor.blackColor colorWithAlphaComponent:0.6f];
+  UIColor *messageColor = self.actionSheet.header.messageLabel.textColor;
+  XCTAssertEqualObjects(messageColor, expectedMessageColor);
 }
 
 - (void)testTitleAndMessageColorWhenMessageSetFirst {
@@ -75,10 +80,13 @@
   self.actionSheet.title = @"Test title";
 
   // Then
-  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor,
-                        [UIColor.blackColor colorWithAlphaComponent:0.87f]);
-  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor,
-                        [UIColor.blackColor colorWithAlphaComponent:0.6f]);
+  UIColor *expectedTitleColor = [UIColor.blackColor colorWithAlphaComponent:0.87f];
+  UIColor *titleColor = self.actionSheet.header.titleLabel.textColor;
+  XCTAssertEqualObjects(titleColor, expectedTitleColor);
+
+  UIColor *expectedMessageColor = [UIColor.blackColor colorWithAlphaComponent:0.6f];
+  UIColor *messageColor = self.actionSheet.header.messageLabel.textColor;
+  XCTAssertEqualObjects(messageColor, expectedMessageColor);
 }
 
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -39,20 +39,46 @@
   self.actionSheet = [[MDCActionSheetController alloc] init];
 }
 
-- (void)testHeaderColor {
+- (void)testTitleColor {
   // When
   self.actionSheet.title = @"Test";
 
   // Then
-  UIColor *expectedColor = [UIColor.blackColor colorWithAlphaComponent:0.6];
-  
-  XCTAssertEqual(self.actionSheet.header.titleLabel.textColor, expectedColor);
+  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor,
+                        [UIColor.blackColor colorWithAlphaComponent:0.6f]);
 }
 
 - (void)testMessageColor {
   // When
+  self.actionSheet.message = @"Test";
 
   // Then
+  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor,
+                        [UIColor.blackColor colorWithAlphaComponent:0.6f]);
+}
+
+- (void)testTitleAndMessageColor {
+  // When
+  self.actionSheet.title = @"Test title";
+  self.actionSheet.message = @"Test message";
+
+  // Then
+  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor,
+                        [UIColor.blackColor colorWithAlphaComponent:0.87f]);
+  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor,
+                        [UIColor.blackColor colorWithAlphaComponent:0.6f]);
+}
+
+- (void)testTitleAndMessageColorWhenMessageSetFirst {
+  // When
+  self.actionSheet.message = @"Test message";
+  self.actionSheet.title = @"Test title";
+
+  // Then
+  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor,
+                        [UIColor.blackColor colorWithAlphaComponent:0.87f]);
+  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor,
+                        [UIColor.blackColor colorWithAlphaComponent:0.6f]);
 }
 
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -16,15 +16,23 @@
 
 #import <XCTest/XCTest.h>
 
-@interface MDCActionSheetTest : XCTestCase
+#import "../../src/private/MDCActionSheetHeaderView.h"
 
+@interface MDCActionSheetHeaderView (Testing)
+@property(nonatomic, strong) UILabel *titleLabel;
+@property(nonatomic, strong) UILabel *messageLabel;
+@end
+
+@interface MDCActionSheetTest : XCTestCase
+@property(nonatomic, strong) MDCActionSheetController *actionSheet;
 @end
 
 @implementation MDCActionSheetTest
 
 - (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+  [super setUp];
+
+  self.actionSheet = [[MDCActionSheetController alloc] init];
 }
 
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -1,0 +1,30 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialActionSheet.h"
+
+#import <XCTest/XCTest.h>
+
+@interface MDCActionSheetTest : XCTestCase
+
+@end
+
+@implementation MDCActionSheetTest
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+@end

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -23,6 +23,10 @@
 @property(nonatomic, strong) UILabel *messageLabel;
 @end
 
+@interface MDCActionSheetController (Testing)
+@property(nonatomic, strong) MDCActionSheetHeaderView *header;
+@end
+
 @interface MDCActionSheetTest : XCTestCase
 @property(nonatomic, strong) MDCActionSheetController *actionSheet;
 @end
@@ -33,6 +37,22 @@
   [super setUp];
 
   self.actionSheet = [[MDCActionSheetController alloc] init];
+}
+
+- (void)testHeaderColor {
+  // When
+  self.actionSheet.title = @"Test";
+
+  // Then
+  UIColor *expectedColor = [UIColor.blackColor colorWithAlphaComponent:0.6];
+  
+  XCTAssertEqual(self.actionSheet.header.titleLabel.textColor, expectedColor);
+}
+
+- (void)testMessageColor {
+  // When
+
+  // Then
 }
 
 @end


### PR DESCRIPTION
Previously all labels used `.alpha` property and now they use `.textColor`.

Related to #4903 