### PR TITLE
[ShadowLayer] Subclass UIView in corner radius example

### DIFF
--- a/components/ShadowLayer/examples/ShadowCornerRadiusExample.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusExample.m
@@ -45,13 +45,9 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27.0f;
     CGRect paperFrame =
         CGRectMake((CGRectGetWidth(frame) - paperDim) / 2, 200.f, paperDim, paperDim);
     _paper = [[ShadowRadiusLabel alloc] initWithFrame:paperFrame];
-    _paper.textAlignment = NSTextAlignmentCenter;
-    _paper.text = [NSString stringWithFormat:@"%ld pt", (long)kShadowElevationsDefault];
-    _paper.autoresizingMask =
-        (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin |
-         UIViewAutoresizingFlexibleRightMargin);
     _paper.cornerRadius = 8.0;
     _paper.elevation = 12.0;
+    _paper.backgroundColor = UIColor.grayColor;
     [self addSubview:_paper];
 
     CGFloat margin = 20.f;
@@ -81,9 +77,7 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27.0f;
 // TODO: (#4848) [ShadowLayer] cornerRadius changes don't render
 - (void)sliderValueChanged:(MDCSlider *)slider {
   NSInteger points = (NSInteger)round(slider.value);
-  _paper.text = [NSString stringWithFormat:@"%ld pt", (long)points];
   _paper.cornerRadius = (CGFloat)points;
-  _elevationLabel.text = _paper.text;
 }
 
 @end

--- a/components/ShadowLayer/examples/ShadowCornerRadiusExample.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusExample.m
@@ -38,7 +38,7 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27.0f;
 
     _elevationLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 20, frame.size.width, 100)];
     _elevationLabel.textAlignment = NSTextAlignmentCenter;
-    _elevationLabel.text = @"MDCShadowElevationFABPressed";
+    _elevationLabel.text = @"8 pt";
     [self addSubview:_elevationLabel];
 
     CGFloat paperDim = 200.f;
@@ -78,6 +78,7 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27.0f;
 - (void)sliderValueChanged:(MDCSlider *)slider {
   NSInteger points = (NSInteger)round(slider.value);
   _paper.cornerRadius = (CGFloat)points;
+  _elevationLabel.text = [NSString stringWithFormat:@"%ld pt", (long)points];
 }
 
 @end

--- a/components/ShadowLayer/examples/ShadowRadiusLabel.h
+++ b/components/ShadowLayer/examples/ShadowRadiusLabel.h
@@ -16,9 +16,8 @@
 
 #import "MaterialShadowElevations.h"
 
-@interface ShadowRadiusLabel : UILabel
+@interface ShadowRadiusLabel : UIView
 
 @property(nonatomic, assign) CGFloat cornerRadius;
 @property(nonatomic, assign) MDCShadowElevation elevation;
-
 @end


### PR DESCRIPTION
### Context
In working on #4848 I noticed that the example uses an UILabel which may have a different backing layer (possibly CATextLayer) than UIView. This change makes it easier for another team member to address this issue.
### The fix
Subclass UIView which I believe is the most common use case for using a custom shadow layer in this example.
### Related issue
#4848
### Videos
| Before | After |
| - | - |
|![develop](https://user-images.githubusercontent.com/7131294/46751924-efc43800-cc89-11e8-8327-b05f6bb5f3f3.gif)|![shadowafter](https://user-images.githubusercontent.com/7131294/46751933-f357bf00-cc89-11e8-9e17-eea6dd0dd7bd.gif)|



