### PR TITLE
[KeyboardWatcher] fix keyboard watcher not taking into regards compatibility mode

### DIFF
--- a/components/private/KeyboardWatcher/src/MDCKeyboardWatcher.m
+++ b/components/private/KeyboardWatcher/src/MDCKeyboardWatcher.m
@@ -100,7 +100,7 @@ static MDCKeyboardWatcher *_sKeyboardWatcher;
   // If the extent of the keyboard is at or below the bottom of the screen it is docked.
   // This handles the case of an external keyboard on iOS8+ where the entire frame of the keyboard
   // view is used, but on the top, the input accessory section is show.
-  BOOL dockedKeyboard = CGRectGetMaxY(screenBounds) <= CGRectGetMaxY(keyWindowBounds);
+  BOOL dockedKeyboard = CGRectGetMaxY(keyWindowBounds) <= CGRectGetMaxY(keyboardRect);
 
   // If the bottom of the keyboard isn't at the bottom of the screen, then it is undocked, and we
   // shouldn't try to account for it.

--- a/components/private/KeyboardWatcher/src/MDCKeyboardWatcher.m
+++ b/components/private/KeyboardWatcher/src/MDCKeyboardWatcher.m
@@ -93,13 +93,17 @@ static MDCKeyboardWatcher *_sKeyboardWatcher;
     return;
   }
 
+  CGRect keyWindowBounds = [UIApplication mdc_safeSharedApplication].keyWindow.bounds;
   CGRect screenBounds = [[UIScreen mainScreen] bounds];
   CGRect intersection = CGRectIntersection(screenBounds, keyboardRect);
+  CGFloat windowHeightDiff =
+      MAX(0, CGRectGetHeight(screenBounds) - CGRectGetHeight(keyWindowBounds));
 
   // If the extent of the keyboard is at or below the bottom of the screen it is docked.
   // This handles the case of an external keyboard on iOS8+ where the entire frame of the keyboard
   // view is used, but on the top, the input accessory section is show.
-  BOOL dockedKeyboard = CGRectGetMaxY(screenBounds) <= CGRectGetMaxY(keyboardRect);
+  BOOL dockedKeyboard =
+      CGRectGetMaxY(screenBounds) <= CGRectGetMaxY(keyboardRect) + windowHeightDiff;
 
   // If the bottom of the keyboard isn't at the bottom of the screen, then it is undocked, and we
   // shouldn't try to account for it.

--- a/components/private/KeyboardWatcher/src/MDCKeyboardWatcher.m
+++ b/components/private/KeyboardWatcher/src/MDCKeyboardWatcher.m
@@ -96,14 +96,12 @@ static MDCKeyboardWatcher *_sKeyboardWatcher;
   CGRect keyWindowBounds = [UIApplication mdc_safeSharedApplication].keyWindow.bounds;
   CGRect screenBounds = [[UIScreen mainScreen] bounds];
   CGRect intersection = CGRectIntersection(screenBounds, keyboardRect);
-  CGFloat windowHeightDiff =
-      MAX(0, CGRectGetHeight(screenBounds) - CGRectGetHeight(keyWindowBounds));
 
   // If the extent of the keyboard is at or below the bottom of the screen it is docked.
   // This handles the case of an external keyboard on iOS8+ where the entire frame of the keyboard
   // view is used, but on the top, the input accessory section is show.
   BOOL dockedKeyboard =
-      CGRectGetMaxY(screenBounds) <= CGRectGetMaxY(keyboardRect) + windowHeightDiff;
+      CGRectGetMaxY(screenBounds) <= CGRectGetMaxY(keyWindowBounds);
 
   // If the bottom of the keyboard isn't at the bottom of the screen, then it is undocked, and we
   // shouldn't try to account for it.

--- a/components/private/KeyboardWatcher/src/MDCKeyboardWatcher.m
+++ b/components/private/KeyboardWatcher/src/MDCKeyboardWatcher.m
@@ -100,8 +100,7 @@ static MDCKeyboardWatcher *_sKeyboardWatcher;
   // If the extent of the keyboard is at or below the bottom of the screen it is docked.
   // This handles the case of an external keyboard on iOS8+ where the entire frame of the keyboard
   // view is used, but on the top, the input accessory section is show.
-  BOOL dockedKeyboard =
-      CGRectGetMaxY(screenBounds) <= CGRectGetMaxY(keyWindowBounds);
+  BOOL dockedKeyboard = CGRectGetMaxY(screenBounds) <= CGRectGetMaxY(keyWindowBounds);
 
   // If the bottom of the keyboard isn't at the bottom of the screen, then it is undocked, and we
   // shouldn't try to account for it.


### PR DESCRIPTION
This is an exploratory PR to resolve #5874 . 

I would love to get another opinion on this as I am not confident this resolves all the corner cases. 
I have tested this with split view and compatibility mode with the new iPad pro, and noticed that the main issue is the UIScreen frame doesn't care about the frame of the compatibility mode whereas the keyWindow does respect it and provides the frame inside the compatibility mode. The keyboard also reacts similarly to the keyWindow and therefore i made the conditional take into regards the keyWindow when checking if the keyboard is docked or not.