### PR TITLE
{scripts/release} Disable git lfs cloning when generating API diff.

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -454,6 +454,8 @@ generate_release_apidiff() {
 
   "$dir/temporary_clone_at_ref" "$OLD_ROOT_PATH" $old_commit
   "$dir/temporary_clone_at_ref" "$NEW_ROOT_PATH" $new_commit
+  
+  unset GIT_LFS_SKIP_SMUDGE
 
   # Find command in all component src directories and grab search path for "Material$component.h"
   old_header_search_paths=""

--- a/scripts/release
+++ b/scripts/release
@@ -447,6 +447,11 @@ generate_release_apidiff() {
     fi
   }
   trap clean_clones EXIT
+
+  # We do not need LFS for the temporary clones; they are used solely to do API diffs.
+  # See https://github.com/git-lfs/git-lfs/issues/2406 for where this flag came from.
+  export GIT_LFS_SKIP_SMUDGE=1
+
   "$dir/temporary_clone_at_ref" "$OLD_ROOT_PATH" $old_commit
   "$dir/temporary_clone_at_ref" "$NEW_ROOT_PATH" $new_commit
 


### PR DESCRIPTION
The `scripts/release apidiff` command needs to create two local temporary clones of the repo in order to generate the API diff. Unfortunately, git lfs fails to clone local copies of a git repo, particularly when not using a `file://` prefix.

The fix is to disable git LFS cloning prior to the API diff temporary clone commands.

```bash
hint: The remote resolves to a file:// URL, which can only work with a
hint: standalone transfer agent.  See section "Using a Custom Transfer Type
hint: without the API server" in custom-transfers.md for details.

hint: The remote resolves to a file:// URL, which can only work with a
hint: standalone transfer agent.  See section "Using a Custom Transfer Type
hint: without the API server" in custom-transfers.md for details.

hint: The remote resolves to a file:// URL, which can only work with a
hint: standalone transfer agent.  See section "Using a Custom Transfer Type
hint: without the API server" in custom-transfers.md for details.

hint: The remote resolves to a file:// URL, which can only work with a
hint: standalone transfer agent.  See section "Using a Custom Transfer Type
hint: without the API server" in custom-transfers.md for details.
Downloading snapshot_test_goldens/goldens_64/MDCCardSnapshotTests/testDefaultCard_11_2@2x.png (1.9 KB)

hint: The remote resolves to a file:// URL, which can only work with a
hint: standalone transfer agent.  See section "Using a Custom Transfer Type
hint: without the API server" in custom-transfers.md for details.
Error downloading object: snapshot_test_goldens/goldens_64/MDCCardSnapshotTests/testDefaultCard_11_2@2x.png (96d48d5): Smudge error: Error downloading snapshot_test_goldens/goldens_64/MDCCardSnapshotTests/testDefaultCard_11_2@2x.png (96d48d51f415dc94427e49a361cf68cdadc86d0e00a6706894a7f82b5d13b086): batch request: missing protocol: "file:///Users/featherless/workbench/material-components-ios/.git/info/lfs"

Errors logged to /private/tmp/mdcios/mdc-ios/.git/lfs/logs/20181218T112727.676554.log
Use `git lfs logs last` to view the log.
error: external filter 'git-lfs filter-process' failed
fatal: snapshot_test_goldens/goldens_64/MDCCardSnapshotTests/testDefaultCard_11_2@2x.png: smudge filter lfs failed
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry the checkout with 'git checkout -f HEAD'
```
