### PR TITLE
[ActivityIndicator] Rename examples

### DIFF
--- a/components/ActivityIndicator/examples/ActivityIndicatorExampleViewController.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorExampleViewController.m
@@ -14,14 +14,14 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialActivityIndicator.h"
 #import "MaterialActivityIndicator+ColorThemer.h"
+#import "MaterialActivityIndicator.h"
 #import "MaterialPalettes.h"
 #import "supplemental/ActivityIndicatorExampleViewControllerSupplemental.h"
 
 #define MDC_CATALOG_BLACK [UIColor colorWithWhite:(CGFloat)0.1 alpha:1]
 #define MDC_CATALOG_GREY [UIColor colorWithWhite:(CGFloat)0.9 alpha:1]
-#define MDC_CATALOG_GREEN [UIColor colorWithRed:0 green:0xe6/255.0f blue:0x76/255.0f alpha:1]
+#define MDC_CATALOG_GREEN [UIColor colorWithRed:0 green:0xe6 / 255.0f blue:0x76 / 255.0f alpha:1]
 
 @interface ActivityIndicatorExampleViewController ()
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;

--- a/components/ActivityIndicator/examples/ActivityIndicatorExampleViewController.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorExampleViewController.m
@@ -67,9 +67,9 @@
   self.activityIndicator3 = [[MDCActivityIndicator alloc] init];
   self.activityIndicator3.delegate = self;
   self.activityIndicator3.indicatorMode = MDCActivityIndicatorModeDeterminate;
-  self.activityIndicator3.cycleColors =  @[
-      [MDCPalette bluePalette].tint500, [MDCPalette redPalette].tint500,
-      [MDCPalette greenPalette].tint500, [MDCPalette yellowPalette].tint500
+  self.activityIndicator3.cycleColors = @[
+    [MDCPalette bluePalette].tint500, [MDCPalette redPalette].tint500,
+    [MDCPalette greenPalette].tint500, [MDCPalette yellowPalette].tint500
   ];
   [self.activityIndicator3 sizeToFit];
 

--- a/components/ActivityIndicator/examples/ActivityIndicatorExampleViewController.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorExampleViewController.m
@@ -17,17 +17,17 @@
 #import "MaterialActivityIndicator.h"
 #import "MaterialActivityIndicator+ColorThemer.h"
 #import "MaterialPalettes.h"
-#import "supplemental/ActivityIndicatorExampleSupplemental.h"
+#import "supplemental/ActivityIndicatorExampleViewControllerSupplemental.h"
 
 #define MDC_CATALOG_BLACK [UIColor colorWithWhite:(CGFloat)0.1 alpha:1]
 #define MDC_CATALOG_GREY [UIColor colorWithWhite:(CGFloat)0.9 alpha:1]
 #define MDC_CATALOG_GREEN [UIColor colorWithRed:0 green:0xe6/255.0f blue:0x76/255.0f alpha:1]
 
-@interface ActivityIndicatorExample ()
+@interface ActivityIndicatorExampleViewController ()
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
 @end
 
-@implementation ActivityIndicatorExample
+@implementation ActivityIndicatorExampleViewController
 
 - (id)init {
   self = [super init];
@@ -41,7 +41,7 @@
 
 @end
 
-@implementation ActivityIndicatorExample (CatalogByConvention)
+@implementation ActivityIndicatorExampleViewController (CatalogByConvention)
 
 - (void)viewDidLoad {
   [super viewDidLoad];

--- a/components/ActivityIndicator/examples/ActivityIndicatorExampleViewController.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorExampleViewController.m
@@ -67,10 +67,10 @@
   self.activityIndicator3 = [[MDCActivityIndicator alloc] init];
   self.activityIndicator3.delegate = self;
   self.activityIndicator3.indicatorMode = MDCActivityIndicatorModeDeterminate;
-  self.activityIndicator3.cycleColors =  @[ [MDCPalette bluePalette].tint500,
-                                            [MDCPalette redPalette].tint500,
-                                            [MDCPalette greenPalette].tint500,
-                                            [MDCPalette yellowPalette].tint500 ];
+  self.activityIndicator3.cycleColors =  @[
+      [MDCPalette bluePalette].tint500, [MDCPalette redPalette].tint500,
+      [MDCPalette greenPalette].tint500, [MDCPalette yellowPalette].tint500
+  ];
   [self.activityIndicator3 sizeToFit];
 
   [self setupExampleViews];

--- a/components/ActivityIndicator/examples/ActivityIndicatorSwiftExampleViewController.swift
+++ b/components/ActivityIndicator/examples/ActivityIndicatorSwiftExampleViewController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import MaterialComponents.MaterialActivityIndicator
 
-class ActivityIndicatorSwiftController: UIViewController {
+class ActivityIndicatorSwiftExampleViewController: UIViewController {
 
    struct MDCPalette {
       static let blue: UIColor = UIColor(red: 0.129, green: 0.588, blue: 0.953, alpha: 1.0)
@@ -78,7 +78,7 @@ class ActivityIndicatorSwiftController: UIViewController {
    }
 }
 
-extension ActivityIndicatorSwiftController : MDCActivityIndicatorDelegate {
+extension ActivityIndicatorSwiftExampleViewController : MDCActivityIndicatorDelegate {
    func activityIndicatorAnimationDidFinish(_ activityIndicator: MDCActivityIndicator) {
       return
    }

--- a/components/ActivityIndicator/examples/ActivityIndicatorTransitionExampleViewController.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorTransitionExampleViewController.m
@@ -23,8 +23,8 @@ static const CGFloat kActivityIndicatorExampleStrokeWidth = 2;
 
 static const NSTimeInterval kActivityIndicatorExampleAnimationDuration = 2.0 / 3.0;
 
-@interface ActivityIndicatorTransitionExampleViewController : UIViewController
-    <MDCActivityIndicatorDelegate>
+@interface ActivityIndicatorTransitionExampleViewController
+    : UIViewController <MDCActivityIndicatorDelegate>
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
 @property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
 @end

--- a/components/ActivityIndicator/examples/ActivityIndicatorTransitionExampleViewController.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorTransitionExampleViewController.m
@@ -23,12 +23,13 @@ static const CGFloat kActivityIndicatorExampleStrokeWidth = 2;
 
 static const NSTimeInterval kActivityIndicatorExampleAnimationDuration = 2.0 / 3.0;
 
-@interface ActivityIndicatorTransitionExample : UIViewController <MDCActivityIndicatorDelegate>
+@interface ActivityIndicatorTransitionExampleViewController : UIViewController
+    <MDCActivityIndicatorDelegate>
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
 @property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
 @end
 
-@implementation ActivityIndicatorTransitionExample {
+@implementation ActivityIndicatorTransitionExampleViewController {
   MDCActivityIndicator *_activityIndicator;
   MDCButton *_button;
 

--- a/components/ActivityIndicator/examples/ActivityIndicatorTransitionExampleViewController.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorTransitionExampleViewController.m
@@ -15,8 +15,8 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialActivityIndicator.h"
-#import "MaterialButtons.h"
 #import "MaterialButtons+ButtonThemer.h"
+#import "MaterialButtons.h"
 
 static const CGFloat kActivityIndicatorExampleArrowHeadSize = 5;
 static const CGFloat kActivityIndicatorExampleStrokeWidth = 2;
@@ -69,8 +69,8 @@ static const NSTimeInterval kActivityIndicatorExampleAnimationDuration = 2.0 / 3
   buttonScheme.typographyScheme = self.typographyScheme;
   [MDCContainedButtonThemer applyScheme:buttonScheme toButton:_button];
   [_button addTarget:self
-              action:@selector(startRefreshing)
-    forControlEvents:UIControlEventTouchUpInside];
+                action:@selector(startRefreshing)
+      forControlEvents:UIControlEventTouchUpInside];
   [_button setTitle:@"Refresh" forState:UIControlStateNormal];
   [_button sizeToFit];
   _button.center = CGPointMake(self.view.bounds.size.width / 2, 200);
@@ -157,15 +157,13 @@ static const NSTimeInterval kActivityIndicatorExampleAnimationDuration = 2.0 / 3
     [self->_refreshArrowPoint removeAllAnimations];
     [CATransaction commit];
 
-    dispatch_time_t stopTime =
-        dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3 * NSEC_PER_SEC));
+    dispatch_time_t stopTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3 * NSEC_PER_SEC));
     dispatch_after(stopTime, dispatch_get_main_queue(), ^{
       [self stopRefreshing];
     });
   };
 
-  [_activityIndicator startAnimatingWithTransition:transition
-                                   cycleStartIndex:1];
+  [_activityIndicator startAnimatingWithTransition:transition cycleStartIndex:1];
 }
 
 - (void)stopRefreshing {
@@ -283,9 +281,9 @@ static const NSTimeInterval kActivityIndicatorExampleAnimationDuration = 2.0 / 3
 
 + (NSDictionary *)catalogMetadata {
   return @{
-    @"breadcrumbs": @[ @"Activity Indicator", @"Activity Indicator Transition" ],
-    @"primaryDemo": @NO,
-    @"presentable": @YES
+    @"breadcrumbs" : @[ @"Activity Indicator", @"Activity Indicator Transition" ],
+    @"primaryDemo" : @NO,
+    @"presentable" : @YES
   };
 }
 

--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleViewControllerSupplemental.h
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleViewControllerSupplemental.h
@@ -28,8 +28,8 @@ static const CGFloat kActivityInitialProgress = (CGFloat)0.6;
 @class ActivityIndicatorExampleViewController;
 @class MDCActivityIndicator;
 
-@interface ActivityIndicatorExampleViewController : UITableViewController
-    <MDCActivityIndicatorDelegate>
+@interface ActivityIndicatorExampleViewController
+    : UITableViewController <MDCActivityIndicatorDelegate>
 
 @property(nonatomic, strong) MDCActivityIndicator *activityIndicator1;
 @property(nonatomic, strong) MDCActivityIndicator *activityIndicator2;

--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleViewControllerSupplemental.h
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleViewControllerSupplemental.h
@@ -25,10 +25,11 @@
 static const CGFloat kActivityIndicatorRadius = 72;
 static const CGFloat kActivityInitialProgress = (CGFloat)0.6;
 
-@class ActivityIndicatorExample;
+@class ActivityIndicatorExampleViewController;
 @class MDCActivityIndicator;
 
-@interface ActivityIndicatorExample : UITableViewController <MDCActivityIndicatorDelegate>
+@interface ActivityIndicatorExampleViewController : UITableViewController
+    <MDCActivityIndicatorDelegate>
 
 @property(nonatomic, strong) MDCActivityIndicator *activityIndicator1;
 @property(nonatomic, strong) MDCActivityIndicator *activityIndicator2;
@@ -41,7 +42,7 @@ static const CGFloat kActivityInitialProgress = (CGFloat)0.6;
 
 @end
 
-@interface ActivityIndicatorExample (Supplemental)
+@interface ActivityIndicatorExampleViewController (Supplemental)
 
 - (void)setupExampleViews;
 

--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleViewControllerSupplemental.m
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleViewControllerSupplemental.m
@@ -17,7 +17,7 @@
  instructions. It is not necessary to import this file to use Material Components for iOS.
  */
 
-#import "ActivityIndicatorExampleSupplemental.h"
+#import "ActivityIndicatorExampleViewControllerSupplemental.h"
 
 #import "MaterialTypography.h"
 
@@ -26,7 +26,7 @@
 static NSString * const kCell = @"Cell";
 
 
-@implementation ActivityIndicatorExample (CatalogByConvention)
+@implementation ActivityIndicatorExampleViewController (CatalogByConvention)
 
 + (NSDictionary *)catalogMetadata {
   return @{
@@ -40,7 +40,7 @@ static NSString * const kCell = @"Cell";
 
 @end
 
-@implementation ActivityIndicatorExample (Supplemental)
+@implementation ActivityIndicatorExampleViewController (Supplemental)
 
 - (void)setupExampleViews {
   [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:kCell];

--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleViewControllerSupplemental.m
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleViewControllerSupplemental.m
@@ -21,9 +21,9 @@
 
 #import "MaterialTypography.h"
 
-#define MDC_CATALOG_GREEN [UIColor colorWithRed:0 green:0xe6/255.0f blue:0x76/255.0f alpha:1]
+#define MDC_CATALOG_GREEN [UIColor colorWithRed:0 green:0xe6 / 255.0f blue:0x76 / 255.0f alpha:1]
 
-static NSString * const kCell = @"Cell";
+static NSString *const kCell = @"Cell";
 
 
 @implementation ActivityIndicatorExampleViewController (CatalogByConvention)

--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleViewControllerSupplemental.m
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleViewControllerSupplemental.m
@@ -29,11 +29,12 @@ static NSString *const kCell = @"Cell";
 
 + (NSDictionary *)catalogMetadata {
   return @{
-    @"breadcrumbs": @[ @"Activity Indicator", @"Activity Indicator" ],
-    @"description": @"Activity Indicator is a visual indication of an app loading content. "
-    @"It can display how long an operation will take or visualize an unspecified wait time.",
-    @"primaryDemo": @YES,
-    @"presentable": @YES
+    @"breadcrumbs" : @[ @"Activity Indicator", @"Activity Indicator" ],
+    @"description" :
+        @"Activity Indicator is a visual indication of an app loading content. "
+        @"It can display how long an operation will take or visualize an unspecified wait time.",
+    @"primaryDemo" : @YES,
+    @"presentable" : @YES
   };
 }
 
@@ -55,16 +56,16 @@ static NSString *const kCell = @"Cell";
 
   self.activityIndicator1.center =
       CGPointMake(indicators.bounds.size.width / 3, indicators.bounds.size.height / 2);
-  self.activityIndicator1.autoresizingMask = (UIViewAutoresizingFlexibleLeftMargin |
-                                              UIViewAutoresizingFlexibleRightMargin);
+  self.activityIndicator1.autoresizingMask =
+      (UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin);
   self.activityIndicator2.center =
       CGPointMake(indicators.bounds.size.width / 2, indicators.bounds.size.height / 2);
-  self.activityIndicator2.autoresizingMask = (UIViewAutoresizingFlexibleLeftMargin |
-                                              UIViewAutoresizingFlexibleRightMargin);
+  self.activityIndicator2.autoresizingMask =
+      (UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin);
   self.activityIndicator3.center =
       CGPointMake(2 * indicators.bounds.size.width / 3, indicators.bounds.size.height / 2);
-  self.activityIndicator3.autoresizingMask = (UIViewAutoresizingFlexibleLeftMargin |
-                                              UIViewAutoresizingFlexibleRightMargin);
+  self.activityIndicator3.autoresizingMask =
+      (UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin);
 
   self.indicators = indicators;
 
@@ -125,8 +126,8 @@ static NSString *const kCell = @"Cell";
   self.activityIndicator1.progress = slider.value;
   self.activityIndicator2.progress = slider.value;
   self.activityIndicator3.progress = slider.value;
-  UITableViewCell *cell =
-      [self.tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:1 inSection:0]];
+  UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:1
+                                                                                   inSection:0]];
   cell.textLabel.text = [NSString stringWithFormat:@"%.00f%%", slider.value * 100];
   [cell setNeedsDisplay];
 }
@@ -141,14 +142,14 @@ static NSString *const kCell = @"Cell";
   if (indexPath.row == 0) {
     return 160;
   }
-  
+
   return 56;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView
          cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-  UITableViewCell *cell =
-      [tableView dequeueReusableCellWithIdentifier:kCell forIndexPath:indexPath];
+  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kCell
+                                                          forIndexPath:indexPath];
   cell.textLabel.text = @"";
   cell.selectionStyle = UITableViewCellSelectionStyleNone;
   switch (indexPath.row) {

--- a/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleViewControllerSupplemental.m
+++ b/components/ActivityIndicator/examples/supplemental/ActivityIndicatorExampleViewControllerSupplemental.m
@@ -25,7 +25,6 @@
 
 static NSString *const kCell = @"Cell";
 
-
 @implementation ActivityIndicatorExampleViewController (CatalogByConvention)
 
 + (NSDictionary *)catalogMetadata {


### PR DESCRIPTION
Renaming each of the example view controllers to include
"ExampleViewController" so they're easier to find. This is closer to our
typical naming pattern for example view controllers.

