### PR TITLE
[TextFields] Allow animations to execute in tests.

### DIFF
--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
@@ -116,10 +116,7 @@
   [self.textField MDCtest_setIsEditing:YES];
 
   // Then
-
-  // TODO(https://github.com/material-components/material-components-ios/issues/5970 ): Fix this
-  // flaky layout of long placeholder labels when floating.
-  [self generateSnapshotAndVerifyWithTolerance:(CGFloat)0.05];
+  [self generateSnapshotAndVerify];
 }
 
 - (void)testOutlinedTextFieldWithShortHelperText {

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.h
@@ -38,12 +38,4 @@
  */
 - (void)generateSnapshotAndVerify;
 
-/**
- Generates a snapshotted view of @c self.textField and verifies it against the golden image.
-
- @param tolerance the percentage (0 - 1) difference allowed between the snapshot and the golden
-                  image.
- **/
-- (void)generateSnapshotAndVerifyWithTolerance:(CGFloat)tolerance;
-
 @end

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
@@ -53,10 +53,6 @@
 }
 
 - (void)generateSnapshotAndVerify {
-  [self generateSnapshotAndVerifyWithTolerance:0];
-}
-
-- (void)generateSnapshotAndVerifyWithTolerance:(CGFloat)tolerance {
   [self triggerTextFieldLayout];
   UIView *snapshotView = [self addBackgroundViewToView:self.textField];
 

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
@@ -31,12 +31,25 @@
   [super tearDown];
 }
 
+#pragma mark - Private methods
+
+- (void)drainMainRunLoop {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"draining the main run loop"];
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [expectation fulfill];
+  });
+
+  [self waitForExpectations:@[expectation] timeout:1];
+}
+
 #pragma mark - Helpers
 
 - (void)triggerTextFieldLayout {
   CGSize aSize = [self.textField sizeThatFits:CGSizeMake(300, INFINITY)];
   self.textField.bounds = CGRectMake(0, 0, aSize.width, aSize.height);
   [self.textField layoutIfNeeded];
+  [self drainMainRunLoop];
 }
 
 - (void)generateSnapshotAndVerify {
@@ -48,7 +61,7 @@
   UIView *snapshotView = [self addBackgroundViewToView:self.textField];
 
   // Perform the actual verification.
-  [self snapshotVerifyView:snapshotView tolerance:tolerance];
+  [self snapshotVerifyView:snapshotView];
 }
 
 @end

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
@@ -33,6 +33,13 @@
 
 #pragma mark - Private methods
 
+/**
+ Inserts a semaphore block into the main run loop and then waits for that sempahore to be executed.
+ This enables other queued actions on the main loop to issue within unit tests.  For example, it can
+ allow animation blocks to execute, but does not necessarily wait for them to complete.
+
+ Note: Although an imperfect solution, it unblocks snapshot testing for now and reduces flakiness.
+ */
 - (void)drainMainRunLoop {
   XCTestExpectation *expectation = [self expectationWithDescription:@"draining the main run loop"];
 
@@ -49,6 +56,9 @@
   CGSize aSize = [self.textField sizeThatFits:CGSizeMake(300, INFINITY)];
   self.textField.bounds = CGRectMake(0, 0, aSize.width, aSize.height);
   [self.textField layoutIfNeeded];
+
+  // Allow animation blocks to issue through the main run loop. This may not be sufficient for all
+  // animations, but it appears to correct and deflake the rendering of long placeholder text.
   [self drainMainRunLoop];
 }
 

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
@@ -40,7 +40,7 @@
     [expectation fulfill];
   });
 
-  [self waitForExpectations:@[expectation] timeout:1];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 #pragma mark - Helpers

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongPlaceholderTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithLongPlaceholderTextIsEditing_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0fedaa817f5c4fb29efadb8d9ae899b12b083654d5ae3f712ccb3b0d10c88b76
-size 14016
+oid sha256:20baffdd7cefa7346a31184b7c6a64a8cd3f53ee3676dc4f2cb9529c34f4b839
+size 15337


### PR DESCRIPTION
Some of TextFields' layout changes only take place inside animation blocks. To
move us closer toward a more "life-like" rendering of the text fields in our
snapshot tests, the test should allow the main run loop to execute any pending
animations before attempting to take a snapshot of the view.

This seems to fix the flakiness seen in #5970, so the `withTolerance` APIs added to support those flaky tests are no longer needed.

Part of #5762
Fixes #5970