### PR TITLE
[Dialogs] add scrimColor to MDCAlertController

### DIFF
--- a/components/Dialogs/examples/DialogsAlertCustomizationViewController.swift
+++ b/components/Dialogs/examples/DialogsAlertCustomizationViewController.swift
@@ -166,7 +166,7 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
   func performScrimColor() -> MDCAlertController {
     let alert = createMDCAlertController(title: "Darker Scrim")
     MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
-    alert.mdc_dialogPresentationController?.scrimColor = UIColor.black.withAlphaComponent(0.6)
+    alert.scrimColor = UIColor.black.withAlphaComponent(0.6)
     return alert
   }
 

--- a/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
+++ b/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
@@ -25,13 +25,7 @@
   alertController.messageColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
   alertController.buttonTitleColor = colorScheme.primaryColor;
   alertController.titleIconTintColor = colorScheme.primaryColor;
-
-  MDCDialogPresentationController *dialogPresentationController =
-      alertController.mdc_dialogPresentationController;
-  if (dialogPresentationController) {
-    dialogPresentationController.scrimColor =
-        [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.32];
-  }
+  alertController.scrimColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.32];
 }
 
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme {

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -97,6 +97,9 @@
 /** The color applied to the button ink effect of Alert Controller.*/
 @property(nonatomic, strong, nullable) UIColor *buttonInkColor;
 
+/** The color applied to the Alert's background when presented by MDCDialogPresentationController.*/
+@property(nonatomic, strong, nullable) UIColor *scrimColor;
+
 /** The corner radius applied to the Alert Controller view. Default to 0 (no round corners) */
 @property(nonatomic, assign) CGFloat cornerRadius;
 

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -236,11 +236,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 
 - (void)setScrimColor:(UIColor *)scrimColor {
   _scrimColor = scrimColor;
-  MDCDialogPresentationController *dialogPresentationController =
-      self.mdc_dialogPresentationController;
-  if (dialogPresentationController) {
-    dialogPresentationController.scrimColor = scrimColor;
-  }
+  self.mdc_dialogPresentationController.scrimColor = scrimColor;
 }
 
 - (void)setCornerRadius:(CGFloat)cornerRadius {
@@ -248,21 +244,12 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   if (self.alertView) {
     self.alertView.cornerRadius = cornerRadius;
   }
-  // make sure to pass the new shape through to the dialog's tracking/shadow layer
-  MDCDialogPresentationController *dialogPresentationController =
-      self.mdc_dialogPresentationController;
-  if (dialogPresentationController) {
-    dialogPresentationController.dialogCornerRadius = cornerRadius;
-  }
+  self.mdc_dialogPresentationController.dialogCornerRadius = cornerRadius;
 }
 
 - (void)setElevation:(CGFloat)elevation {
   _elevation = elevation;
-  MDCDialogPresentationController *dialogPresentationController =
-      self.mdc_dialogPresentationController;
-  if (dialogPresentationController) {
-    dialogPresentationController.dialogElevation = elevation;
-  }
+  self.mdc_dialogPresentationController.dialogElevation = elevation;
 }
 
 - (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -234,6 +234,16 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   }
 }
 
+- (void)setScrimColor:(UIColor *)scrimColor {
+  _scrimColor = scrimColor;
+  // make sure to pass the new shape through to the dialog's tracking/shadow layer
+  MDCDialogPresentationController *dialogPresentationController =
+      self.mdc_dialogPresentationController;
+  if (dialogPresentationController) {
+    dialogPresentationController.scrimColor = scrimColor;
+  }
+}
+
 - (void)setCornerRadius:(CGFloat)cornerRadius {
   _cornerRadius = cornerRadius;
   if (self.alertView) {

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -236,7 +236,6 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 
 - (void)setScrimColor:(UIColor *)scrimColor {
   _scrimColor = scrimColor;
-  // make sure to pass the new shape through to the dialog's tracking/shadow layer
   MDCDialogPresentationController *dialogPresentationController =
       self.mdc_dialogPresentationController;
   if (dialogPresentationController) {

--- a/components/Dialogs/tests/unit/MDCAlertControllerCustomizationTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerCustomizationTests.m
@@ -31,6 +31,7 @@
 - (void)setUp {
   [super setUp];
   self.alert = [MDCAlertController alertControllerWithTitle:@"Title" message:@"Message"];
+  XCTAssertTrue([self.alert.view isKindOfClass:[MDCAlertControllerView class]]);
   self.alertView = (MDCAlertControllerView *)self.alert.view;
   self.presentationController = self.alert.mdc_dialogPresentationController;
 }

--- a/components/Dialogs/tests/unit/MDCAlertControllerCustomizationTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerCustomizationTests.m
@@ -93,7 +93,7 @@ MDCAlertControllerView *alertView;
 
 - (void)testApplyingScrimColorToPresentationController {
   // Given
-  UIColor *scrimColor = [UIColor.orangeColor colorWithAlphaComponent:0.5];
+  UIColor *scrimColor = [UIColor.orangeColor colorWithAlphaComponent:0.5f];
   MDCDialogPresentationController *presentationController = alert.mdc_dialogPresentationController;
   if (presentationController == nil) {
     return;  // don't fail the test if mdc_dialogPresentationController is nil
@@ -108,7 +108,7 @@ MDCAlertControllerView *alertView;
 
 - (void)testApplyingScrimColorToAlert {
   // Given
-  UIColor *scrimColor = [UIColor.blueColor colorWithAlphaComponent:0.3];
+  UIColor *scrimColor = [UIColor.blueColor colorWithAlphaComponent:0.3f];
   MDCDialogPresentationController *presentationController = alert.mdc_dialogPresentationController;
   if (presentationController == nil) {
     return;  // don't fail the test if mdc_dialogPresentationController is nil

--- a/components/Dialogs/tests/unit/MDCAlertControllerCustomizationTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerCustomizationTests.m
@@ -20,18 +20,19 @@
 #import <XCTest/XCTest.h>
 
 @interface MDCAlertControllerCustomizationTests : XCTestCase
+@property(nonatomic, nullable, strong) MDCAlertController *alert;
+@property(nonatomic, nullable, weak) MDCAlertControllerView *alertView;
+@property(nonatomic, nullable, weak) MDCDialogPresentationController *presentationController;
 
 @end
 
 @implementation MDCAlertControllerCustomizationTests
 
-MDCAlertController *alert;
-MDCAlertControllerView *alertView;
-
 - (void)setUp {
   [super setUp];
-  alert = [MDCAlertController alertControllerWithTitle:@"Title" message:@"Message"];
-  alertView = (MDCAlertControllerView *)alert.view;
+  self.alert = [MDCAlertController alertControllerWithTitle:@"Title" message:@"Message"];
+  self.alertView = (MDCAlertControllerView *)self.alert.view;
+  self.presentationController = self.alert.mdc_dialogPresentationController;
 }
 
 - (void)testApplyingTitleAlignment {
@@ -39,11 +40,11 @@ MDCAlertControllerView *alertView;
   NSTextAlignment titleAlignment = NSTextAlignmentCenter;
 
   // When
-  alert.titleAlignment = titleAlignment;
+  self.alert.titleAlignment = titleAlignment;
 
   // Then
-  XCTAssertEqual(alertView.titleAlignment, titleAlignment);
-  XCTAssertEqual(alertView.titleLabel.textAlignment, titleAlignment);
+  XCTAssertEqual(self.alertView.titleAlignment, titleAlignment);
+  XCTAssertEqual(self.alertView.titleLabel.textAlignment, titleAlignment);
 }
 
 - (void)testAddingTitleIconToAlert {
@@ -51,12 +52,12 @@ MDCAlertControllerView *alertView;
   UIImage *icon = TestImage(CGSizeMake(24, 24));
 
   // When
-  alert.titleIcon = icon;
+  self.alert.titleIcon = icon;
 
   // Then
-  XCTAssertNotNil(alert.titleIcon);
-  XCTAssertEqual(alertView.titleIcon, icon);
-  XCTAssertEqual(alertView.titleIconImageView.image, icon);
+  XCTAssertNotNil(self.alert.titleIcon);
+  XCTAssertEqual(self.alertView.titleIcon, icon);
+  XCTAssertEqual(self.alertView.titleIconImageView.image, icon);
 }
 
 - (void)testApplyingTintToTitleIcon {
@@ -65,14 +66,14 @@ MDCAlertControllerView *alertView;
   UIColor *tintColor = UIColor.orangeColor;
 
   // When
-  alert.titleIcon = icon;
-  alert.titleIconTintColor = tintColor;
+  self.alert.titleIcon = icon;
+  self.alert.titleIconTintColor = tintColor;
 
   // Then
-  XCTAssertNotNil(alert.titleIcon);
-  XCTAssertEqualObjects(alertView.titleIcon, icon);
-  XCTAssertEqualObjects(alertView.titleIconTintColor, tintColor);
-  XCTAssertEqualObjects(alertView.titleIconImageView.tintColor, tintColor);
+  XCTAssertNotNil(self.alert.titleIcon);
+  XCTAssertEqualObjects(self.alertView.titleIcon, icon);
+  XCTAssertEqualObjects(self.alertView.titleIconTintColor, tintColor);
+  XCTAssertEqualObjects(self.alertView.titleIconImageView.tintColor, tintColor);
 }
 
 - (void)testApplyingTintToTitleIconInAnyOrder {
@@ -81,44 +82,36 @@ MDCAlertControllerView *alertView;
   UIColor *tintColor = UIColor.orangeColor;
 
   // When
-  alert.titleIconTintColor = tintColor;
-  alert.titleIcon = icon;
+  self.alert.titleIconTintColor = tintColor;
+  self.alert.titleIcon = icon;
 
   // Then
-  XCTAssertNotNil(alert.titleIcon);
-  XCTAssertEqualObjects(alertView.titleIcon, icon);
-  XCTAssertEqualObjects(alertView.titleIconTintColor, tintColor);
-  XCTAssertEqualObjects(alertView.titleIconImageView.tintColor, tintColor);
+  XCTAssertNotNil(self.alert.titleIcon);
+  XCTAssertEqualObjects(self.alertView.titleIcon, icon);
+  XCTAssertEqualObjects(self.alertView.titleIconTintColor, tintColor);
+  XCTAssertEqualObjects(self.alertView.titleIconImageView.tintColor, tintColor);
 }
 
 - (void)testApplyingScrimColorToPresentationController {
   // Given
   UIColor *scrimColor = [UIColor.orangeColor colorWithAlphaComponent:0.5f];
-  MDCDialogPresentationController *presentationController = alert.mdc_dialogPresentationController;
-  if (presentationController == nil) {
-    return;  // don't fail the test if mdc_dialogPresentationController is nil
-  }
 
   // When
-  presentationController.scrimColor = scrimColor;
+  self.presentationController.scrimColor = scrimColor;
 
   // Then
-  XCTAssertEqualObjects(presentationController.scrimColor, scrimColor);
+  XCTAssertEqualObjects(self.presentationController.scrimColor, scrimColor);
 }
 
 - (void)testApplyingScrimColorToAlert {
   // Given
   UIColor *scrimColor = [UIColor.blueColor colorWithAlphaComponent:0.3f];
-  MDCDialogPresentationController *presentationController = alert.mdc_dialogPresentationController;
-  if (presentationController == nil) {
-    return;  // don't fail the test if mdc_dialogPresentationController is nil
-  }
 
   // When
-  alert.scrimColor = scrimColor;
+  self.alert.scrimColor = scrimColor;
 
   // Then
-  XCTAssertEqualObjects(presentationController.scrimColor, scrimColor);
+  XCTAssertEqualObjects(self.presentationController.scrimColor, scrimColor);
 }
 
 #pragma mark - helpers

--- a/components/Dialogs/tests/unit/MDCAlertControllerCustomizationTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerCustomizationTests.m
@@ -96,15 +96,32 @@ MDCAlertControllerView *alertView;
   UIColor *scrimColor = [UIColor.orangeColor colorWithAlphaComponent:0.5];
   MDCDialogPresentationController *presentationController = alert.mdc_dialogPresentationController;
   if (presentationController == nil) {
-    return;  // don't fail the test if mdc_dialogPresentationController is empty
+    return;  // don't fail the test if mdc_dialogPresentationController is nil
   }
 
   // When
   presentationController.scrimColor = scrimColor;
 
   // Then
-  XCTAssertEqualObjects(alert.mdc_dialogPresentationController.scrimColor, scrimColor);
+  XCTAssertEqualObjects(presentationController.scrimColor, scrimColor);
 }
+
+- (void)testApplyingScrimColorToAlert {
+  // Given
+  UIColor *scrimColor = [UIColor.blueColor colorWithAlphaComponent:0.3];
+  MDCDialogPresentationController *presentationController = alert.mdc_dialogPresentationController;
+  if (presentationController == nil) {
+    return;  // don't fail the test if mdc_dialogPresentationController is nil
+  }
+
+  // When
+  alert.scrimColor = scrimColor;
+
+  // Then
+  XCTAssertEqualObjects(presentationController.scrimColor, scrimColor);
+}
+
+#pragma mark - helpers
 
 static inline UIImage *TestImage(CGSize size) {
   CGFloat scale = [UIScreen mainScreen].scale;


### PR DESCRIPTION
Adding the scrimColor property to MDCAlertController, which controls the background color when the alert is presented by a MDCDialogPresentationController. Also, fix MDCAlertColorThemer to use the new property when theming the dialog, and update relevant tests and examples.

Issues: b/116845327, b/117173678.