### PR TITLE
[NavigationDrawer] Fix iOS 9 bottom drawer dismissals

### DIFF
--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -37,6 +37,16 @@ static UIColor *DrawerOverlayBackgroundColor(void) {
 
 @implementation MDCBottomDrawerPresentationController
 
+- (UIView *)presentedView {
+  if ([self.presentedViewController isKindOfClass:[MDCBottomDrawerViewController class]]) {
+    return super.presentedView;
+  } else {
+    // Override the presentedView property getter to return our container view controller's
+    // view instead of the default.
+    return self.bottomDrawerContainerViewController.view;
+  }
+}
+
 - (void)presentationTransitionWillBegin {
   MDCBottomDrawerContainerViewController *bottomDrawerContainerViewController =
       [[MDCBottomDrawerContainerViewController alloc]
@@ -67,7 +77,12 @@ static UIColor *DrawerOverlayBackgroundColor(void) {
   self.scrimView.accessibilityTraits |= UIAccessibilityTraitButton;
 
   [self.containerView addSubview:self.scrimView];
-  [self.presentedView addSubview:self.bottomDrawerContainerViewController.view];
+
+  if ([self.presentedViewController isKindOfClass:[MDCBottomDrawerViewController class]]) {
+    [self.presentedView addSubview:self.bottomDrawerContainerViewController.view];
+  } else {
+    [self.containerView addSubview:self.bottomDrawerContainerViewController.view];
+  }
 
   id<UIViewControllerTransitionCoordinator> transitionCoordinator =
       [[self presentingViewController] transitionCoordinator];

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -37,12 +37,6 @@ static UIColor *DrawerOverlayBackgroundColor(void) {
 
 @implementation MDCBottomDrawerPresentationController
 
-// Override the presentedView property getter to return our container view controller's
-// view instead of the default.
-- (UIView *)presentedView {
-  return self.bottomDrawerContainerViewController.view;
-}
-
 - (void)presentationTransitionWillBegin {
   MDCBottomDrawerContainerViewController *bottomDrawerContainerViewController =
       [[MDCBottomDrawerContainerViewController alloc]
@@ -73,7 +67,7 @@ static UIColor *DrawerOverlayBackgroundColor(void) {
   self.scrimView.accessibilityTraits |= UIAccessibilityTraitButton;
 
   [self.containerView addSubview:self.scrimView];
-  [self.containerView addSubview:self.bottomDrawerContainerViewController.view];
+  [self.presentedView addSubview:self.bottomDrawerContainerViewController.view];
 
   id<UIViewControllerTransitionCoordinator> transitionCoordinator =
       [[self presentingViewController] transitionCoordinator];


### PR DESCRIPTION
I noticed that while trying to dismiss the bottom drawer on iOS 9 I got the following error message:
```
attempt to dismiss modal view controller whose view does not currently appear.
```
Then I noticed that if I commented out our override of `-presentedView` I _could_ dismiss the bottom drawer, but I couldn't interact with it.

Finally, I noticed that if I added `self.bottomDrawerContainerViewController.view` as a subview of `super.presentedView` instead of `self.containerView`, I could both dismiss and interact with the bottom drawer, as expected.

This seems to be a good fix, but I'm not really sure. I'm kind of afraid to break something here. Going to wait for @yarneo's input since he has the most knowledge of this component.

Closes #5153.