### PR TITLE
[MDCSlider] Allow setting exclusiveTouch on Sliders.

### DIFF
--- a/components/Slider/src/MDCSlider.m
+++ b/components/Slider/src/MDCSlider.m
@@ -385,6 +385,11 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
 
 #pragma mark - UIView methods
 
+- (void)setExclusiveTouch:(BOOL)exclusiveTouch {
+  [super setExclusiveTouch:exclusiveTouch];
+  _thumbTrack.exclusiveTouch = exclusiveTouch;
+}
+
 - (CGSize)intrinsicContentSize {
   return CGSizeMake(kSliderDefaultWidth, kSliderFrameHeight);
 }


### PR DESCRIPTION
Exclusivetouch allows the developer to stop multitouch interactions within a window that are undesirable. https://developer.apple.com/documentation/uikit/uiview/1622453-exclusivetouch

closes #5236