### PR TITLE
[ActionSheet] Add color properties to header labels

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -143,6 +143,21 @@ __attribute__((objc_subclassing_restricted))
  */
 @property(nonatomic, nonnull, strong) UIColor *backgroundColor;
 
+/**
+ The color applied to the title of the action sheet controller.
+
+ @note If only using a title and the actions have no icons make sure they are different colors so
+ there is a distinction between the title and actions.
+ */
+@property(nonatomic, strong, nullable) UIColor *titleTextColor;
+/**
+ The color applied to the message of the action sheet controller.
+
+ @note To make for a better user experience we recommend using a different color for the message and
+ actions if there are no icons so there is a distinction between the message and actions.
+ */
+@property(nonatomic, strong, nullable) UIColor *messageTextColor;
+
 @property(nonatomic, strong, readonly, nonnull)
     MDCBottomSheetTransitionController *transitionController;
 

--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -150,6 +150,7 @@ __attribute__((objc_subclassing_restricted))
  there is a distinction between the title and actions.
  */
 @property(nonatomic, strong, nullable) UIColor *titleTextColor;
+
 /**
  The color applied to the message of the action sheet controller.
 

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -322,7 +322,6 @@ static NSString *const ReuseIdentifier = @"BaseCell";
   return self.header.messageTextColor;
 }
 
-
 #pragma mark - Dynamic Type
 
 - (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -306,6 +306,23 @@ static NSString *const ReuseIdentifier = @"BaseCell";
   self.header.backgroundColor = backgroundColor;
 }
 
+- (void)setTitleTextColor:(UIColor *)titleTextColor {
+  self.header.titleTextColor = titleTextColor;
+}
+
+- (UIColor *)titleTextColor {
+  return self.header.titleTextColor;
+}
+
+- (void)setMessageTextColor:(UIColor *)messageTextColor {
+  self.header.messageTextColor = messageTextColor;
+}
+
+- (UIColor *)messageTextColor {
+  return self.header.messageTextColor;
+}
+
+
 #pragma mark - Dynamic Type
 
 - (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {

--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.h
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.h
@@ -32,4 +32,8 @@
 
 @property (nonatomic, strong, nonnull) UIFont *messageFont;
 
+@property(nonatomic, strong, nullable) UIColor *titleTextColor;
+
+@property(nonatomic, strong, nullable) UIColor *messageTextColor;
+
 @end

--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
@@ -122,9 +122,7 @@ static const CGFloat MiddlePadding = 8.f;
 
 - (void)setMessage:(NSString *)message {
   self.messageLabel.text = message;
-  self.titleLabel.textColor = self.titleTextColor ?: [self defaultTitleTextColor];
-  self.messageLabel.textColor =
-      self.messageTextColor ?: [UIColor.blackColor colorWithAlphaComponent:MessageLabelAlpha];
+  [self updateLabelColors];
   [self setNeedsLayout];
 }
 
@@ -207,15 +205,20 @@ static const CGFloat MiddlePadding = 8.f;
   }
 }
 
+- (void)updateLabelColors {
+  self.titleLabel.textColor = self.titleTextColor ?: [self defaultTitleTextColor];
+  self.messageLabel.textColor =
+      self.messageTextColor ?: [UIColor.blackColor colorWithAlphaComponent:MessageLabelAlpha];
+}
+
 - (void)setTitleTextColor:(UIColor *)titleTextColor {
   _titleTextColor = titleTextColor;
-  self.titleLabel.textColor = titleTextColor ?: [self defaultTitleTextColor];
+  [self updateLabelColors];
 }
 
 - (void)setMessageTextColor:(UIColor *)messageTextColor {
   _messageTextColor = messageTextColor;
-  self.messageLabel.textColor =
-      messageTextColor ?: [UIColor.blackColor colorWithAlphaComponent:MessageLabelAlpha];
+  [self updateLabelColors];
 }
 
 @end

--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
@@ -122,15 +122,7 @@ static const CGFloat MiddlePadding = 8.f;
 
 - (void)setMessage:(NSString *)message {
   self.messageLabel.text = message;
-  // If message is empty or nil then the title label's alpha value should be lighter, if there is both
-  // then the title label's alpha should be darker.
-  if (self.message && ![self.message isEqualToString:@""]) {
-    _titleLabel.textColor =
-        self.titleTextColor ?: [UIColor.blackColor colorWithAlphaComponent:TitleLabelAlpha];
-  } else {
-    _titleLabel.textColor =
-        self.titleTextColor ?: [UIColor.blackColor colorWithAlphaComponent:MessageLabelAlpha];
-  }
+  self.titleLabel.textColor = self.titleTextColor ?: [self defaultTitleTextColor];
   self.messageLabel.textColor =
       self.messageTextColor ?: [UIColor.blackColor colorWithAlphaComponent:MessageLabelAlpha];
   [self setNeedsLayout];
@@ -205,14 +197,25 @@ static const CGFloat MiddlePadding = 8.f;
   [self updateFonts];
 }
 
+- (UIColor *)defaultTitleTextColor {
+  // If message is empty or nil then the title label's alpha value should be lighter, if there is both
+  // then the title label's alpha should be darker.
+  if (self.message && ![self.message isEqualToString:@""]) {
+    return [UIColor.blackColor colorWithAlphaComponent:0.87f];
+  } else {
+    return [UIColor.blackColor colorWithAlphaComponent:0.6f];
+  }
+}
+
 - (void)setTitleTextColor:(UIColor *)titleTextColor {
   _titleTextColor = titleTextColor;
-  self.titleLabel.textColor = titleTextColor;
+  self.titleLabel.textColor = titleTextColor ?: [self defaultTitleTextColor];
 }
 
 - (void)setMessageTextColor:(UIColor *)messageTextColor {
   _messageTextColor = messageTextColor;
-  self.messageLabel.textColor = messageTextColor;
+  self.messageLabel.textColor =
+      messageTextColor ?: [UIColor.blackColor colorWithAlphaComponent:MessageLabelAlpha];
 }
 
 @end

--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
@@ -125,10 +125,14 @@ static const CGFloat MiddlePadding = 8.f;
   // If message is empty or nil then the title label's alpha value should be lighter, if there is both
   // then the title label's alpha should be darker.
   if (self.message && ![self.message isEqualToString:@""]) {
-    _titleLabel.textColor = [UIColor.blackColor colorWithAlphaComponent:TitleLabelAlpha];
+    _titleLabel.textColor =
+        self.titleTextColor ?: [UIColor.blackColor colorWithAlphaComponent:TitleLabelAlpha];
   } else {
-    _titleLabel.textColor = [UIColor.blackColor colorWithAlphaComponent:MessageLabelAlpha];
+    _titleLabel.textColor =
+        self.titleTextColor ?: [UIColor.blackColor colorWithAlphaComponent:MessageLabelAlpha];
   }
+  self.messageLabel.textColor =
+      self.messageTextColor ?: [UIColor.blackColor colorWithAlphaComponent:MessageLabelAlpha];
   [self setNeedsLayout];
 }
 

--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
@@ -198,8 +198,8 @@ static const CGFloat MiddlePadding = 8.f;
 }
 
 - (UIColor *)defaultTitleTextColor {
-  // If message is empty or nil then the title label's alpha value should be lighter, if there is both
-  // then the title label's alpha should be darker.
+  // If message is empty or nil then the title label's alpha value should be lighter, if there is
+  // both then the title label's alpha should be darker.
   if (self.message && ![self.message isEqualToString:@""]) {
     return [UIColor.blackColor colorWithAlphaComponent:TitleLabelAlpha];
   } else {

--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
@@ -201,9 +201,9 @@ static const CGFloat MiddlePadding = 8.f;
   // If message is empty or nil then the title label's alpha value should be lighter, if there is both
   // then the title label's alpha should be darker.
   if (self.message && ![self.message isEqualToString:@""]) {
-    return [UIColor.blackColor colorWithAlphaComponent:0.87f];
+    return [UIColor.blackColor colorWithAlphaComponent:TitleLabelAlpha];
   } else {
-    return [UIColor.blackColor colorWithAlphaComponent:0.6f];
+    return [UIColor.blackColor colorWithAlphaComponent:MessageLabelAlpha];
   }
 }
 

--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
@@ -201,4 +201,14 @@ static const CGFloat MiddlePadding = 8.f;
   [self updateFonts];
 }
 
+- (void)setTitleTextColor:(UIColor *)titleTextColor {
+  _titleTextColor = titleTextColor;
+  self.titleLabel.textColor = titleTextColor;
+}
+
+- (void)setMessageTextColor:(UIColor *)messageTextColor {
+  _messageTextColor = messageTextColor;
+  self.messageLabel.textColor = messageTextColor;
+}
+
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -89,4 +89,121 @@
   XCTAssertEqualObjects(messageColor, expectedMessageColor);
 }
 
+- (void)testTitleAndMessageCustomRGBColor {
+  // Given
+  self.actionSheet.title = @"Test title";
+  self.actionSheet.message = @"Test message";
+
+  // When
+  UIColor *titleColor = [UIColor colorWithRed:0.5f green:0.7f blue:0.9f alpha:1.0f];
+  UIColor *messageColor = [UIColor colorWithRed:0.9f green:0.7f blue:0.5f alpha:1.0f];
+
+  self.actionSheet.titleTextColor = titleColor;
+  self.actionSheet.messageTextColor = messageColor;
+
+  // Then
+  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor, titleColor);
+  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor, messageColor);
+}
+
+- (void)testTitleAndMessageCustomHSBColor {
+  // Given
+  self.actionSheet.title = @"Test title";
+  self.actionSheet.message = @"Test message";
+
+  // When
+  UIColor *titleColor = [UIColor colorWithHue:0.5f saturation:0.7f brightness:0.9f alpha:1.0f];
+  UIColor *messageColor = [UIColor colorWithHue:0.9f saturation:0.7f brightness:0.5f alpha:1.0f];
+
+  self.actionSheet.titleTextColor = titleColor;
+  self.actionSheet.messageTextColor = messageColor;
+
+  // Then
+  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor, titleColor);
+  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor, messageColor);
+}
+
+- (void)testTitleAndMessageCustomColor {
+  // Given
+  self.actionSheet.title = @"Test title";
+  self.actionSheet.message = @"Test message";
+
+  // When
+  UIColor *titleColor = [UIColor.blackColor colorWithAlphaComponent:0.3f];
+  UIColor *messageColor = [UIColor.blackColor colorWithAlphaComponent:0.2f];
+
+  self.actionSheet.titleTextColor = titleColor;
+  self.actionSheet.messageTextColor = messageColor;
+
+  // Then
+  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor, titleColor);
+  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor, messageColor);
+}
+
+- (void)testTitleAndMessageColorCorrectAlpha {
+  // Given
+  self.actionSheet.title = @"Test title";
+  self.actionSheet.message = @"Test message";
+  UIColor *titleColor = UIColor.blackColor;
+  UIColor *messageColor = UIColor.blackColor;
+
+  // When
+  UIColor *titleColorChangeAlpha = [titleColor colorWithAlphaComponent:0.6f];
+  UIColor *messageColorChangeAlpha = [messageColor colorWithAlphaComponent:0.5f];
+
+  self.actionSheet.titleTextColor = titleColorChangeAlpha;
+  self.actionSheet.messageTextColor = messageColorChangeAlpha;
+
+  // Then
+  BOOL titleEqual = [titleColor isEqual:self.actionSheet.header.titleLabel.textColor];
+  BOOL messageEqual = [messageColor isEqual:self.actionSheet.header.messageLabel.textColor];
+  XCTAssertFalse(titleEqual);
+  XCTAssertFalse(messageEqual);
+}
+
+- (void)testSetTitleAndMessageAfterCustomColorsSet {
+  // Given
+  UIColor *titleColor = UIColor.blueColor;
+  UIColor *messageColor = UIColor.redColor;
+
+  // When
+  self.actionSheet.titleTextColor = titleColor;
+  self.actionSheet.messageTextColor = messageColor;
+  self.actionSheet.title = @"Test title";
+  self.actionSheet.message = @"Test message";
+
+  // Then
+  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor, titleColor);
+  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor, messageColor);
+}
+
+- (void)testTitleCustomDoesNotChangeAfterSetMessage {
+  // Given
+  UIColor *titleColor = [UIColor.blueColor colorWithAlphaComponent:0.6f];
+  self.actionSheet.title = @"Test title";
+
+  // When
+  self.actionSheet.titleTextColor = titleColor;
+  self.actionSheet.message = @"Test message";
+
+  // Then
+  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor, titleColor);
+}
+
+- (void)testSetNilTitleAndMessageColor {
+  // Given
+  self.actionSheet.title = @"Test title";
+  self.actionSheet.message = @"Test message";
+
+  // When
+  self.actionSheet.titleTextColor = nil;
+  self.actionSheet.messageTextColor = nil;
+
+  // Then
+  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor,
+                        [UIColor.blackColor colorWithAlphaComponent:0.87f]);
+  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor,
+                        [UIColor.blackColor colorWithAlphaComponent:0.6f]);
+}
+
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -155,10 +155,8 @@
   self.actionSheet.messageTextColor = messageColorChangeAlpha;
 
   // Then
-  BOOL titleEqual = [titleColor isEqual:self.actionSheet.header.titleLabel.textColor];
-  BOOL messageEqual = [messageColor isEqual:self.actionSheet.header.messageLabel.textColor];
-  XCTAssertFalse(titleEqual);
-  XCTAssertFalse(messageEqual);
+  XCTAssertFalse([titleColor isEqual:self.actionSheet.header.titleLabel.textColor]);
+  XCTAssertFalse([messageColor isEqual:self.actionSheet.header.messageLabel.textColor]);
 }
 
 - (void)testSetTitleAndMessageAfterCustomColorsSet {


### PR DESCRIPTION
Previously clients had no way of setting custom colors to the title and message labels. This adds the functionality.

Previous discussions were had at #5083 #4993 #4984 #4968 
Related to #5039 #4903 

| Before | After |
| ------- | ------- |
|![simulator screen shot - iphone x - 2018-09-10 at 22 13 58](https://user-images.githubusercontent.com/7131294/45335650-674d5d00-b54e-11e8-9e6e-34ae5bac051c.png)|![simulator screen shot - iphone x - 2018-09-10 at 22 41 43](https://user-images.githubusercontent.com/7131294/45335652-6c121100-b54e-11e8-9fca-50e0a44d099e.png)|