### PR TITLE
[List] SelfSizingStereoCell should invalidate its layout on re-use

### DIFF
--- a/components/List/src/MDCSelfSizingStereoCell.m
+++ b/components/List/src/MDCSelfSizingStereoCell.m
@@ -156,17 +156,15 @@ static const CGFloat kDetailColorOpacity = 0.6f;
 - (void)prepareForReuse {
   [super prepareForReuse];
 
-  [self invalidateCachedLayouts];
-
   self.titleLabel.text = nil;
   self.detailLabel.text = nil;
   self.leadingImageView.image = nil;
   self.trailingImageView.image = nil;
 
+  [self setNeedsLayout];
+
   [self mdc_setAdjustsFontForContentSizeCategory:NO];
   [self resetMDCSelfSizingStereoCellLabelProperties];
-
-  [self setNeedsLayout];
 }
 
 #pragma mark Layout

--- a/components/List/src/MDCSelfSizingStereoCell.m
+++ b/components/List/src/MDCSelfSizingStereoCell.m
@@ -165,6 +165,8 @@ static const CGFloat kDetailColorOpacity = 0.6f;
 
   [self mdc_setAdjustsFontForContentSizeCategory:NO];
   [self resetMDCSelfSizingStereoCellLabelProperties];
+
+  [self setNeedsLayout];
 }
 
 #pragma mark Layout


### PR DESCRIPTION
This change adds a call to -setNeedsLayout in -prepareForReuse. Without this call, the cell may not re-do a layout pass on re-use, causing truncation of the labels.

closes https://github.com/material-components/material-components-ios/issues/5436