### PR TITLE
[NavigationDrawer] Automatically disable scrolling for the internal tracking scroll view

### DIFF
--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -95,7 +95,6 @@ class DrawerContentTableViewController: UITableViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
-    self.tableView.isScrollEnabled = false
   }
 
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/components/NavigationDrawer/examples/BottomDrawerWithChangingContentSize.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithChangingContentSize.swift
@@ -106,7 +106,6 @@ UICollectionViewDelegate, UICollectionViewDataSource {
     collectionView.frame = CGRect(x: 0, y: 0, width: self.view.bounds.width,
                                   height: self.view.bounds.height)
     collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "Cell")
-    collectionView.isScrollEnabled = false
     collectionView.delegate = self
     collectionView.dataSource = self
     collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]

--- a/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
@@ -103,7 +103,6 @@ class DrawerContentWithScrollViewController: UIViewController,
     collectionView.frame = CGRect(x: 0, y: 0, width: self.view.bounds.width,
                              height: self.view.bounds.height)
     collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "Cell")
-    collectionView.isScrollEnabled = false
     collectionView.delegate = self
     collectionView.dataSource = self
     collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -73,6 +73,9 @@
 }
 
 - (void)setTrackingScrollView:(UIScrollView *)trackingScrollView {
+  // Rather than have the client manually disable scrolling on the internal scroll view for
+  // the drawer to work properly, we can disable it if a trackingScrollView is provided.
+  [trackingScrollView setScrollEnabled:NO];
   _transitionController.trackingScrollView = trackingScrollView;
 }
 

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -463,4 +463,12 @@
   XCTAssertEqual(self.drawerViewController.maskLayer.minimumCornerRadius, 3.f);
 }
 
+- (void)testBottomDrawerScrollingEnabled {
+  // When
+  self.drawerViewController.trackingScrollView = self.fakeScrollView;
+
+  // Then
+  XCTAssertEqual(self.fakeScrollView.scrollEnabled, NO);
+}
+
 @end


### PR DESCRIPTION
**Context:**
Some clients were not aware that their content's scroll view needs to be disabled so the content will not start scrolling while dragging the drawer.

**The Problem:**
Clients need to explicitly set their tracking scroll view scrolling to disabled manually.

**The Fix:**
If a tracking scroll view is provided, set the scrolling to disabled automatically and therefore cause less client confusion

**Testing:**
Unit Test + Tested on an iPhone X on all examples.