### PR TITLE
[scripts/release] Ignore more project-wide files when generating release notes.

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -586,7 +586,9 @@ generate_release_notes() {
     path="$2"
     git diff-tree --no-commit-id --name-only -r "$sha" \
       | grep -v "$path" \
-      | grep -v "MaterialComponents.podspec"
+      | grep -v "MaterialComponents.podspec" \
+      | grep -v "MaterialComponentsAlpha.podspec" \
+      | grep -v "catalog/Podfile"
   }
   # Echoes a list of changelog entries that affect a given path and only that path.
   changes_for_path() {


### PR DESCRIPTION
### Context

When determining whether a change affects multiple components we want to ignore changes to CocoaPods files that live outside of the components directories.

### The problem + fix

Prior to this change, if a commit modified MaterialComponentsAlpha.podspec or catalog/Podfile it was being picked up as a multi-component change in the release notes.

After this change, commits affecting those files will not be treated as multi-component changes unless they also touch other files in the repo.

### Opportunities for further improvement

It's likely fair to say that any modification to files outside of the `components/` directory can be ignored. I'm not sure what the best way to filter these types of changes is, but that would be a welcome follow-up simplification of this change that would require less on-going maintenance.