### PR TITLE
[ActionSheet] Add action sheet themer

### DIFF
--- a/MaterialComponentsAlpha.podspec
+++ b/MaterialComponentsAlpha.podspec
@@ -31,6 +31,14 @@ Pod::Spec.new do |mdc|
     end
   end
 
+  mdc.subspec "ActionSheet+ActionSheetThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponentsAlpha/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/schemes/Color"
+  end
+
   mdc.subspec "ActionSheet+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
     extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"

--- a/MaterialComponentsAlpha.podspec
+++ b/MaterialComponentsAlpha.podspec
@@ -37,6 +37,7 @@ Pod::Spec.new do |mdc|
     extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
     extension.dependency "MaterialComponentsAlpha/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Color"
+    extension.dependency "MaterialComponents/schemes/Typography"
   end
 
   mdc.subspec "ActionSheet+ColorThemer" do |extension|

--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -32,6 +32,20 @@ mdc_public_objc_library(
 )
 
 mdc_objc_library(
+    name = "ActionSheetThemer",
+    srcs = native.glob(["src/ActionSheetThemer/*.m"]),
+    hdrs = native.glob(["src/ActionSheetThemer/*.h"]),
+    includes = ["src/ActionSheetThemer"],
+    sdk_frameworks = ["UIKit"],
+    deps = [
+        ":ActionSheet",
+        ":TypographyThemer",
+        ":ColorThemer",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+mdc_objc_library(
     name = "TypographyThemer",
     srcs = native.glob(["src/TypographyThemer/*.m"]),
     hdrs = native.glob(["src/TypographyThemer/*.h"]),
@@ -97,6 +111,7 @@ mdc_objc_library(
     ],
     deps = [
          ":ActionSheet",
+         ":ActionSheetThemer",
          ":ColorThemer",
          ":TypographyThemer",
          ":privateHeaders"

--- a/components/ActionSheet/src/ActionSheetThemer/MDCActionSheetScheme.h
+++ b/components/ActionSheet/src/ActionSheetThemer/MDCActionSheetScheme.h
@@ -1,0 +1,59 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialColorScheme.h"
+#import "MaterialTypographyScheme.h"
+
+#import <Foundation/Foundation.h>
+
+/**
+ MDCActionSheetScheming represents the design parameters for an MDCActionSheet.
+
+ An instance of this protocol can be applied to an instance of MDCAction using the
+ MDCActionSheetThemer API.
+ */
+@protocol MDCActionSheetScheming
+
+/**
+ The color scheme to be applied to an action sheet.
+ */
+@property(nonnull, readonly, nonatomic) id<MDCColorScheming> colorScheme;
+
+/**
+ The typography scheme to be applied to an action sheet.
+ */
+@property(nonnull, readonly, nonatomic) id<MDCTypographyScheming> typographyScheme;
+
+@end
+
+/**
+ An MDCActionSheetScheme is a mutable representation of the design parameters for an MDCActionSheet.
+ */
+@interface MDCActionSheetScheme : NSObject <MDCActionSheetScheming>
+
+/**
+ A mutable representation of a color scheme.
+
+ By default, this is initialized with the latest color scheme defaults.
+ */
+@property(nonnull, readwrite, nonatomic) id<MDCColorScheming> colorScheme;
+
+/**
+ A mutable representation of a typography scheme.
+
+ By default, this is initialized with the latest typography scheme defaults.
+ */
+@property(nonnull, readwrite, nonatomic) id<MDCTypographyScheming> typographyScheme;
+
+@end

--- a/components/ActionSheet/src/ActionSheetThemer/MDCActionSheetScheme.m
+++ b/components/ActionSheet/src/ActionSheetThemer/MDCActionSheetScheme.m
@@ -1,0 +1,28 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCActionSheetScheme.h"
+
+@implementation MDCActionSheetScheme
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _colorScheme = [[MDCSemanticColorScheme alloc] init];
+    _typographyScheme = [[MDCTypographyScheme alloc] init];
+  }
+  return self;
+}
+
+@end

--- a/components/ActionSheet/src/ActionSheetThemer/MDCActionSheetThemer.h
+++ b/components/ActionSheet/src/ActionSheetThemer/MDCActionSheetThemer.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MaterialActionSheet.h"
 #import "MDCActionSheetScheme.h"
+#import "MaterialActionSheet.h"
 
 #import <Foundation/Foundation.h>
 

--- a/components/ActionSheet/src/ActionSheetThemer/MDCActionSheetThemer.h
+++ b/components/ActionSheet/src/ActionSheetThemer/MDCActionSheetThemer.h
@@ -1,0 +1,34 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialActionSheet.h"
+#import "MDCActionSheetScheme.h"
+
+#import <Foundation/Foundation.h>
+
+/**
+ The Material Design action sheet themer for instances of MDCActionSheet.
+ */
+@interface MDCActionSheetThemer : NSObject
+
+/**
+ Applies a action scheme's properties to an MDCActionSheet.
+
+ @param scheme The action sheet scheme to apply to the component instance.
+ @param  actionSheetController component instance to which the scheme should be applied.
+ */
++ (void)applyScheme:(nonnull id<MDCActionSheetScheming>)scheme
+    toActionSheetController:(nonnull MDCActionSheetController *)actionSheetController;
+
+@end

--- a/components/ActionSheet/src/ActionSheetThemer/MDCActionSheetThemer.m
+++ b/components/ActionSheet/src/ActionSheetThemer/MDCActionSheetThemer.m
@@ -19,9 +19,12 @@
 
 @implementation MDCActionSheetThemer
 
-+ (void)applyScheme:(id<MDCActionSheetScheming>)scheme toActionSheetController:(MDCActionSheetController *)actionSheetController {
-  [MDCActionSheetColorThemer applySemanticColorScheme:scheme.colorScheme toActionSheetController:actionSheetController];
-  [MDCActionSheetTypographyThemer applyTypographyScheme:scheme.typographyScheme toActionSheetController:actionSheetController];
++ (void)applyScheme:(id<MDCActionSheetScheming>)scheme
+    toActionSheetController:(MDCActionSheetController *)actionSheetController {
+  [MDCActionSheetColorThemer applySemanticColorScheme:scheme.colorScheme
+                              toActionSheetController:actionSheetController];
+  [MDCActionSheetTypographyThemer applyTypographyScheme:scheme.typographyScheme
+                                toActionSheetController:actionSheetController];
 }
 
 @end

--- a/components/ActionSheet/src/ActionSheetThemer/MDCActionSheetThemer.m
+++ b/components/ActionSheet/src/ActionSheetThemer/MDCActionSheetThemer.m
@@ -1,0 +1,27 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCActionSheetThemer.h"
+
+#import "MaterialActionSheet+ColorThemer.h"
+#import "MaterialActionSheet+TypographyThemer.h"
+
+@implementation MDCActionSheetThemer
+
++ (void)applyScheme:(id<MDCActionSheetScheming>)scheme toActionSheetController:(MDCActionSheetController *)actionSheetController {
+  [MDCActionSheetColorThemer applySemanticColorScheme:scheme.colorScheme toActionSheetController:actionSheetController];
+  [MDCActionSheetTypographyThemer applyTypographyScheme:scheme.typographyScheme toActionSheetController:actionSheetController];
+}
+
+@end

--- a/components/ActionSheet/src/ActionSheetThemer/MaterialActionSheet+ActionSheetThemer.h
+++ b/components/ActionSheet/src/ActionSheetThemer/MaterialActionSheet+ActionSheetThemer.h
@@ -1,0 +1,16 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCActionSheetScheme.h"
+#import "MDCActionSheetThemer.h"

--- a/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
@@ -51,8 +51,8 @@ static const CGFloat kInkAlpha = 0.16f;
   self.colorScheme = [[MDCSemanticColorScheme alloc] init];
   UIColor *surface = UIColor.blueColor;
   UIColor *onSurface = UIColor.redColor;
-  self.colorScheme.primaryColor = surface;
-  self.colorScheme.onPrimaryColor = onSurface;
+  self.colorScheme.surfaceColor = surface;
+  self.colorScheme.onSurfaceColor = onSurface;
   self.typographyScheme = [[MDCTypographyScheme alloc] init];
   UIFont *subtitle = [UIFont systemFontOfSize:12.0 weight:UIFontWeightBold];
   UIFont *body2 = [UIFont systemFontOfSize:10.0 weight:UIFontWeightLight];
@@ -69,8 +69,12 @@ static const CGFloat kInkAlpha = 0.16f;
   MDCSemanticColorScheme *defaultColorScheme = [[MDCSemanticColorScheme alloc] init];
 
   // Then
-  XCTAssertEqualObjects(defaultScheme.typographyScheme, defaultTypographyScheme);
-  XCTAssertEqualObjects(defaultScheme.colorScheme, defaultColorScheme);
+  XCTAssertEqualObjects(defaultScheme.typographyScheme.subtitle1,
+                        defaultTypographyScheme.subtitle1);
+  XCTAssertEqualObjects(defaultScheme.typographyScheme.body2, defaultTypographyScheme.body2);
+  XCTAssertEqualObjects(defaultScheme.colorScheme.surfaceColor, defaultColorScheme.surfaceColor);
+  XCTAssertEqualObjects(defaultScheme.colorScheme.onSurfaceColor,
+                        defaultColorScheme.onSurfaceColor);
 }
 
 - (void)testCustomColorSchemeAppliedToGlobalScheme {

--- a/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
@@ -60,6 +60,43 @@ static const CGFloat kInkAlpha = 0.16f;
   self.typographyScheme.body2 = body2;
 }
 
+#pragma mark - Scheme test
+
+- (void)testDefaultScheme {
+  // Given
+  MDCActionSheetScheme *defaultScheme = [[MDCActionSheetScheme alloc] init];
+  MDCTypographyScheme *defaultTypographyScheme = [[MDCTypographyScheme alloc] init];
+  MDCSemanticColorScheme *defaultColorScheme = [[MDCSemanticColorScheme alloc] init];
+
+  // Then
+  XCTAssertEqualObjects(defaultScheme.typographyScheme, defaultTypographyScheme);
+  XCTAssertEqualObjects(defaultScheme.colorScheme, defaultColorScheme);
+}
+
+- (void)testCustomColorSchemeAppliedToGlobalScheme {
+  // Given
+  MDCActionSheetScheme *scheme = [[MDCActionSheetScheme alloc] init];
+
+  // When
+  scheme.colorScheme = self.colorScheme;
+
+  // Then
+  XCTAssertEqualObjects(scheme.colorScheme.surfaceColor, self.colorScheme.surfaceColor);
+  XCTAssertEqualObjects(scheme.colorScheme.onSurfaceColor, self.colorScheme.onSurfaceColor);
+}
+
+- (void)testCustomTypographySchemeAppliedToGlobalScheme {
+  // Given
+  MDCActionSheetScheme *scheme = [[MDCActionSheetScheme alloc] init];
+
+  // When
+  scheme.typographyScheme = self.typographyScheme;
+
+  // Then
+  XCTAssertEqualObjects(scheme.typographyScheme.subtitle1, self.typographyScheme.subtitle1);
+  XCTAssertEqualObjects(scheme.typographyScheme.body2, self.typographyScheme.body2);
+}
+
 #pragma mark - Header test
 
 - (void)testApplyColorThemerWithTitleAndMessage {

--- a/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetThemeTest.m
@@ -17,6 +17,7 @@
 #import "../../src/private/MDCActionSheetHeaderView.h"
 #import "../../src/private/MDCActionSheetItemTableViewCell.h"
 #import "MDCActionSheetTestHelper.h"
+#import "MaterialActionSheet+ActionSheetThemer.h"
 #import "MaterialActionSheet+ColorThemer.h"
 #import "MaterialActionSheet+TypographyThemer.h"
 
@@ -104,6 +105,31 @@ static const CGFloat kInkAlpha = 0.16f;
 }
 
 #pragma mark - default test
+
+- (void)testApplyThemer {
+  // Given
+  MDCActionSheetController *tempActionSheet = [[MDCActionSheetController alloc] init];
+  MDCActionSheetScheme *scheme = [[MDCActionSheetScheme alloc] init];
+  scheme.colorScheme = self.colorScheme;
+  scheme.typographyScheme = self.typographyScheme;
+
+  // When
+  [MDCActionSheetThemer applyScheme:scheme toActionSheetController:tempActionSheet];
+  [MDCActionSheetColorThemer applySemanticColorScheme:self.colorScheme
+                              toActionSheetController:self.actionSheet];
+  [MDCActionSheetTypographyThemer applyTypographyScheme:self.typographyScheme
+                                toActionSheetController:self.actionSheet];
+
+  // Then
+  XCTAssertEqualObjects(tempActionSheet.backgroundColor, self.actionSheet.backgroundColor);
+  XCTAssertEqualObjects(tempActionSheet.titleTextColor, self.actionSheet.titleTextColor);
+  XCTAssertEqualObjects(tempActionSheet.messageTextColor, self.actionSheet.messageTextColor);
+  XCTAssertEqualObjects(tempActionSheet.titleFont, self.actionSheet.titleFont);
+  XCTAssertEqualObjects(tempActionSheet.messageFont, self.actionSheet.messageFont);
+  XCTAssertEqualObjects(tempActionSheet.actionFont, self.actionSheet.actionFont);
+  XCTAssertEqualObjects(tempActionSheet.actionTintColor, self.actionSheet.actionTintColor);
+  XCTAssertEqualObjects(tempActionSheet.actionTextColor, self.actionSheet.actionTextColor);
+}
 
 - (void)testApplyColorTheme {
   // When


### PR DESCRIPTION
### Context
On of the requirements for new components is to have a _themer_ that applies the typography and color schemes as well as any other properties that are needed to the component.
### The problem
Action sheet didn't have one it just had a color and typography themer that were separate.
### The fix
This PR adds a component themer that applies the typography and color schemes to the component.
