### PR TITLE
[ActionSheet] Remove redundant `visibility` args.

### DIFF
--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -91,7 +91,6 @@ mdc_objc_library(
     name = "privateHeaders",
     testonly = 1,
     hdrs = native.glob(["src/private/*.h"]),
-    visibility = ["//visibility:private"],
     deps = [":ActionSheet"],
 )
 
@@ -99,7 +98,6 @@ mdc_objc_library(
     name = "private",
     hdrs = native.glob(["src/private/*.h"]),
     includes = ["src/private"],
-    visibility = ["//visibility:private"],
 )
 
 mdc_objc_library(
@@ -138,7 +136,6 @@ swift_library(
         "-swift-version",
         "3",
     ],
-    visibility = ["//visibility:private"],
     deps = [
         ":ActionSheet",
         ":ColorThemer",
@@ -158,7 +155,6 @@ mdc_objc_library(
         "CoreImage",
         "XCTest",
     ],
-    visibility = ["//visibility:private"],
     deps = [
         ":ActionSheet",
         ":ActionSheetThemer",


### PR DESCRIPTION
The default visibility of a bazel target is `private`. Unless we are
deviating from that default visibility, we need not explicitly redeclare
the same visibility in every target.
