### PR TITLE
[AppBar] Annotate APIs that need to be deprecated.

### DIFF
--- a/components/AppBar/src/ColorThemer/MDCAppBarColorThemer.h
+++ b/components/AppBar/src/ColorThemer/MDCAppBarColorThemer.h
@@ -44,6 +44,22 @@
 + (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                     toAppBarViewController:(nonnull MDCAppBarViewController *)appBarViewController;
 
+@end
+
+@interface MDCAppBarColorThemer (ToBeDeprecated)
+
+/**
+ Applies a color scheme's properties to an MDCAppBar.
+
+ @warning This method will soon be deprecated. Consider using @c +applySemanticColorScheme:toAppBar:
+ instead. Learn more at components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
+
+ @param colorScheme The color scheme to apply to the component instance.
+ @param appBar A component instance to which the color scheme should be applied.
+ */
++ (void)applyColorScheme:(nonnull id<MDCColorScheme>)colorScheme
+                toAppBar:(nonnull MDCAppBar *)appBar;
+
 /**
  Applies a color scheme's properties to an MDCAppBar using the primary mapping.
 
@@ -65,21 +81,5 @@
  */
 + (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                                   toAppBar:(nonnull MDCAppBar *)appBar;
-
-@end
-
-@interface MDCAppBarColorThemer (ToBeDeprecated)
-
-/**
- Applies a color scheme's properties to an MDCAppBar.
-
- @warning This method will soon be deprecated. Consider using @c +applySemanticColorScheme:toAppBar:
- instead. Learn more at components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
-
- @param colorScheme The color scheme to apply to the component instance.
- @param appBar A component instance to which the color scheme should be applied.
- */
-+ (void)applyColorScheme:(nonnull id<MDCColorScheme>)colorScheme
-                toAppBar:(nonnull MDCAppBar *)appBar;
 
 @end

--- a/components/AppBar/src/TypographyThemer/MDCAppBarTypographyThemer.h
+++ b/components/AppBar/src/TypographyThemer/MDCAppBarTypographyThemer.h
@@ -29,7 +29,9 @@
 + (void)applyTypographyScheme:(nonnull id<MDCTypographyScheming>)typographyScheme
        toAppBarViewController:(nonnull MDCAppBarViewController *)appBarViewController;
 
-#pragma mark - To be deprecated
+@end
+
+@interface MDCAppBarTypographyThemer (ToBeDeprecated)
 
 /**
  Applies a typography scheme's properties to an MDCAppBar.


### PR DESCRIPTION
Several APIs in the AppBar component are intended to be deprecated but were not annotated as such. They have now been annotated as to-be-deprecated.