### PR TITLE
[Alpha] Add MaterialComponents as dependency

### DIFF
--- a/MaterialComponentsAlpha.podspec
+++ b/MaterialComponentsAlpha.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |mdc|
   mdc.source       = { :git => "https://github.com/material-components/material-components-ios.git", :tag => "v#{mdc.version}" }
   mdc.platform     = :ios
   mdc.requires_arc = true
+  mdc.dependency   = "MaterialComponents"
   mdc.ios.deployment_target = '8.0'
 
   # See MaterialComponents.podspec for the subspec structure and template.

--- a/MaterialComponentsAlpha.podspec
+++ b/MaterialComponentsAlpha.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |mdc|
   mdc.source       = { :git => "https://github.com/material-components/material-components-ios.git", :tag => "v#{mdc.version}" }
   mdc.platform     = :ios
   mdc.requires_arc = true
-  mdc.dependency   = "MaterialComponents"
+  mdc.dependency "MaterialComponents"
   mdc.ios.deployment_target = '8.0'
 
   # See MaterialComponents.podspec for the subspec structure and template.


### PR DESCRIPTION
### Context
Currently we ask clients to specify their Podfile to
```
pod 'MaterialComponentsAlpha', :git => 'https://github.com/material-components/material-components-ios.git'
```
in order for this to work correctly we need to have _MaterialComponents_ as a dependency for _MaterialComponentsAlpha_. This will make it easier for external clients to use Alpha components easier. These components aren't ready for production use so we may want to discourage the usage of these components.

### Issues
Closes #5380 