### PR TITLE
[BottomAppBar] Fix it/bottom app bar cut out

### DIFF
--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
@@ -68,6 +68,8 @@ class BottomAppBarTypicalUseSwiftExample: UIViewController {
     // Set the image on the floating button.
     let addImage = UIImage(named:"Add")?.withRenderingMode(.alwaysTemplate)
     bottomBarView.floatingButton.setImage(addImage, for: .normal)
+    bottomBarView.floatingButton.setTitle("Add new item", for: .normal)
+    bottomBarView.floatingButton.mode = .expanded
 
     // Set the position of the floating button.
     bottomBarView.floatingButtonPosition = .center
@@ -141,7 +143,7 @@ extension BottomAppBarTypicalUseSwiftExample {
     return [
       "breadcrumbs": ["Bottom App Bar", "Bottom App Bar (Swift)"],
       "primaryDemo": false,
-      "presentable": false,
+      "presentable": true,
     ]
   }
 

--- a/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
+++ b/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
@@ -75,73 +75,76 @@
   CGFloat width = CGRectGetWidth(rect);
   CGFloat height = CGRectGetHeight(rect);
   CGFloat arcRadius =
-    CGRectGetHeight(floatingButton.bounds) / 2 + kMDCBottomAppBarFloatingButtonRadiusOffset;
+      CGRectGetHeight(floatingButton.bounds) / 2 + kMDCBottomAppBarFloatingButtonRadiusOffset;
 
-  CGPoint arcCenter1 = CGPointMake(floatingButton.center.x -
-                                   CGRectGetWidth(floatingButton.bounds) / 2 + arcRadius -
-                                   kMDCBottomAppBarFloatingButtonRadiusOffset,
-                                   floatingButton.center.y);
-  CGPoint arcCenter2 = CGPointMake(floatingButton.center.x +
-                                   CGRectGetWidth(floatingButton.bounds) / 2 - arcRadius +
-                                   kMDCBottomAppBarFloatingButtonRadiusOffset,
-                                   floatingButton.center.y);
+  CGPoint arcCenter1 =
+      CGPointMake(floatingButton.center.x - CGRectGetWidth(floatingButton.bounds) / 2 + arcRadius -
+                      kMDCBottomAppBarFloatingButtonRadiusOffset,
+                  floatingButton.center.y);
+  CGPoint arcCenter2 =
+      CGPointMake(floatingButton.center.x + CGRectGetWidth(floatingButton.bounds) / 2 - arcRadius +
+                      kMDCBottomAppBarFloatingButtonRadiusOffset,
+                  floatingButton.center.y);
 
   if (shouldCut) {
-    [bottomBarPath moveToPoint: CGPointMake(width, yOffset)];
-    [bottomBarPath addCurveToPoint: CGPointMake(width, yOffset)
-                     controlPoint1: CGPointMake(width, yOffset)
-                     controlPoint2: CGPointMake(width, yOffset)];
-    [bottomBarPath addLineToPoint: CGPointMake(width, height)];
-    [bottomBarPath addLineToPoint: CGPointMake(0, height)];
-    [bottomBarPath addLineToPoint: CGPointMake(0, yOffset)];
-    [bottomBarPath addLineToPoint: CGPointMake(arcCenter1.x - arcRadius, yOffset)];
+    [bottomBarPath moveToPoint:CGPointMake(width, yOffset)];
+    [bottomBarPath addCurveToPoint:CGPointMake(width, yOffset)
+                     controlPoint1:CGPointMake(width, yOffset)
+                     controlPoint2:CGPointMake(width, yOffset)];
 
-    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter1.x - arcRadius, yOffset)
-                     controlPoint1: CGPointMake(arcCenter1.x - arcRadius, yOffset)
-                     controlPoint2: CGPointMake(arcCenter1.x - arcRadius, yOffset)];
-    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter1.x, arcRadius + yOffset)
-                     controlPoint1: CGPointMake(arcCenter1.x - arcRadius, arcRadius / 2 + yOffset)
-                     controlPoint2: CGPointMake(arcCenter1.x - arcRadius / 2, arcRadius + yOffset)];
+    [bottomBarPath addLineToPoint:CGPointMake(width, height)];
 
-    [bottomBarPath addLineToPoint: CGPointMake(arcCenter2.x, arcRadius + yOffset)];
+    [bottomBarPath addLineToPoint:CGPointMake(0, height)];
 
-    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter2.x + arcRadius, yOffset)
-                     controlPoint1: CGPointMake(arcCenter2.x + arcRadius - arcRadius / 2, yOffset + arcRadius)
-                     controlPoint2: CGPointMake(arcCenter2.x + arcRadius, yOffset + arcRadius / 2)];
-    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter2.x + arcRadius, yOffset)
-                     controlPoint1: CGPointMake(arcCenter2.x + arcRadius, yOffset)
-                     controlPoint2: CGPointMake(arcCenter2.x + arcRadius, yOffset)];
+    [bottomBarPath addLineToPoint:CGPointMake(0, yOffset)];
+    [bottomBarPath addLineToPoint:CGPointMake(arcCenter1.x - arcRadius, yOffset)];
 
-    [bottomBarPath addLineToPoint: CGPointMake(width, yOffset)];
+    [bottomBarPath addCurveToPoint:CGPointMake(arcCenter1.x - arcRadius, yOffset)
+                     controlPoint1:CGPointMake(arcCenter1.x - arcRadius, yOffset)
+                     controlPoint2:CGPointMake(arcCenter1.x - arcRadius, yOffset)];
+    [bottomBarPath addCurveToPoint:CGPointMake(arcCenter1.x, arcRadius + yOffset)
+                     controlPoint1:CGPointMake(arcCenter1.x - arcRadius, arcRadius / 2 + yOffset)
+                     controlPoint2:CGPointMake(arcCenter1.x - arcRadius / 2, arcRadius + yOffset)];
+
+    [bottomBarPath addLineToPoint:CGPointMake(arcCenter2.x, arcRadius + yOffset)];
+
+    [bottomBarPath
+        addCurveToPoint:CGPointMake(arcCenter2.x + arcRadius, yOffset)
+          controlPoint1:CGPointMake(arcCenter2.x + arcRadius - arcRadius / 2, yOffset + arcRadius)
+          controlPoint2:CGPointMake(arcCenter2.x + arcRadius, yOffset + arcRadius / 2)];
+    [bottomBarPath addCurveToPoint:CGPointMake(arcCenter2.x + arcRadius, yOffset)
+                     controlPoint1:CGPointMake(arcCenter2.x + arcRadius, yOffset)
+                     controlPoint2:CGPointMake(arcCenter2.x + arcRadius, yOffset)];
+
+    [bottomBarPath addLineToPoint:CGPointMake(width, yOffset)];
     [bottomBarPath closePath];
-  }
-  else {
-    [bottomBarPath moveToPoint: CGPointMake(width, yOffset)];
-    [bottomBarPath addCurveToPoint: CGPointMake(width, yOffset)
-                     controlPoint1: CGPointMake(width, yOffset)
-                     controlPoint2: CGPointMake(width, yOffset)];
-    [bottomBarPath addLineToPoint: CGPointMake(width, height)];
-    [bottomBarPath addLineToPoint: CGPointMake(0, height)];
-    [bottomBarPath addLineToPoint: CGPointMake(0, yOffset)];
-    [bottomBarPath addLineToPoint: CGPointMake(arcCenter1.x - arcRadius, yOffset)];
+  } else {
+    [bottomBarPath moveToPoint:CGPointMake(width, yOffset)];
+    [bottomBarPath addCurveToPoint:CGPointMake(width, yOffset)
+                     controlPoint1:CGPointMake(width, yOffset)
+                     controlPoint2:CGPointMake(width, yOffset)];
+    [bottomBarPath addLineToPoint:CGPointMake(width, height)];
+    [bottomBarPath addLineToPoint:CGPointMake(0, height)];
+    [bottomBarPath addLineToPoint:CGPointMake(0, yOffset)];
+    [bottomBarPath addLineToPoint:CGPointMake(arcCenter1.x - arcRadius, yOffset)];
 
-    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter1.x - arcRadius, yOffset)
-                     controlPoint1: CGPointMake(arcCenter1.x - arcRadius, yOffset)
-                     controlPoint2: CGPointMake(arcCenter1.x - arcRadius, yOffset)];
-    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter1.x, yOffset)
-                     controlPoint1: CGPointMake(arcCenter1.x - arcRadius, yOffset)
-                     controlPoint2: CGPointMake(arcCenter1.x - arcRadius / 2, yOffset)];
+    [bottomBarPath addCurveToPoint:CGPointMake(arcCenter1.x - arcRadius, yOffset)
+                     controlPoint1:CGPointMake(arcCenter1.x - arcRadius, yOffset)
+                     controlPoint2:CGPointMake(arcCenter1.x - arcRadius, yOffset)];
+    [bottomBarPath addCurveToPoint:CGPointMake(arcCenter1.x, yOffset)
+                     controlPoint1:CGPointMake(arcCenter1.x - arcRadius, yOffset)
+                     controlPoint2:CGPointMake(arcCenter1.x - arcRadius / 2, yOffset)];
 
-    [bottomBarPath addLineToPoint: CGPointMake(arcCenter2.x, yOffset)];
+    [bottomBarPath addLineToPoint:CGPointMake(arcCenter2.x, yOffset)];
 
-    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter2.x + arcRadius, yOffset)
-                     controlPoint1: CGPointMake(arcCenter2.x + arcRadius - arcRadius / 2, yOffset)
-                     controlPoint2: CGPointMake(arcCenter2.x + arcRadius, yOffset)];
-    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter2.x + arcRadius, yOffset)
-                     controlPoint1: CGPointMake(arcCenter2.x + arcRadius, yOffset)
-                     controlPoint2: CGPointMake(arcCenter2.x + arcRadius, yOffset)];
+    [bottomBarPath addCurveToPoint:CGPointMake(arcCenter2.x + arcRadius, yOffset)
+                     controlPoint1:CGPointMake(arcCenter2.x + arcRadius - arcRadius / 2, yOffset)
+                     controlPoint2:CGPointMake(arcCenter2.x + arcRadius, yOffset)];
+    [bottomBarPath addCurveToPoint:CGPointMake(arcCenter2.x + arcRadius, yOffset)
+                     controlPoint1:CGPointMake(arcCenter2.x + arcRadius, yOffset)
+                     controlPoint2:CGPointMake(arcCenter2.x + arcRadius, yOffset)];
 
-    [bottomBarPath addLineToPoint: CGPointMake(width, yOffset)];
+    [bottomBarPath addLineToPoint:CGPointMake(width, yOffset)];
     [bottomBarPath closePath];
   }
 

--- a/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
+++ b/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
@@ -74,135 +74,52 @@
 
   CGFloat width = CGRectGetWidth(rect);
   CGFloat height = CGRectGetHeight(rect);
+  CGFloat arcRadius =
+    CGRectGetHeight(floatingButton.bounds) / 2 + kMDCBottomAppBarFloatingButtonRadiusOffset;
+
+  CGPoint arcCenter1 = CGPointMake(floatingButton.center.x -
+                                   CGRectGetWidth(floatingButton.bounds) / 2 + arcRadius -
+                                   kMDCBottomAppBarFloatingButtonRadiusOffset,
+                                   floatingButton.center.y);
+//  CGFloat startAngle1 = (float)M_PI;
+//  CGFloat endAngle1 = (float)M_PI_2;
+//
+//  CGPoint arcCenter2 = CGPointMake(floatingButton.center.x + CGRectGetWidth(floatingButton.bounds) / 2 - arcRadius + kMDCBottomAppBarFloatingButtonRadiusOffset, floatingButton.center.y);
+//  CGFloat startAngle2 = (float)M_PI_2;
+//  CGFloat endAngle2 = 0;
 
   if (shouldCut) {
-    if (floatingButton.mode == MDCFloatingButtonModeExpanded) {
-      CGFloat arcRadius =
-      CGRectGetHeight(floatingButton.bounds) / 2 + kMDCBottomAppBarFloatingButtonRadiusOffset;
+    [bottomBarPath moveToPoint: CGPointMake(0, navigationBarYOffset)];
+    [bottomBarPath addLineToPoint: CGPointMake(arcCenter1.x - arcRadius, navigationBarYOffset)];
+    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter1.x, arcRadius + navigationBarYOffset)
+                     controlPoint1: CGPointMake(arcCenter1.x - arcRadius, navigationBarYOffset)
+                     controlPoint2: CGPointMake(arcCenter1.x - arcRadius, arcRadius + navigationBarYOffset)];
+    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter1.x + arcRadius, navigationBarYOffset)
+                     controlPoint1: CGPointMake(arcCenter1.x + arcRadius, arcRadius + navigationBarYOffset)
+                     controlPoint2: CGPointMake(arcCenter1.x + arcRadius, navigationBarYOffset)];
+    [bottomBarPath addLineToPoint: CGPointMake(width, navigationBarYOffset)];
 
-      CGPoint arcCenter1 = CGPointMake(floatingButton.center.x - CGRectGetWidth(floatingButton.bounds) / 2 + arcRadius - kMDCBottomAppBarFloatingButtonRadiusOffset, floatingButton.center.y);
-      CGFloat startAngle1 = (float)M_PI;
-      CGFloat endAngle1 = (float)M_PI_2;
+    [bottomBarPath addLineToPoint: CGPointMake(width, height * 2 + navigationBarYOffset)];
+    [bottomBarPath addLineToPoint: CGPointMake(0, height * 2 + navigationBarYOffset)];
+    [bottomBarPath closePath];
+  }
+  else {
+    [bottomBarPath moveToPoint: CGPointMake(0, navigationBarYOffset)];
+    [bottomBarPath addLineToPoint: CGPointMake(arcCenter1.x - arcRadius, navigationBarYOffset)];
+    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter1.x, navigationBarYOffset)
+                     controlPoint1: CGPointMake(arcCenter1.x - arcRadius, navigationBarYOffset)
+                     controlPoint2: CGPointMake(arcCenter1.x - arcRadius, navigationBarYOffset)];
+    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter1.x + arcRadius, navigationBarYOffset)
+                     controlPoint1: CGPointMake(arcCenter1.x + arcRadius, navigationBarYOffset)
+                     controlPoint2: CGPointMake(arcCenter1.x + arcRadius, navigationBarYOffset)];
+    [bottomBarPath addLineToPoint: CGPointMake(width, navigationBarYOffset)];
 
-      CGPoint arcCenter2 = CGPointMake(floatingButton.center.x + CGRectGetWidth(floatingButton.bounds) / 2 - arcRadius + kMDCBottomAppBarFloatingButtonRadiusOffset, floatingButton.center.y);
-      CGFloat startAngle2 = (float)M_PI_2;
-      CGFloat endAngle2 = 0;
-
-
-      [self drawWithPathToCut:bottomBarPath
-                      yOffset:navigationBarYOffset
-                        width:width
-                       height:height
-                    arcRadius:arcRadius
-                   arcCenter1:arcCenter1
-                  startAngle1:startAngle1
-                    endAngle1:endAngle1
-                   arcCenter2:arcCenter2
-                  startAngle2:startAngle2
-                    endAngle2:endAngle2];
-    }
-    else {
-      CGFloat arcRadius =
-      CGRectGetHeight(floatingButton.bounds) / 2 + kMDCBottomAppBarFloatingButtonRadiusOffset;
-      CGFloat halfAngle = acosf((float)((navigationBarYOffset - floatingButton.center.y) / arcRadius));
-      CGFloat startAngle = (float)M_PI / 2 + halfAngle;
-      CGFloat endAngle = (float)M_PI / 2 - halfAngle;
-
-      [self drawWithPathToCut:bottomBarPath
-                      yOffset:navigationBarYOffset
-                        width:width
-                       height:height
-                    arcCenter:floatingButton.center
-                    arcRadius:arcRadius
-                   startAngle:startAngle
-                     endAngle:endAngle];
-    }
-  } else {
-    CGFloat arcRadius =
-    CGRectGetHeight(floatingButton.bounds) / 2 + kMDCBottomAppBarFloatingButtonRadiusOffset;
-    [self drawWithPlainPath:bottomBarPath
-                    yOffset:navigationBarYOffset
-                      width:width
-                     height:height
-                  arcCenter:floatingButton.center
-                  arcRadius:arcRadius];
+    [bottomBarPath addLineToPoint: CGPointMake(width, height * 2 + navigationBarYOffset)];
+    [bottomBarPath addLineToPoint: CGPointMake(0, height * 2 + navigationBarYOffset)];
+    [bottomBarPath closePath];
   }
 
   return bottomBarPath.CGPath;
-}
-
-#pragma mark - Draw Helpers
-
-- (UIBezierPath *)drawWithPathToCut:(UIBezierPath *)bottomBarPath
-                            yOffset:(CGFloat)yOffset
-                              width:(CGFloat)width
-                             height:(CGFloat)height
-                          arcCenter:(CGPoint)arcCenter
-                          arcRadius:(CGFloat)arcRadius
-                         startAngle:(CGFloat)startAngle
-                           endAngle:(CGFloat)endAngle {
-  [bottomBarPath moveToPoint:CGPointMake(0, yOffset)];
-  [bottomBarPath addArcWithCenter:arcCenter
-                           radius:arcRadius
-                       startAngle:startAngle
-                         endAngle:endAngle
-                        clockwise:NO];
-  [bottomBarPath addLineToPoint:CGPointMake(width, yOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(width, height * 2 + yOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(0, height * 2 + yOffset)];
-  [bottomBarPath closePath];
-  return bottomBarPath;
-}
-
-- (UIBezierPath *)drawWithPathToCut:(UIBezierPath *)bottomBarPath
-                            yOffset:(CGFloat)yOffset
-                              width:(CGFloat)width
-                             height:(CGFloat)height
-                          arcRadius:(CGFloat)arcRadius
-                         arcCenter1:(CGPoint)arcCenter1
-                        startAngle1:(CGFloat)startAngle1
-                          endAngle1:(CGFloat)endAngle1
-                         arcCenter2:(CGPoint)arcCenter2
-                        startAngle2:(CGFloat)startAngle2
-                          endAngle2:(CGFloat)endAngle2 {
-
-  [bottomBarPath moveToPoint:CGPointMake(0, yOffset)];
-  [bottomBarPath addArcWithCenter:arcCenter1
-                           radius:arcRadius
-                       startAngle:startAngle1
-                         endAngle:endAngle1
-                        clockwise:NO];
-
-  [bottomBarPath addArcWithCenter:arcCenter2
-                           radius:arcRadius
-                       startAngle:startAngle2
-                         endAngle:endAngle2
-                        clockwise:NO];
-  [bottomBarPath addLineToPoint:CGPointMake(width, yOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(width, height * 2 + yOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(0, height * 2 + yOffset)];
-  [bottomBarPath closePath];
-  return bottomBarPath;
-}
-
-
-- (UIBezierPath *)drawWithPlainPath:(UIBezierPath *)bottomBarPath
-                            yOffset:(CGFloat)yOffset
-                              width:(CGFloat)width
-                             height:(CGFloat)height
-                          arcCenter:(CGPoint)arcCenter
-                          arcRadius:(CGFloat)arcRadius {
-  [bottomBarPath moveToPoint:CGPointMake(0, yOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x - arcRadius, yOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x, yOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x + arcRadius, yOffset)];
-  // The extra line is needed to have the same number of control points in boths paths.
-  [bottomBarPath addLineToPoint:CGPointMake(arcCenter.x + arcRadius, yOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(width, yOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(width, height * 2 + yOffset)];
-  [bottomBarPath addLineToPoint:CGPointMake(0, height * 2 + yOffset)];
-  [bottomBarPath closePath];
-  return bottomBarPath;
 }
 
 @end

--- a/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
+++ b/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
@@ -26,6 +26,17 @@
                           arcRadius:(CGFloat)arcRadius
                          startAngle:(CGFloat)startAngle
                            endAngle:(CGFloat)endAngle;
+- (UIBezierPath *)drawWithPathToCut:(UIBezierPath *)bottomBarPath
+                            yOffset:(CGFloat)yOffset
+                              width:(CGFloat)width
+                             height:(CGFloat)height
+                          arcRadius:(CGFloat)arcRadius
+                         arcCenter1:(CGPoint)arcCenter1
+                        startAngle1:(CGFloat)startAngle1
+                          endAngle1:(CGFloat)endAngle1
+                         arcCenter2:(CGPoint)arcCenter2
+                        startAngle2:(CGFloat)startAngle2
+                          endAngle2:(CGFloat)endAngle2;
 - (UIBezierPath *)drawWithPlainPath:(UIBezierPath *)bottomBarPath
                             yOffset:(CGFloat)yOffset
                               width:(CGFloat)width
@@ -59,26 +70,56 @@
                 shouldCut:(BOOL)shouldCut {
   UIBezierPath *bottomBarPath = [UIBezierPath bezierPath];
 
-  CGFloat arcRadius =
-      CGRectGetHeight(floatingButton.bounds) / 2 + kMDCBottomAppBarFloatingButtonRadiusOffset;
   CGFloat navigationBarYOffset = CGRectGetMinY(navigationBarFrame);
-  CGFloat halfAngle = acosf((float)((navigationBarYOffset - floatingButton.center.y) / arcRadius));
-  CGFloat startAngle = (float)M_PI / 2 + halfAngle;
-  CGFloat endAngle = (float)M_PI / 2 - halfAngle;
 
   CGFloat width = CGRectGetWidth(rect);
   CGFloat height = CGRectGetHeight(rect);
 
   if (shouldCut) {
-    [self drawWithPathToCut:bottomBarPath
-                    yOffset:navigationBarYOffset
-                      width:width
-                     height:height
-                  arcCenter:floatingButton.center
-                  arcRadius:arcRadius
-                 startAngle:startAngle
-                   endAngle:endAngle];
+    if (floatingButton.mode == MDCFloatingButtonModeExpanded) {
+      CGFloat arcRadius =
+      CGRectGetHeight(floatingButton.bounds) / 2 + kMDCBottomAppBarFloatingButtonRadiusOffset;
+
+      CGPoint arcCenter1 = CGPointMake(floatingButton.center.x - CGRectGetWidth(floatingButton.bounds) / 2 + arcRadius - kMDCBottomAppBarFloatingButtonRadiusOffset, floatingButton.center.y);
+      CGFloat startAngle1 = (float)M_PI;
+      CGFloat endAngle1 = (float)M_PI_2;
+
+      CGPoint arcCenter2 = CGPointMake(floatingButton.center.x + CGRectGetWidth(floatingButton.bounds) / 2 - arcRadius + kMDCBottomAppBarFloatingButtonRadiusOffset, floatingButton.center.y);
+      CGFloat startAngle2 = (float)M_PI_2;
+      CGFloat endAngle2 = 0;
+
+
+      [self drawWithPathToCut:bottomBarPath
+                      yOffset:navigationBarYOffset
+                        width:width
+                       height:height
+                    arcRadius:arcRadius
+                   arcCenter1:arcCenter1
+                  startAngle1:startAngle1
+                    endAngle1:endAngle1
+                   arcCenter2:arcCenter2
+                  startAngle2:startAngle2
+                    endAngle2:endAngle2];
+    }
+    else {
+      CGFloat arcRadius =
+      CGRectGetHeight(floatingButton.bounds) / 2 + kMDCBottomAppBarFloatingButtonRadiusOffset;
+      CGFloat halfAngle = acosf((float)((navigationBarYOffset - floatingButton.center.y) / arcRadius));
+      CGFloat startAngle = (float)M_PI / 2 + halfAngle;
+      CGFloat endAngle = (float)M_PI / 2 - halfAngle;
+
+      [self drawWithPathToCut:bottomBarPath
+                      yOffset:navigationBarYOffset
+                        width:width
+                       height:height
+                    arcCenter:floatingButton.center
+                    arcRadius:arcRadius
+                   startAngle:startAngle
+                     endAngle:endAngle];
+    }
   } else {
+    CGFloat arcRadius =
+    CGRectGetHeight(floatingButton.bounds) / 2 + kMDCBottomAppBarFloatingButtonRadiusOffset;
     [self drawWithPlainPath:bottomBarPath
                     yOffset:navigationBarYOffset
                       width:width
@@ -112,6 +153,38 @@
   [bottomBarPath closePath];
   return bottomBarPath;
 }
+
+- (UIBezierPath *)drawWithPathToCut:(UIBezierPath *)bottomBarPath
+                            yOffset:(CGFloat)yOffset
+                              width:(CGFloat)width
+                             height:(CGFloat)height
+                          arcRadius:(CGFloat)arcRadius
+                         arcCenter1:(CGPoint)arcCenter1
+                        startAngle1:(CGFloat)startAngle1
+                          endAngle1:(CGFloat)endAngle1
+                         arcCenter2:(CGPoint)arcCenter2
+                        startAngle2:(CGFloat)startAngle2
+                          endAngle2:(CGFloat)endAngle2 {
+
+  [bottomBarPath moveToPoint:CGPointMake(0, yOffset)];
+  [bottomBarPath addArcWithCenter:arcCenter1
+                           radius:arcRadius
+                       startAngle:startAngle1
+                         endAngle:endAngle1
+                        clockwise:NO];
+
+  [bottomBarPath addArcWithCenter:arcCenter2
+                           radius:arcRadius
+                       startAngle:startAngle2
+                         endAngle:endAngle2
+                        clockwise:NO];
+  [bottomBarPath addLineToPoint:CGPointMake(width, yOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(width, height * 2 + yOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(0, height * 2 + yOffset)];
+  [bottomBarPath closePath];
+  return bottomBarPath;
+}
+
 
 - (UIBezierPath *)drawWithPlainPath:(UIBezierPath *)bottomBarPath
                             yOffset:(CGFloat)yOffset

--- a/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
+++ b/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
@@ -70,7 +70,7 @@
                 shouldCut:(BOOL)shouldCut {
   UIBezierPath *bottomBarPath = [UIBezierPath bezierPath];
 
-  CGFloat navigationBarYOffset = CGRectGetMinY(navigationBarFrame);
+  CGFloat yOffset = CGRectGetMinY(navigationBarFrame);
 
   CGFloat width = CGRectGetWidth(rect);
   CGFloat height = CGRectGetHeight(rect);
@@ -81,41 +81,67 @@
                                    CGRectGetWidth(floatingButton.bounds) / 2 + arcRadius -
                                    kMDCBottomAppBarFloatingButtonRadiusOffset,
                                    floatingButton.center.y);
-//  CGFloat startAngle1 = (float)M_PI;
-//  CGFloat endAngle1 = (float)M_PI_2;
-//
-//  CGPoint arcCenter2 = CGPointMake(floatingButton.center.x + CGRectGetWidth(floatingButton.bounds) / 2 - arcRadius + kMDCBottomAppBarFloatingButtonRadiusOffset, floatingButton.center.y);
-//  CGFloat startAngle2 = (float)M_PI_2;
-//  CGFloat endAngle2 = 0;
+  CGPoint arcCenter2 = CGPointMake(floatingButton.center.x +
+                                   CGRectGetWidth(floatingButton.bounds) / 2 - arcRadius +
+                                   kMDCBottomAppBarFloatingButtonRadiusOffset,
+                                   floatingButton.center.y);
 
   if (shouldCut) {
-    [bottomBarPath moveToPoint: CGPointMake(0, navigationBarYOffset)];
-    [bottomBarPath addLineToPoint: CGPointMake(arcCenter1.x - arcRadius, navigationBarYOffset)];
-    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter1.x, arcRadius + navigationBarYOffset)
-                     controlPoint1: CGPointMake(arcCenter1.x - arcRadius, navigationBarYOffset)
-                     controlPoint2: CGPointMake(arcCenter1.x - arcRadius, arcRadius + navigationBarYOffset)];
-    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter1.x + arcRadius, navigationBarYOffset)
-                     controlPoint1: CGPointMake(arcCenter1.x + arcRadius, arcRadius + navigationBarYOffset)
-                     controlPoint2: CGPointMake(arcCenter1.x + arcRadius, navigationBarYOffset)];
-    [bottomBarPath addLineToPoint: CGPointMake(width, navigationBarYOffset)];
+    [bottomBarPath moveToPoint: CGPointMake(width, yOffset)];
+    [bottomBarPath addCurveToPoint: CGPointMake(width, yOffset)
+                     controlPoint1: CGPointMake(width, yOffset)
+                     controlPoint2: CGPointMake(width, yOffset)];
+    [bottomBarPath addLineToPoint: CGPointMake(width, height)];
+    [bottomBarPath addLineToPoint: CGPointMake(0, height)];
+    [bottomBarPath addLineToPoint: CGPointMake(0, yOffset)];
+    [bottomBarPath addLineToPoint: CGPointMake(arcCenter1.x - arcRadius, yOffset)];
 
-    [bottomBarPath addLineToPoint: CGPointMake(width, height * 2 + navigationBarYOffset)];
-    [bottomBarPath addLineToPoint: CGPointMake(0, height * 2 + navigationBarYOffset)];
+    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter1.x - arcRadius, yOffset)
+                     controlPoint1: CGPointMake(arcCenter1.x - arcRadius, yOffset)
+                     controlPoint2: CGPointMake(arcCenter1.x - arcRadius, yOffset)];
+    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter1.x, arcRadius + yOffset)
+                     controlPoint1: CGPointMake(arcCenter1.x - arcRadius, arcRadius / 2 + yOffset)
+                     controlPoint2: CGPointMake(arcCenter1.x - arcRadius / 2, arcRadius + yOffset)];
+
+    [bottomBarPath addLineToPoint: CGPointMake(arcCenter2.x, arcRadius + yOffset)];
+
+    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter2.x + arcRadius, yOffset)
+                     controlPoint1: CGPointMake(arcCenter2.x + arcRadius - arcRadius / 2, yOffset + arcRadius)
+                     controlPoint2: CGPointMake(arcCenter2.x + arcRadius, yOffset + arcRadius / 2)];
+    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter2.x + arcRadius, yOffset)
+                     controlPoint1: CGPointMake(arcCenter2.x + arcRadius, yOffset)
+                     controlPoint2: CGPointMake(arcCenter2.x + arcRadius, yOffset)];
+
+    [bottomBarPath addLineToPoint: CGPointMake(width, yOffset)];
     [bottomBarPath closePath];
   }
   else {
-    [bottomBarPath moveToPoint: CGPointMake(0, navigationBarYOffset)];
-    [bottomBarPath addLineToPoint: CGPointMake(arcCenter1.x - arcRadius, navigationBarYOffset)];
-    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter1.x, navigationBarYOffset)
-                     controlPoint1: CGPointMake(arcCenter1.x - arcRadius, navigationBarYOffset)
-                     controlPoint2: CGPointMake(arcCenter1.x - arcRadius, navigationBarYOffset)];
-    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter1.x + arcRadius, navigationBarYOffset)
-                     controlPoint1: CGPointMake(arcCenter1.x + arcRadius, navigationBarYOffset)
-                     controlPoint2: CGPointMake(arcCenter1.x + arcRadius, navigationBarYOffset)];
-    [bottomBarPath addLineToPoint: CGPointMake(width, navigationBarYOffset)];
+    [bottomBarPath moveToPoint: CGPointMake(width, yOffset)];
+    [bottomBarPath addCurveToPoint: CGPointMake(width, yOffset)
+                     controlPoint1: CGPointMake(width, yOffset)
+                     controlPoint2: CGPointMake(width, yOffset)];
+    [bottomBarPath addLineToPoint: CGPointMake(width, height)];
+    [bottomBarPath addLineToPoint: CGPointMake(0, height)];
+    [bottomBarPath addLineToPoint: CGPointMake(0, yOffset)];
+    [bottomBarPath addLineToPoint: CGPointMake(arcCenter1.x - arcRadius, yOffset)];
 
-    [bottomBarPath addLineToPoint: CGPointMake(width, height * 2 + navigationBarYOffset)];
-    [bottomBarPath addLineToPoint: CGPointMake(0, height * 2 + navigationBarYOffset)];
+    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter1.x - arcRadius, yOffset)
+                     controlPoint1: CGPointMake(arcCenter1.x - arcRadius, yOffset)
+                     controlPoint2: CGPointMake(arcCenter1.x - arcRadius, yOffset)];
+    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter1.x, yOffset)
+                     controlPoint1: CGPointMake(arcCenter1.x - arcRadius, yOffset)
+                     controlPoint2: CGPointMake(arcCenter1.x - arcRadius / 2, yOffset)];
+
+    [bottomBarPath addLineToPoint: CGPointMake(arcCenter2.x, yOffset)];
+
+    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter2.x + arcRadius, yOffset)
+                     controlPoint1: CGPointMake(arcCenter2.x + arcRadius - arcRadius / 2, yOffset)
+                     controlPoint2: CGPointMake(arcCenter2.x + arcRadius, yOffset)];
+    [bottomBarPath addCurveToPoint: CGPointMake(arcCenter2.x + arcRadius, yOffset)
+                     controlPoint1: CGPointMake(arcCenter2.x + arcRadius, yOffset)
+                     controlPoint2: CGPointMake(arcCenter2.x + arcRadius, yOffset)];
+
+    [bottomBarPath addLineToPoint: CGPointMake(width, yOffset)];
     [bottomBarPath closePath];
   }
 

--- a/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
+++ b/components/BottomAppBar/src/private/MDCBottomAppBarLayer.m
@@ -22,26 +22,15 @@
                             yOffset:(CGFloat)yOffset
                               width:(CGFloat)width
                              height:(CGFloat)height
-                          arcCenter:(CGPoint)arcCenter
-                          arcRadius:(CGFloat)arcRadius
-                         startAngle:(CGFloat)startAngle
-                           endAngle:(CGFloat)endAngle;
-- (UIBezierPath *)drawWithPathToCut:(UIBezierPath *)bottomBarPath
-                            yOffset:(CGFloat)yOffset
-                              width:(CGFloat)width
-                             height:(CGFloat)height
                           arcRadius:(CGFloat)arcRadius
                          arcCenter1:(CGPoint)arcCenter1
-                        startAngle1:(CGFloat)startAngle1
-                          endAngle1:(CGFloat)endAngle1
-                         arcCenter2:(CGPoint)arcCenter2
-                        startAngle2:(CGFloat)startAngle2
-                          endAngle2:(CGFloat)endAngle2;
+                         arcCenter2:(CGPoint)arcCenter2;
 - (UIBezierPath *)drawWithPlainPath:(UIBezierPath *)bottomBarPath
                             yOffset:(CGFloat)yOffset
                               width:(CGFloat)width
                              height:(CGFloat)height
-                          arcCenter:(CGPoint)arcCenter
+                         arcCenter1:(CGPoint)arcCenter1
+                         arcCenter2:(CGPoint)arcCenter2
                           arcRadius:(CGFloat)arcRadius;
 @end
 
@@ -87,68 +76,104 @@
                   floatingButton.center.y);
 
   if (shouldCut) {
-    [bottomBarPath moveToPoint:CGPointMake(width, yOffset)];
-    [bottomBarPath addCurveToPoint:CGPointMake(width, yOffset)
-                     controlPoint1:CGPointMake(width, yOffset)
-                     controlPoint2:CGPointMake(width, yOffset)];
-
-    [bottomBarPath addLineToPoint:CGPointMake(width, height)];
-
-    [bottomBarPath addLineToPoint:CGPointMake(0, height)];
-
-    [bottomBarPath addLineToPoint:CGPointMake(0, yOffset)];
-    [bottomBarPath addLineToPoint:CGPointMake(arcCenter1.x - arcRadius, yOffset)];
-
-    [bottomBarPath addCurveToPoint:CGPointMake(arcCenter1.x - arcRadius, yOffset)
-                     controlPoint1:CGPointMake(arcCenter1.x - arcRadius, yOffset)
-                     controlPoint2:CGPointMake(arcCenter1.x - arcRadius, yOffset)];
-    [bottomBarPath addCurveToPoint:CGPointMake(arcCenter1.x, arcRadius + yOffset)
-                     controlPoint1:CGPointMake(arcCenter1.x - arcRadius, arcRadius / 2 + yOffset)
-                     controlPoint2:CGPointMake(arcCenter1.x - arcRadius / 2, arcRadius + yOffset)];
-
-    [bottomBarPath addLineToPoint:CGPointMake(arcCenter2.x, arcRadius + yOffset)];
-
-    [bottomBarPath
-        addCurveToPoint:CGPointMake(arcCenter2.x + arcRadius, yOffset)
-          controlPoint1:CGPointMake(arcCenter2.x + arcRadius - arcRadius / 2, yOffset + arcRadius)
-          controlPoint2:CGPointMake(arcCenter2.x + arcRadius, yOffset + arcRadius / 2)];
-    [bottomBarPath addCurveToPoint:CGPointMake(arcCenter2.x + arcRadius, yOffset)
-                     controlPoint1:CGPointMake(arcCenter2.x + arcRadius, yOffset)
-                     controlPoint2:CGPointMake(arcCenter2.x + arcRadius, yOffset)];
-
-    [bottomBarPath addLineToPoint:CGPointMake(width, yOffset)];
-    [bottomBarPath closePath];
+    [self drawWithPathToCut:bottomBarPath
+                    yOffset:yOffset
+                      width:width
+                     height:height
+                  arcRadius:arcRadius
+                 arcCenter1:arcCenter1
+                 arcCenter2:arcCenter2];
   } else {
-    [bottomBarPath moveToPoint:CGPointMake(width, yOffset)];
-    [bottomBarPath addCurveToPoint:CGPointMake(width, yOffset)
-                     controlPoint1:CGPointMake(width, yOffset)
-                     controlPoint2:CGPointMake(width, yOffset)];
-    [bottomBarPath addLineToPoint:CGPointMake(width, height)];
-    [bottomBarPath addLineToPoint:CGPointMake(0, height)];
-    [bottomBarPath addLineToPoint:CGPointMake(0, yOffset)];
-    [bottomBarPath addLineToPoint:CGPointMake(arcCenter1.x - arcRadius, yOffset)];
-
-    [bottomBarPath addCurveToPoint:CGPointMake(arcCenter1.x - arcRadius, yOffset)
-                     controlPoint1:CGPointMake(arcCenter1.x - arcRadius, yOffset)
-                     controlPoint2:CGPointMake(arcCenter1.x - arcRadius, yOffset)];
-    [bottomBarPath addCurveToPoint:CGPointMake(arcCenter1.x, yOffset)
-                     controlPoint1:CGPointMake(arcCenter1.x - arcRadius, yOffset)
-                     controlPoint2:CGPointMake(arcCenter1.x - arcRadius / 2, yOffset)];
-
-    [bottomBarPath addLineToPoint:CGPointMake(arcCenter2.x, yOffset)];
-
-    [bottomBarPath addCurveToPoint:CGPointMake(arcCenter2.x + arcRadius, yOffset)
-                     controlPoint1:CGPointMake(arcCenter2.x + arcRadius - arcRadius / 2, yOffset)
-                     controlPoint2:CGPointMake(arcCenter2.x + arcRadius, yOffset)];
-    [bottomBarPath addCurveToPoint:CGPointMake(arcCenter2.x + arcRadius, yOffset)
-                     controlPoint1:CGPointMake(arcCenter2.x + arcRadius, yOffset)
-                     controlPoint2:CGPointMake(arcCenter2.x + arcRadius, yOffset)];
-
-    [bottomBarPath addLineToPoint:CGPointMake(width, yOffset)];
-    [bottomBarPath closePath];
+    [self drawWithPlainPath:bottomBarPath
+                    yOffset:yOffset
+                      width:width
+                     height:height
+                 arcCenter1:arcCenter1
+                 arcCenter2:arcCenter2
+                  arcRadius:arcRadius];
   }
 
   return bottomBarPath.CGPath;
+}
+
+#pragma mark - Draw Helpers
+
+- (UIBezierPath *)drawWithPathToCut:(UIBezierPath *)bottomBarPath
+                            yOffset:(CGFloat)yOffset
+                              width:(CGFloat)width
+                             height:(CGFloat)height
+                          arcRadius:(CGFloat)arcRadius
+                         arcCenter1:(CGPoint)arcCenter1
+                         arcCenter2:(CGPoint)arcCenter2 {
+  [bottomBarPath moveToPoint:CGPointMake(width, yOffset)];
+  [bottomBarPath addCurveToPoint:CGPointMake(width, yOffset)
+                   controlPoint1:CGPointMake(width, yOffset)
+                   controlPoint2:CGPointMake(width, yOffset)];
+
+  [bottomBarPath addLineToPoint:CGPointMake(width, height)];
+
+  [bottomBarPath addLineToPoint:CGPointMake(0, height)];
+
+  [bottomBarPath addLineToPoint:CGPointMake(0, yOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(arcCenter1.x - arcRadius, yOffset)];
+
+  [bottomBarPath addCurveToPoint:CGPointMake(arcCenter1.x - arcRadius, yOffset)
+                   controlPoint1:CGPointMake(arcCenter1.x - arcRadius, yOffset)
+                   controlPoint2:CGPointMake(arcCenter1.x - arcRadius, yOffset)];
+  [bottomBarPath addCurveToPoint:CGPointMake(arcCenter1.x, arcRadius + yOffset)
+                   controlPoint1:CGPointMake(arcCenter1.x - arcRadius, arcRadius / 2 + yOffset)
+                   controlPoint2:CGPointMake(arcCenter1.x - arcRadius / 2, arcRadius + yOffset)];
+
+  [bottomBarPath addLineToPoint:CGPointMake(arcCenter2.x, arcRadius + yOffset)];
+
+  [bottomBarPath
+      addCurveToPoint:CGPointMake(arcCenter2.x + arcRadius, yOffset)
+        controlPoint1:CGPointMake(arcCenter2.x + arcRadius - arcRadius / 2, yOffset + arcRadius)
+        controlPoint2:CGPointMake(arcCenter2.x + arcRadius, yOffset + arcRadius / 2)];
+  [bottomBarPath addCurveToPoint:CGPointMake(arcCenter2.x + arcRadius, yOffset)
+                   controlPoint1:CGPointMake(arcCenter2.x + arcRadius, yOffset)
+                   controlPoint2:CGPointMake(arcCenter2.x + arcRadius, yOffset)];
+
+  [bottomBarPath addLineToPoint:CGPointMake(width, yOffset)];
+  [bottomBarPath closePath];
+  return bottomBarPath;
+}
+
+- (UIBezierPath *)drawWithPlainPath:(UIBezierPath *)bottomBarPath
+                            yOffset:(CGFloat)yOffset
+                              width:(CGFloat)width
+                             height:(CGFloat)height
+                         arcCenter1:(CGPoint)arcCenter1
+                         arcCenter2:(CGPoint)arcCenter2
+                          arcRadius:(CGFloat)arcRadius {
+  [bottomBarPath moveToPoint:CGPointMake(width, yOffset)];
+  [bottomBarPath addCurveToPoint:CGPointMake(width, yOffset)
+                   controlPoint1:CGPointMake(width, yOffset)
+                   controlPoint2:CGPointMake(width, yOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(width, height)];
+  [bottomBarPath addLineToPoint:CGPointMake(0, height)];
+  [bottomBarPath addLineToPoint:CGPointMake(0, yOffset)];
+  [bottomBarPath addLineToPoint:CGPointMake(arcCenter1.x - arcRadius, yOffset)];
+
+  [bottomBarPath addCurveToPoint:CGPointMake(arcCenter1.x - arcRadius, yOffset)
+                   controlPoint1:CGPointMake(arcCenter1.x - arcRadius, yOffset)
+                   controlPoint2:CGPointMake(arcCenter1.x - arcRadius, yOffset)];
+  [bottomBarPath addCurveToPoint:CGPointMake(arcCenter1.x, yOffset)
+                   controlPoint1:CGPointMake(arcCenter1.x - arcRadius, yOffset)
+                   controlPoint2:CGPointMake(arcCenter1.x - arcRadius / 2, yOffset)];
+
+  [bottomBarPath addLineToPoint:CGPointMake(arcCenter2.x, yOffset)];
+
+  [bottomBarPath addCurveToPoint:CGPointMake(arcCenter2.x + arcRadius, yOffset)
+                   controlPoint1:CGPointMake(arcCenter2.x + arcRadius - arcRadius / 2, yOffset)
+                   controlPoint2:CGPointMake(arcCenter2.x + arcRadius, yOffset)];
+  [bottomBarPath addCurveToPoint:CGPointMake(arcCenter2.x + arcRadius, yOffset)
+                   controlPoint1:CGPointMake(arcCenter2.x + arcRadius, yOffset)
+                   controlPoint2:CGPointMake(arcCenter2.x + arcRadius, yOffset)];
+
+  [bottomBarPath addLineToPoint:CGPointMake(width, yOffset)];
+  [bottomBarPath closePath];
+  return bottomBarPath;
 }
 
 @end

--- a/components/BottomAppBar/tests/unit/BottomAppBarTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarTests.m
@@ -25,15 +25,15 @@
                             yOffset:(CGFloat)yOffset
                               width:(CGFloat)width
                              height:(CGFloat)height
-                          arcCenter:(CGPoint)arcCenter
                           arcRadius:(CGFloat)arcRadius
-                         startAngle:(CGFloat)startAngle
-                           endAngle:(CGFloat)endAngle;
+                         arcCenter1:(CGPoint)arcCenter1
+                         arcCenter2:(CGPoint)arcCenter2;
 - (UIBezierPath *)drawWithPlainPath:(UIBezierPath *)bottomBarPath
                             yOffset:(CGFloat)yOffset
                               width:(CGFloat)width
                              height:(CGFloat)height
-                          arcCenter:(CGPoint)arcCenter
+                         arcCenter1:(CGPoint)arcCenter1
+                         arcCenter2:(CGPoint)arcCenter2
                           arcRadius:(CGFloat)arcRadius;
 @end
 
@@ -115,15 +115,15 @@
                                          yOffset:fakeYOffset
                                            width:fakeWidth
                                           height:fakeHeight
-                                       arcCenter:fakeCenter
                                        arcRadius:fakeArcRadius
-                                      startAngle:(CGFloat)M_PI
-                                        endAngle:(CGFloat)M_PI_2];
+                                      arcCenter1:fakeCenter
+                                      arcCenter2:fakeCenter];
   fakeFromPath = [bottomAppLayer drawWithPlainPath:fakeFromPath
                                            yOffset:fakeYOffset
                                              width:fakeWidth
                                             height:fakeHeight
-                                         arcCenter:fakeCenter
+                                        arcCenter1:fakeCenter
+                                        arcCenter2:fakeCenter
                                          arcRadius:fakeArcRadius];
 
   // Then


### PR DESCRIPTION
### Context
FABs can be circular or pill-shaped. As described in #5414, the cutout on BottomAppBar does not take into account pill-shaped FABs.

### The Problem
The UIBezierPath used in the current implementation draws a half circle where the FAB appears. For pill-shaped FABS, this doesn't work, as the cutout needs to made up of two quarter circle and a line connecting them.

### The Fix
I implemented a UIBezierPath that is made up of two quarter circles connected by a line, as well as the remainder of the rectangle that makes up the BottomAppBar's background. By doing so, I was able to provide **one** bezier path for both circular and pill-shaped cutouts, and **one** bezier path for a non-cutout version of the rectangle. This results in a smooth animation between the cutout and non-cutout state.

See https://stackoverflow.com/a/9522806 for an explanation of why the cutout and non-cutout bezier paths need to have the same general structure (e.g. number of path elements, and element types).