### PR TITLE
[Snapshots] Only allow snapshot tests to run on the iPhone 7 for now

### DIFF
--- a/components/private/Snapshot/MDCSnapshotTestCase.m
+++ b/components/private/Snapshot/MDCSnapshotTestCase.m
@@ -41,6 +41,11 @@
     return;
   }
 
+  if (UIScreen.mainScreen.scale != 2.0) {
+    NSLog(@"Skipping this test. Snapshot tests currently only run at 2x screen scale");
+    return;
+  }
+
   UIImage *result = nil;
 
   if (@available(iOS 10, *)) {

--- a/components/private/Snapshot/MDCSnapshotTestCase.m
+++ b/components/private/Snapshot/MDCSnapshotTestCase.m
@@ -17,7 +17,7 @@
 #import <sys/utsname.h>
 
 NSString *const iPhone7ModelA = @"iPhone9,1";
-NSString *const iPhone7ModelB = @"iPhone9,3";
+static NSString *const kiPhone7ModelB = @"iPhone9,3";
 
 @implementation MDCSnapshotTestCase
 

--- a/components/private/Snapshot/MDCSnapshotTestCase.m
+++ b/components/private/Snapshot/MDCSnapshotTestCase.m
@@ -16,6 +16,12 @@
 
 #import <sys/utsname.h>
 
+/*
+ Due to differences between the iPhone 6 and iPhone 7 snapshots (when working with textfields), we
+ will limit the snapshot tests to only run on the iPhone 7 until we have a better solution for
+ generating the matrix of devices and OS's that we want to support.
+ https://github.com/material-components/material-components-ios/issues/5888
+ */
 static NSString *const kiPhone7ModelA = @"iPhone9,1";
 static NSString *const kiPhone7ModelB = @"iPhone9,3";
 
@@ -69,13 +75,14 @@ static NSString *const kiPhone7ModelB = @"iPhone9,3";
   if (NSProcessInfo.processInfo.operatingSystemVersion.majorVersion != 11 ||
       NSProcessInfo.processInfo.operatingSystemVersion.minorVersion != 2 ||
       NSProcessInfo.processInfo.operatingSystemVersion.patchVersion != 0) {
-    NSLog(@"Skipping this test. Snapshot tests currently only run on iOS 11.2.0");
+    NSLog(@"Unsupported device. Snapshot tests currently only run on iOS 11.2.0");
     return NO;
   }
 
   NSString *deviceName = [self getDeviceName];
-  if (![deviceName isEqualToString:iPhone7ModelA] && ![deviceName isEqualToString:iPhone7ModelB]) {
-    NSLog(@"Skipping this test. Snapshot tests currently only run on iPhone 7");
+  if (![deviceName isEqualToString:kiPhone7ModelA] &&
+      ![deviceName isEqualToString:kiPhone7ModelB]) {
+    NSLog(@"Unsupported device. Snapshot tests currently only run on iPhone 7");
     return NO;
   }
 

--- a/components/private/Snapshot/MDCSnapshotTestCase.m
+++ b/components/private/Snapshot/MDCSnapshotTestCase.m
@@ -90,8 +90,7 @@ NSString *const iPhone7ModelB = @"iPhone9,3";
 #else
   struct utsname systemInfo;
   uname(&systemInfo);
-  deviceName = [NSString stringWithCString:systemInfo.machine
-                                  encoding:NSUTF8StringEncoding];
+  deviceName = [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
 #endif
   return deviceName;
 }

--- a/components/private/Snapshot/MDCSnapshotTestCase.m
+++ b/components/private/Snapshot/MDCSnapshotTestCase.m
@@ -80,8 +80,8 @@ static NSString *const kiPhone7ModelB = @"iPhone9,3";
   }
 
   NSString *deviceName = [self getDeviceName];
-  if (![deviceName isEqualToString:kiPhone7ModelA] &&
-      ![deviceName isEqualToString:kiPhone7ModelB]) {
+  if (!([deviceName isEqualToString:kiPhone7ModelA] ||
+        [deviceName isEqualToString:kiPhone7ModelB])) {
     NSLog(@"Unsupported device. Snapshot tests currently only run on iPhone 7");
     return NO;
   }

--- a/components/private/Snapshot/MDCSnapshotTestCase.m
+++ b/components/private/Snapshot/MDCSnapshotTestCase.m
@@ -16,7 +16,7 @@
 
 #import <sys/utsname.h>
 
-NSString *const iPhone7ModelA = @"iPhone9,1";
+static NSString *const kiPhone7ModelA = @"iPhone9,1";
 static NSString *const kiPhone7ModelB = @"iPhone9,3";
 
 @implementation MDCSnapshotTestCase

--- a/snapshot_test_goldens/goldens_64/MDCCardSnapshotTests/testDefaultCard_11_2@3x.png
+++ b/snapshot_test_goldens/goldens_64/MDCCardSnapshotTests/testDefaultCard_11_2@3x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8548844edca70ccd69c4a81f8409cd6b47c44d3be2885f191491fe484c54e2bc
-size 3296


### PR DESCRIPTION
For now, we should only allow the snapshot tests to run on the iPhone 7 until we have a good solution for generating the matrix of snapshots we want.
