### PR TITLE
[travis.yml] Update cocoapods install

### DIFF
--- a/contributing/README.md
+++ b/contributing/README.md
@@ -34,6 +34,15 @@ Start the title with `[ComponentName]` to identify which component a change affe
 [FooBar] Removes the deprecated fooWithBar:(Bar*)bar method.
 ```
 
+### Pull request continuous integration for new contributors
+
+Continuous integration will only be initiated automatically for the core team and and
+recognized collaborators.
+
+All other pull requests must be labeled with `kokoro:force-run` by a member of the repo
+in order for continuous integration to be initiated. This label must be added again each
+time the pull request has new commits pushed to it.
+
 #### Using assignee to indicate who should action on a PR
 
 Since PRs on github permanently stay in the `Changes requested` state it is hard to tell when the author has addressed the concerns. By change the assignee to whomever still needs to action (review or modify/justify) we can more easily keep track of what needs attention in our PR queues.

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -43,6 +43,8 @@ All other pull requests must be labeled with `kokoro:force-run` by a member of t
 with write access in order for continuous integration to be initiated. This label must
 be added again each time the pull request has new commits pushed to it.
 
+For Googlers: [b/115490922](http://b/115490922) is tracking making the above work more streamlined for new contributors.
+
 #### Using assignee to indicate who should action on a PR
 
 Since PRs on github permanently stay in the `Changes requested` state it is hard to tell when the author has addressed the concerns. By change the assignee to whomever still needs to action (review or modify/justify) we can more easily keep track of what needs attention in our PR queues.

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -36,8 +36,8 @@ Start the title with `[ComponentName]` to identify which component a change affe
 
 ### Pull request continuous integration for new contributors
 
-Continuous integration will only be initiated automatically for the core team and
-recognized collaborators.
+Continuous integration will only be initiated automatically for the [core team](https://github.com/orgs/material-components/teams/core-ios-team/members)
+and [recognized collaborators](https://github.com/orgs/material-components/teams/recognized-ios-collaborators/members).
 
 All other pull requests must be labeled with `kokoro:force-run` by a member of the repo
 in order for continuous integration to be initiated. This label must be added again each

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -40,8 +40,8 @@ Continuous integration will only be initiated automatically for the [core team](
 and [recognized collaborators](https://github.com/orgs/material-components/teams/recognized-ios-collaborators/members).
 
 All other pull requests must be labeled with `kokoro:force-run` by a member of the repo
-in order for continuous integration to be initiated. This label must be added again each
-time the pull request has new commits pushed to it.
+with write access in order for continuous integration to be initiated. This label must
+be added again each time the pull request has new commits pushed to it.
 
 #### Using assignee to indicate who should action on a PR
 

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -36,7 +36,7 @@ Start the title with `[ComponentName]` to identify which component a change affe
 
 ### Pull request continuous integration for new contributors
 
-Continuous integration will only be initiated automatically for the core team and and
+Continuous integration will only be initiated automatically for the core team and
 recognized collaborators.
 
 All other pull requests must be labeled with `kokoro:force-run` by a member of the repo


### PR DESCRIPTION
We rely on CocoaPods 1.4.0 for our test_spec support. This change updates the cocoapods version installed as part of our Travis CI continuous integration.