### PR TITLE
[MDCTabBar] Remove dependence on a UIWindow for rendering/layout of MDCTabBa

### DIFF
--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -623,10 +623,6 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 }
 
 - (void)updateFlowLayoutMetrics {
-  // Layout metrics cannot be updated while offscreen.
-  if (!self.window) {
-    return;
-  }
 
   UIUserInterfaceSizeClass horizontalSizeClass = [self horizontalSizeClass];
 
@@ -656,7 +652,6 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   // This is not animated because -updateFlowLayoutMetrics may be called in an animation block and
   // the change will be still get animated anyway - using NO avoids 'double' animation and allows
   // this method to be used without animation.
-  NSAssert(_collectionView.window, @"Collection view must be in a window to update layout");
   [_collectionView setCollectionViewLayout:_flowLayout animated:NO];
 
   // Force immediate layout so the selection indicator can be placed accurately.

--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -294,7 +294,8 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
     }
   }
 
-  CGFloat scale = self.window.screen.scale;
+  UIScreen *screen = self.window.screen ?: UIScreen.mainScreen;
+  CGFloat scale = screen.scale;
   _imageView.bounds = imageBounds;
   _imageView.center = MDCRoundCenterWithBoundsAndScale(imageCenter, _imageView.bounds, scale);
 
@@ -317,12 +318,9 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
 - (void)didMoveToWindow {
   [super didMoveToWindow];
 
-  if (self.window) {
-    [self updateTransformsAnimated:NO];
+  [self updateTransformsAnimated:NO];
 
-    // Layout depends on window scale.
-    [self setNeedsLayout];
-  }
+  [self setNeedsLayout];
 }
 
 #pragma mark - UICollectionReusableView
@@ -505,7 +503,7 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3f;
   CGAffineTransform titleTransform = CGAffineTransformIdentity;
   CGAffineTransform imageTransform = CGAffineTransformIdentity;
 
-  UIScreen *screen = self.window.screen;
+  UIScreen *screen = self.window.screen ?: UIScreen.mainScreen;
   const CGFloat screenScale = (screen ? screen.scale : 1);
   CGFloat titleContentsScale = screenScale;
 

--- a/components/Tabs/tests/unit/MaterialTabsTests.m
+++ b/components/Tabs/tests/unit/MaterialTabsTests.m
@@ -85,4 +85,6 @@
   XCTAssertEqual(_tabBar.selectedItem, _itemB);
 }
 
+// TODO(#5199): Add a snapshot test to prove the tabs render without a window
+
 @end


### PR DESCRIPTION
Closes #5245 

Per convention in the rest of the MDC code base - the `UIScreen.mainScreen` is used when a window is not available.
