### PR TITLE
[BottomSheet] [Shape]! Update to the Bottom Sheet Shape Themer

### DIFF
--- a/components/BottomSheet/src/ShapeThemer/MDCBottomSheetControllerShapeThemer.m
+++ b/components/BottomSheet/src/ShapeThemer/MDCBottomSheetControllerShapeThemer.m
@@ -14,27 +14,15 @@
 
 #import "MDCBottomSheetControllerShapeThemer.h"
 
-static const CGFloat kBottomSheetCollapsedBaselineShapeValue = 24.0f;
-
 @implementation MDCBottomSheetControllerShapeThemer
 
 + (void)applyShapeScheme:(id<MDCShapeScheming>)shapeScheme
     toBottomSheetController:(MDCBottomSheetController *)bottomSheetController {
   // Shape Generator for the Extended state of the Bottom Sheet.
-  MDCRectangleShapeGenerator *rectangleShapeExtended = [[MDCRectangleShapeGenerator alloc] init];
-  // For a Bottom Sheet the corner values that can be set are the top corners.
-  rectangleShapeExtended.topLeftCorner = shapeScheme.largeComponentShape.topLeftCorner;
-  rectangleShapeExtended.topRightCorner = shapeScheme.largeComponentShape.topRightCorner;
-  [bottomSheetController setShapeGenerator:rectangleShapeExtended forState:MDCSheetStateExtended];
-
-  // Shape Generator for the Preferred state of the Bottom Sheet.
-  // This is an override of the default scheme to fit the baseline values.
   MDCRectangleShapeGenerator *rectangleShapePreferred = [[MDCRectangleShapeGenerator alloc] init];
-  MDCCornerTreatment *cornerTreatmentPreferred =
-      [[MDCRoundedCornerTreatment alloc] initWithRadius:kBottomSheetCollapsedBaselineShapeValue];
   // For a Bottom Sheet the corner values that can be set are the top corners.
-  rectangleShapePreferred.topLeftCorner = cornerTreatmentPreferred;
-  rectangleShapePreferred.topRightCorner = cornerTreatmentPreferred;
+  rectangleShapePreferred.topLeftCorner = shapeScheme.largeComponentShape.topLeftCorner;
+  rectangleShapePreferred.topRightCorner = shapeScheme.largeComponentShape.topRightCorner;
   [bottomSheetController setShapeGenerator:rectangleShapePreferred forState:MDCSheetStatePreferred];
 }
 

--- a/components/BottomSheet/tests/unit/BottomSheetShapeThemerTests.swift
+++ b/components/BottomSheet/tests/unit/BottomSheetShapeThemerTests.swift
@@ -19,38 +19,12 @@ import MaterialComponents.MaterialShapeLibrary
 
 class BottomSheetShapeThemerTests: XCTestCase {
 
-  func testBottomSheetShapeThemerExtended() {
+  func testBottomSheetShapeThemerPreferred() {
     // Given
     let shapeScheme = MDCShapeScheme()
     let bottomSheet = MDCBottomSheetController(contentViewController: UIViewController())
     shapeScheme.largeComponentShape = MDCShapeCategory(cornersWith: .cut, andSize: 10)
     shapeScheme.largeComponentShape.topRightCorner = MDCCornerTreatment.corner(withRadius: 3)
-    bottomSheet.setShapeGenerator(MDCRectangleShapeGenerator(), for: .extended)
-
-    // When
-    MDCBottomSheetControllerShapeThemer.applyShapeScheme(shapeScheme, to: bottomSheet)
-
-    // Then
-    let extendedShapeGenerator = bottomSheet.shapeGenerator(for: .extended)
-    XCTAssert(extendedShapeGenerator is MDCRectangleShapeGenerator)
-    if let rectangleGenerator = extendedShapeGenerator as? MDCRectangleShapeGenerator {
-      XCTAssertEqual(rectangleGenerator.topLeftCorner,
-                     shapeScheme.largeComponentShape.topLeftCorner)
-      XCTAssertEqual(rectangleGenerator.topRightCorner,
-                     shapeScheme.largeComponentShape.topRightCorner)
-      XCTAssertEqual(rectangleGenerator.bottomLeftCorner, MDCCornerTreatment())
-      XCTAssertEqual(rectangleGenerator.bottomRightCorner, MDCCornerTreatment())
-    }
-
-  }
-
-  func testBottomSheetShapeThemerPreferred() {
-    // Given
-    let collapsedBaselineShapeValue = CGFloat(24)
-    let shapeScheme = MDCShapeScheme()
-    let bottomSheet = MDCBottomSheetController(contentViewController: UIViewController())
-    let generatedCorner = MDCCornerTreatment.corner(withRadius: collapsedBaselineShapeValue)
-    shapeScheme.largeComponentShape = MDCShapeCategory(cornersWith: .cut, andSize: 10)
     bottomSheet.setShapeGenerator(MDCRectangleShapeGenerator(), for: .preferred)
 
     // When
@@ -60,11 +34,12 @@ class BottomSheetShapeThemerTests: XCTestCase {
     let preferredShapeGenerator = bottomSheet.shapeGenerator(for: .preferred)
     XCTAssert(preferredShapeGenerator is MDCRectangleShapeGenerator)
     if let rectangleGenerator = preferredShapeGenerator as? MDCRectangleShapeGenerator {
-      XCTAssertEqual(rectangleGenerator.topLeftCorner, generatedCorner)
-      XCTAssertEqual(rectangleGenerator.topRightCorner, generatedCorner)
+      XCTAssertEqual(rectangleGenerator.topLeftCorner,
+                     shapeScheme.largeComponentShape.topLeftCorner)
+      XCTAssertEqual(rectangleGenerator.topRightCorner,
+                     shapeScheme.largeComponentShape.topRightCorner)
       XCTAssertEqual(rectangleGenerator.bottomLeftCorner, MDCCornerTreatment())
       XCTAssertEqual(rectangleGenerator.bottomRightCorner, MDCCornerTreatment())
     }
   }
-
 }


### PR DESCRIPTION
** This is a breaking change to the Shape Scheme **

Based on recent conversations with design, there has been some updates to the way we theme our bottom sheet using shapes. Namely, the discussions revolved around the different states the sheet can be shaped in, and the different variations of sheets having different shape mappings ([Standard Bottom Sheet](https://material.io/design/components/sheets-bottom.html#standard-bottom-sheet) and [Modal Bottom Sheet](https://material.io/design/components/sheets-bottom.html#modal-bottom-sheet).

In conclusion, it has been decided that for the case of the Modal Bottom Sheet (our current bottom sheet), we map the top 2 corners to the Large Component Shape category when the sheet isn't in a full screen state. When the sheet is in full screen, we should not map it or shape it at all.