### PR TITLE
[Snackbar] Add support to pass MDCSnackbarManager instances to color themer

### DIFF
--- a/components/Snackbar/src/ColorThemer/MDCSnackbarColorThemer.h
+++ b/components/Snackbar/src/ColorThemer/MDCSnackbarColorThemer.h
@@ -29,6 +29,15 @@
  */
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme;
 
+/**
+ Applies a color scheme's properties to all snackbar messages for an instance of MDCSnackbarManager.
+
+ @param colorScheme The color scheme to apply to all snackbar messages.
+ @param snackbarManager The MDCSnackbarManager instance to theme.
+ */
++ (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+               toSnackbarManager:(MDCSnackbarManager *)snackbarManager;
+
 @end
 
 @interface MDCSnackbarColorThemer (Deprecated)

--- a/components/Snackbar/src/ColorThemer/MDCSnackbarColorThemer.h
+++ b/components/Snackbar/src/ColorThemer/MDCSnackbarColorThemer.h
@@ -36,7 +36,7 @@
  @param snackbarManager The MDCSnackbarManager instance to theme.
  */
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
-               toSnackbarManager:(MDCSnackbarManager *)snackbarManager;
+               toSnackbarManager:(nonnull MDCSnackbarManager *)snackbarManager;
 
 @end
 

--- a/components/Snackbar/src/ColorThemer/MDCSnackbarColorThemer.m
+++ b/components/Snackbar/src/ColorThemer/MDCSnackbarColorThemer.m
@@ -26,12 +26,9 @@
       [MDCSemanticColorScheme blendColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:0.8f]
                      withBackgroundColor:colorScheme.surfaceColor];
   snackbarManager.messageTextColor = [colorScheme.surfaceColor colorWithAlphaComponent:0.87f];
-  UIColor *buttonTitleColor = [colorScheme.surfaceColor
-                               colorWithAlphaComponent:0.6f];
-  [snackbarManager setButtonTitleColor:buttonTitleColor
-                              forState:UIControlStateNormal];
-  [snackbarManager setButtonTitleColor:buttonTitleColor
-                              forState:UIControlStateHighlighted];
+  UIColor *buttonTitleColor = [colorScheme.surfaceColor colorWithAlphaComponent:0.6f];
+  [snackbarManager setButtonTitleColor:buttonTitleColor forState:UIControlStateNormal];
+  [snackbarManager setButtonTitleColor:buttonTitleColor forState:UIControlStateHighlighted];
 }
 
 #pragma clang diagnostic push

--- a/components/Snackbar/src/ColorThemer/MDCSnackbarColorThemer.m
+++ b/components/Snackbar/src/ColorThemer/MDCSnackbarColorThemer.m
@@ -17,16 +17,21 @@
 @implementation MDCSnackbarColorThemer
 
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme {
-  MDCSnackbarManager.snackbarMessageViewBackgroundColor =
+  [self applySemanticColorScheme:colorScheme toSnackbarManager:MDCSnackbarManager.defaultManager];
+}
+
++ (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+               toSnackbarManager:(MDCSnackbarManager *)snackbarManager {
+  snackbarManager.snackbarMessageViewBackgroundColor =
       [MDCSemanticColorScheme blendColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:0.8f]
                      withBackgroundColor:colorScheme.surfaceColor];
-  MDCSnackbarManager.messageTextColor = [colorScheme.surfaceColor colorWithAlphaComponent:0.87f];
+  snackbarManager.messageTextColor = [colorScheme.surfaceColor colorWithAlphaComponent:0.87f];
   UIColor *buttonTitleColor = [colorScheme.surfaceColor
-                                       colorWithAlphaComponent:0.6f];
-  [MDCSnackbarManager setButtonTitleColor:buttonTitleColor
-                                 forState:UIControlStateNormal];
-  [MDCSnackbarManager setButtonTitleColor:buttonTitleColor
-                                 forState:UIControlStateHighlighted];
+                               colorWithAlphaComponent:0.6f];
+  [snackbarManager setButtonTitleColor:buttonTitleColor
+                              forState:UIControlStateNormal];
+  [snackbarManager setButtonTitleColor:buttonTitleColor
+                              forState:UIControlStateHighlighted];
 }
 
 #pragma clang diagnostic push

--- a/components/Snackbar/src/ColorThemer/MDCSnackbarColorThemer.m
+++ b/components/Snackbar/src/ColorThemer/MDCSnackbarColorThemer.m
@@ -16,11 +16,11 @@
 
 @implementation MDCSnackbarColorThemer
 
-+ (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme {
++ (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme {
   [self applySemanticColorScheme:colorScheme toSnackbarManager:MDCSnackbarManager.defaultManager];
 }
 
-+ (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
++ (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
                toSnackbarManager:(MDCSnackbarManager *)snackbarManager {
   snackbarManager.snackbarMessageViewBackgroundColor =
       [MDCSemanticColorScheme blendColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:0.8f]

--- a/components/Snackbar/tests/unit/MDCSnackbarColorThemerSingletonTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarColorThemerSingletonTests.m
@@ -1,0 +1,94 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialSnackbar+ColorThemer.h"
+#import "MaterialSnackbar.h"
+
+@interface MDCSnackbarColorThemerSingletonTests : XCTestCase
+
+@property(nonatomic, strong) UIColor *messageTextColor;
+@property(nonatomic, strong) UIColor *snackbarMessageViewShadowColor;
+@property(nonatomic, strong) UIColor *snackbarMessageViewBackgroundColor;
+@property(nonatomic, strong) NSMutableDictionary *titleColorForState;
+
+@end
+
+@implementation MDCSnackbarColorThemerSingletonTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.messageTextColor = MDCSnackbarManager.messageTextColor;
+  self.snackbarMessageViewShadowColor = MDCSnackbarManager.snackbarMessageViewShadowColor;
+  self.snackbarMessageViewBackgroundColor = MDCSnackbarManager.snackbarMessageViewBackgroundColor;
+  self.titleColorForState = [@{} mutableCopy];
+  NSUInteger maxState = UIControlStateNormal | UIControlStateDisabled | UIControlStateSelected |
+                        UIControlStateHighlighted;
+  for (NSUInteger state = 0; state < maxState; ++state) {
+    self.titleColorForState[@(state)] = [MDCSnackbarManager buttonTitleColorForState:state];
+  }
+}
+
+- (void)tearDown {
+  // Restore the Snackbar Manager's state
+  MDCSnackbarManager.messageTextColor = self.messageTextColor;
+  MDCSnackbarManager.snackbarMessageViewShadowColor = self.snackbarMessageViewShadowColor;
+  MDCSnackbarManager.snackbarMessageViewBackgroundColor = self.snackbarMessageViewBackgroundColor;
+  for (NSNumber *state in self.titleColorForState.allKeys) {
+    if (self.titleColorForState[state] != nil) {
+      [MDCSnackbarManager setButtonTitleColor:self.titleColorForState[state]
+                                     forState:state.unsignedIntegerValue];
+    }
+  }
+
+  // Clean-up the test case
+  [self.titleColorForState removeAllObjects];
+  self.titleColorForState = nil;
+  self.messageTextColor = nil;
+  self.snackbarMessageViewShadowColor = nil;
+  self.snackbarMessageViewBackgroundColor = nil;
+
+  [super tearDown];
+}
+
+- (void)testSnackbarColorThemerChangesCorrectParameters {
+  // Given
+  MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
+  colorScheme.surfaceColor = [UIColor redColor];
+  colorScheme.onSurfaceColor = [UIColor blueColor];
+  MDCSnackbarManager.snackbarMessageViewBackgroundColor = [UIColor whiteColor];
+  MDCSnackbarManager.messageTextColor = [UIColor whiteColor];
+  [MDCSnackbarManager setButtonTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+  [MDCSnackbarManager setButtonTitleColor:[UIColor whiteColor] forState:UIControlStateHighlighted];
+  UIColor *blendedBackgroundColor =
+      [MDCSemanticColorScheme blendColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:0.8f]
+                     withBackgroundColor:colorScheme.surfaceColor];
+
+  // When
+  [MDCSnackbarColorThemer applySemanticColorScheme:colorScheme];
+
+  // Then
+  XCTAssertEqualObjects(MDCSnackbarManager.snackbarMessageViewBackgroundColor,
+                        blendedBackgroundColor);
+  XCTAssertEqualObjects(MDCSnackbarManager.messageTextColor,
+                        [colorScheme.surfaceColor colorWithAlphaComponent:0.87f]);
+  XCTAssertEqualObjects([MDCSnackbarManager buttonTitleColorForState:UIControlStateNormal],
+                        [colorScheme.surfaceColor colorWithAlphaComponent:0.6f]);
+  XCTAssertEqualObjects([MDCSnackbarManager buttonTitleColorForState:UIControlStateHighlighted],
+                        [colorScheme.surfaceColor colorWithAlphaComponent:0.6f]);
+}
+
+@end

--- a/components/Snackbar/tests/unit/MDCSnackbarColorThemerTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarColorThemerTests.m
@@ -37,8 +37,7 @@
   [MDCSnackbarColorThemer applySemanticColorScheme:colorScheme toSnackbarManager:snackbarManager];
 
   // Then
-  XCTAssertEqualObjects(snackbarManager.snackbarMessageViewBackgroundColor,
-                        blendedBackgroundColor);
+  XCTAssertEqualObjects(snackbarManager.snackbarMessageViewBackgroundColor, blendedBackgroundColor);
   XCTAssertEqualObjects(snackbarManager.messageTextColor,
                         [colorScheme.surfaceColor colorWithAlphaComponent:0.87f]);
   XCTAssertEqualObjects([snackbarManager buttonTitleColorForState:UIControlStateNormal],

--- a/components/Snackbar/tests/unit/MDCSnackbarColorThemerTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarColorThemerTests.m
@@ -19,75 +19,31 @@
 
 @interface MDCSnackbarColorThemerTests : XCTestCase
 
-@property(nonatomic, strong) UIColor *messageTextColor;
-@property(nonatomic, strong) UIColor *snackbarMessageViewShadowColor;
-@property(nonatomic, strong) UIColor *snackbarMessageViewBackgroundColor;
-@property(nonatomic, strong) NSMutableDictionary *titleColorForState;
-
 @end
 
 @implementation MDCSnackbarColorThemerTests
 
-- (void)setUp {
-  [super setUp];
-
-  self.messageTextColor = MDCSnackbarManager.messageTextColor;
-  self.snackbarMessageViewShadowColor = MDCSnackbarManager.snackbarMessageViewShadowColor;
-  self.snackbarMessageViewBackgroundColor = MDCSnackbarManager.snackbarMessageViewBackgroundColor;
-  self.titleColorForState = [@{} mutableCopy];
-  NSUInteger maxState = UIControlStateNormal | UIControlStateDisabled | UIControlStateSelected |
-                        UIControlStateHighlighted;
-  for (NSUInteger state = 0; state < maxState; ++state) {
-    self.titleColorForState[@(state)] = [MDCSnackbarManager buttonTitleColorForState:state];
-  }
-}
-
-- (void)tearDown {
-  // Restore the Snackbar Manager's state
-  MDCSnackbarManager.messageTextColor = self.messageTextColor;
-  MDCSnackbarManager.snackbarMessageViewShadowColor = self.snackbarMessageViewShadowColor;
-  MDCSnackbarManager.snackbarMessageViewBackgroundColor = self.snackbarMessageViewBackgroundColor;
-  for (NSNumber *state in self.titleColorForState.allKeys) {
-    if (self.titleColorForState[state] != nil) {
-      [MDCSnackbarManager setButtonTitleColor:self.titleColorForState[state]
-                                     forState:state.unsignedIntegerValue];
-    }
-  }
-
-  // Clean-up the test case
-  [self.titleColorForState removeAllObjects];
-  self.titleColorForState = nil;
-  self.messageTextColor = nil;
-  self.snackbarMessageViewShadowColor = nil;
-  self.snackbarMessageViewBackgroundColor = nil;
-
-  [super tearDown];
-}
-
 - (void)testSnackbarColorThemerChangesCorrectParameters {
   // Given
+  MDCSnackbarManager *snackbarManager = [[MDCSnackbarManager alloc] init];
   MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
   colorScheme.surfaceColor = [UIColor redColor];
   colorScheme.onSurfaceColor = [UIColor blueColor];
-  MDCSnackbarManager.snackbarMessageViewBackgroundColor = [UIColor whiteColor];
-  MDCSnackbarManager.messageTextColor = [UIColor whiteColor];
-  [MDCSnackbarManager setButtonTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
-  [MDCSnackbarManager setButtonTitleColor:[UIColor whiteColor] forState:UIControlStateHighlighted];
   UIColor *blendedBackgroundColor =
       [MDCSemanticColorScheme blendColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:0.8f]
                      withBackgroundColor:colorScheme.surfaceColor];
 
   // When
-  [MDCSnackbarColorThemer applySemanticColorScheme:colorScheme];
+  [MDCSnackbarColorThemer applySemanticColorScheme:colorScheme toSnackbarManager:snackbarManager];
 
   // Then
-  XCTAssertEqualObjects(MDCSnackbarManager.snackbarMessageViewBackgroundColor,
+  XCTAssertEqualObjects(snackbarManager.snackbarMessageViewBackgroundColor,
                         blendedBackgroundColor);
-  XCTAssertEqualObjects(MDCSnackbarManager.messageTextColor,
+  XCTAssertEqualObjects(snackbarManager.messageTextColor,
                         [colorScheme.surfaceColor colorWithAlphaComponent:0.87f]);
-  XCTAssertEqualObjects([MDCSnackbarManager buttonTitleColorForState:UIControlStateNormal],
+  XCTAssertEqualObjects([snackbarManager buttonTitleColorForState:UIControlStateNormal],
                         [colorScheme.surfaceColor colorWithAlphaComponent:0.6f]);
-  XCTAssertEqualObjects([MDCSnackbarManager buttonTitleColorForState:UIControlStateHighlighted],
+  XCTAssertEqualObjects([snackbarManager buttonTitleColorForState:UIControlStateHighlighted],
                         [colorScheme.surfaceColor colorWithAlphaComponent:0.6f]);
 }
 


### PR DESCRIPTION
### Context
The color themer for snackbars applies the colors to the MDCSnackbarManager default singleton.

### The problem
By limiting the themer to only work with the default singleton, this restricts the usage of the themer and makes it more difficult to test.

### The fix
Add an additional API to allow a caller to pass in their own MDCSnackbarManager instance. Add a unit test to ensure this works correctly.

**Note:** I have broken the unit tests out into 2 classes to prevent the overhead of setup/teardown of the original singleton test but maintain compatibility with it. If we choose to deprecate the API that assumes use of the default singleton, then we can simply delete that entire test class.

**Additional Note:** The diff appears wonky because Git didn't recognize my rename of the original test class. 

### Related bugs
Closes #5530, b/118386495 
