### PR TITLE
[Dialogs] Enable misspelled test.

### DIFF
--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -278,7 +278,7 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   XCTAssertEqualObjects(button2.accessibilityIdentifier, @"A");
 }
 
-- (void)tesDefaultCornerRadius {
+- (void)testDefaultCornerRadius {
   // Given
   MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
                                                                    message:@"message"];


### PR DESCRIPTION
One of the tests was misspelled and not executing.
