### PR TITLE
[AppBar] Add frame setting recommendation to app bar view controller migration guide.

### DIFF
--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -775,6 +775,12 @@ like so:
 
 // Step 3
 -  appBar.addSubviewsToParent()
++  // Match the width of the parent view.
++  CGRect frame = appBarViewController.view.frame;
++  frame.origin.x = 0;
++  frame.size.width = appBarViewController.parentViewController.view.bounds.size.width;
++  appBarViewController.view.frame = frame;
++
 +  view.addSubview(appBarViewController.view)
 +  appBarViewController.didMove(toParentViewController: self)
 ```

--- a/components/AppBar/docs/migration-guide-appbar-appbarviewcontroller.md
+++ b/components/AppBar/docs/migration-guide-appbar-appbarviewcontroller.md
@@ -19,6 +19,12 @@ like so:
 
 // Step 3
 -  appBar.addSubviewsToParent()
++  // Match the width of the parent view.
++  CGRect frame = appBarViewController.view.frame;
++  frame.origin.x = 0;
++  frame.size.width = appBarViewController.parentViewController.view.bounds.size.width;
++  appBarViewController.view.frame = frame;
++
 +  view.addSubview(appBarViewController.view)
 +  appBarViewController.didMove(toParentViewController: self)
 ```


### PR DESCRIPTION
Setting the view's frame is an important part of migrating from MDCAppBar to MDCAppBarViewController. Failure to do so can result in the app bar's width not matching the parent view's width.