### PR TITLE
[Shape] add hash function to MDCCornerTreatment

### DIFF
--- a/components/private/ShapeLibrary/src/MDCCurvedCornerTreatment.m
+++ b/components/private/ShapeLibrary/src/MDCCurvedCornerTreatment.m
@@ -63,4 +63,8 @@
   return CGSizeEqualToSize(self.size, otherCurvedCorner.size);
 }
 
+- (NSUInteger)hash {
+  return @(self.size.height).hash ^ @(self.size.width).hash ^ (NSUInteger)self.valueType;
+}
+
 @end

--- a/components/private/ShapeLibrary/src/MDCCutCornerTreatment.m
+++ b/components/private/ShapeLibrary/src/MDCCutCornerTreatment.m
@@ -63,5 +63,9 @@ static NSString *const MDCCutCornerTreatmentCutKey = @"MDCCutCornerTreatmentCutK
   return self.cut == otherCutCorner.cut;
 }
 
+- (NSUInteger)hash {
+  return @(self.cut).hash ^ (NSUInteger)self.valueType;
+}
+
 @end
 

--- a/components/private/ShapeLibrary/src/MDCRoundedCornerTreatment.m
+++ b/components/private/ShapeLibrary/src/MDCRoundedCornerTreatment.m
@@ -65,4 +65,8 @@
   return self.radius == otherRoundedCorner.radius;
 }
 
+- (NSUInteger)hash {
+  return @(self.radius).hash ^ (NSUInteger)self.valueType;
+}
+
 @end

--- a/components/private/ShapeLibrary/tests/unit/ShapeLibraryTests.m
+++ b/components/private/ShapeLibrary/tests/unit/ShapeLibraryTests.m
@@ -39,7 +39,6 @@ void GetCGPathAddLineToPointValues(void *info, const CGPathElement *element);
   MDCCornerTreatment *cornerTreatment = [MDCCornerTreatment cornerWithCurve:CGSizeMake(2, 5)];
 
   // When
-  XCTAssertNotEqual(curvedCorner.hash, curvedCorner2.hash);
   XCTAssertNotEqualObjects(curvedCorner, curvedCorner2);
   curvedCorner2.size = CGSizeMake(2, 5);
 

--- a/components/private/ShapeLibrary/tests/unit/ShapeLibraryTests.m
+++ b/components/private/ShapeLibrary/tests/unit/ShapeLibraryTests.m
@@ -39,10 +39,12 @@ void GetCGPathAddLineToPointValues(void *info, const CGPathElement *element);
   MDCCornerTreatment *cornerTreatment = [MDCCornerTreatment cornerWithCurve:CGSizeMake(2, 5)];
 
   // When
+  XCTAssertNotEqual(curvedCorner.hash, curvedCorner2.hash);
   XCTAssertNotEqualObjects(curvedCorner, curvedCorner2);
   curvedCorner2.size = CGSizeMake(2, 5);
 
   // Then
+  XCTAssertEqual(curvedCorner.hash, curvedCorner2.hash);
   XCTAssertEqualObjects(curvedCorner, cornerTreatment);
   XCTAssertEqualObjects(curvedCorner, curvedCorner2);
   XCTAssertEqualObjects(curvedCorner, curvedCorner);
@@ -57,10 +59,12 @@ void GetCGPathAddLineToPointValues(void *info, const CGPathElement *element);
   MDCCornerTreatment *cornerTreatment = [MDCCornerTreatment cornerWithRadius:(CGFloat)3.2];
 
   // When
+  XCTAssertNotEqual(roundedCorner.hash, roundedCorner2.hash);
   XCTAssertNotEqualObjects(roundedCorner, roundedCorner2);
   roundedCorner2.radius = (CGFloat)3.2;
 
   // Then
+  XCTAssertEqual(roundedCorner.hash, roundedCorner2.hash);
   XCTAssertEqualObjects(roundedCorner, cornerTreatment);
   XCTAssertEqualObjects(roundedCorner, roundedCorner2);
   XCTAssertEqualObjects(roundedCorner, roundedCorner);
@@ -73,10 +77,12 @@ void GetCGPathAddLineToPointValues(void *info, const CGPathElement *element);
   MDCCornerTreatment *cornerTreatment = [MDCCornerTreatment cornerWithCut:(CGFloat)3.2];
 
   // When
+  XCTAssertNotEqual(cutCorner.hash, cutCorner2.hash);
   XCTAssertNotEqualObjects(cutCorner, cutCorner2);
   cutCorner2.cut = (CGFloat)3.2;
 
   // Then
+  XCTAssertEqual(cutCorner.hash, cutCorner2.hash);
   XCTAssertEqualObjects(cutCorner, cornerTreatment);
   XCTAssertEqualObjects(cutCorner, cutCorner2);
   XCTAssertEqualObjects(cutCorner, cutCorner);

--- a/components/private/Shapes/src/MDCCornerTreatment.m
+++ b/components/private/Shapes/src/MDCCornerTreatment.m
@@ -49,4 +49,8 @@
   return self.valueType == otherCorner.valueType;
 }
 
+- (NSUInteger)hash {
+  return (NSUInteger)self.valueType;
+}
+
 @end

--- a/components/private/Shapes/tests/unit/ShapesNoopTest.m
+++ b/components/private/Shapes/tests/unit/ShapesNoopTest.m
@@ -27,4 +27,23 @@
   XCTAssertNotNil(view);
 }
 
+- (void)testCornerTreatmentEquality {
+  // Given
+  MDCCornerTreatment *cornerTreatment1 = [[MDCCornerTreatment alloc] init];
+  cornerTreatment1.valueType = MDCCornerTreatmentValueTypeAbsolute;
+  MDCCornerTreatment *cornerTreatment2 = [[MDCCornerTreatment alloc] init];
+  cornerTreatment2.valueType = MDCCornerTreatmentValueTypePercentage;
+
+  // Then
+  XCTAssertNotEqual(cornerTreatment1.hash, cornerTreatment2.hash);
+  XCTAssertNotEqualObjects(cornerTreatment1, cornerTreatment2);
+
+  // When
+  cornerTreatment2.valueType = MDCCornerTreatmentValueTypeAbsolute;
+
+  // Then
+  XCTAssertEqual(cornerTreatment1.hash, cornerTreatment2.hash);
+  XCTAssertEqualObjects(cornerTreatment1, cornerTreatment2);
+}
+
 @end

--- a/components/private/Shapes/tests/unit/ShapesNoopTest.m
+++ b/components/private/Shapes/tests/unit/ShapesNoopTest.m
@@ -27,23 +27,4 @@
   XCTAssertNotNil(view);
 }
 
-- (void)testCornerTreatmentEquality {
-  // Given
-  MDCCornerTreatment *cornerTreatment1 = [[MDCCornerTreatment alloc] init];
-  cornerTreatment1.valueType = MDCCornerTreatmentValueTypeAbsolute;
-  MDCCornerTreatment *cornerTreatment2 = [[MDCCornerTreatment alloc] init];
-  cornerTreatment2.valueType = MDCCornerTreatmentValueTypePercentage;
-
-  // Then
-  XCTAssertNotEqual(cornerTreatment1.hash, cornerTreatment2.hash);
-  XCTAssertNotEqualObjects(cornerTreatment1, cornerTreatment2);
-
-  // When
-  cornerTreatment2.valueType = MDCCornerTreatmentValueTypeAbsolute;
-
-  // Then
-  XCTAssertEqual(cornerTreatment1.hash, cornerTreatment2.hash);
-  XCTAssertEqualObjects(cornerTreatment1, cornerTreatment2);
-}
-
 @end

--- a/components/private/Shapes/tests/unit/ShapesTest.m
+++ b/components/private/Shapes/tests/unit/ShapesTest.m
@@ -28,13 +28,13 @@
   cornerTreatment1.valueType = MDCCornerTreatmentValueTypeAbsolute;
   MDCCornerTreatment *cornerTreatment2 = [[MDCCornerTreatment alloc] init];
   cornerTreatment2.valueType = MDCCornerTreatmentValueTypePercentage;
-  
+
   // Then
   XCTAssertNotEqualObjects(cornerTreatment1, cornerTreatment2);
-  
+
   // When
   cornerTreatment2.valueType = MDCCornerTreatmentValueTypeAbsolute;
-  
+
   // Then
   XCTAssertEqual(cornerTreatment1.hash, cornerTreatment2.hash);
   XCTAssertEqualObjects(cornerTreatment1, cornerTreatment2);

--- a/components/private/Shapes/tests/unit/ShapesTest.m
+++ b/components/private/Shapes/tests/unit/ShapesTest.m
@@ -1,0 +1,43 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialShapes.h"
+
+@interface ShapesTest : XCTestCase
+
+@end
+
+@implementation ShapesTest
+
+- (void)testCornerTreatmentEquality {
+  // Given
+  MDCCornerTreatment *cornerTreatment1 = [[MDCCornerTreatment alloc] init];
+  cornerTreatment1.valueType = MDCCornerTreatmentValueTypeAbsolute;
+  MDCCornerTreatment *cornerTreatment2 = [[MDCCornerTreatment alloc] init];
+  cornerTreatment2.valueType = MDCCornerTreatmentValueTypePercentage;
+  
+  // Then
+  XCTAssertNotEqualObjects(cornerTreatment1, cornerTreatment2);
+  
+  // When
+  cornerTreatment2.valueType = MDCCornerTreatmentValueTypeAbsolute;
+  
+  // Then
+  XCTAssertEqual(cornerTreatment1.hash, cornerTreatment2.hash);
+  XCTAssertEqualObjects(cornerTreatment1, cornerTreatment2);
+}
+
+@end

--- a/components/schemes/Shape/src/MDCShapeCategory.h
+++ b/components/schemes/Shape/src/MDCShapeCategory.h
@@ -32,27 +32,27 @@ typedef NS_ENUM(NSInteger, MDCShapeCornerFamily) {
 
  MDCShapeCategory is built from 4 corners, that can be set to alter the shape value.
  */
-@interface MDCShapeCategory : NSObject
+@interface MDCShapeCategory : NSObject <NSCopying>
 
 /**
  This property represents the shape of the top left corner of the shape.
  */
-@property(strong, nonatomic) MDCCornerTreatment *topLeftCorner;
+@property(nonatomic, copy) MDCCornerTreatment *topLeftCorner;
 
 /**
  This property represents the shape of the top right corner of the shape.
  */
-@property(strong, nonatomic) MDCCornerTreatment *topRightCorner;
+@property(nonatomic, copy) MDCCornerTreatment *topRightCorner;
 
 /**
  This property represents the shape of the bottom left corner of the shape.
  */
-@property(strong, nonatomic) MDCCornerTreatment *bottomLeftCorner;
+@property(nonatomic, copy) MDCCornerTreatment *bottomLeftCorner;
 
 /**
  This property represents the shape of the bottom right corner of the shape.
  */
-@property(strong, nonatomic) MDCCornerTreatment *bottomRightCorner;
+@property(nonatomic, copy) MDCCornerTreatment *bottomRightCorner;
 
 /**
  The default init of the class. It sets all 4 corners with a corner family of

--- a/components/schemes/Shape/src/MDCShapeCategory.m
+++ b/components/schemes/Shape/src/MDCShapeCategory.m
@@ -57,4 +57,18 @@
          [_bottomRightCorner isEqual:other.bottomRightCorner];
 }
 
+- (id)copyWithZone:(NSZone *)zone {
+  MDCShapeCategory *copy = [[MDCShapeCategory alloc] init];
+  copy.topLeftCorner = self.topLeftCorner;
+  copy.topRightCorner = self.topRightCorner;
+  copy.bottomLeftCorner = self.bottomLeftCorner;
+  copy.bottomRightCorner = self.bottomRightCorner;
+  return copy;
+}
+
+- (NSUInteger)hash {
+  return (self.topRightCorner.hash ^ self.topLeftCorner.hash ^ self.bottomRightCorner.hash ^
+          self.bottomLeftCorner.hash);
+}
+
 @end

--- a/components/schemes/Shape/tests/unit/MDCShapeSchemeTests.m
+++ b/components/schemes/Shape/tests/unit/MDCShapeSchemeTests.m
@@ -25,18 +25,19 @@
 
 - (void)testShapeCategoryEquality {
   // Given
-  MDCShapeCategory *cat1 = [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyCut
+  MDCShapeCategory *originalCategory = [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyCut
                                                                    andSize:(CGFloat)2.1];
-  MDCShapeCategory *cat2 = [[MDCShapeCategory alloc] init];
+  MDCShapeCategory *testCategory = [[MDCShapeCategory alloc] init];
   MDCCornerTreatment *corner =
       [MDCCornerTreatment cornerWithCut:(CGFloat)2.1 valueType:MDCCornerTreatmentValueTypeAbsolute];
-  cat2.topLeftCorner = corner;
-  cat2.topRightCorner = corner;
-  cat2.bottomLeftCorner = corner;
-  cat2.bottomRightCorner = corner;
+  testCategory.topLeftCorner = corner;
+  testCategory.topRightCorner = corner;
+  testCategory.bottomLeftCorner = corner;
+  testCategory.bottomRightCorner = corner;
 
   // Then
-  XCTAssertEqualObjects(cat1, cat2);
+  XCTAssertEqual(originalCategory.hash, testCategory.hash);
+  XCTAssertEqualObjects(originalCategory, testCategory);
 }
 
 - (void)testInitMatchesInitWithMaterialDefaults {
@@ -68,4 +69,20 @@
                                                                 andSize:4]);
 }
 
+- (void)testShapeCategoryCopy {
+  // Given
+  MDCShapeCategory *cat = [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyCut
+                                                                  andSize:(CGFloat)2.2];
+
+  // When
+  MDCShapeCategory *copiedCat = [cat copy];
+
+  // Then
+  XCTAssertNotEqual(cat, copiedCat);
+  XCTAssertEqualObjects(cat, copiedCat);
+  XCTAssertEqualObjects(cat.topRightCorner, copiedCat.topRightCorner);
+  XCTAssertEqualObjects(cat.topLeftCorner, copiedCat.topLeftCorner);
+  XCTAssertEqualObjects(cat.bottomRightCorner, copiedCat.bottomRightCorner);
+  XCTAssertEqualObjects(cat.bottomLeftCorner, copiedCat.bottomLeftCorner);
+}
 @end

--- a/components/schemes/Shape/tests/unit/MDCShapeSchemeTests.m
+++ b/components/schemes/Shape/tests/unit/MDCShapeSchemeTests.m
@@ -25,8 +25,8 @@
 
 - (void)testShapeCategoryEquality {
   // Given
-  MDCShapeCategory *originalCategory = [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyCut
-                                                                   andSize:(CGFloat)2.1];
+  MDCShapeCategory *originalCategory =
+      [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyCut andSize:(CGFloat)2.1];
   MDCShapeCategory *testCategory = [[MDCShapeCategory alloc] init];
   MDCCornerTreatment *corner =
       [MDCCornerTreatment cornerWithCut:(CGFloat)2.1 valueType:MDCCornerTreatmentValueTypeAbsolute];


### PR DESCRIPTION
The MDCCornerTreatment already supports equality. hash function is added in this PR to supplement it.

This PR contains a reviewed commit (b461835) merged from https://github.com/material-components/material-components-ios/pull/5946 as a dependency. And https://github.com/material-components/material-components-ios/pull/5938 as a reviewed base PR.