### PR TITLE
[NavigationDrawer] Removed MDCDeviceTopSafeAreaInset

### DIFF
--- a/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
+++ b/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
@@ -18,7 +18,7 @@ import MaterialComponents.MaterialColorScheme
 
 class DrawerContentViewController: UIViewController {
   var colorScheme = MDCSemanticColorScheme()
-  let preferredHeight: CGFloat = 2000
+  let preferredHeight: CGFloat = 1000
 
   override var preferredContentSize: CGSize {
     get {

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -585,9 +585,10 @@ static UIColor *DrawerShadowColor(void) {
 - (CGFloat)topSafeArea {
   if (@available(iOS 11.0, *)) {
     return self.view.safeAreaInsets.top;
-  } else {
-    return kFixedStatusBarHeightOnPreiPhoneXDevices;
   }
+  // On a Pre iPhoneX device the status bar is 20dp tall in portrait and landscape and we need to
+  // account for that.
+  return kFixedStatusBarHeightOnPreiPhoneXDevices;
 }
 
 @end

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -29,6 +29,7 @@ static const CGFloat kHeaderAnimationDistanceAddedDistanceFromTopSafeAreaInset =
 // has the behavior as if we are scrolling at the end of the content, and the scrolling isn't
 // smooth.
 static const CGFloat kScrollViewBufferForPerformance = 20.f;
+static const CGFloat kFixedStatusBarHeightOnPreiPhoneXDevices = 20.f;
 static const CGFloat kDragVelocityThresholdForHidingDrawer = -2.f;
 static NSString *const kContentOffsetKeyPath = @"contentOffset";
 
@@ -361,7 +362,7 @@ static UIColor *DrawerShadowColor(void) {
   CGRect contentViewFrame = self.scrollView.bounds;
   contentViewFrame.origin.y = self.contentHeaderTopInset + self.contentHeaderHeight;
   if (self.trackingScrollView != nil) {
-    CGFloat topAreaInsetForHeader = (self.headerViewController ? MDCDeviceTopSafeAreaInset() : 0);
+    CGFloat topAreaInsetForHeader = (self.headerViewController ? [self topSafeArea] : 0);
     contentViewFrame.size.height -= self.contentHeaderHeight - kScrollViewBufferForPerformance;
     // We add the topAreaInsetForHeader to the height of the content view frame when a tracking
     // scroll view is set, to normalize the algorithm after the removal of this value from the
@@ -582,6 +583,14 @@ static UIColor *DrawerShadowColor(void) {
   }
 }
 
+- (CGFloat)topSafeArea {
+  if (@available(iOS 11.0, *)) {
+    return self.view.safeAreaInsets.top;
+  } else {
+    return kFixedStatusBarHeightOnPreiPhoneXDevices;
+  }
+}
+
 @end
 
 #pragma mark - MDCBottomDrawerContainerViewController + Layout Calculations
@@ -680,7 +689,8 @@ static UIColor *DrawerShadowColor(void) {
     return 0.f;
   }
   CGFloat headerHeight = self.headerViewController.preferredContentSize.height;
-  return headerHeight + MDCDeviceTopSafeAreaInset();
+  headerHeight += [self topSafeArea];
+  return headerHeight;
 }
 
 - (CGFloat)contentHeaderHeight {
@@ -704,14 +714,14 @@ static UIColor *DrawerShadowColor(void) {
   CGFloat headerAnimationDistance =
       kHeaderAnimationDistanceAddedDistanceFromTopSafeAreaInset;
   if (self.contentReachesFullscreen) {
-    headerAnimationDistance += MDCDeviceTopSafeAreaInset();
+    headerAnimationDistance += [self topSafeArea];
   }
   return headerAnimationDistance;
 }
 
 - (CGFloat)addedContentHeightThreshold {
   // TODO: (#4900) change this to use safeAreaInsets as this is a soon to be deprecated API.
-  return MDCDeviceTopSafeAreaInset();
+  return [self topSafeArea];
 }
 
 @end

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -719,7 +719,6 @@ static UIColor *DrawerShadowColor(void) {
 }
 
 - (CGFloat)addedContentHeightThreshold {
-  // TODO: (#4900) change this to use safeAreaInsets as this is a soon to be deprecated API.
   return [self topSafeArea];
 }
 

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -16,7 +16,6 @@
 
 #import "MDCBottomDrawerHeader.h"
 #import "MaterialShadowLayer.h"
-#import "MaterialUIMetrics.h"
 
 static const CGFloat kVerticalShadowAnimationDistance = 10.f;
 static const CGFloat kVerticalDistanceThresholdForDismissal = 40.f;

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -214,7 +214,7 @@ static UIColor *DrawerShadowColor(void) {
 
 - (CGFloat)updateContentOffsetForPerformantScrolling:(CGFloat)contentYOffset {
   CGFloat normalizedYContentOffset = contentYOffset;
-  CGFloat topAreaInsetForHeader = (self.headerViewController ? MDCDeviceTopSafeAreaInset() : 0);
+  CGFloat topAreaInsetForHeader = (self.headerViewController ? [self topSafeArea] : 0);
   // The top area inset for header should be a positive non zero value for the algorithm to
   // correctly work when the drawer is presented in full screen and there is no top inset.
   // The reason being is that otherwise there would be a conflict between if the drawer is currently

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -154,11 +154,6 @@ static UIColor *DrawerShadowColor(void) {
     _contentHeightSurplus = NSNotFound;
     _addedContentHeight = NSNotFound;
     _trackingScrollView = trackingScrollView;
-    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-    [nc addObserver:self
-           selector:@selector(statusBarFrameWillChange:)
-               name:UIApplicationWillChangeStatusBarFrameNotification
-             object:nil];
   }
   return self;
 }
@@ -593,13 +588,6 @@ static UIColor *DrawerShadowColor(void) {
   }
   CGSize statusBarSize = [[UIApplication mdc_safeSharedApplication] statusBarFrame].size;
   return MIN(statusBarSize.width, statusBarSize.height);
-}
-
-- (void)statusBarFrameWillChange:(NSNotification *)notification {
-  [self.headerViewController.view setNeedsLayout];
-  [self.contentViewController.view setNeedsLayout];
-  [self updateContentOffsetForPerformantScrolling:self.scrollView.contentOffset.y];
-  [self updateViewWithContentOffset:self.scrollView.contentOffset];
 }
 
 @end


### PR DESCRIPTION
### Context
We currently are using MDCDeviceTopSafeAreaInset
### The problem
We plan to deprecate MDCDeviceTopSafeAreaInset
### The fix
Remove MDCDeviceTopSafeAreaInset and instead use self.view.safeArea.
### Related issues
#4900 


### Why WIP
Waiting on another PR to land and test against that.
### Screenshots
To come
