### PR TITLE
[Dialogs] Update the themer and scheme to have elevation

### DIFF
--- a/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.m
+++ b/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.m
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 #import "MDCAlertControllerThemer.h"
-
-#import "MaterialShadowElevations.h"
 #import "MDCAlertColorThemer.h"
 #import "MDCAlertTypographyThemer.h"
 
@@ -29,7 +27,7 @@
                                 toAlertController:alertController];
 
   alertController.cornerRadius = alertScheme.cornerRadius;
-  alertController.elevation = MDCShadowElevationDialog;
+  alertController.elevation = alertScheme.elevation;
 }
 
 @end

--- a/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.m
+++ b/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.m
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #import "MDCAlertControllerThemer.h"
+
+#import "MaterialShadowElevations.h"
 #import "MDCAlertColorThemer.h"
 #import "MDCAlertTypographyThemer.h"
 
@@ -27,6 +29,7 @@
                                 toAlertController:alertController];
 
   alertController.cornerRadius = alertScheme.cornerRadius;
+  alertController.elevation = MDCShadowElevationDialog;
 }
 
 @end

--- a/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
+++ b/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
@@ -29,6 +29,9 @@
 /** The corner radius to apply to Dialog. */
 @property(readonly, nonatomic) CGFloat cornerRadius;
 
+/** The elevation to apply to the Dialog. */
+@property(readonly, nonatomic) CGFloat elevation;
+
 @end
 
 /**  A simple implementation of @c MDCAlertScheming that provides default color,
@@ -43,5 +46,8 @@
 
 /** The corner radius to apply to Dialog. */
 @property(readwrite, nonatomic) CGFloat cornerRadius;
+
+/** The elevation to apply to the Dialog. */
+@property(readwrite, nonatomic) CGFloat elevation;
 
 @end

--- a/components/Dialogs/src/DialogThemer/MDCAlertScheme.m
+++ b/components/Dialogs/src/DialogThemer/MDCAlertScheme.m
@@ -14,6 +14,8 @@
 
 #import "MDCAlertScheme.h"
 
+#import "MaterialShadowElevations.h"
+
 static const CGFloat kCornerRadius = 4.0f;
 
 @implementation MDCAlertScheme
@@ -24,6 +26,7 @@ static const CGFloat kCornerRadius = 4.0f;
     _colorScheme = [[MDCSemanticColorScheme alloc] init];
     _typographyScheme = [[MDCTypographyScheme alloc] init];
     _cornerRadius = kCornerRadius;
+    _elevation = MDCShadowElevationDialog;
   }
   return self;
 }

--- a/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
+++ b/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
@@ -14,12 +14,14 @@
 
 import XCTest
 
+import MaterialComponents.MaterialShadowElevations
 import MaterialComponents.MDCAlertScheme
 import MaterialComponents.MDCAlertControllerThemer
 
 class MDCAlertControllerAlertThemerTests: XCTestCase {
 
   let defaultCornerRadius: CGFloat = 4.0
+  let defaultElevation: CGFloat = ShadowElevation.dialog.rawValue
   var alertScheme: MDCAlertScheme = MDCAlertScheme()
   var alert = MDCAlertController(title: "Title", message: "Message")
   var alertView: MDCAlertControllerView { return alert.view as! MDCAlertControllerView }
@@ -38,6 +40,7 @@ class MDCAlertControllerAlertThemerTests: XCTestCase {
     XCTAssertEqual(alertScheme.colorScheme.primaryColor, MDCSemanticColorScheme().primaryColor)
     XCTAssertEqual(alertScheme.typographyScheme.body1, MDCTypographyScheme().body1)
     XCTAssertEqual(alertScheme.cornerRadius, defaultCornerRadius)
+    XCTAssertEqual(alertScheme.elevation, defaultElevation)
   }
 
   func testApplyingAlertSchemeWithCustomColor() {
@@ -122,5 +125,19 @@ class MDCAlertControllerAlertThemerTests: XCTestCase {
     XCTAssertEqual(alertScheme.cornerRadius, cornerRadius, accuracy: 0.0)
     XCTAssertEqual(alertView.cornerRadius, cornerRadius, accuracy: 0.0)
     XCTAssertNotEqual(alertScheme.cornerRadius, defaultCornerRadius, accuracy: 0.0)
+  }
+
+  func testApplyAlertSchemeWithCustomElevation() {
+    // Given
+    let elevation: CGFloat = 10.0
+    alertScheme.elevation = elevation
+
+    // When
+    MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
+
+    // Then
+    XCTAssertEqual(alertScheme.elevation, elevation, accuracy: 0.001)
+    XCTAssertEqual(alert.elevation, elevation, accuracy: 0.001)
+    XCTAssertNotEqual(alertScheme.elevation, defaultElevation, accuracy: 0.001)
   }
 }


### PR DESCRIPTION
### Context
We recently added an `elevation` property to MDCAlertController.
### The problem
The alertScheme didn't set the elevation if an MDCAlertController was themed.
### The fix
This applies the elevation a client sets to their scheme to the AlertController, if no elevation is set then it defaults to the MDCShadowElevationDialog value which is 24dp.
### Related PR
This is the PR that added the elevation property.
#5296 
### Related bug
b/117168419