### PR TITLE
{WIP} [Buttons] Fix `backgroundColorForState:` behavior

### DIFF
--- a/components/Buttons/tests/unit/ButtonThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonThemerTests.m
@@ -70,7 +70,7 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   XCTAssertEqualObjects([button backgroundColorForState:UIControlStateNormal],
                         [UIColor clearColor]);
   XCTAssertEqualObjects([button backgroundColorForState:UIControlStateDisabled],
-                        nil);
+                        [button backgroundColorForState:UIControlStateNormal]);
   XCTAssertEqualObjects([button titleColorForState:UIControlStateNormal],
                         scheme.colorScheme.primaryColor);
   XCTAssertEqualWithAccuracy(button.disabledAlpha, 1, kEpsilonAccuracy);

--- a/components/Buttons/tests/unit/ButtonTitleColorAccessibilityMutatorTests.m
+++ b/components/Buttons/tests/unit/ButtonTitleColorAccessibilityMutatorTests.m
@@ -39,7 +39,11 @@ static NSString *controlStateDescription(UIControlState controlState);
 
 - (void)testMutateChangesTextColor {
   for (UIColor *color in testColors()) {
-    for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
+    for (NSUInteger controlState = 0; controlState <= kNumUIControlStates; ++controlState) {
+      if ((controlState & kUIControlStateDisabledHighlighted) ==
+          kUIControlStateDisabledHighlighted) {
+        continue;
+      }
       // Given
       MDCButton *button = [[MDCButton alloc] init];
       // Making the background color the same as the title color.
@@ -91,7 +95,11 @@ static NSString *controlStateDescription(UIControlState controlState);
 
 - (void)testMutateUsesUnderlyingColorIfButtonBackgroundColorIsTransparent {
   for (UIColor *color in testColors()) {
-    for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
+    for (NSUInteger controlState = 0; controlState <= kNumUIControlStates; ++controlState) {
+      if ((controlState & kUIControlStateDisabledHighlighted) ==
+          kUIControlStateDisabledHighlighted) {
+        continue;
+      }
       // Given
       MDCButton *button = [[MDCButton alloc] init];
       button.underlyingColorHint = color;

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -48,9 +48,12 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
     if ((state == UIControlStateNormal)||(state == UIControlStateDisabled))  {
       continue; // These two states are manually checked above.
     }
-    XCTAssertNil([button backgroundColorForState:state], @"state:%lu", (unsigned long)state);
-    XCTAssertEqualObjects([button titleColorForState:state], colorScheme.primaryColor, @"state:%lu",
+    XCTAssertEqualObjects([button backgroundColorForState:state],
+                          [button backgroundColorForState:UIControlStateNormal], @"state:%lu",
                           (unsigned long)state);
+    XCTAssertEqualObjects(
+        [button titleColorForState:state], [button titleColorForState:UIControlStateNormal],
+        @"state:%lu", (unsigned long)state);
   }
 }
 
@@ -79,9 +82,12 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
     if ((state == UIControlStateNormal)||(state == UIControlStateDisabled))  {
       continue; // These two states are manually checked above.
     }
-    XCTAssertNil([button backgroundColorForState:state], @"state:%lu", (unsigned long)state);
-    XCTAssertEqualObjects([button titleColorForState:state], colorScheme.onPrimaryColor,
-                          @"state:%lu", (unsigned long)state);
+    XCTAssertEqualObjects([button backgroundColorForState:state],
+                          [button backgroundColorForState:UIControlStateNormal], @"state:%lu",
+                          (unsigned long)state);
+    XCTAssertEqualObjects(
+        [button titleColorForState:state], [button titleColorForState:UIControlStateNormal],
+        @"state:%lu", (unsigned long)state);
   }
 }
 
@@ -238,7 +244,8 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
       XCTAssertEqual([button backgroundColorForState:state], colorScheme.secondaryColor);
       XCTAssertEqual([button imageTintColorForState:state], colorScheme.onSecondaryColor);
     } else {
-      XCTAssertEqual([button backgroundColorForState:state], nil);
+      XCTAssertEqual([button backgroundColorForState:state],
+                     [button backgroundColorForState:UIControlStateNormal]);
     }
 
     // TODO(https://github.com/material-components/material-components-ios/issues/3062 ):

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -281,6 +281,37 @@ static NSString *controlStateDescription(UIControlState controlState) {
   }
 }
 
+// Behavioral test to verify that MDCButton's `backgroundColor:forState:` matches the behavior of
+// UIButton's `titleColor:forState:`.  Specifically, to ensure that the special handling of
+// (UIControlStateDisabled | UIControlStateHighlighted) is identical.
+//
+// This test is valuable because clients who are familiar with the fallback behavior of
+// `titleColor:forState:` may be surprised if the MDCButton APIs don't match. For example, setting
+// the titleColor for (UIControlStateDisabled | UIControlStateHighlighted) will actually update the
+// value assigned for UIControlStateHighlighted, but ONLY if it has already been assigned. Otherwise
+// no update will take place.
+- (void)testBackgroundColorForStateBehaviorMatchesTitleColorForState {
+  for (NSInteger lowestAssignState = 7; lowestAssignState >= 0; --lowestAssignState) {
+    MDCButton *testButton = [[MDCButton alloc] init];
+    UIButton *uiButton = [[UIButton alloc] init];
+    [uiButton setTitleColor:[testButton backgroundColorForState:UIControlStateNormal]
+                   forState:UIControlStateNormal];
+
+    for (UIControlState assignState = (NSUInteger)lowestAssignState; assignState <= 7; ++assignState) {
+      [testButton setBackgroundColor:[UIColor colorWithWhite:(CGFloat)(lowestAssignState / 8.0) alpha:(CGFloat)(assignState / 8.0)]
+                            forState:assignState];
+      [uiButton setTitleColor:[UIColor colorWithWhite:(CGFloat)(lowestAssignState / 8.0) alpha:(CGFloat)(assignState / 8.0)]
+                     forState:assignState];
+    }
+    for (UIControlState testState = 0; testState <= 7; ++testState ) {
+      XCTAssertEqualObjects([testButton backgroundColorForState:testState],
+                            [uiButton titleColorForState:testState],
+                            @" for Lowest = (%ld), Test = (%lu)",
+                            lowestAssignState, testState);
+    }
+  }
+}
+
 #pragma mark - shadowColor:forState:
 
 - (void)testRemovedShadowColorForState {


### PR DESCRIPTION
The `backgroundColorForState:` API will now expose the "fallback"
behavior that it would actually use to update the `backgroundColor` API.

