### PR TITLE
[FlexibleHeader] Update indicator insets correctly after changing the trackingScrollView

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -551,10 +551,10 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   info.hasInjectedTopContentInset = NO;
   scrollView.contentInset = insets;
 
-  UIEdgeInsets scrollIndicatorInsets = _trackingScrollView.scrollIndicatorInsets;
+  UIEdgeInsets scrollIndicatorInsets = scrollView.scrollIndicatorInsets;
   scrollIndicatorInsets.top -= info.injectedTopScrollIndicatorInset;
   info.injectedTopScrollIndicatorInset = 0;
-  _trackingScrollView.scrollIndicatorInsets = scrollIndicatorInsets;
+  scrollView.scrollIndicatorInsets = scrollIndicatorInsets;
 }
 
 - (CGFloat)fhv_existingContentInsetAdjustmentForScrollView:(UIScrollView *)scrollView {


### PR DESCRIPTION
Fix a bug where the scroll indicator insets of an incorrect scroll view are reset after changing the trackingScrollView of the flexible header.