### PR TITLE
[Buttons] [MaskedTransition] Apply safe area to floating button example and masked transition example

### DIFF
--- a/components/Buttons/examples/FloatingButtonExampleViewController.m
+++ b/components/Buttons/examples/FloatingButtonExampleViewController.m
@@ -124,6 +124,10 @@ NSString *kMiniButtonLabel = @"Add";
   CGSize largeIconFabSize = self.largeIconFloatingButton.intrinsicContentSize;
 
   CGFloat xOffset = CGRectGetMinX(bounds) + 20;
+  if (@available(iOS 11.0, *)) {
+    xOffset += self.view.safeAreaInsets.left;
+  }
+
   if (!self.iPadLabel.hidden) {
     self.iPadLabel.center =
         CGPointMake(CGRectGetMidX(bounds),

--- a/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
+++ b/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
@@ -179,7 +179,14 @@ private class ModalViewController: UIViewController {
     view.backgroundColor = .white
 
     view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTap)))
+    setupLabel()
+  }
 
+  override var preferredStatusBarStyle: UIStatusBarStyle {
+    return .lightContent
+  }
+
+  func setupLabel() {
     let label = UILabel(frame: view.bounds)
     label.numberOfLines = 0
     label.lineBreakMode = .byWordWrapping
@@ -227,11 +234,7 @@ private class ModalViewController: UIViewController {
                        multiplier: 1,
                        constant: bottomOffset).isActive = true
   }
-
-  override var preferredStatusBarStyle: UIStatusBarStyle {
-    return .lightContent
-  }
-
+  
   func didTap() {
     dismiss(animated: true)
   }

--- a/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
+++ b/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
@@ -24,6 +24,7 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
     let viewControllerType: UIViewController.Type
     let calculateFrame: ((UIPresentationController) -> CGRect)?
     let autoresizingMask: UIViewAutoresizing
+    let useSafeAreaInsets: Bool
   }
   var targets: [TargetInfo] = []
   var colorScheme = MDCSemanticColorScheme()
@@ -61,7 +62,7 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
                     y: info.containerView!.bounds.height - size.height,
                     width: size.width,
                     height: size.height)
-    }, autoresizingMask: [.flexibleWidth, .flexibleTopMargin]))
+    }, autoresizingMask: [.flexibleWidth, .flexibleTopMargin], useSafeAreaInsets: true))
 
     targets.append(.init(name: "Centered card", viewControllerType: ModalViewController.self, calculateFrame: { info in
       let size = CGSize(width: 200, height: 200)
@@ -70,24 +71,29 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
                     width: size.width,
                     height: size.height)
     }, autoresizingMask: [.flexibleLeftMargin, .flexibleTopMargin,
-                          .flexibleRightMargin, .flexibleBottomMargin]))
+                          .flexibleRightMargin, .flexibleBottomMargin],
+       useSafeAreaInsets: false))
 
-    targets.append(.init(name: "Full screen", viewControllerType: ModalViewController.self, calculateFrame: nil, autoresizingMask: [.flexibleWidth, .flexibleHeight]))
+    targets.append(.init(name: "Full screen",
+                         viewControllerType: ModalViewController.self,
+                         calculateFrame: nil,
+                         autoresizingMask: [.flexibleWidth, .flexibleHeight],
+                         useSafeAreaInsets: true))
 
     targets.append(.init(name: "Left card", viewControllerType: ModalViewController.self, calculateFrame: { info in
-      return CGRect(x: self.leftFAB.frame.minX - 16, y: self.leftFAB.frame.minY - 200, width: 200, height: 264)
-    }, autoresizingMask: [.flexibleTopMargin, .flexibleRightMargin, .flexibleBottomMargin]))
+      return CGRect(x: self.leftFAB.frame.minX, y: self.leftFAB.frame.minY - 200, width: 200, height: 264)
+    }, autoresizingMask: [.flexibleTopMargin, .flexibleRightMargin, .flexibleBottomMargin], useSafeAreaInsets: false))
 
     targets.append(.init(name: "Right card", viewControllerType: ModalViewController.self, calculateFrame: { info in
       return CGRect(x: self.rightFAB.frame.maxX - 200, y: self.rightFAB.frame.minY - 200, width: 200, height: 264)
-    }, autoresizingMask: [.flexibleTopMargin, .flexibleLeftMargin, .flexibleBottomMargin]))
+    }, autoresizingMask: [.flexibleTopMargin, .flexibleLeftMargin, .flexibleBottomMargin], useSafeAreaInsets: false))
 
     targets.append(.init(name: "Toolbar", viewControllerType: ToolbarViewController.self, calculateFrame: { info in
       guard let containerView = info.containerView else {
         return .zero
       }
       return CGRect(x: 0, y: containerView.bounds.height - 100, width: containerView.bounds.width, height: 100)
-    }, autoresizingMask: [.flexibleTopMargin, .flexibleWidth]))
+    }, autoresizingMask: [.flexibleTopMargin, .flexibleWidth], useSafeAreaInsets: false))
 
     tableView.selectRow(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .none)
   }
@@ -96,16 +102,16 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
     super.viewDidLayoutSubviews()
 
     let padding: CGFloat = 44.0
-    rightFAB.sizeToFit()
-    rightFAB.center = CGPoint(x: padding, y: view.bounds.height - padding)
-
     leftFAB.sizeToFit()
-    leftFAB.center = CGPoint(x: view.bounds.width - padding, y: view.bounds.height - padding)
+    leftFAB.center = CGPoint(x: padding, y: view.bounds.height - padding)
+
+    rightFAB.sizeToFit()
+    rightFAB.center = CGPoint(x: view.bounds.width - padding, y: view.bounds.height - padding)
     if #available(iOS 11.0, *) {
-      rightFAB.center.x += view.safeAreaInsets.right
-      rightFAB.center.y -= view.safeAreaInsets.bottom
-      leftFAB.center.x -= view.safeAreaInsets.left
+      leftFAB.center.x += view.safeAreaInsets.right
       leftFAB.center.y -= view.safeAreaInsets.bottom
+      rightFAB.center.x -= view.safeAreaInsets.left
+      rightFAB.center.y -= view.safeAreaInsets.bottom
     }
   }
 
@@ -113,6 +119,10 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
   func didTapFab(fab: UIView) {
     let target = targets[tableView.indexPathForSelectedRow!.row]
     let vc = target.viewControllerType.init()
+
+    if #available(iOS 11.0, *), target.useSafeAreaInsets {
+      vc.additionalSafeAreaInsets = view.safeAreaInsets
+    }
 
     vc.view.autoresizingMask = target.autoresizingMask
 
@@ -174,8 +184,48 @@ private class ModalViewController: UIViewController {
     label.numberOfLines = 0
     label.lineBreakMode = .byWordWrapping
     label.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. In aliquam dolor eget orci condimentum, eu blandit metus dictum. Suspendisse vitae metus pellentesque, sagittis massa vel, sodales velit. Aliquam placerat nibh et posuere interdum. Etiam fermentum purus vel turpis lobortis auctor. Curabitur auctor maximus purus, ac iaculis mi. In ac hendrerit sapien, eget porttitor risus. Integer placerat cursus viverra. Proin mollis nulla vitae nisi posuere, eu rutrum mauris condimentum. Nullam in faucibus nulla, non tincidunt lectus. Maecenas mollis massa purus, in viverra elit molestie eu. Nunc volutpat magna eget mi vestibulum pharetra. Suspendisse nulla ligula, laoreet non ante quis, vehicula facilisis libero. Morbi faucibus, sapien a convallis sodales, leo quam scelerisque leo, ut tincidunt diam velit laoreet nulla. Proin at quam vel nibh varius ultrices porta id diam. Pellentesque pretium consequat neque volutpat tristique. Sed placerat a purus ut molestie. Nullam laoreet venenatis urna non pulvinar. Proin a vestibulum nulla, eu placerat est. Morbi molestie aliquam justo, ut aliquet neque tristique consectetur. In hac habitasse platea dictumst. Fusce vehicula justo in euismod elementum. Ut vel malesuada est. Aliquam mattis, ex vel viverra eleifend, mauris nibh faucibus nibh, in fringilla sem purus vitae elit. Donec sed dapibus orci, ut vulputate sapien. Integer eu magna efficitur est pellentesque tempor. Sed ac imperdiet ex. Maecenas congue quis lacus vel dictum. Phasellus dictum mi at sollicitudin euismod. Mauris laoreet, eros vitae euismod commodo, libero ligula pretium massa, in scelerisque eros dui eu metus. Fusce elementum mauris velit, eu tempor nulla congue ut. In at tellus id quam feugiat semper eget ut felis. Nulla quis varius quam. Nullam tincidunt laoreet risus, ut aliquet nisl gravida id. Nulla iaculis mauris velit, vitae feugiat nunc scelerisque ac. Vivamus eget ligula porta, pulvinar ex vitae, sollicitudin erat. Maecenas semper ornare suscipit. Ut et neque condimentum lectus pulvinar maximus in sit amet odio. Aliquam congue purus erat, eu rutrum risus placerat a."
-    label.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    label.translatesAutoresizingMaskIntoConstraints = false
     view.addSubview(label)
+
+    var leftOffset: CGFloat = 0
+    var rightOffset: CGFloat = 0
+    var topOffset: CGFloat = 0
+    var bottomOffset: CGFloat = 0
+    if #available(iOS 11.0, *) {
+      leftOffset += additionalSafeAreaInsets.left
+      rightOffset += additionalSafeAreaInsets.right
+      topOffset += additionalSafeAreaInsets.top
+      bottomOffset += additionalSafeAreaInsets.bottom
+    }
+
+    NSLayoutConstraint(item: view,
+                       attribute: .left,
+                       relatedBy: .equal,
+                       toItem: label,
+                       attribute: .left,
+                       multiplier: 1,
+                       constant: -leftOffset).isActive = true
+    NSLayoutConstraint(item: view,
+                       attribute: .right,
+                       relatedBy: .equal,
+                       toItem: label,
+                       attribute: .right,
+                       multiplier: 1,
+                       constant: rightOffset).isActive = true
+    NSLayoutConstraint(item: view,
+                       attribute: .top,
+                       relatedBy: .equal,
+                       toItem: label,
+                       attribute: .top,
+                       multiplier: 1,
+                       constant: -topOffset).isActive = true
+    NSLayoutConstraint(item: view,
+                       attribute: .bottom,
+                       relatedBy: .equal,
+                       toItem: label,
+                       attribute: .bottom,
+                       multiplier: 1,
+                       constant: bottomOffset).isActive = true
   }
 
   override var preferredStatusBarStyle: UIStatusBarStyle {


### PR DESCRIPTION
This change applies the safe area to the examples for Floating Button and Masked Transition so that they appear correct on notched displays in landscape.

Closes #3702 
Closes #3714 

Floating Buttons Before:
![simulator screen shot - iphone x - 2018-10-10 at 12 53 13](https://user-images.githubusercontent.com/2364772/46752602-a4128e00-cc8b-11e8-8d58-32255db304af.png)

Floating Buttons After:
![simulator screen shot - iphone x - 2018-10-10 at 12 52 33](https://user-images.githubusercontent.com/2364772/46752584-9a892600-cc8b-11e8-9f8f-fafbc67e2a8b.png)

Masked Transition Before:
![simulator screen shot - iphone x - 2018-10-10 at 12 53 23](https://user-images.githubusercontent.com/2364772/46752610-a8d74200-cc8b-11e8-8ed9-ba010d279d9a.png)


Masked Transition After:
![simulator screen shot - iphone x - 2018-10-10 at 12 52 28](https://user-images.githubusercontent.com/2364772/46752564-91985480-cc8b-11e8-82e6-1458de23c38a.png)

Additionally, I noticed in the Masked Transition example that the left/right fabs were swapped in their position so I fixed this. I also applied the safe area to the fullscreen transition example.