### PR TITLE
[AppBar] Initial frame wrong in MDCAppBarViewController for iPad split screen

### DIFF
--- a/components/AppBar/src/MDCAppBarViewController.m
+++ b/components/AppBar/src/MDCAppBarViewController.m
@@ -248,7 +248,7 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
   [self.navigationBar observeNavigationItem:parent.navigationItem];
 
   CGRect frame = self.view.frame;
-  frame.size.width = parent.view.bounds.size.width;
+  frame.size.width = CGRectGetWidth(parent.view.bounds);
   self.view.frame = frame;
 }
 

--- a/components/AppBar/src/MDCAppBarViewController.m
+++ b/components/AppBar/src/MDCAppBarViewController.m
@@ -246,6 +246,10 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
   [super didMoveToParentViewController:parent];
 
   [self.navigationBar observeNavigationItem:parent.navigationItem];
+
+  CGRect frame = self.view.frame;
+  frame.size.width = parent.view.bounds.size.width;
+  self.view.frame = frame;
 }
 
 - (BOOL)accessibilityPerformEscape {


### PR DESCRIPTION
### Context
When the migration from MDCAppBar to MDCAppBarViewController occurred, a small piece of code was left out, specifically in `addSubviewsToParent`.
### The problem
When running the catalog app in split screen on iPad and viewing the examples for MDCAppBarViewController, the App Bar is not sized correctly and overflows outside of the bounds.
### The fix
Re-add the frame width modifying logic from `addSubviewsToParent` into `didMoveToParentViewController:parent` for MDCAppBarViewController.
### Related bugs
closes #5479, b/118126496

### Screenshots
| Before | After |
| - | - |
|![before](https://user-images.githubusercontent.com/2364772/47369472-c35ce280-d6b1-11e8-9526-045b60b271e2.png)|![after](https://user-images.githubusercontent.com/2364772/47369481-c8219680-d6b1-11e8-9b6c-750aa78e5c57.png)|

