### PR TITLE
[Snapshots] Add support to specify insets for snapshot tests

### DIFF
--- a/components/Cards/tests/snapshot/MDCCardSnapshotTests.m
+++ b/components/Cards/tests/snapshot/MDCCardSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCSnapshotTestCase.h"
 #import "MaterialCards+Theming.h"
 #import "MaterialCards.h"
+#import "MaterialSnapshot.h"
 
 @interface MDCCardSnapshotTests : MDCSnapshotTestCase
 

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.h
@@ -14,7 +14,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "MDCSnapshotTestCase.h"
+#import "MaterialSnapshot.h"
 #import "MaterialTextFields.h"
 #import "SnapshotFakeMDCTextField.h"
 

--- a/components/private/Snapshot/MaterialSnapshot.h
+++ b/components/private/Snapshot/MaterialSnapshot.h
@@ -1,0 +1,16 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCSnapshotTestCase.h"
+#import "UIView+MDCSnapshot.h"

--- a/components/private/Snapshot/UIView+MDCSnapshot.h
+++ b/components/private/Snapshot/UIView+MDCSnapshot.h
@@ -18,14 +18,17 @@
 
 /**
  * This method will embed the view in a new larger view with a 10pt inset on all 4 sides.
+ *
+ * @return The background view that was created.
  */
-- (UIView *)addToBackgroundView;
+- (UIView *)mdc_addToBackgroundView;
 
 /**
  * This method will embed the view in a new view with the provided insets.
  *
  * @param insets The insets around the view embedded in a background view.
+ * @return The background view that was created.
  */
-- (UIView *)addToBackgroundViewWithInsets:(UIEdgeInsets)insets;
+- (UIView *)mdc_addToBackgroundViewWithInsets:(UIEdgeInsets)insets;
 
 @end

--- a/components/private/Snapshot/UIView+MDCSnapshot.h
+++ b/components/private/Snapshot/UIView+MDCSnapshot.h
@@ -1,0 +1,31 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+@interface UIView (MDCSnapshot)
+
+/**
+ * This method will embed the view in a new larger view with a 10pt inset on all 4 sides.
+ */
+- (UIView *)addToBackgroundView;
+
+/**
+ * This method will embed the view in a new view with the provided insets.
+ *
+ * @param insets The insets around the view embedded in a background view.
+ */
+- (UIView *)addToBackgroundViewWithInsets:(UIEdgeInsets)insets;
+
+@end

--- a/components/private/Snapshot/UIView+MDCSnapshot.m
+++ b/components/private/Snapshot/UIView+MDCSnapshot.m
@@ -16,11 +16,11 @@
 
 @implementation UIView (MDCSnapshot)
 
-- (UIView *)addToBackgroundView {
-  return [self addToBackgroundViewWithInsets:UIEdgeInsetsMake(10, 10, 10, 10)];
+- (UIView *)mdc_addToBackgroundView {
+  return [self mdc_addToBackgroundViewWithInsets:UIEdgeInsetsMake(10, 10, 10, 10)];
 }
 
-- (UIView *)addToBackgroundViewWithInsets:(UIEdgeInsets)insets {
+- (UIView *)mdc_addToBackgroundViewWithInsets:(UIEdgeInsets)insets {
   UIView *backgroundView = [[UIView alloc]
       initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.bounds) + insets.left + insets.right,
                                CGRectGetHeight(self.bounds) + insets.top + insets.bottom)];

--- a/components/private/Snapshot/UIView+MDCSnapshot.m
+++ b/components/private/Snapshot/UIView+MDCSnapshot.m
@@ -1,0 +1,37 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "UIView+MDCSnapshot.h"
+
+@implementation UIView (MDCSnapshot)
+
+- (UIView *)addToBackgroundView {
+  return [self addToBackgroundViewWithInsets:UIEdgeInsetsMake(10, 10, 10, 10)];
+}
+
+- (UIView *)addToBackgroundViewWithInsets:(UIEdgeInsets)insets {
+  UIView *backgroundView = [[UIView alloc]
+      initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.bounds) + insets.left + insets.right,
+                               CGRectGetHeight(self.bounds) + insets.top + insets.bottom)];
+  backgroundView.backgroundColor = [UIColor colorWithWhite:0.8 alpha:1];
+  [backgroundView addSubview:self];
+
+  CGRect frame = self.frame;
+  frame.origin = CGPointMake(insets.left, insets.top);
+  self.frame = frame;
+
+  return backgroundView;
+}
+
+@end


### PR DESCRIPTION
### The Problem
The current infrastructure for snapshot tests assumes the developer wants to embed their view with 10 points of padding on all sides but this won't always be the case.

### The Solution
Create a UIView category to handle adding the background view and additionally expose an API in the snapshot base class to optionally allow the developer to specify their own custom insets like so:

```objc
[self mdc_addBackgroundViewWithInsets:UIEdgeInsetsMake(10, 10, 10, 10)]
```

A follow-up PR will move our snapshot tests over to this new category.

### Bugs
Part of #5942 