### PR TITLE
[NavigationDrawer] Add scrim color to color themer

### DIFF
--- a/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.m
+++ b/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.m
@@ -14,12 +14,15 @@
 
 #import "MDCBottomDrawerColorThemer.h"
 
+static const CGFloat kScrimAlpha = (CGFloat)0.32;
+
 @implementation MDCBottomDrawerColorThemer
 
 + (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
                   toBottomDrawer:(nonnull MDCBottomDrawerViewController *)bottomDrawer {
   bottomDrawer.headerViewController.view.backgroundColor = colorScheme.surfaceColor;
   bottomDrawer.contentViewController.view.backgroundColor = colorScheme.surfaceColor;
+  bottomDrawer.scrimColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kScrimAlpha];
 }
 
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerThemeTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerThemeTest.m
@@ -18,6 +18,8 @@
 #import "MaterialNavigationDrawer+ColorThemer.h"
 #import "MaterialNavigationDrawer.h"
 
+static const CGFloat kScimAlpha = (CGFloat)0.32;
+
 @interface MDCNavigationDrawerThemeTest : XCTestCase
 @property(nonatomic, strong) MDCBottomDrawerViewController *bottomDrawer;
 @property(nonatomic, strong) MDCNavigationDrawerFakeHeaderViewController *headerViewController;
@@ -38,6 +40,7 @@
 
   self.colorScheme = [[MDCSemanticColorScheme alloc] init];
   self.colorScheme.surfaceColor = UIColor.blueColor;
+  self.colorScheme.onSurfaceColor = UIColor.greenColor;
 }
 
 - (void)tearDown {
@@ -57,6 +60,8 @@
                         self.colorScheme.surfaceColor);
   XCTAssertEqualObjects(self.contentViewController.view.backgroundColor,
                         self.colorScheme.surfaceColor);
+  XCTAssertEqualObjects(self.bottomDrawer.scrimColor,
+                        [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kScimAlpha]);
 }
 
 @end


### PR DESCRIPTION
### Context
In #5458 we did not themer the scrim color because it wasn't a property on NavigationDrawer. The property was added in #5568. This PR themes the scrim color with the correct value. As more properties are added to navigation drawer more adjustments to the themer will need to be made.
### The problem
We aren't theming the scrim color
### The fix
Apply the correct values to the scrim color within the color themer
### Screenshots
| Before | After |
| - | - |
|![simulator screen shot - iphone xs max - 2018-11-01 at 06 47 35](https://user-images.githubusercontent.com/7131294/47847574-08fc6800-dda2-11e8-9241-8dfb33e27389.png)|![simulator screen shot - iphone xs max - 2018-11-01 at 06 46 35](https://user-images.githubusercontent.com/7131294/47847581-0dc11c00-dda2-11e8-8b07-d62cebd28c62.png)|

