### PR TITLE
[TextFields] Refactor snapshot tests into abstract class.

### DIFF
--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.h
@@ -12,19 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <UIKit/UIKit.h>
-
-#import "MDCSnapshotFakeTextInput.h"
+#import "MDCTextFieldSnapshotTestCase.h"
 #import "MaterialTextFields.h"
 
-/**
- A test fake MDCMultilineTextField implementation for Snapshot testing.
- */
-@interface SnapshotFakeMDCMultilineTextField : MDCMultilineTextField <MDCSnapshotFakeTextInput>
-
-/**
- Overrides the value returned by `-isEditing`.
- */
-- (void)MDCtest_setIsEditing:(BOOL)isEditing;
+@interface MDCAbstractTextFieldSnapshotTests : MDCTextFieldSnapshotTestCase
+@property(nonatomic, strong) NSObject<MDCTextInputController> *textFieldController;
 
 @end

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.m
@@ -1,0 +1,392 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "MDCTextFieldSnapshotTestsStrings.h"
+
+@implementation MDCAbstractTextFieldSnapshotTests
+
+- (void)tearDown {
+  self.textFieldController = nil;
+
+  [super tearDown];
+}
+
+#pragma mark - Helpers
+
+- (BOOL)shouldTestExecute {
+  // This class should not actually execute any tests.
+  if ([self class] == [MDCAbstractTextFieldSnapshotTests class]) {
+    return NO;
+  }
+
+  // Always require that `textField` and `textFieldController` are non-nil before starting the test.
+  XCTAssertNotNil(self.textField);
+  XCTAssertNotNil(self.textFieldController);
+
+  return YES;
+}
+
+#pragma mark - Tests
+
+- (void)testTextFieldEmpty {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldEmptyIsEditing {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+#pragma mark - Single field tests
+
+- (void)testTextFieldWithShortPlaceholderText {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithShortPlaceholderTextIsEditing {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithLongPlaceholderText {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithLongPlaceholderTextIsEditing {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithShortHelperText {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithShortHelperTextIsEditing {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithLongHelperText {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithLongHelperTextIsEditing {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithShortErrorText {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithShortErrorTextIsEditing {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithLongErrorText {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithLongErrorTextIsEditing {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithShortInputText {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithShortInputTextIsEditing {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithLongInputText {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithLongInputTextIsEditing {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+#pragma mark - Multiple field tests
+
+- (void)testTextFieldWithShortInputPlaceholderHelperTexts {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithShortInputPlaceholderHelperTextsIsEditing {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithLongInputPlaceholderHelperTexts {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithLongInputPlaceholderHelperTextsIsEditing {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithShortInputPlaceholderErrorTexts {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithShortInputPlaceholderErrorTextsIsEditing {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithLongInputPlaceholderErrorTexts {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+- (void)testTextFieldWithLongInputPlaceholderErrorTextsIsEditing {
+  if (![self shouldTestExecute]) {
+    return;
+  }
+
+  // When
+  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
+                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+  [self.textField MDCtest_setIsEditing:YES];
+
+  // Then
+  [self generateSnapshotAndVerify];
+}
+
+@end

--- a/components/TextFields/tests/snapshot/supplemental/MDCSnapshotFakeTextInput.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCSnapshotFakeTextInput.h
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
-#import "MDCSnapshotFakeTextInput.h"
 #import "MaterialTextFields.h"
 
 /**
- A test fake MDCMultilineTextField implementation for Snapshot testing.
+ Protocol for snapshot testing fakes used in Material Text Fields tests.
  */
-@interface SnapshotFakeMDCMultilineTextField : MDCMultilineTextField <MDCSnapshotFakeTextInput>
+@protocol MDCSnapshotFakeTextInput <MDCTextInput>
 
 /**
  Overrides the value returned by `-isEditing`.

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.h
@@ -24,7 +24,7 @@
  */
 @interface MDCTextFieldSnapshotTestCase : MDCSnapshotTestCase
 
-@property(nonatomic, strong) SnapshotFakeMDCTextField *textField;
+@property(nonatomic, strong) UIView<MDCTextInput, MDCSnapshotFakeTextInput> *textField;
 
 /**
  Attempts to update the text field's layout to how it would appear within a view hierarchy on a

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.h
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.h
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MaterialTextFields.h"
-
 #import <UIKit/UIKit.h>
+
+#import "MDCSnapshotFakeTextInput.h"
+#import "MaterialTextFields.h"
 
 /**
  A test fake MDCTextField implementation for Snapshot testing.
  */
-@interface SnapshotFakeMDCTextField : MDCTextField
+@interface SnapshotFakeMDCTextField : MDCTextField <MDCSnapshotFakeTextInput>
 
 /**
  Overrides the value returned by `-isEditing`.


### PR DESCRIPTION
To avoid having to duplicate test methods across different input controllers
(e.g., outlined or full-width) and text field types (e.g., single- or
multi-line), we can move the actual test logic into an abstract class that
only needs to know about the text properties to be set on the controller or
text input.

Part of #5762
