### PR TITLE
[Debugger] [Swift] Make Swift debugging work again.

### DIFF
--- a/components/AnimationTiming/examples/AnimationTimingExample.swift
+++ b/components/AnimationTiming/examples/AnimationTimingExample.swift
@@ -29,7 +29,7 @@ struct Constants {
    }
 }
 
-class AnimationTimingExample: UIViewController {
+class AnimationTimingExampleSwift: UIViewController {
 
    fileprivate let scrollView: UIScrollView = UIScrollView()
    fileprivate let linearView: UIView = UIView()
@@ -97,7 +97,7 @@ class AnimationTimingExample: UIViewController {
    }
 }
 
-extension AnimationTimingExample {
+extension AnimationTimingExampleSwift {
    fileprivate func setupExampleViews() {
 
       let curveLabel: (String) -> UILabel = { labelTitle in


### PR DESCRIPTION
### Context
When debugging Swift files through our Catalog and Dragons app, we were not able to see the variable values, or invoke a print `p` or print object `po` on variables successfully.

### The problem
There was a Swift class and an Objective-C class named exactly the same which was causing build errors when bridging both Swift and Objective-C in the MaterialComponentsExample module.

### The fix
Rename the Swift file to have a unique class name.

### Related Bugs
*potentially*
Closes #4240 

### Screenshots
#### Before
![screen shot 2018-11-01 at 12 16 54 pm](https://user-images.githubusercontent.com/4066863/47846491-b38b7f80-ddd0-11e8-9779-1e4c7f29e81c.png)
#### After
![screen shot 2018-11-01 at 12 14 37 pm](https://user-images.githubusercontent.com/4066863/47846495-b9816080-ddd0-11e8-8f0c-7ddf58dea716.png)
