### PR TITLE
[Snapshot] Move verification into test methods

### DIFF
--- a/components/Cards/tests/snapshot/MDCCardSnapshotTests.m
+++ b/components/Cards/tests/snapshot/MDCCardSnapshotTests.m
@@ -29,7 +29,8 @@
   MDCCard *card = [[MDCCard alloc] initWithFrame:CGRectMake(0, 0, 50, 50)];
 
   // Then
-  self.testView = [self addBackgroundViewToView:card];
+  UIView *snapshotView = [self addBackgroundViewToView:card];
+  [self snapshotVerifyView:snapshotView];
 }
 
 @end

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerSnapshotTests.m
@@ -48,8 +48,10 @@
 
 - (void)generateSnapshotAndVerify {
   [self triggerTextFieldLayout];
+  UIView *snapshotView = [self addBackgroundViewToView:self.textField];
 
-  self.testView = [self addBackgroundViewToView:self.textField];
+  // Perform the actual verification.
+  [self snapshotVerifyView:snapshotView];
 }
 
 #pragma mark - Tests

--- a/components/private/Snapshot/MDCSnapshotTestCase.h
+++ b/components/private/Snapshot/MDCSnapshotTestCase.h
@@ -16,8 +16,6 @@
 
 @interface MDCSnapshotTestCase : FBSnapshotTestCase
 
-@property(nonatomic, strong) UIView *testView;
-
 /**
  * This method will take a view and add it to as a subview to a new view with a size slightly
  * larger than the argument view.

--- a/components/private/Snapshot/MDCSnapshotTestCase.m
+++ b/components/private/Snapshot/MDCSnapshotTestCase.m
@@ -21,22 +21,6 @@
   self.agnosticOptions = FBSnapshotTestCaseAgnosticOptionOS;
 }
 
-- (void)tearDown {
-  // TODO(https://github.com/material-components/material-components-ios/issues/5888)
-  // Support multiple OS versions for snapshots
-  if (NSProcessInfo.processInfo.operatingSystemVersion.majorVersion != 11 ||
-      NSProcessInfo.processInfo.operatingSystemVersion.minorVersion != 2 ||
-      NSProcessInfo.processInfo.operatingSystemVersion.patchVersion != 0) {
-    NSLog(@"Skipping this test. Snapshot tests currently only run on iOS 11.2.0");
-    [super tearDown];
-    return;
-  }
-
-  NSAssert(self.testView, @"Snapshot tests must set `testView` to the view for snapshotting.");
-  [self snapshotVerifyView:self.testView];
-  [super tearDown];
-}
-
 - (UIView *)addBackgroundViewToView:(UIView *)view {
   UIView *backgroundView =
       [[UIView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(view.bounds) + 20,
@@ -48,6 +32,15 @@
 }
 
 - (void)snapshotVerifyView:(UIView *)view {
+  // TODO(https://github.com/material-components/material-components-ios/issues/5888)
+  // Support multiple OS versions for snapshots
+  if (NSProcessInfo.processInfo.operatingSystemVersion.majorVersion != 11 ||
+      NSProcessInfo.processInfo.operatingSystemVersion.minorVersion != 2 ||
+      NSProcessInfo.processInfo.operatingSystemVersion.patchVersion != 0) {
+    NSLog(@"Skipping this test. Snapshot tests currently only run on iOS 11.2.0");
+    return;
+  }
+
   UIImage *result = nil;
 
   if (@available(iOS 10, *)) {


### PR DESCRIPTION
Instead of implicitly verifying the snapshotted view in the test class
`-tearDown` method, it is clearer to readers if each test explicitly
performs the verification.

Closes #5941
