### PR TITLE
[Bazel] Update MDFInternationalization to 1.1.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,7 +41,7 @@ git_repository(
 git_repository(
     name = "material_internationalization_ios",
     remote = "https://github.com/material-foundation/material-internationalization-ios.git",
-    tag = "v1.0.4",
+    tag = "v1.1.0",
 )
 
 git_repository(


### PR DESCRIPTION
The most recent release of MDFInternationalization seems to support
framework-style ("<>") imports. The WORKSPACE was only including 1.0.4
so PR #5550 was failing when building with Bazel.

Unblocks #5550
