### PR TITLE
Remove remaining _IPHONE_11 checks

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -156,11 +156,9 @@ static const CGFloat kActionTextAlpha = 0.87f;
   CGSize size = [self.header sizeThatFits:CGRectStandardize(self.view.bounds).size];
   self.header.frame = CGRectMake(0, 0, self.view.bounds.size.width, size.height);
   UIEdgeInsets insets = UIEdgeInsetsMake(self.header.frame.size.height, 0, 0, 0);
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     insets.bottom = self.view.safeAreaInsets.bottom;
   }
-#endif
   self.tableView.contentInset = insets;
   self.tableView.contentOffset = CGPointMake(0, -size.height);
 }

--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
@@ -102,12 +102,10 @@ static const CGFloat kMiddlePadding = 8.f;
 
 - (CGRect)frameWithSafeAreaInsets:(CGRect)frame {
   UIEdgeInsets safeAreaInsets = UIEdgeInsetsZero;
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     safeAreaInsets = self.safeAreaInsets;
     safeAreaInsets.top = 0.f;
   }
-#endif
   return UIEdgeInsetsInsetRect(frame, safeAreaInsets);
 }
 

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -317,12 +317,10 @@ static UIColor *DrawerShadowColor(void) {
   [self addScrollViewObserver];
 
   // Scroll view should not update its content insets implicitly.
-#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(iOS 11.0, *)) {
     self.scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
     self.scrollView.insetsLayoutMarginsFromSafeArea = NO;
   }
-#endif  // defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
 }
 
 - (void)viewWillLayoutSubviews {


### PR DESCRIPTION
### Context
In #4915 I believe both ActionSheet and NavDrawer weren't in the codebase yet and didn't remove the checks this removes the checks that are no longer needed as we no longer support XCode 8. 