### PR TITLE
[ActivityIndicator] Fix ActivityIndicatorTransitionExample layout when rotating device

### DIFF
--- a/components/ActivityIndicator/examples/ActivityIndicatorTransitionExample.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorTransitionExample.m
@@ -56,7 +56,8 @@ static const NSTimeInterval kActivityIndicatorExampleAnimationDuration = 2.0 / 3
   _activityIndicator = [[MDCActivityIndicator alloc] initWithFrame:CGRectZero];
   [_activityIndicator sizeToFit];
   _activityIndicator.center = CGPointMake(self.view.bounds.size.width / 2, 130);
-  _activityIndicator.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
+  _activityIndicator.autoresizingMask =
+      UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
   _activityIndicator.delegate = self;
   [self.view addSubview:_activityIndicator];
 
@@ -71,7 +72,8 @@ static const NSTimeInterval kActivityIndicatorExampleAnimationDuration = 2.0 / 3
   [_button setTitle:@"Refresh" forState:UIControlStateNormal];
   [_button sizeToFit];
   _button.center = CGPointMake(self.view.bounds.size.width / 2, 200);
-  _button.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
+  _button.autoresizingMask =
+      UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
   [self.view addSubview:_button];
 
   // Layers used in the custom transition animation.

--- a/components/ActivityIndicator/examples/ActivityIndicatorTransitionExample.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorTransitionExample.m
@@ -55,7 +55,8 @@ static const NSTimeInterval kActivityIndicatorExampleAnimationDuration = 2.0 / 3
 
   _activityIndicator = [[MDCActivityIndicator alloc] initWithFrame:CGRectZero];
   [_activityIndicator sizeToFit];
-  _activityIndicator.center = CGPointMake(self.view.bounds.size.width / 2, 100);
+  _activityIndicator.center = CGPointMake(self.view.bounds.size.width / 2, 130);
+  _activityIndicator.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
   _activityIndicator.delegate = self;
   [self.view addSubview:_activityIndicator];
 
@@ -70,6 +71,7 @@ static const NSTimeInterval kActivityIndicatorExampleAnimationDuration = 2.0 / 3
   [_button setTitle:@"Refresh" forState:UIControlStateNormal];
   [_button sizeToFit];
   _button.center = CGPointMake(self.view.bounds.size.width / 2, 200);
+  _button.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
   [self.view addSubview:_button];
 
   // Layers used in the custom transition animation.


### PR DESCRIPTION
This change applies autoresizing masks to the views in ActivityIndicatorTransitionExample to support rotation. Additionally the Activity Indicator is no longer obscured on iPhone X in Portrait orientation.

Closes #3683 