### PR TITLE
[Typography] make MDCTypography conform to NSCopying

### DIFF
--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -24,67 +24,67 @@
 /**
  The headline 1 font.
  */
-@property(nonatomic, nonnull, readonly) UIFont *headline1;
+@property(nonatomic, nonnull, readonly, copy) UIFont *headline1;
 
 /**
  The headline 2 font.
  */
-@property(nonatomic, nonnull, readonly) UIFont *headline2;
+@property(nonatomic, nonnull, readonly, copy) UIFont *headline2;
 
 /**
  The headline 3 font.
  */
-@property(nonatomic, nonnull, readonly) UIFont *headline3;
+@property(nonatomic, nonnull, readonly, copy) UIFont *headline3;
 
 /**
  The headline 4 font.
  */
-@property(nonatomic, nonnull, readonly) UIFont *headline4;
+@property(nonatomic, nonnull, readonly, copy) UIFont *headline4;
 
 /**
  The headline 5 font.
  */
-@property(nonatomic, nonnull, readonly) UIFont *headline5;
+@property(nonatomic, nonnull, readonly, copy) UIFont *headline5;
 
 /**
  The headline 6 font.
  */
-@property(nonatomic, nonnull, readonly) UIFont *headline6;
+@property(nonatomic, nonnull, readonly, copy) UIFont *headline6;
 
 /**
  The subtitle 1 font.
  */
-@property(nonatomic, nonnull, readonly) UIFont *subtitle1;
+@property(nonatomic, nonnull, readonly, copy) UIFont *subtitle1;
 
 /**
  The subtitle 2 font.
  */
-@property(nonatomic, nonnull, readonly) UIFont *subtitle2;
+@property(nonatomic, nonnull, readonly, copy) UIFont *subtitle2;
 
 /**
  The body 1 font.
  */
-@property(nonatomic, nonnull, readonly) UIFont *body1;
+@property(nonatomic, nonnull, readonly, copy) UIFont *body1;
 
 /**
  Return the body 2 font.
  */
-@property(nonatomic, nonnull, readonly) UIFont *body2;
+@property(nonatomic, nonnull, readonly, copy) UIFont *body2;
 
 /**
  Return the caption font.
  */
-@property(nonatomic, nonnull, readonly) UIFont *caption;
+@property(nonatomic, nonnull, readonly, copy) UIFont *caption;
 
 /**
  Return the button font.
  */
-@property(nonatomic, nonnull, readonly) UIFont *button;
+@property(nonatomic, nonnull, readonly, copy) UIFont *button;
 
 /**
  Return the overline font.
  */
-@property(nonatomic, nonnull, readonly) UIFont *overline;
+@property(nonatomic, nonnull, readonly, copy) UIFont *overline;
 
 @end
 
@@ -102,22 +102,22 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
  A simple implementation of @c MDCTypographyScheming that provides Material default fonts
  from which basic customizations can be made.
  */
-@interface MDCTypographyScheme : NSObject <MDCTypographyScheming>
+@interface MDCTypographyScheme : NSObject <MDCTypographyScheming, NSCopying>
 
 // Redeclare protocol properties as readwrite
-@property(nonatomic, nonnull, readwrite) UIFont *headline1;
-@property(nonatomic, nonnull, readwrite) UIFont *headline2;
-@property(nonatomic, nonnull, readwrite) UIFont *headline3;
-@property(nonatomic, nonnull, readwrite) UIFont *headline4;
-@property(nonatomic, nonnull, readwrite) UIFont *headline5;
-@property(nonatomic, nonnull, readwrite) UIFont *headline6;
-@property(nonatomic, nonnull, readwrite) UIFont *subtitle1;
-@property(nonatomic, nonnull, readwrite) UIFont *subtitle2;
-@property(nonatomic, nonnull, readwrite) UIFont *body1;
-@property(nonatomic, nonnull, readwrite) UIFont *body2;
-@property(nonatomic, nonnull, readwrite) UIFont *caption;
-@property(nonatomic, nonnull, readwrite) UIFont *button;
-@property(nonatomic, nonnull, readwrite) UIFont *overline;
+@property(nonatomic, nonnull, readwrite, copy) UIFont *headline1;
+@property(nonatomic, nonnull, readwrite, copy) UIFont *headline2;
+@property(nonatomic, nonnull, readwrite, copy) UIFont *headline3;
+@property(nonatomic, nonnull, readwrite, copy) UIFont *headline4;
+@property(nonatomic, nonnull, readwrite, copy) UIFont *headline5;
+@property(nonatomic, nonnull, readwrite, copy) UIFont *headline6;
+@property(nonatomic, nonnull, readwrite, copy) UIFont *subtitle1;
+@property(nonatomic, nonnull, readwrite, copy) UIFont *subtitle2;
+@property(nonatomic, nonnull, readwrite, copy) UIFont *body1;
+@property(nonatomic, nonnull, readwrite, copy) UIFont *body2;
+@property(nonatomic, nonnull, readwrite, copy) UIFont *caption;
+@property(nonatomic, nonnull, readwrite, copy) UIFont *button;
+@property(nonatomic, nonnull, readwrite, copy) UIFont *overline;
 
 /**
  Initializes the typography scheme with the latest material defaults.

--- a/components/schemes/Typography/src/MDCTypographyScheme.m
+++ b/components/schemes/Typography/src/MDCTypographyScheme.m
@@ -67,4 +67,25 @@
   return self;
 }
 
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone {
+  MDCTypographyScheme *copy = [[MDCTypographyScheme alloc] init];
+  copy.headline1 = self.headline1;
+  copy.headline2 = self.headline2;
+  copy.headline3 = self.headline3;
+  copy.headline4 = self.headline4;
+  copy.headline5 = self.headline5;
+  copy.headline6 = self.headline6;
+  copy.subtitle1 = self.subtitle1;
+  copy.subtitle2 = self.subtitle2;
+  copy.body1 = self.body1;
+  copy.body2 = self.body2;
+  copy.caption = self.caption;
+  copy.button = self.button;
+  copy.overline = self.overline;
+
+  return copy;
+}
+
 @end

--- a/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
+++ b/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
@@ -44,26 +44,28 @@
   XCTAssertEqual(latestScheme.overline, scheme201804.overline);
 }
 
-- (void)testTypographySchemeCopyTest {
+- (void)testTypographySchemeCopy {
   // Given
   MDCTypographyScheme *typographyScheme = [[MDCTypographyScheme alloc] init];
+
+  // When
   MDCTypographyScheme *typographySchemeCopy = [typographyScheme copy];
 
   // Then
-  XCTAssertFalse(typographyScheme == typographySchemeCopy);
-  XCTAssertEqual(typographyScheme.headline1, typographySchemeCopy.headline1);
-  XCTAssertEqual(typographyScheme.headline2, typographySchemeCopy.headline2);
-  XCTAssertEqual(typographyScheme.headline3, typographySchemeCopy.headline3);
-  XCTAssertEqual(typographyScheme.headline4, typographySchemeCopy.headline4);
-  XCTAssertEqual(typographyScheme.headline5, typographySchemeCopy.headline5);
-  XCTAssertEqual(typographyScheme.headline6, typographySchemeCopy.headline6);
-  XCTAssertEqual(typographyScheme.subtitle1, typographySchemeCopy.subtitle1);
-  XCTAssertEqual(typographyScheme.subtitle2, typographySchemeCopy.subtitle2);
-  XCTAssertEqual(typographyScheme.body1, typographySchemeCopy.body1);
-  XCTAssertEqual(typographyScheme.body2, typographySchemeCopy.body2);
-  XCTAssertEqual(typographyScheme.caption, typographySchemeCopy.caption);
-  XCTAssertEqual(typographyScheme.button, typographySchemeCopy.button);
-  XCTAssertEqual(typographyScheme.overline, typographySchemeCopy.overline);
+  XCTAssertNotEqual(typographyScheme, typographySchemeCopy);
+  XCTAssertEqualObjects(typographyScheme.headline1, typographySchemeCopy.headline1);
+  XCTAssertEqualObjects(typographyScheme.headline2, typographySchemeCopy.headline2);
+  XCTAssertEqualObjects(typographyScheme.headline3, typographySchemeCopy.headline3);
+  XCTAssertEqualObjects(typographyScheme.headline4, typographySchemeCopy.headline4);
+  XCTAssertEqualObjects(typographyScheme.headline5, typographySchemeCopy.headline5);
+  XCTAssertEqualObjects(typographyScheme.headline6, typographySchemeCopy.headline6);
+  XCTAssertEqualObjects(typographyScheme.subtitle1, typographySchemeCopy.subtitle1);
+  XCTAssertEqualObjects(typographyScheme.subtitle2, typographySchemeCopy.subtitle2);
+  XCTAssertEqualObjects(typographyScheme.body1, typographySchemeCopy.body1);
+  XCTAssertEqualObjects(typographyScheme.body2, typographySchemeCopy.body2);
+  XCTAssertEqualObjects(typographyScheme.caption, typographySchemeCopy.caption);
+  XCTAssertEqualObjects(typographyScheme.button, typographySchemeCopy.button);
+  XCTAssertEqualObjects(typographyScheme.overline, typographySchemeCopy.overline);
 }
 
 @end

--- a/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
+++ b/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
@@ -49,7 +49,7 @@
   MDCTypographyScheme *typographyScheme = [[MDCTypographyScheme alloc] init];
   MDCTypographyScheme *typographySchemeCopy = [typographyScheme copy];
 
-  //Then
+  // Then
   XCTAssertFalse(typographyScheme == typographySchemeCopy);
   XCTAssertEqual(typographyScheme.headline1, typographySchemeCopy.headline1);
   XCTAssertEqual(typographyScheme.headline2, typographySchemeCopy.headline2);

--- a/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
+++ b/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
@@ -44,4 +44,26 @@
   XCTAssertEqual(latestScheme.overline, scheme201804.overline);
 }
 
+- (void)testTypographySchemeCopyTest {
+  // Given
+  MDCTypographyScheme *typographyScheme = [[MDCTypographyScheme alloc] init];
+  MDCTypographyScheme *typographySchemeCopy = [typographyScheme copy];
+  
+  //Then
+  XCTAssertFalse(typographyScheme == typographySchemeCopy);
+  XCTAssertEqual(typographyScheme.headline1, typographySchemeCopy.headline1);
+  XCTAssertEqual(typographyScheme.headline2, typographySchemeCopy.headline2);
+  XCTAssertEqual(typographyScheme.headline3, typographySchemeCopy.headline3);
+  XCTAssertEqual(typographyScheme.headline4, typographySchemeCopy.headline4);
+  XCTAssertEqual(typographyScheme.headline5, typographySchemeCopy.headline5);
+  XCTAssertEqual(typographyScheme.headline6, typographySchemeCopy.headline6);
+  XCTAssertEqual(typographyScheme.subtitle1, typographySchemeCopy.subtitle1);
+  XCTAssertEqual(typographyScheme.subtitle2, typographySchemeCopy.subtitle2);
+  XCTAssertEqual(typographyScheme.body1, typographySchemeCopy.body1);
+  XCTAssertEqual(typographyScheme.body2, typographySchemeCopy.body2);
+  XCTAssertEqual(typographyScheme.caption, typographySchemeCopy.caption);
+  XCTAssertEqual(typographyScheme.button, typographySchemeCopy.button);
+  XCTAssertEqual(typographyScheme.overline, typographySchemeCopy.overline);
+}
+
 @end

--- a/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
+++ b/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
@@ -48,7 +48,7 @@
   // Given
   MDCTypographyScheme *typographyScheme = [[MDCTypographyScheme alloc] init];
   MDCTypographyScheme *typographySchemeCopy = [typographyScheme copy];
-  
+
   //Then
   XCTAssertFalse(typographyScheme == typographySchemeCopy);
   XCTAssertEqual(typographyScheme.headline1, typographySchemeCopy.headline1);


### PR DESCRIPTION
closes https://github.com/material-components/material-components-ios/issues/5904

Making MDCTypography conform to NSCopying will reduce developers' effort to create a copy of our scheme object.