### PR TITLE
[.kokoro] Turn off verbose logging for the cocoapods-podspec job.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -305,7 +305,7 @@ run_cocoapods() {
       bash scripts/test_all catalog/MDCCatalog.xcworkspace:MDCCatalog
     fi
   elif [ "$DEPENDENCY_SYSTEM" = "cocoapods-podspec" ]; then
-    pod lib lint MaterialComponents.podspec --verbose --skip-tests
+    pod lib lint MaterialComponents.podspec --skip-tests
   fi
 
   if [ -n "$CODECOV_TOKEN" ]; then


### PR DESCRIPTION
The logs aren't particularly helpful and may be contributing to a longer-than-necessary job duration.