### PR TITLE
[ActionSheet] Expose ink touch controller

### DIFF
--- a/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
+++ b/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
@@ -28,13 +28,13 @@ static const CGFloat kActionItemTitleVerticalPadding = 18.f;
 @interface MDCActionSheetItemTableViewCell ()
 @property(nonatomic, strong) UILabel *actionLabel;
 @property(nonatomic, strong) UIImageView *actionImageView;
+@property(nonatomic, strong) MDCInkTouchController *inkTouchController;
 @end
 
 @implementation MDCActionSheetItemTableViewCell {
   MDCActionSheetAction *_itemAction;
   NSLayoutConstraint *_titleLeadingConstraint;
   NSLayoutConstraint *_titleWidthConstraint;
-  MDCInkTouchController *_inkTouchController;
 }
 
 @synthesize mdc_adjustsFontForContentSizeCategory = _mdc_adjustsFontForContentSizeCategory;


### PR DESCRIPTION
### Context
In order to test all subviews of a class those subviews cannot be an ivar unless we do KVC to get those views.

### The problem
Currently MDCInkTouchController is an ivar of MDCActionSheetItemTableViewCell and it will need to be tested.

### The fix
This changes MDCInkTouchController to be a property instead of an ivar

### Related issues
#5039 

### Related PRs
#5195 relies on this PR
#5190 was a similar PR that I missed exposing InkController
#5157 was also a similar PR