### PR TITLE
[TextFields] Refactor test classes to use subclassing.

### DIFF
--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests.m
@@ -35,6 +35,7 @@
 
 - (void)setUp {
   [super setUp];
+
   // Uncomment below to recreate the golden images for all test methods. Add it to a test method to
   // update only that golden image.
   //  self.recordMode = YES;

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests.m
@@ -40,9 +40,6 @@
   //  self.recordMode = YES;
 
   self.textField.clearButtonMode = UITextFieldViewModeAlways;
-
-  self.textFieldController =
-      [[MDCTextInputControllerOutlined alloc] initWithTextInput:self.textField];
   self.textFieldController.characterCountViewMode = UITextFieldViewModeAlways;
   self.textFieldController.characterCountMax = 50;
 

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
@@ -31,7 +31,7 @@
   // Uncomment below to recreate the golden images for all test methods. Add it to a test method to
   // update only that golden image.
   //  self.recordMode = YES;
-  
+
   self.textField.clearButtonMode = UITextFieldViewModeAlways;
 
   MDCSemanticColorScheme *colorScheme =

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
@@ -31,6 +31,7 @@
   // Uncomment below to recreate the golden images for all test methods. Add it to a test method to
   // update only that golden image.
   //  self.recordMode = YES;
+  
   self.textField.clearButtonMode = UITextFieldViewModeAlways;
 
   MDCSemanticColorScheme *colorScheme =

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCTextFieldSnapshotTestCase.h"
+#import "MDCTextFieldOutlinedControllerSnapshotTests.h"
 #import "MDCTextFieldSnapshotTestsStrings.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
 #import "SnapshotFakeMDCTextField.h"
 
-@interface MDCTextFieldOutlinedControllerBaselineSnapshotTests : MDCTextFieldSnapshotTestCase
-@property(nonatomic, strong) MDCTextInputControllerOutlined *textFieldController;
+@interface MDCTextFieldOutlinedControllerBaselineSnapshotTests
+    : MDCTextFieldOutlinedControllerSnapshotTests
 @end
 
 @implementation MDCTextFieldOutlinedControllerBaselineSnapshotTests
@@ -31,11 +31,8 @@
   // Uncomment below to recreate the golden images for all test methods. Add it to a test method to
   // update only that golden image.
   //  self.recordMode = YES;
-
   self.textField.clearButtonMode = UITextFieldViewModeAlways;
 
-  self.textFieldController =
-      [[MDCTextInputControllerOutlined alloc] initWithTextInput:self.textField];
   MDCSemanticColorScheme *colorScheme =
       [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   MDCTypographyScheme *typographyScheme =
@@ -48,257 +45,6 @@
   [MDCTextFieldTypographyThemer applyTypographyScheme:typographyScheme toTextInput:self.textField];
 }
 
-- (void)tearDown {
-  self.textFieldController = nil;
-
-  [super tearDown];
-}
-
-#pragma mark - Tests
-
-- (void)testOutlinedTextFieldEmpty {
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldEmptyIsEditing {
-  // When
-  [self.textField MDCtest_setIsEditing:YES];
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-#pragma mark - Single field tests
-
-- (void)testOutlinedTextFieldWithShortPlaceholderText {
-  // When
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithShortPlaceholderTextIsEditing {
-  // When
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
-  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithLongPlaceholderText {
-  // When
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithLongPlaceholderTextIsEditing {
-  // When
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
-  [self.textField MDCtest_setIsEditing:YES];
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithShortHelperText {
-  // When
-  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithShortHelperTextIsEditing {
-  // When
-  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
-  [self.textField MDCtest_setIsEditing:YES];
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithLongHelperText {
-  // When
-  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithLongHelperTextIsEditing {
-  // When
-  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
-  [self.textField MDCtest_setIsEditing:YES];
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithShortErrorText {
-  // When
-  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
-                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithShortErrorTextIsEditing {
-  // When
-  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
-                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
-  [self.textField MDCtest_setIsEditing:YES];
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithLongErrorText {
-  // When
-  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
-                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithLongErrorTextIsEditing {
-  // When
-  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
-                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
-  [self.textField MDCtest_setIsEditing:YES];
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithShortInputText {
-  // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithShortInputTextIsEditing {
-  // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
-  [self.textField MDCtest_setIsEditing:YES];
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithLongInputText {
-  // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithLongInputTextIsEditing {
-  // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
-  [self.textField MDCtest_setIsEditing:YES];
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-#pragma mark - Multiple field tests
-
-- (void)testOutlinedTextFieldWithShortInputPlaceholderHelperTexts {
-  // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
-  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithShortInputPlaceholderHelperTextsIsEditing {
-  // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
-  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
-  [self.textField MDCtest_setIsEditing:YES];
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithLongInputPlaceholderHelperTexts {
-  // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
-  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithLongInputPlaceholderHelperTextsIsEditing {
-  // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
-  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
-  [self.textField MDCtest_setIsEditing:YES];
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithShortInputPlaceholderErrorTexts {
-  // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
-  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
-                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithShortInputPlaceholderErrorTextsIsEditing {
-  // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
-  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
-                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
-  [self.textField MDCtest_setIsEditing:YES];
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithLongInputPlaceholderErrorTexts {
-  // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
-  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
-                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
-
-- (void)testOutlinedTextFieldWithLongInputPlaceholderErrorTextsIsEditing {
-  // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
-  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
-                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
-  [self.textField MDCtest_setIsEditing:YES];
-
-  // Then
-  [self generateSnapshotAndVerify];
-}
+// NOTE: All actual test methods are defined in MDCTextFieldOutlinedControllerSnapshotTests.m
 
 @end

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderErrorTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderErrorTextsIsEditing_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b1c8c4ce857bfcb003c2ec81bec88dffd33f677b53543481aaa20f2f70478932
-size 27145
+oid sha256:b64b6097d98f8b0f08ad44e85a66e8619fdae2ec1907dd9edd4b7f7bbe08d636
+size 27800

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderErrorTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderErrorTexts_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a1465900061cd248811b72abaf3c091d0d5addc00cdd99edc95765f5e30b7947
-size 27137
+oid sha256:98b6e573ee999a20add8361d3ed272b41a99c446648ae92b83b068c5c90ee00b
+size 27821

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderHelperTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderHelperTextsIsEditing_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:67f12ebff80ce9240f0f3a21f146b00e53216b7125906d00ab3a190bd432d2fd
-size 27813
+oid sha256:dc4beca7da9037e3503adbe8fc82de771d5cebd764e8119ea9fb843de5f23706
+size 28468

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderHelperTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests/testOutlinedTextFieldWithLongInputPlaceholderHelperTexts_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:640d096cf89efd6a5eb3a45c68b3bdba3159ab2f2a109a7a348b73cd05f5c1ab
-size 27779
+oid sha256:2101cbb68269ce0e789be9a37988711e72cc55e926675fe3b8761999aec8b771
+size 28463

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests/testOutlinedTextFieldWithLongPlaceholderTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests/testOutlinedTextFieldWithLongPlaceholderTextIsEditing_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:33cd26e22f1c05fb8e768deae1d73bff865aa5600dd78007f2aab13d654ea753
-size 16507
+oid sha256:36c36a0dde13c4777f982adaf481839e0350bf4dd163062b3151cc2c32e2a73d
+size 17185

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortPlaceholderTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldOutlinedControllerBaselineSnapshotTests/testOutlinedTextFieldWithShortPlaceholderTextIsEditing_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:569bb6826bbcf769b1fa94a4a66d74a81d547bbd4278717308fadf6ff3f387e1
-size 9061
+oid sha256:7e13349505635b6cf21807060ff4237b36a430c789fc7382f7519c6ae89ac8e3
+size 6652


### PR DESCRIPTION
To help reduce the amount of code required to write Text Field snapshots, we
can subclass test case classes. This allows us to write variants in the
`-setUp` portion of the test case rather than in each test method.

Part of #5762