### PR TITLE
[ChipField] Account for RTL in textRectForBounds override in MDCChipTextField

### DIFF
--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -50,6 +50,15 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
 
 @implementation MDCChipTextField
 
+- (CGRect)textRectForBounds:(CGRect)bounds {
+  CGRect textRect = [super textRectForBounds:bounds];
+  if (self.mdf_effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
+    textRect = MDFRectFlippedHorizontally(textRect, CGRectGetWidth(self.bounds));
+    textRect.origin.x += 5;
+  }
+  return textRect;
+}
+
 #pragma mark UIKeyInput
 
 - (void)deleteBackward {


### PR DESCRIPTION
This PR addresses a bug where the ChipField's TextField's textRect and cursor are hidden under the ChipField's chips when a user types in English in an RTL environment. 

You might notice the magic number in the frame calculation! MDCTextFields have problems with clear button/textRect overlap in RTL that make this necessary. If this weren't so urgent, I would look for a more satisfying fix, but given the priority of the bug I'd say we just go with this for now :/

Before:
![before](https://user-images.githubusercontent.com/8020010/49606628-e097f880-f961-11e8-8063-8fb0be7d8930.gif)

After:
![after](https://user-images.githubusercontent.com/8020010/49606627-e097f880-f961-11e8-87d1-8c818feb1d24.gif)




Closes #5573. 