### PR TITLE
[FlexibleHeader] Fix shift phase behavior when contained in the tracking scroll view.

### DIFF
--- a/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
@@ -25,6 +25,14 @@
 
 @implementation FlexibleHeaderConfiguratorExample
 
+#pragma mark - MDCFlexibleHeaderViewLayoutDelegate
+
+- (void)flexibleHeaderViewController:
+(MDCFlexibleHeaderViewController *)flexibleHeaderViewController
+    flexibleHeaderViewFrameDidChange:(MDCFlexibleHeaderView *)flexibleHeaderView {
+  NSLog(@"Scroll phase: %@ percentage: %@ value: %@", @(flexibleHeaderView.scrollPhase), @(flexibleHeaderView.scrollPhasePercentage), @(flexibleHeaderView.scrollPhaseValue));
+}
+
 // Invoked when the user has changed a control's value.
 - (void)field:(FlexibleHeaderConfiguratorField)field didChangeValue:(NSNumber *)value {
   MDCFlexibleHeaderView *headerView = self.fhvc.headerView;

--- a/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
@@ -27,10 +27,10 @@
 
 #pragma mark - MDCFlexibleHeaderViewLayoutDelegate
 
-- (void)flexibleHeaderViewController:
-(MDCFlexibleHeaderViewController *)flexibleHeaderViewController
+- (void)flexibleHeaderViewController:(MDCFlexibleHeaderViewController *)flexibleHeaderViewController
     flexibleHeaderViewFrameDidChange:(MDCFlexibleHeaderView *)flexibleHeaderView {
-  NSLog(@"Scroll phase: %@ percentage: %@ value: %@", @(flexibleHeaderView.scrollPhase), @(flexibleHeaderView.scrollPhasePercentage), @(flexibleHeaderView.scrollPhaseValue));
+  NSLog(@"Scroll phase: %@ percentage: %@ value: %@", @(flexibleHeaderView.scrollPhase),
+        @(flexibleHeaderView.scrollPhasePercentage), @(flexibleHeaderView.scrollPhaseValue));
 }
 
 // Invoked when the user has changed a control's value.

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.h
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.h
@@ -38,7 +38,7 @@ typedef enum : NSUInteger {
   FlexibleHeaderConfiguratorFieldCanAlwaysExpandToMaximumHeight,
 } FlexibleHeaderConfiguratorField;
 
-@interface FlexibleHeaderConfiguratorExample : UITableViewController
+@interface FlexibleHeaderConfiguratorExample : UITableViewController <MDCFlexibleHeaderViewLayoutDelegate>
 
 - (NSNumber *)valueForField:(FlexibleHeaderConfiguratorField)field;
 - (void)field:(FlexibleHeaderConfiguratorField)field didChangeValue:(NSNumber *)value;

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.h
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.h
@@ -38,7 +38,8 @@ typedef enum : NSUInteger {
   FlexibleHeaderConfiguratorFieldCanAlwaysExpandToMaximumHeight,
 } FlexibleHeaderConfiguratorField;
 
-@interface FlexibleHeaderConfiguratorExample : UITableViewController <MDCFlexibleHeaderViewLayoutDelegate>
+@interface FlexibleHeaderConfiguratorExample
+    : UITableViewController <MDCFlexibleHeaderViewLayoutDelegate>
 
 - (NSNumber *)valueForField:(FlexibleHeaderConfiguratorField)field;
 - (void)field:(FlexibleHeaderConfiguratorField)field didChangeValue:(NSNumber *)value;

--- a/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
+++ b/components/FlexibleHeader/examples/supplemental/FlexibleHeaderConfiguratorSupplemental.m
@@ -78,6 +78,7 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
   self.minimumHeaderHeight = 0;
 
   self.fhvc.headerView.trackingScrollView = self.tableView;
+  self.fhvc.layoutDelegate = self;
 
   self.fhvc.view.frame = self.view.bounds;
   [self.view addSubview:self.fhvc.view];

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -751,9 +751,11 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 - (void)fhv_recalculatePhase {
   CGRect frame = self.frame;
 
-  if (frame.origin.y < 0) {
+  CGFloat topEdge = self.center.y - self.bounds.size.height / 2;
+
+  if (topEdge < 0) {
     _scrollPhase = MDCFlexibleHeaderScrollPhaseShifting;
-    _scrollPhaseValue = frame.origin.y + self.minMaxHeight.minimumHeightWithTopSafeArea;
+    _scrollPhaseValue = topEdge + self.minMaxHeight.minimumHeightWithTopSafeArea;
     CGFloat adjustedHeight = self.minMaxHeight.minimumHeightWithTopSafeArea;
     if ([self fhv_shouldCollapseToStatusBar]) {
       CGFloat statusBarHeight =
@@ -761,7 +763,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
       adjustedHeight -= statusBarHeight;
     }
     if (adjustedHeight > 0) {
-      _scrollPhasePercentage = -frame.origin.y / adjustedHeight;
+      _scrollPhasePercentage = -topEdge / adjustedHeight;
     } else {
       _scrollPhasePercentage = 0;
     }


### PR DESCRIPTION
Closes https://github.com/material-components/material-components-ios/issues/5813

Problem:
Prior to this change, the shift phase values were nonsensical when a flexible header was a child of its tracking scroll view.

Root cause:
The scroll phase value logic was looking at self.frame, which is undefined if self.transform is not the identity. When a flexible header is a child of its tracking scroll view, we modify self.transform in order to keep it "pinned" to the top of the screen. This resulted in unpredictable values for self.frame in the phase calculation logic.

The fix:
Rather than rely on self.frame, we now inspect self.center which is unaffected by self.transform. We calculate what the "top edge" of the flexible header is and feed that value in to the phase calculation logic.

Tested:
Added new log statements to the flexible header configurator demo. Verified that the values output matched the documented behavior of the scroll phase properties.