### PR TITLE
[kokoro] Only post to codecov if we have a token.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -231,7 +231,9 @@ run_cocoapods() {
     fi
   done
 
-  bash <(curl -s https://codecov.io/bash)
+  if [ -n "$CODECOV_TOKEN" ]; then
+    bash <(curl -s https://codecov.io/bash)
+  fi
 }
 
 # For local runs, you must set the following environment variables:


### PR DESCRIPTION
We were previously posting to codecov on all of our jobs, even when we didn't have a token. Only posting when we have a token will reduce CI turnaround times for jobs that aren't generating coverage (which is most of them).