### PR TITLE
[NavigationDrawer] Add Color Themer support

### DIFF
--- a/MaterialComponentsAlpha.podspec
+++ b/MaterialComponentsAlpha.podspec
@@ -73,6 +73,16 @@ Pod::Spec.new do |mdc|
     end
   end
 
+  mdc.subspec "NavigationDrawer+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponentsAlpha/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/schemes/Color"
+  end
+
+  # Private
+
   mdc.subspec "private" do |private_spec|
     # CocoaPods requires at least one file to show up in a subspec, so we depend on the fake
     # "Alpha" component as a baseline.

--- a/components/NavigationDrawer/BUILD
+++ b/components/NavigationDrawer/BUILD
@@ -34,6 +34,19 @@ mdc_public_objc_library(
 )
 
 mdc_objc_library(
+    name = "ColorThemer",
+    srcs = native.glob(["src/ColorThemer/*.m"]),
+    hdrs = native.glob(["src/ColorThemer/*.h"]),
+    includes = ["src/ColorThemer"],
+    sdk_frameworks = ["UIKit"],
+    deps = [
+      ":NavigationDrawer",
+      "//components/schemes/Color",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+mdc_objc_library(
     name = "private",
     hdrs = native.glob(["src/private/*.h"]),
     includes = ["src/private"],
@@ -54,6 +67,7 @@ mdc_objc_library(
     ],
     deps = [
          ":NavigationDrawer",
+         ":ColorThemer",
          ":private",
     ],
     visibility = ["//visibility:private"],

--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -66,6 +66,8 @@ class BottomDrawerInfiniteScrollingExample: UIViewController {
     bottomDrawerViewController.contentViewController = contentViewController
     bottomDrawerViewController.headerViewController = headerViewController
     bottomDrawerViewController.trackingScrollView = contentViewController.tableView
+    MDCBottomDrawerColorThemer.applySemanticColorScheme(colorScheme,
+                                                        toBottomDrawer: bottomDrawerViewController)
     present(bottomDrawerViewController, animated: true, completion: nil)
   }
 }
@@ -92,7 +94,6 @@ class DrawerContentTableViewController: UITableViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    view.backgroundColor = colorScheme.primaryColor
     self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
     self.tableView.isScrollEnabled = false
   }

--- a/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
@@ -28,7 +28,7 @@ class BottomDrawerNoHeaderExample: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     view.backgroundColor = colorScheme.backgroundColor
-    contentViewController.colorScheme = colorScheme
+    contentViewController.view.backgroundColor = colorScheme.primaryColor
 
     bottomAppBar.isFloatingButtonHidden = true
     let barButtonLeadingItem = UIBarButtonItem()

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -28,8 +28,6 @@ class BottomDrawerWithHeaderExample: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     view.backgroundColor = colorScheme.backgroundColor
-    headerViewController.colorScheme = colorScheme
-    contentViewController.colorScheme = colorScheme
 
     bottomAppBar.isFloatingButtonHidden = true
     let barButtonLeadingItem = UIBarButtonItem()
@@ -66,6 +64,8 @@ class BottomDrawerWithHeaderExample: UIViewController {
     let bottomDrawerViewController = MDCBottomDrawerViewController()
     bottomDrawerViewController.contentViewController = contentViewController
     bottomDrawerViewController.headerViewController = headerViewController
+    MDCBottomDrawerColorThemer.applySemanticColorScheme(colorScheme,
+                                                        toBottomDrawer: bottomDrawerViewController)
     present(bottomDrawerViewController, animated: true, completion: nil)
   }
 }

--- a/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
@@ -28,7 +28,6 @@ class BottomDrawerWithScrollableContentExample: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     view.backgroundColor = colorScheme.backgroundColor
-    headerViewController.colorScheme = colorScheme
     contentViewController.colorScheme = colorScheme
 
     bottomAppBar.isFloatingButtonHidden = true
@@ -67,6 +66,8 @@ class BottomDrawerWithScrollableContentExample: UIViewController {
     bottomDrawerViewController.contentViewController = contentViewController
     bottomDrawerViewController.headerViewController = headerViewController
     bottomDrawerViewController.trackingScrollView = contentViewController.collectionView
+    MDCBottomDrawerColorThemer.applySemanticColorScheme(colorScheme,
+                                                        toBottomDrawer: bottomDrawerViewController)
     present(bottomDrawerViewController, animated: true, completion: nil)
   }
 }
@@ -99,7 +100,6 @@ class DrawerContentWithScrollViewController: UIViewController,
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    view.backgroundColor = colorScheme.primaryColor
     collectionView.frame = CGRect(x: 0, y: 0, width: self.view.bounds.width,
                              height: self.view.bounds.height)
     collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "Cell")

--- a/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
+++ b/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
@@ -17,7 +17,6 @@ import MaterialComponentsAlpha.MaterialNavigationDrawer
 import MaterialComponents.MaterialColorScheme
 
 class DrawerContentViewController: UIViewController {
-  var colorScheme = MDCSemanticColorScheme()
   let preferredHeight: CGFloat = 2000
 
   override var preferredContentSize: CGSize {
@@ -36,15 +35,9 @@ class DrawerContentViewController: UIViewController {
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
   }
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    view.backgroundColor = colorScheme.primaryColor
-  }
 }
 
 class DrawerHeaderViewController: UIViewController,MDCBottomDrawerHeader {
-  var colorScheme = MDCSemanticColorScheme()
   let preferredHeight: CGFloat = 80
 
   override var preferredContentSize: CGSize {
@@ -62,10 +55,5 @@ class DrawerHeaderViewController: UIViewController,MDCBottomDrawerHeader {
 
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
-  }
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    view.backgroundColor = colorScheme.secondaryColor
   }
 }

--- a/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.h
+++ b/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.h
@@ -1,0 +1,35 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialNavigationDrawer.h"
+#import "MaterialColorScheme.h"
+
+#import <Foundation/Foundation.h>
+
+/**
+ The Material Design color system's themer for instances of MDCBottomDrawerViewController.
+ */
+@interface MDCBottomDrawerColorThemer : NSObject
+
+/**
+ Applies a color scheme's properties to an MDCBottomDrawerViewController
+
+ @param colorScheme The color scheme to apply to the component instance.
+ @param bottomDrawerController A component instance to which the color scheme should be applied.
+ */
++ (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+        toBottomDrawerController:(nonnull MDCBottomDrawerViewController *)bottomDrawerController;
+
+@end
+

--- a/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.h
+++ b/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MaterialNavigationDrawer.h"
 #import "MaterialColorScheme.h"
+#import "MaterialNavigationDrawer.h"
 
 #import <Foundation/Foundation.h>
 
@@ -29,7 +29,6 @@
  @param bottomDrawer A component instance to which the color scheme should be applied.
  */
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
-        toBottomDrawer:(nonnull MDCBottomDrawerViewController *)bottomDrawer;
+                  toBottomDrawer:(nonnull MDCBottomDrawerViewController *)bottomDrawer;
 
 @end
-

--- a/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.h
+++ b/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.h
@@ -26,10 +26,10 @@
  Applies a color scheme's properties to an MDCBottomDrawerViewController
 
  @param colorScheme The color scheme to apply to the component instance.
- @param bottomDrawerController A component instance to which the color scheme should be applied.
+ @param bottomDrawer A component instance to which the color scheme should be applied.
  */
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
-        toBottomDrawerController:(nonnull MDCBottomDrawerViewController *)bottomDrawerController;
+        toBottomDrawer:(nonnull MDCBottomDrawerViewController *)bottomDrawer;
 
 @end
 

--- a/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.m
+++ b/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.m
@@ -1,0 +1,25 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCBottomDrawerColorThemer.h"
+
+@implementation MDCBottomDrawerColorThemer
+
++ (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
+        toBottomDrawerController:(nonnull MDCBottomDrawerViewController *)bottomDrawerController {
+  bottomDrawerController.contentViewController.view.backgroundColor = colorScheme.surfaceColor;
+  bottomDrawerController.headerViewController.view.backgroundColor = colorScheme.surfaceColor;
+}
+
+@end

--- a/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.m
+++ b/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.m
@@ -17,9 +17,9 @@
 @implementation MDCBottomDrawerColorThemer
 
 + (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
-        toBottomDrawerController:(nonnull MDCBottomDrawerViewController *)bottomDrawerController {
-  bottomDrawerController.headerViewController.view.backgroundColor = colorScheme.surfaceColor;
-  bottomDrawerController.contentViewController.view.backgroundColor = colorScheme.surfaceColor;
+        toBottomDrawer:(nonnull MDCBottomDrawerViewController *)bottomDrawer {
+  bottomDrawer.headerViewController.view.backgroundColor = colorScheme.surfaceColor;
+  bottomDrawer.contentViewController.view.backgroundColor = colorScheme.surfaceColor;
 }
 
 @end

--- a/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.m
+++ b/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.m
@@ -17,7 +17,7 @@
 @implementation MDCBottomDrawerColorThemer
 
 + (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
-        toBottomDrawer:(nonnull MDCBottomDrawerViewController *)bottomDrawer {
+                  toBottomDrawer:(nonnull MDCBottomDrawerViewController *)bottomDrawer {
   bottomDrawer.headerViewController.view.backgroundColor = colorScheme.surfaceColor;
   bottomDrawer.contentViewController.view.backgroundColor = colorScheme.surfaceColor;
 }

--- a/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.m
+++ b/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.m
@@ -18,8 +18,8 @@
 
 + (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
         toBottomDrawerController:(nonnull MDCBottomDrawerViewController *)bottomDrawerController {
-  bottomDrawerController.contentViewController.view.backgroundColor = colorScheme.surfaceColor;
   bottomDrawerController.headerViewController.view.backgroundColor = colorScheme.surfaceColor;
+  bottomDrawerController.contentViewController.view.backgroundColor = colorScheme.surfaceColor;
 }
 
 @end

--- a/components/NavigationDrawer/src/ColorThemer/MaterialNavigationDrawer+ColorThemer.h
+++ b/components/NavigationDrawer/src/ColorThemer/MaterialNavigationDrawer+ColorThemer.h
@@ -1,0 +1,15 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCBottomDrawerColorThemer.h"

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerThemeTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerThemeTest.m
@@ -14,18 +14,13 @@
 
 #import <XCTest/XCTest.h>
 
+#import "MDCNavigationDrawerFakes.h"
 #import "MaterialNavigationDrawer+ColorThemer.h"
 #import "MaterialNavigationDrawer.h"
 
-@interface FakeHeaderViewController : UIViewController <MDCBottomDrawerHeader>
-@end
-
-@implementation FakeHeaderViewController
-@end
-
 @interface MDCNavigationDrawerThemeTest : XCTestCase
 @property(nonatomic, strong) MDCBottomDrawerViewController *bottomDrawer;
-@property(nonatomic, strong) FakeHeaderViewController *headerViewController;
+@property(nonatomic, strong) MDCNavigationDrawerFakeHeaderViewController *headerViewController;
 @property(nonatomic, strong) UIViewController *contentViewController;
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
 @end
@@ -35,7 +30,7 @@
 - (void)setUp {
   [super setUp];
 
-  self.headerViewController = [[FakeHeaderViewController alloc] init];
+  self.headerViewController = [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
   self.contentViewController = [[UIViewController alloc] init];
   self.bottomDrawer = [[MDCBottomDrawerViewController alloc] init];
   self.bottomDrawer.headerViewController = self.headerViewController;

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerThemeTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerThemeTest.m
@@ -14,8 +14,8 @@
 
 #import <XCTest/XCTest.h>
 
-#import "MaterialNavigationDrawer.h"
 #import "MaterialNavigationDrawer+ColorThemer.h"
+#import "MaterialNavigationDrawer.h"
 
 @interface FakeHeaderViewController : UIViewController <MDCBottomDrawerHeader>
 @end
@@ -62,7 +62,6 @@
                         self.colorScheme.surfaceColor);
   XCTAssertEqualObjects(self.contentViewController.view.backgroundColor,
                         self.colorScheme.surfaceColor);
-
 }
 
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerThemeTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerThemeTest.m
@@ -1,0 +1,68 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialNavigationDrawer.h"
+#import "MaterialNavigationDrawer+ColorThemer.h"
+
+@interface FakeHeaderViewController : UIViewController <MDCBottomDrawerHeader>
+@end
+
+@implementation FakeHeaderViewController
+@end
+
+@interface MDCNavigationDrawerThemeTest : XCTestCase
+@property(nonatomic, strong) MDCBottomDrawerViewController *bottomDrawer;
+@property(nonatomic, strong) FakeHeaderViewController *headerViewController;
+@property(nonatomic, strong) UIViewController *contentViewController;
+@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
+@end
+
+@implementation MDCNavigationDrawerThemeTest
+
+- (void)setUp {
+  [super setUp];
+
+  self.headerViewController = [[FakeHeaderViewController alloc] init];
+  self.contentViewController = [[UIViewController alloc] init];
+  self.bottomDrawer = [[MDCBottomDrawerViewController alloc] init];
+  self.bottomDrawer.headerViewController = self.headerViewController;
+  self.bottomDrawer.contentViewController = self.contentViewController;
+
+  self.colorScheme = [[MDCSemanticColorScheme alloc] init];
+  self.colorScheme.surfaceColor = UIColor.blueColor;
+}
+
+- (void)tearDown {
+  self.colorScheme = nil;
+  self.bottomDrawer = nil;
+
+  [super tearDown];
+}
+
+- (void)testApplyColorTheme {
+  // When
+  [MDCBottomDrawerColorThemer applySemanticColorScheme:self.colorScheme
+                              toBottomDrawerController:self.bottomDrawer];
+
+  // Then
+  XCTAssertEqualObjects(self.headerViewController.view.backgroundColor,
+                        self.colorScheme.surfaceColor);
+  XCTAssertEqualObjects(self.contentViewController.view.backgroundColor,
+                        self.colorScheme.surfaceColor);
+
+}
+
+@end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerThemeTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerThemeTest.m
@@ -55,7 +55,7 @@
 - (void)testApplyColorTheme {
   // When
   [MDCBottomDrawerColorThemer applySemanticColorScheme:self.colorScheme
-                              toBottomDrawerController:self.bottomDrawer];
+                                        toBottomDrawer:self.bottomDrawer];
 
   // Then
   XCTAssertEqualObjects(self.headerViewController.view.backgroundColor,


### PR DESCRIPTION
### The problem

BottomDrawer previously had no color themer support

### The fix

This change adds a color themer for BottomDrawer. Additionally this adds unit tests and updates the example to use the color themer. The guidelines indicate the content and header should utilize the semantic surface color, so that is what the themer applies to the BottomDrawer. 

**Note:** The drawer should be configured with its header and content ViewControllers before applying the theme.

### Related issues

Closes #4910 

### Code snippet

#### Swift
```
    let bottomDrawerViewController = MDCBottomDrawerViewController()
    bottomDrawerViewController.contentViewController = contentViewController
    bottomDrawerViewController.headerViewController = headerViewController
    MDCBottomDrawerColorThemer.applySemanticColorScheme(colorScheme,
                                                        toBottomDrawer: bottomDrawerViewController)
```

#### ObjC
```
MDCBottomDrawerViewController *bottomDrawer = [[MDCBottomDrawerViewController alloc] init];
bottomDrawer.contentViewController = contentViewController
bottomDrawer.headerViewController = headerViewController
[MDCBottomDrawerColorThemer applySemanticColorScheme:self.colorScheme
                                      toBottomDrawer:bottomDrawer];
```
