### PR TITLE
[Cards, Textfields] Update snapshot tests to utilize the new API for adding a background view

### DIFF
--- a/components/Cards/tests/snapshot/MDCCardSnapshotTests.m
+++ b/components/Cards/tests/snapshot/MDCCardSnapshotTests.m
@@ -51,7 +51,7 @@
 #pragma mark - Helpers
 
 - (void)generateSnapshotAndVerifyForView:(UIView *)view {
-  UIView *snapshotView = [self addBackgroundViewToView:view];
+  UIView *snapshotView = [view mdc_addToBackgroundView];
   [self snapshotVerifyView:snapshotView];
 }
 

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
@@ -64,7 +64,7 @@
 
 - (void)generateSnapshotAndVerify {
   [self triggerTextFieldLayout];
-  UIView *snapshotView = [self addBackgroundViewToView:self.textField];
+  UIView *snapshotView = [self.textField mdc_addToBackgroundView];
 
   // Perform the actual verification.
   [self snapshotVerifyView:snapshotView];

--- a/components/private/Snapshot/MDCSnapshotTestCase.h
+++ b/components/private/Snapshot/MDCSnapshotTestCase.h
@@ -17,12 +17,6 @@
 @interface MDCSnapshotTestCase : FBSnapshotTestCase
 
 /**
- * This method will take a view and add it to as a subview to a new view with a size slightly
- * larger than the argument view.
- */
-- (UIView *)addBackgroundViewToView:(UIView *)view;
-
-/**
  * This will call FBSnapshotVerifyView but first check for supported iOS versions. Additionally,
  * this will use UIGraphicsImageRenderer to render the view correctly (including shadows).
  *

--- a/components/private/Snapshot/MDCSnapshotTestCase.m
+++ b/components/private/Snapshot/MDCSnapshotTestCase.m
@@ -32,16 +32,6 @@ static NSString *const kiPhone7ModelB = @"iPhone9,3";
   self.agnosticOptions = FBSnapshotTestCaseAgnosticOptionOS;
 }
 
-- (UIView *)addBackgroundViewToView:(UIView *)view {
-  UIView *backgroundView =
-      [[UIView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(view.bounds) + 20,
-                                               CGRectGetHeight(view.bounds) + 20)];
-  backgroundView.backgroundColor = [UIColor colorWithWhite:0.8 alpha:1];
-  [backgroundView addSubview:view];
-  view.center = backgroundView.center;
-  return backgroundView;
-}
-
 - (void)snapshotVerifyView:(UIView *)view {
   [self snapshotVerifyView:view tolerance:0];
 }


### PR DESCRIPTION
### Changes
With the addition of #6057 we now have a category with an improved API to add a background view to the view you wish to snapshot. This change migrates the existing snapshot tests to this new API and removes the old one.

### Bugs
Closes #5942 