### PR TITLE
[kokoro] Pin sourcekitten to 0.21.3

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -324,6 +324,8 @@ generate_apidiff() {
     # 0.21.3 is the last version of sourcekitten to support Xcode 9
     # https://github.com/jpsim/SourceKitten/releases/tag/0.21.3
     brew switch sourcekitten 0.21.3
+    
+    sourcekitten version
   fi
 
   usage() {

--- a/.kokoro
+++ b/.kokoro
@@ -20,7 +20,7 @@ set -e
 # To install homebrew formulas at specific versions we need to point directly
 # to the desired sha in the homebrew formula repository.
 # See https://danepowell.com/blog/homebrew-formula-versions for more details.
-# This points to version: 0.21.3
+# This currently points to version 0.21.3, the last version that supports Xcode 9
 SOURCEKITTEN_FORMULA="https://raw.githubusercontent.com/Homebrew/homebrew-core/c5a8a094f9e1dd8e41ed24785acef07ef7092d0d/Formula/sourcekitten.rb"
 
 fix_bazel_imports() {

--- a/.kokoro
+++ b/.kokoro
@@ -17,6 +17,11 @@
 # Fail on any error.
 set -e
 
+# To install homebrew formulas at specific versions we need to point directly
+# to the desired sha in the homebrew formula repository.
+# This points to version: 0.21.3
+SOURCEKITTEN_FORMULA="https://raw.githubusercontent.com/Homebrew/homebrew-core/c5a8a094f9e1dd8e41ed24785acef07ef7092d0d/Formula/sourcekitten.rb"
+
 fix_bazel_imports() {
   echo "Rewriting imports for bazel..."
 
@@ -319,12 +324,8 @@ generate_apidiff() {
     cd github/repo
 
     # Install sourcekitten, a dependency of the apidiff tool
-    brew install sourcekitten
-    
-    # 0.21.3 is the last version of sourcekitten to support Xcode 9
-    # https://github.com/jpsim/SourceKitten/releases/tag/0.21.3
-    brew switch sourcekitten 0.21.3
-    
+    brew install "$SOURCEKITTEN_FORMULA"
+
     sourcekitten version
   fi
 

--- a/.kokoro
+++ b/.kokoro
@@ -320,6 +320,10 @@ generate_apidiff() {
 
     # Install sourcekitten, a dependency of the apidiff tool
     brew install sourcekitten
+    
+    # 0.21.3 is the last version of sourcekitten to support Xcode 9
+    # https://github.com/jpsim/SourceKitten/releases/tag/0.21.3
+    brew switch sourcekitten 0.21.3
   fi
 
   usage() {

--- a/.kokoro
+++ b/.kokoro
@@ -19,6 +19,7 @@ set -e
 
 # To install homebrew formulas at specific versions we need to point directly
 # to the desired sha in the homebrew formula repository.
+# See https://danepowell.com/blog/homebrew-formula-versions for more details.
 # This points to version: 0.21.3
 SOURCEKITTEN_FORMULA="https://raw.githubusercontent.com/Homebrew/homebrew-core/c5a8a094f9e1dd8e41ed24785acef07ef7092d0d/Formula/sourcekitten.rb"
 


### PR DESCRIPTION
The latest sourcekitten release 0.22 (released last night) requires Xcode 10 to build. In order to continue supporting Xcode 9 we need to pin to the last stable release of sourcekitten that supports Xcode 9, which is 0.21.3.

Relevant sourcekitten release notes:

- https://github.com/jpsim/SourceKitten/releases/tag/0.22.0
- https://github.com/jpsim/SourceKitten/releases/tag/0.21.3