### PR TITLE
[BottomNavigation] Add elevation property

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialShadowElevations.h"
+
 @protocol MDCBottomNavigationBarDelegate;
 
 /** States used to configure bottom navigation on when to show item titles. */
@@ -139,6 +141,11 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarAlignment) {
  12.
  */
 @property(nonatomic, assign) CGFloat itemsContentHorizontalMargin;
+
+/**
+ The elevation of the bottom navigation bar. Defaults to 8.0.
+ */
+@property(nonatomic, assign) MDCShadowElevation elevation;
 
 /**
  Returns the navigation bar subview associated with the specific item.

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -119,7 +119,7 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
 #else
   _shouldPretendToBeATabBar = YES;
 #endif
-  [self setElevation:MDCShadowElevationBottomNavigationBar];
+  _elevation = MDCShadowElevationBottomNavigationBar;
   _itemViews = [NSMutableArray array];
   _itemTitleFont = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleCaption];
 }
@@ -155,6 +155,7 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
 }
 
 - (void)setElevation:(MDCShadowElevation)elevation {
+  _elevation = elevation;
   [(MDCShadowLayer *)self.layer setElevation:elevation];
 }
 

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -119,7 +119,7 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
 #else
   _shouldPretendToBeATabBar = YES;
 #endif
-  _elevation = MDCShadowElevationBottomNavigationBar;
+  [self setElevation:MDCShadowElevationBottomNavigationBar];
   _itemViews = [NSMutableArray array];
   _itemTitleFont = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleCaption];
 }

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -14,9 +14,9 @@
 
 #import <XCTest/XCTest.h>
 
+#import "../../src/private/MDCBottomNavigationItemView.h"
 #import "MaterialBottomNavigation.h"
 #import "MaterialShadowElevations.h"
-#import "../../src/private/MDCBottomNavigationItemView.h"
 
 @interface MDCBottomNavigationBar (Testing)
 @property(nonatomic, strong) NSMutableArray<MDCBottomNavigationItemView *> *itemViews;

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -15,6 +15,7 @@
 #import <XCTest/XCTest.h>
 
 #import "MaterialBottomNavigation.h"
+#import "MaterialShadowElevations.h"
 #import "../../src/private/MDCBottomNavigationItemView.h"
 
 @interface MDCBottomNavigationBar (Testing)
@@ -161,6 +162,22 @@
   self.bottomNavBar.itemViews.lastObject.selected = NO;
   XCTAssert(!self.bottomNavBar.itemViews.firstObject.label.isHidden);
   XCTAssert(self.bottomNavBar.itemViews.lastObject.label.isHidden);
+}
+
+- (void)testDefaultElevation {
+  // Then
+  XCTAssertEqual(self.bottomNavBar.elevation, MDCShadowElevationBottomNavigationBar);
+}
+
+- (void)testCustomElevation {
+  // Given
+  CGFloat customElevation = 20;
+
+  // When
+  self.bottomNavBar.elevation = customElevation;
+
+  // Then
+  XCTAssertEqual(self.bottomNavBar.elevation, customElevation);
 }
 
 - (void)testViewForItemFound {


### PR DESCRIPTION
### Context
Some clients may want to set a custom elevation for their bottom navigation and we currently don't allow this. This change allows clients to set a custom elevation for their bottom navigation bar if they want to and allows us to theme the component more.
### The problem
We don't allow custom elevations
### The fix
Add a property for custom elevations
### Related bugs
#5730 
### Screenshots
| Before | After |
| - | - | 
|![simulator screen shot - iphone xs max - 2018-11-12 at 10 36 22](https://user-images.githubusercontent.com/7131294/48357654-1ac5f100-e667-11e8-829e-3f669aa4c590.png)|![simulator screen shot - iphone xs max - 2018-11-12 at 10 37 09](https://user-images.githubusercontent.com/7131294/48357662-20bbd200-e667-11e8-8816-f99b976390fb.png)|

*__Example snippet__*
```swift
bottomNavBar.elevation = ShadowElevation(rawValue: 0)
```


