### PR TITLE
[FlexibleHeader] Avoid nil logic in multiple tracking scroll view setting.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1719,6 +1719,10 @@ static BOOL isRunningiOS10_3OrAbove() {
     scrollView.contentOffset = offset;
   }
 
+  if (self.trackingScrollView == nil) {
+    return;
+  }
+
   if (_shiftAccumulator >= [self fhv_accumulatorMax]) {
     // We're shifted off-screen, make sure that this scroll view isn't expecting to show the header.
 


### PR DESCRIPTION
When `trackingScrollWillChangeToScrollView:` is used before a tracking scroll view has been set, the logic for matching the header height should not be executed because it assumes that there is presently a tracking scroll view.

This change adds a guard for a nil tracking scroll view so that we don't execute this logic in this case.

Part of supporting https://github.com/material-components/material-components-ios/issues/5156.