### PR TITLE
[ButtonBar] Add a Theming extension.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -317,6 +317,8 @@ Pod::Spec.new do |mdc|
       tests.test_spec 'unit' do |unit_tests|
         unit_tests.source_files = "components/#{component.base_name}/tests/unit/*.{h,m,swift}", "components/#{component.base_name}/tests/unit/supplemental/*.{h,m,swift}"
         unit_tests.resources = "components/#{component.base_name}/tests/unit/resources/*"
+
+        unit_tests.dependency "MaterialComponentsAlpha/#{component.base_name}+Theming"
       end
     end
   end

--- a/MaterialComponentsAlpha.podspec
+++ b/MaterialComponentsAlpha.podspec
@@ -56,6 +56,17 @@ Pod::Spec.new do |mdc|
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 
+  mdc.subspec "ButtonBar+Theming" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
+
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+ColorThemer"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+TypographyThemer"
+    extension.dependency "MaterialComponentsAlpha/schemes/Container"
+  end
+
   mdc.subspec "Buttons+Theming" do |extension|
     extension.ios.deployment_target = '8.0'
     extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"

--- a/catalog/Podfile
+++ b/catalog/Podfile
@@ -12,6 +12,7 @@ target "MDCCatalog" do
     'BottomAppBar/tests/unit',
     'BottomNavigation/tests/unit',
     'BottomSheet/tests/unit',
+    'ButtonBar/tests/unit',
     'Buttons/tests/unit',
     'Cards/tests/unit',
     'Chips/tests/unit',

--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -65,6 +65,21 @@ mdc_objc_library(
 )
 
 mdc_objc_library(
+    name = "Theming",
+    srcs = native.glob(["src/Theming/*.m"]),
+    hdrs = native.glob(["src/Theming/*.h"]),
+    includes = ["src/Theming"],
+    sdk_frameworks = [
+        "UIKit",
+    ],
+    deps = [
+        ":ButtonBar",
+        "//components/schemes/Container",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+mdc_objc_library(
     name = "private",
     hdrs = native.glob(["src/private/*.h"]),
     includes = ["src/private"],
@@ -85,6 +100,7 @@ mdc_objc_library(
     deps = [
         ":ButtonBar",
         ":ColorThemer",
+        ":Theming",
         ":private",
     ],
     visibility = ["//visibility:private"],
@@ -96,6 +112,7 @@ swift_library(
     deps = [
         ":ButtonBar",
         ":ColorThemer",
+        ":Theming",
         ":TypographyThemer",
         ":private",
     ],

--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -74,6 +74,8 @@ mdc_objc_library(
     ],
     deps = [
         ":ButtonBar",
+        ":ColorThemer",
+        ":TypographyThemer",
         "//components/schemes/Container",
     ],
     visibility = ["//visibility:public"],

--- a/components/ButtonBar/examples/ButtonBarCustomizedFontExample.m
+++ b/components/ButtonBar/examples/ButtonBarCustomizedFontExample.m
@@ -14,9 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialButtonBar+Theming.h"
 #import "MaterialButtonBar.h"
-#import "MaterialButtonBar+ColorThemer.h"
-#import "MaterialButtonBar+TypographyThemer.h"
 
 @interface ButtonBarCustomizedFontExample : UIViewController
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
@@ -30,11 +29,19 @@
   if (self) {
     self.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.typographyScheme = [[MDCTypographyScheme alloc] init];
-    
+    self.typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+
     self.title = @"Button Bar";
   }
   return self;
+}
+
+- (MDCContainerScheme *)containerScheme {
+  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+  scheme.colorScheme = self.colorScheme;
+  scheme.typographyScheme = self.typographyScheme;
+  return scheme;
 }
 
 - (void)viewDidLoad {
@@ -42,10 +49,10 @@
 
   MDCButtonBar *buttonBar = [[MDCButtonBar alloc] init];
 
-  self.typographyScheme.button = [UIFont fontWithName:@"American Typewriter" size:10];
-  [MDCButtonBarTypographyThemer applyTypographyScheme:self.typographyScheme toButtonBar:buttonBar];
+  MDCContainerScheme *scheme = [self containerScheme];
+  scheme.typographyScheme.button = [UIFont fontWithName:@"American Typewriter" size:10];
 
-  [MDCButtonBarColorThemer applySemanticColorScheme:self.colorScheme toButtonBar:buttonBar];
+  [buttonBar applyPrimaryThemeWithScheme:scheme];
 
   // MDCButtonBar ignores the style of UIBarButtonItem.
   UIBarButtonItemStyle ignored = UIBarButtonItemStyleDone;

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.m
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.m
@@ -14,12 +14,12 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialButtonBar+Theming.h"
 #import "MaterialButtonBar.h"
-#import "MaterialColorScheme.h"
-#import "MaterialButtonBar+ColorThemer.h"
 
 @interface ButtonBarTypicalUseExample : UIViewController
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
 @end
 
 @implementation ButtonBarTypicalUseExample
@@ -29,15 +29,26 @@
   if (self) {
     self.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    self.typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
     self.title = @"Button Bar";
   }
   return self;
+}
+
+- (MDCContainerScheme *)containerScheme {
+  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+  scheme.colorScheme = self.colorScheme;
+  scheme.typographyScheme = self.typographyScheme;
+  return scheme;
 }
 
 - (void)viewDidLoad {
   [super viewDidLoad];
 
   MDCButtonBar *buttonBar = [[MDCButtonBar alloc] init];
+  MDCContainerScheme *scheme = [self containerScheme];
+  [buttonBar applyPrimaryThemeWithScheme:scheme];
 
   // MDCButtonBar ignores the style of UIBarButtonItem.
   UIBarButtonItemStyle ignored = UIBarButtonItemStyleDone;
@@ -54,8 +65,6 @@
                                       action:@selector(didTapActionButton:)];
 
   buttonBar.items = @[ actionItem, secondActionItem ];
-
-  [MDCButtonBarColorThemer applySemanticColorScheme:self.colorScheme toButtonBar:buttonBar];
 
   // MDCButtonBar's sizeThatFits gives a "best-fit" size of the provided items.
   CGSize size = [buttonBar sizeThatFits:self.view.bounds.size];

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
@@ -13,15 +13,26 @@
 // limitations under the License.
 
 import Foundation
-import MaterialComponents.MaterialButtonBar_ColorThemer
+import MaterialComponents.MaterialButtonBar
+import MaterialComponentsAlpha.MaterialButtonBar_Theming
 
 class ButtonBarTypicalUseSwiftExample: UIViewController {
-  var colorScheme = MDCSemanticColorScheme()
+  var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+  var typographyScheme = MDCTypographyScheme(defaults: .material201804)
+
+  var scheme: MDCContainerScheming {
+    let scheme = MDCContainerScheme()
+    scheme.colorScheme = colorScheme
+    scheme.typographyScheme = typographyScheme
+    return scheme
+  }
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
     let buttonBar = MDCButtonBar()
+    buttonBar.applyPrimaryTheme(withScheme: scheme)
+
     // MDCButtonBar ignores the style of UIBarButtonItem.
     let ignored: UIBarButtonItemStyle = .done
 
@@ -40,8 +51,6 @@ class ButtonBarTypicalUseSwiftExample: UIViewController {
     )
 
     buttonBar.items = [actionItem, secondActionItem]
-
-    MDCButtonBarColorThemer.applySemanticColorScheme(colorScheme, to: buttonBar)
 
     // MDCButtonBar's sizeThatFits gives a "best-fit" size of the provided items.
     let size = buttonBar.sizeThatFits(self.view.bounds.size)

--- a/components/ButtonBar/src/Theming/MDCButtonBar+Theming.h
+++ b/components/ButtonBar/src/Theming/MDCButtonBar+Theming.h
@@ -1,0 +1,30 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialButtonBar.h"
+#import "MaterialContainerScheme.h"
+
+// This category applies Material themes that are defined in the Material Guidelines:
+// https://material.io/design/components/app-bars-top.html
+@interface MDCButtonBar (MaterialTheming)
+
+/**
+ Apply the primary theme to this instance.
+
+ @param scheme A container scheme instance containing any desired customizations to the theming
+ system.
+ */
+- (void)applyPrimaryThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
+@end

--- a/components/ButtonBar/src/Theming/MDCButtonBar+Theming.m
+++ b/components/ButtonBar/src/Theming/MDCButtonBar+Theming.m
@@ -1,0 +1,46 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCButtonBar+Theming.h"
+
+#import "MaterialButtonBar+ColorThemer.h"
+#import "MaterialButtonBar+TypographyThemer.h"
+
+@implementation MDCButtonBar (MaterialTheming)
+
+- (void)applyPrimaryThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme {
+  id<MDCColorScheming> colorScheme = scheme.colorScheme;
+  if (!colorScheme) {
+    colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+  [self applyPrimaryThemeWithColorScheme:colorScheme];
+
+  id<MDCTypographyScheming> typographyScheme = scheme.typographyScheme;
+  if (!typographyScheme) {
+    typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+  }
+  [self applyPrimaryThemeWithTypographyScheme:typographyScheme];
+}
+
+- (void)applyPrimaryThemeWithColorScheme:(nonnull id<MDCColorScheming>)scheme {
+  [MDCButtonBarColorThemer applySemanticColorScheme:scheme toButtonBar:self];
+}
+
+- (void)applyPrimaryThemeWithTypographyScheme:(nonnull id<MDCTypographyScheming>)scheme {
+  [MDCButtonBarTypographyThemer applyTypographyScheme:scheme toButtonBar:self];
+}
+
+@end

--- a/components/ButtonBar/src/Theming/MaterialButtonBar+Theming.h
+++ b/components/ButtonBar/src/Theming/MaterialButtonBar+Theming.h
@@ -1,0 +1,15 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCButtonBar+Theming.h"

--- a/components/ButtonBar/tests/unit/ButtonBarBuilderTests.m
+++ b/components/ButtonBar/tests/unit/ButtonBarBuilderTests.m
@@ -14,6 +14,7 @@
 
 #import <XCTest/XCTest.h>
 #import "MDCAppBarButtonBarBuilder.h"
+#import "MaterialButtonBar+Theming.h"
 #import "MaterialButtonBar.h"
 #import "MaterialButtons.h"
 

--- a/components/ButtonBar/tests/unit/ButtonBarThemingTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarThemingTests.swift
@@ -1,0 +1,44 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import MaterialComponents.MaterialButtonBar
+import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialTypographyScheme
+import MaterialComponentsAlpha.MaterialButtonBar_Theming
+
+class ButtonBarThemingTests: XCTestCase {
+
+  func testPrimaryThemeWithDefaults() {
+    // Given
+    let buttonBar = MDCButtonBar()
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    buttonBar.items = items
+
+    let scheme = MDCContainerScheme()
+    buttonBar.applyPrimaryTheme(withScheme: scheme)
+
+    // Then
+    let colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    XCTAssertEqual(buttonBar.backgroundColor, colorScheme.primaryColor)
+    XCTAssertEqual(buttonBar.tintColor, colorScheme.onPrimaryColor)
+    let typographyScheme = MDCTypographyScheme(defaults: .material201804)
+    for view in buttonBar.subviews {
+      if let button = view as? MDCButton {
+        XCTAssertEqual(button.titleFont(for: .normal), typographyScheme.button)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change makes use of MDCContainerScheme to provide a single theming-related API for ButtonBar.

Includes example updates unit tests.

This change is the first in a series of changes that will be required to add Theming extension support to AppBar:

- [x] ButtonBar
- [ ] NavigationBar
- [ ] HeaderStackView
- [ ] FlexibleHeader
- [ ] AppBar