### PR TITLE
[schemes] Fix pod name in README

### DIFF
--- a/components/schemes/Color/README.md
+++ b/components/schemes/Color/README.md
@@ -88,7 +88,7 @@ colors that they meet [the accessibility guidelines for text and contrasting col
 Add the following to your `Podfile`:
 
 ```bash
-pod 'MaterialComponents/schemes/ColorScheme'
+pod 'MaterialComponents/schemes/Color'
 ```
 <!--{: .code-renderer.code-renderer--install }-->
 

--- a/components/schemes/Color/docs/README.md
+++ b/components/schemes/Color/docs/README.md
@@ -62,7 +62,7 @@ colors that they meet [the accessibility guidelines for text and contrasting col
 Add the following to your `Podfile`:
 
 ```bash
-pod 'MaterialComponents/schemes/ColorScheme'
+pod 'MaterialComponents/schemes/Color'
 ```
 <!--{: .code-renderer.code-renderer--install }-->
 

--- a/components/schemes/Typography/README.md
+++ b/components/schemes/Typography/README.md
@@ -72,7 +72,7 @@ which is larger than headline3 and so on.
 Add the following to your `Podfile`:
 
 ```bash
-pod 'MaterialComponents/schemes/TypographyScheme'
+pod 'MaterialComponents/schemes/Typography'
 ```
 <!--{: .code-renderer.code-renderer--install }-->
 

--- a/components/schemes/Typography/docs/README.md
+++ b/components/schemes/Typography/docs/README.md
@@ -49,7 +49,7 @@ which is larger than headline3 and so on.
 Add the following to your `Podfile`:
 
 ```bash
-pod 'MaterialComponents/schemes/TypographyScheme'
+pod 'MaterialComponents/schemes/Typography'
 ```
 <!--{: .code-renderer.code-renderer--install }-->
 


### PR DESCRIPTION
### Context
In working on #5519 I tried to import "MaterialComponents/schemes/ColorScheme" and "MaterialComponents/schemes/TypographyScheme". Neither of these pods exist and you would get an error.

```bash

[!] CocoaPods could not find compatible versions for pod "MaterialComponents/schemes/ColorScheme":
  In Podfile:
    MaterialComponents/schemes/ColorScheme

None of your spec sources contain a spec satisfying the dependency: `MaterialComponents/schemes/ColorScheme`.

You have either:
 * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.

Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.
```
### The problem
We are adding an extra "scheme" at the end of the podname.
### The fix
Remove extra "scheme" at the end of the podname.

### Test
1. Create a fake project
2. Set your `Podfile` to:

```bash
pod 'MaterialComponentsAlpha', 
:git => 'https://github.com/codeman7/material-components-ios.git', 
:branch => 'schemes'
```