### PR TITLE
[FlexibleHeader] Mark MDCFlexibleHeaderTopSafeArea as final.

### DIFF
--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.h
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.h
@@ -29,7 +29,7 @@
  on all clients enabling inferTopSafeAreaInsetFromViewController on their flexible header view
  controller.
  */
-@interface MDCFlexibleHeaderTopSafeArea : NSObject
+__attribute__((objc_subclassing_restricted)) @interface MDCFlexibleHeaderTopSafeArea : NSObject
 
 #pragma mark Configuring the top safe area source
 


### PR DESCRIPTION
This private class is not intended to be subclassed.