### PR TITLE
[TextFields] Add `editing` snapshots for Outlined Baseline

### DIFF
--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
@@ -17,9 +17,10 @@
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
+#import "SnapshotFakeMDCTextField.h"
 
 @interface MDCTextFieldOutlinedControllerBaselineSnapshotTests : MDCSnapshotTestCase
-@property(nonatomic, strong) MDCTextField *textField;
+@property(nonatomic, strong) SnapshotFakeMDCTextField *textField;
 @property(nonatomic, strong) MDCTextInputControllerOutlined *textFieldController;
 @end
 
@@ -28,7 +29,7 @@
 - (void)setUp {
   [super setUp];
 
-  self.textField = [[MDCTextField alloc] init];
+  self.textField = [[SnapshotFakeMDCTextField alloc] init];
   self.textField.clearButtonMode = UITextFieldViewModeAlways;
 
   self.textFieldController =
@@ -57,6 +58,7 @@
 - (void)triggerTextFieldLayout {
   CGSize aSize = [self.textField sizeThatFits:CGSizeMake(300, INFINITY)];
   self.textField.bounds = CGRectMake(0, 0, aSize.width, aSize.height);
+  [self.textField setNeedsUpdateConstraints];
   [self.textField layoutIfNeeded];
 }
 
@@ -78,6 +80,17 @@
   [self generateSnapshotAndVerify];
 }
 
+- (void)testOutlinedTextFieldEmptyIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
 #pragma mark - Single field tests
 
 - (void)testOutlinedTextFieldWithShortPlaceholderText {
@@ -86,6 +99,18 @@
 
   // When
   self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testOutlinedTextFieldWithShortPlaceholderTextIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
 
   // Then
   [self generateSnapshotAndVerify];
@@ -102,6 +127,18 @@
   [self generateSnapshotAndVerify];
 }
 
+- (void)testOutlinedTextFieldWithLongPlaceholderTextIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
 - (void)testOutlinedTextFieldWithShortHelperText {
   // Uncomment below to recreate the golden
   //  self.recordMode = YES;
@@ -113,12 +150,36 @@
   [self generateSnapshotAndVerify];
 }
 
+- (void)testOutlinedTextFieldWithShortHelperTextIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
 - (void)testOutlinedTextFieldWithLongHelperText {
   // Uncomment below to recreate the golden
   //  self.recordMode = YES;
 
   // When
   self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testOutlinedTextFieldWithLongHelperTextIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -136,6 +197,19 @@
   [self generateSnapshotAndVerify];
 }
 
+- (void)testOutlinedTextFieldWithShortErrorTextIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
 - (void)testOutlinedTextFieldWithLongErrorText {
   // Uncomment below to recreate the golden
   //  self.recordMode = YES;
@@ -143,6 +217,19 @@
   // When
   [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
                  errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testOutlinedTextFieldWithLongErrorTextIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+  [self.textField MDCtest_setIsEditing:YES];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -159,12 +246,36 @@
   [self generateSnapshotAndVerify];
 }
 
+- (void)testOutlinedTextFieldWithShortInputTextIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
 - (void)testOutlinedTextFieldWithLongInputText {
   // Uncomment below to recreate the golden
   //  self.recordMode = YES;
 
   // When
   self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testOutlinedTextFieldWithLongInputTextIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -185,6 +296,20 @@
   [self generateSnapshotAndVerify];
 }
 
+- (void)testOutlinedTextFieldWithShortInputPlaceholderHelperTextsIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
 - (void)testOutlinedTextFieldWithLongInputPlaceholderHelperTexts {
   // Uncomment below to recreate the golden
   //  self.recordMode = YES;
@@ -193,6 +318,20 @@
   self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
   self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
   self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testOutlinedTextFieldWithLongInputPlaceholderHelperTextsIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -212,6 +351,21 @@
   [self generateSnapshotAndVerify];
 }
 
+- (void)testOutlinedTextFieldWithShortInputPlaceholderErrorTextsIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
 - (void)testOutlinedTextFieldWithLongInputPlaceholderErrorTexts {
   // Uncomment below to recreate the golden
   //  self.recordMode = YES;
@@ -221,6 +375,21 @@
   self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
   [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
                  errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testOutlinedTextFieldWithLongInputPlaceholderErrorTextsIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+  [self.textField MDCtest_setIsEditing:YES];
 
   // Then
   [self generateSnapshotAndVerify];

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.h
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.h
@@ -1,0 +1,28 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialTextFields.h"
+
+#import <UIKit/UIKit.h>
+
+/**
+ A test fake MDCTextField implementation for Snapshot testing.
+ */
+@interface SnapshotFakeMDCTextField : MDCTextField
+
+/**
+ Overrides the value returned by `-isEditing`.
+ */
+- (void)MDCtest_setIsEditing:(BOOL)isEditing;
+@end

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.m
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.m
@@ -1,0 +1,34 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "SnapshotFakeMDCTextField.h"
+
+@implementation SnapshotFakeMDCTextField {
+  BOOL _isEditing;
+  BOOL _isEditingOverridden;
+}
+
+- (BOOL)isEditing {
+  if (_isEditingOverridden) {
+    return _isEditing;
+  }
+  return [super isEditing];
+}
+
+- (void)MDCtest_setIsEditing:(BOOL)isEditing {
+  _isEditingOverridden = YES;
+  _isEditing = isEditing;
+}
+
+@end

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldEmptyIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldEmptyIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0f1444cd7a43c8e15759fcf53c26e81b173fb1247bee5d49b2cf77559084255
+size 5192

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongErrorTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongErrorTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a739c87777d958a78fade2c28312d0ed6d19dae8d7c5c0ee83f09a69278d17e6
+size 9883

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongHelperTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongHelperTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96613d1f7e4cb8ec3a75293183ff0b3c020490e31692533d60c4ea19afdf4b57
+size 9710

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderErrorTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderErrorTextsIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c95508bbbe33c93933e9236046d5e33cbabce52af42933c133eeafed95ab5e80
+size 25915

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderHelperTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderHelperTextsIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42ef6736775d79f06dc15de3d2b0b4233a7ceae8fce7715c37f05b3b39420ca0
+size 25558

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongInputTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongInputTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b207340b0a2033d053455383fbf253ffad1fcc15bfd563efd0c543e8d74da2a6
+size 11021

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongPlaceholderTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongPlaceholderTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:055686d2d8f3cb4265ad320c6ac5803d21fcd15ca585119d6080dd0182253a59
+size 13941

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortErrorTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortErrorTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f28cbaa94ff541b27895b08af62992c44b2e9f6c19be91c66eb53cc0d8fd43a0
+size 6685

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortHelperTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortHelperTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c10da8e317adb0bab6f482450a0ae3923726ae5b10bc53d89db6a363ea3b1bb
+size 6478

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortInputPlaceholderErrorTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortInputPlaceholderErrorTextsIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3a8f445f195507eafd0b03a44c8c5563a21f9b414fd5e0c1038ddb378ce4db9
+size 11176

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortInputPlaceholderHelperTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortInputPlaceholderHelperTextsIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:740b314a71deffc3f6d92ecc19c57f096fbbe4d1af8299fa70c79fa7f2db3a19
+size 10983

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortInputTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortInputTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1cfc3451251345a9691e7b2fdea2573c5ab0a39e531df6088ca2530d9a9ca207
+size 8107

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortPlaceholderTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortPlaceholderTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:569bb6826bbcf769b1fa94a4a66d74a81d547bbd4278717308fadf6ff3f387e1
+size 9061


### PR DESCRIPTION
Outlined baseline-themed text fields need to keep snapshots of how they appear when
`isEditing` is true. This is the state when the user is actively focused
on the text field and the text can be edited.

Part of #5762
