### PR TITLE
[NavigationDrawer] Performance improvements and increased support for customizing initial drawer percentage height

### DIFF
--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -190,6 +190,12 @@ static UIColor *DrawerShadowColor(void) {
                                            ? self.scrollViewIsDraggedToBottom
                                            : contentOffset.y < oldContentOffset.y;
 
+    // The normalized content offset takes the content offset and updates it if using the
+    // performance logic that comes with setting the tracking scroll view. The reason we update
+    // the content offset is because the performance logic stops the scrolling internally of the
+    // main scroll view using the bounds origin, and we don't want the view update with content
+    // offset to use the outdated content offset of the main scroll view, so we update it
+    // accordingly.
     CGPoint normalizedContentOffset = contentOffset;
     if (self.trackingScrollView != nil) {
       normalizedContentOffset.y = [self updateContentOffsetForPerformantScrolling:contentOffset.y];


### PR DESCRIPTION
This is the first part of multiple improvements to get the Navigation Drawer to the state that it can receive an arbitrary percentage from 0%-100% of how much of the drawer to present on the screen when displayed (currently it is only at 50% and is uncustomizable).

This PR allows us to set the drawer an arbitrary number without it breaking, with the caveat that it doesnt yet support percentages that are 100% or close to 100%. Once that is supported we will be able to support 100% drawer presented for VO, solving bug #4899 

This also has performance improvements as before when scrolling the drawer up with the trackingScrollView being set, it would call `viewWillLayoutSubviews` because it would think for an instance that it is not in full screen anymore, before reverting back to the correct state.

**Testing:**
Currently to test this addition, I have ran all the examples that provide all the needed use cases of usage for the drawer. They have been run in both portrait and landscape, and by dragging the drawer from the start position, to full screen, to edge of content, and back up again. This process has been run on an iPhone SE with iOS 9.4, an iPhone X with iOS 11.4, an iPhone 6 Plus with iOS 10, and an iPad running iOS 11.4.

I can't see any edge cases with the current support we allow with this component, with the addition that this is an alpha component.