### PR TITLE
Fix for release-candidate merge issue with develop

### DIFF
--- a/MaterialComponentsBeta.podspec
+++ b/MaterialComponentsBeta.podspec
@@ -90,6 +90,16 @@ Pod::Spec.new do |mdc|
     extension.dependency "MaterialComponentsBeta/schemes/Container"
   end
 
+  mdc.subspec "Cards+Theming" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+ColorThemer"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+ShapeThemer"
+    extension.dependency "MaterialComponentsBeta/schemes/Container"
+  end
+
   mdc.subspec "Dialogs+Theming" do |extension|
     extension.ios.deployment_target = '8.0'
     extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"

--- a/components/Cards/BUILD
+++ b/components/Cards/BUILD
@@ -40,6 +40,20 @@ mdc_public_objc_library(
 )
 
 mdc_objc_library(
+    name = "Theming",
+    srcs = native.glob(["src/Theming/*.m"]),
+    hdrs = native.glob(["src/Theming/*.h"]),
+    includes = ["src/Theming"],
+    deps = [
+        ":Cards",
+        ":ColorThemer",
+        ":ShapeThemer",
+        "//components/schemes/Container",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+mdc_objc_library(
     name = "CardThemer",
     srcs = native.glob(["src/CardThemer/*.m"]),
     hdrs = native.glob(["src/CardThemer/*.h"]),
@@ -94,6 +108,7 @@ swift_library(
         ":Cards",
         ":ColorThemer",
         ":ShapeThemer",
+        ":Theming",
     ],
 )
 

--- a/components/Cards/examples/CardExampleViewController.swift
+++ b/components/Cards/examples/CardExampleViewController.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 import MaterialComponents.MaterialButtons_ButtonThemer
-import MaterialComponents.MaterialCards_CardThemer
+import MaterialComponentsBeta.MaterialCards_Theming
 import MaterialComponentsBeta.MaterialContainerScheme
 import MaterialComponentsBeta.MaterialButtons_Theming
 
@@ -27,6 +27,14 @@ class CardExampleViewController: UIViewController {
   var shapeScheme = MDCShapeScheme()
   var typographyScheme = MDCTypographyScheme()
 
+  var scheme: MDCContainerScheming {
+    let scheme = MDCContainerScheme()
+    scheme.colorScheme = colorScheme
+    scheme.typographyScheme = typographyScheme
+    scheme.shapeScheme = shapeScheme
+    return scheme
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -36,12 +44,8 @@ class CardExampleViewController: UIViewController {
     bundle.loadNibNamed("CardExampleViewController", owner: self, options: nil)
     view.frame = self.view.bounds
 
-    button.applyTextTheme(withScheme: MDCContainerScheme())
-
-    let cardScheme = MDCCardScheme();
-    cardScheme.colorScheme = colorScheme
-    cardScheme.shapeScheme = shapeScheme
-    MDCCardThemer.applyScheme(cardScheme, to: card)
+    button.applyTextTheme(withScheme: scheme)
+    card.applyTheme(withScheme: scheme)
     card.isInteractable = false
 
     imageView.isAccessibilityElement = true

--- a/components/Cards/examples/EditReorderCollectionViewController.swift
+++ b/components/Cards/examples/EditReorderCollectionViewController.swift
@@ -14,7 +14,6 @@
 
 import UIKit
 
-import MaterialComponents.MaterialCards_CardThemer
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialTypographyScheme
 import MaterialComponentsBeta.MaterialContainerScheme
@@ -35,7 +34,14 @@ class EditReorderCollectionViewController: UIViewController,
   var colorScheme = MDCSemanticColorScheme()
   var shapeScheme = MDCShapeScheme()
   var typographyScheme = MDCTypographyScheme()
-  let cardScheme = MDCCardScheme()
+
+  var containerScheme: MDCContainerScheming {
+    let scheme = MDCContainerScheme()
+    scheme.colorScheme = colorScheme
+    scheme.typographyScheme = typographyScheme
+    scheme.shapeScheme = shapeScheme
+    return scheme
+  }
 
   let images = [
     (image: "amsterdam-kadoelen",     title: "Kadoelen"),
@@ -49,8 +55,6 @@ class EditReorderCollectionViewController: UIViewController,
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    cardScheme.colorScheme = colorScheme
-    cardScheme.shapeScheme = shapeScheme
     collectionView.frame = view.bounds
     collectionView.dataSource = self
     collectionView.delegate = self
@@ -138,7 +142,7 @@ class EditReorderCollectionViewController: UIViewController,
     let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath)
     guard let cardCell = cell as? CardEditReorderCollectionCell else { return cell }
 
-    cardCell.apply(cardScheme: cardScheme, typographyScheme: typographyScheme)
+    cardCell.apply(containerScheme: containerScheme, typographyScheme: typographyScheme)
 
     let title = dataSource[indexPath.item].title
     let imageName = dataSource[indexPath.item].image

--- a/components/Cards/examples/supplemental/CardEditReorderCollectionCell.swift
+++ b/components/Cards/examples/supplemental/CardEditReorderCollectionCell.swift
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import UIKit
-import MaterialComponents.MaterialCards_CardThemer
 import MaterialComponents.MaterialTypographyScheme
+import MaterialComponentsBeta.MaterialCards_Theming
 
 class CardEditReorderCollectionCell: MDCCardCollectionCell {
 
@@ -52,8 +52,8 @@ class CardEditReorderCollectionCell: MDCCardCollectionCell {
     addConstraints()
   }
 
-  func apply(cardScheme: MDCCardScheme, typographyScheme: MDCTypographyScheme) {
-    MDCCardThemer.applyScheme(cardScheme, toCardCell: self)
+  func apply(containerScheme: MDCContainerScheming, typographyScheme: MDCTypographyScheme) {
+    self.applyTheme(withScheme: containerScheme)
     self.titleLabel.font = typographyScheme.caption
   }
 

--- a/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
+++ b/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
@@ -28,8 +28,8 @@
 #import "MaterialButtons+ShapeThemer.h"
 #import "MaterialButtons+Theming.h"
 #import "MaterialButtons.h"
-#import "MaterialCards+CardThemer.h"
 #import "MaterialCards+ShapeThemer.h"
+#import "MaterialCards+Theming.h"
 #import "MaterialCards.h"
 #import "MaterialChips+ChipThemer.h"
 #import "MaterialChips+ShapeThemer.h"
@@ -138,13 +138,9 @@
   [MDCChipViewThemer applyScheme:chipViewScheme toChipView:self.chipView];
   [self.componentContentView addSubview:self.chipView];
 
-  MDCCardScheme *cardScheme = [[MDCCardScheme alloc] init];
-  cardScheme.colorScheme = self.colorScheme;
-  cardScheme.shapeScheme = self.shapeScheme;
-
   self.card = [[MDCCard alloc] init];
   self.card.translatesAutoresizingMaskIntoConstraints = NO;
-  [MDCCardThemer applyScheme:cardScheme toCard:self.card];
+  [self.card applyThemeWithScheme:self.containerScheme];
   self.card.backgroundColor = _colorScheme.primaryColor;
   [self.componentContentView addSubview:self.card];
 


### PR DESCRIPTION
It appears when the release-candidate was merged back into develop, some code changes were lost/reverted unintentionally. 

See for the details here: https://github.com/material-components/material-components-ios/commit/026a2005e74fb75411295b8f44fd778eb2f87db0

This change brings all the necessary changes back into develop. Specifically around the cards theming extension and the updated Card theming examples.

This issue appears to stem from the fact that these 2 PRs landed in develop after the release-candidate was branched:
#6048
#6049 