### PR TITLE
[Dialogs] Add shadow elevation

### DIFF
--- a/components/Dialogs/examples/DialogsAlertViewController.m
+++ b/components/Dialogs/examples/DialogsAlertViewController.m
@@ -382,7 +382,7 @@
 }
 
 - (IBAction)didTapLowElevationAlert {
-  NSString *titleString = @"Low elevation Material alert controller";
+  NSString *titleString = @"Using Material alert controller?";
   NSString *messageString = @"This is an alert controller with a low elevation.";
 
   MDCAlertController *materialAlertController =
@@ -394,7 +394,6 @@
                                                        NSLog(@"%@", @"OK pressed");
                                                      }];
   [materialAlertController addAction:okAction];
-
   materialAlertController.elevation = 2;
   [self presentViewController:materialAlertController animated:YES completion:NULL];
 }

--- a/components/Dialogs/examples/DialogsAlertViewController.m
+++ b/components/Dialogs/examples/DialogsAlertViewController.m
@@ -391,14 +391,14 @@
   NSString *messageString = @"This is an alert controller with a low elevation.";
 
   MDCAlertController *materialAlertController =
-  [MDCAlertController alertControllerWithTitle:titleString message:messageString];
+      [MDCAlertController alertControllerWithTitle:titleString message:messageString];
   [self themeAlertController:materialAlertController];
 
-  MDCAlertAction *agreeAaction = [MDCAlertAction actionWithTitle:@"OK"
+  MDCAlertAction *okAction = [MDCAlertAction actionWithTitle:@"OK"
                                                          handler:^(MDCAlertAction *action) {
                                                            NSLog(@"%@", @"OK pressed");
                                                          }];
-  [materialAlertController addAction:agreeAaction];
+  [materialAlertController addAction:okAction];
 
   materialAlertController.elevation = 2;
   [self presentViewController:materialAlertController animated:YES completion:NULL];

--- a/components/Dialogs/examples/DialogsAlertViewController.m
+++ b/components/Dialogs/examples/DialogsAlertViewController.m
@@ -31,15 +31,10 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  [self loadCollectionView:
-    @[ @"Show Alert",
-       @"Show Long Alert",
-       @"Non-Dismissable Alert",
-       @"Alert (Dynamic Type enabled)",
-       @"Overpopulated Alert",
-       @"Style Alert",
-       @"Un-style Alert",
-       @"Low elevation Alert"]];
+  [self loadCollectionView:@[
+    @"Show Alert", @"Show Long Alert", @"Non-Dismissable Alert", @"Alert (Dynamic Type enabled)",
+    @"Overpopulated Alert", @"Style Alert", @"Un-style Alert", @"Low elevation Alert"
+  ]];
 }
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
@@ -395,9 +390,9 @@
   [self themeAlertController:materialAlertController];
 
   MDCAlertAction *okAction = [MDCAlertAction actionWithTitle:@"OK"
-                                                         handler:^(MDCAlertAction *action) {
-                                                           NSLog(@"%@", @"OK pressed");
-                                                         }];
+                                                     handler:^(MDCAlertAction *action) {
+                                                       NSLog(@"%@", @"OK pressed");
+                                                     }];
   [materialAlertController addAction:okAction];
 
   materialAlertController.elevation = 2;

--- a/components/Dialogs/examples/DialogsAlertViewController.m
+++ b/components/Dialogs/examples/DialogsAlertViewController.m
@@ -38,7 +38,8 @@
        @"Alert (Dynamic Type enabled)",
        @"Overpopulated Alert",
        @"Style Alert",
-       @"Un-style Alert"]];
+       @"Un-style Alert",
+       @"Low elevation Alert"]];
 }
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
@@ -64,6 +65,9 @@
       break;
     case 6:
       [self didTapUnstyleAlert];
+      break;
+    case 7:
+      [self didTapLowElevationAlert];
       break;
   }
 }
@@ -382,6 +386,22 @@
   [self presentViewController:materialAlertController animated:YES completion:NULL];
 }
 
+- (IBAction)didTapLowElevationAlert {
+  NSString *titleString = @"Low elevation Material alert controller";
+  NSString *messageString = @"This is an alert controller with a low elevation.";
 
+  MDCAlertController *materialAlertController =
+  [MDCAlertController alertControllerWithTitle:titleString message:messageString];
+  [self themeAlertController:materialAlertController];
+
+  MDCAlertAction *agreeAaction = [MDCAlertAction actionWithTitle:@"OK"
+                                                         handler:^(MDCAlertAction *action) {
+                                                           NSLog(@"%@", @"OK pressed");
+                                                         }];
+  [materialAlertController addAction:agreeAaction];
+
+  materialAlertController.elevation = 2;
+  [self presentViewController:materialAlertController animated:YES completion:NULL];
+}
 
 @end

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -100,6 +100,9 @@
 /** The corner radius applied to the Alert Controller view. Default to 0 (no round corners) */
 @property(nonatomic, assign) CGFloat cornerRadius;
 
+/** The elevation that will be applied to the Alert Controller view. Default to 24. */
+@property(nonatomic, assign) CGFloat elevation;
+
 // TODO(iangordon): Add support for preferredAction to match UIAlertController.
 // TODO(iangordon): Consider adding support for UITextFields to match UIAlertController.
 

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -247,6 +247,18 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   }
 }
 
+- (void)setElevation:(CGFloat)elevation {
+  _elevation = elevation;
+  if (self.alertView) {
+    self.alertView.elevation = elevation;
+  }
+  MDCDialogPresentationController *dialogPresentationController =
+      self.mdc_dialogPresentationController;
+  if (dialogPresentationController) {
+    dialogPresentationController.dialogElevation = elevation;
+  }
+}
+
 - (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {
   _mdc_adjustsFontForContentSizeCategory = adjusts;
 

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -249,9 +249,6 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 
 - (void)setElevation:(CGFloat)elevation {
   _elevation = elevation;
-  if (self.alertView) {
-    self.alertView.elevation = elevation;
-  }
   MDCDialogPresentationController *dialogPresentationController =
       self.mdc_dialogPresentationController;
   if (dialogPresentationController) {

--- a/components/Dialogs/src/MDCAlertControllerView.h
+++ b/components/Dialogs/src/MDCAlertControllerView.h
@@ -31,7 +31,6 @@
 @property(nonatomic, strong, nullable) UIColor *buttonInkColor UI_APPEARANCE_SELECTOR;
 
 @property(nonatomic, assign) CGFloat cornerRadius;
-@property(nonatomic, assign) CGFloat elevation;
 
 /*
  Indicates whether the view's contents should automatically update their font when the device’s

--- a/components/Dialogs/src/MDCAlertControllerView.h
+++ b/components/Dialogs/src/MDCAlertControllerView.h
@@ -31,6 +31,7 @@
 @property(nonatomic, strong, nullable) UIColor *buttonInkColor UI_APPEARANCE_SELECTOR;
 
 @property(nonatomic, assign) CGFloat cornerRadius;
+@property(nonatomic, assign) CGFloat elevation;
 
 /*
  Indicates whether the view's contents should automatically update their font when the device’s

--- a/components/Dialogs/src/MDCDialogPresentationController.h
+++ b/components/Dialogs/src/MDCDialogPresentationController.h
@@ -50,6 +50,13 @@
 @property(nonatomic, assign) CGFloat dialogCornerRadius;
 
 /**
+ Customize the elevation of the shadow to match the presented view's shadow.
+
+ Defaults to 24.0.
+ */
+@property(nonatomic, assign) CGFloat dialogElevation;
+
+/**
  Customize the color of the background scrim.
 
  Defaults to a semi-transparent Black.

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -15,7 +15,9 @@
 #import "MDCDialogPresentationController.h"
 
 #import "MaterialKeyboardWatcher.h"
+#import "MaterialShadowLayer.h"
 #import "private/MDCDialogShadowedView.h"
+
 
 static CGFloat MDCDialogMinimumWidth = 280.0f;
 // TODO: Spec indicates 40 side margins and 280 minimum width.
@@ -66,6 +68,21 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
 
 - (UIColor *)scrimColor {
   return self.dimmingView.backgroundColor;
+}
+
+- (void)setDialogElevation:(CGFloat)dialogElevation {
+  if ([_trackingView.layer isKindOfClass:[MDCShadowLayer class]]) {
+    MDCShadowLayer *shadowLayer = (MDCShadowLayer *)_trackingView.layer;
+    [shadowLayer setElevation:dialogElevation];
+  }
+}
+
+- (CGFloat)dialogElevation {
+  if ([_trackingView.layer isKindOfClass:[MDCShadowLayer class]]) {
+    MDCShadowLayer *shadowLayer = (MDCShadowLayer *)_trackingView.layer;
+    return shadowLayer.elevation;
+  }
+  return 0.0;
 }
 
 - (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -82,7 +82,7 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
     MDCShadowLayer *shadowLayer = (MDCShadowLayer *)_trackingView.layer;
     return shadowLayer.elevation;
   }
-  return 0.0;
+  return MDCShadowElevationDialog;
 }
 
 - (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -18,7 +18,6 @@
 #import "MaterialShadowLayer.h"
 #import "private/MDCDialogShadowedView.h"
 
-
 static CGFloat MDCDialogMinimumWidth = 280.0f;
 // TODO: Spec indicates 40 side margins and 280 minimum width.
 // That is incompatible with a 320 wide device.

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -32,7 +32,7 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
 
 // Tracking view that adds a shadow under the presented view. This view's frame should always match
 // the presented view's.
-@property(nonatomic) UIView *trackingView;
+@property(nonatomic) MDCDialogShadowedView *trackingView;
 
 @end
 
@@ -71,18 +71,11 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
 }
 
 - (void)setDialogElevation:(CGFloat)dialogElevation {
-  if ([_trackingView.layer isKindOfClass:[MDCShadowLayer class]]) {
-    MDCShadowLayer *shadowLayer = (MDCShadowLayer *)_trackingView.layer;
-    [shadowLayer setElevation:dialogElevation];
-  }
+  _trackingView.elevation = dialogElevation;
 }
 
 - (CGFloat)dialogElevation {
-  if ([_trackingView.layer isKindOfClass:[MDCShadowLayer class]]) {
-    MDCShadowLayer *shadowLayer = (MDCShadowLayer *)_trackingView.layer;
-    return shadowLayer.elevation;
-  }
-  return MDCShadowElevationDialog;
+  return _trackingView.elevation;
 }
 
 - (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController

--- a/components/Dialogs/src/private/MDCDialogShadowedView.h
+++ b/components/Dialogs/src/private/MDCDialogShadowedView.h
@@ -15,5 +15,5 @@
 #import <UIKit/UIKit.h>
 
 @interface MDCDialogShadowedView : UIView
-
+@property(nonatomic, assign) CGFloat elevation;
 @end

--- a/components/Dialogs/src/private/MDCDialogShadowedView.m
+++ b/components/Dialogs/src/private/MDCDialogShadowedView.m
@@ -35,4 +35,12 @@
   return self;
 }
 
+- (CGFloat)elevation {
+  return [self shadowLayer].elevation;
+}
+
+- (void)setElevation:(CGFloat)elevation {
+  [[self shadowLayer] setElevation:elevation];
+}
+
 @end

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -16,8 +16,8 @@
 #import "MaterialButtons.h"
 #import "MaterialDialogs.h"
 
-#import "MDCAlertControllerView+Private.h"
 #import "../../src/private/MDCDialogShadowedView.h"
+#import "MDCAlertControllerView+Private.h"
 
 #pragma mark - Subclasses for testing
 

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -17,6 +17,7 @@
 #import "MaterialDialogs.h"
 
 #import "MDCAlertControllerView+Private.h"
+#import "../../src/private/MDCDialogShadowedView.h"
 
 #pragma mark - Subclasses for testing
 
@@ -28,6 +29,10 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
 
 @interface MDCAlertControllerSubclass : MDCAlertController
 @property(nonatomic, assign) NSInteger value;
+@end
+
+@interface MDCDialogPresentationController (Testing)
+@property(nonatomic) MDCDialogShadowedView *trackingView;
 @end
 
 @implementation MDCAlertControllerSubclass
@@ -302,6 +307,48 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   XCTAssertEqualWithAccuracy(view.layer.cornerRadius, cornerRadius, 0.0);
   XCTAssertEqualWithAccuracy(alert.mdc_dialogPresentationController.dialogCornerRadius,
                              cornerRadius, 0.0);
+}
+
+- (void)testDefaultElevation {
+  // Given
+  CGFloat elevation = (CGFloat)MDCShadowElevationDialog;
+  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
+                                                                   message:@"message"];
+  [alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
+
+  // Then
+  MDCDialogShadowedView *shadowView = alert.mdc_dialogPresentationController.trackingView;
+  XCTAssertEqual(shadowView.elevation, elevation);
+}
+
+- (void)testCustomElevation {
+  // Given
+  CGFloat elevation = (CGFloat)2.0;
+  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
+                                                                   message:@"message"];
+  [alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
+
+  // When
+  alert.elevation = elevation;
+
+  // Then
+  MDCDialogShadowedView *shadowView = alert.mdc_dialogPresentationController.trackingView;
+  XCTAssertEqual(shadowView.elevation, elevation);
+}
+
+- (void)testCustomDialogPresentationElevation {
+  // Given
+  CGFloat elevation = (CGFloat)2.0;
+  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
+                                                                   message:@"message"];
+  [alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
+
+  // When
+  alert.mdc_dialogPresentationController.dialogElevation = elevation;
+
+  // Then
+  MDCDialogShadowedView *shadowView = alert.mdc_dialogPresentationController.trackingView;
+  XCTAssertEqual(shadowView.elevation, elevation);
 }
 
 @end


### PR DESCRIPTION
### Context
Clients may need to set custom elevation levels for their custom dialogs
### The problem
Currently we don't expose any of the necessary properties to do this.
### The fix
Expose those properties so clients can have a custom elevation for their Dialog.

### Additionally
Test and Examples have been added.


### Screenshots
| Default | Custom |
| - | - |
|![simulator screen shot - iphone x - 2018-10-02 at 15 40 25](https://user-images.githubusercontent.com/7131294/46372705-e7e91000-c659-11e8-875c-132ba70c4b9f.png)|![simulator screen shot - iphone x - 2018-10-02 at 15 40 21](https://user-images.githubusercontent.com/7131294/46372715-ecadc400-c659-11e8-81a7-2f253ebf38e8.png)|



