### PR TITLE
[List] Initialize layoutCache in SelfSizingStereoCell

### DIFF
--- a/components/List/src/MDCSelfSizingStereoCell.m
+++ b/components/List/src/MDCSelfSizingStereoCell.m
@@ -69,6 +69,7 @@
 }
 
 - (void)commonMDCSelfSizingStereoCellInit {
+  self.cachedLayouts = [[NSMutableDictionary alloc] init];
   [self createSubviews];
 }
 


### PR DESCRIPTION
Whoop! Forgot to initialize the layout cache in the `MDCSelfSizingStereoCell`.