### PR TITLE
[List] Do not enforce label text alignment based off effective user interface layout direction

### DIFF
--- a/components/List/src/MDCSelfSizingStereoCell.m
+++ b/components/List/src/MDCSelfSizingStereoCell.m
@@ -123,8 +123,6 @@ static const CGFloat kDetailColorOpacity = 0.6f;
   self.leadingImageView.frame = layout.leadingImageViewFrame;
   self.trailingImageView.frame = layout.trailingImageViewFrame;
   if (self.mdf_effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
-    self.titleLabel.textAlignment = NSTextAlignmentRight;
-    self.detailLabel.textAlignment = NSTextAlignmentRight;
     self.leadingImageView.frame =
         MDFRectFlippedHorizontally(self.leadingImageView.frame, layout.cellWidth);
     self.trailingImageView.frame =
@@ -135,9 +133,6 @@ static const CGFloat kDetailColorOpacity = 0.6f;
         MDFRectFlippedHorizontally(self.titleLabel.frame, self.textContainer.frame.size.width);
     self.detailLabel.frame =
         MDFRectFlippedHorizontally(self.detailLabel.frame, self.textContainer.frame.size.width);
-  } else {
-    self.titleLabel.textAlignment = NSTextAlignmentLeft;
-    self.detailLabel.textAlignment = NSTextAlignmentLeft;
   }
 }
 


### PR DESCRIPTION
The problem:

We were enforcing label text alignment based off effective user interface layout direction.
As a result, if the system language was English and you created an Arabic label (with its textAlignment set to Right) the label would ultimately end up with a textAlignment of Left.

The solution:

Don't set textAlignment from within the cell. Leave it to the client.

Closes #5472.

Before:
![simulator screen shot - iphone x - 2018-10-22 at 16 23 26](https://user-images.githubusercontent.com/8020010/47317932-b50eb800-d618-11e8-999d-19aad687dbf2.png)

After:
![simulator screen shot - iphone x - 2018-10-22 at 16 23 58](https://user-images.githubusercontent.com/8020010/47317931-b50eb800-d618-11e8-9ae1-c70d4af7f3ae.png)
