### PR TITLE
[TextFields] Incomplete snapshot RTL/Arabic support

### DIFF
--- a/MaterialComponentsSnapshotTests.podspec
+++ b/MaterialComponentsSnapshotTests.podspec
@@ -33,6 +33,7 @@ Pod::Spec.new do |s|
         snapshot_tests.source_files = "components/#{component.base_name}/tests/snapshot/*.{h,m,swift}", "components/#{component.base_name}/tests/snapshot/supplemental/*.{h,m,swift}"
         snapshot_tests.resources = "components/#{component.base_name}/tests/snapshot/resources/*"
         snapshot_tests.dependency "MaterialComponentsSnapshotTests/private/Snapshot"
+        snapshot_tests.dependency "MDFInternationalization"
       end
     end
   end

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h
@@ -1,0 +1,23 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCAbstractTextFieldSnapshotTests.h"
+
+@interface MDCAbstractTextFieldSnapshotTests (I18N)
+
+- (void)changeStringsToArabic;
+
+- (void)changeLayoutToRTL;
+
+@end

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.m
@@ -31,6 +31,8 @@
   self.longErrorText = MDCTextFieldSnapshotTestsErrorLongTextArabic;
 }
 
+// TODO(https://github.com/material-components/material-components-ios/issues/6022 ): Get Arabic
+// input text to be on the right side. Get placeholder text to move to the right side.
 - (void)changeLayoutToRTL {
   // Setting semanticContentAttribute results in a call to effectiveUserInterfaceLayoutDirection, so
   // make sure we set it first.

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.m
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #import <UIKit/UIKit.h>
+#import <MDFInternationalization/MDFInternationalization.h>
 
 #import "MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "MDCTextFieldSnapshotTestsStrings.h"
-#import <MDFInternationalization/MDFInternationalization.h>
 
 @implementation MDCAbstractTextFieldSnapshotTests (I18N)
 
@@ -35,7 +35,7 @@
   // Setting semanticContentAttribute results in a call to effectiveUserInterfaceLayoutDirection, so
   // make sure we set it first.
   [self.textField
-       MDCtest_setEffectiveUserInterfaceLayoutDirection:UIUserInterfaceLayoutDirectionRightToLeft];
+      MDCtest_setEffectiveUserInterfaceLayoutDirection:UIUserInterfaceLayoutDirectionRightToLeft];
   
   // UISemanticContentAttribute was added in iOS SDK 9.0 but is available on devices running earlier
   // version of iOS. We ignore the partial-availability warning that gets thrown on our use of this

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <UIKit/UIKit.h>
 #import <MDFInternationalization/MDFInternationalization.h>
+#import <UIKit/UIKit.h>
 
 #import "MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "MDCTextFieldSnapshotTestsStrings.h"

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.m
@@ -38,7 +38,7 @@
   // make sure we set it first.
   [self.textField
       MDCtest_setEffectiveUserInterfaceLayoutDirection:UIUserInterfaceLayoutDirectionRightToLeft];
-  
+
   // UISemanticContentAttribute was added in iOS SDK 9.0 but is available on devices running earlier
   // version of iOS. We ignore the partial-availability warning that gets thrown on our use of this
   // symbol.

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.m
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <UIKit/UIKit.h>
+
 #import "MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "MDCTextFieldSnapshotTestsStrings.h"
 #import <MDFInternationalization/MDFInternationalization.h>
@@ -29,14 +31,19 @@
   self.longErrorText = MDCTextFieldSnapshotTestsErrorLongTextArabic;
 }
 
-// UISemanticContentAttribute was added in iOS SDK 9.0 but is available on devices running earlier
-// version of iOS. We ignore the partial-availability warning that gets thrown on our use of this
-// symbol.
+- (void)changeLayoutToRTL {
+  // Setting semanticContentAttribute results in a call to effectiveUserInterfaceLayoutDirection, so
+  // make sure we set it first.
+  [self.textField
+       MDCtest_setEffectiveUserInterfaceLayoutDirection:UIUserInterfaceLayoutDirectionRightToLeft];
+  
+  // UISemanticContentAttribute was added in iOS SDK 9.0 but is available on devices running earlier
+  // version of iOS. We ignore the partial-availability warning that gets thrown on our use of this
+  // symbol.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
-- (void)changeLayoutToRTL {
-  self.textField.mdf_semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-}
+  self.textField.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
 #pragma clang diagnostic pop
+}
 
 @end

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.m
@@ -1,0 +1,42 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "MDCTextFieldSnapshotTestsStrings.h"
+#import <MDFInternationalization/MDFInternationalization.h>
+
+@implementation MDCAbstractTextFieldSnapshotTests (I18N)
+
+- (void)changeStringsToArabic {
+  self.shortInputText = MDCTextFieldSnapshotTestsInputShortTextArabic;
+  self.longInputText = MDCTextFieldSnapshotTestsInputLongTextArabic;
+  self.shortPlaceholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextArabic;
+  self.longPlaceholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextArabic;
+  self.shortHelperText = MDCTextFieldSnapshotTestsHelperShortTextArabic;
+  self.longHelperText = MDCTextFieldSnapshotTestsHelperLongTextArabic;
+  self.shortErrorText = MDCTextFieldSnapshotTestsErrorShortTextArabic;
+  self.longErrorText = MDCTextFieldSnapshotTestsErrorLongTextArabic;
+}
+
+// UISemanticContentAttribute was added in iOS SDK 9.0 but is available on devices running earlier
+// version of iOS. We ignore the partial-availability warning that gets thrown on our use of this
+// symbol.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+- (void)changeLayoutToRTL {
+  self.textField.mdf_semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
+}
+#pragma clang diagnostic pop
+
+@end

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.h
@@ -16,6 +16,58 @@
 #import "MaterialTextFields.h"
 
 @interface MDCAbstractTextFieldSnapshotTests : MDCTextFieldSnapshotTestCase
+
+/**
+ The text input controller used during testing.
+ */
 @property(nonatomic, strong) NSObject<MDCTextInputController> *textFieldController;
+
+/**
+ A short input text string. When rendered, it should be significantly shorter than the width of the
+ text field.
+ */
+@property(nonatomic, copy) NSString *shortInputText;
+
+/**
+ A long input text string. When rendered, it should be significantly longer than the width of the
+ text field.
+ */
+@property(nonatomic, copy) NSString *longInputText;
+
+/**
+ A short placeholder string. When rendered, it should be significantly shorter than the width of the
+ text field.
+ */
+@property(nonatomic, copy) NSString *shortPlaceholderText;
+
+/**
+ A long placeholder string. When rendered, it should be significantly longer than the width of the
+ text field.
+ */
+@property(nonatomic, copy) NSString *longPlaceholderText;
+
+/**
+ A short helper string. When rendered, it should be significantly shorter than the width of the text
+ field.
+ */
+@property(nonatomic, copy) NSString *shortHelperText;
+
+/**
+ A long helper string. When rendered, it should be significantly longer than the width of the text
+ field.
+ */
+@property(nonatomic, copy) NSString *longHelperText;
+
+/**
+ A short error string. When rendered, it should be significantly shorter than the width of the text
+ field.
+ */
+@property(nonatomic, copy) NSString *shortErrorText;
+
+/**
+ A long error string. When rendered, it should be significantly longer than the width of the text
+ field.
+ */
+@property(nonatomic, copy) NSString *longErrorText;
 
 @end

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.m
@@ -17,6 +17,20 @@
 
 @implementation MDCAbstractTextFieldSnapshotTests
 
+- (void)setUp {
+  [super setUp];
+
+  // Default to Latin strings
+  self.shortInputText = MDCTextFieldSnapshotTestsInputShortTextLatin;
+  self.longInputText = MDCTextFieldSnapshotTestsInputLongTextLatin;
+  self.shortPlaceholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+  self.longPlaceholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+  self.shortHelperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
+  self.longHelperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+  self.shortErrorText = MDCTextFieldSnapshotTestsErrorShortTextLatin;
+  self.longErrorText = MDCTextFieldSnapshotTestsErrorLongTextLatin;
+}
+
 - (void)tearDown {
   self.textFieldController = nil;
 
@@ -69,7 +83,7 @@
   }
 
   // When
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+  self.textFieldController.placeholderText = self.shortPlaceholderText;
 
   // Then
   [self generateSnapshotAndVerify];
@@ -81,7 +95,7 @@
   }
 
   // When
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
+  self.textFieldController.placeholderText = self.shortPlaceholderText;
   [self.textField MDCtest_setIsEditing:YES];
 
   // Then
@@ -94,7 +108,7 @@
   }
 
   // When
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+  self.textFieldController.placeholderText = self.longPlaceholderText;
 
   // Then
   [self generateSnapshotAndVerify];
@@ -106,7 +120,7 @@
   }
 
   // When
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
+  self.textFieldController.placeholderText = self.longPlaceholderText;
   [self.textField MDCtest_setIsEditing:YES];
 
   // Then
@@ -119,7 +133,7 @@
   }
 
   // When
-  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
+  self.textFieldController.helperText = self.shortHelperText;
 
   // Then
   [self generateSnapshotAndVerify];
@@ -131,7 +145,7 @@
   }
 
   // When
-  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
+  self.textFieldController.helperText = self.shortHelperText;
   [self.textField MDCtest_setIsEditing:YES];
 
   // Then
@@ -144,7 +158,7 @@
   }
 
   // When
-  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+  self.textFieldController.helperText = self.longHelperText;
 
   // Then
   [self generateSnapshotAndVerify];
@@ -156,7 +170,7 @@
   }
 
   // When
-  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+  self.textFieldController.helperText = self.longHelperText;
   [self.textField MDCtest_setIsEditing:YES];
 
   // Then
@@ -169,8 +183,8 @@
   }
 
   // When
-  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
-                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
+  [self.textFieldController setErrorText:self.shortErrorText
+                 errorAccessibilityValue:self.shortErrorText];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -182,8 +196,8 @@
   }
 
   // When
-  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
-                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
+  [self.textFieldController setErrorText:self.shortErrorText
+                 errorAccessibilityValue:self.shortErrorText];
   [self.textField MDCtest_setIsEditing:YES];
 
   // Then
@@ -196,8 +210,8 @@
   }
 
   // When
-  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
-                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+  [self.textFieldController setErrorText:self.longErrorText
+                 errorAccessibilityValue:self.longErrorText];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -209,8 +223,8 @@
   }
 
   // When
-  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
-                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+  [self.textFieldController setErrorText:self.longErrorText
+                 errorAccessibilityValue:self.longErrorText];
   [self.textField MDCtest_setIsEditing:YES];
 
   // Then
@@ -223,7 +237,7 @@
   }
 
   // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+  self.textField.text = self.shortInputText;
 
   // Then
   [self generateSnapshotAndVerify];
@@ -235,7 +249,7 @@
   }
 
   // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
+  self.textField.text = self.shortInputText;
   [self.textField MDCtest_setIsEditing:YES];
 
   // Then
@@ -248,7 +262,7 @@
   }
 
   // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+  self.textField.text = self.longInputText;
 
   // Then
   [self generateSnapshotAndVerify];
@@ -260,7 +274,7 @@
   }
 
   // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
+  self.textField.text = self.longInputText;
   [self.textField MDCtest_setIsEditing:YES];
 
   // Then
@@ -275,9 +289,9 @@
   }
 
   // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
-  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
+  self.textField.text = self.shortInputText;
+  self.textFieldController.placeholderText = self.shortPlaceholderText;
+  self.textFieldController.helperText = self.shortHelperText;
 
   // Then
   [self generateSnapshotAndVerify];
@@ -289,9 +303,9 @@
   }
 
   // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
-  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
+  self.textField.text = self.shortInputText;
+  self.textFieldController.placeholderText = self.shortPlaceholderText;
+  self.textFieldController.helperText = self.shortHelperText;
   [self.textField MDCtest_setIsEditing:YES];
 
   // Then
@@ -304,9 +318,9 @@
   }
 
   // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
-  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+  self.textField.text = self.longInputText;
+  self.textFieldController.placeholderText = self.longPlaceholderText;
+  self.textFieldController.helperText = self.longHelperText;
 
   // Then
   [self generateSnapshotAndVerify];
@@ -318,9 +332,9 @@
   }
 
   // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
-  self.textFieldController.helperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
+  self.textField.text = self.longInputText;
+  self.textFieldController.placeholderText = self.longPlaceholderText;
+  self.textFieldController.helperText = self.longHelperText;
   [self.textField MDCtest_setIsEditing:YES];
 
   // Then
@@ -333,10 +347,10 @@
   }
 
   // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
-  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
-                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
+  self.textField.text = self.shortInputText;
+  self.textFieldController.placeholderText = self.shortPlaceholderText;
+  [self.textFieldController setErrorText:self.shortErrorText
+                 errorAccessibilityValue:self.shortErrorText];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -348,10 +362,10 @@
   }
 
   // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputShortTextLatin;
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
-  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorShortTextLatin
-                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorShortTextLatin];
+  self.textField.text = self.shortInputText;
+  self.textFieldController.placeholderText = self.shortPlaceholderText;
+  [self.textFieldController setErrorText:self.shortErrorText
+                 errorAccessibilityValue:self.shortErrorText];
   [self.textField MDCtest_setIsEditing:YES];
 
   // Then
@@ -364,10 +378,10 @@
   }
 
   // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
-  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
-                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+  self.textField.text = self.longInputText;
+  self.textFieldController.placeholderText = self.longPlaceholderText;
+  [self.textFieldController setErrorText:self.longErrorText
+                 errorAccessibilityValue:self.longErrorText];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -379,10 +393,10 @@
   }
 
   // When
-  self.textField.text = MDCTextFieldSnapshotTestsInputLongTextLatin;
-  self.textFieldController.placeholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
-  [self.textFieldController setErrorText:MDCTextFieldSnapshotTestsErrorLongTextLatin
-                 errorAccessibilityValue:MDCTextFieldSnapshotTestsErrorLongTextLatin];
+  self.textField.text = self.longInputText;
+  self.textFieldController.placeholderText = self.longPlaceholderText;
+  [self.textFieldController setErrorText:self.longErrorText
+                 errorAccessibilityValue:self.longErrorText];
   [self.textField MDCtest_setIsEditing:YES];
 
   // Then

--- a/components/TextFields/tests/snapshot/supplemental/MDCSnapshotFakeTextInput.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCSnapshotFakeTextInput.h
@@ -26,4 +26,9 @@
  */
 - (void)MDCtest_setIsEditing:(BOOL)isEditing;
 
+/**
+ Overrides the value returned by @c effectiveUserInterfaceLayoutDirection.
+ */
+- (void)MDCtest_setEffectiveUserInterfaceLayoutDirection:(UIUserInterfaceLayoutDirection)direction;
+
 @end

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.h
@@ -24,7 +24,7 @@
  */
 @interface MDCTextFieldSnapshotTestCase : MDCSnapshotTestCase
 
-@property(nonatomic, strong) UIView<MDCTextInput, MDCSnapshotFakeTextInput> *textField;
+@property(nonatomic, strong) UIView<UITextInput, MDCTextInput, MDCSnapshotFakeTextInput> *textField;
 
 /**
  Attempts to update the text field's layout to how it would appear within a view hierarchy on a

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestsStrings.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestsStrings.h
@@ -29,15 +29,15 @@ static NSString *const MDCTextFieldSnapshotTestsInputLongTextLatin =
 
 #pragma mark - Arabic text
 
-static NSString *const MDCTextFieldSnapshotTestsPlaceholderShortTextArabic = @"P text";
+static NSString *const MDCTextFieldSnapshotTestsPlaceholderShortTextArabic = @"تلك أي.";
 static NSString *const MDCTextFieldSnapshotTestsPlaceholderLongTextArabic =
     @"بـ أخر جسيمة نتيجة بالرّغم, إذ لهيمنة بالولايات غير, أي ذلك بخطوط ليبين العظمى. في لان.";
-static NSString *const MDCTextFieldSnapshotTestsHelperShortTextArabic = @"H text";
+static NSString *const MDCTextFieldSnapshotTestsHelperShortTextArabic = @"العظمى الخطّة.";
 static NSString *const MDCTextFieldSnapshotTestsHelperLongTextArabic =
     @"أن حلّت أعمال وقد, انه ان قادة سبتمبر حاملات, عدد قد وعلى الأثناء،. ما حتى مكّن.";
-static NSString *const MDCTextFieldSnapshotTestsErrorShortTextArabic = @"E text";
+static NSString *const MDCTextFieldSnapshotTestsErrorShortTextArabic = @"على الطرفين.";
 static NSString *const MDCTextFieldSnapshotTestsErrorLongTextArabic =
     @"أسر وتنامت الإتفاقية بـ, قد منتصف التنازلي عدد. الى و أطراف الصين. علاقة مساعدة تلك ما.";
-static NSString *const MDCTextFieldSnapshotTestsInputShortTextArabic = @"I text";
+static NSString *const MDCTextFieldSnapshotTestsInputShortTextArabic = @"ذلك في.";
 static NSString *const MDCTextFieldSnapshotTestsInputLongTextArabic =
     @"إيو التخطيط استمرار اليابان، من. دار خلاف للمجهود تم. يتم من لأداء ومطالبة, كل الهجوم مسؤولية.";

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestsStrings.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestsStrings.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma mark - Latin text
+
 static NSString *const MDCTextFieldSnapshotTestsPlaceholderShortTextLatin = @"P text";
 static NSString *const MDCTextFieldSnapshotTestsPlaceholderLongTextLatin =
     @"Placeholder text placeholder text placeholder text placeholder text placeholder text.";
@@ -24,3 +26,18 @@ static NSString *const MDCTextFieldSnapshotTestsErrorLongTextLatin =
 static NSString *const MDCTextFieldSnapshotTestsInputShortTextLatin = @"I text";
 static NSString *const MDCTextFieldSnapshotTestsInputLongTextLatin =
     @"Input text input text input text input text input text input text input text input text.";
+
+#pragma mark - Arabic text
+
+static NSString *const MDCTextFieldSnapshotTestsPlaceholderShortTextArabic = @"P text";
+static NSString *const MDCTextFieldSnapshotTestsPlaceholderLongTextArabic =
+    @"بـ أخر جسيمة نتيجة بالرّغم, إذ لهيمنة بالولايات غير, أي ذلك بخطوط ليبين العظمى. في لان.";
+static NSString *const MDCTextFieldSnapshotTestsHelperShortTextArabic = @"H text";
+static NSString *const MDCTextFieldSnapshotTestsHelperLongTextArabic =
+    @"أن حلّت أعمال وقد, انه ان قادة سبتمبر حاملات, عدد قد وعلى الأثناء،. ما حتى مكّن.";
+static NSString *const MDCTextFieldSnapshotTestsErrorShortTextArabic = @"E text";
+static NSString *const MDCTextFieldSnapshotTestsErrorLongTextArabic =
+    @"أسر وتنامت الإتفاقية بـ, قد منتصف التنازلي عدد. الى و أطراف الصين. علاقة مساعدة تلك ما.";
+static NSString *const MDCTextFieldSnapshotTestsInputShortTextArabic = @"I text";
+static NSString *const MDCTextFieldSnapshotTestsInputLongTextArabic =
+    @"إيو التخطيط استمرار اليابان، من. دار خلاف للمجهود تم. يتم من لأداء ومطالبة, كل الهجوم مسؤولية.";

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestsStrings.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestsStrings.h
@@ -40,4 +40,4 @@ static NSString *const MDCTextFieldSnapshotTestsErrorLongTextArabic =
     @"أسر وتنامت الإتفاقية بـ, قد منتصف التنازلي عدد. الى و أطراف الصين. علاقة مساعدة تلك ما.";
 static NSString *const MDCTextFieldSnapshotTestsInputShortTextArabic = @"ذلك في.";
 static NSString *const MDCTextFieldSnapshotTestsInputLongTextArabic =
-    @"إيو التخطيط استمرار اليابان، من. دار خلاف للمجهود تم. يتم من لأداء ومطالبة, كل الهجوم مسؤولية.";
+    @"دول السيطرة استطاعوا ٣٠. مليون وفرنسا أوراقهم انه تم, نفس قد والديون العالمية. دون ما تنفّس.";

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCMultilineTextField.m
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCMultilineTextField.m
@@ -13,10 +13,13 @@
 // limitations under the License.
 
 #import "SnapshotFakeMDCMultilineTextField.h"
+#import <MDFInternationalization/MDFInternationalization.h>
 
 @implementation SnapshotFakeMDCMultilineTextField {
   BOOL _isEditing;
   BOOL _isEditingOverridden;
+  BOOL _effectiveUserInterfaceLayoutDirection;
+  BOOL _isEffectiveUserInterfaceLayoutDirectionOverridden;
 }
 
 - (BOOL)isEditing {
@@ -45,6 +48,19 @@
         postNotificationName:UITextFieldTextDidEndEditingNotification
                       object:self];
   }
+}
+
+- (UIUserInterfaceLayoutDirection)effectiveUserInterfaceLayoutDirection {
+  if (_isEffectiveUserInterfaceLayoutDirectionOverridden) {
+    return _effectiveUserInterfaceLayoutDirection;
+  }
+  return [self mdf_effectiveUserInterfaceLayoutDirection];
+}
+
+- (void)MDCtest_setMDFEffectiveUserInterfaceLayoutDirection:
+    (UIUserInterfaceLayoutDirection)direction {
+  _isEffectiveUserInterfaceLayoutDirectionOverridden = YES;
+  _effectiveUserInterfaceLayoutDirection = direction;
 }
 
 @end

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCMultilineTextField.m
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCMultilineTextField.m
@@ -18,7 +18,7 @@
 @implementation SnapshotFakeMDCMultilineTextField {
   BOOL _isEditing;
   BOOL _isEditingOverridden;
-  BOOL _effectiveUserInterfaceLayoutDirection;
+  UIUserInterfaceLayoutDirection _effectiveUserInterfaceLayoutDirection;
   BOOL _isEffectiveUserInterfaceLayoutDirectionOverridden;
 }
 
@@ -57,7 +57,7 @@
   return [self mdf_effectiveUserInterfaceLayoutDirection];
 }
 
-- (void)MDCtest_setMDFEffectiveUserInterfaceLayoutDirection:
+- (void)MDCtest_setEffectiveUserInterfaceLayoutDirection:
     (UIUserInterfaceLayoutDirection)direction {
   _isEffectiveUserInterfaceLayoutDirectionOverridden = YES;
   _effectiveUserInterfaceLayoutDirection = direction;

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCMultilineTextField.m
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCMultilineTextField.m
@@ -54,7 +54,10 @@
   if (_isEffectiveUserInterfaceLayoutDirectionOverridden) {
     return _effectiveUserInterfaceLayoutDirection;
   }
-  return [self mdf_effectiveUserInterfaceLayoutDirection];
+  if (@available(iOS 10.0, *)) {
+    return [super effectiveUserInterfaceLayoutDirection];
+  }
+  return UIApplication.sharedApplication.userInterfaceLayoutDirection;
 }
 
 - (void)MDCtest_setEffectiveUserInterfaceLayoutDirection:(UIUserInterfaceLayoutDirection)direction {

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCMultilineTextField.m
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCMultilineTextField.m
@@ -57,8 +57,7 @@
   return [self mdf_effectiveUserInterfaceLayoutDirection];
 }
 
-- (void)MDCtest_setEffectiveUserInterfaceLayoutDirection:
-    (UIUserInterfaceLayoutDirection)direction {
+- (void)MDCtest_setEffectiveUserInterfaceLayoutDirection:(UIUserInterfaceLayoutDirection)direction {
   _isEffectiveUserInterfaceLayoutDirectionOverridden = YES;
   _effectiveUserInterfaceLayoutDirection = direction;
 }

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.m
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.m
@@ -13,10 +13,13 @@
 // limitations under the License.
 
 #import "SnapshotFakeMDCTextField.h"
+#import <MDFInternationalization/MDFInternationalization.h>
 
 @implementation SnapshotFakeMDCTextField {
   BOOL _isEditing;
   BOOL _isEditingOverridden;
+  UIUserInterfaceLayoutDirection _effectiveUserInterfaceLayoutDirection;
+  BOOL _isEffectiveUserInterfaceLayoutDirectionOverridden;
 }
 
 - (BOOL)isEditing {
@@ -45,6 +48,19 @@
         postNotificationName:UITextFieldTextDidEndEditingNotification
                       object:self];
   }
+}
+
+- (UIUserInterfaceLayoutDirection)effectiveUserInterfaceLayoutDirection {
+  if (_isEffectiveUserInterfaceLayoutDirectionOverridden) {
+    return _effectiveUserInterfaceLayoutDirection;
+  }
+  return [self mdf_effectiveUserInterfaceLayoutDirection];
+}
+
+- (void)MDCtest_setEffectiveUserInterfaceLayoutDirection:
+    (UIUserInterfaceLayoutDirection)direction {
+  _isEffectiveUserInterfaceLayoutDirectionOverridden = YES;
+  _effectiveUserInterfaceLayoutDirection = direction;
 }
 
 @end

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.m
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.m
@@ -54,7 +54,11 @@
   if (_isEffectiveUserInterfaceLayoutDirectionOverridden) {
     return _effectiveUserInterfaceLayoutDirection;
   }
-  return [self mdf_effectiveUserInterfaceLayoutDirection];
+
+  if (@available(iOS 10.0, *)) {
+    return [super effectiveUserInterfaceLayoutDirection];
+  }
+  return UIApplication.sharedApplication.userInterfaceLayoutDirection;
 }
 
 - (void)MDCtest_setEffectiveUserInterfaceLayoutDirection:(UIUserInterfaceLayoutDirection)direction {

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.m
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.m
@@ -57,8 +57,7 @@
   return [self mdf_effectiveUserInterfaceLayoutDirection];
 }
 
-- (void)MDCtest_setEffectiveUserInterfaceLayoutDirection:
-    (UIUserInterfaceLayoutDirection)direction {
+- (void)MDCtest_setEffectiveUserInterfaceLayoutDirection:(UIUserInterfaceLayoutDirection)direction {
   _isEffectiveUserInterfaceLayoutDirectionOverridden = YES;
   _effectiveUserInterfaceLayoutDirection = direction;
 }


### PR DESCRIPTION
Adding RTL layout with Arabic text would be helpful for Text Fields
snapshot tests to ensure we don't break RTL layouts. While this change
paves the way for a scalable way to introduce RTL test classes, it does
not correctly trigger layouts for RTL.

Part of #5762
Source of #6022