### PR TITLE
[Tabs] Add semanticContentAttribute support to MDCTabBar for RTL.

### DIFF
--- a/components/Tabs/BUILD
+++ b/components/Tabs/BUILD
@@ -120,6 +120,7 @@ mdc_objc_library(
         ":Tabs",
         ":TypographyThemer",
         ":private",
+        "@material_internationalization_ios//:MDFInternationalization",
     ],
 )
 

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -14,6 +14,8 @@
 
 #import "MDCTabBar.h"
 
+#import <MDFInternationalization/MDFInternationalization.h>
+
 #import "MDCTabBarIndicatorTemplate.h"
 #import "MDCTabBarUnderlineIndicatorTemplate.h"
 #import "MaterialInk.h"
@@ -373,6 +375,20 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
     _dividerBar.backgroundColor = _bottomDividerColor;
   }
 }
+
+// UISemanticContentAttribute was added in iOS SDK 9.0 but is available on devices running earlier
+// version of iOS. We ignore the partial-availability warning that gets thrown on our use of this
+// symbol.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+- (void)mdf_setSemanticContentAttribute:(UISemanticContentAttribute)semanticContentAttribute {
+  if (semanticContentAttribute == self.mdf_semanticContentAttribute) {
+    return;
+  }
+  [super mdf_setSemanticContentAttribute:semanticContentAttribute];
+  _itemBar.mdf_semanticContentAttribute = semanticContentAttribute;
+}
+#pragma clang diagnostic pop
 
 #pragma mark - MDCAccessibility
 

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -328,6 +328,21 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   [self updateColors];
 }
 
+// UISemanticContentAttribute was added in iOS SDK 9.0 but is available on devices running earlier
+// version of iOS. We ignore the partial-availability warning that gets thrown on our use of this
+// symbol.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+- (void)mdf_setSemanticContentAttribute:(UISemanticContentAttribute)semanticContentAttribute {
+  if (semanticContentAttribute == self.mdf_semanticContentAttribute) {
+    return;
+  }
+  [super mdf_setSemanticContentAttribute:semanticContentAttribute];
+  _collectionView.mdf_semanticContentAttribute = semanticContentAttribute;
+  [_collectionView.collectionViewLayout invalidateLayout];
+}
+#pragma clang diagnostic pop
+
 #pragma mark - UICollectionViewDelegate
 
 - (BOOL)collectionView:(UICollectionView *)collectionView

--- a/components/Tabs/tests/unit/MDCTabBarLayoutTests.m
+++ b/components/Tabs/tests/unit/MDCTabBarLayoutTests.m
@@ -124,13 +124,15 @@ static NSArray<UICollectionViewCell *> *SortedCellsFromCollectionView(
     [_tabBar layoutIfNeeded];
 
     // Then
-    XCTAssertEqual(_tabBar.mdf_semanticContentAttribute, UISemanticContentAttributeForceRightToLeft);
-    XCTAssertEqual(_tabBar.mdf_effectiveUserInterfaceLayoutDirection, UIUserInterfaceLayoutDirectionRightToLeft);
+    XCTAssertEqual(_tabBar.mdf_semanticContentAttribute,
+                   UISemanticContentAttributeForceRightToLeft);
+    XCTAssertEqual(_tabBar.mdf_effectiveUserInterfaceLayoutDirection,
+                   UIUserInterfaceLayoutDirectionRightToLeft);
     NSArray<UICollectionViewCell *> *sortedVisibleItems =
         SortedCellsFromCollectionView(collectionView);
     XCTAssertEqual(sortedVisibleItems.count, 2ul);
     if (sortedVisibleItems.count != 2ul) {
-    // Return early if something went catastrophically wrong with UICollectionView.
+      // Return early if something went catastrophically wrong with UICollectionView.
       return;
     }
     UICollectionViewCell *firstItemCell = sortedVisibleItems.firstObject;
@@ -140,7 +142,8 @@ static NSArray<UICollectionViewCell *> *SortedCellsFromCollectionView(
     CGFloat expectedFirstItemOriginX = totalWidth - leftInset - CGRectGetWidth(firstItemCell.frame);
     XCTAssertEqualWithAccuracy(CGRectGetMinX(firstItemCell.frame), expectedFirstItemOriginX,
                                (CGFloat)0.001);
-    CGFloat expectedSecondItemOriginX = expectedFirstItemOriginX - CGRectGetWidth(secondItemCell.frame);
+    CGFloat expectedSecondItemOriginX =
+        expectedFirstItemOriginX - CGRectGetWidth(secondItemCell.frame);
     XCTAssertEqualWithAccuracy(CGRectGetMinX(secondItemCell.frame), expectedSecondItemOriginX,
                                (CGFloat)0.001);
   }

--- a/components/Tabs/tests/unit/MDCTabBarLayoutTests.m
+++ b/components/Tabs/tests/unit/MDCTabBarLayoutTests.m
@@ -106,31 +106,36 @@ static NSArray<UICollectionViewCell *> *SortedCellsFromCollectionView(
 // Tests that setting UISemanticContentAttributeForceRightToLeft causes the tab bar's collection
 // view to lay out the cells in RTL (right-to-left) manner.
 - (void)testRightToLeftLayout {
-  // Given
-  UICollectionView *collectionView = ExtractCollectionViewFromTabBar(_tabBar);
-  UICollectionViewFlowLayout *flowLayout =
-      (UICollectionViewFlowLayout *)collectionView.collectionViewLayout;
+  // UIKit doesn't support semanticContentAttribute until iOS 9, so only execute the test
+  // conditions when running on iOS 9+.
+  if (@available(iOS 9.0, *)) {
+    // Given
+    UICollectionView *collectionView = ExtractCollectionViewFromTabBar(_tabBar);
+    UICollectionViewFlowLayout *flowLayout =
+        (UICollectionViewFlowLayout *)collectionView.collectionViewLayout;
 
-  // When
-  _tabBar.mdf_semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-  [_tabBar setNeedsLayout];
-  [_tabBar layoutIfNeeded];
+    // When
+    _tabBar.mdf_semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
+    [_tabBar setNeedsLayout];
+    [_tabBar layoutIfNeeded];
 
-  // Then
-  XCTAssertEqual(_tabBar.mdf_semanticContentAttribute, UISemanticContentAttributeForceRightToLeft);
-  NSArray<UICollectionViewCell *> *sortedVisibleItems =
-      SortedCellsFromCollectionView(collectionView);
-  XCTAssertEqual(sortedVisibleItems.count, 2ul);
-  UICollectionViewCell *firstItemCell = sortedVisibleItems.firstObject;
-  UICollectionViewCell *secondItemCell = sortedVisibleItems.lastObject;
-  CGFloat totalWidth = _tabBar.frame.size.width;
-  CGFloat leftInset = flowLayout.sectionInset.left;
-  CGFloat expectedFirstItemOriginX = totalWidth - leftInset - firstItemCell.frame.size.width;
-  XCTAssertEqualWithAccuracy(firstItemCell.frame.origin.x, expectedFirstItemOriginX,
-                             (CGFloat)0.001);
-  CGFloat expectedSecondItemOriginX = expectedFirstItemOriginX - secondItemCell.frame.size.width;
-  XCTAssertEqualWithAccuracy(secondItemCell.frame.origin.x, expectedSecondItemOriginX,
-                             (CGFloat)0.001);
+    // Then
+    XCTAssertEqual(_tabBar.mdf_semanticContentAttribute, UISemanticContentAttributeForceRightToLeft);
+    XCTAssertEqual(_tabBar.mdf_effectiveUserInterfaceLayoutDirection, UIUserInterfaceLayoutDirectionRightToLeft);
+    NSArray<UICollectionViewCell *> *sortedVisibleItems =
+        SortedCellsFromCollectionView(collectionView);
+    XCTAssertEqual(sortedVisibleItems.count, 2ul);
+    UICollectionViewCell *firstItemCell = sortedVisibleItems.firstObject;
+    UICollectionViewCell *secondItemCell = sortedVisibleItems.lastObject;
+    CGFloat totalWidth = _tabBar.frame.size.width;
+    CGFloat leftInset = flowLayout.sectionInset.left;
+    CGFloat expectedFirstItemOriginX = totalWidth - leftInset - firstItemCell.frame.size.width;
+    XCTAssertEqualWithAccuracy(firstItemCell.frame.origin.x, expectedFirstItemOriginX,
+                               (CGFloat)0.001);
+    CGFloat expectedSecondItemOriginX = expectedFirstItemOriginX - secondItemCell.frame.size.width;
+    XCTAssertEqualWithAccuracy(secondItemCell.frame.origin.x, expectedSecondItemOriginX,
+                               (CGFloat)0.001);
+  }
 }
 
 @end

--- a/components/Tabs/tests/unit/MDCTabBarLayoutTests.m
+++ b/components/Tabs/tests/unit/MDCTabBarLayoutTests.m
@@ -29,7 +29,7 @@
   MDCTabBar *tabBar = [[MDCTabBar alloc] initWithFrame:CGRectMake(0, 0, 200, 200)];
   UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"first" image:nil tag:0];
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"second" image:nil tag:0];
-  tabBar.items = @[item1, item2];
+  tabBar.items = @[ item1, item2 ];
   [tabBar setNeedsLayout];
   [tabBar layoutIfNeeded];
 
@@ -60,8 +60,7 @@
   CGFloat leftInset = flowLayout.sectionInset.left;
   XCTAssertEqualWithAccuracy(firstItemCell.frame.origin.x, leftInset, FLT_EPSILON);
   XCTAssertEqualWithAccuracy(secondItemCell.frame.origin.x,
-                             leftInset + firstItemCell.frame.size.width,
-                             FLT_EPSILON);
+                             leftInset + firstItemCell.frame.size.width, FLT_EPSILON);
 
   // Adjust the attribute and force a re-layout.
   tabBar.mdf_semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
@@ -88,4 +87,3 @@
 }
 
 @end
-

--- a/components/Tabs/tests/unit/MDCTabBarLayoutTests.m
+++ b/components/Tabs/tests/unit/MDCTabBarLayoutTests.m
@@ -1,0 +1,91 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <MDFInternationalization/MDFInternationalization.h>
+#import <XCTest/XCTest.h>
+
+#import "MDCItemBar.h"
+#import "MDCTabBar.h"
+
+@interface MDCTabBarLayoutTests : XCTestCase
+
+@end
+
+@implementation MDCTabBarLayoutTests
+
+- (void)testRTL {
+  // Create a tabbar with some dummy items and a dummy frame.
+  MDCTabBar *tabBar = [[MDCTabBar alloc] initWithFrame:CGRectMake(0, 0, 200, 200)];
+  UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"first" image:nil tag:0];
+  UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"second" image:nil tag:0];
+  tabBar.items = @[item1, item2];
+  [tabBar setNeedsLayout];
+  [tabBar layoutIfNeeded];
+
+  // Extract the collection view cells and layout corresponding to the two tab bar items.
+  MDCItemBar *itemBar = nil;
+  for (UIView *subview in tabBar.subviews) {
+    if ([subview isKindOfClass:[MDCItemBar class]]) {
+      itemBar = (MDCItemBar *)subview;
+    }
+  }
+  UICollectionView *collectionView = nil;
+  for (UIView *subview in itemBar.subviews) {
+    if ([subview isKindOfClass:[UICollectionView class]]) {
+      collectionView = (UICollectionView *)subview;
+    }
+  }
+  UICollectionViewFlowLayout *flowLayout =
+      (UICollectionViewFlowLayout *)collectionView.collectionViewLayout;
+  NSArray<UICollectionViewCell *> *visibleCells = collectionView.visibleCells;
+  XCTAssertEqual(visibleCells.count, 2ul);
+  // NOTE: The cells are in reverse order, so the first tab bar item is at the lastObject index.
+  UICollectionViewCell *firstItemCell = visibleCells.lastObject;
+  UICollectionViewCell *secondItemCell = visibleCells.firstObject;
+
+  // Assert the initial state.
+  UISemanticContentAttribute oldAttribute = tabBar.mdf_semanticContentAttribute;
+  XCTAssertEqual(oldAttribute, UISemanticContentAttributeUnspecified);
+  CGFloat leftInset = flowLayout.sectionInset.left;
+  XCTAssertEqualWithAccuracy(firstItemCell.frame.origin.x, leftInset, FLT_EPSILON);
+  XCTAssertEqualWithAccuracy(secondItemCell.frame.origin.x,
+                             leftInset + firstItemCell.frame.size.width,
+                             FLT_EPSILON);
+
+  // Adjust the attribute and force a re-layout.
+  tabBar.mdf_semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
+  [tabBar setNeedsLayout];
+  [tabBar layoutIfNeeded];
+
+  // Grab the new cells after the re-layout.
+  visibleCells = collectionView.visibleCells;
+  XCTAssertEqual(visibleCells.count, 2ul);
+  // NOTE: The cells are in reverse order, so the first tab bar item is at the lastObject index.
+  firstItemCell = visibleCells.lastObject;
+  secondItemCell = visibleCells.firstObject;
+
+  // Verify the attribute and frames were changed correctly.
+  XCTAssertEqual(tabBar.mdf_semanticContentAttribute, UISemanticContentAttributeForceRightToLeft);
+  CGFloat totalWidth = tabBar.frame.size.width;
+  CGFloat expectedFirstItemOriginX = totalWidth - leftInset - firstItemCell.frame.size.width;
+  XCTAssertEqualWithAccuracy(firstItemCell.frame.origin.x, expectedFirstItemOriginX, FLT_EPSILON);
+  CGFloat expectedSecondItemOriginX = expectedFirstItemOriginX - secondItemCell.frame.size.width;
+  XCTAssertEqualWithAccuracy(secondItemCell.frame.origin.x, expectedSecondItemOriginX, FLT_EPSILON);
+
+  // Reset the semantic content attribute.
+  tabBar.mdf_semanticContentAttribute = oldAttribute;
+}
+
+@end
+

--- a/components/Tabs/tests/unit/MDCTabBarLayoutTests.m
+++ b/components/Tabs/tests/unit/MDCTabBarLayoutTests.m
@@ -88,6 +88,10 @@ static NSArray<UICollectionViewCell *> *SortedCellsFromCollectionView(
   NSArray<UICollectionViewCell *> *sortedVisibleItems =
       SortedCellsFromCollectionView(collectionView);
   XCTAssertEqual(sortedVisibleItems.count, 2ul);
+  if (sortedVisibleItems.count != 2ul) {
+    // Return early if something went catastrophically wrong with UICollectionView.
+    return;
+  }
   UICollectionViewCell *firstItemCell = sortedVisibleItems.firstObject;
   UICollectionViewCell *secondItemCell = sortedVisibleItems.lastObject;
   UICollectionViewFlowLayout *flowLayout =
@@ -98,9 +102,9 @@ static NSArray<UICollectionViewCell *> *SortedCellsFromCollectionView(
 
   // Then
   CGFloat leftInset = flowLayout.sectionInset.left;
-  XCTAssertEqualWithAccuracy(firstItemCell.frame.origin.x, leftInset, (CGFloat)0.001);
-  XCTAssertEqualWithAccuracy(secondItemCell.frame.origin.x,
-                             leftInset + firstItemCell.frame.size.width, (CGFloat)0.001);
+  XCTAssertEqualWithAccuracy(CGRectGetMinX(firstItemCell.frame), leftInset, (CGFloat)0.001);
+  XCTAssertEqualWithAccuracy(CGRectGetMinX(secondItemCell.frame),
+                             leftInset + CGRectGetWidth(firstItemCell.frame), (CGFloat)0.001);
 }
 
 // Tests that setting UISemanticContentAttributeForceRightToLeft causes the tab bar's collection
@@ -125,15 +129,19 @@ static NSArray<UICollectionViewCell *> *SortedCellsFromCollectionView(
     NSArray<UICollectionViewCell *> *sortedVisibleItems =
         SortedCellsFromCollectionView(collectionView);
     XCTAssertEqual(sortedVisibleItems.count, 2ul);
+    if (sortedVisibleItems.count != 2ul) {
+    // Return early if something went catastrophically wrong with UICollectionView.
+      return;
+    }
     UICollectionViewCell *firstItemCell = sortedVisibleItems.firstObject;
     UICollectionViewCell *secondItemCell = sortedVisibleItems.lastObject;
-    CGFloat totalWidth = _tabBar.frame.size.width;
+    CGFloat totalWidth = CGRectGetWidth(_tabBar.frame);
     CGFloat leftInset = flowLayout.sectionInset.left;
-    CGFloat expectedFirstItemOriginX = totalWidth - leftInset - firstItemCell.frame.size.width;
-    XCTAssertEqualWithAccuracy(firstItemCell.frame.origin.x, expectedFirstItemOriginX,
+    CGFloat expectedFirstItemOriginX = totalWidth - leftInset - CGRectGetWidth(firstItemCell.frame);
+    XCTAssertEqualWithAccuracy(CGRectGetMinX(firstItemCell.frame), expectedFirstItemOriginX,
                                (CGFloat)0.001);
-    CGFloat expectedSecondItemOriginX = expectedFirstItemOriginX - secondItemCell.frame.size.width;
-    XCTAssertEqualWithAccuracy(secondItemCell.frame.origin.x, expectedSecondItemOriginX,
+    CGFloat expectedSecondItemOriginX = expectedFirstItemOriginX - CGRectGetWidth(secondItemCell.frame);
+    XCTAssertEqualWithAccuracy(CGRectGetMinX(secondItemCell.frame), expectedSecondItemOriginX,
                                (CGFloat)0.001);
   }
 }


### PR DESCRIPTION
The collection view layout used internally to MDCItemBar has support for
RTL, but it checks the effectiveLayoutDirection which is inferred from
the semanticContentAttribute.

This change updates MDCTabBar and MDCItemBar to forward changes of the
semanticContentAttribute down to the collection view such that it lays
itself out for RTL.

**NOTE:** This behavior will not work on iOS 8 because it relies on `semanticContentAttribute` which was introduced in iOS 9.

English pseudo language: https://i.imgur.com/ID7ex1o.png
Hebrew: https://i.imgur.com/wwK3ztK.png

Closes #5578 
