### PR TITLE
[NavigationDrawer] Add support for scrimColor

### DIFF
--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -68,7 +68,6 @@ class BottomDrawerInfiniteScrollingExample: UIViewController {
     bottomDrawerViewController.trackingScrollView = contentViewController.tableView
     MDCBottomDrawerColorThemer.applySemanticColorScheme(colorScheme,
                                                         toBottomDrawer: bottomDrawerViewController)
-    bottomDrawerViewController.scrimColor = UIColor.blue.withAlphaComponent(0.5)
     present(bottomDrawerViewController, animated: true, completion: nil)
   }
 }

--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -68,6 +68,7 @@ class BottomDrawerInfiniteScrollingExample: UIViewController {
     bottomDrawerViewController.trackingScrollView = contentViewController.tableView
     MDCBottomDrawerColorThemer.applySemanticColorScheme(colorScheme,
                                                         toBottomDrawer: bottomDrawerViewController)
+    bottomDrawerViewController.scrimColor = UIColor.blue.withAlphaComponent(0.5)
     present(bottomDrawerViewController, animated: true, completion: nil)
   }
 }

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -65,6 +65,11 @@
 @property(nonatomic, weak, nullable) UIScrollView *trackingScrollView;
 
 /**
+  The color applied to the background scrim.
+ */
+@property(nonatomic, strong, nullable) UIColor *scrimColor;
+
+/**
  Delegate to tell the presenter when the drawer will change state.
  */
 @property(nonatomic, weak, nullable) id<MDCBottomDrawerPresentationControllerDelegate> delegate;

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -17,10 +17,6 @@
 #import "MDCBottomDrawerViewController.h"
 #import "private/MDCBottomDrawerContainerViewController.h"
 
-static UIColor *DrawerOverlayBackgroundColor(void) {
-  return [UIColor colorWithWhite:0 alpha:0.4f];
-}
-
 @interface MDCBottomDrawerPresentationController () <UIGestureRecognizerDelegate,
                                                      MDCBottomDrawerContainerViewControllerDelegate>
 
@@ -76,7 +72,7 @@ static UIColor *DrawerOverlayBackgroundColor(void) {
   self.bottomDrawerContainerViewController.delegate = self;
 
   self.scrimView = [[UIView alloc] initWithFrame:self.containerView.bounds];
-  self.scrimView.backgroundColor = DrawerOverlayBackgroundColor();
+  self.scrimView.backgroundColor = self.scrimColor ?: [UIColor colorWithWhite:0 alpha:(CGFloat)0.32];
   self.scrimView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   self.scrimView.accessibilityIdentifier = @"Close drawer";
@@ -143,6 +139,11 @@ static UIColor *DrawerOverlayBackgroundColor(void) {
   [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
   [self.bottomDrawerContainerViewController viewWillTransitionToSize:size
                                            withTransitionCoordinator:coordinator];
+}
+
+- (void)setScrimColor:(UIColor *)scrimColor {
+  _scrimColor = scrimColor;
+  self.scrimView.backgroundColor = scrimColor;
 }
 
 #pragma mark - Private

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -72,7 +72,8 @@
   self.bottomDrawerContainerViewController.delegate = self;
 
   self.scrimView = [[UIView alloc] initWithFrame:self.containerView.bounds];
-  self.scrimView.backgroundColor = self.scrimColor ?: [UIColor colorWithWhite:0 alpha:(CGFloat)0.32];
+  self.scrimView.backgroundColor =
+      self.scrimColor ?: [UIColor colorWithWhite:0 alpha:(CGFloat)0.32];
   self.scrimView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   self.scrimView.accessibilityIdentifier = @"Close drawer";

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -50,6 +50,11 @@
 @property(nonatomic, readonly) MDCBottomDrawerState drawerState;
 
 /**
+ The color applied to the background scrim.
+ */
+@property(nonatomic, strong, nullable) UIColor *scrimColor;
+
+/**
  Sets the top corners radius for an MDCBottomDrawerState drawerState
 
  @param radius The corner radius to set the top corners.

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -112,6 +112,14 @@
   }
 }
 
+- (void)setScrimColor:(UIColor *)scrimColor {
+  _scrimColor = scrimColor;
+  if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
+    MDCBottomDrawerPresentationController *bottomDrawerPresentation = (MDCBottomDrawerPresentationController *)self.presentationController;
+    bottomDrawerPresentation.scrimColor = scrimColor;
+  }
+}
+
 - (BOOL)isAccessibilityMode {
   return UIAccessibilityIsVoiceOverRunning() || UIAccessibilityIsSwitchControlRunning();
 }

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -115,9 +115,9 @@
 - (void)setScrimColor:(UIColor *)scrimColor {
   _scrimColor = scrimColor;
   if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
-    MDCBottomDrawerPresentationController *bottomDrawerPresentation =
+    MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
         (MDCBottomDrawerPresentationController *)self.presentationController;
-    bottomDrawerPresentation.scrimColor = scrimColor;
+    bottomDrawerPresentationController.scrimColor = scrimColor;
   }
 }
 

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -115,7 +115,8 @@
 - (void)setScrimColor:(UIColor *)scrimColor {
   _scrimColor = scrimColor;
   if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
-    MDCBottomDrawerPresentationController *bottomDrawerPresentation = (MDCBottomDrawerPresentationController *)self.presentationController;
+    MDCBottomDrawerPresentationController *bottomDrawerPresentation =
+        (MDCBottomDrawerPresentationController *)self.presentationController;
     bottomDrawerPresentation.scrimColor = scrimColor;
   }
 }

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
@@ -51,11 +51,14 @@
   self.navigationDrawer.scrimColor = customColor;
 
   // Then
-  if ([self.navigationDrawer.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
-    MDCBottomDrawerPresentationController *presentationController = (MDCBottomDrawerPresentationController *)self.navigationDrawer.presentationController;
+  if ([self.navigationDrawer.presentationController
+          isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
+    MDCBottomDrawerPresentationController *presentationController =
+        (MDCBottomDrawerPresentationController *)self.navigationDrawer.presentationController;
     XCTAssertEqualObjects(presentationController.scrimColor, customColor);
   } else {
-    XCTFail(@"Navigation Drawer isn't using MDCBottomDrawerPresentationController as it's presentationController");
+    XCTFail(@"Navigation Drawer isn't using MDCBottomDrawerPresentationController as it's "
+            @"presentationController");
   }
 }
 

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
@@ -43,4 +43,20 @@
   [super tearDown];
 }
 
+- (void)testScrimColor {
+  // Given
+  UIColor *customColor = UIColor.blueColor;
+
+  // When
+  self.navigationDrawer.scrimColor = customColor;
+
+  // Then
+  if ([self.navigationDrawer.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
+    MDCBottomDrawerPresentationController *presentationController = (MDCBottomDrawerPresentationController *)self.navigationDrawer.presentationController;
+    XCTAssertEqualObjects(presentationController.scrimColor, customColor);
+  } else {
+    XCTFail(@"Navigation Drawer isn't using MDCBottomDrawerPresentationController as it's presentationController");
+  }
+}
+
 @end


### PR DESCRIPTION
### Context
In order to support a fully themable NavigationDrawer we need to be able to set the _scrimColor_ to a custom color. These changes add a property to be able to do so. If the _scrimColor_ isn't set the the `scrimView` in the `MDCBottomNavigationPresentationController` defaults to `[UIColor colorWithWhite:0 alpha:0.32];`.

### Related bug
b/117274465


### Screenshots
| Before | After |
| - | - |
|![simulator screen shot - iphone xs max - 2018-10-31 at 10 53 16](https://user-images.githubusercontent.com/7131294/47796670-30e4c080-dcfb-11e8-9a2a-50a2de9d76dc.png)|![simulator screen shot - iphone xs max - 2018-10-31 at 10 40 39](https://user-images.githubusercontent.com/7131294/47796676-34784780-dcfb-11e8-9957-ba10e0947d54.png)|

**_Code snippet for after screenshot_**

```swift
 bottomDrawerViewController.scrimColor = UIColor.blue.withAlphaComponent(0.5)
```

