### PR TITLE
[Dialogs] Update README for new themer

### DIFF
--- a/components/Dialogs/README.md
+++ b/components/Dialogs/README.md
@@ -44,6 +44,7 @@ involve multiple tasks.
   - [Typical use: modal dialog](#typical-use-modal-dialog)
   - [Typical use: alert](#typical-use-alert)
 - [Extensions](#extensions)
+  - [Theming](#theming)
   - [Color Theming](#color-theming)
   - [Typography Theming](#typography-theming)
 - [Accessibility](#accessibility)
@@ -186,6 +187,49 @@ MDCAlertAction *alertAction =
 
 
 ## Extensions
+
+<!-- Extracted from docs/theming.md -->
+
+### Theming
+
+You can theme an MDCDialog to match the Material Design Dialog using your app's schemes in the DialogThemer
+extension.
+
+You must first add the DialogThemer extension to your project:
+
+```bash
+pod 'MaterialComponents/Dialogs+DialogThemer'
+```
+
+You can then import the extension and create an `MDCAlertControllerThemer` instance. A dialog scheme defines
+the design parameters that you can use to theme your dialogs.
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+// Step 1: Import the DialogThemer extension
+import MaterialComponents.MaterialDialogs_DialogThemer
+
+// Step 2: Create or get a alert scheme
+let alertScheme = MDCAlertScheme()
+
+// Step 3: Apply the alert scheme to your component using the desired alert style
+MDCAlertControllerThemer.applyScheme(scheme, to: alertController)
+```
+
+#### Objective-C
+
+```objc
+// Step 1: Import the DialogThemer extension
+#import "MaterialDialogs+DialogThemer.h"
+
+// Step 2: Create or get a alert scheme
+MDCAlertScheme *alertScheme = [[MDCAlertScheme alloc] init];
+
+// Step 3: Apply the alert scheme to your component using the desired alert style
+[MDCAlertControllerThemer applyScheme:alertScheme toAlertController:alertController];
+```
+<!--</div>-->
 
 <!-- Extracted from docs/color-theming.md -->
 

--- a/components/Dialogs/docs/README.md
+++ b/components/Dialogs/docs/README.md
@@ -47,6 +47,7 @@ according to the Material spec.
 
 ## Extensions
 
+- [Theming](theming.md)
 - [Color Theming](color-theming.md)
 - [Typography Theming](typography-theming.md)
 

--- a/components/Dialogs/docs/theming.md
+++ b/components/Dialogs/docs/theming.md
@@ -1,0 +1,40 @@
+### Theming
+
+You can theme an MDCDialog to match the Material Design Dialog using your app's schemes in the DialogThemer
+extension.
+
+You must first add the DialogThemer extension to your project:
+
+```bash
+pod 'MaterialComponents/Dialogs+DialogThemer'
+```
+
+You can then import the extension and create an `MDCAlertControllerThemer` instance. A dialog scheme defines
+the design parameters that you can use to theme your dialogs.
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+// Step 1: Import the DialogThemer extension
+import MaterialComponents.MaterialDialogs_DialogThemer
+
+// Step 2: Create or get a alert scheme
+let alertScheme = MDCAlertScheme()
+
+// Step 3: Apply the alert scheme to your component using the desired alert style
+MDCAlertControllerThemer.applyScheme(scheme, to: alertController)
+```
+
+#### Objective-C
+
+```objc
+// Step 1: Import the DialogThemer extension
+#import "MaterialDialogs+DialogThemer.h"
+
+// Step 2: Create or get a alert scheme
+MDCAlertScheme *alertScheme = [[MDCAlertScheme alloc] init];
+
+// Step 3: Apply the alert scheme to your component using the desired alert style
+[MDCAlertControllerThemer applyScheme:alertScheme toAlertController:alertController];
+```
+<!--</div>-->


### PR DESCRIPTION
### Context
We recently added an API for a [DialogThemer](https://github.com/material-components/material-components-ios/pull/5102) but we are yet to update the README.
### The problem
We are missing docs for the new API
### The fix
Update the readme to have the new themer API
### Related issues
b/116306933