### PR TITLE
[NavigationDrawer] Fix bug where BottomDrawer layout breaks when there isn't enough cont…

### DIFF
--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -207,12 +207,6 @@ static UIColor *DrawerShadowColor(void) {
                             self.presentingViewBounds.size.height + headerHeightWithoutInset;
   BOOL scrollingUpInFull = contentDiff < 0 && self.trackingScrollView.bounds.origin.y > 0;
   if (self.scrollView.bounds.origin.y >= drawerOffset || scrollingUpInFull) {
-    // Update the main content view's scrollView offset
-    CGRect contentViewBounds = self.trackingScrollView.bounds;
-    contentViewBounds.origin.y += contentDiff;
-    contentViewBounds.origin.y = MIN(maxScrollOrigin, MAX(contentViewBounds.origin.y, 0));
-    self.trackingScrollView.bounds = contentViewBounds;
-
     // If we reach full screen or if we are scrolling up after being in full screen.
     if (self.trackingScrollView.bounds.origin.y < maxScrollOrigin || scrollingUpInFull) {
       // If we still didn't reach the end of the content, or if we are scrolling up after reaching
@@ -227,13 +221,25 @@ static UIColor *DrawerShadowColor(void) {
       CGSize scrollViewContentSize = self.presentingViewBounds.size;
       scrollViewContentSize.height += self.contentHeightSurplus;
       self.scrollView.contentSize = scrollViewContentSize;
+
+      // Update the main content view's scrollView offset
+      CGRect contentViewBounds = self.trackingScrollView.bounds;
+      contentViewBounds.origin.y += contentDiff;
+      contentViewBounds.origin.y = MIN(maxScrollOrigin, MAX(contentViewBounds.origin.y, 0));
+      self.trackingScrollView.bounds = contentViewBounds;
     } else {
-      // Have the drawer's scrollView's content size be static so it will bounce when reaching the
-      // end of the content.
-      CGSize scrollViewContentSize = self.scrollView.contentSize;
-      scrollViewContentSize.height =
-          drawerOffset + self.scrollView.frame.size.height + 2 * topAreaInsetForHeader;
-      self.scrollView.contentSize = scrollViewContentSize;
+      CGFloat trackingScrollViewContentHeight = self.trackingScrollView.contentSize.height;
+      CGFloat scrollViewContentHeight = self.scrollView.contentSize.height;
+      BOOL trackingScrollViewContentFillsScreen =
+          trackingScrollViewContentHeight >= scrollViewContentHeight;
+      if (trackingScrollViewContentFillsScreen) {
+        // Have the drawer's scrollView's content size be static so it will bounce when reaching the
+        // end of the content.
+        CGSize scrollViewContentSize = self.scrollView.contentSize;
+        scrollViewContentSize.height =
+            drawerOffset + self.scrollView.frame.size.height + 2 * topAreaInsetForHeader;
+        self.scrollView.contentSize = scrollViewContentSize;
+      }
     }
   }
 }

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -228,11 +228,7 @@ static UIColor *DrawerShadowColor(void) {
       contentViewBounds.origin.y = MIN(maxScrollOrigin, MAX(contentViewBounds.origin.y, 0));
       self.trackingScrollView.bounds = contentViewBounds;
     } else {
-      CGFloat trackingScrollViewContentHeight = self.trackingScrollView.contentSize.height;
-      CGFloat scrollViewContentHeight = self.scrollView.contentSize.height;
-      BOOL trackingScrollViewContentFillsScreen =
-          trackingScrollViewContentHeight >= scrollViewContentHeight;
-      if (trackingScrollViewContentFillsScreen) {
+      if (self.trackingScrollView.contentSize.height >= self.trackingScrollView.frame.size.height) {
         // Have the drawer's scrollView's content size be static so it will bounce when reaching the
         // end of the content.
         CGSize scrollViewContentSize = self.scrollView.contentSize;


### PR DESCRIPTION
From the internal issue:

> If there is less content in a bottom drawer than vertical available screen space and the content gets dragged to the top (by overextending with the rubber band effect), the layout of the drawer content gets broken and the drawer content snaps to the bottom. This can be reproduced on any iOS version and device I have tested (tested on iOS 9 iPhone 4S, iOS 10 iPhone 5 and iOS 12 iPhone XS Max simulators).

---
Here is a before video of the bug in action:
![shortscrollbroken](https://user-images.githubusercontent.com/8020010/45780222-119e4200-bc2b-11e8-90c4-df558c51b059.gif)

Here is an after video of the bottom drawer working as intended with short trackingScrollView content:
![shortscrollfixed](https://user-images.githubusercontent.com/8020010/45780202-05b28000-bc2b-11e8-94c7-af3dea29229f.gif)

Here is an after video of the bottom drawer working as intended with long trackingScrollView content:
![scrollingwithlongcontent](https://user-images.githubusercontent.com/8020010/45780212-0a773400-bc2b-11e8-9714-128f04939647.gif)

Closes #5147