### PR TITLE
[TextFields] Refactor snapshot test class

### DIFF
--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerSnapshotTests.m
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCSnapshotTestCase.h"
+#import "MDCTextFieldSnapshotTestCase.h"
 #import "MDCTextFieldSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
-@interface MDCTextFieldFilledControllerSnapshotTests : MDCSnapshotTestCase
-@property(nonatomic, strong) MDCTextField *textField;
+@interface MDCTextFieldFilledControllerSnapshotTests : MDCTextFieldSnapshotTestCase
 @property(nonatomic, strong) MDCTextInputControllerFilled *textFieldController;
 @end
 
@@ -26,7 +25,6 @@
 - (void)setUp {
   [super setUp];
 
-  self.textField = [[MDCTextField alloc] init];
   self.textField.clearButtonMode = UITextFieldViewModeAlways;
 
   self.textFieldController =
@@ -35,25 +33,8 @@
 
 - (void)tearDown {
   self.textFieldController = nil;
-  self.textField = nil;
 
   [super tearDown];
-}
-
-#pragma mark - Helpers
-
-- (void)triggerTextFieldLayout {
-  CGSize aSize = [self.textField sizeThatFits:CGSizeMake(300, INFINITY)];
-  self.textField.bounds = CGRectMake(0, 0, aSize.width, aSize.height);
-  [self.textField layoutIfNeeded];
-}
-
-- (void)generateSnapshotAndVerify {
-  [self triggerTextFieldLayout];
-  UIView *snapshotView = [self addBackgroundViewToView:self.textField];
-
-  // Perform the actual verification.
-  [self snapshotVerifyView:snapshotView];
 }
 
 #pragma mark - Tests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerSnapshotTests.m
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCSnapshotTestCase.h"
+#import "MDCTextFieldSnapshotTestCase.h"
 #import "MDCTextFieldSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
-@interface MDCTextFieldFullWidthControllerSnapshotTests : MDCSnapshotTestCase
-@property(nonatomic, strong) MDCTextField *textField;
+@interface MDCTextFieldFullWidthControllerSnapshotTests : MDCTextFieldSnapshotTestCase
 @property(nonatomic, strong) MDCTextInputControllerFullWidth *textFieldController;
 @end
 
@@ -26,32 +25,14 @@
 - (void)setUp {
   [super setUp];
 
-  self.textField = [[MDCTextField alloc] init];
   self.textFieldController =
       [[MDCTextInputControllerFullWidth alloc] initWithTextInput:self.textField];
 }
 
 - (void)tearDown {
   self.textFieldController = nil;
-  self.textField = nil;
 
   [super tearDown];
-}
-
-#pragma mark - Helpers
-
-- (void)triggerTextFieldLayout {
-  CGSize aSize = [self.textField sizeThatFits:CGSizeMake(300, INFINITY)];
-  self.textField.bounds = CGRectMake(0, 0, aSize.width, aSize.height);
-  [self.textField layoutIfNeeded];
-}
-
-- (void)generateSnapshotAndVerify {
-  [self triggerTextFieldLayout];
-  UIView *snapshotView = [self addBackgroundViewToView:self.textField];
-
-  // Perform the actual verification.
-  [self snapshotVerifyView:snapshotView];
 }
 
 #pragma mark - Tests

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCSnapshotTestCase.h"
+#import "MDCTextFieldSnapshotTestCase.h"
 #import "MDCTextFieldSnapshotTestsStrings.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
 #import "SnapshotFakeMDCTextField.h"
 
-@interface MDCTextFieldOutlinedControllerBaselineSnapshotTests : MDCSnapshotTestCase
-@property(nonatomic, strong) SnapshotFakeMDCTextField *textField;
+@interface MDCTextFieldOutlinedControllerBaselineSnapshotTests : MDCTextFieldSnapshotTestCase
 @property(nonatomic, strong) MDCTextInputControllerOutlined *textFieldController;
 @end
 
@@ -29,7 +28,6 @@
 - (void)setUp {
   [super setUp];
 
-  self.textField = [[SnapshotFakeMDCTextField alloc] init];
   self.textField.clearButtonMode = UITextFieldViewModeAlways;
 
   self.textFieldController =
@@ -48,26 +46,8 @@
 
 - (void)tearDown {
   self.textFieldController = nil;
-  self.textField = nil;
 
   [super tearDown];
-}
-
-#pragma mark - Helpers
-
-- (void)triggerTextFieldLayout {
-  CGSize aSize = [self.textField sizeThatFits:CGSizeMake(300, INFINITY)];
-  self.textField.bounds = CGRectMake(0, 0, aSize.width, aSize.height);
-  [self.textField setNeedsUpdateConstraints];
-  [self.textField layoutIfNeeded];
-}
-
-- (void)generateSnapshotAndVerify {
-  [self triggerTextFieldLayout];
-  UIView *snapshotView = [self addBackgroundViewToView:self.textField];
-
-  // Perform the actual verification.
-  [self snapshotVerifyView:snapshotView];
 }
 
 #pragma mark - Tests
@@ -136,13 +116,10 @@
   [self.textField MDCtest_setIsEditing:YES];
 
   // Then
-  [self triggerTextFieldLayout];
-  UIView *snapshotView = [self addBackgroundViewToView:self.textField];
 
-  // Perform the actual verification.
   // TODO(https://github.com/material-components/material-components-ios/issues/5970 ): Fix this
   // flaky layout of long placeholder labels when floating.
-  [self snapshotVerifyView:snapshotView tolerance:0.05];
+  [self generateSnapshotAndVerifyWithTolerance:(CGFloat)0.05];
 }
 
 - (void)testOutlinedTextFieldWithShortHelperText {

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerSnapshotTests.m
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCSnapshotTestCase.h"
+#import "MDCTextFieldSnapshotTestCase.h"
 #import "MDCTextFieldSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
-@interface MDCTextFieldOutlinedControllerSnapshotTests : MDCSnapshotTestCase
-@property(nonatomic, strong) MDCTextField *textField;
+@interface MDCTextFieldOutlinedControllerSnapshotTests : MDCTextFieldSnapshotTestCase
 @property(nonatomic, strong) MDCTextInputControllerOutlined *textFieldController;
 @end
 
@@ -26,7 +25,6 @@
 - (void)setUp {
   [super setUp];
 
-  self.textField = [[MDCTextField alloc] init];
   self.textField.clearButtonMode = UITextFieldViewModeAlways;
 
   self.textFieldController =
@@ -35,25 +33,8 @@
 
 - (void)tearDown {
   self.textFieldController = nil;
-  self.textField = nil;
 
   [super tearDown];
-}
-
-#pragma mark - Helpers
-
-- (void)triggerTextFieldLayout {
-  CGSize aSize = [self.textField sizeThatFits:CGSizeMake(300, INFINITY)];
-  self.textField.bounds = CGRectMake(0, 0, aSize.width, aSize.height);
-  [self.textField layoutIfNeeded];
-}
-
-- (void)generateSnapshotAndVerify {
-  [self triggerTextFieldLayout];
-  UIView *snapshotView = [self addBackgroundViewToView:self.textField];
-
-  // Perform the actual verification.
-  [self snapshotVerifyView:snapshotView];
 }
 
 #pragma mark - Tests

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.h
@@ -1,0 +1,49 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MDCSnapshotTestCase.h"
+#import "MaterialTextFields.h"
+#import "SnapshotFakeMDCTextField.h"
+
+/**
+ A specialized test case class for testing MDCTextFields with different controllers and
+ configurations.
+ */
+@interface MDCTextFieldSnapshotTestCase : MDCSnapshotTestCase
+
+@property(nonatomic, strong) SnapshotFakeMDCTextField *textField;
+
+/**
+ Attempts to update the text field's layout to how it would appear within a view hierarchy on a
+ screen.
+ */
+- (void)triggerTextFieldLayout;
+
+/**
+ Generates a snapshotted view of @c self.textField and verifies it against the golden image with
+ no pixel differences.
+ */
+- (void)generateSnapshotAndVerify;
+
+/**
+ Generates a snapshotted view of @c self.textField and verifies it against the golden image.
+
+ @param tolerance the percentage (0 - 1) difference allowed between the snapshot and the golden
+                  image.
+ **/
+- (void)generateSnapshotAndVerifyWithTolerance:(CGFloat)tolerance;
+
+@end

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
@@ -14,8 +14,8 @@
 
 #import <XCTest/XCTest.h>
 
-#import "SnapshotFakeMDCTextField.h"
 #import "MDCTextFieldSnapshotTestCase.h"
+#import "SnapshotFakeMDCTextField.h"
 
 @implementation MDCTextFieldSnapshotTestCase
 

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
@@ -1,0 +1,54 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "SnapshotFakeMDCTextField.h"
+#import "MDCTextFieldSnapshotTestCase.h"
+
+@implementation MDCTextFieldSnapshotTestCase
+
+- (void)setUp {
+  [super setUp];
+
+  self.textField = [[SnapshotFakeMDCTextField alloc] init];
+}
+
+- (void)tearDown {
+  self.textField = nil;
+
+  [super tearDown];
+}
+
+#pragma mark - Helpers
+
+- (void)triggerTextFieldLayout {
+  CGSize aSize = [self.textField sizeThatFits:CGSizeMake(300, INFINITY)];
+  self.textField.bounds = CGRectMake(0, 0, aSize.width, aSize.height);
+  [self.textField layoutIfNeeded];
+}
+
+- (void)generateSnapshotAndVerify {
+  [self generateSnapshotAndVerifyWithTolerance:0];
+}
+
+- (void)generateSnapshotAndVerifyWithTolerance:(CGFloat)tolerance {
+  [self triggerTextFieldLayout];
+  UIView *snapshotView = [self addBackgroundViewToView:self.textField];
+
+  // Perform the actual verification.
+  [self snapshotVerifyView:snapshotView tolerance:tolerance];
+}
+
+@end


### PR DESCRIPTION
Extracting a common superclass for MDCTextField-related tests. It was becoming
difficult to ensure the frequently-used functionality (layout, snapshots) were
updated consistently.

Part of #5762
