### PR TITLE
[NavigationDrawer] Setup for tests

### DIFF
--- a/components/NavigationDrawer/BUILD
+++ b/components/NavigationDrawer/BUILD
@@ -50,6 +50,5 @@ mdc_objc_library(
 mdc_unit_test_suite(
     deps = [
         ":unit_test_sources",
-        ":unit_test_swift_sources"
     ]
 )

--- a/components/NavigationDrawer/BUILD
+++ b/components/NavigationDrawer/BUILD
@@ -15,8 +15,10 @@
 
 load("//:material_components_ios.bzl",
      "mdc_public_objc_library",
-     "mdc_objc_library")
+     "mdc_objc_library",
+     "mdc_unit_test_suite")
 
+load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
@@ -29,4 +31,25 @@ mdc_public_objc_library(
         "//components/ShadowLayer",
         "//components/private/UIMetrics",
     ],
+)
+
+mdc_objc_library(
+    name = "unit_test_sources",
+    testonly = 1,
+    srcs = native.glob(["tests/unit/*.m"]),
+    sdk_frameworks = [
+        "UIKit",
+        "XCTest",
+    ],
+    deps = [
+         ":NavigationDrawer",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+mdc_unit_test_suite(
+    deps = [
+        ":unit_test_sources",
+        ":unit_test_swift_sources"
+    ]
 )

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
@@ -26,29 +26,6 @@
 @interface MDCNavigationDrawerFakeHeaderViewController : UIViewController <MDCBottomDrawerHeader>
 @end
 
-@implementation MDCNavigationDrawerTest
-
-- (void)setUp {
-  [super setUp];
-
-  MDCNavigationDrawerFakeTableViewController *fakeTableViewController =
-      [[MDCNavigationDrawerFakeTableViewController alloc] init];
-  MDCNavigationDrawerFakeHeaderViewController *fakeHeaderViewController =
-      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
-  self.navigationDrawer = [[MDCBottomDrawerViewController alloc] init];
-  self.navigationDrawer.headerViewController = fakeHeaderViewController;
-  self.navigationDrawer.contentViewController = fakeTableViewController;
-  self.navigationDrawer.trackingScrollView = fakeTableViewController.tableView;
-}
-
-- (void)tearDown {
-  self.navigationDrawer = nil;
-
-  [super tearDown];
-}
-
-@end
-
 static NSString *const reuseIdentifier = @"FakeCell";
 
 @implementation MDCNavigationDrawerFakeTableViewController
@@ -78,6 +55,32 @@ static NSString *const reuseIdentifier = @"FakeCell";
   UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:reuseIdentifier
                                                           forIndexPath:indexPath];
   return cell;
+}
+
+@end
+
+@implementation MDCNavigationDrawerFakeHeaderViewController
+@end
+
+@implementation MDCNavigationDrawerTest
+
+- (void)setUp {
+  [super setUp];
+
+  MDCNavigationDrawerFakeTableViewController *fakeTableViewController =
+      [[MDCNavigationDrawerFakeTableViewController alloc] init];
+  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
+      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+  self.navigationDrawer = [[MDCBottomDrawerViewController alloc] init];
+  self.navigationDrawer.headerViewController = fakeHeader;
+  self.navigationDrawer.contentViewController = fakeTableViewController;
+  self.navigationDrawer.trackingScrollView = fakeTableViewController.tableView;
+}
+
+- (void)tearDown {
+  self.navigationDrawer = nil;
+
+  [super tearDown];
 }
 
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
@@ -23,7 +23,7 @@
 @interface MDCNavigationDrawerFakeTableViewController : UITableViewController
 @end
 
-@interface MDCNavigationDrawerFakeHeaderViewController: UIViewController <MDCBottomDrawerHeader>
+@interface MDCNavigationDrawerFakeHeaderViewController : UIViewController <MDCBottomDrawerHeader>
 @end
 
 @implementation MDCNavigationDrawerTest

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
@@ -23,8 +23,7 @@
 @interface MDCNavigationDrawerFakeTableViewController : UITableViewController
 @end
 
-@interface MDCNavigationDrawerFakeHeaderViewController
-    : UITableViewController <MDCBottomDrawerHeader>
+@interface MDCNavigationDrawerFakeHeaderViewController: UIViewController <MDCBottomDrawerHeader>
 @end
 
 @implementation MDCNavigationDrawerTest

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
@@ -23,7 +23,8 @@
 @interface MDCNavigationDrawerFakeTableViewController : UITableViewController
 @end
 
-@interface MDCNavigationDrawerFakeHeaderViewController : UITableViewController<MDCBottomDrawerHeader>
+@interface MDCNavigationDrawerFakeHeaderViewController
+    : UITableViewController <MDCBottomDrawerHeader>
 @end
 
 @implementation MDCNavigationDrawerTest
@@ -73,9 +74,10 @@ static NSString *const reuseIdentifier = @"FakeCell";
   return 100;
 }
 
-
-- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:reuseIdentifier forIndexPath:indexPath];
+- (UITableViewCell *)tableView:(UITableView *)tableView
+         cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:reuseIdentifier
+                                                          forIndexPath:indexPath];
   return cell;
 }
 

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
@@ -1,0 +1,82 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialNavigationDrawer.h"
+
+@interface MDCNavigationDrawerTest : XCTestCase
+@property(nonatomic, strong) MDCBottomDrawerViewController *navigationDrawer;
+@end
+
+@interface MDCNavigationDrawerFakeTableViewController : UITableViewController
+@end
+
+@interface MDCNavigationDrawerFakeHeaderViewController : UITableViewController<MDCBottomDrawerHeader>
+@end
+
+@implementation MDCNavigationDrawerTest
+
+- (void)setUp {
+  [super setUp];
+
+  MDCNavigationDrawerFakeTableViewController *fakeTableViewController =
+      [[MDCNavigationDrawerFakeTableViewController alloc] init];
+  MDCNavigationDrawerFakeHeaderViewController *fakeHeaderViewController =
+      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+  self.navigationDrawer = [[MDCBottomDrawerViewController alloc] init];
+  self.navigationDrawer.headerViewController = fakeHeaderViewController;
+  self.navigationDrawer.contentViewController = fakeTableViewController;
+  self.navigationDrawer.trackingScrollView = fakeTableViewController.tableView;
+}
+
+- (void)tearDown {
+  self.navigationDrawer = nil;
+
+  [super tearDown];
+}
+
+@end
+
+static NSString *const reuseIdentifier = @"FakeCell";
+
+@implementation MDCNavigationDrawerFakeTableViewController
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:reuseIdentifier];
+    self.tableView.dataSource = self;
+    self.tableView.delegate = self;
+  }
+  return self;
+}
+
+#pragma mark - Table view data source
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+  return 1;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+  return 100;
+}
+
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:reuseIdentifier forIndexPath:indexPath];
+  return cell;
+}
+
+@end


### PR DESCRIPTION
### Context
Set up the everything to start work on unit test for Navigation Drawer. In order to make small changes that are easier to review this sets up the files to get ready for test. This will allow us to work in tandem on unit test for this component once the files are in place.

### The problem
MDCNavigationDrawer doesn't have any unit test

### The fix
This adds the files to the build file and basic setup to add tests

### Related bug
b/117175875