### PR TITLE
[TextFields] Add OutlinedTextArea snapshot tests

### DIFF
--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedTextAreaControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedTextAreaControllerSnapshotTests.m
@@ -1,0 +1,215 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY MDCTextFieldSnapshotTestsIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCSnapshotTestCase.h"
+#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "MaterialTextFields.h"
+
+@interface MDCTextFieldOutlinedTextAreaControllerSnapshotTests : MDCSnapshotTestCase
+@property(nonatomic, strong) MDCMultilineTextField *textField;
+@property(nonatomic, strong) MDCTextInputControllerOutlinedTextArea *textFieldController;
+@end
+
+@implementation MDCTextFieldOutlinedTextAreaControllerSnapshotTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.textField = [[MDCMultilineTextField alloc] init];
+  self.textFieldController =
+      [[MDCTextInputControllerOutlinedTextArea alloc] initWithTextInput:self.textField];
+}
+
+- (void)tearDown {
+  self.textFieldController = nil;
+  self.textField = nil;
+
+  [super tearDown];
+}
+
+#pragma mark - Helpers
+
+- (void)triggerTextFieldLayout {
+  CGSize aSize = [self.textField sizeThatFits:CGSizeMake(300, INFINITY)];
+  self.textField.bounds = CGRectMake(0, 0, aSize.width, aSize.height);
+  [self.textField layoutIfNeeded];
+}
+
+- (void)generateSnapshotAndVerify {
+  [self triggerTextFieldLayout];
+  UIView *snapshotView = [self addBackgroundViewToView:self.textField];
+
+  // Perform the actual verification.
+  [self snapshotVerifyView:snapshotView];
+}
+
+#pragma mark - Tests
+
+- (void)testOutlinedTextFieldEmpty {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+#pragma mark - Single field tests
+
+- (void)testOutlinedTextFieldWithShortPlaceholderText {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testOutlinedTextFieldWithLongPlaceholderText {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testOutlinedTextFieldWithShortHelperText {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testOutlinedTextFieldWithLongHelperText {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testOutlinedTextFieldWithShortErrorText {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testOutlinedTextFieldWithLongErrorText {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testOutlinedTextFieldWithShortInputText {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testOutlinedTextFieldWithLongInputText {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+#pragma mark - Multiple field tests
+
+- (void)testOutlinedTextFieldWithShortInputPlaceholderHelperTexts {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testOutlinedTextFieldWithLongInputPlaceholderHelperTexts {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testOutlinedTextFieldWithShortInputPlaceholderErrorTexts {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testOutlinedTextFieldWithLongInputPlaceholderErrorTexts {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+@end

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldEmpty_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldEmpty_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96146d3065c87ab981d20a0129e0aada2abfcd417480a7b4c906c0f1f99ab380
+size 5700

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithLongErrorText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithLongErrorText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d94fd1d297af3004adc4ba812d8dcdec2d5b79827ee24f58babcb5bcd2e56b50
+size 10697

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithLongHelperText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithLongHelperText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b50c123642bd03f99c56ed16f74b53da52fb61a04302b154bf8646d0a0592629
+size 10379

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderErrorTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderErrorTexts_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:642262b96cfb62b71f66a592bdd0ea6578ff1137f36e9c3383b8608220491211
+size 26414

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderHelperTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderHelperTexts_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a44a2e5649fe25ee6e4f57d5737ad574a9ef4565825720cfa67d7bbe4e63a878
+size 24765

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithLongInputText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithLongInputText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1e8ed9202f71d9141948355772e9968bf881c17f38f3f5b4ef1c1d44b1644c8
+size 13216

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithLongPlaceholderText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithLongPlaceholderText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:508983c6d046f185610d57c31a0f0a8eb0f1a6838fbca4700627a29cc8555d1c
+size 11426

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithShortErrorText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithShortErrorText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e89dfcd92968dfebabd6d5a54b150d4d9e7153fd4b6a684cf4a4b5557805cc01
+size 8048

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithShortHelperText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithShortHelperText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:661325485772d98d3792fd4e57928f638fcc90ce5b5740ff4935ac40cabe9ba2
+size 7490

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithShortInputPlaceholderErrorTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithShortInputPlaceholderErrorTexts_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:396e6d5515e2c0e6157c655270634baf7a62c832a2466ac12bdb391d03378633
+size 10654

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithShortInputPlaceholderHelperTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithShortInputPlaceholderHelperTexts_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b25617ff83fa00b47eaca182749861f74c05ffbd2d3a402332f126376bdf90b8
+size 9958

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithShortInputText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithShortInputText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a8d92a855025049369c6ba0db6e247b146888ee208a31eca92bd28c97982a07
+size 7008

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithShortPlaceholderText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedTextAreaControllerSnapshotTests/testOutlinedTextFieldWithShortPlaceholderText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5ae67e055d635fe8097c885044f7e338318492e0f026f125a357e7fa46c0177
+size 7041


### PR DESCRIPTION
Adding basic (unthemed) snapshot tests for OutlinedTextArea textfield
controllers.

Part of #5762
