### PR TITLE
[automated] Make mdc_unit_test_suite's name explicit.

### DIFF
--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -166,6 +166,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
         ":unit_test_swift_sources",

--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -96,6 +96,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
         ":unit_test_swift_sources",

--- a/components/AnimationTiming/BUILD
+++ b/components/AnimationTiming/BUILD
@@ -43,6 +43,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/AppBar/BUILD
+++ b/components/AppBar/BUILD
@@ -113,6 +113,7 @@ swift_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_swift_sources",
     ],

--- a/components/BottomAppBar/BUILD
+++ b/components/BottomAppBar/BUILD
@@ -83,6 +83,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -109,6 +109,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/BottomSheet/BUILD
+++ b/components/BottomSheet/BUILD
@@ -75,6 +75,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
         ":unit_test_swift_sources",

--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -128,6 +128,7 @@ swift_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
         ":unit_test_swift_sources",

--- a/components/Buttons/BUILD
+++ b/components/Buttons/BUILD
@@ -163,6 +163,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/Cards/BUILD
+++ b/components/Cards/BUILD
@@ -131,6 +131,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
         ":unit_test_swift_sources",

--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -148,6 +148,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/CollectionCells/BUILD
+++ b/components/CollectionCells/BUILD
@@ -75,6 +75,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/CollectionLayoutAttributes/BUILD
+++ b/components/CollectionLayoutAttributes/BUILD
@@ -56,6 +56,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/Collections/BUILD
+++ b/components/Collections/BUILD
@@ -77,6 +77,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -152,6 +152,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/FeatureHighlight/BUILD
+++ b/components/FeatureHighlight/BUILD
@@ -126,6 +126,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -116,6 +116,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
         ":unit_test_swift_sources",

--- a/components/HeaderStackView/BUILD
+++ b/components/HeaderStackView/BUILD
@@ -65,6 +65,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/Ink/BUILD
+++ b/components/Ink/BUILD
@@ -74,6 +74,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/LibraryInfo/BUILD
+++ b/components/LibraryInfo/BUILD
@@ -42,6 +42,7 @@ swift_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_swift_sources",
     ],

--- a/components/List/BUILD
+++ b/components/List/BUILD
@@ -96,6 +96,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/MaskedTransition/BUILD
+++ b/components/MaskedTransition/BUILD
@@ -62,6 +62,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/NavigationBar/BUILD
+++ b/components/NavigationBar/BUILD
@@ -96,6 +96,7 @@ swift_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
         ":unit_test_swift_sources",

--- a/components/NavigationDrawer/BUILD
+++ b/components/NavigationDrawer/BUILD
@@ -77,6 +77,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/OverlayWindow/BUILD
+++ b/components/OverlayWindow/BUILD
@@ -50,6 +50,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/PageControl/BUILD
+++ b/components/PageControl/BUILD
@@ -84,6 +84,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/Palettes/BUILD
+++ b/components/Palettes/BUILD
@@ -50,6 +50,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
         ":unit_test_swift_sources",

--- a/components/ProgressView/BUILD
+++ b/components/ProgressView/BUILD
@@ -79,6 +79,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/ShadowElevations/BUILD
+++ b/components/ShadowElevations/BUILD
@@ -46,6 +46,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/ShadowLayer/BUILD
+++ b/components/ShadowLayer/BUILD
@@ -50,6 +50,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/Slider/BUILD
+++ b/components/Slider/BUILD
@@ -76,6 +76,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/Snackbar/BUILD
+++ b/components/Snackbar/BUILD
@@ -143,6 +143,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
         ":unit_test_swift_sources",

--- a/components/Tabs/BUILD
+++ b/components/Tabs/BUILD
@@ -125,6 +125,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -131,6 +131,7 @@ swift_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
         ":unit_test_swift_sources",

--- a/components/Themes/BUILD
+++ b/components/Themes/BUILD
@@ -57,6 +57,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/Typography/BUILD
+++ b/components/Typography/BUILD
@@ -58,6 +58,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/private/Icons/BUILD
+++ b/components/private/Icons/BUILD
@@ -54,6 +54,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/private/KeyboardWatcher/BUILD
+++ b/components/private/KeyboardWatcher/BUILD
@@ -50,6 +50,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     size = "small",
     deps = [
         ":unit_test_sources",

--- a/components/private/Overlay/BUILD
+++ b/components/private/Overlay/BUILD
@@ -57,6 +57,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/private/ShapeLibrary/BUILD
+++ b/components/private/ShapeLibrary/BUILD
@@ -52,6 +52,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/private/Shapes/BUILD
+++ b/components/private/Shapes/BUILD
@@ -53,6 +53,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/private/ThumbTrack/BUILD
+++ b/components/private/ThumbTrack/BUILD
@@ -66,6 +66,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/schemes/Color/BUILD
+++ b/components/schemes/Color/BUILD
@@ -54,6 +54,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/schemes/Container/BUILD
+++ b/components/schemes/Container/BUILD
@@ -47,6 +47,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/schemes/Shape/BUILD
+++ b/components/schemes/Shape/BUILD
@@ -55,6 +55,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/components/schemes/Typography/BUILD
+++ b/components/schemes/Typography/BUILD
@@ -52,6 +52,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+    name = "unit_tests",
     deps = [
         ":unit_test_sources",
     ],

--- a/contributing/bazel_kokoro.md
+++ b/contributing/bazel_kokoro.md
@@ -93,6 +93,7 @@ mdc_objc_library(
 )
 
 mdc_unit_test_suite(
+  name = "unit_tests",
     deps = [
       ":unit_test_sources",
     ],
@@ -186,6 +187,7 @@ swift_library(
 )
 
 mdc_unit_test_suite(
+  name = "unit_tests",
     deps = [
       ":unit_test_sources",
       ":unit_test_swift_sources"

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -57,7 +57,7 @@ def mdc_public_objc_library(
       **kwargs)
 
 def mdc_unit_test_suite(
-    name = "unit_tests",
+    name,
     deps = [],
     minimum_os_version = "8.0",
     visibility = ["//visibility:private"],


### PR DESCRIPTION
This change was automatically generated by running a find replace of the following strings:

```
mdc_unit_test_suite(

mdc_unit_test_suite(
    name = "unit_tests",
```

And then running buildifier to enforce style:

    find . -name BUILD | xargs ~/buildifier