### PR TITLE
[Dialogs] Theming action buttons in DialogThemer 

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -555,6 +555,7 @@ Pod::Spec.new do |mdc|
 
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Themes"
+    extension.dependency "MaterialComponents/Buttons+ColorThemer"
   end
 
   mdc.subspec "Dialogs+TypographyThemer" do |extension|
@@ -564,6 +565,7 @@ Pod::Spec.new do |mdc|
 
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Typography"
+    extension.dependency "MaterialComponents/Buttons+TypographyThemer"
   end
 
   mdc.subspec "Dialogs+DialogThemer" do |extension|
@@ -574,6 +576,7 @@ Pod::Spec.new do |mdc|
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Dialogs+ColorThemer"
     extension.dependency "MaterialComponents/Dialogs+TypographyThemer"
+    extension.dependency "MaterialComponents/Buttons+ButtonThemer"
   end
 
   # FeatureHighlight

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -53,6 +53,24 @@ objc_bundle(
 )
 
 mdc_objc_library(
+    name = "DialogThemer",
+    srcs = native.glob(["src/DialogThemer/*.m"]),
+    hdrs = native.glob(["src/DialogThemer/*.h"]),
+    includes = ["src/DialogThemer"],
+    sdk_frameworks = [
+        "UIKit",
+    ],
+    deps = [
+        ":Dialogs",
+        "//components/Themes",
+        "//components/Buttons:ButtonThemer",
+        ":ColorThemer",
+        ":TypographyThemer",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+mdc_objc_library(
     name = "ColorThemer",
     srcs = native.glob(["src/ColorThemer/*.m"]),
     hdrs = native.glob(["src/ColorThemer/*.h"]),
@@ -102,6 +120,7 @@ mdc_objc_library(
     ],
     deps = [
         ":Dialogs",
+        ":DialogThemer",
         ":ColorThemer",
         ":TypographyThemer",
         ":private",

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -64,6 +64,7 @@ mdc_objc_library(
         ":Dialogs",
         "//components/Themes",
         "//components/Buttons:ButtonThemer",
+        "//components/Buttons:ColorThemer",
         ":ColorThemer",
         ":TypographyThemer",
     ],
@@ -81,6 +82,7 @@ mdc_objc_library(
     deps = [
         ":Dialogs",
         "//components/Themes",
+        "//components/Buttons:ColorThemer",
     ],
     visibility = ["//visibility:public"],
 )
@@ -96,6 +98,7 @@ mdc_objc_library(
     deps = [
         ":Dialogs",
         "//components/schemes/Typography",
+        "//components/Buttons:TypographyThemer",
     ],
     visibility = ["//visibility:public"],
 )

--- a/components/Dialogs/examples/DialogsAlertCustomizationViewController.swift
+++ b/components/Dialogs/examples/DialogsAlertCustomizationViewController.swift
@@ -70,6 +70,10 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
 
   var menu: [String] = []
 
+  var handler: MDCActionHandler = { action in
+    print(action.title ?? "Some Action")
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -82,6 +86,8 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
       "Right Aligned Title with a Large Icon",
       "Tinted Title Icon, No Title",
       "Darker Scrim",
+      "Emphasis-based Button Theming",
+      "Unthemed Alert",
     ])
   }
 
@@ -109,6 +115,10 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
       return performTintedTitleIconNoTitle()
     case 5:
       return performScrimColor()
+    case 6:
+      return performEmphasisButtonTheming()
+    case 7:
+      return performUnthemed()
     default:
       print("No row is selected")
       return nil
@@ -170,13 +180,32 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
     return alert
   }
 
+  func performEmphasisButtonTheming() -> MDCAlertController {
+    let alert = MDCAlertController(title: "Button Theming", message: "High, Medium & Low Emphasis")
+    alert.enableEmphasisThemingForActionButtons = true
+    alert.addAction(MDCAlertAction(title:"High", emphasis: .high, handler: handler))
+    alert.addAction(MDCAlertAction(title:"Medium", emphasis: .medium, handler: handler))
+    alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
+    MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
+    return alert
+  }
+
+  func performUnthemed() -> MDCAlertController {
+    let alert = MDCAlertController(title: "Unthemed Alert",
+                                   message: "Lorem ipsum dolor sit amet, consectetur adipiscing...")
+    alert.addAction(MDCAlertAction(title:"High", emphasis: .high, handler: handler))
+    alert.addAction(MDCAlertAction(title:"Medium", emphasis: .medium, handler: handler))
+    alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
+    return alert
+  }
+
   private func createMDCAlertController(title: String?) -> MDCAlertController {
     let alertController = MDCAlertController(title: title, message: """
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua.
       """)
-    alertController.addAction(MDCAlertAction(title:"OK") { _ in print("OK") })
-    alertController.addAction(MDCAlertAction(title:"Cancel") { _ in print("Cancel") })
+    alertController.addAction(MDCAlertAction(title:"OK", handler: handler))
+    alertController.addAction(MDCAlertAction(title:"Cancel", handler: handler))
     return alertController
   }
 

--- a/components/Dialogs/examples/DialogsAlertCustomizationViewController.swift
+++ b/components/Dialogs/examples/DialogsAlertCustomizationViewController.swift
@@ -87,9 +87,9 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
       "Tinted Title Icon, No Title",
       "Darker Scrim",
       "Emphasis-based Button Theming",
-      "Old-fashion Button Theming (Will be deprecated)",
-      "Old-fashion Button Theming (The right way)",
-      "Custom Button Theming (The right way)",
+      "Text Button Theming (will be deprecated)",
+      "Text Button Theming (the right way)",
+      "Custom Button Theming",
       "Unthemed Alert",
     ])
   }
@@ -121,9 +121,9 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
     case 6:
       return performEmphasisButtonTheming()
     case 7:
-      return performDeprecatedOldFashionButtonTheming()   // b/117717380: Will be deprecated
+      return performDeprecatedTextButtonTheming()   // b/117717380: Will be deprecated
     case 8:
-      return performOldFashionButtonThemingTheRightWay()
+      return performTextButtonThemingTheRightWay()
     case 9:
       return performCustomButtonTheming()
     case 10:
@@ -176,7 +176,7 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
     alert.titleIcon = sampleIcon()
     MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
 
-    // theming override: set the titleIconTintColor after the color scheme has been applied
+    // Theming override: set the titleIconTintColor after the color scheme has been applied
     alert.titleIconTintColor = .red
 
     return alert
@@ -198,52 +198,54 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
     return alert
   }
 
-  func performOldFashionButtonThemingTheRightWay() -> MDCAlertController {
+  func performDeprecatedTextButtonTheming() -> MDCAlertController {
     let alert = MDCAlertController(title: "Button Theming",
-                                   message: "Use low emphasis for text style for buttons")
-    // use .low emphasis for styling buttons as text buttons
-    alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
-    alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
-    alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
+                                   message: "This method of button theming will be deprecated")
+    // When not specified, the action is low emphasis by default
+    alert.addAction(MDCAlertAction(title:"Text", handler: handler))
+    alert.addAction(MDCAlertAction(title:"Text", handler: handler))
+    alert.addAction(MDCAlertAction(title:"Text", handler: handler))
+    MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
+    alert.buttonTitleColor = .orange   // b/117717380: will be deprecated
+    return alert
+  }
+
+  // The right way to select the type of buttons is by setting empahsis for actions
+  func performTextButtonThemingTheRightWay() -> MDCAlertController {
+    let alert = MDCAlertController(title: "Button Theming",
+                                   message: "Use low emphasis to present buttons as text")
+    // Use .low emphasis to style buttons as text buttons.
+    alert.addAction(MDCAlertAction(title:"Text", emphasis: .low, handler: handler))
+    alert.addAction(MDCAlertAction(title:"Text", emphasis: .low, handler: handler))
+    alert.addAction(MDCAlertAction(title:"Text", emphasis: .low, handler: handler))
     MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
     return alert
   }
 
   func performCustomButtonTheming() -> MDCAlertController {
     let alert = MDCAlertController(title: "Custom Button Theming",
-                                   message: "Custom styling for High, Medium & Low Emphasis")
+                                   message: "Custom styling of High, Medium & Low Emphasis")
     alert.titleIcon = sampleIcon()
 
-    // use .low emphasis for styling buttons as text buttons
-    alert.addAction(MDCAlertAction(title:"High", emphasis: .low, handler: handler))
-    alert.addAction(MDCAlertAction(title:"Medium", emphasis: .low, handler: handler))
+    // Use .low emphasis for styling buttons as text buttons
+    alert.addAction(MDCAlertAction(title:"High", emphasis: .high, handler: handler))
+    alert.addAction(MDCAlertAction(title:"Medium", emphasis: .medium, handler: handler))
     alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
 
     let scheme = MDCAlertScheme()
     scheme.typographyScheme = self.typographyScheme
 
-    // create a color theme with a different primary color
+    // Create a color theme with a different primary color
     let colorScheme = MDCSemanticColorScheme()
     colorScheme.primaryColor = .blue
 
-    // assign the new color theme to both the button and the alert schemes.
+    // Assign the new color theme to both the button and the alert schemes.
     let buttonScheme = MDCButtonScheme()
     buttonScheme.colorScheme = colorScheme
     scheme.colorScheme = colorScheme
     scheme.buttonScheme = buttonScheme
 
     MDCAlertControllerThemer.applyScheme(scheme, to: alert)
-    return alert
-  }
-
-  // b/117717380: This example will be deprecated
-  func performDeprecatedOldFashionButtonTheming() -> MDCAlertController {
-    let alert = MDCAlertController(title: "Button Theming",
-                                   message: "This method of button theming will be deprecated")
-    alert.addAction(MDCAlertAction(title:"High", emphasis: .high, handler: handler))
-    alert.addAction(MDCAlertAction(title:"Medium", emphasis: .medium, handler: handler))
-    alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
-    alert.buttonTitleColor = .orange
     return alert
   }
 

--- a/components/Dialogs/examples/DialogsAlertCustomizationViewController.swift
+++ b/components/Dialogs/examples/DialogsAlertCustomizationViewController.swift
@@ -87,6 +87,9 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
       "Tinted Title Icon, No Title",
       "Darker Scrim",
       "Emphasis-based Button Theming",
+      "Old-fashion Button Theming (Will be deprecated)",
+      "Old-fashion Button Theming (The right way)",
+      "Custom Button Theming (The right way)",
       "Unthemed Alert",
     ])
   }
@@ -118,6 +121,12 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
     case 6:
       return performEmphasisButtonTheming()
     case 7:
+      return performDeprecatedOldFashionButtonTheming()   // b/117717380: Will be deprecated
+    case 8:
+      return performOldFashionButtonThemingTheRightWay()
+    case 9:
+      return performCustomButtonTheming()
+    case 10:
       return performUnthemed()
     default:
       print("No row is selected")
@@ -182,11 +191,59 @@ class DialogsAlertCustomizationViewController: MDCCollectionViewController {
 
   func performEmphasisButtonTheming() -> MDCAlertController {
     let alert = MDCAlertController(title: "Button Theming", message: "High, Medium & Low Emphasis")
-    alert.enableEmphasisThemingForActionButtons = true
     alert.addAction(MDCAlertAction(title:"High", emphasis: .high, handler: handler))
     alert.addAction(MDCAlertAction(title:"Medium", emphasis: .medium, handler: handler))
     alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
     MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
+    return alert
+  }
+
+  func performOldFashionButtonThemingTheRightWay() -> MDCAlertController {
+    let alert = MDCAlertController(title: "Button Theming",
+                                   message: "Use low emphasis for text style for buttons")
+    // use .low emphasis for styling buttons as text buttons
+    alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
+    alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
+    alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
+    MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
+    return alert
+  }
+
+  func performCustomButtonTheming() -> MDCAlertController {
+    let alert = MDCAlertController(title: "Custom Button Theming",
+                                   message: "Custom styling for High, Medium & Low Emphasis")
+    alert.titleIcon = sampleIcon()
+
+    // use .low emphasis for styling buttons as text buttons
+    alert.addAction(MDCAlertAction(title:"High", emphasis: .low, handler: handler))
+    alert.addAction(MDCAlertAction(title:"Medium", emphasis: .low, handler: handler))
+    alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
+
+    let scheme = MDCAlertScheme()
+    scheme.typographyScheme = self.typographyScheme
+
+    // create a color theme with a different primary color
+    let colorScheme = MDCSemanticColorScheme()
+    colorScheme.primaryColor = .blue
+
+    // assign the new color theme to both the button and the alert schemes.
+    let buttonScheme = MDCButtonScheme()
+    buttonScheme.colorScheme = colorScheme
+    scheme.colorScheme = colorScheme
+    scheme.buttonScheme = buttonScheme
+
+    MDCAlertControllerThemer.applyScheme(scheme, to: alert)
+    return alert
+  }
+
+  // b/117717380: This example will be deprecated
+  func performDeprecatedOldFashionButtonTheming() -> MDCAlertController {
+    let alert = MDCAlertController(title: "Button Theming",
+                                   message: "This method of button theming will be deprecated")
+    alert.addAction(MDCAlertAction(title:"High", emphasis: .high, handler: handler))
+    alert.addAction(MDCAlertAction(title:"Medium", emphasis: .medium, handler: handler))
+    alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
+    alert.buttonTitleColor = .orange
     return alert
   }
 

--- a/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
+++ b/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
@@ -14,10 +14,9 @@
 
 #import "MDCAlertColorThemer.h"
 
-#import "MDCAlertController+ButtonForAction.h"
-#import "MaterialButtons+ColorThemer.h"
+#import "../../../Buttons/src/ColorThemer/MaterialButtons+ColorThemer.h"
+#import "../MDCAlertController+ButtonForAction.h"
 #import "MaterialButtons.h"
-#import "MaterialDialogs.h"
 
 @implementation MDCAlertColorThemer
 

--- a/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
+++ b/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
@@ -14,6 +14,9 @@
 
 #import "MDCAlertColorThemer.h"
 
+#import "MDCContainedButtonColorThemer.h"
+#import "MDCOutlinedButtonColorThemer.h"
+#import "MDCTextButtonColorThemer.h"
 #import "MaterialButtons.h"
 #import "MaterialDialogs.h"
 
@@ -23,9 +26,25 @@
                toAlertController:(nonnull MDCAlertController *)alertController {
   alertController.titleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
   alertController.messageColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
-  alertController.buttonTitleColor = colorScheme.primaryColor;
   alertController.titleIconTintColor = colorScheme.primaryColor;
   alertController.scrimColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.32];
+
+  // Apply theming to buttons based on the action emphasis
+  for (MDCAlertAction *action in alertController.actions) {
+    MDCButton *button = [alertController buttonForAction:action];
+    switch (action.emphasis) {
+      case MDCActionEmphasisHigh:
+        [MDCContainedButtonColorThemer applySemanticColorScheme:colorScheme toButton:button];
+        break;
+      case MDCActionEmphasisMedium:
+        [MDCOutlinedButtonColorThemer applySemanticColorScheme:colorScheme toButton:button];
+        break;
+      case MDCActionEmphasisLow:  // fallthrough
+      default:
+        [MDCTextButtonColorThemer applySemanticColorScheme:colorScheme toButton:button];
+        break;
+    }
+  }
 }
 
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme {

--- a/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
+++ b/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
@@ -14,9 +14,8 @@
 
 #import "MDCAlertColorThemer.h"
 
-#import "MDCContainedButtonColorThemer.h"
-#import "MDCOutlinedButtonColorThemer.h"
-#import "MDCTextButtonColorThemer.h"
+#import "MDCAlertController+ButtonForAction.h"
+#import "MaterialButtons+ColorThemer.h"
 #import "MaterialButtons.h"
 #import "MaterialDialogs.h"
 

--- a/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.m
+++ b/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.m
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #import "MDCAlertControllerThemer.h"
+
 #import "MDCAlertColorThemer.h"
+#import "../MDCAlertController+ButtonForAction.h"
 #import "MDCAlertTypographyThemer.h"
 #import "MaterialButtons+ButtonThemer.h"
 

--- a/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.m
+++ b/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.m
@@ -15,6 +15,7 @@
 #import "MDCAlertControllerThemer.h"
 #import "MDCAlertColorThemer.h"
 #import "MDCAlertTypographyThemer.h"
+#import "MaterialButtons+ButtonThemer.h" // todo: update podspec?
 
 @implementation MDCAlertControllerThemer
 
@@ -28,6 +29,24 @@
 
   alertController.cornerRadius = alertScheme.cornerRadius;
   alertController.elevation = alertScheme.elevation;
+
+  for (MDCAlertAction *action in alertController.actions) {
+    MDCButton *button = [alertController buttonForAction:action];
+    switch (action.emphasis) {
+      case MDCActionEmphasisHigh:
+        [MDCContainedButtonThemer applyScheme:alertScheme.buttonScheme toButton:button];
+        break;
+
+      case MDCActionEmphasisMedium:
+        [MDCOutlinedButtonThemer applyScheme:alertScheme.buttonScheme toButton:button];
+        break;
+
+      case MDCActionEmphasisLow:
+      default:
+        [MDCTextButtonThemer applyScheme:alertScheme.buttonScheme toButton:button];
+        break;
+    }
+  }
 }
 
 @end

--- a/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.m
+++ b/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.m
@@ -14,8 +14,8 @@
 
 #import "MDCAlertControllerThemer.h"
 
-#import "MDCAlertColorThemer.h"
 #import "../MDCAlertController+ButtonForAction.h"
+#import "MDCAlertColorThemer.h"
 #import "MDCAlertTypographyThemer.h"
 #import "MaterialButtons+ButtonThemer.h"
 

--- a/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.m
+++ b/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.m
@@ -15,7 +15,7 @@
 #import "MDCAlertControllerThemer.h"
 #import "MDCAlertColorThemer.h"
 #import "MDCAlertTypographyThemer.h"
-#import "MaterialButtons+ButtonThemer.h" // todo: update podspec?
+#import "MaterialButtons+ButtonThemer.h"
 
 @implementation MDCAlertControllerThemer
 
@@ -30,23 +30,22 @@
   alertController.cornerRadius = alertScheme.cornerRadius;
   alertController.elevation = alertScheme.elevation;
 
+  // Apply theming to buttons based on the action emphasis
   for (MDCAlertAction *action in alertController.actions) {
     MDCButton *button = [alertController buttonForAction:action];
+    // todo: b/117265609: Incorporate dynamic type support in semantic themers
     switch (action.emphasis) {
       case MDCActionEmphasisHigh:
         [MDCContainedButtonThemer applyScheme:alertScheme.buttonScheme toButton:button];
         break;
-
       case MDCActionEmphasisMedium:
         [MDCOutlinedButtonThemer applyScheme:alertScheme.buttonScheme toButton:button];
         break;
-
-      case MDCActionEmphasisLow:
+      case MDCActionEmphasisLow:  // fallthrough
       default:
         [MDCTextButtonThemer applyScheme:alertScheme.buttonScheme toButton:button];
         break;
     }
   }
 }
-
 @end

--- a/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
+++ b/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
@@ -14,7 +14,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "MDCButtonScheme.h"
+#import "MaterialButtons+ButtonThemer.h"
 #import "MaterialColorScheme.h"
 #import "MaterialShadowElevations.h"
 #import "MaterialTypographyScheme.h"

--- a/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
+++ b/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
@@ -17,6 +17,7 @@
 #import "MaterialColorScheme.h"
 #import "MaterialShadowElevations.h"
 #import "MaterialTypographyScheme.h"
+#import "MDCButtonScheme.h"
 
 /** Defines a readonly immutable interface for component style data to be applied by a themer. */
 @protocol MDCAlertScheming
@@ -26,6 +27,9 @@
 
 /** The typography scheme to apply to Dialog. */
 @property(nonnull, readonly, nonatomic) id<MDCTypographyScheming> typographyScheme;
+
+/** The button scheme to apply to Dialog's actions. */
+@property(nonnull, readonly, nonatomic) id<MDCButtonScheming> buttonScheme;
 
 /** The corner radius to apply to Dialog. */
 @property(readonly, nonatomic) CGFloat cornerRadius;
@@ -44,6 +48,9 @@
 
 /** The typography scheme to apply to Dialog. */
 @property(nonnull, readwrite, nonatomic) id<MDCTypographyScheming> typographyScheme;
+
+/** The button scheme to apply to Dialog's actions. */
+@property(nonnull, readwrite, nonatomic) id<MDCButtonScheming> buttonScheme;
 
 /** The corner radius to apply to Dialog. */
 @property(readwrite, nonatomic) CGFloat cornerRadius;

--- a/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
+++ b/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
@@ -14,10 +14,10 @@
 
 #import <Foundation/Foundation.h>
 
+#import "MDCButtonScheme.h"
 #import "MaterialColorScheme.h"
 #import "MaterialShadowElevations.h"
 #import "MaterialTypographyScheme.h"
-#import "MDCButtonScheme.h"
 
 /** Defines a readonly immutable interface for component style data to be applied by a themer. */
 @protocol MDCAlertScheming

--- a/components/Dialogs/src/DialogThemer/MDCAlertScheme.m
+++ b/components/Dialogs/src/DialogThemer/MDCAlertScheme.m
@@ -23,6 +23,7 @@ static const CGFloat kCornerRadius = 4.0f;
   if (self) {
     _colorScheme = [[MDCSemanticColorScheme alloc] init];
     _typographyScheme = [[MDCTypographyScheme alloc] init];
+    _buttonScheme = [[MDCButtonScheme alloc] init];
     _cornerRadius = kCornerRadius;
     _elevation = MDCShadowElevationDialog;
   }

--- a/components/Dialogs/src/MDCAlertController+ButtonForAction.h
+++ b/components/Dialogs/src/MDCAlertController+ButtonForAction.h
@@ -1,0 +1,33 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialDialogs.h"
+
+@interface MDCAlertController (ButtonForAction)
+
+/**
+ Returns an MDCButton associated with the given action. This method might create the button if
+ it no associated button exist for the action yet. Buttons returned by thismethod may not (yet)
+ be attached to the view hierarchy at the time the method is called.
+
+ This method is commonly used by themers to style the button associated with the action.
+
+ @param action The action with which the button is associated. Must be an existing action that
+ had been previously added through addAction: to the alert.
+ @return The button associated with the action, or nil if the action doesn't exist (the action
+ must first be added to the alert).
+ */
+- (nullable MDCButton *)buttonForAction:(nonnull MDCAlertAction *)action;
+
+@end

--- a/components/Dialogs/src/MDCAlertController+ButtonForAction.m
+++ b/components/Dialogs/src/MDCAlertController+ButtonForAction.m
@@ -1,0 +1,19 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCAlertController+ButtonForAction.h"
+
+@implementation MDCAlertController (buttonForAction)
+
+@end

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -71,12 +71,15 @@
 /** The color applied to the message of Alert Controller.*/
 @property(nonatomic, strong, nullable) UIColor *messageColor;
 
+// b/117717380: Will be deprecated
 /** The font applied to the button of Alert Controller.*/
 @property(nonatomic, strong, nullable) UIFont *buttonFont;
 
+// b/117717380: Will be deprecated
 /** The color applied to the button title text of Alert Controller.*/
 @property(nonatomic, strong, nullable) UIColor *buttonTitleColor;
 
+// b/117717380: Will be deprecated
 /** The color applied to the button ink effect of Alert Controller.*/
 @property(nonatomic, strong, nullable) UIColor *buttonInkColor;
 
@@ -115,6 +118,13 @@
 @property(nonatomic, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
     BOOL mdc_adjustsFontForContentSizeCategory;
 
+/** MDCAlertController handles its own transitioning delegate. */
+- (void)setTransitioningDelegate:
+    (_Nullable id<UIViewControllerTransitioningDelegate>)transitioningDelegate NS_UNAVAILABLE;
+
+/** MDCAlertController.modalPresentationStyle is always UIModalPresentationCustom. */
+- (void)setModalPresentationStyle:(UIModalPresentationStyle)modalPresentationStyle NS_UNAVAILABLE;
+
 /**
  The actions that the user can take in response to the alert.
 
@@ -148,13 +158,6 @@
           must first be added to the alert).
  */
 - (nullable MDCButton *)buttonForAction:(nonnull MDCAlertAction *)action;
-
-/** MDCAlertController handles its own transitioning delegate. */
-- (void)setTransitioningDelegate:
-(_Nullable id<UIViewControllerTransitioningDelegate>)transitioningDelegate NS_UNAVAILABLE;
-
-/** MDCAlertController.modalPresentationStyle is always UIModalPresentationCustom. */
-- (void)setModalPresentationStyle:(UIModalPresentationStyle)modalPresentationStyle NS_UNAVAILABLE;
 
 @end
 

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import <UIKit/UIKit.h>
+#import "MaterialButtons.h"
 
 #import "MaterialShadowElevations.h"
 
@@ -48,26 +49,6 @@
 
 /** Alert controllers must be created with alertControllerWithTitle:message: */
 - (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder NS_UNAVAILABLE;
-
-/**
- Adds an action to the alert dialog.
-
- Actions are the possible reactions of the user to the presented alert. Actions are added as a
- button at the bottom of the alert. Affirmative actions should be added before dismissive actions.
- Action buttons will be laid out from right to left if possible or top to bottom depending on space.
-
- Material spec recommends alerts should not have more than two actions.
-
- @param action Will be added to the end of MDCAlertController.actions.
- */
-- (void)addAction:(nonnull MDCAlertAction *)action;
-
-/**
- The actions that the user can take in response to the alert.
-
- The order of the actions in the array matches the order in which they were added to the alert.
- */
-@property(nonatomic, nonnull, readonly) NSArray<MDCAlertAction *> *actions;
 
 /** The font applied to the title of Alert Controller.*/
 @property(nonatomic, strong, nullable) UIFont *titleFont;
@@ -134,9 +115,43 @@
 @property(nonatomic, readwrite, setter=mdc_setAdjustsFontForContentSizeCategory:)
     BOOL mdc_adjustsFontForContentSizeCategory;
 
+/**
+ The actions that the user can take in response to the alert.
+
+ The order of the actions in the array matches the order in which they were added to the alert.
+ */
+@property(nonatomic, nonnull, readonly) NSArray<MDCAlertAction *> *actions;
+
+/**
+ Adds an action to the alert dialog.
+
+ Actions are the possible reactions of the user to the presented alert. Actions are added as a
+ button at the bottom of the alert. Affirmative actions should be added before dismissive actions.
+ Action buttons will be laid out from right to left if possible or top to bottom depending on space.
+
+ Material spec recommends alerts should not have more than two actions.
+
+ @param action Will be added to the end of MDCAlertController.actions.
+ */
+- (void)addAction:(nonnull MDCAlertAction *)action;
+
+/**
+ Returns an MDCButton associated with the given action. This method might create the button if
+ it no associated button exist for the action yet. Buttons returned by thismethod may not (yet)
+ be attached to the view hierarchy at the time the method is called.
+
+ This method is commonly used by themers to style the button associated with the action.
+
+ @param action The action with which the button is associated. Must be an existing action that
+               had been previously added through addAction: to the alert.
+ @return The button associated with the action, or nil if the action doesn't exist (the action
+          must first be added to the alert).
+ */
+- (nullable MDCButton *)buttonForAction:(nonnull MDCAlertAction *)action;
+
 /** MDCAlertController handles its own transitioning delegate. */
 - (void)setTransitioningDelegate:
-        (_Nullable id<UIViewControllerTransitioningDelegate>)transitioningDelegate NS_UNAVAILABLE;
+(_Nullable id<UIViewControllerTransitioningDelegate>)transitioningDelegate NS_UNAVAILABLE;
 
 /** MDCAlertController.modalPresentationStyle is always UIModalPresentationCustom. */
 - (void)setModalPresentationStyle:(UIModalPresentationStyle)modalPresentationStyle NS_UNAVAILABLE;

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -158,6 +158,12 @@
 
 @end
 
+typedef NS_ENUM(NSInteger, MDCActionEmphasis) {
+  MDCActionEmphasisLow = 0,
+  MDCActionEmphasisMedium = 1,
+  MDCActionEmphasisHigh = 2,
+};
+
 /**
  MDCActionHandler is a block that will be invoked when the action is selected.
  */
@@ -169,7 +175,8 @@ typedef void (^MDCActionHandler)(MDCAlertAction *_Nonnull action);
 @interface MDCAlertAction : NSObject <NSCopying, UIAccessibilityIdentification>
 
 /**
- Action alerts control the buttons that will be displayed on the bottom of an alert controller.
+ A convenience method for adding actions that will be rendered as low emphasis buttons at the
+ bottom of an alert controller.
 
  @param title The title of the button shown on the alert dialog.
  @param handler A block to execute when the user selects the action.
@@ -178,15 +185,36 @@ typedef void (^MDCActionHandler)(MDCAlertAction *_Nonnull action);
 + (nonnull instancetype)actionWithTitle:(nonnull NSString *)title
                                 handler:(__nullable MDCActionHandler)handler;
 
+/**
+ An action that renders at the bottom of an alert controller as a button of the given emphasis.
+
+ @param title The title of the button shown on the alert dialog.
+ @param emphasis The emphasis of the button that will be rendered in the alert dialog.
+        Unthemed actions will render all emphases as text. Apply themers to the alert
+        to achieve different appearance for different emphases.
+ @param handler A block to execute when the user selects the action.
+ @return An initialized MDCActionAlert object.
+ */
++ (nonnull instancetype)actionWithTitle:(nonnull NSString *)title
+                               emphasis:(MDCActionEmphasis)emphasis
+                                handler:(__nullable MDCActionHandler)handler;
+
 /** Alert actions must be created with actionWithTitle:handler: */
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
 /**
  Title of the button shown on the alert dialog.
 
- Alert actions titles must be set in the actionWithTitle:handler: method.
+ Alert actions titles must be set using either of the actionWithTitle:[emphais:]handler: methods.
  */
 @property(nonatomic, nullable, readonly) NSString *title;
+
+/**
+ The MDCActionEmphasis emphasis of the button that will be rendered for the action.
+
+ Alert actions emphasis must be set in the actionWithTitle:emphasis:handler: method.
+ */
+@property(nonatomic, readonly) MDCActionEmphasis emphasis;
 
 // TODO(iangordon): Add support for enabled property to match UIAlertAction
 

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -145,20 +145,6 @@
  */
 - (void)addAction:(nonnull MDCAlertAction *)action;
 
-/**
- Returns an MDCButton associated with the given action. This method might create the button if
- it no associated button exist for the action yet. Buttons returned by thismethod may not (yet)
- be attached to the view hierarchy at the time the method is called.
-
- This method is commonly used by themers to style the button associated with the action.
-
- @param action The action with which the button is associated. Must be an existing action that
- had been previously added through addAction: to the alert.
- @return The button associated with the action, or nil if the action doesn't exist (the action
- must first be added to the alert).
- */
-- (nullable MDCButton *)buttonForAction:(nonnull MDCAlertAction *)action;
-
 @end
 
 typedef NS_ENUM(NSInteger, MDCActionEmphasis) {

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -153,17 +153,20 @@
  This method is commonly used by themers to style the button associated with the action.
 
  @param action The action with which the button is associated. Must be an existing action that
-               had been previously added through addAction: to the alert.
+ had been previously added through addAction: to the alert.
  @return The button associated with the action, or nil if the action doesn't exist (the action
-          must first be added to the alert).
+ must first be added to the alert).
  */
 - (nullable MDCButton *)buttonForAction:(nonnull MDCAlertAction *)action;
 
 @end
 
 typedef NS_ENUM(NSInteger, MDCActionEmphasis) {
+  /* Low emphasis attribute produces low emphasis appearance when attached to actions or buttons */
   MDCActionEmphasisLow = 0,
+  /* a Medium emphasis attribute produces a medium emphasis appearance */
   MDCActionEmphasisMedium = 1,
+  /* a High emphasis attribute produces a high emphasis appearance */
   MDCActionEmphasisHigh = 2,
 };
 
@@ -207,15 +210,11 @@ typedef void (^MDCActionHandler)(MDCAlertAction *_Nonnull action);
 
 /**
  Title of the button shown on the alert dialog.
-
- Alert actions titles must be set using either of the actionWithTitle:[emphais:]handler: methods.
  */
 @property(nonatomic, nullable, readonly) NSString *title;
 
 /**
  The MDCActionEmphasis emphasis of the button that will be rendered for the action.
-
- Alert actions emphasis must be set in the actionWithTitle:emphasis:handler: method.
  */
 @property(nonatomic, readonly) MDCActionEmphasis emphasis;
 

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -172,9 +172,9 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 - (nullable MDCButton *)buttonForAction:(nonnull MDCAlertAction *)action {
   MDCButton *button = [self.actionManager buttonForAction:action];
   if (!button && [self.actionManager hasAction:action]) {
-    button = [self.actionManager addButtonForAction:action
-                                             target:self
-                                           selector:@selector(actionButtonPressed:)];
+    button = [self.actionManager createButtonForAction:action
+                                                target:self
+                                              selector:@selector(actionButtonPressed:)];
     [MDCAlertControllerView styleAsTextButton:button];
   }
   return button;

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -204,6 +204,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   }
 }
 
+// b/117717380: Will be deprecated
 - (void)setButtonFont:(UIFont *)buttonFont {
   _buttonFont = buttonFont;
   if (self.alertView) {
@@ -225,6 +226,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   }
 }
 
+// b/117717380: Will be deprecated
 - (void)setButtonTitleColor:(UIColor *)buttonColor {
   _buttonTitleColor = buttonColor;
   if (self.alertView) {
@@ -365,15 +367,21 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   self.alertView.messageFont = self.messageFont;
   self.alertView.titleColor = self.titleColor;
   self.alertView.messageColor = self.messageColor;
-  self.alertView.buttonColor = self.buttonTitleColor;
-  self.alertView.buttonFont = self.buttonFont;
-  self.alertView.buttonInkColor = self.buttonInkColor;
+  if (self.buttonTitleColor) {
+    // Avoid reset title color to white when setting it to nil. only set it for an actual UIColor.
+    self.alertView.buttonColor = self.buttonTitleColor;  // b/117717380: Will be deprecated
+  }
+  self.alertView.buttonFont = self.buttonFont;  // b/117717380: Will be deprecated
+  if (self.buttonInkColor) {
+    // Avoid reset ink color to white when setting it to nil. only set it for an actual UIColor.
+    self.alertView.buttonInkColor = self.buttonInkColor;  // b/117717380: Will be deprecated
+  }
   self.alertView.titleAlignment = self.titleAlignment;
   self.alertView.titleIcon = self.titleIcon;
   self.alertView.titleIconTintColor = self.titleIconTintColor;
   self.alertView.cornerRadius = self.cornerRadius;
 
-  // create buttons for the actions (if not already created) and apply default styling
+  // Create buttons for the actions (if not already created) and apply default styling
   for (MDCAlertAction *action in self.actions) {
     [self addButtonToAlertViewForAction:action];
   }

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -40,21 +40,31 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 
 + (instancetype)actionWithTitle:(nonnull NSString *)title
                         handler:(void (^__nullable)(MDCAlertAction *action))handler {
-  return [[MDCAlertAction alloc] initWithTitle:title handler:handler];
+  return [[MDCAlertAction alloc] initWithTitle:title emphasis:MDCActionEmphasisLow handler:handler];
+}
+
++ (instancetype)actionWithTitle:(nonnull NSString *)title
+                       emphasis:(MDCActionEmphasis)emphasis
+                        handler:(void (^__nullable)(MDCAlertAction *action))handler {
+  return [[MDCAlertAction alloc] initWithTitle:title emphasis:emphasis handler:handler];
 }
 
 - (instancetype)initWithTitle:(nonnull NSString *)title
+                     emphasis:(MDCActionEmphasis)emphasis
                       handler:(void (^__nullable)(MDCAlertAction *action))handler {
   self = [super init];
   if (self) {
     _title = [title copy];
+    _emphasis = emphasis;
     _completionHandler = [handler copy];
   }
   return self;
 }
 
 - (id)copyWithZone:(__unused NSZone *)zone {
-  MDCAlertAction *action = [[self class] actionWithTitle:self.title handler:self.completionHandler];
+  MDCAlertAction *action = [[self class] actionWithTitle:self.title
+                                                emphasis:self.emphasis
+                                                 handler:self.completionHandler];
   action.accessibilityIdentifier = self.accessibilityIdentifier;
 
   return action;
@@ -65,8 +75,8 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 @interface MDCAlertController ()
 
 @property(nonatomic, nullable, weak) MDCAlertControllerView *alertView;
-@property(nonatomic, nonnull, strong) MDCAlertActionManager *actionManager;
 @property(nonatomic, strong) MDCDialogTransitionController *transitionController;
+@property(nonatomic, nonnull, strong) MDCAlertActionManager *actionManager;
 
 - (nonnull instancetype)initWithTitle:(nullable NSString *)title
                               message:(nullable NSString *)message;

--- a/components/Dialogs/src/MDCAlertControllerView.h
+++ b/components/Dialogs/src/MDCAlertControllerView.h
@@ -26,6 +26,7 @@
 @property(nonatomic, strong, nullable) UIFont *messageFont UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong, nullable) UIColor *messageColor UI_APPEARANCE_SELECTOR;
 
+// b/117717380: Will be deprecated (x3)
 @property(nonatomic, strong, nullable) UIFont *buttonFont UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong, nullable) UIColor *buttonColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong, nullable) UIColor *buttonInkColor UI_APPEARANCE_SELECTOR;

--- a/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.m
+++ b/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.m
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #import "MDCAlertTypographyThemer.h"
+#import "MDCButtonTypographyThemer.h"
+#import "MaterialTypography.h"
 
 @implementation MDCAlertTypographyThemer
 
@@ -20,7 +22,13 @@
             toAlertController:(nonnull MDCAlertController *)alertController {
   alertController.titleFont = typographyScheme.headline6;
   alertController.messageFont = typographyScheme.body1;
-  alertController.buttonFont = typographyScheme.button;
+
+  // Apply emphasis-based button theming, if enabled
+  for (MDCAlertAction *action in alertController.actions) {
+    MDCButton *button = [alertController buttonForAction:action];
+    // todo: b/117265609: Incorporate dynamic type support in button themers
+    [MDCButtonTypographyThemer applyTypographyScheme:typographyScheme toButton:button];
+  }
 }
 
 @end

--- a/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.m
+++ b/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.m
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MaterialDialogs+TypographyThemer.h"
-#import "MDCButtonTypographyThemer.h"
+#import "MDCAlertTypographyThemer.h"
+
+#import "MDCAlertController+ButtonForAction.h"
+#import "MaterialButtons+TypographyThemer.h"
 #import "MaterialTypography.h"
 
 @implementation MDCAlertTypographyThemer

--- a/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.m
+++ b/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.m
@@ -14,8 +14,8 @@
 
 #import "MDCAlertTypographyThemer.h"
 
-#import "MDCAlertController+ButtonForAction.h"
-#import "MaterialButtons+TypographyThemer.h"
+#import "../../../Buttons/src/TypographyThemer/MaterialButtons+TypographyThemer.h"
+#import "../MDCAlertController+ButtonForAction.h"
 #import "MaterialTypography.h"
 
 @implementation MDCAlertTypographyThemer

--- a/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.m
+++ b/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAlertTypographyThemer.h"
+#import "MaterialDialogs+TypographyThemer.h"
 #import "MDCButtonTypographyThemer.h"
 #import "MaterialTypography.h"
 

--- a/components/Dialogs/src/private/MDCAlertActionManager.h
+++ b/components/Dialogs/src/private/MDCAlertActionManager.h
@@ -18,13 +18,20 @@
 
 @interface MDCAlertActionManager : NSObject
 
-@property(nonatomic, nonnull, strong, readonly) NSArray<MDCAlertAction *> *actions;
 /**
- returns the list of buttons for the provided actions, if they're already created. May
- return a different size list than actions, if the buttons hasn't materialized yet.
- Returns the buttons in the order they appear on screen (matches the order of "actions").
+ List of the actions that were added to the action manager.
  */
-@property(nonatomic, nonnull, strong, readonly) NSArray<MDCButton *> *sortedButtons;
+@property(nonatomic, nonnull, strong, readonly) NSArray<MDCAlertAction *> *actions;
+
+/**
+ Returns the list of buttons for the provided actions. Only returns buttons which have already
+ been created. Unlike buttonForAction, it does not create buttons, and as a results, may
+ return a shorter list than the actions array. Order of buttons resembles order of actions,
+ but is not guaranteed.
+
+ Note: It is the caller's responsibility to make sure buttons is added to the view hierarchy.
+ */
+@property(nonatomic, nonnull, strong, readonly) NSArray<MDCButton *> *buttonsInActionOrder;
 
 /**
  Adding an action with no associated button (will be created later)
@@ -39,7 +46,7 @@
 /**
  Returns the button for the action. Returns nil if the button hasn't been created yet.
 
- Note: It is the caller's responsibility to ensure the button is in the view hierarchy.
+ Note: It is the caller's responsibility to make sure the button is added to the view hierarchy.
  */
 - (nullable MDCButton *)buttonForAction:(nonnull MDCAlertAction *)action;
 
@@ -49,13 +56,15 @@
 - (nullable MDCAlertAction *)actionForButton:(nonnull MDCButton *)button;
 
 /**
- Creates a button and associates it with the action. Given Target and selector are
- assigned to the button.
+ Creates a button for the given action if the action is not yet associated with a button.
+ If the action is already associated with a button, then the existing button is returned.
+ The given Target and selector are assigned to the button when it's created (or ignored
+ if the button is already exists).
 
- Note: It is the caller's responsibility to add the button to the view hierarchy.
+ Note: It is the caller's responsibility to make sure the button is added to the view hierarchy.
  */
-- (nullable MDCButton *)addButtonForAction:(nonnull MDCAlertAction *)action
-                                    target:(nullable id)target
-                                  selector:(SEL _Nonnull)selector;
+- (nullable MDCButton *)createButtonForAction:(nonnull MDCAlertAction *)action
+                                       target:(nullable id)target
+                                     selector:(SEL _Nonnull)selector;
 
 @end

--- a/components/Dialogs/src/private/MDCAlertActionManager.h
+++ b/components/Dialogs/src/private/MDCAlertActionManager.h
@@ -1,0 +1,61 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import "MaterialButtons.h"
+#import "MaterialDialogs.h"
+
+@interface MDCAlertActionManager : NSObject
+
+@property(nonatomic, nonnull, strong, readonly) NSArray<MDCAlertAction *> *actions;
+/**
+ returns the list of buttons for the provided actions, if they're already created. May
+ return a different size list than actions, if the buttons hasn't materialized yet.
+ Returns the buttons in the order they appear on screen (matches the order of "actions").
+ */
+@property(nonatomic, nonnull, strong, readonly) NSArray<MDCButton *> *sortedButtons;
+
+/**
+ Adding an action with no associated button (will be created later)
+ */
+- (void)addAction:(nonnull MDCAlertAction *)action;
+
+/**
+ Returns true if the action has been previously added to the array
+ */
+- (BOOL)hasAction:(nonnull MDCAlertAction *)action;
+
+/**
+ Returns the button for the action. Returns nil if the button hasn't been created yet.
+
+ Note: It is the caller's responsibility to ensure the button is in the view hierarchy.
+ */
+- (nullable MDCButton *)buttonForAction:(nonnull MDCAlertAction *)action;
+
+/**
+ Returns the action for the given button.
+ */
+- (nullable MDCAlertAction *)actionForButton:(nonnull MDCButton *)button;
+
+/**
+ Creates a button and associates it with the action. Given Target and selector are
+ assigned to the button.
+
+ Note: It is the caller's responsibility to add the button to the view hierarchy.
+ */
+- (nullable MDCButton *)addButtonForAction:(nonnull MDCAlertAction *)action
+                                    target:(nullable id)target
+                                  selector:(SEL _Nonnull)selector;
+
+@end

--- a/components/Dialogs/src/private/MDCAlertActionManager.m
+++ b/components/Dialogs/src/private/MDCAlertActionManager.m
@@ -15,14 +15,16 @@
 #import "MDCAlertActionManager.h"
 
 @interface MDCAlertActionManager ()
-@property(nonatomic, nonnull, strong) NSMapTable *actionButtons;
+
+@property(nonatomic, nonnull, strong) NSMapTable<MDCAlertAction *, MDCButton *> *actionButtons;
+
 @end
 
 @implementation MDCAlertActionManager {
   NSMutableArray<MDCAlertAction *> *_actions;
 }
 
-@dynamic sortedButtons;
+@dynamic buttonsInActionOrder;
 
 - (instancetype)init {
   self = [super init];
@@ -34,18 +36,18 @@
   return self;
 }
 
-- (NSArray<MDCButton *> *)sortedButtons {
-  NSMutableArray<MDCButton *> *sortedButtons =
+- (NSArray<MDCButton *> *)buttonsInActionOrder {
+  NSMutableArray<MDCButton *> *buttons =
       [[NSMutableArray alloc] initWithCapacity:self.actions.count];
   if ([self.actionButtons count] > 0) {
     for (MDCAlertAction *action in self.actions) {
       MDCButton *button = [self.actionButtons objectForKey:action];
       if (button) {
-        [sortedButtons addObject:button];
+        [buttons addObject:button];
       }
     }
   }
-  return sortedButtons;
+  return buttons;
 }
 
 - (void)addAction:(nonnull MDCAlertAction *)action {
@@ -61,24 +63,25 @@
 }
 
 - (nullable MDCAlertAction *)actionForButton:(nonnull MDCButton *)button {
-  NSEnumerator *enumerator = [self.actionButtons keyEnumerator];
-  MDCAlertAction *action = nil;
-  while ((action = [enumerator nextObject])) {
+  for (MDCAlertAction *action in self.actionButtons) {
     MDCButton *currButton = [self.actionButtons objectForKey:action];
     if (currButton == button) {
       return action;
     }
   }
-  return action;
+  return nil;
 }
 
 // creating a new buttons and associating it with the given action. the button is not added
 // to view hierarchy.
-- (nullable MDCButton *)addButtonForAction:(nonnull MDCAlertAction *)action
-                                    target:(nullable id)target
-                                  selector:(SEL _Nonnull)selector {
-  MDCButton *button = [self makeButtonForAction:action target:target selector:selector];
-  [self.actionButtons setObject:button forKey:action];
+- (nullable MDCButton *)createButtonForAction:(nonnull MDCAlertAction *)action
+                                       target:(nullable id)target
+                                     selector:(SEL _Nonnull)selector {
+  MDCButton *button = [self.actionButtons objectForKey:action];
+  if (button == nil) {
+    button = [self makeButtonForAction:action target:target selector:selector];
+    [self.actionButtons setObject:button forKey:action];
+  }
   return button;
 }
 

--- a/components/Dialogs/src/private/MDCAlertActionManager.m
+++ b/components/Dialogs/src/private/MDCAlertActionManager.m
@@ -1,0 +1,95 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCAlertActionManager.h"
+
+@interface MDCAlertActionManager ()
+@property(nonatomic, nonnull, strong) NSMapTable *actionButtons;
+@end
+
+@implementation MDCAlertActionManager {
+  NSMutableArray<MDCAlertAction *> *_actions;
+}
+
+@dynamic sortedButtons;
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _actions = [[NSMutableArray alloc] init];
+    _actionButtons = [NSMapTable mapTableWithKeyOptions:NSMapTableWeakMemory
+                                           valueOptions:NSMapTableStrongMemory];
+  }
+  return self;
+}
+
+- (NSArray<MDCButton *> *)sortedButtons {
+  NSMutableArray<MDCButton *> *sortedButtons =
+      [[NSMutableArray alloc] initWithCapacity:self.actions.count];
+  if ([self.actionButtons count] > 0) {
+    for (MDCAlertAction *action in self.actions) {
+      MDCButton *button = [self.actionButtons objectForKey:action];
+      if (button) {
+        [sortedButtons addObject:button];
+      }
+    }
+  }
+  return sortedButtons;
+}
+
+- (void)addAction:(nonnull MDCAlertAction *)action {
+  [_actions addObject:action];
+}
+
+- (BOOL)hasAction:(nonnull MDCAlertAction *)action {
+  return [_actions indexOfObject:action] != NSNotFound;
+}
+
+- (nullable MDCButton *)buttonForAction:(nonnull MDCAlertAction *)action {
+  return [self.actionButtons objectForKey:action];
+}
+
+- (nullable MDCAlertAction *)actionForButton:(nonnull MDCButton *)button {
+  NSEnumerator *enumerator = [self.actionButtons keyEnumerator];
+  MDCAlertAction *action = nil;
+  while ((action = [enumerator nextObject])) {
+    MDCButton *currButton = [self.actionButtons objectForKey:action];
+    if (currButton == button) {
+      return action;
+    }
+  }
+  return action;
+}
+
+// creating a new buttons and associating it with the given action. the button is not added
+// to view hierarchy.
+- (nullable MDCButton *)addButtonForAction:(nonnull MDCAlertAction *)action
+                                    target:(nullable id)target
+                                  selector:(SEL _Nonnull)selector {
+  MDCButton *button = [self makeButtonForAction:action target:target selector:selector];
+  [self.actionButtons setObject:button forKey:action];
+  return button;
+}
+
+- (MDCButton *)makeButtonForAction:(MDCAlertAction *)action
+                            target:(id)target
+                          selector:(SEL)selector {
+  MDCButton *button = [[MDCButton alloc] initWithFrame:CGRectZero];
+  [button setTitle:action.title forState:UIControlStateNormal];
+  button.accessibilityIdentifier = action.accessibilityIdentifier;
+  [button addTarget:target action:selector forControlEvents:UIControlEventTouchUpInside];
+  return button;
+}
+
+@end

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.h
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.h
@@ -14,6 +14,7 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MDCAlertActionManager.h"
 #import "MaterialButtons.h"
 
 @interface MDCAlertControllerView ()
@@ -23,11 +24,10 @@
 
 @property(nonatomic, nullable, strong) UIImageView *titleIconImageView;
 
-@property(nonatomic, nonnull, strong, readonly) NSArray<MDCButton *> *actionButtons;
+@property(nonatomic, nullable, weak) MDCAlertActionManager *actionManager;
 
-- (nonnull MDCButton *)addActionButtonTitle:(NSString *_Nonnull)actionTitle
-                                     target:(nullable id)target
-                                   selector:(SEL _Nonnull)selector;
+- (void)addActionButton:(nonnull MDCButton *)button;
++ (void)styleAsTextButton:(nonnull MDCButton *)button;
 
 - (CGSize)calculatePreferredContentSizeForBounds:(CGSize)boundsSize;
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -131,7 +131,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   }
 }
 
-- (void)styleAsTextButton:(nonnull MDCButton *)button {
++ (void)styleAsTextButton:(nonnull MDCButton *)button {
   // This preserves default buttons style (as MDCFlatButton/text) for backward compatibility reasons
   UIColor *themeColor = [UIColor blackColor];
   [button setBackgroundColor:UIColor.clearColor forState:UIControlStateNormal];
@@ -260,7 +260,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
         [finalButtonFont mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
                                 scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
   }
-  for (MDCButton *button in self.actionManager.sortedButtons) {
+  for (MDCButton *button in self.actionManager.buttonsInActionOrder) {
     [button setTitleFont:finalButtonFont forState:UIControlStateNormal];
   }
 
@@ -278,7 +278,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)setButtonColor:(UIColor *)color {
   _buttonColor = color;
 
-  for (MDCButton *button in self.actionManager.sortedButtons) {
+  for (MDCButton *button in self.actionManager.buttonsInActionOrder) {
     [button setTitleColor:_buttonColor forState:UIControlStateNormal];
   }
 }
@@ -286,7 +286,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)setButtonInkColor:(UIColor *)color {
   _buttonInkColor = color;
 
-  for (MDCButton *button in self.actionManager.sortedButtons) {
+  for (MDCButton *button in self.actionManager.buttonsInActionOrder) {
     button.inkColor = color;
   }
 }
@@ -308,7 +308,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
 - (CGSize)actionButtonsSizeInHorizontalLayout {
   CGSize size = CGSizeZero;
-  NSArray<MDCButton *> *buttons = self.actionManager.sortedButtons;
+  NSArray<MDCButton *> *buttons = self.actionManager.buttonsInActionOrder;
   if (0 < [buttons count]) {
     size.height =
     MDCDialogActionsInsets.top + MDCDialogActionButtonHeight + MDCDialogActionsInsets.bottom;
@@ -327,7 +327,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
 - (CGSize)actionButtonsSizeInVericalLayout {
   CGSize size = CGSizeZero;
-  NSArray<MDCButton *> *buttons = self.actionManager.sortedButtons;
+  NSArray<MDCButton *> *buttons = self.actionManager.buttonsInActionOrder;
   if (0 < [buttons count]) {
     size.height = MDCDialogActionsInsets.top + MDCDialogActionsInsets.bottom;
     size.width = MDCDialogActionsInsets.left + MDCDialogActionsInsets.right;
@@ -426,7 +426,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)layoutSubviews {
   [super layoutSubviews];
 
-  NSArray<MDCButton *> *buttons = self.actionManager.sortedButtons;
+  NSArray<MDCButton *> *buttons = self.actionManager.buttonsInActionOrder;
 
   for (MDCButton *button in buttons) {
     [button sizeToFit];
@@ -616,7 +616,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {
   _mdc_adjustsFontForContentSizeCategory = adjusts;
 
-  for (MDCButton *button in self.actionManager.sortedButtons) {
+  for (MDCButton *button in self.actionManager.buttonsInActionOrder) {
     button.mdc_adjustsFontForContentSizeCategory = adjusts;
   }
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -49,7 +49,6 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 @end
 
 @implementation MDCAlertControllerView {
-  NSMutableArray<MDCButton *> *_actionButtons;
   BOOL _mdc_adjustsFontForContentSizeCategory;
 }
 
@@ -93,8 +92,6 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     self.messageLabel.textColor = [UIColor colorWithWhite:0.0f alpha:MDCDialogMessageOpacity];
     [self.contentScrollView addSubview:self.messageLabel];
 
-    _actionButtons = [[NSMutableArray alloc] init];
-
     [self setNeedsLayout];
   }
 
@@ -103,10 +100,6 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
 - (void)dealloc {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
-- (NSArray<UIButton *>*)actionButtons{
-  return (NSArray<UIButton *>*)_actionButtons;
 }
 
 - (NSString *)title {
@@ -119,31 +112,23 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   [self setNeedsLayout];
 }
 
-- (MDCButton *)addActionButtonTitle:(NSString *)actionTitle target:(id)target selector:(SEL)selector {
-  MDCButton *actionButton = [[MDCButton alloc] initWithFrame:CGRectZero];
-  [self styleAsTextButton:actionButton];
-  actionButton.mdc_adjustsFontForContentSizeCategory = self.mdc_adjustsFontForContentSizeCategory;
-  [actionButton setTitle:actionTitle forState:UIControlStateNormal];
-  [actionButton setTitleColor:_buttonColor forState:UIControlStateNormal];
-  if (_buttonColor) {
-    // We only set if _buttonColor since settingTitleColor to nil doesn't reset the title to the
-    // default
-    [actionButton setTitleColor:_buttonColor forState:UIControlStateNormal];
+- (void)addActionButton:(nonnull MDCButton *)button {
+  if (button.superview == nil) {
+    button.mdc_adjustsFontForContentSizeCategory = self.mdc_adjustsFontForContentSizeCategory;
+    [self.actionsScrollView addSubview:button];
+    if (_buttonColor) {
+      // We only set if _buttonColor since settingTitleColor to nil doesn't
+      // reset the title to the default
+      [button setTitleColor:_buttonColor forState:UIControlStateNormal];
+    }
+    [button setTitleFont:_buttonFont forState:UIControlStateNormal];
+    button.inkColor = self.buttonInkColor;
+    // TODO(#1726): Determine default text color values for Normal and Disabled
+    CGRect buttonRect = button.bounds;
+    buttonRect.size.height = MAX(buttonRect.size.height, MDCDialogActionButtonHeight);
+    buttonRect.size.width = MAX(buttonRect.size.width, MDCDialogActionButtonMinimumWidth);
+    button.frame = buttonRect;
   }
-  [actionButton setTitleFont:_buttonFont forState:UIControlStateNormal];
-  actionButton.inkColor = self.buttonInkColor;
-  // TODO(#1726): Determine default text color values for Normal and Disabled
-  CGRect buttonRect = actionButton.bounds;
-  buttonRect.size.height = MAX(buttonRect.size.height, MDCDialogActionButtonHeight);
-  buttonRect.size.width = MAX(buttonRect.size.width, MDCDialogActionButtonMinimumWidth);
-  actionButton.frame = buttonRect;
-  [actionButton addTarget:target
-                   action:selector
-         forControlEvents:UIControlEventTouchUpInside];
-  [self.actionsScrollView addSubview:actionButton];
-
-  [_actionButtons addObject:actionButton];
-  return actionButton;
 }
 
 - (void)styleAsTextButton:(nonnull MDCButton *)button {
@@ -275,7 +260,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
         [finalButtonFont mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
                                 scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
   }
-  for (MDCButton *button in self.actionButtons) {
+  for (MDCButton *button in self.actionManager.sortedButtons) {
     [button setTitleFont:finalButtonFont forState:UIControlStateNormal];
   }
 
@@ -293,7 +278,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)setButtonColor:(UIColor *)color {
   _buttonColor = color;
 
-  for (MDCButton *button in self.actionButtons) {
+  for (MDCButton *button in self.actionManager.sortedButtons) {
     [button setTitleColor:_buttonColor forState:UIControlStateNormal];
   }
 }
@@ -301,7 +286,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)setButtonInkColor:(UIColor *)color {
   _buttonInkColor = color;
 
-  for (MDCButton *button in self.actionButtons) {
+  for (MDCButton *button in self.actionManager.sortedButtons) {
     button.inkColor = color;
   }
 }
@@ -323,14 +308,15 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
 - (CGSize)actionButtonsSizeInHorizontalLayout {
   CGSize size = CGSizeZero;
-  if (0 < [self.actionButtons count]) {
+  NSArray<MDCButton *> *buttons = self.actionManager.sortedButtons;
+  if (0 < [buttons count]) {
     size.height =
     MDCDialogActionsInsets.top + MDCDialogActionButtonHeight + MDCDialogActionsInsets.bottom;
     size.width = MDCDialogActionsInsets.left + MDCDialogActionsInsets.right;
-    for (UIButton *button in self.actionButtons) {
+    for (UIButton *button in buttons) {
       CGSize buttonSize = [button sizeThatFits:size];
       size.width += buttonSize.width;
-      if (button != [self.actionButtons lastObject]) {
+      if (button != [buttons lastObject]) {
         size.width += MDCDialogActionsHorizontalPadding;
       }
     }
@@ -341,15 +327,16 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
 - (CGSize)actionButtonsSizeInVericalLayout {
   CGSize size = CGSizeZero;
-  if (0 < [self.actionButtons count]) {
+  NSArray<MDCButton *> *buttons = self.actionManager.sortedButtons;
+  if (0 < [buttons count]) {
     size.height = MDCDialogActionsInsets.top + MDCDialogActionsInsets.bottom;
     size.width = MDCDialogActionsInsets.left + MDCDialogActionsInsets.right;
-    for (UIButton *button in self.actionButtons) {
+    for (UIButton *button in buttons) {
       CGSize buttonSize = [button sizeThatFits:size];
       buttonSize.height = MAX(buttonSize.height, MDCDialogActionButtonHeight);
       size.height += buttonSize.height;
       size.width = MAX(size.width, buttonSize.width);
-      if (button != [self.actionButtons lastObject]) {
+      if (button != [buttons lastObject]) {
         size.height += MDCDialogActionsVerticalPadding;
       }
     }
@@ -439,7 +426,9 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)layoutSubviews {
   [super layoutSubviews];
 
-  for (MDCButton *button in self.actionButtons) {
+  NSArray<MDCButton *> *buttons = self.actionManager.sortedButtons;
+
+  for (MDCButton *button in buttons) {
     [button sizeToFit];
     CGRect buttonFrame = button.frame;
     buttonFrame.size.width =
@@ -534,7 +523,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
   CGRect actionsFrame = CGRectZero;
   actionsFrame.size.width = CGRectGetWidth(self.bounds);
-  if (0 < [self.actionButtons count]) {
+  if (0 < [buttons count]) {
     actionsFrame.size.height = actionSize.height;
   }
   self.actionsScrollView.contentSize = actionsFrame.size;
@@ -544,14 +533,14 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     CGPoint buttonCenter;
     buttonCenter.x = self.actionsScrollView.contentSize.width * 0.5f;
     buttonCenter.y = self.actionsScrollView.contentSize.height - MDCDialogActionsInsets.bottom;
-    for (UIButton *button in self.actionButtons) {
+    for (UIButton *button in buttons) {
       CGRect buttonRect = button.frame;
 
       buttonCenter.y -= buttonRect.size.height * 0.5;
 
       button.center = buttonCenter;
 
-      if (button != [self.actionButtons lastObject]) {
+      if (button != [buttons lastObject]) {
         buttonCenter.y -= buttonRect.size.height * 0.5;
         buttonCenter.y -= MDCDialogActionsVerticalPadding;
       }
@@ -560,7 +549,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     CGPoint buttonOrigin = CGPointZero;
     buttonOrigin.x = self.actionsScrollView.contentSize.width - MDCDialogActionsInsets.right;
     buttonOrigin.y = MDCDialogActionsInsets.top;
-    for (UIButton *button in self.actionButtons) {
+    for (UIButton *button in buttons) {
       CGRect buttonRect = button.frame;
 
       buttonOrigin.x -= buttonRect.size.width;
@@ -568,14 +557,14 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
       button.frame = buttonRect;
 
-      if (button != [self.actionButtons lastObject]) {
+      if (button != [buttons lastObject]) {
         buttonOrigin.x -= MDCDialogActionsHorizontalPadding;
       }
     }
     // Handle RTL
     if (self.mdf_effectiveUserInterfaceLayoutDirection ==
         UIUserInterfaceLayoutDirectionRightToLeft) {
-      for (UIButton *button in self.actionButtons) {
+      for (UIButton *button in buttons) {
         CGRect flippedRect =
           MDFRectFlippedHorizontally(button.frame, CGRectGetWidth(self.bounds));
         button.frame = flippedRect;
@@ -627,7 +616,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {
   _mdc_adjustsFontForContentSizeCategory = adjusts;
 
-  for (MDCButton *button in _actionButtons) {
+  for (MDCButton *button in self.actionManager.sortedButtons) {
     button.mdc_adjustsFontForContentSizeCategory = adjusts;
   }
 

--- a/components/Dialogs/tests/unit/MDCAlertActionManagerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertActionManagerTests.m
@@ -1,0 +1,140 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+#import "MDCAlertActionManager.h"
+#import "MDCAlertControllerView+Private.h"
+
+@interface MDCAlertActionManagerTests : XCTestCase
+
+@property(nonatomic, nullable, strong) MDCAlertActionManager *actionManager;
+@property(nonatomic, nullable, strong) MDCAlertAction *action;
+
+@end
+
+@implementation MDCAlertActionManagerTests
+
+- (void)actionButtonPressed:(id)button {
+}
+
+- (void)setUp {
+  [super setUp];
+  self.actionManager = [[MDCAlertActionManager alloc] init];
+  self.action = [MDCAlertAction actionWithTitle:@"title"
+                                        handler:^(MDCAlertAction *_Nonnull act){
+                                        }];
+}
+
+- (void)testAddingActionsDoesnotCreaetButtons {
+  // When
+  [self.actionManager addAction:self.action];
+
+  // Then
+  XCTAssertEqual([[self.actionManager actions] count], 1ul);
+  XCTAssertEqual([[self.actionManager sortedButtons] count], 0ul);
+}
+
+- (void)testActionManager_ButtonForActionReturnsNoButtonsWhenCalledBeforeThemingOrPresentation {
+  // Given
+  [self.actionManager addAction:self.action];
+
+  // When
+  MDCButton *button = [self.actionManager buttonForAction:self.action];
+
+  // Then
+  XCTAssertNil(button);
+  XCTAssertEqual([[self.actionManager actions] count], 1ul);
+  XCTAssertEqual([[self.actionManager sortedButtons] count], 0ul);
+}
+
+- (void)testActionManager_AddingButtonToActionBeforeAlertIsPResentedReturnsDetachedButtons {
+  // Given
+  [self.actionManager addAction:self.action];
+
+  // When
+  MDCButton *button = [self.actionManager addButtonForAction:self.action
+                                                      target:self
+                                                    selector:@selector(actionButtonPressed:)];
+  MDCButton *button2 = [self.actionManager buttonForAction:self.action];
+
+  // Then
+  XCTAssertNotNil(button);
+  XCTAssertNil(button.superview);
+  XCTAssertEqual([[self.actionManager actions] count], 1ul);
+  XCTAssertEqual([[self.actionManager sortedButtons] count], 1ul);
+  XCTAssertEqual(button, button2);
+  XCTAssertEqual([self.actionManager actionForButton:button], self.action);
+}
+
+- (void)testAlertController_AddingActionsToAlertBeforePresentationCreatesDetachedButtons {
+  // Given
+  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title" message:@"msg"];
+  MDCAlertAction *action2 = [MDCAlertAction actionWithTitle:@"action2"
+                                                    handler:^(MDCAlertAction *_Nonnull act){
+                                                    }];
+
+  // When
+  [alert addAction:self.action];
+  MDCButton *button = [alert buttonForAction:self.action];
+  MDCButton *button2 = [alert buttonForAction:action2];
+
+  // Then
+  XCTAssertEqual([alert.actions count], 1ul);
+  XCTAssertNotNil(button);
+  XCTAssertNil(button.superview);
+  XCTAssertNil(button2);  // no button if the action hasn't been added first
+}
+
+- (void)testAlertController_AlertPresentationAttachesButtonsToViewHierarchy {
+  // Given
+  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title" message:@"msg"];
+  [alert addAction:self.action];
+  MDCButton *button = [alert buttonForAction:self.action];
+
+  // When (simulating alert presentation)
+  MDCAlertControllerView *alertView = (MDCAlertControllerView *)alert.view;
+
+  // Then
+  XCTAssertNotNil(button);
+  XCTAssertNotNil(button.superview);
+  XCTAssertEqual([[alertView.actionManager actions] count], 1ul);
+  XCTAssertEqual([[alertView.actionManager sortedButtons] count], 1ul);
+  XCTAssertEqual([alertView.actionManager buttonForAction:self.action], button);
+  XCTAssertEqual([alertView.actionManager actionForButton:button], self.action);
+}
+
+- (void)testAddingActionsToAlertBeforeAndAfterPresentationAddsAllButtonsToViewHierarchy {
+  // Given
+  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title" message:@"msg"];
+  MDCAlertAction *action2 = [MDCAlertAction actionWithTitle:@"action2"
+                                                    handler:^(MDCAlertAction *_Nonnull act){
+                                                    }];
+  [alert addAction:self.action];
+  MDCButton *button = [alert buttonForAction:self.action];
+
+  // When
+  MDCAlertControllerView *alertView = (MDCAlertControllerView *)alert.view;
+  [alert addAction:action2];
+
+  // Then
+  XCTAssertEqual([alert.actions count], 2ul);
+  XCTAssertNotNil(button);
+  XCTAssertNotNil(button.superview);
+  XCTAssertEqual([[alertView.actionManager sortedButtons] count], 2ul);
+  MDCButton *button2 = [alert buttonForAction:action2];
+  XCTAssertNotNil(button2);
+  XCTAssertNotNil(button2.superview);
+}
+
+@end

--- a/components/Dialogs/tests/unit/MDCAlertActionManagerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertActionManagerTests.m
@@ -14,6 +14,7 @@
 
 #import <XCTest/XCTest.h>
 #import "MDCAlertActionManager.h"
+#import "MDCAlertController+ButtonForAction.h"
 #import "MDCAlertControllerView+Private.h"
 
 @interface MDCAlertActionManagerTests : XCTestCase

--- a/components/Dialogs/tests/unit/MDCAlertActionManagerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertActionManagerTests.m
@@ -42,7 +42,7 @@
 
   // Then
   XCTAssertEqual([[self.actionManager actions] count], 1ul);
-  XCTAssertEqual([[self.actionManager sortedButtons] count], 0ul);
+  XCTAssertEqual([[self.actionManager buttonsInActionOrder] count], 0ul);
 }
 
 - (void)testActionManager_ButtonForActionReturnsNoButtonsWhenCalledBeforeThemingOrPresentation {
@@ -55,7 +55,7 @@
   // Then
   XCTAssertNil(button);
   XCTAssertEqual([[self.actionManager actions] count], 1ul);
-  XCTAssertEqual([[self.actionManager sortedButtons] count], 0ul);
+  XCTAssertEqual([[self.actionManager buttonsInActionOrder] count], 0ul);
 }
 
 - (void)testActionManager_AddingButtonToActionBeforeAlertIsPResentedReturnsDetachedButtons {
@@ -63,16 +63,16 @@
   [self.actionManager addAction:self.action];
 
   // When
-  MDCButton *button = [self.actionManager addButtonForAction:self.action
-                                                      target:self
-                                                    selector:@selector(actionButtonPressed:)];
+  MDCButton *button = [self.actionManager createButtonForAction:self.action
+                                                         target:self
+                                                       selector:@selector(actionButtonPressed:)];
   MDCButton *button2 = [self.actionManager buttonForAction:self.action];
 
   // Then
   XCTAssertNotNil(button);
   XCTAssertNil(button.superview);
   XCTAssertEqual([[self.actionManager actions] count], 1ul);
-  XCTAssertEqual([[self.actionManager sortedButtons] count], 1ul);
+  XCTAssertEqual([[self.actionManager buttonsInActionOrder] count], 1ul);
   XCTAssertEqual(button, button2);
   XCTAssertEqual([self.actionManager actionForButton:button], self.action);
 }
@@ -109,7 +109,7 @@
   XCTAssertNotNil(button);
   XCTAssertNotNil(button.superview);
   XCTAssertEqual([[alertView.actionManager actions] count], 1ul);
-  XCTAssertEqual([[alertView.actionManager sortedButtons] count], 1ul);
+  XCTAssertEqual([[alertView.actionManager buttonsInActionOrder] count], 1ul);
   XCTAssertEqual([alertView.actionManager buttonForAction:self.action], button);
   XCTAssertEqual([alertView.actionManager actionForButton:button], self.action);
 }
@@ -131,7 +131,7 @@
   XCTAssertEqual([alert.actions count], 2ul);
   XCTAssertNotNil(button);
   XCTAssertNotNil(button.superview);
-  XCTAssertEqual([[alertView.actionManager sortedButtons] count], 2ul);
+  XCTAssertEqual([[alertView.actionManager buttonsInActionOrder] count], 2ul);
   MDCButton *button2 = [alert buttonForAction:action2];
   XCTAssertNotNil(button2);
   XCTAssertNotNil(button2.superview);

--- a/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
+++ b/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
@@ -89,13 +89,12 @@ class MDCAlertControllerAlertThemerTests: XCTestCase {
   }
 
   func testApplyingAlertSchemeScrimColorToPresentationController() {
-    guard let presentationController = alert.mdc_dialogPresentationController else { return }
-
     // Given
     let colorScheme = MDCSemanticColorScheme()
     colorScheme.onSurfaceColor = UIColor.green
     alertScheme.colorScheme = colorScheme
     let scrimColor = colorScheme.onSurfaceColor.withAlphaComponent(0.32)
+    let presentationController = alert.mdc_dialogPresentationController!
 
     // When
     MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)

--- a/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
+++ b/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
@@ -69,17 +69,15 @@ class MDCAlertControllerAlertThemerTests: XCTestCase {
                    MDCSemanticColorScheme().onSurfaceColor.withAlphaComponent(0.87))
     XCTAssertEqual(alertView.titleIconTintColor, colorScheme.primaryColor)
   }
-    
+
+  // Testing soon-to-be-deprecated old approach to button theming // b/117717380: Will be deprecated
   func testApplyingCustomTitleIconTintColor() {
     // Given
     let iconColor = UIColor.red
     let primaryColor = UIColor.green
-    let colorScheme = MDCSemanticColorScheme()
-    colorScheme.primaryColor = primaryColor
-    alertScheme.colorScheme = colorScheme
 
     // When
-    MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
+    alert.buttonTitleColor = primaryColor
     alert.titleIconTintColor = iconColor
 
     // Then

--- a/components/Dialogs/tests/unit/MDCAlertControllerColorThemerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerColorThemerTests.m
@@ -61,7 +61,7 @@
                 equalsColor2:[colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87]]);
   XCTAssertTrue([self color1:view.messageLabel.textColor
                 equalsColor2:[colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60]]);
-  for (UIButton *button in view.actionManager.sortedButtons) {
+  for (UIButton *button in view.actionManager.buttonsInActionOrder) {
     XCTAssertTrue([self color1:button.titleLabel.textColor equalsColor2:colorScheme.primaryColor]);
   }
 }

--- a/components/Dialogs/tests/unit/MDCAlertControllerColorThemerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerColorThemerTests.m
@@ -50,7 +50,7 @@
           && fabs(alpha1 - alpha2) < CGFLOAT_EPSILON);
 }
 
-- (void)testApplyingTypographyScheme {
+- (void)testApplyingColorScheme {
   MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
                                                                    message:@"message"];
   MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];

--- a/components/Dialogs/tests/unit/MDCAlertControllerColorThemerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerColorThemerTests.m
@@ -61,7 +61,7 @@
                 equalsColor2:[colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87]]);
   XCTAssertTrue([self color1:view.messageLabel.textColor
                 equalsColor2:[colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60]]);
-  for (UIButton *button in view.actionButtons) {
+  for (UIButton *button in view.actionManager.sortedButtons) {
     XCTAssertTrue([self color1:button.titleLabel.textColor equalsColor2:colorScheme.primaryColor]);
   }
 }

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -112,7 +112,7 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
   XCTAssertEqual(view.titleLabel.font, testFont);
   XCTAssertEqual(view.messageLabel.font, testFont);
-  for (UIButton *button in view.actionButtons) {
+  for (UIButton *button in view.actionManager.sortedButtons) {
     XCTAssertEqual(button.titleLabel.font, testFont);
   }
 }
@@ -129,7 +129,7 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
   XCTAssertEqual(view.titleLabel.textColor, testColor);
   XCTAssertEqual(view.messageLabel.textColor, testColor);
-  for (UIButton *button in view.actionButtons) {
+  for (UIButton *button in view.actionManager.sortedButtons) {
     XCTAssertEqual([button titleColorForState:UIControlStateNormal], testColor);
     XCTAssertTrue([button isKindOfClass:[MDCButton class]]);
     XCTAssertEqual([(MDCButton *)button inkColor], testColor);
@@ -154,8 +154,9 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
   XCTAssertEqual(view.titleLabel.textColor, testColor);
   XCTAssertEqual(view.messageLabel.textColor, testColor);
-  XCTAssertEqual((int)view.actionButtons.count, 2);
-  for (UIButton *button in view.actionButtons) {
+  NSArray<MDCButton *> *buttons = view.actionManager.sortedButtons;
+  XCTAssertEqual((int)buttons.count, 2);
+  for (UIButton *button in buttons) {
     XCTAssertEqual([button titleColorForState:UIControlStateNormal], testColor);
     XCTAssertTrue([button isKindOfClass:[MDCButton class]]);
     XCTAssertEqual([(MDCButton *)button inkColor], testColor);
@@ -180,8 +181,9 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
   XCTAssertEqual(view.titleLabel.textColor, testColor);
   XCTAssertEqual(view.messageLabel.textColor, testColor);
-  XCTAssertEqual((int)view.actionButtons.count, 2);
-  for (UIButton *button in view.actionButtons) {
+  NSArray<MDCButton *> *buttons = view.actionManager.sortedButtons;
+  XCTAssertEqual((int)buttons.count, 2);
+  for (UIButton *button in buttons) {
     XCTAssertEqual([button titleColorForState:UIControlStateNormal], testColor);
     XCTAssertTrue([button isKindOfClass:[MDCButton class]]);
     XCTAssertEqual([(MDCButton *)button inkColor], testColor);
@@ -207,8 +209,9 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
   XCTAssertEqual(view.titleLabel.textColor, testColor);
   XCTAssertEqual(view.messageLabel.textColor, testColor);
-  XCTAssertEqual((int)view.actionButtons.count, 2);
-  for (UIButton *button in view.actionButtons) {
+  NSArray<MDCButton *> *buttons = view.actionManager.sortedButtons;
+  XCTAssertEqual((int)buttons.count, 2);
+  for (UIButton *button in buttons) {
     XCTAssertEqual([button titleColorForState:UIControlStateNormal], testColor);
     XCTAssertTrue([button isKindOfClass:[MDCButton class]]);
     XCTAssertEqual([(MDCButton *)button inkColor], testColor);
@@ -265,7 +268,7 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   }
 
   // Then
-  NSArray<UIButton *> *buttons = alertController.alertView.actionButtons;
+  NSArray<UIButton *> *buttons = alertController.alertView.actionManager.sortedButtons;
   XCTAssertEqual(buttons.count, 2U);
   UIButton *button1 = buttons.firstObject;
   UIButton *button2 = buttons.lastObject;

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -112,7 +112,7 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
   XCTAssertEqual(view.titleLabel.font, testFont);
   XCTAssertEqual(view.messageLabel.font, testFont);
-  for (UIButton *button in view.actionManager.sortedButtons) {
+  for (UIButton *button in view.actionManager.buttonsInActionOrder) {
     XCTAssertEqual(button.titleLabel.font, testFont);
   }
 }
@@ -129,7 +129,7 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
   XCTAssertEqual(view.titleLabel.textColor, testColor);
   XCTAssertEqual(view.messageLabel.textColor, testColor);
-  for (UIButton *button in view.actionManager.sortedButtons) {
+  for (UIButton *button in view.actionManager.buttonsInActionOrder) {
     XCTAssertEqual([button titleColorForState:UIControlStateNormal], testColor);
     XCTAssertTrue([button isKindOfClass:[MDCButton class]]);
     XCTAssertEqual([(MDCButton *)button inkColor], testColor);
@@ -154,7 +154,7 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
   XCTAssertEqual(view.titleLabel.textColor, testColor);
   XCTAssertEqual(view.messageLabel.textColor, testColor);
-  NSArray<MDCButton *> *buttons = view.actionManager.sortedButtons;
+  NSArray<MDCButton *> *buttons = view.actionManager.buttonsInActionOrder;
   XCTAssertEqual((int)buttons.count, 2);
   for (UIButton *button in buttons) {
     XCTAssertEqual([button titleColorForState:UIControlStateNormal], testColor);
@@ -181,7 +181,7 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
   XCTAssertEqual(view.titleLabel.textColor, testColor);
   XCTAssertEqual(view.messageLabel.textColor, testColor);
-  NSArray<MDCButton *> *buttons = view.actionManager.sortedButtons;
+  NSArray<MDCButton *> *buttons = view.actionManager.buttonsInActionOrder;
   XCTAssertEqual((int)buttons.count, 2);
   for (UIButton *button in buttons) {
     XCTAssertEqual([button titleColorForState:UIControlStateNormal], testColor);
@@ -209,7 +209,7 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
   XCTAssertEqual(view.titleLabel.textColor, testColor);
   XCTAssertEqual(view.messageLabel.textColor, testColor);
-  NSArray<MDCButton *> *buttons = view.actionManager.sortedButtons;
+  NSArray<MDCButton *> *buttons = view.actionManager.buttonsInActionOrder;
   XCTAssertEqual((int)buttons.count, 2);
   for (UIButton *button in buttons) {
     XCTAssertEqual([button titleColorForState:UIControlStateNormal], testColor);
@@ -268,7 +268,7 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   }
 
   // Then
-  NSArray<UIButton *> *buttons = alertController.alertView.actionManager.sortedButtons;
+  NSArray<UIButton *> *buttons = alertController.alertView.actionManager.buttonsInActionOrder;
   XCTAssertEqual(buttons.count, 2U);
   UIButton *button1 = buttons.firstObject;
   UIButton *button2 = buttons.lastObject;

--- a/components/Dialogs/tests/unit/MDCAlertControllerTypographyThemerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTypographyThemerTests.m
@@ -34,7 +34,7 @@
   MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
   XCTAssertEqual(view.titleLabel.font, typographyScheme.headline6);
   XCTAssertEqual(view.messageLabel.font, typographyScheme.body1);
-  for (UIButton *button in view.actionManager.sortedButtons) {
+  for (UIButton *button in view.actionManager.buttonsInActionOrder) {
     XCTAssertEqual(button.titleLabel.font, typographyScheme.button);
   }
 }

--- a/components/Dialogs/tests/unit/MDCAlertControllerTypographyThemerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTypographyThemerTests.m
@@ -34,7 +34,7 @@
   MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
   XCTAssertEqual(view.titleLabel.font, typographyScheme.headline6);
   XCTAssertEqual(view.messageLabel.font, typographyScheme.body1);
-  for (UIButton *button in view.actionButtons) {
+  for (UIButton *button in view.actionManager.sortedButtons) {
     XCTAssertEqual(button.titleLabel.font, typographyScheme.button);
   }
 }


### PR DESCRIPTION
Adding semantic emphasis to Dialog actions which allows conditional theming of buttons. The MDCDailogScheme now has a button scheme which can be used to theme buttons according to their action's assigned emphasis.
Issue: b/117608629
Design Review document (go/gmdc-ios-dialogs-design-doc).

Notes:
This is a prototype of the 4th approach to action theming in Dialogs. Option 4 is currently the leading favorite among the button theming approaches. See pros and cons discussion in [Dialogs Buttons API Alternatives - Design Review document (go/gmdc-ios-dialogs-design-doc)](go/gmdc-ios-dialogs-design-doc).

Issue: [b/117608629](https://b.corp.google.com/issues/117608629)
Followup issue: [#5447: [Dialogs] Followup work: changing buttons/actions memory structure](https://github.com/material-components/material-components-ios/pull/5447)

Note: also see [Option 3 PR: Custom presentation blocks](https://github.com/material-components/material-components-ios/pull/5366).

The approach taken by option 4 to theming buttons can be summarized with 3 API additions:
- Adding MDCButtonScheme property to MDCDailogScheme, which will be used by MDCAlertControllerThemer to theme action buttons.
- Adding semantic emphasis to MDCAlertActions, which are available to themers (through [MDCAlertController actions])
- Exposing action buttons to themers (through [MDCAlertController buttonForAction:])

This prototype was built in 2 steps, each in a separate commit, to make it easier to review the work (click the commit number of each step to view changes relevant only to the step):

1. [Dialogs] Creating detached buttons for alert actions before the alert is presented.
This step tracks actions and their buttons in a new MDCAlertActionManager class which is used by both MDCAlertController and MDCAlertControllerView to track actions and vend buttons.
The new [MDCAlertController buttonForAction:] button guarantees to return a button for a valid action. The button is created in detached mode (not attached to the view hierarchy) if requested before the alert is presented. Buttons will be created or attached (if already exist) during presentation time.

2.  [Dialogs] Adding emphasis to actions. Adapting Dialog themers to theme actions based on emphasis.
A MDCActionEmphasis enum was created and added as a property to MDCAlertAction.
Additionally, the MDCButtonScheme property was added to MDCAlertScheme.
In this step, MDCAlertControllerThemer is using the appropriate MDC_xxx_ButtonThemer along with the new MDCButtonScheme to style buttons based on their action's emphasis. Clients can now control button theming through manipulation of the buttonScheme property of the AlertScheme class.

Emphasis theming:
![emphasis-theming](https://user-images.githubusercontent.com/2329102/46924701-4668a380-cff5-11e8-9860-9746ae8d4f77.png)
Alert-property theming (current):
![traditional-theming](https://user-images.githubusercontent.com/2329102/46924703-4668a380-cff5-11e8-94b6-23f1d66ba2c3.png)
Un-themed alert:
![unthemed-alert](https://user-images.githubusercontent.com/2329102/46924702-4668a380-cff5-11e8-91f2-f92a4ae5eac9.png)
