### PR TITLE
[Snapshot] Add support for image tolerance.

### DIFF
--- a/components/private/Snapshot/MDCSnapshotTestCase.h
+++ b/components/private/Snapshot/MDCSnapshotTestCase.h
@@ -25,7 +25,20 @@
 /**
  * This will call FBSnapshotVerifyView but first check for supported iOS versions. Additionally,
  * this will use UIGraphicsImageRenderer to render the view correctly (including shadows).
+ *
+ * Permits no changed pixels.
+ *
+ * @param view The view to use for snapshot comparison.
  */
 - (void)snapshotVerifyView:(UIView *)view;
+
+
+/**
+ * This will call FBSnapshotVerifyView but first check for supported iOS versions. Additionally,
+ * this will use UIGraphicsImageRenderer to render the view correctly (including shadows).
+ * @param view the view to use for snapshot comparison.
+ * @param tolerancePercent the percentage of pixels that can differ while still passing.
+ */
+- (void)snapshotVerifyView:(UIView *)view tolerance:(CGFloat)tolerancePercent;
 
 @end

--- a/components/private/Snapshot/MDCSnapshotTestCase.h
+++ b/components/private/Snapshot/MDCSnapshotTestCase.h
@@ -32,12 +32,11 @@
  */
 - (void)snapshotVerifyView:(UIView *)view;
 
-
 /**
  * This will call FBSnapshotVerifyView but first check for supported iOS versions. Additionally,
  * this will use UIGraphicsImageRenderer to render the view correctly (including shadows).
  * @param view the view to use for snapshot comparison.
- * @param tolerancePercent the percentage of pixels that can differ while still passing.
+ * @param tolerancePercent the percentage (0.0 - 1.0) of pixels that can differ while still passing.
  */
 - (void)snapshotVerifyView:(UIView *)view tolerance:(CGFloat)tolerancePercent;
 

--- a/components/private/Snapshot/MDCSnapshotTestCase.m
+++ b/components/private/Snapshot/MDCSnapshotTestCase.m
@@ -43,6 +43,10 @@ static NSString *const kiPhone7ModelB = @"iPhone9,3";
 }
 
 - (void)snapshotVerifyView:(UIView *)view {
+  [self snapshotVerifyView:view tolerance:0];
+}
+
+- (void)snapshotVerifyView:(UIView *)view tolerance:(CGFloat)tolerancePercent {
   if (![self isSupportedDevice]) {
     return;
   }
@@ -66,7 +70,8 @@ static NSString *const kiPhone7ModelB = @"iPhone9,3";
   UIImageView *imageView = [[UIImageView alloc] initWithFrame:view.frame];
   imageView.image = result;
 
-  FBSnapshotVerifyView(imageView, nil);
+  FBSnapshotVerifyViewWithOptions(imageView, nil, FBSnapshotTestCaseDefaultSuffixes(),
+                                  tolerancePercent);
 }
 
 // TODO(https://github.com/material-components/material-components-ios/issues/5888)


### PR DESCRIPTION
Some snapshot tests are flaky (which is a bug). Allow those tests to
allow some small percentage of pixels to change to eliminate the flake
while still detecting larger changes.

Caused by #5970
