### PR TITLE
[ActionSheet] Open to the correct height

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -14,10 +14,10 @@
 
 #import "MDCActionSheetController.h"
 
-#import "private/MDCActionSheetHeaderView.h"
-#import "private/MDCActionSheetItemTableViewCell.h"
 #import "MaterialMath.h"
 #import "MaterialTypography.h"
+#import "private/MDCActionSheetHeaderView.h"
+#import "private/MDCActionSheetItemTableViewCell.h"
 
 static NSString *const ReuseIdentifier = @"BaseCell";
 

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -14,8 +14,9 @@
 
 #import "MDCActionSheetController.h"
 
-#import "private/MDCActionSheetItemTableViewCell.h"
 #import "private/MDCActionSheetHeaderView.h"
+#import "private/MDCActionSheetItemTableViewCell.h"
+#import "MaterialMath.h"
 #import "MaterialTypography.h"
 
 static NSString *const ReuseIdentifier = @"BaseCell";
@@ -142,6 +143,11 @@ static NSString *const ReuseIdentifier = @"BaseCell";
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
 
+  if (self.tableView.contentSize.height > (CGRectGetHeight(self.view.bounds) / 2)) {
+    self.mdc_bottomSheetPresentationController.preferredSheetHeight = [self openingSheetHeight];
+  } else {
+    self.mdc_bottomSheetPresentationController.preferredSheetHeight = 0;
+  }
   CGSize size = [self.header sizeThatFits:CGRectStandardize(self.view.bounds).size];
   self.header.frame = CGRectMake(0, 0, self.view.bounds.size.width, size.height);
   UIEdgeInsets insets = UIEdgeInsetsMake(self.header.frame.size.height, 0, 0, 0);
@@ -152,6 +158,28 @@ static NSString *const ReuseIdentifier = @"BaseCell";
 #endif
   self.tableView.contentInset = insets;
   self.tableView.contentOffset = CGPointMake(0, -size.height);
+}
+
+- (CGFloat)openingSheetHeight {
+  // If there are too many options to fit on half of the screen then show as many options as
+  // possible minus half a cell, to allow for bleeding and signal to the user that the sheet is
+  // scrollable content.
+  CGFloat maxHeight = CGRectGetHeight(self.view.bounds) / 2;
+  CGFloat headerHeight = [self.header sizeThatFits:CGRectStandardize(self.view.bounds).size].height;
+  CGFloat cellHeight = self.tableView.contentSize.height / (CGFloat)_actions.count;
+  CGFloat maxTableHeight = maxHeight - headerHeight;
+  NSInteger amountOfCellsToShow = (NSInteger)(maxTableHeight / cellHeight);
+  // There is already a partially shown cell that is showing and more than half is visable
+  if (fmod(maxTableHeight, cellHeight) > (cellHeight * 0.5f)) {
+    amountOfCellsToShow += 1;
+  }
+  CGFloat preferredHeight = (((CGFloat)amountOfCellsToShow - 0.5f) * cellHeight) + headerHeight;
+  // When updating the preferredSheetHeight the presentation controller takes into account the
+  // safe area so we have to remove that.
+  if (@available(iOS 11.0, *)) {
+    preferredHeight = preferredHeight - self.view.safeAreaInsets.bottom;
+  }
+  return MDCCeil(preferredHeight);
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -385,7 +385,7 @@ static const CGFloat safeAreaAmount = 20.f;
     self.actionSheet.view.bounds = viewRect;
     [self.actionSheet.view setNeedsLayout];
     [self.actionSheet.view layoutIfNeeded];
-    
+
     // Then
     CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
     CGFloat expectedMinusHeader = expectedHeight - headerHeight;

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -13,10 +13,13 @@
 // limitations under the License.
 
 #import "MaterialActionSheet.h"
+#import "MaterialMath.h"
 
 #import <XCTest/XCTest.h>
 
 #import "../../src/private/MDCActionSheetHeaderView.h"
+
+static const CGFloat safeAreaAmount = 20.f;
 
 @interface MDCActionSheetHeaderView (Testing)
 @property(nonatomic, strong) UILabel *titleLabel;
@@ -24,11 +27,24 @@
 @end
 
 @interface MDCActionSheetController (Testing)
+@property(nonatomic, strong) UITableView *tableView;
 @property(nonatomic, strong) MDCActionSheetHeaderView *header;
+- (CGFloat)openingSheetHeight;
 @end
 
 @interface MDCActionSheetTest : XCTestCase
 @property(nonatomic, strong) MDCActionSheetController *actionSheet;
+@end
+
+@interface MDCFakeView : UIView
+@end
+
+@implementation MDCFakeView
+
+- (UIEdgeInsets)safeAreaInsets {
+  return UIEdgeInsetsMake(safeAreaAmount, safeAreaAmount, safeAreaAmount, safeAreaAmount);
+}
+
 @end
 
 @implementation MDCActionSheetTest
@@ -202,6 +218,181 @@
                         [UIColor.blackColor colorWithAlphaComponent:0.87f]);
   XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor,
                         [UIColor.blackColor colorWithAlphaComponent:0.6f]);
+}
+
+#pragma mark - Opening height
+
+- (void)addNumberOfActions:(NSUInteger)actionsCount {
+  for (NSUInteger actionIndex = 0; actionIndex < actionsCount; ++actionIndex) {
+    NSString *actionTitle = [NSString stringWithFormat:@"Action #%@", @(actionIndex)];
+    MDCActionSheetAction *action = [MDCActionSheetAction actionWithTitle:actionTitle
+                                                                   image:nil
+                                                                 handler:nil];
+    [self.actionSheet addAction:action];
+  }
+}
+
+- (CGRect)setUpActionSheetWithHeight:(CGFloat)height
+                            andTitle:(NSString *)title
+                          andMessage:(NSString *)message {
+  // Given
+  CGRect viewRect = CGRectMake(0, 0, 200, height);
+  self.actionSheet.view.bounds = viewRect;
+  self.actionSheet.title = title;
+  self.actionSheet.message = message;
+
+  // When
+  [self addNumberOfActions:100];
+  [self.actionSheet.view setNeedsLayout];
+  [self.actionSheet.view layoutIfNeeded];
+  return viewRect;
+}
+
+- (void)testOpeningHeightWithTitle {
+  // Given
+  CGFloat fakeHeight = 500;
+  CGRect viewRect = [self setUpActionSheetWithHeight:fakeHeight
+                                            andTitle:@"Test Title"
+                                          andMessage:nil];
+
+  CGFloat cellHeight =
+      self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
+  cellHeight = MDCCeil(cellHeight);
+  CGFloat halfCellHeight = cellHeight * 0.5f;
+  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
+
+  for (NSInteger additionalHeight = 0; additionalHeight < cellHeight; ++additionalHeight) {
+    // When
+    viewRect.size.height = fakeHeight + additionalHeight;
+    self.actionSheet.view.bounds = viewRect;
+    [self.actionSheet.view setNeedsLayout];
+    [self.actionSheet.view layoutIfNeeded];
+
+    // Then
+    CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
+    CGFloat expectedMinusHeader = expectedHeight - headerHeight;
+    // Action sheet should show half of the allowed actions but the full last action
+    XCTAssertEqualWithAccuracy(fmod(expectedMinusHeader, halfCellHeight), 0, 0.001);
+    XCTAssertNotEqualWithAccuracy(fmod(expectedMinusHeader, cellHeight), 0, 0.001);
+  }
+}
+
+- (void)testOpeningHeightWithtTitleAndSmallMessage {
+  // Given
+  CGFloat fakeHeight = 500;
+  CGRect viewRect = [self setUpActionSheetWithHeight:fakeHeight
+                                            andTitle:@"Test title"
+                                          andMessage:@"Test message"];
+
+  CGFloat cellHeight =
+      self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
+  cellHeight = MDCCeil(cellHeight);
+  CGFloat halfCellHeight = cellHeight * 0.5f;
+  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
+
+  for (NSInteger additionalHeight = 0; additionalHeight < cellHeight; ++additionalHeight) {
+    // When
+    viewRect.size.height = fakeHeight + additionalHeight;
+    self.actionSheet.view.bounds = viewRect;
+    [self.actionSheet.view setNeedsLayout];
+    [self.actionSheet.view layoutIfNeeded];
+
+    // Then
+    CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
+    CGFloat expectedMinusHeader = expectedHeight - headerHeight;
+    // Action sheet should show half of the allowed actions but the full last action
+    XCTAssertEqualWithAccuracy(fmod(expectedMinusHeader, halfCellHeight), 0, 0.001);
+    XCTAssertNotEqualWithAccuracy(fmod(expectedMinusHeader, cellHeight), 0, 0.001);
+  }
+}
+
+- (void)testOpeningHeightWithTitleAndLargeMessage {
+  // Given
+  CGFloat fakeHeight = 500;
+  NSString *first = @"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ultricies";
+  NSString *second = @"diam libero, eget porta arcu feugiat sit amet Maecenas placerat felis sed ";
+  NSString *third = @"risusnmaximus tempus.Integer feugiat, augue in pellentesque dictum, justo ";
+  NSString *fourth = @"erat ultricies leo, quis eros dictum mi. In finibus vulputate eros, auctor";
+  NSString *messageString = [NSString stringWithFormat:@"%@%@%@%@", first, second, third, fourth];
+  self.actionSheet.message = messageString;
+  CGRect viewRect = [self setUpActionSheetWithHeight:fakeHeight
+                                            andTitle:@"Test title"
+                                          andMessage:messageString];
+
+  CGFloat cellHeight =
+      self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
+  cellHeight = MDCCeil(cellHeight);
+  CGFloat halfCellHeight = cellHeight * 0.5f;
+  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
+
+  for (NSInteger additionalHeight = 0; additionalHeight < cellHeight; ++additionalHeight) {
+    // When
+    viewRect.size.height = fakeHeight + additionalHeight;
+    self.actionSheet.view.bounds = viewRect;
+    [self.actionSheet.view setNeedsLayout];
+    [self.actionSheet.view layoutIfNeeded];
+
+    // Then
+    CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
+    CGFloat expectedMinusHeader = expectedHeight - headerHeight;
+    // Action sheet should show half of the allowed actions but the full last action
+    XCTAssertEqualWithAccuracy(fmod(expectedMinusHeader, halfCellHeight), 0, 0.001);
+    XCTAssertNotEqualWithAccuracy(fmod(expectedMinusHeader, cellHeight), 0, 0.001);
+  }
+}
+
+- (void)testOpeningHeightWithSafeArea {
+  // Given
+  CGFloat fakeHeight = 500;
+  CGRect viewRect = [self setUpActionSheetWithHeight:fakeHeight andTitle:nil andMessage:nil];
+
+  CGFloat cellHeight =
+      self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
+  cellHeight = MDCCeil(cellHeight);
+  CGFloat halfCellHeight = cellHeight * 0.5f;
+  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
+
+  for (NSInteger additionalHeight = 0; additionalHeight < cellHeight; ++additionalHeight) {
+    // When
+    viewRect.size.height = fakeHeight + additionalHeight;
+    self.actionSheet.view.bounds = viewRect;
+    [self.actionSheet.view setNeedsLayout];
+    [self.actionSheet.view layoutIfNeeded];
+
+    // Then
+    CGFloat expectedHeight = [self.actionSheet openingSheetHeight] + safeAreaAmount;
+    CGFloat expectedMinusHeader = expectedHeight - headerHeight;
+    // Action sheet should show half of the allowed actions but the full last action
+    XCTAssertEqualWithAccuracy(fmod(expectedMinusHeader, halfCellHeight), 0, 0.001);
+    XCTAssertNotEqualWithAccuracy(fmod(expectedMinusHeader, cellHeight), 0, 0.001);
+  }
+}
+
+- (void)testOpeningHeightNoHeader {
+  // Given
+  CGFloat fakeHeight = 500;
+  CGRect viewRect = [self setUpActionSheetWithHeight:fakeHeight andTitle:nil andMessage:nil];
+
+  CGFloat cellHeight =
+      self.actionSheet.tableView.contentSize.height / (CGFloat)self.actionSheet.actions.count;
+  cellHeight = MDCCeil(cellHeight);
+  CGFloat halfCellHeight = cellHeight * 0.5f;
+  CGFloat headerHeight = CGRectGetHeight(self.actionSheet.header.frame);
+
+  for (NSInteger additionalHeight = 0; additionalHeight < cellHeight; ++additionalHeight) {
+    // When
+    viewRect.size.height = fakeHeight + additionalHeight;
+    self.actionSheet.view.bounds = viewRect;
+    [self.actionSheet.view setNeedsLayout];
+    [self.actionSheet.view layoutIfNeeded];
+    
+    // Then
+    CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
+    CGFloat expectedMinusHeader = expectedHeight - headerHeight;
+    // Action sheet should show half of the allowed actions but the full last action
+    XCTAssertEqualWithAccuracy(fmod(expectedMinusHeader, halfCellHeight), 0, 0.001);
+    XCTAssertNotEqualWithAccuracy(fmod(expectedMinusHeader, cellHeight), 0, 0.001);
+  }
 }
 
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -360,7 +360,7 @@ static const CGFloat safeAreaAmount = 20.f;
     [self.actionSheet.view layoutIfNeeded];
 
     // Then
-    CGFloat expectedHeight = [self.actionSheet openingSheetHeight] + safeAreaAmount;
+    CGFloat expectedHeight = [self.actionSheet openingSheetHeight];
     CGFloat expectedMinusHeader = expectedHeight - headerHeight;
     // Action sheet should show half of the allowed actions but the full last action
     XCTAssertEqualWithAccuracy(fmod(expectedMinusHeader, halfCellHeight), 0, 0.001);


### PR DESCRIPTION
This will for bleeding if there are too many options to show on screen at once.

_Bleeding_
My understanding after speaking to design is, list with scrollable content within a bottom sheet should open up to half of the screen height minus half of a list item or to the list height. The initial height should be the smaller of those two values. Half of the height of the view is correct. But, if there are more options that will fit on half of the height (of the view) and the list height is a factor of the super view's height then a user may not be aware it is scrollable content. This new behavior is correct and makes for a better user experience in my opinion. The term bleeding was told to be by design, my understanding is the list item bleeds onto the view.

Previous discussions at #5024 & #5175 
Closes #4945 & #5038 

| Before | After |
| ------- | ------- |
|![simulator screen shot - iphone 8 - 2018-09-05 at 15 30 55](https://user-images.githubusercontent.com/7131294/45116429-b21b3f00-b120-11e8-960e-d8e46111e3d0.png)|![simulator screen shot - iphone 8 - 2018-09-05 at 15 28 49](https://user-images.githubusercontent.com/7131294/45116395-8c8e3580-b120-11e8-9d12-2c46d9086294.png)|

In the before example there are 30 actions, you are seeing the fourth action and top of the fifth. But, in some cases it may show exactly four options even though there is 30. This looks at the amount of actions that will fit on half the screen then shifts the content down to fit the header + actions - half an action.