### PR TITLE
[ActionSheet] Fix path for ObjC test source.

### DIFF
--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -94,8 +94,12 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
-    deps = [":ActionSheet",
-            ":privateHeaders"],
+    deps = [
+         ":ActionSheet",
+         ":ColorThemer",
+         ":TypographyThemer",
+         ":privateHeaders"
+    ],
     visibility = ["//visibility:private"],
 )
 

--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -87,8 +87,8 @@ mdc_objc_library(
     name = "unit_test_sources",
     testonly = 1,
     srcs = native.glob([
-        "test/unit/*.m",
-        "test/unit/*.h",
+        "tests/unit/*.m",
+        "tests/unit/*.h",
     ]),
     sdk_frameworks = [
         "UIKit",

--- a/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
@@ -105,7 +105,7 @@ static const CGFloat kInkAlpha = 16.f;
   NSArray *cells = [MDCActionSheetTestHelper getCellsFromActionSheet:self.actionSheet];
 
   // Then
-  XCTAssertNotEqual(cells.count, 0);
+  XCTAssertNotEqual(cells.count, 0U);
   for (MDCActionSheetItemTableViewCell *cell in cells) {
     XCTAssertEqualObjects(cell.actionImageView.tintColor,
                           [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha]);


### PR DESCRIPTION
The path is `tests/` but prior to this change the BUILD file was looking for source in `test/`.