### PR TITLE
[NavigationDrawer] Test content height surplus and scrolls to reveal

### DIFF
--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -225,11 +225,11 @@
   // Given
   CGSize fakePreferredContentSize = CGSizeMake(200, 1000);
   MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
   fakeHeader.preferredContentSize = fakePreferredContentSize;
   self.fakeBottomDrawer.headerViewController = fakeHeader;
   self.fakeBottomDrawer.contentViewController =
-  [[MDCNavigationDrawerFakeTableViewController alloc] init];
+      [[MDCNavigationDrawerFakeTableViewController alloc] init];
   self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1500);
 
   // When
@@ -299,11 +299,11 @@
 - (void)testContentScrollsToRevealTrue {
   CGSize fakePreferredContentSize = CGSizeMake(200, 1000);
   MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
   fakeHeader.preferredContentSize = fakePreferredContentSize;
   self.fakeBottomDrawer.headerViewController = fakeHeader;
   self.fakeBottomDrawer.contentViewController =
-  [[MDCNavigationDrawerFakeTableViewController alloc] init];
+      [[MDCNavigationDrawerFakeTableViewController alloc] init];
   self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1500);
 
   // When

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -25,6 +25,8 @@
 @property(nonatomic, readonly) CGFloat contentHeaderHeight;
 @property(nonatomic, readonly) CGFloat contentHeaderTopInset;
 @property(nonatomic, readonly) CGRect presentingViewBounds;
+@property(nonatomic, readonly) CGFloat contentHeightSurplus;
+@property(nonatomic, readonly) BOOL contentScrollsToReveal;
 - (void)cacheLayoutCalculations;
 
 @end
@@ -158,7 +160,6 @@
   // When
   [self.fakeBottomDrawer cacheLayoutCalculations];
 
-  // Then
   // presentingViewBounds.size.height = 500, contentHeaderHeight = 300
   // contentViewController.preferredContentSize.height = 100
   // 500 - 300 - 100 = 100
@@ -215,6 +216,29 @@
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 400.f, 0.001);
 }
 
+- (void)testContentHeightSurplus {
+  // Then
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeightSurplus, 0.f, 0.001);
+}
+
+- (void)testContentHeightSurplusWithScrollabelContent {
+  // Given
+  CGSize fakePreferredContentSize = CGSizeMake(200, 1000);
+  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
+  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+  fakeHeader.preferredContentSize = fakePreferredContentSize;
+  self.fakeBottomDrawer.headerViewController = fakeHeader;
+  self.fakeBottomDrawer.contentViewController =
+  [[MDCNavigationDrawerFakeTableViewController alloc] init];
+  self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1500);
+
+  // When
+  [self.fakeBottomDrawer cacheLayoutCalculations];
+
+  // Then
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeightSurplus, 2250.f, 0.001);
+}
+
 - (void)testContentHeaderTopInsetForScrollableContentForLargeHeader {
   // Given
   // Setup gives us presentingViewBoudns of (0, 0, 200, 500)
@@ -224,13 +248,15 @@
   fakeHeader.preferredContentSize = fakePreferredContentSize;
   self.fakeBottomDrawer.headerViewController = fakeHeader;
 
-  // When
-  [self.fakeBottomDrawer cacheLayoutCalculations];
-
-  // Then
   // In cacheLayoutCalculation we test if contentScrollsToReveal is true then contentHeaderTopInset
   // should be initialDrawerFactor * presentingViewBounds = 500 * 0.5
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 250.f, 0.001);
+
+}
+
+- (void)testContentScrollsToRevealFalse {
+  // Then
+  XCTAssertFalse(self.fakeBottomDrawer.contentScrollsToReveal);
 }
 
 - (void)testContentHeaderTopInsetForScrollableContentForLargeContent {
@@ -268,6 +294,23 @@
   // In cacheLayoutCalculation we test if contentScrollsToReveal is true then contentHeaderTopInset
   // should be initialDrawerFactor * presentingViewBounds = 500 * 0.5
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 250.f, 0.001);
+}
+
+- (void)testContentScrollsToRevealTrue {
+  CGSize fakePreferredContentSize = CGSizeMake(200, 1000);
+  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
+  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+  fakeHeader.preferredContentSize = fakePreferredContentSize;
+  self.fakeBottomDrawer.headerViewController = fakeHeader;
+  self.fakeBottomDrawer.contentViewController =
+  [[MDCNavigationDrawerFakeTableViewController alloc] init];
+  self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1500);
+
+  // When
+  [self.fakeBottomDrawer cacheLayoutCalculations];
+
+  // Then
+  XCTAssertTrue(self.fakeBottomDrawer.contentScrollsToReveal);
 }
 
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -222,7 +222,7 @@
   // Setup gives us presentingViewBoudns of (0, 0, 200, 500)
   CGSize fakePreferredContentSize = CGSizeMake(200, 700);
   MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
   fakeHeader.preferredContentSize = fakePreferredContentSize;
   self.fakeBottomDrawer.headerViewController = fakeHeader;
 
@@ -239,7 +239,7 @@
   // Given
   // Setup gives us presentingViewBounds of (0, 0, 200, 500)
   self.fakeBottomDrawer.contentViewController =
-  [[MDCNavigationDrawerFakeTableViewController alloc] init];
+      [[MDCNavigationDrawerFakeTableViewController alloc] init];
   self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1000);
 
   // When
@@ -256,11 +256,11 @@
   // Setup gives us presentingViewBounds of (0, 0, 200, 500)
   CGSize fakePreferredContentSize = CGSizeMake(200, 700);
   MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
   fakeHeader.preferredContentSize = fakePreferredContentSize;
   self.fakeBottomDrawer.headerViewController = fakeHeader;
   self.fakeBottomDrawer.contentViewController =
-  [[MDCNavigationDrawerFakeTableViewController alloc] init];
+      [[MDCNavigationDrawerFakeTableViewController alloc] init];
   self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1000);
 
   // When

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -216,6 +216,57 @@
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 400.f, 0.001);
 }
 
+- (void)testContentHeaderTopInsetForScrollableContentForLargeHeader {
+  // Given
+  // Setup gives us presentingViewBoudns of (0, 0, 200, 500)
+  CGSize fakePreferredContentSize = CGSizeMake(200, 700);
+  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
+  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+  fakeHeader.preferredContentSize = fakePreferredContentSize;
+  self.fakeBottomDrawer.headerViewController = fakeHeader;
+
+  // In cacheLayoutCalculation we test if contentScrollsToReveal is true then contentHeaderTopInset
+  // should be initialDrawerFactor * presentingViewBounds = 500 * 0.5
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 250.f, 0.001);
+}
+
+- (void)testContentHeaderTopInsetForScrollableContentForLargeContent {
+  // Given
+  // Setup gives us presentingViewBounds of (0, 0, 200, 500)
+  self.fakeBottomDrawer.contentViewController =
+  [[MDCNavigationDrawerFakeTableViewController alloc] init];
+  self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1000);
+
+  // When
+  [self.fakeBottomDrawer cacheLayoutCalculations];
+
+  // Then
+  // In cacheLayoutCalculation we test if contentScrollsToReveal is true then contentHeaderTopInset
+  // should be initialDrawerFactor * presentingViewBounds = 500 * 0.5
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 250.f, 0.001);
+}
+
+- (void)testContentHeaderTopInsetForScrollableContent {
+  // Given
+  // Setup gives us presentingViewBounds of (0, 0, 200, 500)
+  CGSize fakePreferredContentSize = CGSizeMake(200, 700);
+  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
+  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+  fakeHeader.preferredContentSize = fakePreferredContentSize;
+  self.fakeBottomDrawer.headerViewController = fakeHeader;
+  self.fakeBottomDrawer.contentViewController =
+  [[MDCNavigationDrawerFakeTableViewController alloc] init];
+  self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1000);
+
+  // When
+  [self.fakeBottomDrawer cacheLayoutCalculations];
+
+  // Then
+  // In cacheLayoutCalculation we test if contentScrollsToReveal is true then contentHeaderTopInset
+  // should be initialDrawerFactor * presentingViewBounds = 500 * 0.5
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 250.f, 0.001);
+}
+
 - (void)testContentHeightSurplus {
   // Then
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeightSurplus, 0.f, 0.001);
@@ -239,61 +290,9 @@
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeightSurplus, 2250.f, 0.001);
 }
 
-- (void)testContentHeaderTopInsetForScrollableContentForLargeHeader {
-  // Given
-  // Setup gives us presentingViewBoudns of (0, 0, 200, 500)
-  CGSize fakePreferredContentSize = CGSizeMake(200, 700);
-  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
-  fakeHeader.preferredContentSize = fakePreferredContentSize;
-  self.fakeBottomDrawer.headerViewController = fakeHeader;
-
-  // In cacheLayoutCalculation we test if contentScrollsToReveal is true then contentHeaderTopInset
-  // should be initialDrawerFactor * presentingViewBounds = 500 * 0.5
-  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 250.f, 0.001);
-
-}
-
 - (void)testContentScrollsToRevealFalse {
   // Then
   XCTAssertFalse(self.fakeBottomDrawer.contentScrollsToReveal);
-}
-
-- (void)testContentHeaderTopInsetForScrollableContentForLargeContent {
-  // Given
-  // Setup gives us presentingViewBounds of (0, 0, 200, 500)
-  self.fakeBottomDrawer.contentViewController =
-      [[MDCNavigationDrawerFakeTableViewController alloc] init];
-  self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1000);
-
-  // When
-  [self.fakeBottomDrawer cacheLayoutCalculations];
-
-  // Then
-  // In cacheLayoutCalculation we test if contentScrollsToReveal is true then contentHeaderTopInset
-  // should be initialDrawerFactor * presentingViewBounds = 500 * 0.5
-  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 250.f, 0.001);
-}
-
-- (void)testContentHeaderTopInsetForScrollableContent {
-  // Given
-  // Setup gives us presentingViewBounds of (0, 0, 200, 500)
-  CGSize fakePreferredContentSize = CGSizeMake(200, 700);
-  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
-  fakeHeader.preferredContentSize = fakePreferredContentSize;
-  self.fakeBottomDrawer.headerViewController = fakeHeader;
-  self.fakeBottomDrawer.contentViewController =
-      [[MDCNavigationDrawerFakeTableViewController alloc] init];
-  self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1000);
-
-  // When
-  [self.fakeBottomDrawer cacheLayoutCalculations];
-
-  // Then
-  // In cacheLayoutCalculation we test if contentScrollsToReveal is true then contentHeaderTopInset
-  // should be initialDrawerFactor * presentingViewBounds = 500 * 0.5
-  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 250.f, 0.001);
 }
 
 - (void)testContentScrollsToRevealTrue {

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -160,6 +160,7 @@
   // When
   [self.fakeBottomDrawer cacheLayoutCalculations];
 
+  // Then
   // presentingViewBounds.size.height = 500, contentHeaderHeight = 300
   // contentViewController.preferredContentSize.height = 100
   // 500 - 300 - 100 = 100
@@ -225,6 +226,10 @@
   fakeHeader.preferredContentSize = fakePreferredContentSize;
   self.fakeBottomDrawer.headerViewController = fakeHeader;
 
+  // When
+  [self.fakeBottomDrawer cacheLayoutCalculations];
+
+  // Then
   // In cacheLayoutCalculation we test if contentScrollsToReveal is true then contentHeaderTopInset
   // should be initialDrawerFactor * presentingViewBounds = 500 * 0.5
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderTopInset, 250.f, 0.001);


### PR DESCRIPTION
### Context
NavigationDrawer is missing unit test. One of the _heavy lifting_ functions is `cacheLayoutCalculation`, which has many side effects. One of those side effects is setting the `contentHeightSurplus`. `contentHeightSurplus` effects `scrollsToReveal` so those test were also added. 

**_Note:_** I didn't add any comments in the test but those may be necessary to give future maintainers context on why the test are a given result.

### Related issues
#4911 
### Related PR
#5465 