### PR TITLE
[PageControl] Add respectsUserInterfaceLayoutDirection to MDCPageControl

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -894,6 +894,7 @@ Pod::Spec.new do |mdc|
     component.public_header_files = "components/#{component.base_name}/src/*.h"
     component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
     component.resources = ["components/#{component.base_name}/src/Material#{component.base_name}.bundle"]
+    component.dependency "MDFInternationalization"
 
     component.test_spec 'tests' do |tests|
       tests.test_spec 'unit' do |unit_tests|

--- a/components/PageControl/BUILD
+++ b/components/PageControl/BUILD
@@ -28,6 +28,9 @@ mdc_public_objc_library(
         "CoreGraphics",
         "UIKit",
     ],
+    deps = [
+        "@material_internationalization_ios//:MDFInternationalization",
+    ],
 )
 
 filegroup(

--- a/components/PageControl/examples/PageControlTypicalUseExample.m
+++ b/components/PageControl/examples/PageControlTypicalUseExample.m
@@ -58,7 +58,7 @@
     CGFloat xOffset = [self xOffsetForPage:i numberOfPages:pageColors.count width:boundsWidth];
     CGRect pageFrame = CGRectOffset(self.view.bounds, xOffset, 0);
     UILabel *page = [[UILabel alloc] initWithFrame:pageFrame];
-    CGFloat offsetMultiplier = [self isRTL] ? pageColors.count - i - 1 : i;
+    CGFloat offsetMultiplier = [self offsetMultiplierForPage:i numberOfPages:pageColors.count];
     page.text = [NSString stringWithFormat:@"Page %lu", (unsigned long)offsetMultiplier + 1];
     page.font = [UIFont systemFontOfSize:50];
     page.textColor = [UIColor colorWithWhite:0 alpha:(CGFloat)0.8];
@@ -168,8 +168,11 @@
 - (CGFloat)xOffsetForPage:(NSInteger)page
             numberOfPages:(NSInteger)numberOfPages
                     width:(CGFloat)width {
-  CGFloat offsetMultiplier = [self isRTL] ? numberOfPages - page - 1 : page;
-  return offsetMultiplier * width;
+  return [self offsetMultiplierForPage:page numberOfPages:numberOfPages] * width;
+}
+
+- (CGFloat)offsetMultiplierForPage:(NSInteger)page numberOfPages:(NSInteger)numberOfPages {
+  return [self isRTL] ? numberOfPages - page - 1 : page;
 }
 
 - (BOOL)isRTL {

--- a/components/PageControl/examples/PageControlTypicalUseExample.m
+++ b/components/PageControl/examples/PageControlTypicalUseExample.m
@@ -55,9 +55,10 @@
 
   // Add pages to scrollView.
   for (NSUInteger i = 0; i < pageColors.count; i++) {
-    CGFloat offsetMultiplier = [self offsetMultiplierForPage:i numberOfPages:pageColors.count];
-    CGRect pageFrame = CGRectOffset(self.view.bounds, offsetMultiplier * boundsWidth, 0);
+    CGFloat xOffset = [self xOffsetForPage:i numberOfPages:pageColors.count width:boundsWidth];
+    CGRect pageFrame = CGRectOffset(self.view.bounds, xOffset, 0);
     UILabel *page = [[UILabel alloc] initWithFrame:pageFrame];
+    CGFloat offsetMultiplier = [self isRTL] ? pageColors.count - i - 1 : i;
     page.text = [NSString stringWithFormat:@"Page %lu", (unsigned long)offsetMultiplier + 1];
     page.font = [UIFont systemFontOfSize:50];
     page.textColor = [UIColor colorWithWhite:0 alpha:(CGFloat)0.8];
@@ -98,16 +99,18 @@
   CGRect standardizedFrame = CGRectStandardize(self.view.frame);
   for (NSInteger i = 0; i < pageCount; i++) {
     UILabel *page = _pages[i];
-    CGFloat offsetMultiplier = [self offsetMultiplierForPage:i numberOfPages:pageCount];
-    page.frame =
-        CGRectOffset(self.view.bounds, offsetMultiplier * CGRectGetWidth(standardizedFrame), 0);
+    CGFloat xOffset = [self xOffsetForPage:i
+                             numberOfPages:pageCount
+                                     width:CGRectGetWidth(standardizedFrame)];
+    page.frame = CGRectOffset(self.view.bounds, xOffset, 0);
   }
   _scrollView.contentSize =
       CGSizeMake(CGRectGetWidth(standardizedFrame) * pageCount, CGRectGetHeight(standardizedFrame));
   CGPoint offset = _scrollView.contentOffset;
-  CGFloat offsetMultiplier = [self offsetMultiplierForPage:pageBeforeFrameChange
-                                             numberOfPages:pageCount];
-  offset.x = offsetMultiplier * CGRectGetWidth(standardizedFrame);
+  CGFloat xOffset = [self xOffsetForPage:pageBeforeFrameChange
+                           numberOfPages:pageCount
+                                   width:CGRectGetWidth(standardizedFrame)];
+  offset.x = xOffset;
   // This non-anmiated change of offset ensures we keep the same page
   [_scrollView setContentOffset:offset animated:NO];
   _scrollView.frame = self.view.bounds;
@@ -145,8 +148,8 @@
   NSInteger page = sender.currentPage;
   CGFloat pageWidth = CGRectGetWidth(_scrollView.bounds);
   CGPoint offset = _scrollView.contentOffset;
-  CGFloat offsetMultiplier = [self offsetMultiplierForPage:page numberOfPages:_pages.count];
-  offset.x = offsetMultiplier * pageWidth;
+  CGFloat xOffset = [self xOffsetForPage:page numberOfPages:_pages.count width:pageWidth];
+  offset.x = xOffset;
   [_scrollView setContentOffset:offset animated:YES];
 }
 
@@ -162,8 +165,11 @@
   };
 }
 
-- (CGFloat)offsetMultiplierForPage:(NSInteger)page numberOfPages:(NSInteger)numberOfPages {
-  return [self isRTL] ? numberOfPages - page - 1 : page;
+- (CGFloat)xOffsetForPage:(NSInteger)page
+            numberOfPages:(NSInteger)numberOfPages
+                    width:(CGFloat)width {
+  CGFloat offsetMultiplier = [self isRTL] ? numberOfPages - page - 1 : page;
+  return offsetMultiplier * width;
 }
 
 - (BOOL)isRTL {

--- a/components/PageControl/src/MDCPageControl.h
+++ b/components/PageControl/src/MDCPageControl.h
@@ -98,6 +98,18 @@
 @property(nonatomic) BOOL defersCurrentPageDisplay;
 
 /**
+ When this value is set to YES, the indicators will ascend from right to left in an RTL environment.
+
+ @note In general, the MDCPageControl's UIScrollViewDelegate forwarding methods make assumptions
+ about the originating scrollview's page number based off its contentOffset. When this property is
+ set to YES in an RTL environment, a leftmost content offset will be considered the last page in the
+ scrollview, as opposed to the first.
+
+ The default value is NO.
+ */
+@property(nonatomic) BOOL respectsUserInterfaceLayoutDirection;
+
+/**
  Updates the page indicator to the current page.
 
  This method is ignored if defersCurrentPageDisplay is NO.

--- a/components/PageControl/src/MDCPageControl.m
+++ b/components/PageControl/src/MDCPageControl.m
@@ -14,6 +14,8 @@
 
 #import "MDCPageControl.h"
 
+#import <MDFInternationalization/MDFInternationalization.h>
+
 #import "private/MDCPageControlIndicator.h"
 #import "private/MDCPageControlTrackLayer.h"
 #import "private/MaterialPageControlStrings.h"
@@ -56,8 +58,8 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
 
 @implementation MDCPageControl {
   UIView *_containerView;
-  NSMutableArray<MDCPageControlIndicator *> *_indicators;
-  NSMutableArray<NSValue *> *_indicatorPositions;
+  NSMutableDictionary<NSNumber *, MDCPageControlIndicator *> *_indicators;
+  NSMutableDictionary<NSNumber *, NSValue *> *_indicatorPositions;
   MDCPageControlIndicator *_animatedIndicator;
   MDCPageControlTrackLayer *_trackLayer;
   CGFloat _trackLength;
@@ -111,22 +113,16 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
     return;
   }
   self.hidden = NO;
-  for (MDCPageControlIndicator *indicator in _indicators) {
-    NSInteger indicatorIndex = [_indicators indexOfObject:indicator];
-    if (indicatorIndex == _currentPage) {
+
+  for (NSNumber *pageNumber in [_indicators allKeys]) {
+    MDCPageControlIndicator *indicator = _indicators[pageNumber];
+    if (pageNumber.integerValue == _currentPage) {
       indicator.hidden = YES;
     }
     indicator.color = _pageIndicatorTintColor;
   }
   _animatedIndicator.color = _currentPageIndicatorTintColor;
   _trackLayer.trackColor = _pageIndicatorTintColor;
-
-  // TODO(cjcox): Add back in RTL once we get the view category ready.
-  // This view must be mirrored by flipping instead of relayout, because we want to mirror
-  // the view itself, not its subviews.
-  //  if ([self class] == [MDCPageControl class]) {
-  //    [self mdc_flipViewForRTL];
-  //  }
 }
 
 - (void)setNumberOfPages:(NSInteger)numberOfPages {
@@ -156,11 +152,11 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
 
   if (animated) {
     // Draw and extend track.
-    CGPoint startPoint = [_indicatorPositions[previousPage] CGPointValue];
-    CGPoint endPoint = [_indicatorPositions[currentPage] CGPointValue];
+    CGPoint startPoint = [_indicatorPositions[@(previousPage)] CGPointValue];
+    CGPoint endPoint = [_indicatorPositions[@(currentPage)] CGPointValue];
     if (shouldReverse) {
-      startPoint = [_indicatorPositions[currentPage] CGPointValue];
-      endPoint = [_indicatorPositions[previousPage] CGPointValue];
+      startPoint = [_indicatorPositions[@(currentPage)] CGPointValue];
+      endPoint = [_indicatorPositions[@(previousPage)] CGPointValue];
     }
 
     // Remove track and reveal hidden indicators staggered towards current page indicator. Reveal
@@ -187,13 +183,13 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
                                        completion:completionBlock];
   } else {
     // If not animated, simply move indicator to new position and reset track.
-    CGPoint point = [_indicatorPositions[currentPage] CGPointValue];
+    CGPoint point = [_indicatorPositions[@(currentPage)] CGPointValue];
     [_animatedIndicator updateIndicatorTransformX:point.x - kPageControlIndicatorRadius];
     [_trackLayer resetAtPoint:point];
 
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
-    [_indicators[previousPage] setHidden:NO];
+    [_indicators[@(previousPage)] setHidden:NO];
     [CATransaction commit];
   }
 }
@@ -237,9 +233,13 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
 #pragma mark - Scrolling
 
 - (NSInteger)scrolledPageNumber:(UIScrollView *)scrollView {
-  // Returns paged index of scrollView.
-  NSInteger unboundedPageNumber = lround(scrollView.contentOffset.x / scrollView.frame.size.width);
-  return MAX(0, MIN(_numberOfPages - 1, unboundedPageNumber));
+  NSInteger unboundedPageNumberLTR =
+      lround(scrollView.contentOffset.x / scrollView.frame.size.width);
+  NSInteger scrolledPageNumberLTR = MAX(0, MIN(_numberOfPages - 1, unboundedPageNumberLTR));
+  if ([self isRTL]) {
+    return self.numberOfPages - 1 - scrolledPageNumberLTR;
+  }
+  return scrolledPageNumberLTR;
 }
 
 - (CGFloat)scrolledPercentage:(UIScrollView *)scrollView {
@@ -283,13 +283,21 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
 
     // Determine endpoints for drawing track depending on direction scrolled.
     NSInteger scrolledPageNumber = [self scrolledPageNumber:scrollView];
-    CGPoint startPoint = [_indicatorPositions[scrolledPageNumber] CGPointValue];
+    CGPoint startPoint = [_indicatorPositions[@(scrolledPageNumber)] CGPointValue];
     CGPoint endPoint = startPoint;
     CGFloat radius = kPageControlIndicatorRadius;
     if (transformX > startPoint.x - radius) {
-      endPoint = [_indicatorPositions[scrolledPageNumber + 1] CGPointValue];
+      if ([self isRTL]) {
+        endPoint = [_indicatorPositions[@(scrolledPageNumber - 1)] CGPointValue];
+      } else {
+        endPoint = [_indicatorPositions[@(scrolledPageNumber + 1)] CGPointValue];
+      }
     } else if (transformX < startPoint.x - radius) {
-      startPoint = [_indicatorPositions[scrolledPageNumber - 1] CGPointValue];
+      if ([self isRTL]) {
+        startPoint = [_indicatorPositions[@(scrolledPageNumber + 1)] CGPointValue];
+      } else {
+        startPoint = [_indicatorPositions[@(scrolledPageNumber - 1)] CGPointValue];
+      }
     }
 
     if (scrollView.isDragging) {
@@ -303,7 +311,7 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
 
     // Hide indicators to be shown with animated reveal once track is removed.
     if (!_isDeferredScrolling) {
-      [_indicators[scrolledPageNumber] setHidden:YES];
+      [_indicators[@(scrolledPageNumber)] setHidden:YES];
     }
   }
 }
@@ -311,7 +319,7 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
   // Remove track towards current active indicator position.
   NSInteger scrolledPageNumber = [self scrolledPageNumber:scrollView];
-  CGPoint point = [_indicatorPositions[scrolledPageNumber] CGPointValue];
+  CGPoint point = [_indicatorPositions[@(scrolledPageNumber)] CGPointValue];
   BOOL shouldReverse = (_currentPage > scrolledPageNumber);
   BOOL sendAction = (_currentPage != scrolledPageNumber);
   _currentPage = scrolledPageNumber;
@@ -344,16 +352,24 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
 
 #pragma mark - Indicators
 
+- (NSInteger)pageForIndicator:(MDCPageControlIndicator *)indicator {
+  for (NSNumber *pageNumber in [_indicators allKeys]) {
+    MDCPageControlIndicator *anIndicator = _indicators[pageNumber];
+    if (anIndicator == indicator) {
+      return pageNumber.integerValue;
+    }
+  }
+  return NSNotFound;
+}
+
 - (void)revealIndicatorsReversed:(BOOL)reversed {
   // Animate hidden indicators staggered with delay.
-  NSArray<MDCPageControlIndicator *> *indicators =
-      reversed ? [[_indicators reverseObjectEnumerator] allObjects] : _indicators;
   NSInteger count = 0;
-  for (MDCPageControlIndicator *indicator in indicators) {
+  for (MDCPageControlIndicator *indicator in [_indicators allValues]) {
     // Determine if this is the current page indicator.
-    NSInteger indicatorIndex = [indicators indexOfObject:indicator];
+    NSInteger indicatorIndex = [self pageForIndicator:indicator];
     if (reversed) {
-      indicatorIndex = [indicators count] - 1 - indicatorIndex;
+      indicatorIndex = [[_indicators allValues] count] - 1 - indicatorIndex;
     }
     BOOL isCurrentPageIndicator = indicatorIndex == _currentPage;
 
@@ -402,7 +418,7 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
     for (int i = 0; i < _numberOfPages; i++) {
-      MDCPageControlIndicator *indicator = _indicators[i];
+      MDCPageControlIndicator *indicator = _indicators[@(i)];
       indicator.hidden = (i == _currentPage) ? YES : NO;
     }
     [CATransaction commit];
@@ -446,6 +462,19 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
   }
 }
 
+#pragma mark - Internationalization
+
+- (BOOL)isRTL {
+  return self.respectsUserInterfaceLayoutDirection &&
+         (self.mdf_effectiveUserInterfaceLayoutDirection ==
+          UIUserInterfaceLayoutDirectionRightToLeft);
+}
+
+- (void)setRespectsUserInterfaceLayoutDirection:(BOOL)respectsUserInterfaceLayoutDirection {
+  _respectsUserInterfaceLayoutDirection = respectsUserInterfaceLayoutDirection;
+  [self resetControl];
+}
+
 #pragma mark - Private
 
 - (void)resetControl {
@@ -455,8 +484,8 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
       [layer removeFromSuperlayer];
     }
   }
-  _indicators = [NSMutableArray arrayWithCapacity:_numberOfPages];
-  _indicatorPositions = [NSMutableArray arrayWithCapacity:_numberOfPages];
+  _indicators = [NSMutableDictionary dictionaryWithCapacity:_numberOfPages];
+  _indicatorPositions = [NSMutableDictionary dictionaryWithCapacity:_numberOfPages];
 
   if (_numberOfPages == 0) {
     [self setNeedsLayout];
@@ -474,8 +503,12 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
         [[MDCPageControlIndicator alloc] initWithCenter:center radius:radius];
     indicator.opacity = kPageControlIndicatorDefaultOpacity;
     [_containerView.layer addSublayer:indicator];
-    [_indicators addObject:indicator];
-    [_indicatorPositions addObject:[NSValue valueWithCGPoint:indicator.position]];
+    NSInteger pageNumber = i;
+    if ([self isRTL]) {
+      pageNumber = _numberOfPages - 1 - i;
+    }
+    _indicators[@(pageNumber)] = indicator;
+    _indicatorPositions[@(pageNumber)] = [NSValue valueWithCGPoint:indicator.position];
   }
 
   // Resize container view to keep indicators centered.
@@ -487,7 +520,7 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
   // Add animated indicator that will travel freely across the container. Its transform will be
   // updated by calling its -updateIndicatorTransformX method.
   CGPoint center = CGPointMake(radius, radius);
-  CGPoint point = [_indicatorPositions[_currentPage] CGPointValue];
+  CGPoint point = [_indicatorPositions[@(_currentPage)] CGPointValue];
   _animatedIndicator = [[MDCPageControlIndicator alloc] initWithCenter:center radius:radius];
   [_animatedIndicator updateIndicatorTransformX:point.x - kPageControlIndicatorRadius];
   [_containerView.layer addSublayer:_animatedIndicator];


### PR DESCRIPTION
### The problem

The MDCPageControl has never respected user interface layout direction.

### The solution

Make the MDCPageControl capable of respecting user interface layout direction through the addition of a `respectsUserInterfaceLayoutDirection` property.

Here is a gif of the new RTL behavior, with `respectsUserInterfaceLayoutDirection` set to `YES`:
![after_rtl_2](https://user-images.githubusercontent.com/8020010/48214767-a7fb0400-e34e-11e8-902a-2585c1d5111f.gif)

Here is a gif of the preexisting LTR behavior, with `respectsUserInterfaceLayoutDirection` set to `NO`:
![after_ltr_2](https://user-images.githubusercontent.com/8020010/48214766-a7fb0400-e34e-11e8-974a-b202f600dbc9.gif)

Note that this PR also updates the PageControl typical use example to use this new API.

Closes #5608.
