### PR TITLE
[NavigationDrawer] Add unit test for height related properties

### DIFF
--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -111,14 +111,15 @@
   CGFloat mdcDeviceTopSafeArea = 20.f;
   CGSize fakePreferredContentSize = CGSizeMake(200, 300);
   MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
   self.fakeBottomDrawer.headerViewController = fakeHeader;
 
   // When
   self.fakeBottomDrawer.headerViewController.preferredContentSize = fakePreferredContentSize;
 
   // Then
-  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.topHeaderHeight, mdcDeviceTopSafeArea + fakePreferredContentSize.height, 0.001);
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.topHeaderHeight,
+                             mdcDeviceTopSafeArea + fakePreferredContentSize.height, 0.001);
 }
 
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -21,6 +21,7 @@
 
 @property(nonatomic) BOOL scrollViewObserved;
 @property(nonatomic, readonly) UIScrollView *scrollView;
+@property(nonatomic, readonly) CGFloat topHeaderHeight;
 @property(nonatomic, readonly) CGFloat contentHeaderHeight;
 
 @end
@@ -84,14 +85,40 @@
 - (void)testContentHeaderHeightWithHeader {
   // Given
   CGSize fakePreferredContentSize = CGSizeMake(200, 300);
-  MDCNavigationDrawerFakeHeaderViewController *fakeHeader = [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
+      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
   self.fakeBottomDrawer.headerViewController = fakeHeader;
 
   // When
   self.fakeBottomDrawer.headerViewController.preferredContentSize = fakePreferredContentSize;
 
   // Then
-  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderHeight, fakePreferredContentSize.height, 0.001);
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderHeight,
+                             fakePreferredContentSize.height, 0.001);
+}
+
+- (void)testTopHeaderHeightWithNoHeader {
+  // When
+  self.fakeBottomDrawer.headerViewController = nil;
+
+  // Then
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.topHeaderHeight, 0.f, 0.001);
+}
+
+- (void)testTopHeaderHeightWithHeader {
+  // Given
+  // MDCDeviceTopSafeAreaInset adds 20.f if there is no safe area and you are not in an application
+  CGFloat mdcDeviceTopSafeArea = 20.f;
+  CGSize fakePreferredContentSize = CGSizeMake(200, 300);
+  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
+  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+  self.fakeBottomDrawer.headerViewController = fakeHeader;
+
+  // When
+  self.fakeBottomDrawer.headerViewController.preferredContentSize = fakePreferredContentSize;
+
+  // Then
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.topHeaderHeight, mdcDeviceTopSafeArea + fakePreferredContentSize.height, 0.001);
 }
 
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -21,8 +21,7 @@
 
 @property(nonatomic) BOOL scrollViewObserved;
 @property(nonatomic, readonly) UIScrollView *scrollView;
-@property(nonatomic, readwrite) CGFloat contentHeightSurplus;
-@property(nonatomic) BOOL contentScrollsToReveal;
+@property(nonatomic, readonly) CGFloat contentHeaderHeight;
 
 @end
 
@@ -72,22 +71,6 @@
 
   // Then
   XCTAssertFalse(self.fakeBottomDrawer.scrollViewObserved);
-}
-
-- (void)testContentDoesScrollToReveal {
-  // When
-  self.fakeBottomDrawer.contentHeightSurplus = CGFLOAT_MAX;
-
-  // Then
-  XCTAssertTrue(self.fakeBottomDrawer.contentScrollsToReveal);
-}
-
-- (void)testContentDoesNotScrollToReveal {
-  // When
-  self.fakeBottomDrawer.contentHeightSurplus = CGFLOAT_MIN;
-
-  // Then
-  XCTAssertFalse(self.fakeBottomDrawer.contentScrollsToReveal);
 }
 
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -73,4 +73,25 @@
   XCTAssertFalse(self.fakeBottomDrawer.scrollViewObserved);
 }
 
+- (void)testContentHeaderHeightWithNoHeader {
+  // When
+  self.fakeBottomDrawer.headerViewController = nil;
+
+  // Then
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderHeight, 0.f, 0.001);
+}
+
+- (void)testContentHeaderHeightWithHeader {
+  // Given
+  CGSize fakePreferredContentSize = CGSizeMake(200, 300);
+  MDCNavigationDrawerFakeHeaderViewController *fakeHeader = [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+  self.fakeBottomDrawer.headerViewController = fakeHeader;
+
+  // When
+  self.fakeBottomDrawer.headerViewController.preferredContentSize = fakePreferredContentSize;
+
+  // Then
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderHeight, fakePreferredContentSize.height, 0.001);
+}
+
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -21,7 +21,8 @@
 
 @property(nonatomic) BOOL scrollViewObserved;
 @property(nonatomic, readonly) UIScrollView *scrollView;
-@property(nonatomic) BOOL currentlyFullScreen;
+@property(nonatomic, readwrite) CGFloat contentHeightSurplus;
+@property(nonatomic) BOOL contentScrollsToReveal;
 
 @end
 
@@ -73,13 +74,20 @@
   XCTAssertFalse(self.fakeBottomDrawer.scrollViewObserved);
 }
 
-- (void)testCurrentlyFullScreen {
-  // Given
-  
-
+- (void)testContentDoesScrollToReveal {
   // When
+  self.fakeBottomDrawer.contentHeightSurplus = CGFLOAT_MAX;
 
   // Then
+  XCTAssertTrue(self.fakeBottomDrawer.contentScrollsToReveal);
+}
+
+- (void)testContentDoesNotScrollToReveal {
+  // When
+  self.fakeBottomDrawer.contentHeightSurplus = CGFLOAT_MIN;
+
+  // Then
+  XCTAssertFalse(self.fakeBottomDrawer.contentScrollsToReveal);
 }
 
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -75,6 +75,7 @@
 
 - (void)testCurrentlyFullScreen {
   // Given
+  
 
   // When
 

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
@@ -43,4 +43,6 @@
   [super tearDown];
 }
 
+
+
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
@@ -43,6 +43,4 @@
   [super tearDown];
 }
 
-
-
 @end


### PR DESCRIPTION
### Context
We currently are missing a lot unit test for NavigationDrawer. In order to keep the PR's manageable I have decided to break them up into related groups. This group is the two properties that look at the headerViewControllers.preferredContentSize.height and tests those two.
### The problem
We are missing a lot of unit test for NavigationDrawer
### The fix
Add test for `topHeaderHeight` and `contentHeaderHeight`

### Bugs
Related to #4911 