### PR TITLE
[Chips] Rename internal MDCTextField subclass in MDCChipField

### DIFF
--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -107,8 +107,9 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
 
 @end
 
-@interface MDCChipField ()
-    <MDCChipFieldTextFieldDelegate, MDCTextInputPositioningDelegate, UITextFieldDelegate>
+@interface MDCChipField () <MDCChipFieldTextFieldDelegate,
+                            MDCTextInputPositioningDelegate,
+                            UITextFieldDelegate>
 @end
 
 @implementation MDCChipField {
@@ -122,7 +123,8 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
 
     _chips = [NSMutableArray array];
 
-    MDCChipFieldTextField *chipTextField = [[MDCChipFieldTextField alloc] initWithFrame:self.bounds];
+    MDCChipFieldTextField *chipTextField =
+        [[MDCChipFieldTextField alloc] initWithFrame:self.bounds];
     chipTextField.underline.hidden = YES;
     chipTextField.delegate = self;
     chipTextField.deletionDelegate = self;

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -123,28 +123,28 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
 
     _chips = [NSMutableArray array];
 
-    MDCChipFieldTextField *chipTextField =
+    MDCChipFieldTextField *chipFieldTextField =
         [[MDCChipFieldTextField alloc] initWithFrame:self.bounds];
-    chipTextField.underline.hidden = YES;
-    chipTextField.delegate = self;
-    chipTextField.deletionDelegate = self;
-    chipTextField.positioningDelegate = self;
-    chipTextField.accessibilityTraits = UIAccessibilityTraitNone;
-    chipTextField.autocorrectionType = UITextAutocorrectionTypeNo;
-    chipTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
-    chipTextField.keyboardType = MDCChipFieldDefaultKeyboardType;
+    chipFieldTextField.underline.hidden = YES;
+    chipFieldTextField.delegate = self;
+    chipFieldTextField.deletionDelegate = self;
+    chipFieldTextField.positioningDelegate = self;
+    chipFieldTextField.accessibilityTraits = UIAccessibilityTraitNone;
+    chipFieldTextField.autocorrectionType = UITextAutocorrectionTypeNo;
+    chipFieldTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    chipFieldTextField.keyboardType = MDCChipFieldDefaultKeyboardType;
     // Listen for notifications posted when the text field is the first responder.
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(textFieldDidChange)
                                                  name:UITextFieldTextDidChangeNotification
-                                               object:chipTextField];
+                                               object:chipFieldTextField];
     // Also listen for notifications posted when the text field is not the first responder.
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(textFieldDidChange)
                                                  name:MDCTextFieldTextDidSetTextNotification
-                                               object:chipTextField];
-    [self addSubview:chipTextField];
-    _textField = chipTextField;
+                                               object:chipFieldTextField];
+    [self addSubview:chipFieldTextField];
+    _textField = chipFieldTextField;
   }
   return self;
 }
@@ -555,7 +555,7 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
   }
 }
 
-#pragma mark - MDCChipTextFieldDelegate
+#pragma mark - MDCChipFieldTextFieldDelegate
 
 - (void)textFieldShouldRespondToDeleteBackward:(UITextField *)textField {
   if ([self isAnyChipSelected]) {

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -36,19 +36,19 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
     MDCChipFieldVerticalInset, MDCChipFieldHorizontalInset, MDCChipFieldVerticalInset,
     MDCChipFieldHorizontalInset};
 
-@protocol MDCChipTextFieldDelegate <NSObject>
+@protocol MDCChipFieldTextFieldDelegate <NSObject>
 
 - (void)textFieldShouldRespondToDeleteBackward:(UITextField *)textField;
 
 @end
 
-@interface MDCChipTextField : MDCTextField
+@interface MDCChipFieldTextField : MDCTextField
 
-@property(nonatomic, weak) id<MDCChipTextFieldDelegate> deletionDelegate;
+@property(nonatomic, weak) id<MDCChipFieldTextFieldDelegate> deletionDelegate;
 
 @end
 
-@implementation MDCChipTextField
+@implementation MDCChipFieldTextField
 
 - (CGRect)textRectForBounds:(CGRect)bounds {
   CGRect textRect = [super textRectForBounds:bounds];
@@ -108,7 +108,7 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
 @end
 
 @interface MDCChipField ()
-    <MDCChipTextFieldDelegate, MDCTextInputPositioningDelegate, UITextFieldDelegate>
+    <MDCChipFieldTextFieldDelegate, MDCTextInputPositioningDelegate, UITextFieldDelegate>
 @end
 
 @implementation MDCChipField {
@@ -122,7 +122,7 @@ const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
 
     _chips = [NSMutableArray array];
 
-    MDCChipTextField *chipTextField = [[MDCChipTextField alloc] initWithFrame:self.bounds];
+    MDCChipFieldTextField *chipTextField = [[MDCChipFieldTextField alloc] initWithFrame:self.bounds];
     chipTextField.underline.hidden = YES;
     chipTextField.delegate = self;
     chipTextField.deletionDelegate = self;


### PR DESCRIPTION
### Background
Adding chip support to MDCTextfield (b/118378923) introduces a new MDCChipTextField API.
This PR renames internal classes that start with "MDCChipTextField..." to allow adding the new API. 

There is no change to the MDCChipField public API.

Prework for #5511 