### PR TITLE
[TextFields] Refactor textArea snapshot tests.

### DIFF
--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedTextAreaControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedTextAreaControllerSnapshotTests.m
@@ -15,9 +15,10 @@
 #import "MDCSnapshotTestCase.h"
 #import "MDCTextFieldSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
+#import "SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextFieldOutlinedTextAreaControllerSnapshotTests : MDCSnapshotTestCase
-@property(nonatomic, strong) MDCMultilineTextField *textField;
+@property(nonatomic, strong) SnapshotFakeMDCMultilineTextField *textField;
 @property(nonatomic, strong) MDCTextInputControllerOutlinedTextArea *textFieldController;
 @end
 
@@ -26,7 +27,8 @@
 - (void)setUp {
   [super setUp];
 
-  self.textField = [[MDCMultilineTextField alloc] init];
+  self.textField = [[SnapshotFakeMDCMultilineTextField alloc] init];
+
   self.textFieldController =
       [[MDCTextInputControllerOutlinedTextArea alloc] initWithTextInput:self.textField];
 }

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCMultilineTextField.h
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCMultilineTextField.h
@@ -1,0 +1,29 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialTextFields.h"
+
+#import <UIKit/UIKit.h>
+
+/**
+ A test fake MDCMultilineTextField implementation for Snapshot testing.
+ */
+@interface SnapshotFakeMDCMultilineTextField : MDCMultilineTextField
+
+/**
+ Overrides the value returned by `-isEditing`.
+ */
+- (void)MDCtest_setIsEditing:(BOOL)isEditing;
+
+@end

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCMultilineTextField.m
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCMultilineTextField.m
@@ -1,0 +1,51 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "SnapshotFakeMDCMultilineTextField.h"
+
+@implementation SnapshotFakeMDCMultilineTextField {
+  BOOL _isEditing;
+  BOOL _isEditingOverridden;
+}
+
+- (BOOL)isEditing {
+  if (_isEditingOverridden) {
+    return _isEditing;
+  }
+  return [super isEditing];
+}
+
+- (void)MDCtest_setIsEditing:(BOOL)isEditing {
+  _isEditingOverridden = YES;
+  if (_isEditing == isEditing) {
+    return;
+  }
+  _isEditing = isEditing;
+
+  // MDCTextInputControllers use the UITextField notifications to allow clients to be the text field
+  // delegate. As a result, we need to post the relevant notifications when we programmatically
+  // change the value of `isEditing` in tests.
+  if (_isEditing) {
+    [NSNotificationCenter.defaultCenter
+     postNotificationName:UITextFieldTextDidBeginEditingNotification
+     object:self];
+  } else {
+    [NSNotificationCenter.defaultCenter
+     postNotificationName:UITextFieldTextDidEndEditingNotification
+     object:self];
+  }
+}
+
+
+@end

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCMultilineTextField.m
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCMultilineTextField.m
@@ -38,14 +38,13 @@
   // change the value of `isEditing` in tests.
   if (_isEditing) {
     [NSNotificationCenter.defaultCenter
-     postNotificationName:UITextFieldTextDidBeginEditingNotification
-     object:self];
+        postNotificationName:UITextFieldTextDidBeginEditingNotification
+                      object:self];
   } else {
     [NSNotificationCenter.defaultCenter
-     postNotificationName:UITextFieldTextDidEndEditingNotification
-     object:self];
+        postNotificationName:UITextFieldTextDidEndEditingNotification
+                      object:self];
   }
 }
-
 
 @end


### PR DESCRIPTION
Creating a test fake for MDCMultilineTextField so that the `isEditing:` tests
can be added in a follow-up PR.

Part of #5762
