### PR TITLE
[NavigationDrawer] Add Fakes files for tests

### DIFF
--- a/components/NavigationDrawer/BUILD
+++ b/components/NavigationDrawer/BUILD
@@ -44,7 +44,10 @@ mdc_objc_library(
 mdc_objc_library(
     name = "unit_test_sources",
     testonly = 1,
-    srcs = native.glob(["tests/unit/*.m"]),
+    srcs = native.glob([
+        "tests/unit/*.m",
+        "tests/unit/*.h",
+    ]),
     sdk_frameworks = [
         "UIKit",
         "XCTest",

--- a/components/NavigationDrawer/tests/unit/MDCNavigaitonDrawerFakes.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigaitonDrawerFakes.m
@@ -1,0 +1,51 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCNavigationDrawerFakes.h"
+
+@implementation MDCNavigationDrawerFakeHeaderViewController
+@end
+
+static NSString *const reuseIdentifier = @"FakeCell";
+
+@implementation MDCNavigationDrawerFakeTableViewController
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:reuseIdentifier];
+    self.tableView.dataSource = self;
+    self.tableView.delegate = self;
+  }
+  return self;
+}
+
+#pragma mark - Table view data source
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+  return 1;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+  return 100;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView
+         cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:reuseIdentifier
+                                                          forIndexPath:indexPath];
+  return cell;
+}
+
+@end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerFakes.h
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerFakes.h
@@ -1,0 +1,23 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+#import "MaterialNavigationDrawer.h"
+
+@interface MDCNavigationDrawerFakeHeaderViewController : UIViewController <MDCBottomDrawerHeader>
+@end
+
+@interface MDCNavigationDrawerFakeTableViewController : UITableViewController
+@end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -15,13 +15,13 @@
 #import <XCTest/XCTest.h>
 
 #import "../../src/private/MDCBottomDrawerContainerViewController.h"
+#import "MDCNavigationDrawerFakes.h"
 
 @interface MDCBottomDrawerContainerViewController (ScrollViewTests)
 
 @property(nonatomic) BOOL scrollViewObserved;
 @property(nonatomic, readonly) UIScrollView *scrollView;
-@property(nonatomic, readwrite) CGFloat contentHeightSurplus;
-@property(nonatomic) BOOL contentScrollsToReveal;
+@property(nonatomic, readonly) CGFloat contentHeaderHeight;
 
 @end
 
@@ -71,22 +71,6 @@
 
   // Then
   XCTAssertFalse(self.fakeBottomDrawer.scrollViewObserved);
-}
-
-- (void)testContentDoesScrollToReveal {
-  // When
-  self.fakeBottomDrawer.contentHeightSurplus = CGFLOAT_MAX;
-
-  // Then
-  XCTAssertTrue(self.fakeBottomDrawer.contentScrollsToReveal);
-}
-
-- (void)testContentDoesNotScrollToReveal {
-  // When
-  self.fakeBottomDrawer.contentHeightSurplus = CGFLOAT_MIN;
-
-  // Then
-  XCTAssertFalse(self.fakeBottomDrawer.contentScrollsToReveal);
 }
 
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -21,7 +21,7 @@
 
 @property(nonatomic) BOOL scrollViewObserved;
 @property(nonatomic, readonly) UIScrollView *scrollView;
-@property(nonatomic, readonly) CGFloat contentHeaderHeight;
+@property(nonatomic) BOOL currentlyFullScreen;
 
 @end
 
@@ -71,6 +71,14 @@
 
   // Then
   XCTAssertFalse(self.fakeBottomDrawer.scrollViewObserved);
+}
+
+- (void)testCurrentlyFullScreen {
+  // Given
+
+  // When
+
+  // Then
 }
 
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -20,7 +20,8 @@
 
 @property(nonatomic) BOOL scrollViewObserved;
 @property(nonatomic, readonly) UIScrollView *scrollView;
-@property(nonatomic) BOOL currentlyFullScreen;
+@property(nonatomic, readwrite) CGFloat contentHeightSurplus;
+@property(nonatomic) BOOL contentScrollsToReveal;
 
 @end
 
@@ -72,13 +73,20 @@
   XCTAssertFalse(self.fakeBottomDrawer.scrollViewObserved);
 }
 
-- (void)testCurrentlyFullScreen {
-  // Given
-  
-
+- (void)testContentDoesScrollToReveal {
   // When
+  self.fakeBottomDrawer.contentHeightSurplus = CGFLOAT_MAX;
 
   // Then
+  XCTAssertTrue(self.fakeBottomDrawer.contentScrollsToReveal);
+}
+
+- (void)testContentDoesNotScrollToReveal {
+  // When
+  self.fakeBottomDrawer.contentHeightSurplus = CGFLOAT_MIN;
+
+  // Then
+  XCTAssertFalse(self.fakeBottomDrawer.contentScrollsToReveal);
 }
 
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -74,6 +74,7 @@
 
 - (void)testCurrentlyFullScreen {
   // Given
+  
 
   // When
 

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
@@ -16,50 +16,10 @@
 
 #import "MaterialNavigationDrawer.h"
 
+#import "MDCNavigationDrawerFakes.h"
+
 @interface MDCNavigationDrawerTest : XCTestCase
 @property(nonatomic, strong) MDCBottomDrawerViewController *navigationDrawer;
-@end
-
-@interface MDCNavigationDrawerFakeTableViewController : UITableViewController
-@end
-
-@interface MDCNavigationDrawerFakeHeaderViewController : UIViewController <MDCBottomDrawerHeader>
-@end
-
-static NSString *const reuseIdentifier = @"FakeCell";
-
-@implementation MDCNavigationDrawerFakeTableViewController
-
-- (instancetype)init {
-  self = [super init];
-  if (self) {
-    [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:reuseIdentifier];
-    self.tableView.dataSource = self;
-    self.tableView.delegate = self;
-  }
-  return self;
-}
-
-#pragma mark - Table view data source
-
-- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-  return 1;
-}
-
-- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-  return 100;
-}
-
-- (UITableViewCell *)tableView:(UITableView *)tableView
-         cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:reuseIdentifier
-                                                          forIndexPath:indexPath];
-  return cell;
-}
-
-@end
-
-@implementation MDCNavigationDrawerFakeHeaderViewController
 @end
 
 @implementation MDCNavigationDrawerTest
@@ -82,5 +42,7 @@ static NSString *const reuseIdentifier = @"FakeCell";
 
   [super tearDown];
 }
+
+
 
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
@@ -43,6 +43,4 @@
   [super tearDown];
 }
 
-
-
 @end


### PR DESCRIPTION
### Context
In #5423 my thinking was that we would need to test MDCBottomDrawerViewController but majority of the test are going to be related to MDCBottomDrawerContainerViewController. We may still want to test MDCBottomDrawerViewController so that is why I haven't completely removed that file for tests. But, we need fakes in a couple places so this adds _Fakes_ files so that code can be shared.

### The problem
We need fakes for test in MaterialNavigationDrawer because we can't present and that code should be shared.

### The fix
Add a `MDCNavigationDrawerFakes` files so we can have fakes and they can be shared across test files.

### Related bugs
#4911 