### PR TITLE
[TextFields] Add `isEditing` snapshots for Filled style

### DIFF
--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerSnapshotTests.m
@@ -15,6 +15,7 @@
 #import "MDCTextFieldSnapshotTestCase.h"
 #import "MDCTextFieldSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
+#import "SnapshotFakeMDCTextField.h"
 
 @interface MDCTextFieldFilledControllerSnapshotTests : MDCTextFieldSnapshotTestCase
 @property(nonatomic, strong) MDCTextInputControllerFilled *textFieldController;
@@ -47,6 +48,17 @@
   [self generateSnapshotAndVerify];
 }
 
+- (void)testFilledTextFieldEmptyIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
 #pragma mark - Single field tests
 
 - (void)testFilledTextFieldWithShortPlaceholderText {
@@ -55,6 +67,18 @@
 
   // When
   self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testFilledTextFieldWithShortPlaceholderTextIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -71,6 +95,18 @@
   [self generateSnapshotAndVerify];
 }
 
+- (void)testFilledTextFieldWithLongPlaceholderTextIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
 - (void)testFilledTextFieldWithShortHelperText {
   // Uncomment below to recreate the golden
   //  self.recordMode = YES;
@@ -82,12 +118,36 @@
   [self generateSnapshotAndVerify];
 }
 
+- (void)testFilledTextFieldWithShortHelperTextIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
 - (void)testFilledTextFieldWithLongHelperText {
   // Uncomment below to recreate the golden
   //  self.recordMode = YES;
 
   // When
   self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testFilledTextFieldWithLongHelperTextIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -105,6 +165,19 @@
   [self generateSnapshotAndVerify];
 }
 
+- (void)testFilledTextFieldWithShortErrorTextIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
 - (void)testFilledTextFieldWithLongErrorText {
   // Uncomment below to recreate the golden
   //  self.recordMode = YES;
@@ -112,6 +185,19 @@
   // When
   [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
                  errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testFilledTextFieldWithLongErrorTextIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+  [self.textField MDCtest_setIsEditing:YES];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -128,12 +214,36 @@
   [self generateSnapshotAndVerify];
 }
 
+- (void)testFilledTextFieldWithShortInputTextIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
 - (void)testFilledTextFieldWithLongInputText {
   // Uncomment below to recreate the golden
   //  self.recordMode = YES;
 
   // When
   self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testFilledTextFieldWithLongInputTextIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -154,6 +264,20 @@
   [self generateSnapshotAndVerify];
 }
 
+- (void)testFilledTextFieldWithShortInputPlaceholderHelperTextsIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
 - (void)testFilledTextFieldWithLongInputPlaceholderHelperTexts {
   // Uncomment below to recreate the golden
   //  self.recordMode = YES;
@@ -162,6 +286,20 @@
   self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
   self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
   self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testFilledTextFieldWithLongInputPlaceholderHelperTextsIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -181,6 +319,21 @@
   [self generateSnapshotAndVerify];
 }
 
+- (void)testFilledTextFieldWithShortInputPlaceholderErrorTextsIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
 - (void)testFilledTextFieldWithLongInputPlaceholderErrorTexts {
   // Uncomment below to recreate the golden
   //  self.recordMode = YES;
@@ -190,6 +343,21 @@
   self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
   [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
                  errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testFilledTextFieldWithLongInputPlaceholderErrorTextsIsEditing {
+  // Uncomment below to recreate the golden
+  //  self.recordMode = YES;
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+  [self.textField MDCtest_setIsEditing:YES];
 
   // Then
   [self generateSnapshotAndVerify];

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldEmptyIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldEmptyIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89d751551e2d5443d1e8174fc6a861d0ce37691c780d66661000a030d4139478
+size 3773

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithLongErrorTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithLongErrorTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:861295084c246153c8c49cc28ce14dbc70935f860e557c4a8ba658fd1ade4b90
+size 7554

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithLongHelperTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithLongHelperTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b76881627b26de2a748dbb00f4698a73d81ecca71e1748c5b0764954e4c8479d
+size 7608

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithLongInputPlaceholderErrorTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithLongInputPlaceholderErrorTextsIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6c92f885cffca444c079eca54c219ea6186ba5f1956877042a43993b5650cac
+size 20104

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithLongInputPlaceholderHelperTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithLongInputPlaceholderHelperTextsIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cdac469654763f976ed991907123302a02422efbad19fc06c4da24e7bfbe9db
+size 19842

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithLongInputTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithLongInputTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3ba11290613681cbeba53bfaadc785e4a21ba308bdd6db8a82a831e887249d5
+size 7835

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithLongPlaceholderTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithLongPlaceholderTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73bf7ef8f7ffd89066e51636b7b0918f2ae004e79d625170489bae6983ae5b5f
+size 12386

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithShortErrorTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithShortErrorTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5108c22f88c7e47cc6641e419236e1acc5062b9731db75e649c82e5b672ecda5
+size 5031

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithShortHelperTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithShortHelperTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbaa7f0bdf1e7ae3070025298aeb6f24413d17b0945d7ed20ed1d2e787556d2c
+size 4811

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithShortInputPlaceholderErrorTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithShortInputPlaceholderErrorTextsIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28b482736e57ed20ebbd86e52d7089ad0888a5f60fa1e0cbdb5755f71889ceea
+size 8621

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithShortInputPlaceholderHelperTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithShortInputPlaceholderHelperTextsIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2746c2e43b9e12b390fccafd84de7902bd07e77ac5504da6be1f0d27b03b0c61
+size 8403

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithShortInputTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithShortInputTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b5d2806e638a00af70fefd44a5928eb21f9cf6cba472e2d838ac530d4d3fc0d
+size 6129

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithShortPlaceholderTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledControllerSnapshotTests/testFilledTextFieldWithShortPlaceholderTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b85316778cf2c72b112e73ac9a020595eb23adc3f9e554ca6d54c94e6b68838
+size 5168


### PR DESCRIPTION
Filled controller text fields should have `isEditing` (`active`) snapshots.

Part of #5762
