### PR TITLE
[ActionSheet]Action sheet safe area fix

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -181,7 +181,7 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   // When updating the preferredSheetHeight the presentation controller takes into account the
   // safe area so we have to remove that.
   if (@available(iOS 11.0, *)) {
-    preferredHeight = preferredHeight - self.view.safeAreaInsets.bottom;
+    preferredHeight = preferredHeight - self.tableView.adjustedContentInset.bottom;
   }
   return MDCCeil(preferredHeight);
 }

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -157,7 +157,7 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   self.header.frame = CGRectMake(0, 0, self.view.bounds.size.width, size.height);
   UIEdgeInsets insets = UIEdgeInsetsMake(self.header.frame.size.height, 0, 0, 0);
   if (@available(iOS 11.0, *)) {
-    insets.bottom = self.view.safeAreaInsets.bottom;
+    insets.bottom = self.tableView.adjustedContentInset.bottom;
   }
   self.tableView.contentInset = insets;
   self.tableView.contentOffset = CGPointMake(0, -size.height);
@@ -181,7 +181,7 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   // When updating the preferredSheetHeight the presentation controller takes into account the
   // safe area so we have to remove that.
   if (@available(iOS 11.0, *)) {
-    preferredHeight = preferredHeight - self.view.safeAreaInsets.bottom;
+    preferredHeight = preferredHeight - self.tableView.adjustedContentInset.bottom;
   }
   return MDCCeil(preferredHeight);
 }

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -181,7 +181,7 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   // When updating the preferredSheetHeight the presentation controller takes into account the
   // safe area so we have to remove that.
   if (@available(iOS 11.0, *)) {
-    preferredHeight = preferredHeight - self.view.safeAreaInset.bottom;
+    preferredHeight = preferredHeight - self.view.safeAreaInsets.bottom;
   }
   return MDCCeil(preferredHeight);
 }

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -181,7 +181,7 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   // When updating the preferredSheetHeight the presentation controller takes into account the
   // safe area so we have to remove that.
   if (@available(iOS 11.0, *)) {
-    preferredHeight = preferredHeight - self.tableView.adjustedContentInset.bottom;
+    preferredHeight = preferredHeight - self.view.safeAreaInset.bottom;
   }
   return MDCCeil(preferredHeight);
 }


### PR DESCRIPTION
The MDCActionSheetController currently uses safeAreaInsets to work with the safeArea and alignment. As seen in docs relating to this 
(https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets?language=objc)
if the view is not on the screen or in a view hierarchy yet, the values will be zero. I noticed while using  a new iPad pro that the safeAreaInsets were all 0 and the initial layout of the action sheet would cut into the home bar at the bottom. Changed this to use adjustedContentInset (a scroll view property) (https://developer.apple.com/documentation/uikit/uiscrollview/2902259-adjustedcontentinset?language=objc) which fixes the issue.

closes #5750
