### PR TITLE
[NavigationDrawer] Add API to animate preferred content size

### DIFF
--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -97,14 +97,14 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
     } else {
       height = 2000
     }
-    bottomDrawerViewController.animate(toPreferredContentHeight: height, withDuration: 5) { _ in
+    bottomDrawerViewController.animate(toPreferredContentHeight: height, withDuration: 1.5) { _ in
       if let drawerHeader =
         self.bottomDrawerViewController.headerViewController as? DrawerHeaderViewController {
         drawerHeader.titleLabel.text = "Done animating"
       }
       self.fullScreen = !self.fullScreen
     }
-    UIView.animate(withDuration: 5, animations: {
+    UIView.animate(withDuration: 1.5, animations: {
       self.bottomDrawerViewController.headerViewController?.view.backgroundColor =
         self.colorScheme.primaryColor
     })
@@ -125,6 +125,7 @@ extension BottomDrawerWithHeaderExample {
       "breadcrumbs": ["Navigation Drawer", "Bottom Drawer"],
       "primaryDemo": false,
       "presentable": false,
+      "debug": true,
     ]
   }
 }

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -69,7 +69,6 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
     bottomDrawerViewController = bottomNav
     layoutContentViewController()
     bottomDrawerViewController.setTopCornersRadius(24, for: .collapsed)
-    bottomDrawerViewController.setTopCornersRadius(8, for: .expanded)
     bottomDrawerViewController.isTopHandleHidden = false
     bottomDrawerViewController.topHandleColor = UIColor.lightGray
     bottomDrawerViewController.contentViewController = contentViewController
@@ -99,11 +98,11 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
     } else {
       height = 2000
     }
-    bottomDrawerViewController.animate(toPreferredContentHeight: height, withDuration: 0.2) { _ in
+    bottomDrawerViewController.animate(toPreferredContentHeight: height, withDuration: 2) { _ in
       print("Animation completed")
       self.fullScreen = !self.fullScreen
     }
-    UIView.animate(withDuration: 0.2, animations: {
+    UIView.animate(withDuration: 2, animations: {
       print("Insert custom animation here")
     })
   }

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -23,11 +23,11 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
 
   var colorScheme = MDCSemanticColorScheme()
   let bottomAppBar = MDCBottomAppBarView()
-   var fullScreen: Bool = true
+  var fullScreen: Bool = true
 
   let headerViewController = DrawerHeaderViewController()
   let contentViewController = DrawerContentViewController()
-  var bottomDrawerViewController = MDCBottomDrawerViewController()
+  lazy var bottomDrawerViewController = MDCBottomDrawerViewController()
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -86,7 +86,9 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
     button.sizeToFit()
     button.addTarget(self, action: #selector(expandBottomDrawer), for: .touchUpInside)
     button.center = CGPoint(x: view.frame.width / 2, y: 50)
-    button.backgroundColor = colorScheme.primaryColor
+    let buttonScheme = MDCButtonScheme()
+    buttonScheme.colorScheme = colorScheme
+    MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
     contentViewController.view.addSubview(button)
   }
 
@@ -97,16 +99,12 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
     } else {
       height = 2000
     }
-    bottomDrawerViewController.animate(toPreferredContentHeight: height, withDuration: 5) { _ in
-      if let drawerHeader =
-        self.bottomDrawerViewController.headerViewController as? DrawerHeaderViewController {
-        drawerHeader.titleLabel.text = "Done animating"
-      }
+    bottomDrawerViewController.animate(toPreferredContentHeight: height, withDuration: 0.2) { _ in
+      print("Animation completed")
       self.fullScreen = !self.fullScreen
     }
-    UIView.animate(withDuration: 5, animations: {
-      self.bottomDrawerViewController.headerViewController?.view.backgroundColor =
-        self.colorScheme.primaryColor
+    UIView.animate(withDuration: 0.2, animations: {
+      print("Insert custom animation here")
     })
   }
 

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -27,7 +27,7 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
 
   let headerViewController = DrawerHeaderViewController()
   let contentViewController = DrawerContentViewController()
-  lazy var bottomDrawerViewController = MDCBottomDrawerViewController()
+  var bottomDrawerViewController = MDCBottomDrawerViewController()
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -65,6 +65,8 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
   }
 
   @objc func presentNavigationDrawer() {
+    let bottomNav = MDCBottomDrawerViewController()
+    bottomDrawerViewController = bottomNav
     layoutContentViewController()
     bottomDrawerViewController.setTopCornersRadius(24, for: .collapsed)
     bottomDrawerViewController.setTopCornersRadius(8, for: .expanded)

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -97,14 +97,14 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
     } else {
       height = 2000
     }
-    bottomDrawerViewController.animate(toPreferredContentHeight: height, withDuration: 1.5) { _ in
+    bottomDrawerViewController.animate(toPreferredContentHeight: height, withDuration: 5) { _ in
       if let drawerHeader =
         self.bottomDrawerViewController.headerViewController as? DrawerHeaderViewController {
         drawerHeader.titleLabel.text = "Done animating"
       }
       self.fullScreen = !self.fullScreen
     }
-    UIView.animate(withDuration: 1.5, animations: {
+    UIView.animate(withDuration: 5, animations: {
       self.bottomDrawerViewController.headerViewController?.view.backgroundColor =
         self.colorScheme.primaryColor
     })
@@ -125,7 +125,6 @@ extension BottomDrawerWithHeaderExample {
       "breadcrumbs": ["Navigation Drawer", "Bottom Drawer"],
       "primaryDemo": false,
       "presentable": false,
-      "debug": true,
     ]
   }
 }

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import UIKit
+import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialBottomAppBar_ColorThemer
 import MaterialComponents.MaterialColorScheme
@@ -22,9 +23,11 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
 
   var colorScheme = MDCSemanticColorScheme()
   let bottomAppBar = MDCBottomAppBarView()
+   var fullScreen: Bool = true
 
   let headerViewController = DrawerHeaderViewController()
   let contentViewController = DrawerContentViewController()
+  lazy var bottomDrawerViewController = MDCBottomDrawerViewController()
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -62,7 +65,7 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
   }
 
   @objc func presentNavigationDrawer() {
-    let bottomDrawerViewController = MDCBottomDrawerViewController()
+    layoutContentViewController()
     bottomDrawerViewController.setTopCornersRadius(24, for: .collapsed)
     bottomDrawerViewController.setTopCornersRadius(8, for: .expanded)
     bottomDrawerViewController.isTopHandleHidden = false
@@ -73,6 +76,36 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
     MDCBottomDrawerColorThemer.applySemanticColorScheme(colorScheme,
                                                         toBottomDrawer: bottomDrawerViewController)
     present(bottomDrawerViewController, animated: true, completion: nil)
+  }
+
+  private func layoutContentViewController() {
+    let button = MDCButton(frame: .zero)
+    button.setTitle("Expand", for: .normal)
+    button.sizeToFit()
+    button.addTarget(self, action: #selector(expandBottomDrawer), for: .touchUpInside)
+    button.center = CGPoint(x: view.frame.width / 2, y: 50)
+    button.backgroundColor = colorScheme.primaryColor
+    contentViewController.view.addSubview(button)
+  }
+
+  @objc func expandBottomDrawer() {
+    var height: CGFloat = 0
+    if (!fullScreen) {
+      height = 100
+    } else {
+      height = 2000
+    }
+    bottomDrawerViewController.animate(toPreferredContentHeight: height, withDuration: 5) { _ in
+      if let drawerHeader =
+        self.bottomDrawerViewController.headerViewController as? DrawerHeaderViewController {
+        drawerHeader.titleLabel.text = "Done animating"
+      }
+      self.fullScreen = !self.fullScreen
+    }
+    UIView.animate(withDuration: 5, animations: {
+      self.bottomDrawerViewController.headerViewController?.view.backgroundColor =
+        self.colorScheme.primaryColor
+    })
   }
 
   func bottomDrawerControllerDidChangeTopInset(_ controller: MDCBottomDrawerViewController,

--- a/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
+++ b/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
@@ -55,7 +55,7 @@ class DrawerHeaderViewController: UIViewController,MDCBottomDrawerHeader {
   }
 
   override func viewWillAppear(_ animated: Bool) {
-    viewWillAppear(animated)
+    super.viewWillAppear(animated)
 
     titleLabel.sizeToFit()
   }

--- a/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
+++ b/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
@@ -19,17 +19,10 @@ import MaterialComponents.MaterialNavigationDrawer
 class DrawerContentViewController: UIViewController {
   var preferredHeight: CGFloat = 2000
 
-  override var preferredContentSize: CGSize {
-    get {
-      return CGSize(width: view.bounds.width, height: preferredHeight)
-    }
-    set {
-      super.preferredContentSize = newValue
-    }
-  }
-
   init() {
     super.init(nibName: nil, bundle: nil)
+
+    preferredContentSize = CGSize(width: view.bounds.width, height: preferredHeight)
   }
 
   required init?(coder aDecoder: NSCoder) {
@@ -45,17 +38,10 @@ class DrawerHeaderViewController: UIViewController,MDCBottomDrawerHeader {
     return label
   }()
 
-  override var preferredContentSize: CGSize {
-    get {
-      return CGSize(width: view.bounds.width, height: preferredHeight)
-    }
-    set {
-      super.preferredContentSize = newValue
-    }
-  }
-
   init() {
     super.init(nibName: nil, bundle: nil)
+
+    preferredContentSize = CGSize(width: view.bounds.width, height: preferredHeight)
   }
 
   required init?(coder aDecoder: NSCoder) {
@@ -64,11 +50,19 @@ class DrawerHeaderViewController: UIViewController,MDCBottomDrawerHeader {
 
   override func viewDidLoad() {
     super.viewDidLoad()
+
     view.addSubview(titleLabel)
   }
 
   override func viewWillAppear(_ animated: Bool) {
+    viewWillAppear(animated)
+
     titleLabel.sizeToFit()
+  }
+
+  override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+
     titleLabel.center =
       CGPoint(x: self.view.frame.size.width / 2, y: self.view.frame.size.height / 2)
   }

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -102,10 +102,13 @@
 - (void)setContentOffsetY:(CGFloat)contentOffsetY animated:(BOOL)animated;
 
 /**
- Expands the navigation drawer to maximum height for the content. If content is larger than the
- screen bounds then animates to full screen.
+ Animates the navigation drawer to preferred content height. This ignores the initial height of 50%
+ and animates to full screen if content is large enough. If content is smaller than the screen
+ height then it animates to the height of the content.
 
+ @param preferredContentHeight The new preferred content size of the content view controller.
  @param duration The duration of the animation
+ @param completion The completion block once the animation is done
  */
 - (void)animateToPreferredContentHeight:(CGFloat)preferredContentHeight
                            withDuration:(NSTimeInterval)duration

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -101,4 +101,14 @@
  */
 - (void)setContentOffsetY:(CGFloat)contentOffsetY animated:(BOOL)animated;
 
+/**
+ Expands the navigation drawer to maximum height for the content. If content is larger than the
+ screen bounds then animates to full screen.
+ 
+ @param duration The duration of the animation
+ */
+- (void)animateToPreferredContentHeight:(CGFloat)preferredContentHeight
+                           withDuration:(NSTimeInterval)duration
+                             completion:(void (^__nullable)(BOOL finished))completion;
+
 @end

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -104,7 +104,7 @@
 /**
  Expands the navigation drawer to maximum height for the content. If content is larger than the
  screen bounds then animates to full screen.
- 
+
  @param duration The duration of the animation
  */
 - (void)animateToPreferredContentHeight:(CGFloat)preferredContentHeight

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -106,7 +106,8 @@
  and animates to full screen if content is large enough. If content is smaller than the screen
  height then it animates to the height of the content.
 
- @param preferredContentHeight The new preferred content size of the content view controller.
+ @param preferredContentHeight The new preferred content size of the content view controller. This
+ will set the preferred content height of the content view controller to the desired value.
  @param duration The duration of the animation
  @param completion The completion block once the animation is done
  */

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -106,7 +106,7 @@
  and animates to full screen if content is large enough. If content is smaller than the screen
  height then it animates to the height of the content.
 
- @param preferredContentHeight The new preferred content size of the content view controller. This
+ @param preferredContentHeight The new preferred content height of the content view controller. This
  will set the preferred content height of the content view controller to the desired value.
  @param duration The duration of the animation
  @param completion The completion block once the animation is done

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -228,6 +228,14 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
   return self.bottomDrawerContainerViewController.contentReachesFullscreen;
 }
 
+- (void)animateToPreferredContentHeight:(CGFloat)preferredContentHeight
+                           withDuration:(NSTimeInterval)duration
+                             completion:(void (^_Nullable)(BOOL))completion {
+  [self.bottomDrawerContainerViewController animateToPreferredContentHeight:preferredContentHeight
+                                                               withDuration:duration
+                                                                 completion:completion];
+}
+
 #pragma mark - Private
 
 - (void)hideDrawer {

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -100,6 +100,16 @@
  */
 - (void)setContentOffsetY:(CGFloat)contentOffsetY animated:(BOOL)animated;
 
+/**
+ Expands the navigation drawer to maximum height for the content. If content is larger than the
+ screen bounds then animates to full screen.
+ 
+ @param duration The duration of the animation
+ */
+- (void)animateToPreferredContentHeight:(CGFloat)preferredContentHeight
+                           withDuration:(NSTimeInterval)duration
+                             completion:(void (^__nullable)(BOOL finished))completion;
+
 @end
 
 /**

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -105,7 +105,8 @@
  and animates to full screen if content is large enough. If content is smaller than the screen
  height then it animates to the height of the content.
 
- @param preferredContentHeight The new preferred content size of the content view controller.
+ @param preferredContentHeight The new preferred content size of the content view controller. This
+ will set the preferred content height of the content view controller to the desired value.
  @param duration The duration of the animation
  @param completion The completion block once the animation is done
  */

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -103,7 +103,7 @@
 /**
  Expands the navigation drawer to maximum height for the content. If content is larger than the
  screen bounds then animates to full screen.
- 
+
  @param duration The duration of the animation
  */
 - (void)animateToPreferredContentHeight:(CGFloat)preferredContentHeight

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -101,10 +101,13 @@
 - (void)setContentOffsetY:(CGFloat)contentOffsetY animated:(BOOL)animated;
 
 /**
- Expands the navigation drawer to maximum height for the content. If content is larger than the
- screen bounds then animates to full screen.
+ Animates the navigation drawer to preferred content height. This ignores the initial height of 50%
+ and animates to full screen if content is large enough. If content is smaller than the screen
+ height then it animates to the height of the content.
 
+ @param preferredContentHeight The new preferred content size of the content view controller.
  @param duration The duration of the animation
+ @param completion The completion block once the animation is done
  */
 - (void)animateToPreferredContentHeight:(CGFloat)preferredContentHeight
                            withDuration:(NSTimeInterval)duration

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -105,7 +105,7 @@
  and animates to full screen if content is large enough. If content is smaller than the screen
  height then it animates to the height of the content.
 
- @param preferredContentHeight The new preferred content size of the content view controller. This
+ @param preferredContentHeight The new preferred content height of the content view controller. This
  will set the preferred content height of the content view controller to the desired value.
  @param duration The duration of the animation
  @param completion The completion block once the animation is done

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -214,4 +214,16 @@
   }
 }
 
+- (void)animateToPreferredContentHeight:(CGFloat)preferredContentHeight
+                           withDuration:(NSTimeInterval)duration
+                             completion:(void (^)(BOOL))completion {
+  if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
+    MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
+    (MDCBottomDrawerPresentationController *)self.presentationController;
+    [bottomDrawerPresentationController animateToPreferredContentHeight:preferredContentHeight
+                                                           withDuration:duration
+                                                             completion:completion];
+  }
+}
+
 @end

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -219,7 +219,7 @@
                              completion:(void (^)(BOOL))completion {
   if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
     MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
-    (MDCBottomDrawerPresentationController *)self.presentationController;
+        (MDCBottomDrawerPresentationController *)self.presentationController;
     [bottomDrawerPresentationController animateToPreferredContentHeight:preferredContentHeight
                                                            withDuration:duration
                                                              completion:completion];

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -126,7 +126,8 @@
  and animates to full screen if content is large enough. If content is smaller than the screen
  height then it animates to the height of the content.
 
- @param preferredContentHeight The new preferred content size of the content view controller.
+ @param preferredContentHeight The new preferred content size of the content view controller. This
+ will set the preferred content height of the content view controller to the desired value.
  @param duration The duration of the animation
  @param completion The completion block once the animation is done
  */

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -124,7 +124,7 @@
 /**
  Expands the navigation drawer to maximum height for the content. If content is larger than the
  screen bounds then animates to full screen.
- 
+
  @param duration The duration of the animation
  */
 - (void)animateToPreferredContentHeight:(CGFloat)preferredContentHeight

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -122,10 +122,13 @@
 - (void)setContentOffsetY:(CGFloat)contentOffsetY animated:(BOOL)animated;
 
 /**
- Expands the navigation drawer to maximum height for the content. If content is larger than the
- screen bounds then animates to full screen.
+ Animates the navigation drawer to preferred content height. This ignores the initial height of 50%
+ and animates to full screen if content is large enough. If content is smaller than the screen
+ height then it animates to the height of the content.
 
+ @param preferredContentHeight The new preferred content size of the content view controller.
  @param duration The duration of the animation
+ @param completion The completion block once the animation is done
  */
 - (void)animateToPreferredContentHeight:(CGFloat)preferredContentHeight
                            withDuration:(NSTimeInterval)duration

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -121,4 +121,14 @@
  */
 - (void)setContentOffsetY:(CGFloat)contentOffsetY animated:(BOOL)animated;
 
+/**
+ Expands the navigation drawer to maximum height for the content. If content is larger than the
+ screen bounds then animates to full screen.
+ 
+ @param duration The duration of the animation
+ */
+- (void)animateToPreferredContentHeight:(CGFloat)preferredContentHeight
+                           withDuration:(NSTimeInterval)duration
+                             completion:(void (^__nullable)(BOOL finished))completion;
+
 @end

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -126,7 +126,7 @@
  and animates to full screen if content is large enough. If content is smaller than the screen
  height then it animates to the height of the content.
 
- @param preferredContentHeight The new preferred content size of the content view controller. This
+ @param preferredContentHeight The new preferred content height of the content view controller. This
  will set the preferred content height of the content view controller to the desired value.
  @param duration The duration of the animation
  @param completion The completion block once the animation is done

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -140,10 +140,6 @@ static UIColor *DrawerShadowColor(void) {
 // hidden and 1.0 is full screen.
 @property(nonatomic) CGFloat initialDrawerFactor;
 
-// Should the bottom drawer listen to changes to the child view controller preferredContentSize
-// changes
-@property(nonatomic, assign) BOOL shouldSetChildPreferredContentSize;
-
 /**
  Calculates the contentOffset if contentViewController's preferredContentSize.height was set to
  preferredContentHeight.
@@ -505,19 +501,16 @@ static UIColor *DrawerShadowColor(void) {
 }
 
 - (void)preferredContentSizeDidChangeForChildContentContainer:(id<UIContentContainer>)container {
-  if (self.shouldSetChildPreferredContentSize) {
-    [super preferredContentSizeDidChangeForChildContentContainer:container];
-    _contentHeaderTopInset = NSNotFound;
-    _contentHeightSurplus = NSNotFound;
-    _addedContentHeight = NSNotFound;
-    [self.view setNeedsLayout];
-  }
+  [super preferredContentSizeDidChangeForChildContentContainer:container];
+  _contentHeaderTopInset = NSNotFound;
+  _contentHeightSurplus = NSNotFound;
+  _addedContentHeight = NSNotFound;
+  [self.view setNeedsLayout];
 }
 
 - (void)animateToPreferredContentHeight:(CGFloat)preferredContentHeight
                            withDuration:(NSTimeInterval)duration
                              completion:(void (^_Nullable)(BOOL))completion {
-  self.shouldSetChildPreferredContentSize = NO;
   CGSize newPreferredContentSize =
       CGSizeMake(self.presentingViewBounds.size.width, preferredContentHeight);
   // If we are in landscape or voiceover mode we don't need to animate because the drawer

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -511,12 +511,16 @@ static UIColor *DrawerShadowColor(void) {
 - (void)animateToPreferredContentHeight:(CGFloat)preferredContentHeight
                            withDuration:(NSTimeInterval)duration
                              completion:(void (^_Nullable)(BOOL))completion {
+  CGSize newPreferredContentSize =
+      CGSizeMake(CGRectGetWidth(self.view.bounds), preferredContentHeight);
+  if ([self isMobileLandscape]) {
+    self.contentViewController.preferredContentSize = newPreferredContentSize;
+    return;
+  }
   CGPoint contentOffset =
       [self calculateContentOffsetWithPreferredContentHeight:preferredContentHeight];
   CGFloat precentageOfFullScreen =
       [self precentageOfFullScreenWithPreferredContentHeight:preferredContentHeight];
-  CGSize newPreferredContentSize =
-      CGSizeMake(CGRectGetWidth(self.view.bounds), preferredContentHeight);
   BOOL shouldSetContentHeight = NO;
   if (_contentVCPreferredContentSizeHeightCached > preferredContentHeight) {
     shouldSetContentHeight = YES;

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -153,7 +153,6 @@ static UIColor *DrawerShadowColor(void) {
  */
 - (CGFloat)totalHeightWithAddedContentHeight:(CGFloat)addedContentHeight;
 
-
 @end
 
 @implementation MDCBottomDrawerContainerViewController {
@@ -325,7 +324,6 @@ static UIColor *DrawerShadowColor(void) {
 - (void)setInitialDrawerFactor:(CGFloat)initialDrawerFactor {
   _initialDrawerFactor = initialDrawerFactor;
 }
-
 
 - (void)addScrollViewObserver {
   if (self.scrollViewObserved) {
@@ -514,36 +512,36 @@ static UIColor *DrawerShadowColor(void) {
                            withDuration:(NSTimeInterval)duration
                              completion:(void (^_Nullable)(BOOL))completion {
   CGPoint contentOffset =
-  [self calculateContentOffsetWithPreferredContentHeight:preferredContentHeight];
+      [self calculateContentOffsetWithPreferredContentHeight:preferredContentHeight];
   CGFloat precentageOfFullScreen =
-  [self precentageOfFullScreenWithPreferredContentHeight:preferredContentHeight];
+      [self precentageOfFullScreenWithPreferredContentHeight:preferredContentHeight];
   CGFloat totalHeight = [self totalHeightWithAddedContentHeight:preferredContentHeight];
   BOOL setContentHeight = NO;
   CGSize newPreferredContentSize =
-  CGSizeMake(CGRectGetWidth(self.view.bounds), preferredContentHeight);
+      CGSizeMake(CGRectGetWidth(self.view.bounds), preferredContentHeight);
   if (_contentVCPreferredContentSizeHeightCached > preferredContentHeight) {
     setContentHeight = YES;
   } else {
     self.contentViewController.preferredContentSize = newPreferredContentSize;
   }
   [UIView animateWithDuration:duration
-                   animations:^{
-                     [self.scrollView setContentOffset:contentOffset];
-                   }
-                   completion:^(BOOL finished) {
-                     if (CGRectGetHeight(self.presentingViewBounds) <= totalHeight) {
-                       [self.scrollView setContentOffset:CGPointZero];
-                     }
-                     if (setContentHeight) {
-                       [self resetLayoutWithInitialDrawerFactor:precentageOfFullScreen
-                                           preferredContentSize:newPreferredContentSize];
-                     } else {
-                       [self resetLayoutWithInitialDrawerFactor:precentageOfFullScreen];
-                     }
-                     if (completion) {
-                       completion(YES);
-                     }
-                   }];
+      animations:^{
+        [self.scrollView setContentOffset:contentOffset];
+      }
+      completion:^(BOOL finished) {
+        if (CGRectGetHeight(self.presentingViewBounds) <= totalHeight) {
+          [self.scrollView setContentOffset:CGPointZero];
+        }
+        if (setContentHeight) {
+          [self resetLayoutWithInitialDrawerFactor:precentageOfFullScreen
+                              preferredContentSize:newPreferredContentSize];
+        } else {
+          [self resetLayoutWithInitialDrawerFactor:precentageOfFullScreen];
+        }
+        if (completion) {
+          completion(YES);
+        }
+      }];
 }
 
 - (CGPoint)calculateContentOffsetWithPreferredContentHeight:(CGFloat)preferredContentHeight {

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -575,6 +575,7 @@ static UIColor *DrawerShadowColor(void) {
   CGFloat precentageOfFullScreen = totalHeight / CGRectGetHeight(self.presentingViewBounds);
   return (precentageOfFullScreen > 1) ? 1 : precentageOfFullScreen;
 }
+
 - (CGFloat)totalHeightWithAddedContentHeight:(CGFloat)addedContentHeight {
   return self.headerViewController.preferredContentSize.height + addedContentHeight;
 }

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -516,13 +516,14 @@ static UIColor *DrawerShadowColor(void) {
   CGFloat precentageOfFullScreen =
       [self precentageOfFullScreenWithPreferredContentHeight:preferredContentHeight];
   CGFloat totalHeight = [self totalHeightWithAddedContentHeight:preferredContentHeight];
-  BOOL setContentHeight = NO;
   CGSize newPreferredContentSize =
       CGSizeMake(CGRectGetWidth(self.view.bounds), preferredContentHeight);
+  BOOL setContentHeight = NO;
   if (_contentVCPreferredContentSizeHeightCached > preferredContentHeight) {
     setContentHeight = YES;
   } else {
     self.contentViewController.preferredContentSize = newPreferredContentSize;
+    // Set content offset here to animate correctly for small to large
   }
   [UIView animateWithDuration:duration
       animations:^{
@@ -532,6 +533,7 @@ static UIColor *DrawerShadowColor(void) {
         if (CGRectGetHeight(self.presentingViewBounds) <= totalHeight) {
           [self.scrollView setContentOffset:CGPointZero];
         }
+        [self resetLayoutWithInitialDrawerFactor:precentageOfFullScreen preferredContentSize:newPreferredContentSize];
         if (setContentHeight) {
           [self resetLayoutWithInitialDrawerFactor:precentageOfFullScreen
                               preferredContentSize:newPreferredContentSize];

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -533,7 +533,7 @@ static UIColor *DrawerShadowColor(void) {
           CGRectGetHeight(self.presentingViewBounds) - oldTotalHeight - MDCDeviceTopSafeAreaInset();
       self.contentViewController.preferredContentSize = newPreferredContentSize;
       [self.scrollView setContentOffset:CGPointMake(0, oldTotalHeight)];
-      [self resetLayoutWithInitialDrawerFactor:1];
+      [self resetLayoutWithInitialDrawerFactor:precentageOfFullScreen];
       contentOffset = CGPointMake(0, oldTotalHeight * 2);
     }
   }

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -304,6 +304,7 @@ static UIColor *DrawerShadowColor(void) {
 }
 
 - (BOOL)shouldPresentFullScreen {
+  // TODO: Github issue #5828
   return [self isAccessibilityMode] || [self isMobileLandscape] || _initialDrawerFactor >= 1;
 }
 

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -555,6 +555,7 @@
   // Then
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.scrollView.contentOffset.y, 230, 0.001);
 }
+
 - (void)testExpandToFullScreenAnimationWithSmallScreenContent {
   // Given
   self.fakeBottomDrawer.trackingScrollView = nil;
@@ -567,6 +568,7 @@
   // Then
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.scrollView.contentOffset.y, 50, 0.001);
 }
+
 - (void)testTotalHeightWithAddedContentHeight {
   // Given
   CGSize fakePreferredContentSize = CGSizeMake(200, 700);
@@ -580,6 +582,7 @@
   // Then
   XCTAssertEqualWithAccuracy(totalHeight, expectedHeight, 0.001);
 }
+
 - (void)testPrecentageOfFullScreenWithPreferredContentHeight {
   // Given
   [self setupHeaderWithPreferredContentSize:CGSizeZero];
@@ -592,6 +595,7 @@
   // Then
   XCTAssertEqualWithAccuracy(actualPercentage, (CGFloat)0.4, 0.001);
 }
+
 - (void)testCalculateContentOffsetWithSmallPreferredContentHeight {
   // Given
   [self setupHeaderWithPreferredContentSize:CGSizeZero];
@@ -604,6 +608,7 @@
   // Then
   XCTAssertEqualWithAccuracy(acutalContentOffset.y, 200, 0.001);
 }
+
 - (void)testCalculateContentOffsetWithLargePreferredContentHeight {
   // Given
   [self setupHeaderWithPreferredContentSize:CGSizeZero];

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -61,6 +61,9 @@
 @property(nullable, nonatomic, readonly) UIPresentationController *presentationController;
 - (void)cacheLayoutCalculations;
 - (void)updateDrawerState:(CGFloat)transitionPercentage;
+- (CGPoint)calculateContentOffsetWithPreferredContentHeight:(CGFloat)preferredContentHeight;
+- (CGFloat)precentageOfFullScreenWithPreferredContentHeight:(CGFloat)preferredContentHeight;
+- (CGFloat)totalHeightWithAddedContentHeight:(CGFloat)addedContentHeight;
 @end
 
 @interface MDCBottomDrawerPresentationController (ScrollViewTests) <
@@ -101,6 +104,13 @@
       (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
   presentationController.bottomDrawerContainerViewController = self.fakeBottomDrawer;
   self.fakeBottomDrawer.contentViewController = self.drawerViewController.contentViewController;
+}
+
+- (void)setupHeaderWithPreferredContentSize:(CGSize)size {
+  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
+  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+  fakeHeader.preferredContentSize = size;
+  self.fakeBottomDrawer.headerViewController = fakeHeader;
 }
 
 - (void)tearDown {
@@ -161,12 +171,9 @@
 - (void)testContentHeaderHeightWithHeader {
   // Given
   CGSize fakePreferredContentSize = CGSizeMake(200, 300);
-  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
-  self.fakeBottomDrawer.headerViewController = fakeHeader;
 
   // When
-  self.fakeBottomDrawer.headerViewController.preferredContentSize = fakePreferredContentSize;
+  [self setupHeaderWithPreferredContentSize:fakePreferredContentSize];
 
   // Then
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.contentHeaderHeight,
@@ -186,12 +193,9 @@
   // MDCDeviceTopSafeAreaInset adds 20 if there is no safe area and you are not in an application
   CGFloat mdcDeviceTopSafeArea = 20;
   CGSize fakePreferredContentSize = CGSizeMake(200, 300);
-  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
-  self.fakeBottomDrawer.headerViewController = fakeHeader;
 
   // When
-  self.fakeBottomDrawer.headerViewController.preferredContentSize = fakePreferredContentSize;
+  [self setupHeaderWithPreferredContentSize:fakePreferredContentSize];
 
   // Then
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.topHeaderHeight,
@@ -202,10 +206,7 @@
   // Given
   // Setup gives us presentingViewBounds of (0, 0, 200, 500)
   CGSize fakePreferredContentSize = CGSizeMake(200, 300);
-  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
-  fakeHeader.preferredContentSize = fakePreferredContentSize;
-  self.fakeBottomDrawer.headerViewController = fakeHeader;
+  [self setupHeaderWithPreferredContentSize:fakePreferredContentSize];
   self.fakeBottomDrawer.contentViewController =
       [[MDCNavigationDrawerFakeTableViewController alloc] init];
   self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 100);
@@ -238,10 +239,7 @@
   // Given
   // Setup gives us presentingViewBounds of (0, 0, 200, 500)
   CGSize fakePreferredContentSize = CGSizeMake(200, 300);
-  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
-  fakeHeader.preferredContentSize = fakePreferredContentSize;
-  self.fakeBottomDrawer.headerViewController = fakeHeader;
+  [self setupHeaderWithPreferredContentSize:fakePreferredContentSize];
 
   // When
   [self.fakeBottomDrawer cacheLayoutCalculations];
@@ -274,10 +272,7 @@
   // Given
   // Setup gives us presentingViewBoudns of (0, 0, 200, 500)
   CGSize fakePreferredContentSize = CGSizeMake(200, 700);
-  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
-  fakeHeader.preferredContentSize = fakePreferredContentSize;
-  self.fakeBottomDrawer.headerViewController = fakeHeader;
+  [self setupHeaderWithPreferredContentSize:fakePreferredContentSize];
 
   // When
   [self.fakeBottomDrawer cacheLayoutCalculations];
@@ -308,10 +303,7 @@
   // Given
   // Setup gives us presentingViewBounds of (0, 0, 200, 500)
   CGSize fakePreferredContentSize = CGSizeMake(200, 700);
-  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
-  fakeHeader.preferredContentSize = fakePreferredContentSize;
-  self.fakeBottomDrawer.headerViewController = fakeHeader;
+  [self setupHeaderWithPreferredContentSize:fakePreferredContentSize];
   self.fakeBottomDrawer.contentViewController =
       [[MDCNavigationDrawerFakeTableViewController alloc] init];
   self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1000);
@@ -333,10 +325,7 @@
 - (void)testContentHeightSurplusWithScrollabelContent {
   // Given
   CGSize fakePreferredContentSize = CGSizeMake(200, 1000);
-  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
-  fakeHeader.preferredContentSize = fakePreferredContentSize;
-  self.fakeBottomDrawer.headerViewController = fakeHeader;
+  [self setupHeaderWithPreferredContentSize:fakePreferredContentSize];
   self.fakeBottomDrawer.contentViewController =
       [[MDCNavigationDrawerFakeTableViewController alloc] init];
   self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1500);
@@ -355,10 +344,7 @@
 
 - (void)testContentScrollsToRevealTrue {
   CGSize fakePreferredContentSize = CGSizeMake(200, 1000);
-  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
-  fakeHeader.preferredContentSize = fakePreferredContentSize;
-  self.fakeBottomDrawer.headerViewController = fakeHeader;
+  [self setupHeaderWithPreferredContentSize:fakePreferredContentSize];
   self.fakeBottomDrawer.contentViewController =
       [[MDCNavigationDrawerFakeTableViewController alloc] init];
   self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 1500);
@@ -372,10 +358,7 @@
 
 - (void)testBottomDrawerStateCollapsed {
   CGSize fakePreferredContentSize = CGSizeMake(200, 1000);
-  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
-  fakeHeader.preferredContentSize = fakePreferredContentSize;
-  self.fakeBottomDrawer.headerViewController = fakeHeader;
+  [self setupHeaderWithPreferredContentSize:fakePreferredContentSize];
   self.fakeBottomDrawer.contentViewController =
       [[MDCNavigationDrawerFakeTableViewController alloc] init];
 
@@ -389,10 +372,7 @@
 
 - (void)testBottomDrawerStateExpanded {
   CGSize fakePreferredContentSize = CGSizeMake(200, 100);
-  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
-  fakeHeader.preferredContentSize = fakePreferredContentSize;
-  self.fakeBottomDrawer.headerViewController = fakeHeader;
+  [self setupHeaderWithPreferredContentSize:fakePreferredContentSize];
   self.fakeBottomDrawer.contentViewController =
       [[MDCNavigationDrawerFakeTableViewController alloc] init];
 
@@ -406,10 +386,7 @@
 
 - (void)testBottomDrawerStateFullScreen {
   CGSize fakePreferredContentSize = CGSizeMake(200, 2000);
-  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
-  fakeHeader.preferredContentSize = fakePreferredContentSize;
-  self.fakeBottomDrawer.headerViewController = fakeHeader;
+  [self setupHeaderWithPreferredContentSize:fakePreferredContentSize];
   self.fakeBottomDrawer.contentViewController =
       [[MDCNavigationDrawerFakeTableViewController alloc] init];
 
@@ -423,10 +400,7 @@
 
 - (void)testBottomDrawerStateCallback {
   CGSize fakePreferredContentSize = CGSizeMake(200, 1000);
-  MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
-  fakeHeader.preferredContentSize = fakePreferredContentSize;
-  self.fakeBottomDrawer.headerViewController = fakeHeader;
+  [self setupHeaderWithPreferredContentSize:fakePreferredContentSize];
   self.fakeBottomDrawer.contentViewController =
       [[MDCNavigationDrawerFakeTableViewController alloc] init];
 
@@ -567,6 +541,83 @@
 
   // Then
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.scrollView.contentOffset.y, 500, (CGFloat)0.001);
+}
+
+- (void)testExpandToFullScreenAnimationWithFullScreenContent {
+  // Given
+  self.fakeBottomDrawer.trackingScrollView = nil;
+  self.fakeBottomDrawer.originalPresentingViewController.view.bounds = CGRectMake(0, 0, 200, 500);
+  self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 5000);
+
+  // When
+  [self.fakeBottomDrawer animateToPreferredContentHeight:5000 withDuration:0 completion:nil];
+
+  // Then
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.scrollView.contentOffset.y, 230, 0.001);
+}
+- (void)testExpandToFullScreenAnimationWithSmallScreenContent {
+  // Given
+  self.fakeBottomDrawer.trackingScrollView = nil;
+  self.fakeBottomDrawer.originalPresentingViewController.view.bounds = CGRectMake(0, 0, 200, 500);
+  self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 300);
+
+  // When
+  [self.fakeBottomDrawer animateToPreferredContentHeight:300 withDuration:0 completion:nil];
+
+  // Then
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.scrollView.contentOffset.y, 50, 0.001);
+}
+- (void)testTotalHeightWithAddedContentHeight {
+  // Given
+  CGSize fakePreferredContentSize = CGSizeMake(200, 700);
+  [self setupHeaderWithPreferredContentSize:fakePreferredContentSize];
+  CGFloat fakeAddedHeight = 200;
+  CGFloat expectedHeight = fakeAddedHeight + fakePreferredContentSize.height;
+
+  // When
+  CGFloat totalHeight = [self.fakeBottomDrawer totalHeightWithAddedContentHeight:fakeAddedHeight];
+
+  // Then
+  XCTAssertEqualWithAccuracy(totalHeight, expectedHeight, 0.001);
+}
+- (void)testPrecentageOfFullScreenWithPreferredContentHeight {
+  // Given
+  [self setupHeaderWithPreferredContentSize:CGSizeZero];
+  CGFloat fakeAddedHeight = 200;
+
+  // When
+  CGFloat actualPercentage =
+  [self.fakeBottomDrawer precentageOfFullScreenWithPreferredContentHeight:fakeAddedHeight];
+
+  // Then
+  XCTAssertEqualWithAccuracy(actualPercentage, (CGFloat)0.4, 0.001);
+}
+- (void)testCalculateContentOffsetWithSmallPreferredContentHeight {
+  // Given
+  [self setupHeaderWithPreferredContentSize:CGSizeZero];
+  CGFloat fakeAddedHeight = 200;
+
+  // When
+  CGPoint acutalContentOffset =
+  [self.fakeBottomDrawer calculateContentOffsetWithPreferredContentHeight:fakeAddedHeight];
+
+  // Then
+  XCTAssertEqualWithAccuracy(acutalContentOffset.y, 200, 0.001);
+}
+- (void)testCalculateContentOffsetWithLargePreferredContentHeight {
+  // Given
+  [self setupHeaderWithPreferredContentSize:CGSizeZero];
+  CGFloat fakeAddedHeight = 20000;
+  // Subtract 20 for the top safe area
+  CGFloat expectedYOffset =
+  CGRectGetHeight(self.fakeBottomDrawer.originalPresentingViewController.view.bounds) - 20;
+
+  // When
+  CGPoint acutalContentOffset =
+  [self.fakeBottomDrawer calculateContentOffsetWithPreferredContentHeight:fakeAddedHeight];
+  
+  // Then
+  XCTAssertEqualWithAccuracy(acutalContentOffset.y, expectedYOffset, 0.001);
 }
 
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -108,7 +108,7 @@
 
 - (void)setupHeaderWithPreferredContentSize:(CGSize)size {
   MDCNavigationDrawerFakeHeaderViewController *fakeHeader =
-  [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
+      [[MDCNavigationDrawerFakeHeaderViewController alloc] init];
   fakeHeader.preferredContentSize = size;
   self.fakeBottomDrawer.headerViewController = fakeHeader;
 }
@@ -587,7 +587,7 @@
 
   // When
   CGFloat actualPercentage =
-  [self.fakeBottomDrawer precentageOfFullScreenWithPreferredContentHeight:fakeAddedHeight];
+      [self.fakeBottomDrawer precentageOfFullScreenWithPreferredContentHeight:fakeAddedHeight];
 
   // Then
   XCTAssertEqualWithAccuracy(actualPercentage, (CGFloat)0.4, 0.001);
@@ -599,7 +599,7 @@
 
   // When
   CGPoint acutalContentOffset =
-  [self.fakeBottomDrawer calculateContentOffsetWithPreferredContentHeight:fakeAddedHeight];
+      [self.fakeBottomDrawer calculateContentOffsetWithPreferredContentHeight:fakeAddedHeight];
 
   // Then
   XCTAssertEqualWithAccuracy(acutalContentOffset.y, 200, 0.001);
@@ -610,12 +610,12 @@
   CGFloat fakeAddedHeight = 20000;
   // Subtract 20 for the top safe area
   CGFloat expectedYOffset =
-  CGRectGetHeight(self.fakeBottomDrawer.originalPresentingViewController.view.bounds) - 20;
+      CGRectGetHeight(self.fakeBottomDrawer.originalPresentingViewController.view.bounds) - 20;
 
   // When
   CGPoint acutalContentOffset =
-  [self.fakeBottomDrawer calculateContentOffsetWithPreferredContentHeight:fakeAddedHeight];
-  
+      [self.fakeBottomDrawer calculateContentOffsetWithPreferredContentHeight:fakeAddedHeight];
+
   // Then
   XCTAssertEqualWithAccuracy(acutalContentOffset.y, expectedYOffset, 0.001);
 }


### PR DESCRIPTION
### Context
Clients may want to animate a navigation drawer to full screen once a user has completed a task. Before this change the navigation drawer would jump if a client changed their `preferredContentSize` of either child view controllers. This allows clients to change their `preferredContentSize` to animate to full screen or to the height of the content.

### The problem
If a client set their `preferredContentSize` their drawer would jump to the new height and never passed 50%, because that was the initial drawer height.
### The fix
Add an API to allow clients to change their `preferredContentHeight` to animate the drawer to full screen.

### Remaining work
Animation for top handle and corner radius is still not working.

### Videos
| Device with notch | Older device |
| - | - |
| ![after](https://user-images.githubusercontent.com/7131294/49020920-89bf4180-f15f-11e8-8336-e192c74b4df2.gif)|![olderdevice](https://user-images.githubusercontent.com/7131294/49020929-8d52c880-f15f-11e8-9b83-cc73195a7ed5.gif)|

### Related Bugs
Closes #5600
Related to #5151 