### PR TITLE
[Chips] Fix layout when Chip added programmatically.

### DIFF
--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -31,7 +31,6 @@ mdc_public_objc_library(
         "//components/ShadowElevations",
         "//components/ShadowLayer",
         "//components/TextFields",
-        "//components/TextFields:private",
         "//components/Typography",
         "//components/private/Math",
         "//components/private/ShapeLibrary",

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -16,7 +16,6 @@
 
 #import <MDFInternationalization/MDFInternationalization.h>
 
-#import "../../TextFields/src/private/MDCTextInputCommonFundament.h"
 #import "MaterialMath.h"
 #import "MaterialTextFields.h"
 
@@ -56,14 +55,6 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
 
 @property(nonatomic, weak) id<MDCChipTextFieldDelegate> deletionDelegate;
 
-@end
-
-@interface MDCTextField (MDCChipFieldTestingVisibility)
-@property(nonatomic, strong) MDCTextInputCommonFundament *fundament;
-@end
-
-@interface MDCTextInputCommonFundament (MDCChipFieldTestingVisibility)
-- (void)updatePlaceholderPosition;
 @end
 
 @implementation MDCChipTextField
@@ -327,7 +318,8 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
   if ([self.delegate respondsToSelector:@selector(chipField:didAddChip:)]) {
     [self.delegate chipField:self didAddChip:chip];
   }
-  [self.textField.fundament updatePlaceholderPosition];
+
+  [self.textField setNeedsLayout];
   [self notifyDelegateIfSizeNeedsToBeUpdated];
   [self invalidateIntrinsicContentSize];
   [self setNeedsLayout];
@@ -340,7 +332,7 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
     [self.delegate chipField:self didRemoveChip:chip];
   }
   [self notifyDelegateIfSizeNeedsToBeUpdated];
-  [self.textField.fundament updatePlaceholderPosition];
+  [self.textField setNeedsLayout];
   [self invalidateIntrinsicContentSize];
   [self setNeedsLayout];
 }


### PR DESCRIPTION
When a Chip is added programmatically, we need to tell the TextField that is
layout has changed. Instead of moving the placeholder (what was originally
believed to be the cause), the problem was that the TextField itself did not
change frames.

Closes #5360
Fixes b/116495610
