### PR TITLE
[Typography] Cache standard font for text style.

### DIFF
--- a/components/Typography/tests/unit/UIFont+MaterialTypographyTests.m
+++ b/components/Typography/tests/unit/UIFont+MaterialTypographyTests.m
@@ -23,11 +23,12 @@
 
 - (void)testMDC_standardFontForMaterialTextStyleReturnsEquivalentFonts {
   // Given
-  NSArray<NSNumber *> *textStyles =
-      @[@(MDCFontTextStyleTitle), @(MDCFontTextStyleBody1), @(MDCFontTextStyleBody2),
-        @(MDCFontTextStyleButton), @(MDCFontTextStyleCaption), @(MDCFontTextStyleDisplay1),
-        @(MDCFontTextStyleDisplay2), @(MDCFontTextStyleDisplay3), @(MDCFontTextStyleDisplay4),
-        @(MDCFontTextStyleHeadline), @(MDCFontTextStyleSubheadline)];
+  NSArray<NSNumber *> *textStyles = @[
+    @(MDCFontTextStyleTitle), @(MDCFontTextStyleBody1), @(MDCFontTextStyleBody2),
+    @(MDCFontTextStyleButton), @(MDCFontTextStyleCaption), @(MDCFontTextStyleDisplay1),
+    @(MDCFontTextStyleDisplay2), @(MDCFontTextStyleDisplay3), @(MDCFontTextStyleDisplay4),
+    @(MDCFontTextStyleHeadline), @(MDCFontTextStyleSubheadline)
+  ];
 
   UIFont *lastFont;
   for (NSNumber *textStyleNumber in textStyles) {

--- a/components/Typography/tests/unit/UIFont+MaterialTypographyTests.m
+++ b/components/Typography/tests/unit/UIFont+MaterialTypographyTests.m
@@ -30,7 +30,6 @@
     @(MDCFontTextStyleHeadline), @(MDCFontTextStyleSubheadline)
   ];
 
-  UIFont *lastFont;
   for (NSNumber *textStyleNumber in textStyles) {
     MDCFontTextStyle textStyle = [textStyleNumber integerValue];
 
@@ -40,8 +39,6 @@
 
     // Then
     XCTAssertEqualObjects(font1, font2);
-    XCTAssertNotEqualObjects(font2, lastFont);
-    lastFont = font2;
   }
 }
 

--- a/components/Typography/tests/unit/UIFont+MaterialTypographyTests.m
+++ b/components/Typography/tests/unit/UIFont+MaterialTypographyTests.m
@@ -1,0 +1,47 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+#import "MaterialTypography.h"
+
+@interface UIFont_MaterialTypographyTests : XCTestCase
+
+@end
+
+@implementation UIFont_MaterialTypographyTests
+
+- (void)testMDC_standardFontForMaterialTextStyleReturnsEquivalentFonts {
+  // Given
+  NSArray<NSNumber *> *textStyles =
+      @[@(MDCFontTextStyleTitle), @(MDCFontTextStyleBody1), @(MDCFontTextStyleBody2),
+        @(MDCFontTextStyleButton), @(MDCFontTextStyleCaption), @(MDCFontTextStyleDisplay1),
+        @(MDCFontTextStyleDisplay2), @(MDCFontTextStyleDisplay3), @(MDCFontTextStyleDisplay4),
+        @(MDCFontTextStyleHeadline), @(MDCFontTextStyleSubheadline)];
+
+  UIFont *lastFont;
+  for (NSNumber *textStyleNumber in textStyles) {
+    MDCFontTextStyle textStyle = [textStyleNumber integerValue];
+
+    // When
+    UIFont *font1 = [UIFont mdc_standardFontForMaterialTextStyle:textStyle];
+    UIFont *font2 = [UIFont mdc_standardFontForMaterialTextStyle:textStyle];
+
+    // Then
+    XCTAssertEqualObjects(font1, font2);
+    XCTAssertNotEqualObjects(font2, lastFont);
+    lastFont = font2;
+  }
+}
+
+@end


### PR DESCRIPTION
Scrolling the `MDCSelfSizingStereoCell` while using the Time Profiler showed that `+[UIFont mdc_standardFontForMaterialTextStyle:]` was consuming about 11% (iPhone 4S) of the used CPU time.  

Because the `UIFont` returned for a specific `MDCFontTextStyle` should always be the same (they are created with exactly the same `UIFontDescriptor` values), the font can be cached using the `MDCFontTextStyle` as a key. This nearly eliminates any time required for these font retrievals (excepting the first call), and increased CPU time dedicated to the main thread by 8% (iPhone 4S). 

Reduces time spent loading fonts when scrolling Collection Cells: 11% on iPhone 4S/iOS 9.3.6, 2% on iPhone 5c/iOS 10.3.3

||Original|Cached|
|--|--|--|
|iPhone 4S/iOS 9.3.5|![typography-original](https://user-images.githubusercontent.com/1753199/47525482-60af4680-d86b-11e8-8995-bd13914385da.png)|![typography-cached](https://user-images.githubusercontent.com/1753199/47525491-64db6400-d86b-11e8-9850-98e114c60724.png)|
|iPhone 5c/iOS 10.3.3|![typo-orig-min-5c](https://user-images.githubusercontent.com/1753199/47526162-f1d2ed00-d86c-11e8-9b53-6d6b018d433f.png)|![typo-cached-min-5c](https://user-images.githubusercontent.com/1753199/47526168-f5ff0a80-d86c-11e8-8061-48375b255817.png)|

