### PR TITLE
[Tabs] Add a best-effort justification alignment setting for MDCTabBar.

### DIFF
--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -78,6 +78,9 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
     case MDCTabBarAlignmentJustified:
       return MDCItemBarAlignmentJustified;
 
+    case MDCTabBarAlignmentBestEffortJustified:
+      return MDCItemBarAlignmentBestEffortJustified;
+
     case MDCTabBarAlignmentCenterSelected:
       return MDCItemBarAlignmentCenterSelected;
   }

--- a/components/Tabs/src/MDCTabBarAlignment.h
+++ b/components/Tabs/src/MDCTabBarAlignment.h
@@ -26,6 +26,13 @@ typedef NS_ENUM(NSInteger, MDCTabBarAlignment) {
   MDCTabBarAlignmentJustified,
 
   /**
+   * If the tabs can be nicely justified, in an equal size across the width of the screen, then they
+   * will layout as if `MDCTabBarAlignmentJustified` were set. However if the tabs are too wide to
+   * be nicely justified, then the tabs fall back to using a `MDCTabBarAlignmentLeading` layout.
+   */
+  MDCTabBarAlignmentBestEffortJustified,
+
+  /**
    Items are sized to fit their content and center-aligned as a group. If they do not fit in view,
    they will be leading-aligned instead.
    */

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -76,6 +76,10 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 
   /// Current style properties.
   MDCItemBarStyle *_style;
+
+  /// The current alignment to use for item bar. This may vary from `_alignment` in cases where
+  /// the actual alignment is determined on-the-fly.
+  MDCItemBarAlignment _currentAlignment;
 }
 
 + (CGFloat)defaultHeightForStyle:(nonnull MDCItemBarStyle *)style {
@@ -278,7 +282,7 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   // Update collection metrics if the size has changed.
   if (!CGSizeEqualToSize(bounds.size, _lastSize) ||
       [self adjustedCollectionViewWidth] != _lastAdjustedCollectionViewWidth) {
-    [self updateFlowLayoutMetrics];
+    [self updateAlignmentAnimated:NO];
 
     // Ensure selected item is aligned properly on resize, forcing the new layout to take effect.
     [_collectionView layoutIfNeeded];
@@ -312,14 +316,14 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   [super didMoveToWindow];
 
   // New window: Update for potentially updated size class.
-  [self updateFlowLayoutMetrics];
+  [self updateAlignmentAnimated:NO];
 }
 
 - (void)traitCollectionDidChange:(nullable UITraitCollection *)previousTraitCollection {
   [super traitCollectionDidChange:previousTraitCollection];
 
-  // Update metrics for potentially updated size class.
-  [self updateFlowLayoutMetrics];
+  // Update alignment and layout metrics for potentially updated size class.
+  [self updateAlignmentAnimated:NO];
 }
 
 - (void)tintColorDidChange {
@@ -407,7 +411,7 @@ static void *kItemPropertyContext = &kItemPropertyContext;
                                 style:_style];
 
   // Divide justified items evenly across the view.
-  if (_alignment == MDCItemBarAlignmentJustified) {
+  if (_currentAlignment == MDCItemBarAlignmentJustified) {
     NSInteger count = [self collectionView:_collectionView numberOfItemsInSection:0];
     size.width = [self adjustedCollectionViewWidth] / MAX(count, 1);
   }
@@ -507,7 +511,7 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 
 - (void)reload {
   [_collectionView reloadData];
-  [self updateFlowLayoutMetrics];
+  [self updateAlignmentAnimated:NO];
 }
 
 - (UICollectionViewFlowLayout *)generatedFlowLayout {
@@ -549,8 +553,34 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 }
 
 - (void)updateAlignmentAnimated:(BOOL)animated {
+  [self updateCurrentAlignment];
   [self updateScrollProperties];
   [self updateFlowLayoutMetricsAnimated:animated];
+}
+
+- (void)updateCurrentAlignment {
+  if (_alignment != MDCItemBarAlignmentBestEffortJustified) {
+    _currentAlignment = _alignment;
+    return;
+  }
+
+  // Calculate the "best" alignment for MDCItemBarAlignmentBestEffortJustified. Begin with
+  // Justified alignment, but calculate to see if Leading alignment would be a better fit.
+  _currentAlignment = MDCItemBarAlignmentJustified;
+  const CGFloat widthPerJustifiedItem = [self adjustedCollectionViewWidth] / MAX(_items.count, 1ul);
+  CGSize size = CGSizeMake(CGFLOAT_MAX, self.bounds.size.height);
+  for (UITabBarItem *item in _items) {
+    const CGSize itemSize = [MDCItemBarCell sizeThatFits:size
+                                     horizontalSizeClass:[self horizontalSizeClass]
+                                                    item:item
+                                                   style:_style];
+    const CGFloat itemWidth = itemSize.width;
+    // If any item cannot fit nicely in its portion of the width, fallback to Leading alignment.
+    if (itemWidth >= widthPerJustifiedItem) {
+      _currentAlignment = MDCItemBarAlignmentLeading;
+      break;
+    }
+  }
 }
 
 /// Sets _selectionIndicator's bounds and center to display under the item at the given index with
@@ -619,15 +649,14 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 }
 
 - (void)updateScrollProperties {
-  _collectionView.alwaysBounceHorizontal = (_alignment != MDCItemBarAlignmentJustified);
+  _collectionView.alwaysBounceHorizontal = (_currentAlignment != MDCItemBarAlignmentJustified);
 }
 
 - (void)updateFlowLayoutMetrics {
-
   UIUserInterfaceSizeClass horizontalSizeClass = [self horizontalSizeClass];
 
   UIEdgeInsets newSectionInset = UIEdgeInsetsZero;
-  switch (_alignment) {
+  switch (_currentAlignment) {
     case MDCItemBarAlignmentLeading:
       newSectionInset = [self leadingAlignedInsetsForHorizontalSizeClass:horizontalSizeClass];
       break;
@@ -639,6 +668,10 @@ static void *kItemPropertyContext = &kItemPropertyContext;
       break;
     case MDCItemBarAlignmentCenterSelected:
       newSectionInset = [self centerSelectedInsets];
+      break;
+    case MDCItemBarAlignmentBestEffortJustified:
+      // This case should never be possible, since the _currentAlignment will never be set to
+      // this value.
       break;
   }
 

--- a/components/Tabs/src/private/MDCItemBarAlignment.h
+++ b/components/Tabs/src/private/MDCItemBarAlignment.h
@@ -23,6 +23,14 @@ typedef NS_ENUM(NSInteger, MDCItemBarAlignment) {
   MDCItemBarAlignmentJustified,
 
   /**
+   * If the item bar items can be nicely justified, in an equal size across the width of the screen,
+   * then they will layout as if `MDCItemBarAlignmentJustified` were set. However if the tabs are
+   * too wide to be nicely justified, then the item bar items fall back to using a
+   * `MDCItemBarAlignmentLeading` layout.
+   */
+  MDCItemBarAlignmentBestEffortJustified,
+
+  /**
    * Items are sized to fit their content and center-aligned as a group. If they do not fit in view,
    * they will be leading-aligned instead.
    */


### PR DESCRIPTION
This new alignment will use the Justified alignment, whenever the tabs
are small enough to fit evenly within the width of the view. And if
that's not the case, then it falls back to using Leading alignment.

Example of Justification: https://i.imgur.com/ifC4VW6.png
Example of Leading: https://i.imgur.com/stc42ds.png
Example of Leading->Justification during rotation: https://i.imgur.com/M84r8YZ.png

### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [x] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [ ] Link to GitHub issues it solves. ```closes #1234```
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
pull request.
