### PR TITLE
[FlexibleHeader] Fix an edge case in resetShadowAfterTrackingScrollViewIsReset

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -870,7 +870,9 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   if (!_trackingScrollView) {
     // Set the shadow opacity directly.
     self.layer.shadowOpacity =
-        self.resetShadowAfterTrackingScrollViewIsReset ? 0 : _visibleShadowOpacity;
+        self.resetShadowAfterTrackingScrollViewIsReset && !self.isInFrontOfInfiniteContent
+            ? 0
+            : _visibleShadowOpacity;
     return;
   }
 


### PR DESCRIPTION
Don't reset the shadow opacity to zero if inFrontOfInfiniteContent is set to YES.

This is follow up to #5385, and should unblock me for enabling resetShadowAfterTrackingScrollViewIsReset across all internal clients to eventually close #5281.

Some internal discussion about this PR is in cl/218349237.