### PR TITLE
[ActionSheet] Update MDCActionSheetHelperTest

### DIFF
--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -92,6 +92,7 @@ mdc_objc_library(
     ]),
     sdk_frameworks = [
         "UIKit",
+        "CoreImage",
         "XCTest",
     ],
     deps = [

--- a/components/ActionSheet/tests/unit/MDCActionSheetTestHelper.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTestHelper.m
@@ -14,6 +14,8 @@
 
 #import "MDCActionSheetTestHelper.h"
 
+#import <CoreImage/CoreImage.h>
+
 #import "../../src/private/MDCActionSheetHeaderView.h"
 #import "../../src/private/MDCActionSheetItemTableViewCell.h"
 
@@ -24,8 +26,10 @@
   UIColor *hsbColor = [UIColor colorWithHue:0.8f saturation:0.8f brightness:0.8f alpha:0.8f];
   UIColor *blackWithAlpha = [UIColor.greenColor colorWithAlphaComponent:0.8f];
   UIColor *black = UIColor.blackColor;
+  CIColor *ciColor = [[CIColor alloc] initWithColor:UIColor.blackColor];
+  UIColor *uiColorFromCIColor = [UIColor colorWithCIColor:ciColor];
   UIColor *whiteColor = [UIColor colorWithWhite:0.5f alpha:0.5f];
-  return @[ rgbColor, hsbColor, blackWithAlpha, black, whiteColor ];
+  return @[ rgbColor, hsbColor, blackWithAlpha, black, uiColorFromCIColor, whiteColor ];
 }
 
 + (void)addNumberOfActions:(NSUInteger)actionsCount

--- a/components/ActionSheet/tests/unit/MDCActionSheetTestHelper.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTestHelper.m
@@ -24,10 +24,8 @@
   UIColor *hsbColor = [UIColor colorWithHue:0.8f saturation:0.8f brightness:0.8f alpha:0.8f];
   UIColor *blackWithAlpha = [UIColor.greenColor colorWithAlphaComponent:0.8f];
   UIColor *black = UIColor.blackColor;
-  CIColor *ciColor = [[CIColor alloc] initWithColor:UIColor.blackColor];
-  UIColor *uiColorFromCIColor = [UIColor colorWithCIColor:ciColor];
   UIColor *whiteColor = [UIColor colorWithWhite:0.5f alpha:0.5f];
-  return @[ rgbColor, hsbColor, blackWithAlpha, black, uiColorFromCIColor, whiteColor ];
+  return @[ rgbColor, hsbColor, blackWithAlpha, black, whiteColor ];
 }
 
 + (void)addNumberOfActions:(NSUInteger)actionsCount


### PR DESCRIPTION
### Context
Kokoro doesn't check against frameworks as rigorous as internal test

### Problem
MDCActionSheetHelperTest method colorsToTest used CIColor but CoreImage was never imported.

### The fix
Import CoreImage framework and add it in the BUILD file.
