### PR TITLE
[NavigationDrawer] Add test for contentHeaderTopInset and presentingViewBounds

### DIFF
--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -24,7 +24,6 @@
 @property(nonatomic, readonly) CGFloat topHeaderHeight;
 @property(nonatomic, readonly) CGFloat contentHeaderHeight;
 @property(nonatomic, readonly) CGFloat contentHeaderTopInset;
-@property(nonatomic, readonly) CGFloat contentHeightSurplus;
 @property(nonatomic, readonly) CGRect presentingViewBounds;
 - (void)cacheLayoutCalculations;
 
@@ -214,7 +213,7 @@
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 400.f, 0.001);
 }
 
-- (void)testContentHeaderTopInsetForScrollableContent {
+- (void)testContentHeaderTopInsetForScrollableContentForLargeHeader {
   // Given
   // Setup gives us presentingViewBoudns of (0, 0, 200, 500)
   CGSize fakePreferredContentSize = CGSizeMake(200, 700);
@@ -222,6 +221,21 @@
   [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
   fakeHeader.preferredContentSize = fakePreferredContentSize;
   self.fakeBottomDrawer.headerViewController = fakeHeader;
+
+  // When
+  [self.fakeBottomDrawer cacheLayoutCalculations];
+
+  // Then
+  // In cacheLayoutCalculation we test if contentScrollsToReveal is true then contentHeaderTopInset
+  // should be initialDrawerFactor * presentingViewBounds = 500 * 0.5
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 250.f, 0.001);
+}
+
+- (void)testContentHeaderTopInsetForScrollableContentForLargeContent {
+  // Given
+  // Setup gives us presentingViewBounds of (0, 0, 200, 500)
+  self.fakeBottomDrawer.contentViewController = [[MDCNavigationDrawerFakeTableViewController alloc] init];
+  self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1000);
 
   // When
   [self.fakeBottomDrawer cacheLayoutCalculations];

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -254,11 +254,11 @@
   // Setup gives us presentingViewBounds of (0, 0, 200, 500)
   CGSize fakePreferredContentSize = CGSizeMake(200, 700);
   MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
   fakeHeader.preferredContentSize = fakePreferredContentSize;
   self.fakeBottomDrawer.headerViewController = fakeHeader;
   self.fakeBottomDrawer.contentViewController =
-  [[MDCNavigationDrawerFakeTableViewController alloc] init];
+      [[MDCNavigationDrawerFakeTableViewController alloc] init];
   self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1000);
 
   // When

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -249,4 +249,25 @@
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 250.f, 0.001);
 }
 
+- (void)testContentHeaderTopInsetForScrollableContent {
+  // Given
+  // Setup gives us presentingViewBounds of (0, 0, 200, 500)
+  CGSize fakePreferredContentSize = CGSizeMake(200, 700);
+  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
+  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+  fakeHeader.preferredContentSize = fakePreferredContentSize;
+  self.fakeBottomDrawer.headerViewController = fakeHeader;
+  self.fakeBottomDrawer.contentViewController =
+  [[MDCNavigationDrawerFakeTableViewController alloc] init];
+  self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1000);
+
+  // When
+  [self.fakeBottomDrawer cacheLayoutCalculations];
+
+  // Then
+  // In cacheLayoutCalculation we test if contentScrollsToReveal is true then contentHeaderTopInset
+  // should be initialDrawerFactor * presentingViewBounds = 500 * 0.5
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 250.f, 0.001);
+}
+
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -151,7 +151,8 @@
       [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
   fakeHeader.preferredContentSize = fakePreferredContentSize;
   self.fakeBottomDrawer.headerViewController = fakeHeader;
-  self.fakeBottomDrawer.contentViewController = [[MDCNavigationDrawerFakeTableViewController alloc] init];
+  self.fakeBottomDrawer.contentViewController =
+      [[MDCNavigationDrawerFakeTableViewController alloc] init];
   self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 100);
 
   // When
@@ -183,7 +184,7 @@
   // Setup gives us presentingViewBounds of (0, 0, 200, 500)
   CGSize fakePreferredContentSize = CGSizeMake(200, 300);
   MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
   fakeHeader.preferredContentSize = fakePreferredContentSize;
   self.fakeBottomDrawer.headerViewController = fakeHeader;
 
@@ -200,7 +201,8 @@
 - (void)testContentHeaderTopInsetWithOnlyContentViewController {
   // Given
   // Setup gives us presentingViewBounds of (0, 0, 200, 500)
-  self.fakeBottomDrawer.contentViewController = [[MDCNavigationDrawerFakeTableViewController alloc] init];
+  self.fakeBottomDrawer.contentViewController =
+      [[MDCNavigationDrawerFakeTableViewController alloc] init];
   self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 100);
 
   // When
@@ -218,7 +220,7 @@
   // Setup gives us presentingViewBoudns of (0, 0, 200, 500)
   CGSize fakePreferredContentSize = CGSizeMake(200, 700);
   MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
   fakeHeader.preferredContentSize = fakePreferredContentSize;
   self.fakeBottomDrawer.headerViewController = fakeHeader;
 
@@ -234,7 +236,8 @@
 - (void)testContentHeaderTopInsetForScrollableContentForLargeContent {
   // Given
   // Setup gives us presentingViewBounds of (0, 0, 200, 500)
-  self.fakeBottomDrawer.contentViewController = [[MDCNavigationDrawerFakeTableViewController alloc] init];
+  self.fakeBottomDrawer.contentViewController =
+      [[MDCNavigationDrawerFakeTableViewController alloc] init];
   self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1000);
 
   // When

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -24,6 +24,7 @@
 @property(nonatomic, readonly) CGFloat topHeaderHeight;
 @property(nonatomic, readonly) CGFloat contentHeaderHeight;
 @property(nonatomic, readonly) CGFloat contentHeaderTopInset;
+@property(nonatomic, readonly) CGFloat contentHeightSurplus;
 @property(nonatomic, readonly) CGRect presentingViewBounds;
 - (void)cacheLayoutCalculations;
 
@@ -211,6 +212,24 @@
   // contentViewController.preferredContentSize.height = 100
   // 500 - 0 - 100 = 400
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 400.f, 0.001);
+}
+
+- (void)testContentHeaderTopInsetForScrollableContent {
+  // Given
+  // Setup gives us presentingViewBoudns of (0, 0, 200, 500)
+  CGSize fakePreferredContentSize = CGSizeMake(200, 700);
+  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
+  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+  fakeHeader.preferredContentSize = fakePreferredContentSize;
+  self.fakeBottomDrawer.headerViewController = fakeHeader;
+
+  // When
+  [self.fakeBottomDrawer cacheLayoutCalculations];
+
+  // Then
+  // In cacheLayoutCalculation we test if contentScrollsToReveal is true then contentHeaderTopInset
+  // should be initialDrawerFactor * presentingViewBounds = 500 * 0.5
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 250.f, 0.001);
 }
 
 @end


### PR DESCRIPTION
### Content
NavigationDrawer is missing unit test. One of the _heavy lifting_ functions is `cacheLayoutCalculation`, which has many side effects. One of those side effects is setting the `contentHeaderTopInset`. In cacheLayoutCalculations there is two paths to set `contentHeaderTopInset` one is with scrollable content and one is without scrollable content. If the content isn't scrollable then the `contentHeaderTopInset` is the size of the `presentingViewBounds.size.height` minus the `headerViewController.preferredContentSize.height` and the `contentViewController.preferredContentSize.height`. If the content is scrollable then the `contentHeaderTopInset` is the size of the `presentingViewBounds` * `initialDrawerFactor`.  

### Work in the PR
Test `presentingViewBounds`

Test `contentHeaderTopInset` 
-  Scrollable
   - With large headerViewController
   - With large contentViewController
   - With large contentViewController and headerViewController
- Non-scrollable
  - With only a headerViewController
  - With only a contentViewController
  - With both a contentViewController and a headerViewController
  - With no contentViewController or headerViewController

### Remaining Work
For `cacheLayoutCalculations` we still need to test `contentHeightSurplus`
### Related issues
#4911 