### PR TITLE
[BottomSheet] Respect safe area after upward nudge

### DIFF
--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -161,8 +161,7 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
     self.sheet.scrollView.contentInset = contentInset;
 
     CGRect scrollViewFrame = CGRectStandardize(self.sheet.scrollView.frame);
-    scrollViewFrame.size = CGSizeMake(scrollViewFrame.size.width,
-                                      CGRectGetHeight(self.frame));
+    scrollViewFrame.size = CGSizeMake(scrollViewFrame.size.width, CGRectGetHeight(self.frame));
     self.sheet.scrollView.frame = scrollViewFrame;
   }
 }

--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -162,7 +162,7 @@ static const CGFloat kSheetBounceBuffer = 150.0f;
 
     CGRect scrollViewFrame = CGRectStandardize(self.sheet.scrollView.frame);
     scrollViewFrame.size = CGSizeMake(scrollViewFrame.size.width,
-                                      CGRectGetHeight(self.frame) - self.safeAreaInsets.top);
+                                      CGRectGetHeight(self.frame));
     self.sheet.scrollView.frame = scrollViewFrame;
   }
 }

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
@@ -18,11 +18,16 @@
 #import <XCTest/XCTest.h>
 
 #import "../../src/private/MDCSheetContainerView.h"
+#import "../../src/private/MDCDraggableView.h"
 
 // Exposing internal methods for unit testing
 @interface MDCBottomSheetPresentationController (Testing)
 @property(nonatomic, strong) MDCSheetContainerView *sheetView;
 - (void)updatePreferredSheetHeight;
+@end
+
+@interface MDCSheetContainerView (Testing)
+@property(nonatomic) MDCDraggableView *sheet;
 @end
 
 /**
@@ -231,6 +236,22 @@
 
   // Then
   XCTAssertEqualWithAccuracy(CGRectGetHeight(sheetView.frame), CGRectGetHeight(smallFrame), 0.001);
+}
+
+- (void)testSheetViewFrameMatchesScrollViewFrame {
+  // Given
+  CGFloat scrollViewHeight = 100;
+  CGRect fakeFrame = CGRectMake(0, 0, 200, scrollViewHeight);
+  UIScrollView *scrollView = [[UIScrollView alloc] initWithFrame:CGRectZero];
+  MDCSheetContainerView *fakeSheet = [[MDCSheetContainerView alloc] initWithFrame:fakeFrame contentView:[[UIView alloc] initWithFrame:fakeFrame] scrollView:scrollView];
+
+  // When
+  [fakeSheet setNeedsLayout];
+  [fakeSheet layoutIfNeeded];
+
+  // Then
+  CGRect scrollViewFrame = CGRectStandardize(fakeSheet.sheet.frame);
+  XCTAssertEqualWithAccuracy(scrollViewFrame.size.height, scrollViewHeight, 0.001);
 }
 
 @end

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
@@ -17,8 +17,8 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
-#import "../../src/private/MDCSheetContainerView.h"
 #import "../../src/private/MDCDraggableView.h"
+#import "../../src/private/MDCSheetContainerView.h"
 
 // Exposing internal methods for unit testing
 @interface MDCBottomSheetPresentationController (Testing)
@@ -243,7 +243,10 @@
   CGFloat scrollViewHeight = 100;
   CGRect fakeFrame = CGRectMake(0, 0, 200, scrollViewHeight);
   UIScrollView *scrollView = [[UIScrollView alloc] initWithFrame:CGRectZero];
-  MDCSheetContainerView *fakeSheet = [[MDCSheetContainerView alloc] initWithFrame:fakeFrame contentView:[[UIView alloc] initWithFrame:fakeFrame] scrollView:scrollView];
+  MDCSheetContainerView *fakeSheet =
+      [[MDCSheetContainerView alloc] initWithFrame:fakeFrame
+                                       contentView:[[UIView alloc] initWithFrame:fakeFrame]
+                                        scrollView:scrollView];
 
   // When
   [fakeSheet setNeedsLayout];


### PR DESCRIPTION
### Context
ActionSheet is using MDCBottomSheet presentation controller which uses `MDCSheetContainerView` within the method `safeAreaInsetsDidChange` the `MDCSheetContainerView` would subtract the top safe area inset from the scrollView frame. This caused components using this presentation controller to have the correct layout initially but after a user interacts with it they wouldn't layout correctly.
### The problem
After the bottom sheet rebounds from an upward nudge it doesn't respect the safe area
### The fix
Remove the subtraction from the scrollView's frame.
### Related bugs
b/117286643, #5331

### Videos
| Before | After |
| - | - |
|![before](https://user-images.githubusercontent.com/7131294/47359992-25aae880-d69c-11e8-81fd-7c6675130e93.gif)|![after](https://user-images.githubusercontent.com/7131294/47360004-2b083300-d69c-11e8-864c-bc2022459f25.gif)|


