### PR TITLE
[TextFields] Remove extension check in example

### DIFF
--- a/components/TextFields/examples/TextFieldKitchenSinkExample.swift
+++ b/components/TextFields/examples/TextFieldKitchenSinkExample.swift
@@ -202,7 +202,7 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
     baselineTestLabel.font = textFieldFloatingCharMax.font
     self.scrollView.addSubview(baselineTestLabel)
 
-    if #available(iOSApplicationExtension 9.0, *), #available(iOS 9.0, *) {
+    if #available(iOS 9.0, *) {
       baselineTestLabel.trailingAnchor.constraint(equalTo: textFieldFloatingCharMax.trailingAnchor,
                                                  constant: 0).isActive = true
 


### PR DESCRIPTION
Previously we checked against `iOSApplicationExtension` and `iOS` but if the `iOS` version is 9.0 or above then the ApplicationExtension will be as well. This will remove a lot of warnings in our kokoro logs when trying to track down errors.

| Before | After |
| ------ | ------ |
|![simulator screen shot - iphone xs max - 2018-09-20 at 08 30 07](https://user-images.githubusercontent.com/7131294/45818633-4a342f00-bcb0-11e8-8e36-2c8079581c30.png)|![simulator screen shot - iphone xs max - 2018-09-20 at 08 29 32](https://user-images.githubusercontent.com/7131294/45818638-4e604c80-bcb0-11e8-91ea-664443d4be0a.png)|
|![simulator screen shot - iphone xs max - 2018-09-20 at 08 29 32](https://user-images.githubusercontent.com/7131294/45818703-81a2db80-bcb0-11e8-9e64-f67e6d72d063.png)|![simulator screen shot - iphone xs max - 2018-09-20 at 08 30 07](https://user-images.githubusercontent.com/7131294/45818712-8798bc80-bcb0-11e8-85ea-223859066421.png)|



