### PR TITLE
[Chips] Add support for third party keyboards

### DIFF
--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -31,6 +31,7 @@ mdc_public_objc_library(
         "//components/ShadowElevations",
         "//components/ShadowLayer",
         "//components/TextFields",
+        "//components/TextFields:private",
         "//components/Typography",
         "//components/private/Math",
         "//components/private/ShapeLibrary",

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -16,6 +16,7 @@
 
 #import <MDFInternationalization/MDFInternationalization.h>
 
+#import "../../TextFields/src/private/MDCTextInputCommonFundament.h"
 #import "MaterialMath.h"
 #import "MaterialTextFields.h"
 
@@ -55,6 +56,14 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
 
 @property(nonatomic, weak) id<MDCChipTextFieldDelegate> deletionDelegate;
 
+@end
+
+@interface MDCTextField (Fundament)
+@property(nonatomic, strong) MDCTextInputCommonFundament *fundament;
+@end
+
+@interface MDCTextInputCommonFundament (Placeholder)
+- (void)updatePlaceholderPosition;
 @end
 
 @implementation MDCChipTextField
@@ -330,7 +339,7 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
     [self.delegate chipField:self didRemoveChip:chip];
   }
   [self notifyDelegateIfSizeNeedsToBeUpdated];
-  [self clearTextInput];
+  [self.textField.fundament updatePlaceholderPosition];
   [self invalidateIntrinsicContentSize];
   [self setNeedsLayout];
 }

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -58,11 +58,11 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
 
 @end
 
-@interface MDCTextField (Fundament)
+@interface MDCTextField (MDCChipFieldTestingVisability)
 @property(nonatomic, strong) MDCTextInputCommonFundament *fundament;
 @end
 
-@interface MDCTextInputCommonFundament (Placeholder)
+@interface MDCTextInputCommonFundament (MDCChipFieldTestingVisability)
 - (void)updatePlaceholderPosition;
 @end
 

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -58,11 +58,11 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
 
 @end
 
-@interface MDCTextField (MDCChipFieldTestingVisability)
+@interface MDCTextField (MDCChipFieldTestingVisibility)
 @property(nonatomic, strong) MDCTextInputCommonFundament *fundament;
 @end
 
-@interface MDCTextInputCommonFundament (MDCChipFieldTestingVisability)
+@interface MDCTextInputCommonFundament (MDCChipFieldTestingVisibility)
 - (void)updatePlaceholderPosition;
 @end
 

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -330,6 +330,7 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
     [self.delegate chipField:self didRemoveChip:chip];
   }
   [self notifyDelegateIfSizeNeedsToBeUpdated];
+  [self clearTextInput];
   [self invalidateIntrinsicContentSize];
   [self setNeedsLayout];
 }

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -294,6 +294,39 @@ static inline UIImage *TestImage(CGSize size) {
                         withEvent:nil]);
 }
 
+- (void)testRemoveChipsManually {
+  // Given
+  MDCChipField *field = [[MDCChipField alloc] init];
+  field.frame = CGRectMake(0, 0, 200, 50);
+  field.textField.text = @"Test";
+  field.textField.placeholder = @"Test";
+  [field setNeedsLayout];
+  [field layoutIfNeeded];
+  CGFloat initialPlaceholderOriginX =
+      CGRectStandardize(field.textField.placeholderLabel.frame).origin.x;
+
+  // When
+  [field createNewChipFromInput];
+  [field layoutIfNeeded];
+
+  // Then
+  CGFloat placeholderWithChipOriginX =
+      CGRectStandardize(field.textField.placeholderLabel.frame).origin.x;
+  // Guard's against a silent fail
+  XCTAssertGreaterThan(placeholderWithChipOriginX, initialPlaceholderOriginX);
+  XCTAssertNotEqual(field.chips.count, 0U);
+
+  // When
+  MDCChipView *chip = field.chips[0];
+  [field removeChip:chip];
+  [field layoutIfNeeded];
+
+  // Then
+  CGFloat finalPlaceholderPositionOriginX =
+      CGRectStandardize(field.textField.placeholderLabel.frame).origin.x;
+  XCTAssertEqualWithAccuracy(initialPlaceholderOriginX, finalPlaceholderPositionOriginX, 0.001);
+}
+
 - (void)testChipsWithoutDeleteEnabled {
   // Given
   MDCChipField *field = [[MDCChipField alloc] init];

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -302,21 +302,12 @@ static inline UIImage *TestImage(CGSize size) {
   field.textField.placeholder = @"Test";
   [field setNeedsLayout];
   [field layoutIfNeeded];
-  CGFloat initialPlaceholderOriginX =
-      CGRectStandardize(field.textField.placeholderLabel.frame).origin.x;
 
   // When
   [field createNewChipFromInput];
   [field layoutIfNeeded];
-
-  // Then
   CGFloat placeholderWithChipOriginX =
       CGRectStandardize(field.textField.placeholderLabel.frame).origin.x;
-  // Guard's against a silent fail
-  XCTAssertGreaterThan(placeholderWithChipOriginX, initialPlaceholderOriginX);
-  XCTAssertNotEqual(field.chips.count, 0U);
-
-  // When
   MDCChipView *chip = field.chips[0];
   [field removeChip:chip];
   [field layoutIfNeeded];
@@ -324,7 +315,7 @@ static inline UIImage *TestImage(CGSize size) {
   // Then
   CGFloat finalPlaceholderPositionOriginX =
       CGRectStandardize(field.textField.placeholderLabel.frame).origin.x;
-  XCTAssertEqualWithAccuracy(initialPlaceholderOriginX, finalPlaceholderPositionOriginX, 0.001);
+  XCTAssertGreaterThan(placeholderWithChipOriginX, finalPlaceholderPositionOriginX);
 }
 
 - (void)testChipsWithoutDeleteEnabled {


### PR DESCRIPTION
### Context
A client found that MDCChipFields were acting differently when used with a third party keyboard (GBoard).
### The problem
When a user adds a chip and then taps the "delete" key on the keyboard the chip would delete but the placeholder would not move to the correct place. 
### The fix
Adding a call to `clearTextInput` within the `removeChips` function updates the placeholder to act the way it should. This is the only call in `createNewChipFromInput` that has any effect on the placeholder, so this behavior is the same as when we add the chip.
### Related Bugs
b/116498542

### Tests
Since this is a third party keyboard causing the error, I don't think test are necessary for this PR.

### Videos
| Before | After |
| - | - |
| ![beforeupdate](https://user-images.githubusercontent.com/7131294/46608108-987b6780-cad1-11e8-80f1-cfed266680af.gif)|![chipsafterdelete](https://user-images.githubusercontent.com/7131294/46608114-9e714880-cad1-11e8-85fa-c7abae943290.gif)|


