### PR TITLE
[ActionSheet] Refactor test

### DIFF
--- a/components/ActionSheet/tests/unit/ActionSheetTest.swift
+++ b/components/ActionSheet/tests/unit/ActionSheetTest.swift
@@ -90,17 +90,6 @@ class ActionSheetTest: XCTestCase {
     }
   }
 
-  func testSetBackgroundColor() {
-    // Given
-    let newBackgroundColor: UIColor = .green
-
-    // When
-    actionSheet.backgroundColor = newBackgroundColor
-
-    // Then
-    XCTAssertEqual(actionSheet.backgroundColor, newBackgroundColor)
-  }
-
   func testBackgroundColorMatchesViewBackgroundColor() {
     // Given
     let newBackgroundColor: UIColor = .green

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -89,38 +89,23 @@
   XCTAssertEqualObjects(messageColor, expectedMessageColor);
 }
 
-- (void)testTitleAndMessageCustomRGBColor {
-  // Given
-  self.actionSheet.title = @"Test title";
-  self.actionSheet.message = @"Test message";
-
-  // When
-  UIColor *titleColor = [UIColor colorWithRed:0.5f green:0.7f blue:0.9f alpha:1.0f];
-  UIColor *messageColor = [UIColor colorWithRed:0.9f green:0.7f blue:0.5f alpha:1.0f];
-
-  self.actionSheet.titleTextColor = titleColor;
-  self.actionSheet.messageTextColor = messageColor;
-
-  // Then
-  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor, titleColor);
-  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor, messageColor);
-}
-
-- (void)testTitleAndMessageCustomHSBColor {
-  // Given
-  self.actionSheet.title = @"Test title";
-  self.actionSheet.message = @"Test message";
-
-  // When
-  UIColor *titleColor = [UIColor colorWithHue:0.5f saturation:0.7f brightness:0.9f alpha:1.0f];
-  UIColor *messageColor = [UIColor colorWithHue:0.9f saturation:0.7f brightness:0.5f alpha:1.0f];
-
-  self.actionSheet.titleTextColor = titleColor;
-  self.actionSheet.messageTextColor = messageColor;
-
-  // Then
-  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor, titleColor);
-  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor, messageColor);
+- (NSArray *)colorsToTest {
+  UIColor *rgbColor = [UIColor colorWithRed:0.8f green:0.8f blue:0.8f alpha:0.8f];
+  UIColor *hsbColor = [UIColor colorWithHue:0.8f saturation:0.8f brightness:0.8f alpha:0.8f];
+  UIColor *blackWithAlpha = [UIColor.blackColor colorWithAlphaComponent:0.8f];
+  UIColor *black = UIColor.blackColor;
+  CIColor *ciColor;
+  if (@available(iOS 10.0, *)) {
+    ciColor = [[CIColor alloc] initWithRed:0.8f
+                                     green:0.8f
+                                      blue:0.8f
+                                colorSpace:CGColorSpaceCreateDeviceCMYK()];
+  } else {
+    ciColor = [[CIColor alloc] initWithColor:UIColor.blackColor];
+  }
+  UIColor *uiColorFromCIColor = [UIColor colorWithCIColor:ciColor];
+  UIColor *whiteColor = [UIColor colorWithWhite:0.8f alpha:0.8f];
+  return @[ rgbColor, hsbColor, blackWithAlpha, black, uiColorFromCIColor, whiteColor ];
 }
 
 - (void)testTitleAndMessageCustomColor {
@@ -128,16 +113,19 @@
   self.actionSheet.title = @"Test title";
   self.actionSheet.message = @"Test message";
 
-  // When
-  UIColor *titleColor = [UIColor.blackColor colorWithAlphaComponent:0.3f];
-  UIColor *messageColor = [UIColor.blackColor colorWithAlphaComponent:0.2f];
+  NSArray *colors = [self colorsToTest];
+  for (UIColor *color in colors) {
+    // When
+    UIColor *titleColor = color;
+    UIColor *messageColor = color;
 
-  self.actionSheet.titleTextColor = titleColor;
-  self.actionSheet.messageTextColor = messageColor;
+    self.actionSheet.titleTextColor = titleColor;
+    self.actionSheet.messageTextColor = messageColor;
 
-  // Then
-  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor, titleColor);
-  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor, messageColor);
+    // Then
+    XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor, color);
+    XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor, color);
+  }
 }
 
 - (void)testTitleAndMessageColorCorrectAlpha {

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -108,23 +108,31 @@
   return @[ rgbColor, hsbColor, blackWithAlpha, black, uiColorFromCIColor, whiteColor ];
 }
 
-- (void)testTitleAndMessageCustomColor {
+- (void)testCustomMessageColor {
   // Given
-  self.actionSheet.title = @"Test title";
   self.actionSheet.message = @"Test message";
 
   NSArray *colors = [self colorsToTest];
   for (UIColor *color in colors) {
     // When
-    UIColor *titleColor = color;
-    UIColor *messageColor = color;
+    self.actionSheet.messageTextColor = color;
 
-    self.actionSheet.titleTextColor = titleColor;
-    self.actionSheet.messageTextColor = messageColor;
+    // Then
+    XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor, color);
+  }
+}
+
+- (void)testCustomTitleColor {
+  // Given
+  self.actionSheet.title = @"Test title";
+
+  NSArray *colors = [self colorsToTest];
+  for (UIColor *color in colors) {
+    // When
+    self.actionSheet.titleTextColor = color;
 
     // Then
     XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor, color);
-    XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor, color);
   }
 }
 

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -90,21 +90,21 @@
 }
 
 - (NSArray *)colorsToTest {
-  UIColor *rgbColor = [UIColor colorWithRed:0.8f green:0.8f blue:0.8f alpha:0.8f];
+  UIColor *rgbColor = [UIColor colorWithRed:0.7f green:0.7f blue:0.7f alpha:0.7f];
   UIColor *hsbColor = [UIColor colorWithHue:0.8f saturation:0.8f brightness:0.8f alpha:0.8f];
-  UIColor *blackWithAlpha = [UIColor.blackColor colorWithAlphaComponent:0.8f];
+  UIColor *blackWithAlpha = [UIColor.greenColor colorWithAlphaComponent:0.8f];
   UIColor *black = UIColor.blackColor;
   CIColor *ciColor;
   if (@available(iOS 10.0, *)) {
-    ciColor = [[CIColor alloc] initWithRed:0.8f
-                                     green:0.8f
-                                      blue:0.8f
+    ciColor = [[CIColor alloc] initWithRed:0.9f
+                                     green:0.9f
+                                      blue:0.9f
                                 colorSpace:CGColorSpaceCreateDeviceCMYK()];
   } else {
     ciColor = [[CIColor alloc] initWithColor:UIColor.blackColor];
   }
   UIColor *uiColorFromCIColor = [UIColor colorWithCIColor:ciColor];
-  UIColor *whiteColor = [UIColor colorWithWhite:0.8f alpha:0.8f];
+  UIColor *whiteColor = [UIColor colorWithWhite:0.5f alpha:0.5f];
   return @[ rgbColor, hsbColor, blackWithAlpha, black, uiColorFromCIColor, whiteColor ];
 }
 

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -94,15 +94,7 @@
   UIColor *hsbColor = [UIColor colorWithHue:0.8f saturation:0.8f brightness:0.8f alpha:0.8f];
   UIColor *blackWithAlpha = [UIColor.greenColor colorWithAlphaComponent:0.8f];
   UIColor *black = UIColor.blackColor;
-  CIColor *ciColor;
-  if (@available(iOS 10.0, *)) {
-    ciColor = [[CIColor alloc] initWithRed:0.9f
-                                     green:0.9f
-                                      blue:0.9f
-                                colorSpace:CGColorSpaceCreateDeviceCMYK()];
-  } else {
-    ciColor = [[CIColor alloc] initWithColor:UIColor.blackColor];
-  }
+  CIColor *ciColor = [[CIColor alloc] initWithColor:UIColor.blackColor];
   UIColor *uiColorFromCIColor = [UIColor colorWithCIColor:ciColor];
   UIColor *whiteColor = [UIColor colorWithWhite:0.5f alpha:0.5f];
   return @[ rgbColor, hsbColor, blackWithAlpha, black, uiColorFromCIColor, whiteColor ];
@@ -133,6 +125,18 @@
 
     // Then
     XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor, color);
+  }
+}
+
+- (void)testCustomBackgroundColor {
+  // Given
+  NSArray *colors = [self colorsToTest];
+  for (UIColor *color in colors) {
+    // When
+    self.actionSheet.backgroundColor = color;
+
+    // Then
+    XCTAssertEqualObjects(self.actionSheet.backgroundColor, color);
   }
 }
 


### PR DESCRIPTION
### Context
When testing against colors the goal is to test against every possible way a client might create a color, this lead to me creating different test for different way to create colors. This also didn't test against all the different ways to create colors. Having a new test for all new ways to create a color will lead to having a lot of reused code.

### The problem
This will lead to a lot of repeated code for testing different color spaces vs different properties.

### The fix
This will allow one test for all different properties that checks all different color spaces.

### Related Issues
#5039 