### PR TITLE
[TextFields] Post notifications when `isEditing` changes.

### DIFF
--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
@@ -136,7 +136,13 @@
   [self.textField MDCtest_setIsEditing:YES];
 
   // Then
-  [self generateSnapshotAndVerify];
+  [self triggerTextFieldLayout];
+  UIView *snapshotView = [self addBackgroundViewToView:self.textField];
+
+  // Perform the actual verification.
+  // TODO(https://github.com/material-components/material-components-ios/issues/5970 ): Fix this
+  // flaky layout of long placeholder labels when floating.
+  [self snapshotVerifyView:snapshotView tolerance:0.05];
 }
 
 - (void)testOutlinedTextFieldWithShortHelperText {

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.m
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.m
@@ -28,7 +28,23 @@
 
 - (void)MDCtest_setIsEditing:(BOOL)isEditing {
   _isEditingOverridden = YES;
+  if (_isEditing == isEditing) {
+    return;
+  }
   _isEditing = isEditing;
+  
+  // MDCTextInputControllers use the UITextField notifications to allow clients to be the text field
+  // delegate. As a result, we need to post the relevant notifications when we programmatically
+  // change the value of `isEditing` in tests.
+  if (_isEditing) {
+    [NSNotificationCenter.defaultCenter
+        postNotificationName:UITextFieldTextDidBeginEditingNotification
+                      object:self];
+  } else {
+    [NSNotificationCenter.defaultCenter
+        postNotificationName:UITextFieldTextDidEndEditingNotification
+                      object:self];
+  }
 }
 
 @end

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.m
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.m
@@ -32,7 +32,7 @@
     return;
   }
   _isEditing = isEditing;
-  
+
   // MDCTextInputControllers use the UITextField notifications to allow clients to be the text field
   // delegate. As a result, we need to post the relevant notifications when we programmatically
   // change the value of `isEditing` in tests.

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldEmptyIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldEmptyIsEditing_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b0f1444cd7a43c8e15759fcf53c26e81b173fb1247bee5d49b2cf77559084255
-size 5192
+oid sha256:26f3970513b84f0bd5ab811ea3b7be2f4f5d04db83c4cec1bbde62a5d594791d
+size 4815

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongErrorTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongErrorTextIsEditing_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a739c87777d958a78fade2c28312d0ed6d19dae8d7c5c0ee83f09a69278d17e6
-size 9883
+oid sha256:ce08ff7bf10fa7e4c64437f42a7406f65087f5edee5de4088d12f08b9dd6ff90
+size 9555

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongHelperTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongHelperTextIsEditing_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96613d1f7e4cb8ec3a75293183ff0b3c020490e31692533d60c4ea19afdf4b57
-size 9710
+oid sha256:a8612ca654164cb4d190caa7369480cf888773271a42630fda83dc5e4f56dfa7
+size 9342

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongPlaceholderTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongPlaceholderTextIsEditing_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:055686d2d8f3cb4265ad320c6ac5803d21fcd15ca585119d6080dd0182253a59
-size 13941
+oid sha256:0fedaa817f5c4fb29efadb8d9ae899b12b083654d5ae3f712ccb3b0d10c88b76
+size 14016

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortErrorTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortErrorTextIsEditing_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f28cbaa94ff541b27895b08af62992c44b2e9f6c19be91c66eb53cc0d8fd43a0
-size 6685
+oid sha256:7c8f71d6f6a798494076ac954690549fbe05a045c9e7ac7be11fa717e7ad0660
+size 6380

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortHelperTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortHelperTextIsEditing_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c10da8e317adb0bab6f482450a0ae3923726ae5b10bc53d89db6a363ea3b1bb
-size 6478
+oid sha256:6c90856748f986adb9f252ec6f4298cc5dc7cb5d9ebd55823db88cf80d63755d
+size 6115


### PR DESCRIPTION
To ensure that clients can remain the UITextFieldDelegate of MDCTextField
objects, the MDCTextInputControllers respond to NSNotifications coming from
UITextField when its state changes. To improve correct layout and appearance
of text fields in snapshot tests, any test fakes should post the relevant
notifications when changing the value of `isEditing`.

Part of #5762
