### PR TITLE
[Buttons] Add button theming category method for outlined theming

### DIFF
--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -121,7 +121,7 @@ const CGSize kMinimumAccessibleButtonSize = {64.0, 48.0};
 
   MDCButton *outlinedButton = [[MDCButton alloc] init];
   [outlinedButton setTitle:@"Button" forState:UIControlStateNormal];
-  [MDCOutlinedButtonThemer applyScheme:buttonScheme toButton:outlinedButton];
+  [outlinedButton applyOutlinedThemeWithScheme:self.containerScheme];
   [outlinedButton sizeToFit];
   CGFloat outlineButtonVerticalInset =
       MIN(0, -(kMinimumAccessibleButtonSize.height - CGRectGetHeight(outlinedButton.frame)) / 2);
@@ -139,7 +139,7 @@ const CGSize kMinimumAccessibleButtonSize = {64.0, 48.0};
 
   MDCButton *disabledOutlinedButton = [[MDCButton alloc] init];
   [disabledOutlinedButton setTitle:@"Button" forState:UIControlStateNormal];
-  [MDCOutlinedButtonThemer applyScheme:buttonScheme toButton:disabledOutlinedButton];
+  [disabledOutlinedButton applyOutlinedThemeWithScheme:self.containerScheme];
   [disabledOutlinedButton sizeToFit];
   [disabledOutlinedButton addTarget:self
                              action:@selector(didTap:)

--- a/components/Buttons/src/Theming/MDCButton+Theming.h
+++ b/components/Buttons/src/Theming/MDCButton+Theming.h
@@ -29,4 +29,12 @@
  */
 - (void)applyContainedThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
 
+/**
+ Applies the theme for an outlined button to this instance.
+
+ @param scheme A container scheme instance containing any desired customizations to the theming
+ system.
+ */
+- (void)applyOutlinedThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
 @end

--- a/components/Buttons/src/Theming/MDCButton+Theming.m
+++ b/components/Buttons/src/Theming/MDCButton+Theming.m
@@ -61,4 +61,46 @@
   [MDCButtonShapeThemer applyShapeScheme:shapeScheme toButton:self];
 }
 
+- (void)applyOutlinedThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme {
+  id<MDCColorScheming> colorScheme = scheme.colorScheme;
+  if (!colorScheme) {
+    colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+  [self applyOutlinedThemeWithColorScheme:colorScheme];
+
+  id<MDCShapeScheming> shapeScheme = scheme.shapeScheme;
+  if (shapeScheme) {
+    [self applyOutlinedThemeWithShapeScheme:shapeScheme];
+  } else {
+    self.layer.cornerRadius = (CGFloat)4;
+  }
+
+  id<MDCTypographyScheming> typographyScheme = scheme.typographyScheme;
+  if (!typographyScheme) {
+    typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+  }
+  [self applyOutlinedThemeWithTypographyScheme:typographyScheme];
+
+  self.minimumSize = CGSizeMake(0, 36);
+  NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
+                                 UIControlStateHighlighted | UIControlStateDisabled;
+  for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    [self setBorderWidth:1 forState:state];
+  }
+}
+
+- (void)applyOutlinedThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
+  [MDCOutlinedButtonColorThemer applySemanticColorScheme:colorScheme toButton:self];
+}
+
+- (void)applyOutlinedThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {
+  [MDCButtonTypographyThemer applyTypographyScheme:typographyScheme toButton:self];
+}
+
+- (void)applyOutlinedThemeWithShapeScheme:(id<MDCShapeScheming>)shapeScheme {
+  [MDCButtonShapeThemer applyShapeScheme:shapeScheme toButton:self];
+}
+
 @end

--- a/components/Buttons/tests/unit/ButtonsThemingTest.swift
+++ b/components/Buttons/tests/unit/ButtonsThemingTest.swift
@@ -84,4 +84,52 @@ class ButtonsThemingTest: XCTestCase {
     XCTAssertEqual(buttonShape.bottomRightCorner, shapeScheme.smallComponentShape.bottomRightCorner)
     XCTAssertEqual(buttonShape.bottomLeftCorner, shapeScheme.smallComponentShape.bottomLeftCorner)
   }
+
+  func testOutlinedTheme() {
+    // Given
+    let button = MDCButton()
+    let scheme = MDCContainerScheme()
+    let colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    let typographyScheme = MDCTypographyScheme(defaults: .material201804)
+    let baselineCornerRadius: CGFloat = 4
+
+    // When
+    button.applyOutlinedTheme(withScheme: scheme)
+
+    // Then
+    // Test Colors
+    XCTAssertEqual(button.backgroundColor(for: .normal), .clear)
+    XCTAssertEqual(button.titleColor(for: .normal), colorScheme.primaryColor)
+    XCTAssertEqual(button.titleColor(for: .disabled), colorScheme.onSurfaceColor.withAlphaComponent(0.38))
+    XCTAssertEqual(button.disabledAlpha,1)
+    XCTAssertEqual(button.inkColor,colorScheme.primaryColor.withAlphaComponent(0.16))
+    XCTAssertEqual(button.borderColor(for: .normal), colorScheme.onSurfaceColor.withAlphaComponent(0.12))
+    // Test shape
+    XCTAssertEqual(button.layer.cornerRadius, baselineCornerRadius, accuracy: 0.001)
+    // Test typography
+    XCTAssertEqual(button.titleFont(for: .normal), typographyScheme.button)
+    // Test remaining properties
+    XCTAssertEqual(button.minimumSize.width, 0)
+    XCTAssertEqual(button.minimumSize.height, 36)
+  }
+
+  func testOutlinedThemeWithShapeScheme() {
+    // Given
+    let button = MDCButton()
+    let scheme = MDCContainerScheme()
+    let shapeScheme = MDCShapeScheme()
+    scheme.shapeScheme = shapeScheme
+
+    // When
+    button.applyOutlinedTheme(withScheme: scheme)
+
+    // Then
+    let buttonShape = button.shapeGenerator as! MDCRectangleShapeGenerator
+    XCTAssertEqual(buttonShape.topLeftCorner, shapeScheme.smallComponentShape.topLeftCorner)
+    XCTAssertEqual(buttonShape.topRightCorner, shapeScheme.smallComponentShape.topRightCorner)
+    XCTAssertEqual(buttonShape.bottomRightCorner, shapeScheme.smallComponentShape.bottomRightCorner)
+    XCTAssertEqual(buttonShape.bottomLeftCorner, shapeScheme.smallComponentShape.bottomLeftCorner)
+  }
+
+
 }

--- a/components/Buttons/tests/unit/ButtonsThemingTest.swift
+++ b/components/Buttons/tests/unit/ButtonsThemingTest.swift
@@ -63,8 +63,8 @@ class ButtonsThemingTest: XCTestCase {
     XCTAssertEqual(button.elevation(for: .normal), ShadowElevation.raisedButtonResting)
     XCTAssertEqual(button.elevation(for: .highlighted), ShadowElevation.raisedButtonPressed)
     XCTAssertEqual(button.elevation(for: .disabled), ShadowElevation.none)
-    XCTAssertEqual(button.minimumSize.width, 0)
-    XCTAssertEqual(button.minimumSize.height, 36)
+    XCTAssertEqual(button.minimumSize.width, 0, accuracy: 0.001)
+    XCTAssertEqual(button.minimumSize.height, 36, accuracy: 0.001)
   }
 
   func testContainedThemeWithShapeScheme() {
@@ -109,8 +109,12 @@ class ButtonsThemingTest: XCTestCase {
     // Test typography
     XCTAssertEqual(button.titleFont(for: .normal), typographyScheme.button)
     // Test remaining properties
-    XCTAssertEqual(button.minimumSize.width, 0)
-    XCTAssertEqual(button.minimumSize.height, 36)
+    XCTAssertEqual(button.minimumSize.width, 0, accuracy: 0.001)
+    XCTAssertEqual(button.minimumSize.height, 36, accuracy: 0.001)
+    XCTAssertEqual(button.borderWidth(for: .normal), 1, accuracy: 0.001)
+    XCTAssertEqual(button.borderWidth(for: .selected), 1, accuracy: 0.001)
+    XCTAssertEqual(button.borderWidth(for: .highlighted), 1, accuracy: 0.001)
+    XCTAssertEqual(button.borderWidth(for: .disabled), 1, accuracy: 0.001)
   }
 
   func testOutlinedThemeWithShapeScheme() {

--- a/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
+++ b/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
@@ -26,6 +26,7 @@
 #import "MaterialBottomSheet.h"
 #import "MaterialButtons+ButtonThemer.h"
 #import "MaterialButtons+ShapeThemer.h"
+#import "MaterialButtons+Theming.h"
 #import "MaterialButtons.h"
 #import "MaterialCards+CardThemer.h"
 #import "MaterialCards+ShapeThemer.h"
@@ -42,6 +43,7 @@
 @property(strong, nonatomic) MDCSemanticColorScheme *colorScheme;
 @property(strong, nonatomic) MDCShapeScheme *shapeScheme;
 @property(strong, nonatomic) MDCTypographyScheme *typographyScheme;
+@property(strong, nonatomic) MDCContainerScheme *containerScheme;
 
 @property(weak, nonatomic) IBOutlet MDCShapedView *smallComponentShape;
 @property(weak, nonatomic) IBOutlet MDCShapedView *mediumComponentShape;
@@ -83,10 +85,15 @@
 }
 
 - (void)commonShapeSchemeExampleInit {
-  _colorScheme =
+  self.colorScheme =
       [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  _shapeScheme = [[MDCShapeScheme alloc] init];
-  _typographyScheme = [[MDCTypographyScheme alloc] init];
+  self.shapeScheme = [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  self.typographyScheme =
+      [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+  self.containerScheme = [[MDCContainerScheme alloc] init];
+  self.containerScheme.colorScheme = self.colorScheme;
+  self.containerScheme.shapeScheme = self.shapeScheme;
+  self.containerScheme.typographyScheme = self.typographyScheme;
 }
 
 - (void)viewDidLoad {
@@ -154,7 +161,7 @@
 
   self.presentBottomSheetButton = [[MDCButton alloc] init];
   [self.presentBottomSheetButton setTitle:@"Present Bottom Sheet" forState:UIControlStateNormal];
-  [MDCOutlinedButtonThemer applyScheme:buttonScheme toButton:self.presentBottomSheetButton];
+  [self.presentBottomSheetButton applyOutlinedThemeWithScheme:self.containerScheme];
   self.presentBottomSheetButton.translatesAutoresizingMaskIntoConstraints = NO;
   [self.componentContentView addSubview:self.presentBottomSheetButton];
   [self.presentBottomSheetButton addTarget:self


### PR DESCRIPTION
This PR adds the MDCButton theming category method for outlined buttons.

Closes #5847.