### PR TITLE
[Snapshot] Deallocate `testView` in teardown

### DIFF
--- a/components/private/Snapshot/MDCSnapshotTestCase.m
+++ b/components/private/Snapshot/MDCSnapshotTestCase.m
@@ -29,11 +29,13 @@
       NSProcessInfo.processInfo.operatingSystemVersion.patchVersion != 0) {
     NSLog(@"Skipping this test. Snapshot tests currently only run on iOS 11.2.0");
     [super tearDown];
+    self.testView = nil;
     return;
   }
 
   NSAssert(self.testView, @"Snapshot tests must set `testView` to the view for snapshotting.");
   [self snapshotVerifyView:self.testView];
+  self.testView = nil;
   [super tearDown];
 }
 


### PR DESCRIPTION
To make sure we aren't retaining too much in memory after tests
complete, the `-tearDown` method of Snapshot tests should remove any
remaining references created during their set up.

Found while working on #5939
