### PR TITLE
[Buttons] Add themer for contained buttons with container scheme

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -255,6 +255,16 @@ Pod::Spec.new do |mdc|
     end
   end
 
+  mdc.subspec "Buttons+Theming" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/schemes/Color"
+    extension.dependency "MaterialComponents/schemes/Typography"
+    extension.dependency "MaterialComponents/schemes/Shape"
+  end
+
   mdc.subspec "Buttons+ColorThemer" do |extension|
     extension.ios.deployment_target = '8.0'
     extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -251,18 +251,10 @@ Pod::Spec.new do |mdc|
       tests.test_spec 'unit' do |unit_tests|
         unit_tests.source_files = "components/#{component.base_name}/tests/unit/*.{h,m,swift}", "components/#{component.base_name}/tests/unit/supplemental/*.{h,m,swift}"
         unit_tests.resources = "components/#{component.base_name}/tests/unit/resources/*"
+
+        unit_tests.dependency "MaterialComponentsAlpha/#{component.base_name}+Theming"
       end
     end
-  end
-
-  mdc.subspec "Buttons+Theming" do |extension|
-    extension.ios.deployment_target = '8.0'
-    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
-    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
-    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
-    extension.dependency "MaterialComponents/schemes/Color"
-    extension.dependency "MaterialComponents/schemes/Typography"
-    extension.dependency "MaterialComponents/schemes/Shape"
   end
 
   mdc.subspec "Buttons+ColorThemer" do |extension|

--- a/MaterialComponentsAlpha.podspec
+++ b/MaterialComponentsAlpha.podspec
@@ -56,6 +56,17 @@ Pod::Spec.new do |mdc|
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 
+  mdc.subspec "Buttons+Theming" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+ColorThemer"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+ShapeThemer"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+TypographyThemer"
+    extension.dependency "MaterialComponentsAlpha/schemes/Container"
+  end
+
   mdc.subspec "schemes" do |scheme_spec|
     scheme_spec.subspec "Container" do |scheme|
       scheme.ios.deployment_target = '8.0'

--- a/MaterialComponentsAlpha.podspec
+++ b/MaterialComponentsAlpha.podspec
@@ -64,6 +64,7 @@ Pod::Spec.new do |mdc|
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+ColorThemer"
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+ShapeThemer"
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+TypographyThemer"
+    extension.dependency "MaterialComponents/ShadowElevations"
     extension.dependency "MaterialComponentsAlpha/schemes/Container"
   end
 

--- a/components/Buttons/BUILD
+++ b/components/Buttons/BUILD
@@ -42,6 +42,19 @@ mdc_public_objc_library(
 )
 
 mdc_objc_library(
+    name = "Theming",
+    srcs = native.glob(["src/Theming/*.m"]),
+    hdrs = native.glob(["src/Theming/*.h"]),
+    includes = ["src/Theming"],
+    deps = [
+        ":Buttons",
+        "//components/schemes/Container",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+
+mdc_objc_library(
     name = "ColorThemer",
     srcs = native.glob(["src/ColorThemer/*.m"]),
     hdrs = native.glob(["src/ColorThemer/*.h"]),

--- a/components/Buttons/BUILD
+++ b/components/Buttons/BUILD
@@ -48,6 +48,9 @@ mdc_objc_library(
     includes = ["src/Theming"],
     deps = [
         ":Buttons",
+        ":ColorThemer",
+        ":ShapeThemer",
+        ":TypographyThemer",
         "//components/schemes/Container",
     ],
     visibility = ["//visibility:public"],

--- a/components/Buttons/BUILD
+++ b/components/Buttons/BUILD
@@ -51,6 +51,7 @@ mdc_objc_library(
         ":ColorThemer",
         ":ShapeThemer",
         ":TypographyThemer",
+        "//components/ShadowElevations",
         "//components/schemes/Container",
     ],
     visibility = ["//visibility:public"],

--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -16,6 +16,7 @@
 
 #import "MaterialButtons.h"
 #import "MaterialButtons+ButtonThemer.h"
+#import "MaterialButtons+Theming.h"
 
 @interface ButtonsContentEdgeInsetsExample : UIViewController
 @property(weak, nonatomic) IBOutlet MDCButton *textButton;
@@ -43,8 +44,8 @@
   [super viewDidLoad];
 
   MDCButtonScheme *buttonScheme = [[MDCButtonScheme alloc] init];
-  [MDCContainedButtonThemer applyScheme:buttonScheme toButton:self.containedButton];
   [MDCTextButtonThemer applyScheme:buttonScheme toButton:self.textButton];
+  [self.containedButton applyContainedThemeWithScheme:[self containerScheme]];
 
   self.textButton.contentEdgeInsets = UIEdgeInsetsMake(64, 64, 0, 0);
   self.containedButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, 64, 64);
@@ -53,6 +54,17 @@
                                            inMode:MDCFloatingButtonModeNormal];
 
   [self updateInkStyle:self.inkBoundingSwitch.isOn ? MDCInkStyleBounded : MDCInkStyleUnbounded];
+}
+
+- (MDCContainerScheme *)containerScheme {
+  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+  scheme.colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  scheme.shapeScheme =
+      [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  scheme.typographyScheme =
+      [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+  return scheme;
 }
 
 - (void)updateInkStyle:(MDCInkStyle)inkStyle {

--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -14,9 +14,9 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialButtons.h"
 #import "MaterialButtons+ButtonThemer.h"
 #import "MaterialButtons+Theming.h"
+#import "MaterialButtons.h"
 
 @interface ButtonsContentEdgeInsetsExample : UIViewController
 @property(weak, nonatomic) IBOutlet MDCButton *textButton;

--- a/components/Buttons/examples/ButtonsShapesExampleViewController.m
+++ b/components/Buttons/examples/ButtonsShapesExampleViewController.m
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MaterialButtons.h"
 #import "MaterialButtons+ButtonThemer.h"
-#import "MaterialButtons+Theming.h"
 #import "MaterialButtons+ColorThemer.h"
+#import "MaterialButtons+Theming.h"
 #import "MaterialButtons+TypographyThemer.h"
-#import "MaterialShapes.h"
+#import "MaterialButtons.h"
 #import "MaterialShapeLibrary.h"
+#import "MaterialShapes.h"
 #import "MaterialTypography.h"
 #import "supplemental/ButtonsTypicalUseSupplemental.h"
 

--- a/components/Buttons/examples/ButtonsShapesExampleViewController.m
+++ b/components/Buttons/examples/ButtonsShapesExampleViewController.m
@@ -14,6 +14,7 @@
 
 #import "MaterialButtons.h"
 #import "MaterialButtons+ButtonThemer.h"
+#import "MaterialButtons+Theming.h"
 #import "MaterialButtons+ColorThemer.h"
 #import "MaterialButtons+TypographyThemer.h"
 #import "MaterialShapes.h"
@@ -32,9 +33,19 @@
   if (self) {
     self.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
   }
   return self;
+}
+
+- (MDCContainerScheme *)containerScheme {
+  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+  scheme.colorScheme = self.colorScheme;
+  scheme.shapeScheme =
+      [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  scheme.typographyScheme = self.typographyScheme;
+  return scheme;
 }
 
 - (MDCButton *)buildCustomStrokedButton {
@@ -59,7 +70,7 @@
 
   MDCButton *containedButton = [[MDCButton alloc] init];
   [containedButton setTitle:@"Add To Cart" forState:UIControlStateNormal];
-  [MDCContainedButtonThemer applyScheme:buttonScheme toButton:containedButton];
+  [containedButton applyContainedThemeWithScheme:[self containerScheme]];
 
   UIImage *plusImage = [UIImage imageNamed:@"Plus"];
   plusImage = [plusImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
@@ -80,7 +91,7 @@
 
   MDCButton *disabledContainedButton = [[MDCButton alloc] init];
   [disabledContainedButton setTitle:@"Disabled" forState:UIControlStateNormal];
-  [MDCContainedButtonThemer applyScheme:buttonScheme toButton:disabledContainedButton];
+  [disabledContainedButton applyContainedThemeWithScheme:self.containerScheme];
 
   MDCRectangleShapeGenerator *disabledRaisedShapeGenerator =
       [[MDCRectangleShapeGenerator alloc] init];

--- a/components/Buttons/examples/ButtonsShapesExampleViewController.m
+++ b/components/Buttons/examples/ButtonsShapesExampleViewController.m
@@ -35,17 +35,13 @@
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     self.typographyScheme =
         [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    self.containerScheme.colorScheme = self.colorScheme;
+    self.containerScheme.shapeScheme =
+        [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+    self.containerScheme.typographyScheme = self.typographyScheme;
   }
   return self;
-}
-
-- (MDCContainerScheme *)containerScheme {
-  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-  scheme.colorScheme = self.colorScheme;
-  scheme.shapeScheme =
-      [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
-  scheme.typographyScheme = self.typographyScheme;
-  return scheme;
 }
 
 - (MDCButton *)buildCustomStrokedButton {

--- a/components/Buttons/examples/ButtonsShapesExampleViewController.m
+++ b/components/Buttons/examples/ButtonsShapesExampleViewController.m
@@ -70,7 +70,7 @@
 
   MDCButton *containedButton = [[MDCButton alloc] init];
   [containedButton setTitle:@"Add To Cart" forState:UIControlStateNormal];
-  [containedButton applyContainedThemeWithScheme:[self containerScheme]];
+  [containedButton applyContainedThemeWithScheme:self.containerScheme];
 
   UIImage *plusImage = [UIImage imageNamed:@"Plus"];
   plusImage = [plusImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];

--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MaterialButtons.h"
-#import "MaterialButtons+ButtonThemer.h"
-#import "MaterialButtons+Theming.h"
-#import "MaterialButtons+ColorThemer.h"
-#import "MaterialButtons+TypographyThemer.h"
-#import "MaterialTypography.h"
 #import "MDCTextButtonThemer.h"
+#import "MaterialButtons+ButtonThemer.h"
+#import "MaterialButtons+ColorThemer.h"
+#import "MaterialButtons+Theming.h"
+#import "MaterialButtons+TypographyThemer.h"
+#import "MaterialButtons.h"
+#import "MaterialTypography.h"
 
 #import "supplemental/ButtonsTypicalUseSupplemental.h"
 

--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -14,6 +14,7 @@
 
 #import "MaterialButtons.h"
 #import "MaterialButtons+ButtonThemer.h"
+#import "MaterialButtons+Theming.h"
 #import "MaterialButtons+ColorThemer.h"
 #import "MaterialButtons+TypographyThemer.h"
 #import "MaterialTypography.h"
@@ -34,8 +35,14 @@ const CGSize kMinimumAccessibleButtonSize = {64.0, 48.0};
   if (self) {
     self.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.shapeScheme = [[MDCShapeScheme alloc] init];
-    self.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.shapeScheme =
+        [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+    self.typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    self.containerScheme.colorScheme = self.colorScheme;
+    self.containerScheme.shapeScheme = self.shapeScheme;
+    self.containerScheme.typographyScheme = self.typographyScheme;
   }
   return self;
 }
@@ -54,7 +61,7 @@ const CGSize kMinimumAccessibleButtonSize = {64.0, 48.0};
 
   MDCButton *containedButton = [[MDCButton alloc] init];
   [containedButton setTitle:@"Button" forState:UIControlStateNormal];
-  [MDCContainedButtonThemer applyScheme:buttonScheme toButton:containedButton];
+  [containedButton applyContainedThemeWithScheme:self.containerScheme];
   [containedButton sizeToFit];
   CGFloat containedButtonVerticalInset =
       MIN(0, -(kMinimumAccessibleButtonSize.height - CGRectGetHeight(containedButton.bounds)) / 2);
@@ -72,7 +79,7 @@ const CGSize kMinimumAccessibleButtonSize = {64.0, 48.0};
 
   MDCButton *disabledContainedButton = [[MDCButton alloc] init];
   [disabledContainedButton setTitle:@"Button" forState:UIControlStateNormal];
-  [MDCContainedButtonThemer applyScheme:buttonScheme toButton:disabledContainedButton];
+  [disabledContainedButton applyContainedThemeWithScheme:self.containerScheme];
   [disabledContainedButton sizeToFit];
   [disabledContainedButton addTarget:self
                               action:@selector(didTap:)

--- a/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.h
+++ b/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.h
@@ -19,6 +19,7 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialContainerScheme.h"
 #import "MaterialColorScheme.h"
 #import "MaterialShapeScheme.h"
 #import "MaterialTypographyScheme.h"
@@ -27,6 +28,7 @@
 
 @property(nonatomic, strong) NSArray *buttons;
 @property(nonatomic, strong) NSArray *labels;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
 @property(nonatomic, strong) MDCShapeScheme *shapeScheme;
 @property(nonatomic, strong) MDCTypographyScheme *typographyScheme;

--- a/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.h
+++ b/components/Buttons/examples/supplemental/ButtonsTypicalUseSupplemental.h
@@ -19,8 +19,8 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialContainerScheme.h"
 #import "MaterialColorScheme.h"
+#import "MaterialContainerScheme.h"
 #import "MaterialShapeScheme.h"
 #import "MaterialTypographyScheme.h"
 

--- a/components/Buttons/src/Theming/MDCButton+Theming.h
+++ b/components/Buttons/src/Theming/MDCButton+Theming.h
@@ -1,0 +1,28 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialButtons.h"
+#import "MaterialContainerScheme.h"
+
+@interface MDCButton (MaterialTheming)
+
+/**
+ Applies the theme for a contained button to this instance.
+
+ @param scheme A container scheme instance containing any desired customizations to the theming
+ system.
+ */
+- (void)applyContainedThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
+@end

--- a/components/Buttons/src/Theming/MDCButton+Theming.h
+++ b/components/Buttons/src/Theming/MDCButton+Theming.h
@@ -15,6 +15,10 @@
 #import "MaterialButtons.h"
 #import "MaterialContainerScheme.h"
 
+/**
+ This category is used to style MDCButtons instances to a specific Material style which can be found
+ within the [Material Guidelines](https://material.io/design/components/buttons.html).
+ */
 @interface MDCButton (MaterialTheming)
 
 /**

--- a/components/Buttons/src/Theming/MDCButton+Theming.m
+++ b/components/Buttons/src/Theming/MDCButton+Theming.m
@@ -17,6 +17,7 @@
 #import "MaterialButtons+ColorThemer.h"
 #import "MaterialButtons+ShapeThemer.h"
 #import "MaterialButtons+TypographyThemer.h"
+#import "MaterialShadowElevations.h"
 
 @implementation MDCButton (MaterialTheming)
 
@@ -41,6 +42,11 @@
         [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
   }
   [self applyContainedThemeWithTypographyScheme:typographyScheme];
+
+  [self setElevation:MDCShadowElevationRaisedButtonResting forState:UIControlStateNormal];
+  [self setElevation:MDCShadowElevationRaisedButtonPressed forState:UIControlStateHighlighted];
+  [self setElevation:MDCShadowElevationNone forState:UIControlStateDisabled];
+  self.minimumSize = CGSizeMake(0, 36);
 }
 
 - (void)applyContainedThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {

--- a/components/Buttons/src/Theming/MDCButton+Theming.m
+++ b/components/Buttons/src/Theming/MDCButton+Theming.m
@@ -1,0 +1,13 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/components/Buttons/src/Theming/MDCButton+Theming.m
+++ b/components/Buttons/src/Theming/MDCButton+Theming.m
@@ -11,3 +11,47 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#import "MDCButton+Theming.h"
+
+#import "MaterialButtons+ColorThemer.h"
+#import "MaterialButtons+ShapeThemer.h"
+#import "MaterialButtons+TypographyThemer.h"
+
+@implementation MDCButton (MaterialTheming)
+
+- (void)applyContainedThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme {
+  id<MDCColorScheming> colorScheme = scheme.colorScheme;
+  if (!colorScheme) {
+    colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+  [self applyContainedThemeWithColorScheme:colorScheme];
+
+  id<MDCShapeScheming> shapeScheme = scheme.shapeScheme;
+  if (!shapeScheme) {
+    shapeScheme = [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  }
+  [self applyContainedThemeWithShapeScheme:shapeScheme];
+
+  id<MDCTypographyScheming> typographyScheme = scheme.typographyScheme;
+  if (!typographyScheme) {
+    typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+  }
+  [self applyContainedThemeWithTypographyScheme:typographyScheme];
+}
+
+- (void)applyContainedThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
+  [MDCContainedButtonColorThemer applySemanticColorScheme:colorScheme toButton:self];
+}
+
+- (void)applyContainedThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {
+  [MDCButtonTypographyThemer applyTypographyScheme:typographyScheme toButton:self];
+}
+
+- (void)applyContainedThemeWithShapeScheme:(id<MDCShapeScheming>)shapeScheme {
+  [MDCButtonShapeThemer applyShapeScheme:shapeScheme toButton:self];
+}
+
+@end

--- a/components/Buttons/src/Theming/MDCButton+Theming.m
+++ b/components/Buttons/src/Theming/MDCButton+Theming.m
@@ -29,10 +29,11 @@
   [self applyContainedThemeWithColorScheme:colorScheme];
 
   id<MDCShapeScheming> shapeScheme = scheme.shapeScheme;
-  if (!shapeScheme) {
-    shapeScheme = [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  if (shapeScheme) {
+    [self applyContainedThemeWithShapeScheme:shapeScheme];
+  } else {
+    self.layer.cornerRadius = (CGFloat)4;
   }
-  [self applyContainedThemeWithShapeScheme:shapeScheme];
 
   id<MDCTypographyScheming> typographyScheme = scheme.typographyScheme;
   if (!typographyScheme) {

--- a/components/Buttons/src/Theming/MaterialButtons+Theming.h
+++ b/components/Buttons/src/Theming/MaterialButtons+Theming.h
@@ -1,0 +1,15 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCButton+Theming.h"

--- a/components/Buttons/tests/unit/ButtonThemingTest.swift
+++ b/components/Buttons/tests/unit/ButtonThemingTest.swift
@@ -21,6 +21,11 @@ import MaterialComponents.MaterialTypographyScheme
 import MaterialComponentsAlpha.MaterialButtons_Theming
 
 class ButtonThemingTest: XCTestCase {
+
+  static let disabledOpacity: CGFloat = 0.38
+  static let disabledBackgroundOpacity: CGFloat = 0.12
+  static let inkOpacity: CGFloat = 0.32
+
   func testContainedTheme() {
     // Given
     let button = MDCButton()
@@ -35,12 +40,22 @@ class ButtonThemingTest: XCTestCase {
     // Then
     // Test Colors
     XCTAssertEqual(button.backgroundColor(for: .normal), colorScheme.primaryColor)
-    XCTAssertEqual(button.backgroundColor(for: .disabled), colorScheme.surfaceColor.withAlphaComponent(0.12))
+    XCTAssertEqual(button.backgroundColor(for: .disabled),
+                   colorScheme.surfaceColor.withAlphaComponent(disabledBackgroundOpacity))
     XCTAssertEqual(button.titleColor(for: .normal), colorScheme.onPrimaryColor)
-    XCTAssertEqual(button.titleColor(for: .disabled), colorScheme.onSurfaceColor.withAlphaComponent(0.38))
+    XCTAssertEqual(button.titleColor(for: .disabled),
+                   colorScheme.onSurfaceColor.withAlphaComponent(disabledOpacity))
     XCTAssertEqual(button.imageTintColor(for: .normal), colorScheme.onPrimaryColor)
-    XCTAssertEqual(button.imageTintColor(for: .disabled), colorScheme.onSurfaceColor.withAlphaComponent(0.38))
+    XCTAssertEqual(button.imageTintColor(for: .disabled),
+                   colorScheme.onSurfaceColor.withAlphaComponent(disabledOpacity))
+    XCTAssertEqual(button.inkColor, colorScheme.onPrimaryColor.withAlphaComponent(inkOpacity))
     // Test shape
+    let buttonShape = button.shapeGenerator
+    XCTAssertEqual(buttonShape.topLeftCorner, shapeScheme.smallComponentShape.topLeftCorner)
+    XCTAssertEqual(buttonShape.topRightCorner, shapeScheme.smallComponentShape.topRightCorner)
+    XCTAssertEqual(buttonShape.bottomRightCorner, shapeScheme.smallComponentShape.bottomRightCorner)
+    XCTAssertEqual(buttonShape.bottomLeftCorner, shapeScheme.smallComponentShape.bottomLeftCorner)
     // Test typography
+    XCTAssertEqual(button.titleFont(for: .normal), typographyScheme.button)
   }
 }

--- a/components/Buttons/tests/unit/ButtonThemingTest.swift
+++ b/components/Buttons/tests/unit/ButtonThemingTest.swift
@@ -1,0 +1,46 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialShapeScheme
+import MaterialComponents.MaterialTypographyScheme
+import MaterialComponentsAlpha.MaterialButtons_Theming
+
+class ButtonThemingTest: XCTestCase {
+  func testContainedTheme() {
+    // Given
+    let button = MDCButton()
+    let scheme = MDCContainerScheme()
+    let colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    let shapeScheme = MDCShapeScheme(defaults: .material201809)
+    let typographyScheme = MDCTypographyScheme(defaults: .material201804)
+
+    // When
+    button.applyContainerThemeWithScheme(scheme)
+
+    // Then
+    // Test Colors
+    XCTAssertEqual(button.backgroundColor(for: .normal), colorScheme.primaryColor)
+    XCTAssertEqual(button.backgroundColor(for: .disabled), colorScheme.surfaceColor.withAlphaComponent(0.12))
+    XCTAssertEqual(button.titleColor(for: .normal), colorScheme.onPrimaryColor)
+    XCTAssertEqual(button.titleColor(for: .disabled), colorScheme.onSurfaceColor.withAlphaComponent(0.38))
+    XCTAssertEqual(button.imageTintColor(for: .normal), colorScheme.onPrimaryColor)
+    XCTAssertEqual(button.imageTintColor(for: .disabled), colorScheme.onSurfaceColor.withAlphaComponent(0.38))
+    // Test shape
+    // Test typography
+  }
+}

--- a/components/Buttons/tests/unit/ButtonThemingTest.swift
+++ b/components/Buttons/tests/unit/ButtonThemingTest.swift
@@ -35,20 +35,20 @@ class ButtonThemingTest: XCTestCase {
     let typographyScheme = MDCTypographyScheme(defaults: .material201804)
 
     // When
-    button.applyContainerThemeWithScheme(scheme)
+    button.applyContainerTheme(withScheme: scheme)
 
     // Then
     // Test Colors
     XCTAssertEqual(button.backgroundColor(for: .normal), colorScheme.primaryColor)
     XCTAssertEqual(button.backgroundColor(for: .disabled),
-                   colorScheme.surfaceColor.withAlphaComponent(disabledBackgroundOpacity))
+                   colorScheme.surfaceColor.withAlphaComponent(ButtonThemingTest.disabledBackgroundOpacity))
     XCTAssertEqual(button.titleColor(for: .normal), colorScheme.onPrimaryColor)
     XCTAssertEqual(button.titleColor(for: .disabled),
-                   colorScheme.onSurfaceColor.withAlphaComponent(disabledOpacity))
+                   colorScheme.onSurfaceColor.withAlphaComponent(ButtonThemingTest.disabledOpacity))
     XCTAssertEqual(button.imageTintColor(for: .normal), colorScheme.onPrimaryColor)
     XCTAssertEqual(button.imageTintColor(for: .disabled),
-                   colorScheme.onSurfaceColor.withAlphaComponent(disabledOpacity))
-    XCTAssertEqual(button.inkColor, colorScheme.onPrimaryColor.withAlphaComponent(inkOpacity))
+                   colorScheme.onSurfaceColor.withAlphaComponent(ButtonThemingTest.disabledOpacity))
+    XCTAssertEqual(button.inkColor, colorScheme.onPrimaryColor.withAlphaComponent(ButtonThemingTest.inkOpacity))
     // Test shape
     let buttonShape = button.shapeGenerator
     XCTAssertEqual(buttonShape.topLeftCorner, shapeScheme.smallComponentShape.topLeftCorner)

--- a/components/Buttons/tests/unit/ButtonThemingTest.swift
+++ b/components/Buttons/tests/unit/ButtonThemingTest.swift
@@ -40,15 +40,17 @@ class ButtonThemingTest: XCTestCase {
     // Then
     // Test Colors
     XCTAssertEqual(button.backgroundColor(for: .normal), colorScheme.primaryColor)
-    XCTAssertEqual(button.backgroundColor(for: .disabled),
-                   colorScheme.surfaceColor.withAlphaComponent(ButtonThemingTest.disabledBackgroundOpacity))
+    XCTAssertEqual(
+        button.backgroundColor(for: .disabled),
+        colorScheme.surfaceColor.withAlphaComponent(ButtonThemingTest.disabledBackgroundOpacity))
     XCTAssertEqual(button.titleColor(for: .normal), colorScheme.onPrimaryColor)
     XCTAssertEqual(button.titleColor(for: .disabled),
                    colorScheme.onSurfaceColor.withAlphaComponent(ButtonThemingTest.disabledOpacity))
     XCTAssertEqual(button.imageTintColor(for: .normal), colorScheme.onPrimaryColor)
     XCTAssertEqual(button.imageTintColor(for: .disabled),
                    colorScheme.onSurfaceColor.withAlphaComponent(ButtonThemingTest.disabledOpacity))
-    XCTAssertEqual(button.inkColor, colorScheme.onPrimaryColor.withAlphaComponent(ButtonThemingTest.inkOpacity))
+    XCTAssertEqual(button.inkColor,
+                   colorScheme.onPrimaryColor.withAlphaComponent(ButtonThemingTest.inkOpacity))
     // Test shape
     let buttonShape = button.shapeGenerator
     XCTAssertEqual(buttonShape.topLeftCorner, shapeScheme.smallComponentShape.topLeftCorner)

--- a/components/Buttons/tests/unit/ButtonsThemingTest.swift
+++ b/components/Buttons/tests/unit/ButtonsThemingTest.swift
@@ -34,6 +34,7 @@ class ButtonsThemingTest: XCTestCase {
     let colorScheme = MDCSemanticColorScheme(defaults: .material201804)
     let shapeScheme = MDCShapeScheme(defaults: .material201809)
     let typographyScheme = MDCTypographyScheme(defaults: .material201804)
+    let baselineCornerRadius: CGFloat = 4
 
     // When
     button.applyContainedTheme(withScheme: scheme)
@@ -55,14 +56,14 @@ class ButtonsThemingTest: XCTestCase {
     XCTAssertEqual(button.inkColor,
                    colorScheme.onPrimaryColor.withAlphaComponent(ButtonsThemingTest.inkOpacity))
     // Test shape
-    guard let buttonShape = button.shapeGenerator as? MDCRectangleShapeGenerator else {
-      XCTFail("Shape generator failed to cast as MDCRectangleShapeGenerator")
-      return
+    if let buttonShape = button.shapeGenerator as? MDCRectangleShapeGenerator {
+      XCTAssertEqual(buttonShape.topLeftCorner, shapeScheme.smallComponentShape.topLeftCorner)
+      XCTAssertEqual(buttonShape.topRightCorner, shapeScheme.smallComponentShape.topRightCorner)
+      XCTAssertEqual(buttonShape.bottomRightCorner, shapeScheme.smallComponentShape.bottomRightCorner)
+      XCTAssertEqual(buttonShape.bottomLeftCorner, shapeScheme.smallComponentShape.bottomLeftCorner)
+    } else {
+      XCTAssertEqual(button.layer.cornerRadius, baselineCornerRadius, accuracy: 0.001)
     }
-    XCTAssertEqual(buttonShape.topLeftCorner, shapeScheme.smallComponentShape.topLeftCorner)
-    XCTAssertEqual(buttonShape.topRightCorner, shapeScheme.smallComponentShape.topRightCorner)
-    XCTAssertEqual(buttonShape.bottomRightCorner, shapeScheme.smallComponentShape.bottomRightCorner)
-    XCTAssertEqual(buttonShape.bottomLeftCorner, shapeScheme.smallComponentShape.bottomLeftCorner)
 
     // Test typography
     XCTAssertEqual(button.titleFont(for: .normal), typographyScheme.button)

--- a/components/Buttons/tests/unit/ButtonsThemingTest.swift
+++ b/components/Buttons/tests/unit/ButtonsThemingTest.swift
@@ -32,7 +32,6 @@ class ButtonsThemingTest: XCTestCase {
     let button = MDCButton()
     let scheme = MDCContainerScheme()
     let colorScheme = MDCSemanticColorScheme(defaults: .material201804)
-    let shapeScheme = MDCShapeScheme(defaults: .material201809)
     let typographyScheme = MDCTypographyScheme(defaults: .material201804)
     let baselineCornerRadius: CGFloat = 4
 
@@ -56,16 +55,26 @@ class ButtonsThemingTest: XCTestCase {
     XCTAssertEqual(button.inkColor,
                    colorScheme.onPrimaryColor.withAlphaComponent(ButtonsThemingTest.inkOpacity))
     // Test shape
-    if let buttonShape = button.shapeGenerator as? MDCRectangleShapeGenerator {
-      XCTAssertEqual(buttonShape.topLeftCorner, shapeScheme.smallComponentShape.topLeftCorner)
-      XCTAssertEqual(buttonShape.topRightCorner, shapeScheme.smallComponentShape.topRightCorner)
-      XCTAssertEqual(buttonShape.bottomRightCorner, shapeScheme.smallComponentShape.bottomRightCorner)
-      XCTAssertEqual(buttonShape.bottomLeftCorner, shapeScheme.smallComponentShape.bottomLeftCorner)
-    } else {
-      XCTAssertEqual(button.layer.cornerRadius, baselineCornerRadius, accuracy: 0.001)
-    }
-
+    XCTAssertEqual(button.layer.cornerRadius, baselineCornerRadius, accuracy: 0.001)
     // Test typography
     XCTAssertEqual(button.titleFont(for: .normal), typographyScheme.button)
+  }
+
+  func testContainedThemeWithShapeScheme() {
+    // Given
+    let button = MDCButton()
+    let scheme = MDCContainerScheme()
+    let shapeScheme = MDCShapeScheme()
+    scheme.shapeScheme = shapeScheme
+
+    // When
+    button.applyContainedTheme(withScheme: scheme)
+
+    // Then
+    let buttonShape = button.shapeGenerator as! MDCRectangleShapeGenerator
+    XCTAssertEqual(buttonShape.topLeftCorner, shapeScheme.smallComponentShape.topLeftCorner)
+    XCTAssertEqual(buttonShape.topRightCorner, shapeScheme.smallComponentShape.topRightCorner)
+    XCTAssertEqual(buttonShape.bottomRightCorner, shapeScheme.smallComponentShape.bottomRightCorner)
+    XCTAssertEqual(buttonShape.bottomLeftCorner, shapeScheme.smallComponentShape.bottomLeftCorner)
   }
 }

--- a/components/Buttons/tests/unit/ButtonsThemingTest.swift
+++ b/components/Buttons/tests/unit/ButtonsThemingTest.swift
@@ -16,6 +16,7 @@ import XCTest
 
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialShadowElevations
 import MaterialComponents.MaterialShapeScheme
 import MaterialComponents.MaterialShapeLibrary
 import MaterialComponents.MaterialTypographyScheme
@@ -58,6 +59,12 @@ class ButtonsThemingTest: XCTestCase {
     XCTAssertEqual(button.layer.cornerRadius, baselineCornerRadius, accuracy: 0.001)
     // Test typography
     XCTAssertEqual(button.titleFont(for: .normal), typographyScheme.button)
+    // Test remaining properties
+    XCTAssertEqual(button.elevation(for: .normal), ShadowElevation.raisedButtonResting)
+    XCTAssertEqual(button.elevation(for: .highlighted), ShadowElevation.raisedButtonPressed)
+    XCTAssertEqual(button.elevation(for: .disabled), ShadowElevation.none)
+    XCTAssertEqual(button.minimumSize.width, 0)
+    XCTAssertEqual(button.minimumSize.height, 36)
   }
 
   func testContainedThemeWithShapeScheme() {

--- a/components/Buttons/tests/unit/ButtonsThemingTest.swift
+++ b/components/Buttons/tests/unit/ButtonsThemingTest.swift
@@ -17,10 +17,11 @@ import XCTest
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialShapeScheme
+import MaterialComponents.MaterialShapeLibrary
 import MaterialComponents.MaterialTypographyScheme
 import MaterialComponentsAlpha.MaterialButtons_Theming
 
-class ButtonThemingTest: XCTestCase {
+class ButtonsThemingTest: XCTestCase {
 
   static let disabledOpacity: CGFloat = 0.38
   static let disabledBackgroundOpacity: CGFloat = 0.12
@@ -35,28 +36,34 @@ class ButtonThemingTest: XCTestCase {
     let typographyScheme = MDCTypographyScheme(defaults: .material201804)
 
     // When
-    button.applyContainerTheme(withScheme: scheme)
+    button.applyContainedTheme(withScheme: scheme)
 
     // Then
     // Test Colors
     XCTAssertEqual(button.backgroundColor(for: .normal), colorScheme.primaryColor)
     XCTAssertEqual(
         button.backgroundColor(for: .disabled),
-        colorScheme.surfaceColor.withAlphaComponent(ButtonThemingTest.disabledBackgroundOpacity))
+        colorScheme.onSurfaceColor.withAlphaComponent(ButtonsThemingTest.disabledBackgroundOpacity))
     XCTAssertEqual(button.titleColor(for: .normal), colorScheme.onPrimaryColor)
-    XCTAssertEqual(button.titleColor(for: .disabled),
-                   colorScheme.onSurfaceColor.withAlphaComponent(ButtonThemingTest.disabledOpacity))
+    XCTAssertEqual(
+        button.titleColor(for: .disabled),
+        colorScheme.onSurfaceColor.withAlphaComponent(ButtonsThemingTest.disabledOpacity))
     XCTAssertEqual(button.imageTintColor(for: .normal), colorScheme.onPrimaryColor)
-    XCTAssertEqual(button.imageTintColor(for: .disabled),
-                   colorScheme.onSurfaceColor.withAlphaComponent(ButtonThemingTest.disabledOpacity))
+    XCTAssertEqual(
+        button.imageTintColor(for: .disabled),
+        colorScheme.onSurfaceColor.withAlphaComponent(ButtonsThemingTest.disabledOpacity))
     XCTAssertEqual(button.inkColor,
-                   colorScheme.onPrimaryColor.withAlphaComponent(ButtonThemingTest.inkOpacity))
+                   colorScheme.onPrimaryColor.withAlphaComponent(ButtonsThemingTest.inkOpacity))
     // Test shape
-    let buttonShape = button.shapeGenerator
+    guard let buttonShape = button.shapeGenerator as? MDCRectangleShapeGenerator else {
+      XCTFail("Shape generator failed to cast as MDCRectangleShapeGenerator")
+      return
+    }
     XCTAssertEqual(buttonShape.topLeftCorner, shapeScheme.smallComponentShape.topLeftCorner)
     XCTAssertEqual(buttonShape.topRightCorner, shapeScheme.smallComponentShape.topRightCorner)
     XCTAssertEqual(buttonShape.bottomRightCorner, shapeScheme.smallComponentShape.bottomRightCorner)
     XCTAssertEqual(buttonShape.bottomLeftCorner, shapeScheme.smallComponentShape.bottomLeftCorner)
+
     // Test typography
     XCTAssertEqual(button.titleFont(for: .normal), typographyScheme.button)
   }


### PR DESCRIPTION
### Context
As the team pivots to using theming within extensions we have started off with buttons as a test run. This will be part fo the work with buttons only addressing the contained button type. This adds a new method to MDCButton - `applyContainedThemeWithScheme:(id<MDCContainerScheming>)scheme`

### The problem
We currently do not theme buttons the way the team has decided to theme them

### The fix
This themes Contained buttons with the new style we have all agreed on.

### Remaining Work
Theming for Text and Outlined buttons in this new style.