### PR TITLE
[Chips] Respect safe area for Chips examples

### DIFF
--- a/components/Chips/examples/ChipsActionExampleViewController.m
+++ b/components/Chips/examples/ChipsActionExampleViewController.m
@@ -58,7 +58,7 @@
   if (@available(iOS 11.0, *)) {
     _collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
   }
-  
+
   // This is used to calculate the size of each chip based on the chip setup
   _sizingChip = [[MDCChipView alloc] init];
 

--- a/components/Chips/examples/ChipsActionExampleViewController.m
+++ b/components/Chips/examples/ChipsActionExampleViewController.m
@@ -55,6 +55,10 @@
   [_collectionView registerClass:[MDCChipCollectionViewCell class]
       forCellWithReuseIdentifier:@"Cell"];
 
+  if (@available(iOS 11.0, *)) {
+    _collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
+  }
+  
   // This is used to calculate the size of each chip based on the chip setup
   _sizingChip = [[MDCChipView alloc] init];
 

--- a/components/Chips/examples/ChipsChoiceExampleViewController.m
+++ b/components/Chips/examples/ChipsChoiceExampleViewController.m
@@ -60,7 +60,7 @@
   if (@available(iOS 11.0, *)) {
     _collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
   }
-  
+
   [self.view addSubview:_collectionView];
 }
 

--- a/components/Chips/examples/ChipsChoiceExampleViewController.m
+++ b/components/Chips/examples/ChipsChoiceExampleViewController.m
@@ -57,6 +57,10 @@
   [_collectionView registerClass:[MDCChipCollectionViewCell class]
       forCellWithReuseIdentifier:@"Cell"];
 
+  if (@available(iOS 11.0, *)) {
+    _collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
+  }
+  
   [self.view addSubview:_collectionView];
 }
 

--- a/components/Chips/examples/ChipsFilterExampleViewController.m
+++ b/components/Chips/examples/ChipsFilterExampleViewController.m
@@ -61,7 +61,7 @@
   if (@available(iOS 11.0, *)) {
     _collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
   }
-  
+
   // This is used to calculate the size of each chip based on the chip setup
   _sizingChip = [[MDCChipView alloc] init];
 

--- a/components/Chips/examples/ChipsFilterExampleViewController.m
+++ b/components/Chips/examples/ChipsFilterExampleViewController.m
@@ -58,6 +58,10 @@
   [_collectionView registerClass:[MDCChipCollectionViewCell class]
       forCellWithReuseIdentifier:@"Cell"];
 
+  if (@available(iOS 11.0, *)) {
+    _collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
+  }
+  
   // This is used to calculate the size of each chip based on the chip setup
   _sizingChip = [[MDCChipView alloc] init];
 

--- a/components/Chips/examples/ChipsTypicalUseViewController.m
+++ b/components/Chips/examples/ChipsTypicalUseViewController.m
@@ -78,9 +78,7 @@
                                            selector:@selector(contentSizeCategoryDidChange)
                                                name:UIContentSizeCategoryDidChangeNotification
                                              object:nil];
-  if (@available(iOS 11.0, *)) {
-    self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
-  }
+
   [self updateClearButton];
 }
 


### PR DESCRIPTION
Several examples under Chips were not respecting the safe area and therefore obscruing content on iPhone X in landscape. This change fixes that for:
* ChipsActionExampleViewController
* ChipsChoiceExampleViewController
* ChipsFilterExampleViewController

Closes #3705 
Closes #3706 
Closes #3707 


Before:
![simulator screen shot - iphone x - 2018-10-09 at 15 52 46](https://user-images.githubusercontent.com/2364772/46696484-378e8500-cbe0-11e8-9eb0-fedb5f3a0da9.png)

After:
![simulator screen shot - iphone x - 2018-10-09 at 15 55 43](https://user-images.githubusercontent.com/2364772/46696489-3bbaa280-cbe0-11e8-8cfe-e79118205c67.png)
