### PR TITLE
[bazel] Add mdc_private_hdrs_objc_library rule.

### DIFF
--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -22,16 +22,18 @@ def mdc_objc_library(
       **kwargs)
 
 def mdc_private_hdrs_objc_library(
+    name = "privateHeaders",
     deps = [],
     **kwargs):
   """Declare a target for exposing private component headers for testing
 
   Args:
+    name: The name of the library.
     deps: The dependencies of the library. Typically the main target.
     **kwargs: Any arguments accepted by _mdc_objc_library().
   """
   mdc_objc_library(
-    name = "privateHeaders",
+    name = name,
     deps = deps,
     testonly = 1,
     hdrs = native.glob(["src/private/*.h"]),

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -21,6 +21,23 @@ def mdc_objc_library(
       copts = copts,
       **kwargs)
 
+def mdc_private_hdrs_objc_library(
+    deps = [],
+    **kwargs):
+  """Declare a target for exposing private component headers for testing
+
+  Args:
+    deps: The dependencies of the library. Typically the main target.
+    **kwargs: Any arguments accepted by _mdc_objc_library().
+  """
+  mdc_objc_library(
+    name = "privateHeaders",
+    deps = deps,
+    testonly = 1,
+    hdrs = native.glob(["src/private/*.h"]),
+    includes = ["src/private"],
+    **kwargs)
+
 def mdc_public_objc_library(
     name,
     deps = [],


### PR DESCRIPTION
A large number of our components redeclare a nearly-identical `private`
or `privateHeaders` target that exposes the `src/private/` header files
of the main component code. To reduce boilerplate, a custom build rule
can be created to handle most of the duplicated arguments.

**Example**

```
mdc_private_hdrs_objc_library(
    deps = [":ActionSheet"],
)
```
