### PR TITLE
{docs/releasing.md} Fix the name of the release-blocking client group

### DIFF
--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -67,7 +67,7 @@ that the `cut` script generated.
 
 Name the Pull Request title "[WIP] Release Candidate." until you are able to provide the version as the title.
 
-Add "@Release-blocking clients" to the pull request's reviewers. This is the mechanism by which
+Add the group `material-components/release-blocking-clients` to the pull request's reviewers. This is the mechanism by which
 release-blocking clients are notified of a new release.
 
 **Do not use GitHub's big green button to merge the approved pull request.** Release are an


### PR DESCRIPTION
The name was incorrect in the docs.