### PR TITLE
Update clang-format to r345798

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -443,8 +443,8 @@ lint_clang_format() {
 
     # Install clang-format
     echo "Downloading clang-format..."
-    CLANG_FORMAT_SHA="9d2a3aeaee65f09ae5405dd33812d167fadd48aba712965cdb3238e5d8837255"
-    curl -Ls "https://github.com/material-foundation/clang-format/releases/download/r343360/clang-format" -o "clang-format"
+    CLANG_FORMAT_SHA="7584ce5ff2633d3a38f41cc41906d328d07b0afdda4adb56edb6fef58042d33a"
+    curl -Ls "https://github.com/material-foundation/clang-format/releases/download/r345798/clang-format" -o "clang-format"
     if openssl sha -sha256 "clang-format" | grep -q "$CLANG_FORMAT_SHA"; then
       echo "SHAs match. Proceeding."
     else


### PR DESCRIPTION
This updates our CI clang-format to the latest version being used internally.