### PR TITLE
[Dialogs] Customizing scrim color in presentation controller

### DIFF
--- a/components/Dialogs/examples/DialogsAlertCustomizationViewController.swift
+++ b/components/Dialogs/examples/DialogsAlertCustomizationViewController.swift
@@ -81,6 +81,7 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
       "Naturally Aligned Title with an Icon",
       "Right Aligned Title with a Large Icon",
       "Tinted Title Icon, No Title",
+      "Darker Scrim",
     ])
   }
 
@@ -106,6 +107,8 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
       return performRightTitleWithResizedIcon()
     case 4:
       return performTintedTitleIconNoTitle()
+    case 5:
+      return performScrimColor()
     default:
       print("No row is selected")
       return nil
@@ -157,6 +160,13 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
     // theming override: set the titleIconTintColor after the color scheme has been applied
     alert.titleIconTintColor = .red
 
+    return alert
+  }
+
+  func performScrimColor() -> MDCAlertController {
+    let alert = createMDCAlertController(title: "Darker Scrim")
+    MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
+    alert.mdc_dialogPresentationController?.scrimColor = UIColor.black.withAlphaComponent(0.6)
     return alert
   }
 

--- a/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
+++ b/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
@@ -25,6 +25,13 @@
   alertController.messageColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
   alertController.buttonTitleColor = colorScheme.primaryColor;
   alertController.titleIconTintColor = colorScheme.primaryColor;
+
+  MDCDialogPresentationController *dialogPresentationController =
+      alertController.mdc_dialogPresentationController;
+  if (dialogPresentationController) {
+    dialogPresentationController.scrimColor =
+        [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.32];
+  }
 }
 
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme {

--- a/components/Dialogs/src/MDCDialogPresentationController.h
+++ b/components/Dialogs/src/MDCDialogPresentationController.h
@@ -50,6 +50,13 @@
 @property(nonatomic, assign) CGFloat dialogCornerRadius;
 
 /**
+ Customize the color of the background scrim.
+
+ Defaults to a semi-transparent White.
+ */
+@property(nonatomic, strong, nullable) UIColor *scrimColor;
+
+/**
  Returns the size of the specified child view controller's content.
 
  The size is initially based on container.preferredSize. Width is will have a minimum of 280 and a

--- a/components/Dialogs/src/MDCDialogPresentationController.h
+++ b/components/Dialogs/src/MDCDialogPresentationController.h
@@ -52,7 +52,7 @@
 /**
  Customize the color of the background scrim.
 
- Defaults to a semi-transparent White.
+ Defaults to a semi-transparent Black.
  */
 @property(nonatomic, strong, nullable) UIColor *scrimColor;
 

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -60,6 +60,14 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
   return _trackingView.layer.cornerRadius;
 }
 
+- (void)setScrimColor:(UIColor *)scrimColor {
+  self.dimmingView.backgroundColor = scrimColor;
+}
+
+- (UIColor *)scrimColor {
+  return self.dimmingView.backgroundColor;
+}
+
 - (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController
                        presentingViewController:(UIViewController *)presentingViewController {
   self = [super initWithPresentedViewController:presentedViewController

--- a/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
+++ b/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
@@ -78,7 +78,6 @@ class MDCAlertControllerAlertThemerTests: XCTestCase {
   }
 
   func testApplyingAlertSchemeScrimColorToPresentationController() {
-
     guard let presentationController = alert.mdc_dialogPresentationController else { return }
 
     // Given
@@ -93,7 +92,6 @@ class MDCAlertControllerAlertThemerTests: XCTestCase {
     // Then
     XCTAssertEqual(presentationController.scrimColor, scrimColor)
   }
-
 
   func testApplyingAlertSchemeWithCustomTypography() {
     // Given

--- a/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
+++ b/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
@@ -77,6 +77,24 @@ class MDCAlertControllerAlertThemerTests: XCTestCase {
     XCTAssertEqual(alertView.titleIconTintColor, iconColor)
   }
 
+  func testApplyingAlertSchemeScrimColorToPresentationController() {
+
+    guard let presentationController = alert.mdc_dialogPresentationController else { return }
+
+    // Given
+    let colorScheme = MDCSemanticColorScheme()
+    colorScheme.onSurfaceColor = UIColor.green
+    alertScheme.colorScheme = colorScheme
+    let scrimColor = colorScheme.onSurfaceColor.withAlphaComponent(0.32)
+
+    // When
+    MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
+
+    // Then
+    XCTAssertEqual(presentationController.scrimColor, scrimColor)
+  }
+
+
   func testApplyingAlertSchemeWithCustomTypography() {
     // Given
     let typographyScheme = MDCTypographyScheme()

--- a/components/Dialogs/tests/unit/MDCAlertControllerCustomizationTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerCustomizationTests.m
@@ -91,6 +91,18 @@ MDCAlertControllerView *alertView;
   XCTAssertEqualObjects(alertView.titleIconImageView.tintColor, tintColor);
 }
 
+- (void)testApplyingScrimColorToPresentationController {
+  // Given
+  UIColor *scrimColor = [UIColor.orangeColor colorWithAlphaComponent:0.5];
+  MDCDialogPresentationController *presentationController = alert.mdc_dialogPresentationController;
+
+  // When
+  presentationController.scrimColor = scrimColor;
+
+  // Then
+  XCTAssertEqualObjects(alert.mdc_dialogPresentationController.scrimColor, scrimColor);
+}
+
 static inline UIImage *TestImage(CGSize size) {
   CGFloat scale = [UIScreen mainScreen].scale;
   UIGraphicsBeginImageContextWithOptions(size, false, scale);

--- a/components/Dialogs/tests/unit/MDCAlertControllerCustomizationTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerCustomizationTests.m
@@ -95,6 +95,9 @@ MDCAlertControllerView *alertView;
   // Given
   UIColor *scrimColor = [UIColor.orangeColor colorWithAlphaComponent:0.5];
   MDCDialogPresentationController *presentationController = alert.mdc_dialogPresentationController;
+  if (presentationController == nil) {
+    return;  // don't fail the test if mdc_dialogPresentationController is empty
+  }
 
   // When
   presentationController.scrimColor = scrimColor;


### PR DESCRIPTION
Adding the API to customize the color of MDCAlertController's background scrim, and to apply the color during theming. Also includes tests & an example.
Issue: #5279 
Issue: b/116845327
