### PR TITLE
[scripts/release] Fix component extension output in apidiff command.

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -482,7 +482,11 @@ generate_release_apidiff() {
       echo >> $ALL_CHANGELOG_PATH
       echo "### $component" >> $ALL_CHANGELOG_PATH
       echo >> $ALL_CHANGELOG_PATH
-      echo "**New component.**" >> $ALL_CHANGELOG_PATH
+      if [[ $component = *"+"* ]]; then
+        echo "**New extension.**" >> $ALL_CHANGELOG_PATH
+      else
+        echo "**New component.**" >> $ALL_CHANGELOG_PATH
+      fi
 
       echo "New!"
       continue

--- a/scripts/release
+++ b/scripts/release
@@ -482,7 +482,7 @@ generate_release_apidiff() {
       echo >> $ALL_CHANGELOG_PATH
       echo "### $component" >> $ALL_CHANGELOG_PATH
       echo >> $ALL_CHANGELOG_PATH
-      if [[ $component = *"+"* ]]; then
+      if [[ "$component" = *"+"* ]]; then
         echo "**New extension.**" >> $ALL_CHANGELOG_PATH
       else
         echo "**New component.**" >> $ALL_CHANGELOG_PATH


### PR DESCRIPTION
Prior to this change, `Component+Extension` additions would be incorrectly listed as a "New component" in the API diff.

After this change, `Componet+Extension` additions will be listed as "New extension" in the API diff.