### PR TITLE
[Documentation] Clean up doc links to guidelines

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -24,9 +24,10 @@
 
  A Material Action Sheet consists of a title, message and a list of actions.
 
- Learn more about [Material bottom
- sheet](https://material.io/design/components/sheets-bottom.html)
- [Material spec list](https://material.io/design/components/lists.html)
+ The [Material Guidelines article for Bottom
+ Sheets](https://material.io/design/components/sheets-bottom.html) and the
+ [Material Guidelines article for Lists](https://material.io/design/components/lists.html) have more
+ detailed guidance about how to style and use Action Sheets.
 
  To learn more about
  [UIAlertController](https://developer.apple.com/documentation/uikit/uialertcontroller)

--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -31,9 +31,11 @@
 
  To learn more about
  [UIAlertController](https://developer.apple.com/documentation/uikit/uialertcontroller)
- or [UIAlertControllerStyleActionSheet](https://developer.apple.com/documentation/uikit/uialertcontrollerstyle/uialertcontrollerstyleactionsheet)
+ or
+ [UIAlertControllerStyleActionSheet](https://developer.apple.com/documentation/uikit/uialertcontrollerstyle/uialertcontrollerstyleactionsheet)
 
- MDCActionSheetController does not support UIPopoverController, instead it will always be presented in a sheet from the bottom.
+ MDCActionSheetController does not support UIPopoverController, instead it will always be presented
+ in a sheet from the bottom.
 
  */
 __attribute__((objc_subclassing_restricted))

--- a/components/AppBar/src/MDCAppBarViewController.h
+++ b/components/AppBar/src/MDCAppBarViewController.h
@@ -47,8 +47,9 @@
  A Material App Bar consists of a Flexible Header View with a shadow, a Navigation Bar, and space
  for flexible content such as a photo.
 
- Learn more at the [Material
- spec](https://material.io/guidelines/patterns/scrolling-techniques.html)
+ The [Material Guidelines article for Scrolling
+ Techniques](https://material.io/archive/guidelines/patterns/scrolling-techniques.html) has more
+ detailed recommendations and guidance.
 
  ### Dependencies
 

--- a/components/Buttons/src/Theming/MDCFloatingButton+Theming.h
+++ b/components/Buttons/src/Theming/MDCFloatingButton+Theming.h
@@ -24,8 +24,9 @@
  @param scheme A container scheme instance containing any desired customizations to the theming
  system.
 
- Learn more at the [Material
- Guidelines](https://material.io/design/components/buttons-floating-action-button.html#theming)
+ The [Material Guidelines article for Floating Action
+ Buttons](https://material.io/design/components/buttons-floating-action-button.html#theming) has
+ more details about how Floating Action Buttons can be styled and used.
  */
 - (void)applySecondaryThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
 

--- a/components/Collections/src/MDCCollectionViewFlowLayout.h
+++ b/components/Collections/src/MDCCollectionViewFlowLayout.h
@@ -18,8 +18,9 @@
  The MDCCollectionViewFlowLayout class provides a Material Design layout implementation of a
  UICollectionViewFlowLayout layout.
 
- Learn more at the
- [Material spec](https://material.io/go/design-lists#lists-specs)
+ The [Material Guidelines article for
+ Lists](https://material.io/design/components/lists.html#lists-specs) has more details about how
+ Lists can be styled and used.
  */
 @interface MDCCollectionViewFlowLayout : UICollectionViewFlowLayout
 


### PR DESCRIPTION
Several of our header documentation comments had links to the Material
Guidelines pages that were less descriptive than they could have been.
By surrounding more contextual text in the anchor, it can help screen
reader users navigating the rendered page to quickly find relevant links
in the document.

Based on conversation in https://github.com/material-components/material-components-ios/pull/5869#discussion_r238699872

The change is being made across several components at once because it wasn't possible to change only a single component's docs in a PR. By changing multiple components, we can work around the consistency requirement of the style guide.
