### PR TITLE
{Git-LFS} Exclude git-lfs from `stable`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-snapshot_test_goldens/**/*.png filter=lfs diff=lfs merge=lfs -text
+# Do not add git-lfs attributes to this files. It causes problems with Cocoapods.
+# snapshot_test_goldens/**/*.png filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Git LFS integration is only valuable for contributors. However, having the `.gitattributes` settings in the `stable` branch means it will propagate to clients attempting to integrate MaterialComponents via CocoaPods. If the client doesn't have git-lfs installed, then they only get arcane errors when attempting to update.

#5956