### PR TITLE
[CI] Fix the test_all script.

### DIFF
--- a/scripts/test_all
+++ b/scripts/test_all
@@ -33,41 +33,35 @@ function guess_failure() {
   fi
 }
 
-if [[ $# -lt 1 ]]; then
-  WORKSPACE_SCHEMES=$("$SCRIPTS_DIR"/xcode/list_all_xcode_schemes)
-else
-  WORKSPACE_SCHEMES=$*
+xcodebuid_test() {
+  if hash xcpretty 2>/dev/null; then
+    set -o pipefail # Required for xcpretty to propagate failure.
+    xcodebuild test "${@:1}" "$COVERAGE_OPTIONS" -destination "$DESTINATION" | xcpretty
+  else
+    xcodebuild test "${@:1}" "$COVERAGE_OPTIONS" -destination "$DESTINATION"
+  fi
+}
+
+if [ ! -d "$ROOT_DIR/catalog/MDCCatalog.xcworkspace" ]; then
+  pod install --project-directory="$ROOT_DIR/catalog"
 fi
 
-all_tests_ok=1
-for workspace_scheme in $WORKSPACE_SCHEMES; do
-  workspace=$(echo $workspace_scheme | cut -d: -f1)
-  scheme=$(echo $workspace_scheme | cut -d: -f2)
+did_any_fail=false
 
-  # Assume any scheme with the name "*Tests*" is a testing scheme.
-  if [[ $scheme != *Tests* ]]; then
-    continue
-  fi
-  echo $workspace $scheme
-  log_file=$(dirname "$workspace")/"test_log_for_scheme_${scheme}.txt"
-  options="-workspace $workspace -scheme $scheme"
-  if xcodebuild test $options $COVERAGE_OPTIONS -destination "$DESTINATION" >"$log_file" 2>&1; then
-    rm "$log_file"
-  else
-    all_tests_ok=0
-    echo
-    echo "Failed to test $scheme in $workspace."
-    guess_failure "$log_file"
-    echo "Log left in $log_file."
-    echo "Continuing with next test..."
-    echo
-  fi
-done
+xcodebuid_test \
+  -workspace "$ROOT_DIR/catalog/MDCCatalog.xcworkspace" \
+  -scheme "MaterialComponents-Unit-Tests"
+if [ $? -ne 0 ]; then
+  did_any_fail=true
+fi
 
-# If any test failed, exit with a failure exit status so continuous integration
-# tools can react appropriately.
-if [ "$all_tests_ok" -eq 1 ]; then
-  exit 0
-else
+xcodebuid_test \
+  -workspace "$ROOT_DIR/catalog/MDCCatalog.xcworkspace" \
+  -scheme "MaterialComponentsAlpha-Unit-Tests"
+if [ $? -ne 0 ]; then
+  did_any_fail=true
+fi
+
+if $did_any_fail; then
   exit 1
 fi


### PR DESCRIPTION
## Prior to this change

Our test_all script was using an Xcode schemes search and filter to identify any test schemes that exist in the repository and test them. Unfortunately, the script was not also testing to confirm that it found at least *some* tests, meaning if it did not find any tests it would silently succeed.

The script was essentially optimized for us adding multiple test schemes in the future. In practice, the frequency with which we add new test schemes is low (we've added only one in the past year via MaterialComponentsAlpha).

## The root cause

With d238c86d47eb072617d285106147ace613321aee, our Xcode test scheme names changed and our scheme search was no longer returning our unit test schemes, resulting in test_all succeeding even though it hadn't run any tests.

## After this change

The test_all script will explicitly test specific schemes. If these schemes change or move in the future, this script will fail until we also update the script's schemes.

This script now also pipes the test output through xcpretty if it is available.

Closes https://github.com/material-components/material-components-ios/issues/5539