### PR TITLE
[Buttons] Add tests for backgroundColorForState:

### DIFF
--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -319,9 +319,8 @@ static NSString *controlStateDescription(UIControlState controlState) {
     button.selected = isSelected;
     button.highlighted = isHighlighted;
 
-    XCTAssertEqualObjects(button.backgroundColor, color,
-                          @"Background color (%@) does not equal (%@) for state (%lu).",
-                          button.backgroundColor, color, (unsigned long)testState);
+    XCTAssertEqualObjects(button.backgroundColor, color, @"for state (%lu).",
+                          (unsigned long)testState);
   }
 }
 
@@ -340,12 +339,9 @@ static NSString *controlStateDescription(UIControlState controlState) {
     button.selected = isSelected;
     button.highlighted = isHighlighted;
 
-    XCTAssertEqualObjects(button.backgroundColor,
-                          [button backgroundColorForState:UIControlStateNormal],
-                          @"Background color (%@) does not equal (%@) for state (%lu).",
-                          button.backgroundColor,
-                          [button backgroundColorForState:UIControlStateNormal],
-                          (unsigned long)controlState);
+    XCTAssertEqualObjects(
+        button.backgroundColor, [button backgroundColorForState:UIControlStateNormal],
+        @"for state (%lu).", (unsigned long)controlState);
   }
 }
 

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -281,6 +281,74 @@ static NSString *controlStateDescription(UIControlState controlState) {
   }
 }
 
+// TODO(https://github.com/material-components/material-components-ios/issues/3411 ): Enable this
+//   test when the behavior in MDCButton is fixed.
+- (void)_disabled_testBackgroundColorForStateFallbackBehavior {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+
+  // When
+  [button setBackgroundColor:UIColor.purpleColor forState:UIControlStateNormal];
+
+  // Then
+  for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
+    XCTAssertEqualObjects([button backgroundColorForState:controlState], UIColor.purpleColor);
+  }
+}
+
+- (void)testBackgroundColorForStateUpdatesBackgroundColor {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+
+  for (NSUInteger controlState = 0; controlState <= kNumUIControlStates; ++controlState) {
+    // Disabling the button removes any highlighted state
+    UIControlState testState = controlState;
+    if ((testState & UIControlStateDisabled) == UIControlStateDisabled) {
+      testState &= ~UIControlStateHighlighted;
+    }
+    BOOL isDisabled = (testState & UIControlStateDisabled) == UIControlStateDisabled;
+    BOOL isSelected = (testState & UIControlStateSelected) == UIControlStateSelected;
+    BOOL isHighlighted = (testState & UIControlStateHighlighted) == UIControlStateHighlighted;
+
+    // Also given
+    UIColor *color = randomColor();
+    [button setBackgroundColor:color forState:testState];
+
+    // When
+    button.enabled = !isDisabled;
+    button.selected = isSelected;
+    button.highlighted = isHighlighted;
+
+    XCTAssertEqualObjects(button.backgroundColor, color,
+                          @"Background color (%@) does not equal (%@) for state (%lu).",
+                          button.backgroundColor, color, (unsigned long)testState);
+  }
+}
+
+- (void)testBackgroundColorForStateUpdatesBackgroundColorWithFallback {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+  [button setBackgroundColor:UIColor.magentaColor forState:UIControlStateNormal];
+
+  for (NSUInteger controlState = 0; controlState <= kNumUIControlStates; ++controlState) {
+    BOOL isDisabled = (controlState & UIControlStateDisabled) == UIControlStateDisabled;
+    BOOL isSelected = (controlState & UIControlStateSelected) == UIControlStateSelected;
+    BOOL isHighlighted = (controlState & UIControlStateHighlighted) == UIControlStateHighlighted;
+
+    // When
+    button.enabled = !isDisabled;
+    button.selected = isSelected;
+    button.highlighted = isHighlighted;
+
+    XCTAssertEqualObjects(button.backgroundColor,
+                          [button backgroundColorForState:UIControlStateNormal],
+                          @"Background color (%@) does not equal (%@) for state (%lu).",
+                          button.backgroundColor,
+                          [button backgroundColorForState:UIControlStateNormal],
+                          (unsigned long)controlState);
+  }
+}
+
 #pragma mark - shadowColor:forState:
 
 - (void)testRemovedShadowColorForState {

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -339,9 +339,9 @@ static NSString *controlStateDescription(UIControlState controlState) {
     button.selected = isSelected;
     button.highlighted = isHighlighted;
 
-    XCTAssertEqualObjects(
-        button.backgroundColor, [button backgroundColorForState:UIControlStateNormal],
-        @"for state (%lu).", (unsigned long)controlState);
+    XCTAssertEqualObjects(button.backgroundColor,
+                          [button backgroundColorForState:UIControlStateNormal],
+                          @"for state (%lu).", (unsigned long)controlState);
   }
 }
 


### PR DESCRIPTION
Three new tests are added to test the `backgroundColorForState:` API in
MDCButton. Two of them pass successfully and test that values passed to
`setBackgroundColor:forState:` are rendered successfully in
`backgroundColor` when the MDCButton is in that state. The third is
tests whether the fallback behavior of `backgroundColorForState:`
matches the fallback behavior of `backgroundColor` for the same set
values. This third test is currently disabled due to a bug in MDCButton
(#3411).

Context and Background
----------------------

The `backgroundColorForState:` API does not correctly return the
"fallback" color it will render in the `backgroundColor` property when
an explicit color for a control state is unset. However, it does
actually render the color because it updates what is returned by the
`backgroundColor` property.

As an example, setting `[button setBackgroundColor:UIColor.purpleColor
forState:UIControlStateNormal]` will make the button's background color
purple for all states (the fallback behavior). However, if the returned
value of `[button backgroundColorForState:UIControlStateSelected]` is
inspected, it would be `nil`. This can lead to confusion or programming
errors by clients if they attempt to interrogate the `forState:` API to
retrieve the color value.

An upcoming change will correct this bug, but these are unit tests to
verify that the current behavior does not change when the bug is fixed.

Prework for #3411