### PR TITLE
[TextFields] Override System Initiated VoiceOver Message When Leaving Error State

### DIFF
--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -1545,6 +1545,8 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
     // If there is a saved state, use it.
     if (self.previousLeadingText) {
       self.textInput.leadingUnderlineLabel.text = self.previousLeadingText;
+      UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification,
+                                      self.textInput.leadingUnderlineLabel);
     }
 
     // Clear out saved state.

--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -1545,8 +1545,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
     // If there is a saved state, use it.
     if (self.previousLeadingText) {
       self.textInput.leadingUnderlineLabel.text = self.previousLeadingText;
-      UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification,
-                                      self.textInput.leadingUnderlineLabel);
     }
 
     // Clear out saved state.
@@ -1582,7 +1580,6 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
     self.textInput.leadingUnderlineLabel.accessibilityLabel =
         [NSString stringWithFormat:@"Error: %@.",
                                    leadingUnderlineLabelText ? leadingUnderlineLabelText : @""];
-    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self.textInput.leadingUnderlineLabel);
   } else {
     self.textInput.accessibilityValue = nil;
     if ([self.textInput.leadingUnderlineLabel.text isEqualToString:self.helperText]) {
@@ -1591,6 +1588,8 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
       self.textInput.leadingUnderlineLabel.accessibilityLabel = nil;
     }
   }
+  UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification,
+                                  self.textInput.leadingUnderlineLabel);
 }
 
 -(void)setHelperText:(NSString *)helperText


### PR DESCRIPTION
Closes #5250.

The crux of the bug is that when you pass nil to `-setErrorText:errorAccessibilityLabel:` the VoiceOver message that immediately follows (which is not triggered explicitly by us) still mentions the previous error state. By forcing an announcement in this situation we override the problematic system-initiated VoiceOver message. We basically do the same thing when _entering_ the error state on line 1583. This is the same idea.