### PR TITLE
[ActionSheets] Fix podspec for global themer

### DIFF
--- a/MaterialComponentsAlpha.podspec
+++ b/MaterialComponentsAlpha.podspec
@@ -36,8 +36,8 @@ Pod::Spec.new do |mdc|
     extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
     extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
     extension.dependency "MaterialComponentsAlpha/#{extension.base_name.split('+')[0]}"
-    extension.dependency "MaterialComponents/schemes/Color"
-    extension.dependency "MaterialComponents/schemes/Typography"
+    extension.dependency "MaterialComponentsAlpha/ActionSheet+ColorThemer"
+    extension.dependency "MaterialComponentsAlpha/ActionSheet+TypographyThemer"
   end
 
   mdc.subspec "ActionSheet+ColorThemer" do |extension|


### PR DESCRIPTION
### Context
In #5345 the podspec is wrong, it depends on the system schemes instead of the other themers.
### The fix
Update the podspec to match other components and depend on other subspecs instead of schemes.