### PR TITLE
[Shape]! Terminology updates to the Shape Scheme

### DIFF
--- a/components/BottomSheet/src/ShapeThemer/MDCBottomSheetControllerShapeThemer.m
+++ b/components/BottomSheet/src/ShapeThemer/MDCBottomSheetControllerShapeThemer.m
@@ -23,8 +23,8 @@ static const CGFloat kBottomSheetCollapsedBaselineShapeValue = 24.0f;
   // Shape Generator for the Extended state of the Bottom Sheet.
   MDCRectangleShapeGenerator *rectangleShapeExtended = [[MDCRectangleShapeGenerator alloc] init];
   // For a Bottom Sheet the corner values that can be set are the top corners.
-  rectangleShapeExtended.topLeftCorner = shapeScheme.largeSurfaceShape.topLeftCorner;
-  rectangleShapeExtended.topRightCorner = shapeScheme.largeSurfaceShape.topRightCorner;
+  rectangleShapeExtended.topLeftCorner = shapeScheme.largeComponentShape.topLeftCorner;
+  rectangleShapeExtended.topRightCorner = shapeScheme.largeComponentShape.topRightCorner;
   [bottomSheetController setShapeGenerator:rectangleShapeExtended forState:MDCSheetStateExtended];
 
   // Shape Generator for the Preferred state of the Bottom Sheet.

--- a/components/BottomSheet/tests/unit/BottomSheetShapeThemerTests.swift
+++ b/components/BottomSheet/tests/unit/BottomSheetShapeThemerTests.swift
@@ -23,8 +23,8 @@ class BottomSheetShapeThemerTests: XCTestCase {
     // Given
     let shapeScheme = MDCShapeScheme()
     let bottomSheet = MDCBottomSheetController(contentViewController: UIViewController())
-    shapeScheme.largeSurfaceShape = MDCShapeCategory(cornersWith: .angled, andSize: 10)
-    shapeScheme.largeSurfaceShape.topRightCorner = MDCCornerTreatment.corner(withRadius: 3)
+    shapeScheme.largeComponentShape = MDCShapeCategory(cornersWith: .cut, andSize: 10)
+    shapeScheme.largeComponentShape.topRightCorner = MDCCornerTreatment.corner(withRadius: 3)
     bottomSheet.setShapeGenerator(MDCRectangleShapeGenerator(), for: .extended)
 
     // When
@@ -35,9 +35,9 @@ class BottomSheetShapeThemerTests: XCTestCase {
     XCTAssert(extendedShapeGenerator is MDCRectangleShapeGenerator)
     if let rectangleGenerator = extendedShapeGenerator as? MDCRectangleShapeGenerator {
       XCTAssertEqual(rectangleGenerator.topLeftCorner,
-                     shapeScheme.largeSurfaceShape.topLeftCorner)
+                     shapeScheme.largeComponentShape.topLeftCorner)
       XCTAssertEqual(rectangleGenerator.topRightCorner,
-                     shapeScheme.largeSurfaceShape.topRightCorner)
+                     shapeScheme.largeComponentShape.topRightCorner)
       XCTAssertEqual(rectangleGenerator.bottomLeftCorner, MDCCornerTreatment())
       XCTAssertEqual(rectangleGenerator.bottomRightCorner, MDCCornerTreatment())
     }
@@ -50,7 +50,7 @@ class BottomSheetShapeThemerTests: XCTestCase {
     let shapeScheme = MDCShapeScheme()
     let bottomSheet = MDCBottomSheetController(contentViewController: UIViewController())
     let generatedCorner = MDCCornerTreatment.corner(withRadius: collapsedBaselineShapeValue)
-    shapeScheme.largeSurfaceShape = MDCShapeCategory(cornersWith: .angled, andSize: 10)
+    shapeScheme.largeComponentShape = MDCShapeCategory(cornersWith: .cut, andSize: 10)
     bottomSheet.setShapeGenerator(MDCRectangleShapeGenerator(), for: .preferred)
 
     // When

--- a/components/Buttons/src/ShapeThemer/MDCButtonShapeThemer.m
+++ b/components/Buttons/src/ShapeThemer/MDCButtonShapeThemer.m
@@ -19,10 +19,10 @@
 + (void)applyShapeScheme:(nonnull id<MDCShapeScheming>)shapeScheme
                 toButton:(nonnull MDCButton *)button {
   MDCRectangleShapeGenerator *rectangleShape = [[MDCRectangleShapeGenerator alloc] init];
-  rectangleShape.topLeftCorner = shapeScheme.smallSurfaceShape.topLeftCorner;
-  rectangleShape.topRightCorner = shapeScheme.smallSurfaceShape.topRightCorner;
-  rectangleShape.bottomLeftCorner = shapeScheme.smallSurfaceShape.bottomLeftCorner;
-  rectangleShape.bottomRightCorner = shapeScheme.smallSurfaceShape.bottomRightCorner;
+  rectangleShape.topLeftCorner = shapeScheme.smallComponentShape.topLeftCorner;
+  rectangleShape.topRightCorner = shapeScheme.smallComponentShape.topRightCorner;
+  rectangleShape.bottomLeftCorner = shapeScheme.smallComponentShape.bottomLeftCorner;
+  rectangleShape.bottomRightCorner = shapeScheme.smallComponentShape.bottomRightCorner;
   button.shapeGenerator = rectangleShape;
 }
 

--- a/components/Buttons/tests/unit/ButtonsShapeThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsShapeThemerTests.m
@@ -39,9 +39,9 @@
 
 - (void)testMDCButtonShapeThemer {
   // Given
-  self.shapeScheme.smallSurfaceShape =
-      [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyAngled andSize:10];
-  self.shapeScheme.smallSurfaceShape.topRightCorner = [MDCCornerTreatment cornerWithRadius:3.f];
+  self.shapeScheme.smallComponentShape =
+      [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyCut andSize:10];
+  self.shapeScheme.smallComponentShape.topRightCorner = [MDCCornerTreatment cornerWithRadius:3.f];
   self.button.shapeGenerator = [[MDCRectangleShapeGenerator alloc] init];
 
   // When
@@ -49,19 +49,20 @@
 
   // Then
   MDCRectangleShapeGenerator *rect = (MDCRectangleShapeGenerator *)self.button.shapeGenerator;
-  XCTAssertEqualObjects(rect.topLeftCorner, self.shapeScheme.smallSurfaceShape.topLeftCorner);
-  XCTAssertEqualObjects(rect.topRightCorner, self.shapeScheme.smallSurfaceShape.topRightCorner);
-  XCTAssertEqualObjects(rect.bottomLeftCorner, self.shapeScheme.smallSurfaceShape.bottomLeftCorner);
+  XCTAssertEqualObjects(rect.topLeftCorner, self.shapeScheme.smallComponentShape.topLeftCorner);
+  XCTAssertEqualObjects(rect.topRightCorner, self.shapeScheme.smallComponentShape.topRightCorner);
+  XCTAssertEqualObjects(rect.bottomLeftCorner,
+                        self.shapeScheme.smallComponentShape.bottomLeftCorner);
   XCTAssertEqualObjects(rect.bottomRightCorner,
-                        self.shapeScheme.smallSurfaceShape.bottomRightCorner);
+                        self.shapeScheme.smallComponentShape.bottomRightCorner);
 }
 
 - (void)testMDCFloatingButtonShapeThemer {
   // Given
   MDCFloatingButton *FAB = [[MDCFloatingButton alloc] initWithFrame:CGRectZero
                                                               shape:MDCFloatingButtonShapeDefault];
-  self.shapeScheme.smallSurfaceShape =
-      [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyAngled andSize:10];
+  self.shapeScheme.smallComponentShape =
+      [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyCut andSize:10];
   FAB.shapeGenerator = [[MDCRectangleShapeGenerator alloc] init];
 
   // When

--- a/components/Cards/src/ShapeThemer/MDCCardsShapeThemer.m
+++ b/components/Cards/src/ShapeThemer/MDCCardsShapeThemer.m
@@ -27,10 +27,10 @@
 
 + (id<MDCShapeGenerating>)cardShapeGeneratorFromScheme:(id<MDCShapeScheming>)shapeScheme {
   MDCRectangleShapeGenerator *rectangleShape = [[MDCRectangleShapeGenerator alloc] init];
-  rectangleShape.topLeftCorner = shapeScheme.mediumSurfaceShape.topLeftCorner;
-  rectangleShape.topRightCorner = shapeScheme.mediumSurfaceShape.topRightCorner;
-  rectangleShape.bottomLeftCorner = shapeScheme.mediumSurfaceShape.bottomLeftCorner;
-  rectangleShape.bottomRightCorner = shapeScheme.mediumSurfaceShape.bottomRightCorner;
+  rectangleShape.topLeftCorner = shapeScheme.mediumComponentShape.topLeftCorner;
+  rectangleShape.topRightCorner = shapeScheme.mediumComponentShape.topRightCorner;
+  rectangleShape.bottomLeftCorner = shapeScheme.mediumComponentShape.bottomLeftCorner;
+  rectangleShape.bottomRightCorner = shapeScheme.mediumComponentShape.bottomRightCorner;
   return rectangleShape;
 }
 

--- a/components/Cards/tests/unit/MDCCardShapeThemerTests.swift
+++ b/components/Cards/tests/unit/MDCCardShapeThemerTests.swift
@@ -23,8 +23,8 @@ class CardShapeThemerTests: XCTestCase {
     // Given
     let shapeScheme = MDCShapeScheme()
     let card = MDCCard()
-    shapeScheme.mediumSurfaceShape = MDCShapeCategory(cornersWith: .angled, andSize: 10)
-    shapeScheme.mediumSurfaceShape.topRightCorner = MDCCornerTreatment.corner(withRadius: 3)
+    shapeScheme.mediumComponentShape = MDCShapeCategory(cornersWith: .cut, andSize: 10)
+    shapeScheme.mediumComponentShape.topRightCorner = MDCCornerTreatment.corner(withRadius: 3)
     card.shapeGenerator = MDCRectangleShapeGenerator()
 
     // When
@@ -33,20 +33,20 @@ class CardShapeThemerTests: XCTestCase {
     // Then
     XCTAssert(card.shapeGenerator is MDCRectangleShapeGenerator);
     XCTAssertEqual((card.shapeGenerator as! MDCRectangleShapeGenerator).topLeftCorner,
-                   shapeScheme.mediumSurfaceShape.topLeftCorner)
+                   shapeScheme.mediumComponentShape.topLeftCorner)
     XCTAssertEqual((card.shapeGenerator as! MDCRectangleShapeGenerator).topRightCorner,
-                   shapeScheme.mediumSurfaceShape.topRightCorner)
+                   shapeScheme.mediumComponentShape.topRightCorner)
     XCTAssertEqual((card.shapeGenerator as! MDCRectangleShapeGenerator).bottomLeftCorner,
-                   shapeScheme.mediumSurfaceShape.bottomLeftCorner)
+                   shapeScheme.mediumComponentShape.bottomLeftCorner)
     XCTAssertEqual((card.shapeGenerator as! MDCRectangleShapeGenerator).bottomRightCorner,
-                   shapeScheme.mediumSurfaceShape.bottomRightCorner)
+                   shapeScheme.mediumComponentShape.bottomRightCorner)
   }
 
   func testCardCollectionCellShapeThemer() {
     // Given
     let shapeScheme = MDCShapeScheme()
     let cardCell = MDCCardCollectionCell()
-    shapeScheme.mediumSurfaceShape = MDCShapeCategory(cornersWith: .angled, andSize: 10)
+    shapeScheme.mediumComponentShape = MDCShapeCategory(cornersWith: .cut, andSize: 10)
     cardCell.shapeGenerator = MDCRectangleShapeGenerator()
 
     // When
@@ -55,12 +55,12 @@ class CardShapeThemerTests: XCTestCase {
     // Then
     XCTAssert(cardCell.shapeGenerator is MDCRectangleShapeGenerator);
     XCTAssertEqual((cardCell.shapeGenerator as! MDCRectangleShapeGenerator).topLeftCorner,
-                   shapeScheme.mediumSurfaceShape.topLeftCorner)
+                   shapeScheme.mediumComponentShape.topLeftCorner)
     XCTAssertEqual((cardCell.shapeGenerator as! MDCRectangleShapeGenerator).topRightCorner,
-                   shapeScheme.mediumSurfaceShape.topRightCorner)
+                   shapeScheme.mediumComponentShape.topRightCorner)
     XCTAssertEqual((cardCell.shapeGenerator as! MDCRectangleShapeGenerator).bottomLeftCorner,
-                   shapeScheme.mediumSurfaceShape.bottomLeftCorner)
+                   shapeScheme.mediumComponentShape.bottomLeftCorner)
     XCTAssertEqual((cardCell.shapeGenerator as! MDCRectangleShapeGenerator).bottomRightCorner,
-                   shapeScheme.mediumSurfaceShape.bottomRightCorner)
+                   shapeScheme.mediumComponentShape.bottomRightCorner)
   }
 }

--- a/components/Chips/tests/unit/ChipViewShapeThemerTests.m
+++ b/components/Chips/tests/unit/ChipViewShapeThemerTests.m
@@ -39,8 +39,8 @@
 
 - (void)testChipViewShapeThemer {
   // Given
-  self.shapeScheme.smallSurfaceShape =
-      [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyAngled andSize:10];
+  self.shapeScheme.smallComponentShape =
+      [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyCut andSize:10];
   self.chip.shapeGenerator = [[MDCRectangleShapeGenerator alloc] init];
 
   // When

--- a/components/schemes/Shape/src/MDCShapeCategory.h
+++ b/components/schemes/Shape/src/MDCShapeCategory.h
@@ -19,11 +19,11 @@
  This enum consists of the different types of shape corners.
 
  - MDCShapeCornerFamilyRounded: A rounded corner.
- - MDCShapeCornerFamilyAngled: An angled/cut corner.
+ - MDCShapeCornerFamilyCut: A cut corner.
  */
 typedef NS_ENUM(NSInteger, MDCShapeCornerFamily) {
   MDCShapeCornerFamilyRounded,
-  MDCShapeCornerFamilyAngled,
+  MDCShapeCornerFamilyCut,
 };
 
 /**

--- a/components/schemes/Shape/src/MDCShapeCategory.m
+++ b/components/schemes/Shape/src/MDCShapeCategory.m
@@ -26,7 +26,7 @@
   if (self = [super init]) {
     MDCCornerTreatment *cornerTreatment;
     switch (cornerFamily) {
-      case MDCShapeCornerFamilyAngled:
+      case MDCShapeCornerFamilyCut:
         cornerTreatment = [MDCCornerTreatment cornerWithCut:cornerSize];
         break;
       case MDCShapeCornerFamilyRounded:

--- a/components/schemes/Shape/src/MDCShapeScheme.h
+++ b/components/schemes/Shape/src/MDCShapeScheme.h
@@ -26,19 +26,19 @@
 @protocol MDCShapeScheming
 
 /**
- The shape defining the small surfaced components.
+ The shape defining small sized components.
  */
-@property(nonnull, readonly, nonatomic) MDCShapeCategory *smallSurfaceShape;
+@property(nonnull, readonly, nonatomic) MDCShapeCategory *smallComponentShape;
 
 /**
- The shape defining the medium surfaced components.
+ The shape defining medium sized components.
  */
-@property(nonnull, readonly, nonatomic) MDCShapeCategory *mediumSurfaceShape;
+@property(nonnull, readonly, nonatomic) MDCShapeCategory *mediumComponentShape;
 
 /**
- The shape defining the large surfaced components.
+ The shape defining large sized components.
  */
-@property(nonnull, readonly, nonatomic) MDCShapeCategory *largeSurfaceShape;
+@property(nonnull, readonly, nonatomic) MDCShapeCategory *largeComponentShape;
 
 @end
 
@@ -59,9 +59,9 @@ typedef NS_ENUM(NSInteger, MDCShapeSchemeDefaults) {
 @interface MDCShapeScheme : NSObject <MDCShapeScheming>
 
 // Redeclare protocol properties as readwrite
-@property(nonnull, readwrite, nonatomic) MDCShapeCategory *smallSurfaceShape;
-@property(nonnull, readwrite, nonatomic) MDCShapeCategory *mediumSurfaceShape;
-@property(nonnull, readwrite, nonatomic) MDCShapeCategory *largeSurfaceShape;
+@property(nonnull, readwrite, nonatomic) MDCShapeCategory *smallComponentShape;
+@property(nonnull, readwrite, nonatomic) MDCShapeCategory *mediumComponentShape;
+@property(nonnull, readwrite, nonatomic) MDCShapeCategory *largeComponentShape;
 
 /**
  Initializes the shape scheme with the latest material defaults.

--- a/components/schemes/Shape/src/MDCShapeScheme.m
+++ b/components/schemes/Shape/src/MDCShapeScheme.m
@@ -25,13 +25,13 @@
   if (self) {
     switch (defaults) {
       case MDCShapeSchemeDefaultsMaterial201809:
-        _smallSurfaceShape =
+        _smallComponentShape =
             [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyRounded
                                                     andSize:4.f];
-        _mediumSurfaceShape =
+        _mediumComponentShape =
             [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyRounded
                                                     andSize:4.f];
-        _largeSurfaceShape =
+        _largeComponentShape =
             [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyRounded
                                                     andSize:0.f];
         break;

--- a/components/schemes/Shape/tests/unit/MDCShapeSchemeTests.m
+++ b/components/schemes/Shape/tests/unit/MDCShapeSchemeTests.m
@@ -26,7 +26,7 @@
 - (void)testShapeCategoryEquality {
   // Given
   MDCShapeCategory *cat1 =
-      [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyAngled andSize:2.1f];
+      [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyCut andSize:2.1f];
   MDCShapeCategory *cat2 = [[MDCShapeCategory alloc] init];
   MDCCornerTreatment *corner =
       [MDCCornerTreatment cornerWithCut:2.1f valueType:MDCCornerTreatmentValueTypeAbsolute];
@@ -46,9 +46,9 @@
       [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
 
   // Then
-  XCTAssertEqualObjects(initScheme.largeSurfaceShape, mdDefaultScheme.largeSurfaceShape);
-  XCTAssertEqualObjects(initScheme.mediumSurfaceShape, mdDefaultScheme.mediumSurfaceShape);
-  XCTAssertEqualObjects(initScheme.smallSurfaceShape, mdDefaultScheme.smallSurfaceShape);
+  XCTAssertEqualObjects(initScheme.largeComponentShape, mdDefaultScheme.largeComponentShape);
+  XCTAssertEqualObjects(initScheme.mediumComponentShape, mdDefaultScheme.mediumComponentShape);
+  XCTAssertEqualObjects(initScheme.smallComponentShape, mdDefaultScheme.smallComponentShape);
 }
 
 - (void)testInitWithMaterialDefaults {
@@ -57,13 +57,13 @@
       [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
 
   // Then
-  XCTAssertEqualObjects(shapeScheme.largeSurfaceShape,
+  XCTAssertEqualObjects(shapeScheme.largeComponentShape,
                         [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyRounded
                                                                 andSize:0.f]);
-  XCTAssertEqualObjects(shapeScheme.mediumSurfaceShape,
+  XCTAssertEqualObjects(shapeScheme.mediumComponentShape,
                         [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyRounded
                                                                 andSize:4.f]);
-  XCTAssertEqualObjects(shapeScheme.smallSurfaceShape,
+  XCTAssertEqualObjects(shapeScheme.smallComponentShape,
                         [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyRounded
                                                                 andSize:4.f]);
 }

--- a/components/schemes/Shape/tests/unit/MDCShapeSchemeTests.m
+++ b/components/schemes/Shape/tests/unit/MDCShapeSchemeTests.m
@@ -25,8 +25,8 @@
 
 - (void)testShapeCategoryEquality {
   // Given
-  MDCShapeCategory *cat1 =
-      [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyCut andSize:2.1f];
+  MDCShapeCategory *cat1 = [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyCut
+                                                                   andSize:2.1f];
   MDCShapeCategory *cat2 = [[MDCShapeCategory alloc] init];
   MDCCornerTreatment *corner =
       [MDCCornerTreatment cornerWithCut:2.1f valueType:MDCCornerTreatmentValueTypeAbsolute];


### PR DESCRIPTION
**<><>This is a breaking change<><>**

There are slight terminology updates to the current Shape Scheme. 

First, we are staying with the Cut notion for cut corners rather than Angled. This is on par with our current naming of the CutCornerTreatment.

Secondly, we are moving from the term S/M/L Surface to S/M/L Component for the scheme categories.