### PR TITLE
[Xcode10] Enable the legacy build system.

### DIFF
--- a/catalog/MDCCatalog.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/catalog/MDCCatalog.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>


### PR DESCRIPTION
The new Xcode 10 build system does not play well with CocoaPods, resulting in iterative builds not picking up changes in source files. This results in a remarkably frustrating debugging experience because breakpoints will often not be associated with the lines you expect them to be, and functionality that you're testing won't actually be testable until you perform a clean build.

As such, we cannot use the new Xcode 10 build system until this is resolved in upstream Xcode. As of this writing, the Xcode 10 GM version also is known to exhibit this undesirable behavior.

See https://github.com/CocoaPods/CocoaPods/issues/8073 for additional details.