### PR TITLE
[BottomNavigation] Fix selection animation for badge

### DIFF
--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -194,8 +194,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
       [UIView animateWithDuration:kMDCBottomNavigationItemViewTransitionDuration animations:^(void) {
         self.iconImageView.center = iconImageViewCenter;
         self.badge.center =
-            [self badgeCenterFromIconFrame:CGRectStandardize(self.iconImageView.frame)
-                                     isRTL:isRTL];
+            [self badgeCenterFromIconFrame:CGRectStandardize(self.iconImageView.frame) isRTL:isRTL];
       }];
     } else {
       self.iconImageView.center = iconImageViewCenter;

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -193,9 +193,14 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
     if (animated) {
       [UIView animateWithDuration:kMDCBottomNavigationItemViewTransitionDuration animations:^(void) {
         self.iconImageView.center = iconImageViewCenter;
+        self.badge.center =
+            [self badgeCenterFromIconFrame:CGRectStandardize(self.iconImageView.frame)
+                                     isRTL:isRTL];
       }];
     } else {
       self.iconImageView.center = iconImageViewCenter;
+      self.badge.center = [self badgeCenterFromIconFrame:CGRectStandardize(self.iconImageView.frame)
+                                                   isRTL:isRTL];
     }
     self.label.textAlignment = NSTextAlignmentCenter;
   } else {
@@ -218,9 +223,9 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
       self.label.center = CGPointMake(labelCenterX, centerY);
       self.label.textAlignment = NSTextAlignmentRight;
     }
+    self.badge.center = [self badgeCenterFromIconFrame:CGRectStandardize(self.iconImageView.frame)
+                                                 isRTL:isRTL];
   }
-  self.badge.center = [self badgeCenterFromIconFrame:CGRectStandardize(self.iconImageView.frame)
-                                               isRTL:isRTL];
 }
 
 - (void)updateLabelVisibility {


### PR DESCRIPTION
### Context
In #5339 this bug was introduced. The motivation that lead to this bug was not having to recall this function in three different places. In doing it all in once place the animation broke.
### The problem
When _BottomNavigationItemView_ would animate the badge would jump to its new position while the title and icon would animate.
### The fix
Call `badgeCenterFromIconFrame` in the `UIView animation` block.

| Before | After | 
| - | - |
|![before](https://user-images.githubusercontent.com/7131294/47934001-857b6d80-deac-11e8-9ca0-eaa869a7c339.gif)|![after](https://user-images.githubusercontent.com/7131294/47934010-8a402180-deac-11e8-930f-8b6542495410.gif)|

**_Code snippet for video_**
`static const NSTimeInterval kMDCBottomNavigationItemViewTransitionDuration = 2.180f;`

