### PR TITLE
[Shape] add NSCopying support to ShapeCategory

### DIFF
--- a/components/schemes/Shape/src/MDCShapeCategory.h
+++ b/components/schemes/Shape/src/MDCShapeCategory.h
@@ -32,27 +32,27 @@ typedef NS_ENUM(NSInteger, MDCShapeCornerFamily) {
 
  MDCShapeCategory is built from 4 corners, that can be set to alter the shape value.
  */
-@interface MDCShapeCategory : NSObject
+@interface MDCShapeCategory : NSObject <NSCopying>
 
 /**
  This property represents the shape of the top left corner of the shape.
  */
-@property(strong, nonatomic) MDCCornerTreatment *topLeftCorner;
+@property(nonatomic, copy) MDCCornerTreatment *topLeftCorner;
 
 /**
  This property represents the shape of the top right corner of the shape.
  */
-@property(strong, nonatomic) MDCCornerTreatment *topRightCorner;
+@property(nonatomic, copy) MDCCornerTreatment *topRightCorner;
 
 /**
  This property represents the shape of the bottom left corner of the shape.
  */
-@property(strong, nonatomic) MDCCornerTreatment *bottomLeftCorner;
+@property(nonatomic, copy) MDCCornerTreatment *bottomLeftCorner;
 
 /**
  This property represents the shape of the bottom right corner of the shape.
  */
-@property(strong, nonatomic) MDCCornerTreatment *bottomRightCorner;
+@property(nonatomic, copy) MDCCornerTreatment *bottomRightCorner;
 
 /**
  The default init of the class. It sets all 4 corners with a corner family of

--- a/components/schemes/Shape/src/MDCShapeCategory.m
+++ b/components/schemes/Shape/src/MDCShapeCategory.m
@@ -57,4 +57,18 @@
          [_bottomRightCorner isEqual:other.bottomRightCorner];
 }
 
+- (id)copyWithZone:(NSZone *)zone {
+  MDCShapeCategory *copy = [[MDCShapeCategory alloc] init];
+  copy.topLeftCorner = self.topLeftCorner;
+  copy.topRightCorner = self.topRightCorner;
+  copy.bottomLeftCorner = self.bottomLeftCorner;
+  copy.bottomRightCorner = self.bottomRightCorner;
+  return copy;
+}
+
+- (NSUInteger)hash {
+  return (self.topRightCorner.hash ^ self.topLeftCorner.hash ^ self.bottomRightCorner.hash ^
+          self.bottomLeftCorner.hash);
+}
+
 @end

--- a/components/schemes/Shape/tests/unit/MDCShapeSchemeTests.m
+++ b/components/schemes/Shape/tests/unit/MDCShapeSchemeTests.m
@@ -25,19 +25,19 @@
 
 - (void)testShapeCategoryEquality {
   // Given
-  MDCShapeCategory *cat1 = [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyCut
+  MDCShapeCategory *originalCategory = [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyCut
                                                                    andSize:(CGFloat)2.1];
-  MDCShapeCategory *cat2 = [[MDCShapeCategory alloc] init];
+  MDCShapeCategory *testCategory = [[MDCShapeCategory alloc] init];
   MDCCornerTreatment *corner =
       [MDCCornerTreatment cornerWithCut:(CGFloat)2.1 valueType:MDCCornerTreatmentValueTypeAbsolute];
-  cat2.topLeftCorner = corner;
-  cat2.topRightCorner = corner;
-  cat2.bottomLeftCorner = corner;
-  cat2.bottomRightCorner = corner;
+  testCategory.topLeftCorner = corner;
+  testCategory.topRightCorner = corner;
+  testCategory.bottomLeftCorner = corner;
+  testCategory.bottomRightCorner = corner;
 
   // Then
-  XCTAssertEqual(cat1.hash, cat2.hash);
-  XCTAssertEqualObjects(cat1, cat2);
+  XCTAssertEqual(originalCategory.hash, testCategory.hash);
+  XCTAssertEqualObjects(originalCategory, testCategory);
 }
 
 - (void)testInitMatchesInitWithMaterialDefaults {

--- a/components/schemes/Shape/tests/unit/MDCShapeSchemeTests.m
+++ b/components/schemes/Shape/tests/unit/MDCShapeSchemeTests.m
@@ -36,6 +36,7 @@
   cat2.bottomRightCorner = corner;
 
   // Then
+  XCTAssertEqual(cat1.hash, cat2.hash);
   XCTAssertEqualObjects(cat1, cat2);
 }
 
@@ -68,4 +69,20 @@
                                                                 andSize:4]);
 }
 
+- (void)testShapeCategoryCopy {
+  // Given
+  MDCShapeCategory *cat = [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyCut
+                                                                  andSize:(CGFloat)2.2];
+
+  // When
+  MDCShapeCategory *copiedCat = [cat copy];
+
+  // Then
+  XCTAssertNotEqual(cat, copiedCat);
+  XCTAssertEqualObjects(cat, copiedCat);
+  XCTAssertEqualObjects(cat.topRightCorner, copiedCat.topRightCorner);
+  XCTAssertEqualObjects(cat.topLeftCorner, copiedCat.topLeftCorner);
+  XCTAssertEqualObjects(cat.bottomRightCorner, copiedCat.bottomRightCorner);
+  XCTAssertEqualObjects(cat.bottomLeftCorner, copiedCat.bottomLeftCorner);
+}
 @end


### PR DESCRIPTION
Adding NSCopying support to ShapeCategory would facilitate deep copying for any class that uses it.