### PR TITLE
[ShadowLayer] Fix layout of shadow layer example.

### DIFF
--- a/components/ShadowLayer/examples/ShadowCornerRadiusExample.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusExample.m
@@ -96,12 +96,26 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27.0f;
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+
   self.view.backgroundColor = [UIColor whiteColor];
   self.title = @"Shadow Corner Radius";
   _shadowsView = [[ShadowCornerRadiusView alloc] initWithFrame:self.view.bounds];
   _shadowsView.autoresizingMask =
       UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
   [self.view addSubview:_shadowsView];
+}
+
+- (void)viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
+
+  if (@available(iOS 11.0, *)) {
+    _shadowsView.frame = UIEdgeInsetsInsetRect(self.view.bounds, self.view.safeAreaInsets);
+  } else {
+    CGRect frame = self.view.bounds;
+    frame.origin.y += self.topLayoutGuide.length;
+    frame.size.height -= self.topLayoutGuide.length;
+    _shadowsView.frame = frame;
+  }
 }
 
 #pragma mark catalog by convention


### PR DESCRIPTION
It now respects the top layout guide of the app bar.

| Before | After |
|--------|-------|
| ![simulator screen shot - iphone 8 plus - 2018-09-24 at 23 19 06](https://user-images.githubusercontent.com/45670/45976735-40178500-c050-11e8-9128-e581436dbb50.png) | ![simulator screen shot - iphone 8 plus - 2018-09-24 at 23 18 17](https://user-images.githubusercontent.com/45670/45976719-368e1d00-c050-11e8-8885-212dd34d9dd1.png) |
