### PR TITLE
[BottomNavigation] Fix MDCBottomNavigationBar elevation on MDCBottomNavigationBarController

### DIFF
--- a/components/BottomNavigation/examples/MDCBottomNavigationBarController.m
+++ b/components/BottomNavigation/examples/MDCBottomNavigationBarController.m
@@ -44,8 +44,8 @@
   self.navigationBar.delegate = self;
 
   // Add subviews and create their constraints
-  [self.view addSubview:self.navigationBar];
   [self.view addSubview:self.content];
+  [self.view addSubview:self.navigationBar];
   [self loadConstraints];
 }
 


### PR DESCRIPTION
Inverted the order the subviews are added to the `MDCBottomNavigationBarController`. This fixes the elevation of `MDCBottomNavigationBar` not being shown due to its z-index.

Follow-up for #5886
Part of #4160