### PR TITLE
[.kokoro] Add a new affected_targets job.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -187,6 +187,11 @@ run_bazel_affected() {
   if [ -z "$TARGET" ]; then
     TARGET="$(scripts/affected_targets test)"
   fi
+  
+  if [ -z "$TARGET" ]; then
+    echo "Nothing to build."
+    exit 0
+  fi
 
   # Run against whichever Xcode is currently selected.
   selected_xcode_developer_path=$(xcode-select -p)

--- a/.kokoro
+++ b/.kokoro
@@ -157,6 +157,70 @@ upload_bazel_test_artifacts() {
   find -L . -name "sponge_log.xml" -type f | copy_to_artifacts
 }
 
+run_bazel_affected() {
+  echo "Running bazel affected..."
+
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    move_derived_data_to_tmp
+  fi
+
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    bazel version
+    use_bazel.sh 0.20.0
+    bazel version
+  fi
+
+  if [ -n "$VERBOSE_OUTPUT" ]; then
+    verbosity_args="-s"
+  fi
+
+  if [ -z "$COMMAND" ]; then
+    COMMAND="test"
+  fi
+  if [ -z "$TARGET" ]; then
+    TARGET="$(scripts/affected_targets test)"
+  fi
+
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    select_xcode "$XCODE_VERSION"
+
+    # Move into our cloned repo
+    cd github/repo
+  fi
+
+  # Run against whichever Xcode is currently selected.
+  selected_xcode_developer_path=$(xcode-select -p)
+  selected_xcode_contents_path=$(dirname "$selected_xcode_developer_path")
+
+  xcode_version=$(cat "$selected_xcode_contents_path/version.plist" \
+    | grep "CFBundleShortVersionString" -A1 \
+    | grep string \
+    | cut -d'>' -f2 \
+    | cut -d'<' -f1)
+
+  if [ "$COMMAND" == "build" ]; then
+    echo "🏗️  $COMMAND with Xcode $xcode_version..."
+  elif [ "$COMMAND" == "test" ]; then
+    echo "🛠️  $COMMAND with Xcode $xcode_version..."
+
+    if [ -n "$VERBOSE_OUTPUT" ]; then
+      extra_args="--test_output=all"
+    else
+      extra_args="--test_output=errors"
+    fi
+  fi
+
+  fix_bazel_imports
+  if [ -n "$KOKORO_ARTIFACTS_DIR" ]; then
+    # Especially in the event of failure, we want our test artifacts to be uploaded.
+    trap upload_bazel_test_artifacts EXIT
+  fi
+
+  echo "Running bazel $COMMAND with the following target(s):"
+  echo "$TARGET"
+  bazel $COMMAND $TARGET --xcode_version $xcode_version --ios_minimum_os=8.0 --ios_multi_cpus=i386,x86_64 $extra_args $verbosity_args
+}
+
 run_bazel() {
   echo "Running bazel builds..."
 
@@ -485,6 +549,7 @@ fi
 
 case "$DEPENDENCY_SYSTEM" in
   "bazel")      run_bazel ;;
+  "bazel-affected")      run_bazel_affected ;;
   "cocoapods")  run_cocoapods ;;
   "cocoapods-podspec")  run_cocoapods ;;
   "website")    generate_website ;;

--- a/.kokoro
+++ b/.kokoro
@@ -158,72 +158,36 @@ upload_bazel_test_artifacts() {
 }
 
 run_bazel_affected() {
-  echo "Running bazel affected..."
-
-  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-    move_derived_data_to_tmp
-  fi
-
-  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-    bazel version
-    use_bazel.sh 0.20.0
-    bazel version
-  fi
-
-  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-    select_xcode "$XCODE_VERSION"
-
-    # Move into our cloned repo
-    cd github/repo
-  fi
-
-  if [ -n "$VERBOSE_OUTPUT" ]; then
-    verbosity_args="-s"
-  fi
-
+  echo "Checking affected targets..."
   if [ -z "$COMMAND" ]; then
     COMMAND="test"
   fi
   if [ -z "$TARGET" ]; then
-    TARGET="$(scripts/affected_targets test)"
+    if [ "$COMMAND" == "test" ]; then
+      # Only return test targets.
+      rule_kind="test"
+    else
+      # Return all affected targets.
+      rule_kind="rule"
+    fi
+
+    if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+      pushd github/repo >> /dev/null
+    fi
+
+    TARGET="$(scripts/affected_targets $rule_kind)"
+    
+    if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+      popd github/repo >> /dev/null
+    fi
   fi
   
   if [ -z "$TARGET" ]; then
     echo "Nothing to build."
     exit 0
   fi
-
-  # Run against whichever Xcode is currently selected.
-  selected_xcode_developer_path=$(xcode-select -p)
-  selected_xcode_contents_path=$(dirname "$selected_xcode_developer_path")
-
-  xcode_version=$(cat "$selected_xcode_contents_path/version.plist" \
-    | grep "CFBundleShortVersionString" -A1 \
-    | grep string \
-    | cut -d'>' -f2 \
-    | cut -d'<' -f1)
-
-  if [ "$COMMAND" == "build" ]; then
-    echo "🏗️  $COMMAND with Xcode $xcode_version..."
-  elif [ "$COMMAND" == "test" ]; then
-    echo "🛠️  $COMMAND with Xcode $xcode_version..."
-
-    if [ -n "$VERBOSE_OUTPUT" ]; then
-      extra_args="--test_output=all"
-    else
-      extra_args="--test_output=errors"
-    fi
-  fi
-
-  fix_bazel_imports
-  if [ -n "$KOKORO_ARTIFACTS_DIR" ]; then
-    # Especially in the event of failure, we want our test artifacts to be uploaded.
-    trap upload_bazel_test_artifacts EXIT
-  fi
-
-  echo "Running bazel $COMMAND with the following target(s):"
-  echo "$TARGET"
-  bazel $COMMAND $TARGET --xcode_version $xcode_version --ios_minimum_os=8.0 --ios_multi_cpus=i386,x86_64 $extra_args $verbosity_args
+  
+  run_bazel
 }
 
 run_bazel() {

--- a/.kokoro
+++ b/.kokoro
@@ -170,6 +170,13 @@ run_bazel_affected() {
     bazel version
   fi
 
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    select_xcode "$XCODE_VERSION"
+
+    # Move into our cloned repo
+    cd github/repo
+  fi
+
   if [ -n "$VERBOSE_OUTPUT" ]; then
     verbosity_args="-s"
   fi
@@ -179,13 +186,6 @@ run_bazel_affected() {
   fi
   if [ -z "$TARGET" ]; then
     TARGET="$(scripts/affected_targets test)"
-  fi
-
-  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-    select_xcode "$XCODE_VERSION"
-
-    # Move into our cloned repo
-    cd github/repo
   fi
 
   # Run against whichever Xcode is currently selected.

--- a/.kokoro
+++ b/.kokoro
@@ -178,7 +178,7 @@ run_bazel_affected() {
     TARGET="$(scripts/affected_targets $rule_kind)"
     
     if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-      popd github/repo >> /dev/null
+      popd >> /dev/null
     fi
   fi
   

--- a/scripts/affected_targets
+++ b/scripts/affected_targets
@@ -43,7 +43,7 @@ directly_modified_targets() {
   done | sort | uniq
 }
 
-# Reads a list of targets and generates a transitive list of dependencies that depend on on those
+# Reads a list of targets and generates a transitive list of dependencies that depend on those
 # targets.
 indirectly_modified_targets() {
   type="$1"

--- a/scripts/affected_targets
+++ b/scripts/affected_targets
@@ -16,8 +16,11 @@
 #
 # Finds all targets of a given kind affected by changes since origin/develop.
 
+# type should be a bazel `kind` type. E.g. test or rule.
+# https://docs.bazel.build/versions/master/query.html#kind
 type="$1"
 
+# Generates a list of files that were modified since origin/develop.
 modified_files() {
   git log --name-only --pretty=oneline --full-index $(git merge-base origin/develop HEAD)...HEAD \
     | grep -vE '^[0-9a-f]{40} ' \
@@ -27,6 +30,7 @@ modified_files() {
 
 # TODO: Add check for whether we need to rebuild everything.
 
+# Generates a list of targets that are affected by the files modified since origin/develop.
 directly_modified_targets() {
   for line in $(modified_files); do
     label=$(bazel query $line 2>/dev/null)
@@ -39,6 +43,8 @@ directly_modified_targets() {
   done | sort | uniq
 }
 
+# Reads a list of targets and generates a transitive list of dependencies that depend on on those
+# targets.
 indirectly_modified_targets() {
   type="$1"
   while read target; do
@@ -46,4 +52,5 @@ indirectly_modified_targets() {
   done | sort | uniq
 }
 
+# Generate the transitive list of affected targets.
 directly_modified_targets | indirectly_modified_targets "$type"

--- a/scripts/affected_targets
+++ b/scripts/affected_targets
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Finds all targets of a given kind affected by changes since origin/develop.
+
+type="$1"
+
+modified_files() {
+  git log --name-only --pretty=oneline --full-index $(git merge-base origin/develop HEAD)...HEAD \
+    | grep -vE '^[0-9a-f]{40} ' \
+    | sort \
+    | uniq
+}
+
+# TODO: Add check for whether we need to rebuild everything.
+
+directly_modified_targets() {
+  for line in $(modified_files); do
+    label=$(bazel query $line 2>/dev/null)
+    if [ "$(basename $line)" == "BUILD" ]; then
+      # All targets are affected
+      echo "$(dirname $line)/..."
+      continue
+    fi
+    bazel query "attr('srcs', $label, ${label//:*/}:*) union attr('hdrs', $label, ${label//:*/}:*)" 2>/dev/null
+  done | sort | uniq
+}
+
+indirectly_modified_targets() {
+  type="$1"
+  while read target; do
+    bazel query --universe_scope=//... --order_output=no "kind($type, allrdeps($target))" 2>/dev/null
+  done | sort | uniq
+}
+
+directly_modified_targets | indirectly_modified_targets "$type"


### PR DESCRIPTION
This new bazel job will only build targets that are affected by the change.

Affected targets are determined via the scripts/affected_targets command.

This job has some rough edges that need to be smoothed out:

- Some changes should result in all targets being affected. E.g. the material_components_ios.bzl file.
- We're only picking up srcs and hdrs modifications right now. We will need to pick up other assets as well (bundles, assets, etc...).

This new job will be enabled, but not required, until we've ensured that its coverage is accurate.