### PR TITLE
Fix status bar color appearing incorrect in some Catalog examples

### DIFF
--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -122,6 +122,7 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
     }
     MDCFlexibleHeaderColorThemer.applySemanticColorScheme(colorScheme,
                                                           to: headerViewController.headerView)
+    setNeedsStatusBarAppearanceUpdate()
 
     titleLabel.textColor = colorScheme.onPrimaryColor
     menuButton.tintColor = colorScheme.onPrimaryColor

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -239,6 +239,7 @@ class MDCNodeListViewController: CBCNodeListViewController {
   }
 
   func themeDidChange(notification: NSNotification) {
+    setNeedsStatusBarAppearanceUpdate()
     self.tableView.reloadData()
   }
 }

--- a/components/AppBar/examples/AppBarPresentedExample.m
+++ b/components/AppBar/examples/AppBarPresentedExample.m
@@ -84,6 +84,10 @@
                                       action:@selector(dismiss)];
 }
 
+- (UIStatusBarStyle)preferredStatusBarStyle {
+  return UIStatusBarStyleLightContent;
+}
+
 - (void)dismiss {
   [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
 }

--- a/components/AppBar/examples/AppBarWrappedExample.m
+++ b/components/AppBar/examples/AppBarWrappedExample.m
@@ -78,6 +78,10 @@
   [self.appBarContainerViewController didMoveToParentViewController:self];
 }
 
+- (UIViewController *)childViewControllerForStatusBarStyle {
+  return self.appBarContainerViewController;
+}
+
 @end
 
 @implementation AppBarWrappedExample (CatalogByConvention)

--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.m
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.m
@@ -68,7 +68,6 @@
   [self.bottomBarView setTrailingBarButtonItems:@[ barButtonTrailingItem ]];
 }
 
-
 - (void)viewDidLoad {
   [super viewDidLoad];
   [self commonBottomBarSetup];
@@ -81,6 +80,7 @@
   [MDCBottomAppBarColorThemer applySurfaceVariantWithSemanticColorScheme:self.colorScheme
                                                       toBottomAppBarView:self.bottomBarView];
 }
+
 - (void)didTapFloatingButton:(id)sender {
   [self.bottomBarView setFloatingButtonHidden:YES animated:YES];
 }

--- a/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseSupplemental.m
+++ b/components/BottomAppBar/examples/supplemental/BottomAppBarTypicalUseSupplemental.m
@@ -61,6 +61,10 @@ static NSString *const kCellIdentifier = @"cell";
   [self.navigationController setNavigationBarHidden:YES animated:animated];
 }
 
+- (UIViewController *)childViewControllerForStatusBarStyle {
+  return self.viewController;
+}
+
 @end
 
 @implementation BottomAppBarExampleTableViewController
@@ -113,6 +117,10 @@ static NSString *const kCellIdentifier = @"cell";
   UIEdgeInsets contentInset = self.tableView.contentInset;
   contentInset.bottom = bottomAppBarFrame.size.height;
   self.tableView.contentInset = contentInset;
+}
+
+- (UIViewController *)childViewControllerForStatusBarStyle {
+  return self.appBarViewController;
 }
 
 #pragma mark - Table view data source


### PR DESCRIPTION
I did an audit of the Catalog app to track down screens with an incorrect status bar color and the ones that I found are:
* AppBar -> Presented (This example does not use the app theme so I was able to set the style directly)
* AppBar -> Wrapped
* BottomAppBar

Additionally, I found that changing the Catalog theme from black to another color (and vice-versa) resulted in the status bar being incorrect until the next page navigation. So I created a fix for this too.

Closes #3778 
