### PR TITLE
[Buttons, TextFields] fix typo in header doc

### DIFF
--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -110,7 +110,7 @@
  UIContentSizeCategory is changed.
 
  This property is modeled after the adjustsFontForContentSizeCategory property in the
- UIConnectSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
+ UIContentSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
 
  If set to YES, this button will base its text font on MDCFontTextStyleButton.
 

--- a/components/TextFields/src/MDCTextInput.h
+++ b/components/TextFields/src/MDCTextInput.h
@@ -124,7 +124,7 @@ typedef NS_ENUM(NSUInteger, MDCTextInputTextInsetsMode) {
  UIContentSizeCategory changes.
 
  This property is modeled after the adjustsFontForContentSizeCategory property in the
- UIConnectSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
+ UIContentSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
 
  Default value is NO.
  */

--- a/components/TextFields/src/MDCTextInputController.h
+++ b/components/TextFields/src/MDCTextInputController.h
@@ -157,7 +157,7 @@
  UIContentSizeCategory changes.
 
  This property is modeled after the adjustsFontForContentSizeCategory property in the
- UIConnectSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
+ UIContentSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
 
  Default is mdc_adjustsFontForContentSizeCategoryDefault.
  */


### PR DESCRIPTION
fix typo UIConnectSizeCategoryAdjusting -> UIContentSizeCategoryAdjusting 