### PR TITLE
[ActionSheet] Update examples to use global themer

### DIFF
--- a/components/ActionSheet/examples/ActionSheetSwiftExample.swift
+++ b/components/ActionSheet/examples/ActionSheetSwiftExample.swift
@@ -14,8 +14,7 @@
 
 import UIKit
 import MaterialComponentsAlpha.MaterialActionSheet
-import MaterialComponentsAlpha.MaterialActionSheet_ColorThemer
-import MaterialComponentsAlpha.MaterialActionSheet_TypographyThemer
+import MaterialComponentsAlpha.MaterialActionSheet_ActionSheetThemer
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialTypographyScheme
 
@@ -23,6 +22,7 @@ class ActionSheetSwiftExample: UIViewController {
 
   var colorScheme = MDCSemanticColorScheme()
   var typographyScheme = MDCTypographyScheme()
+  var actionSheetScheme = MDCActionSheetScheme()
   let tableView = UITableView()
   enum ActionSheetExampleType {
     case typical, title, message, noIcons, titleAndMessage, dynamicType, delayed, thirtyOptions
@@ -88,8 +88,9 @@ class ActionSheetSwiftExample: UIViewController {
     case .thirtyOptions:
       actionSheet = ActionSheetSwiftExample.thirtyOptions()
     }
-    MDCActionSheetColorThemer.applySemanticColorScheme(colorScheme, to: actionSheet)
-    MDCActionSheetTypographyThemer.applyTypographyScheme(typographyScheme, to: actionSheet)
+    actionSheetScheme.colorScheme = colorScheme
+    actionSheetScheme.typographyScheme = typographyScheme
+    MDCActionSheetThemer.applyScheme(actionSheetScheme, to: actionSheet)
     present(actionSheet, animated: true, completion: nil)
   }
 }

--- a/components/ActionSheet/examples/ActionSheetTypicalUse.m
+++ b/components/ActionSheet/examples/ActionSheetTypicalUse.m
@@ -14,8 +14,7 @@
 
 #import "ActionSheetTypicalUse.h"
 
-#import "MaterialActionSheet+ColorThemer.h"
-#import "MaterialActionSheet+TypographyThemer.h"
+#import "MaterialActionSheet+ActionSheetThemer.h"
 #import "MaterialButtons+ButtonThemer.h"
 #import "MaterialButtons.h"
 
@@ -27,6 +26,7 @@
 
 @implementation ActionSheetTypicalUse {
   MDCButtonScheme *_buttonScheme;
+  MDCActionSheetScheme *_actionSheetScheme;
 }
 
 - (instancetype)init {
@@ -37,6 +37,7 @@
     _typographyScheme = [[MDCTypographyScheme alloc] init];
     _showButton = [[MDCButton alloc] init];
     _buttonScheme = [[MDCButtonScheme alloc] init];
+    _actionSheetScheme = [[MDCActionSheetScheme alloc] init];
   }
   return self;
 }
@@ -54,6 +55,9 @@
                   action:@selector(showActionSheet)
         forControlEvents:UIControlEventTouchUpInside];
   [self.view addSubview:_showButton];
+
+  _actionSheetScheme.colorScheme = self.colorScheme;
+  _actionSheetScheme.typographyScheme = self.typographyScheme;
 }
 
 - (void)viewDidLayoutSubviews {
@@ -84,10 +88,7 @@
   [actionSheet addAction:homeAction];
   [actionSheet addAction:favoriteAction];
   [actionSheet addAction:emailAction];
-  [MDCActionSheetColorThemer applySemanticColorScheme:self.colorScheme
-                              toActionSheetController:actionSheet];
-  [MDCActionSheetTypographyThemer applyTypographyScheme:self.typographyScheme
-                                toActionSheetController:actionSheet];
+  [MDCActionSheetThemer applyScheme:_actionSheetScheme toActionSheetController:actionSheet];
   [self presentViewController:actionSheet animated:YES completion:nil];
 }
 


### PR DESCRIPTION
### Context
Before #5345 there wasn't a global themer so the examples used the typography themer and color themer.
### The problem
There is now a global themer that isn't being used
### The fix
Apply the global themer to all examples instead of the typography themer and color themer.
### Bug
Closes #5391 
### Screenshots
| Before | After |
| - | - |
|![simulator screen shot - iphone x - 2018-10-10 at 10 03 11](https://user-images.githubusercontent.com/7131294/46741777-b680cd80-cc73-11e8-952e-79d514259ad3.png)|![simulator screen shot - iphone x - 2018-10-10 at 10 01 33](https://user-images.githubusercontent.com/7131294/46741787-baaceb00-cc73-11e8-9640-5f0f33e3b7ae.png)|

