### PR TITLE
[ActionSheet] Try to fix MaterialComponentsAlpha

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -49,6 +49,7 @@ fix_bazel_imports() {
   rewrite_tests "s/import MaterialComponents.Material(.+)/import components_\1_\1/"
   rewrite_source "s/import <Motion(.+)\/Motion.+\.h>/import \"Motion\1.h\"/"
   rewrite_source "s/import <MDF(.+)\/MDF.+\.h>/import \"MDF\1.h\"/"
+  rewrite_source "s/import <MaterialComponents\/Material(.+)\.h>/import\/\*framework import\*\/ \"Material\1.h\"/"
   rewrite_tests "s/import MDFTextAccessibility/import material_text_accessibility_ios_MDFTextAccessibility/"
   rewrite_tests "s/import MDFInternationalization/import material_internationalization_ios_MDFInternationalization/"
   stashed_dir="$(pwd)/"
@@ -63,6 +64,7 @@ fix_bazel_imports() {
     rewrite_tests "s/import components_(.+)_(.+)/import MaterialComponents.Material\1_\2/"
     rewrite_source "s/import \"Motion(.+)\.h\"/import <Motion\1\/Motion\1.h>/"
     rewrite_source "s/import \"MDF(.+)\.h\"/import <MDF\1\/MDF\1.h>/"
+    rewrite_source "s/import\/\*framework import\*\/ \"Material(.+)\.h\"/import <MaterialComponents\/Material\1\.h>/"
     rewrite_tests "s/import material_text_accessibility_ios_MDFTextAccessibility/import MDFTextAccessibility/"
     rewrite_tests "s/import material_internationalization_ios_MDFInternationalization/import MDFInternationalization/"
   }

--- a/components/ActionSheet/src/ActionSheetThemer/MDCActionSheetScheme.h
+++ b/components/ActionSheet/src/ActionSheetThemer/MDCActionSheetScheme.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@import MaterialComponents.MaterialColorScheme;
-@import MaterialComponents.MaterialTypographyScheme;
+#import <MaterialComponents/MaterialColorScheme.h>
+#import <MaterialComponents/MaterialTypographyScheme.h>
 
 #import <Foundation/Foundation.h>
 

--- a/components/ActionSheet/src/ActionSheetThemer/MDCActionSheetScheme.h
+++ b/components/ActionSheet/src/ActionSheetThemer/MDCActionSheetScheme.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MaterialColorScheme.h"
-#import "MaterialTypographyScheme.h"
+@import MaterialComponents.MaterialColorScheme;
+@import MaterialComponents.MaterialTypographyScheme;
 
 #import <Foundation/Foundation.h>
 

--- a/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.h
+++ b/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #import "MaterialActionSheet.h"
-#import "MaterialColorScheme.h"
+@import MaterialComponents.MaterialColorScheme;
 
 #import <Foundation/Foundation.h>
 

--- a/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.h
+++ b/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.h
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 #import "MaterialActionSheet.h"
-@import MaterialComponents.MaterialColorScheme;
 
 #import <Foundation/Foundation.h>
+
+#import <MaterialComponents/MaterialColorScheme.h>
 
 /**
  The Material Design color system's themer for instances of MDCActionSheetController.

--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -14,7 +14,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialBottomSheet.h"
+@import MaterialComponents.MaterialBottomSheet;
 
 @class MDCActionSheetAction;
 

--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -14,7 +14,7 @@
 
 #import <UIKit/UIKit.h>
 
-@import MaterialComponents.MaterialBottomSheet;
+#import <MaterialComponents/MaterialBottomSheet.h>
 
 @class MDCActionSheetAction;
 

--- a/components/ActionSheet/src/TypographyThemer/MDCActionSheetTypographyThemer.h
+++ b/components/ActionSheet/src/TypographyThemer/MDCActionSheetTypographyThemer.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #import "MaterialActionSheet.h"
-#import "MaterialTypographyScheme.h"
+@import MaterialComponents.MaterialTypographyScheme;
 
 #import <Foundation/Foundation.h>
 

--- a/components/ActionSheet/src/TypographyThemer/MDCActionSheetTypographyThemer.h
+++ b/components/ActionSheet/src/TypographyThemer/MDCActionSheetTypographyThemer.h
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 #import "MaterialActionSheet.h"
-@import MaterialComponents.MaterialTypographyScheme;
 
 #import <Foundation/Foundation.h>
+
+#import <MaterialComponents/MaterialTypographyScheme.h>
 
 /**
  The Material Design typography system's themer for instances of MDCActionSheetController.


### PR DESCRIPTION
With these changes I'm able to create a project with `MaterialComponentsAlpha` in its Podile and import `MaterialComponentsAlpha.MaterialActionSheet` into a Swift file in said project without getting the "Could not build Objective-C module" error message.
 
`@import MaterialComponents.MaterialTypographyScheme;` and `#import <MaterialComponents/MaterialTypographyScheme.h>` both seem to work. With the `#import` statement you can jump to the definition, and with the `@import` statement you can't, which is a little weird!

This change also brings the number of validation errors from running `pod lib lint MaterialComponentsAlpha.podspec` from 6 down to 1. I haven't figured out how to get rid of the last one, which is a little concerning, and suggests that this may not be a complete fix? Hmmm. The compilation errors seem to be fixed though!

Closes #5380. Maybe.