### PR TITLE
[NavigationDrawer] Attempt to fix header shadow not being removed

### DIFF
--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -191,6 +191,9 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
 
 - (void)dismissalTransitionDidEnd:(BOOL)completed {
   if (completed) {
+    if ([self.presentedViewController isKindOfClass:[MDCBottomDrawerViewController class]]) {
+      [self.bottomDrawerContainerViewController removeFromParentViewController];
+    }
     [self.scrimView removeFromSuperview];
     [self.topHandle removeFromSuperview];
   }

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -191,9 +191,6 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
 
 - (void)dismissalTransitionDidEnd:(BOOL)completed {
   if (completed) {
-    if ([self.presentedViewController isKindOfClass:[MDCBottomDrawerViewController class]]) {
-      [self.bottomDrawerContainerViewController removeFromParentViewController];
-    }
     [self.scrimView removeFromSuperview];
     [self.topHandle removeFromSuperview];
   }

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -495,6 +495,10 @@ static UIColor *DrawerShadowColor(void) {
 - (void)viewDidDisappear:(BOOL)animated {
   [super viewDidDisappear:animated];
 
+  [self willMoveToParentViewController:nil];
+  [self.view removeFromSuperview];
+  [self removeFromParentViewController];
+
   [self removeScrollViewObserver];
   [self.headerShadowLayer removeFromSuperlayer];
   self.headerShadowLayer = nil;

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -177,11 +177,9 @@ static UIColor *DrawerShadowColor(void) {
 }
 
 - (void)dealloc {
-  [self willMoveToParentViewController:nil];
-  [self.view removeFromSuperview];
-  [self removeFromParentViewController];
-
   [self removeScrollViewObserver];
+  [self.headerShadowLayer removeFromSuperlayer];
+  self.headerShadowLayer = nil;
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
@@ -494,14 +492,6 @@ static UIColor *DrawerShadowColor(void) {
   [self setupLayout];
   [self.headerViewController.view.superview bringSubviewToFront:self.headerViewController.view];
   [self updateViewWithContentOffset:self.scrollView.contentOffset];
-}
-
-- (void)viewDidDisappear:(BOOL)animated {
-  [super viewDidDisappear:animated];
-
-  [self removeScrollViewObserver];
-  [self.headerShadowLayer removeFromSuperlayer];
-  self.headerShadowLayer = nil;
 }
 
 - (void)preferredContentSizeDidChangeForChildContentContainer:(id<UIContentContainer>)container {

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -177,6 +177,10 @@ static UIColor *DrawerShadowColor(void) {
 }
 
 - (void)dealloc {
+  [self willMoveToParentViewController:nil];
+  [self.view removeFromSuperview];
+  [self removeFromParentViewController];
+
   [self removeScrollViewObserver];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
@@ -494,10 +498,6 @@ static UIColor *DrawerShadowColor(void) {
 
 - (void)viewDidDisappear:(BOOL)animated {
   [super viewDidDisappear:animated];
-
-  [self willMoveToParentViewController:nil];
-  [self.view removeFromSuperview];
-  [self removeFromParentViewController];
 
   [self removeScrollViewObserver];
   [self.headerShadowLayer removeFromSuperlayer];

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -494,6 +494,11 @@ static UIColor *DrawerShadowColor(void) {
   [self updateViewWithContentOffset:self.scrollView.contentOffset];
 }
 
+- (void)viewDidDisappear:(BOOL)animated {
+  [super viewDidDisappear:animated];
+  [self removeScrollViewObserver];
+}
+
 - (void)preferredContentSizeDidChangeForChildContentContainer:(id<UIContentContainer>)container {
   [super preferredContentSizeDidChangeForChildContentContainer:container];
   if ([container isKindOfClass:[UIViewController class]]) {


### PR DESCRIPTION
This pull request attempts to fix an issue where in some cases, the Navigation Drawer can be dismissed, but the header shadow will not be removed from the super layer. The cause of this is because the bottomDrawerContainerViewController in MDCBottomDrawerPresentationController is removed before the completeTransition in MDCBottomDrawerTransitionController (which triggers viewDidDisappear in MDCBottomDrawerContainerViewController).

Internal issue: b/120989705
Closes: #6011 

### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [ ] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [ ] Link to GitHub issues it solves. ```closes #1234```
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
pull request.
