### PR TITLE
[scripts/release] Improve the notes command output.

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -570,6 +570,136 @@ generate_release_diff() {
 }
 
 generate_release_notes() {
+  # Echoes the SHA's title as a CHANGELOG.md entry.
+  sha_to_changelog_entry() {
+    sha="$1"
+    git log \
+      -1 \
+      --pretty="* [%s](https://github.com/material-components/material-components-ios/commit/%H) (%an)" \
+      --no-merges \
+      "$sha"
+  }
+  # Returns a non-zero value if the given SHA affects any paths other than the given path.
+  # Ignores modifications to MaterialComponents.podspec.
+  does_commit_affect_other_paths() {
+    sha="$1"
+    path="$2"
+    git diff-tree --no-commit-id --name-only -r "$sha" \
+      | grep -v "$path" \
+      | grep -v "MaterialComponents.podspec"
+  }
+  # Echoes a list of changelog entries that affect a given path and only that path.
+  changes_for_path() {
+    path="${1:-components/}"
+    git log \
+        --pretty="%H" \
+        --no-merges \
+        origin/stable..$(get_latest_branch) "$path" | while read sha; do
+      if [[ ! $(does_commit_affect_other_paths "$sha" "$path") ]]; then
+        sha_to_changelog_entry "$sha"
+      fi
+    done
+  }
+  # Echoes a list of changes that affect the given path AND other paths.
+  changes_for_multiple_paths() {
+    path="${1:-components/}"
+    git log \
+        --pretty="%H" \
+        --no-merges \
+        origin/stable..$(get_latest_branch) "$path" | while read sha; do
+      if [[ $(does_commit_affect_other_paths "$sha" "$path") ]]; then
+        sha_to_changelog_entry "$sha"
+      fi
+    done
+  }
+  # Echoes a list of breaking changelog entries for a given path.
+  filter_breaking_changes() {
+    cat - | grep "\[.*\]\!" | perl -pe "s|\* \[\[.+?\]!|* [**Breaking**:|" | sort
+  }
+  # Echoes a list of non-breaking changelog entries for a given path.
+  filter_non_breaking_changes() {
+    cat - | grep -v "\[.*\]\!" | perl -pe "s|\* \[\[.+?\] |* [|" | sort
+  }
+
+  has_breaking_changes=false
+  has_non_breaking_changes=false
+
+  # Output breaking changes that affect specific components.
+
+  find components -type d -name 'src' | sort | while read path; do
+    folder=$(dirname $path)
+
+    if [[ $(changes_for_path "$folder" | filter_breaking_changes) ]]; then
+      component=$(echo $folder | cut -d'/' -f2-)
+
+      if [ "$has_breaking_changes" = false ]; then
+        has_breaking_changes=true
+        echo
+        echo "## Breaking changes"
+      fi
+      echo
+      echo "### $component"
+      echo
+
+      changes_for_path "$folder" | filter_breaking_changes
+    fi
+  done
+
+  # Output breaking changes that affect multiple components.
+
+  all_breaking_changes_for_multiple_paths() {
+    find components -type d -name 'src' | while read path; do
+      folder=$(dirname $path)
+      changes_for_multiple_paths "$folder" | filter_breaking_changes
+    done | sort | uniq
+  }
+  if [[ $(all_breaking_changes_for_multiple_paths) ]]; then
+    has_breaking_changes=true
+    echo
+    echo "## Multi-component breaking changes"
+    echo
+    all_breaking_changes_for_multiple_paths
+  fi
+
+  # Output changes that affect specific components.
+
+  find components -type d -name 'src' | sort | while read path; do
+    folder=$(dirname $path)
+
+    if [[ $(changes_for_path "$folder" | filter_non_breaking_changes) ]]; then
+      component=$(echo $folder | cut -d'/' -f2-)
+
+      if [ "$has_non_breaking_changes" = false ]; then
+        has_non_breaking_changes=true
+        echo
+        echo "## Changes"
+      fi
+      echo
+      echo "### $component"
+      echo
+
+      changes_for_path "$folder" | filter_non_breaking_changes
+    fi
+  done
+
+  # Output changes that affect multiple components.
+
+  all_non_breaking_changes_for_multiple_paths() {
+    find components -type d -name 'src' | while read path; do
+      folder=$(dirname $path)
+      changes_for_multiple_paths "$folder" | filter_non_breaking_changes
+    done | sort | uniq
+  }
+  if [[ $(all_non_breaking_changes_for_multiple_paths) ]]; then
+    has_non_breaking_changes=true
+    echo
+    echo "## Multi-component changes"
+    echo
+    all_non_breaking_changes_for_multiple_paths
+  fi
+}
+
+other_thing() {
   find components -type d -name 'src' | sort | while read path; do
     folder=$(dirname $path)
     component=$(echo $folder | cut -d'/' -f2-)


### PR DESCRIPTION
The script now outputs four groups of changelogs:

1. Breaking changes for specific components.
2. Breaking changes across multiple components.
3. Changes for specific components.
4. Changes acrosss multiple components.

# Example output

Generated by running `./scripts/release notes`

## Breaking changes

### Buttons

* [**Breaking**: Remove property coding support from MDCFloatingButton and MDCFlatButton. (#5787)](https://github.com/material-components/material-components-ios/commit/9564c50eaa08ee5cf79a0fc31adb9cd67972aa28) (featherless)

## Changes

### BottomNavigation

* [Support `accessibilityLabel`, `accessibilityHint`, and `isAccessibilityElement` (#5736)](https://github.com/material-components/material-components-ios/commit/0affb857649cd620eac7912edf0a396f966b20a1) (andrewplai)

### Dialogs

* [Add an Alert width upper bound (#4914)](https://github.com/material-components/material-components-ios/commit/a063cd7552ecf0fea5abebe071455f7b69d940f7) (ianegordon)

### NavigationDrawer

* [Position handle using NSLayoutConstraints (#5760)](https://github.com/material-components/material-components-ios/commit/deac15a06c31d854d4fefd964905b48181469ebe) (Andrew Overton)

### PageControl

* [Add respectsUserInterfaceLayoutDirection to MDCPageControl (#5711)](https://github.com/material-components/material-components-ios/commit/21dfce7f5fb97038ae3b5e81b4acada796fa2c08) (Andrew Overton)