### PR TITLE
[BottomNavigation] Minor code clean-up.

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -143,7 +143,7 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarAlignment) {
 @property(nonatomic, assign) CGFloat itemsContentHorizontalMargin;
 
 /**
- The elevation of the bottom navigation bar. Defaults to 8.0.
+ The elevation of the bottom navigation bar. Defaults to @c MDCShadowElevationBottomNavigationBar .
  */
 @property(nonatomic, assign) MDCShadowElevation elevation;
 

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -119,7 +119,8 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
 #else
   _shouldPretendToBeATabBar = YES;
 #endif
-  [self setElevation:MDCShadowElevationBottomNavigationBar];
+  _elevation = MDCShadowElevationBottomNavigationBar;
+  [(MDCShadowLayer *)self.layer setElevation:_elevation];
   _itemViews = [NSMutableArray array];
   _itemTitleFont = [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleCaption];
 }

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -166,7 +166,8 @@
 
 - (void)testDefaultElevation {
   // Then
-  XCTAssertEqual(self.bottomNavBar.elevation, MDCShadowElevationBottomNavigationBar);
+  XCTAssertEqualWithAccuracy(self.bottomNavBar.elevation, MDCShadowElevationBottomNavigationBar,
+                             0.001);
 }
 
 - (void)testCustomElevation {
@@ -177,7 +178,7 @@
   self.bottomNavBar.elevation = customElevation;
 
   // Then
-  XCTAssertEqual(self.bottomNavBar.elevation, customElevation);
+  XCTAssertEqualWithAccuracy(self.bottomNavBar.elevation, customElevation, 0.001);
 }
 
 - (void)testViewForItemFound {


### PR DESCRIPTION
*   Directly set elevation properties in init instead of invoking the setter.
    This prevents unexpected behavior for subclasses.
*   Use XCTAssertEqualsWithAccuracy in tests comparing floating-point values.
*   Document the default elevation as "MDCShadowElevationBottomNavigationBar"
    rather than a literal value that may become incorrect over time.

Follow-up work for #5730
