### PR TITLE
[Snackbar] Clean up unit test.

### DIFF
--- a/components/Snackbar/tests/unit/MDCSnackbarManagerInstanceTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarManagerInstanceTests.m
@@ -28,7 +28,7 @@
 
 @implementation MDCSnackbarManagerInstanceTests
 
-// The fact that MDCSnackbarManager.defaultInstance is a singelton means it's incredibly hard to
+// The fact that MDCSnackbarManager.defaultInstance is a singleton means it's incredibly hard to
 // test correctly. The -setUp and -tearDown methods below attempt to save/restore the
 // defaultManager's tested state as well as possible. If either these tests or any of the "default"
 // styling tests begin to flake/fail, it's probably best to remove these methods as well as
@@ -39,7 +39,7 @@
 
   self.messageTextColor = MDCSnackbarManager.messageTextColor;
   self.snackbarMessageViewShadowColor = MDCSnackbarManager.snackbarMessageViewShadowColor;
-  self.snackbarMessageViewShadowColor = MDCSnackbarManager.snackbarMessageViewBackgroundColor;
+  self.snackbarMessageViewBackgroundColor = MDCSnackbarManager.snackbarMessageViewBackgroundColor;
   self.titleColorForState = [@{} mutableCopy];
   NSUInteger maxState = UIControlStateNormal | UIControlStateDisabled | UIControlStateSelected
     | UIControlStateHighlighted;


### PR DESCRIPTION
One of the tests was never assigning the correct background color for Snackbar
message views.
