### PR TITLE
[ActionSheet] Fix ink color for themer

### DIFF
--- a/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.m
+++ b/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.m
@@ -16,7 +16,7 @@
 
 static const CGFloat kHighAlpha = 0.87f;
 static const CGFloat kMediumAlpha = 0.6f;
-static const CGFloat kInkAlpha = 16.f;
+static const CGFloat kInkAlpha = 0.16f;
 
 @implementation MDCActionSheetColorThemer
 

--- a/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
@@ -22,7 +22,7 @@
 
 static const CGFloat kHighAlpha = 0.87f;
 static const CGFloat kMediumAlpha = 0.6f;
-static const CGFloat kInkAlpha = 16.f;
+static const CGFloat kInkAlpha = 0.16f;
 
 @interface MDCActionSheetHeaderView (Testing)
 @property(nonatomic, strong) UILabel *titleLabel;


### PR DESCRIPTION
### Context
At some point the inkColor for action sheet became fully black in all examples
### The problem
The constant for inkColor when a color themer is applied was `16.f` instead of `0.16f`.
### The fix
Update the constant in implementation and the test.
### Tests
All the test passed because the constant was wrong in the test and implementation

### Screenshot
| Before | After |
| - | - |
|![simulator screen shot - iphone x - 2018-10-01 at 09 40 45](https://user-images.githubusercontent.com/7131294/46292097-171a5700-c55e-11e8-9b73-f2b96c9008c6.png)|![simulator screen shot - iphone x - 2018-10-01 at 09 39 32](https://user-images.githubusercontent.com/7131294/46292113-1bdf0b00-c55e-11e8-9cdb-4d620c868e68.png)|

