### PR TITLE
[Dialogs] Update default scrim color to match spec

### DIFF
--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -83,7 +83,7 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
                        presentingViewController:presentingViewController];
   if (self) {
     _dimmingView = [[UIView alloc] initWithFrame:CGRectZero];
-    _dimmingView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.4f];
+    _dimmingView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.32f];
     _dimmingView.alpha = 0.0f;
     _dismissGestureRecognizer =
         [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismiss:)];


### PR DESCRIPTION
### Context
I believe the scrim color didn't match what the value should be, possibly design changed this value and we didn't get that updated. I noticed this when trying to theme the scrim color with the color themer.
### The problem
The scrim color doesn't match internal document
### The fix
Update the value to desired default scrim color
### Screenshot
| Before | After | 
| - | - |
|![simulator screen shot - iphone xr - 2018-10-03 at 11 39 58](https://user-images.githubusercontent.com/7131294/46421895-2d144d00-c701-11e8-8bc7-a2b97b04dc3b.png)|![simulator screen shot - iphone xr - 2018-10-03 at 11 40 18](https://user-images.githubusercontent.com/7131294/46421904-31406a80-c701-11e8-905e-a385d6bebb85.png)|
I can't see a difference in the screenshots I think it's because the values are so close.

