### PR TITLE
[List] Allow stereo cell labels to take up all available space

### DIFF
--- a/components/List/src/private/MDCSelfSizingStereoCellLayout.m
+++ b/components/List/src/private/MDCSelfSizingStereoCellLayout.m
@@ -109,9 +109,7 @@ static const CGFloat kImageSideLengthMax = 56.0;
   const CGSize fittingSize = CGSizeMake(textContainerWidth, CGFLOAT_MAX);
 
   CGSize titleSize = [titleLabel sizeThatFits:fittingSize];
-  if (titleLabel.numberOfLines != 0 && titleSize.width > textContainerWidth) {
-    titleSize.width = textContainerWidth;
-  }
+  titleSize.width = textContainerWidth;
   const CGFloat titleLabelMinX = 0;
   CGFloat titleLabelMinY = 0;
   CGPoint titleOrigin = CGPointMake(titleLabelMinX, titleLabelMinY);
@@ -121,9 +119,7 @@ static const CGFloat kImageSideLengthMax = 56.0;
   self.titleLabelFrame = titleFrame;
 
   CGSize detailSize = [detailLabel sizeThatFits:fittingSize];
-  if (detailLabel.numberOfLines != 0 && detailSize.width > textContainerWidth) {
-    detailSize.width = textContainerWidth;
-  }
+  detailSize.width = textContainerWidth;
   const CGFloat detailLabelMinX = 0;
   CGFloat detailLabelMinY = CGRectGetMaxY(titleFrame);
   if (titleLabel.text.length > 0 && detailLabel.text.length > 0) {


### PR DESCRIPTION
The problem:

The label wasn't taking up all available space. That way, with sufficiently short text, a right aligned Arabic label would appear to be left aligned. See before and after pics from the view debugger below.

The solution:

Allow stereo cell labels to take up all available space.

Before:
<img width="565" alt="screen shot 2018-10-22 at 4 42 29 pm" src="https://user-images.githubusercontent.com/8020010/47318438-11260c00-d61a-11e8-9c25-c541dfabf9ca.png">

After:
<img width="561" alt="screen shot 2018-10-22 at 4 43 40 pm" src="https://user-images.githubusercontent.com/8020010/47318437-11260c00-d61a-11e8-8c93-a9594970aa63.png">

Closes #5473.