### PR TITLE
{Documentation} Mark "Sanity check" as optional.

### DIFF
--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -161,7 +161,7 @@ We do not presently have an automated way to identify visual changes between rel
 issue #290](https://github.com/material-components/material-components-ios/issues/290) for a
 discussion on the topic.
 
-### Sanity check: inspect the changes
+### [Optional] Sanity check: inspect the changes
 
 #### Diff just the components
 


### PR DESCRIPTION
The Sanity Check steps seem to be a bunch of required steps that aren't
necessary if the release engineer has followed the previous instructions.
Instead, it can be an optional set of helpful commands.
