### PR TITLE
[Shapes] Added shapes documentation to GitHub

### DIFF
--- a/components/private/ShapeLibrary/.jazzy.yaml
+++ b/components/private/ShapeLibrary/.jazzy.yaml
@@ -1,0 +1,4 @@
+module: ShapeLibrary
+umbrella_header: src/MaterialShapeLibrary.h
+objc: true
+sdk: iphonesimulator

--- a/components/private/ShapeLibrary/.vars
+++ b/components/private/ShapeLibrary/.vars
@@ -1,0 +1,4 @@
+root_path=/catalog/shapelibrary
+icon_id=shapelibrary
+short_description=ShapeLibrary consists of convenience APIs to create shaped surfaces.
+guidelines_title=ShapeLibrary

--- a/components/private/ShapeLibrary/.vars
+++ b/components/private/ShapeLibrary/.vars
@@ -1,4 +1,5 @@
 root_path=/catalog/shapelibrary
 icon_id=shapelibrary
+component_name=ShapeLibrary
 short_description=ShapeLibrary consists of convenience APIs to create shaped surfaces.
 guidelines_title=ShapeLibrary

--- a/components/private/ShapeLibrary/README.md
+++ b/components/private/ShapeLibrary/README.md
@@ -1,0 +1,89 @@
+<!--docs:
+title: "<#component_name#>"
+layout: detail
+section: components
+excerpt: "ShapeLibrary consists of convenience APIs to create shaped surfaces."
+iconId: shapelibrary
+path: /catalog/shapelibrary/
+api_doc_root: true
+-->
+
+<!-- This file was auto-generated using scripts/generate_readme private/ShapeLibrary -->
+
+# Shape Library
+
+Our Shape Library consists of different convenience API and classes we use to build a shape.
+Specifically, the classes in this library sit on top of our [core Shapes implementation](Shapes), and that implementation
+should be understood and used before making use of the classes here.
+
+## Related Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--link"><a href="Shapes">Core Shapes Implementation</a></li>
+</ul>
+
+## Table of contents
+
+- [Overview](#overview)
+- [Usage](#usage)
+
+- - -
+
+## Overview
+
+The classes described below sit as convenience APIs on top of `MDCRectangleShapeGenerator`:
+
+#### MDCCurvedCornerTreatment
+Generates an MDCCornerTreatment that is curved and receives a size to define the size of the curve.
+
+#### MDCCutCornerTreatment
+Generates an MDCCornerTreatment that is a cut corner and receives a cut to define by how much to cut.
+
+#### MDCRoundedCornerTreatment
+Generates an MDCCornerTreatment that is rounded and receives a radius to define the radius of the rounding.
+
+#### MDCTriangleEdgeTreatment
+Generates an MDCEdgeTreatment that consists of a triangle of a settable size and style.
+
+The classes described below are convenience shape generators that create an `MDCRectangleShapeGenerator` subclass that consist of preset corner and edge treatments:
+
+#### MDCCurvedRectShapeGenerator
+This generates a shape using MDCRectangleShapeGenerator with MDCCurvedCornerTreatment for its corners.
+
+#### MDCPillShapeGenerator
+This generates a shape using MDCRectangleShapeGenerator with MDCRoundedCornerTreatment for its corners.
+
+#### MDCSlantedRectShapeGenerator
+This generates a shape using MDCRectangleShapeGenerator and adds a slant to its corners using a simple offset to its corners.
+
+
+## Usage
+
+You'll typically create an `MDCRectangleShapeGenerator` instance that you set your component with.
+Components that support the shape system will have a `id<MDCShapeGenerating> shapeGenerator` property as part of their API.
+By setting the `shapeGenerator` property with your `MDCRectangleShapeGenerator`, you will provide the defined shape to your component.
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+let card = MDCCard()
+let shapeGenerator = MDCRectangleShapeGenerator()
+let cutCornerTreatment = MDCCutCornerTreatment(cut: 4)
+shapeGenerator.setCorners(cutCornerTreatment)
+let triangleEdgeTreatment = MDCTriangleEdgeTreatment(size: 8, style: MDCTriangleEdgeStyleCut)
+shapeGenerator.setEdges(triangleEdgeTreatment)
+card.shapeGenerator = shapeGenerator
+```
+
+#### Objective-C
+
+```objc
+MDCCard *card = [[MDCCard alloc] init];
+MDCRectangleShapeGenerator *shapeGenerator = [[MDCRectangleShapeGenerator alloc] init];
+MDCCutCornerTreatment *cutCornerTreatment = [[MDCCutCornerTreatment alloc] initWithCut: 4.f];
+[shapeGenerator setCorners:cutCornerTreatment];
+MDCTriangleEdgeTreatment *triangleEdgeTreatment = [[MDCTriangleEdgeTreatment alloc] initWithSize: 8.f style: MDCTriangleEdgeStyleCut];
+[shapeGenerator setEdges:triangleEdgeTreatment];
+card.shapeGenerator = shapeGenerator;
+```
+<!--</div>-->

--- a/components/private/ShapeLibrary/README.md
+++ b/components/private/ShapeLibrary/README.md
@@ -13,13 +13,13 @@ api_doc_root: true
 # Shape Library
 
 Our Shape Library consists of different convenience API and classes we use to build a shape.
-Specifically, the classes in this library sit on top of our [core Shapes implementation](Shapes), and that implementation
+Specifically, the classes in this library sit on top of our [core Shapes implementation](../Shapes), and that implementation
 should be understood and used before making use of the classes here.
 
 ## Related Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--link"><a href="Shapes">Core Shapes Implementation</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="../Shapes">Core Shapes Implementation</a></li>
 </ul>
 
 ## Table of contents

--- a/components/private/ShapeLibrary/README.md
+++ b/components/private/ShapeLibrary/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title: "<#component_name#>"
+title: "ShapeLibrary"
 layout: detail
 section: components
 excerpt: "ShapeLibrary consists of convenience APIs to create shaped surfaces."

--- a/components/private/ShapeLibrary/README.md
+++ b/components/private/ShapeLibrary/README.md
@@ -12,7 +12,7 @@ api_doc_root: true
 
 # Shape Library
 
-Our Shape Library consists of different convenience API and classes we use to build a shape.
+Our Shape Library consists of different convenience APIs and classes we use to build a shape.
 Specifically, the classes in this library sit on top of our [core Shapes implementation](../Shapes), and that implementation
 should be understood and used before making use of the classes here.
 
@@ -31,29 +31,36 @@ should be understood and used before making use of the classes here.
 
 ## Overview
 
-The classes described below sit as convenience APIs on top of `MDCRectangleShapeGenerator`:
+The classes described below are convenience APIs on top of `MDCRectangleShapeGenerator`:
 
 #### MDCCurvedCornerTreatment
+
 Generates an MDCCornerTreatment that is curved and receives a size to define the size of the curve.
 
 #### MDCCutCornerTreatment
+
 Generates an MDCCornerTreatment that is a cut corner and receives a cut to define by how much to cut.
 
 #### MDCRoundedCornerTreatment
+
 Generates an MDCCornerTreatment that is rounded and receives a radius to define the radius of the rounding.
 
 #### MDCTriangleEdgeTreatment
+
 Generates an MDCEdgeTreatment that consists of a triangle of a settable size and style.
 
 The classes described below are convenience shape generators that create an `MDCRectangleShapeGenerator` subclass that consist of preset corner and edge treatments:
 
 #### MDCCurvedRectShapeGenerator
+
 This generates a shape using MDCRectangleShapeGenerator with MDCCurvedCornerTreatment for its corners.
 
 #### MDCPillShapeGenerator
+
 This generates a shape using MDCRectangleShapeGenerator with MDCRoundedCornerTreatment for its corners.
 
 #### MDCSlantedRectShapeGenerator
+
 This generates a shape using MDCRectangleShapeGenerator and adds a slant to its corners using a simple offset to its corners.
 
 

--- a/components/private/ShapeLibrary/docs/README.md
+++ b/components/private/ShapeLibrary/docs/README.md
@@ -1,0 +1,72 @@
+# Shape Library
+
+Our Shape Library consists of different convenience API and classes we use to build a shape.
+Specifically, the classes in this library sit on top of our [core Shapes implementation](../Shapes), and that implementation
+should be understood and used before making use of the classes here.
+
+## Related Documentation
+
+* [Core Shapes Implementation](../Shapes)
+
+<!-- toc -->
+
+- - -
+
+## Overview
+
+The classes described below sit as convenience APIs on top of `MDCRectangleShapeGenerator`:
+
+#### MDCCurvedCornerTreatment
+Generates an MDCCornerTreatment that is curved and receives a size to define the size of the curve.
+
+#### MDCCutCornerTreatment
+Generates an MDCCornerTreatment that is a cut corner and receives a cut to define by how much to cut.
+
+#### MDCRoundedCornerTreatment
+Generates an MDCCornerTreatment that is rounded and receives a radius to define the radius of the rounding.
+
+#### MDCTriangleEdgeTreatment
+Generates an MDCEdgeTreatment that consists of a triangle of a settable size and style.
+
+The classes described below are convenience shape generators that create an `MDCRectangleShapeGenerator` subclass that consist of preset corner and edge treatments:
+
+#### MDCCurvedRectShapeGenerator
+This generates a shape using MDCRectangleShapeGenerator with MDCCurvedCornerTreatment for its corners.
+
+#### MDCPillShapeGenerator
+This generates a shape using MDCRectangleShapeGenerator with MDCRoundedCornerTreatment for its corners.
+
+#### MDCSlantedRectShapeGenerator
+This generates a shape using MDCRectangleShapeGenerator and adds a slant to its corners using a simple offset to its corners.
+
+
+## Usage
+
+You'll typically create an `MDCRectangleShapeGenerator` instance that you set your component with.
+Components that support the shape system will have a `id<MDCShapeGenerating> shapeGenerator` property as part of their API.
+By setting the `shapeGenerator` property with your `MDCRectangleShapeGenerator`, you will provide the defined shape to your component.
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+let card = MDCCard()
+let shapeGenerator = MDCRectangleShapeGenerator()
+let cutCornerTreatment = MDCCutCornerTreatment(cut: 4)
+shapeGenerator.setCorners(cutCornerTreatment)
+let triangleEdgeTreatment = MDCTriangleEdgeTreatment(size: 8, style: MDCTriangleEdgeStyleCut)
+shapeGenerator.setEdges(triangleEdgeTreatment)
+card.shapeGenerator = shapeGenerator
+```
+
+#### Objective-C
+
+```objc
+MDCCard *card = [[MDCCard alloc] init];
+MDCRectangleShapeGenerator *shapeGenerator = [[MDCRectangleShapeGenerator alloc] init];
+MDCCutCornerTreatment *cutCornerTreatment = [[MDCCutCornerTreatment alloc] initWithCut: 4.f];
+[shapeGenerator setCorners:cutCornerTreatment];
+MDCTriangleEdgeTreatment *triangleEdgeTreatment = [[MDCTriangleEdgeTreatment alloc] initWithSize: 8.f style: MDCTriangleEdgeStyleCut];
+[shapeGenerator setEdges:triangleEdgeTreatment];
+card.shapeGenerator = shapeGenerator;
+```
+<!--</div>-->

--- a/components/private/ShapeLibrary/docs/README.md
+++ b/components/private/ShapeLibrary/docs/README.md
@@ -1,6 +1,6 @@
 # Shape Library
 
-Our Shape Library consists of different convenience API and classes we use to build a shape.
+Our Shape Library consists of different convenience APIs and classes we use to build a shape.
 Specifically, the classes in this library sit on top of our [core Shapes implementation](../../Shapes), and that implementation
 should be understood and used before making use of the classes here.
 
@@ -14,29 +14,36 @@ should be understood and used before making use of the classes here.
 
 ## Overview
 
-The classes described below sit as convenience APIs on top of `MDCRectangleShapeGenerator`:
+The classes described below are convenience APIs on top of `MDCRectangleShapeGenerator`:
 
 #### MDCCurvedCornerTreatment
+
 Generates an MDCCornerTreatment that is curved and receives a size to define the size of the curve.
 
 #### MDCCutCornerTreatment
+
 Generates an MDCCornerTreatment that is a cut corner and receives a cut to define by how much to cut.
 
 #### MDCRoundedCornerTreatment
+
 Generates an MDCCornerTreatment that is rounded and receives a radius to define the radius of the rounding.
 
 #### MDCTriangleEdgeTreatment
+
 Generates an MDCEdgeTreatment that consists of a triangle of a settable size and style.
 
 The classes described below are convenience shape generators that create an `MDCRectangleShapeGenerator` subclass that consist of preset corner and edge treatments:
 
 #### MDCCurvedRectShapeGenerator
+
 This generates a shape using MDCRectangleShapeGenerator with MDCCurvedCornerTreatment for its corners.
 
 #### MDCPillShapeGenerator
+
 This generates a shape using MDCRectangleShapeGenerator with MDCRoundedCornerTreatment for its corners.
 
 #### MDCSlantedRectShapeGenerator
+
 This generates a shape using MDCRectangleShapeGenerator and adds a slant to its corners using a simple offset to its corners.
 
 

--- a/components/private/ShapeLibrary/docs/README.md
+++ b/components/private/ShapeLibrary/docs/README.md
@@ -1,12 +1,12 @@
 # Shape Library
 
 Our Shape Library consists of different convenience API and classes we use to build a shape.
-Specifically, the classes in this library sit on top of our [core Shapes implementation](../Shapes), and that implementation
+Specifically, the classes in this library sit on top of our [core Shapes implementation](../../Shapes), and that implementation
 should be understood and used before making use of the classes here.
 
 ## Related Documentation
 
-* [Core Shapes Implementation](../Shapes)
+* [Core Shapes Implementation](../../Shapes)
 
 <!-- toc -->
 

--- a/components/private/Shapes/.jazzy.yaml
+++ b/components/private/Shapes/.jazzy.yaml
@@ -1,0 +1,4 @@
+module: Shapes
+umbrella_header: src/MaterialShapes.h
+objc: true
+sdk: iphonesimulator

--- a/components/private/Shapes/.vars
+++ b/components/private/Shapes/.vars
@@ -1,4 +1,5 @@
 root_path=/catalog/shapes
 icon_id=shapes
+component_name=Shapes
 short_description=Shapes consists of core APIs to create shaped surfaces.
 guidelines_title=Shapes

--- a/components/private/Shapes/.vars
+++ b/components/private/Shapes/.vars
@@ -1,0 +1,4 @@
+root_path=/catalog/shapes
+icon_id=shapes
+short_description=Shapes consists of core APIs to create shaped surfaces.
+guidelines_title=Shapes

--- a/components/private/Shapes/README.md
+++ b/components/private/Shapes/README.md
@@ -22,7 +22,7 @@ the `MDCShapeGenerating` protocol, and applies the provided shape on the compone
 ## Related Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--link"><a href="ShapeLibrary">Shape Library</a></li>
+  <li class="icon-list-item icon-list-item--link"><a href="../ShapeLibrary">Shape Library</a></li>
 </ul>
 
 ## Table of contents

--- a/components/private/Shapes/README.md
+++ b/components/private/Shapes/README.md
@@ -1,5 +1,5 @@
 <!--docs:
-title: "<#component_name#>"
+title: "Shapes"
 layout: detail
 section: components
 excerpt: "Shapes consists of core APIs to create shaped surfaces."
@@ -12,12 +12,11 @@ api_doc_root: true
 
 # Shapes Core
 
-Our Shapes Core library consists of different APIs and classes we use to build shapes for our components. 
-Concretely, to create a shape object, you'll need to create an object that implements the protocol `MDCShapeGenerating`. 
+This library consists of several classes that are often used together to implement Shape behavior on a component.
+Concretely, to create a shape object, you'll need to create an object that implements the `MDCShapeGenerating` protocol. 
 `MDCShapeGenerating` only has one method, `(CGPath *)pathForSize:(CGSize)size` that returns the shape’s `CGPath` for the expected size.
 
-Our components support shapes by providing in their API a property called `id<MDCShapeGenerating> shapeGenerator`, which can receive any object that implements
-the `MDCShapeGenerating` protocol, and applies the provided shape on the component.
+Our components support shapes by providing a property called `id<MDCShapeGenerating> shapeGenerator` and applies the provided shape to the component.
 
 ## Related Documentation
 
@@ -34,25 +33,47 @@ the `MDCShapeGenerating` protocol, and applies the provided shape on the compone
 
 ## Overview
 
-For our convenience there are a few classes that help create an object that implements the protocol `MDCShapeGenerating`.
+Listed below are classes that can be used to create an object that implements the `MDCShapeGenerating` protocol.
 
 #### MDCPathGenerator
-At the core there is `MDCPathGenerator`, which has a few helper methods to build a `CGPath`.
+
+At the core there is `MDCPathGenerator`, which provides helper methods for building a `CGPath`.
 By providing a start point and end point, and using its different APIs to draw lines/curves between points, a CGPath is created.
 
 #### MDCShapedShadowLayer
-An `MDCShapedShadowLayer` class is used as the base layer of the component's view instead of `MDCShadowLayer` 
+
+An `MDCShapedShadowLayer` class is used as the main layer class of the component's view instead of `MDCShadowLayer` 
 to allow shapes to work well with shadows, borders, and background color.
 
+The same way we override the layer in our components with `MDCShadowLayer` to achieve a shadow, we instead use `MDCShapedShadowLayer` like so:
+
+```objc
+@interface Component ()
+@property(nonatomic, readonly, strong) MDCShapedShadowLayer *layer;
+@end
+
+@implementation Component
+
+@dynamic layer;
+
++ (Class)layerClass {
+  return [MDCShapedShadowLayer class];
+}
+@end
+```
+
 #### MDCShapedView
-`MDCShapedView` is a base `UIView` that already incorporates `MDCShapedShadowLayer`, a shapeGenerator object,
+
+`MDCShapedView` is a base `UIView` that incorporates `MDCShapedShadowLayer`, a shapeGenerator object,
 and elevation, to provide a minimal view that has full shape support. 
-This can be used as a basic building block to build on top of when building new components that need shape support from the get go.
+This can be used as a building block for components that need shape support.
 
 #### MDCCornerTreatment and MDCEdgeTreatment
-`MDCCornerTreatment` and `MDCEdgeTreatment` are both classes that provide a more modular approach for defining specifically the `CGPath` for a specific edge or corner.
+
+`MDCCornerTreatment` and `MDCEdgeTreatment` are both classes that provide a modular approach for defining specifically the `CGPath` for a specific edge or corner.
 
 #### MDCRectangleShapeGenerator
+
 The last class in the Shapes Core library is `MDCRectangleShapeGenerator`. 
 It is a shapeGenerator on its own (meaning it implements `MDCShapeGenerating`),
 and generates a `CGPath` but allows good customization as part of its implementation. 

--- a/components/private/Shapes/README.md
+++ b/components/private/Shapes/README.md
@@ -1,0 +1,83 @@
+<!--docs:
+title: "<#component_name#>"
+layout: detail
+section: components
+excerpt: "Shapes consists of core APIs to create shaped surfaces."
+iconId: shapes
+path: /catalog/shapes/
+api_doc_root: true
+-->
+
+<!-- This file was auto-generated using scripts/generate_readme private/Shapes -->
+
+# Shapes Core
+
+Our Shapes Core library consists of different APIs and classes we use to build shapes for our components. 
+Concretely, to create a shape object, you'll need to create an object that implements the protocol `MDCShapeGenerating`. 
+`MDCShapeGenerating` only has one method, `(CGPath *)pathForSize:(CGSize)size` that returns the shape’s `CGPath` for the expected size.
+
+Our components support shapes by providing in their API a property called `id<MDCShapeGenerating> shapeGenerator`, which can receive any object that implements
+the `MDCShapeGenerating` protocol, and applies the provided shape on the component.
+
+## Related Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--link"><a href="ShapeLibrary">Shape Library</a></li>
+</ul>
+
+## Table of contents
+
+- [Overview](#overview)
+- [Usage](#usage)
+
+- - -
+
+## Overview
+
+For our convenience there are a few classes that help create an object that implements the protocol `MDCShapeGenerating`.
+
+#### MDCPathGenerator
+At the core there is `MDCPathGenerator`, which has a few helper methods to build a `CGPath`.
+By providing a start point and end point, and using its different APIs to draw lines/curves between points, a CGPath is created.
+
+#### MDCShapedShadowLayer
+An `MDCShapedShadowLayer` class is used as the base layer of the component's view instead of `MDCShadowLayer` 
+to allow shapes to work well with shadows, borders, and background color.
+
+#### MDCShapedView
+`MDCShapedView` is a base `UIView` that already incorporates `MDCShapedShadowLayer`, a shapeGenerator object,
+and elevation, to provide a minimal view that has full shape support. 
+This can be used as a basic building block to build on top of when building new components that need shape support from the get go.
+
+#### MDCCornerTreatment and MDCEdgeTreatment
+`MDCCornerTreatment` and `MDCEdgeTreatment` are both classes that provide a more modular approach for defining specifically the `CGPath` for a specific edge or corner.
+
+#### MDCRectangleShapeGenerator
+The last class in the Shapes Core library is `MDCRectangleShapeGenerator`. 
+It is a shapeGenerator on its own (meaning it implements `MDCShapeGenerating`),
+and generates a `CGPath` but allows good customization as part of its implementation. 
+It allows to set each of its corners and edges by using its `MDCCornerTreatments` and `MDCEdgeTreatment`. 
+With this class we can basically build any Shape we want.
+
+## Usage
+
+You'll typically create an `MDCRectangleShapeGenerator` instance that you set your component with.
+Components that support the shape system will have a `id<MDCShapeGenerating> shapeGenerator` property as part of their API.
+By setting the `shapeGenerator` property with your `MDCRectangleShapeGenerator`, you will provide the defined shape to your component.
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+let card = MDCCard()
+let shapeGenerator = MDCRectangleShapeGenerator()
+card.shapeGenerator = MDCRectangleShapeGenerator()
+```
+
+#### Objective-C
+
+```objc
+MDCCard *card = [[MDCCard alloc] init];
+MDCRectangleShapeGenerator *shapeGenerator = [[MDCRectangleShapeGenerator alloc] init];
+card.shapeGenerator = shapeGenerator;
+```
+<!--</div>-->

--- a/components/private/Shapes/docs/README.md
+++ b/components/private/Shapes/docs/README.md
@@ -9,7 +9,7 @@ the `MDCShapeGenerating` protocol, and applies the provided shape on the compone
 
 ## Related Documentation
 
-* [Shape Library](../ShapeLibrary)
+* [Shape Library](../../ShapeLibrary)
 
 <!-- toc -->
 

--- a/components/private/Shapes/docs/README.md
+++ b/components/private/Shapes/docs/README.md
@@ -1,0 +1,66 @@
+# Shapes Core
+
+Our Shapes Core library consists of different APIs and classes we use to build shapes for our components. 
+Concretely, to create a shape object, you'll need to create an object that implements the protocol `MDCShapeGenerating`. 
+`MDCShapeGenerating` only has one method, `(CGPath *)pathForSize:(CGSize)size` that returns the shape’s `CGPath` for the expected size.
+
+Our components support shapes by providing in their API a property called `id<MDCShapeGenerating> shapeGenerator`, which can receive any object that implements
+the `MDCShapeGenerating` protocol, and applies the provided shape on the component.
+
+## Related Documentation
+
+* [Shape Library](../ShapeLibrary)
+
+<!-- toc -->
+
+- - -
+
+## Overview
+
+For our convenience there are a few classes that help create an object that implements the protocol `MDCShapeGenerating`.
+
+#### MDCPathGenerator
+At the core there is `MDCPathGenerator`, which has a few helper methods to build a `CGPath`.
+By providing a start point and end point, and using its different APIs to draw lines/curves between points, a CGPath is created.
+
+#### MDCShapedShadowLayer
+An `MDCShapedShadowLayer` class is used as the base layer of the component's view instead of `MDCShadowLayer` 
+to allow shapes to work well with shadows, borders, and background color.
+
+#### MDCShapedView
+`MDCShapedView` is a base `UIView` that already incorporates `MDCShapedShadowLayer`, a shapeGenerator object,
+and elevation, to provide a minimal view that has full shape support. 
+This can be used as a basic building block to build on top of when building new components that need shape support from the get go.
+
+#### MDCCornerTreatment and MDCEdgeTreatment
+`MDCCornerTreatment` and `MDCEdgeTreatment` are both classes that provide a more modular approach for defining specifically the `CGPath` for a specific edge or corner.
+
+#### MDCRectangleShapeGenerator
+The last class in the Shapes Core library is `MDCRectangleShapeGenerator`. 
+It is a shapeGenerator on its own (meaning it implements `MDCShapeGenerating`),
+and generates a `CGPath` but allows good customization as part of its implementation. 
+It allows to set each of its corners and edges by using its `MDCCornerTreatments` and `MDCEdgeTreatment`. 
+With this class we can basically build any Shape we want.
+
+## Usage
+
+You'll typically create an `MDCRectangleShapeGenerator` instance that you set your component with.
+Components that support the shape system will have a `id<MDCShapeGenerating> shapeGenerator` property as part of their API.
+By setting the `shapeGenerator` property with your `MDCRectangleShapeGenerator`, you will provide the defined shape to your component.
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+let card = MDCCard()
+let shapeGenerator = MDCRectangleShapeGenerator()
+card.shapeGenerator = MDCRectangleShapeGenerator()
+```
+
+#### Objective-C
+
+```objc
+MDCCard *card = [[MDCCard alloc] init];
+MDCRectangleShapeGenerator *shapeGenerator = [[MDCRectangleShapeGenerator alloc] init];
+card.shapeGenerator = shapeGenerator;
+```
+<!--</div>-->

--- a/components/private/Shapes/docs/README.md
+++ b/components/private/Shapes/docs/README.md
@@ -1,11 +1,10 @@
 # Shapes Core
 
 Our Shapes Core library consists of different APIs and classes we use to build shapes for our components. 
-Concretely, to create a shape object, you'll need to create an object that implements the protocol `MDCShapeGenerating`. 
+Concretely, to create a shape object, you'll need to create an object that implements the `MDCShapeGenerating` protocol. 
 `MDCShapeGenerating` only has one method, `(CGPath *)pathForSize:(CGSize)size` that returns the shape’s `CGPath` for the expected size.
 
-Our components support shapes by providing in their API a property called `id<MDCShapeGenerating> shapeGenerator`, which can receive any object that implements
-the `MDCShapeGenerating` protocol, and applies the provided shape on the component.
+Our components support shapes by providing a property called `id<MDCShapeGenerating> shapeGenerator` and applies the provided shape to the component.
 
 ## Related Documentation
 
@@ -17,25 +16,30 @@ the `MDCShapeGenerating` protocol, and applies the provided shape on the compone
 
 ## Overview
 
-For our convenience there are a few classes that help create an object that implements the protocol `MDCShapeGenerating`.
+Listed below are classes that can be used to create an object that implements the `MDCShapeGenerating` protocol.
 
 #### MDCPathGenerator
-At the core there is `MDCPathGenerator`, which has a few helper methods to build a `CGPath`.
+
+At the core there is `MDCPathGenerator`, which provides helper methods for building a `CGPath`.
 By providing a start point and end point, and using its different APIs to draw lines/curves between points, a CGPath is created.
 
 #### MDCShapedShadowLayer
+
 An `MDCShapedShadowLayer` class is used as the base layer of the component's view instead of `MDCShadowLayer` 
 to allow shapes to work well with shadows, borders, and background color.
 
 #### MDCShapedView
-`MDCShapedView` is a base `UIView` that already incorporates `MDCShapedShadowLayer`, a shapeGenerator object,
+
+`MDCShapedView` is a base `UIView` that incorporates `MDCShapedShadowLayer`, a shapeGenerator object,
 and elevation, to provide a minimal view that has full shape support. 
 This can be used as a basic building block to build on top of when building new components that need shape support from the get go.
 
 #### MDCCornerTreatment and MDCEdgeTreatment
-`MDCCornerTreatment` and `MDCEdgeTreatment` are both classes that provide a more modular approach for defining specifically the `CGPath` for a specific edge or corner.
+
+`MDCCornerTreatment` and `MDCEdgeTreatment` are both classes that provide a modular approach for defining specifically the `CGPath` for a specific edge or corner.
 
 #### MDCRectangleShapeGenerator
+
 The last class in the Shapes Core library is `MDCRectangleShapeGenerator`. 
 It is a shapeGenerator on its own (meaning it implements `MDCShapeGenerating`),
 and generates a `CGPath` but allows good customization as part of its implementation. 

--- a/components/private/Shapes/docs/README.md
+++ b/components/private/Shapes/docs/README.md
@@ -1,6 +1,6 @@
 # Shapes Core
 
-Our Shapes Core library consists of different APIs and classes we use to build shapes for our components. 
+This library consists of several classes that are often used together to implement Shape behavior on a component.
 Concretely, to create a shape object, you'll need to create an object that implements the `MDCShapeGenerating` protocol. 
 `MDCShapeGenerating` only has one method, `(CGPath *)pathForSize:(CGSize)size` that returns the shape’s `CGPath` for the expected size.
 
@@ -25,14 +25,31 @@ By providing a start point and end point, and using its different APIs to draw l
 
 #### MDCShapedShadowLayer
 
-An `MDCShapedShadowLayer` class is used as the base layer of the component's view instead of `MDCShadowLayer` 
+An `MDCShapedShadowLayer` class is used as the main layer class of the component's view instead of `MDCShadowLayer` 
 to allow shapes to work well with shadows, borders, and background color.
+
+The same way we override the layer in our components with `MDCShadowLayer` to achieve a shadow, we instead use `MDCShapedShadowLayer` like so:
+
+```objc
+@interface Component ()
+@property(nonatomic, readonly, strong) MDCShapedShadowLayer *layer;
+@end
+
+@implementation Component
+
+@dynamic layer;
+
++ (Class)layerClass {
+  return [MDCShapedShadowLayer class];
+}
+@end
+```
 
 #### MDCShapedView
 
 `MDCShapedView` is a base `UIView` that incorporates `MDCShapedShadowLayer`, a shapeGenerator object,
 and elevation, to provide a minimal view that has full shape support. 
-This can be used as a basic building block to build on top of when building new components that need shape support from the get go.
+This can be used as a building block for components that need shape support.
 
 #### MDCCornerTreatment and MDCEdgeTreatment
 


### PR DESCRIPTION
In this PR I am adding an initial Shapes documentation to both our core shape implementation library under the folder Shape/ and the convenience APIs on top of the shape implementation located under ShapeLibrary/.

The documentation was created under the docs/ folders and generated using the .jazzy.yaml files.