### PR TITLE
[ActionSheet] Open to the correct height

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -145,6 +145,8 @@ static NSString *const ReuseIdentifier = @"BaseCell";
 
   if (self.tableView.contentSize.height > (CGRectGetHeight(self.view.bounds) / 2)) {
     self.mdc_bottomSheetPresentationController.preferredSheetHeight = [self openingSheetHeight];
+  } else {
+    self.mdc_bottomSheetPresentationController.preferredSheetHeight = 0;
   }
   CGSize size = [self.header sizeThatFits:CGRectStandardize(self.view.bounds).size];
   self.header.frame = CGRectMake(0, 0, self.view.bounds.size.width, size.height);
@@ -165,7 +167,12 @@ static NSString *const ReuseIdentifier = @"BaseCell";
   CGFloat maxHeight = CGRectGetHeight(self.view.bounds) / 2;
   CGFloat headerHeight = [self.header sizeThatFits:CGRectStandardize(self.view.bounds).size].height;
   CGFloat cellHeight = self.tableView.contentSize.height / (CGFloat)_actions.count;
-  NSInteger amountOfCellsToShow = (NSInteger)((maxHeight - headerHeight) / cellHeight);
+  CGFloat maxTableHeight = maxHeight - headerHeight;
+  NSInteger amountOfCellsToShow = (NSInteger)(maxTableHeight / cellHeight);
+  // There is already a partially shown cell that is showing and more than half is visable
+  if (fmod(maxTableHeight, cellHeight) > (cellHeight * 0.5f)) {
+    amountOfCellsToShow += 1;
+  }
   CGFloat preferredHeight = (((CGFloat)amountOfCellsToShow - 0.5f) * cellHeight) + headerHeight;
   // When updating the preferredSheetHeight the presentation controller takes into account the
   // safe area so we have to remove that.

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -142,6 +142,9 @@ static NSString *const ReuseIdentifier = @"BaseCell";
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
 
+  if (self.tableView.contentSize.height > (CGRectGetHeight(self.view.bounds) / 2)) {
+    self.mdc_bottomSheetPresentationController.preferredSheetHeight = [self openingSheetHeight];
+  }
   CGSize size = [self.header sizeThatFits:CGRectStandardize(self.view.bounds).size];
   self.header.frame = CGRectMake(0, 0, self.view.bounds.size.width, size.height);
   UIEdgeInsets insets = UIEdgeInsetsMake(self.header.frame.size.height, 0, 0, 0);
@@ -152,6 +155,23 @@ static NSString *const ReuseIdentifier = @"BaseCell";
 #endif
   self.tableView.contentInset = insets;
   self.tableView.contentOffset = CGPointMake(0, -size.height);
+}
+
+- (CGFloat)openingSheetHeight {
+  // If there are too many options to fit on half of the screen then show as many options as
+  // possible minus half a cell, to allow for bleeding and signal to the user that the sheet is
+  // scrollable content.
+  CGFloat maxHeight = CGRectGetHeight(self.view.bounds) / 2;
+  CGFloat headerHeight = [self.header sizeThatFits:CGRectStandardize(self.view.bounds).size].height;
+  CGFloat cellHeight = self.tableView.contentSize.height / (CGFloat)_actions.count;
+  NSInteger amountOfCellsToShow = (NSInteger)(maxHeight - headerHeight) / (NSInteger)cellHeight;
+  CGFloat preferredHeight = (((CGFloat)amountOfCellsToShow - 0.5f) * cellHeight) + headerHeight;
+  // When updating the preferredSheetHeight the presentation controller takes into account the
+  // safe area so we have to remove that.
+  if (@available(iOS 11.0, *)) {
+    preferredHeight = preferredHeight - self.view.safeAreaInsets.bottom;
+  }
+  return preferredHeight;
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -165,7 +165,7 @@ static NSString *const ReuseIdentifier = @"BaseCell";
   CGFloat maxHeight = CGRectGetHeight(self.view.bounds) / 2;
   CGFloat headerHeight = [self.header sizeThatFits:CGRectStandardize(self.view.bounds).size].height;
   CGFloat cellHeight = self.tableView.contentSize.height / (CGFloat)_actions.count;
-  NSInteger amountOfCellsToShow = (NSInteger)(maxHeight - headerHeight) / (NSInteger)cellHeight;
+  NSInteger amountOfCellsToShow = (NSInteger)((maxHeight - headerHeight) / cellHeight);
   CGFloat preferredHeight = (((CGFloat)amountOfCellsToShow - 0.5f) * cellHeight) + headerHeight;
   // When updating the preferredSheetHeight the presentation controller takes into account the
   // safe area so we have to remove that.

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -14,8 +14,8 @@
 
 #import "MDCActionSheetController.h"
 
-#import "private/MDCActionSheetItemTableViewCell.h"
 #import "private/MDCActionSheetHeaderView.h"
+#import "private/MDCActionSheetItemTableViewCell.h"
 #import "MaterialMath.h"
 #import "MaterialTypography.h"
 

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -16,6 +16,7 @@
 
 #import "private/MDCActionSheetItemTableViewCell.h"
 #import "private/MDCActionSheetHeaderView.h"
+#import "MaterialMath.h"
 #import "MaterialTypography.h"
 
 static NSString *const ReuseIdentifier = @"BaseCell";
@@ -171,7 +172,7 @@ static NSString *const ReuseIdentifier = @"BaseCell";
   if (@available(iOS 11.0, *)) {
     preferredHeight = preferredHeight - self.view.safeAreaInsets.bottom;
   }
-  return preferredHeight;
+  return MDCCeil(preferredHeight);
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -232,131 +232,166 @@ static const CGFloat safeAreaAmount = 20.f;
   }
 }
 
-- (void)testOpenningHeightWithNoHeader {
+- (CGRect)setUpActionSheetWithHeight:(CGFloat) height
+                          andTitle:(NSString *)title
+                        andMessage:(NSString *)message {
   // Given
-  CGFloat fakeHeight = 500;
-  self.actionSheet.view.bounds = CGRectMake(0, 0, 200, fakeHeight);
+  CGRect viewRect = CGRectMake(0, 0, 200, height);
+  self.actionSheet.view.bounds = viewRect;
+  self.actionSheet.title = title;
+  self.actionSheet.message = message;
 
   // When
   [self addNumberOfActions:100];
   [self.actionSheet.view setNeedsLayout];
   [self.actionSheet.view layoutIfNeeded];
-
-  // Then
-  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
-  CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
-  CGFloat expectedMinusHeader = expectedHeight - headerHeight;
-  CGFloat cellHeight =
-      self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
-  cellHeight = MDCCeil(cellHeight);
-  CGFloat halfCellHeight = cellHeight * 0.5f;
-  // Action sheet should show half of the allowed actions but the full last action
-  XCTAssertEqual(fmod(expectedMinusHeader, halfCellHeight), 0);
-  XCTAssertNotEqual(fmod(expectedMinusHeader, cellHeight), 0);
+  return viewRect;
 }
 
 - (void)testOpeningHeightWithTitle {
   // Given
   CGFloat fakeHeight = 500;
-  self.actionSheet.view.bounds = CGRectMake(0, 0, 200, fakeHeight);
-  self.actionSheet.title = @"Test title";
+  CGRect viewRect = [self setUpActionSheetWithHeight:fakeHeight
+                                            andTitle:@"Test Title"
+                                          andMessage:nil];
 
-  // When
-  [self addNumberOfActions:100];
-  [self.actionSheet.view setNeedsLayout];
-  [self.actionSheet.view layoutIfNeeded];
-
-  // Then
-  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
-  CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
-  CGFloat expectedMinusHeader = expectedHeight - headerHeight;
   CGFloat cellHeight =
-      self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
+     self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
   cellHeight = MDCCeil(cellHeight);
   CGFloat halfCellHeight = cellHeight * 0.5f;
-  // Action sheet should show half of the allowed actions but the full last action
-  XCTAssertEqual(fmod(expectedMinusHeader, halfCellHeight), 0);
-  XCTAssertNotEqual(fmod(expectedMinusHeader, cellHeight), 0);
+  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
+
+  for (NSInteger additionalHeight = 0; additionalHeight < cellHeight; ++additionalHeight) {
+    // When
+    viewRect.size.height = fakeHeight + additionalHeight;
+    self.actionSheet.view.bounds = viewRect;
+    [self.actionSheet.view setNeedsLayout];
+    [self.actionSheet.view layoutIfNeeded];
+
+    // Then
+    CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
+    CGFloat expectedMinusHeader = expectedHeight - headerHeight;
+    // Action sheet should show half of the allowed actions but the full last action
+    XCTAssertEqualWithAccuracy(fmod(expectedMinusHeader, halfCellHeight), 0, 0.001);
+    XCTAssertNotEqualWithAccuracy(fmod(expectedMinusHeader, cellHeight), 0, 0.001);
+  }
 }
 
 - (void)testOpeningHeightWithtTitleAndSmallMessage {
   // Given
   CGFloat fakeHeight = 500;
-  self.actionSheet.view.bounds = CGRectMake(0, 0, 200, fakeHeight);
-  self.actionSheet.title = @"Test title";
-  self.actionSheet.message = @"Test message";
+  CGRect viewRect = [self setUpActionSheetWithHeight:fakeHeight
+                                            andTitle:@"Test title"
+                                          andMessage:@"Test message"];
 
-  // When
-  [self addNumberOfActions:100];
-  [self.actionSheet.view setNeedsLayout];
-  [self.actionSheet.view layoutIfNeeded];
-
-  // Then
-  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
-  CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
-  CGFloat expectedMinusHeader = expectedHeight - headerHeight;
   CGFloat cellHeight =
       self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
   cellHeight = MDCCeil(cellHeight);
   CGFloat halfCellHeight = cellHeight * 0.5f;
-  // Action sheet should show half of the allowed actions but the full last action
-  XCTAssertEqual(fmod(expectedMinusHeader, halfCellHeight), 0);
-  XCTAssertNotEqual(fmod(expectedMinusHeader, cellHeight), 0);
+  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
+
+  for (NSInteger additionalHeight = 0; additionalHeight < cellHeight; ++additionalHeight) {
+    // When
+    viewRect.size.height = fakeHeight + additionalHeight;
+    self.actionSheet.view.bounds = viewRect;
+    [self.actionSheet.view setNeedsLayout];
+    [self.actionSheet.view layoutIfNeeded];
+
+    // Then
+    CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
+    CGFloat expectedMinusHeader = expectedHeight - headerHeight;
+    // Action sheet should show half of the allowed actions but the full last action
+    XCTAssertEqualWithAccuracy(fmod(expectedMinusHeader, halfCellHeight), 0, 0.001);
+    XCTAssertNotEqualWithAccuracy(fmod(expectedMinusHeader, cellHeight), 0, 0.001);
+  }
 }
 
 - (void)testOpeningHeightWithTitleAndLargeMessage {
   // Given
   CGFloat fakeHeight = 500;
-  self.actionSheet.view.bounds = CGRectMake(0, 0, 200, fakeHeight);
-  self.actionSheet.title = @"Test title";
   NSString *first = @"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ultricies";
   NSString *second = @"diam libero, eget porta arcu feugiat sit amet Maecenas placerat felis sed ";
   NSString *third = @"risusnmaximus tempus.Integer feugiat, augue in pellentesque dictum, justo ";
   NSString *fourth = @"erat ultricies leo, quis eros dictum mi. In finibus vulputate eros, auctor";
   NSString *messageString = [NSString stringWithFormat:@"%@%@%@%@", first, second, third, fourth];
   self.actionSheet.message = messageString;
+  CGRect viewRect = [self setUpActionSheetWithHeight:fakeHeight
+                                            andTitle:@"Test title"
+                                          andMessage:messageString];
 
-  // When
-  [self addNumberOfActions:100];
-  [self.actionSheet.view setNeedsLayout];
-  [self.actionSheet.view layoutIfNeeded];
-
-  // Then
-  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
-  CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
-  CGFloat expectedMinusHeader = expectedHeight - headerHeight;
   CGFloat cellHeight =
       self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
   cellHeight = MDCCeil(cellHeight);
   CGFloat halfCellHeight = cellHeight * 0.5f;
-  // Action sheet should show half of the allowed actions but the full last action
-  XCTAssertEqual(fmod(expectedMinusHeader, halfCellHeight), 0);
-  XCTAssertNotEqual(fmod(expectedMinusHeader, cellHeight), 0);
+  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
+
+  for (NSInteger additionalHeight = 0; additionalHeight < cellHeight; ++additionalHeight) {
+    // When
+    viewRect.size.height = fakeHeight + additionalHeight;
+    self.actionSheet.view.bounds = viewRect;
+    [self.actionSheet.view setNeedsLayout];
+    [self.actionSheet.view layoutIfNeeded];
+
+    // Then
+    CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
+    CGFloat expectedMinusHeader = expectedHeight - headerHeight;
+    // Action sheet should show half of the allowed actions but the full last action
+    XCTAssertEqualWithAccuracy(fmod(expectedMinusHeader, halfCellHeight), 0, 0.001);
+    XCTAssertNotEqualWithAccuracy(fmod(expectedMinusHeader, cellHeight), 0, 0.001);
+  }
 }
 
 - (void)testOpeningHeightWithSafeArea {
   // Given
   CGFloat fakeHeight = 500;
-  CGRect viewRect = CGRectMake(0, 0, 200, fakeHeight);
-  self.actionSheet.view.bounds = viewRect;
-  self.actionSheet.view = [[MDCFakeView alloc] initWithFrame:viewRect];
+  CGRect viewRect = [self setUpActionSheetWithHeight:fakeHeight andTitle:nil andMessage:nil];
 
-  // When
-  [self addNumberOfActions:100];
-  [self.actionSheet.view setNeedsLayout];
-  [self.actionSheet.view layoutIfNeeded];
-
-  // Then
-  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
-  CGFloat expectedHeight = [self.actionSheet openingSheetHeight] + safeAreaAmount;
-  CGFloat expectedMinusHeader = expectedHeight - headerHeight;
   CGFloat cellHeight =
       self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
   cellHeight = MDCCeil(cellHeight);
   CGFloat halfCellHeight = cellHeight * 0.5f;
-  // Action sheet should show half of the allowed actions but the full last action
-  XCTAssertEqual(fmod(expectedMinusHeader, halfCellHeight), 0);
-  XCTAssertNotEqual(fmod(expectedMinusHeader, cellHeight), 0);
+  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
+
+  for (NSInteger additionalHeight = 0; additionalHeight < cellHeight; ++additionalHeight) {
+    // When
+    viewRect.size.height = fakeHeight + additionalHeight;
+    self.actionSheet.view.bounds = viewRect;
+    [self.actionSheet.view setNeedsLayout];
+    [self.actionSheet.view layoutIfNeeded];
+
+    // Then
+    CGFloat expectedHeight = [self.actionSheet openingSheetHeight] + safeAreaAmount;
+    CGFloat expectedMinusHeader = expectedHeight - headerHeight;
+    // Action sheet should show half of the allowed actions but the full last action
+    XCTAssertEqualWithAccuracy(fmod(expectedMinusHeader, halfCellHeight), 0, 0.001);
+    XCTAssertNotEqualWithAccuracy(fmod(expectedMinusHeader, cellHeight), 0, 0.001);
+  }
+}
+
+- (void)testOpeningHeightNoHeader {
+  // Given
+  CGFloat fakeHeight = 500;
+  CGRect viewRect = [self setUpActionSheetWithHeight:fakeHeight andTitle:nil andMessage:nil];
+  CGFloat cellHeight =
+    self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
+  cellHeight = MDCCeil(cellHeight);
+  CGFloat halfCellHeight = cellHeight * 0.5f;
+  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
+
+  for (NSInteger additionalHeight = 0; additionalHeight < cellHeight; ++additionalHeight) {
+    // When
+    viewRect.size.height = fakeHeight + additionalHeight;
+    self.actionSheet.view.bounds = viewRect;
+    [self.actionSheet.view setNeedsLayout];
+    [self.actionSheet.view layoutIfNeeded];
+
+    // Then
+    CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
+    CGFloat expectedMinusHeader = expectedHeight - headerHeight;
+    // Action sheet should show half of the allowed actions but the full last action
+    XCTAssertEqualWithAccuracy(fmod(expectedMinusHeader, halfCellHeight), 0, 0.001);
+    XCTAssertNotEqualWithAccuracy(fmod(expectedMinusHeader, cellHeight), 0, 0.001);
+  }
 }
 
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -40,7 +40,7 @@ static const CGFloat safeAreaAmount = 20.f;
 @end
 
 @implementation MDCFakeView
--(UIEdgeInsets)safeAreaInsets {
+- (UIEdgeInsets)safeAreaInsets {
   return UIEdgeInsetsMake(safeAreaAmount, safeAreaAmount, safeAreaAmount, safeAreaAmount);
 }
 @end
@@ -216,6 +216,7 @@ static const CGFloat safeAreaAmount = 20.f;
                         [UIColor.blackColor colorWithAlphaComponent:0.87f]);
   XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor,
                         [UIColor.blackColor colorWithAlphaComponent:0.6f]);
+}
 
 #pragma mark - Opening height
 

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -233,8 +233,8 @@ static const CGFloat safeAreaAmount = 20.f;
 }
 
 - (CGRect)setUpActionSheetWithHeight:(CGFloat) height
-                          andTitle:(NSString *)title
-                        andMessage:(NSString *)message {
+                            andTitle:(NSString *)title
+                          andMessage:(NSString *)message {
   // Given
   CGRect viewRect = CGRectMake(0, 0, 200, height);
   self.actionSheet.view.bounds = viewRect;
@@ -256,7 +256,7 @@ static const CGFloat safeAreaAmount = 20.f;
                                           andMessage:nil];
 
   CGFloat cellHeight =
-     self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
+      self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
   cellHeight = MDCCeil(cellHeight);
   CGFloat halfCellHeight = cellHeight * 0.5f;
   CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
@@ -373,7 +373,7 @@ static const CGFloat safeAreaAmount = 20.f;
   CGFloat fakeHeight = 500;
   CGRect viewRect = [self setUpActionSheetWithHeight:fakeHeight andTitle:nil andMessage:nil];
   CGFloat cellHeight =
-    self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
+      self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
   cellHeight = MDCCeil(cellHeight);
   CGFloat halfCellHeight = cellHeight * 0.5f;
   CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -232,7 +232,7 @@ static const CGFloat safeAreaAmount = 20.f;
   }
 }
 
-- (CGRect)setUpActionSheetWithHeight:(CGFloat) height
+- (CGRect)setUpActionSheetWithHeight:(CGFloat)height
                             andTitle:(NSString *)title
                           andMessage:(NSString *)message {
   // Given

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import "MaterialActionSheet.h"
+#import "MaterialMath.h"
 
 #import <XCTest/XCTest.h>
 
@@ -104,8 +105,8 @@ static const CGFloat safeAreaAmount = 20.f;
 
 #pragma mark - Opening height
 
-- (void)addActions {
-  for (NSUInteger i = 0; i < 100; ++i) {
+- (void)addActions:(NSUInteger)actions {
+  for (NSUInteger i = 0; i < actions; ++i) {
     MDCActionSheetAction *action =
         [MDCActionSheetAction actionWithTitle:@"Title" image:nil handler:nil];
     [self.actionSheet addAction:action];
@@ -118,13 +119,21 @@ static const CGFloat safeAreaAmount = 20.f;
   self.actionSheet.view.bounds = CGRectMake(0, 0, 200, fakeHeight);
 
   // When
-  [self addActions];
+  [self addActions:100];
   [self.actionSheet.view setNeedsLayout];
   [self.actionSheet.view layoutIfNeeded];
 
   // Then
-  CGFloat 
-  XCTAssertEqualWithAccuracy(self.actionSheet.mdc_bottomSheetPresentationController.preferredSheetHeight, (fakeHeight / 2) - cellHeight, 0.001);
+  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
+  CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
+  CGFloat expectedMinusHeader = expectedHeight - headerHeight;
+  CGFloat cellHeight =
+      self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
+  cellHeight = MDCCeil(cellHeight);
+  CGFloat halfCellHeight = cellHeight * 0.5f;
+  // Action sheet should show half of the allowed actions but the full last action
+  XCTAssertEqual(fmod(expectedMinusHeader, halfCellHeight), 0);
+  XCTAssertNotEqual(fmod(expectedMinusHeader, cellHeight), 0);
 }
 
 - (void)testOpeningHeightWithTitle {
@@ -134,13 +143,76 @@ static const CGFloat safeAreaAmount = 20.f;
   self.actionSheet.title = @"Test title";
 
   // When
-  [self addActions];
-  CGFloat cellHeight =
-      self.actionSheet.tableView.contentSize.height / (CGFloat)(self.actionSheet.actions.count);
+  [self addActions:100];
+  [self.actionSheet.view setNeedsLayout];
+  [self.actionSheet.view layoutIfNeeded];
 
   // Then
-  CGFloat openingHeight = [self.actionSheet openingSheetHeight];
-  XCTAssertEqualWithAccuracy(openingHeight, (fakeHeight / 2) - cellHeight, 0.001);
+  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
+  CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
+  CGFloat expectedMinusHeader = expectedHeight - headerHeight;
+  CGFloat cellHeight =
+      self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
+  cellHeight = MDCCeil(cellHeight);
+  CGFloat halfCellHeight = cellHeight * 0.5f;
+  // Action sheet should show half of the allowed actions but the full last action
+  XCTAssertEqual(fmod(expectedMinusHeader, halfCellHeight), 0);
+  XCTAssertNotEqual(fmod(expectedMinusHeader, cellHeight), 0);
+}
+
+- (void)testOpeningHeightWithtTitleAndSmallMessage {
+  // Given
+  CGFloat fakeHeight = 500;
+  self.actionSheet.view.bounds = CGRectMake(0, 0, 200, fakeHeight);
+  self.actionSheet.title = @"Test title";
+  self.actionSheet.message = @"Test message";
+
+  // When
+  [self addActions:100];
+  [self.actionSheet.view setNeedsLayout];
+  [self.actionSheet.view layoutIfNeeded];
+
+  // Then
+  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
+  CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
+  CGFloat expectedMinusHeader = expectedHeight - headerHeight;
+  CGFloat cellHeight =
+  self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
+  cellHeight = MDCCeil(cellHeight);
+  CGFloat halfCellHeight = cellHeight * 0.5f;
+  // Action sheet should show half of the allowed actions but the full last action
+  XCTAssertEqual(fmod(expectedMinusHeader, halfCellHeight), 0);
+  XCTAssertNotEqual(fmod(expectedMinusHeader, cellHeight), 0);
+}
+
+- (void)testOpeningHeightWithTitleAndLargeMessage {
+  // Given
+  CGFloat fakeHeight = 500;
+  self.actionSheet.view.bounds = CGRectMake(0, 0, 200, fakeHeight);
+  self.actionSheet.title = @"Test title";
+  NSString *first = @"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ultricies";
+  NSString *second = @"diam libero, eget porta arcu feugiat sit amet Maecenas placerat felis sed ";
+  NSString *third = @"risusnmaximus tempus.Integer feugiat, augue in pellentesque dictum, justo ";
+  NSString *fourth = @"erat ultricies leo, quis eros dictum mi. In finibus vulputate eros, auctor";
+  NSString *messageString = [NSString stringWithFormat:@"%@%@%@%@", first, second, third, fourth];
+  self.actionSheet.message = messageString;
+
+  // When
+  [self addActions:100];
+  [self.actionSheet.view setNeedsLayout];
+  [self.actionSheet.view layoutIfNeeded];
+
+  // Then
+  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
+  CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
+  CGFloat expectedMinusHeader = expectedHeight - headerHeight;
+  CGFloat cellHeight =
+      self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
+  cellHeight = MDCCeil(cellHeight);
+  CGFloat halfCellHeight = cellHeight * 0.5f;
+  // Action sheet should show half of the allowed actions but the full last action
+  XCTAssertEqual(fmod(expectedMinusHeader, halfCellHeight), 0);
+  XCTAssertNotEqual(fmod(expectedMinusHeader, cellHeight), 0);
 }
 
 - (void)testOpeningHeightWithSafeArea {
@@ -151,13 +223,21 @@ static const CGFloat safeAreaAmount = 20.f;
   self.actionSheet.view = [[MDCFakeView alloc] initWithFrame:viewRect];
 
   // When
-  [self addActions];
-  CGFloat cellHeight =
-      self.actionSheet.tableView.contentSize.height / (CGFloat)(self.actionSheet.actions.count);
+  [self addActions:100];
+  [self.actionSheet.view setNeedsLayout];
+  [self.actionSheet.view layoutIfNeeded];
 
   // Then
-  CGFloat openingHeight = [self.actionSheet openingSheetHeight];
-  XCTAssertEqualWithAccuracy(openingHeight, (fakeHeight / 2) - cellHeight - safeAreaAmount, 0.001);
+  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
+  CGFloat expectedHeight = [self.actionSheet openingSheetHeight] + safeAreaAmount;
+  CGFloat expectedMinusHeader = expectedHeight - headerHeight;
+  CGFloat cellHeight =
+      self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
+  cellHeight = MDCCeil(cellHeight);
+  CGFloat halfCellHeight = cellHeight * 0.5f;
+  // Action sheet should show half of the allowed actions but the full last action
+  XCTAssertEqual(fmod(expectedMinusHeader, halfCellHeight), 0);
+  XCTAssertNotEqual(fmod(expectedMinusHeader, cellHeight), 0);
 }
 
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -40,9 +40,11 @@ static const CGFloat safeAreaAmount = 20.f;
 @end
 
 @implementation MDCFakeView
+
 - (UIEdgeInsets)safeAreaInsets {
   return UIEdgeInsetsMake(safeAreaAmount, safeAreaAmount, safeAreaAmount, safeAreaAmount);
 }
+
 @end
 
 @implementation MDCActionSheetTest
@@ -220,9 +222,10 @@ static const CGFloat safeAreaAmount = 20.f;
 
 #pragma mark - Opening height
 
-- (void)addActions:(NSUInteger)actions {
-  for (NSUInteger i = 0; i < actions; ++i) {
-    MDCActionSheetAction *action = [MDCActionSheetAction actionWithTitle:@"Title"
+- (void)addNumberOfActions:(NSUInteger)actionsCount {
+  for (NSUInteger actionIndex = 0; actionIndex < actionsCount; ++actionIndex) {
+    NSString *actionTitle = [NSString stringWithFormat:@"Action #%@", @(actionIndex)];
+    MDCActionSheetAction *action = [MDCActionSheetAction actionWithTitle:actionTitle
                                                                    image:nil
                                                                  handler:nil];
     [self.actionSheet addAction:action];
@@ -235,7 +238,7 @@ static const CGFloat safeAreaAmount = 20.f;
   self.actionSheet.view.bounds = CGRectMake(0, 0, 200, fakeHeight);
 
   // When
-  [self addActions:100];
+  [self addNumberOfActions:100];
   [self.actionSheet.view setNeedsLayout];
   [self.actionSheet.view layoutIfNeeded];
 
@@ -259,7 +262,7 @@ static const CGFloat safeAreaAmount = 20.f;
   self.actionSheet.title = @"Test title";
 
   // When
-  [self addActions:100];
+  [self addNumberOfActions:100];
   [self.actionSheet.view setNeedsLayout];
   [self.actionSheet.view layoutIfNeeded];
 
@@ -284,7 +287,7 @@ static const CGFloat safeAreaAmount = 20.f;
   self.actionSheet.message = @"Test message";
 
   // When
-  [self addActions:100];
+  [self addNumberOfActions:100];
   [self.actionSheet.view setNeedsLayout];
   [self.actionSheet.view layoutIfNeeded];
 
@@ -314,7 +317,7 @@ static const CGFloat safeAreaAmount = 20.f;
   self.actionSheet.message = messageString;
 
   // When
-  [self addActions:100];
+  [self addNumberOfActions:100];
   [self.actionSheet.view setNeedsLayout];
   [self.actionSheet.view layoutIfNeeded];
 
@@ -339,7 +342,7 @@ static const CGFloat safeAreaAmount = 20.f;
   self.actionSheet.view = [[MDCFakeView alloc] initWithFrame:viewRect];
 
   // When
-  [self addActions:100];
+  [self addNumberOfActions:100];
   [self.actionSheet.view setNeedsLayout];
   [self.actionSheet.view layoutIfNeeded];
 

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -222,8 +222,9 @@ static const CGFloat safeAreaAmount = 20.f;
 
 - (void)addActions:(NSUInteger)actions {
   for (NSUInteger i = 0; i < actions; ++i) {
-    MDCActionSheetAction *action =
-        [MDCActionSheetAction actionWithTitle:@"Title" image:nil handler:nil];
+    MDCActionSheetAction *action = [MDCActionSheetAction actionWithTitle:@"Title"
+                                                                   image:nil
+                                                                 handler:nil];
     [self.actionSheet addAction:action];
   }
 }
@@ -292,7 +293,7 @@ static const CGFloat safeAreaAmount = 20.f;
   CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
   CGFloat expectedMinusHeader = expectedHeight - headerHeight;
   CGFloat cellHeight =
-  self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
+      self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
   cellHeight = MDCCeil(cellHeight);
   CGFloat halfCellHeight = cellHeight * 0.5f;
   // Action sheet should show half of the allowed actions but the full last action


### PR DESCRIPTION
This will for bleeding if there are too many options to show on screen at once.

_Bleeding_
My understanding after speaking to design is, list with scrollable content within a bottom sheet should open up to half of the screen height minus half of a list item or to the list height. The initial height should be the smaller of those two values. Half of the height of the view is correct. But, if there are more options that will fit on half of the height (of the view) and the list height is a factor of the super view's height then a user may not be aware it is scrollable content. This new behavior is correct and makes for a better user experience in my opinion. The term bleeding was told to be by design, my understanding is the list item bleeds onto the view.

Previous discussions at #5024 
Closes #4945 & #5038 


| Before | After |
| ------- | ------- |
|![simulator screen shot - iphone 8 - 2018-09-05 at 15 30 55](https://user-images.githubusercontent.com/7131294/45116429-b21b3f00-b120-11e8-960e-d8e46111e3d0.png)|![simulator screen shot - iphone 8 - 2018-09-05 at 15 28 49](https://user-images.githubusercontent.com/7131294/45116395-8c8e3580-b120-11e8-9d12-2c46d9086294.png)|