### PR TITLE
[Buttons] Fix titleColorForState in Floating Button themer.

### DIFF
--- a/components/Buttons/src/ColorThemer/MDCFloatingButtonColorThemer.m
+++ b/components/Buttons/src/ColorThemer/MDCFloatingButtonColorThemer.m
@@ -20,6 +20,7 @@
                         toButton:(nonnull MDCFloatingButton *)button {
   [self resetUIControlStatesForButtonTheming:button];
   [button setBackgroundColor:colorScheme.secondaryColor forState:UIControlStateNormal];
+  [button setTitleColor:colorScheme.onSecondaryColor forState:UIControlStateNormal];
   [button setImageTintColor:colorScheme.onSecondaryColor forState:UIControlStateNormal];
 
   button.disabledAlpha = 1;

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -237,13 +237,25 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
     if (state == UIControlStateNormal) {
       XCTAssertEqual([button backgroundColorForState:state], colorScheme.secondaryColor);
       XCTAssertEqual([button imageTintColorForState:state], colorScheme.onSecondaryColor);
-   } else {
+    } else {
       XCTAssertEqual([button backgroundColorForState:state], nil);
+    }
+
+    // TODO(https://github.com/material-components/material-components-ios/issues/3062 ):
+    //   Title color for state is forced to UIColor.black in disabled state unless a disabled color
+    //   is set explicitly.
+    if (state == UIControlStateDisabled) {
+      XCTAssertEqualObjects([button titleColorForState:state], UIColor.blackColor,
+                            @"Title color for the disabled state should be black.");
+    } else {
+      XCTAssertEqualObjects([button titleColorForState:state], colorScheme.onSecondaryColor,
+                            @"Title color (%@) is not equal to (%@) for state (%lu).)",
+                            [button titleColorForState:state], colorScheme.onSecondaryColor,
+                            (unsigned long)state);
     }
   }
 
   XCTAssertEqualWithAccuracy(button.disabledAlpha, 1, (CGFloat)0.001);
 }
-
 
 @end


### PR DESCRIPTION
The Floating Action Button themer was not correctly setting the title color,
which would result in titles having the wrong color in Extended FABs.

The Material Guidelines article shows that secondary-colored FABS should have
matching image and title colors. Although the example is for the "Reply"
study, it makes sense in general that the two colors should be aligned.

## Screenshots on iPad 2/iOS 8.1 (Simulator)
|Before|After|
|--|--|
|![fab-themer-before](https://user-images.githubusercontent.com/1753199/49471793-c9c79980-f7db-11e8-9c7d-97edbdbc70c8.png)|![fab-themer-after](https://user-images.githubusercontent.com/1753199/49471802-ce8c4d80-f7db-11e8-86ff-3a9f751cc306.png)|



Closes #5911
