### PR TITLE
[Chips] Create theming extension for Chips

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -408,6 +408,7 @@ Pod::Spec.new do |mdc|
       tests.test_spec 'unit' do |unit_tests|
         unit_tests.source_files = "components/#{component.base_name}/tests/unit/*.{h,m,swift}", "components/#{component.base_name}/tests/unit/supplemental/*.{h,m,swift}"
         unit_tests.resources = "components/#{component.base_name}/tests/unit/resources/*"
+        unit_tests.dependency "MaterialComponentsBeta/#{component.base_name}+Theming"
       end
     end
   end

--- a/MaterialComponentsBeta.podspec
+++ b/MaterialComponentsBeta.podspec
@@ -100,6 +100,17 @@ Pod::Spec.new do |mdc|
     extension.dependency "MaterialComponentsBeta/schemes/Container"
   end
 
+  mdc.subspec "Chips+Theming" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+ColorThemer"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+ShapeThemer"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+TypographyThemer"
+    extension.dependency "MaterialComponentsBeta/schemes/Container"
+  end
+
   mdc.subspec "Dialogs+Theming" do |extension|
     extension.ios.deployment_target = '8.0'
     extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"

--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -42,6 +42,21 @@ mdc_public_objc_library(
 )
 
 mdc_objc_library(
+    name = "Theming",
+    srcs = native.glob(["src/Theming/*.m"]),
+    hdrs = native.glob(["src/Theming/*.h"]),
+    includes = ["src/Theming"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":Chips",
+        ":ColorThemer",
+        ":ShapeThemer",
+        ":TypographyThemer",
+        "//components/schemes/Container",
+    ],
+)
+
+mdc_objc_library(
     name = "ChipThemer",
     srcs = native.glob(["src/ChipThemer/*.m"]),
     hdrs = native.glob(["src/ChipThemer/*.h"]),
@@ -119,6 +134,23 @@ mdc_objc_library(
     hdrs = native.glob(["src/private/*.h"]),
     includes = ["src/private"],
     visibility = ["//visibility:private"],
+)
+
+swift_library(
+    name = "unit_test_swift_sources",
+    srcs = glob(["tests/unit/*.swift"]),
+    copts = [
+        "-swift-version",
+        "3",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":Chips",
+        ":ColorThemer",
+        ":ShapeThemer",
+        ":Theming",
+        ":TypographyThemer",
+    ],
 )
 
 mdc_objc_library(

--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -19,6 +19,7 @@ load(
     "mdc_public_objc_library",
     "mdc_unit_test_suite",
 )
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -147,6 +147,9 @@ swift_library(
     deps = [
         ":Chips",
         ":Theming",
+        "//components/schemes/Color",
+        "//components/schemes/Shape",
+        "//components/schemes/Typography",
     ],
 )
 

--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -47,7 +47,6 @@ mdc_objc_library(
     srcs = native.glob(["src/Theming/*.m"]),
     hdrs = native.glob(["src/Theming/*.h"]),
     includes = ["src/Theming"],
-    visibility = ["//visibility:public"],
     deps = [
         ":Chips",
         ":ColorThemer",
@@ -147,10 +146,7 @@ swift_library(
     visibility = ["//visibility:private"],
     deps = [
         ":Chips",
-        ":ColorThemer",
-        ":ShapeThemer",
         ":Theming",
-        ":TypographyThemer",
     ],
 )
 

--- a/components/Chips/src/Theming/MDCChipView+MaterialTheming.h
+++ b/components/Chips/src/Theming/MDCChipView+MaterialTheming.h
@@ -1,0 +1,40 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialChips.h"
+#import "MaterialContainerScheme.h"
+
+/**
+ This category is used to style MDCChipView instances to a specific Material style which can be
+ found within the [Material Guidelines](https://material.io/design/components/chips.html).
+ */
+@interface MDCChipView (MaterialTheming)
+
+/**
+ Applies the Material Chip style to an MDCChipView instance.
+
+ @param scheme A container scheme instance containing any desired customizations to the theming
+ system.
+ */
+- (void)applyThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
+/**
+ Applies the Material Outlined Chip style to an MDCChipView instance.
+
+ @param scheme A container scheme instance containing any desired customizations to the theming
+ system.
+ */
+- (void)applyOutlinedThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
+@end

--- a/components/Chips/src/Theming/MDCChipView+MaterialTheming.m
+++ b/components/Chips/src/Theming/MDCChipView+MaterialTheming.m
@@ -32,8 +32,7 @@
 
   id<MDCShapeScheming> shapeScheme = scheme.shapeScheme;
   if (!shapeScheme) {
-    shapeScheme =
-        [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+    shapeScheme = [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
   }
   [self applyThemeWithShapeScheme:shapeScheme];
 
@@ -44,9 +43,8 @@
   }
   [self applyThemeWithTypographyScheme:typographyScheme];
 
-  NSUInteger maximumStateValue =
-      UIControlStateNormal | UIControlStateSelected | UIControlStateHighlighted |
-      UIControlStateDisabled;
+  NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
+                                 UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
     [self setBorderWidth:0 forState:state];
   }
@@ -76,8 +74,7 @@
 
   id<MDCShapeScheming> shapeScheme = scheme.shapeScheme;
   if (!shapeScheme) {
-    shapeScheme =
-        [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+    shapeScheme = [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
   }
   [self applyThemeWithShapeScheme:shapeScheme];
 
@@ -88,9 +85,8 @@
   }
   [self applyThemeWithTypographyScheme:typographyScheme];
 
-  NSUInteger maximumStateValue =
-      UIControlStateNormal | UIControlStateSelected | UIControlStateHighlighted |
-      UIControlStateDisabled;
+  NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
+                                 UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
     [self setBorderWidth:1 forState:state];
   }

--- a/components/Chips/src/Theming/MDCChipView+MaterialTheming.m
+++ b/components/Chips/src/Theming/MDCChipView+MaterialTheming.m
@@ -1,0 +1,103 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCChipView+MaterialTheming.h"
+
+#import "MaterialChips+ColorThemer.h"
+#import "MaterialChips+ShapeThemer.h"
+#import "MaterialChips+TypographyThemer.h"
+
+@implementation MDCChipView (MaterialTheming)
+
+#pragma mark - Standard Chip
+
+- (void)applyThemeWithScheme:(id<MDCContainerScheming>)scheme {
+  id<MDCColorScheming> colorScheme = scheme.colorScheme;
+  if (!colorScheme) {
+    colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+  [self applyThemeWithColorScheme:colorScheme];
+
+  id<MDCShapeScheming> shapeScheme = scheme.shapeScheme;
+  if (!shapeScheme) {
+    shapeScheme =
+        [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  }
+  [self applyThemeWithShapeScheme:shapeScheme];
+
+  id<MDCTypographyScheming> typographyScheme = scheme.typographyScheme;
+  if (!typographyScheme) {
+    typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+  }
+  [self applyThemeWithTypographyScheme:typographyScheme];
+
+  NSUInteger maximumStateValue =
+      UIControlStateNormal | UIControlStateSelected | UIControlStateHighlighted |
+      UIControlStateDisabled;
+  for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    [self setBorderWidth:0 forState:state];
+  }
+}
+
+- (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
+  [MDCChipViewColorThemer applySemanticColorScheme:colorScheme toChipView:self];
+}
+
+- (void)applyThemeWithShapeScheme:(id<MDCShapeScheming>)shapeScheme {
+  [MDCChipViewShapeThemer applyShapeScheme:shapeScheme toChipView:self];
+}
+
+- (void)applyThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {
+  [MDCChipViewTypographyThemer applyTypographyScheme:typographyScheme toChipView:self];
+}
+
+#pragma mark - Outlined Chip
+
+- (void)applyOutlinedThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme {
+  id<MDCColorScheming> colorScheme = scheme.colorScheme;
+  if (!colorScheme) {
+    colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+  [self applyOutlinedThemeWithColorScheme:colorScheme];
+
+  id<MDCShapeScheming> shapeScheme = scheme.shapeScheme;
+  if (!shapeScheme) {
+    shapeScheme =
+        [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  }
+  [self applyThemeWithShapeScheme:shapeScheme];
+
+  id<MDCTypographyScheming> typographyScheme = scheme.typographyScheme;
+  if (!typographyScheme) {
+    typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+  }
+  [self applyThemeWithTypographyScheme:typographyScheme];
+
+  NSUInteger maximumStateValue =
+      UIControlStateNormal | UIControlStateSelected | UIControlStateHighlighted |
+      UIControlStateDisabled;
+  for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    [self setBorderWidth:1 forState:state];
+  }
+}
+
+- (void)applyOutlinedThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
+  [MDCChipViewColorThemer applyOutlinedVariantWithColorScheme:colorScheme toChipView:self];
+}
+
+@end

--- a/components/Chips/src/Theming/MaterialChips+Theming.h
+++ b/components/Chips/src/Theming/MaterialChips+Theming.h
@@ -1,0 +1,15 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCChipView+MaterialTheming.h"

--- a/components/Chips/tests/unit/ChipsMaterialThemingTests.swift
+++ b/components/Chips/tests/unit/ChipsMaterialThemingTests.swift
@@ -1,0 +1,156 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+import MaterialComponents.MaterialChips
+import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialShapeScheme
+import MaterialComponents.MaterialShapeLibrary
+import MaterialComponents.MaterialTypographyScheme
+import MaterialComponentsBeta.MaterialChips_Theming
+import MaterialComponentsBeta.MaterialContainerScheme
+
+class ChipsMaterialThemingTests: XCTestCase {
+
+  func testThemedChip() {
+    // Given
+    let chip = MDCChipView()
+    let scheme = MDCContainerScheme()
+    let colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    let shapeScheme = MDCShapeScheme(defaults: .material201809)
+    let typographyScheme = MDCTypographyScheme(defaults: .material201804)
+    scheme.colorScheme = colorScheme
+    scheme.shapeScheme = shapeScheme
+    scheme.typographyScheme = typographyScheme
+
+    let onSurface12OpacityColor = colorScheme.onSurfaceColor.withAlphaComponent(0.12)
+    let onSurface87OpacityColor = colorScheme.onSurfaceColor.withAlphaComponent(0.87)
+    let onSurface16OpacityColor = colorScheme.onSurfaceColor.withAlphaComponent(0.16)
+    let backgroundColor =
+        MDCSemanticColorScheme.blendColor(onSurface12OpacityColor,
+                                           withBackgroundColor: colorScheme.surfaceColor)
+    let selectedBackgroundColor =
+        MDCSemanticColorScheme.blendColor(onSurface12OpacityColor,
+                                           withBackgroundColor: backgroundColor)
+    let textColor =
+        MDCSemanticColorScheme.blendColor(onSurface87OpacityColor,
+                                           withBackgroundColor: backgroundColor)
+    let selectedTextColor =
+        MDCSemanticColorScheme.blendColor(onSurface87OpacityColor,
+                                           withBackgroundColor: selectedBackgroundColor)
+
+    // When
+    chip.applyTheme(withScheme: scheme)
+
+    // Then
+    // Test Colors
+    XCTAssertEqual(chip.inkColor(for: .normal), onSurface16OpacityColor)
+    XCTAssertEqual(chip.backgroundColor(for: .normal), backgroundColor)
+    XCTAssertEqual(chip.backgroundColor(for: .selected), selectedBackgroundColor)
+    XCTAssertEqual(chip.backgroundColor(for: .disabled), backgroundColor.withAlphaComponent(0.38))
+    XCTAssertEqual(chip.titleColor(for: .normal), textColor)
+    XCTAssertEqual(chip.titleColor(for: .selected), selectedTextColor)
+    XCTAssertEqual(chip.titleColor(for: .disabled), textColor.withAlphaComponent(0.38))
+
+    // Test shape
+    if let cardShape = chip.shapeGenerator as? MDCRectangleShapeGenerator {
+      let corner = MDCCornerTreatment.corner(withRadius: 0.5)
+      corner?.valueType = .percentage
+      XCTAssertEqual(cardShape.topLeftCorner, corner)
+      XCTAssertEqual(cardShape.topRightCorner, corner)
+      XCTAssertEqual(cardShape.bottomRightCorner, corner)
+      XCTAssertEqual(cardShape.bottomLeftCorner, corner)
+    } else {
+      XCTFail("Chip.shapeGenerator was not a MDCRectangularShapeGenerator")
+    }
+
+    // Test typography
+    XCTAssertEqual(chip.titleFont, typographyScheme.body2)
+
+    // Test remaining properties
+    [.normal, .highlighted, .selected, .disabled].forEach {
+      XCTAssertEqual(chip.borderWidth(for: $0),
+                     0,
+                     accuracy: 0.001,
+                     "Border width incorrect for state \($0)")
+    }
+  }
+
+  func testOutlinedThemedChip() {
+    // Given
+    let chip = MDCChipView()
+    let scheme = MDCContainerScheme()
+    let colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    let shapeScheme = MDCShapeScheme(defaults: .material201809)
+    let typographyScheme = MDCTypographyScheme(defaults: .material201804)
+    scheme.colorScheme = colorScheme
+    scheme.shapeScheme = shapeScheme
+    scheme.typographyScheme = typographyScheme
+
+    let onSurface12OpacityColor = colorScheme.onSurfaceColor.withAlphaComponent(0.12)
+    let onSurface87OpacityColor = colorScheme.onSurfaceColor.withAlphaComponent(0.87)
+    let onSurface16OpacityColor = colorScheme.onSurfaceColor.withAlphaComponent(0.16)
+    let borderColor =
+      MDCSemanticColorScheme.blendColor(onSurface12OpacityColor,
+                                        withBackgroundColor: colorScheme.surfaceColor)
+    let selectedBackgroundColor =
+      MDCSemanticColorScheme.blendColor(onSurface12OpacityColor,
+                                        withBackgroundColor: colorScheme.surfaceColor)
+    let textColor =
+      MDCSemanticColorScheme.blendColor(onSurface87OpacityColor,
+                                        withBackgroundColor: colorScheme.surfaceColor)
+    let selectedTextColor =
+      MDCSemanticColorScheme.blendColor(onSurface87OpacityColor,
+                                        withBackgroundColor: selectedBackgroundColor)
+
+    // When
+    chip.applyOutlinedTheme(withScheme: scheme)
+
+    // Then
+    // Test Colors
+    XCTAssertEqual(chip.inkColor(for: .normal), onSurface16OpacityColor)
+    XCTAssertEqual(chip.borderColor(for: .normal), borderColor)
+    XCTAssertEqual(chip.borderColor(for: .selected), .clear)
+    XCTAssertEqual(chip.backgroundColor(for: .normal), colorScheme.surfaceColor)
+    XCTAssertEqual(chip.backgroundColor(for: .selected), selectedBackgroundColor)
+    XCTAssertEqual(chip.backgroundColor(for: .disabled), colorScheme.surfaceColor.withAlphaComponent(0.38))
+    XCTAssertEqual(chip.titleColor(for: .normal), textColor)
+    XCTAssertEqual(chip.titleColor(for: .selected), selectedTextColor)
+    XCTAssertEqual(chip.titleColor(for: .disabled), textColor.withAlphaComponent(0.38))
+
+    // Test shape
+    if let cardShape = chip.shapeGenerator as? MDCRectangleShapeGenerator {
+      let corner = MDCCornerTreatment.corner(withRadius: 0.5)
+      corner?.valueType = .percentage
+      XCTAssertEqual(cardShape.topLeftCorner, corner)
+      XCTAssertEqual(cardShape.topRightCorner, corner)
+      XCTAssertEqual(cardShape.bottomRightCorner, corner)
+      XCTAssertEqual(cardShape.bottomLeftCorner, corner)
+    } else {
+      XCTFail("Chip.shapeGenerator was not a MDCRectangularShapeGenerator")
+    }
+
+    // Test typography
+    XCTAssertEqual(chip.titleFont, typographyScheme.body2)
+
+    // Test remaining properties
+    [.normal, .highlighted, .selected, .disabled].forEach {
+      XCTAssertEqual(chip.borderWidth(for: $0),
+                     1,
+                     accuracy: 0.001,
+                     "Border width incorrect for state \($0)")
+    }
+  }
+}


### PR DESCRIPTION
### Context
As the team pivots to using theming within extensions we continue this work with Chips.

### The problem
We currently do not theme chips using a theming extension

### The fix
* Add theming extension for MDCChipView
* Write unit tests for new extension

In follow-up PRs, I will update the existing examples to utilize the new extension and write snapshot tests as well.

### Bug
Part of #6083 
