### PR TITLE
[TextFields] "SimpleTextField" Example Prototype

### DIFF
--- a/MaterialComponentsExamples.podspec
+++ b/MaterialComponentsExamples.podspec
@@ -1,3 +1,9 @@
+experimental = [
+  'components/*/examples/experimental/supplemental/*.{h,m,swift}',
+  'components/*/examples/experimental/*.{h,m,swift}',
+  'components/*/examples/experimental/resources/*'
+]
+
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsExamples"
   s.version      = "72.2.0"
@@ -9,7 +15,8 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/material-components/material-components-ios.git", :tag => "v#{s.version}" }
   s.platform     = :ios, '8.0'
   s.requires_arc = true
-  s.source_files = 'components/*/examples/*.{h,m,swift}', 'components/*/examples/supplemental/*.{h,m,swift}', 'components/private/*/examples/*.{h,m,swift}', 'components/schemes/*/examples/*.{h,m,swift}', 'components/schemes/*/examples/supplemental/*.{h,m,swift}'
+  s.source_files = experimental + ['components/*/examples/*.{h,m,swift}', 'components/*/examples/supplemental/*.{h,m,swift}', 'components/private/*/examples/*.{h,m,swift}', 'components/schemes/*/examples/*.{h,m,swift}', 'components/schemes/*/examples/supplemental/*.{h,m,swift}']
+  
   s.resources = ['components/*/examples/resources/*', 'components/private/*/examples/resources/*', 'components/schemes/*/examples/resources/*']
   s.dependency 'MaterialComponents'
   s.dependency 'MaterialComponentsBeta'

--- a/MaterialComponentsExamples.podspec
+++ b/MaterialComponentsExamples.podspec
@@ -3,9 +3,15 @@ experimental_sources = [
   'components/*/examples/experimental/*.{h,m,swift}',
 ]
 
+experimental_headers = [
+  'components/*/examples/experimental/supplemental/*.h',
+  'components/*/examples/experimental/*.h',
+]
+
 experimental_resources = [
   'components/*/examples/experimental/resources/*'
 ]
+
 
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsExamples"
@@ -23,5 +29,5 @@ Pod::Spec.new do |s|
   s.resources = experimental_resources + ['components/*/examples/resources/*', 'components/private/*/examples/resources/*', 'components/schemes/*/examples/resources/*']
   s.dependency 'MaterialComponents'
   s.dependency 'MaterialComponentsBeta'
-  s.public_header_files = 'components/*/examples/*.h', 'components/*/examples/supplemental/*.h', 'components/private/*/examples/*.h', 'components/schemes/*/examples/*.h'
+  s.public_header_files = experimental_headers + ['components/*/examples/*.h', 'components/*/examples/supplemental/*.h', 'components/private/*/examples/*.h', 'components/schemes/*/examples/*.h']
 end

--- a/MaterialComponentsExamples.podspec
+++ b/MaterialComponentsExamples.podspec
@@ -1,6 +1,9 @@
-experimental = [
+experimental_sources = [
   'components/*/examples/experimental/supplemental/*.{h,m,swift}',
   'components/*/examples/experimental/*.{h,m,swift}',
+]
+
+experimental_resources = [
   'components/*/examples/experimental/resources/*'
 ]
 
@@ -15,9 +18,9 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/material-components/material-components-ios.git", :tag => "v#{s.version}" }
   s.platform     = :ios, '8.0'
   s.requires_arc = true
-  s.source_files = experimental + ['components/*/examples/*.{h,m,swift}', 'components/*/examples/supplemental/*.{h,m,swift}', 'components/private/*/examples/*.{h,m,swift}', 'components/schemes/*/examples/*.{h,m,swift}', 'components/schemes/*/examples/supplemental/*.{h,m,swift}']
-  
-  s.resources = ['components/*/examples/resources/*', 'components/private/*/examples/resources/*', 'components/schemes/*/examples/resources/*']
+  s.source_files = experimental_sources + ['components/*/examples/*.{h,m,swift}', 'components/*/examples/supplemental/*.{h,m,swift}', 'components/private/*/examples/*.{h,m,swift}', 'components/schemes/*/examples/*.{h,m,swift}', 'components/schemes/*/examples/supplemental/*.{h,m,swift}']
+
+  s.resources = experimental_resources + ['components/*/examples/resources/*', 'components/private/*/examples/resources/*', 'components/schemes/*/examples/resources/*']
   s.dependency 'MaterialComponents'
   s.dependency 'MaterialComponentsBeta'
   s.public_header_files = 'components/*/examples/*.h', 'components/*/examples/supplemental/*.h', 'components/private/*/examples/*.h', 'components/schemes/*/examples/*.h'

--- a/components/TextFields/examples/experimental/SimpleTextFieldManualLayoutExampleViewController.h
+++ b/components/TextFields/examples/experimental/SimpleTextFieldManualLayoutExampleViewController.h
@@ -1,0 +1,19 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+@interface SimpleTextFieldManualLayoutExampleViewController : UIViewController
+
+@end

--- a/components/TextFields/examples/experimental/SimpleTextFieldManualLayoutExampleViewController.m
+++ b/components/TextFields/examples/experimental/SimpleTextFieldManualLayoutExampleViewController.m
@@ -1,0 +1,251 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "SimpleTextFieldManualLayoutExampleViewController.h"
+
+#import "MaterialButtons.h"
+
+#import "SimpleTextField.h"
+#import "MaterialColorScheme.h"
+#import "MaterialButtons+Theming.h"
+
+#import "MaterialAppBar+ColorThemer.h"
+#import "MaterialAppBar+TypographyThemer.h"
+#import "MaterialButtons+ButtonThemer.h"
+
+
+@interface SimpleTextFieldManualLayoutExampleViewController ()
+
+@property (strong, nonatomic) MDCButton *resignFirstResponderButton;
+@property (strong, nonatomic) SimpleTextField *filledTextField;
+@property (strong, nonatomic) SimpleTextField *outlinedTextField;
+@property (strong, nonatomic) UITextField *uiTextField;
+
+@property (strong, nonatomic) MDCContainerScheme *containerScheme;
+
+@end
+
+@implementation SimpleTextFieldManualLayoutExampleViewController
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  self.view.backgroundColor = [UIColor whiteColor];
+  [self setUpSchemes];
+  [self addSubviews];
+}
+
+- (void)viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
+  [self positionSubviews];
+}
+
+- (void)addSubviews {
+  [self addResignFirstResponderButton];
+  [self addFilledTextField];
+  [self addOutlinedTextField];
+  [self addUiTextField];
+}
+
+- (void)positionSubviews {
+  CGFloat appBarSafeArea = CGRectGetMinY(self.view.bounds);
+  if (@available(iOS 11.0, *)) {
+    appBarSafeArea = self.view.safeAreaInsets.top;
+  }
+  
+  CGFloat padding = 30;
+  CGFloat resignFirstResponderButtonMinX = padding;
+  CGFloat resignFirstResponderButtonMinY = appBarSafeArea + padding;
+  CGFloat resignFirstResponderButtonWidth = CGRectGetWidth(self.resignFirstResponderButton.frame);
+  CGFloat resignFirstResponderButtonHeight = CGRectGetHeight(self.resignFirstResponderButton.frame);
+  CGRect resignFirstResponderButtonFrame = CGRectMake(resignFirstResponderButtonMinX,
+                                                      resignFirstResponderButtonMinY,
+                                                      resignFirstResponderButtonWidth,
+                                                      resignFirstResponderButtonHeight);
+  self.resignFirstResponderButton.frame = resignFirstResponderButtonFrame;
+
+  CGFloat filledTextFieldMinX = padding;
+  CGFloat filledTextFieldMinY = resignFirstResponderButtonMinY + resignFirstResponderButtonHeight + padding;
+  [self.filledTextField sizeToFit];
+  CGFloat filledTextFieldWidth = CGRectGetWidth(self.filledTextField.frame);
+  CGFloat filledTextFieldHeight = CGRectGetHeight(self.filledTextField.frame);
+  CGRect filledTextFieldButtonFrame = CGRectMake(filledTextFieldMinX,
+                                                 filledTextFieldMinY,
+                                                 filledTextFieldWidth,
+                                                 filledTextFieldHeight);
+  self.filledTextField.frame = filledTextFieldButtonFrame;
+
+  CGFloat outlinedTextFieldMinX = padding;
+  CGFloat outlinedTextFieldMinY = filledTextFieldMinY + filledTextFieldHeight + padding;
+  [self.outlinedTextField sizeToFit];
+  CGFloat outlinedTextFieldWidth = CGRectGetWidth(self.outlinedTextField.frame);
+  CGFloat outlinedTextFieldHeight = CGRectGetHeight(self.outlinedTextField.frame);
+  CGRect outlinedTextFieldFrame = CGRectMake(outlinedTextFieldMinX,
+                                             outlinedTextFieldMinY,
+                                             outlinedTextFieldWidth,
+                                             outlinedTextFieldHeight);
+  self.outlinedTextField.frame = outlinedTextFieldFrame;
+  
+  CGFloat uiTextFieldMinX = padding;
+  CGFloat uiTextFieldMinY = outlinedTextFieldMinY + outlinedTextFieldHeight + padding;
+  CGFloat uiTextFieldWidth = CGRectGetWidth(self.uiTextField.frame);
+  CGFloat uiTextFieldHeight = CGRectGetHeight(self.uiTextField.frame);
+  CGRect uiTextFieldFrame = CGRectMake(uiTextFieldMinX,
+                                       uiTextFieldMinY,
+                                       uiTextFieldWidth,
+                                       uiTextFieldHeight);
+  self.uiTextField.frame = uiTextFieldFrame;
+}
+
+- (void)addResignFirstResponderButton {
+  self.resignFirstResponderButton = [[MDCButton alloc] init];
+  [self.resignFirstResponderButton setTitle:@"Resign first responder" forState:UIControlStateNormal];
+  [self.resignFirstResponderButton addTarget:self
+                  action:@selector(buttonTapped:)
+        forControlEvents:UIControlEventTouchUpInside];
+  [self.resignFirstResponderButton applyContainedThemeWithScheme:self.containerScheme];
+  [self.resignFirstResponderButton sizeToFit];
+  [self.view addSubview:self.resignFirstResponderButton];
+}
+
+- (void)addFilledTextField {
+  CGFloat textFieldWidth = CGRectGetWidth(self.view.frame) - 100;
+  CGRect frame = CGRectMake(0, 0, textFieldWidth, 100);
+  self.filledTextField = [[SimpleTextField alloc] initWithFrame:frame];
+  [self.view addSubview:self.filledTextField];
+  self.filledTextField.textFieldStyle = TextFieldStyleFilled;
+  self.filledTextField.placeholder = @"placeholder";
+  self.filledTextField.canPlaceholderFloat = YES;
+  self.filledTextField.leadingViewMode = UITextFieldViewModeWhileEditing;
+  self.filledTextField.trailingViewMode = UITextFieldViewModeAlways;
+  self.filledTextField.leadingViewMode = UITextFieldViewModeNever;
+  self.filledTextField.trailingViewMode = UITextFieldViewModeNever;
+  self.filledTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
+
+  CGRect trailingViewFrame = CGRectMake(0, 0, 20, 20);
+  UILabel *trailingView = [[UILabel alloc] initWithFrame:trailingViewFrame];
+  trailingView.backgroundColor = [UIColor redColor];
+  trailingView.text = @"T";
+  self.filledTextField.trailingView = trailingView;
+
+  CGRect leadingViewFrame = CGRectMake(0, 0, 20, 20);
+  UILabel *leadingView = [[UILabel alloc] initWithFrame:leadingViewFrame];
+  leadingView.backgroundColor = [UIColor magentaColor];
+  leadingView.text = @"L";
+  self.filledTextField.leadingView = leadingView;
+
+  self.filledTextField.underlineLabelDrawPriority = UnderlineLabelDrawPriorityCustom;
+  self.filledTextField.customUnderlineLabelDrawPriority = 0.75;
+
+  self.filledTextField.underlineLabelDrawPriority = UnderlineLabelDrawPriorityLeading;
+  self.filledTextField.underlineLabelDrawPriority = UnderlineLabelDrawPriorityTrailing;
+  // leading and trailing underline views
+//  self.filledTextField.leadingUnderlineLabel.text = @"Vivamus finibus egestas dolor, id facilisis lacus hendrerit ac. Nunc molestie dolor felis, et rutrum tellus tristique sit amet. Donec sollicitudin, nisi ac suscipit mattis, orci urna gravida sem, non molestie mi est sed leo.";
+//  self.filledTextField.trailingUnderlineLabel.text = @"Hello world";
+  [self.filledTextField sizeToFit];
+  self.filledTextField.center = CGPointMake(CGRectGetMidX(self.view.frame), 125);
+}
+
+
+- (void)addOutlinedTextField {
+  CGFloat textFieldWidth = CGRectGetWidth(self.view.frame) - 100;
+  CGRect frame = CGRectMake(0, 0, textFieldWidth, 100);
+  self.outlinedTextField = [[SimpleTextField alloc] initWithFrame:frame];
+  [self.view addSubview:self.outlinedTextField];
+  self.outlinedTextField.textFieldStyle = TextFieldStyleOutline;
+  //  self.outlinedTextField.textFieldStyle = TextFieldStyleFilled;
+  self.outlinedTextField.placeholder = @"placeholder";
+  self.outlinedTextField.canPlaceholderFloat = YES;
+  //  self.outlinedTextField.leadingViewMode = UITextFieldViewModeWhileEditing;
+  //  self.outlinedTextField.trailingViewMode = UITextFieldViewModeAlways;
+  self.outlinedTextField.leadingViewMode = UITextFieldViewModeNever;
+  self.outlinedTextField.trailingViewMode = UITextFieldViewModeNever;
+  self.outlinedTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
+
+  CGRect trailingViewFrame = CGRectMake(0, 0, 20, 20);
+  UILabel *trailingView = [[UILabel alloc] initWithFrame:trailingViewFrame];
+  trailingView.backgroundColor = [UIColor redColor];
+  trailingView.text = @"T";
+  self.outlinedTextField.trailingView = trailingView;
+
+  CGRect leadingViewFrame = CGRectMake(0, 0, 20, 20);
+  UILabel *leadingView = [[UILabel alloc] initWithFrame:leadingViewFrame];
+  leadingView.backgroundColor = [UIColor magentaColor];
+  leadingView.text = @"L";
+  self.outlinedTextField.leadingView = leadingView;
+
+  self.outlinedTextField.underlineLabelDrawPriority = UnderlineLabelDrawPriorityCustom;
+//  self.outlinedTextField.customUnderlineLabelDrawPriority = 0.75;
+  //  self.outlinedTextField.underlineLabelDrawPriority = UnderlineLabelDrawPriorityLeading;
+  //  self.outlinedTextField.underlineLabelDrawPriority = UnderlineLabelDrawPriorityTrailing;
+
+  // leading and trailing underline views
+//  self.outlinedTextField.leadingUnderlineLabel.text = @"Vivamus finibus egestas dolor, id facilisis lacus hendrerit ac. Nunc molestie dolor felis, et rutrum tellus tristique sit amet. Donec sollicitudin, nisi ac suscipit mattis, orci urna gravida sem, non molestie mi est sed leo.";
+//  self.outlinedTextField.trailingUnderlineLabel.text = @"Hello world";
+  self.outlinedTextField.center = CGPointMake(CGRectGetMidX(self.view.frame), 225);
+//  CGRect frame2 = self.outlinedTextField.frame;
+  [self.outlinedTextField sizeToFit];
+//  CGRect f = self.outlinedTextField.frame;
+//  f.size.height += 70;
+//  self.outlinedTextField.frame = f;
+  //  self.outlinedTextField.layer.borderColor = UIColor.blueColor.CGColor;
+//  self.outlinedTextField.layer.borderWidth = 2;
+
+}
+
+- (void)addUiTextField {
+  CGFloat textFieldWidth = CGRectGetWidth(self.view.frame) - 100;
+  CGRect frame = CGRectMake(0, 0, textFieldWidth, 50);
+  self.uiTextField = [[UITextField alloc] initWithFrame:frame];
+  //  self.uiTextField.backgroundColor = [UIColor blueColor];
+  self.uiTextField.borderStyle = UITextBorderStyleRoundedRect;
+  self.uiTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
+  self.uiTextField.leftViewMode = UITextFieldViewModeNever;
+  [self.view addSubview:self.uiTextField];
+
+  CGRect accessoryViewFrame = CGRectMake(0, 0, 20, 20);
+  UILabel *accessoryView = [[UILabel alloc] initWithFrame:accessoryViewFrame];
+  accessoryView.backgroundColor = [UIColor magentaColor];
+  accessoryView.text = @"L";
+  self.uiTextField.leftView = accessoryView;
+
+  self.uiTextField.center = CGPointMake(CGRectGetMidX(self.view.frame), 275);
+}
+
+#pragma mark Theming
+
+- (void)setUpSchemes {
+  self.containerScheme = [[MDCContainerScheme alloc] init];
+}
+
+#pragma mark UITextFieldDelegate
+
+#pragma mark IBActions
+
+- (void)buttonTapped:(UIButton *)button {
+  [self.filledTextField resignFirstResponder];
+  [self.outlinedTextField resignFirstResponder];
+  [self.uiTextField resignFirstResponder];
+}
+
+#pragma mark Catalog By Convention
+
++ (NSDictionary *)catalogMetadata {
+  return @{
+           @"breadcrumbs": @[ @"Text Field", @"Simple Text Field (Manual Layout)" ],
+           @"primaryDemo": @NO,
+           @"presentable": @NO,
+           };
+}
+
+@end

--- a/components/TextFields/examples/experimental/SimpleTextFieldManualLayoutExampleViewController.m
+++ b/components/TextFields/examples/experimental/SimpleTextFieldManualLayoutExampleViewController.m
@@ -124,7 +124,7 @@
   self.filledTextField = [[SimpleTextField alloc] initWithFrame:frame];
   [self.view addSubview:self.filledTextField];
   self.filledTextField.textFieldStyle = TextFieldStyleFilled;
-  self.filledTextField.placeholder = @"placeholder";
+  self.filledTextField.placeholder = @"This is a placeholder";
   self.filledTextField.canPlaceholderFloat = YES;
   self.filledTextField.leadingViewMode = UITextFieldViewModeWhileEditing;
   self.filledTextField.trailingViewMode = UITextFieldViewModeAlways;
@@ -220,6 +220,14 @@
   self.uiTextField.leftView = accessoryView;
 
   self.uiTextField.center = CGPointMake(CGRectGetMidX(self.view.frame), 275);
+  
+//  self.uiTextField.selected = YES;
+  self.uiTextField.enabled = NO;
+
+  
+
+
+
 }
 
 #pragma mark Theming

--- a/components/TextFields/examples/experimental/SimpleTextFieldManualLayoutExampleViewController.m
+++ b/components/TextFields/examples/experimental/SimpleTextFieldManualLayoutExampleViewController.m
@@ -193,7 +193,6 @@
   self.filledTextField = [[SimpleTextField alloc] init];
   self.filledTextField.textFieldStyle = TextFieldStyleFilled;
   self.filledTextField.placeholder = @"This is a placeholder";
-  self.filledTextField.canPlaceholderFloat = YES;
   self.filledTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
   self.filledTextField.leadingUnderlineLabel.numberOfLines = 0;
   [self.scrollView addSubview:self.filledTextField];
@@ -203,7 +202,6 @@
   self.outlinedTextField = [[SimpleTextField alloc] init];
   self.outlinedTextField.textFieldStyle = TextFieldStyleOutline;
   self.outlinedTextField.placeholder = @"This is another placeholder";
-  self.outlinedTextField.canPlaceholderFloat = YES;
   self.outlinedTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
   [self.scrollView addSubview:self.outlinedTextField];
 }

--- a/components/TextFields/examples/experimental/SimpleTextFieldManualLayoutExampleViewController.m
+++ b/components/TextFields/examples/experimental/SimpleTextFieldManualLayoutExampleViewController.m
@@ -16,25 +16,27 @@
 
 #import "MaterialButtons.h"
 
-#import "SimpleTextField.h"
-#import "MaterialColorScheme.h"
 #import "MaterialButtons+Theming.h"
+#import "MaterialColorScheme.h"
+#import "SimpleTextField.h"
 
 #import "MaterialAppBar+ColorThemer.h"
 #import "MaterialAppBar+TypographyThemer.h"
 #import "MaterialButtons+ButtonThemer.h"
 
-
 @interface SimpleTextFieldManualLayoutExampleViewController ()
 
-@property (strong, nonatomic) UIScrollView *scrollView;
+@property(strong, nonatomic) UIScrollView *scrollView;
 
-@property (strong, nonatomic) MDCButton *resignFirstResponderButton;
-@property (strong, nonatomic) SimpleTextField *filledTextField;
-@property (strong, nonatomic) SimpleTextField *outlinedTextField;
-@property (strong, nonatomic) UITextField *uiTextField;
+@property(strong, nonatomic) MDCButton *resignFirstResponderButton;
+@property(strong, nonatomic) MDCButton *toggleErrorButton;
+@property(strong, nonatomic) SimpleTextField *filledTextField;
+@property(strong, nonatomic) SimpleTextField *outlinedTextField;
+@property(strong, nonatomic) UITextField *uiTextField;
 
-@property (strong, nonatomic) MDCContainerScheme *containerScheme;
+@property(strong, nonatomic) MDCContainerScheme *containerScheme;
+
+@property(nonatomic, assign) BOOL isErrored;
 
 @end
 
@@ -42,31 +44,49 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+  [self addObservers];
   self.view.backgroundColor = [UIColor whiteColor];
-  [self setUpSchemes];
+  self.containerScheme = [[MDCContainerScheme alloc] init];
   [self addSubviews];
 }
 
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
-  [self positionScrollView];
-  [self positionScrollViewSubviews];
+  [self layoutScrollView];
+  [self layoutScrollViewSubviews];
   [self updateScrollViewContentSize];
+  [self updateToggleButtonTheme];
+}
+
+- (void)addObservers {
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(keyboardWillShow:)
+                                               name:UIKeyboardWillShowNotification
+                                             object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(keyboardWillHide:)
+                                               name:UIKeyboardWillHideNotification
+                                             object:nil];
+}
+
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (void)addSubviews {
   [self addScrollView];
   [self addResignFirstResponderButton];
+  [self addToggleErrorButton];
   [self addFilledTextField];
   [self addOutlinedTextField];
   [self addUiTextField];
 }
 
-- (void)positionScrollView {
-  CGFloat originX = self.view.bounds.origin.x;
-  CGFloat originY = self.view.bounds.origin.y;
-  CGFloat width = self.view.bounds.size.width;
-  CGFloat height = self.view.bounds.size.height;
+- (void)layoutScrollView {
+  CGFloat originX = CGRectGetMinX(self.view.bounds);
+  CGFloat originY = CGRectGetMinY(self.view.bounds);
+  CGFloat width = CGRectGetWidth(self.view.bounds);
+  CGFloat height = CGRectGetHeight(self.view.bounds);
   if (@available(iOS 11.0, *)) {
     originX += self.view.safeAreaInsets.left;
     originY += self.view.safeAreaInsets.top;
@@ -77,51 +97,57 @@
   self.scrollView.frame = frame;
 }
 
-- (void)positionScrollViewSubviews {
+- (void)layoutScrollViewSubviews {
   CGFloat padding = 30;
   CGFloat resignFirstResponderButtonMinX = padding;
   CGFloat resignFirstResponderButtonMinY = padding;
   CGFloat resignFirstResponderButtonWidth = CGRectGetWidth(self.resignFirstResponderButton.frame);
   CGFloat resignFirstResponderButtonHeight = CGRectGetHeight(self.resignFirstResponderButton.frame);
-  CGRect resignFirstResponderButtonFrame = CGRectMake(resignFirstResponderButtonMinX,
-                                                      resignFirstResponderButtonMinY,
-                                                      resignFirstResponderButtonWidth,
-                                                      resignFirstResponderButtonHeight);
+  CGRect resignFirstResponderButtonFrame =
+      CGRectMake(resignFirstResponderButtonMinX, resignFirstResponderButtonMinY,
+                 resignFirstResponderButtonWidth, resignFirstResponderButtonHeight);
   self.resignFirstResponderButton.frame = resignFirstResponderButtonFrame;
+
+  CGFloat toggleErrorButtonMinX = padding;
+  CGFloat toggleErrorButtonMinY =
+      resignFirstResponderButtonMinY + resignFirstResponderButtonHeight + padding;
+  CGFloat toggleErrorButtonWidth = CGRectGetWidth(self.toggleErrorButton.frame);
+  CGFloat toggleErrorButtonHeight = CGRectGetHeight(self.toggleErrorButton.frame);
+  CGRect toggleErrorButtonFrame = CGRectMake(toggleErrorButtonMinX, toggleErrorButtonMinY,
+                                             toggleErrorButtonWidth, toggleErrorButtonHeight);
+  self.toggleErrorButton.frame = toggleErrorButtonFrame;
 
   CGFloat textFieldWidth = CGRectGetWidth(self.scrollView.frame) - (2 * padding);
   CGSize textFieldFittingSize = CGSizeMake(textFieldWidth, CGFLOAT_MAX);
-  
+
   CGFloat filledTextFieldMinX = padding;
-  CGFloat filledTextFieldMinY = resignFirstResponderButtonMinY + resignFirstResponderButtonHeight + padding;
+  CGFloat filledTextFieldMinY = toggleErrorButtonMinY + toggleErrorButtonHeight + padding;
   CGSize filledTextFieldSize = [self.filledTextField sizeThatFits:textFieldFittingSize];
-  CGRect filledTextFieldButtonFrame = CGRectMake(filledTextFieldMinX,
-                                                 filledTextFieldMinY,
-                                                 filledTextFieldSize.width,
-                                                 filledTextFieldSize.height);
+  CGRect filledTextFieldButtonFrame =
+      CGRectMake(filledTextFieldMinX, filledTextFieldMinY, filledTextFieldSize.width,
+                 filledTextFieldSize.height);
   self.filledTextField.frame = filledTextFieldButtonFrame;
+  [self.filledTextField setNeedsLayout];
 
   CGFloat outlinedTextFieldMinX = padding;
   CGFloat outlinedTextFieldMinY = filledTextFieldMinY + filledTextFieldSize.height + padding;
   CGSize outlinedTextFieldSize = [self.outlinedTextField sizeThatFits:textFieldFittingSize];
-  CGRect outlinedTextFieldFrame = CGRectMake(outlinedTextFieldMinX,
-                                             outlinedTextFieldMinY,
-                                             outlinedTextFieldSize.width,
-                                             outlinedTextFieldSize.height);
+  CGRect outlinedTextFieldFrame =
+      CGRectMake(outlinedTextFieldMinX, outlinedTextFieldMinY, outlinedTextFieldSize.width,
+                 outlinedTextFieldSize.height);
   self.outlinedTextField.frame = outlinedTextFieldFrame;
-  
+  [self.outlinedTextField setNeedsLayout];
+
   CGFloat uiTextFieldMinX = padding;
   CGFloat uiTextFieldMinY = outlinedTextFieldMinY + outlinedTextFieldSize.height + padding;
-  CGRect uiTextFieldFrame = CGRectMake(uiTextFieldMinX,
-                                       uiTextFieldMinY,
-                                       textFieldWidth,
+  CGRect uiTextFieldFrame = CGRectMake(uiTextFieldMinX, uiTextFieldMinY, textFieldWidth,
                                        CGRectGetHeight(self.uiTextField.frame));
   self.uiTextField.frame = uiTextFieldFrame;
 }
 
 - (void)updateScrollViewContentSize {
-  CGFloat maxX = 0;
-  CGFloat maxY = 0;
+  CGFloat maxX = CGRectGetWidth(self.scrollView.bounds);
+  CGFloat maxY = CGRectGetHeight(self.scrollView.bounds);
   for (UIView *subview in self.scrollView.subviews) {
     CGFloat subViewMaxX = CGRectGetMaxX(subview.frame);
     if (subViewMaxX > maxX) {
@@ -135,22 +161,32 @@
   self.scrollView.contentSize = CGSizeMake(maxX, maxY);
 }
 
-
 - (void)addScrollView {
   self.scrollView = [[UIScrollView alloc] init];
   [self.view addSubview:self.scrollView];
 }
 
-
 - (void)addResignFirstResponderButton {
   self.resignFirstResponderButton = [[MDCButton alloc] init];
-  [self.resignFirstResponderButton setTitle:@"Resign first responder" forState:UIControlStateNormal];
+  [self.resignFirstResponderButton setTitle:@"Resign first responder"
+                                   forState:UIControlStateNormal];
   [self.resignFirstResponderButton addTarget:self
-                  action:@selector(buttonTapped:)
-        forControlEvents:UIControlEventTouchUpInside];
+                                      action:@selector(resignFirstResponderButtonTapped:)
+                            forControlEvents:UIControlEventTouchUpInside];
   [self.resignFirstResponderButton applyContainedThemeWithScheme:self.containerScheme];
   [self.resignFirstResponderButton sizeToFit];
   [self.scrollView addSubview:self.resignFirstResponderButton];
+}
+
+- (void)addToggleErrorButton {
+  self.toggleErrorButton = [[MDCButton alloc] init];
+  [self.toggleErrorButton setTitle:@"Toggle error" forState:UIControlStateNormal];
+  [self.toggleErrorButton addTarget:self
+                             action:@selector(toggleErrorButtonTapped:)
+                   forControlEvents:UIControlEventTouchUpInside];
+  [self.toggleErrorButton applyContainedThemeWithScheme:self.containerScheme];
+  [self.toggleErrorButton sizeToFit];
+  [self.scrollView addSubview:self.toggleErrorButton];
 }
 
 - (void)addFilledTextField {
@@ -158,58 +194,17 @@
   self.filledTextField.textFieldStyle = TextFieldStyleFilled;
   self.filledTextField.placeholder = @"This is a placeholder";
   self.filledTextField.canPlaceholderFloat = YES;
-  self.filledTextField.leadingViewMode = UITextFieldViewModeWhileEditing;
-  self.filledTextField.trailingViewMode = UITextFieldViewModeAlways;
-  self.filledTextField.leadingViewMode = UITextFieldViewModeNever;
-  self.filledTextField.trailingViewMode = UITextFieldViewModeNever;
   self.filledTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
-
-  CGRect trailingViewFrame = CGRectMake(0, 0, 20, 20);
-  UILabel *trailingView = [[UILabel alloc] initWithFrame:trailingViewFrame];
-  trailingView.backgroundColor = [UIColor redColor];
-  trailingView.text = @"T";
-  self.filledTextField.trailingView = trailingView;
-
-  CGRect leadingViewFrame = CGRectMake(0, 0, 20, 20);
-  UILabel *leadingView = [[UILabel alloc] initWithFrame:leadingViewFrame];
-  leadingView.backgroundColor = [UIColor magentaColor];
-  leadingView.text = @"L";
-  self.filledTextField.leadingView = leadingView;
-
-  self.filledTextField.underlineLabelDrawPriority = UnderlineLabelDrawPriorityCustom;
-  self.filledTextField.customUnderlineLabelDrawPriority = 0.75;
-
-  self.filledTextField.underlineLabelDrawPriority = UnderlineLabelDrawPriorityLeading;
-  self.filledTextField.underlineLabelDrawPriority = UnderlineLabelDrawPriorityTrailing;
-  self.filledTextField.leadingUnderlineLabel.text = @"Vivamus finibus egestas dolor, id facilisis lacus hendrerit ac. Nunc molestie dolor felis, et rutrum tellus tristique sit amet. Donec sollicitudin, nisi ac suscipit mattis, orci urna gravida sem, non molestie mi est sed leo.";
-  self.filledTextField.trailingUnderlineLabel.text = @"Hello world";
-  [self.filledTextField sizeToFit];
+  self.filledTextField.leadingUnderlineLabel.numberOfLines = 0;
   [self.scrollView addSubview:self.filledTextField];
 }
-
 
 - (void)addOutlinedTextField {
   self.outlinedTextField = [[SimpleTextField alloc] init];
   self.outlinedTextField.textFieldStyle = TextFieldStyleOutline;
-  self.outlinedTextField.placeholder = @"placeholder";
+  self.outlinedTextField.placeholder = @"This is another placeholder";
   self.outlinedTextField.canPlaceholderFloat = YES;
-  self.outlinedTextField.leadingViewMode = UITextFieldViewModeNever;
-  self.outlinedTextField.trailingViewMode = UITextFieldViewModeNever;
   self.outlinedTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
-  self.outlinedTextField.underlineLabelDrawPriority = UnderlineLabelDrawPriorityCustom;
-
-  CGRect trailingViewFrame = CGRectMake(0, 0, 20, 20);
-  UILabel *trailingView = [[UILabel alloc] initWithFrame:trailingViewFrame];
-  trailingView.backgroundColor = [UIColor redColor];
-  trailingView.text = @"T";
-  self.outlinedTextField.trailingView = trailingView;
-
-  CGRect leadingViewFrame = CGRectMake(0, 0, 20, 20);
-  UILabel *leadingView = [[UILabel alloc] initWithFrame:leadingViewFrame];
-  leadingView.backgroundColor = [UIColor magentaColor];
-  leadingView.text = @"L";
-  self.outlinedTextField.leadingView = leadingView;
-
   [self.scrollView addSubview:self.outlinedTextField];
 }
 
@@ -228,30 +223,71 @@
   [self.scrollView addSubview:self.uiTextField];
 }
 
-#pragma mark Theming
+#pragma mark Private
 
-- (void)setUpSchemes {
-  self.containerScheme = [[MDCContainerScheme alloc] init];
+- (void)updateToggleButtonTheme {
+  if (self.isErrored) {
+    MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
+    colorScheme.primaryColor = colorScheme.errorColor;
+    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+    containerScheme.colorScheme = colorScheme;
+    [self.toggleErrorButton applyContainedThemeWithScheme:containerScheme];
+  } else {
+    [self.toggleErrorButton applyOutlinedThemeWithScheme:self.containerScheme];
+  }
 }
 
-#pragma mark UITextFieldDelegate
+- (void)updateTextFieldStates {
+  if (self.isErrored) {
+    self.filledTextField.isErrored = YES;
+    self.filledTextField.leadingUnderlineLabel.text =
+        @"Suspendisse quam elit, mattis sit amet justo vel, venenatis lobortis massa. Donec metus "
+        @"dolor.";
+
+    self.outlinedTextField.isErrored = YES;
+    self.outlinedTextField.leadingUnderlineLabel.text = @"This is an error.";
+    self.outlinedTextField.leadingUnderlineLabel.numberOfLines = 0;
+  } else {
+    self.filledTextField.isErrored = NO;
+    self.filledTextField.leadingUnderlineLabel.text = @"This is helper text.";
+
+    self.outlinedTextField.isErrored = NO;
+    self.outlinedTextField.leadingUnderlineLabel.text = nil;
+  }
+  [self.view setNeedsLayout];
+}
+
+- (void)keyboardWillShow:(NSNotification *)notification {
+  CGRect frame = [[notification.userInfo valueForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
+  self.scrollView.contentInset = UIEdgeInsetsMake(0, 0, CGRectGetHeight(frame), 0);
+}
+
+- (void)keyboardWillHide:(NSNotification *)notification {
+  self.scrollView.contentInset = UIEdgeInsetsMake(0, 0, 0, 0);
+}
 
 #pragma mark IBActions
 
-- (void)buttonTapped:(UIButton *)button {
+- (void)resignFirstResponderButtonTapped:(UIButton *)button {
   [self.filledTextField resignFirstResponder];
   [self.outlinedTextField resignFirstResponder];
   [self.uiTextField resignFirstResponder];
+}
+
+- (void)toggleErrorButtonTapped:(UIButton *)button {
+  self.isErrored = !self.isErrored;
+  [self updateToggleButtonTheme];
+  [self updateTextFieldStates];
 }
 
 #pragma mark Catalog By Convention
 
 + (NSDictionary *)catalogMetadata {
   return @{
-           @"breadcrumbs": @[ @"Text Field", @"Simple Text Field (Manual Layout)" ],
-           @"primaryDemo": @NO,
-           @"presentable": @NO,
-           };
+    @"breadcrumbs" : @[ @"Text Field", @"Simple Text Field (Manual Layout)" ],
+    @"primaryDemo" : @NO,
+    @"presentable" : @NO,
+  };
 }
 
 @end

--- a/components/TextFields/examples/experimental/SimpleTextFieldManualLayoutExampleViewController.m
+++ b/components/TextFields/examples/experimental/SimpleTextFieldManualLayoutExampleViewController.m
@@ -211,13 +211,7 @@
   self.uiTextField = [[UITextField alloc] init];
   self.uiTextField.borderStyle = UITextBorderStyleRoundedRect;
   self.uiTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
-  self.uiTextField.leftViewMode = UITextFieldViewModeNever;
 
-  CGRect accessoryViewFrame = CGRectMake(0, 0, 20, 20);
-  UILabel *accessoryView = [[UILabel alloc] initWithFrame:accessoryViewFrame];
-  accessoryView.backgroundColor = [UIColor magentaColor];
-  accessoryView.text = @"L";
-  self.uiTextField.leftView = accessoryView;
 
   [self.scrollView addSubview:self.uiTextField];
 }

--- a/components/TextFields/examples/experimental/SimpleTextFieldManualLayoutExampleViewController.m
+++ b/components/TextFields/examples/experimental/SimpleTextFieldManualLayoutExampleViewController.m
@@ -212,7 +212,6 @@
   self.uiTextField.borderStyle = UITextBorderStyleRoundedRect;
   self.uiTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
 
-
   [self.scrollView addSubview:self.uiTextField];
 }
 

--- a/components/TextFields/examples/experimental/SimpleTextFieldManualLayoutExampleViewController.m
+++ b/components/TextFields/examples/experimental/SimpleTextFieldManualLayoutExampleViewController.m
@@ -195,6 +195,7 @@
   self.filledTextField.placeholder = @"This is a placeholder";
   self.filledTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
   self.filledTextField.leadingUnderlineLabel.numberOfLines = 0;
+  self.filledTextField.leadingUnderlineLabel.text = @"This is helper text.";
   [self.scrollView addSubview:self.filledTextField];
 }
 

--- a/components/TextFields/examples/experimental/SimpleTextFieldStoryboardExampleViewController.swift
+++ b/components/TextFields/examples/experimental/SimpleTextFieldStoryboardExampleViewController.swift
@@ -1,0 +1,106 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+final class SimpleTextFieldStoryboardExampleViewController: UIViewController {
+
+  @IBOutlet var filledTextField: UIView!
+  @IBOutlet weak var outletTextFields: UITextField!
+  
+  required init?(coder aDecoder: NSCoder) {
+    super.init(coder: aDecoder)
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+  }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    registerKeyboardNotifications()
+  }
+
+}
+
+extension SimpleTextFieldStoryboardExampleViewController: UITextFieldDelegate {
+  func textField(_ textField: UITextField,
+                 shouldChangeCharactersIn range: NSRange,
+                 replacementString string: String) -> Bool {
+    return true
+  }
+  
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    return false
+  }
+}
+
+extension SimpleTextFieldStoryboardExampleViewController: UITextViewDelegate {
+  func textViewDidEndEditing(_ textView: UITextView) {
+    print(textView.text)
+  }
+}
+
+// MARK: - Keyboard Handling
+
+extension SimpleTextFieldStoryboardExampleViewController {
+  func registerKeyboardNotifications() {
+    let notificationCenter = NotificationCenter.default
+    notificationCenter.addObserver(
+      self,
+      selector: #selector(keyboardWillShow(notif:)),
+      name: .UIKeyboardWillShow,
+      object: nil)
+    notificationCenter.addObserver(
+      self,
+      selector: #selector(keyboardWillHide(notif:)),
+      name: .UIKeyboardWillHide,
+      object: nil)
+    notificationCenter.addObserver(
+      self,
+      selector: #selector(keyboardWillShow(notif:)),
+      name: .UIKeyboardWillChangeFrame,
+      object: nil)
+  }
+  
+  @objc func keyboardWillShow(notif: Notification) {
+    guard let _ = notif.userInfo?[UIKeyboardFrameEndUserInfoKey] as? CGRect else {
+      return
+    }
+  }
+  
+  @objc func keyboardWillHide(notif: Notification) {
+  }
+}
+
+// MARK: - Status Bar Style
+
+extension SimpleTextFieldStoryboardExampleViewController {
+  override var preferredStatusBarStyle: UIStatusBarStyle {
+    return .lightContent
+  }
+}
+
+// MARK: - CatalogByConvention
+
+extension SimpleTextFieldStoryboardExampleViewController {
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Text Field", "Simple Text Field (Storyboard)"],
+      "description": "Text fields let users enter and edit text.",
+      "primaryDemo": false,
+      "presentable": false,
+      "storyboardName": "SimpleTextFieldStoryboardExampleViewController"
+    ]
+  }
+}
+

--- a/components/TextFields/examples/experimental/SimpleTextFieldStoryboardExampleViewController.swift
+++ b/components/TextFields/examples/experimental/SimpleTextFieldStoryboardExampleViewController.swift
@@ -14,8 +14,8 @@
 
 final class SimpleTextFieldStoryboardExampleViewController: UIViewController {
 
-  @IBOutlet var filledTextField: UIView!
-  @IBOutlet weak var outletTextFields: UITextField!
+  @IBOutlet var filledTextField: UITextField!
+  @IBOutlet weak var outlinedTextField: UITextField!
   
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
@@ -28,6 +28,7 @@ final class SimpleTextFieldStoryboardExampleViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     registerKeyboardNotifications()
+
   }
 
 }

--- a/components/TextFields/examples/experimental/resources/SimpleTextFieldStoryboardExampleViewController.storyboard
+++ b/components/TextFields/examples/experimental/resources/SimpleTextFieldStoryboardExampleViewController.storyboard
@@ -45,8 +45,8 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="filledTextField" destination="UE3-bb-fYA" id="R1V-WG-yPu"/>
-                        <outlet property="outletTextFields" destination="0wE-6b-dmp" id="tAR-Py-4Ig"/>
+                        <outlet property="filledTextField" destination="pr7-c9-ngn" id="GbE-SG-Umb"/>
+                        <outlet property="outlinedTextField" destination="0wE-6b-dmp" id="RPR-U3-VZh"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="1ue-b6-bbM" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/components/TextFields/examples/experimental/resources/SimpleTextFieldStoryboardExampleViewController.storyboard
+++ b/components/TextFields/examples/experimental/resources/SimpleTextFieldStoryboardExampleViewController.storyboard
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="EkN-UR-mAg">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Simple Text Field Storyboard Example View Controller-->
+        <scene sceneID="Ver-Oe-5lZ">
+            <objects>
+                <viewController id="EkN-UR-mAg" customClass="SimpleTextFieldStoryboardExampleViewController" customModule="MaterialComponentsExamples" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="EjN-PI-765"/>
+                        <viewControllerLayoutGuide type="bottom" id="Z2k-fX-Sgr"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="UE3-bb-fYA">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textField opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="pr7-c9-ngn" customClass="SimpleTextField">
+                                <rect key="frame" x="50" y="70" width="275" height="30"/>
+                                <nil key="textColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <textField opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="0wE-6b-dmp" customClass="SimpleTextField">
+                                <rect key="frame" x="50" y="150" width="275" height="30"/>
+                                <nil key="textColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="pr7-c9-ngn" firstAttribute="top" secondItem="EjN-PI-765" secondAttribute="bottom" constant="50" id="NtI-1Y-7UZ"/>
+                            <constraint firstAttribute="trailing" secondItem="pr7-c9-ngn" secondAttribute="trailing" constant="50" id="RnL-sP-ZPc"/>
+                            <constraint firstItem="0wE-6b-dmp" firstAttribute="leading" secondItem="UE3-bb-fYA" secondAttribute="leading" constant="50" id="RqY-GK-Ptq"/>
+                            <constraint firstAttribute="trailing" secondItem="0wE-6b-dmp" secondAttribute="trailing" constant="50" id="fG4-Ws-dHp"/>
+                            <constraint firstItem="pr7-c9-ngn" firstAttribute="leading" secondItem="UE3-bb-fYA" secondAttribute="leading" constant="50" id="l64-zo-HdD"/>
+                            <constraint firstItem="0wE-6b-dmp" firstAttribute="top" secondItem="pr7-c9-ngn" secondAttribute="bottom" constant="50" id="nT7-ba-4KV"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="filledTextField" destination="UE3-bb-fYA" id="R1V-WG-yPu"/>
+                        <outlet property="outletTextFields" destination="0wE-6b-dmp" id="tAR-Py-4Ig"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="1ue-b6-bbM" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-273" y="4"/>
+        </scene>
+    </scenes>
+</document>

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextField.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextField.h
@@ -4,6 +4,7 @@
 
 #import "MaterialColorScheme.h"
 
+#import "MaterialContainerScheme.h"
 
 
 /**
@@ -47,6 +48,7 @@
 @property (nonatomic, assign) UITextFieldViewMode trailingViewMode;
 
 
+@property (strong, nonatomic) MDCContainerScheme *containerScheme;
 
 /**
  This property toggles a state (similar to @c isHighlighted, @c isEnabled, @c isSelected, etc.) that
@@ -73,14 +75,5 @@
  */
 @property (nonatomic, assign) CGFloat customUnderlineLabelDrawPriority;
 
-
-- (void)setColorScheme:(MDCSemanticColorScheme *)colorScheme
-              forState:(TextFieldState)textFieldState;
-
-- (MDCSemanticColorScheme *)colorSchemeForState:(TextFieldState)textFieldState;
-
-- (void)applyColorScheme:(MDCSemanticColorScheme *)colorScheme;
-
-+ (MDCSemanticColorScheme *)defaultColorSchemeForState:(TextFieldState)textFieldState;
 
 @end

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextField.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextField.h
@@ -4,9 +4,6 @@
 
 @interface SimpleTextField : UITextField
 
-/**
- The default style is .underline
- */
 @property (nonatomic, assign) TextFieldStyle textFieldStyle;
 @property (nonatomic, assign) BOOL canPlaceholderFloat;
 @property (strong, nonatomic, readonly, nonnull) UILabel *leadingUnderlineLabel;
@@ -17,9 +14,14 @@
 @property (nonatomic, assign) UITextFieldViewMode leadingViewMode;
 @property (nonatomic, assign) UITextFieldViewMode trailingViewMode;
 
-// 0 means only trailing. .5 means 50/50. 1 means only leading. only used if draw priority is .custom.
+/**
+ When @c underlineLabelDrawPriority is set to @c .custom the value of this property helps determine
+ what percentage of the available width each underline label gets. It can be thought of as a
+ divider. A value of @c 0 would result in the trailing underline label getting all the available
+ width. A value of @c 1 would result in the leading underline label getting all the available width.
+ A value of @c .5 would result in each underline label getting 50% of the available width.
+ */
 @property (nonatomic, assign) CGFloat customUnderlineLabelDrawPriority;
-
 
 
 @end

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextField.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextField.h
@@ -1,3 +1,17 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #import <UIKit/UIKit.h>
 
 #import "SimpleTextFieldLayoutUtils.h"
@@ -7,7 +21,7 @@
 #import "MaterialContainerScheme.h"
 
 /**
- A UITextField that attempts to do the following:
+ A UITextField subclass that attempts to do the following:
 
  - Earnestly interpret and actualize the Material guidelines for text fields, which can be found
  here: https://material.io/design/components/text-fields.html#outlined-text-field
@@ -20,47 +34,78 @@
 @interface SimpleTextField : UITextField
 
 /**
-  property acts as a complement of @c UIControl's state system
- as well as an interpretation of the state soutlined in the Material guidelines for Text Fields,
- which can be found here:
- https://material.io/design/components/text-fields.html#outlined-text-field
+ Dictates the @c TextFieldStyle of the text field.
  */
 @property(nonatomic, assign) TextFieldStyle textFieldStyle;
 
 /**
- This class-specific @c TextFieldState property acts as a complement of @c UIControl's state system
- as well as an interpretation of the state soutlined in the Material guidelines for Text Fields,
- which can be found here:
- https://material.io/design/components/text-fields.html#outlined-text-field
+ This is a computed property that determines the current @c TextFieldState of the text field.
  */
 @property(nonatomic, assign, readonly) TextFieldState textFieldState;
 
+/**
+ When set to YES, the placeholder floats above the text when the TextFieldState is @c .focused. When
+ set to NO, it does not.
+
+ @note The default is YES.
+ @note When set to YES, the text field will reserve space for the floating placeholder in the
+ layout, which will result in a text field that requires more height to render properly. Consider
+ resizing the text field after setting this property, perhaps by calling @c -sizeToFit.
+ */
 @property(nonatomic, assign) BOOL canPlaceholderFloat;
 
+/**
+ The @c leadingUnderlineLabel can be used to display helper or error text.
+ */
 @property(strong, nonatomic, readonly, nonnull) UILabel *leadingUnderlineLabel;
+
+/**
+ The @c trailingUnderlineLabel can be used to display helper or error text.
+ */
 @property(strong, nonatomic, readonly, nonnull) UILabel *trailingUnderlineLabel;
+
+/**
+ This property is used to determine how much horizontal space to allot for each of the two underline
+ labels.
+ */
 @property(nonatomic, assign) UnderlineLabelDrawPriority underlineLabelDrawPriority;
 
+/**
+ This is essentially an RTL-aware wrapper around UITextField's leftView/rightView class.
+ */
 @property(strong, nonatomic, nullable) UIView *leadingView;
+
+/**
+ This is essentially an RTL-aware wrapper around UITextField's leftView/rightView class.
+ */
 @property(strong, nonatomic, nullable) UIView *trailingView;
+
+/**
+ This is essentially an RTL-aware wrapper around UITextField's leftViewMode/rightViewMode class.
+ */
 @property(nonatomic, assign) UITextFieldViewMode leadingViewMode;
+
+/**
+ This is essentially an RTL-aware wrapper around UITextField's leftViewMode/rightViewMode class.
+ */
 @property(nonatomic, assign) UITextFieldViewMode trailingViewMode;
 
+/**
+ Setting this property determines the typography and coloring of the text field.
+ */
 @property(strong, nonatomic) MDCContainerScheme *containerScheme;
 
 /**
  This property toggles a state (similar to @c isHighlighted, @c isEnabled, @c isSelected, etc.) that
  is part of a general interpretation of the states outlined in the Material guidelines for Text
- Fields, which can be found here:
- https://material.io/design/components/text-fields.html#outlined-text-field
+ Fields. See the @c TextFieldState enum for more information.
  */
 @property(nonatomic, assign) BOOL isErrored;
 
 /**
  This property toggles a state (similar to @c isHighlighted, @c isEnabled, @c isSelected, etc.) that
  is part of a general interpretation of the states outlined in the Material guidelines for Text
- Fields, which can be found here:
- https://material.io/design/components/text-fields.html#outlined-text-field
+ Fields. See the @c TextFieldState enum for more information.
  */
 @property(nonatomic, assign) BOOL isActivated;
 

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextField.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextField.h
@@ -4,18 +4,28 @@
 
 #import "MaterialColorScheme.h"
 
+
+
+/**
+ A UITextField that attempts to do the following:
+ 
+ - Earnestly interpret and actualize the Material guidelines for text fields, which can be found here:
+ https://material.io/design/components/text-fields.html#outlined-text-field
+
+ - Feel intuitive for someone used to the conventions of iOS development and UIKit controls.
+ 
+ - Enable easy set up and reliable and predictable behavior.
+ 
+ */
 @interface SimpleTextField : UITextField
 
+/**
+  property acts as a complement of @c UIControl's state system
+ as well as an interpretation of the state soutlined in the Material guidelines for Text Fields,
+ which can be found here:
+ https://material.io/design/components/text-fields.html#outlined-text-field
+ */
 @property (nonatomic, assign) TextFieldStyle textFieldStyle;
-@property (nonatomic, assign) BOOL canPlaceholderFloat;
-@property (strong, nonatomic, readonly, nonnull) UILabel *leadingUnderlineLabel;
-@property (strong, nonatomic, readonly, nonnull) UILabel *trailingUnderlineLabel;
-@property (nonatomic, assign) UnderlineLabelDrawPriority underlineLabelDrawPriority;
-@property (strong, nonatomic, nullable) UIView *leadingView;
-@property (strong, nonatomic, nullable) UIView *trailingView;
-@property (nonatomic, assign) UITextFieldViewMode leadingViewMode;
-@property (nonatomic, assign) UITextFieldViewMode trailingViewMode;
-
 
 /**
  This class-specific @c TextFieldState property acts as a complement of @c UIControl's state system
@@ -24,6 +34,19 @@
  https://material.io/design/components/text-fields.html#outlined-text-field
  */
 @property (nonatomic, assign, readonly) TextFieldState textFieldState;
+
+@property (nonatomic, assign) BOOL canPlaceholderFloat;
+
+@property (strong, nonatomic, readonly, nonnull) UILabel *leadingUnderlineLabel;
+@property (strong, nonatomic, readonly, nonnull) UILabel *trailingUnderlineLabel;
+@property (nonatomic, assign) UnderlineLabelDrawPriority underlineLabelDrawPriority;
+
+@property (strong, nonatomic, nullable) UIView *leadingView;
+@property (strong, nonatomic, nullable) UIView *trailingView;
+@property (nonatomic, assign) UITextFieldViewMode leadingViewMode;
+@property (nonatomic, assign) UITextFieldViewMode trailingViewMode;
+
+
 
 /**
  This property toggles a state (similar to @c isHighlighted, @c isEnabled, @c isSelected, etc.) that
@@ -54,7 +77,10 @@
 - (void)setColorScheme:(MDCSemanticColorScheme *)colorScheme
               forState:(TextFieldState)textFieldState;
 
-- (MDCSemanticColorScheme *)colorScheme:(MDCSemanticColorScheme *)colorScheme
-                               foletextrState:(TextFieldState)textFieldState;
+- (MDCSemanticColorScheme *)colorSchemeForState:(TextFieldState)textFieldState;
+
+- (void)applyColorScheme:(MDCSemanticColorScheme *)colorScheme;
+
++ (MDCSemanticColorScheme *)defaultColorSchemeForState:(TextFieldState)textFieldState;
 
 @end

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextField.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextField.h
@@ -1,0 +1,25 @@
+#import <UIKit/UIKit.h>
+
+#import "SimpleTextFieldLayoutUtils.h"
+
+@interface SimpleTextField : UITextField
+
+/**
+ The default style is .underline
+ */
+@property (nonatomic, assign) TextFieldStyle textFieldStyle;
+@property (nonatomic, assign) BOOL canPlaceholderFloat;
+@property (strong, nonatomic, readonly, nonnull) UILabel *leadingUnderlineLabel;
+@property (strong, nonatomic, readonly, nonnull) UILabel *trailingUnderlineLabel;
+@property (nonatomic, assign) UnderlineLabelDrawPriority underlineLabelDrawPriority;
+@property (strong, nonatomic, nullable) UIView *leadingView;
+@property (strong, nonatomic, nullable) UIView *trailingView;
+@property (nonatomic, assign) UITextFieldViewMode leadingViewMode;
+@property (nonatomic, assign) UITextFieldViewMode trailingViewMode;
+
+// 0 means only trailing. .5 means 50/50. 1 means only leading. only used if draw priority is .custom.
+@property (nonatomic, assign) CGFloat customUnderlineLabelDrawPriority;
+
+
+
+@end

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextField.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextField.h
@@ -6,17 +6,16 @@
 
 #import "MaterialContainerScheme.h"
 
-
 /**
  A UITextField that attempts to do the following:
- 
- - Earnestly interpret and actualize the Material guidelines for text fields, which can be found here:
- https://material.io/design/components/text-fields.html#outlined-text-field
+
+ - Earnestly interpret and actualize the Material guidelines for text fields, which can be found
+ here: https://material.io/design/components/text-fields.html#outlined-text-field
 
  - Feel intuitive for someone used to the conventions of iOS development and UIKit controls.
- 
+
  - Enable easy set up and reliable and predictable behavior.
- 
+
  */
 @interface SimpleTextField : UITextField
 
@@ -26,7 +25,7 @@
  which can be found here:
  https://material.io/design/components/text-fields.html#outlined-text-field
  */
-@property (nonatomic, assign) TextFieldStyle textFieldStyle;
+@property(nonatomic, assign) TextFieldStyle textFieldStyle;
 
 /**
  This class-specific @c TextFieldState property acts as a complement of @c UIControl's state system
@@ -34,29 +33,20 @@
  which can be found here:
  https://material.io/design/components/text-fields.html#outlined-text-field
  */
-@property (nonatomic, assign, readonly) TextFieldState textFieldState;
+@property(nonatomic, assign, readonly) TextFieldState textFieldState;
 
-@property (nonatomic, assign) BOOL canPlaceholderFloat;
+@property(nonatomic, assign) BOOL canPlaceholderFloat;
 
-@property (strong, nonatomic, readonly, nonnull) UILabel *leadingUnderlineLabel;
-@property (strong, nonatomic, readonly, nonnull) UILabel *trailingUnderlineLabel;
-@property (nonatomic, assign) UnderlineLabelDrawPriority underlineLabelDrawPriority;
+@property(strong, nonatomic, readonly, nonnull) UILabel *leadingUnderlineLabel;
+@property(strong, nonatomic, readonly, nonnull) UILabel *trailingUnderlineLabel;
+@property(nonatomic, assign) UnderlineLabelDrawPriority underlineLabelDrawPriority;
 
-@property (strong, nonatomic, nullable) UIView *leadingView;
-@property (strong, nonatomic, nullable) UIView *trailingView;
-@property (nonatomic, assign) UITextFieldViewMode leadingViewMode;
-@property (nonatomic, assign) UITextFieldViewMode trailingViewMode;
+@property(strong, nonatomic, nullable) UIView *leadingView;
+@property(strong, nonatomic, nullable) UIView *trailingView;
+@property(nonatomic, assign) UITextFieldViewMode leadingViewMode;
+@property(nonatomic, assign) UITextFieldViewMode trailingViewMode;
 
-
-@property (strong, nonatomic) MDCContainerScheme *containerScheme;
-
-/**
- This property toggles a state (similar to @c isHighlighted, @c isEnabled, @c isSelected, etc.) that
- is part of a general interpretation of the states outlined in the Material guidelines for Text
- Fields, which can be found here:
- https://material.io/design/components/text-fields.html#outlined-text-field
- */
-@property (nonatomic, assign) BOOL isErrored;
+@property(strong, nonatomic) MDCContainerScheme *containerScheme;
 
 /**
  This property toggles a state (similar to @c isHighlighted, @c isEnabled, @c isSelected, etc.) that
@@ -64,7 +54,15 @@
  Fields, which can be found here:
  https://material.io/design/components/text-fields.html#outlined-text-field
  */
-@property (nonatomic, assign) BOOL isActivated;
+@property(nonatomic, assign) BOOL isErrored;
+
+/**
+ This property toggles a state (similar to @c isHighlighted, @c isEnabled, @c isSelected, etc.) that
+ is part of a general interpretation of the states outlined in the Material guidelines for Text
+ Fields, which can be found here:
+ https://material.io/design/components/text-fields.html#outlined-text-field
+ */
+@property(nonatomic, assign) BOOL isActivated;
 
 /**
  When @c underlineLabelDrawPriority is set to @c .custom the value of this property helps determine
@@ -73,7 +71,6 @@
  width. A value of @c 1 would result in the leading underline label getting all the available width.
  A value of @c .5 would result in each underline label getting 50% of the available width.
  */
-@property (nonatomic, assign) CGFloat customUnderlineLabelDrawPriority;
-
+@property(nonatomic, assign) CGFloat customUnderlineLabelDrawPriority;
 
 @end

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextField.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextField.h
@@ -2,6 +2,8 @@
 
 #import "SimpleTextFieldLayoutUtils.h"
 
+#import "MaterialColorScheme.h"
+
 @interface SimpleTextField : UITextField
 
 @property (nonatomic, assign) TextFieldStyle textFieldStyle;
@@ -14,6 +16,31 @@
 @property (nonatomic, assign) UITextFieldViewMode leadingViewMode;
 @property (nonatomic, assign) UITextFieldViewMode trailingViewMode;
 
+
+/**
+ This class-specific @c TextFieldState property acts as a complement of @c UIControl's state system
+ as well as an interpretation of the state soutlined in the Material guidelines for Text Fields,
+ which can be found here:
+ https://material.io/design/components/text-fields.html#outlined-text-field
+ */
+@property (nonatomic, assign, readonly) TextFieldState textFieldState;
+
+/**
+ This property toggles a state (similar to @c isHighlighted, @c isEnabled, @c isSelected, etc.) that
+ is part of a general interpretation of the states outlined in the Material guidelines for Text
+ Fields, which can be found here:
+ https://material.io/design/components/text-fields.html#outlined-text-field
+ */
+@property (nonatomic, assign) BOOL isErrored;
+
+/**
+ This property toggles a state (similar to @c isHighlighted, @c isEnabled, @c isSelected, etc.) that
+ is part of a general interpretation of the states outlined in the Material guidelines for Text
+ Fields, which can be found here:
+ https://material.io/design/components/text-fields.html#outlined-text-field
+ */
+@property (nonatomic, assign) BOOL isActivated;
+
 /**
  When @c underlineLabelDrawPriority is set to @c .custom the value of this property helps determine
  what percentage of the available width each underline label gets. It can be thought of as a
@@ -23,5 +50,11 @@
  */
 @property (nonatomic, assign) CGFloat customUnderlineLabelDrawPriority;
 
+
+- (void)setColorScheme:(MDCSemanticColorScheme *)colorScheme
+              forState:(TextFieldState)textFieldState;
+
+- (MDCSemanticColorScheme *)colorScheme:(MDCSemanticColorScheme *)colorScheme
+                               foletextrState:(TextFieldState)textFieldState;
 
 @end

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextField.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextField.h
@@ -93,7 +93,7 @@
 /**
  Setting this property determines the typography and coloring of the text field.
  */
-@property(strong, nonatomic) MDCContainerScheme *containerScheme;
+@property(strong, nonatomic, nullable) MDCContainerScheme *containerScheme;
 
 /**
  This property toggles a state (similar to @c isHighlighted, @c isEnabled, @c isSelected, etc.) that

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextField.m
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextField.m
@@ -1,0 +1,1029 @@
+//
+//  TextField.m
+//  ComponentsProject
+//
+//  Created by Andrew Overton on 9/6/18.
+//  Copyright © 2018 andrewoverton. All rights reserved.
+//
+
+#import "SimpleTextField.h"
+
+#import <MDFInternationalization/MDFInternationalization.h>
+#import <MaterialComponents/MDCMath.h>
+
+#import "SimpleTextFieldLayout.h"
+#import "SimpleTextFieldLayoutUtils.h"
+
+@interface SimpleTextField ()
+
+@property (strong, nonatomic) UIFont *floatingPlaceholderFont;
+@property (strong, nonatomic) UIFont *placeholderFont;
+
+@property (strong, nonatomic) UIButton *clearButton;
+@property (strong, nonatomic) UIImageView *clearButtonImageView;
+@property (strong, nonatomic) UILabel *placeholderLabel;
+@property (strong, nonatomic) UILabel *leftUnderlineLabel;
+@property (strong, nonatomic) UILabel *rightUnderlineLabel;
+
+@property (strong, nonatomic) SimpleTextFieldLayout *layout;
+
+@property (strong, nonatomic) CAShapeLayer *outlinedSublayer;
+@property (strong, nonatomic) CAShapeLayer *filledSublayer;
+@property (strong, nonatomic) CAShapeLayer *filledSublayerUnderline;
+
+@property (nonatomic, assign) UIUserInterfaceLayoutDirection layoutDirection;
+
+@end
+
+// TODO: Go through UITextField.h and make sure you consider the entire public API
+@implementation SimpleTextField
+
+#pragma mark Object Lifecycle
+
+-(instancetype)init {
+  self = [super init];
+  if (self) {
+    [self commonSimpleTextFieldInit];
+  }
+  return self;
+}
+
+-(instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+  if (self) {
+    [self commonSimpleTextFieldInit];
+  }
+  return self;
+}
+
+-(instancetype)initWithCoder:(NSCoder *)aDecoder {
+  self = [super initWithCoder:aDecoder];
+  if (self) {
+    [self commonSimpleTextFieldInit];
+  }
+  return self;
+}
+
+- (void)commonSimpleTextFieldInit {
+  [self addObservers];
+  [self setUpFonts];
+  [self setUpLayoutDirection];
+  [self setUpPlaceholderLabel];
+  [self setUpUnderlineLabels];
+  [self setUpClearButton];
+  [self setUpStyleLayers];
+}
+
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+#pragma mark View Setup
+
+- (void)setUpLayoutDirection {
+  self.layoutDirection = self.mdf_effectiveUserInterfaceLayoutDirection;
+}
+
+- (void)setUpFonts {
+  self.placeholderFont = self.effectiveFont;
+  self.floatingPlaceholderFont = [self floatingPlaceholderFontWithFont:self.effectiveFont
+                                                        textFieldStyle:self.textFieldStyle];
+}
+
+- (void)setUpStyleLayers {
+  [self setUpOutlineSublayer];
+  [self setUpFilledSublayer];
+  // TODO: Underline
+}
+
+- (void)setUpOutlineSublayer {
+  self.outlinedSublayer = [[CAShapeLayer alloc] init];
+  self.outlinedSublayer.strokeColor = [UIColor purpleColor].CGColor;
+  self.outlinedSublayer.fillColor = [UIColor clearColor].CGColor;
+  self.outlinedSublayer.lineWidth = 2.0;
+}
+
+- (void)setUpFilledSublayer {
+  UIColor *fillColor = [UIColor colorWithWhite:0 alpha:0.2];
+  UIColor *underlineFillColor = [UIColor purpleColor];
+  self.filledSublayer = [[CAShapeLayer alloc] init];
+  self.filledSublayer.fillColor = fillColor.CGColor;
+  self.filledSublayer.lineWidth = 0.0;
+  self.filledSublayerUnderline = [[CAShapeLayer alloc] init];
+  self.filledSublayerUnderline.fillColor = underlineFillColor.CGColor;
+  [self.filledSublayer addSublayer:self.filledSublayerUnderline];
+}
+
+- (void)setUpUnderlineLabels {
+  self.leftUnderlineLabel = [[UILabel alloc] init];
+  [self addSubview:self.leadingUnderlineLabel];
+  self.rightUnderlineLabel = [[UILabel alloc] init];
+  [self addSubview:self.trailingUnderlineLabel];
+}
+
+- (void)setUpPlaceholderLabel {
+  self.placeholderLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, -10, 200, 60)];
+  [self addSubview:self.placeholderLabel];
+}
+
+- (void)setUpClearButton {
+  CGRect clearButtonFrame = CGRectMake(0, 0, kClearButtonTouchTargetSideLength, kClearButtonTouchTargetSideLength);
+  self.clearButton = [[UIButton alloc] initWithFrame:clearButtonFrame];
+  [self.clearButton addTarget:self
+                       action:@selector(clearButtonPressed:)
+             forControlEvents:UIControlEventTouchUpInside];
+
+  CGFloat clearButtonImageViewSideLength = [self clearButtonImageViewSideLength];
+  CGRect clearButtonImageViewRect = CGRectMake(0, 0, clearButtonImageViewSideLength, clearButtonImageViewSideLength);
+  self.clearButtonImageView = [[UIImageView alloc] initWithFrame:clearButtonImageViewRect];
+  self.clearButtonImageView.image = [self clearButtonImage];
+  self.clearButtonImageView.tintColor = UIColor.lightGrayColor;
+  [self.clearButton addSubview:self.clearButtonImageView];
+  [self addSubview:self.clearButton];
+  self.clearButtonImageView.center = self.clearButton.center;
+}
+
+- (void)addObservers {
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(textFieldDidEndEditingWithNotification:) name:UITextFieldTextDidEndEditingNotification object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(textFieldDidBeginEditingWithNotification:) name:UITextFieldTextDidBeginEditingNotification object:nil];
+}
+
+#pragma mark UIView Overrides
+
+- (SimpleTextFieldLayout *)calculateLayoutWithTextFieldBounds:(CGRect)textFieldBounds {
+  UIFont *effectiveFont = self.effectiveFont;
+  UIFont *floatingFont = [self floatingPlaceholderFontWithFont:effectiveFont
+                                                textFieldStyle:self.textFieldStyle];
+  CGFloat normalizedCustomUnderlineLabelDrawPriority =
+  [self normalizedCustomUnderlineLabelDrawPriority:self.customUnderlineLabelDrawPriority];
+  return [[SimpleTextFieldLayout alloc] initWithTextFieldBounds:textFieldBounds
+                                                 textFieldStyle:self.textFieldStyle
+                                                           text:self.text
+                                                    placeholder:self.placeholder
+                                                           font:effectiveFont
+                                        floatingPlaceholderFont:floatingFont
+                                            canPlaceholderFloat:self.canPlaceholderFloat
+                                                       leftView:self.leftView
+                                                   leftViewMode:self.leftViewMode
+                                                      rightView:self.rightView
+                                                  rightViewMode:self.rightViewMode
+                                                    clearButton:self.clearButton
+                                                clearButtonMode:self.clearButtonMode
+                                             leftUnderlineLabel:self.leftUnderlineLabel
+                                            rightUnderlineLabel:self.rightUnderlineLabel
+                                     underlineLabelDrawPriority:self.underlineLabelDrawPriority
+                               customUnderlineLabelDrawPriority:normalizedCustomUnderlineLabelDrawPriority
+                                                          isRTL:[self isRTL]
+                                                      isEditing:self.isEditing];
+}
+
+-(void)layoutSubviews {
+  self.layout = [self calculateLayoutWithTextFieldBounds:self.bounds];
+  // important layout methods like -textRectForBounds: are called in the super class implementation
+  // so we want to have values for them figured out ahead of time.
+  [super layoutSubviews];
+
+  PlaceholderState state = [self determineCurrentPlaceholderState];
+  [self layOutPlaceholderWithState:state];
+
+  BOOL isFloatingPlaceholder = state == PlaceholderStateFloating;
+  [self applyTextFieldStyle:self.textFieldStyle
+            textFieldBounds:self.bounds
+   floatingPlaceholderFrame:self.layout.placeholderFrameFloating
+    topRowBottomRowDividerY:self.layout.topRowBottomRowDividerY
+      isFloatingPlaceholder:isFloatingPlaceholder];
+
+  self.clearButton.frame = self.layout.clearButtonFrame;
+  self.clearButton.hidden = self.layout.clearButtonHidden;
+  self.leftUnderlineLabel.frame = self.layout.leftUnderlineLabelFrame;
+  self.rightUnderlineLabel.frame = self.layout.rightUnderlineLabelFrame;
+  self.leftView.hidden = self.layout.leftViewHidden;
+  self.rightView.hidden = self.layout.rightViewHidden;
+
+
+  // TODO: Hide any views that the layout says to hide
+  // TODO: Hide views that won't fit by validating frames (checking if they fit inside the bounds and don't overlap)
+}
+
+// UIView's sizeToFit calls this method.
+// UITextField's sizeToFit calls this method and then also calls setNeedsLayout.
+// When the system calls this method the size parameter is the view's current size.
+// A vanilla UITextField returns a 9x21 size as the smallest UITextFields
+// It does so irrespective of leftView/rightView, but it does take into account text.
+// I think that this implementation should calculate a height for size.width.
+-(CGSize)sizeThatFits:(CGSize)size {
+  return [self preferredSizeWithWidth:size.width];
+}
+
+- (CGSize)preferredSizeWithWidth:(CGFloat)width {
+  if (!self.layout) {
+    self.layout = [self calculateLayoutWithTextFieldBounds:self.bounds];
+  }
+  return CGSizeMake(width, self.layout.calculatedHeight);
+}
+
+-(CGSize)intrinsicContentSize {
+  return [self preferredSizeWithWidth:CGRectGetWidth(self.bounds)];
+}
+
+- (NSLayoutConstraint *)highestPriorityConstraintOnView:(UIView *)view
+                                          withAttribute:(NSLayoutAttribute)attribute {
+  UILayoutPriority maxPriority = 0;
+  NSLayoutConstraint *result = nil;
+  for (NSLayoutConstraint *constraint in view.constraints) {
+    BOOL isAHeightConstraintOnSelf =
+    (constraint.firstItem == view && constraint.firstAttribute == attribute) ||
+    (constraint.secondItem == view && constraint.secondAttribute == attribute);
+    if (isAHeightConstraintOnSelf && constraint.priority > maxPriority) {
+      result = constraint;
+    }
+  }
+  return result;
+}
+
+- (CGSize)systemLayoutSizeFittingSize:(CGSize)targetSize {
+  NSLog(@"TODO: Implement systemLayoutSizeFittingSize:");
+  return [super systemLayoutSizeFittingSize:targetSize];
+}
+
+-(void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+  [self setUpLayoutDirection];
+}
+
+#pragma mark UITextField Accessor Overrides
+
+-(void)setFont:(UIFont *)font {
+  [super setFont:font];
+  [self setUpFonts];
+}
+
+-(void)setPlaceholder:(NSString *)placeholder {
+  self.placeholderLabel.attributedText = nil;
+  self.placeholderLabel.text = [placeholder copy];
+  // TODO: Determine if setNeedsLayout is necessary here. I think it might be...
+}
+
+-(NSString *)placeholder {
+  return self.placeholderLabel.text;
+}
+
+-(void)setAttributedPlaceholder:(NSAttributedString *)attributedPlaceholder {
+  self.placeholderLabel.text = nil;
+  self.placeholderLabel.attributedText = attributedPlaceholder;
+  // TODO: Determine if setNeedsLayout is necessary here. I think it might be...
+  // TODO: Also make layout aware of attributedPlaceholder
+}
+
+-(NSAttributedString *)attributedPlaceholder {
+  return self.placeholderLabel.attributedText;
+}
+
+-(void)setLeftViewMode:(UITextFieldViewMode)leftViewMode {
+  NSLog(@"Setting leftViewMode is not recommended. Consider setting leadingViewMode and trailingViewMode instead.");
+  [self mdc_setLeftViewMode:leftViewMode];
+}
+
+-(void)setRightViewMode:(UITextFieldViewMode)rightViewMode {
+  NSLog(@"Setting rightViewMode is not recommended. Consider setting leadingViewMode and trailingViewMode instead.");
+  [self mdc_setRightViewMode:rightViewMode];
+}
+
+-(void)setLeftView:(UIView *)leftView {
+  NSLog(@"Setting rightView and leftView are not recommended. Consider setting leadingView and trailingView instead.");
+  [self mdc_setLeftView:leftView];
+}
+
+-(void)setRightView:(UIView *)rightView {
+  NSLog(@"Setting rightView and leftView are not recommended. Consider setting leadingView and trailingView instead.");
+  [self mdc_setRightView:rightView];
+}
+
+-(void)setClearButtonMode:(UITextFieldViewMode)clearButtonMode {
+  [super setClearButtonMode:clearButtonMode];
+  //TODO: determine whether a call to setNeedsLayout is necessary. I don't think it is...
+}
+
+-(void)setBorderStyle:(UITextBorderStyle)borderStyle {
+  // enforce UITextBorderStyle.none
+  [super setBorderStyle:UITextBorderStyleNone];
+}
+
+#pragma mark Custom Accessors
+
+-(UILabel *)leadingUnderlineLabel {
+  if ([self isRTL]) {
+    return self.rightUnderlineLabel;
+  } else {
+    return self.leftUnderlineLabel;
+  }
+}
+
+-(UILabel *)trailingUnderlineLabel {
+  if ([self isRTL]) {
+    return self.leftUnderlineLabel;
+  } else {
+    return self.rightUnderlineLabel;
+  }
+}
+
+-(void)setLayoutDirection:(UIUserInterfaceLayoutDirection)layoutDirection {
+  if (_layoutDirection == layoutDirection) {
+    return;
+  }
+  _layoutDirection = layoutDirection;
+  [self setNeedsLayout];
+}
+
+-(void)setTrailingView:(UIView *)trailingView {
+  if ([self isRTL]) {
+    [self mdc_setLeftView:trailingView];
+  } else {
+    [self mdc_setRightView:trailingView];
+  }
+}
+
+-(UIView *)trailingView {
+  if ([self isRTL]) {
+    return self.leftView;
+  } else {
+    return self.rightView;
+  }
+}
+
+-(void)setLeadingView:(UIView *)leadingView {
+  if ([self isRTL]) {
+    [self mdc_setRightView:leadingView];
+  } else {
+    [self mdc_setLeftView:leadingView];
+  }
+}
+
+-(UIView *)leadingView {
+  if ([self isRTL]) {
+    return self.rightView;
+  } else {
+    return self.leftView;
+  }
+}
+
+- (void)mdc_setLeftView:(UIView *)leftView {
+  [super setLeftView:leftView];
+  // TODO: Determine if a call to setNeedsLayout is necessary
+}
+
+- (void)mdc_setRightView:(UIView *)rightView {
+  [super setRightView:rightView];
+}
+
+-(void)setTrailingViewMode:(UITextFieldViewMode)trailingViewMode {
+  if ([self isRTL]) {
+    [self mdc_setLeftViewMode:trailingViewMode];
+  } else {
+    [self mdc_setRightViewMode:trailingViewMode];
+  }
+}
+
+-(UITextFieldViewMode)trailingViewMode {
+  if ([self isRTL]) {
+    return self.leftViewMode;
+  } else {
+    return self.rightViewMode;
+  }
+}
+
+-(void)setLeadingViewMode:(UITextFieldViewMode)leadingViewMode {
+  if ([self isRTL]) {
+    [self mdc_setRightViewMode:leadingViewMode];
+  } else {
+    [self mdc_setLeftViewMode:leadingViewMode];
+  }
+}
+
+-(UITextFieldViewMode)leadingViewMode {
+  if ([self isRTL]) {
+    return self.rightViewMode;
+  } else {
+    return self.leftViewMode;
+  }
+}
+
+- (void)mdc_setLeftViewMode:(UITextFieldViewMode)leftViewMode {
+  [super setLeftViewMode:leftViewMode];
+}
+
+- (void)mdc_setRightViewMode:(UITextFieldViewMode)rightViewMode {
+  [super setRightViewMode:rightViewMode];
+}
+
+-(void)setCanPlaceholderFloat:(BOOL)canPlaceholderFloat {
+  if (_canPlaceholderFloat == canPlaceholderFloat) {
+    return;
+  }
+  _canPlaceholderFloat = canPlaceholderFloat;
+  [self setNeedsLayout];
+}
+
+#pragma mark UITextField Layout Overrides
+
+-(CGRect)textRectForBounds:(CGRect)bounds {
+  return [self adjustTextAreaFrame:self.layout.textAreaFrame
+      withParentClassTextAreaFrame:[super textRectForBounds:bounds]];
+}
+
+-(CGRect)editingRectForBounds:(CGRect)bounds {
+  return [self adjustTextAreaFrame:self.layout.textAreaFrame
+      withParentClassTextAreaFrame:[super editingRectForBounds:bounds]];
+}
+
+- (CGRect)adjustTextAreaFrame:(CGRect)textAreaFrame
+ withParentClassTextAreaFrame:(CGRect)parentClassTextAreaFrame {
+  CGFloat height = CGRectGetHeight(parentClassTextAreaFrame);
+  CGFloat minY = CGRectGetMidY(textAreaFrame) - (height * 0.5);
+  return CGRectMake(CGRectGetMinX(textAreaFrame), minY, CGRectGetWidth(textAreaFrame), height);
+}
+
+-(CGRect)leftViewRectForBounds:(CGRect)bounds {
+  return self.layout.leftViewFrame;
+}
+
+-(CGRect)rightViewRectForBounds:(CGRect)bounds {
+  return self.layout.rightViewFrame;
+}
+
+- (CGRect)borderRectForBounds:(CGRect)bounds {
+  return CGRectZero;
+}
+
+- (CGRect)clearButtonRectForBounds:(CGRect)bounds {
+  return CGRectZero;
+}
+
+#pragma mark Custom Layout Methods
+
+- (CGFloat)normalizedCustomUnderlineLabelDrawPriority:(CGFloat)customPriority {
+  CGFloat value = customPriority;
+  if (value < 0) {
+    value = 0;
+  } else if (value > 1) {
+    value = 1;
+  }
+  return value;
+}
+
+
+#pragma mark Fonts
+
+- (UIFont *)effectiveFont {
+  return self.font ?: [self uiTextFieldDefaultFont];
+}
+
+- (UIFont *)uiTextFieldDefaultFont {
+  static dispatch_once_t onceToken;
+  static UIFont *font;
+  dispatch_once(&onceToken, ^{
+    font = [UIFont systemFontOfSize:[UIFont systemFontSize]];
+  });
+  return font;
+}
+
+#pragma mark Clear Button
+
+- (UIImage *)clearButtonImage {
+  CGFloat clearButtonImageViewSideLength = [self clearButtonImageViewSideLength];
+  CGSize clearButtonSize = CGSizeMake(clearButtonImageViewSideLength, clearButtonImageViewSideLength);
+  CGRect rect = CGRectMake(0, 0, clearButtonSize.width, clearButtonSize.height);
+  UIGraphicsBeginImageContextWithOptions(rect.size, false, 0);
+  [[UIColor grayColor] setFill];
+  [[self pathForClearButtonImageWithFrame:rect] fill];
+  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+  image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+  return image;
+}
+
+// This generated code is taken from the MDCTextField.
+- (UIBezierPath *)pathForClearButtonImageWithFrame:(CGRect)frame {
+  CGRect innerBounds =
+  CGRectMake(CGRectGetMinX(frame) + 2, CGRectGetMinY(frame) + 2,
+             MDCFloor((frame.size.width - 2) * (CGFloat)0.90909 + (CGFloat)0.5),
+             MDCFloor((frame.size.height - 2) * (CGFloat)0.90909 + (CGFloat)0.5));
+
+  UIBezierPath *ic_clear_path = [UIBezierPath bezierPath];
+  [ic_clear_path moveToPoint:CGPointMake(CGRectGetMinX(innerBounds) +
+                                         (CGFloat)0.50000 * innerBounds.size.width,
+                                         CGRectGetMinY(innerBounds) + 0 * innerBounds.size.height)];
+  [ic_clear_path
+   addCurveToPoint:CGPointMake(
+                               CGRectGetMinX(innerBounds) + 1 * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + (CGFloat)0.50000 * innerBounds.size.height)
+   controlPoint1:CGPointMake(
+                             CGRectGetMinX(innerBounds) + (CGFloat)0.77600 * innerBounds.size.width,
+                             CGRectGetMinY(innerBounds) + 0 * innerBounds.size.height)
+   controlPoint2:CGPointMake(
+                             CGRectGetMinX(innerBounds) + 1 * innerBounds.size.width,
+                             CGRectGetMinY(innerBounds) + (CGFloat)0.22400 * innerBounds.size.height)];
+  [ic_clear_path
+   addCurveToPoint:CGPointMake(
+                               CGRectGetMinX(innerBounds) + (CGFloat)0.50000 * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + 1 * innerBounds.size.height)
+   controlPoint1:CGPointMake(
+                             CGRectGetMinX(innerBounds) + 1 * innerBounds.size.width,
+                             CGRectGetMinY(innerBounds) + (CGFloat)0.77600 * innerBounds.size.height)
+   controlPoint2:CGPointMake(
+                             CGRectGetMinX(innerBounds) + (CGFloat)0.77600 * innerBounds.size.width,
+                             CGRectGetMinY(innerBounds) + 1 * innerBounds.size.height)];
+  [ic_clear_path
+   addCurveToPoint:CGPointMake(
+                               CGRectGetMinX(innerBounds) + 0 * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + (CGFloat)0.50000 * innerBounds.size.height)
+   controlPoint1:CGPointMake(
+                             CGRectGetMinX(innerBounds) + (CGFloat)0.22400 * innerBounds.size.width,
+                             CGRectGetMinY(innerBounds) + 1 * innerBounds.size.height)
+   controlPoint2:CGPointMake(
+                             CGRectGetMinX(innerBounds) + 0 * innerBounds.size.width,
+                             CGRectGetMinY(innerBounds) + (CGFloat)0.77600 * innerBounds.size.height)];
+  [ic_clear_path
+   addCurveToPoint:CGPointMake(
+                               CGRectGetMinX(innerBounds) + (CGFloat)0.50000 * innerBounds.size.width,
+                               CGRectGetMinY(innerBounds) + 0 * innerBounds.size.height)
+   controlPoint1:CGPointMake(
+                             CGRectGetMinX(innerBounds) + 0 * innerBounds.size.width,
+                             CGRectGetMinY(innerBounds) + (CGFloat)0.22400 * innerBounds.size.height)
+   controlPoint2:CGPointMake(
+                             CGRectGetMinX(innerBounds) + (CGFloat)0.22400 * innerBounds.size.width,
+                             CGRectGetMinY(innerBounds) + 0 * innerBounds.size.height)];
+  [ic_clear_path closePath];
+  [ic_clear_path
+   moveToPoint:CGPointMake(
+                           CGRectGetMinX(innerBounds) + (CGFloat)0.73417 * innerBounds.size.width,
+                           CGRectGetMinY(innerBounds) + (CGFloat)0.31467 * innerBounds.size.height)];
+  [ic_clear_path
+   addLineToPoint:CGPointMake(
+                              CGRectGetMinX(innerBounds) + (CGFloat)0.68700 * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + (CGFloat)0.26750 * innerBounds.size.height)];
+  [ic_clear_path
+   addLineToPoint:CGPointMake(
+                              CGRectGetMinX(innerBounds) + (CGFloat)0.50083 * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + (CGFloat)0.45367 * innerBounds.size.height)];
+  [ic_clear_path
+   addLineToPoint:CGPointMake(
+                              CGRectGetMinX(innerBounds) + (CGFloat)0.31467 * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + (CGFloat)0.26750 * innerBounds.size.height)];
+  [ic_clear_path
+   addLineToPoint:CGPointMake(
+                              CGRectGetMinX(innerBounds) + (CGFloat)0.26750 * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + (CGFloat)0.31467 * innerBounds.size.height)];
+  [ic_clear_path
+   addLineToPoint:CGPointMake(
+                              CGRectGetMinX(innerBounds) + (CGFloat)0.45367 * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + (CGFloat)0.50083 * innerBounds.size.height)];
+  [ic_clear_path
+   addLineToPoint:CGPointMake(
+                              CGRectGetMinX(innerBounds) + (CGFloat)0.26750 * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + (CGFloat)0.68700 * innerBounds.size.height)];
+  [ic_clear_path
+   addLineToPoint:CGPointMake(
+                              CGRectGetMinX(innerBounds) + (CGFloat)0.31467 * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + (CGFloat)0.73417 * innerBounds.size.height)];
+  [ic_clear_path
+   addLineToPoint:CGPointMake(
+                              CGRectGetMinX(innerBounds) + (CGFloat)0.50083 * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + (CGFloat)0.54800 * innerBounds.size.height)];
+  [ic_clear_path
+   addLineToPoint:CGPointMake(
+                              CGRectGetMinX(innerBounds) + (CGFloat)0.68700 * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + (CGFloat)0.73417 * innerBounds.size.height)];
+  [ic_clear_path
+   addLineToPoint:CGPointMake(
+                              CGRectGetMinX(innerBounds) + (CGFloat)0.73417 * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + (CGFloat)0.68700 * innerBounds.size.height)];
+  [ic_clear_path
+   addLineToPoint:CGPointMake(
+                              CGRectGetMinX(innerBounds) + (CGFloat)0.54800 * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + (CGFloat)0.50083 * innerBounds.size.height)];
+  [ic_clear_path
+   addLineToPoint:CGPointMake(
+                              CGRectGetMinX(innerBounds) + (CGFloat)0.73417 * innerBounds.size.width,
+                              CGRectGetMinY(innerBounds) + (CGFloat)0.31467 * innerBounds.size.height)];
+  [ic_clear_path closePath];
+
+  return ic_clear_path;
+}
+
+-(void)prepareForInterfaceBuilder {
+  [super prepareForInterfaceBuilder];
+  [self invalidateIntrinsicContentSize];
+}
+
+#pragma mark Placeholder Management
+
+- (void)layOutPlaceholderWithState:(PlaceholderState)state {
+  UIFont *font = nil;
+  CGRect frame = CGRectZero;
+  UIColor *color = UIColor.darkGrayColor;
+  // TODO: Take color into account
+  BOOL placeholderShouldHide = NO;
+  switch (state) {
+    case PlaceholderStateFloating:
+      font = self.floatingPlaceholderFont;
+      frame = self.layout.placeholderFrameFloating;
+      color = UIColor.purpleColor;
+      break;
+    case PlaceholderStateNormal:
+      font = self.placeholderFont;
+      frame = self.layout.placeholderFrameNormal;
+      break;
+    case PlaceholderStateNone:
+      font = self.placeholderFont;
+      frame = self.layout.placeholderFrameNormal;
+      placeholderShouldHide = YES;
+      break;
+    default:
+      break;
+  }
+  self.placeholderLabel.hidden = placeholderShouldHide;
+  __weak typeof(self) weakSelf = self;
+  // TODO: Figure out a better way of doing this.
+  // One idea: Make it so placeholder animation is actually of a layer transform
+  // but at the end you really change the font and frame and stuff.
+  [UIView animateWithDuration:kFloatingPlaceholderAnimationDuration animations:^{
+    weakSelf.placeholderLabel.frame = frame;
+    weakSelf.placeholderLabel.font = font;
+    weakSelf.placeholderLabel.textColor = color;
+  }];
+}
+
+- (PlaceholderState)determineCurrentPlaceholderState {
+  return [self placeholderStateWithPlaceholder:self.placeholder
+                                          text:self.text
+                           canPlaceholderFloat:self.canPlaceholderFloat
+                                     isEditing:self.isEditing];
+}
+
+- (PlaceholderState)placeholderStateWithPlaceholder:(NSString *)placeholder
+                                               text:(NSString *)text
+                                canPlaceholderFloat:(BOOL)canPlaceholderFloat
+                                          isEditing:(BOOL)isEditing {
+  BOOL hasPlaceholder = placeholder.length > 0;
+  BOOL hasText = text.length > 0;
+  if (hasPlaceholder) {
+    if (canPlaceholderFloat) {
+      if (isEditing) {
+        return PlaceholderStateFloating;
+      } else {
+        if (hasText) {
+          return PlaceholderStateFloating;
+        } else {
+          return PlaceholderStateNormal;
+        }
+      }
+    } else {
+      if (hasText) {
+        return PlaceholderStateNone;
+      } else {
+        return PlaceholderStateNormal;
+      }
+    }
+  } else {
+    return PlaceholderStateNone;
+  }
+}
+
+- (UIFont *)floatingPlaceholderFontWithFont:(UIFont *)font
+                             textFieldStyle:(TextFieldStyle)textFieldStyle {
+  CGFloat floatingPlaceholderFontSize = 0.0;
+  CGFloat outlinedFloatingPlaceholderScale = (CGFloat)41 / (CGFloat)55;
+  CGFloat filledFloatingPlaceholderScale = (CGFloat)53 / (CGFloat)71;
+  switch (textFieldStyle) {
+    case TextFieldStyleFilled:
+      floatingPlaceholderFontSize = round((double)(font.pointSize * filledFloatingPlaceholderScale));
+      break;
+    case TextFieldStyleOutline:
+      floatingPlaceholderFontSize = round((double)(font.pointSize * outlinedFloatingPlaceholderScale));
+      break;
+    default:
+      break;
+  }
+  return [font fontWithSize:floatingPlaceholderFontSize];
+}
+
+- (CGFloat)clearButtonImageViewSideLength {
+  return kClearButtonTouchTargetSideLength - kTextRectSidePadding;
+}
+
+#pragma mark User Actions
+
+- (void)clearButtonPressed:(UIButton *)clearButton {
+  self.text = nil;
+  // TODO: I'm pretty sure there is a control event or notification UITextField sens or posts here. Add it!
+}
+
+#pragma mark Notification Listener Methods
+
+- (void)textFieldDidEndEditingWithNotification:(NSNotification *)notification {
+  if (notification.object != self) {
+    return;
+  }
+}
+
+//- (void)textFieldDidChangeWithNotification:(NSNotification *)notification {
+//  if (notification.object != self) {
+//    return;
+//  }
+//  BOOL shouldHidePlaceholder = NO;
+//  if (self.text.length > 0 && !self.canPlaceholderFloat) {
+//    shouldHidePlaceholder = YES;
+//  }
+//  self.placeholderLabel.hidden = shouldHidePlaceholder;
+//}
+
+- (void)textFieldDidBeginEditingWithNotification:(NSNotification *)notification {
+  if (notification.object != self) {
+    return;
+  }
+}
+
+#pragma mark Internationalization
+
+- (BOOL)isRTL {
+  return self.layoutDirection == UIUserInterfaceLayoutDirectionRightToLeft;
+}
+
+#pragma mark Style Management
+
+- (void)applyCurrentStyle {
+  
+}
+
+- (void)applyTextFieldStyle:(TextFieldStyle)textFieldStyle
+            textFieldBounds:(CGRect)textFieldBounds
+   floatingPlaceholderFrame:(CGRect)floatingPlaceholderFrame
+    topRowBottomRowDividerY:(CGFloat)topRowBottomRowDividerY
+      isFloatingPlaceholder:(BOOL)isFloatingPlaceholder {
+  [self applyOutlinedStyle:textFieldStyle == TextFieldStyleOutline
+           textFieldBounds:textFieldBounds
+  floatingPlaceholderFrame:floatingPlaceholderFrame
+   topRowBottomRowDividerY:topRowBottomRowDividerY
+     isFloatingPlaceholder:isFloatingPlaceholder];
+  [self applyFilledStyle:textFieldStyle == TextFieldStyleFilled
+         textFieldBounds:textFieldBounds
+ topRowBottomRowDividerY:topRowBottomRowDividerY];
+}
+
+- (void)applyOutlinedStyle:(BOOL)isOutlined
+           textFieldBounds:(CGRect)textFieldBounds
+  floatingPlaceholderFrame:(CGRect)floatingPlaceholderFrame
+   topRowBottomRowDividerY:(CGFloat)topRowBottomRowDividerY
+     isFloatingPlaceholder:(BOOL)isFloatingPlaceholder {
+  if (!isOutlined) {
+    [self.outlinedSublayer removeFromSuperlayer];
+    return;
+  }
+  UIBezierPath *path = [self outlinePathWithTextFieldBounds:textFieldBounds
+                                   floatingPlaceholderFrame:floatingPlaceholderFrame
+                                    topRowBottomRowDividerY:topRowBottomRowDividerY
+                                      isFloatingPlaceholder:isFloatingPlaceholder];
+  self.outlinedSublayer.path = path.CGPath;
+  if (self.outlinedSublayer.superlayer != self.layer) {
+    [self.layer insertSublayer:self.outlinedSublayer atIndex:0];
+  }
+}
+
+- (void)applyFilledStyle:(BOOL)isFilled
+         textFieldBounds:(CGRect)textFieldBounds
+ topRowBottomRowDividerY:(CGFloat)topRowBottomRowDividerY {
+  if (!isFilled) {
+    [self.filledSublayer removeFromSuperlayer];
+    return;
+  }
+
+  UIBezierPath *filledSublayerPath = [self filledSublayerPathWithTextFieldBounds:textFieldBounds
+                                                         topRowBottomRowDividerY:topRowBottomRowDividerY];
+  UIBezierPath *filledSublayerUnderlinePath = [self filledSublayerUnderlinePathWithTextFieldBounds:textFieldBounds
+                                                                           topRowBottomRowDividerY:topRowBottomRowDividerY];
+  self.filledSublayer.path = filledSublayerPath.CGPath;
+  self.filledSublayerUnderline.path = filledSublayerUnderlinePath.CGPath;
+  if (self.filledSublayer.superlayer != self.layer) {
+    [self.layer insertSublayer:self.filledSublayer atIndex:0];
+  }
+}
+
+
+#pragma mark Path Drawing
+
+- (UIBezierPath *)outlinePathWithTextFieldBounds:(CGRect)textFieldBounds
+                        floatingPlaceholderFrame:(CGRect)floatingPlaceholderFrame
+                         topRowBottomRowDividerY:(CGFloat)topRowBottomRowDividerY
+                           isFloatingPlaceholder:(BOOL)isFloatingPlaceholder {
+  UIBezierPath *path = [[UIBezierPath alloc] init];
+  //TODO: inject state so you can set width and color correctly
+  CGFloat radius = kOutlinedTextFieldCornerRadius;
+  CGFloat textFieldWidth = CGRectGetWidth(textFieldBounds);
+  CGFloat sublayerMinY = 0;
+//  if (CGSizeEqualToSize(CGSizeZero, floatingPlaceholderFrame.size)) {
+//    sublayerMinY = CGRectGetMidY(floatingPlaceholderFrame);
+//  }
+  CGFloat sublayerMaxY = topRowBottomRowDividerY;
+
+  CGPoint startingPoint = CGPointMake(radius, sublayerMinY);
+  CGPoint topRightCornerPoint1 = CGPointMake(textFieldWidth - radius, sublayerMinY);
+  [path moveToPoint:startingPoint];
+  if (isFloatingPlaceholder) {
+    CGFloat leftLineBreak = CGRectGetMinX(floatingPlaceholderFrame) - kFloatingPlaceholderSideMargin;
+    CGFloat rightLineBreak = CGRectGetMaxX(floatingPlaceholderFrame) + kFloatingPlaceholderSideMargin;
+    [path addLineToPoint:CGPointMake(leftLineBreak, sublayerMinY)];
+    [path moveToPoint:CGPointMake(rightLineBreak, sublayerMinY)];
+    [path addLineToPoint:CGPointMake(rightLineBreak, sublayerMinY)];
+  } else {
+    [path addLineToPoint:topRightCornerPoint1];
+  }
+
+  CGPoint topRightCornerPoint2 = CGPointMake(textFieldWidth, sublayerMinY + radius);
+  [self addTopRightCornerToPath:path
+                      fromPoint:topRightCornerPoint1
+                        toPoint:topRightCornerPoint2
+                     withRadius:radius];
+
+  CGPoint bottomRightCornerPoint1 = CGPointMake(textFieldWidth, sublayerMaxY - radius);
+  CGPoint bottomRightCornerPoint2 = CGPointMake(textFieldWidth - radius, sublayerMaxY);
+  [path addLineToPoint:bottomRightCornerPoint1];
+  [self addBottomRightCornerToPath:path
+                         fromPoint:bottomRightCornerPoint1
+                           toPoint:bottomRightCornerPoint2
+                        withRadius:radius];
+
+  CGPoint bottomLeftCornerPoint1 = CGPointMake(radius, sublayerMaxY);
+  CGPoint bottomLeftCornerPoint2 = CGPointMake(0, sublayerMaxY - radius);
+  [path addLineToPoint:bottomLeftCornerPoint1];
+  [self addBottomLeftCornerToPath:path
+                        fromPoint:bottomLeftCornerPoint1
+                          toPoint:bottomLeftCornerPoint2
+                       withRadius:radius];
+
+  CGPoint topLeftCornerPoint1 = CGPointMake(0, sublayerMinY + radius);
+  CGPoint topLeftCornerPoint2 = CGPointMake(radius, sublayerMinY);
+  [path addLineToPoint:topLeftCornerPoint1];
+  [self addTopLeftCornerToPath:path
+                     fromPoint:topLeftCornerPoint1
+                       toPoint:topLeftCornerPoint2
+                    withRadius:radius];
+
+  return path;
+}
+
+- (UIBezierPath *)filledSublayerPathWithTextFieldBounds:(CGRect)textFieldBounds
+                                topRowBottomRowDividerY:(CGFloat)topRowBottomRowDividerY {
+  UIBezierPath *path = [[UIBezierPath alloc] init];
+  CGFloat topRadius = kFilledTextFieldTopCornerRadius;
+  CGFloat bottomRadius = 0;
+  CGFloat textFieldWidth = CGRectGetWidth(textFieldBounds);
+  CGFloat sublayerMinY = 0;
+  CGFloat sublayerMaxY = topRowBottomRowDividerY;
+
+  CGPoint startingPoint = CGPointMake(topRadius, sublayerMinY);
+  CGPoint topRightCornerPoint1 = CGPointMake(textFieldWidth - topRadius, sublayerMinY);
+  [path moveToPoint:startingPoint];
+  [path addLineToPoint:topRightCornerPoint1];
+
+  CGPoint topRightCornerPoint2 = CGPointMake(textFieldWidth, sublayerMinY + topRadius);
+  [self addTopRightCornerToPath:path
+                      fromPoint:topRightCornerPoint1
+                        toPoint:topRightCornerPoint2
+                     withRadius:topRadius];
+
+  CGPoint bottomRightCornerPoint1 = CGPointMake(textFieldWidth, sublayerMaxY - bottomRadius);
+  CGPoint bottomRightCornerPoint2 = CGPointMake(textFieldWidth - bottomRadius, sublayerMaxY);
+  [path addLineToPoint:bottomRightCornerPoint1];
+  [self addBottomRightCornerToPath:path
+                         fromPoint:bottomRightCornerPoint1
+                           toPoint:bottomRightCornerPoint2
+                        withRadius:bottomRadius];
+
+  CGPoint bottomLeftCornerPoint1 = CGPointMake(bottomRadius, sublayerMaxY);
+  CGPoint bottomLeftCornerPoint2 = CGPointMake(0, sublayerMaxY - bottomRadius);
+  [path addLineToPoint:bottomLeftCornerPoint1];
+  [self addBottomLeftCornerToPath:path
+                        fromPoint:bottomLeftCornerPoint1
+                          toPoint:bottomLeftCornerPoint2
+                       withRadius:bottomRadius];
+
+  CGPoint topLeftCornerPoint1 = CGPointMake(0, sublayerMinY + topRadius);
+  CGPoint topLeftCornerPoint2 = CGPointMake(topRadius, sublayerMinY);
+  [path addLineToPoint:topLeftCornerPoint1];
+  [self addTopLeftCornerToPath:path
+                     fromPoint:topLeftCornerPoint1
+                       toPoint:topLeftCornerPoint2
+                    withRadius:topRadius];
+
+  return path;
+}
+
+- (UIBezierPath *)filledSublayerUnderlinePathWithTextFieldBounds:(CGRect)textFieldBounds
+                                         topRowBottomRowDividerY:(CGFloat)topRowBottomRowDividerY {
+  //TODO: Consider underline labels, don't place underline under them
+  UIBezierPath *path = [[UIBezierPath alloc] init];
+  CGFloat textFieldWidth = CGRectGetWidth(textFieldBounds);
+  CGFloat sublayerMaxY = topRowBottomRowDividerY;
+  CGFloat sublayerMinY = sublayerMaxY - kFilledTextFieldUnderlineHeight;
+
+  CGPoint startingPoint = CGPointMake(0, sublayerMinY);
+  CGPoint topRightCornerPoint1 = CGPointMake(textFieldWidth, sublayerMinY);
+  [path moveToPoint:startingPoint];
+  [path addLineToPoint:topRightCornerPoint1];
+
+  CGPoint topRightCornerPoint2 = CGPointMake(textFieldWidth, sublayerMinY);
+  [self addTopRightCornerToPath:path
+                      fromPoint:topRightCornerPoint1
+                        toPoint:topRightCornerPoint2
+                     withRadius:0];
+
+  CGPoint bottomRightCornerPoint1 = CGPointMake(textFieldWidth, sublayerMaxY);
+  CGPoint bottomRightCornerPoint2 = CGPointMake(textFieldWidth, sublayerMaxY);
+  [path addLineToPoint:bottomRightCornerPoint1];
+  [self addBottomRightCornerToPath:path
+                         fromPoint:bottomRightCornerPoint1
+                           toPoint:bottomRightCornerPoint2
+                        withRadius:0];
+
+  CGPoint bottomLeftCornerPoint1 = CGPointMake(0, sublayerMaxY);
+  CGPoint bottomLeftCornerPoint2 = CGPointMake(0, sublayerMaxY);
+  [path addLineToPoint:bottomLeftCornerPoint1];
+  [self addBottomLeftCornerToPath:path
+                        fromPoint:bottomLeftCornerPoint1
+                          toPoint:bottomLeftCornerPoint2
+                       withRadius:0];
+
+  CGPoint topLeftCornerPoint1 = CGPointMake(0, sublayerMinY);
+  CGPoint topLeftCornerPoint2 = CGPointMake(0, sublayerMinY);
+  [path addLineToPoint:topLeftCornerPoint1];
+  [self addTopLeftCornerToPath:path
+                     fromPoint:topLeftCornerPoint1
+                       toPoint:topLeftCornerPoint2
+                    withRadius:0];
+
+  return path;
+}
+
+
+- (void)addTopRightCornerToPath:(UIBezierPath *)path
+                      fromPoint:(CGPoint)point1
+                        toPoint:(CGPoint)point2
+                     withRadius:(CGFloat)radius {
+  CGFloat startAngle = - (CGFloat)(M_PI / 2);
+  CGFloat endAngle = 0;
+  CGPoint center = CGPointMake(point1.x, point2.y);
+  [path addArcWithCenter:center
+                  radius:radius
+              startAngle:startAngle
+                endAngle:endAngle
+               clockwise:YES];
+}
+
+- (void)addBottomRightCornerToPath:(UIBezierPath *)path
+                         fromPoint:(CGPoint)point1
+                           toPoint:(CGPoint)point2
+                        withRadius:(CGFloat)radius {
+  CGFloat startAngle = 0;
+  CGFloat endAngle = - (CGFloat)((M_PI * 3) / 2);
+  CGPoint center = CGPointMake(point2.x, point1.y);
+  [path addArcWithCenter:center
+                  radius:radius
+              startAngle:startAngle
+                endAngle:endAngle
+               clockwise:YES];
+}
+
+- (void)addBottomLeftCornerToPath:(UIBezierPath *)path
+                        fromPoint:(CGPoint)point1
+                          toPoint:(CGPoint)point2
+                       withRadius:(CGFloat)radius {
+  CGFloat startAngle = - (CGFloat)((M_PI * 3) / 2);
+  CGFloat endAngle = - (CGFloat)M_PI;
+  CGPoint center = CGPointMake(point1.x, point2.y);
+  [path addArcWithCenter:center
+                  radius:radius
+              startAngle:startAngle
+                endAngle:endAngle
+               clockwise:YES];
+}
+
+- (void)addTopLeftCornerToPath:(UIBezierPath *)path
+                     fromPoint:(CGPoint)point1
+                       toPoint:(CGPoint)point2
+                    withRadius:(CGFloat)radius {
+  CGFloat startAngle = - (CGFloat)M_PI;
+  CGFloat endAngle = - (CGFloat)(M_PI / 2);
+  CGPoint center = CGPointMake(point1.x + radius, point2.y + radius);
+  [path addArcWithCenter:center
+                  radius:radius
+              startAngle:startAngle
+                endAngle:endAngle
+               clockwise:YES];
+}
+
+
+
+- (IBAction)outletTextField:(id)sender {
+}
+@end

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextField.m
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextField.m
@@ -53,12 +53,15 @@
 - (void)assignPropertiesWithColorScheme:(MDCSemanticColorScheme *)colorScheme
                          textFieldState:(TextFieldState)textFieldState {
   UIColor *textColor = colorScheme.onSurfaceColor;
-  UIColor *underlineLabelColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
-  UIColor *placeholderLabelColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
+  UIColor *underlineLabelColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+  UIColor *placeholderLabelColor =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
   UIColor *outlineColor = colorScheme.onSurfaceColor;
   UIColor *filledSublayerUnderlineFillColor = colorScheme.onSurfaceColor;
-  UIColor *filledSublayerFillColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.15];
-  UIColor *clearButtonTintColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.20];
+  UIColor *filledSublayerFillColor =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.15];
+  UIColor *clearButtonTintColor =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.20];
 
   switch (textFieldState) {
     case TextFieldStateNormal:
@@ -66,7 +69,7 @@
     case TextFieldStateActivated:
       break;
     case TextFieldStateDisabled:
-      placeholderLabelColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.10];
+      placeholderLabelColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.10];
       break;
     case TextFieldStateErrored:
       placeholderLabelColor = colorScheme.errorColor;
@@ -532,7 +535,7 @@
 - (CGRect)adjustTextAreaFrame:(CGRect)textAreaFrame
     withParentClassTextAreaFrame:(CGRect)parentClassTextAreaFrame {
   CGFloat systemDefinedHeight = CGRectGetHeight(parentClassTextAreaFrame);
-  CGFloat minY = CGRectGetMidY(textAreaFrame) - (systemDefinedHeight * 0.5);
+  CGFloat minY = CGRectGetMidY(textAreaFrame) - (systemDefinedHeight * (CGFloat)0.5);
   return CGRectMake(CGRectGetMinX(textAreaFrame), minY, CGRectGetWidth(textAreaFrame),
                     systemDefinedHeight);
 }
@@ -823,11 +826,11 @@
     case TextFieldStyleFilled:
     default:
       floatingPlaceholderFontSize =
-          round((double)(font.pointSize * filledFloatingPlaceholderScale));
+          (CGFloat)round((double)(font.pointSize * filledFloatingPlaceholderScale));
       break;
     case TextFieldStyleOutline:
       floatingPlaceholderFontSize =
-          round((double)(font.pointSize * outlinedFloatingPlaceholderScale));
+          (CGFloat)round((double)(font.pointSize * outlinedFloatingPlaceholderScale));
       break;
   }
   return [font fontWithSize:floatingPlaceholderFontSize];

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextField.m
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextField.m
@@ -34,23 +34,23 @@
 @property(strong, nonatomic) UIColor *clearButtonTintColor;
 
 - (instancetype)initWithColorScheme:(nonnull MDCSemanticColorScheme *)colorScheme
-                 withTextFieldState:(TextFieldState)textFieldState;
+                     textFieldState:(TextFieldState)textFieldState;
 
 @end
 
 @implementation SimpleTextFieldColorAdapter
 
 - (instancetype)initWithColorScheme:(MDCSemanticColorScheme *)colorScheme
-                 withTextFieldState:(TextFieldState)textFieldState {
+                     textFieldState:(TextFieldState)textFieldState {
   self = [super init];
   if (self) {
-    [self assignPropertiesWithColorScheme:colorScheme withTextFieldState:textFieldState];
+    [self assignPropertiesWithColorScheme:colorScheme textFieldState:textFieldState];
   }
   return self;
 }
 
 - (void)assignPropertiesWithColorScheme:(MDCSemanticColorScheme *)colorScheme
-                     withTextFieldState:(TextFieldState)textFieldState {
+                         textFieldState:(TextFieldState)textFieldState {
   UIColor *placeholderLabelColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
   UIColor *underlineLabelColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
   UIColor *outlineColor = colorScheme.onSurfaceColor;
@@ -208,9 +208,8 @@
                        action:@selector(clearButtonPressed:)
              forControlEvents:UIControlEventTouchUpInside];
 
-  CGFloat clearButtonImageViewSideLength = [self clearButtonImageViewSideLength];
   CGRect clearButtonImageViewRect =
-      CGRectMake(0, 0, clearButtonImageViewSideLength, clearButtonImageViewSideLength);
+      CGRectMake(0, 0, kClearButtonImageViewSideLength, kClearButtonImageViewSideLength);
   self.clearButtonImageView = [[UIImageView alloc] initWithFrame:clearButtonImageViewRect];
   UIImage *clearButtonImage =
       [[self untintedClearButtonImage] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
@@ -281,7 +280,7 @@
   self.placeholderState = [self determineCurrentPlaceholderState];
   SimpleTextFieldColorAdapter *colorAdapter =
       [[SimpleTextFieldColorAdapter alloc] initWithColorScheme:self.containerScheme.colorScheme
-                                            withTextFieldState:self.textFieldState];
+                                                textFieldState:self.textFieldState];
   [self applyColorAdapter:colorAdapter];
   [self applyTypographyScheme:self.containerScheme.typographyScheme];
   CGSize fittingSize = CGSizeMake(CGRectGetWidth(self.frame), CGFLOAT_MAX);
@@ -540,12 +539,22 @@
                     systemDefinedHeight);
 }
 
+// TODO: Explain why this confusing implementation is the way it is.
 - (CGRect)leftViewRectForBounds:(CGRect)bounds {
-  return self.layout.leftViewFrame;
+  if ([self isRTL]) {
+    return self.layout.rightViewFrame;
+  } else {
+    return self.layout.leftViewFrame;
+  }
 }
 
+// TODO: Explain why this confusing implementation is the way it is.
 - (CGRect)rightViewRectForBounds:(CGRect)bounds {
-  return self.layout.rightViewFrame;
+  if ([self isRTL]) {
+    return self.layout.leftViewFrame;
+  } else {
+    return self.layout.rightViewFrame;
+  }
 }
 
 - (CGRect)borderRectForBounds:(CGRect)bounds {
@@ -608,9 +617,8 @@
 #pragma mark Clear Button
 
 - (UIImage *)untintedClearButtonImage {
-  CGFloat clearButtonImageViewSideLength = [self clearButtonImageViewSideLength];
   CGSize clearButtonSize =
-      CGSizeMake(clearButtonImageViewSideLength, clearButtonImageViewSideLength);
+      CGSizeMake(kClearButtonImageViewSideLength, kClearButtonImageViewSideLength);
   CGRect rect = CGRectMake(0, 0, clearButtonSize.width, clearButtonSize.height);
   UIGraphicsBeginImageContextWithOptions(rect.size, false, 0);
   [[UIColor blackColor] setFill];
@@ -619,10 +627,6 @@
   UIGraphicsEndImageContext();
   image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   return image;
-}
-
-- (CGFloat)clearButtonImageViewSideLength {
-  return kClearButtonTouchTargetSideLength - kTextRectSidePadding;
 }
 
 // This generated code is taken from the MDCTextField.
@@ -977,9 +981,9 @@
   [path moveToPoint:startingPoint];
   if (isFloatingPlaceholder) {
     CGFloat leftLineBreak =
-        CGRectGetMinX(floatingPlaceholderFrame) - kFloatingPlaceholderSideMargin;
+        CGRectGetMinX(floatingPlaceholderFrame) - kFloatingPlaceholderOutlineSidePadding;
     CGFloat rightLineBreak =
-        CGRectGetMaxX(floatingPlaceholderFrame) + kFloatingPlaceholderSideMargin;
+        CGRectGetMaxX(floatingPlaceholderFrame) + kFloatingPlaceholderOutlineSidePadding;
     [path addLineToPoint:CGPointMake(leftLineBreak, sublayerMinY)];
     [path moveToPoint:CGPointMake(rightLineBreak, sublayerMinY)];
     [path addLineToPoint:CGPointMake(rightLineBreak, sublayerMinY)];

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextField.m
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextField.m
@@ -203,6 +203,7 @@
 
   // TODO: Hide any views that the layout says to hide
   // TODO: Hide views that won't fit by validating frames (checking if they fit inside the bounds and don't overlap)
+  [self determineCurrentTextFieldState];
 }
 
 // UIView's sizeToFit calls this method.
@@ -1024,6 +1025,78 @@
 
 
 
-- (IBAction)outletTextField:(id)sender {
+- (TextFieldState)determineCurrentTextFieldState {
+  NSString *stateString = @"NA";
+  switch (self.state) {
+    case UIControlStateNormal:
+      stateString = @"Normal";
+      break;
+    case UIControlStateHighlighted:
+      stateString = @"Highlighted";
+      break;
+    case UIControlStateDisabled:
+      stateString = @"Disabled";
+      break;
+    case UIControlStateSelected:
+      stateString = @"Selected";
+      break;
+    case UIControlStateFocused:
+      stateString = @"Focused";
+      break;
+    case UIControlStateApplication:
+      stateString = @"Application";
+      break;
+    case UIControlStateReserved:
+      stateString = @"Reserved";
+      break;
+  }
+
+  NSLog(@"----------");
+  NSLog(@"isHighlighted: %@",@(self.isHighlighted));
+  NSLog(@"isSelected: %@",@(self.isSelected));
+  NSLog(@"isFirstResponder: %@",@(self.isFirstResponder));
+  NSLog(@"state: %@",stateString);
+  NSLog(@"----------");
+
+  if (self.isEnabled) {
+    if (self.isErrored) {
+      // Error
+    } else {
+      if (self.isSelected || self.isActivated) {
+        // activated
+        
+      } else {
+        // normal
+        
+      }
+    }
+  } else {
+    // disabled
+  }
+  
+  if (self.isErrored) {
+    
+  } else {
+    
+  }
+  
 }
+
+- (void)setColorScheme:(MDCSemanticColorScheme *)colorScheme
+              forState:(TextFieldState)textFieldState {
+  
+}
+
+- (MDCSemanticColorScheme *)colorScheme:(MDCSemanticColorScheme *)colorScheme
+                               forState:(TextFieldState)textFieldState {
+  
+}
+
+
+
+/**
+ Focused -
+ */
+
+
 @end

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextField.m
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextField.m
@@ -16,28 +16,94 @@
 
 #import <Foundation/Foundation.h>
 
+@interface SimpleTextFieldColorAdapter : NSObject
+
+@property(strong, nonatomic) UIColor *underlineLabelColor;
+@property(strong, nonatomic) UIColor *outlineColor;
+@property(strong, nonatomic) UIColor *placeholderLabelColor;
+@property(strong, nonatomic) UIColor *filledSublayerFillColor;
+@property(strong, nonatomic) UIColor *filledSublayerUnderlineFillColor;
+@property(strong, nonatomic) UIColor *clearButtonTintColor;
+
+- (instancetype)initWithColorScheme:(nonnull MDCSemanticColorScheme *)colorScheme
+                 withTextFieldState:(TextFieldState)textFieldState;
+
+@end
+
+@implementation SimpleTextFieldColorAdapter
+
+- (instancetype)initWithColorScheme:(MDCSemanticColorScheme *)colorScheme
+                 withTextFieldState:(TextFieldState)textFieldState {
+  self = [super init];
+  if (self) {
+    [self assignPropertiesWithColorScheme:colorScheme withTextFieldState:textFieldState];
+  }
+  return self;
+}
+
+- (void)assignPropertiesWithColorScheme:(MDCSemanticColorScheme *)colorScheme
+                     withTextFieldState:(TextFieldState)textFieldState {
+  UIColor *placeholderLabelColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
+  UIColor *underlineLabelColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
+  UIColor *outlineColor = colorScheme.onSurfaceColor;
+  UIColor *filledSublayerUnderlineFillColor = colorScheme.onSurfaceColor;
+  UIColor *filledSublayerFillColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.15];
+  UIColor *clearButtonTintColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.20];
+
+  switch (textFieldState) {
+    case TextFieldStateNormal:
+      break;
+    case TextFieldStateActivated:
+      break;
+    case TextFieldStateDisabled:
+      placeholderLabelColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.10];
+      break;
+    case TextFieldStateErrored:
+      placeholderLabelColor = colorScheme.errorColor;
+      underlineLabelColor = colorScheme.errorColor;
+      filledSublayerUnderlineFillColor = colorScheme.errorColor;
+      outlineColor = colorScheme.errorColor;
+      break;
+    case TextFieldStateFocused:
+      outlineColor = colorScheme.primaryColor;
+      placeholderLabelColor = colorScheme.primaryColor;
+      filledSublayerUnderlineFillColor = colorScheme.primaryColor;
+      break;
+    default:
+      break;
+  }
+  self.filledSublayerFillColor = filledSublayerFillColor;
+  self.filledSublayerUnderlineFillColor = filledSublayerUnderlineFillColor;
+  self.underlineLabelColor = underlineLabelColor;
+  self.outlineColor = outlineColor;
+  self.placeholderLabelColor = placeholderLabelColor;
+  self.clearButtonTintColor = clearButtonTintColor;
+}
+
+@end
+
 @interface SimpleTextField ()
 
-@property (strong, nonatomic) UIFont *floatingPlaceholderFont;
-@property (strong, nonatomic) UIFont *placeholderFont;
+@property(strong, nonatomic) UIFont *floatingPlaceholderFont;
+@property(strong, nonatomic) UIFont *placeholderFont;
 
-@property (strong, nonatomic) UIButton *clearButton;
-@property (strong, nonatomic) UIImageView *clearButtonImageView;
-@property (strong, nonatomic) UILabel *placeholderLabel;
+@property(strong, nonatomic) UIButton *clearButton;
+@property(strong, nonatomic) UIImageView *clearButtonImageView;
+@property(strong, nonatomic) UILabel *placeholderLabel;
 
-@property (strong, nonatomic) UILabel *leftUnderlineLabel;
-@property (strong, nonatomic) UILabel *rightUnderlineLabel;
+@property(strong, nonatomic) UILabel *leftUnderlineLabel;
+@property(strong, nonatomic) UILabel *rightUnderlineLabel;
 
-@property (strong, nonatomic) SimpleTextFieldLayout *layout;
+@property(strong, nonatomic) SimpleTextFieldLayout *layout;
 
-@property (strong, nonatomic) CAShapeLayer *outlinedSublayer;
-@property (strong, nonatomic) CAShapeLayer *filledSublayer;
-@property (strong, nonatomic) CAShapeLayer *filledSublayerUnderline;
+@property(strong, nonatomic) CAShapeLayer *outlinedSublayer;
+@property(strong, nonatomic) CAShapeLayer *filledSublayer;
+@property(strong, nonatomic) CAShapeLayer *filledSublayerUnderline;
 
-@property (nonatomic, assign) UIUserInterfaceLayoutDirection layoutDirection;
+@property(nonatomic, assign) UIUserInterfaceLayoutDirection layoutDirection;
 
-@property (nonatomic, assign) TextFieldState textFieldState;
-@property (nonatomic, assign) PlaceholderState placeholderState;
+@property(nonatomic, assign) TextFieldState textFieldState;
+@property(nonatomic, assign) PlaceholderState placeholderState;
 
 @end
 
@@ -46,7 +112,7 @@
 
 #pragma mark Object Lifecycle
 
--(instancetype)initWithFrame:(CGRect)frame {
+- (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];
   if (self) {
     [self commonSimpleTextFieldInit];
@@ -54,7 +120,7 @@
   return self;
 }
 
--(instancetype)initWithCoder:(NSCoder *)aDecoder {
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
   self = [super initWithCoder:aDecoder];
   if (self) {
     [self commonSimpleTextFieldInit];
@@ -122,32 +188,32 @@
 }
 
 - (void)setUpClearButton {
-  CGRect clearButtonFrame = CGRectMake(0, 0, kClearButtonTouchTargetSideLength, kClearButtonTouchTargetSideLength);
+  CGRect clearButtonFrame =
+      CGRectMake(0, 0, kClearButtonTouchTargetSideLength, kClearButtonTouchTargetSideLength);
   self.clearButton = [[UIButton alloc] initWithFrame:clearButtonFrame];
   [self.clearButton addTarget:self
                        action:@selector(clearButtonPressed:)
              forControlEvents:UIControlEventTouchUpInside];
-  
+
   CGFloat clearButtonImageViewSideLength = [self clearButtonImageViewSideLength];
-  CGRect clearButtonImageViewRect = CGRectMake(0, 0, clearButtonImageViewSideLength, clearButtonImageViewSideLength);
+  CGRect clearButtonImageViewRect =
+      CGRectMake(0, 0, clearButtonImageViewSideLength, clearButtonImageViewSideLength);
   self.clearButtonImageView = [[UIImageView alloc] initWithFrame:clearButtonImageViewRect];
-  self.clearButtonImageView.image = [self clearButtonImage];
-  self.clearButtonImageView.tintColor = UIColor.lightGrayColor;
+  UIImage *clearButtonImage =
+      [[self untintedClearButtonImage] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+  self.clearButtonImageView.image = clearButtonImage;
   [self.clearButton addSubview:self.clearButtonImageView];
   [self addSubview:self.clearButton];
   self.clearButtonImageView.center = self.clearButton.center;
 }
 
-
 - (void)setUpStyleLayers {
   [self setUpOutlineSublayer];
   [self setUpFilledSublayer];
-  // TODO: Underline
 }
 
 - (void)setUpOutlineSublayer {
   self.outlinedSublayer = [[CAShapeLayer alloc] init];
-  self.outlinedSublayer.strokeColor = [UIColor purpleColor].CGColor;
   self.outlinedSublayer.fillColor = [UIColor clearColor].CGColor;
   self.outlinedSublayer.lineWidth = [self outlineLineWidthForState:self.textFieldState];
 }
@@ -169,20 +235,23 @@
 }
 
 - (void)setUpFilledSublayer {
-  UIColor *fillColor = [UIColor colorWithWhite:0 alpha:0.2];
-  UIColor *underlineFillColor = [UIColor purpleColor];
   self.filledSublayer = [[CAShapeLayer alloc] init];
-  self.filledSublayer.fillColor = fillColor.CGColor;
   self.filledSublayer.lineWidth = 0.0;
   self.filledSublayerUnderline = [[CAShapeLayer alloc] init];
-  self.filledSublayerUnderline.fillColor = underlineFillColor.CGColor;
   [self.filledSublayer addSublayer:self.filledSublayerUnderline];
 }
 
-
 - (void)addObservers {
-  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(textFieldDidEndEditingWithNotification:) name:UITextFieldTextDidEndEditingNotification object:nil];
-  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(textFieldDidBeginEditingWithNotification:) name:UITextFieldTextDidBeginEditingNotification object:nil];
+  [[NSNotificationCenter defaultCenter]
+      addObserver:self
+         selector:@selector(textFieldDidEndEditingWithNotification:)
+             name:UITextFieldTextDidEndEditingNotification
+           object:nil];
+  [[NSNotificationCenter defaultCenter]
+      addObserver:self
+         selector:@selector(textFieldDidBeginEditingWithNotification:)
+             name:UITextFieldTextDidBeginEditingNotification
+           object:nil];
 }
 
 #pragma mark UIView Overrides
@@ -192,29 +261,30 @@
   UIFont *floatingFont = [self floatingPlaceholderFontWithFont:effectiveFont
                                                 textFieldStyle:self.textFieldStyle];
   CGFloat normalizedCustomUnderlineLabelDrawPriority =
-  [self normalizedCustomUnderlineLabelDrawPriority:self.customUnderlineLabelDrawPriority];
-  return [[SimpleTextFieldLayout alloc] initWithTextFieldSize:textFieldSize
-                                                 textFieldStyle:self.textFieldStyle
-                                                           text:self.text
-                                                    placeholder:self.placeholder
-                                                           font:effectiveFont
-                                        floatingPlaceholderFont:floatingFont
-                                            canPlaceholderFloat:self.canPlaceholderFloat
-                                                       leftView:self.leftView
-                                                   leftViewMode:self.leftViewMode
-                                                      rightView:self.rightView
-                                                  rightViewMode:self.rightViewMode
-                                                    clearButton:self.clearButton
-                                                clearButtonMode:self.clearButtonMode
-                                             leftUnderlineLabel:self.leftUnderlineLabel
-                                            rightUnderlineLabel:self.rightUnderlineLabel
-                                     underlineLabelDrawPriority:self.underlineLabelDrawPriority
-                               customUnderlineLabelDrawPriority:normalizedCustomUnderlineLabelDrawPriority
-                                                          isRTL:[self isRTL]
-                                                      isEditing:self.isEditing];
+      [self normalizedCustomUnderlineLabelDrawPriority:self.customUnderlineLabelDrawPriority];
+  return [[SimpleTextFieldLayout alloc]
+                 initWithTextFieldSize:textFieldSize
+                        textFieldStyle:self.textFieldStyle
+                                  text:self.text
+                           placeholder:self.placeholder
+                                  font:effectiveFont
+               floatingPlaceholderFont:floatingFont
+                   canPlaceholderFloat:self.canPlaceholderFloat
+                              leftView:self.leftView
+                          leftViewMode:self.leftViewMode
+                             rightView:self.rightView
+                         rightViewMode:self.rightViewMode
+                           clearButton:self.clearButton
+                       clearButtonMode:self.clearButtonMode
+                    leftUnderlineLabel:self.leftUnderlineLabel
+                   rightUnderlineLabel:self.rightUnderlineLabel
+            underlineLabelDrawPriority:self.underlineLabelDrawPriority
+      customUnderlineLabelDrawPriority:normalizedCustomUnderlineLabelDrawPriority
+                                 isRTL:[self isRTL]
+                             isEditing:self.isEditing];
 }
 
--(void)layoutSubviews {
+- (void)layoutSubviews {
   [self preLayoutSubviews];
   [super layoutSubviews];
   [self postLayoutSubviews];
@@ -223,8 +293,10 @@
 - (void)preLayoutSubviews {
   self.textFieldState = [self determineCurrentTextFieldState];
   self.placeholderState = [self determineCurrentPlaceholderState];
-  [self applyColorScheme:self.containerScheme.colorScheme
-      withTextFieldState:self.textFieldState];
+  SimpleTextFieldColorAdapter *colorAdapter =
+      [[SimpleTextFieldColorAdapter alloc] initWithColorScheme:self.containerScheme.colorScheme
+                                            withTextFieldState:self.textFieldState];
+  [self applyColorAdapter:colorAdapter];
   [self applyTypographyScheme:self.containerScheme.typographyScheme];
   CGSize fittingSize = CGSizeMake(CGRectGetWidth(self.frame), CGFLOAT_MAX);
   self.layout = [self calculateLayoutWithTextFieldSize:fittingSize];
@@ -232,11 +304,11 @@
 
 - (void)postLayoutSubviews {
   [self applyTextFieldStyle:self.textFieldStyle
-             textFieldState:self.textFieldState
-            textFieldBounds:self.bounds
-   floatingPlaceholderFrame:self.layout.placeholderFrameFloating
-    topRowBottomRowDividerY:self.layout.topRowBottomRowDividerY
-      isFloatingPlaceholder:self.placeholderState == PlaceholderStateFloating];
+                textFieldState:self.textFieldState
+               textFieldBounds:self.bounds
+      floatingPlaceholderFrame:self.layout.placeholderFrameFloating
+       topRowBottomRowDividerY:self.layout.topRowBottomRowDividerY
+         isFloatingPlaceholder:self.placeholderState == PlaceholderStateFloating];
   [self layOutPlaceholderWithState:self.placeholderState];
   self.clearButton.frame = self.layout.clearButtonFrame;
   self.clearButton.hidden = self.layout.clearButtonHidden;
@@ -254,7 +326,7 @@
 // A vanilla UITextField returns a 9x21 size as the smallest UITextFields
 // It does so irrespective of leftView/rightView, but it does take into account text.
 // I think that this implementation should calculate a height for size.width.
--(CGSize)sizeThatFits:(CGSize)size {
+- (CGSize)sizeThatFits:(CGSize)size {
   return [self preferredSizeWithWidth:size.width];
 }
 
@@ -264,7 +336,7 @@
   return CGSizeMake(width, layout.calculatedHeight);
 }
 
--(CGSize)intrinsicContentSize {
+- (CGSize)intrinsicContentSize {
   return [self preferredSizeWithWidth:CGRectGetWidth(self.bounds)];
 }
 
@@ -274,8 +346,8 @@
   NSLayoutConstraint *result = nil;
   for (NSLayoutConstraint *constraint in view.constraints) {
     BOOL isAHeightConstraintOnSelf =
-    (constraint.firstItem == view && constraint.firstAttribute == attribute) ||
-    (constraint.secondItem == view && constraint.secondAttribute == attribute);
+        (constraint.firstItem == view && constraint.firstAttribute == attribute) ||
+        (constraint.secondItem == view && constraint.secondAttribute == attribute);
     if (isAHeightConstraintOnSelf && constraint.priority > maxPriority) {
       result = constraint;
     }
@@ -283,77 +355,76 @@
   return result;
 }
 
-- (CGSize)systemLayoutSizeFittingSize:(CGSize)targetSize {
-  NSLog(@"TODO: Implement systemLayoutSizeFittingSize:");
-  return [super systemLayoutSizeFittingSize:targetSize];
-}
-
--(void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
   [super traitCollectionDidChange:previousTraitCollection];
   [self setUpLayoutDirection];
 }
 
 #pragma mark UITextField Accessor Overrides
 
--(void)setFont:(UIFont *)font {
+- (void)setFont:(UIFont *)font {
   [super setFont:font];
   [self setUpFonts];
 }
 
--(void)setPlaceholder:(NSString *)placeholder {
+- (void)setPlaceholder:(NSString *)placeholder {
   self.placeholderLabel.attributedText = nil;
   self.placeholderLabel.text = [placeholder copy];
   // TODO: Determine if setNeedsLayout is necessary here. I think it might be...
 }
 
--(NSString *)placeholder {
+- (NSString *)placeholder {
   return self.placeholderLabel.text;
 }
 
--(void)setAttributedPlaceholder:(NSAttributedString *)attributedPlaceholder {
+- (void)setAttributedPlaceholder:(NSAttributedString *)attributedPlaceholder {
   self.placeholderLabel.text = nil;
   self.placeholderLabel.attributedText = attributedPlaceholder;
   // TODO: Determine if setNeedsLayout is necessary here. I think it might be...
   // TODO: Also make layout aware of attributedPlaceholder
 }
 
--(NSAttributedString *)attributedPlaceholder {
+- (NSAttributedString *)attributedPlaceholder {
   return self.placeholderLabel.attributedText;
 }
 
--(void)setLeftViewMode:(UITextFieldViewMode)leftViewMode {
-  NSLog(@"Setting leftViewMode is not recommended. Consider setting leadingViewMode and trailingViewMode instead.");
+- (void)setLeftViewMode:(UITextFieldViewMode)leftViewMode {
+  NSLog(@"Setting leftViewMode is not recommended. Consider setting leadingViewMode and "
+        @"trailingViewMode instead.");
   [self mdc_setLeftViewMode:leftViewMode];
 }
 
--(void)setRightViewMode:(UITextFieldViewMode)rightViewMode {
-  NSLog(@"Setting rightViewMode is not recommended. Consider setting leadingViewMode and trailingViewMode instead.");
+- (void)setRightViewMode:(UITextFieldViewMode)rightViewMode {
+  NSLog(@"Setting rightViewMode is not recommended. Consider setting leadingViewMode and "
+        @"trailingViewMode instead.");
   [self mdc_setRightViewMode:rightViewMode];
 }
 
--(void)setLeftView:(UIView *)leftView {
-  NSLog(@"Setting rightView and leftView are not recommended. Consider setting leadingView and trailingView instead.");
+- (void)setLeftView:(UIView *)leftView {
+  NSLog(@"Setting rightView and leftView are not recommended. Consider setting leadingView and "
+        @"trailingView instead.");
   [self mdc_setLeftView:leftView];
 }
 
--(void)setRightView:(UIView *)rightView {
-  NSLog(@"Setting rightView and leftView are not recommended. Consider setting leadingView and trailingView instead.");
+- (void)setRightView:(UIView *)rightView {
+  NSLog(@"Setting rightView and leftView are not recommended. Consider setting leadingView and "
+        @"trailingView instead.");
   [self mdc_setRightView:rightView];
 }
 
--(void)setClearButtonMode:(UITextFieldViewMode)clearButtonMode {
+- (void)setClearButtonMode:(UITextFieldViewMode)clearButtonMode {
   [super setClearButtonMode:clearButtonMode];
-  //TODO: determine whether a call to setNeedsLayout is necessary. I don't think it is...
+  // TODO: determine whether a call to setNeedsLayout is necessary. I don't think it is...
 }
 
--(void)setBorderStyle:(UITextBorderStyle)borderStyle {
+- (void)setBorderStyle:(UITextBorderStyle)borderStyle {
   // enforce UITextBorderStyle.none
   [super setBorderStyle:UITextBorderStyleNone];
 }
 
 #pragma mark Custom Accessors
 
--(UILabel *)leadingUnderlineLabel {
+- (UILabel *)leadingUnderlineLabel {
   if ([self isRTL]) {
     return self.rightUnderlineLabel;
   } else {
@@ -361,7 +432,7 @@
   }
 }
 
--(UILabel *)trailingUnderlineLabel {
+- (UILabel *)trailingUnderlineLabel {
   if ([self isRTL]) {
     return self.leftUnderlineLabel;
   } else {
@@ -369,7 +440,7 @@
   }
 }
 
--(void)setLayoutDirection:(UIUserInterfaceLayoutDirection)layoutDirection {
+- (void)setLayoutDirection:(UIUserInterfaceLayoutDirection)layoutDirection {
   if (_layoutDirection == layoutDirection) {
     return;
   }
@@ -377,7 +448,7 @@
   [self setNeedsLayout];
 }
 
--(void)setTrailingView:(UIView *)trailingView {
+- (void)setTrailingView:(UIView *)trailingView {
   if ([self isRTL]) {
     [self mdc_setLeftView:trailingView];
   } else {
@@ -385,7 +456,7 @@
   }
 }
 
--(UIView *)trailingView {
+- (UIView *)trailingView {
   if ([self isRTL]) {
     return self.leftView;
   } else {
@@ -393,7 +464,7 @@
   }
 }
 
--(void)setLeadingView:(UIView *)leadingView {
+- (void)setLeadingView:(UIView *)leadingView {
   if ([self isRTL]) {
     [self mdc_setRightView:leadingView];
   } else {
@@ -401,7 +472,7 @@
   }
 }
 
--(UIView *)leadingView {
+- (UIView *)leadingView {
   if ([self isRTL]) {
     return self.rightView;
   } else {
@@ -418,7 +489,7 @@
   [super setRightView:rightView];
 }
 
--(void)setTrailingViewMode:(UITextFieldViewMode)trailingViewMode {
+- (void)setTrailingViewMode:(UITextFieldViewMode)trailingViewMode {
   if ([self isRTL]) {
     [self mdc_setLeftViewMode:trailingViewMode];
   } else {
@@ -426,7 +497,7 @@
   }
 }
 
--(UITextFieldViewMode)trailingViewMode {
+- (UITextFieldViewMode)trailingViewMode {
   if ([self isRTL]) {
     return self.leftViewMode;
   } else {
@@ -434,7 +505,7 @@
   }
 }
 
--(void)setLeadingViewMode:(UITextFieldViewMode)leadingViewMode {
+- (void)setLeadingViewMode:(UITextFieldViewMode)leadingViewMode {
   if ([self isRTL]) {
     [self mdc_setRightViewMode:leadingViewMode];
   } else {
@@ -442,7 +513,7 @@
   }
 }
 
--(UITextFieldViewMode)leadingViewMode {
+- (UITextFieldViewMode)leadingViewMode {
   if ([self isRTL]) {
     return self.rightViewMode;
   } else {
@@ -458,7 +529,7 @@
   [super setRightViewMode:rightViewMode];
 }
 
--(void)setCanPlaceholderFloat:(BOOL)canPlaceholderFloat {
+- (void)setCanPlaceholderFloat:(BOOL)canPlaceholderFloat {
   if (_canPlaceholderFloat == canPlaceholderFloat) {
     return;
   }
@@ -468,28 +539,28 @@
 
 #pragma mark UITextField Layout Overrides
 
--(CGRect)textRectForBounds:(CGRect)bounds {
+- (CGRect)textRectForBounds:(CGRect)bounds {
   return [self adjustTextAreaFrame:self.layout.textAreaFrame
       withParentClassTextAreaFrame:[super textRectForBounds:bounds]];
 }
 
--(CGRect)editingRectForBounds:(CGRect)bounds {
+- (CGRect)editingRectForBounds:(CGRect)bounds {
   return [self adjustTextAreaFrame:self.layout.textAreaFrame
       withParentClassTextAreaFrame:[super editingRectForBounds:bounds]];
 }
 
 - (CGRect)adjustTextAreaFrame:(CGRect)textAreaFrame
- withParentClassTextAreaFrame:(CGRect)parentClassTextAreaFrame {
+    withParentClassTextAreaFrame:(CGRect)parentClassTextAreaFrame {
   CGFloat height = CGRectGetHeight(parentClassTextAreaFrame);
   CGFloat minY = CGRectGetMidY(textAreaFrame) - (height * 0.5);
   return CGRectMake(CGRectGetMinX(textAreaFrame), minY, CGRectGetWidth(textAreaFrame), height);
 }
 
--(CGRect)leftViewRectForBounds:(CGRect)bounds {
+- (CGRect)leftViewRectForBounds:(CGRect)bounds {
   return self.layout.leftViewFrame;
 }
 
--(CGRect)rightViewRectForBounds:(CGRect)bounds {
+- (CGRect)rightViewRectForBounds:(CGRect)bounds {
   return self.layout.rightViewFrame;
 }
 
@@ -512,7 +583,6 @@
   }
   return value;
 }
-
 
 #pragma mark Fonts
 
@@ -538,12 +608,13 @@
 
 #pragma mark Clear Button
 
-- (UIImage *)clearButtonImage {
+- (UIImage *)untintedClearButtonImage {
   CGFloat clearButtonImageViewSideLength = [self clearButtonImageViewSideLength];
-  CGSize clearButtonSize = CGSizeMake(clearButtonImageViewSideLength, clearButtonImageViewSideLength);
+  CGSize clearButtonSize =
+      CGSizeMake(clearButtonImageViewSideLength, clearButtonImageViewSideLength);
   CGRect rect = CGRectMake(0, 0, clearButtonSize.width, clearButtonSize.height);
   UIGraphicsBeginImageContextWithOptions(rect.size, false, 0);
-  [[UIColor grayColor] setFill];
+  [[UIColor blackColor] setFill];
   [[self pathForClearButtonImageWithFrame:rect] fill];
   UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
   UIGraphicsEndImageContext();
@@ -554,113 +625,113 @@
 // This generated code is taken from the MDCTextField.
 - (UIBezierPath *)pathForClearButtonImageWithFrame:(CGRect)frame {
   CGRect innerBounds =
-  CGRectMake(CGRectGetMinX(frame) + 2, CGRectGetMinY(frame) + 2,
-             MDCFloor((frame.size.width - 2) * (CGFloat)0.90909 + (CGFloat)0.5),
-             MDCFloor((frame.size.height - 2) * (CGFloat)0.90909 + (CGFloat)0.5));
+      CGRectMake(CGRectGetMinX(frame) + 2, CGRectGetMinY(frame) + 2,
+                 MDCFloor((frame.size.width - 2) * (CGFloat)0.90909 + (CGFloat)0.5),
+                 MDCFloor((frame.size.height - 2) * (CGFloat)0.90909 + (CGFloat)0.5));
 
   UIBezierPath *ic_clear_path = [UIBezierPath bezierPath];
   [ic_clear_path moveToPoint:CGPointMake(CGRectGetMinX(innerBounds) +
-                                         (CGFloat)0.50000 * innerBounds.size.width,
+                                             (CGFloat)0.50000 * innerBounds.size.width,
                                          CGRectGetMinY(innerBounds) + 0 * innerBounds.size.height)];
   [ic_clear_path
-   addCurveToPoint:CGPointMake(
-                               CGRectGetMinX(innerBounds) + 1 * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + (CGFloat)0.50000 * innerBounds.size.height)
-   controlPoint1:CGPointMake(
-                             CGRectGetMinX(innerBounds) + (CGFloat)0.77600 * innerBounds.size.width,
-                             CGRectGetMinY(innerBounds) + 0 * innerBounds.size.height)
-   controlPoint2:CGPointMake(
-                             CGRectGetMinX(innerBounds) + 1 * innerBounds.size.width,
-                             CGRectGetMinY(innerBounds) + (CGFloat)0.22400 * innerBounds.size.height)];
+      addCurveToPoint:CGPointMake(
+                          CGRectGetMinX(innerBounds) + 1 * innerBounds.size.width,
+                          CGRectGetMinY(innerBounds) + (CGFloat)0.50000 * innerBounds.size.height)
+        controlPoint1:CGPointMake(
+                          CGRectGetMinX(innerBounds) + (CGFloat)0.77600 * innerBounds.size.width,
+                          CGRectGetMinY(innerBounds) + 0 * innerBounds.size.height)
+        controlPoint2:CGPointMake(
+                          CGRectGetMinX(innerBounds) + 1 * innerBounds.size.width,
+                          CGRectGetMinY(innerBounds) + (CGFloat)0.22400 * innerBounds.size.height)];
   [ic_clear_path
-   addCurveToPoint:CGPointMake(
-                               CGRectGetMinX(innerBounds) + (CGFloat)0.50000 * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + 1 * innerBounds.size.height)
-   controlPoint1:CGPointMake(
-                             CGRectGetMinX(innerBounds) + 1 * innerBounds.size.width,
-                             CGRectGetMinY(innerBounds) + (CGFloat)0.77600 * innerBounds.size.height)
-   controlPoint2:CGPointMake(
-                             CGRectGetMinX(innerBounds) + (CGFloat)0.77600 * innerBounds.size.width,
-                             CGRectGetMinY(innerBounds) + 1 * innerBounds.size.height)];
+      addCurveToPoint:CGPointMake(
+                          CGRectGetMinX(innerBounds) + (CGFloat)0.50000 * innerBounds.size.width,
+                          CGRectGetMinY(innerBounds) + 1 * innerBounds.size.height)
+        controlPoint1:CGPointMake(
+                          CGRectGetMinX(innerBounds) + 1 * innerBounds.size.width,
+                          CGRectGetMinY(innerBounds) + (CGFloat)0.77600 * innerBounds.size.height)
+        controlPoint2:CGPointMake(
+                          CGRectGetMinX(innerBounds) + (CGFloat)0.77600 * innerBounds.size.width,
+                          CGRectGetMinY(innerBounds) + 1 * innerBounds.size.height)];
   [ic_clear_path
-   addCurveToPoint:CGPointMake(
-                               CGRectGetMinX(innerBounds) + 0 * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + (CGFloat)0.50000 * innerBounds.size.height)
-   controlPoint1:CGPointMake(
-                             CGRectGetMinX(innerBounds) + (CGFloat)0.22400 * innerBounds.size.width,
-                             CGRectGetMinY(innerBounds) + 1 * innerBounds.size.height)
-   controlPoint2:CGPointMake(
-                             CGRectGetMinX(innerBounds) + 0 * innerBounds.size.width,
-                             CGRectGetMinY(innerBounds) + (CGFloat)0.77600 * innerBounds.size.height)];
+      addCurveToPoint:CGPointMake(
+                          CGRectGetMinX(innerBounds) + 0 * innerBounds.size.width,
+                          CGRectGetMinY(innerBounds) + (CGFloat)0.50000 * innerBounds.size.height)
+        controlPoint1:CGPointMake(
+                          CGRectGetMinX(innerBounds) + (CGFloat)0.22400 * innerBounds.size.width,
+                          CGRectGetMinY(innerBounds) + 1 * innerBounds.size.height)
+        controlPoint2:CGPointMake(
+                          CGRectGetMinX(innerBounds) + 0 * innerBounds.size.width,
+                          CGRectGetMinY(innerBounds) + (CGFloat)0.77600 * innerBounds.size.height)];
   [ic_clear_path
-   addCurveToPoint:CGPointMake(
-                               CGRectGetMinX(innerBounds) + (CGFloat)0.50000 * innerBounds.size.width,
-                               CGRectGetMinY(innerBounds) + 0 * innerBounds.size.height)
-   controlPoint1:CGPointMake(
-                             CGRectGetMinX(innerBounds) + 0 * innerBounds.size.width,
-                             CGRectGetMinY(innerBounds) + (CGFloat)0.22400 * innerBounds.size.height)
-   controlPoint2:CGPointMake(
-                             CGRectGetMinX(innerBounds) + (CGFloat)0.22400 * innerBounds.size.width,
-                             CGRectGetMinY(innerBounds) + 0 * innerBounds.size.height)];
+      addCurveToPoint:CGPointMake(
+                          CGRectGetMinX(innerBounds) + (CGFloat)0.50000 * innerBounds.size.width,
+                          CGRectGetMinY(innerBounds) + 0 * innerBounds.size.height)
+        controlPoint1:CGPointMake(
+                          CGRectGetMinX(innerBounds) + 0 * innerBounds.size.width,
+                          CGRectGetMinY(innerBounds) + (CGFloat)0.22400 * innerBounds.size.height)
+        controlPoint2:CGPointMake(
+                          CGRectGetMinX(innerBounds) + (CGFloat)0.22400 * innerBounds.size.width,
+                          CGRectGetMinY(innerBounds) + 0 * innerBounds.size.height)];
   [ic_clear_path closePath];
   [ic_clear_path
-   moveToPoint:CGPointMake(
-                           CGRectGetMinX(innerBounds) + (CGFloat)0.73417 * innerBounds.size.width,
-                           CGRectGetMinY(innerBounds) + (CGFloat)0.31467 * innerBounds.size.height)];
+      moveToPoint:CGPointMake(
+                      CGRectGetMinX(innerBounds) + (CGFloat)0.73417 * innerBounds.size.width,
+                      CGRectGetMinY(innerBounds) + (CGFloat)0.31467 * innerBounds.size.height)];
   [ic_clear_path
-   addLineToPoint:CGPointMake(
-                              CGRectGetMinX(innerBounds) + (CGFloat)0.68700 * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + (CGFloat)0.26750 * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(
+                         CGRectGetMinX(innerBounds) + (CGFloat)0.68700 * innerBounds.size.width,
+                         CGRectGetMinY(innerBounds) + (CGFloat)0.26750 * innerBounds.size.height)];
   [ic_clear_path
-   addLineToPoint:CGPointMake(
-                              CGRectGetMinX(innerBounds) + (CGFloat)0.50083 * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + (CGFloat)0.45367 * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(
+                         CGRectGetMinX(innerBounds) + (CGFloat)0.50083 * innerBounds.size.width,
+                         CGRectGetMinY(innerBounds) + (CGFloat)0.45367 * innerBounds.size.height)];
   [ic_clear_path
-   addLineToPoint:CGPointMake(
-                              CGRectGetMinX(innerBounds) + (CGFloat)0.31467 * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + (CGFloat)0.26750 * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(
+                         CGRectGetMinX(innerBounds) + (CGFloat)0.31467 * innerBounds.size.width,
+                         CGRectGetMinY(innerBounds) + (CGFloat)0.26750 * innerBounds.size.height)];
   [ic_clear_path
-   addLineToPoint:CGPointMake(
-                              CGRectGetMinX(innerBounds) + (CGFloat)0.26750 * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + (CGFloat)0.31467 * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(
+                         CGRectGetMinX(innerBounds) + (CGFloat)0.26750 * innerBounds.size.width,
+                         CGRectGetMinY(innerBounds) + (CGFloat)0.31467 * innerBounds.size.height)];
   [ic_clear_path
-   addLineToPoint:CGPointMake(
-                              CGRectGetMinX(innerBounds) + (CGFloat)0.45367 * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + (CGFloat)0.50083 * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(
+                         CGRectGetMinX(innerBounds) + (CGFloat)0.45367 * innerBounds.size.width,
+                         CGRectGetMinY(innerBounds) + (CGFloat)0.50083 * innerBounds.size.height)];
   [ic_clear_path
-   addLineToPoint:CGPointMake(
-                              CGRectGetMinX(innerBounds) + (CGFloat)0.26750 * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + (CGFloat)0.68700 * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(
+                         CGRectGetMinX(innerBounds) + (CGFloat)0.26750 * innerBounds.size.width,
+                         CGRectGetMinY(innerBounds) + (CGFloat)0.68700 * innerBounds.size.height)];
   [ic_clear_path
-   addLineToPoint:CGPointMake(
-                              CGRectGetMinX(innerBounds) + (CGFloat)0.31467 * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + (CGFloat)0.73417 * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(
+                         CGRectGetMinX(innerBounds) + (CGFloat)0.31467 * innerBounds.size.width,
+                         CGRectGetMinY(innerBounds) + (CGFloat)0.73417 * innerBounds.size.height)];
   [ic_clear_path
-   addLineToPoint:CGPointMake(
-                              CGRectGetMinX(innerBounds) + (CGFloat)0.50083 * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + (CGFloat)0.54800 * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(
+                         CGRectGetMinX(innerBounds) + (CGFloat)0.50083 * innerBounds.size.width,
+                         CGRectGetMinY(innerBounds) + (CGFloat)0.54800 * innerBounds.size.height)];
   [ic_clear_path
-   addLineToPoint:CGPointMake(
-                              CGRectGetMinX(innerBounds) + (CGFloat)0.68700 * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + (CGFloat)0.73417 * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(
+                         CGRectGetMinX(innerBounds) + (CGFloat)0.68700 * innerBounds.size.width,
+                         CGRectGetMinY(innerBounds) + (CGFloat)0.73417 * innerBounds.size.height)];
   [ic_clear_path
-   addLineToPoint:CGPointMake(
-                              CGRectGetMinX(innerBounds) + (CGFloat)0.73417 * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + (CGFloat)0.68700 * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(
+                         CGRectGetMinX(innerBounds) + (CGFloat)0.73417 * innerBounds.size.width,
+                         CGRectGetMinY(innerBounds) + (CGFloat)0.68700 * innerBounds.size.height)];
   [ic_clear_path
-   addLineToPoint:CGPointMake(
-                              CGRectGetMinX(innerBounds) + (CGFloat)0.54800 * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + (CGFloat)0.50083 * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(
+                         CGRectGetMinX(innerBounds) + (CGFloat)0.54800 * innerBounds.size.width,
+                         CGRectGetMinY(innerBounds) + (CGFloat)0.50083 * innerBounds.size.height)];
   [ic_clear_path
-   addLineToPoint:CGPointMake(
-                              CGRectGetMinX(innerBounds) + (CGFloat)0.73417 * innerBounds.size.width,
-                              CGRectGetMinY(innerBounds) + (CGFloat)0.31467 * innerBounds.size.height)];
+      addLineToPoint:CGPointMake(
+                         CGRectGetMinX(innerBounds) + (CGFloat)0.73417 * innerBounds.size.width,
+                         CGRectGetMinY(innerBounds) + (CGFloat)0.31467 * innerBounds.size.height)];
   [ic_clear_path closePath];
 
   return ic_clear_path;
 }
 
--(void)prepareForInterfaceBuilder {
+- (void)prepareForInterfaceBuilder {
   [super prepareForInterfaceBuilder];
   [self invalidateIntrinsicContentSize];
 }
@@ -670,7 +741,6 @@
 - (void)layOutPlaceholderWithState:(PlaceholderState)state {
   UIFont *font = nil;
   CGRect frame = CGRectZero;
-  // TODO: Take color into account
   BOOL placeholderShouldHide = NO;
   switch (state) {
     case PlaceholderStateFloating:
@@ -694,10 +764,11 @@
   // TODO: Figure out a better way of doing this.
   // One idea: Make it so placeholder animation is actually of a layer transform
   // but at the end you really change the font and frame and stuff.
-  [UIView animateWithDuration:kFloatingPlaceholderAnimationDuration animations:^{
-    weakSelf.placeholderLabel.frame = frame;
-    weakSelf.placeholderLabel.font = font;
-  }];
+  [UIView animateWithDuration:kFloatingPlaceholderAnimationDuration
+                   animations:^{
+                     weakSelf.placeholderLabel.frame = frame;
+                     weakSelf.placeholderLabel.font = font;
+                   }];
 }
 
 - (PlaceholderState)placeholderStateWithPlaceholder:(NSString *)placeholder
@@ -736,10 +807,12 @@
   CGFloat filledFloatingPlaceholderScale = (CGFloat)53 / (CGFloat)71;
   switch (textFieldStyle) {
     case TextFieldStyleFilled:
-      floatingPlaceholderFontSize = round((double)(font.pointSize * filledFloatingPlaceholderScale));
+      floatingPlaceholderFontSize =
+          round((double)(font.pointSize * filledFloatingPlaceholderScale));
       break;
     case TextFieldStyleOutline:
-      floatingPlaceholderFontSize = round((double)(font.pointSize * outlinedFloatingPlaceholderScale));
+      floatingPlaceholderFontSize =
+          round((double)(font.pointSize * outlinedFloatingPlaceholderScale));
       break;
     default:
       break;
@@ -755,7 +828,8 @@
 
 - (void)clearButtonPressed:(UIButton *)clearButton {
   self.text = nil;
-  // TODO: I'm pretty sure there is a control event or notification UITextField sens or posts here. Add it!
+  // TODO: I'm pretty sure there is a control event or notification UITextField sens or posts here.
+  // Add it!
 }
 
 #pragma mark Notification Listener Methods
@@ -792,29 +866,29 @@
 #pragma mark Style Management
 
 - (void)applyTextFieldStyle:(TextFieldStyle)textFieldStyle
-             textFieldState:(TextFieldState)textFieldState
-            textFieldBounds:(CGRect)textFieldBounds
-   floatingPlaceholderFrame:(CGRect)floatingPlaceholderFrame
-    topRowBottomRowDividerY:(CGFloat)topRowBottomRowDividerY
-      isFloatingPlaceholder:(BOOL)isFloatingPlaceholder {
+              textFieldState:(TextFieldState)textFieldState
+             textFieldBounds:(CGRect)textFieldBounds
+    floatingPlaceholderFrame:(CGRect)floatingPlaceholderFrame
+     topRowBottomRowDividerY:(CGFloat)topRowBottomRowDividerY
+       isFloatingPlaceholder:(BOOL)isFloatingPlaceholder {
   [self applyOutlinedStyle:textFieldStyle == TextFieldStyleOutline
-            textFieldState:textFieldState
-           textFieldBounds:textFieldBounds
-  floatingPlaceholderFrame:floatingPlaceholderFrame
-   topRowBottomRowDividerY:topRowBottomRowDividerY
-     isFloatingPlaceholder:isFloatingPlaceholder];
+                textFieldState:textFieldState
+               textFieldBounds:textFieldBounds
+      floatingPlaceholderFrame:floatingPlaceholderFrame
+       topRowBottomRowDividerY:topRowBottomRowDividerY
+         isFloatingPlaceholder:isFloatingPlaceholder];
   [self applyFilledStyle:textFieldStyle == TextFieldStyleFilled
-      WithTextFieldState:textFieldState
-         textFieldBounds:textFieldBounds
- topRowBottomRowDividerY:topRowBottomRowDividerY];
+           WithTextFieldState:textFieldState
+              textFieldBounds:textFieldBounds
+      topRowBottomRowDividerY:topRowBottomRowDividerY];
 }
 
 - (void)applyOutlinedStyle:(BOOL)isOutlined
-            textFieldState:(TextFieldState)textFieldState
-           textFieldBounds:(CGRect)textFieldBounds
-  floatingPlaceholderFrame:(CGRect)floatingPlaceholderFrame
-   topRowBottomRowDividerY:(CGFloat)topRowBottomRowDividerY
-     isFloatingPlaceholder:(BOOL)isFloatingPlaceholder {
+              textFieldState:(TextFieldState)textFieldState
+             textFieldBounds:(CGRect)textFieldBounds
+    floatingPlaceholderFrame:(CGRect)floatingPlaceholderFrame
+     topRowBottomRowDividerY:(CGFloat)topRowBottomRowDividerY
+       isFloatingPlaceholder:(BOOL)isFloatingPlaceholder {
   if (!isOutlined) {
     [self.outlinedSublayer removeFromSuperlayer];
     return;
@@ -833,20 +907,22 @@
 }
 
 - (void)applyFilledStyle:(BOOL)isFilled
-      WithTextFieldState:(TextFieldState)textFieldState
-         textFieldBounds:(CGRect)textFieldBounds
- topRowBottomRowDividerY:(CGFloat)topRowBottomRowDividerY {
+         WithTextFieldState:(TextFieldState)textFieldState
+            textFieldBounds:(CGRect)textFieldBounds
+    topRowBottomRowDividerY:(CGFloat)topRowBottomRowDividerY {
   if (!isFilled) {
     [self.filledSublayer removeFromSuperlayer];
     return;
   }
 
-  UIBezierPath *filledSublayerPath = [self filledSublayerPathWithTextFieldBounds:textFieldBounds
-                                                         topRowBottomRowDividerY:topRowBottomRowDividerY];
+  UIBezierPath *filledSublayerPath =
+      [self filledSublayerPathWithTextFieldBounds:textFieldBounds
+                          topRowBottomRowDividerY:topRowBottomRowDividerY];
   CGFloat underlineThickness = [self underlineThicknessWithTextFieldState:textFieldState];
-  UIBezierPath *filledSublayerUnderlinePath = [self filledSublayerUnderlinePathWithTextFieldBounds:textFieldBounds
-                                                                           topRowBottomRowDividerY:topRowBottomRowDividerY
-                                                                                underlineThickness:underlineThickness];
+  UIBezierPath *filledSublayerUnderlinePath =
+      [self filledSublayerUnderlinePathWithTextFieldBounds:textFieldBounds
+                                   topRowBottomRowDividerY:topRowBottomRowDividerY
+                                        underlineThickness:underlineThickness];
   self.filledSublayer.path = filledSublayerPath.CGPath;
   self.filledSublayerUnderline.path = filledSublayerUnderlinePath.CGPath;
   if (self.filledSublayer.superlayer != self.layer) {
@@ -878,21 +954,22 @@
                                        lineWidth:(CGFloat)lineWidth
                            isFloatingPlaceholder:(BOOL)isFloatingPlaceholder {
   UIBezierPath *path = [[UIBezierPath alloc] init];
-  //TODO: inject state so you can set width and color correctly
   CGFloat radius = kOutlinedTextFieldCornerRadius;
   CGFloat textFieldWidth = CGRectGetWidth(textFieldBounds);
   CGFloat sublayerMinY = 0;
-//  if (CGSizeEqualToSize(CGSizeZero, floatingPlaceholderFrame.size)) {
-//    sublayerMinY = CGRectGetMidY(floatingPlaceholderFrame);
-//  }
+  //  if (CGSizeEqualToSize(CGSizeZero, floatingPlaceholderFrame.size)) {
+  //    sublayerMinY = CGRectGetMidY(floatingPlaceholderFrame);
+  //  }
   CGFloat sublayerMaxY = topRowBottomRowDividerY;
 
   CGPoint startingPoint = CGPointMake(radius, sublayerMinY);
   CGPoint topRightCornerPoint1 = CGPointMake(textFieldWidth - radius, sublayerMinY);
   [path moveToPoint:startingPoint];
   if (isFloatingPlaceholder) {
-    CGFloat leftLineBreak = CGRectGetMinX(floatingPlaceholderFrame) - kFloatingPlaceholderSideMargin;
-    CGFloat rightLineBreak = CGRectGetMaxX(floatingPlaceholderFrame) + kFloatingPlaceholderSideMargin;
+    CGFloat leftLineBreak =
+        CGRectGetMinX(floatingPlaceholderFrame) - kFloatingPlaceholderSideMargin;
+    CGFloat rightLineBreak =
+        CGRectGetMaxX(floatingPlaceholderFrame) + kFloatingPlaceholderSideMargin;
     [path addLineToPoint:CGPointMake(leftLineBreak, sublayerMinY)];
     [path moveToPoint:CGPointMake(rightLineBreak, sublayerMinY)];
     [path addLineToPoint:CGPointMake(rightLineBreak, sublayerMinY)];
@@ -983,7 +1060,6 @@
 - (UIBezierPath *)filledSublayerUnderlinePathWithTextFieldBounds:(CGRect)textFieldBounds
                                          topRowBottomRowDividerY:(CGFloat)topRowBottomRowDividerY
                                               underlineThickness:(CGFloat)underlineThickness {
-  //TODO: Consider underline labels, don't place underline under them
   UIBezierPath *path = [[UIBezierPath alloc] init];
   CGFloat textFieldWidth = CGRectGetWidth(textFieldBounds);
   CGFloat sublayerMaxY = topRowBottomRowDividerY;
@@ -1027,12 +1103,11 @@
   return path;
 }
 
-
 - (void)addTopRightCornerToPath:(UIBezierPath *)path
                       fromPoint:(CGPoint)point1
                         toPoint:(CGPoint)point2
                      withRadius:(CGFloat)radius {
-  CGFloat startAngle = - (CGFloat)(M_PI / 2);
+  CGFloat startAngle = -(CGFloat)(M_PI / 2);
   CGFloat endAngle = 0;
   CGPoint center = CGPointMake(point1.x, point2.y);
   [path addArcWithCenter:center
@@ -1047,7 +1122,7 @@
                            toPoint:(CGPoint)point2
                         withRadius:(CGFloat)radius {
   CGFloat startAngle = 0;
-  CGFloat endAngle = - (CGFloat)((M_PI * 3) / 2);
+  CGFloat endAngle = -(CGFloat)((M_PI * 3) / 2);
   CGPoint center = CGPointMake(point2.x, point1.y);
   [path addArcWithCenter:center
                   radius:radius
@@ -1060,8 +1135,8 @@
                         fromPoint:(CGPoint)point1
                           toPoint:(CGPoint)point2
                        withRadius:(CGFloat)radius {
-  CGFloat startAngle = - (CGFloat)((M_PI * 3) / 2);
-  CGFloat endAngle = - (CGFloat)M_PI;
+  CGFloat startAngle = -(CGFloat)((M_PI * 3) / 2);
+  CGFloat endAngle = -(CGFloat)M_PI;
   CGPoint center = CGPointMake(point1.x, point2.y);
   [path addArcWithCenter:center
                   radius:radius
@@ -1074,8 +1149,8 @@
                      fromPoint:(CGPoint)point1
                        toPoint:(CGPoint)point2
                     withRadius:(CGFloat)radius {
-  CGFloat startAngle = - (CGFloat)M_PI;
-  CGFloat endAngle = - (CGFloat)(M_PI / 2);
+  CGFloat startAngle = -(CGFloat)M_PI;
+  CGFloat endAngle = -(CGFloat)(M_PI / 2);
   CGPoint center = CGPointMake(point1.x + radius, point2.y + radius);
   [path addArcWithCenter:center
                   radius:radius
@@ -1116,30 +1191,19 @@
   }
 }
 
+#pragma mark Theming
 
-/*
-_primaryColor = ColorFromRGB(0x6200EE); // purple
-_primaryColorVariant = ColorFromRGB(0x3700B3); //dark purple
-_secondaryColor = ColorFromRGB(0x03DAC6); // seafoam green
-_errorColor = ColorFromRGB(0xB00020); // royal red
-_surfaceColor = ColorFromRGB(0xFFFFFF); // white
-_backgroundColor = ColorFromRGB(0xFFFFFF); // white
-_onPrimaryColor = ColorFromRGB(0xFFFFFF); // white
-_onSecondaryColor = ColorFromRGB(0x000000); // black
-_onSurfaceColor = ColorFromRGB(0x000000);  // black
-_onBackgroundColor = ColorFromRGB(0x000000);  // black
-*/
+- (void)applyColorAdapter:(SimpleTextFieldColorAdapter *)colorAdapter {
+  self.leadingUnderlineLabel.textColor = colorAdapter.underlineLabelColor;
+  self.trailingUnderlineLabel.textColor = colorAdapter.underlineLabelColor;
+  self.placeholderLabel.textColor = colorAdapter.placeholderLabelColor;
 
-/*
- _primaryColor = ColorFromRGB(0x6200EE); // purple
- _errorColor = ColorFromRGB(0xB00020); // royal red
- _surfaceColor = ColorFromRGB(0xFFFFFF); // white
- _backgroundColor = ColorFromRGB(0xFFFFFF); // white
- _onPrimaryColor = ColorFromRGB(0xFFFFFF); // white
- _onSecondaryColor = ColorFromRGB(0x000000); // black
- _onSurfaceColor = ColorFromRGB(0x000000);  // black
- _onBackgroundColor = ColorFromRGB(0x000000);  // black
- */
+  self.clearButtonImageView.tintColor = colorAdapter.clearButtonTintColor;
+
+  self.outlinedSublayer.strokeColor = colorAdapter.outlineColor.CGColor;
+  self.filledSublayerUnderline.fillColor = colorAdapter.filledSublayerUnderlineFillColor.CGColor;
+  self.filledSublayer.fillColor = colorAdapter.filledSublayerFillColor.CGColor;
+}
 
 - (void)applyTypographyScheme:(MDCTypographyScheme *)typographyScheme {
   self.font = typographyScheme.subtitle1;
@@ -1150,50 +1214,4 @@ _onBackgroundColor = ColorFromRGB(0x000000);  // black
   self.trailingUnderlineLabel.font = typographyScheme.caption;
 }
 
-- (void)applyColorScheme:(MDCSemanticColorScheme *)colorScheme
-      withTextFieldState:(TextFieldState)textFieldState {
-  UIColor *placeholderLabelColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
-  UIColor *filledUnderlineFillColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.60];
-  UIColor *outlineColor = colorScheme.onSurfaceColor;
-  UIColor *filledSublayerUnderlineColor = colorScheme.onSurfaceColor;
-  switch (textFieldState) {
-    case TextFieldStateNormal:
-      break;
-    case TextFieldStateActivated:
-      break;
-    case TextFieldStateDisabled:
-      placeholderLabelColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:0.10];
-      break;
-    case TextFieldStateErrored:
-      placeholderLabelColor = colorScheme.errorColor;
-      break;
-    case TextFieldStateFocused:
-      outlineColor = colorScheme.primaryColor;
-      placeholderLabelColor = colorScheme.primaryColor;
-      filledSublayerUnderlineColor = colorScheme.primaryColor;
-      filledUnderlineFillColor = colorScheme.primaryColor;
-      break;
-    default:
-      break;
-  }
-  if (self.textFieldState) {
-    
-  }
-  
-  self.leadingUnderlineLabel.textColor = placeholderLabelColor;
-  self.trailingUnderlineLabel.textColor = placeholderLabelColor;
-  self.outlinedSublayer.strokeColor = outlineColor.CGColor;
-  self.placeholderLabel.textColor = placeholderLabelColor;
-  self.filledSublayerUnderline.fillColor = filledSublayerUnderlineColor.CGColor;
-}
-
 @end
-
-
-//@interface SimpleTextFieldColorAdapter : NSObject
-//@property (strong, nonatomic) UIColor *placeholderLabelColor;
-//@property (strong, nonatomic) UIColor *placeholderLabelColor;
-//@end
-//
-//@implementation SimpleTextFieldColorAdapter
-//@end

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextField.m
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextField.m
@@ -368,6 +368,7 @@
 - (void)setAttributedPlaceholder:(NSAttributedString *)attributedPlaceholder {
   self.placeholderLabel.text = [attributedPlaceholder string];
   self.placeholderLabel.attributedText = [attributedPlaceholder copy];
+  // TODO: Actually support this by incorporating it into the layout calculations
 }
 
 - (NSAttributedString *)attributedPlaceholder {

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.h
@@ -15,22 +15,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SimpleTextFieldLayout : NSObject
 
-@property (nonatomic, assign) BOOL leftViewHidden;
-@property (nonatomic, assign) BOOL rightViewHidden;
-@property (nonatomic, assign) BOOL clearButtonHidden;
-@property (nonatomic, assign) BOOL placeholderHidden;
+@property(nonatomic, assign) BOOL leftViewHidden;
+@property(nonatomic, assign) BOOL rightViewHidden;
+@property(nonatomic, assign) BOOL clearButtonHidden;
+@property(nonatomic, assign) BOOL placeholderHidden;
 
-@property (nonatomic, assign) CGRect placeholderFrameFloating;
-@property (nonatomic, assign) CGRect placeholderFrameNormal;
-@property (nonatomic, assign) CGRect textAreaFrame;
-@property (nonatomic, assign) CGRect clearButtonFrame;
-@property (nonatomic, assign) CGRect leftViewFrame;
-@property (nonatomic, assign) CGRect rightViewFrame;
-@property (nonatomic, assign) CGRect leftUnderlineLabelFrame;
-@property (nonatomic, assign) CGRect rightUnderlineLabelFrame;
+@property(nonatomic, assign) CGRect placeholderFrameFloating;
+@property(nonatomic, assign) CGRect placeholderFrameNormal;
+@property(nonatomic, assign) CGRect textAreaFrame;
+@property(nonatomic, assign) CGRect clearButtonFrame;
+@property(nonatomic, assign) CGRect leftViewFrame;
+@property(nonatomic, assign) CGRect rightViewFrame;
+@property(nonatomic, assign) CGRect leftUnderlineLabelFrame;
+@property(nonatomic, assign) CGRect rightUnderlineLabelFrame;
 
-@property (nonatomic, readonly) CGFloat calculatedHeight;
-@property (nonatomic, assign) CGFloat topRowBottomRowDividerY;
+@property(nonatomic, readonly) CGFloat calculatedHeight;
+@property(nonatomic, assign) CGFloat topRowBottomRowDividerY;
 
 - (instancetype)initWithTextFieldSize:(CGSize)textFieldSize
                        textFieldStyle:(TextFieldStyle)textFieldStyle
@@ -51,7 +51,6 @@ NS_ASSUME_NONNULL_BEGIN
      customUnderlineLabelDrawPriority:(CGFloat)customUnderlineLabelDrawPriority
                                 isRTL:(BOOL)isRTL
                             isEditing:(BOOL)isEditing;
-
 
 @end
 

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.h
@@ -32,25 +32,25 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) CGFloat calculatedHeight;
 @property (nonatomic, assign) CGFloat topRowBottomRowDividerY;
 
-- (instancetype)initWithTextFieldBounds:(CGRect)textFieldBounds
-                         textFieldStyle:(TextFieldStyle)textFieldStyle
-                                   text:(NSString *)text
-                            placeholder:(NSString *)placeholder
-                                   font:(UIFont *)font
-                floatingPlaceholderFont:(UIFont *)floatingPlaceholderFont
-                    canPlaceholderFloat:(BOOL)canPlaceholderFloat
-                               leftView:(UIView *)leftView
-                           leftViewMode:(UITextFieldViewMode)leftViewMode
-                              rightView:(UIView *)rightView
-                          rightViewMode:(UITextFieldViewMode)rightViewMode
-                            clearButton:(UIButton *)clearButton
-                        clearButtonMode:(UITextFieldViewMode)clearButtonMode
-                     leftUnderlineLabel:(UILabel *)leftUnderlineLabel
-                    rightUnderlineLabel:(UILabel *)rightUnderlineLabel
-             underlineLabelDrawPriority:(UnderlineLabelDrawPriority)underlineLabelDrawPriority
-       customUnderlineLabelDrawPriority:(CGFloat)customUnderlineLabelDrawPriority
-                                  isRTL:(BOOL)isRTL
-                              isEditing:(BOOL)isEditing;
+- (instancetype)initWithTextFieldSize:(CGSize)textFieldSize
+                       textFieldStyle:(TextFieldStyle)textFieldStyle
+                                 text:(NSString *)text
+                          placeholder:(NSString *)placeholder
+                                 font:(UIFont *)font
+              floatingPlaceholderFont:(UIFont *)floatingPlaceholderFont
+                  canPlaceholderFloat:(BOOL)canPlaceholderFloat
+                             leftView:(UIView *)leftView
+                         leftViewMode:(UITextFieldViewMode)leftViewMode
+                            rightView:(UIView *)rightView
+                        rightViewMode:(UITextFieldViewMode)rightViewMode
+                          clearButton:(UIButton *)clearButton
+                      clearButtonMode:(UITextFieldViewMode)clearButtonMode
+                   leftUnderlineLabel:(UILabel *)leftUnderlineLabel
+                  rightUnderlineLabel:(UILabel *)rightUnderlineLabel
+           underlineLabelDrawPriority:(UnderlineLabelDrawPriority)underlineLabelDrawPriority
+     customUnderlineLabelDrawPriority:(CGFloat)customUnderlineLabelDrawPriority
+                                isRTL:(BOOL)isRTL
+                            isEditing:(BOOL)isEditing;
 
 
 @end

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.h
@@ -1,10 +1,16 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
 //
-//  SimpleTextFieldLayout.h
-//  ComponentsProject
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Andrew Overton on 12/6/18.
-//  Copyright © 2018 andrewoverton. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.h
@@ -1,0 +1,58 @@
+//
+//  SimpleTextFieldLayout.h
+//  ComponentsProject
+//
+//  Created by Andrew Overton on 12/6/18.
+//  Copyright © 2018 andrewoverton. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+#import "SimpleTextFieldLayoutUtils.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SimpleTextFieldLayout : NSObject
+
+@property (nonatomic, assign) BOOL leftViewHidden;
+@property (nonatomic, assign) BOOL rightViewHidden;
+@property (nonatomic, assign) BOOL clearButtonHidden;
+@property (nonatomic, assign) BOOL placeholderHidden;
+
+@property (nonatomic, assign) CGRect placeholderFrameFloating;
+@property (nonatomic, assign) CGRect placeholderFrameNormal;
+@property (nonatomic, assign) CGRect textAreaFrame;
+@property (nonatomic, assign) CGRect clearButtonFrame;
+@property (nonatomic, assign) CGRect leftViewFrame;
+@property (nonatomic, assign) CGRect rightViewFrame;
+@property (nonatomic, assign) CGRect leftUnderlineLabelFrame;
+@property (nonatomic, assign) CGRect rightUnderlineLabelFrame;
+
+@property (nonatomic, readonly) CGFloat calculatedHeight;
+@property (nonatomic, assign) CGFloat topRowBottomRowDividerY;
+
+- (instancetype)initWithTextFieldBounds:(CGRect)textFieldBounds
+                         textFieldStyle:(TextFieldStyle)textFieldStyle
+                                   text:(NSString *)text
+                            placeholder:(NSString *)placeholder
+                                   font:(UIFont *)font
+                floatingPlaceholderFont:(UIFont *)floatingPlaceholderFont
+                    canPlaceholderFloat:(BOOL)canPlaceholderFloat
+                               leftView:(UIView *)leftView
+                           leftViewMode:(UITextFieldViewMode)leftViewMode
+                              rightView:(UIView *)rightView
+                          rightViewMode:(UITextFieldViewMode)rightViewMode
+                            clearButton:(UIButton *)clearButton
+                        clearButtonMode:(UITextFieldViewMode)clearButtonMode
+                     leftUnderlineLabel:(UILabel *)leftUnderlineLabel
+                    rightUnderlineLabel:(UILabel *)rightUnderlineLabel
+             underlineLabelDrawPriority:(UnderlineLabelDrawPriority)underlineLabelDrawPriority
+       customUnderlineLabelDrawPriority:(CGFloat)customUnderlineLabelDrawPriority
+                                  isRTL:(BOOL)isRTL
+                              isEditing:(BOOL)isEditing;
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.m
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.m
@@ -224,7 +224,8 @@
   }
 
   CGFloat textAreaWidth = textAreaMaxX - textAreaMinX;
-  CGFloat textAreaMinY = round((double)(topRowSubviewCenterY - (textAreaHeight * 0.5)));
+  CGFloat textAreaMinY =
+      (CGFloat)round((double)(topRowSubviewCenterY - (textAreaHeight * (CGFloat)0.5)));
   CGFloat textAreaMaxY = textAreaMinY + textAreaHeight;
   CGRect textAreaFrame = CGRectMake(textAreaMinX, textAreaMinY, textAreaWidth, textAreaHeight);
   CGRect leftViewFrame = CGRectMake(leftViewMinX, leftViewMinY, leftViewWidth, leftViewHeight);
@@ -407,7 +408,7 @@
 }
 
 - (CGFloat)minYForSubviewWithHeight:(CGFloat)height centerY:(CGFloat)centerY {
-  return round((double)(centerY - (0.5 * height)));
+  return (CGFloat)round((double)(centerY - ((CGFloat)0.5 * height)));
 }
 
 - (BOOL)shouldAttemptToDisplaySideView:(UIView *)subview
@@ -469,12 +470,12 @@
   if (placeholderCanFloat) {
     CGFloat spaceBetweenPlaceholderAndTextArea = 0;
     CGFloat floatingPlaceholderMaxY = floatingPlaceholderMinY + floatingPlaceholderHeight;
-    CGFloat outlinedTextFieldSpaceHeuristic = floatingPlaceholderHeight * 0.22;
+    CGFloat outlinedTextFieldSpaceHeuristic = floatingPlaceholderHeight * (CGFloat)0.22;
     switch (textFieldStyle) {
       case TextFieldStyleNone:
       case TextFieldStyleFilled:
       default:
-        spaceBetweenPlaceholderAndTextArea = (0.25 * floatingPlaceholderMaxY);
+        spaceBetweenPlaceholderAndTextArea = ((CGFloat)0.25 * floatingPlaceholderMaxY);
         break;
       case TextFieldStyleOutline:
         spaceBetweenPlaceholderAndTextArea =
@@ -483,10 +484,10 @@
     }
     CGFloat lowestAllowableTextAreaMinY =
         floatingPlaceholderMaxY + spaceBetweenPlaceholderAndTextArea;
-    return lowestAllowableTextAreaMinY + (0.5 * textAreaHeight);
+    return lowestAllowableTextAreaMinY + ((CGFloat)0.5 * textAreaHeight);
   } else {
     CGFloat lowestAllowableTextAreaMinY = kTopRowBottomRowDividerVerticalPadding;
-    return lowestAllowableTextAreaMinY + (0.5 * textAreaHeight);
+    return lowestAllowableTextAreaMinY + ((CGFloat)0.5 * textAreaHeight);
   }
 }
 
@@ -499,7 +500,7 @@
   CGFloat floatingPlaceholderMinY = 0;
   switch (textFieldStyle) {
     case TextFieldStyleOutline:
-      floatingPlaceholderMinY = 0 - (0.5 * floatingPlaceholderHeight);
+      floatingPlaceholderMinY = (CGFloat)0 - ((CGFloat)0.5 * floatingPlaceholderHeight);
       break;
     case TextFieldStyleNone:
     case TextFieldStyleFilled:
@@ -519,7 +520,7 @@
              lowestAllowableTextAreaCenterY:(CGFloat)lowestAllowableTextAreaCenterY {
   CGFloat sideViewMaxHeight =
       MAX(CGRectGetHeight(leftView.bounds), CGRectGetHeight(rightView.bounds));
-  CGFloat lowestAllowableSideViewCenterY = kTopMargin + (0.5 * sideViewMaxHeight);
+  CGFloat lowestAllowableSideViewCenterY = kTopMargin + ((CGFloat)0.5 * sideViewMaxHeight);
   CGFloat sharedCenterY = MAX(lowestAllowableTextAreaCenterY, lowestAllowableSideViewCenterY);
   return sharedCenterY;
 }
@@ -594,7 +595,7 @@
       size = [self placeholderSizeWithPlaceholder:placeholder
                               maxPlaceholderWidth:maxPlaceholderWidth
                                              font:font];
-      originY = textAreaMidY - (0.5 * size.height);
+      originY = textAreaMidY - ((CGFloat)0.5 * size.height);
       if (isRTL) {
         originX = textAreaMaxX - size.width;
       } else {
@@ -609,7 +610,7 @@
 }
 
 - (CGFloat)textHeightWithFont:(UIFont *)font {
-  return ceil((double)font.lineHeight);
+  return (CGFloat)ceil((double)font.lineHeight);
 }
 
 - (CGFloat)calculatedHeight {

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.m
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.m
@@ -1,0 +1,583 @@
+//
+//  SimpleTextFieldLayout.m
+//  ComponentsProject
+//
+//  Created by Andrew Overton on 12/6/18.
+//  Copyright © 2018 andrewoverton. All rights reserved.
+//
+
+#import "SimpleTextFieldLayout.h"
+
+#import "SimpleTextField.h"
+#import "SimpleTextFieldLayoutUtils.h"
+
+
+@interface SimpleTextFieldLayout ()
+@end
+
+@implementation SimpleTextFieldLayout
+
+#pragma mark Object Lifecycle
+
+- (instancetype)initWithTextFieldBounds:(CGRect)textFieldBounds
+                         textFieldStyle:(TextFieldStyle)textFieldStyle
+                                   text:(NSString *)text
+                            placeholder:(NSString *)placeholder
+                                   font:(UIFont *)font
+                floatingPlaceholderFont:(UIFont *)floatingPlaceholderFont
+                    canPlaceholderFloat:(BOOL)canPlaceholderFloat
+                               leftView:(UIView *)leftView
+                           leftViewMode:(UITextFieldViewMode)leftViewMode
+                              rightView:(UIView *)rightView
+                          rightViewMode:(UITextFieldViewMode)rightViewMode
+                            clearButton:(UIButton *)clearButton
+                        clearButtonMode:(UITextFieldViewMode)clearButtonMode
+                     leftUnderlineLabel:(UILabel *)leftUnderlineLabel
+                    rightUnderlineLabel:(UILabel *)rightUnderlineLabel
+             underlineLabelDrawPriority:(UnderlineLabelDrawPriority)underlineLabelDrawPriority
+       customUnderlineLabelDrawPriority:(CGFloat)customUnderlineLabelDrawPriority
+                                  isRTL:(BOOL)isRTL
+                              isEditing:(BOOL)isEditing {
+  self = [super init];
+  if (self) {
+    [self calculateLayoutWithTextFieldBounds:textFieldBounds
+                              textFieldStyle:textFieldStyle
+                                        text:text
+                                 placeholder:placeholder
+                                        font:font
+                     floatingPlaceholderFont:floatingPlaceholderFont
+                         canPlaceholderFloat:canPlaceholderFloat
+                                    leftView:leftView
+                                leftViewMode:leftViewMode
+                                   rightView:rightView
+                               rightViewMode:rightViewMode
+                                 clearButton:clearButton
+                             clearButtonMode:clearButtonMode
+                          leftUnderlineLabel:leftUnderlineLabel
+                         rightUnderlineLabel:rightUnderlineLabel
+                  underlineLabelDrawPriority:underlineLabelDrawPriority
+            customUnderlineLabelDrawPriority:customUnderlineLabelDrawPriority
+                                       isRTL:isRTL
+                                   isEditing:isEditing];
+    return self;
+  }
+  return nil;
+}
+
+#pragma mark Layout Calculation
+
+- (void)calculateLayoutWithTextFieldBounds:(CGRect)textFieldBounds
+                            textFieldStyle:(TextFieldStyle)textFieldStyle
+                                      text:(NSString *)text
+                               placeholder:(NSString *)placeholder
+                                      font:(UIFont *)font
+                   floatingPlaceholderFont:(UIFont *)floatingPlaceholderFont
+                       canPlaceholderFloat:(BOOL)canPlaceholderFloat
+                                  leftView:(UIView *)leftView
+                              leftViewMode:(UITextFieldViewMode)leftViewMode
+                                 rightView:(UIView *)rightView
+                             rightViewMode:(UITextFieldViewMode)rightViewMode
+                               clearButton:(UIButton *)clearButton
+                           clearButtonMode:(UITextFieldViewMode)clearButtonMode
+                        leftUnderlineLabel:(UILabel *)leftUnderlineLabel
+                       rightUnderlineLabel:(UILabel *)rightUnderlineLabel
+                underlineLabelDrawPriority:(UnderlineLabelDrawPriority)underlineLabelDrawPriority
+          customUnderlineLabelDrawPriority:(CGFloat)customUnderlineLabelDrawPriority
+                                     isRTL:(BOOL)isRTL
+                                 isEditing:(BOOL)isEditing {
+
+  BOOL shouldAttemptToDisplayLeftView = [self shouldAttemptToDisplaySideView:leftView
+                                                                    viewMode:leftViewMode
+                                                                   isEditing:isEditing];
+  BOOL shouldAttemptToDisplayRightView = [self shouldAttemptToDisplaySideView:rightView
+                                                                     viewMode:rightViewMode
+                                                                    isEditing:isEditing];
+  BOOL shouldAttemptToDisplayClearButton = [self shouldAttemptToDisplayClearButton:clearButton
+                                                                          viewMode:clearButtonMode
+                                                                         isEditing:isEditing
+                                                                              text:text];
+
+  CGFloat leftViewWidth = CGRectGetWidth(leftView.frame);
+  CGFloat leftViewMinX = 0;
+  CGFloat leftViewMaxX = 0;
+  if (shouldAttemptToDisplayLeftView) {
+    leftViewMinX = [self minXForLeftView:leftView
+                                   isRTL:isRTL];
+    leftViewMaxX = leftViewMinX + leftViewWidth;
+  }
+
+  CGFloat textFieldWidth = CGRectGetWidth(textFieldBounds);
+  CGFloat rightViewMinX = 0;
+  if (shouldAttemptToDisplayRightView) {
+    rightViewMinX = [self minXForRightView:rightView
+                            textFieldWidth:textFieldWidth
+                                     isRTL:isRTL];
+  }
+
+  CGFloat clearButtonMinX = 0;
+  if (shouldAttemptToDisplayClearButton) {
+    CGFloat leftMargin = isRTL ? kLeadingMargin : kTrailingMargin;
+    CGFloat rightMargin = isRTL ? kTrailingMargin : kLeadingMargin;
+    CGFloat lowestPossibleMinX = shouldAttemptToDisplayLeftView ? leftViewMaxX : leftMargin;
+    CGFloat highestPossibleMaxX = shouldAttemptToDisplayRightView ? rightViewMinX : textFieldWidth - rightMargin;
+    clearButtonMinX = [self clearButtonMinXWithLowestPossibleMinX:lowestPossibleMinX
+                                              highestPossibleMaxX:highestPossibleMaxX
+                                                            isRTL:isRTL];
+  }
+  CGFloat floatingPlaceholderHeight =
+      canPlaceholderFloat ? [self textHeightWithFont:floatingPlaceholderFont] : 0;
+  CGFloat floatingPlaceholderMinY =
+        [self floatingPlaceholderMinYWithFloatingHeight:floatingPlaceholderHeight
+                                         textFieldStyle:textFieldStyle];
+
+  CGFloat textAreaHeight = [self textHeightWithFont:font];
+  CGFloat lowestAllowableTextAreaCenterY =
+      [self lowestAllowableTextAreaCenterYWithFloatingPlaceholderMinY:floatingPlaceholderMinY
+                                            floatingPlaceholderHeight:floatingPlaceholderHeight
+                                                       textAreaHeight:textAreaHeight
+                                                       textFieldStyle:textFieldStyle
+                                                  placeholderCanFloat:canPlaceholderFloat];
+
+  CGFloat topRowSubviewCenterY =
+  [self topRowSubviewCenterYWithLeftView:leftView
+                               rightView:rightView
+                                    font:font
+                            floatingFont:floatingPlaceholderFont
+                          textFieldStyle:textFieldStyle
+          lowestAllowableTextAreaCenterY:lowestAllowableTextAreaCenterY];
+
+  CGFloat leftViewHeight = CGRectGetHeight(leftView.frame);
+  CGFloat leftViewMinY = 0;
+  CGFloat leftViewMaxY = 0;
+  if (shouldAttemptToDisplayLeftView) {
+    leftViewMinY = [self minYForSubviewWithHeight:leftViewHeight
+                                          centerY:topRowSubviewCenterY];
+    leftViewMaxY = leftViewMinY + leftViewHeight;
+  }
+
+  CGFloat rightViewHeight = CGRectGetHeight(rightView.frame);
+  CGFloat rightViewMinY = 0;
+  CGFloat rightViewMaxY = 0;
+  if (shouldAttemptToDisplayRightView) {
+    rightViewMinY = [self minYForSubviewWithHeight:rightViewHeight
+                                           centerY:topRowSubviewCenterY];
+    rightViewMaxY = rightViewMinY + rightViewHeight;
+  }
+
+  CGFloat clearButtonMinY = 0;
+  if (shouldAttemptToDisplayClearButton) {
+    clearButtonMinY = [self minYForSubviewWithHeight:kClearButtonTouchTargetSideLength
+                                             centerY:topRowSubviewCenterY];
+  }
+
+  CGFloat textAreaMinX = 0;
+  CGFloat textAreaMaxX = 0;
+  if (isRTL) {
+    textAreaMinX = kTrailingMargin;
+    if (shouldAttemptToDisplayClearButton) {
+      CGFloat clearButtonMaxX = clearButtonMinX + kClearButtonTouchTargetSideLength;
+      textAreaMinX = clearButtonMaxX;
+    } else if (shouldAttemptToDisplayLeftView) {
+      textAreaMinX = leftViewMaxX + kTextRectSidePadding;
+    }
+
+    textAreaMaxX = textFieldWidth - kLeadingMargin;
+    if (shouldAttemptToDisplayRightView) {
+      textAreaMaxX = rightViewMinX - kTextRectSidePadding;
+    }
+  } else {
+    textAreaMinX = kLeadingMargin;
+    if (shouldAttemptToDisplayLeftView) {
+      textAreaMinX = leftViewMaxX + kTextRectSidePadding;
+    }
+    textAreaMaxX = textFieldWidth - kTrailingMargin;
+    if (shouldAttemptToDisplayClearButton) {
+      textAreaMaxX = clearButtonMinX - kTextRectSidePadding;
+    } else if (shouldAttemptToDisplayRightView) {
+      textAreaMaxX = rightViewMinX - kTextRectSidePadding;
+    }
+  }
+
+  CGFloat textAreaWidth = textAreaMaxX - textAreaMinX;
+  CGFloat textAreaMinY = round((double)(topRowSubviewCenterY - (textAreaHeight * 0.5)));
+  CGFloat textAreaMaxY = textAreaMinY + textAreaHeight;
+  CGRect textAreaFrame = CGRectMake(textAreaMinX, textAreaMinY, textAreaWidth, textAreaHeight);
+  CGRect leftViewFrame = CGRectMake(leftViewMinX, leftViewMinY, leftViewWidth, leftViewHeight);
+  CGFloat rightViewWidth = CGRectGetWidth(rightView.frame);
+  CGRect rightViewFrame = CGRectMake(rightViewMinX, rightViewMinY, rightViewWidth, rightViewHeight);
+  CGRect clearButtonFrame = CGRectMake(clearButtonMinX, clearButtonMinY, kClearButtonTouchTargetSideLength, kClearButtonTouchTargetSideLength);
+
+  CGRect placeholderFrameNormal = [self placeholderFrameWithPlaceholder:placeholder
+                                                         textFieldStyle:textFieldStyle
+                                                       placeholderState:PlaceholderStateNormal
+                                                                   font:font
+                                                floatingPlaceholderFont:floatingPlaceholderFont
+                                                floatingPlaceholderMinY:floatingPlaceholderMinY
+                                                           textAreaRect:textAreaFrame];
+  CGRect placeholderFrameFloating = [self placeholderFrameWithPlaceholder:placeholder
+                                                           textFieldStyle:textFieldStyle
+                                                         placeholderState:PlaceholderStateFloating
+                                                                     font:font
+                                                  floatingPlaceholderFont:floatingPlaceholderFont
+                                                  floatingPlaceholderMinY:floatingPlaceholderMinY
+                                                             textAreaRect:textAreaFrame];
+
+  CGFloat underlineLabelsCombinedMinX = isRTL ? kTrailingMargin : kLeadingMargin;
+  CGFloat underlineLabelsCombinedMaxX = isRTL ? textFieldWidth - kLeadingMargin : textFieldWidth - kTrailingMargin;
+  CGFloat underlineLabelsCombinedMaxWidth = underlineLabelsCombinedMaxX - underlineLabelsCombinedMinX;
+
+  CGFloat topRowSubviewMaxY = [self topRowSubviewMaxYWithTextAreaMaxY:textAreaMaxY
+                                                         leftViewMaxY:leftViewMaxY
+                                                        rightViewMaxY:rightViewMaxY];
+
+  CGFloat topRowBottomRowDividerY = topRowSubviewCenterY;
+  if (textFieldStyle == TextFieldStyleOutline) {
+    topRowBottomRowDividerY = topRowSubviewCenterY * 2;
+  } else if (textFieldStyle == TextFieldStyleFilled) {
+    topRowBottomRowDividerY = topRowSubviewMaxY + kTopRowSubviewVerticalPadding;
+  }
+
+  CGFloat underlineLabelsCombinedMinY = topRowBottomRowDividerY + kUnderlineLabelsTopPadding;
+  CGFloat leadingUnderlineLabelWidth = 0;
+  CGFloat trailingUnderlineLabelWidth = 0;
+  CGSize leadingUnderlineLabelSize = CGSizeZero;
+  CGSize trailingUnderlineLabelSize = CGSizeZero;
+  UILabel *leadingUnderlineLabel = isRTL ? rightUnderlineLabel : leftUnderlineLabel;
+  UILabel *trailingUnderlineLabel = isRTL ? leftUnderlineLabel : rightUnderlineLabel;
+  switch (underlineLabelDrawPriority) {
+    case UnderlineLabelDrawPriorityCustom:
+      leadingUnderlineLabelWidth = [self leadingUnderlineLabelWidthWithCombinedUnderlineLabelsWidth:underlineLabelsCombinedMaxWidth
+                                                                                 customDrawPriority:customUnderlineLabelDrawPriority];
+      trailingUnderlineLabelWidth = underlineLabelsCombinedMaxWidth - leadingUnderlineLabelWidth;
+      leadingUnderlineLabelSize = [self underlineLabelSizeWithLabel:leadingUnderlineLabel
+                                                 constrainedToWidth:leadingUnderlineLabelWidth];
+      trailingUnderlineLabelSize = [self underlineLabelSizeWithLabel:trailingUnderlineLabel
+                                                  constrainedToWidth:trailingUnderlineLabelWidth];
+      break;
+    case UnderlineLabelDrawPriorityLeading:
+      leadingUnderlineLabelSize = [self underlineLabelSizeWithLabel:leadingUnderlineLabel
+                                                 constrainedToWidth:underlineLabelsCombinedMaxWidth];
+      trailingUnderlineLabelSize = [self underlineLabelSizeWithLabel:trailingUnderlineLabel
+                                                  constrainedToWidth:underlineLabelsCombinedMaxWidth - leadingUnderlineLabelSize.width];
+      break;
+    case UnderlineLabelDrawPriorityTrailing:
+      trailingUnderlineLabelSize = [self underlineLabelSizeWithLabel:trailingUnderlineLabel
+                                                  constrainedToWidth:underlineLabelsCombinedMaxWidth];
+      leadingUnderlineLabelSize = [self underlineLabelSizeWithLabel:leadingUnderlineLabel
+                                                 constrainedToWidth:underlineLabelsCombinedMaxWidth - trailingUnderlineLabelSize.width];
+      break;
+    default:
+      break;
+  }
+
+  CGSize leftUnderlineLabelSize = isRTL ? trailingUnderlineLabelSize : leadingUnderlineLabelSize;
+  CGSize rightUnderlineLabelSize = isRTL ? leadingUnderlineLabelSize : trailingUnderlineLabelSize;
+  CGRect leftUnderlineLabelFrame = CGRectZero;
+  CGRect rightUnderlineLabelFrame = CGRectZero;
+  if (!CGSizeEqualToSize(leftUnderlineLabelSize, CGSizeZero)) {
+    leftUnderlineLabelFrame = CGRectMake(underlineLabelsCombinedMinX,
+                                         underlineLabelsCombinedMinY,
+                                         leftUnderlineLabelSize.width,
+                                         leftUnderlineLabelSize.height);
+  }
+  if (!CGSizeEqualToSize(rightUnderlineLabelSize, CGSizeZero)) {
+    rightUnderlineLabelFrame = CGRectMake(underlineLabelsCombinedMaxX - rightUnderlineLabelSize.width,
+                                          underlineLabelsCombinedMinY,
+                                          rightUnderlineLabelSize.width,
+                                          rightUnderlineLabelSize.height);
+  }
+
+  self.leftViewFrame = leftViewFrame;
+  self.rightViewFrame = rightViewFrame;
+  self.clearButtonFrame = clearButtonFrame;
+  self.textAreaFrame = textAreaFrame;
+  self.placeholderFrameFloating = placeholderFrameFloating;
+  self.placeholderFrameNormal = placeholderFrameNormal;
+  self.leftUnderlineLabelFrame = leftUnderlineLabelFrame;
+  self.rightUnderlineLabelFrame = rightUnderlineLabelFrame;
+  self.topRowBottomRowDividerY = topRowBottomRowDividerY;
+  self.clearButtonHidden = !shouldAttemptToDisplayClearButton;
+  self.leftViewHidden = !shouldAttemptToDisplayLeftView;
+  self.rightViewHidden = !shouldAttemptToDisplayRightView;
+  self.topRowBottomRowDividerY = topRowBottomRowDividerY;
+}
+
+- (CGFloat)topRowSubviewMaxYWithTextAreaMaxY:(CGFloat)textAreaMaxY
+                                leftViewMaxY:(CGFloat)leftViewMaxY
+                               rightViewMaxY:(CGFloat)rightViewMaxY {
+  CGFloat max = textAreaMaxY;
+  max = MAX(max, leftViewMaxY);
+  max = MAX(max, rightViewMaxY);
+  return max;
+}
+
+- (CGSize)underlineLabelSizeWithLabel:(UILabel *)label
+                   constrainedToWidth:(CGFloat)maxWidth {
+  if (maxWidth <= 0 || label.text.length <= 0 || label.hidden) {
+    return CGSizeZero;
+  }
+  CGSize fittingSize = CGSizeMake(maxWidth, CGFLOAT_MAX);
+  CGSize size = [label sizeThatFits:fittingSize];
+  if (size.width > maxWidth) {
+    size.width = maxWidth;
+  }
+  return size;
+}
+
+- (CGFloat)leadingUnderlineLabelWidthWithCombinedUnderlineLabelsWidth:(CGFloat)totalUnderlineLabelsWidth
+                                                   customDrawPriority:(CGFloat)customDrawPriority {
+  return customDrawPriority * totalUnderlineLabelsWidth;
+}
+
+
+- (CGFloat)minXForLeftUnderlineLabel:(UILabel *)label
+                               isRTL:(BOOL)isRTL {
+  return isRTL ? kTrailingMargin : kLeadingMargin;
+}
+
+- (CGFloat)maxXForRightUnderlineLabel:(UILabel *)label
+                                isRTL:(BOOL)isRTL {
+  return isRTL ? kTrailingMargin : kLeadingMargin;
+}
+
+
+- (CGFloat)minXForLeftView:(UIView *)leftView
+                     isRTL:(BOOL)isRTL {
+  return isRTL ? kTrailingMargin : kLeadingMargin;
+}
+
+- (CGFloat)minXForRightView:(UIView *)rightView
+             textFieldWidth:(CGFloat)textFieldWidth
+                      isRTL:(BOOL)isRTL {
+  CGFloat rightMargin = isRTL ? kLeadingMargin : kTrailingMargin;
+  CGFloat maxX = textFieldWidth - rightMargin;
+  return maxX - CGRectGetWidth(rightView.frame);
+}
+
+- (CGFloat)clearButtonMinXWithLowestPossibleMinX:(CGFloat)lowestPossibleMinX
+                             highestPossibleMaxX:(CGFloat)highestPossibleMaxX
+                                           isRTL:(BOOL)isRTL {
+  CGFloat minX = 0;
+  if (isRTL) {
+    minX = lowestPossibleMinX;
+  } else {
+    minX = highestPossibleMaxX - kClearButtonTouchTargetSideLength;
+  }
+  return minX;
+}
+
+- (CGFloat)minYForSubviewWithHeight:(CGFloat)height centerY:(CGFloat)centerY {
+  return round((double)(centerY - (0.5 * height)));
+}
+
+- (BOOL)shouldAttemptToDisplaySideView:(UIView *)subview
+                              viewMode:(UITextFieldViewMode)viewMode
+                             isEditing:(BOOL)isEditing {
+  BOOL shouldAttemptToDisplaySideView = NO;
+  if (subview && !CGSizeEqualToSize(CGSizeZero, subview.frame.size)) {
+    switch (viewMode) {
+      case UITextFieldViewModeWhileEditing:
+        shouldAttemptToDisplaySideView = isEditing;
+        break;
+      case UITextFieldViewModeUnlessEditing:
+        shouldAttemptToDisplaySideView = !isEditing;
+        break;
+      case UITextFieldViewModeAlways:
+        shouldAttemptToDisplaySideView = YES;
+        break;
+      case UITextFieldViewModeNever:
+        shouldAttemptToDisplaySideView = NO;
+        break;
+      default:
+        break;
+    }
+  }
+  return shouldAttemptToDisplaySideView;
+}
+
+
+- (BOOL)shouldAttemptToDisplayClearButton:(UIButton *)clearButton
+                                 viewMode:(UITextFieldViewMode)viewMode
+                                isEditing:(BOOL)isEditing
+                                     text:(NSString *)text {
+  BOOL hasText = text.length > 0;
+  BOOL shouldAttemptToDisplayClearButton = NO;
+  switch (viewMode) {
+    case UITextFieldViewModeWhileEditing:
+      shouldAttemptToDisplayClearButton = isEditing && hasText;
+      break;
+    case UITextFieldViewModeUnlessEditing:
+      shouldAttemptToDisplayClearButton = !isEditing;
+      break;
+    case UITextFieldViewModeAlways:
+      shouldAttemptToDisplayClearButton = YES;
+      break;
+    case UITextFieldViewModeNever:
+      shouldAttemptToDisplayClearButton = NO;
+      break;
+    default:
+      break;
+  }
+  return shouldAttemptToDisplayClearButton;
+}
+
+- (CGFloat)lowestAllowableTextAreaCenterYWithFloatingPlaceholderMinY:(CGFloat)floatingPlaceholderMinY
+                                           floatingPlaceholderHeight:(CGFloat)floatingPlaceholderHeight
+                                                      textAreaHeight:(CGFloat)textAreaHeight
+                                                      textFieldStyle:(TextFieldStyle)textFieldStyle
+                                                 placeholderCanFloat:(BOOL)placeholderCanFloat {
+  if (placeholderCanFloat) {
+    CGFloat spaceBetweenPlaceholderAndTextArea = 0;
+    CGFloat floatingPlaceholderMaxY = floatingPlaceholderMinY + floatingPlaceholderHeight;
+    CGFloat outlinedTextFieldSpaceHeuristic = floatingPlaceholderHeight * 0.22;
+    if (textFieldStyle == TextFieldStyleFilled) {
+      spaceBetweenPlaceholderAndTextArea = (0.25 * floatingPlaceholderMaxY);
+    } else if (textFieldStyle == TextFieldStyleOutline) {
+      spaceBetweenPlaceholderAndTextArea = floatingPlaceholderMaxY + outlinedTextFieldSpaceHeuristic;
+    }
+    CGFloat lowestAllowableTextAreaMinY = floatingPlaceholderMaxY + spaceBetweenPlaceholderAndTextArea;
+    return lowestAllowableTextAreaMinY + (0.5 * textAreaHeight);
+  } else {
+    CGFloat lowestAllowableTextAreaMinY = kTopRowSubviewVerticalPadding;
+    return lowestAllowableTextAreaMinY + (0.5 * textAreaHeight);
+  }
+}
+
+- (CGFloat)floatingPlaceholderMinYWithFloatingHeight:(CGFloat)floatingPlaceholderHeight
+                                      textFieldStyle:(TextFieldStyle)textFieldStyle {
+  if (floatingPlaceholderHeight <= 0) {
+    return 0;
+  }
+  CGFloat filledPlaceholderTopPaddingScaleHeuristic = ((CGFloat)50.0 / (CGFloat)70.0);
+  CGFloat floatingPlaceholderMinY = 0;
+  switch (textFieldStyle) {
+    case TextFieldStyleFilled:
+      floatingPlaceholderMinY = filledPlaceholderTopPaddingScaleHeuristic * floatingPlaceholderHeight;
+      break;
+    case TextFieldStyleOutline:
+      floatingPlaceholderMinY = 0 - (0.5 * floatingPlaceholderHeight);
+      break;
+    default:
+      floatingPlaceholderMinY = kTopMargin;
+      break;
+  }
+  return floatingPlaceholderMinY;
+}
+
+- (CGFloat)topRowSubviewCenterYWithLeftView:(UIView *)leftView
+                                  rightView:(UIView *)rightView
+                                       font:(UIFont *)font
+                               floatingFont:(UIFont *)floatingFont
+                             textFieldStyle:(TextFieldStyle)textFieldStyle
+             lowestAllowableTextAreaCenterY:(CGFloat)lowestAllowableTextAreaCenterY {
+  CGFloat sideViewMaxHeight = MAX(CGRectGetHeight(leftView.bounds), CGRectGetHeight(rightView.bounds));
+  CGFloat lowestAllowableSideViewCenterY = kTopMargin + (0.5 * sideViewMaxHeight);
+  CGFloat sharedCenterY = MAX(lowestAllowableTextAreaCenterY, lowestAllowableSideViewCenterY);
+  return sharedCenterY;
+}
+
+- (CGSize)placeholderSizeWithPlaceholder:(NSString *)placeholder
+                           textAreaWidth:(CGFloat)textAreaWidth
+                                    font:(UIFont *)font {
+  if (!font) {
+    return CGSizeZero;
+  }
+  CGSize fittingSize = CGSizeMake(textAreaWidth, CGFLOAT_MAX);
+  NSDictionary *attributes = @{NSFontAttributeName: font};
+  CGRect rect = [placeholder boundingRectWithSize:fittingSize
+                                          options:NSStringDrawingUsesLineFragmentOrigin
+                                       attributes:attributes
+                                          context:nil];
+  return rect.size;
+}
+
+- (CGRect)placeholderFrameWithPlaceholder:(NSString *)placeholder
+                           textFieldStyle:(TextFieldStyle)textFieldStyle
+                         placeholderState:(PlaceholderState)placeholderState
+                                     font:(UIFont *)font
+                  floatingPlaceholderFont:(UIFont *)floatingPlaceholderFont
+                  floatingPlaceholderMinY:(CGFloat)floatingPlaceholderMinY
+                             textAreaRect:(CGRect)textAreaRect {
+  CGFloat textAreaWidth = CGRectGetWidth(textAreaRect);
+  CGFloat textAreaMinX = CGRectGetMinX(textAreaRect);
+  CGFloat textAreaMidY = CGRectGetMidY(textAreaRect);
+  CGSize size = CGSizeZero;
+  CGRect rect = CGRectZero;
+  CGFloat originX = 0;
+  CGFloat originY = 0;
+  switch (placeholderState) {
+    case PlaceholderStateNone:
+      break;
+    case PlaceholderStateFloating:
+      size = [self placeholderSizeWithPlaceholder:placeholder
+                                    textAreaWidth:textAreaWidth
+                                             font:floatingPlaceholderFont];
+      originY = floatingPlaceholderMinY;
+      originX = textAreaMinX;
+      if (textFieldStyle == TextFieldStyleOutline) {
+        originX += kFloatingPlaceholderXOffsetFromTextArea;
+      }
+      rect = CGRectMake(originX, originY, size.width, size.height);
+      break;
+    case PlaceholderStateNormal:
+      size = [self placeholderSizeWithPlaceholder:placeholder
+                                    textAreaWidth:textAreaWidth
+                                             font:font];
+      originY = textAreaMidY - (0.5 * size.height);
+      originX = textAreaMinX;
+      rect = CGRectMake(originX, originY, size.width, size.height);
+      break;
+    default:
+      break;
+  }
+  return rect;
+}
+
+
+
+- (CGFloat)textHeightWithFont:(UIFont *)font {
+  return ceil((double)font.lineHeight);
+}
+
+- (CGFloat)calculatedHeight {
+  CGFloat maxY = 0;
+  CGFloat placeholderFrameFloatingMaxY = CGRectGetMaxY(self.placeholderFrameFloating);
+  if (placeholderFrameFloatingMaxY > maxY) {
+    maxY = placeholderFrameFloatingMaxY;
+  }
+  CGFloat placeholderFrameNormalMaxY = CGRectGetMaxY(self.placeholderFrameNormal);
+  if (placeholderFrameFloatingMaxY > maxY) {
+    maxY = placeholderFrameNormalMaxY;
+  }
+  CGFloat textAreaFrameMaxY = CGRectGetMaxY(self.textAreaFrame);
+  if (textAreaFrameMaxY > maxY) {
+    maxY = textAreaFrameMaxY;
+  }
+  CGFloat clearButtonFrameMaxY = CGRectGetMaxY(self.clearButtonFrame);
+  if (clearButtonFrameMaxY > maxY) {
+    maxY = clearButtonFrameMaxY;
+  }
+  CGFloat leftViewFrameMaxY = CGRectGetMaxY(self.leftViewFrame);
+  if (leftViewFrameMaxY > maxY) {
+    maxY = leftViewFrameMaxY;
+  }
+  CGFloat rightViewFrameMaxY = CGRectGetMaxY(self.rightViewFrame);
+  if (rightViewFrameMaxY > maxY) {
+    maxY = rightViewFrameMaxY;
+  }
+  CGFloat leftUnderlineLabelFrameMaxY = CGRectGetMaxY(self.leftUnderlineLabelFrame);
+  if (leftUnderlineLabelFrameMaxY > maxY) {
+    maxY = leftUnderlineLabelFrameMaxY;
+  }
+  CGFloat rightUnderlineLabelFrameMaxY = CGRectGetMaxY(self.rightUnderlineLabelFrame);
+  if (rightUnderlineLabelFrameMaxY > maxY) {
+    maxY = rightUnderlineLabelFrameMaxY;
+  }
+  if (self.topRowBottomRowDividerY > maxY) {
+    maxY = self.topRowBottomRowDividerY;
+  }
+  return maxY;
+}
+
+
+@end

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.m
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.m
@@ -19,46 +19,46 @@
 
 #pragma mark Object Lifecycle
 
-- (instancetype)initWithTextFieldBounds:(CGRect)textFieldBounds
-                         textFieldStyle:(TextFieldStyle)textFieldStyle
-                                   text:(NSString *)text
-                            placeholder:(NSString *)placeholder
-                                   font:(UIFont *)font
-                floatingPlaceholderFont:(UIFont *)floatingPlaceholderFont
-                    canPlaceholderFloat:(BOOL)canPlaceholderFloat
-                               leftView:(UIView *)leftView
-                           leftViewMode:(UITextFieldViewMode)leftViewMode
-                              rightView:(UIView *)rightView
-                          rightViewMode:(UITextFieldViewMode)rightViewMode
-                            clearButton:(UIButton *)clearButton
-                        clearButtonMode:(UITextFieldViewMode)clearButtonMode
-                     leftUnderlineLabel:(UILabel *)leftUnderlineLabel
-                    rightUnderlineLabel:(UILabel *)rightUnderlineLabel
-             underlineLabelDrawPriority:(UnderlineLabelDrawPriority)underlineLabelDrawPriority
-       customUnderlineLabelDrawPriority:(CGFloat)customUnderlineLabelDrawPriority
-                                  isRTL:(BOOL)isRTL
-                              isEditing:(BOOL)isEditing {
+- (instancetype)initWithTextFieldSize:(CGSize)textFieldSize
+                       textFieldStyle:(TextFieldStyle)textFieldStyle
+                                 text:(NSString *)text
+                          placeholder:(NSString *)placeholder
+                                 font:(UIFont *)font
+              floatingPlaceholderFont:(UIFont *)floatingPlaceholderFont
+                  canPlaceholderFloat:(BOOL)canPlaceholderFloat
+                             leftView:(UIView *)leftView
+                         leftViewMode:(UITextFieldViewMode)leftViewMode
+                            rightView:(UIView *)rightView
+                        rightViewMode:(UITextFieldViewMode)rightViewMode
+                          clearButton:(UIButton *)clearButton
+                      clearButtonMode:(UITextFieldViewMode)clearButtonMode
+                   leftUnderlineLabel:(UILabel *)leftUnderlineLabel
+                  rightUnderlineLabel:(UILabel *)rightUnderlineLabel
+           underlineLabelDrawPriority:(UnderlineLabelDrawPriority)underlineLabelDrawPriority
+     customUnderlineLabelDrawPriority:(CGFloat)customUnderlineLabelDrawPriority
+                                isRTL:(BOOL)isRTL
+                            isEditing:(BOOL)isEditing {
   self = [super init];
   if (self) {
-    [self calculateLayoutWithTextFieldBounds:textFieldBounds
-                              textFieldStyle:textFieldStyle
-                                        text:text
-                                 placeholder:placeholder
-                                        font:font
-                     floatingPlaceholderFont:floatingPlaceholderFont
-                         canPlaceholderFloat:canPlaceholderFloat
-                                    leftView:leftView
-                                leftViewMode:leftViewMode
-                                   rightView:rightView
-                               rightViewMode:rightViewMode
-                                 clearButton:clearButton
-                             clearButtonMode:clearButtonMode
-                          leftUnderlineLabel:leftUnderlineLabel
-                         rightUnderlineLabel:rightUnderlineLabel
-                  underlineLabelDrawPriority:underlineLabelDrawPriority
-            customUnderlineLabelDrawPriority:customUnderlineLabelDrawPriority
-                                       isRTL:isRTL
-                                   isEditing:isEditing];
+    [self calculateLayoutWithTextFieldSize:textFieldSize
+                            textFieldStyle:textFieldStyle
+                                      text:text
+                               placeholder:placeholder
+                                      font:font
+                   floatingPlaceholderFont:floatingPlaceholderFont
+                       canPlaceholderFloat:canPlaceholderFloat
+                                  leftView:leftView
+                              leftViewMode:leftViewMode
+                                 rightView:rightView
+                             rightViewMode:rightViewMode
+                               clearButton:clearButton
+                           clearButtonMode:clearButtonMode
+                        leftUnderlineLabel:leftUnderlineLabel
+                       rightUnderlineLabel:rightUnderlineLabel
+                underlineLabelDrawPriority:underlineLabelDrawPriority
+          customUnderlineLabelDrawPriority:customUnderlineLabelDrawPriority
+                                     isRTL:isRTL
+                                 isEditing:isEditing];
     return self;
   }
   return nil;
@@ -66,25 +66,25 @@
 
 #pragma mark Layout Calculation
 
-- (void)calculateLayoutWithTextFieldBounds:(CGRect)textFieldBounds
-                            textFieldStyle:(TextFieldStyle)textFieldStyle
-                                      text:(NSString *)text
-                               placeholder:(NSString *)placeholder
-                                      font:(UIFont *)font
-                   floatingPlaceholderFont:(UIFont *)floatingPlaceholderFont
-                       canPlaceholderFloat:(BOOL)canPlaceholderFloat
-                                  leftView:(UIView *)leftView
-                              leftViewMode:(UITextFieldViewMode)leftViewMode
-                                 rightView:(UIView *)rightView
-                             rightViewMode:(UITextFieldViewMode)rightViewMode
-                               clearButton:(UIButton *)clearButton
-                           clearButtonMode:(UITextFieldViewMode)clearButtonMode
-                        leftUnderlineLabel:(UILabel *)leftUnderlineLabel
-                       rightUnderlineLabel:(UILabel *)rightUnderlineLabel
-                underlineLabelDrawPriority:(UnderlineLabelDrawPriority)underlineLabelDrawPriority
-          customUnderlineLabelDrawPriority:(CGFloat)customUnderlineLabelDrawPriority
-                                     isRTL:(BOOL)isRTL
-                                 isEditing:(BOOL)isEditing {
+- (void)calculateLayoutWithTextFieldSize:(CGSize)textFieldSize
+                          textFieldStyle:(TextFieldStyle)textFieldStyle
+                                    text:(NSString *)text
+                             placeholder:(NSString *)placeholder
+                                    font:(UIFont *)font
+                 floatingPlaceholderFont:(UIFont *)floatingPlaceholderFont
+                     canPlaceholderFloat:(BOOL)canPlaceholderFloat
+                                leftView:(UIView *)leftView
+                            leftViewMode:(UITextFieldViewMode)leftViewMode
+                               rightView:(UIView *)rightView
+                           rightViewMode:(UITextFieldViewMode)rightViewMode
+                             clearButton:(UIButton *)clearButton
+                         clearButtonMode:(UITextFieldViewMode)clearButtonMode
+                      leftUnderlineLabel:(UILabel *)leftUnderlineLabel
+                     rightUnderlineLabel:(UILabel *)rightUnderlineLabel
+              underlineLabelDrawPriority:(UnderlineLabelDrawPriority)underlineLabelDrawPriority
+        customUnderlineLabelDrawPriority:(CGFloat)customUnderlineLabelDrawPriority
+                                   isRTL:(BOOL)isRTL
+                               isEditing:(BOOL)isEditing {
 
   BOOL shouldAttemptToDisplayLeftView = [self shouldAttemptToDisplaySideView:leftView
                                                                     viewMode:leftViewMode
@@ -106,7 +106,7 @@
     leftViewMaxX = leftViewMinX + leftViewWidth;
   }
 
-  CGFloat textFieldWidth = CGRectGetWidth(textFieldBounds);
+  CGFloat textFieldWidth = textFieldSize.width;
   CGFloat rightViewMinX = 0;
   if (shouldAttemptToDisplayRightView) {
     rightViewMinX = [self minXForRightView:rightView

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.m
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.m
@@ -11,7 +11,6 @@
 #import "SimpleTextField.h"
 #import "SimpleTextFieldLayoutUtils.h"
 
-
 @interface SimpleTextFieldLayout ()
 @end
 
@@ -85,7 +84,6 @@
         customUnderlineLabelDrawPriority:(CGFloat)customUnderlineLabelDrawPriority
                                    isRTL:(BOOL)isRTL
                                isEditing:(BOOL)isEditing {
-
   BOOL shouldAttemptToDisplayLeftView = [self shouldAttemptToDisplaySideView:leftView
                                                                     viewMode:leftViewMode
                                                                    isEditing:isEditing];
@@ -101,17 +99,14 @@
   CGFloat leftViewMinX = 0;
   CGFloat leftViewMaxX = 0;
   if (shouldAttemptToDisplayLeftView) {
-    leftViewMinX = [self minXForLeftView:leftView
-                                   isRTL:isRTL];
+    leftViewMinX = [self minXForLeftView:leftView isRTL:isRTL];
     leftViewMaxX = leftViewMinX + leftViewWidth;
   }
 
   CGFloat textFieldWidth = textFieldSize.width;
   CGFloat rightViewMinX = 0;
   if (shouldAttemptToDisplayRightView) {
-    rightViewMinX = [self minXForRightView:rightView
-                            textFieldWidth:textFieldWidth
-                                     isRTL:isRTL];
+    rightViewMinX = [self minXForRightView:rightView textFieldWidth:textFieldWidth isRTL:isRTL];
   }
 
   CGFloat clearButtonMinX = 0;
@@ -119,7 +114,8 @@
     CGFloat leftMargin = isRTL ? kLeadingMargin : kTrailingMargin;
     CGFloat rightMargin = isRTL ? kTrailingMargin : kLeadingMargin;
     CGFloat lowestPossibleMinX = shouldAttemptToDisplayLeftView ? leftViewMaxX : leftMargin;
-    CGFloat highestPossibleMaxX = shouldAttemptToDisplayRightView ? rightViewMinX : textFieldWidth - rightMargin;
+    CGFloat highestPossibleMaxX =
+        shouldAttemptToDisplayRightView ? rightViewMinX : textFieldWidth - rightMargin;
     clearButtonMinX = [self clearButtonMinXWithLowestPossibleMinX:lowestPossibleMinX
                                               highestPossibleMaxX:highestPossibleMaxX
                                                             isRTL:isRTL];
@@ -127,8 +123,8 @@
   CGFloat floatingPlaceholderHeight =
       canPlaceholderFloat ? [self textHeightWithFont:floatingPlaceholderFont] : 0;
   CGFloat floatingPlaceholderMinY =
-        [self floatingPlaceholderMinYWithFloatingHeight:floatingPlaceholderHeight
-                                         textFieldStyle:textFieldStyle];
+      [self floatingPlaceholderMinYWithFloatingHeight:floatingPlaceholderHeight
+                                       textFieldStyle:textFieldStyle];
 
   CGFloat textAreaHeight = [self textHeightWithFont:font];
   CGFloat lowestAllowableTextAreaCenterY =
@@ -139,19 +135,18 @@
                                                   placeholderCanFloat:canPlaceholderFloat];
 
   CGFloat topRowSubviewCenterY =
-  [self topRowSubviewCenterYWithLeftView:leftView
-                               rightView:rightView
-                                    font:font
-                            floatingFont:floatingPlaceholderFont
-                          textFieldStyle:textFieldStyle
-          lowestAllowableTextAreaCenterY:lowestAllowableTextAreaCenterY];
+      [self topRowSubviewCenterYWithLeftView:leftView
+                                   rightView:rightView
+                                        font:font
+                                floatingFont:floatingPlaceholderFont
+                              textFieldStyle:textFieldStyle
+              lowestAllowableTextAreaCenterY:lowestAllowableTextAreaCenterY];
 
   CGFloat leftViewHeight = CGRectGetHeight(leftView.frame);
   CGFloat leftViewMinY = 0;
   CGFloat leftViewMaxY = 0;
   if (shouldAttemptToDisplayLeftView) {
-    leftViewMinY = [self minYForSubviewWithHeight:leftViewHeight
-                                          centerY:topRowSubviewCenterY];
+    leftViewMinY = [self minYForSubviewWithHeight:leftViewHeight centerY:topRowSubviewCenterY];
     leftViewMaxY = leftViewMinY + leftViewHeight;
   }
 
@@ -159,8 +154,7 @@
   CGFloat rightViewMinY = 0;
   CGFloat rightViewMaxY = 0;
   if (shouldAttemptToDisplayRightView) {
-    rightViewMinY = [self minYForSubviewWithHeight:rightViewHeight
-                                           centerY:topRowSubviewCenterY];
+    rightViewMinY = [self minYForSubviewWithHeight:rightViewHeight centerY:topRowSubviewCenterY];
     rightViewMaxY = rightViewMinY + rightViewHeight;
   }
 
@@ -205,7 +199,9 @@
   CGRect leftViewFrame = CGRectMake(leftViewMinX, leftViewMinY, leftViewWidth, leftViewHeight);
   CGFloat rightViewWidth = CGRectGetWidth(rightView.frame);
   CGRect rightViewFrame = CGRectMake(rightViewMinX, rightViewMinY, rightViewWidth, rightViewHeight);
-  CGRect clearButtonFrame = CGRectMake(clearButtonMinX, clearButtonMinY, kClearButtonTouchTargetSideLength, kClearButtonTouchTargetSideLength);
+  CGRect clearButtonFrame =
+      CGRectMake(clearButtonMinX, clearButtonMinY, kClearButtonTouchTargetSideLength,
+                 kClearButtonTouchTargetSideLength);
 
   CGRect placeholderFrameNormal = [self placeholderFrameWithPlaceholder:placeholder
                                                          textFieldStyle:textFieldStyle
@@ -223,8 +219,10 @@
                                                              textAreaRect:textAreaFrame];
 
   CGFloat underlineLabelsCombinedMinX = isRTL ? kTrailingMargin : kLeadingMargin;
-  CGFloat underlineLabelsCombinedMaxX = isRTL ? textFieldWidth - kLeadingMargin : textFieldWidth - kTrailingMargin;
-  CGFloat underlineLabelsCombinedMaxWidth = underlineLabelsCombinedMaxX - underlineLabelsCombinedMinX;
+  CGFloat underlineLabelsCombinedMaxX =
+      isRTL ? textFieldWidth - kLeadingMargin : textFieldWidth - kTrailingMargin;
+  CGFloat underlineLabelsCombinedMaxWidth =
+      underlineLabelsCombinedMaxX - underlineLabelsCombinedMinX;
 
   CGFloat topRowSubviewMaxY = [self topRowSubviewMaxYWithTextAreaMaxY:textAreaMaxY
                                                          leftViewMaxY:leftViewMaxY
@@ -246,8 +244,10 @@
   UILabel *trailingUnderlineLabel = isRTL ? leftUnderlineLabel : rightUnderlineLabel;
   switch (underlineLabelDrawPriority) {
     case UnderlineLabelDrawPriorityCustom:
-      leadingUnderlineLabelWidth = [self leadingUnderlineLabelWidthWithCombinedUnderlineLabelsWidth:underlineLabelsCombinedMaxWidth
-                                                                                 customDrawPriority:customUnderlineLabelDrawPriority];
+      leadingUnderlineLabelWidth = [self
+          leadingUnderlineLabelWidthWithCombinedUnderlineLabelsWidth:underlineLabelsCombinedMaxWidth
+                                                  customDrawPriority:
+                                                      customUnderlineLabelDrawPriority];
       trailingUnderlineLabelWidth = underlineLabelsCombinedMaxWidth - leadingUnderlineLabelWidth;
       leadingUnderlineLabelSize = [self underlineLabelSizeWithLabel:leadingUnderlineLabel
                                                  constrainedToWidth:leadingUnderlineLabelWidth];
@@ -255,16 +255,22 @@
                                                   constrainedToWidth:trailingUnderlineLabelWidth];
       break;
     case UnderlineLabelDrawPriorityLeading:
-      leadingUnderlineLabelSize = [self underlineLabelSizeWithLabel:leadingUnderlineLabel
-                                                 constrainedToWidth:underlineLabelsCombinedMaxWidth];
-      trailingUnderlineLabelSize = [self underlineLabelSizeWithLabel:trailingUnderlineLabel
-                                                  constrainedToWidth:underlineLabelsCombinedMaxWidth - leadingUnderlineLabelSize.width];
+      leadingUnderlineLabelSize =
+          [self underlineLabelSizeWithLabel:leadingUnderlineLabel
+                         constrainedToWidth:underlineLabelsCombinedMaxWidth];
+      trailingUnderlineLabelSize =
+          [self underlineLabelSizeWithLabel:trailingUnderlineLabel
+                         constrainedToWidth:underlineLabelsCombinedMaxWidth -
+                                            leadingUnderlineLabelSize.width];
       break;
     case UnderlineLabelDrawPriorityTrailing:
-      trailingUnderlineLabelSize = [self underlineLabelSizeWithLabel:trailingUnderlineLabel
-                                                  constrainedToWidth:underlineLabelsCombinedMaxWidth];
-      leadingUnderlineLabelSize = [self underlineLabelSizeWithLabel:leadingUnderlineLabel
-                                                 constrainedToWidth:underlineLabelsCombinedMaxWidth - trailingUnderlineLabelSize.width];
+      trailingUnderlineLabelSize =
+          [self underlineLabelSizeWithLabel:trailingUnderlineLabel
+                         constrainedToWidth:underlineLabelsCombinedMaxWidth];
+      leadingUnderlineLabelSize =
+          [self underlineLabelSizeWithLabel:leadingUnderlineLabel
+                         constrainedToWidth:underlineLabelsCombinedMaxWidth -
+                                            trailingUnderlineLabelSize.width];
       break;
     default:
       break;
@@ -275,16 +281,14 @@
   CGRect leftUnderlineLabelFrame = CGRectZero;
   CGRect rightUnderlineLabelFrame = CGRectZero;
   if (!CGSizeEqualToSize(leftUnderlineLabelSize, CGSizeZero)) {
-    leftUnderlineLabelFrame = CGRectMake(underlineLabelsCombinedMinX,
-                                         underlineLabelsCombinedMinY,
-                                         leftUnderlineLabelSize.width,
-                                         leftUnderlineLabelSize.height);
+    leftUnderlineLabelFrame =
+        CGRectMake(underlineLabelsCombinedMinX, underlineLabelsCombinedMinY,
+                   leftUnderlineLabelSize.width, leftUnderlineLabelSize.height);
   }
   if (!CGSizeEqualToSize(rightUnderlineLabelSize, CGSizeZero)) {
-    rightUnderlineLabelFrame = CGRectMake(underlineLabelsCombinedMaxX - rightUnderlineLabelSize.width,
-                                          underlineLabelsCombinedMinY,
-                                          rightUnderlineLabelSize.width,
-                                          rightUnderlineLabelSize.height);
+    rightUnderlineLabelFrame = CGRectMake(
+        underlineLabelsCombinedMaxX - rightUnderlineLabelSize.width, underlineLabelsCombinedMinY,
+        rightUnderlineLabelSize.width, rightUnderlineLabelSize.height);
   }
 
   self.leftViewFrame = leftViewFrame;
@@ -311,8 +315,7 @@
   return max;
 }
 
-- (CGSize)underlineLabelSizeWithLabel:(UILabel *)label
-                   constrainedToWidth:(CGFloat)maxWidth {
+- (CGSize)underlineLabelSizeWithLabel:(UILabel *)label constrainedToWidth:(CGFloat)maxWidth {
   if (maxWidth <= 0 || label.text.length <= 0 || label.hidden) {
     return CGSizeZero;
   }
@@ -324,25 +327,21 @@
   return size;
 }
 
-- (CGFloat)leadingUnderlineLabelWidthWithCombinedUnderlineLabelsWidth:(CGFloat)totalUnderlineLabelsWidth
+- (CGFloat)leadingUnderlineLabelWidthWithCombinedUnderlineLabelsWidth:
+               (CGFloat)totalUnderlineLabelsWidth
                                                    customDrawPriority:(CGFloat)customDrawPriority {
   return customDrawPriority * totalUnderlineLabelsWidth;
 }
 
-
-- (CGFloat)minXForLeftUnderlineLabel:(UILabel *)label
-                               isRTL:(BOOL)isRTL {
+- (CGFloat)minXForLeftUnderlineLabel:(UILabel *)label isRTL:(BOOL)isRTL {
   return isRTL ? kTrailingMargin : kLeadingMargin;
 }
 
-- (CGFloat)maxXForRightUnderlineLabel:(UILabel *)label
-                                isRTL:(BOOL)isRTL {
+- (CGFloat)maxXForRightUnderlineLabel:(UILabel *)label isRTL:(BOOL)isRTL {
   return isRTL ? kTrailingMargin : kLeadingMargin;
 }
 
-
-- (CGFloat)minXForLeftView:(UIView *)leftView
-                     isRTL:(BOOL)isRTL {
+- (CGFloat)minXForLeftView:(UIView *)leftView isRTL:(BOOL)isRTL {
   return isRTL ? kTrailingMargin : kLeadingMargin;
 }
 
@@ -395,7 +394,6 @@
   return shouldAttemptToDisplaySideView;
 }
 
-
 - (BOOL)shouldAttemptToDisplayClearButton:(UIButton *)clearButton
                                  viewMode:(UITextFieldViewMode)viewMode
                                 isEditing:(BOOL)isEditing
@@ -421,11 +419,12 @@
   return shouldAttemptToDisplayClearButton;
 }
 
-- (CGFloat)lowestAllowableTextAreaCenterYWithFloatingPlaceholderMinY:(CGFloat)floatingPlaceholderMinY
-                                           floatingPlaceholderHeight:(CGFloat)floatingPlaceholderHeight
-                                                      textAreaHeight:(CGFloat)textAreaHeight
-                                                      textFieldStyle:(TextFieldStyle)textFieldStyle
-                                                 placeholderCanFloat:(BOOL)placeholderCanFloat {
+- (CGFloat)
+    lowestAllowableTextAreaCenterYWithFloatingPlaceholderMinY:(CGFloat)floatingPlaceholderMinY
+                                    floatingPlaceholderHeight:(CGFloat)floatingPlaceholderHeight
+                                               textAreaHeight:(CGFloat)textAreaHeight
+                                               textFieldStyle:(TextFieldStyle)textFieldStyle
+                                          placeholderCanFloat:(BOOL)placeholderCanFloat {
   if (placeholderCanFloat) {
     CGFloat spaceBetweenPlaceholderAndTextArea = 0;
     CGFloat floatingPlaceholderMaxY = floatingPlaceholderMinY + floatingPlaceholderHeight;
@@ -433,9 +432,11 @@
     if (textFieldStyle == TextFieldStyleFilled) {
       spaceBetweenPlaceholderAndTextArea = (0.25 * floatingPlaceholderMaxY);
     } else if (textFieldStyle == TextFieldStyleOutline) {
-      spaceBetweenPlaceholderAndTextArea = floatingPlaceholderMaxY + outlinedTextFieldSpaceHeuristic;
+      spaceBetweenPlaceholderAndTextArea =
+          floatingPlaceholderMaxY + outlinedTextFieldSpaceHeuristic;
     }
-    CGFloat lowestAllowableTextAreaMinY = floatingPlaceholderMaxY + spaceBetweenPlaceholderAndTextArea;
+    CGFloat lowestAllowableTextAreaMinY =
+        floatingPlaceholderMaxY + spaceBetweenPlaceholderAndTextArea;
     return lowestAllowableTextAreaMinY + (0.5 * textAreaHeight);
   } else {
     CGFloat lowestAllowableTextAreaMinY = kTopRowSubviewVerticalPadding;
@@ -452,7 +453,8 @@
   CGFloat floatingPlaceholderMinY = 0;
   switch (textFieldStyle) {
     case TextFieldStyleFilled:
-      floatingPlaceholderMinY = filledPlaceholderTopPaddingScaleHeuristic * floatingPlaceholderHeight;
+      floatingPlaceholderMinY =
+          filledPlaceholderTopPaddingScaleHeuristic * floatingPlaceholderHeight;
       break;
     case TextFieldStyleOutline:
       floatingPlaceholderMinY = 0 - (0.5 * floatingPlaceholderHeight);
@@ -470,7 +472,8 @@
                                floatingFont:(UIFont *)floatingFont
                              textFieldStyle:(TextFieldStyle)textFieldStyle
              lowestAllowableTextAreaCenterY:(CGFloat)lowestAllowableTextAreaCenterY {
-  CGFloat sideViewMaxHeight = MAX(CGRectGetHeight(leftView.bounds), CGRectGetHeight(rightView.bounds));
+  CGFloat sideViewMaxHeight =
+      MAX(CGRectGetHeight(leftView.bounds), CGRectGetHeight(rightView.bounds));
   CGFloat lowestAllowableSideViewCenterY = kTopMargin + (0.5 * sideViewMaxHeight);
   CGFloat sharedCenterY = MAX(lowestAllowableTextAreaCenterY, lowestAllowableSideViewCenterY);
   return sharedCenterY;
@@ -501,7 +504,7 @@
     return CGSizeZero;
   }
   CGSize fittingSize = CGSizeMake(maxPlaceholderWidth, CGFLOAT_MAX);
-  NSDictionary *attributes = @{NSFontAttributeName: font};
+  NSDictionary *attributes = @{NSFontAttributeName : font};
   CGRect rect = [placeholder boundingRectWithSize:fittingSize
                                           options:NSStringDrawingUsesLineFragmentOrigin
                                        attributes:attributes
@@ -550,8 +553,6 @@
   return rect;
 }
 
-
-
 - (CGFloat)textHeightWithFont:(UIFont *)font {
   return ceil((double)font.lineHeight);
 }
@@ -595,6 +596,5 @@
   }
   return maxY;
 }
-
 
 @end

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.m
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.m
@@ -1,10 +1,16 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
 //
-//  SimpleTextFieldLayout.m
-//  ComponentsProject
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Andrew Overton on 12/6/18.
-//  Copyright © 2018 andrewoverton. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #import "SimpleTextFieldLayout.h"
 
@@ -209,14 +215,16 @@
                                                                    font:font
                                                 floatingPlaceholderFont:floatingPlaceholderFont
                                                 floatingPlaceholderMinY:floatingPlaceholderMinY
-                                                           textAreaRect:textAreaFrame];
+                                                           textAreaRect:textAreaFrame
+                                                                  isRTL:isRTL];
   CGRect placeholderFrameFloating = [self placeholderFrameWithPlaceholder:placeholder
                                                            textFieldStyle:textFieldStyle
                                                          placeholderState:PlaceholderStateFloating
                                                                      font:font
                                                   floatingPlaceholderFont:floatingPlaceholderFont
                                                   floatingPlaceholderMinY:floatingPlaceholderMinY
-                                                             textAreaRect:textAreaFrame];
+                                                             textAreaRect:textAreaFrame
+                                                                    isRTL:isRTL];
 
   CGFloat underlineLabelsCombinedMinX = isRTL ? kTrailingMargin : kLeadingMargin;
   CGFloat underlineLabelsCombinedMaxX =
@@ -518,11 +526,13 @@
                                      font:(UIFont *)font
                   floatingPlaceholderFont:(UIFont *)floatingPlaceholderFont
                   floatingPlaceholderMinY:(CGFloat)floatingPlaceholderMinY
-                             textAreaRect:(CGRect)textAreaRect {
+                             textAreaRect:(CGRect)textAreaRect
+                                    isRTL:(BOOL)isRTL {
   CGFloat textAreaWidth = CGRectGetWidth(textAreaRect);
   CGFloat maxPlaceholderWidth = [self maxPlaceholderWidthWithTextAreaWidth:textAreaWidth
                                                           placeholderState:placeholderState];
   CGFloat textAreaMinX = CGRectGetMinX(textAreaRect);
+  CGFloat textAreaMaxX = CGRectGetMaxX(textAreaRect);
   CGFloat textAreaMidY = CGRectGetMidY(textAreaRect);
   CGSize size = CGSizeZero;
   CGRect rect = CGRectZero;
@@ -536,7 +546,11 @@
                               maxPlaceholderWidth:maxPlaceholderWidth
                                              font:floatingPlaceholderFont];
       originY = floatingPlaceholderMinY;
-      originX = textAreaMinX + kFloatingPlaceholderXOffsetFromTextArea;
+      if (isRTL) {
+        originX = textAreaMaxX - kFloatingPlaceholderXOffsetFromTextArea - size.width;
+      } else {
+        originX = textAreaMinX + kFloatingPlaceholderXOffsetFromTextArea;
+      }
       rect = CGRectMake(originX, originY, size.width, size.height);
       break;
     case PlaceholderStateNormal:
@@ -544,7 +558,11 @@
                               maxPlaceholderWidth:maxPlaceholderWidth
                                              font:font];
       originY = textAreaMidY - (0.5 * size.height);
-      originX = textAreaMinX;
+      if (isRTL) {
+        originX = textAreaMaxX - size.width;
+      } else {
+        originX = textAreaMinX;
+      }
       rect = CGRectMake(originX, originY, size.width, size.height);
       break;
     default:

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.m
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.m
@@ -476,13 +476,31 @@
   return sharedCenterY;
 }
 
+- (CGFloat)maxPlaceholderWidthWithTextAreaWidth:(CGFloat)textAreaWidth
+                               placeholderState:(PlaceholderState)placeholderState {
+  CGFloat maxPlaceholderWidth = 0;
+  switch (placeholderState) {
+    case PlaceholderStateNone:
+      break;
+    case PlaceholderStateFloating:
+      maxPlaceholderWidth = textAreaWidth - (2 * kFloatingPlaceholderXOffsetFromTextArea);
+      break;
+    case PlaceholderStateNormal:
+      maxPlaceholderWidth = textAreaWidth;
+      break;
+    default:
+      break;
+  }
+  return maxPlaceholderWidth;
+}
+
 - (CGSize)placeholderSizeWithPlaceholder:(NSString *)placeholder
-                           textAreaWidth:(CGFloat)textAreaWidth
+                     maxPlaceholderWidth:(CGFloat)maxPlaceholderWidth
                                     font:(UIFont *)font {
   if (!font) {
     return CGSizeZero;
   }
-  CGSize fittingSize = CGSizeMake(textAreaWidth, CGFLOAT_MAX);
+  CGSize fittingSize = CGSizeMake(maxPlaceholderWidth, CGFLOAT_MAX);
   NSDictionary *attributes = @{NSFontAttributeName: font};
   CGRect rect = [placeholder boundingRectWithSize:fittingSize
                                           options:NSStringDrawingUsesLineFragmentOrigin
@@ -499,6 +517,8 @@
                   floatingPlaceholderMinY:(CGFloat)floatingPlaceholderMinY
                              textAreaRect:(CGRect)textAreaRect {
   CGFloat textAreaWidth = CGRectGetWidth(textAreaRect);
+  CGFloat maxPlaceholderWidth = [self maxPlaceholderWidthWithTextAreaWidth:textAreaWidth
+                                                          placeholderState:placeholderState];
   CGFloat textAreaMinX = CGRectGetMinX(textAreaRect);
   CGFloat textAreaMidY = CGRectGetMidY(textAreaRect);
   CGSize size = CGSizeZero;
@@ -510,18 +530,15 @@
       break;
     case PlaceholderStateFloating:
       size = [self placeholderSizeWithPlaceholder:placeholder
-                                    textAreaWidth:textAreaWidth
+                              maxPlaceholderWidth:maxPlaceholderWidth
                                              font:floatingPlaceholderFont];
       originY = floatingPlaceholderMinY;
-      originX = textAreaMinX;
-      if (textFieldStyle == TextFieldStyleOutline) {
-        originX += kFloatingPlaceholderXOffsetFromTextArea;
-      }
+      originX = textAreaMinX + kFloatingPlaceholderXOffsetFromTextArea;
       rect = CGRectMake(originX, originY, size.width, size.height);
       break;
     case PlaceholderStateNormal:
       size = [self placeholderSizeWithPlaceholder:placeholder
-                                    textAreaWidth:textAreaWidth
+                              maxPlaceholderWidth:maxPlaceholderWidth
                                              font:font];
       originY = textAreaMidY - (0.5 * size.height);
       originX = textAreaMinX;

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.m
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayout.m
@@ -122,7 +122,8 @@
   if (shouldAttemptToDisplayClearButton) {
     // RTL
     CGFloat uncorrectedVisualLeftMargin = isRTL ? kTrailingMargin : kLeadingMargin;
-    CGFloat correctedVisualLeftMargin = uncorrectedVisualLeftMargin - clearButtonImageViewSideMargin;
+    CGFloat correctedVisualLeftMargin =
+        uncorrectedVisualLeftMargin - clearButtonImageViewSideMargin;
     CGFloat lowestPossibleMinX = 0;
     if (shouldAttemptToDisplayLeftView) {
       lowestPossibleMinX = leftViewMaxX + correctedVisualLeftMargin;
@@ -132,7 +133,8 @@
 
     // LTR
     CGFloat uncorrectedVisualRightMargin = isRTL ? kLeadingMargin : kTrailingMargin;
-    CGFloat correctedVisualRightMargin = uncorrectedVisualRightMargin - clearButtonImageViewSideMargin;
+    CGFloat correctedVisualRightMargin =
+        uncorrectedVisualRightMargin - clearButtonImageViewSideMargin;
     CGFloat highestPossibleMaxX = 0;
     if (shouldAttemptToDisplayRightView) {
       highestPossibleMaxX = rightViewMinX - correctedVisualRightMargin;
@@ -193,7 +195,8 @@
   CGFloat textAreaMaxX = 0;
   if (isRTL) {
     if (shouldAttemptToDisplayClearButton) {
-      CGFloat clearButtonMaxX = clearButtonMinX + kClearButtonTouchTargetSideLength + clearButtonImageViewSideMargin;
+      CGFloat clearButtonMaxX =
+          clearButtonMinX + kClearButtonTouchTargetSideLength + clearButtonImageViewSideMargin;
       textAreaMinX = clearButtonMaxX;
     } else if (shouldAttemptToDisplayLeftView) {
       textAreaMinX = leftViewMaxX + kTrailingMargin;
@@ -257,14 +260,22 @@
                                                          leftViewMaxY:leftViewMaxY
                                                         rightViewMaxY:rightViewMaxY];
 
-  CGFloat topRowBottomRowDividerY = topRowSubviewCenterY;
-  if (textFieldStyle == TextFieldStyleOutline) {
-    topRowBottomRowDividerY = topRowSubviewCenterY * 2;
-  } else if (textFieldStyle == TextFieldStyleFilled) {
-    topRowBottomRowDividerY = topRowSubviewMaxY + kTopRowBottomRowDividerVerticalPadding;
+  CGFloat topRowBottomRowDividerY = 0;
+  switch (textFieldStyle) {
+    case TextFieldStyleNone:
+      topRowBottomRowDividerY = topRowSubviewMaxY;
+      break;
+    case TextFieldStyleFilled:
+    default:
+      topRowBottomRowDividerY = topRowSubviewMaxY + kTopRowBottomRowDividerVerticalPadding;
+      break;
+    case TextFieldStyleOutline:
+      topRowBottomRowDividerY = topRowSubviewCenterY * 2;
+      break;
   }
 
-  CGFloat underlineLabelsCombinedMinY = topRowBottomRowDividerY + kTopRowBottomRowDividerVerticalPadding;
+  CGFloat underlineLabelsCombinedMinY =
+      topRowBottomRowDividerY + kTopRowBottomRowDividerVerticalPadding;
   CGFloat leadingUnderlineLabelWidth = 0;
   CGFloat trailingUnderlineLabelWidth = 0;
   CGSize leadingUnderlineLabelSize = CGSizeZero;
@@ -459,11 +470,16 @@
     CGFloat spaceBetweenPlaceholderAndTextArea = 0;
     CGFloat floatingPlaceholderMaxY = floatingPlaceholderMinY + floatingPlaceholderHeight;
     CGFloat outlinedTextFieldSpaceHeuristic = floatingPlaceholderHeight * 0.22;
-    if (textFieldStyle == TextFieldStyleFilled) {
-      spaceBetweenPlaceholderAndTextArea = (0.25 * floatingPlaceholderMaxY);
-    } else if (textFieldStyle == TextFieldStyleOutline) {
-      spaceBetweenPlaceholderAndTextArea =
-          floatingPlaceholderMaxY + outlinedTextFieldSpaceHeuristic;
+    switch (textFieldStyle) {
+      case TextFieldStyleNone:
+      case TextFieldStyleFilled:
+      default:
+        spaceBetweenPlaceholderAndTextArea = (0.25 * floatingPlaceholderMaxY);
+        break;
+      case TextFieldStyleOutline:
+        spaceBetweenPlaceholderAndTextArea =
+            floatingPlaceholderMaxY + outlinedTextFieldSpaceHeuristic;
+        break;
     }
     CGFloat lowestAllowableTextAreaMinY =
         floatingPlaceholderMaxY + spaceBetweenPlaceholderAndTextArea;
@@ -482,15 +498,14 @@
   CGFloat filledPlaceholderTopPaddingScaleHeuristic = ((CGFloat)50.0 / (CGFloat)70.0);
   CGFloat floatingPlaceholderMinY = 0;
   switch (textFieldStyle) {
-    case TextFieldStyleFilled:
-      floatingPlaceholderMinY =
-          filledPlaceholderTopPaddingScaleHeuristic * floatingPlaceholderHeight;
-      break;
     case TextFieldStyleOutline:
       floatingPlaceholderMinY = 0 - (0.5 * floatingPlaceholderHeight);
       break;
+    case TextFieldStyleNone:
+    case TextFieldStyleFilled:
     default:
-      floatingPlaceholderMinY = kTopMargin;
+      floatingPlaceholderMinY =
+          filledPlaceholderTopPaddingScaleHeuristic * floatingPlaceholderHeight;
       break;
   }
   return floatingPlaceholderMinY;

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
@@ -37,6 +37,7 @@ static const CGFloat kTopRowBottomRowDividerVerticalPadding = 9.0;
  are derived from the styles outlined in the Material Guidelines for Text Fields.
  */
 typedef NS_ENUM(NSUInteger, TextFieldStyle) {
+  TextFieldStyleNone,
   TextFieldStyleFilled,
   TextFieldStyleOutline,
 };

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
@@ -15,22 +15,22 @@
 #ifndef SimpleTextFieldLayoutUtils_h
 #define SimpleTextFieldLayoutUtils_h
 
-static const CGFloat kFloatingPlaceholderAnimationDuration = 0.15;
+static const CGFloat kFloatingPlaceholderAnimationDuration = (CGFloat)0.15;
 
-static const CGFloat kLeadingMargin = 12.0;
-static const CGFloat kTrailingMargin = 12.0;
+static const CGFloat kLeadingMargin = (CGFloat)12.0;
+static const CGFloat kTrailingMargin = (CGFloat)12.0;
 
-static const CGFloat kFloatingPlaceholderOutlineSidePadding = 5.0;
-static const CGFloat kFloatingPlaceholderXOffsetFromTextArea = 3.0;
+static const CGFloat kFloatingPlaceholderOutlineSidePadding = (CGFloat)5.0;
+static const CGFloat kFloatingPlaceholderXOffsetFromTextArea = (CGFloat)3.0;
 
-static const CGFloat kFilledTextFieldTopCornerRadius = 4.0;
-static const CGFloat kOutlinedTextFieldCornerRadius = 4.0;
+static const CGFloat kFilledTextFieldTopCornerRadius = (CGFloat)4.0;
+static const CGFloat kOutlinedTextFieldCornerRadius = (CGFloat)4.0;
 
-static const CGFloat kClearButtonTouchTargetSideLength = 30.0;
-static const CGFloat kClearButtonImageViewSideLength = 18.0;
+static const CGFloat kClearButtonTouchTargetSideLength = (CGFloat)30.0;
+static const CGFloat kClearButtonImageViewSideLength = (CGFloat)18.0;
 
-static const CGFloat kTopMargin = 5.0;
-static const CGFloat kTopRowBottomRowDividerVerticalPadding = 9.0;
+static const CGFloat kTopMargin = (CGFloat)5.0;
+static const CGFloat kTopRowBottomRowDividerVerticalPadding = (CGFloat)9.0;
 
 /**
  TextFieldStyle dictates what type of text field it will be from a cosmetic standpoint. The values

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
@@ -20,19 +20,17 @@ static const CGFloat kFloatingPlaceholderAnimationDuration = 0.15;
 static const CGFloat kLeadingMargin = 12.0;
 static const CGFloat kTrailingMargin = 12.0;
 
+static const CGFloat kFloatingPlaceholderOutlineSidePadding = 5.0;
+static const CGFloat kFloatingPlaceholderXOffsetFromTextArea = 3.0;
+
 static const CGFloat kFilledTextFieldTopCornerRadius = 4.0;
 static const CGFloat kOutlinedTextFieldCornerRadius = 4.0;
-static const CGFloat kFloatingPlaceholderSideMargin = 5.0;
-static const CGFloat kFloatingPlaceholderXOffsetFromTextArea = 3.0;
-static const CGFloat kTopMargin = 5.0;
 
 static const CGFloat kClearButtonTouchTargetSideLength = 30.0;
-static const CGFloat kTextRectSidePadding = 12.0;
+static const CGFloat kClearButtonImageViewSideLength = 18.0;
 
-static const CGFloat kUnderlineLabelsTopPadding = 8.0;
-static const CGFloat kTopRowSubviewVerticalPadding = 10.0;
-
-static const UIControlState UIControlStateError = 1 << 10;
+static const CGFloat kTopMargin = 5.0;
+static const CGFloat kTopRowBottomRowDividerVerticalPadding = 9.0;
 
 /**
  TextFieldStyle dictates what type of text field it will be from a cosmetic standpoint. The values

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
@@ -19,7 +19,7 @@ static const CGFloat kFilledTextFieldTopCornerRadius = 4.0;
 static const CGFloat kOutlinedTextFieldCornerRadius = 4.0;
 //static const CGFloat kFloatingPlaceholderTopMargin = 5.0;
 static const CGFloat kFloatingPlaceholderSideMargin = 5.0;
-static const CGFloat kFloatingPlaceholderXOffsetFromTextArea = 4.0;
+static const CGFloat kFloatingPlaceholderXOffsetFromTextArea = 3.0;
 static const CGFloat kTopMargin = 5.0;
 
 static const CGFloat kClearButtonTouchTargetSideLength = 30.0;

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
@@ -1,0 +1,84 @@
+//
+//  SimpleTextFieldLayoutUtils.h
+//  ComponentsProject
+//
+//  Created by Andrew Overton on 12/6/18.
+//  Copyright © 2018 andrewoverton. All rights reserved.
+//
+
+#ifndef SimpleTextFieldLayoutUtils_h
+#define SimpleTextFieldLayoutUtils_h
+
+static const CGFloat kFloatingPlaceholderAnimationDuration = 0.15;
+
+static const CGFloat kLeadingMargin = 16.0;
+static const CGFloat kTrailingMargin = 16.0;
+
+static const CGFloat kFilledTextFieldUnderlineHeight = 3;
+static const CGFloat kFilledTextFieldTopCornerRadius = 4.0;
+static const CGFloat kOutlinedTextFieldCornerRadius = 4.0;
+//static const CGFloat kFloatingPlaceholderTopMargin = 5.0;
+static const CGFloat kFloatingPlaceholderSideMargin = 5.0;
+static const CGFloat kFloatingPlaceholderXOffsetFromTextArea = 4.0;
+static const CGFloat kTopMargin = 5.0;
+
+static const CGFloat kClearButtonTouchTargetSideLength = 30.0;
+static const CGFloat kTextRectSidePadding = 12.0;
+//static const CGFloat kLeftRightViewSidePadding = 5.0;
+
+static const CGFloat kUnderlineLabelsTopPadding = 8.0;
+static const CGFloat kTopRowSubviewVerticalPadding = 10.0;
+
+static const UIControlState UIControlStateError = 1 << 10;
+
+
+
+/**
+ Dictates the input style.
+ */
+typedef NS_ENUM(NSUInteger, TextFieldMode) {
+  TextFieldModeNormal,
+  TextFieldModeInputChip,
+
+  
+  
+};
+
+
+/**
+ Dictates what type of text field it will be from a cosmetic standpoint.
+ */
+typedef NS_ENUM(NSUInteger, TextFieldStyle) {
+  TextFieldStyleFilled,
+  TextFieldStyleOutline,
+};
+
+/**
+ Dictates the relative importance of the underline labels, and the order in which they are laid out.
+ */
+typedef NS_ENUM(NSUInteger, UnderlineLabelDrawPriority) {
+  /**
+   When the priority is @c .leading, the @c leadingUnderlineLabel will be laid out first within the horizontal space available for @b both underline labels. Any remaining space will then be given for the @c trailingUnderlineLabel.
+   */
+  UnderlineLabelDrawPriorityLeading,
+  /**
+   When the priority is @c .trailing, the @c trailingUnderlineLabel will be laid out first within the horizontal space available for @b both underline labels. Any remaining space will then be given for the @c leadingUnderlineLabel.
+   */
+  UnderlineLabelDrawPriorityTrailing,
+  /**
+   When the priority is @c .custom, the @c customUnderlineLabelDrawPriority property will be used to divide the space available for the two underline labels.
+   */
+  UnderlineLabelDrawPriorityCustom,
+};
+
+typedef NS_ENUM(NSUInteger, PlaceholderState) {
+  PlaceholderStateNone,
+  PlaceholderStateFloating,
+  PlaceholderStateNormal,
+};
+
+//typedef NS_ENUM(NSUInteger, TextFieldState) {
+//  
+//}
+
+#endif /* SimpleTextFieldLayoutUtils_h */

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
@@ -16,14 +16,14 @@ static const CGFloat kTrailingMargin = 16.0;
 
 static const CGFloat kFilledTextFieldTopCornerRadius = 4.0;
 static const CGFloat kOutlinedTextFieldCornerRadius = 4.0;
-//static const CGFloat kFloatingPlaceholderTopMargin = 5.0;
+// static const CGFloat kFloatingPlaceholderTopMargin = 5.0;
 static const CGFloat kFloatingPlaceholderSideMargin = 5.0;
 static const CGFloat kFloatingPlaceholderXOffsetFromTextArea = 3.0;
 static const CGFloat kTopMargin = 5.0;
 
 static const CGFloat kClearButtonTouchTargetSideLength = 30.0;
 static const CGFloat kTextRectSidePadding = 12.0;
-//static const CGFloat kLeftRightViewSidePadding = 5.0;
+// static const CGFloat kLeftRightViewSidePadding = 5.0;
 
 static const CGFloat kUnderlineLabelsTopPadding = 8.0;
 static const CGFloat kTopRowSubviewVerticalPadding = 10.0;
@@ -52,15 +52,20 @@ typedef NS_ENUM(NSUInteger, TextFieldStyle) {
  */
 typedef NS_ENUM(NSUInteger, UnderlineLabelDrawPriority) {
   /**
-   When the priority is @c .leading, the @c leadingUnderlineLabel will be laid out first within the horizontal space available for @b both underline labels. Any remaining space will then be given for the @c trailingUnderlineLabel.
+   When the priority is @c .leading, the @c leadingUnderlineLabel will be laid out first within the
+   horizontal space available for @b both underline labels. Any remaining space will then be given
+   for the @c trailingUnderlineLabel.
    */
   UnderlineLabelDrawPriorityLeading,
   /**
-   When the priority is @c .trailing, the @c trailingUnderlineLabel will be laid out first within the horizontal space available for @b both underline labels. Any remaining space will then be given for the @c leadingUnderlineLabel.
+   When the priority is @c .trailing, the @c trailingUnderlineLabel will be laid out first within
+   the horizontal space available for @b both underline labels. Any remaining space will then be
+   given for the @c leadingUnderlineLabel.
    */
   UnderlineLabelDrawPriorityTrailing,
   /**
-   When the priority is @c .custom, the @c customUnderlineLabelDrawPriority property will be used to divide the space available for the two underline labels.
+   When the priority is @c .custom, the @c customUnderlineLabelDrawPriority property will be used to
+   divide the space available for the two underline labels.
    */
   UnderlineLabelDrawPriorityCustom,
 };
@@ -86,7 +91,5 @@ typedef NS_ENUM(NSUInteger, TextFieldState) {
   TextFieldStateErrored,
   TextFieldStateDisabled,
 };
-
-
 
 #endif /* SimpleTextFieldLayoutUtils_h */

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
@@ -1,10 +1,16 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
 //
-//  SimpleTextFieldLayoutUtils.h
-//  ComponentsProject
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Andrew Overton on 12/6/18.
-//  Copyright © 2018 andrewoverton. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #ifndef SimpleTextFieldLayoutUtils_h
 #define SimpleTextFieldLayoutUtils_h
@@ -16,14 +22,12 @@ static const CGFloat kTrailingMargin = 16.0;
 
 static const CGFloat kFilledTextFieldTopCornerRadius = 4.0;
 static const CGFloat kOutlinedTextFieldCornerRadius = 4.0;
-// static const CGFloat kFloatingPlaceholderTopMargin = 5.0;
 static const CGFloat kFloatingPlaceholderSideMargin = 5.0;
 static const CGFloat kFloatingPlaceholderXOffsetFromTextArea = 3.0;
 static const CGFloat kTopMargin = 5.0;
 
 static const CGFloat kClearButtonTouchTargetSideLength = 30.0;
 static const CGFloat kTextRectSidePadding = 12.0;
-// static const CGFloat kLeftRightViewSidePadding = 5.0;
 
 static const CGFloat kUnderlineLabelsTopPadding = 8.0;
 static const CGFloat kTopRowSubviewVerticalPadding = 10.0;
@@ -31,16 +35,8 @@ static const CGFloat kTopRowSubviewVerticalPadding = 10.0;
 static const UIControlState UIControlStateError = 1 << 10;
 
 /**
- Dictates the input style.
- */
-typedef NS_ENUM(NSUInteger, TextFieldMode) {
-  TextFieldModeNormal,
-  TextFieldModeInputChip,
-};
-
-/**
- Dictates what type of text field it will be from a cosmetic standpoint. The values are derived from
- the styles outlined in the Material Guidelines for Text Fields.
+ TextFieldStyle dictates what type of text field it will be from a cosmetic standpoint. The values
+ are derived from the styles outlined in the Material Guidelines for Text Fields.
  */
 typedef NS_ENUM(NSUInteger, TextFieldStyle) {
   TextFieldStyleFilled,

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
@@ -14,7 +14,6 @@ static const CGFloat kFloatingPlaceholderAnimationDuration = 0.15;
 static const CGFloat kLeadingMargin = 16.0;
 static const CGFloat kTrailingMargin = 16.0;
 
-static const CGFloat kFilledTextFieldUnderlineHeight = 3;
 static const CGFloat kFilledTextFieldTopCornerRadius = 4.0;
 static const CGFloat kOutlinedTextFieldCornerRadius = 4.0;
 //static const CGFloat kFloatingPlaceholderTopMargin = 5.0;

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
@@ -31,19 +31,13 @@ static const CGFloat kTopRowSubviewVerticalPadding = 10.0;
 
 static const UIControlState UIControlStateError = 1 << 10;
 
-
-
 /**
  Dictates the input style.
  */
 typedef NS_ENUM(NSUInteger, TextFieldMode) {
   TextFieldModeNormal,
   TextFieldModeInputChip,
-
-  
-  
 };
-
 
 /**
  Dictates what type of text field it will be from a cosmetic standpoint.
@@ -71,14 +65,28 @@ typedef NS_ENUM(NSUInteger, UnderlineLabelDrawPriority) {
   UnderlineLabelDrawPriorityCustom,
 };
 
+/**
+ This enum allows us to differentiate between traditional UITextField placeholders and the
+ "floating" style customary in Text Fields outlined in the Material guidelines.
+ */
 typedef NS_ENUM(NSUInteger, PlaceholderState) {
   PlaceholderStateNone,
   PlaceholderStateFloating,
   PlaceholderStateNormal,
 };
 
-//typedef NS_ENUM(NSUInteger, TextFieldState) {
-//  
-//}
+/**
+ A representation of Text Field state that is compatible with UIControlState as well as an
+ interpretation of the states outlined in the Material guidelines for Text Fields, which can be
+ found here: https://material.io/design/components/text-fields.html#outlined-text-field
+ */
+typedef NS_ENUM(NSUInteger, TextFieldState) {
+  TextFieldStateNormal,
+  TextFieldStateActivated,
+  TextFieldStateError,
+  TextFieldStateDisabled,
+};
+
+
 
 #endif /* SimpleTextFieldLayoutUtils_h */

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
@@ -17,8 +17,8 @@
 
 static const CGFloat kFloatingPlaceholderAnimationDuration = 0.15;
 
-static const CGFloat kLeadingMargin = 16.0;
-static const CGFloat kTrailingMargin = 16.0;
+static const CGFloat kLeadingMargin = 12.0;
+static const CGFloat kTrailingMargin = 12.0;
 
 static const CGFloat kFilledTextFieldTopCornerRadius = 4.0;
 static const CGFloat kOutlinedTextFieldCornerRadius = 4.0;

--- a/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
+++ b/components/TextFields/examples/experimental/supplemental/SimpleTextFieldLayoutUtils.h
@@ -40,7 +40,8 @@ typedef NS_ENUM(NSUInteger, TextFieldMode) {
 };
 
 /**
- Dictates what type of text field it will be from a cosmetic standpoint.
+ Dictates what type of text field it will be from a cosmetic standpoint. The values are derived from
+ the styles outlined in the Material Guidelines for Text Fields.
  */
 typedef NS_ENUM(NSUInteger, TextFieldStyle) {
   TextFieldStyleFilled,
@@ -77,13 +78,13 @@ typedef NS_ENUM(NSUInteger, PlaceholderState) {
 
 /**
  A representation of Text Field state that is compatible with UIControlState as well as an
- interpretation of the states outlined in the Material guidelines for Text Fields, which can be
- found here: https://material.io/design/components/text-fields.html#outlined-text-field
+ interpretation of the states outlined in the Material guidelines for Text Fields.
  */
 typedef NS_ENUM(NSUInteger, TextFieldState) {
   TextFieldStateNormal,
+  TextFieldStateFocused,
   TextFieldStateActivated,
-  TextFieldStateError,
+  TextFieldStateErrored,
   TextFieldStateDisabled,
 };
 

--- a/components/schemes/Color/src/MDCSemanticColorScheme.m
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.m
@@ -67,10 +67,10 @@ static CGFloat blendColorChannel(CGFloat value, CGFloat bValue, CGFloat alpha, C
   CGFloat bRed = 0.0, bGreen = 0.0, bBlue = 0.0, bAlpha = 0.0;
   [backgroundColor getRed:&bRed green:&bGreen blue:&bBlue alpha:&bAlpha];
 
-  return [UIColor colorWithRed:blendColorChannel(red, bRed, alpha, bAlpha)  //
+  return [UIColor colorWithRed:blendColorChannel(red, bRed, alpha, bAlpha)
                          green:blendColorChannel(green, bGreen, alpha, bAlpha)
                           blue:blendColorChannel(blue, bBlue, alpha, bAlpha)
-                         alpha:alpha + bAlpha * (1 - alpha)];
+                         alpha:alpha + bAlpha*(1 - alpha)];
 }
 
 #pragma mark - NSCopying

--- a/components/schemes/Color/src/MDCSemanticColorScheme.m
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.m
@@ -67,7 +67,7 @@ static CGFloat blendColorChannel(CGFloat value, CGFloat bValue, CGFloat alpha, C
   CGFloat bRed = 0.0, bGreen = 0.0, bBlue = 0.0, bAlpha = 0.0;
   [backgroundColor getRed:&bRed green:&bGreen blue:&bBlue alpha:&bAlpha];
 
-  return [UIColor colorWithRed:blendColorChannel(red, bRed, alpha, bAlpha)
+  return [UIColor colorWithRed:blendColorChannel(red, bRed, alpha, bAlpha)//
                          green:blendColorChannel(green, bGreen, alpha, bAlpha)
                           blue:blendColorChannel(blue, bBlue, alpha, bAlpha)
                          alpha:alpha + bAlpha*(1 - alpha)];

--- a/components/schemes/Color/src/MDCSemanticColorScheme.m
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.m
@@ -67,10 +67,10 @@ static CGFloat blendColorChannel(CGFloat value, CGFloat bValue, CGFloat alpha, C
   CGFloat bRed = 0.0, bGreen = 0.0, bBlue = 0.0, bAlpha = 0.0;
   [backgroundColor getRed:&bRed green:&bGreen blue:&bBlue alpha:&bAlpha];
 
-  return [UIColor colorWithRed:blendColorChannel(red, bRed, alpha, bAlpha)//
+  return [UIColor colorWithRed:blendColorChannel(red, bRed, alpha, bAlpha)  //
                          green:blendColorChannel(green, bGreen, alpha, bAlpha)
                           blue:blendColorChannel(blue, bBlue, alpha, bAlpha)
-                         alpha:alpha + bAlpha*(1 - alpha)];
+                         alpha:alpha + bAlpha * (1 - alpha)];
 }
 
 #pragma mark - NSCopying


### PR DESCRIPTION
This PR adds an experimental `UITextField` subclass called `SimpleTextField` and accompanying examples to the `MaterialComponentExamples` (i.e. not `MaterialComponents` or `MaterialComponentsAlpha`) pod.

The ultimate aim of this text field is to complement (not replace) `MDCTextField` by:
- Providing an alternative when ongoing and difficult to fix `MDCTextField` bugs are blockers for clients/potential clients.
- Providing an alternative for clients who prefer not to work with `MDCTextInputControllers` due to perceived overhead.
- Hopefully doing two things (being a simple or filled text field) very well, rather than trying to do the many things `MDCTextField` and its related classes do.

Things I'm still thinking about/working on:

- VoiceOver. I haven't thought about VoiceOver at all yet. It would be nice to be able to just do what super would do and append the underline labels' and side views' accessibilityLabels/Values to that.
- Should it have some kind of input chip functionality? I'd say this is doable, but would require some thinking.
- Text field density support - The spec mentions "high-density" text fields--this refers to text fields whose bounds fit more snugly around the text, etc. My best idea for achieving this involves a `CGFloat` property called `desiredMainContentHeight`. "Main content height" refers to the area of the text field that contains the text, left/right view, placeholder, clear button, etc. Basically everything but the underline labels. With this property set to 0 (the default) the text field layout would be determined as it is right now. If set to anything other than that, the layout calculation would use the assigned value for the main area height, rather than the value it calculates.
- The manual layout example has some scroll view weirdness that I haven't had time to really fix yet. Also, the Swift storyboard example is basically useless because I can't refer to `SimpleTextField`, an Objective-C class in the same module, from it. I haven't had time to figure this out yet.
- It would be cool if some of the properties supported IBDesignable. I don't know IBDesignable that well, but I think doing this might make it so that you could specify outlined or filled in the storyboard and not have to write any code to achieve either style.
- This isn't code related, but I want to move away from this "Utils" file. It's a catch-all for things that could be more thoughtfully structured. The file structure in general really needs some work.
- There are no tests!

Feel free to look at the examples! "Simple Text Field (Manual Layout)" is better than "Simple Text Field (Storyboard)" right now. 

Here's an LTR video:
![simple-text-field-ltr](https://user-images.githubusercontent.com/8020010/49957272-4beb4880-fed5-11e8-85f4-9ab8a79c0305.gif)

And an RTL video:
![simple-text-field-rtl](https://user-images.githubusercontent.com/8020010/49957270-4beb4880-fed5-11e8-8fc6-e4af04c5a74b.gif)
