### PR TITLE
[Buttons] Improve color themer tests.

### DIFF
--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -234,12 +234,21 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   NSUInteger maximumStateValue =
       UIControlStateSelected | UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    // TODO(https://github.com/material-components/material-components-ios/issues/3411 ):
+    //   MDCButton does not return the correct value for `backgroundColorForState:`
     if (state == UIControlStateNormal) {
-      XCTAssertEqual([button backgroundColorForState:state], colorScheme.secondaryColor);
-      XCTAssertEqual([button imageTintColorForState:state], colorScheme.onSecondaryColor);
-   } else {
+      XCTAssertEqualObjects([button backgroundColorForState:state], colorScheme.secondaryColor,
+                            @"Background color (%@) is not equal to (%@) for state (%lu).",
+                            [button backgroundColorForState:state], colorScheme.secondaryColor,
+                            (unsigned long)state);
+    } else {
       XCTAssertEqual([button backgroundColorForState:state], nil);
     }
+
+    XCTAssertEqualObjects([button imageTintColorForState:state], colorScheme.onSecondaryColor,
+                          @"Image tint color (%@) is not equal to (%@) for state (%lu).",
+                          [button imageTintColorForState:state], colorScheme.onSecondaryColor,
+                          (unsigned long)state);
   }
 
   XCTAssertEqualWithAccuracy(button.disabledAlpha, 1, (CGFloat)0.001);


### PR DESCRIPTION
The MDCFloatingButtonColorThemer test was not checking all states for
the image tint color. Also adding a TODO for the broken
`backgroundColorForState:` API.

Noticed when working on #5912
