### PR TITLE
[Snapshot] Tweak snapshot test base class to handle the verify in tearDown

### DIFF
--- a/components/Cards/tests/snapshot/MDCCardSnapshotTests.m
+++ b/components/Cards/tests/snapshot/MDCCardSnapshotTests.m
@@ -27,10 +27,9 @@
 
   // Given
   MDCCard *card = [[MDCCard alloc] initWithFrame:CGRectMake(0, 0, 50, 50)];
-  UIView *backgroundView = [self addBackgroundViewToView:card];
 
-  // Then
-  [self snapshotVerifyView:backgroundView];
+  // When
+  self.testView = [self addBackgroundViewToView:card];
 }
 
 @end

--- a/components/Cards/tests/snapshot/MDCCardSnapshotTests.m
+++ b/components/Cards/tests/snapshot/MDCCardSnapshotTests.m
@@ -28,7 +28,7 @@
   // Given
   MDCCard *card = [[MDCCard alloc] initWithFrame:CGRectMake(0, 0, 50, 50)];
 
-  // When
+  // Then
   self.testView = [self addBackgroundViewToView:card];
 }
 

--- a/components/private/Snapshot/MDCSnapshotTestCase.h
+++ b/components/private/Snapshot/MDCSnapshotTestCase.h
@@ -16,6 +16,8 @@
 
 @interface MDCSnapshotTestCase : FBSnapshotTestCase
 
+@property(nonatomic, strong) UIView *testView;
+
 /**
  * This method will take a view and add it to as a subview to a new view with a size slightly
  * larger than the argument view.

--- a/components/private/Snapshot/MDCSnapshotTestCase.m
+++ b/components/private/Snapshot/MDCSnapshotTestCase.m
@@ -21,6 +21,22 @@
   self.agnosticOptions = FBSnapshotTestCaseAgnosticOptionOS;
 }
 
+- (void)tearDown {
+  // TODO(https://github.com/material-components/material-components-ios/issues/5888)
+  // Support multiple OS versions for snapshots
+  if (NSProcessInfo.processInfo.operatingSystemVersion.majorVersion != 11 ||
+      NSProcessInfo.processInfo.operatingSystemVersion.minorVersion != 2 ||
+      NSProcessInfo.processInfo.operatingSystemVersion.patchVersion != 0) {
+    NSLog(@"Skipping this test. Snapshot tests currently only run on iOS 11.2.0");
+    [super tearDown];
+    return;
+  }
+
+  NSAssert(self.testView, @"Snapshot tests must set `testView` to the view for snapshotting.");
+  [self snapshotVerifyView:self.testView];
+  [super tearDown];
+}
+
 - (UIView *)addBackgroundViewToView:(UIView *)view {
   UIView *backgroundView =
       [[UIView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(view.bounds) + 20,
@@ -32,15 +48,6 @@
 }
 
 - (void)snapshotVerifyView:(UIView *)view {
-  // TODO(https://github.com/material-components/material-components-ios/issues/5888)
-  // Support multiple OS versions for snapshots
-  if (NSProcessInfo.processInfo.operatingSystemVersion.majorVersion != 11 ||
-      NSProcessInfo.processInfo.operatingSystemVersion.minorVersion != 2 ||
-      NSProcessInfo.processInfo.operatingSystemVersion.patchVersion != 0) {
-    NSLog(@"Skipping this test. Snapshot tests currently only run on iOS 11.2.0");
-    return;
-  }
-
   UIImage *result = nil;
 
   if (@available(iOS 10, *)) {


### PR DESCRIPTION
This change simplifies the way a developer would have to write a snapshot test. The logic to verify the view is in the tearDown and will enforce the developer to write the test correctly.