### PR TITLE
Fix owner of Dialogs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,7 +23,7 @@
 /components/CollectionCells/      @yarneo
 /components/CollectionLayoutAttributes/ @ianegordon
 /components/Collections/          @ianegordon
-/components/Dialogs/              @galiak
+/components/Dialogs/              @galiak11
 /components/FeatureHighlight/     @codeman7
 /components/FlexibleHeader/       @jverkoey
 /components/HeaderStackView/      @jverkoey


### PR DESCRIPTION
The recent change to attempt to make @galiak11 the CODEOWNER of Dialogs accidentally added another account. This results in Dialogs having no effective owner since the errant account is not a contributor of MDC-iOS.
