### PR TITLE
[ListItems] Improve BiDi example performance.

### DIFF
--- a/components/List/examples/MDCSelfSizingStereoCellExample.m
+++ b/components/List/examples/MDCSelfSizingStereoCellExample.m
@@ -128,9 +128,10 @@ static NSString *const kSelfSizingStereoCellExampleDescription =
 
 - (NSTextAlignment)textAlignmentForText:(NSString *)text {
   if (text.length > 0) {
-    if (text.mdf_calculatedLanguageDirection == NSLocaleLanguageDirectionLeftToRight) {
+    NSLocaleLanguageDirection textDirection = text.mdf_calculatedLanguageDirection;
+    if (textDirection == NSLocaleLanguageDirectionLeftToRight) {
       return NSTextAlignmentLeft;
-    } else if (text.mdf_calculatedLanguageDirection == NSLocaleLanguageDirectionRightToLeft) {
+    } else if (textDirection == NSLocaleLanguageDirectionRightToLeft) {
       return NSTextAlignmentRight;
     }
   }


### PR DESCRIPTION
The example showing how to use MDF Internationalization's language
direction code was somewhat inefficient, calling the method twice on the
same string. Instead it should be called once and the result checked.

In manual testing, dropped overhead from 0.8% of Main Thread time to
0.4% while scrolling the example.

Improves #5500
