### PR TITLE
[TextFields] Show clearButton in baseline snapshot

### DIFF
--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
@@ -29,6 +29,8 @@
   [super setUp];
 
   self.textField = [[MDCTextField alloc] init];
+  self.textField.clearButtonMode = UITextFieldViewModeAlways;
+
   self.textFieldController =
       [[MDCTextInputControllerOutlined alloc] initWithTextInput:self.textField];
   MDCSemanticColorScheme *colorScheme =

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderErrorTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderErrorTexts_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c00005d600211f4911194c21debf15b2dac04cd286ad12edccc5d3e6021c42ac
-size 24974
+oid sha256:6cd8b1a1969f3f8fea10d54bcc7986f8016e2894c254b1c38a0a3782a5f79fda
+size 25880

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderHelperTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderHelperTexts_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5f685d3b4c3c2a0fd8c61cdeb101264e2f4ec9e3da5d96915bdb04b1b13d87e
-size 21697
+oid sha256:12c28c75861290efd587ec1423b87bfaeff1b7e91e18b6f9e18bdf7a1bf9b7dc
+size 22582

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongInputText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongInputText_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b0a131b2d99caacd158671e7b3cbcf28b4421dfce1b70f8960870b80369acba
-size 9775
+oid sha256:c63f9acff8ac33fd0d8de5718da95c2a8fb06a7c5c39311866b1f1bc21088ac7
+size 10642

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortInputPlaceholderErrorTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortInputPlaceholderErrorTexts_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:200aeab867c77bd5e923f42eb3e53c5d34210e51b3c8bac59c8bc66b8160ebf7
-size 9951
+oid sha256:98a1860f9a9756314e98509773c1c546e0f3b3bda6465a3b18db6d8fb00dee4a
+size 11082

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortInputPlaceholderHelperTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortInputPlaceholderHelperTexts_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dd3142df167ab68887734bc60f717a9fd5f035b28a8cb04f0942e0ee9bb69ada
-size 9153
+oid sha256:1e5f2ea4f9b8afbc75eeab43e57aa417881ebbec117458ea6f9d2a454f8a620c
+size 10236

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortInputText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortInputText_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b18af94ecb6b205b4d58f2f1732afb6b38061fab016c4cc48ff744209c2e5cba
-size 6621
+oid sha256:d83f59c1c4fb7f8f8c731767ae0b6e2623fc45a638ade7e5b8c8c647154f7a2c
+size 7723


### PR DESCRIPTION
Turning on the `clearButton` in all outlined baseline snapshot tests that include input
text. Having the button visible will help detect layout or color changes
relative to the input text.

Part of #5762
