### PR TITLE
[Catalog] Update examples to use container scheme

### DIFF
--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -38,10 +38,6 @@ const CGSize kMinimumAccessibleButtonSize = {64.0, 48.0};
         [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
     self.typographyScheme =
         [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
-    self.containerScheme = [[MDCContainerScheme alloc] init];
-    self.containerScheme.colorScheme = self.colorScheme;
-    self.containerScheme.shapeScheme = self.shapeScheme;
-    self.containerScheme.typographyScheme = self.typographyScheme;
   }
   return self;
 }

--- a/components/Cards/examples/CardExampleViewController.swift
+++ b/components/Cards/examples/CardExampleViewController.swift
@@ -24,6 +24,13 @@ class CardExampleViewController: UIViewController {
   var colorScheme = MDCSemanticColorScheme()
   var shapeScheme = MDCShapeScheme()
   var typographyScheme = MDCTypographyScheme()
+  var containerScheme: MDCContainerScheme {
+    let scheme = MDCContainerScheme()
+    scheme.colorScheme = self.colorScheme
+    scheme.typographyScheme = self.typographyScheme
+    scheme.shapeScheme = self.shapeScheme
+    return scheme
+  }
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -34,7 +41,7 @@ class CardExampleViewController: UIViewController {
     bundle.loadNibNamed("CardExampleViewController", owner: self, options: nil)
     view.frame = self.view.bounds
 
-    button.applyTextTheme(withScheme: MDCContainerScheme())
+    button.applyTextTheme(withScheme: self.containerScheme)
 
     let cardScheme = MDCCardScheme();
     cardScheme.colorScheme = colorScheme

--- a/components/Dialogs/examples/DialogsTypicalUseViewController.m
+++ b/components/Dialogs/examples/DialogsTypicalUseViewController.m
@@ -70,15 +70,15 @@
 }
 
 - (MDCContainerScheme *)containerScheme {
-  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-  scheme.colorScheme = self.colorScheme;
-  scheme.shapeScheme =
-      [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
-  scheme.typographyScheme =
-      [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
   if (!_containerScheme) {
-    _containerScheme = scheme;
+    _containerScheme = [[MDCContainerScheme alloc] init];
   }
+  _containerScheme.colorScheme = self.colorScheme;
+  _containerScheme.shapeScheme =
+      [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  _containerScheme.typographyScheme =
+      [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+
   return _containerScheme;
 }
 

--- a/components/Dialogs/examples/DialogsTypicalUseViewController.m
+++ b/components/Dialogs/examples/DialogsTypicalUseViewController.m
@@ -34,9 +34,6 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  if (!self.containerScheme) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
-  }
   if (!self.colorScheme) {
     self.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
@@ -70,6 +67,19 @@
                                 multiplier:1.0
                                   constant:0.0]
   ]];
+}
+
+- (MDCContainerScheme *)containerScheme {
+  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+  scheme.colorScheme = self.colorScheme;
+  scheme.shapeScheme =
+      [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  scheme.typographyScheme =
+      [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+  if (!_containerScheme) {
+    _containerScheme = scheme;
+  }
+  return _containerScheme;
 }
 
 - (void)showAlert:(UIButton *)button {


### PR DESCRIPTION
### Context
The examples were using the wrong scheme and we had unintended changes because the way we inject schemes in the catalog.
### The problem
Some examples were the wrong color
### The fix
Update container scheme in those examples

### Screenshots
|Before | After |
| - | - |
|![simulator screen shot - iphone xs max - 2018-12-06 at 11 03 15](https://user-images.githubusercontent.com/7131294/49595709-95bcb780-f946-11e8-820b-80b0247d015c.png)|![simulator screen shot - iphone xs max - 2018-12-06 at 11 01 14](https://user-images.githubusercontent.com/7131294/49595719-9b1a0200-f946-11e8-80f2-617c139a950f.png)|
|![simulator screen shot - iphone xs max - 2018-12-06 at 11 04 37](https://user-images.githubusercontent.com/7131294/49595780-c00e7500-f946-11e8-9ab8-1fb9904e9fda.png)|![simulator screen shot - iphone xs max - 2018-12-06 at 11 00 52](https://user-images.githubusercontent.com/7131294/49595783-c3a1fc00-f946-11e8-81f5-4d047fb1ed11.png)|
|![simulator screen shot - iphone xs max - 2018-12-06 at 11 04 43](https://user-images.githubusercontent.com/7131294/49595801-cf8dbe00-f946-11e8-8af1-6d9dfa32bb3e.png)|![simulator screen shot - iphone xs max - 2018-12-06 at 11 01 09](https://user-images.githubusercontent.com/7131294/49595805-d4527200-f946-11e8-8d52-cae35f30ff9e.png)|

| Example View Controller name |
| - |
| ButtonsTypicalUseExampleViewController.m |
| CardExampleViewController.swift |
| DialogsTypicalUseViewController.m |
This is reflected in the files changed.






