### PR TITLE
[Dialogs] Fix elevation to use MDCShadowElevation

### DIFF
--- a/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
+++ b/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
@@ -15,6 +15,7 @@
 #import <Foundation/Foundation.h>
 
 #import "MaterialColorScheme.h"
+#import "MaterialShadowElevations.h"
 #import "MaterialTypographyScheme.h"
 
 /** Defines a readonly immutable interface for component style data to be applied by a themer. */
@@ -48,6 +49,6 @@
 @property(readwrite, nonatomic) CGFloat cornerRadius;
 
 /** The elevation to apply to the Dialog. */
-@property(readwrite, nonatomic) CGFloat elevation;
+@property(readwrite, nonatomic) MDCShadowElevation elevation;
 
 @end

--- a/components/Dialogs/src/DialogThemer/MDCAlertScheme.m
+++ b/components/Dialogs/src/DialogThemer/MDCAlertScheme.m
@@ -14,8 +14,6 @@
 
 #import "MDCAlertScheme.h"
 
-#import "MaterialShadowElevations.h"
-
 static const CGFloat kCornerRadius = 4.0f;
 
 @implementation MDCAlertScheme

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialShadowElevations.h"
+
 @class MDCAlertAction;
 
 /**
@@ -104,7 +106,7 @@
 @property(nonatomic, assign) CGFloat cornerRadius;
 
 /** The elevation that will be applied to the Alert Controller view. Default to 24. */
-@property(nonatomic, assign) CGFloat elevation;
+@property(nonatomic, assign) MDCShadowElevation elevation;
 
 // TODO(iangordon): Add support for preferredAction to match UIAlertController.
 // TODO(iangordon): Consider adding support for UITextFields to match UIAlertController.

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -247,7 +247,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   self.mdc_dialogPresentationController.dialogCornerRadius = cornerRadius;
 }
 
-- (void)setElevation:(CGFloat)elevation {
+- (void)setElevation:(MDCShadowElevation)elevation {
   _elevation = elevation;
   self.mdc_dialogPresentationController.dialogElevation = elevation;
 }

--- a/components/Dialogs/src/MDCDialogPresentationController.h
+++ b/components/Dialogs/src/MDCDialogPresentationController.h
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialShadowElevations.h"
+
 /**
  MDCDialogPresentationController will present a modal ViewController as a dialog according to the
  Material spec.
@@ -54,7 +56,7 @@
 
  Defaults to 24.0.
  */
-@property(nonatomic, assign) CGFloat dialogElevation;
+@property(nonatomic, assign) MDCShadowElevation dialogElevation;
 
 /**
  Customize the color of the background scrim.

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -69,7 +69,7 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
   return self.dimmingView.backgroundColor;
 }
 
-- (void)setDialogElevation:(CGFloat)dialogElevation {
+- (void)setDialogElevation:(MDCShadowElevation)dialogElevation {
   _trackingView.elevation = dialogElevation;
 }
 

--- a/components/Dialogs/src/private/MDCDialogShadowedView.h
+++ b/components/Dialogs/src/private/MDCDialogShadowedView.h
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialShadowElevations.h"
+
 @interface MDCDialogShadowedView : UIView
-@property(nonatomic, assign) CGFloat elevation;
+@property(nonatomic, assign) MDCShadowElevation elevation;
 @end

--- a/components/Dialogs/src/private/MDCDialogShadowedView.m
+++ b/components/Dialogs/src/private/MDCDialogShadowedView.m
@@ -35,11 +35,11 @@
   return self;
 }
 
-- (CGFloat)elevation {
+- (MDCShadowElevation)elevation {
   return [self shadowLayer].elevation;
 }
 
-- (void)setElevation:(CGFloat)elevation {
+- (void)setElevation:(MDCShadowElevation)elevation {
   [[self shadowLayer] setElevation:elevation];
 }
 

--- a/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
+++ b/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
@@ -21,7 +21,7 @@ import MaterialComponents.MDCAlertControllerThemer
 class MDCAlertControllerAlertThemerTests: XCTestCase {
 
   let defaultCornerRadius: CGFloat = 4.0
-  let defaultElevation: CGFloat = ShadowElevation.dialog.rawValue
+  let defaultElevation: ShadowElevation = .dialog
   var alertScheme: MDCAlertScheme! = MDCAlertScheme()
   var alert: MDCAlertController! = MDCAlertController(title: "Title", message: "Message")
   var alertView: MDCAlertControllerView! { return alert.view as! MDCAlertControllerView }
@@ -137,15 +137,15 @@ class MDCAlertControllerAlertThemerTests: XCTestCase {
 
   func testApplyAlertSchemeWithCustomElevation() {
     // Given
-    let elevation: CGFloat = 10.0
+    let elevation: ShadowElevation = ShadowElevation(rawValue: 10.0)
     alertScheme.elevation = elevation
 
     // When
     MDCAlertControllerThemer.applyScheme(alertScheme, to: alert)
 
     // Then
-    XCTAssertEqual(alertScheme.elevation, elevation, accuracy: 0.001)
-    XCTAssertEqual(alert.elevation, elevation, accuracy: 0.001)
-    XCTAssertNotEqual(alertScheme.elevation, defaultElevation, accuracy: 0.001)
+    XCTAssertEqual(alertScheme.elevation.rawValue, elevation.rawValue, accuracy: 0.001)
+    XCTAssertEqual(alert.elevation.rawValue, elevation.rawValue, accuracy: 0.001)
+    XCTAssertNotEqual(alertScheme.elevation.rawValue, defaultElevation.rawValue, accuracy: 0.001)
   }
 }


### PR DESCRIPTION
### Context
In working on #5296 and #5301 I used `CGFloat` instead of `MDCShadowElevation`. We have the `MDCShadowElevation` data type strictly for this exact use case and I missed that. This goes back and fixes those changes to match all other components. This shouldn't cause any changes in behavior but screenshots are added to make sure. Clients should be unaffected by this change even if they were using a custom elevation. 
```objc
dialog.elevation = 2;
```
Will work the same as before.

### The problem
MDCAlertController (and all related classes) used `CGFloat` instead of `MDCShadowElevation`.

### The fix
Replace `MDCShadowElevation` with `CGFloat`.

| Before | After |
| - | - |
|![simulator screen shot - iphone xs max - 2018-10-19 at 08 43 51](https://user-images.githubusercontent.com/7131294/47219484-e8cdb180-d37c-11e8-8a5f-1df485420582.png)|![simulator screen shot - iphone xs max - 2018-10-19 at 08 39 31](https://user-images.githubusercontent.com/7131294/47219488-ecf9cf00-d37c-11e8-8f52-a309752b5cdb.png)|



