### PR TITLE
[BottomAppBar] Fix path animation

### DIFF
--- a/components/BottomAppBar/BUILD
+++ b/components/BottomAppBar/BUILD
@@ -69,6 +69,7 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
         "XCTest",
+        "CoreGraphics",
     ],
     deps = [
         ":BottomAppBar",

--- a/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
+++ b/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
@@ -48,7 +48,6 @@
   CGFloat halfAngle = acosf((float)((navigationBarYOffset - floatingButton.center.y) / arcRadius));
   CGFloat startAngle = (float)M_PI / 2.0f + halfAngle;
   CGFloat endAngle = (float)M_PI / 2.0f - halfAngle;
-  CGFloat halfOfHypotenuseLength = sinf((float)halfAngle) * arcRadius;
 
   CGFloat width = CGRectGetWidth(rect);
   CGFloat height = CGRectGetHeight(rect);
@@ -68,7 +67,7 @@
                       width:width
                      height:height
                   arcCenter:floatingButton.center
-           hypotenuseLength:halfOfHypotenuseLength * 2];
+                  arcRadius:arcRadius];
   }
 
   return bottomBarPath.CGPath;
@@ -102,12 +101,12 @@
                               width:(CGFloat)width
                              height:(CGFloat)height
                           arcCenter:(CGPoint)arcCenter
-                   hypotenuseLength:(CGFloat)hypotenuseLength {
-  CGFloat halfOfHypotenuseLength = hypotenuseLength / 2;
+                          arcRadius:(CGFloat)arcRadius {
   [bottomBarPath moveToPoint:CGPointMake(0, yOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x - halfOfHypotenuseLength, yOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x - arcRadius, yOffset)];
   [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x, yOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x + halfOfHypotenuseLength, yOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x + arcRadius, yOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x + arcRadius, yOffset)];
   [bottomBarPath addLineToPoint:CGPointMake(width, yOffset)];
   [bottomBarPath addLineToPoint:CGPointMake(width, height * 2 + yOffset)];
   [bottomBarPath addLineToPoint:CGPointMake(0, height * 2 + yOffset)];

--- a/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
+++ b/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
@@ -17,6 +17,16 @@
 #import "MaterialMath.h"
 #import "MDCBottomAppBarAttributes.h"
 
+@interface MDCBottomAppBarLayer (PathGenerators)
+- (UIBezierPath *)drawWithPathToCut:(UIBezierPath *)bottomBarPath yOffset:(CGFloat)yOffset
+                              width:(CGFloat)width height:(CGFloat)height
+                          arcCenter:(CGPoint)arcCenter arcRadius:(CGFloat)arcRadius
+                         startAngle:(CGFloat)startAngle endAngle:(CGFloat)endAngle;
+- (UIBezierPath *)drawWithPlainPath:(UIBezierPath *)bottomBarPath yOffset:(CGFloat)yOffset
+                              width:(CGFloat)width height:(CGFloat)height
+                          arcCenter:(CGPoint)arcCenter arcRadius:(CGFloat)arcRadius;
+@end
+
 @implementation MDCBottomAppBarLayer
 
 + (instancetype)layer {
@@ -106,6 +116,7 @@
   [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x - arcRadius, yOffset)];
   [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x, yOffset)];
   [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x + arcRadius, yOffset)];
+  // The extra line is needed to have the same number of control points in boths paths.
   [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x + arcRadius, yOffset)];
   [bottomBarPath addLineToPoint:CGPointMake(width, yOffset)];
   [bottomBarPath addLineToPoint:CGPointMake(width, height * 2 + yOffset)];

--- a/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
+++ b/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
@@ -18,13 +18,20 @@
 #import "MDCBottomAppBarAttributes.h"
 
 @interface MDCBottomAppBarLayer (PathGenerators)
-- (UIBezierPath *)drawWithPathToCut:(UIBezierPath *)bottomBarPath yOffset:(CGFloat)yOffset
-                              width:(CGFloat)width height:(CGFloat)height
-                          arcCenter:(CGPoint)arcCenter arcRadius:(CGFloat)arcRadius
-                         startAngle:(CGFloat)startAngle endAngle:(CGFloat)endAngle;
-- (UIBezierPath *)drawWithPlainPath:(UIBezierPath *)bottomBarPath yOffset:(CGFloat)yOffset
-                              width:(CGFloat)width height:(CGFloat)height
-                          arcCenter:(CGPoint)arcCenter arcRadius:(CGFloat)arcRadius;
+- (UIBezierPath *)drawWithPathToCut:(UIBezierPath *)bottomBarPath
+                            yOffset:(CGFloat)yOffset
+                              width:(CGFloat)width
+                             height:(CGFloat)height
+                          arcCenter:(CGPoint)arcCenter
+                          arcRadius:(CGFloat)arcRadius
+                         startAngle:(CGFloat)startAngle
+                           endAngle:(CGFloat)endAngle;
+- (UIBezierPath *)drawWithPlainPath:(UIBezierPath *)bottomBarPath
+                            yOffset:(CGFloat)yOffset
+                              width:(CGFloat)width
+                             height:(CGFloat)height
+                          arcCenter:(CGPoint)arcCenter
+                          arcRadius:(CGFloat)arcRadius;
 @end
 
 @implementation MDCBottomAppBarLayer

--- a/components/BottomAppBar/tests/unit/BottomAppBarTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarTests.m
@@ -117,8 +117,8 @@
                                           height:fakeHeight
                                        arcCenter:fakeCenter
                                        arcRadius:fakeArcRadius
-                                      startAngle:M_PI
-                                        endAngle:M_PI_2];
+                                      startAngle:(CGFloat)M_PI
+                                        endAngle:(CGFloat)gM_PI_2];
   fakeFromPath = [bottomAppLayer drawWithPlainPath:fakeFromPath
                                            yOffset:fakeYOffset
                                              width:fakeWidth

--- a/components/BottomAppBar/tests/unit/BottomAppBarTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarTests.m
@@ -132,6 +132,7 @@
 
 - (int)numberOfPointsInPath:(UIBezierPath *)bezierPath {
   __block int numberOfPoints = 0;
+  if (@available(iOS 11.0, *)) {
   CGPathApplyWithBlock(bezierPath.CGPath, ^(const CGPathElement *_Nonnull element) {
     switch (element->type) {
       case kCGPathElementMoveToPoint:
@@ -153,6 +154,9 @@
     }
   });
   return numberOfPoints;
+  } else {
+    return numberOfPoints;
+  }
 }
 
 @end

--- a/components/BottomAppBar/tests/unit/BottomAppBarTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarTests.m
@@ -14,20 +14,27 @@
 
 #import "MaterialBottomAppBar.h"
 
-#import <XCTest/XCTest.h>
 #import <CoreGraphics/CoreGraphics.h>
+#import <XCTest/XCTest.h>
 
-#import "MaterialNavigationBar.h"
 #import "../../src/private/MDCBottomAppBarLayer.h"
+#import "MaterialNavigationBar.h"
 
 @interface MDCBottomAppBarLayer (Testing)
-- (UIBezierPath *)drawWithPathToCut:(UIBezierPath *)bottomBarPath yOffset:(CGFloat)yOffset
-                              width:(CGFloat)width height:(CGFloat)height
-                          arcCenter:(CGPoint)arcCenter arcRadius:(CGFloat)arcRadius
-                         startAngle:(CGFloat)startAngle endAngle:(CGFloat)endAngle;
-- (UIBezierPath *)drawWithPlainPath:(UIBezierPath *)bottomBarPath yOffset:(CGFloat)yOffset
-                              width:(CGFloat)width height:(CGFloat)height
-                          arcCenter:(CGPoint)arcCenter arcRadius:(CGFloat)arcRadius;
+- (UIBezierPath *)drawWithPathToCut:(UIBezierPath *)bottomBarPath
+                            yOffset:(CGFloat)yOffset
+                              width:(CGFloat)width
+                             height:(CGFloat)height
+                          arcCenter:(CGPoint)arcCenter
+                          arcRadius:(CGFloat)arcRadius
+                         startAngle:(CGFloat)startAngle
+                           endAngle:(CGFloat)endAngle;
+- (UIBezierPath *)drawWithPlainPath:(UIBezierPath *)bottomBarPath
+                            yOffset:(CGFloat)yOffset
+                              width:(CGFloat)width
+                             height:(CGFloat)height
+                          arcCenter:(CGPoint)arcCenter
+                          arcRadius:(CGFloat)arcRadius;
 @end
 
 @interface MDCBottomAppBarView (Testing)
@@ -104,11 +111,17 @@
   CGPoint fakeCenter = CGPointMake(207, 38);
 
   // When
-  fakeToPath = [bottomAppLayer drawWithPathToCut:fakeToPath yOffset:fakeYOffset width:fakeWidth
+  fakeToPath = [bottomAppLayer drawWithPathToCut:fakeToPath
+                                         yOffset:fakeYOffset
+                                           width:fakeWidth
                                           height:fakeHeight
                                        arcCenter:fakeCenter
-                                       arcRadius:fakeArcRadius startAngle:M_PI endAngle:M_PI_2];
-  fakeFromPath = [bottomAppLayer drawWithPlainPath:fakeFromPath yOffset:fakeYOffset width:fakeWidth
+                                       arcRadius:fakeArcRadius
+                                      startAngle:M_PI
+                                        endAngle:M_PI_2];
+  fakeFromPath = [bottomAppLayer drawWithPlainPath:fakeFromPath
+                                           yOffset:fakeYOffset
+                                             width:fakeWidth
                                             height:fakeHeight
                                          arcCenter:fakeCenter
                                          arcRadius:fakeArcRadius];
@@ -119,7 +132,7 @@
 
 - (int)numberOfPointsInPath:(UIBezierPath *)bezierPath {
   __block int numberOfPoints = 0;
-  CGPathApplyWithBlock(bezierPath.CGPath, ^(const CGPathElement * _Nonnull element) {
+  CGPathApplyWithBlock(bezierPath.CGPath, ^(const CGPathElement *_Nonnull element) {
     switch (element->type) {
       case kCGPathElementMoveToPoint:
         numberOfPoints = numberOfPoints + 1;

--- a/components/BottomAppBar/tests/unit/BottomAppBarTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarTests.m
@@ -133,27 +133,27 @@
 - (int)numberOfPointsInPath:(UIBezierPath *)bezierPath {
   __block int numberOfPoints = 0;
   if (@available(iOS 11.0, *)) {
-  CGPathApplyWithBlock(bezierPath.CGPath, ^(const CGPathElement *_Nonnull element) {
-    switch (element->type) {
-      case kCGPathElementMoveToPoint:
-        numberOfPoints = numberOfPoints + 1;
-        break;
-      case kCGPathElementAddLineToPoint:
-        numberOfPoints = numberOfPoints + 1;
-        break;
-      case kCGPathElementAddCurveToPoint:
-        numberOfPoints = numberOfPoints + 3;
-        break;
-      case kCGPathElementAddQuadCurveToPoint:
-        numberOfPoints = numberOfPoints + 2;
-        break;
-      case kCGPathElementCloseSubpath:
-        break;
-      default:
-        break;
-    }
-  });
-  return numberOfPoints;
+    CGPathApplyWithBlock(bezierPath.CGPath, ^(const CGPathElement *_Nonnull element) {
+      switch (element->type) {
+        case kCGPathElementMoveToPoint:
+          numberOfPoints = numberOfPoints + 1;
+          break;
+        case kCGPathElementAddLineToPoint:
+          numberOfPoints = numberOfPoints + 1;
+          break;
+        case kCGPathElementAddCurveToPoint:
+          numberOfPoints = numberOfPoints + 3;
+          break;
+        case kCGPathElementAddQuadCurveToPoint:
+          numberOfPoints = numberOfPoints + 2;
+          break;
+        case kCGPathElementCloseSubpath:
+          break;
+        default:
+          break;
+      }
+    });
+    return numberOfPoints;
   } else {
     return numberOfPoints;
   }

--- a/components/BottomAppBar/tests/unit/BottomAppBarTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarTests.m
@@ -118,7 +118,7 @@
                                        arcCenter:fakeCenter
                                        arcRadius:fakeArcRadius
                                       startAngle:(CGFloat)M_PI
-                                        endAngle:(CGFloat)gM_PI_2];
+                                        endAngle:(CGFloat)M_PI_2];
   fakeFromPath = [bottomAppLayer drawWithPlainPath:fakeFromPath
                                            yOffset:fakeYOffset
                                              width:fakeWidth


### PR DESCRIPTION
### Context
As of #5155 our animation didn't have an equal number of points in the bezierPath when there was or wasn't a FAB. When doing an animation between two `CGPath`s the points need to be the same in order to animate correctly.
### The problem
There were not an equal number of points between both paths so the animation didn't know how to map the values in each path to each other.
### The fix
Update the path to render correctly by adding a point to the `withoutCut` function.
### Related bug
#5603 
### Videos
| Before | After |
| - | - |
|![before](https://user-images.githubusercontent.com/7131294/48082558-f4183e00-e1c0-11e8-9439-ff8bcd9337ff.gif)|![after](https://user-images.githubusercontent.com/7131294/48082568-f9758880-e1c0-11e8-925b-c663c20f4865.gif)|

**_note_** Example Code snippet

```objc
// In MDCBottomAppBarAttributes.h
kMDCFloatingButtonExitDuration = 2.180
kMDCFloatingButtonEnterDuration = 2.270

// In example file
[bottomAppBar.floatingButton removeFromSuperview];
// toggle between
BOOL animate = true
[bottomAppBar setFloatingButtonHidden:animate animated:YES];
animate = !animate
```

