### PR TITLE
[AnimationTiming] Rename examples view controllers

### DIFF
--- a/components/AnimationTiming/examples/AnimationTimingExampleViewController.m
+++ b/components/AnimationTiming/examples/AnimationTimingExampleViewController.m
@@ -13,16 +13,16 @@
 // limitations under the License.
 
 #import "MaterialAnimationTiming.h"
-#import "supplemental/AnimationTimingExampleSupplemental.h"
+#import "supplemental/AnimationTimingExampleViewControllerSupplemental.h"
 
 const NSTimeInterval kAnimationTimeInterval = 1;
 const NSTimeInterval kAnimationTimeDelay = 0.5;
 
-@interface AnimationTimingExample ()
+@interface AnimationTimingExampleViewController ()
 
 @end
 
-@implementation AnimationTimingExample
+@implementation AnimationTimingExampleViewController
 
 - (void)didTapAnimateButton:(UIButton *)sender {
   sender.enabled = NO;

--- a/components/AnimationTiming/examples/AnimationTimingExampleViewController.m
+++ b/components/AnimationTiming/examples/AnimationTimingExampleViewController.m
@@ -64,12 +64,12 @@ const NSTimeInterval kAnimationTimeDelay = 0.5;
   [self applyAnimationToView:_materialAccelerationView
           withTimingFunction:materialAccelerationCurve
                   completion:nil];
-   
+
   CAMediaTimingFunction *materialSharpCurve =
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionSharp];
-   [self applyAnimationToView:_materialSharpView
-           withTimingFunction:materialSharpCurve
-                   completion:completion];
+  [self applyAnimationToView:_materialSharpView
+          withTimingFunction:materialSharpCurve
+                  completion:completion];
 }
 
 - (void)applyAnimationToView:(UIView *)view

--- a/components/AnimationTiming/examples/AnimationTimingSwiftExampleViewController.swift
+++ b/components/AnimationTiming/examples/AnimationTimingSwiftExampleViewController.swift
@@ -29,7 +29,7 @@ struct Constants {
    }
 }
 
-class AnimationTimingExampleSwift: UIViewController {
+class AnimationTimingSwiftExampleViewController: UIViewController {
 
    fileprivate let scrollView: UIScrollView = UIScrollView()
    fileprivate let linearView: UIView = UIView()
@@ -97,7 +97,7 @@ class AnimationTimingExampleSwift: UIViewController {
    }
 }
 
-extension AnimationTimingExampleSwift {
+extension AnimationTimingSwiftExampleViewController {
    fileprivate func setupExampleViews() {
 
       let curveLabel: (String) -> UILabel = { labelTitle in

--- a/components/AnimationTiming/examples/supplemental/AnimationTimingExampleViewControllerSupplemental.h
+++ b/components/AnimationTiming/examples/supplemental/AnimationTimingExampleViewControllerSupplemental.h
@@ -14,7 +14,7 @@
 
 #import <UIKit/UIKit.h>
 
-@interface AnimationTimingExample : UIViewController
+@interface AnimationTimingExampleViewController : UIViewController
 
 @property(nonatomic, strong) NSTimer *animationLoop;
 @property(nonatomic, strong) UIScrollView *scrollView;
@@ -26,7 +26,7 @@
 
 @end
 
-@interface AnimationTimingExample (Supplemental)
+@interface AnimationTimingExampleViewController (Supplemental)
 
 - (void)setupExampleViews;
 

--- a/components/AnimationTiming/examples/supplemental/AnimationTimingExampleViewControllerSupplemental.m
+++ b/components/AnimationTiming/examples/supplemental/AnimationTimingExampleViewControllerSupplemental.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "AnimationTimingExampleSupplemental.h"
+#import "AnimationTimingExampleViewControllerSupplemental.h"
 
 #import "MaterialTypography.h"
 
@@ -23,7 +23,7 @@ const CGFloat kTextOffset = 16;
 // Size of the circle we animate.
 static const CGSize kAnimationCircleSize = {48, 48};
 
-@implementation AnimationTimingExample (CatalogByConvention)
+@implementation AnimationTimingExampleViewController (CatalogByConvention)
 
 + (NSDictionary *)catalogMetadata {
   return @{
@@ -37,7 +37,7 @@ static const CGSize kAnimationCircleSize = {48, 48};
 
 @end
 
-@implementation AnimationTimingExample (Supplemental)
+@implementation AnimationTimingExampleViewController (Supplemental)
 
 - (void)setupExampleViews {
   self.view.backgroundColor = UIColor.whiteColor;
@@ -89,7 +89,7 @@ static const CGSize kAnimationCircleSize = {48, 48};
   }
 
   CGFloat lineSpace = (CGRectGetHeight(self.view.frame) - 50) / 5;
-  UILabel *linearLabel = [AnimationTimingExample curveLabelWithTitle:@"Linear"];
+  UILabel *linearLabel = [AnimationTimingExampleViewController curveLabelWithTitle:@"Linear"];
   linearLabel.frame =
       CGRectMake(kLeftGutter, kTopMargin, linearLabel.frame.size.width, linearLabel.frame.size.height);
   [self.scrollView addSubview:linearLabel];
@@ -97,12 +97,12 @@ static const CGSize kAnimationCircleSize = {48, 48};
   CGRect linearViewFrame =
       CGRectMake(kLeftGutter, kTextOffset + kTopMargin, kAnimationCircleSize.width, kAnimationCircleSize.height);
   self.linearView = [[UIView alloc] initWithFrame:linearViewFrame];
-  self.linearView.backgroundColor = [AnimationTimingExample defaultColors][0];
+  self.linearView.backgroundColor = [AnimationTimingExampleViewController defaultColors][0];
   self.linearView.layer.cornerRadius = kAnimationCircleSize.width / 2;
   [self.scrollView addSubview:self.linearView];
 
   UILabel *materialEaseInOutLabel =
-      [AnimationTimingExample curveLabelWithTitle:@"MDCAnimationTimingFunctionStandard"];
+      [AnimationTimingExampleViewController curveLabelWithTitle:@"MDCAnimationTimingFunctionStandard"];
   materialEaseInOutLabel.frame =
       CGRectMake(kLeftGutter, lineSpace, materialEaseInOutLabel.frame.size.width,
                  materialEaseInOutLabel.frame.size.height);
@@ -112,12 +112,12 @@ static const CGSize kAnimationCircleSize = {48, 48};
       CGRectMake(kLeftGutter, lineSpace + kTextOffset, kAnimationCircleSize.width,
                  kAnimationCircleSize.height);
   self.materialStandardView = [[UIView alloc] initWithFrame:materialEaseInOutViewFrame];
-  self.materialStandardView.backgroundColor = [AnimationTimingExample defaultColors][1];
+  self.materialStandardView.backgroundColor = [AnimationTimingExampleViewController defaultColors][1];
   self.materialStandardView.layer.cornerRadius = kAnimationCircleSize.width / 2;
   [self.scrollView addSubview:self.materialStandardView];
 
   UILabel *materialEaseOutLabel =
-      [AnimationTimingExample curveLabelWithTitle:@"MDCAnimationTimingFunctionDeceleration"];
+      [AnimationTimingExampleViewController curveLabelWithTitle:@"MDCAnimationTimingFunctionDeceleration"];
   materialEaseOutLabel.frame =
       CGRectMake(kLeftGutter, lineSpace * 2, materialEaseOutLabel.frame.size.width,
                  materialEaseOutLabel.frame.size.height);
@@ -127,12 +127,12 @@ static const CGSize kAnimationCircleSize = {48, 48};
       CGRectMake(kLeftGutter, lineSpace * 2 + kTextOffset, kAnimationCircleSize.width,
                  kAnimationCircleSize.height);
   self.materialDecelerationView = [[UIView alloc] initWithFrame:materialDecelerationViewFrame];
-  self.materialDecelerationView.backgroundColor = [AnimationTimingExample defaultColors][2];
+  self.materialDecelerationView.backgroundColor = [AnimationTimingExampleViewController defaultColors][2];
   self.materialDecelerationView.layer.cornerRadius = kAnimationCircleSize.width / 2;
   [self.scrollView addSubview:self.materialDecelerationView];
 
   UILabel *materialEaseInLabel =
-      [AnimationTimingExample curveLabelWithTitle:@"MDCAnimationTimingFunctionAcceleration"];
+      [AnimationTimingExampleViewController curveLabelWithTitle:@"MDCAnimationTimingFunctionAcceleration"];
   materialEaseInLabel.frame =
       CGRectMake(kLeftGutter, lineSpace * 3, materialEaseInLabel.frame.size.width,
                  materialEaseInLabel.frame.size.height);
@@ -142,12 +142,12 @@ static const CGSize kAnimationCircleSize = {48, 48};
       CGRectMake(kLeftGutter, lineSpace * 3 + kTextOffset, kAnimationCircleSize.width,
                  kAnimationCircleSize.height);
   self.materialAccelerationView = [[UIView alloc] initWithFrame:materialAccelerationViewFrame];
-  self.materialAccelerationView.backgroundColor = [AnimationTimingExample defaultColors][3];
+  self.materialAccelerationView.backgroundColor = [AnimationTimingExampleViewController defaultColors][3];
   self.materialAccelerationView.layer.cornerRadius = kAnimationCircleSize.width / 2;
   [self.scrollView addSubview:self.materialAccelerationView];
    
    UILabel *materialSharpLabel =
-       [AnimationTimingExample curveLabelWithTitle:@"MDCAnimationTimingFunctionSharp"];
+       [AnimationTimingExampleViewController curveLabelWithTitle:@"MDCAnimationTimingFunctionSharp"];
    materialSharpLabel.frame =
        CGRectMake(kLeftGutter, lineSpace * 4, CGRectGetWidth(materialSharpLabel.frame),
                   CGRectGetHeight(materialSharpLabel.frame));
@@ -157,7 +157,7 @@ static const CGSize kAnimationCircleSize = {48, 48};
        CGRectMake(kLeftGutter, lineSpace * 4 + kTextOffset, kAnimationCircleSize.width,
                   kAnimationCircleSize.height);
    self.materialSharpView = [[UIView alloc] initWithFrame:materialSharpViewFrame];
-   self.materialSharpView.backgroundColor = [AnimationTimingExample defaultColors][4];
+   self.materialSharpView.backgroundColor = [AnimationTimingExampleViewController defaultColors][4];
    self.materialSharpView.layer.cornerRadius = kAnimationCircleSize.width / 2;
    [self.scrollView addSubview:self.materialSharpView];
 }

--- a/components/AnimationTiming/examples/supplemental/AnimationTimingExampleViewControllerSupplemental.m
+++ b/components/AnimationTiming/examples/supplemental/AnimationTimingExampleViewControllerSupplemental.m
@@ -27,11 +27,11 @@ static const CGSize kAnimationCircleSize = {48, 48};
 
 + (NSDictionary *)catalogMetadata {
   return @{
-    @"breadcrumbs": @[ @"Animation Timing", @"Animation Timing" ],
-    @"description": @"Animation timing easing curves create smooth and consistent motion. "
-    @"Easing curves allow elements to move between positions or states.",
-    @"primaryDemo": @YES,
-    @"presentable": @YES
+    @"breadcrumbs" : @[ @"Animation Timing", @"Animation Timing" ],
+    @"description" : @"Animation timing easing curves create smooth and consistent motion. "
+                     @"Easing curves allow elements to move between positions or states.",
+    @"primaryDemo" : @YES,
+    @"presentable" : @YES
   };
 }
 
@@ -45,8 +45,8 @@ static const CGSize kAnimationCircleSize = {48, 48};
 
   self.scrollView = [[UIScrollView alloc] initWithFrame:self.view.bounds];
 
-  self.scrollView.contentSize = CGSizeMake(CGRectGetWidth(self.view.frame),
-                                           CGRectGetHeight(self.view.frame) + kTopMargin);
+  self.scrollView.contentSize =
+      CGSizeMake(CGRectGetWidth(self.view.frame), CGRectGetHeight(self.view.frame) + kTopMargin);
   self.scrollView.clipsToBounds = YES;
   [self.view addSubview:self.scrollView];
 
@@ -56,36 +56,36 @@ static const CGSize kAnimationCircleSize = {48, 48};
         UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   } else {
     self.scrollView.translatesAutoresizingMaskIntoConstraints = NO;
-    [NSLayoutConstraint activateConstraints:
-     @[[NSLayoutConstraint constraintWithItem:self.scrollView
-                                    attribute:NSLayoutAttributeTop
-                                    relatedBy:NSLayoutRelationEqual
-                                       toItem:self.topLayoutGuide
-                                    attribute:NSLayoutAttributeBottom
-                                   multiplier:1.0
-                                     constant:0],
-       [NSLayoutConstraint constraintWithItem:self.scrollView
-                                    attribute:NSLayoutAttributeBottom
-                                    relatedBy:NSLayoutRelationEqual
-                                       toItem:self.view
-                                    attribute:NSLayoutAttributeBottom
-                                   multiplier:1.0
-                                     constant:0],
-       [NSLayoutConstraint constraintWithItem:self.scrollView
-                                    attribute:NSLayoutAttributeLeft
-                                    relatedBy:NSLayoutRelationEqual
-                                       toItem:self.view
-                                    attribute:NSLayoutAttributeLeft
-                                   multiplier:1.0
-                                     constant:0],
-       [NSLayoutConstraint constraintWithItem:self.scrollView
-                                    attribute:NSLayoutAttributeRight
-                                    relatedBy:NSLayoutRelationEqual
-                                       toItem:self.view
-                                    attribute:NSLayoutAttributeRight
-                                   multiplier:1.0
-                                     constant:0]
-       ]];
+    [NSLayoutConstraint activateConstraints:@[
+      [NSLayoutConstraint constraintWithItem:self.scrollView
+                                   attribute:NSLayoutAttributeTop
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:self.topLayoutGuide
+                                   attribute:NSLayoutAttributeBottom
+                                  multiplier:1.0
+                                    constant:0],
+      [NSLayoutConstraint constraintWithItem:self.scrollView
+                                   attribute:NSLayoutAttributeBottom
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:self.view
+                                   attribute:NSLayoutAttributeBottom
+                                  multiplier:1.0
+                                    constant:0],
+      [NSLayoutConstraint constraintWithItem:self.scrollView
+                                   attribute:NSLayoutAttributeLeft
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:self.view
+                                   attribute:NSLayoutAttributeLeft
+                                  multiplier:1.0
+                                    constant:0],
+      [NSLayoutConstraint constraintWithItem:self.scrollView
+                                   attribute:NSLayoutAttributeRight
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:self.view
+                                   attribute:NSLayoutAttributeRight
+                                  multiplier:1.0
+                                    constant:0]
+    ]];
   }
 
   CGFloat lineSpace = (CGRectGetHeight(self.view.frame) - 50) / 5;
@@ -101,9 +101,8 @@ static const CGSize kAnimationCircleSize = {48, 48};
   self.linearView.layer.cornerRadius = kAnimationCircleSize.width / 2;
   [self.scrollView addSubview:self.linearView];
 
-  UILabel *materialEaseInOutLabel =
-      [AnimationTimingExampleViewController
-          curveLabelWithTitle:@"MDCAnimationTimingFunctionStandard"];
+  UILabel *materialEaseInOutLabel = [AnimationTimingExampleViewController
+      curveLabelWithTitle:@"MDCAnimationTimingFunctionStandard"];
   materialEaseInOutLabel.frame =
       CGRectMake(kLeftGutter, lineSpace, materialEaseInOutLabel.frame.size.width,
                  materialEaseInOutLabel.frame.size.height);
@@ -118,9 +117,8 @@ static const CGSize kAnimationCircleSize = {48, 48};
   self.materialStandardView.layer.cornerRadius = kAnimationCircleSize.width / 2;
   [self.scrollView addSubview:self.materialStandardView];
 
-  UILabel *materialEaseOutLabel =
-      [AnimationTimingExampleViewController
-          curveLabelWithTitle:@"MDCAnimationTimingFunctionDeceleration"];
+  UILabel *materialEaseOutLabel = [AnimationTimingExampleViewController
+      curveLabelWithTitle:@"MDCAnimationTimingFunctionDeceleration"];
   materialEaseOutLabel.frame =
       CGRectMake(kLeftGutter, lineSpace * 2, materialEaseOutLabel.frame.size.width,
                  materialEaseOutLabel.frame.size.height);
@@ -135,9 +133,8 @@ static const CGSize kAnimationCircleSize = {48, 48};
   self.materialDecelerationView.layer.cornerRadius = kAnimationCircleSize.width / 2;
   [self.scrollView addSubview:self.materialDecelerationView];
 
-  UILabel *materialEaseInLabel =
-      [AnimationTimingExampleViewController
-          curveLabelWithTitle:@"MDCAnimationTimingFunctionAcceleration"];
+  UILabel *materialEaseInLabel = [AnimationTimingExampleViewController
+      curveLabelWithTitle:@"MDCAnimationTimingFunctionAcceleration"];
   materialEaseInLabel.frame =
       CGRectMake(kLeftGutter, lineSpace * 3, materialEaseInLabel.frame.size.width,
                  materialEaseInLabel.frame.size.height);
@@ -151,12 +148,12 @@ static const CGSize kAnimationCircleSize = {48, 48};
       [AnimationTimingExampleViewController defaultColors][3];
   self.materialAccelerationView.layer.cornerRadius = kAnimationCircleSize.width / 2;
   [self.scrollView addSubview:self.materialAccelerationView];
-   
+
   UILabel *materialSharpLabel =
       [AnimationTimingExampleViewController curveLabelWithTitle:@"MDCAnimationTimingFunctionSharp"];
   materialSharpLabel.frame =
       CGRectMake(kLeftGutter, lineSpace * 4, CGRectGetWidth(materialSharpLabel.frame),
-                CGRectGetHeight(materialSharpLabel.frame));
+                 CGRectGetHeight(materialSharpLabel.frame));
   [self.scrollView addSubview:materialSharpLabel];
 
   CGRect materialSharpViewFrame =

--- a/components/AnimationTiming/examples/supplemental/AnimationTimingExampleViewControllerSupplemental.m
+++ b/components/AnimationTiming/examples/supplemental/AnimationTimingExampleViewControllerSupplemental.m
@@ -158,7 +158,7 @@ static const CGSize kAnimationCircleSize = {48, 48};
 
   CGRect materialSharpViewFrame =
       CGRectMake(kLeftGutter, lineSpace * 4 + kTextOffset, kAnimationCircleSize.width,
-                kAnimationCircleSize.height);
+                 kAnimationCircleSize.height);
   self.materialSharpView = [[UIView alloc] initWithFrame:materialSharpViewFrame];
   self.materialSharpView.backgroundColor = [AnimationTimingExampleViewController defaultColors][4];
   self.materialSharpView.layer.cornerRadius = kAnimationCircleSize.width / 2;

--- a/components/AnimationTiming/examples/supplemental/AnimationTimingExampleViewControllerSupplemental.m
+++ b/components/AnimationTiming/examples/supplemental/AnimationTimingExampleViewControllerSupplemental.m
@@ -90,19 +90,20 @@ static const CGSize kAnimationCircleSize = {48, 48};
 
   CGFloat lineSpace = (CGRectGetHeight(self.view.frame) - 50) / 5;
   UILabel *linearLabel = [AnimationTimingExampleViewController curveLabelWithTitle:@"Linear"];
-  linearLabel.frame =
-      CGRectMake(kLeftGutter, kTopMargin, linearLabel.frame.size.width, linearLabel.frame.size.height);
+  linearLabel.frame = CGRectMake(kLeftGutter, kTopMargin, linearLabel.frame.size.width,
+                                 linearLabel.frame.size.height);
   [self.scrollView addSubview:linearLabel];
 
-  CGRect linearViewFrame =
-      CGRectMake(kLeftGutter, kTextOffset + kTopMargin, kAnimationCircleSize.width, kAnimationCircleSize.height);
+  CGRect linearViewFrame = CGRectMake(kLeftGutter, kTextOffset + kTopMargin,
+                                      kAnimationCircleSize.width, kAnimationCircleSize.height);
   self.linearView = [[UIView alloc] initWithFrame:linearViewFrame];
   self.linearView.backgroundColor = [AnimationTimingExampleViewController defaultColors][0];
   self.linearView.layer.cornerRadius = kAnimationCircleSize.width / 2;
   [self.scrollView addSubview:self.linearView];
 
   UILabel *materialEaseInOutLabel =
-      [AnimationTimingExampleViewController curveLabelWithTitle:@"MDCAnimationTimingFunctionStandard"];
+      [AnimationTimingExampleViewController
+          curveLabelWithTitle:@"MDCAnimationTimingFunctionStandard"];
   materialEaseInOutLabel.frame =
       CGRectMake(kLeftGutter, lineSpace, materialEaseInOutLabel.frame.size.width,
                  materialEaseInOutLabel.frame.size.height);
@@ -112,12 +113,14 @@ static const CGSize kAnimationCircleSize = {48, 48};
       CGRectMake(kLeftGutter, lineSpace + kTextOffset, kAnimationCircleSize.width,
                  kAnimationCircleSize.height);
   self.materialStandardView = [[UIView alloc] initWithFrame:materialEaseInOutViewFrame];
-  self.materialStandardView.backgroundColor = [AnimationTimingExampleViewController defaultColors][1];
+  self.materialStandardView.backgroundColor =
+      [AnimationTimingExampleViewController defaultColors][1];
   self.materialStandardView.layer.cornerRadius = kAnimationCircleSize.width / 2;
   [self.scrollView addSubview:self.materialStandardView];
 
   UILabel *materialEaseOutLabel =
-      [AnimationTimingExampleViewController curveLabelWithTitle:@"MDCAnimationTimingFunctionDeceleration"];
+      [AnimationTimingExampleViewController
+          curveLabelWithTitle:@"MDCAnimationTimingFunctionDeceleration"];
   materialEaseOutLabel.frame =
       CGRectMake(kLeftGutter, lineSpace * 2, materialEaseOutLabel.frame.size.width,
                  materialEaseOutLabel.frame.size.height);
@@ -127,12 +130,14 @@ static const CGSize kAnimationCircleSize = {48, 48};
       CGRectMake(kLeftGutter, lineSpace * 2 + kTextOffset, kAnimationCircleSize.width,
                  kAnimationCircleSize.height);
   self.materialDecelerationView = [[UIView alloc] initWithFrame:materialDecelerationViewFrame];
-  self.materialDecelerationView.backgroundColor = [AnimationTimingExampleViewController defaultColors][2];
+  self.materialDecelerationView.backgroundColor =
+      [AnimationTimingExampleViewController defaultColors][2];
   self.materialDecelerationView.layer.cornerRadius = kAnimationCircleSize.width / 2;
   [self.scrollView addSubview:self.materialDecelerationView];
 
   UILabel *materialEaseInLabel =
-      [AnimationTimingExampleViewController curveLabelWithTitle:@"MDCAnimationTimingFunctionAcceleration"];
+      [AnimationTimingExampleViewController
+          curveLabelWithTitle:@"MDCAnimationTimingFunctionAcceleration"];
   materialEaseInLabel.frame =
       CGRectMake(kLeftGutter, lineSpace * 3, materialEaseInLabel.frame.size.width,
                  materialEaseInLabel.frame.size.height);
@@ -142,24 +147,25 @@ static const CGSize kAnimationCircleSize = {48, 48};
       CGRectMake(kLeftGutter, lineSpace * 3 + kTextOffset, kAnimationCircleSize.width,
                  kAnimationCircleSize.height);
   self.materialAccelerationView = [[UIView alloc] initWithFrame:materialAccelerationViewFrame];
-  self.materialAccelerationView.backgroundColor = [AnimationTimingExampleViewController defaultColors][3];
+  self.materialAccelerationView.backgroundColor =
+      [AnimationTimingExampleViewController defaultColors][3];
   self.materialAccelerationView.layer.cornerRadius = kAnimationCircleSize.width / 2;
   [self.scrollView addSubview:self.materialAccelerationView];
    
-   UILabel *materialSharpLabel =
-       [AnimationTimingExampleViewController curveLabelWithTitle:@"MDCAnimationTimingFunctionSharp"];
-   materialSharpLabel.frame =
-       CGRectMake(kLeftGutter, lineSpace * 4, CGRectGetWidth(materialSharpLabel.frame),
-                  CGRectGetHeight(materialSharpLabel.frame));
-   [self.scrollView addSubview:materialSharpLabel];
+  UILabel *materialSharpLabel =
+      [AnimationTimingExampleViewController curveLabelWithTitle:@"MDCAnimationTimingFunctionSharp"];
+  materialSharpLabel.frame =
+      CGRectMake(kLeftGutter, lineSpace * 4, CGRectGetWidth(materialSharpLabel.frame),
+                CGRectGetHeight(materialSharpLabel.frame));
+  [self.scrollView addSubview:materialSharpLabel];
 
-   CGRect materialSharpViewFrame =
-       CGRectMake(kLeftGutter, lineSpace * 4 + kTextOffset, kAnimationCircleSize.width,
-                  kAnimationCircleSize.height);
-   self.materialSharpView = [[UIView alloc] initWithFrame:materialSharpViewFrame];
-   self.materialSharpView.backgroundColor = [AnimationTimingExampleViewController defaultColors][4];
-   self.materialSharpView.layer.cornerRadius = kAnimationCircleSize.width / 2;
-   [self.scrollView addSubview:self.materialSharpView];
+  CGRect materialSharpViewFrame =
+      CGRectMake(kLeftGutter, lineSpace * 4 + kTextOffset, kAnimationCircleSize.width,
+                kAnimationCircleSize.height);
+  self.materialSharpView = [[UIView alloc] initWithFrame:materialSharpViewFrame];
+  self.materialSharpView.backgroundColor = [AnimationTimingExampleViewController defaultColors][4];
+  self.materialSharpView.layer.cornerRadius = kAnimationCircleSize.width / 2;
+  [self.scrollView addSubview:self.materialSharpView];
 }
 
 + (UILabel *)curveLabelWithTitle:(NSString *)text {


### PR DESCRIPTION
Renaming each of the example view controllers to include
"ExampleViewController" so they're easier to find. This is closer to our
typical naming pattern for example view controllers.
