### PR TITLE
[Dialogs] Refactor test to use setup and teardown

### DIFF
--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -55,30 +55,35 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
 #pragma mark - Tests
 
 @interface MDCAlertControllerTests : XCTestCase
-
+@property(nonatomic, nullable) MDCAlertController *alert;
 @end
 
 @implementation MDCAlertControllerTests
 
-- (void)testInit {
-  // Given
-  MDCAlertController *alert = [[MDCAlertController alloc] init];
+- (void)setUp {
+  [super setUp];
 
+  self.alert = [MDCAlertController alertControllerWithTitle:@"title" message:@"message"];
+}
+
+- (void)tearDown {
+  self.alert = nil;
+
+  [super tearDown];
+}
+
+- (void)testInit {
   // Then
-  XCTAssertNotNil(alert.actions);
-  XCTAssertNil(alert.title);
-  XCTAssertNil(alert.message);
+  XCTAssertNotNil(self.alert.actions);
+  XCTAssertNotNil(self.alert.title);
+  XCTAssertNotNil(self.alert.message);
 }
 
 - (void)testAlertControllerWithTitleMessage {
-  // Given
-  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
-                                                                   message:@"message"];
-
   // Then
-  XCTAssertNotNil(alert.actions);
-  XCTAssertEqualObjects(alert.title, @"title");
-  XCTAssertEqualObjects(alert.message, @"message");
+  XCTAssertNotNil(self.alert.actions);
+  XCTAssertEqualObjects(self.alert.title, @"title");
+  XCTAssertEqualObjects(self.alert.message, @"message");
 }
 
 - (void)testSubclassEncodingFails {
@@ -102,14 +107,12 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
 }
 
 - (void)testAlertControllerTyphography {
-  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
-                                                                   message:@"message"];
   UIFont *testFont = [UIFont boldSystemFontOfSize:30];
-  alert.titleFont = testFont;
-  alert.messageFont = testFont;
-  alert.buttonFont = testFont;
+  self.alert.titleFont = testFont;
+  self.alert.messageFont = testFont;
+  self.alert.buttonFont = testFont;
 
-  MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertEqual(view.titleLabel.font, testFont);
   XCTAssertEqual(view.messageLabel.font, testFont);
   for (UIButton *button in view.actionManager.buttonsInActionOrder) {
@@ -118,15 +121,13 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
 }
 
 - (void)testAlertControllerColorSetting {
-  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
-                                                                   message:@"message"];
   UIColor *testColor = [UIColor redColor];
-  alert.titleColor = testColor;
-  alert.messageColor = testColor;
-  alert.buttonTitleColor = testColor;
-  alert.buttonInkColor = testColor;
+  self.alert.titleColor = testColor;
+  self.alert.messageColor = testColor;
+  self.alert.buttonTitleColor = testColor;
+  self.alert.buttonInkColor = testColor;
 
-  MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertEqual(view.titleLabel.textColor, testColor);
   XCTAssertEqual(view.messageLabel.textColor, testColor);
   for (UIButton *button in view.actionManager.buttonsInActionOrder) {
@@ -139,19 +140,18 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
 - (void)testAlertControllerColorSettingBeforeActions {
   // Given
   UIColor *testColor = [UIColor redColor];
-  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
-                                                                   message:@"message"];
-  // When
-  alert.titleColor = testColor;
-  alert.messageColor = testColor;
-  alert.buttonTitleColor = testColor;
-  alert.buttonInkColor = testColor;
 
-  [alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
-  [alert addAction:[MDCAlertAction actionWithTitle:@"action2" handler:nil]];
+  // When
+  self.alert.titleColor = testColor;
+  self.alert.messageColor = testColor;
+  self.alert.buttonTitleColor = testColor;
+  self.alert.buttonInkColor = testColor;
+
+  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
+  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action2" handler:nil]];
 
   // Then
-  MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertEqual(view.titleLabel.textColor, testColor);
   XCTAssertEqual(view.messageLabel.textColor, testColor);
   NSArray<MDCButton *> *buttons = view.actionManager.buttonsInActionOrder;
@@ -166,19 +166,18 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
 - (void)testAlertControllerColorSettingAfterActions {
   // Given
   UIColor *testColor = [UIColor redColor];
-  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
-                                                                   message:@"message"];
-  // When
-  [alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
-  [alert addAction:[MDCAlertAction actionWithTitle:@"action2" handler:nil]];
 
-  alert.titleColor = testColor;
-  alert.messageColor = testColor;
-  alert.buttonTitleColor = testColor;
-  alert.buttonInkColor = testColor;
+  // When
+  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
+  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action2" handler:nil]];
+
+  self.alert.titleColor = testColor;
+  self.alert.messageColor = testColor;
+  self.alert.buttonTitleColor = testColor;
+  self.alert.buttonInkColor = testColor;
 
   // Then
-  MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertEqual(view.titleLabel.textColor, testColor);
   XCTAssertEqual(view.messageLabel.textColor, testColor);
   NSArray<MDCButton *> *buttons = view.actionManager.buttonsInActionOrder;
@@ -193,20 +192,19 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
 - (void)testAlertControllerColorSettingBetweenActions {
   // Given
   UIColor *testColor = [UIColor redColor];
-  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
-                                                                   message:@"message"];
+
   // When
-  [alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
+  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
 
-  alert.titleColor = testColor;
-  alert.messageColor = testColor;
-  alert.buttonTitleColor = testColor;
-  alert.buttonInkColor = testColor;
+  self.alert.titleColor = testColor;
+  self.alert.messageColor = testColor;
+  self.alert.buttonTitleColor = testColor;
+  self.alert.buttonInkColor = testColor;
 
-  [alert addAction:[MDCAlertAction actionWithTitle:@"action2" handler:nil]];
+  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action2" handler:nil]];
 
   // Then
-  MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertEqual(view.titleLabel.textColor, testColor);
   XCTAssertEqual(view.messageLabel.textColor, testColor);
   NSArray<MDCButton *> *buttons = view.actionManager.buttonsInActionOrder;
@@ -221,54 +219,49 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
 - (void)testAlertControllerSettingTitleAndMessage {
   NSString *title = @"title";
   NSString *message = @"message";
-  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:title
-                                                                   message:message];
-  alert.titleFont = [UIFont systemFontOfSize:25];
 
-  MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
+  self.alert.titleFont = [UIFont systemFontOfSize:25];
+
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertEqual(view.titleLabel.text, title);
   XCTAssertEqual(view.messageLabel.text, message);
 }
 
 - (void)testTheViewIsNotLoadedWhenPropertiesAreSet {
-  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
-                                                                   message:@"message"];
   UIColor *testColor = [UIColor redColor];
-  alert.titleColor = testColor;
-  alert.messageColor = testColor;
-  alert.buttonTitleColor = testColor;
-  alert.buttonInkColor = testColor;
-  alert.titleFont = [UIFont systemFontOfSize:12];
-  alert.messageFont = [UIFont systemFontOfSize:14];
-  alert.buttonFont = [UIFont systemFontOfSize:10];
-  [alert addAction:[MDCAlertAction actionWithTitle:@"test"
+  self.alert.titleColor = testColor;
+  self.alert.messageColor = testColor;
+  self.alert.buttonTitleColor = testColor;
+  self.alert.buttonInkColor = testColor;
+  self.alert.titleFont = [UIFont systemFontOfSize:12];
+  self.alert.messageFont = [UIFont systemFontOfSize:14];
+  self.alert.buttonFont = [UIFont systemFontOfSize:10];
+  [self.alert addAction:[MDCAlertAction actionWithTitle:@"test"
                                            handler:^(MDCAlertAction * _Nonnull action) {
                                            }]];
-  XCTAssertFalse(alert.isViewLoaded);
+  XCTAssertFalse(self.alert.isViewLoaded);
 }
 
 - (void)testAccessibilityIdentifiersAppliesToAlertControllerViewButtons {
   // Given
-  MDCAlertController *alertController = [MDCAlertController alertControllerWithTitle:@"Title"
-                                                                             message:@"message"];
   MDCAlertAction *action1 = [MDCAlertAction actionWithTitle:@"button1" handler:nil];
   action1.accessibilityIdentifier = @"1";
   MDCAlertAction *action2 = [MDCAlertAction actionWithTitle:@"buttonA" handler:nil];
   action2.accessibilityIdentifier = @"A";
 
   // When
-  [alertController addAction:action1];
-  [alertController addAction:action2];
+  [self.alert addAction:action1];
+  [self.alert addAction:action2];
   
   // Force the view to load
   if (@available(iOS 9.0, *)) {
-    [alertController loadViewIfNeeded];
+    [self.alert loadViewIfNeeded];
   } else {
-    (void)alertController.view;
+    (void)self.alert.view;
   }
 
   // Then
-  NSArray<UIButton *> *buttons = alertController.alertView.actionManager.buttonsInActionOrder;
+  NSArray<UIButton *> *buttons = self.alert.alertView.actionManager.buttonsInActionOrder;
   XCTAssertEqual(buttons.count, 2U);
   UIButton *button1 = buttons.firstObject;
   UIButton *button2 = buttons.lastObject;
@@ -283,74 +276,64 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
 
 - (void)testDefaultCornerRadius {
   // Given
-  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
-                                                                   message:@"message"];
-  [alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
-  [alert addAction:[MDCAlertAction actionWithTitle:@"action2" handler:nil]];
+  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
+  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action2" handler:nil]];
 
   // Then
-  MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertEqualWithAccuracy(view.layer.cornerRadius, 0.0, 0.0);
-  XCTAssertEqualWithAccuracy(alert.mdc_dialogPresentationController.dialogCornerRadius, 0.0, 0.0);
+  XCTAssertEqualWithAccuracy(self.alert.mdc_dialogPresentationController.dialogCornerRadius, 0.0, 0.0);
 }
 
 - (void)testCustomCornerRadius {
   // Given
   CGFloat cornerRadius = (CGFloat)36.0;
-  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
-                                                                   message:@"message"];
-  [alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
-  [alert addAction:[MDCAlertAction actionWithTitle:@"action2" handler:nil]];
+  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
+  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action2" handler:nil]];
 
   // When
-  alert.cornerRadius = cornerRadius;
+  self.alert.cornerRadius = cornerRadius;
 
   // Then
-  MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertEqualWithAccuracy(view.layer.cornerRadius, cornerRadius, 0.0);
-  XCTAssertEqualWithAccuracy(alert.mdc_dialogPresentationController.dialogCornerRadius,
+  XCTAssertEqualWithAccuracy(self.alert.mdc_dialogPresentationController.dialogCornerRadius,
                              cornerRadius, 0.0);
 }
 
 - (void)testDefaultElevation {
   // Given
   CGFloat elevation = (CGFloat)MDCShadowElevationDialog;
-  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
-                                                                   message:@"message"];
-  [alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
+  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
 
   // Then
-  MDCDialogShadowedView *shadowView = alert.mdc_dialogPresentationController.trackingView;
+  MDCDialogShadowedView *shadowView = self.alert.mdc_dialogPresentationController.trackingView;
   XCTAssertEqual(shadowView.elevation, elevation);
 }
 
 - (void)testCustomElevation {
   // Given
   CGFloat elevation = (CGFloat)2.0;
-  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
-                                                                   message:@"message"];
-  [alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
+  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
 
   // When
-  alert.elevation = elevation;
+  self.alert.elevation = elevation;
 
   // Then
-  MDCDialogShadowedView *shadowView = alert.mdc_dialogPresentationController.trackingView;
+  MDCDialogShadowedView *shadowView = self.alert.mdc_dialogPresentationController.trackingView;
   XCTAssertEqual(shadowView.elevation, elevation);
 }
 
 - (void)testCustomDialogPresentationElevation {
   // Given
   CGFloat elevation = (CGFloat)2.0;
-  MDCAlertController *alert = [MDCAlertController alertControllerWithTitle:@"title"
-                                                                   message:@"message"];
-  [alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
+  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
 
   // When
-  alert.mdc_dialogPresentationController.dialogElevation = elevation;
+  self.alert.mdc_dialogPresentationController.dialogElevation = elevation;
 
   // Then
-  MDCDialogShadowedView *shadowView = alert.mdc_dialogPresentationController.trackingView;
+  MDCDialogShadowedView *shadowView = self.alert.mdc_dialogPresentationController.trackingView;
   XCTAssertEqual(shadowView.elevation, elevation);
 }
 

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -107,11 +107,15 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
 }
 
 - (void)testAlertControllerTyphography {
+  // Given
   UIFont *testFont = [UIFont boldSystemFontOfSize:30];
+
+  // When
   self.alert.titleFont = testFont;
   self.alert.messageFont = testFont;
   self.alert.buttonFont = testFont;
 
+  // Then
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertEqual(view.titleLabel.font, testFont);
   XCTAssertEqual(view.messageLabel.font, testFont);
@@ -121,12 +125,16 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
 }
 
 - (void)testAlertControllerColorSetting {
+  // Given
   UIColor *testColor = [UIColor redColor];
+
+  // When
   self.alert.titleColor = testColor;
   self.alert.messageColor = testColor;
   self.alert.buttonTitleColor = testColor;
   self.alert.buttonInkColor = testColor;
 
+  // Then
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertEqual(view.titleLabel.textColor, testColor);
   XCTAssertEqual(view.messageLabel.textColor, testColor);
@@ -217,11 +225,14 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
 }
 
 - (void)testAlertControllerSettingTitleAndMessage {
+  // Given
   NSString *title = @"title";
   NSString *message = @"message";
 
+  // When
   self.alert.titleFont = [UIFont systemFontOfSize:25];
 
+  // Then
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertEqual(view.titleLabel.text, title);
   XCTAssertEqual(view.messageLabel.text, message);
@@ -275,36 +286,29 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
 }
 
 - (void)testDefaultCornerRadius {
-  // Given
-  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
-  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action2" handler:nil]];
-
   // Then
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
-  XCTAssertEqualWithAccuracy(view.layer.cornerRadius, 0.0, 0.0);
-  XCTAssertEqualWithAccuracy(self.alert.mdc_dialogPresentationController.dialogCornerRadius, 0.0, 0.0);
+  XCTAssertEqualWithAccuracy(view.layer.cornerRadius, 0.0, 0.001);
+  XCTAssertEqualWithAccuracy(self.alert.mdc_dialogPresentationController.dialogCornerRadius, 0.0, 0.001);
 }
 
 - (void)testCustomCornerRadius {
   // Given
   CGFloat cornerRadius = (CGFloat)36.0;
-  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
-  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action2" handler:nil]];
 
   // When
   self.alert.cornerRadius = cornerRadius;
 
   // Then
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
-  XCTAssertEqualWithAccuracy(view.layer.cornerRadius, cornerRadius, 0.0);
+  XCTAssertEqualWithAccuracy(view.layer.cornerRadius, cornerRadius, 0.001);
   XCTAssertEqualWithAccuracy(self.alert.mdc_dialogPresentationController.dialogCornerRadius,
-                             cornerRadius, 0.0);
+                             cornerRadius, 0.001);
 }
 
 - (void)testDefaultElevation {
   // Given
   CGFloat elevation = (CGFloat)MDCShadowElevationDialog;
-  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
 
   // Then
   MDCDialogShadowedView *shadowView = self.alert.mdc_dialogPresentationController.trackingView;
@@ -314,7 +318,6 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
 - (void)testCustomElevation {
   // Given
   CGFloat elevation = (CGFloat)2.0;
-  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
 
   // When
   self.alert.elevation = elevation;
@@ -327,7 +330,6 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
 - (void)testCustomDialogPresentationElevation {
   // Given
   CGFloat elevation = (CGFloat)2.0;
-  [self.alert addAction:[MDCAlertAction actionWithTitle:@"action1" handler:nil]];
 
   // When
   self.alert.mdc_dialogPresentationController.dialogElevation = elevation;

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -248,8 +248,8 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   self.alert.messageFont = [UIFont systemFontOfSize:14];
   self.alert.buttonFont = [UIFont systemFontOfSize:10];
   [self.alert addAction:[MDCAlertAction actionWithTitle:@"test"
-                                           handler:^(MDCAlertAction * _Nonnull action) {
-                                           }]];
+                                                handler:^(MDCAlertAction *_Nonnull action){
+                                                }]];
   XCTAssertFalse(self.alert.isViewLoaded);
 }
 
@@ -263,7 +263,7 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   // When
   [self.alert addAction:action1];
   [self.alert addAction:action2];
-  
+
   // Force the view to load
   if (@available(iOS 9.0, *)) {
     [self.alert loadViewIfNeeded];
@@ -289,7 +289,8 @@ static NSString *const MDCAlertControllerSubclassValueKey = @"MDCAlertController
   // Then
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertEqualWithAccuracy(view.layer.cornerRadius, 0.0, 0.001);
-  XCTAssertEqualWithAccuracy(self.alert.mdc_dialogPresentationController.dialogCornerRadius, 0.0, 0.001);
+  XCTAssertEqualWithAccuracy(self.alert.mdc_dialogPresentationController.dialogCornerRadius, 0.0,
+                             0.001);
 }
 
 - (void)testCustomCornerRadius {


### PR DESCRIPTION
### Context
In working on #5296 I noticed a lot of the test had repeated code that can be pulled into a `setup` function. Additionally some of the test were missing _Given_, _When_, and _Then_ statements so those were added. This change hopefully makes this code more readable to future maintainers. I also noticed some of the test had extra work in the _Given_ that wasn't necessary so I removed that.
### The problem
Repeated steps in the _Given_ section of the test
### The fix
Implement the `setup` and `teardown` functions as well as add missing _Given_, _When_, and _Then_ comments.

### Related bugs
This isn't related to any bugs this is just something that I saw that could be improved.