### PR TITLE
[List] Revert "SelfSizingStereoCell should use MDCTypography instead of hard…

### DIFF
--- a/components/List/src/MDCSelfSizingStereoCell.m
+++ b/components/List/src/MDCSelfSizingStereoCell.m
@@ -24,6 +24,9 @@
 
 #import "private/MDCSelfSizingStereoCellLayout.h"
 
+static const CGFloat kTitleColorOpacity = 0.87f;
+static const CGFloat kDetailColorOpacity = 0.6f;
+
 @interface MDCSelfSizingStereoCell ()
 
 @property(nonatomic, strong) UIView *textContainer;
@@ -243,11 +246,11 @@
 }
 
 - (UIColor *)defaultTitleLabelTextColor {
-  return [UIColor colorWithWhite:0 alpha:[MDCTypography subheadFontOpacity]];
+  return [UIColor colorWithWhite:0 alpha:kTitleColorOpacity];
 }
 
 - (UIColor *)defaultDetailLabelTextColor {
-  return [UIColor colorWithWhite:0 alpha:[MDCTypography captionFontOpacity]];
+  return [UIColor colorWithWhite:0 alpha:kDetailColorOpacity];
 }
 
 @end


### PR DESCRIPTION
This reverts commit 5dbec5b8a9b7324d1f02bbfd0eaf877fc8b6bb50.

Per convention, components should have reasonable defaults and limited dependencies on a theming systems.  This addresses comments from within b/117395438 and https://github.com/material-components/material-components-ios/issues/5348