### PR TITLE
[ActionSheet] Add color themer

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -58,7 +58,6 @@ fix_bazel_imports() {
   done
   rewrite_tests "s/import MaterialComponentsAlpha.Material(.+)_(.+)/import components_\1_\2 \/\/ Alpha/"
   rewrite_tests "s/import MaterialComponentsAlpha.Material(.+)/import components_\1_\1 \/\/ Alpha/"
-  rewrite_tests "s/import MaterialComponentsAlpha.Material(.+)_(.+)/import components_\1_\2 \/\/ Alpha/"
   rewrite_tests "s/import MaterialComponents.Material(.+)/import components_\1_\1/"
   rewrite_source "s/import <Motion(.+)\/Motion.+\.h>/import \"Motion\1.h\"/"
   rewrite_source "s/import <MDF(.+)\/MDF.+\.h>/import \"MDF\1.h\"/"
@@ -68,7 +67,6 @@ fix_bazel_imports() {
   reset_imports() {
     # Undoes our source changes from above.
     rewrite_tests "s/import components_(.+)_\1 \/\/ Alpha/import MaterialComponentsAlpha.Material\1/"
-    rewrite_tests "s/import components_(.+)_(.+) \/\/ Alpha/import MaterialComponentsAlpha.Material\1_\2/"
     rewrite_tests "s/import components_schemes_(.+)_.+/import MaterialComponents.Material\1Scheme/"
     rewrite_tests "s/import components_private_(.+)_.+/import MaterialComponents.Material\1/"
     rewrite_tests "s/import components_(.+)_\1/import MaterialComponents.Material\1/"

--- a/.kokoro
+++ b/.kokoro
@@ -58,6 +58,7 @@ fix_bazel_imports() {
   done
   rewrite_tests "s/import MaterialComponentsAlpha.Material(.+)_(.+)/import components_\1_\2 \/\/ Alpha/"
   rewrite_tests "s/import MaterialComponentsAlpha.Material(.+)/import components_\1_\1 \/\/ Alpha/"
+  rewrite_tests "s/import MaterialComponentsAlpha.Material(.+)_(.+)/import components_\1_\2 \/\/ Alpha/"
   rewrite_tests "s/import MaterialComponents.Material(.+)/import components_\1_\1/"
   rewrite_source "s/import <Motion(.+)\/Motion.+\.h>/import \"Motion\1.h\"/"
   rewrite_source "s/import <MDF(.+)\/MDF.+\.h>/import \"MDF\1.h\"/"

--- a/.kokoro
+++ b/.kokoro
@@ -58,7 +58,7 @@ fix_bazel_imports() {
   done
   rewrite_tests "s/import MaterialComponentsAlpha.Material(.+)_(.+)/import components_\1_\2 \/\/ Alpha/"
   rewrite_tests "s/import MaterialComponentsAlpha.Material(.+)/import components_\1_\1 \/\/ Alpha/"
-  rewrite_tests "s/import MaterialComponentsAlpha.Material(.+)_(.+)/import components_\1_\2 \/\/ Alpha/"
+  rewrite_tests "s/import MaterialComponentsAlpha.Material(.+)_(.+)/import components_\1_\1_\2 \/\/ Alpha/"
   rewrite_tests "s/import MaterialComponents.Material(.+)/import components_\1_\1/"
   rewrite_source "s/import <Motion(.+)\/Motion.+\.h>/import \"Motion\1.h\"/"
   rewrite_source "s/import <MDF(.+)\/MDF.+\.h>/import \"MDF\1.h\"/"

--- a/.kokoro
+++ b/.kokoro
@@ -58,7 +58,7 @@ fix_bazel_imports() {
   done
   rewrite_tests "s/import MaterialComponentsAlpha.Material(.+)_(.+)/import components_\1_\2 \/\/ Alpha/"
   rewrite_tests "s/import MaterialComponentsAlpha.Material(.+)/import components_\1_\1 \/\/ Alpha/"
-  rewrite_tests "s/import MaterialComponentsAlpha.Material(.+)_(.+)/import components_\1_\1_\2 \/\/ Alpha/"
+  rewrite_tests "s/import MaterialComponentsAlpha.Material(.+)_(.+)/import components_\1_\2 \/\/ Alpha/"
   rewrite_tests "s/import MaterialComponents.Material(.+)/import components_\1_\1/"
   rewrite_source "s/import <Motion(.+)\/Motion.+\.h>/import \"Motion\1.h\"/"
   rewrite_source "s/import <MDF(.+)\/MDF.+\.h>/import \"MDF\1.h\"/"

--- a/MaterialComponentsAlpha.podspec
+++ b/MaterialComponentsAlpha.podspec
@@ -18,8 +18,7 @@ Pod::Spec.new do |mdc|
   mdc.subspec "ActionSheet" do |component|
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
-
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
     component.dependency "MaterialComponents/BottomSheet"
     component.dependency "MaterialComponents/Ink"
     component.dependency "MaterialComponents/Typography"
@@ -29,6 +28,14 @@ Pod::Spec.new do |mdc|
         unit_tests.source_files = "components/#{component.base_name}/tests/unit/*.{h,m,swift}", "components/#{component.base_name}/tests/unit/supplemental/*.{h,m,swift}"
       end
     end
+  end
+
+  mdc.subspec "ActionSheet+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponentsAlpha/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/schemes/Color"
   end
 
   mdc.subspec "ActionSheet+TypographyThemer" do |extension|

--- a/MaterialComponentsAlpha.podspec
+++ b/MaterialComponentsAlpha.podspec
@@ -18,7 +18,8 @@ Pod::Spec.new do |mdc|
   mdc.subspec "ActionSheet" do |component|
     component.ios.deployment_target = '8.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"
-    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+
     component.dependency "MaterialComponents/BottomSheet"
     component.dependency "MaterialComponents/Ink"
     component.dependency "MaterialComponents/Typography"

--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -77,6 +77,7 @@ swift_library(
     srcs = glob(["tests/unit/*.swift"]),
     deps = [
         ":ActionSheet",
+        ":ColorThemer",
         ":private",
     ],
     visibility = ["//visibility:private"],

--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -36,9 +36,23 @@ mdc_objc_library(
     srcs = native.glob(["src/TypographyThemer/*.m"]),
     hdrs = native.glob(["src/TypographyThemer/*.h"]),
     includes = ["src/TypographyThemer"],
+    sdk_frameworks = ["UIKit"],
     deps = [
         ":ActionSheet",
         "//components/schemes/Typography",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+mdc_objc_library(
+    name = "ColorThemer",
+    srcs = native.glob(["src/ColorThemer/*.m"]),
+    hdrs = native.glob(["src/ColorThemer/*.h"]),
+    includes = ["src/ColorThemer"],
+    sdk_frameworks = ["UIKit"],
+    deps = [
+        ":ActionSheet",
+        "//components/schemes/Color",
     ],
     visibility = ["//visibility:public"],
 )

--- a/components/ActionSheet/examples/ActionSheetSwiftExample.swift
+++ b/components/ActionSheet/examples/ActionSheetSwiftExample.swift
@@ -14,6 +14,7 @@
 
 import UIKit
 import MaterialComponentsAlpha.MaterialActionSheet
+import MaterialComponentsAlpha.MaterialActionSheet_ColorThemer
 import MaterialComponentsAlpha.MaterialActionSheet_TypographyThemer
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialTypographyScheme
@@ -87,6 +88,7 @@ class ActionSheetSwiftExample: UIViewController {
     case .thirtyOptions:
       actionSheet = ActionSheetSwiftExample.thirtyOptions()
     }
+    MDCActionSheetColorThemer.applySemanticColorScheme(colorScheme, to: actionSheet)
     MDCActionSheetTypographyThemer.applyTypographyScheme(typographyScheme, to: actionSheet)
     present(actionSheet, animated: true, completion: nil)
   }

--- a/components/ActionSheet/examples/ActionSheetTypicalUse.m
+++ b/components/ActionSheet/examples/ActionSheetTypicalUse.m
@@ -14,8 +14,10 @@
 
 #import "ActionSheetTypicalUse.h"
 
-#import "MaterialButtons.h"
+#import "MaterialActionSheet+ColorThemer.h"
+#import "MaterialActionSheet+TypographyThemer.h"
 #import "MaterialButtons+ButtonThemer.h"
+#import "MaterialButtons.h"
 
 @interface ActionSheetTypicalUse ()
 
@@ -82,6 +84,10 @@
   [actionSheet addAction:homeAction];
   [actionSheet addAction:favoriteAction];
   [actionSheet addAction:emailAction];
+  [MDCActionSheetColorThemer applySemanticColorScheme:self.colorScheme
+                              toActionSheetController:actionSheet];
+  [MDCActionSheetTypographyThemer applyTypographyScheme:self.typographyScheme
+                                toActionSheetController:actionSheet];
   [self presentViewController:actionSheet animated:YES completion:nil];
 }
 

--- a/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.h
+++ b/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.h
@@ -17,6 +17,9 @@
 
 #import <Foundation/Foundation.h>
 
+/**
+ The Material Design color system's themer for instances of MDCActionSheetController.
+ */
 @interface MDCActionSheetColorThemer : NSObject
 
 /**

--- a/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.h
+++ b/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.h
@@ -19,7 +19,6 @@
 
 @interface MDCActionSheetColorThemer : NSObject
 
-
 /**
  Applies a color scheme's properties to an MDCActionSheetController
 

--- a/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.h
+++ b/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.h
@@ -24,9 +24,9 @@
  Applies a color scheme's properties to an MDCActionSheetController
 
  @param colorScheme The color scheme to apply to the component instance.
- @param actionSheet A component instance to which the olor scheme should be applied.
+ @param actionSheetController A component instance to which the olor scheme should be applied.
  */
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
-                   toActionSheet:(nonnull MDCActionSheetController *)actionSheet;
+         toActionSheetController:(nonnull MDCActionSheetController *)actionSheetController;
 
 @end

--- a/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.h
+++ b/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.h
@@ -1,0 +1,32 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialActionSheet.h"
+#import "MaterialColorScheme.h"
+
+#import <Foundation/Foundation.h>
+
+@interface MDCActionSheetColorThemer : NSObject
+
+
+/**
+ Applies a color scheme's properties to an MDCActionSheetController
+
+ @param colorScheme The color scheme to apply to the component instance.
+ @param actionSheet A component instance to which the olor scheme should be applied.
+ */
++ (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+                   toActionSheet:(nonnull MDCActionSheetController *)actionSheet;
+
+@end

--- a/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.m
+++ b/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.m
@@ -21,22 +21,24 @@ static const CGFloat kInkAlpha = 16.f;
 @implementation MDCActionSheetColorThemer
 
 + (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
-                   toActionSheet:(MDCActionSheetController *)actionSheet {
-  actionSheet.backgroundColor = colorScheme.surfaceColor;
-  if (actionSheet.message && ![actionSheet.message isEqualToString:@""]) {
+         toActionSheetController:(MDCActionSheetController *)actionSheetController {
+  actionSheetController.backgroundColor = colorScheme.surfaceColor;
+  if (actionSheetController.message && ![actionSheetController.message isEqualToString:@""]) {
     // If there is a message then this can be high opacity and won't clash with actions.
-    actionSheet.titleTextColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
+    actionSheetController.titleTextColor =
+        [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
   } else {
-    actionSheet.titleTextColor =
+    actionSheetController.titleTextColor =
         [colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha];
   }
-  actionSheet.messageTextColor =
+  actionSheetController.messageTextColor =
       [colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha];
-  actionSheet.imageRenderingMode = UIImageRenderingModeAlwaysTemplate;
-  actionSheet.actionTintColor =
+  actionSheetController.imageRenderingMode = UIImageRenderingModeAlwaysTemplate;
+  actionSheetController.actionTintColor =
       [colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha];
-  actionSheet.actionTextColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
-  actionSheet.inkColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
+  actionSheetController.actionTextColor =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
+  actionSheetController.inkColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
 }
 
 @end

--- a/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.m
+++ b/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.m
@@ -14,8 +14,9 @@
 
 #import "MDCActionSheetColorThemer.h"
 
-static const CGFloat kHighOpacity = 0.87f;
-static const CGFloat kMediumOpacity = 0.6f;
+static const CGFloat kHighAlpha = 0.87f;
+static const CGFloat kMediumAlpha = 0.6f;
+static const CGFloat kInkAlpha = 16.f;
 
 @implementation MDCActionSheetColorThemer
 
@@ -24,17 +25,18 @@ static const CGFloat kMediumOpacity = 0.6f;
   actionSheet.backgroundColor = colorScheme.surfaceColor;
   if (actionSheet.message && ![actionSheet.message isEqualToString:@""]) {
     // If there is a message then this can be high opacity and won't clash with actions.
-    actionSheet.titleTextColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighOpacity];
+    actionSheet.titleTextColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
   } else {
     actionSheet.titleTextColor =
-        [colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumOpacity];
+        [colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha];
   }
   actionSheet.messageTextColor =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumOpacity];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha];
   actionSheet.imageRenderingMode = UIImageRenderingModeAlwaysTemplate;
   actionSheet.actionTintColor =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumOpacity];
-  actionSheet.actionTextColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighOpacity];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha];
+  actionSheet.actionTextColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
+  actionSheet.inkColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
 }
 
 @end

--- a/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.m
+++ b/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.m
@@ -1,0 +1,40 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCActionSheetColorThemer.h"
+
+static const CGFloat kHighOpacity = 0.87f;
+static const CGFloat kMediumOpacity = 0.6f;
+
+@implementation MDCActionSheetColorThemer
+
++ (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
+                   toActionSheet:(MDCActionSheetController *)actionSheet {
+  actionSheet.backgroundColor = colorScheme.surfaceColor;
+  if (actionSheet.message && ![actionSheet.message isEqualToString:@""]) {
+    // If there is a message then this can be high opacity and won't clash with actions.
+    actionSheet.titleTextColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighOpacity];
+  } else {
+    actionSheet.titleTextColor =
+        [colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumOpacity];
+  }
+  actionSheet.messageTextColor =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumOpacity];
+  actionSheet.imageRenderingMode = UIImageRenderingModeAlwaysTemplate;
+  actionSheet.actionTintColor =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumOpacity];
+  actionSheet.actionTextColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighOpacity];
+}
+
+@end

--- a/components/ActionSheet/src/ColorThemer/MaterialActionSheet+ColorThemer.h
+++ b/components/ActionSheet/src/ColorThemer/MaterialActionSheet+ColorThemer.h
@@ -1,0 +1,15 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCActionSheetColorThemer.h"

--- a/components/ActionSheet/tests/unit/ActionSheetTest.swift
+++ b/components/ActionSheet/tests/unit/ActionSheetTest.swift
@@ -14,6 +14,7 @@
 
 import XCTest
 import MaterialComponentsAlpha.MaterialActionSheet
+import MaterialComponentsAlpha.MaterialActionSheet_ColorThemer
 
 class ActionSheetTest: XCTestCase {
 
@@ -101,5 +102,20 @@ class ActionSheetTest: XCTestCase {
     // Then
     XCTAssertEqual(actionSheet.view.backgroundColor, actionSheet.backgroundColor)
     XCTAssertEqual(actionSheet.view.backgroundColor, newBackgroundColor)
+  }
+
+  func testApplyThemerToBackgroundColor() {
+    // Given
+    let surfaceColor: UIColor = .blue
+    let colorScheme = MDCSemanticColorScheme()
+    colorScheme.surfaceColor = surfaceColor
+
+    // When
+    MDCActionSheetColorThemer.applySemanticColorScheme(colorScheme, to: actionSheet)
+    let _ = actionSheet.view
+
+    // Then
+    XCTAssertEqual(actionSheet.view.backgroundColor, surfaceColor)
+    XCTAssertEqual(actionSheet.backgroundColor, surfaceColor)
   }
 }

--- a/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
@@ -14,12 +14,25 @@
 
 #import <XCTest/XCTest.h>
 
+#import "../../src/private/MDCActionSheetHeaderView.h"
+#import "../../src/private/MDCActionSheetItemTableViewCell.h"
 #import "MDCActionSheetTestHelper.h"
 #import "MaterialActionSheet+ColorThemer.h"
 
 static const CGFloat kHighAlpha = 0.87f;
 static const CGFloat kMediumAlpha = 0.6f;
 static const CGFloat kInkAlpha = 16.f;
+
+@interface MDCActionSheetHeaderView (Testing)
+@property(nonatomic, strong) UILabel *titleLabel;
+@property(nonatomic, strong) UILabel *messageLabel;
+@end
+
+@interface MDCActionSheetItemTableViewCell (Testing)
+@property(nonatomic, strong) UILabel *actionLabel;
+@property(nonatomic, strong) UIImageView *actionImageView;
+@property(nonatomic, strong) MDCInkTouchController *inkTouchController;
+@end
 
 @interface MDCActionSheetThemeTest : XCTestCase
 @property(nonatomic, strong) MDCActionSheetController *actionSheet;
@@ -33,41 +46,71 @@ static const CGFloat kInkAlpha = 16.f;
 
   self.actionSheet = [[MDCActionSheetController alloc] init];
   self.colorScheme = [[MDCSemanticColorScheme alloc] init];
+  UIColor *surface = UIColor.blueColor;
+  UIColor *onSurface = UIColor.redColor;
+  self.colorScheme.primaryColor = surface;
+  self.colorScheme.onPrimaryColor = onSurface;
 }
 
+#pragma mark - Header test
 - (void)testApplyColorThemerWithTitleAndMessage {
   // Given
-  UIColor *primary = UIColor.blueColor;
-  UIColor *onPrimary = UIColor.redColor;
-  self.colorScheme.primaryColor = primary;
-  self.colorScheme.onPrimaryColor = onPrimary;
   self.actionSheet.title = @"Test title";
   self.actionSheet.message = @"Test message";
-  NSArray *cells = [MDCActionSheetTestHelper getCellsFromActionSheet:self.actionSheet];
 
   // When
   [MDCActionSheetColorThemer applySemanticColorScheme:self.colorScheme
-                                        toActionSheet:self.actionSheet];
+                              toActionSheetController:self.actionSheet];
 
   // Then
-  XCTAssertEqualObjects(self.actionSheet.backgroundColor, primary);
   XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor,
-                        [onPrimary colorWithAlphaComponent:kHighAlpha]);
+                        [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha]);
   XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor,
-                        [onPrimary colorWithAlphaComponent:kMediumAlpha]);
-  for (MDCActionSheetItemTableViewCell *cell in cells) {
-    XCTAssertEqualObjects(cell.actionImageView.tintColor,
-                          [onPrimary colorWithAlphaComponent:kMediumAlpha]);
-    XCTAssertEqualObjects(cell.actionLabel.textColor,
-                          [onPrimary colorWithAlphaComponent:kHighAlpha]);
-    XCTAssertEqualObjects(cell.inkTouchController.defaultInkView.inkColor,
-                          [onPrimary colorWithAlphaComponent:kInkAlpha]);
-  }
+                        [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha]);
 }
 
 - (void)testApplyThemerWithOnlyTitle {
   // Given
+  self.actionSheet.title = @"Test title";
 
+  // When
+  [MDCActionSheetColorThemer applySemanticColorScheme:self.colorScheme
+                              toActionSheetController:self.actionSheet];
+
+  // Then
+  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor,
+                        [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha]);
+}
+
+- (void)testApplyThemerWithOnlyMessage {
+  // Given
+  self.actionSheet.message = @"Test message";
+
+  // When
+  [MDCActionSheetColorThemer applySemanticColorScheme:self.colorScheme
+                              toActionSheetController:self.actionSheet];
+
+  // Then
+  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor,
+                        [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha]);
+}
+
+#pragma mark - default test
+- (void)testApplyThemeToCells {
+  // When
+  [MDCActionSheetColorThemer applySemanticColorScheme:self.colorScheme
+                              toActionSheetController:self.actionSheet];
+  NSArray *cells = [MDCActionSheetTestHelper getCellsFromActionSheet:self.actionSheet];
+
+  // Then
+  for (MDCActionSheetItemTableViewCell *cell in cells) {
+    XCTAssertEqualObjects(cell.actionImageView.tintColor,
+                          [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha]);
+    XCTAssertEqualObjects(cell.actionLabel.textColor,
+                          [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha]);
+    XCTAssertEqualObjects(cell.inkTouchController.defaultInkView.inkColor,
+                          [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha]);
+  }
 }
 
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
@@ -1,0 +1,27 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+@interface MDCActionSheetThemeTest : XCTestCase
+
+@end
+
+@implementation MDCActionSheetThemeTest
+
+- (void)setUp {
+  [super setUp];
+}
+
+@end

--- a/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
@@ -14,14 +14,60 @@
 
 #import <XCTest/XCTest.h>
 
-@interface MDCActionSheetThemeTest : XCTestCase
+#import "MDCActionSheetTestHelper.h"
+#import "MaterialActionSheet+ColorThemer.h"
 
+static const CGFloat kHighAlpha = 0.87f;
+static const CGFloat kMediumAlpha = 0.6f;
+static const CGFloat kInkAlpha = 16.f;
+
+@interface MDCActionSheetThemeTest : XCTestCase
+@property(nonatomic, strong) MDCActionSheetController *actionSheet;
+@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
 @end
 
 @implementation MDCActionSheetThemeTest
 
 - (void)setUp {
   [super setUp];
+
+  self.actionSheet = [[MDCActionSheetController alloc] init];
+  self.colorScheme = [[MDCSemanticColorScheme alloc] init];
+}
+
+- (void)testApplyColorThemerWithTitleAndMessage {
+  // Given
+  UIColor *primary = UIColor.blueColor;
+  UIColor *onPrimary = UIColor.redColor;
+  self.colorScheme.primaryColor = primary;
+  self.colorScheme.onPrimaryColor = onPrimary;
+  self.actionSheet.title = @"Test title";
+  self.actionSheet.message = @"Test message";
+  NSArray *cells = [MDCActionSheetTestHelper getCellsFromActionSheet:self.actionSheet];
+
+  // When
+  [MDCActionSheetColorThemer applySemanticColorScheme:self.colorScheme
+                                        toActionSheet:self.actionSheet];
+
+  // Then
+  XCTAssertEqualObjects(self.actionSheet.backgroundColor, primary);
+  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor,
+                        [onPrimary colorWithAlphaComponent:kHighAlpha]);
+  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor,
+                        [onPrimary colorWithAlphaComponent:kMediumAlpha]);
+  for (MDCActionSheetItemTableViewCell *cell in cells) {
+    XCTAssertEqualObjects(cell.actionImageView.tintColor,
+                          [onPrimary colorWithAlphaComponent:kMediumAlpha]);
+    XCTAssertEqualObjects(cell.actionLabel.textColor,
+                          [onPrimary colorWithAlphaComponent:kHighAlpha]);
+    XCTAssertEqualObjects(cell.inkTouchController.defaultInkView.inkColor,
+                          [onPrimary colorWithAlphaComponent:kInkAlpha]);
+  }
+}
+
+- (void)testApplyThemerWithOnlyTitle {
+  // Given
+
 }
 
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
@@ -53,6 +53,7 @@ static const CGFloat kInkAlpha = 16.f;
 }
 
 #pragma mark - Header test
+
 - (void)testApplyColorThemerWithTitleAndMessage {
   // Given
   self.actionSheet.title = @"Test title";
@@ -96,6 +97,7 @@ static const CGFloat kInkAlpha = 16.f;
 }
 
 #pragma mark - default test
+
 - (void)testApplyThemeToCells {
   // When
   [MDCActionSheetColorThemer applySemanticColorScheme:self.colorScheme
@@ -103,6 +105,7 @@ static const CGFloat kInkAlpha = 16.f;
   NSArray *cells = [MDCActionSheetTestHelper getCellsFromActionSheet:self.actionSheet];
 
   // Then
+  XCTAssertNotEqual(cells.count, 0);
   for (MDCActionSheetItemTableViewCell *cell in cells) {
     XCTAssertEqualObjects(cell.actionImageView.tintColor,
                           [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha]);


### PR DESCRIPTION
### The problem

ActionSheet previously didn't have a color themer at all.

### The fix

This adds a color themer to ActionSheet, as well as test to test these use cases

### Related issues

#5039 

### Code snippet

#### Swift
```
let actionSheet = MDCActionSheetController()
MDCActionSheetColorThemer.applySemanticColorScheme(colorScheme, to: actionSheet)
```

#### ObjC
```
MDCActionSheetController *actionSheet = [[MDCActionSheetController alloc] init];
[MDCActionSheetColorThemer applySemanticColorScheme:self.colorScheme
                            toActionSheetController:actionSheet];
```

### Screenshots
| Before | After |
| ------ | ----- |
|![simulator screen shot - iphone x - 2018-09-24 at 09 17 13](https://user-images.githubusercontent.com/7131294/45954309-ae216500-bfda-11e8-8114-eb971ce36567.png)|![simulator screen shot - iphone x - 2018-09-24 at 09 16 10](https://user-images.githubusercontent.com/7131294/45954316-b2e61900-bfda-11e8-9e5a-16ff2e65cf7c.png)|

_Screenshot generated with_
```
self.colorScheme.surfaceColor = .yellow
self.colorScheme.onSurfaceColor = .magenta
```