### PR TITLE
[ShadowLayer] Expose shadow spread method

### DIFF
--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -87,6 +87,7 @@ static const float kAmbientShadowOpacity = 0.08f;
 @property(nonatomic, strong) CAShapeLayer *bottomShadow;
 @property(nonatomic, strong) CAShapeLayer *topShadowMask;
 @property(nonatomic, strong) CAShapeLayer *bottomShadowMask;
++ (CGSize)shadowSpreadForElevation:(CGFloat)elevation;
 
 @end
 


### PR DESCRIPTION
### Context
In order for client teams to easily see what spread they should use for a given shadow elevation we can expose this and they can use it with a category. Currently clients can reimplement the method with the existing APIs of MDCShadowMetrics this change just makes it easier for them. This allows clients to stay in sync if they are using this method in their code and if we change it later then they will get those changes.

### The problem
Clients have to reimplement this method if they want to know what spread to use for a shadow layer.

### The fix
Expose this in the existing category.

### The risk
If we later delete or rename this method this will cause a bug in clients code that are using a category to work with this method.

### Snippet
Currently clients would have to:

```objc
+ (CGSize)shadowSpreadForElevation:(CGFloat)elevation {
  MDCShadowMetrics *metrics = [MDCShadowMetrics metricsWithElevation:elevation];

  CGSize shadowSpread = CGSizeZero;
  shadowSpread.width = MAX(metrics.topShadowRadius, metrics.bottomShadowRadius) +
                       MAX(metrics.topShadowOffset.width, metrics.bottomShadowOffset.width);
  shadowSpread.height = MAX(metrics.topShadowRadius, metrics.bottomShadowRadius) +
                        MAX(metrics.topShadowOffset.height, metrics.bottomShadowOffset.height);

  return shadowSpread;
}
```

After this change clients can:

```objc
@interface MDCShadowLayer (CustomAnimation)
+ (CGSize) shadowSpreadForElevation:(CGFloat)elevation;
@end
```