### PR TITLE
[FlexibleHeader] Improve tracking scroll view switching logic.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1422,6 +1422,7 @@ static BOOL isRunningiOS10_3OrAbove() {
 
   _trackingInfo = [_trackedScrollViews objectForKey:_trackingScrollView];
   _trackingInfo.stashedHeightIsValid = NO;
+  _trackingInfo.stashedHeight = 0;
 
   [self fhv_enforceInsetsForScrollView:_trackingScrollView];
 
@@ -1442,9 +1443,6 @@ static BOOL isRunningiOS10_3OrAbove() {
     // How much will our height change if we do nothing right now?
     const CGFloat heightDelta = self.bounds.size.height - headerHeight;
 
-    // Adjust the accumulator so that our height won't change.
-    _shiftAccumulator -= heightDelta;
-
     // Cap the accumulator to ensure it's valid.
     CGFloat accumulatorMin;
     if (headerHeight > self.computedMinimumHeight + DBL_EPSILON) {
@@ -1453,7 +1451,9 @@ static BOOL isRunningiOS10_3OrAbove() {
     } else {
       accumulatorMin = [self fhv_accumulatorMin];
     }
-    _shiftAccumulator = MAX(accumulatorMin, MIN([self fhv_accumulatorMax], _shiftAccumulator));
+    // Adjust the accumulator so that our height won't change and cap it to the possible range.
+    _shiftAccumulator = MAX(accumulatorMin, MIN([self fhv_accumulatorMax],
+                                                _shiftAccumulator - heightDelta));
   }
 
   void (^animate)(void) = ^{

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1452,8 +1452,8 @@ static BOOL isRunningiOS10_3OrAbove() {
       accumulatorMin = [self fhv_accumulatorMin];
     }
     // Adjust the accumulator so that our height won't change and cap it to the possible range.
-    _shiftAccumulator = MAX(accumulatorMin, MIN([self fhv_accumulatorMax],
-                                                _shiftAccumulator - heightDelta));
+    _shiftAccumulator =
+        MAX(accumulatorMin, MIN([self fhv_accumulatorMax], _shiftAccumulator - heightDelta));
   }
 
   void (^animate)(void) = ^{

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -101,6 +101,13 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 // The amount injected into scrollIndicatorInsets.top
 @property(nonatomic) CGFloat injectedTopScrollIndicatorInset;
 
+// When working with multiple tracking scroll views, this property keeps track of what the last
+// header height for a given tracking scroll view was. When we return to a tracking scroll view,
+// we're able to use this property to calculate any additional content offset shift that may be
+// required in order to maintain a consistent physical placement within the content.
+@property(nonatomic) CGFloat stashedHeight;
+@property(nonatomic) BOOL stashedHeightIsValid;
+
 @end
 
 @implementation MDCFlexibleHeaderView {
@@ -1329,22 +1336,17 @@ static BOOL isRunningiOS10_3OrAbove() {
       offset.y = -rawTopInset;
       scrollView.contentOffset = offset;
     }
+  }
 
-  } else if (self.trackingScrollView.contentOffset.y != scrollView.contentOffset.y &&
-             self.trackingScrollView.contentOffset.y <= 0 && scrollView.contentOffset.y <= 0) {
-    // Our content is expanding the header in both columns, let's match up the content offsets so
-    // that the header's height won't change.
-    CGPoint offset = scrollView.contentOffset;
-    offset.y = self.trackingScrollView.contentOffset.y;
-    scrollView.contentOffset = offset;
-
-  } else if (self.trackingScrollView.contentOffset.y > scrollView.contentOffset.y &&
-             scrollView.contentOffset.y < 0) {  // Destination is showing an expanded header.
-    // Our header is possibly smaller now than it will be when we move to the new content.
-    // Scroll the new content such that we collapse the header to the current height.
-    CGPoint offset = scrollView.contentOffset;
-    offset.y = MIN(self.trackingScrollView.contentOffset.y, 0);
-    scrollView.contentOffset = offset;
+  if (info.stashedHeightIsValid) {
+    // Did our height change since the last time we saw this content?
+    const CGFloat heightDelta = self.bounds.size.height - info.stashedHeight;
+    if (fabs(heightDelta) > DBL_EPSILON) {
+      // Offset our content accordingly so that we're still viewing what we were viewing last time.
+      CGPoint offset = scrollView.contentOffset;
+      offset.y -= heightDelta;
+      scrollView.contentOffset = offset;
+    }
   }
 }
 
@@ -1400,6 +1402,11 @@ static BOOL isRunningiOS10_3OrAbove() {
 
   UIScrollView *oldTrackingScrollView = _trackingScrollView;
 
+  if (_trackingInfo != nil) {
+    _trackingInfo.stashedHeight = self.bounds.size.height;
+    _trackingInfo.stashedHeightIsValid = YES;
+  }
+
   BOOL wasTrackingScrollView = _trackingScrollView != nil;
   _trackingScrollView = trackingScrollView;
 
@@ -1414,11 +1421,41 @@ static BOOL isRunningiOS10_3OrAbove() {
   _shiftAccumulatorDeltaY = 0;
 
   _trackingInfo = [_trackedScrollViews objectForKey:_trackingScrollView];
+  _trackingInfo.stashedHeightIsValid = NO;
 
   [self fhv_enforceInsetsForScrollView:_trackingScrollView];
 
   if (self.observesTrackingScrollViewScrollEvents) {
     [self fhv_startObservingContentOffset];
+  }
+
+  // When canAlwaysExpandToMaximumHeight is enabled our header's height no longer directly
+  // correlates to the content offset - it's also augmented by the shift accumulator. In order to
+  // keep the header's height constant when changing the tracking scroll view, we need to adjust
+  // the shift accumulator accordingly.
+  if (self.canAlwaysExpandToMaximumHeight &&
+      self.sharedWithManyScrollViews && wasTrackingScrollView) {
+
+    // What's our expected height now that we've changed the tracking scroll view?
+    CGFloat headerHeight = -[self fhv_contentOffsetWithoutInjectedTopInset];
+    headerHeight =
+        MAX(self.computedMinimumHeight, MIN(self.computedMaximumHeight, headerHeight));
+
+    // How much will our height change if we do nothing right now?
+    const CGFloat heightDelta = self.bounds.size.height - headerHeight;
+
+    // Adjust the accumulator so that our height won't change.
+    _shiftAccumulator -= heightDelta;
+
+    // Cap the accumulator to ensure it's valid.
+    CGFloat accumulatorMin;
+    if (headerHeight > self.computedMinimumHeight + DBL_EPSILON) {
+      // We're attached to the content, so don't allow any height accumulation.
+      accumulatorMin = 0;
+    } else{
+      accumulatorMin = [self fhv_accumulatorMin];
+    }
+    _shiftAccumulator = MAX(accumulatorMin, MIN([self fhv_accumulatorMax], _shiftAccumulator));
   }
 
   void (^animate)(void) = ^{

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1433,13 +1433,11 @@ static BOOL isRunningiOS10_3OrAbove() {
   // correlates to the content offset - it's also augmented by the shift accumulator. In order to
   // keep the header's height constant when changing the tracking scroll view, we need to adjust
   // the shift accumulator accordingly.
-  if (self.canAlwaysExpandToMaximumHeight &&
-      self.sharedWithManyScrollViews && wasTrackingScrollView) {
-
+  if (self.canAlwaysExpandToMaximumHeight && self.sharedWithManyScrollViews &&
+      wasTrackingScrollView) {
     // What's our expected height now that we've changed the tracking scroll view?
     CGFloat headerHeight = -[self fhv_contentOffsetWithoutInjectedTopInset];
-    headerHeight =
-        MAX(self.computedMinimumHeight, MIN(self.computedMaximumHeight, headerHeight));
+    headerHeight = MAX(self.computedMinimumHeight, MIN(self.computedMaximumHeight, headerHeight));
 
     // How much will our height change if we do nothing right now?
     const CGFloat heightDelta = self.bounds.size.height - headerHeight;
@@ -1452,7 +1450,7 @@ static BOOL isRunningiOS10_3OrAbove() {
     if (headerHeight > self.computedMinimumHeight + DBL_EPSILON) {
       // We're attached to the content, so don't allow any height accumulation.
       accumulatorMin = 0;
-    } else{
+    } else {
       accumulatorMin = [self fhv_accumulatorMin];
     }
     _shiftAccumulator = MAX(accumulatorMin, MIN([self fhv_accumulatorMax], _shiftAccumulator));


### PR DESCRIPTION
## Context

The flexible header component supports horizontal-paging interfaces that consist of multiple vertically scrolling scroll views. This type of interface is most commonly paired with a tabs component that makes it possible to quickly jump to a specific column. I will use the term "switching tabs" to refer to the act of changing from tracking one vertical scroll view to another.

## The problem

When switching tabs we can't guarantee that the content we're moving to will have a comparable content offset as the content we're switching from. This can be problematic in cases where the flexible header's height is able to expand or when the flexible header is able to shift off screen because the height or off-screen position might have to change.

## Repro cases

All of these repro cases share the same common configuration:

```swift
appBarViewController.headerView.minMaxHeightIncludesSafeArea = false
appBarViewController.inferTopSafeAreaInsetFromViewController = true
appBarViewController.headerView.canAlwaysExpandToMaximumHeight = true
appBarViewController.headerView.sharedWithManyScrollViews = true

appBarViewController.headerView.minimumHeight = 56
appBarViewController.headerView.maximumHeight = 128
```

You can test these repro cases in the AppBarManualTabsExample, found under "App Bar", "Manual tabs".

All of these test cases assume that you've viewed each of the tabs at least once already (see "Open issues" below for more details).

### Case 1

1. Scroll tab 1 down until row 20 is just below the header.
2. Change to tab 2.

The header should remain collapsed. Row 0 should be just below the header.

### Case 2

1. Scroll tab 1 down until row 20 is just below the header.
2. Change to tab 2.
3. Scroll up until the header is fully expanded.
3. Change to tab 1.

The header should be fully expanded. Row 20 should still be just below the header.

### Case 3

1. Scroll tab 1 down until row 20 is just below the header.
2. Change to tab 2.
3. Scroll up until the header is partially expanded.
3. Change to tab 1.

The header should be partially expanded. Row 20 should still be just below the header.

## Additional details

Prior to this change, the header's height would often animate between different heights when changing tabs. We had some rudimentary logic that attempted to adjust the target tab's content offset before moving, but this only handled a few cases and was also too aggressive in some cases (e.g. we'd make the destination tab's content offset match the source tab's content offset, disregarding the user's position in the destination content).

After this change, we stash the header height for a given tab when we move away from it. When we're about to return to this tab we look at the header's current height and the stashed height. If these two values don't match, we offset the destination's tab's content offset with the delta. This keeps the destination's content "pinned" just below the header.

When self.canAlwaysExpandToMaximumHeight is enabled, we also need to adjust the shift accumulator once we've changed tabs so that we're not increasing the height of the header too much. This logic follows similar reasoning as the content offset adjustment: use the height delta to adjust the shift accumulator. If the header is not floating in front of the content we also just want to blow away any shift accumulation entirely; this handles the case where tab 1 is fully expanded but floating and we move to tab 2 which is at the top of its content. In this case tab 2 doesn't need any shift accumulation.

## Testing

I will be pursuing a comprehensive approach to testing of the flexible header in https://github.com/material-components/material-components-ios/issues/5060, so this particular PR does not introduce any additional unit tests. I expect this added logic to be testable as part of a "height" unit of logic that encompasses everything related to height calculations for the flexible header.

## Open issues

https://github.com/material-components/material-components-ios/issues/5176

## Closed issues

Closes https://github.com/material-components/material-components-ios/issues/5156
Closes https://github.com/material-components/material-components-ios/issues/4117
Closes https://github.com/material-components/material-components-ios/issues/3130

## Videos

### Case 1

| Before | After |
|:-------|:------|
| ![before](https://user-images.githubusercontent.com/45670/45771215-32778f00-bc4d-11e8-826e-681c8d1d73b7.gif) | ![after](https://user-images.githubusercontent.com/45670/45771221-399e9d00-bc4d-11e8-8bf0-9254d5123d5d.gif) |