### PR TITLE
[.kokoro] Install bazel quietly.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -221,7 +221,7 @@ run_bazel() {
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     bazel version
-    use_bazel.sh 0.20.0
+    use_bazel.sh 0.20.0 --quiet
     bazel version
   fi
 


### PR DESCRIPTION
Adds `--quiet` to the bazel installation script so that we don't generate as much noise in the logs.