### PR TITLE
{WIP} [Dialogs] Design Review: theming dialog buttons using custom presentation blocks

### DIFF
--- a/components/Dialogs/examples/DialogsAlertCustomizationViewController.swift
+++ b/components/Dialogs/examples/DialogsAlertCustomizationViewController.swift
@@ -82,6 +82,8 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
       "Right Aligned Title with a Large Icon",
       "Tinted Title Icon, No Title",
       "Darker Scrim",
+      "Buttons: Model Customization",
+      "Buttons: View Customization",
     ])
   }
 
@@ -109,6 +111,10 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
       return performTintedTitleIconNoTitle()
     case 5:
       return performScrimColor()
+    case 6:
+      return performButtonModelCustomization()
+    case 7:
+      return performButtonViewCustomization()
     default:
       print("No row is selected")
       return nil
@@ -167,6 +173,43 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
     let alert = createMDCAlertController(title: "Darker Scrim")
     MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
     alert.mdc_dialogPresentationController?.scrimColor = UIColor.black.withAlphaComponent(0.6)
+    return alert
+  }
+
+  func performButtonModelCustomization() -> MDCAlertController {
+    let alert = createMDCAlertController(title: "Buttons: Model Theming")
+    MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
+    alert.buttonTitleColor = UIColor.red;
+    return alert
+  }
+
+  func performButtonViewCustomization() -> MDCAlertController {
+
+    // create a button scheme
+    let buttonScheme = MDCButtonScheme()
+    let colorScheme = MDCSemanticColorScheme()
+    colorScheme.primaryColor = .orange
+    buttonScheme.colorScheme = colorScheme
+
+    // define a "didSelect" handler
+    let didSelectAction: MDCActionHandler = { action in
+      print(action.title ?? "Unknown Action")
+    }
+
+    // create and theme the alert controller
+    let alert = MDCAlertController(title: "Buttons: View Theming",
+                                   message: "Lorem ipsum dolor sit amet, consectetur adipiscing")
+    MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
+
+    // create and theme the actions
+    let okAction = MDCAlertAction(title: "Okay", didSelect: didSelectAction) { button in
+      MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
+      button.isUppercaseTitle = false
+    }
+    let cancelAction = MDCAlertAction(title: "Cancel", handler: didSelectAction)
+    alert.addAction(okAction)
+    alert.addAction(cancelAction)
+
     return alert
   }
 

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import <UIKit/UIKit.h>
+#import "MaterialButtons.h"
 
 @class MDCAlertAction;
 
@@ -144,6 +145,12 @@
 typedef void (^MDCActionHandler)(MDCAlertAction *_Nonnull action);
 
 /**
+ MDCActionPresentationHandler is a block that will be invoked when the action is presented.
+ Intended for theming and appearance customization.
+ */
+typedef void (^MDCActionPresentationHandler)(MDCButton *_Nonnull button);
+
+/**
  MDCAlertAction is passed to an MDCAlertController to add a button to the alert dialog.
  */
 @interface MDCAlertAction : NSObject <NSCopying, UIAccessibilityIdentification>
@@ -155,8 +162,22 @@ typedef void (^MDCActionHandler)(MDCAlertAction *_Nonnull action);
  @param handler A block to execute when the user selects the action.
  @return An initialized MDCActionAlert object.
  */
+// question: should we keep the old API "as is" to preserve backward-compatibility ?
 + (nonnull instancetype)actionWithTitle:(nonnull NSString *)title
                                 handler:(__nullable MDCActionHandler)handler;
+
+/**
+ Action alerts control the buttons that will be displayed on the bottom of an alert controller.
+
+ @param title The title of the button shown on the alert dialog.
+ @param didSelectHandler A block to execute when the user selects the action.
+ @param willPresentHandler A block to execute when the an action is presented. A good place
+ for theming customization.
+ @return An initialized MDCActionAlert object.
+ */
++ (nonnull instancetype)actionWithTitle:(nonnull NSString *)title
+                              didSelect:(__nullable MDCActionHandler)didSelectHandler
+                            willPresent:(__nullable MDCActionPresentationHandler)willPresentHandler;
 
 /** Alert actions must be created with actionWithTitle:handler: */
 - (nonnull instancetype)init NS_UNAVAILABLE;

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.h
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.h
@@ -16,8 +16,6 @@
 
 #import "MaterialButtons.h"
 
-@class MDCFlatButton;
-
 @interface MDCAlertControllerView ()
 
 @property(nonatomic, nonnull, strong) UILabel *titleLabel;
@@ -25,7 +23,7 @@
 
 @property(nonatomic, nullable, strong) UIImageView *titleIconImageView;
 
-@property(nonatomic, nonnull, strong, readonly) NSArray<MDCFlatButton *> *actionButtons;
+@property(nonatomic, nonnull, strong, readonly) NSArray<MDCButton *> *actionButtons;
 
 - (nonnull MDCButton *)addActionButtonTitle:(NSString *_Nonnull)actionTitle
                                      target:(nullable id)target

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -49,8 +49,8 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 @end
 
 @implementation MDCAlertControllerView {
-    NSMutableArray<MDCFlatButton *> *_actionButtons;
-    BOOL _mdc_adjustsFontForContentSizeCategory;
+  NSMutableArray<MDCButton *> *_actionButtons;
+  BOOL _mdc_adjustsFontForContentSizeCategory;
 }
 
 @dynamic titleAlignment;
@@ -133,6 +133,8 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   }
   [actionButton setTitleFont:_buttonFont forState:UIControlStateNormal];
   actionButton.inkColor = self.buttonInkColor;
+  actionButton.backgroundColor = UIColor.clearColor;
+
   // TODO(#1726): Determine default text color values for Normal and Disabled
   CGRect buttonRect = actionButton.bounds;
   buttonRect.size.height = MAX(buttonRect.size.height, MDCDialogActionButtonHeight);
@@ -277,7 +279,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
         [finalButtonFont mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
                                 scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
   }
-  for (MDCFlatButton *button in self.actionButtons) {
+  for (MDCButton *button in self.actionButtons) {
     [button setTitleFont:finalButtonFont forState:UIControlStateNormal];
   }
 
@@ -295,7 +297,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)setButtonColor:(UIColor *)color {
   _buttonColor = color;
 
-  for (MDCFlatButton *button in self.actionButtons) {
+  for (MDCButton *button in self.actionButtons) {
     [button setTitleColor:_buttonColor forState:UIControlStateNormal];
   }
 }
@@ -629,7 +631,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {
   _mdc_adjustsFontForContentSizeCategory = adjusts;
 
-  for (MDCFlatButton *button in _actionButtons) {
+  for (MDCButton *button in _actionButtons) {
     button.mdc_adjustsFontForContentSizeCategory = adjusts;
   }
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -120,9 +120,12 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 }
 
 - (MDCButton *)addActionButtonTitle:(NSString *)actionTitle target:(id)target selector:(SEL)selector {
-  MDCFlatButton *actionButton = [[MDCFlatButton alloc] initWithFrame:CGRectZero];
+  MDCButton *actionButton = [[MDCButton alloc] initWithFrame:CGRectZero];
+  // maintain the Dialogs's default buttons style (as text) after switching to the MDCButton class.
+  [self styleAsTextButton:actionButton];
   actionButton.mdc_adjustsFontForContentSizeCategory = self.mdc_adjustsFontForContentSizeCategory;
   [actionButton setTitle:actionTitle forState:UIControlStateNormal];
+  [actionButton setTitleColor:_buttonColor forState:UIControlStateNormal];
   if (_buttonColor) {
     // We only set if _buttonColor since settingTitleColor to nil doesn't reset the title to the
     // default
@@ -142,6 +145,18 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
   [_actionButtons addObject:actionButton];
   return actionButton;
+}
+
+- (void)styleAsTextButton:(nonnull MDCButton *)button {
+  UIColor *lightTitleColor = [UIColor.blackColor colorWithAlphaComponent:0.38f];
+  [button setBackgroundColor:UIColor.clearColor forState:UIControlStateNormal];
+  [button setBackgroundColor:UIColor.clearColor forState:UIControlStateDisabled];
+  [button setTitleColor:UIColor.blackColor forState:UIControlStateNormal];
+  [button setTitleColor:lightTitleColor forState:UIControlStateDisabled];
+  [button setImageTintColor:UIColor.blackColor forState:UIControlStateNormal];
+  [button setImageTintColor:lightTitleColor forState:UIControlStateDisabled];
+  button.disabledAlpha = 1.f;
+  button.inkColor = [UIColor.blackColor colorWithAlphaComponent:0.16f];
 }
 
 - (void)setTitleFont:(UIFont *)font {


### PR DESCRIPTION
**Do Not Merge.**

Enable theming of dialog buttons by adding custom presentation blocks to MDCDialogAction, and invoking them before the dialog is presented, and after the buttons materialize and themed by the dialog's "model" properties like "alertController.buttonTitleColor" (so individual button theming overrides the dialog's model theming).

Pending Dialogs/Buttons design review.

Issue: b/116447500

Also see alternative theming approach using semantic meanings in PR #5387.

![dialogs buttons model theming](https://user-images.githubusercontent.com/2329102/46643268-6279ca00-cb49-11e8-881f-6f68eafa19e9.png)
![dialogs buttons view theming](https://user-images.githubusercontent.com/2329102/46643267-6279ca00-cb49-11e8-9e95-7385561f64fd.png)
