### PR TITLE
[Cards] Add back missing dependency for cards test spec

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -357,6 +357,7 @@ Pod::Spec.new do |mdc|
       tests.test_spec 'unit' do |unit_tests|
         unit_tests.source_files = "components/#{component.base_name}/tests/unit/*.{h,m,swift}", "components/#{component.base_name}/tests/unit/supplemental/*.{h,m,swift}"
         unit_tests.resources = "components/#{component.base_name}/tests/unit/resources/*"
+        unit_tests.dependency "MaterialComponentsBeta/#{component.base_name}+Theming"
       end
     end
   end


### PR DESCRIPTION
It looks like I missed this line in my fix PR from yesterday #6068 

This change was originally undone by the merge commit from yesterday's release: https://github.com/material-components/material-components-ios/commit/026a2005e74fb75411295b8f44fd778eb2f87db0