### PR TITLE
[ActionSheet] Update cells to be testable

### DIFF
--- a/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
+++ b/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
@@ -25,9 +25,9 @@ static const CGFloat TitleLeadingPadding = 72.f;
 static const CGFloat TitleTrailingPadding = 16.f;
 static const CGFloat ActionItemTitleVerticalPadding = 18.f;
 
-@interface MDCActionSheetItemTableViewCell
-@property(nonatomic, strong) UILabel *textLabel;
-@property(nonatomic, strong) UIImageView *imageView;
+@interface MDCActionSheetItemTableViewCell ()
+@property(nonatomic, strong) UILabel *actionLabel;
+@property(nonatomic, strong) UIImageView *actionImageView;
 @end
 
 @implementation MDCActionSheetItemTableViewCell {
@@ -52,35 +52,35 @@ static const CGFloat ActionItemTitleVerticalPadding = 18.f;
   self.translatesAutoresizingMaskIntoConstraints = NO;
   self.selectionStyle = UITableViewCellSelectionStyleNone;
   self.accessibilityTraits = UIAccessibilityTraitButton;
-  _textLabel = [[UILabel alloc] init];
-  [self.contentView addSubview:_textLabel];
-  _textLabel.numberOfLines = 0;
-  _textLabel.translatesAutoresizingMaskIntoConstraints = NO;
-  [_textLabel sizeToFit];
-  _textLabel.font = [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleSubheadline];
-  _textLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
-  _textLabel.textColor = [UIColor.blackColor colorWithAlphaComponent:LabelAlpha];
+  _actionLabel = [[UILabel alloc] init];
+  [self.contentView addSubview:_actionLabel];
+  _actionLabel.numberOfLines = 0;
+  _actionLabel.translatesAutoresizingMaskIntoConstraints = NO;
+  [_actionLabel sizeToFit];
+  _actionLabel.font = [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleSubheadline];
+  _actionLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
+  _actionLabel.textColor = [UIColor.blackColor colorWithAlphaComponent:LabelAlpha];
   CGFloat leadingConstant;
   if (_itemAction.image) {
     leadingConstant = TitleLeadingPadding;
   } else {
     leadingConstant = ImageLeadingPadding;
   }
-  [NSLayoutConstraint constraintWithItem:_textLabel
+  [NSLayoutConstraint constraintWithItem:_actionLabel
                                attribute:NSLayoutAttributeTop
                                relatedBy:NSLayoutRelationEqual
                                   toItem:self.contentView
                                attribute:NSLayoutAttributeTop
                               multiplier:1
                                 constant:ActionItemTitleVerticalPadding].active = YES;
-  [NSLayoutConstraint constraintWithItem:_textLabel
+  [NSLayoutConstraint constraintWithItem:_actionLabel
                                attribute:NSLayoutAttributeBottom
                                relatedBy:NSLayoutRelationEqual
                                   toItem:self.contentView
                                attribute:NSLayoutAttributeBottom
                               multiplier:1
                                 constant:-ActionItemTitleVerticalPadding].active = YES;
-  _titleLeadingConstraint = [NSLayoutConstraint constraintWithItem:_textLabel
+  _titleLeadingConstraint = [NSLayoutConstraint constraintWithItem:_actionLabel
                                                          attribute:NSLayoutAttributeLeading
                                                          relatedBy:NSLayoutRelationEqual
                                                             toItem:self.contentView
@@ -89,7 +89,7 @@ static const CGFloat ActionItemTitleVerticalPadding = 18.f;
                                                           constant:leadingConstant];
   _titleLeadingConstraint.active = YES;
   CGFloat width = CGRectGetWidth(self.contentView.frame) - leadingConstant - TitleTrailingPadding;
-  _titleWidthConstraint = [NSLayoutConstraint constraintWithItem:_textLabel
+  _titleWidthConstraint = [NSLayoutConstraint constraintWithItem:_actionLabel
                                                        attribute:NSLayoutAttributeWidth
                                                        relatedBy:NSLayoutRelationEqual
                                                           toItem:nil
@@ -102,32 +102,32 @@ static const CGFloat ActionItemTitleVerticalPadding = 18.f;
     [_inkTouchController addInkView];
   }
 
-  _imageView = [[UIImageView alloc] init];
-  [self.contentView addSubview:_imageView];
-  _imageView.translatesAutoresizingMaskIntoConstraints = NO;
-  _imageView.alpha = ImageAlpha;
-  [NSLayoutConstraint constraintWithItem:_imageView
+  _actionImageView = [[UIImageView alloc] init];
+  [self.contentView addSubview:_actionImageView];
+  _actionImageView.translatesAutoresizingMaskIntoConstraints = NO;
+  _actionImageView.alpha = ImageAlpha;
+  [NSLayoutConstraint constraintWithItem:_actionImageView
                                attribute:NSLayoutAttributeTop
                                relatedBy:NSLayoutRelationEqual
                                   toItem:self.contentView
                                attribute:NSLayoutAttributeTop
                               multiplier:1
                                 constant:ImageTopPadding].active = YES;
-  [NSLayoutConstraint constraintWithItem:_imageView
+  [NSLayoutConstraint constraintWithItem:_actionImageView
                                attribute:NSLayoutAttributeLeading
                                relatedBy:NSLayoutRelationEqual
                                   toItem:self.contentView
                                attribute:NSLayoutAttributeLeading
                               multiplier:1
                                 constant:ImageLeadingPadding].active = YES;
-  [NSLayoutConstraint constraintWithItem:_imageView
+  [NSLayoutConstraint constraintWithItem:_actionImageView
                                attribute:NSLayoutAttributeWidth
                                relatedBy:NSLayoutRelationEqual
                                   toItem:nil
                                attribute:NSLayoutAttributeNotAnAttribute
                               multiplier:1
                                 constant:ImageHeightAndWidth].active = YES;
-  [NSLayoutConstraint constraintWithItem:_imageView
+  [NSLayoutConstraint constraintWithItem:_actionImageView
                                attribute:NSLayoutAttributeHeight
                                relatedBy:NSLayoutRelationEqual
                                   toItem:nil
@@ -139,7 +139,7 @@ static const CGFloat ActionItemTitleVerticalPadding = 18.f;
 - (void)layoutSubviews {
   [super layoutSubviews];
 
-  self.textLabel.text = _itemAction.title;
+  self.actionLabel.text = _itemAction.title;
   CGFloat leadingConstant;
   if (_itemAction.image) {
     leadingConstant = TitleLeadingPadding;
@@ -150,13 +150,13 @@ static const CGFloat ActionItemTitleVerticalPadding = 18.f;
   CGFloat width = CGRectGetWidth(self.contentView.frame) - leadingConstant - TitleTrailingPadding;
   _titleWidthConstraint.constant = width;
 
-  self.imageView.image = _itemAction.image;
+  self.actionImageView.image = _itemAction.image;
 }
 
 - (void)setAction:(MDCActionSheetAction *)action {
   _itemAction = [action copy];
-  self.textLabel.text = _itemAction.title;
-  self.imageView.image = _itemAction.image;
+  self.actionLabel.text = _itemAction.title;
+  self.actionImageView.image = _itemAction.image;
   [self setNeedsLayout];
 }
 
@@ -173,11 +173,11 @@ static const CGFloat ActionItemTitleVerticalPadding = 18.f;
   UIFont *titleFont = _actionFont ?:
       [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleSubheadline];
   if (self.mdc_adjustsFontForContentSizeCategory) {
-    self.textLabel.font =
+    self.actionLabel.font =
         [titleFont mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleSubheadline
                                 scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
   } else {
-    self.textLabel.font = titleFont;
+    self.actionLabel.font = titleFont;
   }
   [self setNeedsLayout];
 }

--- a/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
+++ b/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
@@ -32,8 +32,6 @@ static const CGFloat ActionItemTitleVerticalPadding = 18.f;
 
 @implementation MDCActionSheetItemTableViewCell {
   MDCActionSheetAction *_itemAction;
-  UILabel *_textLabel;
-  UIImageView *_imageView;
   NSLayoutConstraint *_titleLeadingConstraint;
   NSLayoutConstraint *_titleWidthConstraint;
   MDCInkTouchController *_inkTouchController;
@@ -141,7 +139,7 @@ static const CGFloat ActionItemTitleVerticalPadding = 18.f;
 - (void)layoutSubviews {
   [super layoutSubviews];
 
-  _textLabel.text = _itemAction.title;
+  self.textLabel.text = _itemAction.title;
   CGFloat leadingConstant;
   if (_itemAction.image) {
     leadingConstant = TitleLeadingPadding;
@@ -152,13 +150,13 @@ static const CGFloat ActionItemTitleVerticalPadding = 18.f;
   CGFloat width = CGRectGetWidth(self.contentView.frame) - leadingConstant - TitleTrailingPadding;
   _titleWidthConstraint.constant = width;
 
-  _imageView.image = _itemAction.image;
+  self.imageView.image = _itemAction.image;
 }
 
 - (void)setAction:(MDCActionSheetAction *)action {
   _itemAction = [action copy];
-  _textLabel.text = _itemAction.title;
-  _imageView.image = _itemAction.image;
+  self.textLabel.text = _itemAction.title;
+  self.imageView.image = _itemAction.image;
   [self setNeedsLayout];
 }
 
@@ -175,11 +173,11 @@ static const CGFloat ActionItemTitleVerticalPadding = 18.f;
   UIFont *titleFont = _actionFont ?:
       [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleSubheadline];
   if (self.mdc_adjustsFontForContentSizeCategory) {
-    _textLabel.font =
+    self.textLabel.font =
         [titleFont mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleSubheadline
                                 scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
   } else {
-    _textLabel.font = titleFont;
+    self.textLabel.font = titleFont;
   }
   [self setNeedsLayout];
 }

--- a/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
+++ b/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
@@ -72,14 +72,16 @@ static const CGFloat ActionItemTitleVerticalPadding = 18.f;
                                   toItem:self.contentView
                                attribute:NSLayoutAttributeTop
                               multiplier:1
-                                constant:ActionItemTitleVerticalPadding].active = YES;
+                                constant:ActionItemTitleVerticalPadding]
+      .active = YES;
   [NSLayoutConstraint constraintWithItem:_actionLabel
                                attribute:NSLayoutAttributeBottom
                                relatedBy:NSLayoutRelationEqual
                                   toItem:self.contentView
                                attribute:NSLayoutAttributeBottom
                               multiplier:1
-                                constant:-ActionItemTitleVerticalPadding].active = YES;
+                                constant:-ActionItemTitleVerticalPadding]
+      .active = YES;
   _titleLeadingConstraint = [NSLayoutConstraint constraintWithItem:_actionLabel
                                                          attribute:NSLayoutAttributeLeading
                                                          relatedBy:NSLayoutRelationEqual
@@ -112,28 +114,32 @@ static const CGFloat ActionItemTitleVerticalPadding = 18.f;
                                   toItem:self.contentView
                                attribute:NSLayoutAttributeTop
                               multiplier:1
-                                constant:ImageTopPadding].active = YES;
+                                constant:ImageTopPadding]
+      .active = YES;
   [NSLayoutConstraint constraintWithItem:_actionImageView
                                attribute:NSLayoutAttributeLeading
                                relatedBy:NSLayoutRelationEqual
                                   toItem:self.contentView
                                attribute:NSLayoutAttributeLeading
                               multiplier:1
-                                constant:ImageLeadingPadding].active = YES;
+                                constant:ImageLeadingPadding]
+      .active = YES;
   [NSLayoutConstraint constraintWithItem:_actionImageView
                                attribute:NSLayoutAttributeWidth
                                relatedBy:NSLayoutRelationEqual
                                   toItem:nil
                                attribute:NSLayoutAttributeNotAnAttribute
                               multiplier:1
-                                constant:ImageHeightAndWidth].active = YES;
+                                constant:ImageHeightAndWidth]
+      .active = YES;
   [NSLayoutConstraint constraintWithItem:_actionImageView
                                attribute:NSLayoutAttributeHeight
                                relatedBy:NSLayoutRelationEqual
                                   toItem:nil
                                attribute:NSLayoutAttributeNotAnAttribute
                               multiplier:1
-                                constant:ImageHeightAndWidth].active = YES;
+                                constant:ImageHeightAndWidth]
+      .active = YES;
 }
 
 - (void)layoutSubviews {

--- a/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
+++ b/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
@@ -25,6 +25,11 @@ static const CGFloat TitleLeadingPadding = 72.f;
 static const CGFloat TitleTrailingPadding = 16.f;
 static const CGFloat ActionItemTitleVerticalPadding = 18.f;
 
+@interface MDCActionSheetItemTableViewCell
+@property(nonatomic, strong) UILabel *textLabel;
+@property(nonatomic, strong) UIImageView *imageView;
+@end
+
 @implementation MDCActionSheetItemTableViewCell {
   MDCActionSheetAction *_itemAction;
   UILabel *_textLabel;


### PR DESCRIPTION
### The problem
When writing test if we want to test against `imageView` or `textLabel` it will look at UITableViewCell properties because those are exposed in UITableViewCell header file and we had them as `ivars`. This makes it so we cannot get to them within test unless if we check against the `UITableViewCell.contentView.subviews`. Exposing these clashes with UITableViewCell properties.

### The fix
Change these properties to properties on the class instead of `ivars` therefore allowing us to expose and rename them in test.

### Related issues
#5039 