### PR TITLE
[NavigationDrawer] Improve performance for heavy preferredContentSize calls

### DIFF
--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -88,7 +88,7 @@
 @property(nonatomic, strong, nullable) UIColor *topHandleColor;
 
 /**
- Whether the content/drawer reaches the full screen of the device.
+A boolean value that indicates whether the drawer is currently the full height of the window.
  */
 @property(nonatomic, readonly) BOOL contentReachesFullscreen;
 

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -87,4 +87,9 @@
  */
 @property(nonatomic, strong, nullable) UIColor *topHandleColor;
 
+/**
+ Whether the content/drawer reaches the full screen of the device.
+ */
+@property(nonatomic, readonly) BOOL contentReachesFullscreen;
+
 @end

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -194,6 +194,10 @@ static CGFloat kTopHandleYCenter = (CGFloat)6.0;
   self.topHandle.backgroundColor = topHandleColor;
 }
 
+- (BOOL)contentReachesFullscreen {
+  return self.bottomDrawerContainerViewController.contentReachesFullscreen;
+}
+
 #pragma mark - Private
 
 - (void)hideDrawer {

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -28,7 +28,7 @@
 
 @implementation MDCBottomDrawerViewController {
   NSMutableDictionary<NSNumber *, NSNumber *> *_topCornersRadius;
-  BOOL _maskApplied;
+  BOOL _isMaskAppliedFirstTime;
 }
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
@@ -53,15 +53,14 @@
   _topCornersRadius[@(MDCBottomDrawerStateCollapsed)] = @(0);
   _maskLayer = [[MDCBottomDrawerHeaderMask alloc] initWithMaximumCornerRadius:0
                                                           minimumCornerRadius:0];
-  _maskApplied = NO;
 }
 
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
-  if (!_maskApplied) {
+  if (!_isMaskAppliedFirstTime) {
     _maskLayer.minimumCornerRadius = [self minimumCornerRadius];
     [_maskLayer applyMask];
-    _maskApplied = YES;
+    _isMaskAppliedFirstTime = YES;
   }
 }
 

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -28,6 +28,7 @@
 
 @implementation MDCBottomDrawerViewController {
   NSMutableDictionary<NSNumber *, NSNumber *> *_topCornersRadius;
+  BOOL _maskApplied;
 }
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
@@ -52,13 +53,16 @@
   _topCornersRadius[@(MDCBottomDrawerStateCollapsed)] = @(0);
   _maskLayer = [[MDCBottomDrawerHeaderMask alloc] initWithMaximumCornerRadius:0
                                                           minimumCornerRadius:0];
+  _maskApplied = NO;
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-  [super viewWillAppear:animated];
-
-  _maskLayer.minimumCornerRadius = [self minimumCornerRadius];
-  [_maskLayer applyMask];
+- (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
+  if (!_maskApplied) {
+    _maskLayer.minimumCornerRadius = [self minimumCornerRadius];
+    [_maskLayer applyMask];
+    _maskApplied = YES;
+  }
 }
 
 - (id<UIViewControllerTransitioningDelegate>)transitioningDelegate {
@@ -125,13 +129,23 @@
   }
 }
 
+- (BOOL)isAccessibilityMode {
+  return UIAccessibilityIsVoiceOverRunning() || UIAccessibilityIsSwitchControlRunning();
+}
+- (BOOL)isMobileLandscape {
+  return self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact;
+}
+- (BOOL)shouldPresentFullScreen {
+  return [self isAccessibilityMode] || [self isMobileLandscape];
+}
+
 - (BOOL)contentReachesFullScreen {
   if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
     MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
         (MDCBottomDrawerPresentationController *)self.presentationController;
     return bottomDrawerPresentationController.contentReachesFullscreen;
   }
-  return YES;
+  return [self shouldPresentFullScreen];
 }
 
 - (void)setTopHandleHidden:(BOOL)topHandleHidden {

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -125,25 +125,13 @@
   }
 }
 
-- (BOOL)isAccessibilityMode {
-  return UIAccessibilityIsVoiceOverRunning() || UIAccessibilityIsSwitchControlRunning();
-}
-
-- (BOOL)isMobileLandscape {
-  return self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact;
-}
-
-- (BOOL)shouldPresentFullScreen {
-  return [self isAccessibilityMode] || [self isMobileLandscape];
-}
-
 - (BOOL)contentReachesFullScreen {
-  if ([self shouldPresentFullScreen]) {
-    return YES;
+  if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
+    MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
+        (MDCBottomDrawerPresentationController *)self.presentationController;
+    return bottomDrawerPresentationController.contentReachesFullscreen;
   }
-  return CGRectGetHeight(self.view.bounds) <=
-         self.headerViewController.preferredContentSize.height +
-             self.contentViewController.preferredContentSize.height;
+  return YES;
 }
 
 - (void)setTopHandleHidden:(BOOL)topHandleHidden {

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -108,7 +108,7 @@
 @property(nonatomic, readonly) MDCBottomDrawerState drawerState;
 
 /**
- Whether the content/drawer reaches the full screen of the device.
+ A boolean value that indicates whether the drawer is currently the full height of the window.
  */
 @property(nonatomic, readonly) BOOL contentReachesFullscreen;
 @end

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -107,4 +107,8 @@
  */
 @property(nonatomic, readonly) MDCBottomDrawerState drawerState;
 
+/**
+ Whether the content/drawer reaches the full screen of the device.
+ */
+@property(nonatomic, readonly) BOOL contentReachesFullscreen;
 @end

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -88,9 +88,6 @@ static UIColor *DrawerShadowColor(void) {
 // The presenting view's bounds after it has been standardized.
 @property(nonatomic, readonly) CGRect presentingViewBounds;
 
-// Whether the content reaches to fullscreen.
-@property(nonatomic, readonly) BOOL contentReachesFullscreen;
-
 // Whether the content height exceeds the visible height when it's first displayed.
 @property(nonatomic, readonly) BOOL contentScrollsToReveal;
 
@@ -414,7 +411,7 @@ static UIColor *DrawerShadowColor(void) {
       contentViewFrame.size.height += topAreaInsetForHeader;
     }
   } else {
-    contentViewFrame.size.height = self.contentViewController.preferredContentSize.height;
+    contentViewFrame.size.height = _contentVCPreferredContentSizeHeightCached;
     if ([self shouldPresentFullScreen]) {
       contentViewFrame.size.height =
           MAX(contentViewFrame.size.height,

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -100,7 +100,7 @@
   MDCBottomDrawerPresentationController *presentationController =
       (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
   presentationController.bottomDrawerContainerViewController = self.fakeBottomDrawer;
-  _fakeBottomDrawer.contentViewController = self.drawerViewController.contentViewController;
+  self.fakeBottomDrawer.contentViewController = self.drawerViewController.contentViewController;
 }
 
 - (void)tearDown {
@@ -548,6 +548,17 @@
 
   // Then
   XCTAssertEqualWithAccuracy(fakeHeader.topInset, (CGFloat)7.0, (CGFloat)0.001);
+}
+
+- (void)testContentReachesFullscreenPresentationControllerValue {
+  // When
+  [self.presentationController presentationTransitionWillBegin];
+  [self.presentationController.bottomDrawerContainerViewController cacheLayoutCalculations];
+
+  // Then
+  XCTAssertEqual(
+      self.presentationController.bottomDrawerContainerViewController.contentReachesFullscreen,
+      self.presentationController.contentReachesFullscreen);
 }
 
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -449,7 +449,7 @@
 - (void)testBottomDrawerCornersAPIExpanded {
   // When
   MDCBottomDrawerPresentationController *presentationController =
-  (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
+      (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
   presentationController.bottomDrawerContainerViewController = self.fakeBottomDrawer;
   self.drawerViewController.contentViewController.preferredContentSize = CGSizeMake(100, 100);
   self.fakeBottomDrawer.contentViewController = self.drawerViewController.contentViewController;

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -448,7 +448,12 @@
 
 - (void)testBottomDrawerCornersAPIExpanded {
   // When
+  MDCBottomDrawerPresentationController *presentationController =
+  (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
+  presentationController.bottomDrawerContainerViewController = self.fakeBottomDrawer;
   self.drawerViewController.contentViewController.preferredContentSize = CGSizeMake(100, 100);
+  self.fakeBottomDrawer.contentViewController = self.drawerViewController.contentViewController;
+  [self.fakeBottomDrawer cacheLayoutCalculations];
   [self.drawerViewController setTopCornersRadius:5 forDrawerState:MDCBottomDrawerStateExpanded];
 
   // Then
@@ -457,7 +462,12 @@
 
 - (void)testBottomDrawerCornersAPIFullScreen {
   // When
+  MDCBottomDrawerPresentationController *presentationController =
+      (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
+  presentationController.bottomDrawerContainerViewController = self.fakeBottomDrawer;
   self.drawerViewController.contentViewController.preferredContentSize = CGSizeMake(100, 5000);
+  self.fakeBottomDrawer.contentViewController = self.drawerViewController.contentViewController;
+  [self.fakeBottomDrawer cacheLayoutCalculations];
   [self.drawerViewController setTopCornersRadius:3 forDrawerState:MDCBottomDrawerStateFullScreen];
 
   // Then

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -97,6 +97,10 @@
       initWithPresentedViewController:_drawerViewController
              presentingViewController:nil];
   _delegateTest = [[MDCBottomDrawerDelegateTest alloc] init];
+  MDCBottomDrawerPresentationController *presentationController =
+      (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
+  presentationController.bottomDrawerContainerViewController = self.fakeBottomDrawer;
+  _fakeBottomDrawer.contentViewController = self.drawerViewController.contentViewController;
 }
 
 - (void)tearDown {
@@ -448,11 +452,7 @@
 
 - (void)testBottomDrawerCornersAPIExpanded {
   // When
-  MDCBottomDrawerPresentationController *presentationController =
-      (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
-  presentationController.bottomDrawerContainerViewController = self.fakeBottomDrawer;
   self.drawerViewController.contentViewController.preferredContentSize = CGSizeMake(100, 100);
-  self.fakeBottomDrawer.contentViewController = self.drawerViewController.contentViewController;
   [self.fakeBottomDrawer cacheLayoutCalculations];
   [self.drawerViewController setTopCornersRadius:5 forDrawerState:MDCBottomDrawerStateExpanded];
 
@@ -462,11 +462,7 @@
 
 - (void)testBottomDrawerCornersAPIFullScreen {
   // When
-  MDCBottomDrawerPresentationController *presentationController =
-      (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
-  presentationController.bottomDrawerContainerViewController = self.fakeBottomDrawer;
   self.drawerViewController.contentViewController.preferredContentSize = CGSizeMake(100, 5000);
-  self.fakeBottomDrawer.contentViewController = self.drawerViewController.contentViewController;
   [self.fakeBottomDrawer cacheLayoutCalculations];
   [self.drawerViewController setTopCornersRadius:3 forDrawerState:MDCBottomDrawerStateFullScreen];
 


### PR DESCRIPTION
**Context:**
There is degraded scrolling performance for clients who have heavier calculations when providing the `contentViewController`'s `preferredContentSize`. This is pretty common for dynamically sized content.

**Problem:**
We are calling preferredContentSize more times than we should, when we can defer re-calling it unless we are receiving a `preferredContentSizeDidChangeForChildContentContainer` call.

**Solution:**
Have `preferredContentSize` only called in `cacheLayoutCalculations`. The other unneeded `preferredContentSize` calls take their value either from another class that has already calculated the `preferredContentSize`, or within its own class as a property which caches the latest `preferredContentSize`.

**Related Bugs**
Closes #5715 