### PR TITLE
[ActionSheet] Add test for setting fonts

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -397,6 +397,11 @@ static const CGFloat kActionTextAlpha = 0.87f;
 
 #pragma mark - Table customization
 
+- (void)setActionFont:(UIFont *)actionFont {
+  _actionFont = actionFont;
+  [self.tableView reloadData];
+}
+
 - (void)setActionTextColor:(UIColor *)actionTextColor {
   _actionTextColor = actionTextColor;
   [self.tableView reloadData];

--- a/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
+++ b/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
@@ -168,7 +168,7 @@ static const CGFloat kActionItemTitleVerticalPadding = 18.f;
   return _itemAction;
 }
 
-- (void)setActionsFont:(UIFont *)actionFont {
+- (void)setActionFont:(UIFont *)actionFont {
   _actionFont = actionFont;
   [self updateTitleFont];
 }

--- a/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
@@ -132,4 +132,18 @@
   }
 }
 
+- (void)testSetActionFont {
+  // Given
+  UIFont *actionFont = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
+
+  // When
+  self.actionSheet.actionFont = actionFont;
+  NSArray *cells = [MDCActionSheetTestHelper getCellsFromActionSheet:self.actionSheet];
+  XCTAssertNotEqual(cells.count, 0);
+  for (MDCActionSheetItemTableViewCell *cell in cells) {
+    // Then
+    XCTAssertEqual(cell.actionLabel.font, actionFont);
+  }
+}
+
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -373,7 +373,6 @@ static const CGFloat kSafeAreaAmount = 20.f;
 - (void)testSetTitleFont {
   // Given
   UIFont *titleFont = [UIFont preferredFontForTextStyle:UIFontTextStyleCallout];
-  self.actionSheet.title = @"Test title";
 
   // When
   self.actionSheet.titleFont = titleFont;
@@ -385,7 +384,6 @@ static const CGFloat kSafeAreaAmount = 20.f;
 - (void)testSetMessageFont {
   // Given
   UIFont *messageFont = [UIFont preferredFontForTextStyle:UIFontTextStyleCaption1];
-  self.actionSheet.message = @"Test message";
 
   // When
   self.actionSheet.messageFont = messageFont;

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -368,4 +368,30 @@ static const CGFloat kSafeAreaAmount = 20.f;
   }
 }
 
+#pragma mark - Fonts
+
+- (void)testSetTitleFont {
+  // Given
+  UIFont *titleFont = [UIFont preferredFontForTextStyle:UIFontTextStyleCallout];
+  self.actionSheet.title = @"Test title";
+
+  // When
+  self.actionSheet.titleFont = titleFont;
+
+  // Then
+  XCTAssertEqual(self.actionSheet.header.titleLabel.font, titleFont);
+}
+
+- (void)testSetMessageFont {
+  // Given
+  UIFont *messageFont = [UIFont preferredFontForTextStyle:UIFontTextStyleCaption1];
+  self.actionSheet.message = @"Test message";
+
+  // When
+  self.actionSheet.messageFont = messageFont;
+
+  // Then
+  XCTAssertEqual(self.actionSheet.header.messageLabel.font, messageFont);
+}
+
 @end


### PR DESCRIPTION
### The problem
During development test were never added for custom fonts
### The fix
This adds test to MDCActionSheetController for setting the font on cells and both header labels
### Bugs found
These test discovered a typo in MDCActionSheetItemTableViewCell for setting the font. Also MDCActionSheetController was missing a setter for the ActionFont property.

### Screenshots
| Before | After |
| ------ | ------ |
|![simulator screen shot - iphone xr - 2018-09-25 at 07 59 40](https://user-images.githubusercontent.com/7131294/46013086-26e6f680-c099-11e8-8594-d3a895c38da1.png)|![simulator screen shot - iphone xr - 2018-09-25 at 08 00 45](https://user-images.githubusercontent.com/7131294/46013092-2a7a7d80-c099-11e8-9b37-675e3744a57c.png)|



#### Screenshot snippet
```swift
actionSheet.actionFont = UIFont.systemFont(ofSize: 20.0, weight: UIFontWeightLight)
actionSheet.titleFont = UIFont.systemFont(ofSize: 22.0, weight: UIFontWeightUltraLight)
actionSheet.messageFont = UIFont.systemFont(ofSize: 24.0, weight: UIFontWeightHeavy)
```