### PR TITLE
[Docs] This add the shape theming doc generation for our components

### DIFF
--- a/scripts/apply_all_templates
+++ b/scripts/apply_all_templates
@@ -24,6 +24,15 @@ find components -type d | grep ColorThemer | sort | uniq | while read line; do
   ./scripts/apply_template $component scripts/templates/component/docs/color-theming.md.template components/$component/docs/color-theming.md
 done
 
+find components -type d | grep ShapeThemer | sort | uniq | while read line; do
+  component=$(echo "$line" | cut -d'/' -f2)
+  themer=$(echo "$line" | cut -d'/' -f4)
+
+  echo "Generating shape theming documentation for $component..."
+
+  ./scripts/apply_template $component scripts/templates/component/docs/shape-theming.md.template components/$component/docs/shape-theming.md
+done
+
 find components -type d | grep TypographyThemer | sort | uniq | while read line; do
   component=$(echo "$line" | cut -d'/' -f2)
   themer=$(echo "$line" | cut -d'/' -f4)

--- a/scripts/templates/component/docs/README.md.template
+++ b/scripts/templates/component/docs/README.md.template
@@ -53,5 +53,7 @@ the component.
 <!-- Template: Extensions should be called out separately from Usage docs.
 
 - [Color Theming](color-theming.md)
+
+- [Shape Theming](shape-theming.md)
 -->
 

--- a/scripts/templates/component/docs/shape-theming.md.template
+++ b/scripts/templates/component/docs/shape-theming.md.template
@@ -1,0 +1,37 @@
+### Shape Theming
+
+You can theme <#a_component_name#> with your app's shape scheme using the ShapeThemer extension.
+
+You must first add the ShapeThemer extension to your project:
+
+```bash
+pod 'MaterialComponents/<#component#>+ShapeThemer'
+```
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+// Step 1: Import the ShapeThemer extension
+import MaterialComponents.Material<#component#>_ShapeThemer
+
+// Step 2: Create or get a shape scheme
+let shapeScheme = MDCShapeScheme()
+
+// Step 3: Apply the shape scheme to your component
+<#shape_themer_api#>.applyShapeScheme(shapeScheme, to: component)
+```
+
+#### Objective-C
+
+```objc
+// Step 1: Import the ShapeThemer extension
+#import "Material<#component#>+ShapeThemer.h"
+
+// Step 2: Create or get a shape scheme
+id<MDCShapeScheming> shapeScheme = [[MDCShapeScheme alloc] init];
+
+// Step 3: Apply the shape scheme to your component
+[<#shape_themer_api#> applyShapeScheme:shapeScheme
+     to<#themer_parameter_name#>:component];
+```
+<!--</div>-->


### PR DESCRIPTION
This add the shape theming doc generation for our components. Same as we did for color, we are adding the shape theming template so then it can be easily generated for our docs. I will generate the shape theming docs for our components in a follow up PR.