### PR TITLE
[NavigationDrawer] Allow clients to expand/collapse drawer

### DIFF
--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -106,6 +106,7 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
         print("Expand complete")
         sender.setTitle(newTitle, for: .normal)
         sender.sizeToFit()
+        sender.center = self.contentViewController.view.center
       }
       UIView.animate(withDuration: 5.2, animations: {
         print("Insert custom animation here")
@@ -115,6 +116,7 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
         print("Collapse complete")
         sender.setTitle(newTitle, for: .normal)
         sender.sizeToFit()
+        sender.center = self.contentViewController.view.center
       }
     }
     UIView.animate(withDuration: 5.2, animations: {

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -99,23 +99,8 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
   }
 
   @objc func expandBottomDrawer(sender: MDCButton) {
-    let shouldExpand = sender.titleLabel?.text == "EXPAND"
-    let newTitle = shouldExpand ? "COLLAPSE" : "EXPAND"
-    if (shouldExpand) {
-      bottomDrawerViewController.expandToFullHeight(withDuration: 5.2) { _ in
-        print("Expand complete")
-        sender.setTitle(newTitle, for: .normal)
-        sender.sizeToFit()
-      }
-      UIView.animate(withDuration: 5.2, animations: {
-        print("Insert custom animation here")
-      })
-    } else {
-      bottomDrawerViewController.collapseToOriginalHeight(withDuration: 5.2) { _ in
-        print("Collapse complete")
-        sender.setTitle(newTitle, for: .normal)
-        sender.sizeToFit()
-      }
+    bottomDrawerViewController.expandToFullHeight(withDuration: 0.2) { _ in
+      print("Expand complete")
     }
     UIView.animate(withDuration: 5.2, animations: {
       print("Insert custom animation here")

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -106,7 +106,6 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
         print("Expand complete")
         sender.setTitle(newTitle, for: .normal)
         sender.sizeToFit()
-        sender.center = self.contentViewController.view.center
       }
       UIView.animate(withDuration: 5.2, animations: {
         print("Insert custom animation here")
@@ -116,7 +115,6 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
         print("Collapse complete")
         sender.setTitle(newTitle, for: .normal)
         sender.sizeToFit()
-        sender.center = self.contentViewController.view.center
       }
     }
     UIView.animate(withDuration: 5.2, animations: {

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import UIKit
+import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialBottomAppBar_ColorThemer
 import MaterialComponents.MaterialColorScheme
@@ -25,6 +26,8 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
 
   let headerViewController = DrawerHeaderViewController()
   let contentViewController = DrawerContentViewController()
+  lazy var bottomDrawerViewController = MDCBottomDrawerViewController()
+
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -62,7 +65,8 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
   }
 
   @objc func presentNavigationDrawer() {
-    let bottomDrawerViewController = MDCBottomDrawerViewController()
+    bottomDrawerViewController = MDCBottomDrawerViewController()
+    layoutContentViewController()
     bottomDrawerViewController.setTopCornersRadius(24, for: .collapsed)
     bottomDrawerViewController.setTopCornersRadius(8, for: .expanded)
     bottomDrawerViewController.isTopHandleHidden = false
@@ -80,6 +84,42 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
     headerViewController.titleLabel.center =
       CGPoint(x: headerViewController.view.frame.size.width / 2,
               y: (headerViewController.view.frame.size.height + topInset) / 2)
+  }
+
+  private func layoutContentViewController() {
+    let button = MDCButton(frame: .zero)
+    button.setTitle("Expand", for: .normal)
+    button.sizeToFit()
+    button.addTarget(self, action: #selector(expandBottomDrawer), for: .touchUpInside)
+    button.center = CGPoint(x: view.frame.width / 2, y: 50)
+    let buttonScheme = MDCButtonScheme()
+    buttonScheme.colorScheme = colorScheme
+    MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
+    contentViewController.view.addSubview(button)
+  }
+
+  @objc func expandBottomDrawer(sender: MDCButton) {
+    let shouldExpand = sender.titleLabel?.text == "EXPAND"
+    let newTitle = shouldExpand ? "COLLAPSE" : "EXPAND"
+    if (shouldExpand) {
+      bottomDrawerViewController.expandToFullHeight(withDuration: 5.2) { _ in
+        print("Expand complete")
+        sender.setTitle(newTitle, for: .normal)
+        sender.sizeToFit()
+      }
+      UIView.animate(withDuration: 5.2, animations: {
+        print("Insert custom animation here")
+      })
+    } else {
+      bottomDrawerViewController.collapseToOriginalHeight(withDuration: 5.2) { _ in
+        print("Collapse complete")
+        sender.setTitle(newTitle, for: .normal)
+        sender.sizeToFit()
+      }
+    }
+    UIView.animate(withDuration: 5.2, animations: {
+      print("Insert custom animation here")
+    })
   }
 }
 

--- a/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
+++ b/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
@@ -17,7 +17,7 @@ import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialNavigationDrawer
 
 class DrawerContentViewController: UIViewController {
-  var preferredHeight: CGFloat = 2000
+  var preferredHeight: CGFloat = 450
 
   override var preferredContentSize: CGSize {
     get {

--- a/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
+++ b/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
@@ -17,7 +17,7 @@ import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialNavigationDrawer
 
 class DrawerContentViewController: UIViewController {
-  var preferredHeight: CGFloat = 450
+  var preferredHeight: CGFloat = 2000
 
   override var preferredContentSize: CGSize {
     get {

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -101,4 +101,9 @@
  */
 - (void)setContentOffsetY:(CGFloat)contentOffsetY animated:(BOOL)animated;
 
+- (void)expandToFullHeightWithDuration:(NSTimeInterval)duration
+                         completion:(void (^__nullable)(BOOL finished))completion;
+
+- (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
+                               completion:(void (^__nullable)(BOOL finished))completion;
 @end

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -101,9 +101,18 @@
  */
 - (void)setContentOffsetY:(CGFloat)contentOffsetY animated:(BOOL)animated;
 
+/**
+ Animates the navigation drawer to the full height of it's content, if the content is larger than
+ the screen height then this animates to full screen height.
+
+ @param duration The total duration of the animations, measured in seconds. If you specify a
+ negative value or 0, the changes are made without animating them.
+ @param completion A block object to be executed when the animation sequence ends. This block has
+ no return value and takes a single Boolean argument that indicates whether or not the animations
+ actually finished before the completion handler was called. If the duration of the animation is 0,
+ this block is performed at the beginning of the next run loop cycle. This parameter may be NULL.
+ */
 - (void)expandToFullHeightWithDuration:(NSTimeInterval)duration
                             completion:(void (^__nullable)(BOOL finished))completion;
 
-- (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
-                                  completion:(void (^__nullable)(BOOL finished))completion;
 @end

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -102,8 +102,8 @@
 - (void)setContentOffsetY:(CGFloat)contentOffsetY animated:(BOOL)animated;
 
 - (void)expandToFullHeightWithDuration:(NSTimeInterval)duration
-                         completion:(void (^__nullable)(BOOL finished))completion;
+                            completion:(void (^__nullable)(BOOL finished))completion;
 
 - (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
-                               completion:(void (^__nullable)(BOOL finished))completion;
+                                  completion:(void (^__nullable)(BOOL finished))completion;
 @end

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -274,10 +274,4 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
                                                                 completion:completion];
 }
 
-- (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
-                                  completion:(void (^)(BOOL))completion {
-  [self.bottomDrawerContainerViewController collapseToOriginalHeightWithDuration:duration
-                                                                      completion:completion];
-}
-
 @end

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -268,15 +268,16 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
   [self.bottomDrawerContainerViewController setContentOffsetY:contentOffsetY animated:animated];
 }
 
-- (void)expandToFullHeightWithDuration:(NSTimeInterval)duration completion:(void (^)(BOOL))completion {
+- (void)expandToFullHeightWithDuration:(NSTimeInterval)duration
+                            completion:(void (^)(BOOL))completion {
   [self.bottomDrawerContainerViewController expandToFullHeightWithDuration:duration
-                                                             completion:completion];
+                                                                completion:completion];
 }
 
 - (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
-                               completion:(void (^)(BOOL))completion {
+                                  completion:(void (^)(BOOL))completion {
   [self.bottomDrawerContainerViewController collapseToOriginalHeightWithDuration:duration
-                                                                   completion:completion];
+                                                                      completion:completion];
 }
 
 @end

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -268,4 +268,15 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
   [self.bottomDrawerContainerViewController setContentOffsetY:contentOffsetY animated:animated];
 }
 
+- (void)expandToFullHeightWithDuration:(NSTimeInterval)duration completion:(void (^)(BOOL))completion {
+  [self.bottomDrawerContainerViewController expandToFullHeightWithDuration:duration
+                                                             completion:completion];
+}
+
+- (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
+                               completion:(void (^)(BOOL))completion {
+  [self.bottomDrawerContainerViewController collapseToOriginalHeightWithDuration:duration
+                                                                   completion:completion];
+}
+
 @end

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -101,10 +101,10 @@
 - (void)setContentOffsetY:(CGFloat)contentOffsetY animated:(BOOL)animated;
 
 - (void)expandToFullHeightWithDuration:(NSTimeInterval)duration
-                           completion:(void (^__nullable)(BOOL finished))completion;
+                            completion:(void (^__nullable)(BOOL finished))completion;
 
 - (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
-                               completion:(void (^__nullable)(BOOL finished))completion;
+                                  completion:(void (^__nullable)(BOOL finished))completion;
 
 @end
 

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -100,11 +100,19 @@
  */
 - (void)setContentOffsetY:(CGFloat)contentOffsetY animated:(BOOL)animated;
 
+/**
+ Animates the navigation drawer to the full height of it's content, if the content is larger than
+ the screen height then this animates to full screen height.
+
+ @param duration The total duration of the animations, measured in seconds. If you specify a
+ negative value or 0, the changes are made without animating them.
+ @param completion A block object to be executed when the animation sequence ends. This block has
+ no return value and takes a single Boolean argument that indicates whether or not the animations
+ actually finished before the completion handler was called. If the duration of the animation is 0,
+ this block is performed at the beginning of the next run loop cycle. This parameter may be NULL.
+ */
 - (void)expandToFullHeightWithDuration:(NSTimeInterval)duration
                             completion:(void (^__nullable)(BOOL finished))completion;
-
-- (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
-                                  completion:(void (^__nullable)(BOOL finished))completion;
 
 @end
 

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -100,6 +100,12 @@
  */
 - (void)setContentOffsetY:(CGFloat)contentOffsetY animated:(BOOL)animated;
 
+- (void)expandToFullHeightWithDuration:(NSTimeInterval)duration
+                           completion:(void (^__nullable)(BOOL finished))completion;
+
+- (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
+                               completion:(void (^__nullable)(BOOL finished))completion;
+
 @end
 
 /**

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -175,16 +175,6 @@
   }
 }
 
-- (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
-                                  completion:(void (^)(BOOL))completion {
-  if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
-    MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
-        (MDCBottomDrawerPresentationController *)self.presentationController;
-    [bottomDrawerPresentationController collapseToOriginalHeightWithDuration:duration
-                                                                  completion:completion];
-  }
-}
-
 #pragma mark UIAccessibilityAction
 
 // Adds the Z gesture for dismissal.

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -165,21 +165,23 @@
   }
 }
 
-- (void)expandToFullHeightWithDuration:(NSTimeInterval)duration completion:(void (^)(BOOL))completion {
+- (void)expandToFullHeightWithDuration:(NSTimeInterval)duration
+                            completion:(void (^)(BOOL))completion {
   if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
     MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
-    (MDCBottomDrawerPresentationController *)self.presentationController;
-    [bottomDrawerPresentationController expandToFullHeightWithDuration:duration completion:completion];
+        (MDCBottomDrawerPresentationController *)self.presentationController;
+    [bottomDrawerPresentationController expandToFullHeightWithDuration:duration
+                                                            completion:completion];
   }
 }
 
 - (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
-                               completion:(void (^)(BOOL))completion {
+                                  completion:(void (^)(BOOL))completion {
   if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
     MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
-    (MDCBottomDrawerPresentationController *)self.presentationController;
+        (MDCBottomDrawerPresentationController *)self.presentationController;
     [bottomDrawerPresentationController collapseToOriginalHeightWithDuration:duration
-                                                               completion:completion];
+                                                                  completion:completion];
   }
 }
 

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -165,6 +165,24 @@
   }
 }
 
+- (void)expandToFullHeightWithDuration:(NSTimeInterval)duration completion:(void (^)(BOOL))completion {
+  if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
+    MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
+    (MDCBottomDrawerPresentationController *)self.presentationController;
+    [bottomDrawerPresentationController expandToFullHeightWithDuration:duration completion:completion];
+  }
+}
+
+- (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
+                               completion:(void (^)(BOOL))completion {
+  if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
+    MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
+    (MDCBottomDrawerPresentationController *)self.presentationController;
+    [bottomDrawerPresentationController collapseToOriginalHeightWithDuration:duration
+                                                               completion:completion];
+  }
+}
+
 #pragma mark UIAccessibilityAction
 
 // Adds the Z gesture for dismissal.

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -133,6 +133,6 @@
  this block is performed at the beginning of the next run loop cycle. This parameter may be NULL.
  */
 - (void)expandToFullHeightWithDuration:(NSTimeInterval)duration
-                            completion:(void (^ __nullable)(BOOL))completion;
+                            completion:(void (^__nullable)(BOOL))completion;
 
 @end

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -121,10 +121,18 @@
  */
 - (void)setContentOffsetY:(CGFloat)contentOffsetY animated:(BOOL)animated;
 
+/**
+ Animates the navigation drawer to the full height of it's content, if the content is larger than
+ the screen height then this animates to full screen height.
+
+ @param duration The total duration of the animations, measured in seconds. If you specify a
+ negative value or 0, the changes are made without animating them.
+ @param completion A block object to be executed when the animation sequence ends. This block has
+ no return value and takes a single Boolean argument that indicates whether or not the animations
+ actually finished before the completion handler was called. If the duration of the animation is 0,
+ this block is performed at the beginning of the next run loop cycle. This parameter may be NULL.
+ */
 - (void)expandToFullHeightWithDuration:(NSTimeInterval)duration
                             completion:(void (^)(BOOL))completion;
-
-- (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
-                                  completion:(void (^)(BOOL))completion;
 
 @end

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -133,6 +133,6 @@
  this block is performed at the beginning of the next run loop cycle. This parameter may be NULL.
  */
 - (void)expandToFullHeightWithDuration:(NSTimeInterval)duration
-                            completion:(void (^)(BOOL))completion;
+                            completion:(void (^ __nullable)(BOOL))completion;
 
 @end

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -121,4 +121,9 @@
  */
 - (void)setContentOffsetY:(CGFloat)contentOffsetY animated:(BOOL)animated;
 
+- (void)expandToFullHeightWithDuration:(NSTimeInterval)duration completion:(void (^)(BOOL))completion;
+
+- (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
+                               completion:(void (^)(BOOL))completion;
+
 @end

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -121,9 +121,10 @@
  */
 - (void)setContentOffsetY:(CGFloat)contentOffsetY animated:(BOOL)animated;
 
-- (void)expandToFullHeightWithDuration:(NSTimeInterval)duration completion:(void (^)(BOOL))completion;
+- (void)expandToFullHeightWithDuration:(NSTimeInterval)duration
+                            completion:(void (^)(BOOL))completion;
 
 - (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
-                               completion:(void (^)(BOOL))completion;
+                                  completion:(void (^)(BOOL))completion;
 
 @end

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -388,21 +388,6 @@ static UIColor *DrawerShadowColor(void) {
                     completion:completion];
 }
 
-- (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
-                                  completion:(void (^)(BOOL))completion {
-  if ([self shouldPresentFullScreen]) {
-    return;
-  }
-  CGPoint contentOffset = CGPointZero;
-  if (self.trackingScrollView != nil) {
-    contentOffset.y = [self updateContentOffsetForPerformantScrolling:contentOffset.y];
-  }
-  [self animateToContentOffset:contentOffset
-           withTransitionRatio:0
-                      duration:duration
-                    completion:completion];
-}
-
 - (void)animateToContentOffset:(CGPoint)contentOffset
            withTransitionRatio:(CGFloat)transitionRatio
                       duration:(NSTimeInterval)duration

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -368,24 +368,28 @@ static UIColor *DrawerShadowColor(void) {
   _scrollToContentOffsetY = 0;
 }
 
-- (void)expandToFullHeightWithDuration:(NSTimeInterval)duration completion:(void (^)(BOOL))completion {
+- (void)expandToFullHeightWithDuration:(NSTimeInterval)duration
+                            completion:(void (^)(BOOL))completion {
   CGFloat contentYOffset = self.contentHeaderTopInset - MDCDeviceTopSafeAreaInset();
   CGPoint contentOffset = CGPointMake(self.scrollView.contentOffset.x, contentYOffset);
   CGFloat totalHeight = self.headerViewController.preferredContentSize.height +
-      _contentVCPreferredContentSizeHeightCached;
+                        _contentVCPreferredContentSizeHeightCached;
   if (totalHeight < self.presentingViewBounds.size.height) {
-    CGFloat diff = self.presentingViewBounds.size.height - totalHeight - MDCDeviceTopSafeAreaInset();
+    CGFloat diff =
+        self.presentingViewBounds.size.height - totalHeight - MDCDeviceTopSafeAreaInset();
     contentOffset.y -= diff;
   }
   if (self.trackingScrollView != nil) {
     contentOffset.y = [self updateContentOffsetForPerformantScrolling:contentOffset.y];
   }
-  [self animateToContentOffset:contentOffset withTransitionRatio:1 duration:duration
+  [self animateToContentOffset:contentOffset
+           withTransitionRatio:1
+                      duration:duration
                     completion:completion];
 }
 
 - (void)collapseToOriginalHeightWithDuration:(NSTimeInterval)duration
-                               completion:(void (^)(BOOL))completion {
+                                  completion:(void (^)(BOOL))completion {
   if ([self shouldPresentFullScreen]) {
     return;
   }
@@ -393,22 +397,28 @@ static UIColor *DrawerShadowColor(void) {
   if (self.trackingScrollView != nil) {
     contentOffset.y = [self updateContentOffsetForPerformantScrolling:contentOffset.y];
   }
-  [self animateToContentOffset:contentOffset withTransitionRatio:0 duration:duration
+  [self animateToContentOffset:contentOffset
+           withTransitionRatio:0
+                      duration:duration
                     completion:completion];
 }
 
-- (void)animateToContentOffset:(CGPoint)contentOffset withTransitionRatio:(CGFloat)transitionRatio
-                      duration:(NSTimeInterval)duration completion:(void (^)(BOOL))completion {
-  [UIView animateWithDuration:duration animations:^{
-    [self.delegate bottomDrawerContainerViewControllerTopTransitionRatio:self
-                                                         transitionRatio:transitionRatio];
-    [self.scrollView setContentOffset:contentOffset];
-  } completion:^(BOOL finished) {
-    [self updateViewWithContentOffset:contentOffset];
-    if (completion) {
-      completion(YES);
-    }
-  }];
+- (void)animateToContentOffset:(CGPoint)contentOffset
+           withTransitionRatio:(CGFloat)transitionRatio
+                      duration:(NSTimeInterval)duration
+                    completion:(void (^)(BOOL))completion {
+  [UIView animateWithDuration:duration
+      animations:^{
+        [self.delegate bottomDrawerContainerViewControllerTopTransitionRatio:self
+                                                             transitionRatio:transitionRatio];
+        [self.scrollView setContentOffset:contentOffset];
+      }
+      completion:^(BOOL finished) {
+        [self updateViewWithContentOffset:contentOffset];
+        if (completion) {
+          completion(YES);
+        }
+      }];
 }
 
 #pragma mark UIViewController

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -569,12 +569,23 @@
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.scrollView.contentOffset.y, 500, (CGFloat)0.001);
 }
 
-- (void)testExpandToFullScreen {
+- (void)testExpandToFullHeightLargeContent {
+  // Given
+  self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 5000);
+  self.fakeBottomDrawer.originalPresentingViewController.view.bounds = CGRectMake(0, 0, 200, 500);
+
   // When
-  [self.drawerViewController expandToFullHeightWithDuration:0.0 completion:nil];
+  [self.fakeBottomDrawer.view setNeedsLayout];
+  [self.fakeBottomDrawer.view layoutIfNeeded];
+  [self.fakeBottomDrawer expandToFullHeightWithDuration:0 completion:nil];
 
   // Then
-  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.scrollView.contentOffset.y, 0.0, 0.001);
+  // Safe area is always 20 in test unless explicitly set otherwise
+  CGFloat safeArea = 20;
+  CGFloat expectedContentOffset =
+      self.fakeBottomDrawer.presentingViewBounds.size.height - safeArea;
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.scrollView.contentOffset.y + safeArea,
+                             expectedContentOffset, 0.001);
 }
 
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -582,8 +582,7 @@
   // Then
   // Safe area is always 20 in test unless explicitly set otherwise
   CGFloat safeArea = 20;
-  CGFloat expectedContentOffset =
-      self.fakeBottomDrawer.presentingViewBounds.size.height - safeArea;
+  CGFloat expectedContentOffset = self.fakeBottomDrawer.presentingViewBounds.size.height - safeArea;
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.scrollView.contentOffset.y + safeArea,
                              expectedContentOffset, 0.001);
 }

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -569,4 +569,12 @@
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.scrollView.contentOffset.y, 500, (CGFloat)0.001);
 }
 
+- (void)testExpandToFullScreen {
+  // When
+  [self.drawerViewController expandToFullHeightWithDuration:0.0 completion:nil];
+
+  // Then
+  XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.scrollView.contentOffset.y, 0.0, 0.001);
+}
+
 @end


### PR DESCRIPTION
This will allow clients to expand or collapse the drawer to the full height of their `headerViewController.preferredContentSize.height` + `contentViewController.preferredContentSize.height`. If the height of the two combined is 300 on a 400pt screen this this expands the drawer to 75%. If the height is 1000 on a 400pt screen this expands the drawer to 100%. 

This is a prototype, it is missing test and docs. 

This is an alternative to #5826 