### PR TITLE
[NavigationDrawer] Add buttons to example to present navigation drawer

### DIFF
--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -15,6 +15,7 @@
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
 import MaterialComponents.MaterialBottomAppBar
+import MaterialComponents.MaterialBottomAppBar_ColorThemer
 import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerInfiniteScrollingExample: UIViewController {
@@ -36,15 +37,21 @@ class BottomDrawerInfiniteScrollingExample: UIViewController {
     barButtonLeadingItem.target = self
     barButtonLeadingItem.action = #selector(presentNavigationDrawer)
     bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
+    MDCBottomAppBarColorThemer.applySurfaceVariant(withSemanticColorScheme: colorScheme,
+                                                   to: bottomAppBar)
     view.addSubview(bottomAppBar)
   }
 
-  func layoutBottomAppBar() {
+  private func layoutBottomAppBar() {
     let size = bottomAppBar.sizeThatFits(view.bounds.size)
-    let bottomBarViewFrame = CGRect(x: 0,
+    var bottomBarViewFrame = CGRect(x: 0,
                                     y: view.bounds.size.height - size.height,
                                     width: size.width,
                                     height: size.height)
+    if #available(iOS 11.0, *) {
+      bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
+      bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+    }
     bottomAppBar.frame = bottomBarViewFrame
   }
 

--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -14,10 +14,12 @@
 
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
+import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerInfiniteScrollingExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()
+  let button = MDCButton()
 
   let headerViewController = DrawerHeaderViewController()
   let contentViewController = DrawerContentTableViewController()
@@ -26,17 +28,29 @@ class BottomDrawerInfiniteScrollingExample: UIViewController {
     super.viewDidLoad()
     view.backgroundColor = colorScheme.backgroundColor
     contentViewController.colorScheme = colorScheme
+
+    button.setTitle("Show Navigation Drawer", for: .normal)
+    button.sizeToFit()
+    let buttonScheme = MDCButtonScheme()
+    buttonScheme.colorScheme = colorScheme
+    MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
+    button.addTarget(self, action: #selector(presentNavigationDrawer), for: .touchUpInside)
+    view.addSubview(button)
   }
 
-  override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+
+    button.center = view.center
+  }
+
+  @objc private func presentNavigationDrawer() {
     let bottomDrawerViewController = MDCBottomDrawerViewController()
     bottomDrawerViewController.contentViewController = contentViewController
     bottomDrawerViewController.headerViewController = headerViewController
     bottomDrawerViewController.trackingScrollView = contentViewController.tableView
     present(bottomDrawerViewController, animated: true, completion: nil)
   }
-
 }
 
 class DrawerContentTableViewController: UITableViewController {
@@ -70,6 +84,9 @@ class DrawerContentTableViewController: UITableViewController {
     let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
     cell.textLabel?.text = "cell #\(indexPath.item)"
     cell.backgroundColor = colorScheme.surfaceColor
+    if #available(iOS 10.0, *) {
+      cell.textLabel?.adjustsFontForContentSizeCategory = true
+    }
     print(cell.textLabel?.text ?? "")
     return cell
   }

--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -85,9 +85,6 @@ class DrawerContentTableViewController: UITableViewController {
     let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
     cell.textLabel?.text = "cell #\(indexPath.item)"
     cell.backgroundColor = colorScheme.surfaceColor
-    if #available(iOS 10.0, *) {
-      cell.textLabel?.adjustsFontForContentSizeCategory = true
-    }
     print(cell.textLabel?.text ?? "")
     return cell
   }

--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -15,6 +15,7 @@
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
 import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialButtons_ButtonThemer
 import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerInfiniteScrollingExample: UIViewController {

--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -14,13 +14,12 @@
 
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
-import MaterialComponents.MaterialButtons
-import MaterialComponents.MaterialButtons_ButtonThemer
+import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerInfiniteScrollingExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()
-  let button = MDCButton()
+  let bottomAppBar = MDCBottomAppBarView()
 
   let headerViewController = DrawerHeaderViewController()
   let contentViewController = DrawerContentTableViewController()
@@ -30,19 +29,29 @@ class BottomDrawerInfiniteScrollingExample: UIViewController {
     view.backgroundColor = colorScheme.backgroundColor
     contentViewController.colorScheme = colorScheme
 
-    button.setTitle("Show Navigation Drawer", for: .normal)
-    button.sizeToFit()
-    let buttonScheme = MDCButtonScheme()
-    buttonScheme.colorScheme = colorScheme
-    MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
-    button.addTarget(self, action: #selector(presentNavigationDrawer), for: .touchUpInside)
-    view.addSubview(button)
+    bottomAppBar.isFloatingButtonHidden = true
+    let barButtonLeadingItem = UIBarButtonItem()
+    let menuImage = UIImage(named:"Menu")?.withRenderingMode(.alwaysTemplate)
+    barButtonLeadingItem.image = menuImage
+    barButtonLeadingItem.target = self
+    barButtonLeadingItem.action = #selector(presentNavigationDrawer)
+    bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
+    view.addSubview(bottomAppBar)
+  }
+
+  func layoutBottomAppBar() {
+    let size = bottomAppBar.sizeThatFits(view.bounds.size)
+    let bottomBarViewFrame = CGRect(x: 0,
+                                    y: view.bounds.size.height - size.height,
+                                    width: size.width,
+                                    height: size.height)
+    bottomAppBar.frame = bottomBarViewFrame
   }
 
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
 
-    button.center = view.center
+    layoutBottomAppBar()
   }
 
   @objc private func presentNavigationDrawer() {

--- a/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
@@ -14,14 +14,14 @@
 
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
-import MaterialComponents.MaterialButtons
-import MaterialComponents.MaterialButtons_ButtonThemer
+import MaterialComponents.MaterialBottomAppBar
+import MaterialComponents.MaterialBottomAppBar_ColorThemer
 import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerNoHeaderExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()
-
-  let button = MDCButton()
+  let bottomAppBar = MDCBottomAppBarView()
+  
   let contentViewController = DrawerContentViewController()
   let bottomDrawerTransitionController = MDCBottomDrawerTransitionController()
 
@@ -30,19 +30,35 @@ class BottomDrawerNoHeaderExample: UIViewController {
     view.backgroundColor = colorScheme.backgroundColor
     contentViewController.colorScheme = colorScheme
 
-    button.setTitle("Show Navigation Drawer", for: .normal)
-    button.sizeToFit()
-    let buttonScheme = MDCButtonScheme()
-    buttonScheme.colorScheme = colorScheme
-    MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
-    button.addTarget(self, action: #selector(presentNavigationDrawer), for: .touchUpInside)
-    view.addSubview(button)
+    bottomAppBar.isFloatingButtonHidden = true
+    let barButtonLeadingItem = UIBarButtonItem()
+    let menuImage = UIImage(named:"Menu")?.withRenderingMode(.alwaysTemplate)
+    barButtonLeadingItem.image = menuImage
+    barButtonLeadingItem.target = self
+    barButtonLeadingItem.action = #selector(presentNavigationDrawer)
+    bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
+    MDCBottomAppBarColorThemer.applySurfaceVariant(withSemanticColorScheme: colorScheme,
+                                                   to: bottomAppBar)
+    view.addSubview(bottomAppBar)
   }
 
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
 
-    button.center = view.center
+    layoutBottomAppBar()
+  }
+
+  private func layoutBottomAppBar() {
+    let size = bottomAppBar.sizeThatFits(view.bounds.size)
+    var bottomBarViewFrame = CGRect(x: 0,
+                                    y: view.bounds.size.height - size.height,
+                                    width: size.width,
+                                    height: size.height)
+    if #available(iOS 11.0, *) {
+      bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
+      bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+    }
+    bottomAppBar.frame = bottomBarViewFrame
   }
 
   @objc func presentNavigationDrawer() {

--- a/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
@@ -14,11 +14,13 @@
 
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
+import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerNoHeaderExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()
 
+  let button = MDCButton()
   let contentViewController = DrawerContentViewController()
   let bottomDrawerTransitionController = MDCBottomDrawerTransitionController()
 
@@ -26,19 +28,31 @@ class BottomDrawerNoHeaderExample: UIViewController {
     super.viewDidLoad()
     view.backgroundColor = colorScheme.backgroundColor
     contentViewController.colorScheme = colorScheme
+
+    button.setTitle("Show Navigation Drawer", for: .normal)
+    button.sizeToFit()
+    let buttonScheme = MDCButtonScheme()
+    buttonScheme.colorScheme = colorScheme
+    MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
+    button.addTarget(self, action: #selector(presentNavigationDrawer), for: .touchUpInside)
+    view.addSubview(button)
   }
 
-  override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
-    // This shows that it is possible to present the content view controller directly without
-    // the need of the MDCBottomDrawerViewController wrapper. To present the view controller
-    // inside the drawer, both the transition controller and the custom presentation controller
-    // of the drawer need to be set.
-    contentViewController.transitioningDelegate = bottomDrawerTransitionController
-    contentViewController.modalPresentationStyle = .custom
-    present(contentViewController, animated: true, completion: nil)
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+
+    button.center = view.center
   }
 
+  @objc func presentNavigationDrawer() {
+  // This shows that it is possible to present the content view controller directly without
+  // the need of the MDCBottomDrawerViewController wrapper. To present the view controller
+  // inside the drawer, both the transition controller and the custom presentation controller
+  // of the drawer need to be set.
+  contentViewController.transitioningDelegate = bottomDrawerTransitionController
+  contentViewController.modalPresentationStyle = .custom
+  present(contentViewController, animated: true, completion: nil)
+  }
 }
 
 extension BottomDrawerNoHeaderExample {

--- a/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
@@ -15,6 +15,7 @@
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
 import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialButtons_ButtonThemer
 import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerNoHeaderExample: UIViewController {

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -14,13 +14,13 @@
 
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
-import MaterialComponents.MaterialButtons
-import MaterialComponents.MaterialButtons_ButtonThemer
+import MaterialComponents.MaterialBottomAppBar
+import MaterialComponents.MaterialBottomAppBar_ColorThemer
 import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerWithHeaderExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()
-  let button = MDCButton()
+  let bottomAppBar = MDCBottomAppBarView()
 
   let headerViewController = DrawerHeaderViewController()
   let contentViewController = DrawerContentViewController()
@@ -31,19 +31,35 @@ class BottomDrawerWithHeaderExample: UIViewController {
     headerViewController.colorScheme = colorScheme
     contentViewController.colorScheme = colorScheme
 
-    button.setTitle("Show Navigation Drawer", for: .normal)
-    button.sizeToFit()
-    let buttonScheme = MDCButtonScheme()
-    buttonScheme.colorScheme = colorScheme
-    MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
-    button.addTarget(self, action: #selector(presentNavigationDrawer), for: .touchUpInside)
-    view.addSubview(button)
+    bottomAppBar.isFloatingButtonHidden = true
+    let barButtonLeadingItem = UIBarButtonItem()
+    let menuImage = UIImage(named:"Menu")?.withRenderingMode(.alwaysTemplate)
+    barButtonLeadingItem.image = menuImage
+    barButtonLeadingItem.target = self
+    barButtonLeadingItem.action = #selector(presentNavigationDrawer)
+    bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
+    MDCBottomAppBarColorThemer.applySurfaceVariant(withSemanticColorScheme: colorScheme,
+                                                   to: bottomAppBar)
+    view.addSubview(bottomAppBar)
+  }
+
+  private func layoutBottomAppBar() {
+    let size = bottomAppBar.sizeThatFits(view.bounds.size)
+    var bottomBarViewFrame = CGRect(x: 0,
+                                    y: view.bounds.size.height - size.height,
+                                    width: size.width,
+                                    height: size.height)
+    if #available(iOS 11.0, *) {
+      bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
+      bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+    }
+    bottomAppBar.frame = bottomBarViewFrame
   }
 
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
 
-    button.center = view.center
+    layoutBottomAppBar()
   }
 
   @objc func presentNavigationDrawer() {

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -15,6 +15,7 @@
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
 import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialButtons_ButtonThemer
 import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerWithHeaderExample: UIViewController {

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -14,10 +14,12 @@
 
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
+import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerWithHeaderExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()
+  let button = MDCButton()
 
   let headerViewController = DrawerHeaderViewController()
   let contentViewController = DrawerContentViewController()
@@ -27,16 +29,28 @@ class BottomDrawerWithHeaderExample: UIViewController {
     view.backgroundColor = colorScheme.backgroundColor
     headerViewController.colorScheme = colorScheme
     contentViewController.colorScheme = colorScheme
+
+    button.setTitle("Show Navigation Drawer", for: .normal)
+    button.sizeToFit()
+    let buttonScheme = MDCButtonScheme()
+    buttonScheme.colorScheme = colorScheme
+    MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
+    button.addTarget(self, action: #selector(presentNavigationDrawer), for: .touchUpInside)
+    view.addSubview(button)
   }
 
-  override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+
+    button.center = view.center
+  }
+
+  @objc func presentNavigationDrawer() {
     let bottomDrawerViewController = MDCBottomDrawerViewController()
     bottomDrawerViewController.contentViewController = contentViewController
     bottomDrawerViewController.headerViewController = headerViewController
     present(bottomDrawerViewController, animated: true, completion: nil)
   }
-
 }
 
 extension BottomDrawerWithHeaderExample {

--- a/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
@@ -18,6 +18,7 @@ import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerWithScrollableContentExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()
+  let button = MDCButton()
 
   let headerViewController = DrawerHeaderViewController()
   let contentViewController = DrawerContentWithScrollViewController()
@@ -27,17 +28,23 @@ class BottomDrawerWithScrollableContentExample: UIViewController {
     view.backgroundColor = colorScheme.backgroundColor
     headerViewController.colorScheme = colorScheme
     contentViewController.colorScheme = colorScheme
+
+    button.setTitle("Show Navigation Drawer", for: .normal)
+    button.sizeToFit()
+    let buttonScheme = MDCButtonScheme()
+    buttonScheme.colorScheme = colorScheme
+    MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
+    button.addTarget(self, action: #selector(presentNavigationDrawer), for: .touchUpInside)
+    view.addSubview(button)
   }
 
-  override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
+  @objc func presentNavigationDrawer() {
     let bottomDrawerViewController = MDCBottomDrawerViewController()
     bottomDrawerViewController.contentViewController = contentViewController
     bottomDrawerViewController.headerViewController = headerViewController
     bottomDrawerViewController.trackingScrollView = contentViewController.collectionView
     present(bottomDrawerViewController, animated: true, completion: nil)
   }
-
 }
 
 class DrawerContentWithScrollViewController: UIViewController,

--- a/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
@@ -14,6 +14,8 @@
 
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
+import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialButtons_ButtonThemer
 import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerWithScrollableContentExample: UIViewController {
@@ -36,6 +38,12 @@ class BottomDrawerWithScrollableContentExample: UIViewController {
     MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
     button.addTarget(self, action: #selector(presentNavigationDrawer), for: .touchUpInside)
     view.addSubview(button)
+  }
+
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+
+    button.center = view.center
   }
 
   @objc func presentNavigationDrawer() {

--- a/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
@@ -14,13 +14,13 @@
 
 import UIKit
 import MaterialComponentsAlpha.MaterialNavigationDrawer
-import MaterialComponents.MaterialButtons
-import MaterialComponents.MaterialButtons_ButtonThemer
+import MaterialComponents.MaterialBottomAppBar
+import MaterialComponents.MaterialBottomAppBar_ColorThemer
 import MaterialComponents.MaterialColorScheme
 
 class BottomDrawerWithScrollableContentExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()
-  let button = MDCButton()
+  let bottomAppBar = MDCBottomAppBarView()
 
   let headerViewController = DrawerHeaderViewController()
   let contentViewController = DrawerContentWithScrollViewController()
@@ -31,19 +31,35 @@ class BottomDrawerWithScrollableContentExample: UIViewController {
     headerViewController.colorScheme = colorScheme
     contentViewController.colorScheme = colorScheme
 
-    button.setTitle("Show Navigation Drawer", for: .normal)
-    button.sizeToFit()
-    let buttonScheme = MDCButtonScheme()
-    buttonScheme.colorScheme = colorScheme
-    MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
-    button.addTarget(self, action: #selector(presentNavigationDrawer), for: .touchUpInside)
-    view.addSubview(button)
+    bottomAppBar.isFloatingButtonHidden = true
+    let barButtonLeadingItem = UIBarButtonItem()
+    let menuImage = UIImage(named:"Menu")?.withRenderingMode(.alwaysTemplate)
+    barButtonLeadingItem.image = menuImage
+    barButtonLeadingItem.target = self
+    barButtonLeadingItem.action = #selector(presentNavigationDrawer)
+    bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
+    MDCBottomAppBarColorThemer.applySurfaceVariant(withSemanticColorScheme: colorScheme,
+                                                   to: bottomAppBar)
+    view.addSubview(bottomAppBar)
+  }
+
+  private func layoutBottomAppBar() {
+    let size = bottomAppBar.sizeThatFits(view.bounds.size)
+    var bottomBarViewFrame = CGRect(x: 0,
+                                    y: view.bounds.size.height - size.height,
+                                    width: size.width,
+                                    height: size.height)
+    if #available(iOS 11.0, *) {
+      bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
+      bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+    }
+    bottomAppBar.frame = bottomBarViewFrame
   }
 
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
 
-    button.center = view.center
+    layoutBottomAppBar()
   }
 
   @objc func presentNavigationDrawer() {


### PR DESCRIPTION
### Context
In working on navigation drawer bugs the navigation drawer presents itself right when you open the example view controller.
### The problem
This makes it hard to do screenshot testing and harder to work on because you have to go back to the table view and then select the example again every time you want to present.
### The fix
Add a button to present the navigation drawer.