### PR TITLE
[Chips] Fix placeholder for manually adding chips

### DIFF
--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -58,11 +58,11 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
 
 @end
 
-@interface MDCTextField (MDCChipFieldTestingVisibility)
+@interface MDCTextField (MDCChipFieldTestingVisability)
 @property(nonatomic, strong) MDCTextInputCommonFundament *fundament;
 @end
 
-@interface MDCTextInputCommonFundament (MDCChipFieldTestingVisibility)
+@interface MDCTextInputCommonFundament (MDCChipFieldTestingVisability)
 - (void)updatePlaceholderPosition;
 @end
 

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -58,11 +58,11 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
 
 @end
 
-@interface MDCTextField (MDCChipFieldTestingVisability)
+@interface MDCTextField (MDCChipFieldTestingVisibility)
 @property(nonatomic, strong) MDCTextInputCommonFundament *fundament;
 @end
 
-@interface MDCTextInputCommonFundament (MDCChipFieldTestingVisability)
+@interface MDCTextInputCommonFundament (MDCChipFieldTestingVisibility)
 - (void)updatePlaceholderPosition;
 @end
 

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -19,7 +19,6 @@
 #import "../../TextFields/src/private/MDCTextInputCommonFundament.h"
 #import "MaterialMath.h"
 #import "MaterialTextFields.h"
-#import "../../TextFields/src/private/MDCTextInputCommonFundament.h"
 
 static NSString *const MDCChipFieldTextFieldKey = @"textField";
 static NSString *const MDCChipFieldDelegateKey = @"delegate";

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -327,6 +327,7 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
   if ([self.delegate respondsToSelector:@selector(chipField:didAddChip:)]) {
     [self.delegate chipField:self didAddChip:chip];
   }
+  [self clearTextInput];
   [self notifyDelegateIfSizeNeedsToBeUpdated];
   [self invalidateIntrinsicContentSize];
   [self setNeedsLayout];

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -19,6 +19,7 @@
 #import "../../TextFields/src/private/MDCTextInputCommonFundament.h"
 #import "MaterialMath.h"
 #import "MaterialTextFields.h"
+#import "../../TextFields/src/private/MDCTextInputCommonFundament.h"
 
 static NSString *const MDCChipFieldTextFieldKey = @"textField";
 static NSString *const MDCChipFieldDelegateKey = @"delegate";
@@ -327,7 +328,7 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
   if ([self.delegate respondsToSelector:@selector(chipField:didAddChip:)]) {
     [self.delegate chipField:self didAddChip:chip];
   }
-  [self clearTextInput];
+  [self.textField.fundament updatePlaceholderPosition];
   [self notifyDelegateIfSizeNeedsToBeUpdated];
   [self invalidateIntrinsicContentSize];
   [self setNeedsLayout];

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -318,6 +318,26 @@ static inline UIImage *TestImage(CGSize size) {
   XCTAssertGreaterThan(placeholderWithChipOriginX, finalPlaceholderPositionOriginX);
 }
 
+- (void)testAddChipsManuallyPlaceholderCorrectPosition {
+  // Given
+  MDCChipView *fakeChip = [[MDCChipView alloc] init];
+  fakeChip.titleLabel.text = @"Fake chip";
+  MDCChipField *fakeField = [[MDCChipField alloc] init];
+  fakeField.frame = CGRectMake(0, 0, 200, 100);
+
+  // When
+  [fakeField setNeedsLayout];
+  [fakeField layoutIfNeeded];
+  [fakeField addChip:fakeChip];
+  [fakeField layoutIfNeeded];
+
+  // Then
+  CGRect placeholderFrame = CGRectStandardize(fakeField.textField.placeholderLabel.frame);
+  // MDCTextField's adds 8dp padding to the text
+  CGFloat expectedXPosition = CGRectGetWidth(fakeChip.frame) + 8.f;
+  XCTAssertEqual(placeholderFrame.origin.x, expectedXPosition);
+}
+
 - (void)testChipsWithoutDeleteEnabled {
   // Given
   MDCChipField *field = [[MDCChipField alloc] init];

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -324,6 +324,7 @@ static inline UIImage *TestImage(CGSize size) {
   fakeChip.titleLabel.text = @"Fake chip";
   MDCChipField *fakeField = [[MDCChipField alloc] init];
   fakeField.frame = CGRectMake(0, 0, 200, 100);
+  fakeField.textField.placeholder = @"Test";
 
   // When
   [fakeField setNeedsLayout];

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -329,14 +329,15 @@ static inline UIImage *TestImage(CGSize size) {
   // When
   [fakeField setNeedsLayout];
   [fakeField layoutIfNeeded];
+  CGFloat initialPlaceholderOriginX =
+      CGRectStandardize(fakeField.textField.placeholderLabel.frame).origin.x;
   [fakeField addChip:fakeChip];
   [fakeField layoutIfNeeded];
 
   // Then
-  CGRect placeholderFrame = CGRectStandardize(fakeField.textField.placeholderLabel.frame);
-  // MDCTextField's adds 8dp padding to the text
-  CGFloat expectedXPosition = CGRectGetWidth(fakeChip.frame) + 8.f;
-  XCTAssertEqual(placeholderFrame.origin.x, expectedXPosition);
+  CGFloat finalPlaceholderOriginX =
+      CGRectStandardize(fakeField.textField.placeholderLabel.frame).origin.x;
+  XCTAssertGreaterThan(finalPlaceholderOriginX, initialPlaceholderOriginX);
 }
 
 - (void)testChipsWithoutDeleteEnabled {

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -332,6 +332,8 @@ static inline UIImage *TestImage(CGSize size) {
   CGFloat initialPlaceholderOriginX =
       CGRectStandardize(fakeField.textField.placeholderLabel.frame).origin.x;
   [fakeField addChip:fakeChip];
+  fakeField.textField.placeholder = fakeField.textField.placeholder;
+  [fakeField setNeedsLayout];
   [fakeField layoutIfNeeded];
 
   // Then


### PR DESCRIPTION
### Context
A client is adding chips using the `addChip` function with chips they have created. 
### The problem
When you call the `addChip` function with your custom chip the placeholder wouldn't update its position.
### The fix
Add a call to `clearTextInput` within the `addChip` function, this matches what is done in `createNewChipFromInput`.
### Related bugs
b/116495610

### Alternatives
We could expose the `clearTextInput` method and allow clients to call that right after they call `addChip`
or
We could ask clients to update the placeholder within the MDCTextField in MDCChipField
Neither of which I felt was as clean as this approach.

### Videos

| Before | After |
| - | - | 
|![develop](https://user-images.githubusercontent.com/7131294/46609394-bc40ac80-cad5-11e8-8b4e-b07265007da3.gif)|![chips-add](https://user-images.githubusercontent.com/7131294/46609399-bfd43380-cad5-11e8-8322-d1763b9cba68.gif)|

**_Note_** In video I am tapping the "add chip" button.

### Snippet to reproduce
```diff
+ ChipsInputExampleViewController.m
```

```objectivec

- (void)viewDidLoad {
  UIButton *_button = [[UIButton alloc] init];
  _button.backgroundColor = self.colorScheme.onBackgroundColor;
  [_button setTitle:@"Add chip" forState:UIControlStateNormal];
  [_button sizeToFit];
  _button.center = self.view.center;
  [_button addTarget:self action:@selector(addChipX) forControlEvents:UIControlEventTouchUpInside];
  [self.view addSubview:_button];
}
- (void)addChipX {
  MDCChipView *chip = [[MDCChipView alloc] init];
  chip.titleLabel.text = @"Chips";
  MDCChipViewScheme *scheme = [[MDCChipViewScheme alloc] init];
  scheme.colorScheme = self.colorScheme;
  scheme.typographyScheme = self.typographyScheme;
  scheme.shapeScheme = self.shapeScheme;
  [MDCChipViewThemer applyScheme:scheme toChipView:chip];

  [_chipField addChip:chip];
}
```