### PR TITLE
[BottomNavigation] Change badge position

### DIFF
--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -39,7 +39,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 @property(nonatomic, strong) UIImageView *iconImageView;
 @property(nonatomic, strong) UILabel *label;
 @property(nonatomic) BOOL shouldPretendToBeATab;
-- (CGPoint)badgeCenterFrom:(CGRect)iconFrame isRTL:(BOOL)isRTL;
+- (CGPoint)badgeCenterFromIconFrame:(CGRect)iconFrame isRTL:(BOOL)isRTL;
 
 @end
 
@@ -193,13 +193,9 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
     if (animated) {
       [UIView animateWithDuration:kMDCBottomNavigationItemViewTransitionDuration animations:^(void) {
         self.iconImageView.center = iconImageViewCenter;
-        self.badge.center = [self badgeCenterFrom:CGRectStandardize(self.iconImageView.frame)
-                                            isRTL:isRTL];
       }];
     } else {
       self.iconImageView.center = iconImageViewCenter;
-      self.badge.center = [self badgeCenterFrom:CGRectStandardize(self.iconImageView.frame)
-                                          isRTL:isRTL];
     }
     self.label.textAlignment = NSTextAlignmentCenter;
   } else {
@@ -212,8 +208,6 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
       CGFloat labelCenterX =
           iconImageViewCenter.x + contentsWidth / 2 + self.contentHorizontalMargin;
       self.label.center = CGPointMake(labelCenterX, centerY);
-      self.badge.center = [self badgeCenterFrom:CGRectStandardize(self.iconImageView.frame)
-                                          isRTL:isRTL];
       self.label.textAlignment = NSTextAlignmentLeft;
     } else {
       CGPoint iconImageViewCenter =
@@ -222,11 +216,11 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
       CGFloat labelCenterX =
           iconImageViewCenter.x - contentsWidth / 2 - self.contentHorizontalMargin;
       self.label.center = CGPointMake(labelCenterX, centerY);
-      self.badge.center = [self badgeCenterFrom:CGRectStandardize(self.iconImageView.frame)
-                                          isRTL:isRTL];
       self.label.textAlignment = NSTextAlignmentRight;
     }
   }
+  self.badge.center = [self badgeCenterFromIconFrame:CGRectStandardize(self.iconImageView.frame)
+                                               isRTL:isRTL];
 }
 
 - (void)updateLabelVisibility {
@@ -276,14 +270,13 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
   return [labelComponents componentsJoinedByString:@", "];
 }
 
-- (CGPoint)badgeCenterFrom:(CGRect)iconFrame isRTL:(BOOL)isRTL {
+- (CGPoint)badgeCenterFromIconFrame:(CGRect)iconFrame isRTL:(BOOL)isRTL {
   if (isRTL) {
     return CGPointMake(CGRectGetMinX(iconFrame),
                        CGRectGetMinY(iconFrame) + kMDCBottomNavigationItemViewBadgeYOffset);
-  } else {
-    return CGPointMake(CGRectGetMaxX(iconFrame),
-                       CGRectGetMinY(iconFrame) + kMDCBottomNavigationItemViewBadgeYOffset);
   }
+  return CGPointMake(CGRectGetMaxX(iconFrame),
+                     CGRectGetMinY(iconFrame) + kMDCBottomNavigationItemViewBadgeYOffset);
 }
 
 - (NSString *)badgeValue {

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -214,9 +214,8 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
           iconImageViewCenter.x + contentsWidth / 2 + self.contentHorizontalMargin;
       CGFloat iconImageOriginY = iconImageViewCenter.y - CGRectGetMidY(self.iconImageView.bounds);
       self.label.center = CGPointMake(labelCenterX, centerY);
-      self.badge.center =
-          CGPointMake(iconImageViewCenter.x + CGRectGetMidX(iconBounds),
-                      iconImageOriginY + CGRectGetMidY(self.badge.bounds));
+      self.badge.center = CGPointMake(iconImageViewCenter.x + CGRectGetMidX(iconBounds),
+                                      iconImageOriginY + CGRectGetMidY(self.badge.bounds));
       self.label.textAlignment = NSTextAlignmentLeft;
     } else {
       CGPoint iconImageViewCenter =
@@ -226,9 +225,8 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
           iconImageViewCenter.x - contentsWidth / 2 - self.contentHorizontalMargin;
       self.label.center = CGPointMake(labelCenterX, centerY);
       CGFloat iconImageOriginY = iconImageViewCenter.y - CGRectGetMidY(self.iconImageView.bounds);
-      self.badge.center =
-          CGPointMake(iconImageViewCenter.x - CGRectGetMidX(iconBounds),
-                      iconImageOriginY + CGRectGetMidY(self.badge.bounds));
+      self.badge.center = CGPointMake(iconImageViewCenter.x - CGRectGetMidX(iconBounds),
+                                      iconImageOriginY + CGRectGetMidY(self.badge.bounds));
       self.label.textAlignment = NSTextAlignmentRight;
     }
   }

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -194,12 +194,12 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
       [UIView animateWithDuration:kMDCBottomNavigationItemViewTransitionDuration animations:^(void) {
         self.iconImageView.center = iconImageViewCenter;
         self.badge.center = [self badgeCenterFrom:CGRectStandardize(self.iconImageView.frame)
-                                              isRTL:isRTL];
+                                            isRTL:isRTL];
       }];
     } else {
       self.iconImageView.center = iconImageViewCenter;
       self.badge.center = [self badgeCenterFrom:CGRectStandardize(self.iconImageView.frame)
-                                            isRTL:isRTL];
+                                          isRTL:isRTL];
     }
     self.label.textAlignment = NSTextAlignmentCenter;
   } else {
@@ -213,7 +213,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
           iconImageViewCenter.x + contentsWidth / 2 + self.contentHorizontalMargin;
       self.label.center = CGPointMake(labelCenterX, centerY);
       self.badge.center = [self badgeCenterFrom:CGRectStandardize(self.iconImageView.frame)
-                                            isRTL:isRTL];
+                                          isRTL:isRTL];
       self.label.textAlignment = NSTextAlignmentLeft;
     } else {
       CGPoint iconImageViewCenter =
@@ -223,7 +223,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
           iconImageViewCenter.x - contentsWidth / 2 - self.contentHorizontalMargin;
       self.label.center = CGPointMake(labelCenterX, centerY);
       self.badge.center = [self badgeCenterFrom:CGRectStandardize(self.iconImageView.frame)
-                                            isRTL:isRTL];
+                                          isRTL:isRTL];
       self.label.textAlignment = NSTextAlignmentRight;
     }
   }

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -39,6 +39,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 @property(nonatomic, strong) UIImageView *iconImageView;
 @property(nonatomic, strong) UILabel *label;
 @property(nonatomic) BOOL shouldPretendToBeATab;
+- (CGPoint)badgeCenterFrom:(CGRect)iconFrame isRTL:(BOOL)isRTL;
 
 @end
 
@@ -193,12 +194,12 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
       [UIView animateWithDuration:kMDCBottomNavigationItemViewTransitionDuration animations:^(void) {
         self.iconImageView.center = iconImageViewCenter;
         self.badge.center = [self badgeCenterFrom:CGRectStandardize(self.iconImageView.frame)
-                                              rtl:isRTL];
+                                              isRTL:isRTL];
       }];
     } else {
       self.iconImageView.center = iconImageViewCenter;
       self.badge.center = [self badgeCenterFrom:CGRectStandardize(self.iconImageView.frame)
-                                            rtl:isRTL];
+                                            isRTL:isRTL];
     }
     self.label.textAlignment = NSTextAlignmentCenter;
   } else {
@@ -212,7 +213,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
           iconImageViewCenter.x + contentsWidth / 2 + self.contentHorizontalMargin;
       self.label.center = CGPointMake(labelCenterX, centerY);
       self.badge.center = [self badgeCenterFrom:CGRectStandardize(self.iconImageView.frame)
-                                            rtl:isRTL];
+                                            isRTL:isRTL];
       self.label.textAlignment = NSTextAlignmentLeft;
     } else {
       CGPoint iconImageViewCenter =
@@ -222,7 +223,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
           iconImageViewCenter.x - contentsWidth / 2 - self.contentHorizontalMargin;
       self.label.center = CGPointMake(labelCenterX, centerY);
       self.badge.center = [self badgeCenterFrom:CGRectStandardize(self.iconImageView.frame)
-                                            rtl:isRTL];
+                                            isRTL:isRTL];
       self.label.textAlignment = NSTextAlignmentRight;
     }
   }
@@ -275,8 +276,8 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
   return [labelComponents componentsJoinedByString:@", "];
 }
 
-- (CGPoint)badgeCenterFrom:(CGRect)iconFrame rtl:(BOOL)rtl {
-  if (rtl) {
+- (CGPoint)badgeCenterFrom:(CGRect)iconFrame isRTL:(BOOL)isRTL {
+  if (isRTL) {
     return CGPointMake(CGRectGetMinX(iconFrame),
                        CGRectGetMinY(iconFrame) + kMDCBottomNavigationItemViewBadgeYOffset);
   } else {

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -188,9 +188,10 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
     }
     CGPoint iconImageViewCenter =
         CGPointMake(centerX, centerY - totalContentHeight / 2 + iconHeight / 2);
+    CGFloat iconImageOriginY = iconImageViewCenter.y - CGRectGetMidY(self.iconImageView.bounds);
     CGPoint badgeCenter =
         CGPointMake(iconImageViewCenter.x + CGRectGetMidX(iconBounds) * (isRTL ? -1 : 1),
-                    iconImageViewCenter.y - CGRectGetMidY(iconBounds));
+                    iconImageOriginY + CGRectGetMidY(self.badge.bounds));
     self.label.center = CGPointMake(centerX, centerY + totalContentHeight / 2 - labelHeight / 2);
     if (animated) {
       [UIView animateWithDuration:kMDCBottomNavigationItemViewTransitionDuration animations:^(void) {
@@ -211,10 +212,11 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
       self.iconImageView.center = iconImageViewCenter;
       CGFloat labelCenterX =
           iconImageViewCenter.x + contentsWidth / 2 + self.contentHorizontalMargin;
+      CGFloat iconImageOriginY = iconImageViewCenter.y - CGRectGetMidY(self.iconImageView.bounds);
       self.label.center = CGPointMake(labelCenterX, centerY);
       self.badge.center =
           CGPointMake(iconImageViewCenter.x + CGRectGetMidX(iconBounds),
-                      iconImageViewCenter.y - CGRectGetMidY(iconBounds));
+                      iconImageOriginY + CGRectGetMidY(self.badge.bounds));
       self.label.textAlignment = NSTextAlignmentLeft;
     } else {
       CGPoint iconImageViewCenter =
@@ -223,9 +225,10 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
       CGFloat labelCenterX =
           iconImageViewCenter.x - contentsWidth / 2 - self.contentHorizontalMargin;
       self.label.center = CGPointMake(labelCenterX, centerY);
+      CGFloat iconImageOriginY = iconImageViewCenter.y - CGRectGetMidY(self.iconImageView.bounds);
       self.badge.center =
           CGPointMake(iconImageViewCenter.x - CGRectGetMidX(iconBounds),
-                      iconImageViewCenter.y - CGRectGetMidY(iconBounds));
+                      iconImageOriginY + CGRectGetMidY(self.badge.bounds));
       self.label.textAlignment = NSTextAlignmentRight;
     }
   }

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -24,7 +24,7 @@
 
 static const CGFloat MDCBottomNavigationItemViewInkOpacity = 0.150f;
 static const CGFloat MDCBottomNavigationItemViewTitleFontSize = 12.f;
-static const CGFloat kMDCBottomNavigationBadgeYOffset = 4.f;
+static const CGFloat kMDCBottomNavigationItemViewBadgeYOffset = 4.f;
 
 // The duration of the selection transition animation.
 static const NSTimeInterval kMDCBottomNavigationItemViewTransitionDuration = 0.180f;
@@ -278,10 +278,10 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 - (CGPoint)badgeCenterFrom:(CGRect)iconFrame rtl:(BOOL)rtl {
   if (rtl) {
     return CGPointMake(CGRectGetMinX(iconFrame),
-                       CGRectGetMinY(iconFrame) + kMDCBottomNavigationBadgeYOffset);
+                       CGRectGetMinY(iconFrame) + kMDCBottomNavigationItemViewBadgeYOffset);
   } else {
     return CGPointMake(CGRectGetMaxX(iconFrame),
-                       CGRectGetMinY(iconFrame) + kMDCBottomNavigationBadgeYOffset);
+                       CGRectGetMinY(iconFrame) + kMDCBottomNavigationItemViewBadgeYOffset);
   }
 }
 

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -168,7 +168,6 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 
 - (void)centerLayoutAnimated:(BOOL)animated {
   CGRect contentBoundingRect = UIEdgeInsetsInsetRect(self.bounds, self.contentInsets);
-  CGRect iconBounds = self.iconImageView.bounds;
   CGFloat centerY = CGRectGetMidY(contentBoundingRect);
   CGFloat centerX = CGRectGetMidX(contentBoundingRect);
   UIUserInterfaceLayoutDirection layoutDirection = self.mdf_effectiveUserInterfaceLayoutDirection;
@@ -189,20 +188,17 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
     }
     CGPoint iconImageViewCenter =
         CGPointMake(centerX, centerY - totalContentHeight / 2 + iconHeight / 2);
-    CGFloat iconImageOriginY = iconImageViewCenter.y - CGRectGetMidY(self.iconImageView.bounds);
-    CGFloat badgeYPosition =
-        iconImageOriginY - kMDCBottomNavigationBadgeYOffset + CGRectGetMidY(self.badge.bounds);
-    CGPoint badgeCenter = CGPointMake(
-        iconImageViewCenter.x + CGRectGetMidX(iconBounds) * (isRTL ? -1 : 1), badgeYPosition);
     self.label.center = CGPointMake(centerX, centerY + totalContentHeight / 2 - labelHeight / 2);
     if (animated) {
       [UIView animateWithDuration:kMDCBottomNavigationItemViewTransitionDuration animations:^(void) {
         self.iconImageView.center = iconImageViewCenter;
-        self.badge.center = badgeCenter;
+        self.badge.center = [self badgeCenterFrom:CGRectStandardize(self.iconImageView.frame)
+                                              rtl:isRTL];
       }];
     } else {
       self.iconImageView.center = iconImageViewCenter;
-      self.badge.center = badgeCenter;
+      self.badge.center = [self badgeCenterFrom:CGRectStandardize(self.iconImageView.frame)
+                                            rtl:isRTL];
     }
     self.label.textAlignment = NSTextAlignmentCenter;
   } else {
@@ -214,12 +210,9 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
       self.iconImageView.center = iconImageViewCenter;
       CGFloat labelCenterX =
           iconImageViewCenter.x + contentsWidth / 2 + self.contentHorizontalMargin;
-      CGFloat iconImageOriginY = iconImageViewCenter.y - CGRectGetMidY(self.iconImageView.bounds);
       self.label.center = CGPointMake(labelCenterX, centerY);
-      CGFloat badgeYPosition =
-          iconImageOriginY - kMDCBottomNavigationBadgeYOffset + CGRectGetMidY(self.badge.bounds);
-      self.badge.center =
-          CGPointMake(iconImageViewCenter.x + CGRectGetMidX(iconBounds), badgeYPosition);
+      self.badge.center = [self badgeCenterFrom:CGRectStandardize(self.iconImageView.frame)
+                                            rtl:isRTL];
       self.label.textAlignment = NSTextAlignmentLeft;
     } else {
       CGPoint iconImageViewCenter =
@@ -228,11 +221,8 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
       CGFloat labelCenterX =
           iconImageViewCenter.x - contentsWidth / 2 - self.contentHorizontalMargin;
       self.label.center = CGPointMake(labelCenterX, centerY);
-      CGFloat iconImageOriginY = iconImageViewCenter.y - CGRectGetMidY(self.iconImageView.bounds);
-      CGFloat badgeYPosition =
-          iconImageOriginY - kMDCBottomNavigationBadgeYOffset + CGRectGetMidY(self.badge.bounds);
-      self.badge.center =
-          CGPointMake(iconImageViewCenter.x - CGRectGetMidX(iconBounds), badgeYPosition);
+      self.badge.center = [self badgeCenterFrom:CGRectStandardize(self.iconImageView.frame)
+                                            rtl:isRTL];
       self.label.textAlignment = NSTextAlignmentRight;
     }
   }
@@ -283,6 +273,16 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 
   // Speak components with a pause in between.
   return [labelComponents componentsJoinedByString:@", "];
+}
+
+- (CGPoint)badgeCenterFrom:(CGRect)iconFrame rtl:(BOOL)rtl {
+  if (rtl) {
+    return CGPointMake(CGRectGetMinX(iconFrame),
+                       CGRectGetMinY(iconFrame) + kMDCBottomNavigationBadgeYOffset);
+  } else {
+    return CGPointMake(CGRectGetMaxX(iconFrame),
+                       CGRectGetMinY(iconFrame) + kMDCBottomNavigationBadgeYOffset);
+  }
 }
 
 - (NSString *)badgeValue {

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -24,6 +24,7 @@
 
 static const CGFloat MDCBottomNavigationItemViewInkOpacity = 0.150f;
 static const CGFloat MDCBottomNavigationItemViewTitleFontSize = 12.f;
+static const CGFloat kMDCBottomNavigationBadgeYOffset = 4.f;
 
 // The duration of the selection transition animation.
 static const NSTimeInterval kMDCBottomNavigationItemViewTransitionDuration = 0.180f;
@@ -189,9 +190,10 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
     CGPoint iconImageViewCenter =
         CGPointMake(centerX, centerY - totalContentHeight / 2 + iconHeight / 2);
     CGFloat iconImageOriginY = iconImageViewCenter.y - CGRectGetMidY(self.iconImageView.bounds);
-    CGPoint badgeCenter =
-        CGPointMake(iconImageViewCenter.x + CGRectGetMidX(iconBounds) * (isRTL ? -1 : 1),
-                    iconImageOriginY + CGRectGetMidY(self.badge.bounds));
+    CGFloat badgeYPosition =
+        iconImageOriginY - kMDCBottomNavigationBadgeYOffset + CGRectGetMidY(self.badge.bounds);
+    CGPoint badgeCenter = CGPointMake(
+        iconImageViewCenter.x + CGRectGetMidX(iconBounds) * (isRTL ? -1 : 1), badgeYPosition);
     self.label.center = CGPointMake(centerX, centerY + totalContentHeight / 2 - labelHeight / 2);
     if (animated) {
       [UIView animateWithDuration:kMDCBottomNavigationItemViewTransitionDuration animations:^(void) {
@@ -214,8 +216,10 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
           iconImageViewCenter.x + contentsWidth / 2 + self.contentHorizontalMargin;
       CGFloat iconImageOriginY = iconImageViewCenter.y - CGRectGetMidY(self.iconImageView.bounds);
       self.label.center = CGPointMake(labelCenterX, centerY);
-      self.badge.center = CGPointMake(iconImageViewCenter.x + CGRectGetMidX(iconBounds),
-                                      iconImageOriginY + CGRectGetMidY(self.badge.bounds));
+      CGFloat badgeYPosition =
+          iconImageOriginY - kMDCBottomNavigationBadgeYOffset + CGRectGetMidY(self.badge.bounds);
+      self.badge.center =
+          CGPointMake(iconImageViewCenter.x + CGRectGetMidX(iconBounds), badgeYPosition);
       self.label.textAlignment = NSTextAlignmentLeft;
     } else {
       CGPoint iconImageViewCenter =
@@ -225,8 +229,10 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
           iconImageViewCenter.x - contentsWidth / 2 - self.contentHorizontalMargin;
       self.label.center = CGPointMake(labelCenterX, centerY);
       CGFloat iconImageOriginY = iconImageViewCenter.y - CGRectGetMidY(self.iconImageView.bounds);
-      self.badge.center = CGPointMake(iconImageViewCenter.x - CGRectGetMidX(iconBounds),
-                                      iconImageOriginY + CGRectGetMidY(self.badge.bounds));
+      CGFloat badgeYPosition =
+          iconImageOriginY - kMDCBottomNavigationBadgeYOffset + CGRectGetMidY(self.badge.bounds);
+      self.badge.center =
+          CGPointMake(iconImageViewCenter.x - CGRectGetMidX(iconBounds), badgeYPosition);
       self.label.textAlignment = NSTextAlignmentRight;
     }
   }

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
@@ -152,7 +152,8 @@ static UIImage *fakeImage(void) {
                                       tag:0];
   tabBarItem3.badgeValue = @"111";
   bottomNavBar.items = @[ tabBarItem1, tabBarItem2, tabBarItem3 ];
-  // Setting one selected and 
+  // Setting one selected and title visablilty to selected test against both with and without
+  // a title label.
   bottomNavBar.titleVisibility = MDCBottomNavigationBarTitleVisibilitySelected;
   bottomNavBar.selectedItem = tabBarItem2;
   
@@ -161,9 +162,12 @@ static UIImage *fakeImage(void) {
   [bottomNavBar layoutIfNeeded];
 
   // Then
-  for (MDCBottomNavigationItemView *itemView in bottomNavBar.subviews) {
-    XCTAssertEqualWithAccuracy(CGRectGetMinY(itemView.badge.frame),
-                               CGRectGetMidY(itemView.iconImageView.frame), 0.001);
+  for (UIView *containerView in bottomNavBar.subviews) {
+    for (MDCBottomNavigationItemView *itemView in containerView.subviews) {
+      CGRect badgeRect = CGRectStandardize(itemView.badge.frame);
+      CGRect iconImageRect = CGRectStandardize(itemView.iconImageView.frame);
+      XCTAssertEqualWithAccuracy(badgeRect.origin.y, iconImageRect.origin.y, 0.001);
+    }
   }
 }
 

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
@@ -29,12 +29,13 @@ static UIImage *fakeImage(void) {
   return image;
 }
 
-static const CGFloat kMDCBottomNavigationBadgeYOffset = 4.f;
+static const CGFloat kMDCBottomNavigationItemViewBadgeYOffset = 4.f;
 
 @interface MDCBottomNavigationItemView (Testing)
 @property(nonatomic, strong) UIImageView *iconImageView;
 @property(nonatomic, strong) UILabel *label;
 @property(nonatomic, strong) MDCBottomNavigationItemBadge *badge;
+- (CGPoint)badgeCenterFrom:(CGRect)iconFrame isRTL:(BOOL)isRTL;
 @end
 
 @interface BottomNavigationItemViewTests : XCTestCase
@@ -131,42 +132,40 @@ static const CGFloat kMDCBottomNavigationBadgeYOffset = 4.f;
   XCTAssertNotEqualObjects(item2.inkView.inkColor, item2DefaultInkColor);
 }
 
-- (void)testBadgeAndIconHaveSameOriginY {
+- (void)testBadgeCenterIsCorrectWithoutRTL {
   // Given
-  CGRect bottomNavFrame = CGRectMake(0, 0, 200, 56);
-  MDCBottomNavigationBar *bottomNavBar =
-      [[MDCBottomNavigationBar alloc] initWithFrame:bottomNavFrame];
-  UITabBarItem *tabBarItem1 = [[UITabBarItem alloc] initWithTitle:@"Home" image:fakeImage() tag:0];
-  tabBarItem1.badgeValue = @"111";
-
-  UITabBarItem *tabBarItem2 = [[UITabBarItem alloc] initWithTitle:@"Messages"
-                                                            image:fakeImage()
-                                                              tag:0];
-  tabBarItem2.badgeValue = @"111";
-
-  UITabBarItem *tabBarItem3 = [[UITabBarItem alloc] initWithTitle:@"Favorites"
-                                                            image:fakeImage()
-                                                              tag:0];
-  tabBarItem3.badgeValue = @"111";
-  bottomNavBar.items = @[ tabBarItem1, tabBarItem2, tabBarItem3 ];
-  // Setting one selected and title visablilty to selected test against both with and without
-  // a title label.
-  bottomNavBar.titleVisibility = MDCBottomNavigationBarTitleVisibilitySelected;
-  bottomNavBar.selectedItem = tabBarItem2;
+  MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];
+  itemView.iconImageView.frame = CGRectMake(8, 8, 24, 24);
 
   // When
-  [bottomNavBar setNeedsLayout];
-  [bottomNavBar layoutIfNeeded];
+  CGPoint badgePoint = [itemView badgeCenterFrom:CGRectStandardize(itemView.iconImageView.frame)
+                                           isRTL:NO];
 
   // Then
-  for (UIView *containerView in bottomNavBar.subviews) {
-    for (MDCBottomNavigationItemView *itemView in containerView.subviews) {
-      CGPoint badgeCenter = itemView.badge.center;
-      CGRect iconImageRect = CGRectStandardize(itemView.iconImageView.frame);
-      XCTAssertEqualWithAccuracy(badgeCenter.y - kMDCBottomNavigationBadgeYOffset,
-                                 iconImageRect.origin.y, 0.001);
-    }
-  }
+  CGRect iconFrame = itemView.iconImageView.frame;
+  CGPoint expectPoint =
+      CGPointMake(CGRectGetMaxX(iconFrame),
+                  CGRectGetMinY(iconFrame) + kMDCBottomNavigationItemViewBadgeYOffset);
+  XCTAssertEqualWithAccuracy(badgePoint.x, expectPoint.x, 0.001);
+  XCTAssertEqualWithAccuracy(badgePoint.y, expectPoint.y, 0.001);
+}
+
+- (void)testBadgeCenterIsCorrectWithRTL {
+  // Given
+  MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];
+  itemView.iconImageView.frame = CGRectMake(8, 8, 24, 24);
+
+  // When
+  CGPoint badgePoint = [itemView badgeCenterFrom:CGRectStandardize(itemView.iconImageView.frame)
+                                           isRTL:YES];
+
+  // Then
+  CGRect iconFrame = itemView.iconImageView.frame;
+  CGPoint expectPoint =
+  CGPointMake(CGRectGetMinX(iconFrame),
+              CGRectGetMinY(iconFrame) + kMDCBottomNavigationItemViewBadgeYOffset);
+  XCTAssertEqualWithAccuracy(badgePoint.x, expectPoint.x, 0.001);
+  XCTAssertEqualWithAccuracy(badgePoint.y, expectPoint.y, 0.001);
 }
 
 @end

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
@@ -161,9 +161,9 @@ static const CGFloat kMDCBottomNavigationBadgeYOffset = 4.f;
   // Then
   for (UIView *containerView in bottomNavBar.subviews) {
     for (MDCBottomNavigationItemView *itemView in containerView.subviews) {
-      CGRect badgeRect = CGRectStandardize(itemView.badge.frame);
+      CGPoint badgeCenter = itemView.badge.center;
       CGRect iconImageRect = CGRectStandardize(itemView.iconImageView.frame);
-      XCTAssertEqualWithAccuracy(badgeRect.origin.y + kMDCBottomNavigationBadgeYOffset,
+      XCTAssertEqualWithAccuracy(badgeCenter.y - kMDCBottomNavigationBadgeYOffset,
                                  iconImageRect.origin.y, 0.001);
     }
   }

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
@@ -29,8 +29,6 @@ static UIImage *fakeImage(void) {
   return image;
 }
 
-static const CGFloat kMDCBottomNavigationItemViewBadgeYOffset = 4.f;
-
 @interface MDCBottomNavigationItemView (Testing)
 @property(nonatomic, strong) UIImageView *iconImageView;
 @property(nonatomic, strong) UILabel *label;
@@ -136,36 +134,28 @@ static const CGFloat kMDCBottomNavigationItemViewBadgeYOffset = 4.f;
   // Given
   MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];
   itemView.iconImageView.frame = CGRectMake(8, 8, 24, 24);
+  CGPoint expectedCenter = CGPointMake(32, 12);
 
   // When
   CGPoint badgePoint =
       [itemView badgeCenterFromIconFrame:CGRectStandardize(itemView.iconImageView.frame) isRTL:NO];
-
   // Then
-  CGRect iconFrame = itemView.iconImageView.frame;
-  CGPoint expectPoint =
-      CGPointMake(CGRectGetMaxX(iconFrame),
-                  CGRectGetMinY(iconFrame) + kMDCBottomNavigationItemViewBadgeYOffset);
-  XCTAssertEqualWithAccuracy(badgePoint.x, expectPoint.x, 0.001);
-  XCTAssertEqualWithAccuracy(badgePoint.y, expectPoint.y, 0.001);
+  XCTAssertEqualWithAccuracy(badgePoint.x, expectedCenter.x, 0.001);
+  XCTAssertEqualWithAccuracy(badgePoint.y, expectedCenter.y, 0.001);
 }
 
 - (void)testBadgeCenterIsCorrectWithRTL {
   // Given
   MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];
   itemView.iconImageView.frame = CGRectMake(8, 8, 24, 24);
+  CGPoint expectedCenter = CGPointMake(8, 12);
 
   // When
-  CGPoint badgePoint =
-      [itemView badgeCenterFromIconFrame:CGRectStandardize(itemView.iconImageView.frame) isRTL:YES];
+  CGPoint badgePoint = [itemView badgeCenterFromIconFrame:CGRectStandardize(itemView.iconImageView.frame) isRTL:YES];
 
   // Then
-  CGRect iconFrame = itemView.iconImageView.frame;
-  CGPoint expectPoint =
-      CGPointMake(CGRectGetMinX(iconFrame),
-                  CGRectGetMinY(iconFrame) + kMDCBottomNavigationItemViewBadgeYOffset);
-  XCTAssertEqualWithAccuracy(badgePoint.x, expectPoint.x, 0.001);
-  XCTAssertEqualWithAccuracy(badgePoint.y, expectPoint.y, 0.001);
+  XCTAssertEqualWithAccuracy(badgePoint.x, expectedCenter.x, 0.001);
+  XCTAssertEqualWithAccuracy(badgePoint.y, expectedCenter.y, 0.001);
 }
 
 @end

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
@@ -14,6 +14,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import "../../src/private/MDCBottomNavigationItemBadge.h"
 #import "../../src/private/MDCBottomNavigationItemView.h"
 
 #import "MaterialInk.h"
@@ -31,6 +32,7 @@ static UIImage *fakeImage(void) {
 @interface MDCBottomNavigationItemView (Testing)
 @property(nonatomic, strong) UIImageView *iconImageView;
 @property(nonatomic, strong) UILabel *label;
+@property(nonatomic, strong) MDCBottomNavigationItemBadge *badge;
 @end
 
 @interface BottomNavigationItemViewTests : XCTestCase
@@ -125,6 +127,44 @@ static UIImage *fakeImage(void) {
   // Then
   XCTAssertNotEqualObjects(item1.inkView.inkColor, item1DefaultInkColor);
   XCTAssertNotEqualObjects(item2.inkView.inkColor, item2DefaultInkColor);
+}
+
+- (void)testBadgeAndIconHaveSameOriginY {
+  // Given
+  CGRect bottomNavFrame = CGRectMake(0, 0, 200, 56);
+  MDCBottomNavigationBar *bottomNavBar =
+      [[MDCBottomNavigationBar alloc] initWithFrame:bottomNavFrame];
+  UITabBarItem *tabBarItem1 =
+      [[UITabBarItem alloc] initWithTitle:@"Home"
+                                    image:fakeImage()
+                                      tag:0];
+  tabBarItem1.badgeValue = @"111";
+
+  UITabBarItem *tabBarItem2 =
+      [[UITabBarItem alloc] initWithTitle:@"Messages"
+                                    image:fakeImage()
+                                      tag:0];
+  tabBarItem2.badgeValue = @"111";
+  
+  UITabBarItem *tabBarItem3 =
+      [[UITabBarItem alloc] initWithTitle:@"Favorites"
+                                    image:fakeImage()
+                                      tag:0];
+  tabBarItem3.badgeValue = @"111";
+  bottomNavBar.items = @[ tabBarItem1, tabBarItem2, tabBarItem3 ];
+  // Setting one selected and 
+  bottomNavBar.titleVisibility = MDCBottomNavigationBarTitleVisibilitySelected;
+  bottomNavBar.selectedItem = tabBarItem2;
+  
+  // When
+  [bottomNavBar setNeedsLayout];
+  [bottomNavBar layoutIfNeeded];
+
+  // Then
+  for (MDCBottomNavigationItemView *itemView in bottomNavBar.subviews) {
+    XCTAssertEqualWithAccuracy(CGRectGetMinY(itemView.badge.frame),
+                               CGRectGetMidY(itemView.iconImageView.frame), 0.001);
+  }
 }
 
 @end

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
@@ -134,29 +134,24 @@ static UIImage *fakeImage(void) {
   CGRect bottomNavFrame = CGRectMake(0, 0, 200, 56);
   MDCBottomNavigationBar *bottomNavBar =
       [[MDCBottomNavigationBar alloc] initWithFrame:bottomNavFrame];
-  UITabBarItem *tabBarItem1 =
-      [[UITabBarItem alloc] initWithTitle:@"Home"
-                                    image:fakeImage()
-                                      tag:0];
+  UITabBarItem *tabBarItem1 = [[UITabBarItem alloc] initWithTitle:@"Home" image:fakeImage() tag:0];
   tabBarItem1.badgeValue = @"111";
 
-  UITabBarItem *tabBarItem2 =
-      [[UITabBarItem alloc] initWithTitle:@"Messages"
-                                    image:fakeImage()
-                                      tag:0];
+  UITabBarItem *tabBarItem2 = [[UITabBarItem alloc] initWithTitle:@"Messages"
+                                                            image:fakeImage()
+                                                              tag:0];
   tabBarItem2.badgeValue = @"111";
-  
-  UITabBarItem *tabBarItem3 =
-      [[UITabBarItem alloc] initWithTitle:@"Favorites"
-                                    image:fakeImage()
-                                      tag:0];
+
+  UITabBarItem *tabBarItem3 = [[UITabBarItem alloc] initWithTitle:@"Favorites"
+                                                            image:fakeImage()
+                                                              tag:0];
   tabBarItem3.badgeValue = @"111";
   bottomNavBar.items = @[ tabBarItem1, tabBarItem2, tabBarItem3 ];
   // Setting one selected and title visablilty to selected test against both with and without
   // a title label.
   bottomNavBar.titleVisibility = MDCBottomNavigationBarTitleVisibilitySelected;
   bottomNavBar.selectedItem = tabBarItem2;
-  
+
   // When
   [bottomNavBar setNeedsLayout];
   [bottomNavBar layoutIfNeeded];

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
@@ -151,7 +151,8 @@ static UIImage *fakeImage(void) {
   CGPoint expectedCenter = CGPointMake(8, 12);
 
   // When
-  CGPoint badgePoint = [itemView badgeCenterFromIconFrame:CGRectStandardize(itemView.iconImageView.frame) isRTL:YES];
+  CGPoint badgePoint =
+      [itemView badgeCenterFromIconFrame:CGRectStandardize(itemView.iconImageView.frame) isRTL:YES];
 
   // Then
   XCTAssertEqualWithAccuracy(badgePoint.x, expectedCenter.x, 0.001);

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
@@ -29,6 +29,8 @@ static UIImage *fakeImage(void) {
   return image;
 }
 
+static const CGFloat kMDCBottomNavigationBadgeYOffset = 4.f;
+
 @interface MDCBottomNavigationItemView (Testing)
 @property(nonatomic, strong) UIImageView *iconImageView;
 @property(nonatomic, strong) UILabel *label;
@@ -161,7 +163,8 @@ static UIImage *fakeImage(void) {
     for (MDCBottomNavigationItemView *itemView in containerView.subviews) {
       CGRect badgeRect = CGRectStandardize(itemView.badge.frame);
       CGRect iconImageRect = CGRectStandardize(itemView.iconImageView.frame);
-      XCTAssertEqualWithAccuracy(badgeRect.origin.y, iconImageRect.origin.y, 0.001);
+      XCTAssertEqualWithAccuracy(badgeRect.origin.y + kMDCBottomNavigationBadgeYOffset,
+                                 iconImageRect.origin.y, 0.001);
     }
   }
 }

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
@@ -162,8 +162,8 @@ static const CGFloat kMDCBottomNavigationItemViewBadgeYOffset = 4.f;
   // Then
   CGRect iconFrame = itemView.iconImageView.frame;
   CGPoint expectPoint =
-  CGPointMake(CGRectGetMinX(iconFrame),
-              CGRectGetMinY(iconFrame) + kMDCBottomNavigationItemViewBadgeYOffset);
+      CGPointMake(CGRectGetMinX(iconFrame),
+                  CGRectGetMinY(iconFrame) + kMDCBottomNavigationItemViewBadgeYOffset);
   XCTAssertEqualWithAccuracy(badgePoint.x, expectPoint.x, 0.001);
   XCTAssertEqualWithAccuracy(badgePoint.y, expectPoint.y, 0.001);
 }

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
@@ -35,7 +35,7 @@ static const CGFloat kMDCBottomNavigationItemViewBadgeYOffset = 4.f;
 @property(nonatomic, strong) UIImageView *iconImageView;
 @property(nonatomic, strong) UILabel *label;
 @property(nonatomic, strong) MDCBottomNavigationItemBadge *badge;
-- (CGPoint)badgeCenterFrom:(CGRect)iconFrame isRTL:(BOOL)isRTL;
+- (CGPoint)badgeCenterFromIconFrame:(CGRect)iconFrame isRTL:(BOOL)isRTL;
 @end
 
 @interface BottomNavigationItemViewTests : XCTestCase
@@ -138,8 +138,8 @@ static const CGFloat kMDCBottomNavigationItemViewBadgeYOffset = 4.f;
   itemView.iconImageView.frame = CGRectMake(8, 8, 24, 24);
 
   // When
-  CGPoint badgePoint = [itemView badgeCenterFrom:CGRectStandardize(itemView.iconImageView.frame)
-                                           isRTL:NO];
+  CGPoint badgePoint =
+      [itemView badgeCenterFromIconFrame:CGRectStandardize(itemView.iconImageView.frame) isRTL:NO];
 
   // Then
   CGRect iconFrame = itemView.iconImageView.frame;
@@ -156,8 +156,8 @@ static const CGFloat kMDCBottomNavigationItemViewBadgeYOffset = 4.f;
   itemView.iconImageView.frame = CGRectMake(8, 8, 24, 24);
 
   // When
-  CGPoint badgePoint = [itemView badgeCenterFrom:CGRectStandardize(itemView.iconImageView.frame)
-                                           isRTL:YES];
+  CGPoint badgePoint =
+      [itemView badgeCenterFromIconFrame:CGRectStandardize(itemView.iconImageView.frame) isRTL:YES];
 
   // Then
   CGRect iconFrame = itemView.iconImageView.frame;


### PR DESCRIPTION
<h4>

```diff
- Warning - This may break screenshot testing -
```
</h4>

### Context
Currently the badge is centered on the top of the `iconImageView`. The `iconImageView`'s  `origin.y` is at 8.883 in MDC because we vertically center the _content_ in the MDCBottomNavigationItemView. We get the _content_ height by:

_contentHeight_ = icon.height + label.height + contentVerticalMargin

_contentVerticalMargin_ is the spacing between the icon and label.

The **_badge_** is 14dp tall. Centering the badge on the `iconImageView`'s `origin.y` puts the badge at 1.883.
### The problem
The badge is too high in relation to the top of the bottom navigation bar and doesn't match internal guidance.
### The fix
Make the badge and iconImageView have the same origin y, giving users more separation between the top of the navigation bar and the top of the badge.
### Related PR
Closes #4731 
### Screenshots
| Before | After |
| - | - |
|![simulator screen shot - iphone x - 2018-10-06 at 11 10 04](https://user-images.githubusercontent.com/7131294/46572709-65fa2f00-c958-11e8-8f57-5c0d389ae7c0.png)|![simulator screen shot - iphone x - 2018-10-06 at 11 09 29](https://user-images.githubusercontent.com/7131294/46572711-698db600-c958-11e8-838e-ee6ec31c7c50.png)|
