### PR TITLE
[FlexibleHeader] Refactor min/max height behavior to a separate object.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -774,8 +774,8 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   if (frame.size.height < self.minMaxHeight.maximumHeightWithTopSafeArea) {
     _scrollPhase = MDCFlexibleHeaderScrollPhaseCollapsing;
 
-    CGFloat heightLength =
-        self.minMaxHeight.maximumHeightWithTopSafeArea - self.minMaxHeight.minimumHeightWithTopSafeArea;
+    CGFloat heightLength = self.minMaxHeight.maximumHeightWithTopSafeArea -
+                           self.minMaxHeight.minimumHeightWithTopSafeArea;
     if (heightLength > 0) {
       _scrollPhasePercentage =
           (frame.size.height - self.minMaxHeight.minimumHeightWithTopSafeArea) / heightLength;
@@ -788,8 +788,9 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
   _scrollPhase = MDCFlexibleHeaderScrollPhaseOverExtending;
   if (self.minMaxHeight.maximumHeightWithTopSafeArea > 0) {
-    _scrollPhasePercentage = 1 + (frame.size.height - self.minMaxHeight.maximumHeightWithTopSafeArea) /
-                                     self.minMaxHeight.maximumHeightWithTopSafeArea;
+    _scrollPhasePercentage =
+        1 + (frame.size.height - self.minMaxHeight.maximumHeightWithTopSafeArea) /
+                self.minMaxHeight.maximumHeightWithTopSafeArea;
   } else {
     _scrollPhasePercentage = 0;
   }
@@ -905,9 +906,9 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   if (self.hidesStatusBarWhenCollapsed) {
     // Calculate the desired shadow strength for the offset & accumulator and then take the
     // weakest strength.
-    CGFloat accumulator = MAX(
-        0,
-        MIN(kShadowScaleLength, self.minMaxHeight.minimumHeightWithTopSafeArea - boundedAccumulator));
+    CGFloat accumulator =
+        MAX(0, MIN(kShadowScaleLength,
+                   self.minMaxHeight.minimumHeightWithTopSafeArea - boundedAccumulator));
     if (self.isInFrontOfInfiniteContent) {
       // When in front of infinite content we only care to hide the shadow when our header is
       // off-screen.
@@ -1138,8 +1139,8 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
     CGFloat additionalHeightInjection = MAX(0, -_shiftAccumulator);
 
     if (_canOverExtend && !UIAccessibilityIsVoiceOverRunning()) {
-      bounds.size.height =
-          MAX(self.minMaxHeight.minimumHeightWithTopSafeArea, headerHeight) + additionalHeightInjection;
+      bounds.size.height = MAX(self.minMaxHeight.minimumHeightWithTopSafeArea, headerHeight) +
+                           additionalHeightInjection;
     } else {
       bounds.size.height = (MAX(self.minMaxHeight.minimumHeightWithTopSafeArea,
                                 MIN(self.minMaxHeight.maximumHeightWithTopSafeArea, headerHeight)) +

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -17,6 +17,7 @@
 #import "MDCFlexibleHeaderView+ShiftBehavior.h"
 #import "MaterialApplication.h"
 #import "MaterialUIMetrics.h"
+#import "private/MDCFlexibleHeaderMinMaxHeight.h"
 #import "private/MDCFlexibleHeaderTopSafeArea.h"
 #import "private/MDCFlexibleHeaderView+Private.h"
 #import "private/MDCStatusBarShifter.h"
@@ -24,9 +25,6 @@
 #if TARGET_IPHONE_SIMULATOR
 float UIAnimationDragCoefficient(void);  // Private API for simulator animation speed
 #endif
-
-// The default maximum height for the header. Does not include the status bar height.
-static const CGFloat kFlexibleHeaderDefaultHeight = 56;
 
 // The maximum default opacity of the shadow.
 static const float kDefaultVisibleShadowOpacity = (float)0.4;
@@ -79,7 +77,9 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   return intendedShiftBehavior;
 }
 
-@interface MDCFlexibleHeaderView () <MDCStatusBarShifterDelegate, MDCFlexibleHeaderSafeAreaDelegate>
+@interface MDCFlexibleHeaderView () <MDCStatusBarShifterDelegate,
+                                     MDCFlexibleHeaderSafeAreaDelegate,
+                                     MDCFlexibleHeaderMinMaxHeightDelegate>
 
 // The intensity strength of the shadow being displayed under the flexible header. Use this property
 // to check what the intensity of a custom shadow should be depending on a scroll position. Valid
@@ -145,10 +145,6 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   // is interacting with the header or if we're presently animating it.
   BOOL _wantsToBeHidden;
 
-  // This will help us track if the size has been explicitly set or if we're using the defaults.
-  BOOL _hasExplicitlySetMinHeight;
-  BOOL _hasExplicitlySetMaxHeight;
-
   // Shift behavior state
 
   // Prevents delta calculations on first update pass.
@@ -199,11 +195,19 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   // Keeps track of whether the client called ...WillEndDraggingWithVelocity:...
   BOOL _didAdjustTargetContentOffset;
 #endif
+
+  // Extracted logic units
+  MDCFlexibleHeaderMinMaxHeight *_minMaxHeight;
 }
 
 // Owned by _topSafeArea
 @dynamic topSafeAreaSourceViewController;
 @dynamic inferTopSafeAreaInsetFromViewController;
+
+// Owned by _minMaxHeight
+@dynamic minimumHeight;
+@dynamic maximumHeight;
+@dynamic minMaxHeightIncludesSafeArea;
 
 // MDCFlexibleHeader properties
 @synthesize trackingScrollViewIsBeingScrubbed = _trackingScrollViewIsBeingScrubbed;
@@ -213,8 +217,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
 // MDCFlexibleHeaderConfiguration properties
 @synthesize trackingScrollView = _trackingScrollView;
-@synthesize minimumHeight = _minimumHeight;
-@synthesize maximumHeight = _maximumHeight;
+
 @synthesize canOverExtend = _canOverExtend;
 @synthesize inFrontOfInfiniteContent = _inFrontOfInfiniteContent;
 @synthesize sharedWithManyScrollViews = _sharedWithManyScrollViews;
@@ -251,6 +254,9 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   _topSafeArea = [[MDCFlexibleHeaderTopSafeArea alloc] init];
   _topSafeArea.delegate = self;
 
+  _minMaxHeight = [[MDCFlexibleHeaderMinMaxHeight alloc] initWithTopSafeArea:_topSafeArea];
+  _minMaxHeight.delegate = self;
+
   _wkWebViewClass = NSClassFromString(@"WKWebView");
 
   _statusBarShifter = [[MDCStatusBarShifter alloc] init];
@@ -271,12 +277,6 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   _headerContentImportance = MDCFlexibleHeaderContentImportanceDefault;
   _statusBarHintCanOverlapHeader = YES;
 
-  const CGFloat topSafeAreaInset = [_topSafeArea topSafeAreaInset];
-
-  _minMaxHeightIncludesSafeArea = YES;
-  _minimumHeight = kFlexibleHeaderDefaultHeight + topSafeAreaInset;
-  _maximumHeight = _minimumHeight;
-
   _visibleShadowOpacity = kDefaultVisibleShadowOpacity;
   _canOverExtend = YES;
 
@@ -294,7 +294,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   [self.layer addSublayer:_customShadowLayer];
 
   _topSafeAreaGuide = [[UIView alloc] init];
-  _topSafeAreaGuide.frame = CGRectMake(0, 0, 0, topSafeAreaInset);
+  _topSafeAreaGuide.frame = CGRectMake(0, 0, 0, [_topSafeArea topSafeAreaInset]);
   [self addSubview:_topSafeAreaGuide];
 
   _contentView = [[UIView alloc] initWithFrame:self.bounds];
@@ -360,7 +360,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 #pragma mark - UIView
 
 - (CGSize)sizeThatFits:(CGSize)size {
-  return CGSizeMake(size.width, self.computedMinimumHeight);
+  return CGSizeMake(size.width, _minMaxHeight.minimumHeightWithTopSafeArea);
 }
 
 - (void)layoutSubviews {
@@ -471,17 +471,9 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 #pragma mark MDCFlexibleHeaderSafeAreaDelegate
 
 - (void)flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
+  [_minMaxHeight recalculateMinMaxHeight];
+
   const CGFloat topSafeAreaInset = [_topSafeArea topSafeAreaInset];
-
-  // If the min or max height have been explicitly set, don't adjust anything if the values
-  // already include a Safe Area inset.
-  BOOL hasSetMinOrMaxHeight = _hasExplicitlySetMinHeight || _hasExplicitlySetMaxHeight;
-  if (!hasSetMinOrMaxHeight && _minMaxHeightIncludesSafeArea) {
-    // If we're using the defaults we need to update them to account for the new Safe Area inset.
-    _minimumHeight = kFlexibleHeaderDefaultHeight + topSafeAreaInset;
-    _maximumHeight = _minimumHeight;
-  }
-
   _topSafeAreaGuide.frame = CGRectMake(0, 0, self.bounds.size.width, topSafeAreaInset);
 
   // Adjust the scroll view insets to account for the new Safe Area inset.
@@ -493,7 +485,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   // The changes might require us to re-calculate the frame, or update the entire layout.
   if (!_trackingScrollView) {
     CGRect bounds = self.bounds;
-    bounds.size.height = self.computedMinimumHeight;
+    bounds.size.height = _minMaxHeight.minimumHeightWithTopSafeArea;
     self.bounds = bounds;
     CGPoint position = self.center;
     position.y = -MIN([self fhv_accumulatorMax], _shiftAccumulator);
@@ -513,6 +505,16 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
 - (CGFloat)flexibleHeaderSafeAreaDeviceTopSafeAreaInset:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
   return MDCDeviceTopSafeAreaInset();
+}
+
+#pragma mark - MDCFlexibleHeaderMinMaxHeightDelegate
+
+- (void)flexibleHeaderMaximumHeightDidChange:(MDCFlexibleHeaderMinMaxHeight *)safeAreas {
+  [self fhv_adjustTrackingScrollViewInsets];
+}
+
+- (void)flexibleHeaderMinMaxHeightDidChange:(MDCFlexibleHeaderMinMaxHeight *)safeAreas {
+  [self fhv_updateLayout];
 }
 
 #pragma mark - Private (fhv_ prefix)
@@ -616,17 +618,13 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
   CGFloat existingContentInsetAdjustment =
       [self fhv_existingContentInsetAdjustmentForScrollView:scrollView];
-  CGFloat desiredTopInset = self.computedMaximumHeight - existingContentInsetAdjustment;
+  CGFloat desiredTopInset =
+      _minMaxHeight.maximumHeightWithTopSafeArea - existingContentInsetAdjustment;
 
   // During modal presentation on non-X devices our top safe area inset can be much larger than it
   // actually will be, causing desiredTopInset to be small or even negative. To guard against this,
   // we ensure that our desired top inset is always at least the header height.
-  CGFloat minimumTopInset;
-  if (_minMaxHeightIncludesSafeArea) {
-    minimumTopInset = _maximumHeight - [_topSafeArea topSafeAreaInset];
-  } else {
-    minimumTopInset = _maximumHeight;
-  }
+  CGFloat minimumTopInset = _minMaxHeight.maximumHeightWithoutTopSafeArea;
   desiredTopInset = MAX(minimumTopInset, desiredTopInset);
 
   UIEdgeInsets insets = scrollView.contentInset;
@@ -702,8 +700,9 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 - (CGFloat)fhv_accumulatorMax {
   BOOL shouldCollapseToStatusBar = [self fhv_shouldCollapseToStatusBar];
   CGFloat statusBarHeight = [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
-  return (shouldCollapseToStatusBar ? MAX(0, self.computedMinimumHeight - statusBarHeight) :
-             self.computedMinimumHeight);
+  return (shouldCollapseToStatusBar
+              ? MAX(0, _minMaxHeight.minimumHeightWithTopSafeArea - statusBarHeight)
+              : _minMaxHeight.minimumHeightWithTopSafeArea);
 }
 
 #pragma mark Logical short forms
@@ -756,8 +755,8 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
   if (frame.origin.y < 0) {
     _scrollPhase = MDCFlexibleHeaderScrollPhaseShifting;
-    _scrollPhaseValue = frame.origin.y + self.computedMinimumHeight;
-    CGFloat adjustedHeight = self.computedMinimumHeight;
+    _scrollPhaseValue = frame.origin.y + _minMaxHeight.minimumHeightWithTopSafeArea;
+    CGFloat adjustedHeight = _minMaxHeight.minimumHeightWithTopSafeArea;
     if ([self fhv_shouldCollapseToStatusBar]) {
       CGFloat statusBarHeight =
           [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
@@ -774,12 +773,14 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
   _scrollPhaseValue = frame.size.height;
 
-  if (frame.size.height < self.computedMaximumHeight) {
+  if (frame.size.height < _minMaxHeight.maximumHeightWithTopSafeArea) {
     _scrollPhase = MDCFlexibleHeaderScrollPhaseCollapsing;
 
-    CGFloat heightLength = self.computedMaximumHeight - self.computedMinimumHeight;
+    CGFloat heightLength =
+        _minMaxHeight.maximumHeightWithTopSafeArea - _minMaxHeight.minimumHeightWithTopSafeArea;
     if (heightLength > 0) {
-      _scrollPhasePercentage = (frame.size.height - self.computedMinimumHeight) / heightLength;
+      _scrollPhasePercentage =
+          (frame.size.height - _minMaxHeight.minimumHeightWithTopSafeArea) / heightLength;
     } else {
       _scrollPhasePercentage = 0;
     }
@@ -788,9 +789,9 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   }
 
   _scrollPhase = MDCFlexibleHeaderScrollPhaseOverExtending;
-  if (self.computedMaximumHeight > 0) {
-    _scrollPhasePercentage = 1 +
-        (frame.size.height - self.computedMaximumHeight) / self.computedMaximumHeight;
+  if (_minMaxHeight.maximumHeightWithTopSafeArea > 0) {
+    _scrollPhasePercentage = 1 + (frame.size.height - _minMaxHeight.maximumHeightWithTopSafeArea) /
+                                     _minMaxHeight.maximumHeightWithTopSafeArea;
   } else {
     _scrollPhasePercentage = 0;
   }
@@ -906,8 +907,9 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   if (self.hidesStatusBarWhenCollapsed) {
     // Calculate the desired shadow strength for the offset & accumulator and then take the
     // weakest strength.
-    CGFloat accumulator = MAX(0, MIN(kShadowScaleLength,
-                                     self.computedMinimumHeight - boundedAccumulator));
+    CGFloat accumulator = MAX(
+        0,
+        MIN(kShadowScaleLength, _minMaxHeight.minimumHeightWithTopSafeArea - boundedAccumulator));
     if (self.isInFrontOfInfiniteContent) {
       // When in front of infinite content we only care to hide the shadow when our header is
       // off-screen.
@@ -938,8 +940,9 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   [_statusBarShifter setOffset:boundedAccumulator];
 
   // Small performance improvement to not set the hidden property on every scroll tick.
-  BOOL isShiftedOffscreen = boundedAccumulator >= self.computedMinimumHeight;
-  BOOL isFullyCollapsed = frame.size.height <= self.computedMinimumHeight + DBL_EPSILON;
+  BOOL isShiftedOffscreen = boundedAccumulator >= _minMaxHeight.minimumHeightWithTopSafeArea;
+  BOOL isFullyCollapsed =
+      frame.size.height <= _minMaxHeight.minimumHeightWithTopSafeArea + DBL_EPSILON;
   BOOL isHidden = isShiftedOffscreen && isFullyCollapsed;
   if (isHidden != self.hidden) {
     self.hidden = isHidden;
@@ -968,12 +971,12 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
   if (self.canAlwaysExpandToMaximumHeight) {
     CGFloat maxExpansion;
-    if (headerHeight < self.computedMinimumHeight) {
+    if (headerHeight < _minMaxHeight.minimumHeightWithTopSafeArea) {
       // The header is detached from the content and able to fully expand.
       maxExpansion = self.maximumHeight - self.minimumHeight;
     } else {
       // We're now attached to the content and need to constrain our possible expansion.
-      maxExpansion = self.computedMaximumHeight - headerHeight;
+      maxExpansion = _minMaxHeight.maximumHeightWithTopSafeArea - headerHeight;
     }
     // Expansion is tracked via negative accumulation.
     lowerBound = MIN(0, -maxExpansion);
@@ -995,11 +998,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   // incorrect min/max height. In order to update min/max to the correct heights we need to update
   // our dimensions sometime after the window has been been made key, so the next best place is
   // here.
-  BOOL hasSetMinOrMaxHeight = _hasExplicitlySetMinHeight || _hasExplicitlySetMaxHeight;
-  if (!hasSetMinOrMaxHeight && _minMaxHeightIncludesSafeArea) {
-    _minimumHeight = kFlexibleHeaderDefaultHeight + [_topSafeArea topSafeAreaInset];
-    _maximumHeight = _minimumHeight;
-  }
+  [_minMaxHeight recalculateMinMaxHeight];
 
   // If the status bar changes without us knowing then this ensures that our content insets
   // are up-to-date before we process the content offset.
@@ -1048,7 +1047,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
       if (self.canAlwaysExpandToMaximumHeight) {
         // When still attached to the top content, don't accumulate negatively.
-        if (headerHeight >= self.computedMinimumHeight) {
+        if (headerHeight >= _minMaxHeight.minimumHeightWithTopSafeArea) {
           deltaY = MAX(0, deltaY);
         }
       }
@@ -1062,14 +1061,14 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
       CGFloat previousHeaderHeight = headerHeight + deltaY;
 
       // Overshoot coming in
-      if (headerHeight < self.computedMinimumHeight &&
-          previousHeaderHeight > self.computedMinimumHeight) {
-        deltaY = self.computedMinimumHeight - headerHeight;
+      if (headerHeight < _minMaxHeight.minimumHeightWithTopSafeArea &&
+          previousHeaderHeight > _minMaxHeight.minimumHeightWithTopSafeArea) {
+        deltaY = _minMaxHeight.minimumHeightWithTopSafeArea - headerHeight;
 
         // Overshoot going out
-      } else if (headerHeight > self.computedMinimumHeight &&
-                 previousHeaderHeight < self.computedMinimumHeight) {
-        deltaY = (headerHeight + deltaY) - self.computedMinimumHeight;
+      } else if (headerHeight > _minMaxHeight.minimumHeightWithTopSafeArea &&
+                 previousHeaderHeight < _minMaxHeight.minimumHeightWithTopSafeArea) {
+        deltaY = (headerHeight + deltaY) - _minMaxHeight.minimumHeightWithTopSafeArea;
       }
 
       // Calculate the upper bound of the accumulator based on what phase we're in.
@@ -1082,7 +1081,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
       } else if (headerHeight < 0) {
         // Header is shifting while detached from content.
         upperBound = [self fhv_accumulatorMax] + [self fhv_anchorLength];
-      } else if (headerHeight < self.computedMinimumHeight) {
+      } else if (headerHeight < _minMaxHeight.minimumHeightWithTopSafeArea) {
         // Header is shifting while attached to content.
         upperBound = [self fhv_accumulatorMax];
       } else {
@@ -1107,10 +1106,10 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   if (!self.canAlwaysExpandToMaximumHeight) {
     CGRect bounds = self.bounds;
     if (_canOverExtend && !UIAccessibilityIsVoiceOverRunning()) {
-      bounds.size.height = MAX(self.computedMinimumHeight, headerHeight);
+      bounds.size.height = MAX(_minMaxHeight.minimumHeightWithTopSafeArea, headerHeight);
     } else {
-      bounds.size.height =
-          MAX(self.computedMinimumHeight, MIN(self.computedMaximumHeight, headerHeight));
+      bounds.size.height = MAX(_minMaxHeight.minimumHeightWithTopSafeArea,
+                               MIN(_minMaxHeight.maximumHeightWithTopSafeArea, headerHeight));
     }
     self.bounds = bounds;
   }
@@ -1142,11 +1141,11 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
     if (_canOverExtend && !UIAccessibilityIsVoiceOverRunning()) {
       bounds.size.height =
-          MAX(self.computedMinimumHeight, headerHeight) + additionalHeightInjection;
+          MAX(_minMaxHeight.minimumHeightWithTopSafeArea, headerHeight) + additionalHeightInjection;
     } else {
-      bounds.size.height =
-          (MAX(self.computedMinimumHeight, MIN(self.computedMaximumHeight, headerHeight)) +
-           additionalHeightInjection);
+      bounds.size.height = (MAX(_minMaxHeight.minimumHeightWithTopSafeArea,
+                                MIN(_minMaxHeight.maximumHeightWithTopSafeArea, headerHeight)) +
+                            additionalHeightInjection);
     }
 
     // Avoid excessive writes - the default behavior of the flexible header has minimal height
@@ -1469,7 +1468,8 @@ static BOOL isRunningiOS10_3OrAbove() {
   if (self.sharedWithManyScrollViews && wasTrackingScrollView) {
     // What's our expected height now that we've changed the tracking scroll view?
     CGFloat headerHeight = -[self fhv_contentOffsetWithoutInjectedTopInset];
-    headerHeight = MAX(self.computedMinimumHeight, MIN(self.computedMaximumHeight, headerHeight));
+    headerHeight = MAX(_minMaxHeight.minimumHeightWithTopSafeArea,
+                       MIN(_minMaxHeight.maximumHeightWithTopSafeArea, headerHeight));
 
     // How much will our height change if we do nothing right now?
     const CGFloat heightDelta = stashedHeight - headerHeight;
@@ -1481,7 +1481,7 @@ static BOOL isRunningiOS10_3OrAbove() {
     if (self.canAlwaysExpandToMaximumHeight) {
       // Cap the accumulator to ensure it's valid.
       CGFloat accumulatorMin;
-      if (headerHeight > self.computedMinimumHeight + kHeightEpsilon) {
+      if (headerHeight > _minMaxHeight.minimumHeightWithTopSafeArea + kHeightEpsilon) {
         // We're attached to the content, so don't allow any height accumulation.
         accumulatorMin = 0;
       } else {
@@ -1724,75 +1724,28 @@ static BOOL isRunningiOS10_3OrAbove() {
   [_forwardingViews removeObject:view];
 }
 
+- (CGFloat)minimumHeight {
+  return _minMaxHeight.minimumHeight;
+}
+
 - (void)setMinimumHeight:(CGFloat)minimumHeight {
-  _hasExplicitlySetMinHeight = YES;
-  if (_minimumHeight == minimumHeight) {
-    return;
-  }
+  _minMaxHeight.minimumHeight = minimumHeight;
+}
 
-  _minimumHeight = minimumHeight;
-
-  if (_minimumHeight > _maximumHeight) {
-    [self setMaximumHeight:_minimumHeight];
-  } else {
-    [self fhv_updateLayout];
-  }
+- (CGFloat)maximumHeight {
+  return _minMaxHeight.maximumHeight;
 }
 
 - (void)setMaximumHeight:(CGFloat)maximumHeight {
-  _hasExplicitlySetMaxHeight = YES;
-  if (_maximumHeight == maximumHeight) {
-    return;
-  }
-
-  _maximumHeight = maximumHeight;
-
-  [self fhv_adjustTrackingScrollViewInsets];
-
-  if (_maximumHeight < _minimumHeight) {
-    [self setMinimumHeight:_maximumHeight];
-  } else {
-    [self fhv_updateLayout];
-  }
+  _minMaxHeight.maximumHeight = maximumHeight;
 }
 
-- (CGFloat)computedMinimumHeight {
-  if (_minMaxHeightIncludesSafeArea) {
-    return _minimumHeight;
-  } else {
-    return _minimumHeight + [_topSafeArea topSafeAreaInset];
-  }
-}
-
-- (CGFloat)computedMaximumHeight {
-  if (_minMaxHeightIncludesSafeArea) {
-    return _maximumHeight;
-  } else {
-    return _maximumHeight + [_topSafeArea topSafeAreaInset];
-  }
+- (BOOL)minMaxHeightIncludesSafeArea {
+  return _minMaxHeight.minMaxHeightIncludesSafeArea;
 }
 
 - (void)setMinMaxHeightIncludesSafeArea:(BOOL)minMaxHeightIncludesSafeArea {
-  if (_minMaxHeightIncludesSafeArea == minMaxHeightIncludesSafeArea) {
-    return;
-  }
-  _minMaxHeightIncludesSafeArea = minMaxHeightIncludesSafeArea;
-
-  // Update default values accordingly.
-  if (!_hasExplicitlySetMinHeight) {
-    if (_minMaxHeightIncludesSafeArea) {
-      _minimumHeight = kFlexibleHeaderDefaultHeight + [_topSafeArea topSafeAreaInset];
-    } else {
-      _minimumHeight = kFlexibleHeaderDefaultHeight;
-    }
-  }
-  if (!_hasExplicitlySetMaxHeight) {
-    if (_minMaxHeightIncludesSafeArea) {
-      _maximumHeight = kFlexibleHeaderDefaultHeight + [_topSafeArea topSafeAreaInset];
-    } else {
-      _maximumHeight = kFlexibleHeaderDefaultHeight;
-    }
-  }
+  _minMaxHeight.minMaxHeightIncludesSafeArea = minMaxHeightIncludesSafeArea;
 }
 
 - (void)setInFrontOfInfiniteContent:(BOOL)inFrontOfInfiniteContent {
@@ -1826,12 +1779,12 @@ static BOOL isRunningiOS10_3OrAbove() {
     CGFloat flexHeight = -offsetTargetY;
 
     if ([self fhv_canShiftOffscreen] &&
-        (0 < flexHeight && flexHeight < self.computedMinimumHeight)) {
+        (0 < flexHeight && flexHeight < _minMaxHeight.minimumHeightWithTopSafeArea)) {
       // Don't allow the header to be partially visible.
       if (_wantsToBeHidden) {
         target.y = -[self fhv_rawTopContentInset];
       } else {
-        target.y = -self.computedMinimumHeight - [self fhv_rawTopContentInset];
+        target.y = -_minMaxHeight.minimumHeightWithTopSafeArea - [self fhv_rawTopContentInset];
       }
       *targetContentOffset = target;
       return YES;

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderMinMaxHeight.h
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderMinMaxHeight.h
@@ -1,0 +1,147 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <CoreGraphics/CoreGraphics.h>
+#import <Foundation/Foundation.h>
+
+@class MDCFlexibleHeaderTopSafeArea;
+@protocol MDCFlexibleHeaderMinMaxHeightDelegate;
+
+/**
+ Manages the height behavior for MDCFlexibleHeaderView.
+
+ In an ideal configuration, minMaxHeightIncludesSafeArea is disabled and the behavior of this class
+ is as follows.
+
+ minimumHeight and maximumHeight define the lower and upper bounds of MDCFlexibleHeaderView
+ without safe area insets taken into account. This class calculates minimum and maximum height
+ values that include the top safe area value and, most importantly, will react to changes of the top
+ safe area value.
+
+ Note: the top safe area value varies based on both the hardware (iPhone SE vs iPhone X) and the
+ hardware's orientation (iPhone X portrait, iPhone X landscape).
+
+ ## When minMaxHeightIncludesSafeArea is true
+
+ If minMaxHeightIncludesSafeArea is enabled then the behavior of this class is a bit more complex.
+ Notably, minimumHeight and maximumHeight are assumed to *include* the top safe area inset value.
+ This means that the client is expected to update the minimumHeight and maximumHeight any time the
+ top safe area value changes.
+
+ minMaxHeightIncludesSafeArea being set to true is the "legacy" behavior that existed prior to the
+ iPhone X and the existence of dynamic top safe areas. At the time of this property's introduction
+ we wanted to ensure that as many clients as possible would support the correct safe area behavior
+ with minimal code modifications. This meant assuming that minMaxHeightIncludesSafeArea was true but
+ finding a way for minimumHeight and maximumHeight to update in reaction to changes in the top safe
+ area.
+
+ If neither the minimumHeight nor maximumHeight are modified, this class will dynamically update
+ both properties as the top safe area inset changes with the assumption that it completely owns
+ both property's values. This covers the majority case of clients that are using the default
+ values. For all other clients that set explicit minimumHeight and maximumHeight values, we
+ recommend that they disable minMaxHeightIncludesSafeArea rather than attempt to implement the
+ correct top safe area logic themselves.
+ */
+__attribute__((objc_subclassing_restricted)) @interface MDCFlexibleHeaderMinMaxHeight : NSObject
+
+#pragma mark Initializing a min/max height object
+
+/**
+ Initializes this instance with a given top safe area instance.
+ */
+- (nonnull instancetype)initWithTopSafeArea:(nonnull MDCFlexibleHeaderTopSafeArea *)topSafeArea
+    NS_DESIGNATED_INITIALIZER;
+
+#pragma mark Configuring the minimum and maximum height
+
+/**
+ See MDCFlexibleHeaderView.h for complete documentation of this property.
+ */
+@property(nonatomic) CGFloat minimumHeight;
+
+/**
+ See MDCFlexibleHeaderView.h for complete documentation of this property.
+ */
+@property(nonatomic) CGFloat maximumHeight;
+
+#pragma mark Calculating the minimum and maximum height with/without the top safe area
+
+/**
+ Returns minimum height including the top safe area amount.
+ */
+- (CGFloat)minimumHeightWithTopSafeArea;
+
+/**
+ Returns maximum height including the top safe area amount.
+ */
+- (CGFloat)maximumHeightWithTopSafeArea;
+
+/**
+ Returns maximum height without the top safe area amount.
+ */
+- (CGFloat)maximumHeightWithoutTopSafeArea;
+
+#pragma mark Delegating changes in minimum and maximum height
+
+/**
+ The delegate may react to changes in the minimumHeight and maximumHeight.
+ */
+@property(nonatomic, weak, nullable) id<MDCFlexibleHeaderMinMaxHeightDelegate> delegate;
+
+/**
+ Unavailable. Use initWithTopSafeArea: instead.
+ */
+- (nonnull instancetype)init NS_UNAVAILABLE;
+
+@end
+
+#pragma mark APIs that will be deprecated
+
+@interface MDCFlexibleHeaderMinMaxHeight ()
+
+/**
+ See MDCFlexibleHeaderView.h for complete documentation of this property.
+
+ This property will eventually be disabled by default, deprecated, and then removed.
+ */
+@property(nonatomic) BOOL minMaxHeightIncludesSafeArea;
+
+/**
+ Informs the receiver that it should update the minimumHeight and maximumHeight.
+
+ Does nothing if minMaxHeightIncludesSafeArea is disabled.
+ This property can be removed once minMaxHeightIncludesSafeArea is removed.
+ */
+- (void)recalculateMinMaxHeight;
+
+@end
+
+/**
+ The delegate protocol through which MDCFlexibleHeaderMinMaxHeight communicates changes in the
+ minimum and maximum height.
+ */
+@protocol MDCFlexibleHeaderMinMaxHeightDelegate <NSObject>
+@required
+
+/**
+ Informs the receiver that the maximum height has changed.
+ */
+- (void)flexibleHeaderMaximumHeightDidChange:(nonnull MDCFlexibleHeaderMinMaxHeight *)safeAreas;
+
+/**
+ Informs the receiver that either the minimum or maximum height have changed.
+ */
+- (void)flexibleHeaderMinMaxHeightDidChange:(nonnull MDCFlexibleHeaderMinMaxHeight *)safeAreas;
+
+@end

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderMinMaxHeight.m
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderMinMaxHeight.m
@@ -1,0 +1,139 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCFlexibleHeaderMinMaxHeight.h"
+
+#import "MDCFlexibleHeaderTopSafeArea.h"
+
+// The default maximum height for the header. Does not include the status bar height.
+static const CGFloat kFlexibleHeaderDefaultHeight = 56;
+
+@interface MDCFlexibleHeaderMinMaxHeight ()
+
+@property(nonatomic, strong) MDCFlexibleHeaderTopSafeArea *topSafeArea;
+
+@property(nonatomic) BOOL hasExplicitlySetMinHeight;
+@property(nonatomic) BOOL hasExplicitlySetMaxHeight;
+
+@end
+
+@implementation MDCFlexibleHeaderMinMaxHeight
+
+- (instancetype)initWithTopSafeArea:(MDCFlexibleHeaderTopSafeArea *)topSafeArea {
+  self = [super init];
+  if (self) {
+    self.topSafeArea = topSafeArea;
+
+    const CGFloat topSafeAreaInset = [self.topSafeArea topSafeAreaInset];
+
+    _minMaxHeightIncludesSafeArea = YES;
+    _minimumHeight = kFlexibleHeaderDefaultHeight + topSafeAreaInset;
+    _maximumHeight = _minimumHeight;
+  }
+  return self;
+}
+
+#pragma mark - Public
+
+- (void)setMinimumHeight:(CGFloat)minimumHeight {
+  _hasExplicitlySetMinHeight = YES;
+  if (_minimumHeight == minimumHeight) {
+    return;
+  }
+
+  _minimumHeight = minimumHeight;
+
+  if (_minimumHeight > self.maximumHeight) {
+    [self setMaximumHeight:_minimumHeight];
+  } else {
+    [self.delegate flexibleHeaderMinMaxHeightDidChange:self];
+  }
+}
+
+- (void)setMaximumHeight:(CGFloat)maximumHeight {
+  _hasExplicitlySetMaxHeight = YES;
+  if (_maximumHeight == maximumHeight) {
+    return;
+  }
+
+  _maximumHeight = maximumHeight;
+
+  [self.delegate flexibleHeaderMaximumHeightDidChange:self];
+
+  if (self.maximumHeight < _minimumHeight) {
+    [self setMinimumHeight:self.maximumHeight];
+  } else {
+    [self.delegate flexibleHeaderMinMaxHeightDidChange:self];
+  }
+}
+
+- (void)setMinMaxHeightIncludesSafeArea:(BOOL)minMaxHeightIncludesSafeArea {
+  if (_minMaxHeightIncludesSafeArea == minMaxHeightIncludesSafeArea) {
+    return;
+  }
+  _minMaxHeightIncludesSafeArea = minMaxHeightIncludesSafeArea;
+
+  // Update default values accordingly.
+  if (!_hasExplicitlySetMinHeight) {
+    if (_minMaxHeightIncludesSafeArea) {
+      _minimumHeight = kFlexibleHeaderDefaultHeight + [self.topSafeArea topSafeAreaInset];
+    } else {
+      _minimumHeight = kFlexibleHeaderDefaultHeight;
+    }
+  }
+  if (!_hasExplicitlySetMaxHeight) {
+    if (_minMaxHeightIncludesSafeArea) {
+      self.maximumHeight = kFlexibleHeaderDefaultHeight + [self.topSafeArea topSafeAreaInset];
+    } else {
+      self.maximumHeight = kFlexibleHeaderDefaultHeight;
+    }
+  }
+}
+
+- (void)recalculateMinMaxHeight {
+  // If the min or max height have been explicitly set, don't adjust anything if the values
+  // already include a Safe Area inset.
+  BOOL hasSetMinOrMaxHeight = self.hasExplicitlySetMinHeight || self.hasExplicitlySetMaxHeight;
+  if (!hasSetMinOrMaxHeight && self.minMaxHeightIncludesSafeArea) {
+    // If we're using the defaults we need to update them to account for the new Safe Area inset.
+    self.minimumHeight = kFlexibleHeaderDefaultHeight + self.topSafeArea.topSafeAreaInset;
+    self.maximumHeight = self.minimumHeight;
+  }
+}
+
+- (CGFloat)minimumHeightWithTopSafeArea {
+  if (self.minMaxHeightIncludesSafeArea) {
+    return self.minimumHeight;
+  } else {
+    return self.minimumHeight + [self.topSafeArea topSafeAreaInset];
+  }
+}
+
+- (CGFloat)maximumHeightWithTopSafeArea {
+  if (_minMaxHeightIncludesSafeArea) {
+    return self.maximumHeight;
+  } else {
+    return self.maximumHeight + [self.topSafeArea topSafeAreaInset];
+  }
+}
+
+- (CGFloat)maximumHeightWithoutTopSafeArea {
+  if (_minMaxHeightIncludesSafeArea) {
+    return self.maximumHeight - [self.topSafeArea topSafeAreaInset];
+  } else {
+    return self.maximumHeight;
+  };
+}
+
+@end

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderMinMaxHeight.m
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderMinMaxHeight.m
@@ -85,6 +85,7 @@ static const CGFloat kFlexibleHeaderDefaultHeight = 56;
   _minMaxHeightIncludesSafeArea = minMaxHeightIncludesSafeArea;
 
   // Update default values accordingly.
+  // Note that we intentionally set the ivars because we do not want to invoke the setter delegates.
   if (!_hasExplicitlySetMinHeight) {
     if (_minMaxHeightIncludesSafeArea) {
       _minimumHeight = kFlexibleHeaderDefaultHeight + [self.topSafeArea topSafeAreaInset];
@@ -94,9 +95,9 @@ static const CGFloat kFlexibleHeaderDefaultHeight = 56;
   }
   if (!_hasExplicitlySetMaxHeight) {
     if (_minMaxHeightIncludesSafeArea) {
-      self.maximumHeight = kFlexibleHeaderDefaultHeight + [self.topSafeArea topSafeAreaInset];
+      _maximumHeight = kFlexibleHeaderDefaultHeight + [self.topSafeArea topSafeAreaInset];
     } else {
-      self.maximumHeight = kFlexibleHeaderDefaultHeight;
+      _maximumHeight = kFlexibleHeaderDefaultHeight;
     }
   }
 }
@@ -107,8 +108,10 @@ static const CGFloat kFlexibleHeaderDefaultHeight = 56;
   BOOL hasSetMinOrMaxHeight = self.hasExplicitlySetMinHeight || self.hasExplicitlySetMaxHeight;
   if (!hasSetMinOrMaxHeight && self.minMaxHeightIncludesSafeArea) {
     // If we're using the defaults we need to update them to account for the new Safe Area inset.
-    self.minimumHeight = kFlexibleHeaderDefaultHeight + self.topSafeArea.topSafeAreaInset;
-    self.maximumHeight = self.minimumHeight;
+    // Note that we intentionally set the ivars because we do not want to invoke the setter
+    // delegates.
+    _minimumHeight = kFlexibleHeaderDefaultHeight + self.topSafeArea.topSafeAreaInset;
+    _maximumHeight = self.minimumHeight;
   }
 }
 

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderMinMaxHeightIncludesSafeAreaTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderMinMaxHeightIncludesSafeAreaTests.m
@@ -1,0 +1,183 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "../../src/private/MDCFlexibleHeaderMinMaxHeight.h"
+#import "MaterialFlexibleHeader.h"
+#import "supplemental/FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate.h"
+
+@interface FlexibleHeaderMinMaxHeightIncludesSafeAreaTests : XCTestCase
+@end
+
+@implementation FlexibleHeaderMinMaxHeightIncludesSafeAreaTests {
+  MDCFlexibleHeaderMinMaxHeight *_minMaxHeight;
+  MDCFlexibleHeaderTopSafeArea *_topSafeArea;
+  FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate *_delegate;
+}
+
+- (void)setUp {
+  [super setUp];
+
+  _topSafeArea = [[MDCFlexibleHeaderTopSafeArea alloc] init];
+  _delegate = [[FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate alloc] init];
+  _topSafeArea.delegate = _delegate;
+}
+
+- (void)tearDown {
+  _topSafeArea = nil;
+  _delegate = nil;
+  _minMaxHeight = nil;
+
+  [super tearDown];
+}
+
+#pragma mark - Defaults
+
+- (void)testDefaults {
+  // Given
+  _delegate.deviceTopSafeAreaInset = 123;
+
+  // When
+  _minMaxHeight = [[MDCFlexibleHeaderMinMaxHeight alloc] initWithTopSafeArea:_topSafeArea];
+  _minMaxHeight.minMaxHeightIncludesSafeArea = YES;
+
+  // Then
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeight, 56 + _delegate.deviceTopSafeAreaInset,
+                             0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeight, 56 + _delegate.deviceTopSafeAreaInset,
+                             0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeightWithTopSafeArea,
+                             56 + _delegate.deviceTopSafeAreaInset, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithTopSafeArea,
+                             56 + _delegate.deviceTopSafeAreaInset, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithoutTopSafeArea, 56, 0.0001);
+}
+
+#pragma mark - recalculateMinMaxHeight
+
+- (void)testRecalculateMinMaxHeight {
+  // Given
+  _delegate.deviceTopSafeAreaInset = 123;
+  _minMaxHeight = [[MDCFlexibleHeaderMinMaxHeight alloc] initWithTopSafeArea:_topSafeArea];
+  _minMaxHeight.minMaxHeightIncludesSafeArea = YES;
+
+  // When
+  _delegate.deviceTopSafeAreaInset = 50;
+  [_minMaxHeight recalculateMinMaxHeight];
+
+  // Then
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeight, 56 + _delegate.deviceTopSafeAreaInset,
+                             0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeight, 56 + _delegate.deviceTopSafeAreaInset,
+                             0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeightWithTopSafeArea,
+                             56 + _delegate.deviceTopSafeAreaInset, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithTopSafeArea,
+                             56 + _delegate.deviceTopSafeAreaInset, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithoutTopSafeArea, 56, 0.0001);
+}
+
+#pragma mark - Setting min/max stops automatic safe area adjustment
+
+- (void)testSettingMinStopsAutomaticSafeAreaAdjustmentForMin {
+  // Given
+  _delegate.deviceTopSafeAreaInset = 123;
+  _minMaxHeight = [[MDCFlexibleHeaderMinMaxHeight alloc] initWithTopSafeArea:_topSafeArea];
+  _minMaxHeight.minMaxHeightIncludesSafeArea = YES;
+
+  // When
+  _minMaxHeight.minimumHeight = 30;
+
+  // Then
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeight, 30, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeight, 56 + _delegate.deviceTopSafeAreaInset,
+                             0.0001);
+  // MDCFlexibleHeaderMinMaxHeight is now assuming that min/max height include the safe area insets
+  // because minMaxHeightIncludesSafeArea is YES.
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeightWithTopSafeArea, 30, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithTopSafeArea,
+                             56 + _delegate.deviceTopSafeAreaInset, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithoutTopSafeArea, 56, 0.0001);
+}
+
+- (void)testSettingMaxStopsAutomaticSafeAreaAdjustmentForMax {
+  // Given
+  _delegate.deviceTopSafeAreaInset = 123;
+  _minMaxHeight = [[MDCFlexibleHeaderMinMaxHeight alloc] initWithTopSafeArea:_topSafeArea];
+  _minMaxHeight.minMaxHeightIncludesSafeArea = YES;
+
+  // When
+  _minMaxHeight.maximumHeight = 200;
+
+  // Then
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeight, 56 + _delegate.deviceTopSafeAreaInset,
+                             0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeight, 200, 0.0001);
+  // MDCFlexibleHeaderMinMaxHeight is now assuming that min/max height include the safe area insets
+  // because minMaxHeightIncludesSafeArea is YES.
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeightWithTopSafeArea,
+                             56 + _delegate.deviceTopSafeAreaInset, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithTopSafeArea, 200, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithoutTopSafeArea,
+                             200 - _delegate.deviceTopSafeAreaInset, 0.0001);
+}
+
+#pragma mark - Side effects of min/max setters
+
+- (void)testSettingMaxLessThanMinAdjustsMin {
+  // Given
+  _delegate.deviceTopSafeAreaInset = 123;
+  _minMaxHeight = [[MDCFlexibleHeaderMinMaxHeight alloc] initWithTopSafeArea:_topSafeArea];
+  _minMaxHeight.minMaxHeightIncludesSafeArea = YES;
+
+  // When
+  _minMaxHeight.minimumHeight = 50;
+  _minMaxHeight.maximumHeight = 30;
+
+  // Then
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeight, 30, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeight, 30, 0.0001);
+  // MDCFlexibleHeaderMinMaxHeight is now assuming that min/max height include the safe area insets
+  // because minMaxHeightIncludesSafeArea is YES.
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeightWithTopSafeArea, 30, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithTopSafeArea, 30, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithoutTopSafeArea,
+                             30 - _delegate.deviceTopSafeAreaInset, 0.0001);
+}
+
+- (void)testSettingMinGreaterThanMaxAdjustsMax {
+  // Given
+  _delegate.deviceTopSafeAreaInset = 123;
+  _minMaxHeight = [[MDCFlexibleHeaderMinMaxHeight alloc] initWithTopSafeArea:_topSafeArea];
+  _minMaxHeight.minMaxHeightIncludesSafeArea = YES;
+
+  // When
+  _minMaxHeight.maximumHeight = 100;
+  _minMaxHeight.minimumHeight = 200;
+
+  // Then
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeight, 200, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeight, 200, 0.0001);
+  // MDCFlexibleHeaderMinMaxHeight is now assuming that min/max height include the safe area insets
+  // because minMaxHeightIncludesSafeArea is YES.
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeightWithTopSafeArea, 200, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithTopSafeArea, 200, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithoutTopSafeArea,
+                             200 - _delegate.deviceTopSafeAreaInset, 0.0001);
+}
+
+@end

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderMinMaxHeightTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderMinMaxHeightTests.m
@@ -1,0 +1,131 @@
+/*
+ Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "../../src/private/MDCFlexibleHeaderMinMaxHeight.h"
+#import "MaterialFlexibleHeader.h"
+#import "supplemental/FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate.h"
+
+@interface FlexibleHeaderMinMaxHeightTests : XCTestCase
+@end
+
+@implementation FlexibleHeaderMinMaxHeightTests {
+  MDCFlexibleHeaderMinMaxHeight *_minMaxHeight;
+  MDCFlexibleHeaderTopSafeArea *_topSafeArea;
+  FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate *_delegate;
+}
+
+- (void)setUp {
+  [super setUp];
+
+  _topSafeArea = [[MDCFlexibleHeaderTopSafeArea alloc] init];
+  _delegate = [[FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate alloc] init];
+  _topSafeArea.delegate = _delegate;
+}
+
+- (void)tearDown {
+  _topSafeArea = nil;
+  _delegate = nil;
+  _minMaxHeight = nil;
+
+  [super tearDown];
+}
+
+#pragma mark - Defaults
+
+- (void)testDefaults {
+  // Given
+  _delegate.deviceTopSafeAreaInset = 123;
+
+  // When
+  _minMaxHeight = [[MDCFlexibleHeaderMinMaxHeight alloc] initWithTopSafeArea:_topSafeArea];
+  _minMaxHeight.minMaxHeightIncludesSafeArea = NO;
+
+  // Then
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeight, 56, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeight, 56, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeightWithTopSafeArea,
+                             56 + _delegate.deviceTopSafeAreaInset, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithTopSafeArea,
+                             56 + _delegate.deviceTopSafeAreaInset, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithoutTopSafeArea, 56, 0.0001);
+}
+
+#pragma mark - Changes when top safe area inset changes
+
+- (void)testMinMaxHeightWithTopSafeAreaChangesWhenTopSafeAreaChanges {
+  // Given
+  _delegate.deviceTopSafeAreaInset = 123;
+  _minMaxHeight = [[MDCFlexibleHeaderMinMaxHeight alloc] initWithTopSafeArea:_topSafeArea];
+  _minMaxHeight.minMaxHeightIncludesSafeArea = NO;
+
+  // When
+  _delegate.deviceTopSafeAreaInset = 50;
+
+  // Then
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeight, 56, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeight, 56, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeightWithTopSafeArea,
+                             56 + _delegate.deviceTopSafeAreaInset, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithTopSafeArea,
+                             56 + _delegate.deviceTopSafeAreaInset, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithoutTopSafeArea, 56, 0.0001);
+}
+
+#pragma mark - Side effects of min/max setters
+
+- (void)testSettingMaxLessThanMinAdjustsMin {
+  // Given
+  _delegate.deviceTopSafeAreaInset = 123;
+  _minMaxHeight = [[MDCFlexibleHeaderMinMaxHeight alloc] initWithTopSafeArea:_topSafeArea];
+  _minMaxHeight.minMaxHeightIncludesSafeArea = NO;
+
+  // When
+  _minMaxHeight.minimumHeight = 50;
+  _minMaxHeight.maximumHeight = 30;
+
+  // Then
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeight, 30, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeight, 30, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeightWithTopSafeArea,
+                             30 + _delegate.deviceTopSafeAreaInset, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithTopSafeArea,
+                             30 + _delegate.deviceTopSafeAreaInset, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithoutTopSafeArea, 30, 0.0001);
+}
+
+- (void)testSettingMinGreaterThanMaxAdjustsMax {
+  // Given
+  _delegate.deviceTopSafeAreaInset = 123;
+  _minMaxHeight = [[MDCFlexibleHeaderMinMaxHeight alloc] initWithTopSafeArea:_topSafeArea];
+  _minMaxHeight.minMaxHeightIncludesSafeArea = NO;
+
+  // When
+  _minMaxHeight.maximumHeight = 100;
+  _minMaxHeight.minimumHeight = 200;
+
+  // Then
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeight, 200, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeight, 200, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.minimumHeightWithTopSafeArea,
+                             200 + _delegate.deviceTopSafeAreaInset, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithTopSafeArea,
+                             200 + _delegate.deviceTopSafeAreaInset, 0.0001);
+  XCTAssertEqualWithAccuracy(_minMaxHeight.maximumHeightWithoutTopSafeArea, 200, 0.0001);
+}
+
+@end


### PR DESCRIPTION
This is the second attempt at https://github.com/material-components/material-components-ios/pull/5594

This second attempt reduces the amount of change in behavior by replacing some invocations of the min/max height setters with ivar assignment to more closely match the original code.

The original change description is below:

---

This work is part of https://github.com/material-components/material-components-ios/issues/5060

This change pulls the minimumHeight and maximumHeight logic out to a separate, private class within the FlexibleHeader component. All of the associated state and APIs have been moved as well, and the existing MDCFlexibleHeaderView public APIs now pass-through to this internal object.

The intent of this change, like b8090cb before it, is to break the MDCFlexibleHeaderView implementation into smaller, more testable units of code.

The new MDCFlexibleHeaderMinMaxHeight object implements two paths of logic: the legacy, pre-iPhone X behavior, and the modern aware-of-safe-areas behavior. minMaxHeightIncludesSafeArea is the flag that governs which path of logic we'll use and we intend to deprecate it as part of https://github.com/material-components/material-components-ios/issues/4764. There are now two separate unit test class for each of the possible states of minMaxHeightIncludesSafeArea.