### PR TITLE
[Dialogs, Shape] Fix cross-component imports.

### DIFF
--- a/components/ActionSheet/tests/unit/ActionSheetTest.swift
+++ b/components/ActionSheet/tests/unit/ActionSheetTest.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 import MaterialComponentsAlpha.MaterialActionSheet
-import MaterialComponentsAlpha.MaterialActionSheet_ColorThemer
+import MaterialComponents.MaterialActionSheet_ColorThemer // Alpha
 
 class ActionSheetTest: XCTestCase {
 

--- a/components/ActionSheet/tests/unit/ActionSheetTest.swift
+++ b/components/ActionSheet/tests/unit/ActionSheetTest.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 import MaterialComponentsAlpha.MaterialActionSheet
-import MaterialComponents.MaterialActionSheet_ColorThemer // Alpha
+import MaterialComponentsAlpha.MaterialActionSheet_ColorThemer
 
 class ActionSheetTest: XCTestCase {
 

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -30,6 +30,8 @@ mdc_public_objc_library(
     ],
     deps = [
         "//components/Buttons",
+        "//components/Buttons:ColorThemer",
+        "//components/Buttons:TypographyThemer",
         "//components/ShadowElevations",
         "//components/ShadowLayer",
         "//components/Typography",

--- a/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
+++ b/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
@@ -14,8 +14,8 @@
 
 #import "MDCAlertColorThemer.h"
 
-#import "../../../Buttons/src/ColorThemer/MaterialButtons+ColorThemer.h"
 #import "../MDCAlertController+ButtonForAction.h"
+#import "MaterialButtons+ColorThemer.h"
 #import "MaterialButtons.h"
 
 @implementation MDCAlertColorThemer

--- a/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
+++ b/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
@@ -14,7 +14,7 @@
 
 #import "MDCAlertColorThemer.h"
 
-#import "../MDCAlertController+ButtonForAction.h"
+#import "MDCAlertController+ButtonForAction.h"
 #import "MaterialButtons+ColorThemer.h"
 #import "MaterialButtons.h"
 

--- a/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.m
+++ b/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.m
@@ -14,7 +14,7 @@
 
 #import "MDCAlertTypographyThemer.h"
 
-#import "../MDCAlertController+ButtonForAction.h"
+#import "MDCAlertController+ButtonForAction.h"
 #import "MaterialButtons+TypographyThemer.h"
 #import "MaterialTypography.h"
 

--- a/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.m
+++ b/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.m
@@ -14,8 +14,8 @@
 
 #import "MDCAlertTypographyThemer.h"
 
-#import "../../../Buttons/src/TypographyThemer/MaterialButtons+TypographyThemer.h"
 #import "../MDCAlertController+ButtonForAction.h"
+#import "MaterialButtons+TypographyThemer.h"
 #import "MaterialTypography.h"
 
 @implementation MDCAlertTypographyThemer

--- a/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
+++ b/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
@@ -14,7 +14,7 @@
 
 #import "MDCShapeSchemeExampleViewController.h"
 
-#import "../../../BottomSheet/examples/supplemental/BottomSheetDummyCollectionViewController.h"
+#import "supplemental/MDCShapeExamplesDummyCollectionViewController.h"
 #import "supplemental/MDCBottomSheetControllerShapeThemerDefaultMapping.h"
 #import "supplemental/MDCChipViewShapeThemerDefaultMapping.h"
 #import "supplemental/MDCFloatingButtonShapeThemerDefaultMapping.h"
@@ -184,8 +184,8 @@
 }
 
 - (void)presentBottomSheet {
-  BottomSheetDummyCollectionViewController *viewController =
-      [[BottomSheetDummyCollectionViewController alloc] initWithNumItems:102];
+  MDCShapeExamplesDummyCollectionViewController *viewController =
+      [[MDCShapeExamplesDummyCollectionViewController alloc] initWithNumItems:102];
   viewController.title = @"Shaped bottom sheet example";
 
   MDCAppBarContainerViewController *container =

--- a/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
+++ b/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
@@ -14,10 +14,10 @@
 
 #import "MDCShapeSchemeExampleViewController.h"
 
-#import "supplemental/MDCShapeExamplesDummyCollectionViewController.h"
 #import "supplemental/MDCBottomSheetControllerShapeThemerDefaultMapping.h"
 #import "supplemental/MDCChipViewShapeThemerDefaultMapping.h"
 #import "supplemental/MDCFloatingButtonShapeThemerDefaultMapping.h"
+#import "supplemental/MDCShapeExamplesDummyCollectionViewController.h"
 
 #import "MaterialAppBar+ColorThemer.h"
 #import "MaterialAppBar+TypographyThemer.h"

--- a/components/schemes/Shape/examples/supplemental/MDCShapeExamplesDummyCollectionViewController.h
+++ b/components/schemes/Shape/examples/supplemental/MDCShapeExamplesDummyCollectionViewController.h
@@ -18,6 +18,6 @@
 - (instancetype)initWithNumItems:(NSInteger)numItems NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout NS_UNAVAILABLE;
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
-- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
-NS_UNAVAILABLE;
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil
+                         bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 @end

--- a/components/schemes/Shape/examples/supplemental/MDCShapeExamplesDummyCollectionViewController.h
+++ b/components/schemes/Shape/examples/supplemental/MDCShapeExamplesDummyCollectionViewController.h
@@ -1,0 +1,23 @@
+// Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+@interface MDCShapeExamplesDummyCollectionViewController : UICollectionViewController
+- (instancetype)initWithNumItems:(NSInteger)numItems NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout NS_UNAVAILABLE;
+- (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+NS_UNAVAILABLE;
+@end

--- a/components/schemes/Shape/examples/supplemental/MDCShapeExamplesDummyCollectionViewController.m
+++ b/components/schemes/Shape/examples/supplemental/MDCShapeExamplesDummyCollectionViewController.m
@@ -1,0 +1,76 @@
+// Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCShapeExamplesDummyCollectionViewController.h"
+
+@interface MDCShapeExamplesDummyCollectionViewController () <UICollectionViewDataSource>
+@end
+
+@interface MDCShapeExamplesDummyCollectionViewCell : UICollectionViewCell
+@end
+
+static NSString *kReuseIdentifier = @"dummyCell";
+
+@implementation MDCShapeExamplesDummyCollectionViewController {
+  NSInteger _numItems;
+  UICollectionViewFlowLayout *_layout;
+}
+
+- (instancetype)initWithNumItems:(NSInteger)numItems {
+  UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
+  layout.minimumInteritemSpacing = 0;
+  layout.minimumLineSpacing = 0;
+  if (self = [super initWithCollectionViewLayout:layout]) {
+    _layout = layout;
+
+    _numItems = numItems;
+  }
+  return self;
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  self.collectionView.backgroundColor = [UIColor whiteColor];
+
+  [self.collectionView registerClass:[MDCShapeExamplesDummyCollectionViewCell class]
+          forCellWithReuseIdentifier:kReuseIdentifier];
+}
+
+- (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
+
+  CGFloat s = self.view.frame.size.width / 3;
+  _layout.itemSize = CGSizeMake(s, s);
+}
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView
+     numberOfItemsInSection:(NSInteger)section {
+  return _numItems;
+}
+
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
+                  cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+  MDCShapeExamplesDummyCollectionViewCell *cell =
+      [collectionView dequeueReusableCellWithReuseIdentifier:kReuseIdentifier
+                                                forIndexPath:indexPath];
+  cell.backgroundColor = [UIColor colorWithWhite:(indexPath.row % 2) * (CGFloat)0.2 + (CGFloat)0.8
+                                           alpha:1];
+  return cell;
+}
+
+@end
+
+@implementation MDCShapeExamplesDummyCollectionViewCell
+@end


### PR DESCRIPTION
Some of our examples and component code was depending on other components by
using relative path imports. Instead, they should be relying on the build
system to expose headers and importing those from the include paths.