### PR TITLE
[Buttons, Shape] Fix shape example to use new contained button theming

### DIFF
--- a/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
+++ b/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
@@ -109,14 +109,9 @@
 }
 
 - (void)initializeComponentry {
-  MDCButtonScheme *buttonScheme = [[MDCButtonScheme alloc] init];
-  buttonScheme.colorScheme = self.colorScheme;
-  buttonScheme.shapeScheme = self.shapeScheme;
-  buttonScheme.typographyScheme = self.typographyScheme;
-
   self.containedButton = [[MDCButton alloc] init];
   [self.containedButton setTitle:@"Button" forState:UIControlStateNormal];
-  [MDCContainedButtonThemer applyScheme:buttonScheme toButton:self.containedButton];
+  [self.containedButton applyContainedThemeWithScheme:self.containerScheme];
   self.containedButton.translatesAutoresizingMaskIntoConstraints = NO;
   [self.componentContentView addSubview:self.containedButton];
 


### PR DESCRIPTION
When we added support for the theming extension for MDCButtons, we missed an example that is still using the old method.