### PR TITLE
[TextFields] Show clearButton in outlined snapshots.

### DIFF
--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerSnapshotTests.m
@@ -27,6 +27,8 @@
   [super setUp];
 
   self.textField = [[MDCTextField alloc] init];
+  self.textField.clearButtonMode = UITextFieldViewModeAlways;
+  
   self.textFieldController =
       [[MDCTextInputControllerOutlined alloc] initWithTextInput:self.textField];
 }

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerSnapshotTests.m
@@ -28,7 +28,7 @@
 
   self.textField = [[MDCTextField alloc] init];
   self.textField.clearButtonMode = UITextFieldViewModeAlways;
-  
+
   self.textFieldController =
       [[MDCTextInputControllerOutlined alloc] initWithTextInput:self.textField];
 }

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderErrorTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderErrorTexts_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:706a8cefea2e5358fefea39364dd5f20f175cf84c4ff4bd0d1dadffd795f12d1
-size 23952
+oid sha256:c0b666d5e6d7b86644e9695cba2404105b5066bb4ac1bd838f02e6392ae11aef
+size 24901

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderHelperTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderHelperTexts_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd639b34dcac3f02dea4055eedf5c8d19a36145c45fde0b2ff85db7dab094501
-size 20599
+oid sha256:22e2f759eaea9bb294e1d4c73eefed9b61d54d75a116695d1ccbdce8da359576
+size 21509

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerSnapshotTests/testOutlinedTextFieldWithLongInputText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerSnapshotTests/testOutlinedTextFieldWithLongInputText_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0cef325e9fca918dc565571683c69e769582779a4e0a18ed9a8dedb3cfbe15d
-size 8939
+oid sha256:77d329937e6f083191181b3cbad5c712e1cba1d92487a653543af5d6e38cb646
+size 9905

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerSnapshotTests/testOutlinedTextFieldWithShortInputPlaceholderErrorTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerSnapshotTests/testOutlinedTextFieldWithShortInputPlaceholderErrorTexts_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4560eb414ef261a862fb406d35b66e892679f1578e036e90edc8faeed7d7e5ff
-size 9877
+oid sha256:c7be391f7c88054aa49db91b21c33995bf5d08cd09fc0a422e9fa16f88b9893c
+size 11107

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerSnapshotTests/testOutlinedTextFieldWithShortInputPlaceholderHelperTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerSnapshotTests/testOutlinedTextFieldWithShortInputPlaceholderHelperTexts_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a291dff41cd44d4304575caa4a9ba26226f669c8b22158fe3db4d0dcde4f6b0f
-size 8913
+oid sha256:e7ee1b847484444ef69adb8df3a4d101160e25024acb6bcdbf81a1836259337d
+size 10081

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerSnapshotTests/testOutlinedTextFieldWithShortInputText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerSnapshotTests/testOutlinedTextFieldWithShortInputText_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d7eac2bc3ab8aa4ba8e8c80e3122153e2afec3ea66a7c99aff217a5686f95fa
-size 6436
+oid sha256:191ae1b68a46e9a4fd3f1ac0e00ea9663f5759fff3aba1ebb8360ffcac666c64
+size 7692


### PR DESCRIPTION
Turning on the `clearButton` in all Outlined unthemed snapshot tests that include input
text. A matrix of all possible configurations would be ideal for
coverage. For now, having the button visible in the tests is better than
not since it can detect color changes and some positional changes
(relative to input text).

Part of #5762