### PR TITLE
[NavigationDrawer] Add the bottom drawer container view controller as a child view controller

### DIFF
--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -147,15 +147,13 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
       .active = YES;
   if ([self.presentedViewController isKindOfClass:[MDCBottomDrawerViewController class]]) {
     [self.presentedView addSubview:self.bottomDrawerContainerViewController.view];
+    [self.presentedViewController addChildViewController:self.bottomDrawerContainerViewController];
   } else {
     [self.containerView addSubview:self.bottomDrawerContainerViewController.view];
   }
 
   id<UIViewControllerTransitionCoordinator> transitionCoordinator =
       [[self presentingViewController] transitionCoordinator];
-  if ([self.presentedViewController isKindOfClass:[MDCBottomDrawerViewController class]]) {
-    [self.presentedViewController addChildViewController:self.bottomDrawerContainerViewController];
-  }
 
   // Fade in the scrim view during the transition.
   self.scrimView.alpha = 0.0;

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -153,6 +153,7 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
 
   id<UIViewControllerTransitionCoordinator> transitionCoordinator =
       [[self presentingViewController] transitionCoordinator];
+  [[self presentedViewController] addChildViewController:self.bottomDrawerContainerViewController];
 
   // Fade in the scrim view during the transition.
   self.scrimView.alpha = 0.0;

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -153,7 +153,9 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
 
   id<UIViewControllerTransitionCoordinator> transitionCoordinator =
       [[self presentingViewController] transitionCoordinator];
-  [[self presentedViewController] addChildViewController:self.bottomDrawerContainerViewController];
+  if ([self.presentedViewController isKindOfClass:[MDCBottomDrawerViewController class]]) {
+    [self.presentedViewController addChildViewController:self.bottomDrawerContainerViewController];
+  }
 
   // Fade in the scrim view during the transition.
   self.scrimView.alpha = 0.0;


### PR DESCRIPTION
The bottom drawer container is missing from the view controller hierarchy. This causes issues with forwarding system calls such as UIViewController's dismissViewController:animated:completion: