### PR TITLE
[FlexibleHeader] Allow clearing shadow when trackingScrollView is emptied

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -272,6 +272,18 @@ IB_DESIGNABLE
 
 @property(nonatomic) float visibleShadowOpacity;  ///< The visible shadow opacity. Default: 0.4
 
+/**
+ * Whether or not shadow opacity (if using the default shadow layer) should be reset to 0 when
+ * trackingScrollView is set to nil. If the flexible header view is created without ever setting
+ * trackingScrollView, it always has 0 opacity for the default shadow layer regardless of the value
+ * of this flag. If trackingScrollView is ever set, then this flag enables resetting the shadow
+ * opacity back to 0 when trackingScrollView is set to nil.
+ *
+ * Default: NO, but we are planning to change it to YES very soon, so all clients should set this
+ * property to YES.
+ */
+@property(nonatomic) BOOL resetShadowAfterTrackingScrollViewIsReset;
+
 #pragma mark Scroll View Tracking
 
 /**

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -306,11 +306,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
 - (void)setVisibleShadowOpacity:(float)visibleShadowOpacity {
   _visibleShadowOpacity = visibleShadowOpacity;
-  if (!_trackingScrollView) {
-    self.layer.shadowOpacity = visibleShadowOpacity;
-  } else {
-    [self fhv_accumulatorDidChange];
-  }
+  [self fhv_accumulatorDidChange];
 }
 
 - (void)fhv_setShadowLayer:(CALayer *)shadowLayer
@@ -872,7 +868,8 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
 - (void)fhv_accumulatorDidChange {
   if (!_trackingScrollView) {
-    return;
+    self.layer.shadowOpacity =
+        self.resetShadowAfterTrackingScrollViewIsReset ? 0 : _visibleShadowOpacity;
   }
 
   CGRect frame = self.frame;
@@ -1468,8 +1465,7 @@ static BOOL isRunningiOS10_3OrAbove() {
 
     // When the tracking scroll view is cleared we need a shadow update.
     if (!self.trackingScrollView) {
-      self.layer.shadowOpacity =
-          self.resetShadowAfterTrackingScrollViewIsReset ? 0 : _visibleShadowOpacity;
+      [self fhv_accumulatorDidChange];
     }
   };
   if (wasTrackingScrollView) {

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -870,6 +870,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   if (!_trackingScrollView) {
     self.layer.shadowOpacity =
         self.resetShadowAfterTrackingScrollViewIsReset ? 0 : _visibleShadowOpacity;
+    return;
   }
 
   CGRect frame = self.frame;

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -868,6 +868,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
 - (void)fhv_accumulatorDidChange {
   if (!_trackingScrollView) {
+    // Set the shadow opacity directly.
     self.layer.shadowOpacity =
         self.resetShadowAfterTrackingScrollViewIsReset ? 0 : _visibleShadowOpacity;
     return;

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -306,7 +306,11 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
 - (void)setVisibleShadowOpacity:(float)visibleShadowOpacity {
   _visibleShadowOpacity = visibleShadowOpacity;
-  [self fhv_accumulatorDidChange];
+  if (!_trackingScrollView) {
+    self.layer.shadowOpacity = visibleShadowOpacity;
+  } else {
+    [self fhv_accumulatorDidChange];
+  }
 }
 
 - (void)fhv_setShadowLayer:(CALayer *)shadowLayer
@@ -868,8 +872,6 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
 - (void)fhv_accumulatorDidChange {
   if (!_trackingScrollView) {
-    // Set the shadow opacity directly.
-    self.layer.shadowOpacity = _visibleShadowOpacity;
     return;
   }
 
@@ -1466,7 +1468,8 @@ static BOOL isRunningiOS10_3OrAbove() {
 
     // When the tracking scroll view is cleared we need a shadow update.
     if (!self.trackingScrollView) {
-      [self fhv_accumulatorDidChange];
+      self.layer.shadowOpacity =
+          self.resetShadowAfterTrackingScrollViewIsReset ? 0 : _visibleShadowOpacity;
     }
   };
   if (wasTrackingScrollView) {


### PR DESCRIPTION
Expose a property that enables resetting the visible shadow opacity to 0 when setting trackingScrollView to 0.

resetShadowAfterTrackingScrollViewIsReset is now exposed. When it's set to YES by clients, we clear the shadow when trackingScrollView is set to Nil. I am planning to adopt the flag internally where applicable, and change the default value to YES and mark as deprecated after that. 

Partially addresses #5281, but will need to keep it open until the default value has changed.

Internal testing of this PR is being done in cl/215723028.

Internal discussion about the effect of this flag when enabled on clients in b/117269330.