### PR TITLE
[Buttons] Update secondary floating action button themer examples

### DIFF
--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.m
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.m
@@ -16,7 +16,7 @@
 
 #import "MaterialBottomAppBar+ColorThemer.h"
 #import "MaterialBottomAppBar.h"
-#import "MaterialButtons+ButtonThemer.h"
+#import "MaterialButtons+Theming.h"
 
 #import "supplemental/BottomAppBarTypicalUseSupplemental.h"
 
@@ -31,6 +31,13 @@
     _typographyScheme = [[MDCTypographyScheme alloc] init];
   }
   return self;
+}
+
+- (MDCContainerScheme *)containerScheme {
+  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+  scheme.colorScheme = self.colorScheme;
+  scheme.typographyScheme = self.typographyScheme;
+  return scheme;
 }
 
 - (void)commonBottomBarSetup {
@@ -73,11 +80,7 @@
   [super viewDidLoad];
   [self commonBottomBarSetup];
 
-  MDCButtonScheme *buttonScheme = [[MDCButtonScheme alloc] init];
-  buttonScheme.colorScheme = self.colorScheme;
-  buttonScheme.typographyScheme = self.typographyScheme;
-  [MDCFloatingActionButtonThemer applyScheme:buttonScheme
-                                    toButton:self.bottomBarView.floatingButton];
+  [self.bottomBarView.floatingButton applySecondaryThemeWithScheme:[self containerScheme]];
   [MDCBottomAppBarColorThemer applySurfaceVariantWithSemanticColorScheme:self.colorScheme
                                                       toBottomAppBarView:self.bottomBarView];
 }

--- a/components/Buttons/examples/ButtonsShapesExampleViewController.m
+++ b/components/Buttons/examples/ButtonsShapesExampleViewController.m
@@ -180,7 +180,7 @@
       setCorners:[[MDCCutCornerTreatment alloc]
                      initWithCut:CGRectGetWidth(self.floatingButton.bounds) / 2]];
   self.floatingButton.shapeGenerator = floatingShapeGenerator;
-  [MDCFloatingActionButtonThemer applyScheme:buttonScheme toButton:self.floatingButton];
+  [self.floatingButton applySecondaryThemeWithScheme:self.containerScheme];
 
   [self.floatingButton addTarget:self
                           action:@selector(didTap:)

--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -46,6 +46,14 @@ const CGSize kMinimumAccessibleButtonSize = {64.0, 48.0};
   return self;
 }
 
+- (MDCContainerScheme *)containerScheme {
+  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+  scheme.colorScheme = self.colorScheme;
+  scheme.shapeScheme = self.shapeScheme;
+  scheme.typographyScheme = self.typographyScheme;
+  return scheme;
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -157,7 +165,7 @@ const CGSize kMinimumAccessibleButtonSize = {64.0, 48.0};
   UIImage *plusImage =
       [[UIImage imageNamed:@"Plus"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   [self.floatingButton setImage:plusImage forState:UIControlStateNormal];
-  [MDCFloatingActionButtonThemer applyScheme:buttonScheme toButton:self.floatingButton];
+  [self.floatingButton applySecondaryThemeWithScheme:[self containerScheme]];
   self.floatingButton.accessibilityLabel = @"Create";
   [self.view addSubview:self.floatingButton];
 

--- a/components/Buttons/src/Theming/MaterialButtons+Theming.h
+++ b/components/Buttons/src/Theming/MaterialButtons+Theming.h
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 #import "MDCButton+Theming.h"
+#import "MDCFloatingButton+Theming.h"

--- a/components/FeatureHighlight/examples/FeatureHighlightShownViewExample.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightShownViewExample.m
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #import "MaterialButtons.h"
-#import "MaterialButtons+ButtonThemer.h"
+#import "MaterialButtons+Theming.h"
 #import "MaterialFeatureHighlight.h"
 #import "MaterialFeatureHighlight+ColorThemer.h"
 #import "MaterialFeatureHighlight+FeatureHighlightAccessibilityMutator.h"
@@ -32,17 +32,20 @@
   return self;
 }
 
-- (void)didTapButton:(id)sender {
-  MDCButtonScheme *buttonScheme = [[MDCButtonScheme alloc] init];
-  buttonScheme.colorScheme = self.colorScheme;
-  buttonScheme.typographyScheme = self.typographyScheme;
+- (MDCContainerScheme *)containerScheme {
+  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+  scheme.colorScheme = self.colorScheme;
+  scheme.typographyScheme = self.typographyScheme;
+  return scheme;
+}
 
+- (void)didTapButton:(id)sender {
   MDCFloatingButton *fab = [[MDCFloatingButton alloc] init];
   [fab setImage:[UIImage imageNamed:@"Plus"] forState:UIControlStateNormal];
   [fab sizeToFit];
   fab.center = _button.center;
 
-  [MDCFloatingActionButtonThemer applyScheme:buttonScheme toButton:fab];
+  [fab applySecondaryThemeWithScheme:self.containerScheme];
 
   MDCFeatureHighlightViewController *vc =
       [[MDCFeatureHighlightViewController alloc] initWithHighlightedView:_button

--- a/components/FeatureHighlight/examples/FeatureHighlightShownViewExample.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightShownViewExample.m
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MaterialButtons.h"
 #import "MaterialButtons+Theming.h"
-#import "MaterialFeatureHighlight.h"
+#import "MaterialButtons.h"
 #import "MaterialFeatureHighlight+ColorThemer.h"
 #import "MaterialFeatureHighlight+FeatureHighlightAccessibilityMutator.h"
 #import "MaterialFeatureHighlight+TypographyThemer.h"
+#import "MaterialFeatureHighlight.h"
 #import "supplemental/FeatureHighlightExampleSupplemental.h"
 
 @implementation FeatureHighlightShownViewExample

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.h
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.h
@@ -16,6 +16,7 @@
 
 #import "MaterialCollections.h"
 #import "MaterialColorScheme.h"
+#import "MaterialContainerScheme.h"
 #import "MaterialTypographyScheme.h"
 
 @interface FeatureHighlightTypicalUseViewController : UIViewController
@@ -47,6 +48,7 @@
 
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
 @property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
+@property(nonatomic, readonly, strong) MDCContainerScheme *containerScheme;
 
 - (void)didTapButton:(id)sender;
 @end

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
@@ -16,6 +16,7 @@
 
 #import "MaterialButtons.h"
 #import "MaterialButtons+ButtonThemer.h"
+#import "MaterialButtons+Theming.h"
 #import "MaterialMath.h"
 #import "MaterialPalettes.h"
 #import "MaterialTypography.h"
@@ -209,8 +210,7 @@ static NSString *const reuseIdentifier = @"Cell";
   self.button = fab;
   [self.view addSubview:self.button];
 
-  [MDCFloatingActionButtonThemer applyScheme:buttonScheme toButton:fab];
-
+  [fab applySecondaryThemeWithScheme:self.containerScheme];
 
   MDCButton *actionButton = [[MDCButton alloc] init];
   self.actionButton = actionButton;

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
@@ -14,9 +14,9 @@
 
 #import "FeatureHighlightExampleSupplemental.h"
 
-#import "MaterialButtons.h"
 #import "MaterialButtons+ButtonThemer.h"
 #import "MaterialButtons+Theming.h"
+#import "MaterialButtons.h"
 #import "MaterialMath.h"
 #import "MaterialPalettes.h"
 #import "MaterialTypography.h"

--- a/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
+++ b/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
@@ -25,6 +25,7 @@
 #import "MaterialBottomSheet+ShapeThemer.h"
 #import "MaterialBottomSheet.h"
 #import "MaterialButtons+ButtonThemer.h"
+#import "MaterialButtons+Theming.h"
 #import "MaterialButtons+ShapeThemer.h"
 #import "MaterialButtons+Theming.h"
 #import "MaterialButtons.h"
@@ -35,6 +36,7 @@
 #import "MaterialChips+ShapeThemer.h"
 #import "MaterialChips.h"
 #import "MaterialColorScheme.h"
+#import "MaterialContainerScheme.h"
 #import "MaterialShapeLibrary.h"
 #import "MaterialShapeScheme.h"
 #import "MaterialTypographyScheme.h"
@@ -123,7 +125,7 @@
   UIImage *plusImage =
       [[UIImage imageNamed:@"Plus"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   [self.floatingButton setImage:plusImage forState:UIControlStateNormal];
-  [MDCFloatingActionButtonThemer applyScheme:buttonScheme toButton:self.floatingButton];
+  [self.floatingButton applySecondaryThemeWithScheme:[self containerScheme]];
   [self.floatingButton sizeToFit];
   self.floatingButton.translatesAutoresizingMaskIntoConstraints = NO;
   [self.componentContentView addSubview:self.floatingButton];

--- a/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
+++ b/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
@@ -25,7 +25,6 @@
 #import "MaterialBottomSheet+ShapeThemer.h"
 #import "MaterialBottomSheet.h"
 #import "MaterialButtons+ButtonThemer.h"
-#import "MaterialButtons+Theming.h"
 #import "MaterialButtons+ShapeThemer.h"
 #import "MaterialButtons+Theming.h"
 #import "MaterialButtons.h"


### PR DESCRIPTION
Update examples to use secondary floating button theming extension method instead of calling themer's class methods.

Related https://github.com/material-components/material-components-ios/issues/5844
