### PR TITLE
[BottomAppBar] clean up how bottom app bar path renders to avoid using hardcoded values

### DIFF
--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -56,14 +56,16 @@ static const int kMDCButtonAnimationDuration = 200;
 @implementation MDCBottomAppBarView
 
 - (instancetype)initWithFrame:(CGRect)frame {
-  if (self = [super initWithFrame:frame]) {
+  self = [super initWithFrame:frame];
+  if (self) {
     [self commonMDCBottomAppBarViewInit];
   }
   return self;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
-  if (self = [super initWithCoder:aDecoder]) {
+  self = [super initWithCoder:aDecoder];
+  if (self) {
     [self commonMDCBottomAppBarViewInit];
   }
   return self;

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -56,16 +56,14 @@ static const int kMDCButtonAnimationDuration = 200;
 @implementation MDCBottomAppBarView
 
 - (instancetype)initWithFrame:(CGRect)frame {
-  self = [super initWithFrame:frame];
-  if (self) {
+  if (self = [super initWithFrame:frame]) {
     [self commonMDCBottomAppBarViewInit];
   }
   return self;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
-  self = [super initWithCoder:aDecoder];
-  if (self) {
+  if (self = [super initWithCoder:aDecoder]) {
     [self commonMDCBottomAppBarViewInit];
   }
   return self;
@@ -151,16 +149,16 @@ static const int kMDCButtonAnimationDuration = 200;
 }
 
 - (void)cutBottomAppBarViewAnimated:(BOOL)animated {
-  CGPathRef cutPath =
-      [self.bottomBarLayer pathWithCutFromRect:self.bounds
-                        floatingButtonPosition:self.floatingButtonPosition
-                               layoutDirection:self.layoutDirection];
+  CGPathRef pathWithCut = [self.bottomBarLayer pathFromRect:self.bounds
+                                             floatingButton:self.floatingButton
+                                         navigationBarFrame:self.navBar.frame
+                                                  shouldCut:YES];
   if (animated) {
     CABasicAnimation *pathAnimation =
         [CABasicAnimation animationWithKeyPath:kMDCBottomAppBarViewPathString];
     pathAnimation.duration = kMDCFloatingButtonExitDuration;
     pathAnimation.fromValue = (id)self.bottomBarLayer.presentationLayer.path;
-    pathAnimation.toValue = (__bridge id _Nullable)(cutPath);
+    pathAnimation.toValue = (__bridge id _Nullable)(pathWithCut);
     pathAnimation.fillMode = kCAFillModeForwards;
     pathAnimation.removedOnCompletion = NO;
     pathAnimation.delegate = self;
@@ -168,21 +166,21 @@ static const int kMDCButtonAnimationDuration = 200;
                      forKey:kMDCBottomAppBarViewAnimKeyString];
     [self.bottomBarLayer addAnimation:pathAnimation forKey:kMDCBottomAppBarViewPathString];
   } else {
-    self.bottomBarLayer.path = cutPath;
+    self.bottomBarLayer.path = pathWithCut;
   }
 }
 
 - (void)healBottomAppBarViewAnimated:(BOOL)animated  {
-  CGPathRef withoutCutPath =
-      [self.bottomBarLayer pathWithoutCutFromRect:self.bounds
-                           floatingButtonPosition:self.floatingButtonPosition
-                                  layoutDirection:self.layoutDirection];
+  CGPathRef pathWithoutCut = [self.bottomBarLayer pathFromRect:self.bounds
+                                                floatingButton:self.floatingButton
+                                            navigationBarFrame:self.navBar.frame
+                                                     shouldCut:NO];
   if (animated) {
     CABasicAnimation *pathAnimation =
         [CABasicAnimation animationWithKeyPath:kMDCBottomAppBarViewPathString];
     pathAnimation.duration = kMDCFloatingButtonEnterDuration;
     pathAnimation.fromValue = (id)self.bottomBarLayer.presentationLayer.path;
-    pathAnimation.toValue = (__bridge id _Nullable)(withoutCutPath);
+    pathAnimation.toValue = (__bridge id _Nullable)(pathWithoutCut);
     pathAnimation.fillMode = kCAFillModeForwards;
     pathAnimation.removedOnCompletion = NO;
     pathAnimation.delegate = self;
@@ -190,7 +188,7 @@ static const int kMDCButtonAnimationDuration = 200;
                      forKey:kMDCBottomAppBarViewAnimKeyString];
     [self.bottomBarLayer addAnimation:pathAnimation forKey:kMDCBottomAppBarViewPathString];
   } else {
-    self.bottomBarLayer.path = withoutCutPath;
+    self.bottomBarLayer.path = pathWithoutCut;
   }
 }
 
@@ -239,10 +237,9 @@ static const int kMDCButtonAnimationDuration = 200;
       [self getFloatingButtonCenterPositionForWidth:CGRectGetWidth(self.bounds)];
   [self renderPathBasedOnFloatingButtonVisibitlityAnimated:NO];
 
-  CGRect navBarFrame = CGRectMake(0,
-                                  kMDCBottomAppBarYOffset,
-                                  CGRectGetWidth(self.bounds),
-                                  kMDCBottomAppBarHeight - kMDCBottomAppBarYOffset);
+  CGRect navBarFrame =
+      CGRectMake(0, kMDCBottomAppBarNavigationViewYOffset, CGRectGetWidth(self.bounds),
+                 kMDCBottomAppBarHeight - kMDCBottomAppBarNavigationViewYOffset);
   self.navBar.frame = navBarFrame;
 }
 
@@ -361,8 +358,8 @@ static const int kMDCButtonAnimationDuration = 200;
     }];
   } else {
     _floatingButton.hidden = NO;
-    [self cutBottomAppBarViewAnimated:animated];
     [_floatingButton expand:animated completion:nil];
+    [self cutBottomAppBarViewAnimated:animated];
   }
 }
 

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -360,8 +360,8 @@ static const int kMDCButtonAnimationDuration = 200;
     }];
   } else {
     _floatingButton.hidden = NO;
-    [_floatingButton expand:animated completion:nil];
     [self cutBottomAppBarViewAnimated:animated];
+    [_floatingButton expand:animated completion:nil];
   }
 }
 

--- a/components/BottomAppBar/src/private/MDCBottomAppBarAttributes.h
+++ b/components/BottomAppBar/src/private/MDCBottomAppBarAttributes.h
@@ -25,7 +25,7 @@ static const CGFloat kMDCBottomAppBarNavigationViewYOffset = 38.f;
 static const CGFloat kMDCBottomAppBarFloatingButtonPositionX = 64.f;
 
 // The delta radius of the path cut for the floating button to the floating button's radius.
-static const CGFloat kMDCBottomAppBarFloatingButtonRadiusOffset = 5.f;
+static const CGFloat kMDCBottomAppBarFloatingButtonRadiusOffset = 4.f;
 
 // The duration of the enter animation of the path cut, same as floating button enter animation.
 static const NSTimeInterval kMDCFloatingButtonEnterDuration = 0.270f;

--- a/components/BottomAppBar/src/private/MDCBottomAppBarAttributes.h
+++ b/components/BottomAppBar/src/private/MDCBottomAppBarAttributes.h
@@ -17,18 +17,15 @@
 // The height of the bottom app bar navigation area in collapsed state.
 static const CGFloat kMDCBottomAppBarHeight = 96.f;
 
-// The offset of the top of the containing view of the bottom app bar and the visible layer of the
-// bottom app bar.
-static const CGFloat kMDCBottomAppBarYOffset = 38.f;
+// The offset from the top of the navigation view of the bottom app bar to the
+// bottom app bar position
+static const CGFloat kMDCBottomAppBarNavigationViewYOffset = 38.f;
 
 // The horizontal position of the center of the floating button when in leading or trailing state.
 static const CGFloat kMDCBottomAppBarFloatingButtonPositionX = 64.f;
 
-// The vertical position of the center of the floating button.
-static const CGFloat kMDCBottomAppBarFloatingButtonPositionY = 10.f;
-
-// The radius of the path cut for the floating button.
-static const CGFloat kMDCBottomAppBarFloatingButtonRadius = 32.f;
+// The delta radius of the path cut for the floating button to the floating button's radius.
+static const CGFloat kMDCBottomAppBarFloatingButtonRadiusOffset = 5.f;
 
 // The duration of the enter animation of the path cut, same as floating button enter animation.
 static const NSTimeInterval kMDCFloatingButtonEnterDuration = 0.270f;

--- a/components/BottomAppBar/src/private/MDCBottomAppBarLayer.h
+++ b/components/BottomAppBar/src/private/MDCBottomAppBarLayer.h
@@ -18,12 +18,9 @@
 
 @interface MDCBottomAppBarLayer : CAShapeLayer
 
-- (CGPathRef)pathWithCutFromRect:(CGRect)rect
-          floatingButtonPosition:(MDCBottomAppBarFloatingButtonPosition)floatingButtonPosition
-                 layoutDirection:(UIUserInterfaceLayoutDirection)layoutDirection;
-
-- (CGPathRef)pathWithoutCutFromRect:(CGRect)rect
-             floatingButtonPosition:(MDCBottomAppBarFloatingButtonPosition)floatingButtonPosition
-                    layoutDirection:(UIUserInterfaceLayoutDirection)layoutDirection;
+- (CGPathRef)pathFromRect:(CGRect)rect
+           floatingButton:(MDCFloatingButton *)floatingButton
+       navigationBarFrame:(CGRect)navigationBarFrame
+                shouldCut:(BOOL)shouldCut;
 
 @end

--- a/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
+++ b/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
@@ -46,8 +46,8 @@
       CGRectGetHeight(floatingButton.bounds) / 2 + kMDCBottomAppBarFloatingButtonRadiusOffset;
   CGFloat navigationBarYOffset = CGRectGetMinY(navigationBarFrame);
   CGFloat halfAngle = acosf((float)((navigationBarYOffset - floatingButton.center.y) / arcRadius));
-  CGFloat startAngle = M_PI / 2.0f + halfAngle;
-  CGFloat endAngle = M_PI / 2.0f - halfAngle;
+  CGFloat startAngle = (float)M_PI / 2.0f + halfAngle;
+  CGFloat endAngle = (float)M_PI / 2.0f - halfAngle;
   CGFloat halfOfHypotenuseLength = sinf((float)halfAngle) * arcRadius;
 
   CGFloat width = CGRectGetWidth(rect);

--- a/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
+++ b/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
@@ -36,228 +36,81 @@
   return layer;
 }
 
-- (CGPathRef)pathWithCutFromRect:(CGRect)rect
-          floatingButtonPosition:(MDCBottomAppBarFloatingButtonPosition)floatingButtonPosition
-                 layoutDirection:(UIUserInterfaceLayoutDirection)layoutDirection {
+- (CGPathRef)pathFromRect:(CGRect)rect
+           floatingButton:(MDCFloatingButton *)floatingButton
+       navigationBarFrame:(CGRect)navigationBarFrame
+                shouldCut:(BOOL)shouldCut {
   UIBezierPath *bottomBarPath = [UIBezierPath bezierPath];
 
-  static CGFloat kStartAngle;
-  static CGFloat kEndAngle;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    // Since we know the hypotenuse (radius) and opposite side (height above the line) we can
-    // compute the angle.
-    // sin( θ ) = opposite / hypotenuse
-    // θ = arcsin( opposite / hypotenuse )
-    // More reading: https://www.mathsisfun.com/algebra/trig-finding-angle-right-triangle.html
-    kEndAngle = (CGFloat)asin(kMDCBottomAppBarFloatingButtonPositionY /
-                              kMDCBottomAppBarFloatingButtonRadius);
-    kStartAngle = (CGFloat)(M_PI - kEndAngle);
-  });
+  CGFloat arcRadius =
+      CGRectGetHeight(floatingButton.bounds) / 2 + kMDCBottomAppBarFloatingButtonRadiusOffset;
+  CGFloat navigationBarYOffset = CGRectGetMinY(navigationBarFrame);
+  CGFloat halfAngle = acos((navigationBarYOffset - floatingButton.center.y) / arcRadius);
+  CGFloat startAngle = M_PI / 2 + halfAngle;
+  CGFloat endAngle = M_PI / 2 - halfAngle;
+  CGFloat halfOfHypotenuseLength = sin(halfAngle) * arcRadius;
 
   CGFloat width = CGRectGetWidth(rect);
   CGFloat height = CGRectGetHeight(rect);
-  CGFloat midX = CGRectGetMidX(rect);
 
-  // Paths generated below differ based on the placement of the floating button.
-  switch (floatingButtonPosition) {
-    case MDCBottomAppBarFloatingButtonPositionLeading: {
-      if (layoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
-        [self pathWithCutRight:bottomBarPath
-                         width:width
-                        height:height
-                    startAngle:kStartAngle
-                      endAngle:kEndAngle];
-      } else {
-        [self pathWithCutLeft:bottomBarPath
-                        width:width
-                       height:height
-                   startAngle:kStartAngle
-                     endAngle:kEndAngle];
-      }
-      break;
-    }
-    case MDCBottomAppBarFloatingButtonPositionCenter: {
-      [bottomBarPath moveToPoint:CGPointMake(0, kMDCBottomAppBarYOffset)];
-      CGPoint centerPath = CGPointMake(midX,
-                                       kMDCBottomAppBarYOffset -
-                                       kMDCBottomAppBarFloatingButtonPositionY);
-      [bottomBarPath addArcWithCenter:centerPath
-                               radius:kMDCBottomAppBarFloatingButtonRadius
-                           startAngle:kStartAngle
-                             endAngle:kEndAngle
-                            clockwise:NO];
-      [bottomBarPath addLineToPoint:CGPointMake(width, kMDCBottomAppBarYOffset)];
-      [bottomBarPath addLineToPoint:CGPointMake(width, height * 2)];
-      [bottomBarPath addLineToPoint:CGPointMake(0, height * 2)];
-      [bottomBarPath closePath];
-      break;
-    }
-    case MDCBottomAppBarFloatingButtonPositionTrailing: {
-      if (layoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
-        [self pathWithCutLeft:bottomBarPath
-                        width:width
-                       height:height
-                   startAngle:kStartAngle
-                     endAngle:kEndAngle];
-      } else {
-        [self pathWithCutRight:bottomBarPath
-                         width:width
-                        height:height
-                    startAngle:kStartAngle
-                      endAngle:kEndAngle];
-      }
-      break;
-    }
-    default: {
-
-      // The default path does not contain a cut for the floating button. However, it is necessary
-      // to include the same number of points as the cut path version so there is a smooth
-      // transition between cut and without cut paths.
-      [bottomBarPath moveToPoint:CGPointMake(0, kMDCBottomAppBarYOffset)];
-      [bottomBarPath addLineToPoint:CGPointMake(height, kMDCBottomAppBarYOffset)];
-      [bottomBarPath addLineToPoint:CGPointMake(height,
-                                                height * 2 + kMDCBottomAppBarYOffset)];
-      [bottomBarPath addLineToPoint:CGPointMake(0, height * 2 + kMDCBottomAppBarYOffset)];
-      [bottomBarPath closePath];
-      break;
-    }
+  if (shouldCut) {
+    [self drawWithPathToCut:bottomBarPath
+                    yOffset:navigationBarYOffset
+                      width:width
+                     height:height
+                  arcCenter:floatingButton.center
+                  arcRadius:arcRadius
+                 startAngle:startAngle
+                   endAngle:endAngle];
+  } else {
+    [self drawWithPlainPath:bottomBarPath
+                    yOffset:navigationBarYOffset
+                      width:width
+                     height:height
+                  arcCenter:floatingButton.center
+           hypotenuseLength:halfOfHypotenuseLength * 2];
   }
+
   return bottomBarPath.CGPath;
 }
 
-- (UIBezierPath *)pathWithCutLeft:(UIBezierPath *)bottomBarPath
-                            width:(CGFloat)width
-                           height:(CGFloat)height
-                       startAngle:(CGFloat)startAngle
-                         endAngle:(CGFloat)endAngle {
-  [bottomBarPath moveToPoint:CGPointMake(0, kMDCBottomAppBarYOffset)];
-  CGPoint centerPath = CGPointMake(kMDCBottomAppBarFloatingButtonPositionX,
-                                   kMDCBottomAppBarYOffset -
-                                   kMDCBottomAppBarFloatingButtonPositionY);
-  [bottomBarPath addArcWithCenter:centerPath
-                           radius:kMDCBottomAppBarFloatingButtonRadius
+#pragma mark - Draw Helpers
+
+- (UIBezierPath *)drawWithPathToCut:(UIBezierPath *)bottomBarPath
+                            yOffset:(CGFloat)yOffset
+                              width:(CGFloat)width
+                             height:(CGFloat)height
+                          arcCenter:(CGPoint)arcCenter
+                          arcRadius:(CGFloat)arcRadius
+                         startAngle:(CGFloat)startAngle
+                           endAngle:(CGFloat)endAngle {
+  [bottomBarPath moveToPoint:CGPointMake(0, yOffset)];
+  [bottomBarPath addArcWithCenter:arcCenter
+                           radius:arcRadius
                        startAngle:startAngle
                          endAngle:endAngle
                         clockwise:NO];
-  [bottomBarPath addLineToPoint:CGPointMake(width, kMDCBottomAppBarYOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(width,
-                                            height * 2 + kMDCBottomAppBarYOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(0, height * 2 + kMDCBottomAppBarYOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(width, yOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(width, height * 2 + yOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(0, height * 2 + yOffset)];
   [bottomBarPath closePath];
   return bottomBarPath;
 }
 
-- (UIBezierPath *)pathWithCutRight:(UIBezierPath *)bottomBarPath
-                             width:(CGFloat)width
-                            height:(CGFloat)height
-                        startAngle:(CGFloat)startAngle
-                          endAngle:(CGFloat)endAngle {
-  [bottomBarPath moveToPoint:CGPointMake(0, kMDCBottomAppBarYOffset)];
-  CGPoint centerPath = CGPointMake(width - kMDCBottomAppBarFloatingButtonPositionX,
-                                   kMDCBottomAppBarYOffset -
-                                   kMDCBottomAppBarFloatingButtonPositionY);
-  [bottomBarPath addArcWithCenter:centerPath
-                           radius:kMDCBottomAppBarFloatingButtonRadius
-                       startAngle:startAngle
-                         endAngle:endAngle
-                        clockwise:NO];
-  [bottomBarPath addLineToPoint:CGPointMake(width, kMDCBottomAppBarYOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(width, height * 2 + kMDCBottomAppBarYOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(0, height * 2 + kMDCBottomAppBarYOffset)];
-  [bottomBarPath closePath];
-  return bottomBarPath;
-}
-
-- (CGPathRef)pathWithoutCutFromRect:(CGRect)rect
-             floatingButtonPosition:(MDCBottomAppBarFloatingButtonPosition)floatingButtonPosition
-                    layoutDirection:(UIUserInterfaceLayoutDirection)layoutDirection {
-
-  CGFloat height = CGRectGetHeight(rect);
-  CGFloat width = CGRectGetWidth(rect);
-  CGFloat midX = CGRectGetMidX(rect);
-
-  UIBezierPath *bottomBarPath = [UIBezierPath bezierPath];
-  switch (floatingButtonPosition) {
-    case MDCBottomAppBarFloatingButtonPositionLeading: {
-      if (layoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
-        [self pathWithoutCutRight:bottomBarPath width:width height:height];
-      } else {
-        [self pathWithoutCutLeft:bottomBarPath width:width height:height];
-      }
-      break;
-    }
-    case MDCBottomAppBarFloatingButtonPositionCenter: {
-      CGFloat offsetRadiusDiff = kMDCBottomAppBarYOffset - kMDCBottomAppBarFloatingButtonRadius;
-      [bottomBarPath moveToPoint:CGPointMake(0, kMDCBottomAppBarYOffset)];
-      [bottomBarPath addLineToPoint:CGPointMake(midX - offsetRadiusDiff,
-                                                kMDCBottomAppBarYOffset)];
-      [bottomBarPath addLineToPoint:CGPointMake(midX, kMDCBottomAppBarYOffset)];
-      [bottomBarPath addLineToPoint:CGPointMake(midX + offsetRadiusDiff,
-                                                kMDCBottomAppBarYOffset)];
-      [bottomBarPath addLineToPoint:CGPointMake(width, kMDCBottomAppBarYOffset)];
-      [bottomBarPath addLineToPoint:CGPointMake(width, height * 2 + kMDCBottomAppBarYOffset)];
-      [bottomBarPath addLineToPoint:CGPointMake(0, height * 2 + kMDCBottomAppBarYOffset)];
-      [bottomBarPath closePath];
-      break;
-    }
-    case MDCBottomAppBarFloatingButtonPositionTrailing: {
-      if (layoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
-        [self pathWithoutCutLeft:bottomBarPath width:width height:height];
-      } else {
-        [self pathWithoutCutRight:bottomBarPath width:width height:height];
-      }
-      break;
-    }
-    default: {
-      [bottomBarPath moveToPoint:CGPointMake(0, kMDCBottomAppBarYOffset)];
-      [bottomBarPath addLineToPoint:CGPointMake(height, kMDCBottomAppBarYOffset)];
-      [bottomBarPath addLineToPoint:CGPointMake(height,
-                                                height * 2 + kMDCBottomAppBarYOffset)];
-      [bottomBarPath addLineToPoint:CGPointMake(0, height * 2 + kMDCBottomAppBarYOffset)];
-      [bottomBarPath closePath];
-      break;
-    }
-  }
-  return bottomBarPath.CGPath;
-}
-
-- (UIBezierPath *)pathWithoutCutLeft:(UIBezierPath *)bottomBarPath
-                               width:(CGFloat)width
-                              height:(CGFloat)height {
-  CGFloat offsetRadiusDiff = kMDCBottomAppBarYOffset - kMDCBottomAppBarFloatingButtonRadius;
-  [bottomBarPath moveToPoint:CGPointMake(0, kMDCBottomAppBarYOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(kMDCBottomAppBarFloatingButtonPositionX -
-                                            offsetRadiusDiff,
-                                            kMDCBottomAppBarYOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(kMDCBottomAppBarFloatingButtonPositionX,
-                                            kMDCBottomAppBarYOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(kMDCBottomAppBarFloatingButtonPositionX +
-                                            offsetRadiusDiff,
-                                            kMDCBottomAppBarYOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(width, kMDCBottomAppBarYOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(width, height * 2 + kMDCBottomAppBarYOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(0, height * 2 + kMDCBottomAppBarYOffset)];
-  [bottomBarPath closePath];
-  return bottomBarPath;
-}
-
-- (UIBezierPath *)pathWithoutCutRight:(UIBezierPath *)bottomBarPath
-                                width:(CGFloat)width
-                               height:(CGFloat)height {
-  CGFloat offsetRadiusDiff = kMDCBottomAppBarYOffset - kMDCBottomAppBarFloatingButtonRadius;
-  [bottomBarPath moveToPoint:CGPointMake(0, kMDCBottomAppBarYOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(width - kMDCBottomAppBarFloatingButtonPositionX -
-                                            offsetRadiusDiff,
-                                            kMDCBottomAppBarYOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(width - kMDCBottomAppBarFloatingButtonPositionX,
-                                            kMDCBottomAppBarYOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(width - kMDCBottomAppBarFloatingButtonPositionX +
-                                            offsetRadiusDiff,
-                                            kMDCBottomAppBarYOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(width, kMDCBottomAppBarYOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(width, height * 2 + kMDCBottomAppBarYOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(0, height * 2 + kMDCBottomAppBarYOffset)];
+- (UIBezierPath *)drawWithPlainPath:(UIBezierPath *)bottomBarPath
+                            yOffset:(CGFloat)yOffset
+                              width:(CGFloat)width
+                             height:(CGFloat)height
+                          arcCenter:(CGPoint)arcCenter
+                   hypotenuseLength:(CGFloat)hypotenuseLength {
+  CGFloat halfOfHypotenuseLength = hypotenuseLength / 2;
+  [bottomBarPath moveToPoint:CGPointMake(0, yOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x - halfOfHypotenuseLength, yOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x, yOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x + halfOfHypotenuseLength, yOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(width, yOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(width, height * 2 + yOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(0, height * 2 + yOffset)];
   [bottomBarPath closePath];
   return bottomBarPath;
 }

--- a/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
+++ b/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
@@ -45,10 +45,10 @@
   CGFloat arcRadius =
       CGRectGetHeight(floatingButton.bounds) / 2 + kMDCBottomAppBarFloatingButtonRadiusOffset;
   CGFloat navigationBarYOffset = CGRectGetMinY(navigationBarFrame);
-  CGFloat halfAngle = acos((navigationBarYOffset - floatingButton.center.y) / arcRadius);
-  CGFloat startAngle = M_PI / 2 + halfAngle;
-  CGFloat endAngle = M_PI / 2 - halfAngle;
-  CGFloat halfOfHypotenuseLength = sin(halfAngle) * arcRadius;
+  CGFloat halfAngle = acosf((float)((navigationBarYOffset - floatingButton.center.y) / arcRadius));
+  CGFloat startAngle = M_PI / 2.0f + halfAngle;
+  CGFloat endAngle = M_PI / 2.0f - halfAngle;
+  CGFloat halfOfHypotenuseLength = sinf((float)halfAngle) * arcRadius;
 
   CGFloat width = CGRectGetWidth(rect);
   CGFloat height = CGRectGetHeight(rect);


### PR DESCRIPTION
Both floating button and the path cut depended on many position constants to decide their position. This change removes the dependency of the path cut on those constant since the path cut should follow the floating button's realtime position.

Before the change:
![simulator screen shot - iphone x - 2018-09-18 at 10 47 56](https://user-images.githubusercontent.com/8836258/45695891-61e4a980-bb30-11e8-97ef-b309d91db0f8.png)


After the change:
![simulator screen shot - iphone x - 2018-09-18 at 10 46 46](https://user-images.githubusercontent.com/8836258/45695877-5c875f00-bb30-11e8-8697-7aa80948edad.png)