### PR TITLE
[Snackbar] Fix for Snackbar themer breaking Snackbar examples on dragons

### DIFF
--- a/components/Snackbar/examples/SnackbarOverlayViewExample.m
+++ b/components/Snackbar/examples/SnackbarOverlayViewExample.m
@@ -32,6 +32,13 @@ static const CGFloat kBottomBarHeight = 44;
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+
+  if (!self.colorScheme) {
+    self.colorScheme = [[MDCSemanticColorScheme alloc] init];
+  }
+  if (!self.typographyScheme) {
+    self.typographyScheme = [[MDCTypographyScheme alloc] init];
+  }
   [self setupExampleViews:@[ @"Show Snackbar", @"Toggle bottom bar" ]];
   self.title = @"Snackbar Overlay View";
 

--- a/components/Snackbar/examples/SnackbarOverlayViewExample.m
+++ b/components/Snackbar/examples/SnackbarOverlayViewExample.m
@@ -34,10 +34,12 @@ static const CGFloat kBottomBarHeight = 44;
   [super viewDidLoad];
 
   if (!self.colorScheme) {
-    self.colorScheme = [[MDCSemanticColorScheme alloc] init];
+    self.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   }
   if (!self.typographyScheme) {
-    self.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
   }
   [self setupExampleViews:@[ @"Show Snackbar", @"Toggle bottom bar" ]];
   self.title = @"Snackbar Overlay View";

--- a/components/Snackbar/examples/SnackbarSimpleExample.m
+++ b/components/Snackbar/examples/SnackbarSimpleExample.m
@@ -25,6 +25,13 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+
+  if (!self.colorScheme) {
+    self.colorScheme = [[MDCSemanticColorScheme alloc] init];
+  }
+  if (!self.typographyScheme) {
+    self.typographyScheme = [[MDCTypographyScheme alloc] init];
+  }
   [self setupExampleViews:@[
       @"Simple Snackbar",
       @"Snackbar with Action Button",

--- a/components/Snackbar/examples/SnackbarSimpleExample.m
+++ b/components/Snackbar/examples/SnackbarSimpleExample.m
@@ -27,10 +27,12 @@
   [super viewDidLoad];
 
   if (!self.colorScheme) {
-    self.colorScheme = [[MDCSemanticColorScheme alloc] init];
+    self.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   }
   if (!self.typographyScheme) {
-    self.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
   }
   [self setupExampleViews:@[
       @"Simple Snackbar",

--- a/components/Snackbar/examples/SnackbarSuspensionExample.m
+++ b/components/Snackbar/examples/SnackbarSuspensionExample.m
@@ -37,6 +37,13 @@ static NSString *const kCategoryB = @"CategoryB";
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+
+  if (!self.colorScheme) {
+    self.colorScheme = [[MDCSemanticColorScheme alloc] init];
+  }
+  if (!self.typographyScheme) {
+    self.typographyScheme = [[MDCTypographyScheme alloc] init];
+  }
   [self setupExampleViews:@[
       @"Show Category A Message",
       @"Show Category B Message",

--- a/components/Snackbar/examples/SnackbarSuspensionExample.m
+++ b/components/Snackbar/examples/SnackbarSuspensionExample.m
@@ -39,10 +39,12 @@ static NSString *const kCategoryB = @"CategoryB";
   [super viewDidLoad];
 
   if (!self.colorScheme) {
-    self.colorScheme = [[MDCSemanticColorScheme alloc] init];
+    self.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   }
   if (!self.typographyScheme) {
-    self.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
   }
   [self setupExampleViews:@[
       @"Show Category A Message",


### PR DESCRIPTION
When the Scheme is nil, the Snackbar gets weird colors and is presented wrong. Because Dragons doesn't receive a scheme, we need to explicitly create a scheme in each of the examples to fix the color for Snackbars.