### PR TITLE
[bazel] Extract minimum_os_version to a constant in material_components_ios.bzl

### DIFF
--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -98,7 +98,7 @@ def mdc_extension_objc_library(
 def mdc_unit_test_suite(
     name,
     deps = [],
-    minimum_os_version = IOS_MINIMUM_Os,
+    minimum_os_version = IOS_MINIMUM_OS,
     visibility = ["//visibility:private"],
     size = "medium",
     **kwargs):

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -4,6 +4,8 @@ load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_
 load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
 
+IOS_MINIMUM_OS = "8.0"
+
 DEFAULT_IOS_RUNNER_TARGETS = [
     "//components/testing/runners:IPHONE_5_IN_8_1",
     "//components/testing/runners:IPAD_PRO_12_9_IN_9_3",
@@ -79,6 +81,7 @@ def mdc_extension_objc_library(
     **kwarrgs: Any arrguments accepted by _mdc_objc_library().
   """
   mdc_objc_library(
+  
       name = name,
       deps = deps,
       sdk_frameworks = sdk_frameworks,
@@ -96,7 +99,7 @@ def mdc_extension_objc_library(
 def mdc_unit_test_suite(
     name,
     deps = [],
-    minimum_os_version = "8.0",
+    minimum_os_version = IOS_MINIMUM_Os,
     visibility = ["//visibility:private"],
     size = "medium",
     **kwargs):

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -81,7 +81,6 @@ def mdc_extension_objc_library(
     **kwarrgs: Any arrguments accepted by _mdc_objc_library().
   """
   mdc_objc_library(
-  
       name = name,
       deps = deps,
       sdk_frameworks = sdk_frameworks,


### PR DESCRIPTION
This will enable future targets to refer to the same minimum os constant.
