### PR TITLE
[TextFields] Add Baseline Filled snapshots.

### DIFF
--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests.m
@@ -1,0 +1,55 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY MDCTextFieldSnapshotTestsIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "MaterialTextFields+ColorThemer.h"
+#import "MaterialTextFields+TypographyThemer.h"
+#import "MaterialTextFields.h"
+
+@interface MDCTextFieldFilledFloatingControllerBaselineSnapshotTests
+    : MDCAbstractTextFieldSnapshotTests
+@property(nonatomic, strong) MDCTextInputControllerFilled *textFieldController;
+@end
+
+@implementation MDCTextFieldFilledFloatingControllerBaselineSnapshotTests
+@dynamic textFieldController;
+
+- (void)setUp {
+  [super setUp];
+
+  // Uncomment below to recreate the golden images for all test methods. Add it to a test method to
+  // update only that golden image.
+  //  self.recordMode = YES;
+
+  self.textField.clearButtonMode = UITextFieldViewModeAlways;
+
+  self.textFieldController =
+      [[MDCTextInputControllerFilled alloc] initWithTextInput:self.textField];
+  self.textFieldController.floatingEnabled = YES;
+
+  MDCSemanticColorScheme *colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  MDCTypographyScheme *typographyScheme =
+      [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+
+  [MDCFilledTextFieldColorThemer applySemanticColorScheme:colorScheme
+                              toTextInputControllerFilled:self.textFieldController];
+  [MDCTextFieldTypographyThemer applyTypographyScheme:typographyScheme
+                                toTextInputController:self.textFieldController];
+  [MDCTextFieldTypographyThemer applyTypographyScheme:typographyScheme toTextInput:self.textField];
+}
+
+// NOTE: Additional test methods can be found in MDCAbstractTextFieldSnapshotTests.m
+
+@end

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldEmptyDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldEmptyDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21f52a02120da7f46dac0435fd4167ecac4c49e0449e68cb4b76df10856861cf
+size 3932

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldEmptyIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldEmptyIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a77f250044e2cb50f1901f66da5d038999983c941ca70255bbafa13d41063fbb
+size 3800

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldEmpty_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldEmpty_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0206eabf58128b59b36f50cf05f4cf216b147992443165fcec6682edfd98576
+size 3896

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongErrorTextDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongErrorTextDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3d4c8cd681867e9e6155db2c01e6b1acecff55030669c8bd7c789d957107067
+size 7612

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongErrorTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongErrorTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23fabc7b9bfa4a98d2522b759c988d10e67a5f13009dcc403bc7be21dd4e0dd8
+size 7529

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongErrorText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongErrorText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbc3a6ab683186de14a92adfc02eb8d37779ab708c6e977af2a559ab5a0b1a0d
+size 7559

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongHelperTextDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongHelperTextDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4df758f93a65540d150cfa15b6cc35d9cf68268a5164aa8e5f2847494ce96d36
+size 7798

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongHelperTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongHelperTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31ac6103c8b4fc66b7544cf170d3faf029b8455f027321b7f521d1a3faaed3d1
+size 7713

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongHelperText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongHelperText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:566583c6920c160f46db3bedc74b85e3991a811a759a1555a54466dba9704775
+size 7772

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputPlaceholderErrorTextsDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputPlaceholderErrorTextsDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d4fcebc9658d848982c3b76e35354005f07ceb88a00865e74576202c4edf589
+size 19033

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputPlaceholderErrorTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputPlaceholderErrorTextsIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a0593982243ac141f2964163a44707ab08509eeb07252b5ff8b47b7b67d1332
+size 20690

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputPlaceholderErrorTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputPlaceholderErrorTexts_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e25e91f01de685232e12dc678d5559833b241f1a6de00839f11c018588dbd087
+size 20741

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputPlaceholderHelperTextsDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputPlaceholderHelperTextsDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04afb60864782e50d9fc7c6b8717de17aa413b1942480a11a3540c38665eea03
+size 19249

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputPlaceholderHelperTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputPlaceholderHelperTextsIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0d654d72b1ffdce6edf3c419685fb7b14c0881b896cf68b1a1d2ac3d0ed86fc
+size 20566

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputPlaceholderHelperTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputPlaceholderHelperTexts_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d5a0b0a3f4728f805bf1b04faf019cba6aaae43571b154154a7740f67f01c19
+size 19706

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputTextDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputTextDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9f347e70481bae0ff7ee32e1bbc64d3171a20011644a515ef51e5f255729962
+size 8596

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e90c448929403245c3f3549b73ea0bae03697d02452206fbb91901ebd68716b
+size 8496

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongInputText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e944fdbec771ff0654d33e59010b006875314d29955f265138777654622e7b2
+size 8580

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongPlaceholderTextDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongPlaceholderTextDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4488d457e5272ee1064de3591e41453b029d5c361a4d4a10a0c74fa14c4eadf
+size 10317

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongPlaceholderTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongPlaceholderTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:210fc5bb382b8ef06836793289d82faef64a220d00c94b0801892fb7370c88d9
+size 12453

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongPlaceholderText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithLongPlaceholderText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eec02cd9286bbf4b54857e00d215df73319705da44645f6951ddd35ef1b22ba2
+size 10639

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortErrorTextDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortErrorTextDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6266745f18793cddbeed3790417f637d246ae7efd3d4ba97191344c53fe741fc
+size 5123

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortErrorTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortErrorTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51cef05eb18186840b0316810cf25e9a620cecd4af8cb31c2e72198ee92443b0
+size 5016

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortErrorText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortErrorText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f15df8f4122845b000727c6c5c3f2003c69572b09646a26bb40b94049b71dd3c
+size 5058

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortHelperTextDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortHelperTextDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2d58a65b2a36ceb08090f5d6f2fbe89d28afd24b57472b5627a4c50937e089b
+size 4936

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortHelperTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortHelperTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74194f24c8c76ca049350e641067af986773237d942201c86a889c95dcf0709d
+size 4839

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortHelperText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortHelperText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb5dcb7c7c7a3d76c3d42c9262af166695cdaf31ef40c915f02937fe082e3e0d
+size 4903

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputPlaceholderErrorTextsDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputPlaceholderErrorTextsDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cfb2d846dc590e417fd006d1fcba691a9378e4d1df665aa9e4c4ae80815a485
+size 8521

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputPlaceholderErrorTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputPlaceholderErrorTextsIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9836790b223fcb10377672c3172601e3a88fa482c2620c52d3deb9105f64e66
+size 8771

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputPlaceholderErrorTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputPlaceholderErrorTexts_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c22498c89c19c8c8be69647a673b28f7cd07212b67b72dbf0be3b3265b352ad
+size 8798

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputPlaceholderHelperTextsDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputPlaceholderHelperTextsDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f8924e4508b45c34ac258cd574a8bb023b82853029615689bfd700f73623e4f
+size 8360

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputPlaceholderHelperTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputPlaceholderHelperTextsIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6cc377c7b1e16b8d43fbce480815a63cfebb84dd3b20c3255e94d1d75e6cc81e
+size 8603

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputPlaceholderHelperTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputPlaceholderHelperTexts_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8dfee3fb5a32896d2c7bce73158bc79b9afe501a8610bf5a40246aac743fdac
+size 8502

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputTextDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputTextDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67decb837df90a376ddfac063d962845bdb6c6663df7531902ef4f11a85feeee
+size 6285

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5e6d0935875cbfd1d6579a201092cc5581a07bb018dd091813bf05ce3c319f6
+size 6238

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortInputText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27626ca10eba10d83770d15daa2abdbfa94d7b1c4d5d9af72f4a74fe955a97e0
+size 6299

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortPlaceholderTextDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortPlaceholderTextDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35ed0994fad94e61845e48e7ffef0790b77bd363766d388028b3b0c385dc1ae2
+size 5304

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortPlaceholderTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortPlaceholderTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7aa0642f2308d68a0c0a1042bfc19b54aa6658e58b9b7a1a5f9c33eec547ba09
+size 5289

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortPlaceholderText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests/testTextFieldWithShortPlaceholderText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:468379060b4ed0317fea155b10c2a48e109f9520669ab3c063e5e791d25162f7
+size 5422


### PR DESCRIPTION
Adding snapshot tests for Filled text input controller styled with the
Material Baseline theme.

Part of #5762
