### PR TITLE
[Buttons] Fix unsafe access to self.bounds.size

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -251,7 +251,8 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
     CGFloat offsetX = contentCenterPoint.x - boundsCenterPoint.x;
     CGFloat offsetY = contentCenterPoint.y - boundsCenterPoint.y;
-    _inkView.frame = CGRectMake(offsetX, offsetY, self.bounds.size.width, self.bounds.size.height);
+    _inkView.frame =
+        CGRectMake(offsetX, offsetY, CGRectGetWidth(self.bounds), CGRectGetHeight(self.bounds));
   } else {
     _inkView.frame = self.bounds;
   }


### PR DESCRIPTION
There were two unsafe (unstandardized) accesses to the bounds' size field
which could be negative and lead to unexpected results.
