### PR TITLE
[BottomNavigation] Fix swift example

### DIFF
--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
@@ -25,6 +25,7 @@ class BottomNavigationTypicalUseSwiftExample: UIViewController {
 
   init() {
     super.init(nibName: nil, bundle: nil)
+    commonBottomNavigationTypicalUseSwiftExampleInit()
   }
 
   @available(*, unavailable)
@@ -56,10 +57,14 @@ class BottomNavigationTypicalUseSwiftExample: UIViewController {
   
   func layoutBottomNavBar() {
     let size = bottomNavBar.sizeThatFits(view.bounds.size)
-    let bottomNavBarFrame = CGRect(x: 0,
+    var bottomNavBarFrame = CGRect(x: 0,
                                    y: view.bounds.height - size.height,
                                    width: size.width,
                                    height: size.height)
+    if #available(iOS 11.0, *) {
+      bottomNavBarFrame.size.height += view.safeAreaInsets.bottom
+      bottomNavBarFrame.origin.y -= view.safeAreaInsets.bottom
+    }
     bottomNavBar.frame = bottomNavBarFrame
   }
 
@@ -67,14 +72,6 @@ class BottomNavigationTypicalUseSwiftExample: UIViewController {
     super.viewWillLayoutSubviews()
     layoutBottomNavBar()
   }
-
-  #if swift(>=3.2)
-  @available(iOS 11, *)
-  override func viewSafeAreaInsetsDidChange() {
-    super.viewSafeAreaInsetsDidChange()
-    layoutBottomNavBar()
-  }
-  #endif
 
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)


### PR DESCRIPTION
### Context
In working on #4042 I discovered that Bottom Navigation (Swift) example isn't working as intended
### The problem
No elements were on screen
### The fix
Call the common init in the initializer

### Screenshots
| Before | After |
| ----- | ----- |
|![simulator screen shot - iphone xs max - 2018-09-25 at 15 18 57](https://user-images.githubusercontent.com/7131294/46037525-5ff18c00-c0d6-11e8-9b70-d43a98626acf.png)|![simulator screen shot - iphone xs max - 2018-09-25 at 15 14 18](https://user-images.githubusercontent.com/7131294/46037533-63851300-c0d6-11e8-8253-cc99f7db504c.png)|

