### PR TITLE
[NavigationDrawer] Graduation from Beta to Ready

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -841,6 +841,31 @@ Pod::Spec.new do |mdc|
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 
+  # NavigationDrawer
+
+  mdc.subspec "NavigationDrawer" do |component|
+    component.ios.deployment_target = '8.0'
+    component.public_header_files = "components/#{component.base_name}/src/*.h"
+    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
+
+    component.dependency "MaterialComponents/ShadowLayer"
+    component.dependency "MaterialComponents/private/UIMetrics"
+
+    component.test_spec 'tests' do |tests|
+      tests.test_spec 'unit' do |unit_tests|
+        unit_tests.source_files = "components/#{component.base_name}/tests/unit/*.{h,m,swift}", "components/#{component.base_name}/tests/unit/supplemental/*.{h,m,swift}"
+      end
+    end
+  end
+
+  mdc.subspec "NavigationDrawer+ColorThemer" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/schemes/Color"
+  end
+
   # OverlayWindow
 
   mdc.subspec "OverlayWindow" do |component|

--- a/MaterialComponentsAlpha.podspec
+++ b/MaterialComponentsAlpha.podspec
@@ -56,31 +56,6 @@ Pod::Spec.new do |mdc|
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 
-  # NavigationDrawer
-
-  mdc.subspec "NavigationDrawer" do |component|
-    component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
-
-    component.dependency "MaterialComponents/ShadowLayer"
-    component.dependency "MaterialComponents/private/UIMetrics"
-
-    component.test_spec 'tests' do |tests|
-      tests.test_spec 'unit' do |unit_tests|
-        unit_tests.source_files = "components/#{component.base_name}/tests/unit/*.{h,m,swift}", "components/#{component.base_name}/tests/unit/supplemental/*.{h,m,swift}"
-      end
-    end
-  end
-
-  mdc.subspec "NavigationDrawer+ColorThemer" do |extension|
-    extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
-    extension.dependency "MaterialComponentsAlpha/#{extension.base_name.split('+')[0]}"
-    extension.dependency "MaterialComponents/schemes/Color"
-  end
-
   # Private
 
   mdc.subspec "private" do |private_spec|

--- a/catalog/Podfile
+++ b/catalog/Podfile
@@ -27,6 +27,7 @@ target "MDCCatalog" do
     'List/tests/unit',
     'MaskedTransition/tests/unit',
     'NavigationBar/tests/unit',
+    'NavigationDrawer/tests/unit',
     'OverlayWindow/tests/unit',
     'PageControl/tests/unit',
     'Palettes/tests/unit',
@@ -53,7 +54,6 @@ target "MDCCatalog" do
   ]
   pod 'MaterialComponentsAlpha', :path => '../', :testspecs => [
     'ActionSheet/tests/unit',
-    'NavigationDrawer/tests/unit',
   ]
   pod 'CatalogByConvention', "~> 2.5"
   pod 'MaterialCatalog', :path => 'MaterialCatalog/'

--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 import UIKit
-import MaterialComponentsAlpha.MaterialNavigationDrawer
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialBottomAppBar_ColorThemer
 import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialNavigationDrawer
 
 class BottomDrawerInfiniteScrollingExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()

--- a/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 import UIKit
-import MaterialComponentsAlpha.MaterialNavigationDrawer
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialBottomAppBar_ColorThemer
 import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialNavigationDrawer
 
 class BottomDrawerNoHeaderExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 import UIKit
-import MaterialComponentsAlpha.MaterialNavigationDrawer
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialBottomAppBar_ColorThemer
 import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialNavigationDrawer
 
 class BottomDrawerWithHeaderExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()

--- a/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 import UIKit
-import MaterialComponentsAlpha.MaterialNavigationDrawer
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialBottomAppBar_ColorThemer
 import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialNavigationDrawer
 
 class BottomDrawerWithScrollableContentExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()

--- a/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
+++ b/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import UIKit
-import MaterialComponentsAlpha.MaterialNavigationDrawer
 import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialNavigationDrawer
 
 class DrawerContentViewController: UIViewController {
   let preferredHeight: CGFloat = 2000


### PR DESCRIPTION
This PR is the last step in graduating the Navigation Drawer component from Beta to Ready.

We have resolved all the outstanding issues in the Navigation Drawer Project here: https://github.com/material-components/material-components-ios/projects/85 and hotlist: 1230549 .
The only outstanding issue is the unit tests ( #5466 , #5465 ) which were approved and are pending due to GitHub issues causing CI not to run.

We are essentially migrating here the NavigationDrawer component from the MaterialComponentsAlpha podspec to the MaterialComponents podspec so it can be used publicly using the normal means of installing our Pod.

This PR is blocked and can land once #5466 and #5465 land.

Closes #5333 