### PR TITLE
[automated] Pin all swift_library targets to Swift 3.

### DIFF
--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -105,6 +105,10 @@ mdc_objc_library(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
+    copts = [
+        "-swift-version",
+        "3",
+    ],
     visibility = ["//visibility:private"],
     deps = [
         ":ActionSheet",

--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -68,6 +68,10 @@ mdc_objc_library(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
+    copts = [
+        "-swift-version",
+        "3",
+    ],
     visibility = ["//visibility:private"],
     deps = [
         ":ActivityIndicator",

--- a/components/AppBar/BUILD
+++ b/components/AppBar/BUILD
@@ -99,6 +99,10 @@ mdc_objc_library(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
+    copts = [
+        "-swift-version",
+        "3",
+    ],
     visibility = ["//visibility:private"],
     deps = [
         ":AppBar",

--- a/components/BottomSheet/BUILD
+++ b/components/BottomSheet/BUILD
@@ -84,6 +84,10 @@ mdc_unit_test_suite(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
+    copts = [
+        "-swift-version",
+        "3",
+    ],
     visibility = ["//visibility:private"],
     deps = [
         ":BottomSheet",

--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -113,6 +113,10 @@ mdc_objc_library(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = native.glob(["tests/unit/*.swift"]),
+    copts = [
+        "-swift-version",
+        "3",
+    ],
     visibility = ["//visibility:private"],
     deps = [
         ":ButtonBar",

--- a/components/Cards/BUILD
+++ b/components/Cards/BUILD
@@ -85,6 +85,10 @@ mdc_objc_library(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
+    copts = [
+        "-swift-version",
+        "3",
+    ],
     visibility = ["//visibility:private"],
     deps = [
         ":Cards",

--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -81,6 +81,10 @@ mdc_objc_library(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
+    copts = [
+        "-swift-version",
+        "3",
+    ],
     visibility = ["//visibility:private"],
     deps = [
         ":CanAlwaysExpandToMaximumHeight",

--- a/components/LibraryInfo/BUILD
+++ b/components/LibraryInfo/BUILD
@@ -33,6 +33,10 @@ mdc_public_objc_library(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
+    copts = [
+        "-swift-version",
+        "3",
+    ],
     visibility = ["//visibility:private"],
     deps = [":LibraryInfo"],
 )

--- a/components/NavigationBar/BUILD
+++ b/components/NavigationBar/BUILD
@@ -84,6 +84,10 @@ mdc_objc_library(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = native.glob(["tests/unit/*.swift"]),
+    copts = [
+        "-swift-version",
+        "3",
+    ],
     visibility = ["//visibility:private"],
     deps = [
         ":ColorThemer",

--- a/components/Palettes/BUILD
+++ b/components/Palettes/BUILD
@@ -29,6 +29,10 @@ mdc_public_objc_library(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
+    copts = [
+        "-swift-version",
+        "3",
+    ],
     visibility = ["//visibility:private"],
     deps = [":Palettes"],
 )

--- a/components/Snackbar/BUILD
+++ b/components/Snackbar/BUILD
@@ -107,6 +107,10 @@ mdc_objc_library(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
+    copts = [
+        "-swift-version",
+        "3",
+    ],
     visibility = ["//visibility:private"],
     deps = [
         ":ColorThemer",

--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -117,6 +117,10 @@ mdc_objc_library(
 swift_library(
     name = "unit_test_swift_sources",
     srcs = glob(["tests/unit/*.swift"]),
+    copts = [
+        "-swift-version",
+        "3",
+    ],
     visibility = ["//visibility:private"],
     deps = [
         ":ColorThemer",


### PR DESCRIPTION
This ensures that code will be built against the Swift version it was written in if/when the default Swift version changes.

This is an automated change generated by running:

    buildozer 'add copts -swift-version 3' //...:%swift_library

buildozer can be downloaded and installed from https://github.com/bazelbuild/buildtools