### PR TITLE
[schemes] Make MDCColorScheme conform to NSCopying

### DIFF
--- a/components/schemes/Color/src/MDCSemanticColorScheme.h
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.h
@@ -24,56 +24,56 @@
 /**
  Displayed most frequently across your app.
  */
-@property(nonnull, readonly, nonatomic) UIColor *primaryColor;
+@property(nonnull, readonly, copy, nonatomic) UIColor *primaryColor;
 
 /**
  A tonal variation of primary color.
  */
-@property(nonnull, readonly, nonatomic) UIColor *primaryColorVariant;
+@property(nonnull, readonly, copy, nonatomic) UIColor *primaryColorVariant;
 
 /**
  Accents select parts of your UI.
  */
-@property(nonnull, readonly, nonatomic) UIColor *secondaryColor;
+@property(nonnull, readonly, copy, nonatomic) UIColor *secondaryColor;
 
 /**
  The color used to indicate error status.
  */
-@property(nonnull, readonly, nonatomic) UIColor *errorColor;
+@property(nonnull, readonly, copy, nonatomic) UIColor *errorColor;
 
 /**
  The color of surfaces such as cards, sheets, menus.
  */
-@property(nonnull, readonly, nonatomic) UIColor *surfaceColor;
+@property(nonnull, readonly, copy, nonatomic) UIColor *surfaceColor;
 
 /**
  The underlying color of an app’s content.
  */
-@property(nonnull, readonly, nonatomic) UIColor *backgroundColor;
+@property(nonnull, readonly, copy, nonatomic) UIColor *backgroundColor;
 
 /**
  A color that passes accessibility guidelines for text/iconography when drawn on top of
  @c primaryColor.
  */
-@property(nonnull, readonly, nonatomic) UIColor *onPrimaryColor;
+@property(nonnull, readonly, copy, nonatomic) UIColor *onPrimaryColor;
 
 /**
  A color that passes accessibility guidelines for text/iconography when drawn on top of
  @c secondaryColor.
  */
-@property(nonnull, readonly, nonatomic) UIColor *onSecondaryColor;
+@property(nonnull, readonly, copy, nonatomic) UIColor *onSecondaryColor;
 
 /**
  A color that passes accessibility guidelines for text/iconography when drawn on top of
  @c surfaceColor.
  */
-@property(nonnull, readonly, nonatomic) UIColor *onSurfaceColor;
+@property(nonnull, readonly, copy, nonatomic) UIColor *onSurfaceColor;
 
 /**
  A color that passes accessibility guidelines for text/iconography when drawn on top of
  @c backgroundColor.
  */
-@property(nonnull, readonly, nonatomic) UIColor *onBackgroundColor;
+@property(nonnull, readonly, copy, nonatomic) UIColor *onBackgroundColor;
 @end
 
 /**
@@ -90,19 +90,19 @@ typedef NS_ENUM(NSInteger, MDCColorSchemeDefaults) {
  A simple implementation of @c MDCColorScheming that provides Material default color values from
  which basic customizations can be made.
  */
-@interface MDCSemanticColorScheme : NSObject <MDCColorScheming>
+@interface MDCSemanticColorScheme : NSObject <MDCColorScheming, NSCopying>
 
 // Redeclare protocol properties as readwrite
-@property(nonnull, readwrite, nonatomic) UIColor *primaryColor;
-@property(nonnull, readwrite, nonatomic) UIColor *primaryColorVariant;
-@property(nonnull, readwrite, nonatomic) UIColor *secondaryColor;
-@property(nonnull, readwrite, nonatomic) UIColor *errorColor;
-@property(nonnull, readwrite, nonatomic) UIColor *surfaceColor;
-@property(nonnull, readwrite, nonatomic) UIColor *backgroundColor;
-@property(nonnull, readwrite, nonatomic) UIColor *onPrimaryColor;
-@property(nonnull, readwrite, nonatomic) UIColor *onSecondaryColor;
-@property(nonnull, readwrite, nonatomic) UIColor *onSurfaceColor;
-@property(nonnull, readwrite, nonatomic) UIColor *onBackgroundColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *primaryColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *primaryColorVariant;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *secondaryColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *errorColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *surfaceColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *backgroundColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *onPrimaryColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *onSecondaryColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *onSurfaceColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *onBackgroundColor;
 
 /**
  Initializes the color scheme with the latest material defaults.

--- a/components/schemes/Color/src/MDCSemanticColorScheme.m
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.m
@@ -73,5 +73,23 @@ static CGFloat blendColorChannel(CGFloat value, CGFloat bValue, CGFloat alpha, C
                          alpha:alpha + bAlpha*(1 - alpha)];
 }
 
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone {
+  MDCSemanticColorScheme *copy = [[MDCSemanticColorScheme alloc] init];
+  copy.primaryColor = self.primaryColor;
+  copy.primaryColorVariant = self.primaryColorVariant;
+  copy.secondaryColor = self.secondaryColor;
+  copy.surfaceColor = self.surfaceColor;
+  copy.backgroundColor = self.backgroundColor;
+  copy.errorColor = self.errorColor;
+  copy.onPrimaryColor = self.onPrimaryColor;
+  copy.onSecondaryColor = self.onSecondaryColor;
+  copy.onSurfaceColor = self.onSurfaceColor;
+  copy.onBackgroundColor = self.onBackgroundColor;
+
+  return copy;
+}
+
 @end
 

--- a/components/schemes/Color/tests/unit/MDCSemanticColorSchemeTests.m
+++ b/components/schemes/Color/tests/unit/MDCSemanticColorSchemeTests.m
@@ -177,4 +177,21 @@ static UIColor *ColorFromRGB(uint32_t colorValue) {
           MDCCGFloatEqual(fAlpha, sAlpha));
 }
 
+- (void)testColorSchemeCopyTest {
+  // Given
+  MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
+  MDCSemanticColorScheme *colorSchemeCopy = [colorScheme copy];
+  XCTAssertFalse(colorScheme == colorSchemeCopy);
+  XCTAssertEqual(colorScheme.primaryColor, colorSchemeCopy.primaryColor);
+  XCTAssertEqual(colorScheme.primaryColorVariant, colorSchemeCopy.primaryColorVariant);
+  XCTAssertEqual(colorScheme.secondaryColor, colorSchemeCopy.secondaryColor);
+  XCTAssertEqual(colorScheme.surfaceColor, colorSchemeCopy.surfaceColor);
+  XCTAssertEqual(colorScheme.backgroundColor, colorSchemeCopy.backgroundColor);
+  XCTAssertEqual(colorScheme.errorColor, colorSchemeCopy.errorColor);
+  XCTAssertEqual(colorScheme.onPrimaryColor, colorSchemeCopy.onPrimaryColor);
+  XCTAssertEqual(colorScheme.onSecondaryColor, colorSchemeCopy.onSecondaryColor);
+  XCTAssertEqual(colorScheme.onSurfaceColor, colorSchemeCopy.onSurfaceColor);
+  XCTAssertEqual(colorScheme.onBackgroundColor, colorSchemeCopy.onBackgroundColor);
+}
+
 @end

--- a/components/schemes/Color/tests/unit/MDCSemanticColorSchemeTests.m
+++ b/components/schemes/Color/tests/unit/MDCSemanticColorSchemeTests.m
@@ -181,6 +181,8 @@ static UIColor *ColorFromRGB(uint32_t colorValue) {
   // Given
   MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
   MDCSemanticColorScheme *colorSchemeCopy = [colorScheme copy];
+
+  // Then
   XCTAssertFalse(colorScheme == colorSchemeCopy);
   XCTAssertEqual(colorScheme.primaryColor, colorSchemeCopy.primaryColor);
   XCTAssertEqual(colorScheme.primaryColorVariant, colorSchemeCopy.primaryColorVariant);

--- a/components/schemes/Color/tests/unit/MDCSemanticColorSchemeTests.m
+++ b/components/schemes/Color/tests/unit/MDCSemanticColorSchemeTests.m
@@ -177,23 +177,25 @@ static UIColor *ColorFromRGB(uint32_t colorValue) {
           MDCCGFloatEqual(fAlpha, sAlpha));
 }
 
-- (void)testColorSchemeCopyTest {
+- (void)testColorSchemeCopy {
   // Given
   MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
+
+  // When
   MDCSemanticColorScheme *colorSchemeCopy = [colorScheme copy];
 
   // Then
-  XCTAssertFalse(colorScheme == colorSchemeCopy);
-  XCTAssertEqual(colorScheme.primaryColor, colorSchemeCopy.primaryColor);
-  XCTAssertEqual(colorScheme.primaryColorVariant, colorSchemeCopy.primaryColorVariant);
-  XCTAssertEqual(colorScheme.secondaryColor, colorSchemeCopy.secondaryColor);
-  XCTAssertEqual(colorScheme.surfaceColor, colorSchemeCopy.surfaceColor);
-  XCTAssertEqual(colorScheme.backgroundColor, colorSchemeCopy.backgroundColor);
-  XCTAssertEqual(colorScheme.errorColor, colorSchemeCopy.errorColor);
-  XCTAssertEqual(colorScheme.onPrimaryColor, colorSchemeCopy.onPrimaryColor);
-  XCTAssertEqual(colorScheme.onSecondaryColor, colorSchemeCopy.onSecondaryColor);
-  XCTAssertEqual(colorScheme.onSurfaceColor, colorSchemeCopy.onSurfaceColor);
-  XCTAssertEqual(colorScheme.onBackgroundColor, colorSchemeCopy.onBackgroundColor);
+  XCTAssertNotEqual(colorScheme, colorSchemeCopy);
+  XCTAssertEqualObjects(colorScheme.primaryColor, colorSchemeCopy.primaryColor);
+  XCTAssertEqualObjects(colorScheme.primaryColorVariant, colorSchemeCopy.primaryColorVariant);
+  XCTAssertEqualObjects(colorScheme.secondaryColor, colorSchemeCopy.secondaryColor);
+  XCTAssertEqualObjects(colorScheme.surfaceColor, colorSchemeCopy.surfaceColor);
+  XCTAssertEqualObjects(colorScheme.backgroundColor, colorSchemeCopy.backgroundColor);
+  XCTAssertEqualObjects(colorScheme.errorColor, colorSchemeCopy.errorColor);
+  XCTAssertEqualObjects(colorScheme.onPrimaryColor, colorSchemeCopy.onPrimaryColor);
+  XCTAssertEqualObjects(colorScheme.onSecondaryColor, colorSchemeCopy.onSecondaryColor);
+  XCTAssertEqualObjects(colorScheme.onSurfaceColor, colorSchemeCopy.onSurfaceColor);
+  XCTAssertEqualObjects(colorScheme.onBackgroundColor, colorSchemeCopy.onBackgroundColor);
 }
 
 @end


### PR DESCRIPTION
closes https://github.com/material-components/material-components-ios/issues/5907 https://github.com/material-components/material-components-ios/issues/5840

Making MDCColorScheme conform to NSCopying will reduce developers' effort to create a copy of our scheme object.
