### PR TITLE
[NavigationDrawer] Remove bottom drawer container view as child upon dismissal

### DIFF
--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -190,6 +190,7 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
 
 - (void)dismissalTransitionDidEnd:(BOOL)completed {
   if (completed) {
+    [self.bottomDrawerContainerViewController removeFromParentViewController];
     [self.scrimView removeFromSuperview];
     [self.topHandle removeFromSuperview];
   }

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -190,7 +190,9 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
 
 - (void)dismissalTransitionDidEnd:(BOOL)completed {
   if (completed) {
-    [self.bottomDrawerContainerViewController removeFromParentViewController];
+    if ([self.presentedViewController isKindOfClass:[MDCBottomDrawerViewController class]]) {
+      [self.bottomDrawerContainerViewController removeFromParentViewController];
+    }
     [self.scrimView removeFromSuperview];
     [self.topHandle removeFromSuperview];
   }


### PR DESCRIPTION
This pull request prevents a crash (due to 'UIViewControllerHierarchyInconsistency') that occurs if the user of the NavigationDrawer reuses the view controllers (i.e. they do not create a new view controller that is passed to the NavigationDrawer each time the drawer is presented). #5821 added the bottomDrawerContainer as the child view, and this pull request will remove the bottomDrawerContainer from the parent upon dismissal.

### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [ ] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [ ] Link to GitHub issues it solves. ```closes #1234```
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
pull request.
