### PR TITLE
[ShadowLayer] Add support for responding to cornerRadius changes.

### DIFF
--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -219,6 +219,12 @@ static const float kAmbientShadowOpacity = 0.08f;
   _bottomShadow.shadowColor = shadowColor;
 }
 
+- (void)setCornerRadius:(CGFloat)cornerRadius {
+  super.cornerRadius = cornerRadius;
+
+  [self updateShadowPaths];
+}
+
 #pragma mark - shouldRasterize forwarding
 
 - (void)setShouldRasterize:(BOOL)shouldRasterize {
@@ -324,6 +330,10 @@ static const float kAmbientShadowOpacity = 0.08f;
   _topShadow.position = CGPointMake(CGRectGetMidX(bounds), CGRectGetMidY(bounds));
   _topShadow.bounds = bounds;
 
+  [self updateShadowPaths];
+}
+
+- (void)updateShadowPaths {
   if (_shadowMaskEnabled) {
     [self configureShadowLayerMaskForLayer:_topShadowMask];
     [self configureShadowLayerMaskForLayer:_bottomShadowMask];


### PR DESCRIPTION
Prior to this change, changing the cornerRadius of a shadow layer would not propagate to the shadow paths until the next time the shadow layer's layoutSubviews was invoked.

After this change, changing the cornerRadius will immediately update the shadow paths of the shadow layer.

Closes https://github.com/material-components/material-components-ios/issues/4848

Internal CL to test: [cl/214326774](http://cl/214326774).

| Before | After |
|--|--|
|![shadowradius-broken](https://user-images.githubusercontent.com/1121006/44730113-367d1a80-aaae-11e8-9b55-024f97b797e0.gif)|![shadowradius-fixed](https://user-images.githubusercontent.com/1121006/44730119-3d0b9200-aaae-11e8-8798-98ae8100f671.gif)|
