### PR TITLE
[kokoro] Improvements to the affected_targets job.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -197,19 +197,22 @@ run_bazel_affected() {
       pushd github/repo >> /dev/null
     fi
 
+    # `target_branch` is either the Pull Request destination branch (where it will be merged) or if
+    # none can be determined, defaults to `develop`.
     if [ -n "$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH" ]; then
       target_branch="$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH"
     else
       target_branch=develop
     fi
-    if [ $(git branch --list "$target_branch") ]; then
-      base_sha=$(git merge-base "$target_branch" HEAD)
-    else
-      base_sha="HEAD^"
-    fi
 
+    # `base_sha` is the merge base of `target_branch` and the current HEAD.
+    base_sha=$(git merge-base "$target_branch" HEAD)
+
+    # `TARGET` is then all bazel targets affected by changes in the commit range between `base_sha`
+    # and `HEAD`.  By default, that becomes all changes between the `develop` branch and the latest
+    #  commit.
     TARGET="$(scripts/affected_targets $rule_kind $base_sha...HEAD)"
-    
+
     if [ -n "$KOKORO_BUILD_NUMBER" ]; then
       popd >> /dev/null
     fi

--- a/.kokoro
+++ b/.kokoro
@@ -187,10 +187,10 @@ run_bazel_affected() {
   if [ -z "$TARGET" ]; then
     if [ "$COMMAND" == "test" ]; then
       # Only return test targets.
-      rule_kind="test"
+      bazel_kind="test"
     else
       # Return all affected targets.
-      rule_kind="rule"
+      bazel_kind="rule"
     fi
 
     if [ -n "$KOKORO_BUILD_NUMBER" ]; then
@@ -211,7 +211,7 @@ run_bazel_affected() {
     # `TARGET` is then all bazel targets affected by changes in the commit range between `base_sha`
     # and `HEAD`.  By default, that becomes all changes between the `develop` branch and the latest
     #  commit.
-    TARGET="$(scripts/affected_targets $rule_kind $base_sha...HEAD)"
+    TARGET="$(scripts/affected_targets $bazel_kind $base_sha...HEAD)"
 
     if [ -n "$KOKORO_BUILD_NUMBER" ]; then
       popd >> /dev/null

--- a/.kokoro
+++ b/.kokoro
@@ -197,7 +197,18 @@ run_bazel_affected() {
       pushd github/repo >> /dev/null
     fi
 
-    TARGET="$(scripts/affected_targets $rule_kind)"
+    if [ -n "$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH" ]; then
+      target_branch="$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH"
+    else
+      target_branch=develop
+    fi
+    if [ $(git branch --list "$target_branch") ]; then
+      base_sha=$(git merge-base "$target_branch" HEAD)
+    else
+      base_sha="HEAD^"
+    fi
+
+    TARGET="$(scripts/affected_targets $rule_kind $base_sha...HEAD)"
     
     if [ -n "$KOKORO_BUILD_NUMBER" ]; then
       popd >> /dev/null
@@ -208,6 +219,8 @@ run_bazel_affected() {
     echo "Nothing to build."
     exit 0
   fi
+
+  echo "$TARGET"
   
   run_bazel
 }

--- a/scripts/affected_targets
+++ b/scripts/affected_targets
@@ -55,7 +55,8 @@ files_that_affect_everything() {
   grep -e "\.bzl$" \
     -e "WORKSPACE" \
     -e "\.kokoro" \
-    -e "$SCRIPT_NAME" \
+    -e "\.gitattributes" \
+    -e "${SCRIPT_NAME/\./\\.}" \
     "$@"
 }
 
@@ -64,27 +65,27 @@ if modified_files | files_that_affect_everything -q; then
   exit 0
 fi
 
-# Generates a list of targets that are affected by the files modified since origin/develop.
-directly_modified_targets() {
-  while read line; do
-    label=$(bazel query $line 2>/dev/null)
-    if [ "$(basename $line)" == "BUILD" ]; then
+# Reads a list of file paths and generates a list of bazel targets that would be affected by changes
+# to these files.
+affected_targets() {
+  while read file_path; do
+    if [ "$(basename $file_path)" == "BUILD" ]; then
       # All targets are affected
-      echo "//$(dirname $line)/..."
-      continue
+      query="//$(dirname $file_path)/..."
+    else
+      query="$file_path"
     fi
-    bazel query "attr('srcs', $label, ${label//:*/}:*) union attr('hdrs', $label, ${label//:*/}:*)" 2>/dev/null
-  done | sort | uniq
-}
 
-# Reads a list of targets and generates a transitive list of dependencies that depend on those
-# targets.
-indirectly_modified_targets() {
-  type="$1"
-  while read target; do
-    bazel query --universe_scope=//... --order_output=no "kind($type, allrdeps($target))" 2>/dev/null
+    # allrdeps is part of Sky Query, which can only be accessed when universe_scope and order_output
+    # are provided. See the following docs for more details:
+    # https://docs.bazel.build/versions/master/query.html#sky-query
+    bazel query \
+      --universe_scope=//... \
+      --order_output=no \
+      "kind($type, allrdeps($query))" \
+      2>/dev/null
   done | sort | uniq
 }
 
 # Generate the transitive list of affected targets.
-modified_files | directly_modified_targets | indirectly_modified_targets "$type"
+modified_files | affected_targets "$type"

--- a/scripts/affected_targets
+++ b/scripts/affected_targets
@@ -18,14 +18,14 @@
 
 SCRIPT_NAME=$(basename "$0")
 
-# rule_kind should be a bazel `kind` type. E.g. test or rule.
+# bazel_kind should be a bazel `kind` type. E.g. test or rule.
 # https://docs.bazel.build/versions/master/query.html#kind
-rule_kind="$1"
+bazel_kind="$1"
 
 # range should be a valid git diff/log range. E.g. origin/develop...HEAD
 range="$2"
 
-if [ -z "$rule_kind" ]; then
+if [ -z "$bazel_kind" ]; then
   echo "Please provide a blaze rule kind to query for."
   exit 1
 fi
@@ -82,7 +82,7 @@ affected_targets() {
     bazel query \
       --universe_scope=//... \
       --order_output=no \
-      "kind($rule_kind, allrdeps('$query'))" \
+      "kind($bazel_kind, allrdeps('$query'))" \
       2>/dev/null
   done | sort | uniq
 }

--- a/scripts/affected_targets
+++ b/scripts/affected_targets
@@ -70,7 +70,7 @@ directly_modified_targets() {
     label=$(bazel query $line 2>/dev/null)
     if [ "$(basename $line)" == "BUILD" ]; then
       # All targets are affected
-      echo "$(dirname $line)/..."
+      echo "//$(dirname $line)/..."
       continue
     fi
     bazel query "attr('srcs', $label, ${label//:*/}:*) union attr('hdrs', $label, ${label//:*/}:*)" 2>/dev/null

--- a/scripts/affected_targets
+++ b/scripts/affected_targets
@@ -18,15 +18,15 @@
 
 SCRIPT_NAME=$(basename "$0")
 
-# type should be a bazel `kind` type. E.g. test or rule.
+# rule_kind should be a bazel `kind` type. E.g. test or rule.
 # https://docs.bazel.build/versions/master/query.html#kind
-type="$1"
+rule_kind="$1"
 
 # range should be a valid git diff/log range. E.g. origin/develop...HEAD
 range="$2"
 
-if [ -z "$type" ]; then
-  echo "Please provide a blaze rule type to query for."
+if [ -z "$rule_kind" ]; then
+  echo "Please provide a blaze rule kind to query for."
   exit 1
 fi
 
@@ -82,10 +82,10 @@ affected_targets() {
     bazel query \
       --universe_scope=//... \
       --order_output=no \
-      "kind($type, allrdeps('$query'))" \
+      "kind($rule_kind, allrdeps('$query'))" \
       2>/dev/null
   done | sort | uniq
 }
 
 # Generate the transitive list of affected targets.
-modified_files | affected_targets "$type"
+modified_files | affected_targets

--- a/scripts/affected_targets
+++ b/scripts/affected_targets
@@ -20,19 +20,47 @@
 # https://docs.bazel.build/versions/master/query.html#kind
 type="$1"
 
+# range should be a valid git diff/log range. E.g. origin/develop...HEAD
+range="$2"
+
+if [ -z "$type" ]; then
+  echo "Please provide a blaze rule type to query for."
+  exit 1
+fi
+
+if [ -z "$range" ]; then
+  echo "Please provide a diff range."
+  exit 1
+fi
+
+if [ $(git branch --list "$TARGET_BRANCH") ]; then
+  base_sha=$(git merge-base "$TARGET_BRANCH" HEAD)
+else
+  base_sha="HEAD^"
+fi
+
 # Generates a list of files that were modified since origin/develop.
 modified_files() {
-  git log --name-only --pretty=oneline --full-index $(git merge-base origin/develop HEAD)...HEAD \
+  git log --name-only --pretty=oneline --full-index "$range" \
     | grep -vE '^[0-9a-f]{40} ' \
     | sort \
     | uniq
 }
 
-# TODO: Add check for whether we need to rebuild everything.
+# Reads a list of files and generates a list of files that will affect the entire
+# build system.
+files_that_affect_everything() {
+  grep -e "\.bzl$" -e "WORKSPACE" -e "\.kokoro" "$@"
+}
+
+if modified_files | files_that_affect_everything -q; then
+  echo "//..."
+  exit 0
+fi
 
 # Generates a list of targets that are affected by the files modified since origin/develop.
 directly_modified_targets() {
-  for line in $(modified_files); do
+  while read line; do
     label=$(bazel query $line 2>/dev/null)
     if [ "$(basename $line)" == "BUILD" ]; then
       # All targets are affected
@@ -53,4 +81,4 @@ indirectly_modified_targets() {
 }
 
 # Generate the transitive list of affected targets.
-directly_modified_targets | indirectly_modified_targets "$type"
+modified_files | directly_modified_targets | indirectly_modified_targets "$type"

--- a/scripts/affected_targets
+++ b/scripts/affected_targets
@@ -82,7 +82,7 @@ affected_targets() {
     bazel query \
       --universe_scope=//... \
       --order_output=no \
-      "kind($type, allrdeps($query))" \
+      "kind($type, allrdeps('$query'))" \
       2>/dev/null
   done | sort | uniq
 }

--- a/scripts/affected_targets
+++ b/scripts/affected_targets
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Finds all targets of a given kind affected by changes since origin/develop.
+# Finds all targets of a given kind affected by changes in a given commit range.
+
+SCRIPT_NAME=$(basename "$0")
 
 # type should be a bazel `kind` type. E.g. test or rule.
 # https://docs.bazel.build/versions/master/query.html#kind
@@ -50,7 +52,11 @@ modified_files() {
 # Reads a list of files and generates a list of files that will affect the entire
 # build system.
 files_that_affect_everything() {
-  grep -e "\.bzl$" -e "WORKSPACE" -e "\.kokoro" "$@"
+  grep -e "\.bzl$" \
+    -e "WORKSPACE" \
+    -e "\.kokoro" \
+    -e "$SCRIPT_NAME" \
+    "$@"
 }
 
 if modified_files | files_that_affect_everything -q; then


### PR DESCRIPTION
- The affected_targets script now accepts a range.
- The .kokoro script now determines the correct range of changes using the target branch.
- Changes to `*.bzl`, `WORKSPACE`, `.kokoro`, `affected_targets`, or `.gitattributes` will now result in a complete build.

E.g. this PR should result in a complete build because it is modifying the .kokoro file.

We can now test `scripts/affected_targets` with various commits like so:

```bash
> scripts/affected_targets test 026a2005e74fb75411295b8f44fd778eb2f87db0...8297e5dca167f72ee1b69d3acfec5507fccceaf7
//components/Tabs:unit_tests
//components/Tabs:unit_tests_IPAD_PRO_12_9_IN_9_3
//components/Tabs:unit_tests_IPAD_PRO_12_9_IN_9_3_test_bundle
//components/Tabs:unit_tests_IPHONE_5_IN_8_1
//components/Tabs:unit_tests_IPHONE_5_IN_8_1_test_bundle
//components/Tabs:unit_tests_IPHONE_7_PLUS_IN_10_3
//components/Tabs:unit_tests_IPHONE_7_PLUS_IN_10_3_test_bundle
//components/Tabs:unit_tests_IPHONE_X_IN_11_0
//components/Tabs:unit_tests_IPHONE_X_IN_11_0_test_bundle
```