### PR TITLE
[BottomNavigation] Use designated initializers.

### DIFF
--- a/components/BottomNavigation/examples/MDCBottomNavigationBarController.m
+++ b/components/BottomNavigation/examples/MDCBottomNavigationBarController.m
@@ -26,13 +26,17 @@
 
 @implementation MDCBottomNavigationBarController
 
+- (void)MDCBottomNavigationBarController_commonInit {
+  _navigationBar = [[MDCBottomNavigationBar alloc] init];
+  _content = [[UIView alloc] init];
+  _viewControllers = @[];
+  _selectedIndex = NSNotFound;
+}
+
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
   self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
   if (self) {
-    _navigationBar = [[MDCBottomNavigationBar alloc] init];
-    _content = [[UIView alloc] init];
-    _viewControllers = @[];
-    _selectedIndex = NSNotFound;
+    [self MDCBottomNavigationBarController_commonInit];
   }
 
   return self;
@@ -41,10 +45,7 @@
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
   self = [super initWithCoder:aDecoder];
   if (self) {
-    _navigationBar = [[MDCBottomNavigationBar alloc] init];
-    _content = [[UIView alloc] init];
-    _viewControllers = @[];
-    _selectedIndex = NSNotFound;
+    [self MDCBottomNavigationBarController_commonInit];
   }
   return self;
 }

--- a/components/BottomNavigation/examples/MDCBottomNavigationBarController.m
+++ b/components/BottomNavigation/examples/MDCBottomNavigationBarController.m
@@ -26,8 +26,8 @@
 
 @implementation MDCBottomNavigationBarController
 
-- (instancetype)init {
-  self = [super init];
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+  self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
   if (self) {
     _navigationBar = [[MDCBottomNavigationBar alloc] init];
     _content = [[UIView alloc] init];
@@ -35,6 +35,17 @@
     _selectedIndex = NSNotFound;
   }
 
+  return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+  self = [super initWithCoder:aDecoder];
+  if (self) {
+    _navigationBar = [[MDCBottomNavigationBar alloc] init];
+    _content = [[UIView alloc] init];
+    _viewControllers = @[];
+    _selectedIndex = NSNotFound;
+  }
   return self;
 }
 

--- a/components/BottomNavigation/examples/tests/unit/MDCBottomNavigationBarControllerTests.m
+++ b/components/BottomNavigation/examples/tests/unit/MDCBottomNavigationBarControllerTests.m
@@ -57,6 +57,22 @@ static CGFloat const kDefaultExpectationTimeout = 15;
   _bottomNavigationBarController = nil;
 }
 
+- (void)testInitWithNibNameBundle {
+  // Given
+  MDCBottomNavigationBarController *controller =
+      [[MDCBottomNavigationBarController alloc] initWithNibName:nil bundle:nil];
+
+  // When
+  if (@available(iOS 9.0, *)) {
+    [controller loadViewIfNeeded];
+  } else {
+    (void)controller.view;
+  }
+
+  // Then
+  XCTAssertNotNil(controller.navigationBar);
+}
+
 - (void)testSetViewControllers {
   // Given
   UITabBarItem *tabBarItem1 = [[UITabBarItem alloc] initWithTitle:@"Title1" image:nil tag:0];


### PR DESCRIPTION
Instead of having only a convenience `-init` method, the BottomNavigationController should implement the UIViewController designated initializers.

Follow-up for #5886
Part of #4160