### PR TITLE
Extract clang-format-ci to a separate command.

### DIFF
--- a/.clang-format-ci
+++ b/.clang-format-ci
@@ -18,7 +18,10 @@
 set -e
 
 # The tagged version of https://github.com/material-foundation/clang-format-ci to check out.
+# A * wildcard can be used to check out the latest release of a given version.
 CLANG_FORMAT_CI_VERSION="v1.*"
+
+CLANG_FORMAT_CI_SRC_DIR=".clang-format-ci-src"
 
 # Will run git clang-format on the branch's changes, reporting a failure if the linter generated any
 # stylistic changes.
@@ -35,14 +38,15 @@ CLANG_FORMAT_CI_VERSION="v1.*"
 # - clang-format
 # - git-clang-format
 lint_clang_format() {
-  if [ ! -d .clang-format-ci-src ]; then
-    git clone --recurse-submodules https://github.com/material-foundation/clang-format-ci.git .clang-format-ci-src
+  if [ ! -d "$CLANG_FORMAT_CI_SRC_DIR" ]; then
+    git clone --recurse-submodules https://github.com/material-foundation/clang-format-ci.git "$CLANG_FORMAT_CI_SRC_DIR"
   fi
 
-  pushd .clang-format-ci-src
+  pushd "$CLANG_FORMAT_CI_SRC_DIR"
   git fetch > /dev/null
   TAG=$(git tag --sort=v:refname -l "$CLANG_FORMAT_CI_VERSION" | tail -n1)
   git checkout "$TAG" > /dev/null
+  echo "Using clang-format-ci $TAG"
   popd
 
   .clang-format-ci-src/from-kokoro.sh "material-components/material-components-ios"

--- a/.clang-format-ci
+++ b/.clang-format-ci
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Copyright 2018-present The Material Components for iOS Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fail on any error.
+set -e
+
+# The tagged version of https://github.com/material-foundation/clang-format-ci to check out.
+CLANG_FORMAT_CI_VERSION="v1.*"
+
+# Will run git clang-format on the branch's changes, reporting a failure if the linter generated any
+# stylistic changes.
+#
+# For local runs, you must set the following environment variables:
+#
+#   GITHUB_API_TOKEN -> Create a token here: https://github.com/settings/tokens.
+#                       Must have public_repo scope.
+#   KOKORO_GITHUB_PULL_REQUEST_NUMBER="###" -> The PR # you want to post the API diff results to.
+#   KOKORO_GITHUB_PULL_REQUEST_COMMIT="..." -> The PR commit you want to post to.
+#
+# And install the following tools:
+#
+# - clang-format
+# - git-clang-format
+lint_clang_format() {
+  if [ ! -d .clang-format-ci-src ]; then
+    git clone --recurse-submodules https://github.com/material-foundation/clang-format-ci.git .clang-format-ci-src
+  fi
+
+  pushd .clang-format-ci-src
+  git fetch > /dev/null
+  TAG=$(git tag --sort=v:refname -l "$CLANG_FORMAT_CI_VERSION" | tail -n1)
+  git checkout "$TAG" > /dev/null
+  popd
+
+  .clang-format-ci-src/from-kokoro.sh "material-components/material-components-ios"
+}
+
+lint_clang_format

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 bazel-*
 .kokoro-ios-runner
-.clang-format-ci
+.clang-format-ci-src
 gh-pages/
 
 node_modules/

--- a/.kokoro
+++ b/.kokoro
@@ -393,36 +393,6 @@ generate_apidiff() {
   fi
 }
 
-# Will run git clang-format on the branch's changes, reporting a failure if the linter generated any
-# stylistic changes.
-#
-# For local runs, you must set the following environment variables:
-#
-#   GITHUB_API_TOKEN -> Create a token here: https://github.com/settings/tokens.
-#                       Must have public_repo scope.
-#   KOKORO_GITHUB_PULL_REQUEST_NUMBER="###" -> The PR # you want to post the API diff results to.
-#   KOKORO_GITHUB_PULL_REQUEST_COMMIT="..." -> The PR commit you want to post to.
-#
-# And install the following tools:
-#
-# - clang-format
-# - git-clang-format
-lint_clang_format() {
-  CLANG_FORMAT_CI_VERSION="v1.*"
-
-  if [ ! -d .clang-format-ci ]; then
-    git clone --recurse-submodules https://github.com/material-foundation/clang-format-ci.git .clang-format-ci
-  fi
-
-  pushd .clang-format-ci
-  git fetch > /dev/null
-  TAG=$(git tag --sort=v:refname -l "$CLANG_FORMAT_CI_VERSION" | tail -n1)
-  git checkout "$TAG" > /dev/null
-  popd
-
-  .clang-format-ci/from-kokoro.sh "material-components/material-components-ios"
-}
-
 # This command can be used when a pull request should always be put into a failure state.
 # For example, we do not want to allow pull requests to be merged into stable.
 fail_immediately() {
@@ -497,7 +467,6 @@ fi
 
 case "$DEPENDENCY_SYSTEM" in
   "bazel")      run_bazel ;;
-  "clang-format")  lint_clang_format ;;
   "cocoapods")  run_cocoapods ;;
   "cocoapods-podspec")  run_cocoapods ;;
   "website")    generate_website ;;


### PR DESCRIPTION
This aligns the clang-format-ci job with how we expect other teams to use it.

Notably, this change introduces a new kokoro job for [clang-format-ci](https://github.com/material-foundation/clang-format-ci) that runs the `.clang-format-ci` script. The kokoro job that runs this script is not configured in this repository - see [go/mdc-kokoro](http://go/mdc-kokoro) for the internal job configuration. This change also turns down the .kokoro clang-format job, so `.kokoro -d clang-format` has been removed.