### PR TITLE
[BottomSheet] Fix for No safeaAreaInsets when presenting with MDCBottomSheetController

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -50,6 +50,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
+  self.view.preservesSuperviewLayoutMargins = YES;
   self.contentViewController.view.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   self.contentViewController.view.frame = self.view.bounds;

--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -105,6 +105,7 @@ static const CGFloat kSheetBounceBuffer = 150;
     if (@available(iOS 11.0, *)) {
       scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
     }
+    scrollView.preservesSuperviewLayoutMargins = YES;
   }
   return self;
 }


### PR DESCRIPTION
This is a fix for a client issue regarding when using MDCBottomSheetController to display UICollectionViewController or UITableViewController, the safeAreaInsets are zero.

To fix this we needed the BottomSheetController view and the content main scrollView to preserve the layout margins of its superview. Specifically the layout margins of the MDCSheetContainerView needs to be respected by its subviews. The MDCSheetContainerView layout margins are set in its `safeAreaInsetsDidChange` method.

Before:
<img width="885" alt="screen shot 2018-12-14 at 1 39 08 pm" src="https://user-images.githubusercontent.com/4066863/50021026-ba97d700-ffa5-11e8-8855-a7dc8ba92841.png">

After:
<img width="881" alt="screen shot 2018-12-14 at 1 39 33 pm" src="https://user-images.githubusercontent.com/4066863/50021030-bff52180-ffa5-11e8-8f29-1d72f294d8f4.png">

Closes #5889 