### PR TITLE
[NavigationDrawer] Fix jump when perferredContentSize changes

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -857,6 +857,7 @@ Pod::Spec.new do |mdc|
 
     component.dependency "MaterialComponents/Palettes"
     component.dependency "MaterialComponents/ShadowLayer"
+    component.dependency "MaterialComponents/private/Math"
     component.dependency "MaterialComponents/private/UIMetrics"
 
     component.test_spec 'tests' do |tests|

--- a/components/NavigationDrawer/BUILD
+++ b/components/NavigationDrawer/BUILD
@@ -30,6 +30,7 @@ mdc_public_objc_library(
     deps = [
         "//components/Palettes",
         "//components/ShadowLayer",
+        "//components/private/Math",
         "//components/private/UIMetrics",
     ],
 )

--- a/components/NavigationDrawer/examples/BottomDrawerWithChangingContentSize.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithChangingContentSize.swift
@@ -63,6 +63,9 @@ class BottomDrawerWithChangingContentSizeExample: UIViewController {
 
   @objc func presentNavigationDrawer() {
     let bottomDrawerViewController = MDCBottomDrawerViewController()
+    bottomDrawerViewController.setTopCornersRadius(8, for: .collapsed)
+    bottomDrawerViewController.setTopCornersRadius(0, for: .expanded)
+    bottomDrawerViewController.isTopHandleHidden = false
     bottomDrawerViewController.contentViewController = contentViewController
     bottomDrawerViewController.headerViewController = headerViewController
     bottomDrawerViewController.trackingScrollView = contentViewController.collectionView

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -508,8 +508,10 @@ static UIColor *DrawerShadowColor(void) {
     precentageOfFullScreen = 0.5;
   }
   self.initialDrawerFactor = precentageOfFullScreen;
-  CGFloat diff = _contentVCPreferredContentSizeHeightCached - height;
-  [self.scrollView setContentOffset:CGPointMake(0, diff)];
+  if (![self shouldPresentFullScreen]) {
+    CGFloat diff = _contentVCPreferredContentSizeHeightCached - height;
+    [self.scrollView setContentOffset:CGPointMake(0, diff)];
+  }
 }
 
 #pragma mark Set ups (Private)

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -516,7 +516,9 @@ static UIColor *DrawerShadowColor(void) {
   self.initialDrawerFactor = precentageOfFullScreen;
   if (![self shouldPresentFullScreen]) {
     CGFloat diff = _contentVCPreferredContentSizeHeightCached - height;
-    [self.scrollView setContentOffset:CGPointMake(0, diff)];
+    CGPoint contentOffset = CGPointMake(0, diff);
+    [self.scrollView setContentOffset:contentOffset];
+    [self updateViewWithContentOffset:contentOffset];
   }
 }
 

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -16,6 +16,7 @@
 
 #import "MDCBottomDrawerHeader.h"
 #import "MDCBottomDrawerHeaderMask.h"
+#import "MaterialMath.h"
 #import "MaterialShadowLayer.h"
 #import "MaterialUIMetrics.h"
 
@@ -136,8 +137,13 @@ static UIColor *DrawerShadowColor(void) {
 // The current bottom drawer state.
 @property(nonatomic) MDCBottomDrawerState drawerState;
 
-// The height of the drawer at time of layout, in relation to the screen height, 0.0 is totally
-// hidden and 1.0 is full screen.
+/**
+ The height of the drawer at initial layout. This value is a percentage between 0-100% (0-1).
+ - 1 or 100% indicates the drawer is full screen.
+ - 0 or 0% indicates that drawer if hidden.
+
+ @note In voiceover and landscape this value will be 1.
+ */
 @property(nonatomic) CGFloat initialDrawerFactor;
 
 @end
@@ -290,7 +296,7 @@ static UIColor *DrawerShadowColor(void) {
 
 - (BOOL)shouldPresentFullScreen {
   // TODO: Github issue #5828
-  return [self isAccessibilityMode] || [self isMobileLandscape] || _initialDrawerFactor >= 1;
+  return [self isAccessibilityMode] || [self isMobileLandscape];
 }
 
 /**
@@ -498,7 +504,7 @@ static UIColor *DrawerShadowColor(void) {
 }
 
 - (void)resetInitialDrawerFactorWithHeight:(CGFloat)height {
-  if (_contentVCPreferredContentSizeHeightCached == 0) {
+  if (MDCCGFloatEqual(_contentVCPreferredContentSizeHeightCached, 0)) {
     [self cacheLayoutCalculations];
   }
   CGFloat totalHeight = self.headerViewController.preferredContentSize.height +

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -295,7 +295,6 @@ static UIColor *DrawerShadowColor(void) {
 }
 
 - (BOOL)shouldPresentFullScreen {
-  // TODO: Github issue #5828
   return [self isAccessibilityMode] || [self isMobileLandscape];
 }
 

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -494,7 +494,7 @@ static UIColor *DrawerShadowColor(void) {
     UIViewController *containerViewController = (UIViewController *)container;
     if (containerViewController == self.contentViewController) {
       CGFloat height = containerViewController.preferredContentSize.height;
-      [self resetInitialDrawerFactorWithHeight:height];
+      self.initialDrawerFactor = [self calculateInitialDrawerFactorWithHeight:height];
     }
   }
   _contentHeaderTopInset = NSNotFound;
@@ -503,7 +503,7 @@ static UIColor *DrawerShadowColor(void) {
   [self.view setNeedsLayout];
 }
 
-- (void)resetInitialDrawerFactorWithHeight:(CGFloat)height {
+- (CGFloat)calculateInitialDrawerFactorWithHeight:(CGFloat)height {
   if (MDCCGFloatEqual(_contentVCPreferredContentSizeHeightCached, 0)) {
     [self cacheLayoutCalculations];
   }
@@ -513,7 +513,7 @@ static UIColor *DrawerShadowColor(void) {
   if (precentageOfFullScreen > 0.5) {
     precentageOfFullScreen = 0.5;
   }
-  self.initialDrawerFactor = precentageOfFullScreen;
+  return precentageOfFullScreen;
 }
 
 #pragma mark Set ups (Private)

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -146,6 +146,9 @@ static UIColor *DrawerShadowColor(void) {
  */
 @property(nonatomic) CGFloat initialDrawerFactor;
 
+// Calculates the initial drawer factor.
+- (CGFloat)calculateInitialDrawerFactor;
+
 @end
 
 @implementation MDCBottomDrawerContainerViewController {
@@ -492,8 +495,7 @@ static UIColor *DrawerShadowColor(void) {
   if ([container isKindOfClass:[UIViewController class]]) {
     UIViewController *containerViewController = (UIViewController *)container;
     if (containerViewController == self.contentViewController) {
-      CGFloat height = containerViewController.preferredContentSize.height;
-      self.initialDrawerFactor = [self calculateInitialDrawerFactorWithHeight:height];
+      self.initialDrawerFactor = [self calculateInitialDrawerFactor];
     }
   }
   _contentHeaderTopInset = NSNotFound;
@@ -502,7 +504,7 @@ static UIColor *DrawerShadowColor(void) {
   [self.view setNeedsLayout];
 }
 
-- (CGFloat)calculateInitialDrawerFactorWithHeight:(CGFloat)height {
+- (CGFloat)calculateInitialDrawerFactor {
   if (MDCCGFloatEqual(_contentVCPreferredContentSizeHeightCached, 0)) {
     [self cacheLayoutCalculations];
   }

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -514,12 +514,6 @@ static UIColor *DrawerShadowColor(void) {
     precentageOfFullScreen = 0.5;
   }
   self.initialDrawerFactor = precentageOfFullScreen;
-  if (![self shouldPresentFullScreen]) {
-    CGFloat diff = _contentVCPreferredContentSizeHeightCached - height;
-    CGPoint contentOffset = CGPointMake(0, diff);
-    [self.scrollView setContentOffset:contentOffset];
-    [self updateViewWithContentOffset:contentOffset];
-  }
 }
 
 #pragma mark Set ups (Private)

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -58,9 +58,11 @@
 @property(nonatomic, readonly) CGFloat contentHeightSurplus;
 @property(nonatomic, readonly) BOOL contentScrollsToReveal;
 @property(nonatomic) MDCBottomDrawerState drawerState;
+@property(nonatomic) CGFloat initialDrawerFactor;
 @property(nullable, nonatomic, readonly) UIPresentationController *presentationController;
 - (void)cacheLayoutCalculations;
 - (void)updateDrawerState:(CGFloat)transitionPercentage;
+- (CGFloat)calculateInitialDrawerFactor;
 @end
 
 @interface MDCBottomDrawerPresentationController (ScrollViewTests) <
@@ -538,6 +540,32 @@
 
   // Then
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.scrollView.contentOffset.y, 500, (CGFloat)0.001);
+}
+
+- (void)testCalculateInitialDrawerFactorWithSmallHeight {
+  // Given
+  CGRect fakeRect = CGRectMake(0, 0, 250, 500);
+  self.fakeBottomDrawer.originalPresentingViewController.view.bounds = fakeRect;
+  self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(250, 100);
+
+  // When
+  CGFloat drawerFactor = [self.fakeBottomDrawer calculateInitialDrawerFactor];
+
+  // Then
+  XCTAssertEqualWithAccuracy(drawerFactor, 0.2, 0.001);
+}
+
+- (void)testCalculateInitialDrawerFactorWithLargeHeight {
+  // Given
+  CGRect fakeRect = CGRectMake(0, 0, 250, 500);
+  self.fakeBottomDrawer.originalPresentingViewController.view.bounds = fakeRect;
+  self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(250, 1000);
+
+  // When
+  CGFloat drawerFactor = [self.fakeBottomDrawer calculateInitialDrawerFactor];
+
+  // Then
+  XCTAssertEqualWithAccuracy(drawerFactor, 0.5, 0.001);
 }
 
 @end


### PR DESCRIPTION
### Context
Currently `MDCBottomDrawerViewController` _jumps_ if the preferredContentSize changes. A client is asking for this _jump_ to not happen but instead the drawer will look the same but have more content. 

#### Conditional checks

1. The check to see if `_contentVCPreferredContentSizeHeightCached` is zero is because on initial layout this value is 0 until we call `cacheLayoutCalculations` which sets this value. 
2. The check to see if `percentageFullScreen > 0.5` is there to make sure we never have an initial drawer factor more than design has specified.

### The problem
`MDCBottomDrawerViewController` _jumps_ if the preferredContentSize changes

### The fix
Set initialDrawerFactor to a custom value so that change doesn't cause a jump.

### Videos
| Before | After |
| - | - |
|![before](https://user-images.githubusercontent.com/7131294/49542847-a0267500-f8a4-11e8-90c9-e5304e5da9a2.gif)|![after](https://user-images.githubusercontent.com/7131294/49542855-a4eb2900-f8a4-11e8-9db3-3b163dbe5e9b.gif)|

