### PR TITLE
[ShadowLayer] Add API to animate corner radius

### DIFF
--- a/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.h
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.h
@@ -1,0 +1,23 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ShadowCornerRadiusAnimationViewController : UIViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.h
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.h
@@ -14,10 +14,6 @@
 
 #import <UIKit/UIKit.h>
 
-NS_ASSUME_NONNULL_BEGIN
-
 @interface ShadowCornerRadiusAnimationViewController : UIViewController
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
@@ -21,6 +21,7 @@
 
 static const CGFloat kStartCornerRadius = (CGFloat)0.001;
 static const CGFloat kEndCornerRadius = (CGFloat)25.0;
+static const CGFloat kAnimationDuration = (CGFloat)0.125;
 
 @interface CustomView : UIView
 
@@ -80,9 +81,9 @@ static const CGFloat kEndCornerRadius = (CGFloat)25.0;
 
 - (void)animateView {
   if (!_animated) {
-    [self.customView.shadowLayer animateCornerRadius:kEndCornerRadius];
+    [self.customView.shadowLayer animateCornerRadius:kEndCornerRadius withDuration:kAnimationDuration];
   } else {
-    [self.customView.shadowLayer animateCornerRadius:kStartCornerRadius];
+    [self.customView.shadowLayer animateCornerRadius:kStartCornerRadius withDuration:kAnimationDuration];
   }
   _animated = !_animated;
 }

--- a/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
@@ -15,8 +15,8 @@
 #import "ShadowCornerRadiusAnimationViewController.h"
 
 #import "MaterialAnimationTiming.h"
-#import "MaterialButtons.h"
 #import "MaterialButtons+ButtonThemer.h"
+#import "MaterialButtons.h"
 #import "MaterialShadowLayer.h"
 
 static const CGFloat kStartCornerRadius = (CGFloat)0.001;
@@ -61,7 +61,8 @@ static const CGFloat kAnimationDuration = (CGFloat)0.125;
   [self.button setTitle:@"Animation View" forState:UIControlStateNormal];
   [MDCContainedButtonThemer applyScheme:[[MDCButtonScheme alloc] init] toButton:self.button];
   [self.button sizeToFit];
-  [self.button addTarget:self action:@selector(animateView)
+  [self.button addTarget:self
+                  action:@selector(animateView)
         forControlEvents:UIControlEventTouchUpInside];
   [self.view addSubview:self.button];
 
@@ -81,20 +82,22 @@ static const CGFloat kAnimationDuration = (CGFloat)0.125;
 
 - (void)animateView {
   if (!_animated) {
-    [self.customView.shadowLayer animateCornerRadius:kEndCornerRadius withDuration:kAnimationDuration];
+    [self.customView.shadowLayer animateCornerRadius:kEndCornerRadius
+                                        withDuration:kAnimationDuration];
   } else {
-    [self.customView.shadowLayer animateCornerRadius:kStartCornerRadius withDuration:kAnimationDuration];
+    [self.customView.shadowLayer animateCornerRadius:kStartCornerRadius
+                                        withDuration:kAnimationDuration];
   }
   _animated = !_animated;
 }
 
 + (NSDictionary *)catalogMetadata {
   return @{
-           @"breadcrumbs": @[ @"Shadow", @"Shadow Corner Animation" ],
-           @"description": @"Animate shadows within a CABasicAnimation.",
-           @"primaryDemo": @NO,
-           @"presentable": @NO,
-           };
+    @"breadcrumbs" : @[ @"Shadow", @"Shadow Corner Animation" ],
+    @"description" : @"Animate shadows within a CABasicAnimation.",
+    @"primaryDemo" : @NO,
+    @"presentable" : @NO,
+  };
 }
 
 @end

--- a/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
@@ -85,11 +85,11 @@ static const CGFloat kAnimationDuration = (CGFloat)2.5;
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionEaseInOut];
   if (!_animated) {
     [self.customView.shadowLayer animateCornerRadius:kEndCornerRadius
-                                      timingFunction:timingFunction
+                                      withTimingFunction:timingFunction
                                             duration:kAnimationDuration];
   } else {
     [self.customView.shadowLayer animateCornerRadius:kStartCornerRadius
-                                      timingFunction:timingFunction
+                                      withTimingFunction:timingFunction
                                             duration:kAnimationDuration];
   }
   _animated = !_animated;

--- a/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
@@ -14,25 +14,86 @@
 
 #import "ShadowCornerRadiusAnimationViewController.h"
 
-@interface ShadowCornerRadiusAnimationViewController ()
+#import "MaterialAnimationTiming.h"
+#import "MaterialButtons.h"
+#import "MaterialButtons+ButtonThemer.h"
+#import "MaterialShadowLayer.h"
+
+static const CGFloat kStartCornerRadius = (CGFloat)0.001;
+static const CGFloat kEndCornerRadius = (CGFloat)25.0;
+
+@interface CustomView : UIView
 
 @end
 
-@implementation ShadowCornerRadiusAnimationViewController
+@implementation CustomView
+
++ (Class)layerClass {
+  return [MDCShadowLayer class];
+}
+
+- (MDCShadowLayer *)shadowLayer {
+  return (MDCShadowLayer *)self.layer;
+}
+
+- (void)setElevation:(CGFloat)points {
+  [(MDCShadowLayer *)self.layer setElevation:points];
+}
+
+@end
+
+@interface ShadowCornerRadiusAnimationViewController ()
+@property(nonatomic, strong, nullable) MDCButton *button;
+@property(nonatomic, strong, nullable) CustomView *customView;
+@end
+
+@implementation ShadowCornerRadiusAnimationViewController {
+  BOOL _animated;
+}
 
 - (void)viewDidLoad {
-    [super viewDidLoad];
-    // Do any additional setup after loading the view.
+  [super viewDidLoad];
+
+  _animated = NO;
+  self.view.backgroundColor = UIColor.whiteColor;
+  self.button = [[MDCButton alloc] init];
+  [self.button setTitle:@"Animation View" forState:UIControlStateNormal];
+  [MDCContainedButtonThemer applyScheme:[[MDCButtonScheme alloc] init] toButton:self.button];
+  [self.button sizeToFit];
+  [self.button addTarget:self action:@selector(animateView)
+        forControlEvents:UIControlEventTouchUpInside];
+  [self.view addSubview:self.button];
+
+  self.customView = [[CustomView alloc] initWithFrame:CGRectZero];
+  self.customView.backgroundColor = UIColor.lightGrayColor;
+  [self.customView setElevation:(CGFloat)8.0];
+  [self.view addSubview:self.customView];
 }
 
-/*
-#pragma mark - Navigation
+- (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
 
-// In a storyboard-based application, you will often want to do a little preparation before navigation
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    // Get the new view controller using [segue destinationViewController].
-    // Pass the selected object to the new view controller.
+  self.button.center = CGPointMake(self.view.center.x, self.view.center.y - 100);
+  self.customView.bounds = CGRectMake(0, 0, 100, 100);
+  self.customView.center = CGPointMake(self.view.center.x, self.view.center.y + 20);
 }
-*/
+
+- (void)animateView {
+  if (!_animated) {
+    [self.customView.shadowLayer animateCornerRadius:kEndCornerRadius];
+  } else {
+    [self.customView.shadowLayer animateCornerRadius:kStartCornerRadius];
+  }
+  _animated = !_animated;
+}
+
++ (NSDictionary *)catalogMetadata {
+  return @{
+           @"breadcrumbs": @[ @"Shadow", @"Shadow Corner Animation" ],
+           @"description": @"Animate shadows within a CABasicAnimation.",
+           @"primaryDemo": @NO,
+           @"presentable": @NO,
+           };
+}
 
 @end

--- a/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
@@ -1,0 +1,38 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "ShadowCornerRadiusAnimationViewController.h"
+
+@interface ShadowCornerRadiusAnimationViewController ()
+
+@end
+
+@implementation ShadowCornerRadiusAnimationViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+}
+
+/*
+#pragma mark - Navigation
+
+// In a storyboard-based application, you will often want to do a little preparation before navigation
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+    // Get the new view controller using [segue destinationViewController].
+    // Pass the selected object to the new view controller.
+}
+*/
+
+@end

--- a/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
@@ -84,13 +84,13 @@ static const CGFloat kAnimationDuration = (CGFloat)2.5;
   CAMediaTimingFunction *timingFunction =
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionEaseInOut];
   if (!_animated) {
-    CAAnimationGroup *group = [self.customView.shadowLayer animateCornerRadius:kEndCornerRadius];
-    group.timingFunction = timingFunction;
-    group.duration = kAnimationDuration;
+    [self.customView.shadowLayer animateCornerRadius:kEndCornerRadius
+                                      timingFunction:timingFunction
+                                            duration:kAnimationDuration];
   } else {
-    CAAnimationGroup *group = [self.customView.shadowLayer animateCornerRadius:kStartCornerRadius];
-    group.timingFunction = timingFunction;
-    group.duration = kAnimationDuration;
+    [self.customView.shadowLayer animateCornerRadius:kStartCornerRadius
+                                      timingFunction:timingFunction
+                                            duration:kAnimationDuration];
   }
   _animated = !_animated;
 }

--- a/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
@@ -81,12 +81,16 @@ static const CGFloat kAnimationDuration = (CGFloat)0.125;
 }
 
 - (void)animateView {
+  CAMediaTimingFunction *timingFunction =
+      [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionEaseInOut];
   if (!_animated) {
     [self.customView.shadowLayer animateCornerRadius:kEndCornerRadius
-                                        withDuration:kAnimationDuration];
+                                      timingFunction:timingFunction
+                                            duration:kAnimationDuration];
   } else {
     [self.customView.shadowLayer animateCornerRadius:kStartCornerRadius
-                                        withDuration:kAnimationDuration];
+                                      timingFunction:timingFunction
+                                            duration:kAnimationDuration];
   }
   _animated = !_animated;
 }

--- a/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
@@ -17,7 +17,9 @@
 #import "MaterialAnimationTiming.h"
 #import "MaterialButtons+ButtonThemer.h"
 #import "MaterialButtons.h"
+#import "MaterialColorScheme.h"
 #import "MaterialShadowLayer.h"
+#import "MaterialTypographyScheme.h"
 
 static const CGFloat kStartCornerRadius = (CGFloat)0.001;
 static const CGFloat kEndCornerRadius = (CGFloat)25.0;
@@ -44,6 +46,8 @@ static const CGFloat kAnimationDuration = (CGFloat)2.5;
 @end
 
 @interface ShadowCornerRadiusAnimationViewController ()
+@property(nonatomic, strong, nonnull) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong, nonnull) MDCTypographyScheme *typographyScheme;
 @property(nonatomic, strong, nullable) MDCButton *button;
 @property(nonatomic, strong, nullable) CustomView *customView;
 @end
@@ -52,22 +56,35 @@ static const CGFloat kAnimationDuration = (CGFloat)2.5;
   BOOL _animated;
 }
 
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _colorScheme = [[MDCSemanticColorScheme alloc] init];
+    _typographyScheme = [[MDCTypographyScheme alloc] init];
+    _button = [[MDCButton alloc] init];
+    _customView = [[CustomView alloc] initWithFrame:CGRectZero];
+  }
+  return self;
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
 
   _animated = NO;
-  self.view.backgroundColor = UIColor.whiteColor;
-  self.button = [[MDCButton alloc] init];
-  [self.button setTitle:@"Animation View" forState:UIControlStateNormal];
-  [MDCContainedButtonThemer applyScheme:[[MDCButtonScheme alloc] init] toButton:self.button];
+  self.view.backgroundColor = self.colorScheme.backgroundColor;
+
+  [self.button setTitle:@"Animate View" forState:UIControlStateNormal];
+  MDCButtonScheme *buttonScheme = [[MDCButtonScheme alloc] init];
+  buttonScheme.typographyScheme = self.typographyScheme;
+  buttonScheme.colorScheme = self.colorScheme;
+  [MDCContainedButtonThemer applyScheme:buttonScheme toButton:self.button];
   [self.button sizeToFit];
   [self.button addTarget:self
                   action:@selector(animateView)
         forControlEvents:UIControlEventTouchUpInside];
   [self.view addSubview:self.button];
 
-  self.customView = [[CustomView alloc] initWithFrame:CGRectZero];
-  self.customView.backgroundColor = UIColor.lightGrayColor;
+  self.customView.backgroundColor = self.colorScheme.surfaceColor;
   [self.customView setElevation:(CGFloat)8.0];
   [self.view addSubview:self.customView];
 }

--- a/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
@@ -85,11 +85,11 @@ static const CGFloat kAnimationDuration = (CGFloat)2.5;
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionEaseInOut];
   if (!_animated) {
     [self.customView.shadowLayer animateCornerRadius:kEndCornerRadius
-                                      withTimingFunction:timingFunction
+                                  withTimingFunction:timingFunction
                                             duration:kAnimationDuration];
   } else {
     [self.customView.shadowLayer animateCornerRadius:kStartCornerRadius
-                                      withTimingFunction:timingFunction
+                                  withTimingFunction:timingFunction
                                             duration:kAnimationDuration];
   }
   _animated = !_animated;

--- a/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
@@ -21,7 +21,7 @@
 
 static const CGFloat kStartCornerRadius = (CGFloat)0.001;
 static const CGFloat kEndCornerRadius = (CGFloat)25.0;
-static const CGFloat kAnimationDuration = (CGFloat)0.125;
+static const CGFloat kAnimationDuration = (CGFloat)2.5;
 
 @interface CustomView : UIView
 

--- a/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
@@ -84,13 +84,13 @@ static const CGFloat kAnimationDuration = (CGFloat)2.5;
   CAMediaTimingFunction *timingFunction =
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionEaseInOut];
   if (!_animated) {
-    [self.customView.shadowLayer animateCornerRadius:kEndCornerRadius
-                                      timingFunction:timingFunction
-                                            duration:kAnimationDuration];
+    CAAnimationGroup *group = [self.customView.shadowLayer animateCornerRadius:kEndCornerRadius];
+    group.timingFunction = timingFunction;
+    group.duration = kAnimationDuration;
   } else {
-    [self.customView.shadowLayer animateCornerRadius:kStartCornerRadius
-                                      timingFunction:timingFunction
-                                            duration:kAnimationDuration];
+    CAAnimationGroup *group = [self.customView.shadowLayer animateCornerRadius:kStartCornerRadius];
+    group.timingFunction = timingFunction;
+    group.duration = kAnimationDuration;
   }
   _animated = !_animated;
 }

--- a/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusAnimationViewController.m
@@ -17,9 +17,7 @@
 #import "MaterialAnimationTiming.h"
 #import "MaterialButtons+ButtonThemer.h"
 #import "MaterialButtons.h"
-#import "MaterialColorScheme.h"
 #import "MaterialShadowLayer.h"
-#import "MaterialTypographyScheme.h"
 
 static const CGFloat kStartCornerRadius = (CGFloat)0.001;
 static const CGFloat kEndCornerRadius = (CGFloat)25.0;
@@ -46,8 +44,6 @@ static const CGFloat kAnimationDuration = (CGFloat)2.5;
 @end
 
 @interface ShadowCornerRadiusAnimationViewController ()
-@property(nonatomic, strong, nonnull) MDCSemanticColorScheme *colorScheme;
-@property(nonatomic, strong, nonnull) MDCTypographyScheme *typographyScheme;
 @property(nonatomic, strong, nullable) MDCButton *button;
 @property(nonatomic, strong, nullable) CustomView *customView;
 @end
@@ -56,35 +52,22 @@ static const CGFloat kAnimationDuration = (CGFloat)2.5;
   BOOL _animated;
 }
 
-- (instancetype)init {
-  self = [super init];
-  if (self) {
-    _colorScheme = [[MDCSemanticColorScheme alloc] init];
-    _typographyScheme = [[MDCTypographyScheme alloc] init];
-    _button = [[MDCButton alloc] init];
-    _customView = [[CustomView alloc] initWithFrame:CGRectZero];
-  }
-  return self;
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
   _animated = NO;
-  self.view.backgroundColor = self.colorScheme.backgroundColor;
-
-  [self.button setTitle:@"Animate View" forState:UIControlStateNormal];
-  MDCButtonScheme *buttonScheme = [[MDCButtonScheme alloc] init];
-  buttonScheme.typographyScheme = self.typographyScheme;
-  buttonScheme.colorScheme = self.colorScheme;
-  [MDCContainedButtonThemer applyScheme:buttonScheme toButton:self.button];
+  self.view.backgroundColor = UIColor.whiteColor;
+  self.button = [[MDCButton alloc] init];
+  [self.button setTitle:@"Animation View" forState:UIControlStateNormal];
+  [MDCContainedButtonThemer applyScheme:[[MDCButtonScheme alloc] init] toButton:self.button];
   [self.button sizeToFit];
   [self.button addTarget:self
                   action:@selector(animateView)
         forControlEvents:UIControlEventTouchUpInside];
   [self.view addSubview:self.button];
 
-  self.customView.backgroundColor = self.colorScheme.surfaceColor;
+  self.customView = [[CustomView alloc] initWithFrame:CGRectZero];
+  self.customView.backgroundColor = UIColor.lightGrayColor;
   [self.customView setElevation:(CGFloat)8.0];
   [self.view addSubview:self.customView];
 }

--- a/components/ShadowLayer/src/MDCShadowLayer.h
+++ b/components/ShadowLayer/src/MDCShadowLayer.h
@@ -77,8 +77,8 @@
 @property(nonatomic, getter=isShadowMaskEnabled, assign) BOOL shadowMaskEnabled;
 
 /**
- Used to animate a MaterialShadowLayer within an animation, if animating the @c cornerRadius does not
- work for your use case please use this.
+ Used to animate a MaterialShadowLayer within an animation, if animating the @c cornerRadius does
+ not work for your use case please use this.
 
  @note At the end of the animation the corner radius is set to your desired corner radius.
 
@@ -87,8 +87,8 @@
  @param duration The duration of the animation
  */
 - (void)animateCornerRadius:(CGFloat)cornerRadius
-             timingFunction:(CAMediaTimingFunction *)timingFunction
-                  duration:(NSTimeInterval)duration;
+             timingFunction:(nonnull CAMediaTimingFunction *)timingFunction
+                   duration:(NSTimeInterval)duration;
 
 @end
 

--- a/components/ShadowLayer/src/MDCShadowLayer.h
+++ b/components/ShadowLayer/src/MDCShadowLayer.h
@@ -86,7 +86,7 @@
  @param duration The duration of the animation
  */
 - (void)animateCornerRadius:(CGFloat)cornerRadius
-             timingFunction:(nonnull CAMediaTimingFunction *)timingFunction
+         withTimingFunction:(nonnull CAMediaTimingFunction *)timingFunction
                    duration:(NSTimeInterval)duration;
 
 @end

--- a/components/ShadowLayer/src/MDCShadowLayer.h
+++ b/components/ShadowLayer/src/MDCShadowLayer.h
@@ -78,7 +78,7 @@
 
 - (void)animateCornerRadius:(CGFloat)cornerRadius
              timingFunction:(CAMediaTimingFunction *)timingFunction
-                  duuration:(NSTimeInterval)duration;
+                  duration:(NSTimeInterval)duration;
 
 @end
 

--- a/components/ShadowLayer/src/MDCShadowLayer.h
+++ b/components/ShadowLayer/src/MDCShadowLayer.h
@@ -76,6 +76,16 @@
  */
 @property(nonatomic, getter=isShadowMaskEnabled, assign) BOOL shadowMaskEnabled;
 
+/**
+ Used to animate a MaterialShadowLayer within an animation, if animating the @c cornerRadius does not
+ work for your use case please use this.
+
+ @note At the end of the animation the corner radius is set to your desired corner radius.
+
+ @param cornerRadius The desired corner radius at the end of the animation
+ @param timingFunction The timing function you desire for the animation
+ @param duration The duration of the animation
+ */
 - (void)animateCornerRadius:(CGFloat)cornerRadius
              timingFunction:(CAMediaTimingFunction *)timingFunction
                   duration:(NSTimeInterval)duration;

--- a/components/ShadowLayer/src/MDCShadowLayer.h
+++ b/components/ShadowLayer/src/MDCShadowLayer.h
@@ -82,12 +82,8 @@
  @note At the end of the animation the corner radius is set to your desired corner radius.
 
  @param cornerRadius The desired corner radius at the end of the animation
- @param timingFunction The timing function you desire for the animation
- @param duration The duration of the animation
  */
-- (void)animateCornerRadius:(CGFloat)cornerRadius
-             timingFunction:(nonnull CAMediaTimingFunction *)timingFunction
-                   duration:(NSTimeInterval)duration;
+- (CAAnimationGroup *)animateCornerRadius:(CGFloat)cornerRadius;
 
 @end
 

--- a/components/ShadowLayer/src/MDCShadowLayer.h
+++ b/components/ShadowLayer/src/MDCShadowLayer.h
@@ -76,6 +76,8 @@
  */
 @property(nonatomic, getter=isShadowMaskEnabled, assign) BOOL shadowMaskEnabled;
 
+- (void)animateCornerRadius:(CGFloat)cornerRadius;
+
 @end
 
 /**

--- a/components/ShadowLayer/src/MDCShadowLayer.h
+++ b/components/ShadowLayer/src/MDCShadowLayer.h
@@ -76,7 +76,9 @@
  */
 @property(nonatomic, getter=isShadowMaskEnabled, assign) BOOL shadowMaskEnabled;
 
-- (void)animateCornerRadius:(CGFloat)cornerRadius withDuration:(NSTimeInterval)duration;
+- (void)animateCornerRadius:(CGFloat)cornerRadius
+             timingFunction:(CAMediaTimingFunction *)timingFunction
+                  duuration:(NSTimeInterval)duration;
 
 @end
 

--- a/components/ShadowLayer/src/MDCShadowLayer.h
+++ b/components/ShadowLayer/src/MDCShadowLayer.h
@@ -77,8 +77,7 @@
 @property(nonatomic, getter=isShadowMaskEnabled, assign) BOOL shadowMaskEnabled;
 
 /**
- Used to animate a MaterialShadowLayer within an animation, if animating the @c cornerRadius does
- not work for your use case please use this.
+ Animates the layer's corner radius
 
  @note At the end of the animation the corner radius is set to your desired corner radius.
 

--- a/components/ShadowLayer/src/MDCShadowLayer.h
+++ b/components/ShadowLayer/src/MDCShadowLayer.h
@@ -76,7 +76,7 @@
  */
 @property(nonatomic, getter=isShadowMaskEnabled, assign) BOOL shadowMaskEnabled;
 
-- (void)animateCornerRadius:(CGFloat)cornerRadius;
+- (void)animateCornerRadius:(CGFloat)cornerRadius withDuration:(NSTimeInterval)duration;
 
 @end
 

--- a/components/ShadowLayer/src/MDCShadowLayer.h
+++ b/components/ShadowLayer/src/MDCShadowLayer.h
@@ -82,8 +82,12 @@
  @note At the end of the animation the corner radius is set to your desired corner radius.
 
  @param cornerRadius The desired corner radius at the end of the animation
+ @param timingFunction The timing function you desire for the animation
+ @param duration The duration of the animation
  */
-- (CAAnimationGroup *)animateCornerRadius:(CGFloat)cornerRadius;
+- (void)animateCornerRadius:(CGFloat)cornerRadius
+             timingFunction:(nonnull CAMediaTimingFunction *)timingFunction
+                   duration:(NSTimeInterval)duration;
 
 @end
 

--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -372,10 +372,10 @@ static const float kAmbientShadowOpacity = 0.08f;
   CGFloat newCornerRadius = (cornerRadius <= 0) ? 0.001 : cornerRadius;
   [CATransaction begin];
   // Create the paths
-  UIBezierPath *currentLayerPath = [UIBezierPath  bezierPathWithRoundedRect:self.bounds
-                                                                cornerRadius:currentCornerRadius];
+  UIBezierPath *currentLayerPath = [UIBezierPath bezierPathWithRoundedRect:self.bounds
+                                                              cornerRadius:currentCornerRadius];
   UIBezierPath *newLayerPath = [UIBezierPath bezierPathWithRoundedRect:self.bounds
-                                                           cornerRadius:newCornerRadius];
+                                                          cornerRadius:newCornerRadius];
 
   UIBezierPath *currentMaskPath = [self outerMaskPath];
   [currentMaskPath appendPath:currentLayerPath];
@@ -422,7 +422,7 @@ static const float kAmbientShadowOpacity = 0.08f;
 
   // Set completion block
   [CATransaction setAnimationDuration:duration];
-  [CATransaction setCompletionBlock:^(void){
+  [CATransaction setCompletionBlock:^(void) {
     self.topShadow.shadowPath = newLayerPath.CGPath;
     self.bottomShadow.shadowPath = newLayerPath.CGPath;
     self.topShadowMask.path = newMaskPath.CGPath;

--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -370,7 +370,7 @@ static const float kAmbientShadowOpacity = 0.08f;
          withTimingFunction:(CAMediaTimingFunction *)timingFunction
                    duration:(NSTimeInterval)duration {
   [CATransaction begin];
-  [CATransaction setDisableActions:NO];
+  [CATransaction setDisableActions:YES];
   CGFloat currentCornerRadius = (self.cornerRadius <= 0) ? (CGFloat)0.001 : self.cornerRadius;
   CGFloat newCornerRadius = (cornerRadius <= 0) ? (CGFloat)0.001 : cornerRadius;
   // Create the paths

--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -386,29 +386,31 @@ static const float kAmbientShadowOpacity = 0.08f;
   [newMaskPath setUsesEvenOddFillRule:YES];
 
   // Animate the top layers
-  CABasicAnimation *topLayerAnimation = [CABasicAnimation animationWithKeyPath:@"path"];
+  NSString *shadowPathKey = @"shadowPath";
+  CABasicAnimation *topLayerAnimation = [CABasicAnimation animationWithKeyPath:shadowPathKey];
   topLayerAnimation.fromValue = (__bridge id)currentLayerPath.CGPath;
   topLayerAnimation.toValue = (__bridge id)newLayerPath.CGPath;
   topLayerAnimation.duration = duration;
-  [self.topShadow addAnimation:topLayerAnimation forKey:@"path"];
-  CABasicAnimation *bottomLayerAnimation = [CABasicAnimation animationWithKeyPath:@"path"];
+  [self.topShadow addAnimation:topLayerAnimation forKey:shadowPathKey];
+  CABasicAnimation *bottomLayerAnimation = [CABasicAnimation animationWithKeyPath:shadowPathKey];
   bottomLayerAnimation.fromValue = (__bridge id)currentLayerPath.CGPath;
   bottomLayerAnimation.toValue = (__bridge id)newLayerPath.CGPath;
   bottomLayerAnimation.duration = duration;
-  [self.bottomShadow addAnimation:bottomLayerAnimation forKey:@"path"];
+  [self.bottomShadow addAnimation:bottomLayerAnimation forKey:shadowPathKey];
 
   // Animate the masks
   if (self.shadowMaskEnabled) {
-    CABasicAnimation *topMaskLayerAnimation = [CABasicAnimation animationWithKeyPath:@"path"];
+    NSString *pathKey = @"path";
+    CABasicAnimation *topMaskLayerAnimation = [CABasicAnimation animationWithKeyPath:pathKey];
     topMaskLayerAnimation.fromValue = (__bridge id)currentMaskPath.CGPath;
     topMaskLayerAnimation.toValue = (__bridge id)newMaskPath.CGPath;
     topMaskLayerAnimation.duration = duration;
-    [self.topShadowMask addAnimation:topMaskLayerAnimation forKey:@"path"];
-    CABasicAnimation *bottomMaskLayerAnimation = [CABasicAnimation animationWithKeyPath:@"path"];
+    [self.topShadowMask addAnimation:topMaskLayerAnimation forKey:pathKey];
+    CABasicAnimation *bottomMaskLayerAnimation = [CABasicAnimation animationWithKeyPath:pathKey];
     bottomMaskLayerAnimation.fromValue = (__bridge id)currentMaskPath.CGPath;
     bottomMaskLayerAnimation.toValue = (__bridge id)newMaskPath.CGPath;
     bottomMaskLayerAnimation.duration = duration;
-    [self.bottomShadowMask addAnimation:bottomMaskLayerAnimation forKey:@"path"];
+    [self.bottomShadowMask addAnimation:bottomMaskLayerAnimation forKey:pathKey];
   }
 
   // Animate the corner radius
@@ -421,8 +423,8 @@ static const float kAmbientShadowOpacity = 0.08f;
   // Set completion block
   [CATransaction setAnimationDuration:duration];
   [CATransaction setCompletionBlock:^(void){
-    self.topShadow.path = newLayerPath.CGPath;
-    self.bottomShadow.path = newLayerPath.CGPath;
+    self.topShadow.shadowPath = newLayerPath.CGPath;
+    self.bottomShadow.shadowPath = newLayerPath.CGPath;
     self.topShadowMask.path = newMaskPath.CGPath;
     self.bottomShadowMask.path = newMaskPath.CGPath;
     self.cornerRadius = newCornerRadius;

--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -300,8 +300,7 @@ static const float kAmbientShadowOpacity = 0.08f;
 }
 
 - (UIBezierPath *)outerMaskPath {
-  UIBezierPath *path = [UIBezierPath bezierPathWithRect:[self maskRect]];
-  return path;
+  return [UIBezierPath bezierPathWithRect:[self maskRect]];
 }
 
 - (void)setElevation:(CGFloat)elevation {
@@ -368,7 +367,7 @@ static const float kAmbientShadowOpacity = 0.08f;
 }
 
 - (void)animateCornerRadius:(CGFloat)cornerRadius
-             timingFunction:(CAMediaTimingFunction *)timingFunction
+         withTimingFunction:(CAMediaTimingFunction *)timingFunction
                    duration:(NSTimeInterval)duration {
   CGFloat currentCornerRadius = (self.cornerRadius <= 0) ? (CGFloat)0.001 : self.cornerRadius;
   CGFloat newCornerRadius = (cornerRadius <= 0) ? (CGFloat)0.001 : cornerRadius;

--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -369,6 +369,8 @@ static const float kAmbientShadowOpacity = 0.08f;
 - (void)animateCornerRadius:(CGFloat)cornerRadius
          withTimingFunction:(CAMediaTimingFunction *)timingFunction
                    duration:(NSTimeInterval)duration {
+  [CATransaction begin];
+  [CATransaction setDisableActions:NO];
   CGFloat currentCornerRadius = (self.cornerRadius <= 0) ? (CGFloat)0.001 : self.cornerRadius;
   CGFloat newCornerRadius = (cornerRadius <= 0) ? (CGFloat)0.001 : cornerRadius;
   // Create the paths
@@ -379,11 +381,11 @@ static const float kAmbientShadowOpacity = 0.08f;
 
   UIBezierPath *currentMaskPath = [self outerMaskPath];
   [currentMaskPath appendPath:currentLayerPath];
-  [currentMaskPath setUsesEvenOddFillRule:YES];
+  currentMaskPath.usesEvenOddFillRule = YES;
 
   UIBezierPath *newMaskPath = [self outerMaskPath];
   [newMaskPath appendPath:newLayerPath];
-  [newMaskPath setUsesEvenOddFillRule:YES];
+  newMaskPath.usesEvenOddFillRule = YES;
 
   // Animate the top layers
   NSString *shadowPathKey = @"shadowPath";
@@ -429,6 +431,7 @@ static const float kAmbientShadowOpacity = 0.08f;
   cornerRadiusAnimation.timingFunction = timingFunction;
   self.cornerRadius = cornerRadius;
   [self addAnimation:cornerRadiusAnimation forKey:@"cornerRadius"];
+  [CATransaction commit];
 }
 
 @end

--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -370,8 +370,8 @@ static const float kAmbientShadowOpacity = 0.08f;
 - (void)animateCornerRadius:(CGFloat)cornerRadius
              timingFunction:(CAMediaTimingFunction *)timingFunction
                    duration:(NSTimeInterval)duration {
-  CGFloat currentCornerRadius = (self.cornerRadius <= 0) ? 0.001 : self.cornerRadius;
-  CGFloat newCornerRadius = (cornerRadius <= 0) ? 0.001 : cornerRadius;
+  CGFloat currentCornerRadius = (self.cornerRadius <= 0) ? (CGFloat)0.001 : self.cornerRadius;
+  CGFloat newCornerRadius = (cornerRadius <= 0) ? (CGFloat)0.001 : cornerRadius;
   [CATransaction begin];
   // Create the paths
   UIBezierPath *currentLayerPath = [UIBezierPath bezierPathWithRoundedRect:self.bounds

--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -367,7 +367,7 @@ static const float kAmbientShadowOpacity = 0.08f;
   _shadowPathIsInvalid = NO;
 }
 
-- (void)animateCornerRadius:(CGFloat)cornerRadius {
+- (void)animateCornerRadius:(CGFloat)cornerRadius withDuration:(NSTimeInterval)duration {
   CGFloat currentCornerRadius = (self.cornerRadius <= 0) ? 0.001 : self.cornerRadius;
   CGFloat newCornerRadius = (cornerRadius <= 0) ? 0.001 : cornerRadius;
   [CATransaction begin];
@@ -389,12 +389,12 @@ static const float kAmbientShadowOpacity = 0.08f;
   CABasicAnimation *topLayerAnimation = [CABasicAnimation animationWithKeyPath:@"path"];
   topLayerAnimation.fromValue = (__bridge id)currentLayerPath.CGPath;
   topLayerAnimation.toValue = (__bridge id)newLayerPath.CGPath;
-  topLayerAnimation.duration = 3.0;
+  topLayerAnimation.duration = duration;
   [self.topShadow addAnimation:topLayerAnimation forKey:@"path"];
   CABasicAnimation *bottomLayerAnimation = [CABasicAnimation animationWithKeyPath:@"path"];
   bottomLayerAnimation.fromValue = (__bridge id)currentLayerPath.CGPath;
   bottomLayerAnimation.toValue = (__bridge id)newLayerPath.CGPath;
-  bottomLayerAnimation.duration = 3.0;
+  bottomLayerAnimation.duration = duration;
   [self.bottomShadow addAnimation:bottomLayerAnimation forKey:@"path"];
 
   // Animate the masks
@@ -402,12 +402,12 @@ static const float kAmbientShadowOpacity = 0.08f;
     CABasicAnimation *topMaskLayerAnimation = [CABasicAnimation animationWithKeyPath:@"path"];
     topMaskLayerAnimation.fromValue = (__bridge id)currentMaskPath.CGPath;
     topMaskLayerAnimation.toValue = (__bridge id)newMaskPath.CGPath;
-    topMaskLayerAnimation.duration = 3.0;
+    topMaskLayerAnimation.duration = duration;
     [self.topShadowMask addAnimation:topMaskLayerAnimation forKey:@"path"];
     CABasicAnimation *bottomMaskLayerAnimation = [CABasicAnimation animationWithKeyPath:@"path"];
     bottomMaskLayerAnimation.fromValue = (__bridge id)currentMaskPath.CGPath;
     bottomMaskLayerAnimation.toValue = (__bridge id)newMaskPath.CGPath;
-    bottomMaskLayerAnimation.duration = 3.0;
+    bottomMaskLayerAnimation.duration = duration;
     [self.bottomShadowMask addAnimation:bottomMaskLayerAnimation forKey:@"path"];
   }
 
@@ -415,11 +415,11 @@ static const float kAmbientShadowOpacity = 0.08f;
   CABasicAnimation *cornerRadiusAnimation = [CABasicAnimation animationWithKeyPath:@"cornerRadius"];
   cornerRadiusAnimation.fromValue = @((CGFloat)currentCornerRadius);
   cornerRadiusAnimation.toValue = @((CGFloat)newCornerRadius);
-  cornerRadiusAnimation.duration = 3.0;
+  cornerRadiusAnimation.duration = duration;
   [self addAnimation:cornerRadiusAnimation forKey:@"cornerRadius"];
 
   // Set completion block
-  [CATransaction setAnimationDuration:3.0];
+  [CATransaction setAnimationDuration:duration];
   [CATransaction setCompletionBlock:^(void){
     self.topShadow.path = newLayerPath.CGPath;
     self.bottomShadow.path = newLayerPath.CGPath;

--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -360,6 +360,21 @@ static const float kAmbientShadowOpacity = 0.08f;
   _shadowPathIsInvalid = NO;
 }
 
+- (void)animateCornerRadius:(CGFloat)cornerRadius {
+  CGFloat currentCornerRadius = (self.cornerRadius <= 0) ? 0.001 : self.cornerRadius;
+  CGFloat newCornerRadius = (cornerRadius <= 0) ? 0.001 : cornerRadius;
+  [CATransaction begin];
+  // Create the paths
+
+  // Animate the top layers
+
+  // Animate the masks
+
+  // Set completion block
+
+  [CATransaction commit];
+}
+
 @end
 
 @implementation MDCPendingAnimation

--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -367,7 +367,9 @@ static const float kAmbientShadowOpacity = 0.08f;
   _shadowPathIsInvalid = NO;
 }
 
-- (void)animateCornerRadius:(CGFloat)cornerRadius withDuration:(NSTimeInterval)duration {
+- (void)animateCornerRadius:(CGFloat)cornerRadius
+             timingFunction:(CAMediaTimingFunction *)timingFunction
+                   duration:(NSTimeInterval)duration {
   CGFloat currentCornerRadius = (self.cornerRadius <= 0) ? 0.001 : self.cornerRadius;
   CGFloat newCornerRadius = (cornerRadius <= 0) ? 0.001 : cornerRadius;
   [CATransaction begin];
@@ -391,11 +393,13 @@ static const float kAmbientShadowOpacity = 0.08f;
   topLayerAnimation.fromValue = (__bridge id)currentLayerPath.CGPath;
   topLayerAnimation.toValue = (__bridge id)newLayerPath.CGPath;
   topLayerAnimation.duration = duration;
+  topLayerAnimation.timingFunction = timingFunction;
   [self.topShadow addAnimation:topLayerAnimation forKey:shadowPathKey];
   CABasicAnimation *bottomLayerAnimation = [CABasicAnimation animationWithKeyPath:shadowPathKey];
   bottomLayerAnimation.fromValue = (__bridge id)currentLayerPath.CGPath;
   bottomLayerAnimation.toValue = (__bridge id)newLayerPath.CGPath;
   bottomLayerAnimation.duration = duration;
+  bottomLayerAnimation.timingFunction = timingFunction;
   [self.bottomShadow addAnimation:bottomLayerAnimation forKey:shadowPathKey];
 
   // Animate the masks
@@ -405,11 +409,13 @@ static const float kAmbientShadowOpacity = 0.08f;
     topMaskLayerAnimation.fromValue = (__bridge id)currentMaskPath.CGPath;
     topMaskLayerAnimation.toValue = (__bridge id)newMaskPath.CGPath;
     topMaskLayerAnimation.duration = duration;
+    topMaskLayerAnimation.timingFunction = timingFunction;
     [self.topShadowMask addAnimation:topMaskLayerAnimation forKey:pathKey];
     CABasicAnimation *bottomMaskLayerAnimation = [CABasicAnimation animationWithKeyPath:pathKey];
     bottomMaskLayerAnimation.fromValue = (__bridge id)currentMaskPath.CGPath;
     bottomMaskLayerAnimation.toValue = (__bridge id)newMaskPath.CGPath;
     bottomMaskLayerAnimation.duration = duration;
+    bottomMaskLayerAnimation.timingFunction = timingFunction;
     [self.bottomShadowMask addAnimation:bottomMaskLayerAnimation forKey:pathKey];
   }
 

--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -424,6 +424,7 @@ static const float kAmbientShadowOpacity = 0.08f;
   cornerRadiusAnimation.fromValue = @((CGFloat)currentCornerRadius);
   cornerRadiusAnimation.toValue = @((CGFloat)newCornerRadius);
   cornerRadiusAnimation.duration = duration;
+  cornerRadiusAnimation.timingFunction = timingFunction;
   [self addAnimation:cornerRadiusAnimation forKey:@"cornerRadius"];
 
   // Set completion block

--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -367,8 +367,9 @@ static const float kAmbientShadowOpacity = 0.08f;
   _shadowPathIsInvalid = NO;
 }
 
-- (CAAnimationGroup *)animateCornerRadius:(CGFloat)cornerRadius {
-  CAAnimationGroup *animationGroup = [[CAAnimationGroup alloc] init];
+- (void)animateCornerRadius:(CGFloat)cornerRadius
+             timingFunction:(CAMediaTimingFunction *)timingFunction
+                   duration:(NSTimeInterval)duration {
   CGFloat currentCornerRadius = (self.cornerRadius <= 0) ? (CGFloat)0.001 : self.cornerRadius;
   CGFloat newCornerRadius = (cornerRadius <= 0) ? (CGFloat)0.001 : cornerRadius;
   // Create the paths
@@ -390,14 +391,16 @@ static const float kAmbientShadowOpacity = 0.08f;
   CABasicAnimation *topLayerAnimation = [CABasicAnimation animationWithKeyPath:shadowPathKey];
   topLayerAnimation.fromValue = (__bridge id)currentLayerPath.CGPath;
   topLayerAnimation.toValue = (__bridge id)newLayerPath.CGPath;
+  topLayerAnimation.duration = duration;
+  topLayerAnimation.timingFunction = timingFunction;
   self.topShadow.shadowPath = newLayerPath.CGPath;
   [self.topShadow addAnimation:topLayerAnimation forKey:shadowPathKey];
-  [animationGroup.animations arrayByAddingObject:topLayerAnimation];
   CABasicAnimation *bottomLayerAnimation = [CABasicAnimation animationWithKeyPath:shadowPathKey];
   bottomLayerAnimation.fromValue = (__bridge id)currentLayerPath.CGPath;
   bottomLayerAnimation.toValue = (__bridge id)newLayerPath.CGPath;
+  bottomLayerAnimation.duration = duration;
+  bottomLayerAnimation.timingFunction = timingFunction;
   self.bottomShadow.shadowPath = newLayerPath.CGPath;
-  [animationGroup.animations arrayByAddingObject:bottomLayerAnimation];
   [self.bottomShadow addAnimation:bottomLayerAnimation forKey:shadowPathKey];
 
   // Animate the masks
@@ -406,14 +409,16 @@ static const float kAmbientShadowOpacity = 0.08f;
     CABasicAnimation *topMaskLayerAnimation = [CABasicAnimation animationWithKeyPath:pathKey];
     topMaskLayerAnimation.fromValue = (__bridge id)currentMaskPath.CGPath;
     topMaskLayerAnimation.toValue = (__bridge id)newMaskPath.CGPath;
+    topMaskLayerAnimation.duration = duration;
+    topMaskLayerAnimation.timingFunction = timingFunction;
     self.topShadowMask.path = newMaskPath.CGPath;
-    [animationGroup.animations arrayByAddingObject:topMaskLayerAnimation];
     [self.topShadowMask addAnimation:topMaskLayerAnimation forKey:pathKey];
     CABasicAnimation *bottomMaskLayerAnimation = [CABasicAnimation animationWithKeyPath:pathKey];
     bottomMaskLayerAnimation.fromValue = (__bridge id)currentMaskPath.CGPath;
     bottomMaskLayerAnimation.toValue = (__bridge id)newMaskPath.CGPath;
+    bottomMaskLayerAnimation.duration = duration;
+    bottomMaskLayerAnimation.timingFunction = timingFunction;
     self.bottomShadowMask.path = newMaskPath.CGPath;
-    [animationGroup.animations arrayByAddingObject:bottomMaskLayerAnimation];
     [self.bottomShadowMask addAnimation:bottomMaskLayerAnimation forKey:pathKey];
   }
 
@@ -421,11 +426,10 @@ static const float kAmbientShadowOpacity = 0.08f;
   CABasicAnimation *cornerRadiusAnimation = [CABasicAnimation animationWithKeyPath:@"cornerRadius"];
   cornerRadiusAnimation.fromValue = @((CGFloat)currentCornerRadius);
   cornerRadiusAnimation.toValue = @((CGFloat)newCornerRadius);
-  self.cornerRadius = newCornerRadius;
+  cornerRadiusAnimation.duration = duration;
+  cornerRadiusAnimation.timingFunction = timingFunction;
+  self.cornerRadius = cornerRadius;
   [self addAnimation:cornerRadiusAnimation forKey:@"cornerRadius"];
-  [animationGroup.animations arrayByAddingObject:cornerRadiusAnimation];
-
-  return animationGroup;
 }
 
 @end


### PR DESCRIPTION
### Context
A client is wanting to animate the corner radius of a view that has a `MDCShadowLayer` backing layer. This currently doesn't render correctly. The work done in #5398 still does not support animating the corner radius. #5398 additionally doesn't animate the `shadowPath` property so it still won't work properly. We set the properties in the `CATransaction completionBlock` because this prevents the layer from snapping back to it's original state after the animation completes. If a client desires to use a `CATransaction` wrapper around this animation they can do so as outlined [here](https://developer.apple.com/documentation/quartzcore/catransaction).
### The problem
Animating corner radius changes in a CAAnimation don't render
### The fix
Add an API to allow clients to animate corner radius changes for MDCShadowLayer.
### Alternatives
1. Alternatives to adding a new API would be to have the a client use our private API which isn't desirable and not future proof as discussed in #5566.

2. Add an API `- (CAGroupAnimation *)animateCornerRadius:(CGFloat)cornerRadius;` that would return all 5 of the animations and clients could set the duration and timingFunction themselves but this doesn't allow for the layers to stay animated after completion. If we want the layer to be animated after completion we could use `kCAFillModeForwards` and `removeOnCompletion = NO` but that would prevent use from animating back to the original state.
### Videos
| Before | After |
| - | - |
|![before](https://user-images.githubusercontent.com/7131294/47959028-d1fba180-dfaf-11e8-99fb-3aedd0a5010e.gif)|![after](https://user-images.githubusercontent.com/7131294/47959029-d6c05580-dfaf-11e8-97c4-68a46bbd4c7f.gif)|

| Alternative 2 | Without corner radius |
| - | - |
|![group](https://user-images.githubusercontent.com/7131294/47959034-eb9ce900-dfaf-11e8-8c92-18e668aeb21d.gif)|![nocornerradius](https://user-images.githubusercontent.com/7131294/47959036-ef307000-dfaf-11e8-83eb-dee49d2de36a.gif)|

### Bugs remaining
1. Set the MDShadowLayer cornerRadius to 0.
2. Call the new API with a duration of 5 seconds and a cornerRadius of 10.
3. Before that animation completes call the API again with a cornerRadius of 0.
#### Expected behavior
The first animation would complete and then the second animation would start.
#### Actual behavior
The animation jumps to 10 and then animates back to 0.

**_note_** This could be avoided if we added a property `BOOL` called `_isAnimating` and if that is set to `YES` then we would stash the next animation. This isn't added because most animations will be too fast for a user to tap that fast.

### Tested
cl/219964460