### PR TITLE
[Cards] Add theming extension for Cards component

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -357,6 +357,8 @@ Pod::Spec.new do |mdc|
       tests.test_spec 'unit' do |unit_tests|
         unit_tests.source_files = "components/#{component.base_name}/tests/unit/*.{h,m,swift}", "components/#{component.base_name}/tests/unit/supplemental/*.{h,m,swift}"
         unit_tests.resources = "components/#{component.base_name}/tests/unit/resources/*"
+
+        unit_tests.dependency "MaterialComponentsBeta/#{component.base_name}+Theming"
       end
     end
   end

--- a/MaterialComponentsBeta.podspec
+++ b/MaterialComponentsBeta.podspec
@@ -90,6 +90,16 @@ Pod::Spec.new do |mdc|
     extension.dependency "MaterialComponentsBeta/schemes/Container"
   end
 
+  mdc.subspec "Cards+Theming" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+ColorThemer"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+ShapeThemer"
+    extension.dependency "MaterialComponentsBeta/schemes/Container"
+  end
+
   mdc.subspec "Dialogs+Theming" do |extension|
     extension.ios.deployment_target = '8.0'
     extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"

--- a/components/Cards/BUILD
+++ b/components/Cards/BUILD
@@ -108,6 +108,7 @@ swift_library(
         ":Cards",
         ":ColorThemer",
         ":ShapeThemer",
+        ":Theming",
     ],
 )
 

--- a/components/Cards/BUILD
+++ b/components/Cards/BUILD
@@ -40,6 +40,20 @@ mdc_public_objc_library(
 )
 
 mdc_objc_library(
+    name = "Theming",
+    srcs = native.glob(["src/Theming/*.m"]),
+    hdrs = native.glob(["src/Theming/*.h"]),
+    includes = ["src/Theming"],
+    deps = [
+        ":Cards",
+        ":ColorThemer",
+        ":ShapeThemer",
+        "//components/schemes/Container",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+mdc_objc_library(
     name = "CardThemer",
     srcs = native.glob(["src/CardThemer/*.m"]),
     hdrs = native.glob(["src/CardThemer/*.h"]),

--- a/components/Cards/examples/CardExampleViewController.swift
+++ b/components/Cards/examples/CardExampleViewController.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 import MaterialComponents.MaterialButtons_ButtonThemer
-import MaterialComponents.MaterialCards_CardThemer
+import MaterialComponentsBeta.MaterialCards_Theming
 import MaterialComponentsBeta.MaterialContainerScheme
 import MaterialComponentsBeta.MaterialButtons_Theming
 

--- a/components/Cards/examples/CardExampleViewController.swift
+++ b/components/Cards/examples/CardExampleViewController.swift
@@ -27,6 +27,14 @@ class CardExampleViewController: UIViewController {
   var shapeScheme = MDCShapeScheme()
   var typographyScheme = MDCTypographyScheme()
 
+  var scheme: MDCContainerScheming {
+    let scheme = MDCContainerScheme()
+    scheme.colorScheme = colorScheme
+    scheme.typographyScheme = typographyScheme
+    scheme.shapeScheme = shapeScheme
+    return scheme
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -36,12 +44,8 @@ class CardExampleViewController: UIViewController {
     bundle.loadNibNamed("CardExampleViewController", owner: self, options: nil)
     view.frame = self.view.bounds
 
-    button.applyTextTheme(withScheme: MDCContainerScheme())
-
-    let cardScheme = MDCCardScheme();
-    cardScheme.colorScheme = colorScheme
-    cardScheme.shapeScheme = shapeScheme
-    MDCCardThemer.applyScheme(cardScheme, to: card)
+    button.applyTextTheme(withScheme: scheme)
+    card.applyTheme(withScheme: scheme)
     card.isInteractable = false
 
     imageView.isAccessibilityElement = true

--- a/components/Cards/examples/EditReorderCollectionViewController.swift
+++ b/components/Cards/examples/EditReorderCollectionViewController.swift
@@ -34,7 +34,14 @@ class EditReorderCollectionViewController: UIViewController,
   var colorScheme = MDCSemanticColorScheme()
   var shapeScheme = MDCShapeScheme()
   var typographyScheme = MDCTypographyScheme()
-  let cardScheme = MDCCardScheme()
+
+  var containerScheme: MDCContainerScheming {
+    let scheme = MDCContainerScheme()
+    scheme.colorScheme = colorScheme
+    scheme.typographyScheme = typographyScheme
+    scheme.shapeScheme = shapeScheme
+    return scheme
+  }
 
   let images = [
     (image: "amsterdam-kadoelen",     title: "Kadoelen"),
@@ -48,8 +55,6 @@ class EditReorderCollectionViewController: UIViewController,
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    cardScheme.colorScheme = colorScheme
-    cardScheme.shapeScheme = shapeScheme
     collectionView.frame = view.bounds
     collectionView.dataSource = self
     collectionView.delegate = self
@@ -137,7 +142,7 @@ class EditReorderCollectionViewController: UIViewController,
     let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath)
     guard let cardCell = cell as? CardEditReorderCollectionCell else { return cell }
 
-    cardCell.apply(cardScheme: cardScheme, typographyScheme: typographyScheme)
+    cardCell.apply(containerScheme: containerScheme, typographyScheme: typographyScheme)
 
     let title = dataSource[indexPath.item].title
     let imageName = dataSource[indexPath.item].image

--- a/components/Cards/examples/supplemental/CardEditReorderCollectionCell.swift
+++ b/components/Cards/examples/supplemental/CardEditReorderCollectionCell.swift
@@ -52,8 +52,8 @@ class CardEditReorderCollectionCell: MDCCardCollectionCell {
     addConstraints()
   }
 
-  func apply(cardScheme: MDCCardScheme, typographyScheme: MDCTypographyScheme) {
-    MDCCardThemer.applyScheme(cardScheme, toCardCell: self)
+  func apply(containerScheme: MDCContainerScheming, typographyScheme: MDCTypographyScheme) {
+    self.applyTheme(withScheme: containerScheme)
     self.titleLabel.font = typographyScheme.caption
   }
 

--- a/components/Cards/examples/supplemental/CardEditReorderCollectionCell.swift
+++ b/components/Cards/examples/supplemental/CardEditReorderCollectionCell.swift
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import UIKit
-import MaterialComponents.MaterialCards_CardThemer
 import MaterialComponents.MaterialTypographyScheme
+import MaterialComponentsBeta.MaterialCards_Theming
 
 class CardEditReorderCollectionCell: MDCCardCollectionCell {
 

--- a/components/Cards/src/Theming/MDCCard+MaterialTheming.h
+++ b/components/Cards/src/Theming/MDCCard+MaterialTheming.h
@@ -1,0 +1,40 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialCards.h"
+#import "MaterialContainerScheme.h"
+
+/**
+ This category is used to style MDCCard instances to a specific Material style which can be found
+ within the [Material Guidelines](https://material.io/design/components/cards.html).
+ */
+@interface MDCCard (MaterialTheming)
+
+/**
+ Applies the Material Card style to an MDCCard instance.
+
+ @param scheme A container scheme instance containing any desired customizations to the theming
+ system.
+ */
+- (void)applyThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
+/**
+ Applies the Material Outlined Card style to an MDCCard instance.
+
+ @param scheme A container scheme instance containing any desired customizations to the theming
+ system.
+ */
+- (void)applyOutlinedThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
+@end

--- a/components/Cards/src/Theming/MDCCard+MaterialTheming.m
+++ b/components/Cards/src/Theming/MDCCard+MaterialTheming.m
@@ -58,7 +58,7 @@ static const CGFloat kBorderWidth = 1;
   id<MDCColorScheming> colorScheme = scheme.colorScheme;
   if (!colorScheme) {
     colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   }
   [self applyOutlinedThemeWithColorScheme:colorScheme];
 
@@ -68,9 +68,8 @@ static const CGFloat kBorderWidth = 1;
   }
   [self applyThemeWithShapeScheme:shapeScheme];
 
-  NSUInteger maximumStateValue =
-      UIControlStateNormal | UIControlStateSelected | UIControlStateHighlighted |
-      UIControlStateDisabled;
+  NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
+                                 UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
     [self setBorderWidth:kBorderWidth forState:state];
   }

--- a/components/Cards/src/Theming/MDCCard+MaterialTheming.m
+++ b/components/Cards/src/Theming/MDCCard+MaterialTheming.m
@@ -34,14 +34,15 @@ static const CGFloat kBorderWidth = 1;
   [self applyThemeWithColorScheme:colorScheme];
 
   id<MDCShapeScheming> shapeScheme = scheme.shapeScheme;
-  if (!shapeScheme) {
-    shapeScheme = [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  if (shapeScheme) {
+    [self applyThemeWithShapeScheme:shapeScheme];
+  } else {
+    self.layer.cornerRadius = (CGFloat)4;
   }
-  [self applyThemeWithShapeScheme:shapeScheme];
 
   [self setShadowElevation:kNormalElevation forState:UIControlStateNormal];
   [self setShadowElevation:kHighlightedElevation forState:UIControlStateHighlighted];
-  self.interactable = YES;
+  self.interactable = YES; // To achieve baseline themed, the card should be interactable.
 }
 
 - (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
@@ -63,10 +64,11 @@ static const CGFloat kBorderWidth = 1;
   [self applyOutlinedThemeWithColorScheme:colorScheme];
 
   id<MDCShapeScheming> shapeScheme = scheme.shapeScheme;
-  if (!shapeScheme) {
-    shapeScheme = [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  if (shapeScheme) {
+    [self applyThemeWithShapeScheme:shapeScheme];
+  } else {
+    self.layer.cornerRadius = (CGFloat)4;
   }
-  [self applyThemeWithShapeScheme:shapeScheme];
 
   NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
                                  UIControlStateHighlighted | UIControlStateDisabled;

--- a/components/Cards/src/Theming/MDCCard+MaterialTheming.m
+++ b/components/Cards/src/Theming/MDCCard+MaterialTheming.m
@@ -1,0 +1,84 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCCard+MaterialTheming.h"
+
+#import "MaterialCards+ColorThemer.h"
+#import "MaterialCards+ShapeThemer.h"
+
+static const MDCShadowElevation kNormalElevation = 1;
+static const MDCShadowElevation kHighlightedElevation = 4;
+static const CGFloat kBorderWidth = 1;
+
+@implementation MDCCard (MaterialTheming)
+
+#pragma mark - Standard Card
+
+- (void)applyThemeWithScheme:(id<MDCContainerScheming>)scheme {
+  id<MDCColorScheming> colorScheme = scheme.colorScheme;
+  if (!colorScheme) {
+    colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+  [self applyThemeWithColorScheme:colorScheme];
+
+  id<MDCShapeScheming> shapeScheme = scheme.shapeScheme;
+  if (!shapeScheme) {
+    shapeScheme = [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  }
+  [self applyThemeWithShapeScheme:shapeScheme];
+
+  [self setShadowElevation:kNormalElevation forState:UIControlStateNormal];
+  [self setShadowElevation:kHighlightedElevation forState:UIControlStateHighlighted];
+  self.interactable = YES;
+}
+
+- (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
+  [MDCCardsColorThemer applySemanticColorScheme:colorScheme toCard:self];
+}
+
+- (void)applyThemeWithShapeScheme:(id<MDCShapeScheming>)shapeScheme {
+  [MDCCardsShapeThemer applyShapeScheme:shapeScheme toCard:self];
+}
+
+#pragma mark - Outlined Card
+
+- (void)applyOutlinedThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme {
+  id<MDCColorScheming> colorScheme = scheme.colorScheme;
+  if (!colorScheme) {
+    colorScheme =
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+  [self applyOutlinedThemeWithColorScheme:colorScheme];
+
+  id<MDCShapeScheming> shapeScheme = scheme.shapeScheme;
+  if (!shapeScheme) {
+    shapeScheme = [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  }
+  [self applyThemeWithShapeScheme:shapeScheme];
+
+  NSUInteger maximumStateValue =
+      UIControlStateNormal | UIControlStateSelected | UIControlStateHighlighted |
+      UIControlStateDisabled;
+  for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    [self setBorderWidth:kBorderWidth forState:state];
+  }
+  [self setShadowElevation:kHighlightedElevation forState:UIControlStateHighlighted];
+}
+
+- (void)applyOutlinedThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
+  [MDCCardsColorThemer applyOutlinedVariantWithColorScheme:colorScheme toCard:self];
+}
+
+@end

--- a/components/Cards/src/Theming/MDCCard+MaterialTheming.m
+++ b/components/Cards/src/Theming/MDCCard+MaterialTheming.m
@@ -42,7 +42,7 @@ static const CGFloat kBorderWidth = 1;
 
   [self setShadowElevation:kNormalElevation forState:UIControlStateNormal];
   [self setShadowElevation:kHighlightedElevation forState:UIControlStateHighlighted];
-  self.interactable = YES; // To achieve baseline themed, the card should be interactable.
+  self.interactable = YES;  // To achieve baseline themed, the card should be interactable.
 }
 
 - (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {

--- a/components/Cards/src/Theming/MDCCardCollectionCell+MaterialTheming.h
+++ b/components/Cards/src/Theming/MDCCardCollectionCell+MaterialTheming.h
@@ -1,0 +1,40 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialCards.h"
+#import "MaterialContainerScheme.h"
+
+/**
+ This category is used to style MDCCardCollectionCell instances to a specific Material style which
+ can be found within the [Material Guidelines](https://material.io/design/components/cards.html).
+ */
+@interface MDCCardCollectionCell (MaterialTheming)
+
+/**
+ Applies the Material Card style to an MDCCardCollectionCell instance.
+
+ @param scheme A container scheme instance containing any desired customizations to the theming
+ system.
+ */
+- (void)applyThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
+/**
+ Applies the Material Outlined Card style to an MDCCardCollectionCell instance.
+
+ @param scheme A container scheme instance containing any desired customizations to the theming
+ system.
+ */
+- (void)applyOutlinedThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
+@end

--- a/components/Cards/src/Theming/MDCCardCollectionCell+MaterialTheming.m
+++ b/components/Cards/src/Theming/MDCCardCollectionCell+MaterialTheming.m
@@ -30,7 +30,7 @@ static const CGFloat kBorderWidth = 1;
   id<MDCColorScheming> colorScheme = scheme.colorScheme;
   if (!colorScheme) {
     colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   }
   [self applyThemeWithColorScheme:colorScheme];
 
@@ -60,7 +60,7 @@ static const CGFloat kBorderWidth = 1;
   id<MDCColorScheming> colorScheme = scheme.colorScheme;
   if (!colorScheme) {
     colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   }
   [self applyOutlinedThemeWithColorScheme:colorScheme];
 

--- a/components/Cards/src/Theming/MDCCardCollectionCell+MaterialTheming.m
+++ b/components/Cards/src/Theming/MDCCardCollectionCell+MaterialTheming.m
@@ -1,0 +1,85 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCCardCollectionCell+MaterialTheming.h"
+
+#import "MaterialCards+ColorThemer.h"
+#import "MaterialCards+ShapeThemer.h"
+
+static const MDCShadowElevation kNormalElevation = 1;
+static const MDCShadowElevation kHighlightedElevation = 4;
+static const MDCShadowElevation kSelectedElevation = 4;
+static const CGFloat kBorderWidth = 1;
+
+@implementation MDCCardCollectionCell (MaterialTheming)
+
+#pragma mark - Standard Card
+
+- (void)applyThemeWithScheme:(id<MDCContainerScheming>)scheme {
+  id<MDCColorScheming> colorScheme = scheme.colorScheme;
+  if (!colorScheme) {
+    colorScheme =
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+  [self applyThemeWithColorScheme:colorScheme];
+
+  id<MDCShapeScheming> shapeScheme = scheme.shapeScheme;
+  if (!shapeScheme) {
+    shapeScheme = [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  }
+  [self applyThemeWithShapeScheme:shapeScheme];
+
+  [self setShadowElevation:kNormalElevation forState:MDCCardCellStateNormal];
+  [self setShadowElevation:kHighlightedElevation forState:MDCCardCellStateHighlighted];
+  [self setShadowElevation:kSelectedElevation forState:MDCCardCellStateSelected];
+  self.interactable = YES;
+}
+
+- (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
+  [MDCCardsColorThemer applySemanticColorScheme:colorScheme toCardCell:self];
+}
+
+- (void)applyThemeWithShapeScheme:(id<MDCShapeScheming>)shapeScheme {
+  [MDCCardsShapeThemer applyShapeScheme:shapeScheme toCardCell:self];
+}
+
+#pragma mark - Outlined Card
+
+- (void)applyOutlinedThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme {
+  id<MDCColorScheming> colorScheme = scheme.colorScheme;
+  if (!colorScheme) {
+    colorScheme =
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+  [self applyOutlinedThemeWithColorScheme:colorScheme];
+
+  id<MDCShapeScheming> shapeScheme = scheme.shapeScheme;
+  if (!shapeScheme) {
+    shapeScheme = [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  }
+  [self applyThemeWithShapeScheme:shapeScheme];
+
+  for (MDCCardCellState state = MDCCardCellStateNormal; state <= MDCCardCellStateSelected;
+       state++) {
+    [self setBorderWidth:kBorderWidth forState:state];
+  }
+  [self setShadowElevation:kHighlightedElevation forState:MDCCardCellStateHighlighted];
+  [self setShadowElevation:kSelectedElevation forState:MDCCardCellStateSelected];
+}
+
+- (void)applyOutlinedThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
+  [MDCCardsColorThemer applyOutlinedVariantWithColorScheme:colorScheme toCardCell:self];
+}
+
+@end

--- a/components/Cards/src/Theming/MDCCardCollectionCell+MaterialTheming.m
+++ b/components/Cards/src/Theming/MDCCardCollectionCell+MaterialTheming.m
@@ -44,7 +44,7 @@ static const CGFloat kBorderWidth = 1;
   [self setShadowElevation:kNormalElevation forState:MDCCardCellStateNormal];
   [self setShadowElevation:kHighlightedElevation forState:MDCCardCellStateHighlighted];
   [self setShadowElevation:kSelectedElevation forState:MDCCardCellStateSelected];
-  self.interactable = YES; // To achieve baseline themed, the card should be interactable.
+  self.interactable = YES;  // To achieve baseline themed, the card should be interactable.
 }
 
 - (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {

--- a/components/Cards/src/Theming/MDCCardCollectionCell+MaterialTheming.m
+++ b/components/Cards/src/Theming/MDCCardCollectionCell+MaterialTheming.m
@@ -35,15 +35,16 @@ static const CGFloat kBorderWidth = 1;
   [self applyThemeWithColorScheme:colorScheme];
 
   id<MDCShapeScheming> shapeScheme = scheme.shapeScheme;
-  if (!shapeScheme) {
-    shapeScheme = [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  if (shapeScheme) {
+    [self applyThemeWithShapeScheme:shapeScheme];
+  } else {
+    self.layer.cornerRadius = (CGFloat)4;
   }
-  [self applyThemeWithShapeScheme:shapeScheme];
 
   [self setShadowElevation:kNormalElevation forState:MDCCardCellStateNormal];
   [self setShadowElevation:kHighlightedElevation forState:MDCCardCellStateHighlighted];
   [self setShadowElevation:kSelectedElevation forState:MDCCardCellStateSelected];
-  self.interactable = YES;
+  self.interactable = YES; // To achieve baseline themed, the card should be interactable.
 }
 
 - (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
@@ -65,10 +66,11 @@ static const CGFloat kBorderWidth = 1;
   [self applyOutlinedThemeWithColorScheme:colorScheme];
 
   id<MDCShapeScheming> shapeScheme = scheme.shapeScheme;
-  if (!shapeScheme) {
-    shapeScheme = [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  if (shapeScheme) {
+    [self applyThemeWithShapeScheme:shapeScheme];
+  } else {
+    self.layer.cornerRadius = (CGFloat)4;
   }
-  [self applyThemeWithShapeScheme:shapeScheme];
 
   for (MDCCardCellState state = MDCCardCellStateNormal; state <= MDCCardCellStateSelected;
        state++) {

--- a/components/Cards/src/Theming/MaterialCards+Theming.h
+++ b/components/Cards/src/Theming/MaterialCards+Theming.h
@@ -1,0 +1,16 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCCard+MaterialTheming.h"
+#import "MDCCardCollectionCell+MaterialTheming.h"

--- a/components/Cards/tests/unit/CardsMaterialThemingTests.swift
+++ b/components/Cards/tests/unit/CardsMaterialThemingTests.swift
@@ -29,6 +29,8 @@ class CardsMaterialThemingTests: XCTestCase {
     let scheme = MDCContainerScheme()
     let colorScheme = MDCSemanticColorScheme(defaults: .material201804)
     let shapeScheme = MDCShapeScheme(defaults: .material201809)
+    scheme.colorScheme = colorScheme
+    scheme.shapeScheme = shapeScheme
 
     // When
     card.applyTheme(withScheme: scheme)
@@ -54,12 +56,27 @@ class CardsMaterialThemingTests: XCTestCase {
     XCTAssertTrue(card.isInteractable)
   }
 
+  func testThemedCardWithoutShapeScheme() {
+    // Given
+    let card = MDCCard()
+    let scheme = MDCContainerScheme()
+
+    // When
+    card.applyTheme(withScheme: scheme)
+
+    // Then
+    XCTAssertEqual(card.layer.cornerRadius, 4, accuracy: 0.001)
+    XCTAssertNil(card.shapeGenerator)
+  }
+
   func testOutlinedThemedCard() {
     // Given
     let card = MDCCard()
     let scheme = MDCContainerScheme()
     let colorScheme = MDCSemanticColorScheme(defaults: .material201804)
     let shapeScheme = MDCShapeScheme(defaults: .material201809)
+    scheme.colorScheme = colorScheme
+    scheme.shapeScheme = shapeScheme
 
     // When
     card.applyOutlinedTheme(withScheme: scheme)
@@ -89,12 +106,27 @@ class CardsMaterialThemingTests: XCTestCase {
     XCTAssertEqual(card.shadowElevation(for: .highlighted), ShadowElevation(rawValue: 4))
   }
 
+  func testOutlinedThemedCardWithoutShapeScheme() {
+    // Given
+    let card = MDCCard()
+    let scheme = MDCContainerScheme()
+
+    // When
+    card.applyOutlinedTheme(withScheme: scheme)
+
+    // Then
+    XCTAssertEqual(card.layer.cornerRadius, 4, accuracy: 0.001)
+    XCTAssertNil(card.shapeGenerator)
+  }
+
   func testThemedCardCell() {
     // Given
     let cardCell = MDCCardCollectionCell()
     let scheme = MDCContainerScheme()
     let colorScheme = MDCSemanticColorScheme(defaults: .material201804)
     let shapeScheme = MDCShapeScheme(defaults: .material201809)
+    scheme.colorScheme = colorScheme
+    scheme.shapeScheme = shapeScheme
 
     // When
     cardCell.applyTheme(withScheme: scheme)
@@ -121,12 +153,27 @@ class CardsMaterialThemingTests: XCTestCase {
     XCTAssertTrue(cardCell.isInteractable)
   }
 
+  func testThemedCardCellWithoutShapeScheme() {
+    // Given
+    let cardCell = MDCCardCollectionCell()
+    let scheme = MDCContainerScheme()
+
+    // When
+    cardCell.applyTheme(withScheme: scheme)
+
+    // Then
+    XCTAssertEqual(cardCell.layer.cornerRadius, 4, accuracy: 0.001)
+    XCTAssertNil(cardCell.shapeGenerator)
+  }
+
   func testOutlinedThemedCardCell() {
     // Given
     let cardCell = MDCCardCollectionCell()
     let scheme = MDCContainerScheme()
     let colorScheme = MDCSemanticColorScheme(defaults: .material201804)
     let shapeScheme = MDCShapeScheme(defaults: .material201809)
+    scheme.colorScheme = colorScheme
+    scheme.shapeScheme = shapeScheme
 
     // When
     cardCell.applyOutlinedTheme(withScheme: scheme)
@@ -154,5 +201,18 @@ class CardsMaterialThemingTests: XCTestCase {
     XCTAssertEqual(cardCell.borderWidth(for: .highlighted), 1, accuracy: 0.001)
     XCTAssertEqual(cardCell.shadowElevation(for: .highlighted), ShadowElevation(rawValue: 4))
     XCTAssertEqual(cardCell.shadowElevation(for: .selected), ShadowElevation(rawValue: 4))
+  }
+
+  func testOutlinedThemedCardCellWithoutShapeScheme() {
+    // Given
+    let cardCell = MDCCardCollectionCell()
+    let scheme = MDCContainerScheme()
+
+    // When
+    cardCell.applyOutlinedTheme(withScheme: scheme)
+
+    // Then
+    XCTAssertEqual(cardCell.layer.cornerRadius, 4, accuracy: 0.001)
+    XCTAssertNil(cardCell.shapeGenerator)
   }
 }

--- a/components/Cards/tests/unit/CardsMaterialThemingTests.swift
+++ b/components/Cards/tests/unit/CardsMaterialThemingTests.swift
@@ -1,0 +1,158 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+import MaterialComponents.MaterialCards
+import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialShapeScheme
+import MaterialComponents.MaterialShapeLibrary
+import MaterialComponentsBeta.MaterialCards_Theming
+import MaterialComponentsBeta.MaterialContainerScheme
+
+class CardsMaterialThemingTests: XCTestCase {
+
+  func testThemedCard() {
+    // Given
+    let card = MDCCard()
+    let scheme = MDCContainerScheme()
+    let colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    let shapeScheme = MDCShapeScheme(defaults: .material201809)
+
+    // When
+    card.applyTheme(withScheme: scheme)
+
+    // Then
+    // Test Colors
+    XCTAssertEqual(card.backgroundColor, colorScheme.surfaceColor)
+
+    // Test shape
+    if let cardShape = card.shapeGenerator as? MDCRectangleShapeGenerator {
+      XCTAssertEqual(cardShape.topLeftCorner, shapeScheme.mediumComponentShape.topLeftCorner)
+      XCTAssertEqual(cardShape.topRightCorner, shapeScheme.mediumComponentShape.topRightCorner)
+      XCTAssertEqual(cardShape.bottomRightCorner,
+                     shapeScheme.mediumComponentShape.bottomRightCorner)
+      XCTAssertEqual(cardShape.bottomLeftCorner, shapeScheme.mediumComponentShape.bottomLeftCorner)
+    } else {
+      XCTFail("Card.shapeGenerator was not a MDCRectangularShapeGenerator")
+    }
+
+    // Test remaining properties
+    XCTAssertEqual(card.shadowElevation(for: .normal), ShadowElevation(rawValue: 1))
+    XCTAssertEqual(card.shadowElevation(for: .highlighted), ShadowElevation(rawValue: 4))
+    XCTAssertTrue(card.isInteractable)
+  }
+
+  func testOutlinedThemedCard() {
+    // Given
+    let card = MDCCard()
+    let scheme = MDCContainerScheme()
+    let colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    let shapeScheme = MDCShapeScheme(defaults: .material201809)
+
+    // When
+    card.applyOutlinedTheme(withScheme: scheme)
+
+    // Then
+    // Test Colors
+    XCTAssertEqual(card.backgroundColor, colorScheme.surfaceColor)
+    XCTAssertEqual(card.borderColor(for: .normal),
+                   colorScheme.onSurfaceColor.withAlphaComponent(0.37))
+
+    // Test shape
+    if let cardShape = card.shapeGenerator as? MDCRectangleShapeGenerator {
+      XCTAssertEqual(cardShape.topLeftCorner, shapeScheme.mediumComponentShape.topLeftCorner)
+      XCTAssertEqual(cardShape.topRightCorner, shapeScheme.mediumComponentShape.topRightCorner)
+      XCTAssertEqual(cardShape.bottomRightCorner,
+                     shapeScheme.mediumComponentShape.bottomRightCorner)
+      XCTAssertEqual(cardShape.bottomLeftCorner, shapeScheme.mediumComponentShape.bottomLeftCorner)
+    } else {
+      XCTFail("Card.shapeGenerator was not a MDCRectangularShapeGenerator")
+    }
+
+    // Test remaining properties
+    XCTAssertEqual(card.borderWidth(for: .normal), 1, accuracy: 0.001)
+    XCTAssertEqual(card.borderWidth(for: .selected), 1, accuracy: 0.001)
+    XCTAssertEqual(card.borderWidth(for: .highlighted), 1, accuracy: 0.001)
+    XCTAssertEqual(card.borderWidth(for: .disabled), 1, accuracy: 0.001)
+    XCTAssertEqual(card.shadowElevation(for: .highlighted), ShadowElevation(rawValue: 4))
+  }
+
+  func testThemedCardCell() {
+    // Given
+    let cardCell = MDCCardCollectionCell()
+    let scheme = MDCContainerScheme()
+    let colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    let shapeScheme = MDCShapeScheme(defaults: .material201809)
+
+    // When
+    cardCell.applyTheme(withScheme: scheme)
+
+    // Then
+    // Test Colors
+    XCTAssertEqual(cardCell.backgroundColor, colorScheme.surfaceColor)
+
+    // Test shape
+    if let cardShape = cardCell.shapeGenerator as? MDCRectangleShapeGenerator {
+      XCTAssertEqual(cardShape.topLeftCorner, shapeScheme.mediumComponentShape.topLeftCorner)
+      XCTAssertEqual(cardShape.topRightCorner, shapeScheme.mediumComponentShape.topRightCorner)
+      XCTAssertEqual(cardShape.bottomRightCorner,
+                     shapeScheme.mediumComponentShape.bottomRightCorner)
+      XCTAssertEqual(cardShape.bottomLeftCorner, shapeScheme.mediumComponentShape.bottomLeftCorner)
+    } else {
+      XCTFail("Card.shapeGenerator was not a MDCRectangularShapeGenerator")
+    }
+
+    // Test remaining properties
+    XCTAssertEqual(cardCell.shadowElevation(for: .normal), ShadowElevation(rawValue: 1))
+    XCTAssertEqual(cardCell.shadowElevation(for: .highlighted), ShadowElevation(rawValue: 4))
+    XCTAssertEqual(cardCell.shadowElevation(for: .selected), ShadowElevation(rawValue: 4))
+    XCTAssertTrue(cardCell.isInteractable)
+  }
+
+  func testOutlinedThemedCardCell() {
+    // Given
+    let cardCell = MDCCardCollectionCell()
+    let scheme = MDCContainerScheme()
+    let colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    let shapeScheme = MDCShapeScheme(defaults: .material201809)
+
+    // When
+    cardCell.applyOutlinedTheme(withScheme: scheme)
+
+    // Then
+    // Test Colors
+    XCTAssertEqual(cardCell.backgroundColor, colorScheme.surfaceColor)
+    XCTAssertEqual(cardCell.borderColor(for: .normal),
+                   colorScheme.onSurfaceColor.withAlphaComponent(0.37))
+
+    // Test shape
+    if let cardShape = cardCell.shapeGenerator as? MDCRectangleShapeGenerator {
+      XCTAssertEqual(cardShape.topLeftCorner, shapeScheme.mediumComponentShape.topLeftCorner)
+      XCTAssertEqual(cardShape.topRightCorner, shapeScheme.mediumComponentShape.topRightCorner)
+      XCTAssertEqual(cardShape.bottomRightCorner,
+                     shapeScheme.mediumComponentShape.bottomRightCorner)
+      XCTAssertEqual(cardShape.bottomLeftCorner, shapeScheme.mediumComponentShape.bottomLeftCorner)
+    } else {
+      XCTFail("Card.shapeGenerator was not a MDCRectangularShapeGenerator")
+    }
+
+    // Test remaining properties
+    XCTAssertEqual(cardCell.borderWidth(for: .normal), 1, accuracy: 0.001)
+    XCTAssertEqual(cardCell.borderWidth(for: .selected), 1, accuracy: 0.001)
+    XCTAssertEqual(cardCell.borderWidth(for: .highlighted), 1, accuracy: 0.001)
+    XCTAssertEqual(cardCell.shadowElevation(for: .highlighted), ShadowElevation(rawValue: 4))
+    XCTAssertEqual(cardCell.shadowElevation(for: .selected), ShadowElevation(rawValue: 4))
+  }
+}

--- a/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
+++ b/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
@@ -30,6 +30,7 @@
 #import "MaterialButtons.h"
 #import "MaterialCards+CardThemer.h"
 #import "MaterialCards+ShapeThemer.h"
+#import "MaterialCards+Theming.h"
 #import "MaterialCards.h"
 #import "MaterialChips+ChipThemer.h"
 #import "MaterialChips+ShapeThemer.h"
@@ -143,13 +144,9 @@
   [MDCChipViewThemer applyScheme:chipViewScheme toChipView:self.chipView];
   [self.componentContentView addSubview:self.chipView];
 
-  MDCCardScheme *cardScheme = [[MDCCardScheme alloc] init];
-  cardScheme.colorScheme = self.colorScheme;
-  cardScheme.shapeScheme = self.shapeScheme;
-
   self.card = [[MDCCard alloc] init];
   self.card.translatesAutoresizingMaskIntoConstraints = NO;
-  [MDCCardThemer applyScheme:cardScheme toCard:self.card];
+  [self.card applyThemeWithScheme:self.containerScheme];
   self.card.backgroundColor = _colorScheme.primaryColor;
   [self.componentContentView addSubview:self.card];
 


### PR DESCRIPTION
### Context
As the team pivots to using theming within extensions we continue this work with Cards.

### The problem
We currently do not theme cards using a theming extension

### The fix
* Add theming extension for MDCCard and MDCCardCollectionCell
* Write unit tests for new extension
* Update existing examples to utilize the extension

### Bug
Closes #6030 

### Screenshots
Everything should be exactly the same visually.

| Before | After |
| - | - |
|![simulator screen shot - iphone 7 - 2018-12-17 at 13 59 52](https://user-images.githubusercontent.com/2364772/50110092-65f39680-0207-11e9-9a32-02161f7b2df4.png)|![simulator screen shot - iphone 7 - 2018-12-17 at 14 01 51](https://user-images.githubusercontent.com/2364772/50110130-7dcb1a80-0207-11e9-83d9-53bc98ad374b.png)|



