### PR TITLE
[ActionSheet] Fix rotation bug

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -243,21 +243,6 @@ static const CGFloat kActionTextAlpha = 0.87f;
   return;
 }
 
-- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:
-    (id<UIViewControllerTransitionCoordinator>)coordinator {
-  [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-
-  [coordinator animateAlongsideTransition:
-      ^(__unused id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
-        CGRect frame = self.view.bounds;
-        frame.size = size;
-        frame.origin = CGPointZero;
-        self.view.frame = frame;
-        [self.view setNeedsLayout];
-        [self.view layoutIfNeeded];
-      }                        completion:nil];
-}
-
 #pragma mark - Table view
 
 - (void)updateTable {


### PR DESCRIPTION
### Context
In development of MDCActionSheet I thought it was necessary to have this extra work for `viewWillTransitionToSize:withTransitionCoordinator:`. After putting this into production it is no longer necessary and is causing bugs.

### The problem
ActionSheet doesn't layout correctly after a rotation

### The fix
Remove the extra work in `viewWillTransitionToSize:withTransitionCoordinator:` and let `layoutSubviews` handle layout.

### Testing
This was tested in iOS 11.1 and iOS 12 for iPhone X, iPhone XS Max, and iPad (Split View, Regular)

### Related bugs
Closes #5409 

### Screenshots
| Before | After |
| - | - |
|![simulator screen shot - iphone x - 2018-10-24 at 12 47 31](https://user-images.githubusercontent.com/7131294/47447197-fb842400-d78a-11e8-9724-4272c27395d3.png)|![simulator screen shot - iphone x - 2018-10-24 at 12 45 59](https://user-images.githubusercontent.com/7131294/47447227-076fe600-d78b-11e8-86b6-a59f7ba735c9.png)|

**_Note:_** Screenshot is generated from an iPhone X on iOS 12 starting from portrait, rotating to landscape and back to portrait.

