### PR TITLE
[bazel] Add component "extensions" rule.

### DIFF
--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -56,6 +56,43 @@ def mdc_public_objc_library(
       enable_modules = 1,
       **kwargs)
 
+def mdc_extension_objc_library(
+    name,
+    deps = [],
+    sdk_frameworks = [],
+    visibility = ["//visibility:public"],
+    **kwargs):
+  """Declare a public MDC component extension as an Objective-C library according to MDC's 
+     conventions.
+
+  The conventions for an MDC component extensino are:
+  - The public implementation lives in `src/$name/`.
+  - The private implementation lives in `src/$name/private`.
+
+  The default visibility can be overridde.
+
+  Args:
+    name: The name of the extension. It must match the folder it resides in.
+    deps: The dependencies of the extension.
+    sdk_frameworks: Extra SDK frameworks (e.g., CoreGraphics) required by the extension.
+    visibility: The visibility of the extension.
+    **kwarrgs: Any arrguments accepted by _mdc_objc_library().
+  """
+  mdc_objc_library(
+      name = name,
+      deps = deps,
+      sdk_frameworks = sdk_frameworks,
+      visibility = visibility,
+      srcs = native.glob([
+          "src/" + name + "/*.m",
+          "src/" + name + "/private/*.m",
+          "src/" + name + "/private/*.h",
+      ]),
+      hdrs = native.glob(["src/" + name + "/*.h"]),
+      includes = ["src/" + name],
+      enable_modules = 1,
+      **kwargs)
+
 def mdc_unit_test_suite(
     name,
     deps = [],


### PR DESCRIPTION
Since our extensions should generally follow the file system convention
for naming, we can create a custom bazel rule that reduces some
boilerplate code.

----

Example
-------

**Before**

```
mdc_objc_library(
    name = "Theming",
    srcs = native.glob(["src/Theming/*.m"]),
    hdrs = native.glob(["src/Theming/*.h"]),
    includes = ["src/Theming"],
    visibility = ["//visibility:public"],
    deps = [
        ":ActionSheet",
        ":ColorThemer",
        ":TypographyThemer",
        "//components/schemes/Container",
    ],
)
```

**After**

```
mdc_extension_objc_library(
    name = "Theming",
    deps = [
        ":ActionSheet",
        ":ColorThemer",
        ":TypographyThemer",
        "//components/schemes/Container",
    ],
)
```
