### PR TITLE
Bump MotionInterchange to 1.6.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -53,7 +53,7 @@ git_repository(
 git_repository(
     name = "motion_interchange_objc",
     remote = "https://github.com/material-motion/motion-interchange-objc.git",
-    tag = "v1.4.0",
+    tag = "v1.6.0",
 )
 
 git_repository(


### PR DESCRIPTION
Increasing the Bazel version to 1.6.0 to match what Cocoapods has.