### PR TITLE
[FlexibleHeader] Fix animation glitches when switching between UITableView tabs

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1374,7 +1374,7 @@ static BOOL isRunningiOS10_3OrAbove() {
   if (info.stashedHeightIsValid) {
     // Did our height change since the last time we saw this content?
     const CGFloat heightDelta = self.bounds.size.height - info.stashedHeight;
-    if (fabs(heightDelta) > kContentOffsetEpsilon) {
+    if (fabs(heightDelta) > kHeightEpsilon) {
       // Offset our content accordingly so that we're still viewing what we were viewing last time.
       CGPoint offset = scrollView.contentOffset;
       offset.y -= heightDelta;

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -46,6 +46,9 @@ static const NSTimeInterval kTrackingScrollViewDidChangeAnimationDuration = 0.2;
 // on/off-screen with the display link.
 static const float kShiftEpsilon = 0.1f;
 
+// The epsilon used when comparing height values.
+static const CGFloat kHeightEpsilon = 0.001f;
+
 // The epsilon used when comparing content offset values.
 static const CGFloat kContentOffsetEpsilon = 0.001f;
 
@@ -1369,7 +1372,7 @@ static BOOL isRunningiOS10_3OrAbove() {
   if (info.stashedHeightIsValid) {
     // Did our height change since the last time we saw this content?
     const CGFloat heightDelta = self.bounds.size.height - info.stashedHeight;
-    if (fabs(heightDelta) > DBL_EPSILON) {
+    if (fabs(heightDelta) > kContentOffsetEpsilon) {
       // Offset our content accordingly so that we're still viewing what we were viewing last time.
       CGPoint offset = scrollView.contentOffset;
       offset.y -= heightDelta;
@@ -1476,7 +1479,7 @@ static BOOL isRunningiOS10_3OrAbove() {
     if (self.canAlwaysExpandToMaximumHeight) {
       // Cap the accumulator to ensure it's valid.
       CGFloat accumulatorMin;
-      if (headerHeight > self.computedMinimumHeight + DBL_EPSILON) {
+      if (headerHeight > self.computedMinimumHeight + kHeightEpsilon) {
         // We're attached to the content, so don't allow any height accumulation.
         accumulatorMin = 0;
       } else {

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1190,7 +1190,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
     _trackingInfo.shouldIgnoreNextSafeAreaAdjustment = NO;
 
     if (_shiftAccumulatorLastContentOffsetIsValid) {
-      CGFloat delta =
+      CGFloat delta = (CGFloat)
           fabs(_shiftAccumulatorLastContentOffset.y - self.trackingScrollView.contentOffset.y);
       if (fabs(delta - [_topSafeArea topSafeAreaInset]) < kContentOffsetEpsilon) {
         // Looks like a top safe area inset adjustment. Let's ignore it.

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -46,6 +46,9 @@ static const NSTimeInterval kTrackingScrollViewDidChangeAnimationDuration = 0.2;
 // on/off-screen with the display link.
 static const float kShiftEpsilon = 0.1f;
 
+// The epsilon used when comparing content offset values.
+static const float kContentOffsetEpsilon = 0.001f;
+
 // The minimum delta y before we change the scroll direction.
 static const CGFloat kDeltaYSlop = 5;
 
@@ -1189,7 +1192,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
     if (_shiftAccumulatorLastContentOffsetIsValid) {
       CGFloat delta =
           fabs(_shiftAccumulatorLastContentOffset.y - self.trackingScrollView.contentOffset.y);
-      if (fabs(delta - [_topSafeArea topSafeAreaInset]) < 0.001) {
+      if (fabs(delta - [_topSafeArea topSafeAreaInset]) < kContentOffsetEpsilon) {
         // Looks like a top safe area inset adjustment. Let's ignore it.
         self.trackingScrollView.contentOffset = _shiftAccumulatorLastContentOffset;
       }

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -103,6 +103,8 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 // desirable, this behavior clashes with our own top safe area insets management resulting
 // in the table view "jumping" when it first appears. To counter this behavior, we
 // intentionally ignore the next content offset change if it looks like a safe area adjustment.
+// See https://github.com/material-components/material-components-ios/issues/5412 for additional
+// details.
 @property(nonatomic) BOOL shouldIgnoreNextSafeAreaAdjustment;
 
 // The amount injected into contentInsets.top

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1190,8 +1190,8 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
     _trackingInfo.shouldIgnoreNextSafeAreaAdjustment = NO;
 
     if (_shiftAccumulatorLastContentOffsetIsValid) {
-      CGFloat delta = (CGFloat)
-          fabs(_shiftAccumulatorLastContentOffset.y - self.trackingScrollView.contentOffset.y);
+      CGFloat delta = (CGFloat)fabs(_shiftAccumulatorLastContentOffset.y -
+                                    self.trackingScrollView.contentOffset.y);
       if (fabs(delta - [_topSafeArea topSafeAreaInset]) < kContentOffsetEpsilon) {
         // Looks like a top safe area inset adjustment. Let's ignore it.
         self.trackingScrollView.contentOffset = _shiftAccumulatorLastContentOffset;

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1435,7 +1435,7 @@ static BOOL isRunningiOS10_3OrAbove() {
 
   UIScrollView *oldTrackingScrollView = _trackingScrollView;
 
-  CGFloat stashedHeight = self.bounds.size.height;
+  CGFloat stashedHeight = CGRectGetHeight(self.bounds);
   if (_trackingInfo != nil) {
     _trackingInfo.stashedHeight = stashedHeight;
     _trackingInfo.stashedHeightIsValid = YES;

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1200,10 +1200,10 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
       if (fabs(delta - [_topSafeArea topSafeAreaInset]) < kContentOffsetEpsilon) {
         // Looks like a top safe area inset adjustment. Let's ignore it.
         self.trackingScrollView.contentOffset = _shiftAccumulatorLastContentOffset;
+        return;
       }
     }
     _shiftAccumulatorLastContentOffsetIsValid = NO;
-    return;
   }
 
   if (self.trackingScrollView.isTracking) {

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -47,7 +47,7 @@ static const NSTimeInterval kTrackingScrollViewDidChangeAnimationDuration = 0.2;
 static const float kShiftEpsilon = 0.1f;
 
 // The epsilon used when comparing content offset values.
-static const float kContentOffsetEpsilon = 0.001f;
+static const CGFloat kContentOffsetEpsilon = 0.001f;
 
 // The minimum delta y before we change the scroll direction.
 static const CGFloat kDeltaYSlop = 5;

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1456,7 +1456,7 @@ static BOOL isRunningiOS10_3OrAbove() {
     [self fhv_startObservingContentOffset];
   }
 
-  BOOL shouldAnimate = YES;
+  BOOL shouldAnimate = NO;
 
   if (self.sharedWithManyScrollViews && wasTrackingScrollView) {
     // What's our expected height now that we've changed the tracking scroll view?
@@ -1484,7 +1484,6 @@ static BOOL isRunningiOS10_3OrAbove() {
           MAX(accumulatorMin, MIN([self fhv_accumulatorMax], _shiftAccumulator - heightDelta));
       if (_shiftAccumulator != desiredShiftAccumulatorValue) {
         _shiftAccumulator = desiredShiftAccumulatorValue;
-        shouldAnimate = NO;
       }
     }
 
@@ -1496,7 +1495,10 @@ static BOOL isRunningiOS10_3OrAbove() {
     if (headerHeight > stashedHeight) {
       // If so, shift the content up so that the header matches our current height.
       offset.y -= heightDelta;
-      shouldAnimate = NO;
+    } else if (headerHeight < stashedHeight) {
+      // We're about to shrink the header - this is the only case where we want to animate the
+      // header's height change.
+      shouldAnimate = YES;
     }
 
     if (!CGPointEqualToPoint(self.trackingScrollView.contentOffset, offset)) {

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -92,7 +92,11 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 // A separate info object is tracked for each scroll view tracked by the flexible header view.
 @interface MDCFlexibleHeaderScrollViewInfo : NSObject
 
-// Whether or not to ignore the next content offset change.
+// UITableView, when added to a UIWindow for the first time, may automatically adjust
+// its content offset to take into account the top safe area insets. While typically
+// desirable, this behavior clashes with our own top safe area insets management resulting
+// in the table view "jumping" when it first appears. To counter this behavior, we
+// intentionally ignore the next content offset change if it looks like a safe area adjustment.
 @property(nonatomic) BOOL shouldIgnoreNextSafeAreaAdjustment;
 
 // The amount injected into contentInsets.top
@@ -1183,7 +1187,6 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
     _trackingInfo.shouldIgnoreNextSafeAreaAdjustment = NO;
 
     if (_shiftAccumulatorLastContentOffsetIsValid) {
-      // Ignore this change.
       CGFloat delta =
           fabs(_shiftAccumulatorLastContentOffset.y - self.trackingScrollView.contentOffset.y);
       if (fabs(delta - [_topSafeArea topSafeAreaInset]) < 0.001) {
@@ -1501,12 +1504,6 @@ static BOOL isRunningiOS10_3OrAbove() {
     }
 
     if (trackingScrollViewIsUITableView) {
-      // UITableView, when added to a UIWindow for the first time, may automatically adjust
-      // its content offset to take into account the top safe area insets. While typically
-      // desirable, this behavior clashes with our own top safe area insets management resulting
-      // in the table view "jumping" when it first appears. To counter this behavior, we
-      // intentionally ignore the next content offset change if it happens to match our safe area
-      // insets adjustment.
       _trackingInfo.shouldIgnoreNextSafeAreaAdjustment = YES;
     }
   }


### PR DESCRIPTION
## Context

See https://github.com/material-components/material-components-ios/issues/5412 for the full context.

## Prior to this change

There was a visible animation glitch when changing the tracking scroll view to a new UITableView instance.

## Root cause analysis

This animation glitch had two root causes:

1. Logic in setTrackingScrollView: animates the flexible header's height change when changing to a new tracking scroll view.
2. UIKit's UITableView implementation adjusts its content offset to take into account the top safe area when the content offset isn't scrolled all the way to the top.

## After this change

This change introduces a couple related changes that are required to fix this bug.

First, we no longer assume that the flexible header should animate itself when the tracking scroll view changes. In conjunction with 54853b4e1dcfabcd85bae450c2dc33d2be89089b, this change improves the logic with which we change tabs well enough that there is now only one case in which the flexible header's height needs an animation when changing tabs: when the header needs to shrink. As such, the header only animates itself when the header's height will decrease.

Second, we need to proactively combat UIKit's well-meaning attempt to adjust the content offset in order to take into consideration the top safe area inset. Unfortunately, this adjustment happens in a call stack that's initiated by private UIKit APIs, meaning there's no simple way to distinguish between a legitimate content offset change and one that was initiated as an adjustment for safe area insets (e.g. one signal that would be helpful here is if the call originated from a safe area insets did change event).

<img width="412" alt="screen shot 2018-10-26 at 4 20 07 pm" src="https://user-images.githubusercontent.com/45670/47590670-0978a700-d93b-11e8-9e48-9aca679f8941.png">

Note: this adjustment behavior is not reproducible when the UITableView instance is created and owned by a UITableViewController. This behavior was only reproducible in the AppBarJumpExample example.

In essence we want to ignore this content offset adjustment because it's wrong in this case, so this change introduces very logic that only runs under specific conditions:

1. The tracking scroll view is a UITableView.
2. The header is tracking multiple scroll views.
3. The header will shrink when moving to the new UITableView.

If these conditions are met, then the next time we receive a content offset change event, if that event looks like it's adjusting the content offset for safe area insets then we ignore it.

The above two changes come together to resolve the visual animation glitch that was described in #5412.

Closes https://github.com/material-components/material-components-ios/issues/5412