### PR TITLE
[ActivityIndicator] Stop activity indicator animating when hidden

### DIFF
--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -221,6 +221,11 @@ static const CGFloat kSingleCycleRotation =
   return CGSizeMake(edge, edge);
 }
 
+- (void)setHidden:(BOOL)hidden {
+  [super setHidden:hidden];
+  [self stopAnimating];
+}
+
 #pragma mark - Public methods
 
 - (void)startAnimating {

--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -223,7 +223,10 @@ static const CGFloat kSingleCycleRotation =
 
 - (void)setHidden:(BOOL)hidden {
   [super setHidden:hidden];
-  [self stopAnimating];
+
+  if (hidden) {
+    [self stopAnimating];
+  }
 }
 
 #pragma mark - Public methods

--- a/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.m
+++ b/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.m
@@ -155,6 +155,18 @@ static CGFloat randomNumber() {
   XCTAssertEqualObjects(indicator.accessibilityLabel, testString);
 }
 
+- (void)testStopsAnimatingWhenHidden {
+  // Given
+  MDCActivityIndicator *indicator = [[MDCActivityIndicator alloc] init];
+  [indicator startAnimating];
+
+  // When
+  indicator.hidden = YES;
+
+  // Then
+  XCTAssertFalse(indicator.animating);
+}
+
 #pragma mark - Helpers
 
 - (void)verifySettingProgressOnIndicator:(MDCActivityIndicator *)indicator animated:(BOOL)animated {


### PR DESCRIPTION
### The problem
When a client hides an activity indicator, the animation would continue despite not being necessary

### The solution
Override `setHidden` and stop the animation when hidden is true.

### Bugs
Closes #5955 