### PR TITLE
[automated] Ran buildifier against all BUILD files.

### DIFF
--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -36,13 +38,13 @@ mdc_objc_library(
     srcs = native.glob(["src/Theming/*.m"]),
     hdrs = native.glob(["src/Theming/*.h"]),
     includes = ["src/Theming"],
+    visibility = ["//visibility:public"],
     deps = [
         ":ActionSheet",
         ":ColorThemer",
         ":TypographyThemer",
         "//components/schemes/Container",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -51,12 +53,12 @@ mdc_objc_library(
     hdrs = native.glob(["src/ActionSheetThemer/*.h"]),
     includes = ["src/ActionSheetThemer"],
     sdk_frameworks = ["UIKit"],
+    visibility = ["//visibility:public"],
     deps = [
         ":ActionSheet",
-        ":TypographyThemer",
         ":ColorThemer",
+        ":TypographyThemer",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -65,11 +67,11 @@ mdc_objc_library(
     hdrs = native.glob(["src/TypographyThemer/*.h"]),
     includes = ["src/TypographyThemer"],
     sdk_frameworks = ["UIKit"],
+    visibility = ["//visibility:public"],
     deps = [
         ":ActionSheet",
         "//components/schemes/Typography",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -78,11 +80,11 @@ mdc_objc_library(
     hdrs = native.glob(["src/ColorThemer/*.h"]),
     includes = ["src/ColorThemer"],
     sdk_frameworks = ["UIKit"],
+    visibility = ["//visibility:public"],
     deps = [
         ":ActionSheet",
         "//components/schemes/Color",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -103,12 +105,12 @@ mdc_objc_library(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
+    visibility = ["//visibility:private"],
     deps = [
         ":ActionSheet",
         ":ColorThemer",
         ":private",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_objc_library(
@@ -123,20 +125,20 @@ mdc_objc_library(
         "CoreImage",
         "XCTest",
     ],
-    deps = [
-         ":ActionSheet",
-         ":Theming",
-         ":ActionSheetThemer",
-         ":ColorThemer",
-         ":TypographyThemer",
-         ":privateHeaders"
-    ],
     visibility = ["//visibility:private"],
+    deps = [
+        ":ActionSheet",
+        ":ActionSheetThemer",
+        ":ColorThemer",
+        ":Theming",
+        ":TypographyThemer",
+        ":privateHeaders",
+    ],
 )
 
 mdc_unit_test_suite(
     deps = [
         ":unit_test_sources",
-        ":unit_test_swift_sources"
-    ]
+        ":unit_test_swift_sources",
+    ],
 )

--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -31,8 +33,8 @@ mdc_public_objc_library(
         "//components/Palettes",
         "//components/private/Application",
         "@material_internationalization_ios//:MDFInternationalization",
-        "@motion_interchange_objc//:MotionInterchange",
         "@motion_animator_objc//:MotionAnimator",
+        "@motion_interchange_objc//:MotionInterchange",
     ],
 )
 
@@ -56,21 +58,21 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":ActivityIndicator",
         "//components/schemes/Color",
     ],
-    visibility = ["//visibility:public"],
 )
 
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
+    visibility = ["//visibility:private"],
     deps = [
         ":ActivityIndicator",
         ":ColorThemer",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_objc_library(
@@ -82,16 +84,16 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":ActivityIndicator",
         ":ColorThemer",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
-      ":unit_test_swift_sources"
+        ":unit_test_sources",
+        ":unit_test_swift_sources",
     ],
 )

--- a/components/AnimationTiming/BUILD
+++ b/components/AnimationTiming/BUILD
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -36,12 +38,12 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
-    deps = [":AnimationTiming"],
     visibility = ["//visibility:private"],
+    deps = [":AnimationTiming"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/AppBar/BUILD
+++ b/components/AppBar/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -63,13 +65,13 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":AppBar",
-        "//components/Themes",
         "//components/FlexibleHeader:ColorThemer",
         "//components/NavigationBar:ColorThemer",
+        "//components/Themes",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -80,11 +82,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":AppBar",
         "//components/NavigationBar:TypographyThemer",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -97,18 +99,17 @@ mdc_objc_library(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
+    visibility = ["//visibility:private"],
     deps = [
         ":AppBar",
         ":ColorThemer",
-        ":private",
         ":TypographyThemer",
+        ":private",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_swift_sources",
+        ":unit_test_swift_sources",
     ],
 )
-

--- a/components/BottomAppBar/BUILD
+++ b/components/BottomAppBar/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -51,12 +53,12 @@ mdc_objc_library(
     sdk_frameworks = [
         "Foundation",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":BottomAppBar",
         "//components/Themes",
         "//components/schemes/Color",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -71,17 +73,17 @@ mdc_objc_library(
         "XCTest",
         "CoreGraphics",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":BottomAppBar",
         ":ColorThemer",
         ":private",
         "//components/NavigationBar",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -57,13 +59,12 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":BottomNavigation",
         "//components/schemes/Color",
     ],
-    visibility = ["//visibility:public"],
 )
-
 
 mdc_objc_library(
     name = "TypographyThemer",
@@ -73,11 +74,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "Foundation",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":BottomNavigation",
         "//components/schemes/Typography",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -98,17 +99,17 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":BottomNavigation",
         ":ColorThemer",
         ":TypographyThemer",
         ":private",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/BottomSheet/BUILD
+++ b/components/BottomSheet/BUILD
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -27,10 +29,10 @@ mdc_public_objc_library(
         "UIKit",
     ],
     deps = [
-      "//components/private/KeyboardWatcher",
-      "//components/private/Math",
-      "//components/private/ShapeLibrary",
-      "//components/private/Shapes",
+        "//components/private/KeyboardWatcher",
+        "//components/private/Math",
+        "//components/private/ShapeLibrary",
+        "//components/private/Shapes",
     ],
 )
 
@@ -49,11 +51,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":BottomSheet",
         "//components/schemes/Shape",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -65,26 +67,26 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":BottomSheet",
         ":privateHeaders",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
-      ":unit_test_swift_sources",
+        ":unit_test_sources",
+        ":unit_test_swift_sources",
     ],
 )
 
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
+    visibility = ["//visibility:private"],
     deps = [
         ":BottomSheet",
         ":ShapeThemer",
     ],
-    visibility = ["//visibility:private"],
 )

--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -42,11 +44,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":ButtonBar",
         "//components/Themes",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -57,11 +59,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":ButtonBar",
         "//components/schemes/Typography",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -72,13 +74,13 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":ButtonBar",
         ":ColorThemer",
         ":TypographyThemer",
         "//components/schemes/Container",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -99,18 +101,19 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":ButtonBar",
         ":ColorThemer",
         ":Theming",
         ":private",
     ],
-    visibility = ["//visibility:private"],
 )
 
 swift_library(
     name = "unit_test_swift_sources",
     srcs = native.glob(["tests/unit/*.swift"]),
+    visibility = ["//visibility:private"],
     deps = [
         ":ButtonBar",
         ":ColorThemer",
@@ -118,12 +121,11 @@ swift_library(
         ":TypographyThemer",
         ":private",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
-      ":unit_test_swift_sources",
+        ":unit_test_sources",
+        ":unit_test_swift_sources",
     ],
 )

--- a/components/Buttons/BUILD
+++ b/components/Buttons/BUILD
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -46,6 +48,7 @@ mdc_objc_library(
     srcs = native.glob(["src/Theming/*.m"]),
     hdrs = native.glob(["src/Theming/*.h"]),
     includes = ["src/Theming"],
+    visibility = ["//visibility:public"],
     deps = [
         ":Buttons",
         ":ColorThemer",
@@ -54,20 +57,18 @@ mdc_objc_library(
         "//components/ShadowElevations",
         "//components/schemes/Container",
     ],
-    visibility = ["//visibility:public"],
 )
-
 
 mdc_objc_library(
     name = "ColorThemer",
     srcs = native.glob(["src/ColorThemer/*.m"]),
     hdrs = native.glob(["src/ColorThemer/*.h"]),
     includes = ["src/ColorThemer"],
+    visibility = ["//visibility:public"],
     deps = [
         ":Buttons",
         "//components/schemes/Color",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -75,11 +76,11 @@ mdc_objc_library(
     srcs = native.glob(["src/TitleColorAccessibilityMutator/*.m"]),
     hdrs = native.glob(["src/TitleColorAccessibilityMutator/*.h"]),
     includes = ["src/TitleColorAccessibilityMutator"],
+    visibility = ["//visibility:public"],
     deps = [
         ":Buttons",
         "@material_text_accessibility_ios//:MDFTextAccessibility",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -87,11 +88,11 @@ mdc_objc_library(
     srcs = native.glob(["src/ShapeThemer/*.m"]),
     hdrs = native.glob(["src/ShapeThemer/*.h"]),
     includes = ["src/ShapeThemer"],
+    visibility = ["//visibility:public"],
     deps = [
         ":Buttons",
         "//components/schemes/Shape",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -99,11 +100,11 @@ mdc_objc_library(
     srcs = native.glob(["src/TypographyThemer/*.m"]),
     hdrs = native.glob(["src/TypographyThemer/*.h"]),
     includes = ["src/TypographyThemer"],
+    visibility = ["//visibility:public"],
     deps = [
         ":Buttons",
         "//components/schemes/Typography",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -111,13 +112,13 @@ mdc_objc_library(
     srcs = native.glob(["src/ButtonThemer/*.m"]),
     hdrs = native.glob(["src/ButtonThemer/*.h"]),
     includes = ["src/ButtonThemer"],
+    visibility = ["//visibility:public"],
     deps = [
         ":Buttons",
         ":ColorThemer",
         ":ShapeThemer",
         ":TypographyThemer",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -147,22 +148,22 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
+    xibs = native.glob(["tests/unit/resources/*.xib"]),
     deps = [
-        ":Buttons",
         ":ButtonThemer",
+        ":Buttons",
         ":ColorThemer",
-        ":private",
         ":ShapeThemer",
         ":TitleColorAccessibilityMutator",
         ":TypographyThemer",
+        ":private",
         "//components/Palettes",
     ],
-    visibility = ["//visibility:private"],
-    xibs = native.glob(["tests/unit/resources/*.xib"]),
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/Cards/BUILD
+++ b/components/Cards/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -30,8 +32,8 @@ mdc_public_objc_library(
     deps = [
         "//components/Ink",
         "//components/ShadowLayer",
-        "//components/private/Math",
         "//components/private/Icons/icons/ic_check_circle",
+        "//components/private/Math",
         "//components/private/ShapeLibrary",
         "//components/private/Shapes",
     ],
@@ -42,12 +44,12 @@ mdc_objc_library(
     srcs = native.glob(["src/CardThemer/*.m"]),
     hdrs = native.glob(["src/CardThemer/*.h"]),
     includes = ["src/CardThemer"],
+    visibility = ["//visibility:public"],
     deps = [
         ":Cards",
         ":ColorThemer",
         ":ShapeThemer",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -58,11 +60,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":Cards",
         "//components/schemes/Color",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -73,22 +75,22 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":Cards",
         "//components/schemes/Shape",
     ],
-    visibility = ["//visibility:public"],
 )
 
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
+    visibility = ["//visibility:private"],
     deps = [
         ":Cards",
         ":ColorThemer",
         ":ShapeThemer",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_objc_library(
@@ -102,17 +104,16 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":Cards",
         "//components/private/Icons/icons/ic_info",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
-      ":unit_test_swift_sources"
+        ":unit_test_sources",
+        ":unit_test_swift_sources",
     ],
 )
-

--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -44,13 +46,13 @@ mdc_objc_library(
     srcs = native.glob(["src/ChipThemer/*.m"]),
     hdrs = native.glob(["src/ChipThemer/*.h"]),
     includes = ["src/ChipThemer"],
+    visibility = ["//visibility:public"],
     deps = [
         ":Chips",
         ":ColorThemer",
         ":ShapeThemer",
         ":TypographyThemer",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -92,11 +94,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":Chips",
         "//components/schemes/Shape",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -130,9 +132,10 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
-        ":Chips",
         ":ChipThemer",
+        ":Chips",
         ":ColorThemer",
         ":FontThemer",
         ":ShapeThemer",
@@ -142,11 +145,10 @@ mdc_objc_library(
         "//components/TextFields:private",
         "//components/private/ShapeLibrary",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/CollectionCells/BUILD
+++ b/components/CollectionCells/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -27,8 +29,8 @@ mdc_public_objc_library(
         "UIKit",
     ],
     deps = [
-        "//components/Ink",
         "//components/CollectionLayoutAttributes",
+        "//components/Ink",
         "//components/Palettes",
         "//components/Typography",
         "//components/private/Icons",
@@ -66,14 +68,14 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":CollectionCells",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/CollectionLayoutAttributes/BUILD
+++ b/components/CollectionLayoutAttributes/BUILD
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -47,14 +49,14 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":CollectionLayoutAttributes",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/Collections/BUILD
+++ b/components/Collections/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -67,15 +69,15 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":Collections",
         ":private",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -59,15 +61,15 @@ mdc_objc_library(
     srcs = native.glob(["src/Theming/*.m"]),
     hdrs = native.glob(["src/Theming/*.h"]),
     includes = ["src/Theming"],
+    visibility = ["//visibility:public"],
     deps = [
-        ":Dialogs",
         ":ColorThemer",
+        ":Dialogs",
         ":TypographyThemer",
         "//components/Buttons:Theming",
         "//components/ShadowElevations",
         "//components/schemes/Container",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -78,15 +80,15 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
+        ":ColorThemer",
         ":Dialogs",
-        "//components/Themes",
+        ":TypographyThemer",
         "//components/Buttons:ButtonThemer",
         "//components/Buttons:ColorThemer",
-        ":ColorThemer",
-        ":TypographyThemer",
+        "//components/Themes",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -97,12 +99,12 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":Dialogs",
-        "//components/Themes",
         "//components/Buttons:ColorThemer",
+        "//components/Themes",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -113,12 +115,12 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":Dialogs",
-        "//components/schemes/Typography",
         "//components/Buttons:TypographyThemer",
+        "//components/schemes/Typography",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -139,18 +141,18 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
-        ":Dialogs",
-        ":DialogThemer",
         ":ColorThemer",
+        ":DialogThemer",
+        ":Dialogs",
         ":TypographyThemer",
         ":private",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/FeatureHighlight/BUILD
+++ b/components/FeatureHighlight/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -51,11 +53,11 @@ mdc_objc_library(
     srcs = native.glob(["src/ColorThemer/*.m"]),
     hdrs = native.glob(["src/ColorThemer/*.h"]),
     includes = ["src/ColorThemer"],
+    visibility = ["//visibility:public"],
     deps = [
         ":FeatureHighlight",
         "//components/Themes",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -63,11 +65,11 @@ mdc_objc_library(
     srcs = native.glob(["src/FontThemer/*.m"]),
     hdrs = native.glob(["src/FontThemer/*.h"]),
     includes = ["src/FontThemer"],
+    visibility = ["//visibility:public"],
     deps = [
         ":FeatureHighlight",
         "//components/Themes",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -75,11 +77,11 @@ mdc_objc_library(
     srcs = native.glob(["src/TypographyThemer/*.m"]),
     hdrs = native.glob(["src/TypographyThemer/*.h"]),
     includes = ["src/TypographyThemer"],
+    visibility = ["//visibility:public"],
     deps = [
         ":FeatureHighlight",
         "//components/schemes/Typography",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -87,11 +89,11 @@ mdc_objc_library(
     srcs = native.glob(["src/FeatureHighlightAccessibilityMutator/*.m"]),
     hdrs = native.glob(["src/FeatureHighlightAccessibilityMutator/*.h"]),
     includes = ["src/FeatureHighlightAccessibilityMutator"],
+    visibility = ["//visibility:public"],
     deps = [
         ":FeatureHighlight",
         "@material_text_accessibility_ios//:MDFTextAccessibility",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -112,19 +114,19 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
-        ":FeatureHighlight",
         ":ColorThemer",
-        ":FontThemer",
+        ":FeatureHighlight",
         ":FeatureHighlightAccessibilityMutator",
+        ":FontThemer",
         ":TypographyThemer",
         ":private",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -27,9 +29,9 @@ mdc_public_objc_library(
         "UIKit",
     ],
     deps = [
-      "//components/private/Application",
-      "//components/private/UIMetrics",
-      "@material_text_accessibility_ios//:MDFTextAccessibility",
+        "//components/private/Application",
+        "//components/private/UIMetrics",
+        "@material_text_accessibility_ios//:MDFTextAccessibility",
     ],
 )
 
@@ -41,11 +43,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":FlexibleHeader",
         "//components/schemes/Color",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -70,21 +72,21 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":FlexibleHeader",
     ],
-    visibility = ["//visibility:public"],
 )
 
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
-    deps = [
-        ":FlexibleHeader",
-        ":ColorThemer",
-        ":CanAlwaysExpandToMaximumHeight",
-    ],
     visibility = ["//visibility:private"],
+    deps = [
+        ":CanAlwaysExpandToMaximumHeight",
+        ":ColorThemer",
+        ":FlexibleHeader",
+    ],
 )
 
 mdc_objc_library(
@@ -100,18 +102,18 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
-    deps = [
-        ":private",
-        ":FlexibleHeader",
-        ":ColorThemer",
-        ":CanAlwaysExpandToMaximumHeight",
-    ],
     visibility = ["//visibility:private"],
+    deps = [
+        ":CanAlwaysExpandToMaximumHeight",
+        ":ColorThemer",
+        ":FlexibleHeader",
+        ":private",
+    ],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
-      ":unit_test_swift_sources"
+        ":unit_test_sources",
+        ":unit_test_swift_sources",
     ],
 )

--- a/components/HeaderStackView/BUILD
+++ b/components/HeaderStackView/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -37,11 +39,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":HeaderStackView",
         "//components/Themes",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -55,15 +57,15 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
-    deps = [
-        ":HeaderStackView",
-        ":ColorThemer",
-    ],
     visibility = ["//visibility:private"],
+    deps = [
+        ":ColorThemer",
+        ":HeaderStackView",
+    ],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/Ink/BUILD
+++ b/components/Ink/BUILD
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -27,7 +29,7 @@ mdc_public_objc_library(
         "UIKit",
     ],
     deps = [
-      "//components/private/Math",
+        "//components/private/Math",
     ],
 )
 
@@ -39,19 +41,19 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":Ink",
         "//components/Themes",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
     name = "private",
     hdrs = native.glob(["src/private/*.h"]),
-    deps = [":Ink"],
     includes = ["src/private"],
     visibility = ["//visibility:private"],
+    deps = [":Ink"],
 )
 
 mdc_objc_library(
@@ -63,16 +65,16 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
-    deps = [
-        ":Ink",
-        ":ColorThemer",
-        ":private"
-    ],
     visibility = ["//visibility:private"],
+    deps = [
+        ":ColorThemer",
+        ":Ink",
+        ":private",
+    ],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/LibraryInfo/BUILD
+++ b/components/LibraryInfo/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -31,12 +33,12 @@ mdc_public_objc_library(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
-    deps = [":LibraryInfo"],
     visibility = ["//visibility:private"],
+    deps = [":LibraryInfo"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_swift_sources",
+        ":unit_test_swift_sources",
     ],
 )

--- a/components/List/BUILD
+++ b/components/List/BUILD
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -27,8 +29,8 @@ mdc_public_objc_library(
     ],
     deps = [
         "//components/Ink",
-        "//components/ShadowLayer",
         "//components/ShadowElevations",
+        "//components/ShadowLayer",
         "//components/Typography",
         "@material_internationalization_ios//:MDFInternationalization",
     ],
@@ -40,11 +42,11 @@ mdc_objc_library(
     hdrs = native.glob(["src/TypographyThemer/*.h"]),
     includes = ["src/TypographyThemer"],
     sdk_frameworks = ["UIKit"],
+    visibility = ["//visibility:public"],
     deps = [
         ":List",
         "//components/schemes/Typography",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -53,11 +55,11 @@ mdc_objc_library(
     hdrs = native.glob(["src/ColorThemer/*.h"]),
     includes = ["src/ColorThemer"],
     sdk_frameworks = ["UIKit"],
+    visibility = ["//visibility:public"],
     deps = [
         ":List",
         "//components/schemes/Color",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -66,12 +68,12 @@ mdc_objc_library(
     hdrs = native.glob(["src/ListThemer/*.h"]),
     includes = ["src/ListThemer"],
     sdk_frameworks = ["UIKit"],
+    visibility = ["//visibility:public"],
     deps = [
+        ":ColorThemer",
         ":List",
         ":TypographyThemer",
-        ":ColorThemer",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -84,17 +86,17 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
-    deps = [
-         ":List",
-         ":ListThemer",
-         ":ColorThemer",
-         ":TypographyThemer",
-    ],
     visibility = ["//visibility:private"],
+    deps = [
+        ":ColorThemer",
+        ":List",
+        ":ListThemer",
+        ":TypographyThemer",
+    ],
 )
 
 mdc_unit_test_suite(
     deps = [
         ":unit_test_sources",
-    ]
+    ],
 )

--- a/components/MaskedTransition/BUILD
+++ b/components/MaskedTransition/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -52,15 +54,15 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":MaskedTransition",
         ":private",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/NavigationBar/BUILD
+++ b/components/NavigationBar/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -40,11 +42,11 @@ mdc_objc_library(
     srcs = native.glob(["src/ColorThemer/*.m"]),
     hdrs = native.glob(["src/ColorThemer/*.h"]),
     includes = ["src/ColorThemer"],
+    visibility = ["//visibility:public"],
     deps = [
         ":NavigationBar",
         "//components/schemes/Color",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -52,11 +54,11 @@ mdc_objc_library(
     srcs = native.glob(["src/TypographyThemer/*.m"]),
     hdrs = native.glob(["src/TypographyThemer/*.h"]),
     includes = ["src/TypographyThemer"],
+    visibility = ["//visibility:public"],
     deps = [
         ":NavigationBar",
         "//components/schemes/Typography",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -64,34 +66,34 @@ mdc_objc_library(
     testonly = 1,
     srcs = native.glob([
         "tests/unit/*.m",
-        "tests/unit/*.h"
+        "tests/unit/*.h",
     ]),
     sdk_frameworks = [
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
-        ":NavigationBar",
         ":ColorThemer",
+        ":NavigationBar",
         ":TypographyThemer",
         "@material_text_accessibility_ios//:MDFTextAccessibility",
     ],
-    visibility = ["//visibility:private"],
 )
 
 swift_library(
     name = "unit_test_swift_sources",
     srcs = native.glob(["tests/unit/*.swift"]),
-    deps = [
-        ":NavigationBar",
-        ":ColorThemer",
-    ],
     visibility = ["//visibility:private"],
+    deps = [
+        ":ColorThemer",
+        ":NavigationBar",
+    ],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
-      ":unit_test_swift_sources",
+        ":unit_test_sources",
+        ":unit_test_swift_sources",
     ],
 )

--- a/components/NavigationDrawer/BUILD
+++ b/components/NavigationDrawer/BUILD
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
-
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
+
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
@@ -41,11 +43,11 @@ mdc_objc_library(
     hdrs = native.glob(["src/ColorThemer/*.h"]),
     includes = ["src/ColorThemer"],
     sdk_frameworks = ["UIKit"],
-    deps = [
-      ":NavigationDrawer",
-      "//components/schemes/Color",
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        ":NavigationDrawer",
+        "//components/schemes/Color",
+    ],
 )
 
 mdc_objc_library(
@@ -53,7 +55,6 @@ mdc_objc_library(
     hdrs = native.glob(["src/private/*.h"]),
     includes = ["src/private"],
     visibility = ["//visibility:private"],
-
 )
 
 mdc_objc_library(
@@ -67,16 +68,16 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
-    deps = [
-         ":NavigationDrawer",
-         ":ColorThemer",
-         ":private",
-    ],
     visibility = ["//visibility:private"],
+    deps = [
+        ":ColorThemer",
+        ":NavigationDrawer",
+        ":private",
+    ],
 )
 
 mdc_unit_test_suite(
     deps = [
         ":unit_test_sources",
-    ]
+    ],
 )

--- a/components/OverlayWindow/BUILD
+++ b/components/OverlayWindow/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -41,14 +43,14 @@ mdc_objc_library(
     sdk_frameworks = [
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":OverlayWindow",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/PageControl/BUILD
+++ b/components/PageControl/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -50,11 +52,11 @@ mdc_objc_library(
     srcs = native.glob(["src/ColorThemer/*.m"]),
     hdrs = native.glob(["src/ColorThemer/*.h"]),
     includes = ["src/ColorThemer"],
+    visibility = ["//visibility:public"],
     deps = [
         ":PageControl",
         "//components/Themes",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -74,15 +76,15 @@ mdc_objc_library(
     sdk_frameworks = [
         "XCTest",
     ],
-    deps = [
-        ":PageControl",
-        ":ColorThemer",
-    ],
     visibility = ["//visibility:private"],
+    deps = [
+        ":ColorThemer",
+        ":PageControl",
+    ],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/Palettes/BUILD
+++ b/components/Palettes/BUILD
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -27,8 +29,8 @@ mdc_public_objc_library(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
-    deps = [":Palettes"],
     visibility = ["//visibility:private"],
+    deps = [":Palettes"],
 )
 
 mdc_objc_library(
@@ -39,13 +41,13 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
-    deps = [":Palettes"],
     visibility = ["//visibility:private"],
+    deps = [":Palettes"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
-      ":unit_test_swift_sources",
+        ":unit_test_sources",
+        ":unit_test_swift_sources",
     ],
 )

--- a/components/ProgressView/BUILD
+++ b/components/ProgressView/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -43,11 +45,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":ProgressView",
         "//components/Themes",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -68,16 +70,16 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
-        ":ProgressView",
         ":ColorThemer",
+        ":ProgressView",
         ":private",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/ShadowElevations/BUILD
+++ b/components/ShadowElevations/BUILD
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -33,18 +35,18 @@ mdc_objc_library(
     testonly = 1,
     srcs = glob([
         "tests/unit/*.m",
-        "tests/unit/*.h"
+        "tests/unit/*.h",
     ]),
     sdk_frameworks = [
         "UIKit",
         "XCTest",
     ],
-    deps = [":ShadowElevations"],
     visibility = ["//visibility:private"],
+    deps = [":ShadowElevations"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/ShadowLayer/BUILD
+++ b/components/ShadowLayer/BUILD
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -37,18 +39,18 @@ mdc_objc_library(
     testonly = 1,
     srcs = glob([
         "tests/unit/*.m",
-        "tests/unit/*.h"
+        "tests/unit/*.h",
     ]),
     sdk_frameworks = [
         "UIKit",
         "XCTest",
     ],
-    deps = [":ShadowLayer"],
     visibility = ["//visibility:private"],
+    deps = [":ShadowLayer"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/Slider/BUILD
+++ b/components/Slider/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -40,11 +42,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":Slider",
         "//components/schemes/Color",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -65,16 +67,16 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
-        ":Slider",
         ":ColorThemer",
+        ":Slider",
         ":private",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/Snackbar/BUILD
+++ b/components/Snackbar/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -61,11 +63,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":Snackbar",
         "//components/schemes/Color",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -76,11 +78,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":Snackbar",
         "//components/Themes",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -88,11 +90,11 @@ mdc_objc_library(
     srcs = native.glob(["src/TypographyThemer/*.m"]),
     hdrs = native.glob(["src/TypographyThemer/*.h"]),
     includes = ["src/TypographyThemer"],
+    visibility = ["//visibility:public"],
     deps = [
         ":Snackbar",
         "//components/schemes/Typography",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -105,13 +107,13 @@ mdc_objc_library(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
-    deps = [
-        ":Snackbar",
-        ":private",
-        ":ColorThemer",
-        ":TypographyThemer",
-    ],
     visibility = ["//visibility:private"],
+    deps = [
+        ":ColorThemer",
+        ":Snackbar",
+        ":TypographyThemer",
+        ":private",
+    ],
 )
 
 mdc_objc_library(
@@ -127,19 +129,18 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
-        ":Snackbar",
         ":ColorThemer",
         ":FontThemer",
+        ":Snackbar",
         ":private",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
-      ":unit_test_swift_sources",
+        ":unit_test_sources",
+        ":unit_test_swift_sources",
     ],
 )
-

--- a/components/Tabs/BUILD
+++ b/components/Tabs/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -29,9 +31,9 @@ mdc_public_objc_library(
     deps = [
         "//components/AnimationTiming",
         "//components/Ink",
-        "//components/Typography",
         "//components/ShadowElevations",
         "//components/ShadowLayer",
+        "//components/Typography",
         "@material_internationalization_ios//:MDFInternationalization",
     ],
 )
@@ -56,11 +58,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":Tabs",
         "//components/schemes/Color",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -71,11 +73,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":Tabs",
         "//components/Themes",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -86,11 +88,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":Tabs",
         "//components/schemes/Typography",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -111,18 +113,18 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
-        ":Tabs",
         ":ColorThemer",
         ":FontThemer",
+        ":Tabs",
         ":TypographyThemer",
         ":private",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -32,7 +34,7 @@ package_group(
     packages = [
         "//components/Chips/...",
         "//components/TextFields/...",
-    ]
+    ],
 )
 
 mdc_public_objc_library(
@@ -43,9 +45,9 @@ mdc_public_objc_library(
     ],
     deps = [
         "//components/AnimationTiming",
-        "//components/private/Math",
         "//components/Palettes",
-        "//components/Typography"
+        "//components/Typography",
+        "//components/private/Math",
     ],
 )
 
@@ -57,11 +59,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":TextFields",
         "//components/Themes",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -72,11 +74,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":TextFields",
         "//components/Themes",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -87,11 +89,11 @@ mdc_objc_library(
     sdk_frameworks = [
         "UIKit",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":TextFields",
         "//components/schemes/Typography",
     ],
-    visibility = ["//visibility:public"],
 )
 
 mdc_objc_library(
@@ -103,30 +105,30 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
-        ":TextFields",
         ":ColorThemer",
         ":FontThemer",
+        ":TextFields",
         ":TypographyThemer",
     ],
-    visibility = ["//visibility:private"],
 )
 
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
-    deps = [
-        ":TextFields",
-        ":ColorThemer",
-        "//components/private/Math",
-        "//components/Palettes",
-    ],
     visibility = ["//visibility:private"],
+    deps = [
+        ":ColorThemer",
+        ":TextFields",
+        "//components/Palettes",
+        "//components/private/Math",
+    ],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
-      ":unit_test_swift_sources",
+        ":unit_test_sources",
+        ":unit_test_swift_sources",
     ],
 )

--- a/components/Themes/BUILD
+++ b/components/Themes/BUILD
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -47,15 +49,15 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":Themes",
         "//components/Palettes",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/Typography/BUILD
+++ b/components/Typography/BUILD
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -28,7 +30,7 @@ mdc_public_objc_library(
     deps = [
         "//components/private/Application",
         "//components/private/Math",
-        "@material_internationalization_ios//:MDFInternationalization"
+        "@material_internationalization_ios//:MDFInternationalization",
     ],
 )
 
@@ -48,15 +50,15 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":Typography",
         ":private",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/private/Icons/BUILD
+++ b/components/private/Icons/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -35,6 +37,7 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":Icons",
         "//components/private/Icons/icons/ic_arrow_back",
@@ -48,11 +51,10 @@ mdc_objc_library(
         "//components/private/Icons/icons/ic_radio_button_unchecked",
         "//components/private/Icons/icons/ic_reorder",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/private/Icons/icons/ic_check/BUILD
+++ b/components/private/Icons/icons/ic_check/BUILD
@@ -10,12 +10,12 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 # implied.
-# See the License for the specific language governing permissions and 
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
 
-licenses(["notice"])  # Apache 2.0 
+licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_check",
@@ -33,4 +33,3 @@ objc_bundle(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
-

--- a/components/private/Icons/icons/ic_check_circle/BUILD
+++ b/components/private/Icons/icons/ic_check_circle/BUILD
@@ -10,12 +10,12 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 # implied.
-# See the License for the specific language governing permissions and 
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
 
-licenses(["notice"])  # Apache 2.0 
+licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_check_circle",
@@ -33,4 +33,3 @@ objc_bundle(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
-

--- a/components/private/Icons/icons/ic_chevron_right/BUILD
+++ b/components/private/Icons/icons/ic_chevron_right/BUILD
@@ -10,12 +10,12 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 # implied.
-# See the License for the specific language governing permissions and 
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
 
-licenses(["notice"])  # Apache 2.0 
+licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_chevron_right",
@@ -33,4 +33,3 @@ objc_bundle(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
-

--- a/components/private/Icons/icons/ic_color_lens/BUILD
+++ b/components/private/Icons/icons/ic_color_lens/BUILD
@@ -10,12 +10,12 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 # implied.
-# See the License for the specific language governing permissions and 
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
 
-licenses(["notice"])  # Apache 2.0 
+licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_color_lens",
@@ -33,4 +33,3 @@ objc_bundle(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
-

--- a/components/private/Icons/icons/ic_help_outline/BUILD
+++ b/components/private/Icons/icons/ic_help_outline/BUILD
@@ -10,12 +10,12 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 # implied.
-# See the License for the specific language governing permissions and 
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
 
-licenses(["notice"])  # Apache 2.0 
+licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_help_outline",
@@ -33,4 +33,3 @@ objc_bundle(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
-

--- a/components/private/Icons/icons/ic_info/BUILD
+++ b/components/private/Icons/icons/ic_info/BUILD
@@ -10,12 +10,12 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 # implied.
-# See the License for the specific language governing permissions and 
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
 
-licenses(["notice"])  # Apache 2.0 
+licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_info",
@@ -33,4 +33,3 @@ objc_bundle(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
-

--- a/components/private/Icons/icons/ic_more_horiz/BUILD
+++ b/components/private/Icons/icons/ic_more_horiz/BUILD
@@ -10,12 +10,12 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 # implied.
-# See the License for the specific language governing permissions and 
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
 
-licenses(["notice"])  # Apache 2.0 
+licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_more_horiz",
@@ -33,4 +33,3 @@ objc_bundle(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
-

--- a/components/private/Icons/icons/ic_radio_button_unchecked/BUILD
+++ b/components/private/Icons/icons/ic_radio_button_unchecked/BUILD
@@ -10,12 +10,12 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 # implied.
-# See the License for the specific language governing permissions and 
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
 
-licenses(["notice"])  # Apache 2.0 
+licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_radio_button_unchecked",
@@ -33,4 +33,3 @@ objc_bundle(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
-

--- a/components/private/Icons/icons/ic_reorder/BUILD
+++ b/components/private/Icons/icons/ic_reorder/BUILD
@@ -10,12 +10,12 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 # implied.
-# See the License for the specific language governing permissions and 
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
 
-licenses(["notice"])  # Apache 2.0 
+licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_reorder",
@@ -33,4 +33,3 @@ objc_bundle(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
-

--- a/components/private/Icons/icons/ic_settings/BUILD
+++ b/components/private/Icons/icons/ic_settings/BUILD
@@ -10,12 +10,12 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 # implied.
-# See the License for the specific language governing permissions and 
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
 
-licenses(["notice"])  # Apache 2.0 
+licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_settings",
@@ -33,4 +33,3 @@ objc_bundle(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
-

--- a/components/private/KeyboardWatcher/BUILD
+++ b/components/private/KeyboardWatcher/BUILD
@@ -12,21 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_objc_library",
-     "mdc_public_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "KeyboardWatcher",
-    deps = [
-        "//components/private/Application",
-    ],
     sdk_frameworks = [
         "CoreGraphics",
         "UIKit",
+    ],
+    deps = [
+        "//components/private/Application",
     ],
 )
 
@@ -41,15 +43,15 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":KeyboardWatcher",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
-    deps = [
-      ":unit_test_sources",
-    ],
     size = "small",
+    deps = [
+        ":unit_test_sources",
+    ],
 )

--- a/components/private/Overlay/BUILD
+++ b/components/private/Overlay/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -47,15 +49,15 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":Overlay",
         ":private",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/private/ShapeLibrary/BUILD
+++ b/components/private/ShapeLibrary/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -43,14 +45,14 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":ShapeLibrary",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/private/Shapes/BUILD
+++ b/components/private/Shapes/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -44,14 +46,14 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":Shapes",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/private/ThumbTrack/BUILD
+++ b/components/private/ThumbTrack/BUILD
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_public_objc_library",
-     "mdc_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -41,8 +43,8 @@ mdc_objc_library(
     testonly = 1,
     hdrs = native.glob(["src/private/*.h"]),
     includes = ["src/private"],
-    deps = [":ThumbTrack"],
     visibility = ["//visibility:private"],
+    deps = [":ThumbTrack"],
 )
 
 mdc_objc_library(
@@ -56,15 +58,15 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":ThumbTrack",
         ":private_headers",
     ],
-    visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/schemes/Color/BUILD
+++ b/components/schemes/Color/BUILD
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_objc_library",
-     "mdc_public_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -43,16 +45,16 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":Color",
         "//components/Palettes",
         "//components/private/Math",
-   ],
-    visibility = ["//visibility:private"],
+    ],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/schemes/Container/BUILD
+++ b/components/schemes/Container/BUILD
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_objc_library",
-     "mdc_public_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -38,14 +40,14 @@ mdc_objc_library(
     sdk_frameworks = [
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":Container",
-   ],
-    visibility = ["//visibility:private"],
+    ],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/schemes/Shape/BUILD
+++ b/components/schemes/Shape/BUILD
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_objc_library",
-     "mdc_public_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -46,14 +48,14 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":Shape",
-   ],
-    visibility = ["//visibility:private"],
+    ],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/schemes/Typography/BUILD
+++ b/components/schemes/Typography/BUILD
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:material_components_ios.bzl",
-     "mdc_objc_library",
-     "mdc_public_objc_library",
-     "mdc_unit_test_suite")
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+    "mdc_unit_test_suite",
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -43,14 +45,14 @@ mdc_objc_library(
         "UIKit",
         "XCTest",
     ],
-    deps = [
-        ":Typography"
-    ],
     visibility = ["//visibility:private"],
+    deps = [
+        ":Typography",
+    ],
 )
 
 mdc_unit_test_suite(
     deps = [
-      ":unit_test_sources",
+        ":unit_test_sources",
     ],
 )

--- a/components/testing/runners/BUILD
+++ b/components/testing/runners/BUILD
@@ -6,21 +6,27 @@ ios_test_runner(
     os_version = "8.1",
     visibility = ["//visibility:public"],
 )
+
 ios_test_runner(
     name = "IPAD_PRO_12_9_IN_9_3",
     device_type = "iPad Pro (12.9-inch)",
     os_version = "9.3",
     visibility = ["//visibility:public"],
 )
+
 ios_test_runner(
     name = "IPHONE_7_PLUS_IN_10_3",
     device_type = "iPhone 7 Plus",
     os_version = "10.3",
     visibility = ["//visibility:public"],
 )
+
 ios_test_runner(
     name = "IPHONE_X_IN_11_0",
-    device_type = select({":xcode_9_0": "iPhone2017-C", "//conditions:default": "iPhone X" }),
+    device_type = select({
+        ":xcode_9_0": "iPhone2017-C",
+        "//conditions:default": "iPhone X",
+    }),
     os_version = "11.0",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This is an automated change generated by running the following command:

    find . -name BUILD | xargs buildifier

buildifier can be installed from https://github.com/bazelbuild/buildtools

This change formats all of our BUILD files with the buildifier formatter in preparation for us having a BUILD format linter as part of our presubmits and so that we can cleanly run buildozer commands against the codebase.