### PR TITLE
[.kokoro] Post the affected bazel targets back to the PR.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -119,6 +119,97 @@ move_derived_data_to_tmp() {
   fi
 }
 
+# Posts a comment to the current pull request.
+# Args:
+#   $1: A unique identifier for this comment.
+#   $2: A path to a file containing the body of the comment to post.
+post_comment() {
+  identifier="$1"
+  comment_body_file="$2"
+
+  if [ -z "$identifier" ]; then
+    echo "Please pass an identifier as the first argument."
+    exit 1
+  fi
+
+  if [ -z "$comment_body_file" ]; then
+    echo "Please pass the path to a comment_body file as the second argument."
+    exit 1
+  fi
+
+  if [ -z "$GITHUB_API_TOKEN" ]; then
+    echo "No GITHUB_API_TOKEN provided; can't post a comment."
+    exit 1
+  fi
+
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    # Move into our cloned repo
+    pushd github/repo
+  fi
+
+  if [ ! -f scripts/external/github-comment/.git ]; then
+    git submodule update --init --recursive scripts/external/github-comment
+  fi
+
+  pushd scripts/external/github-comment >> /dev/null
+
+  swift run github-comment \
+    --repo=material-components/material-components-ios \
+    --github_token="$GITHUB_API_TOKEN" \
+    --pull_request_number="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" \
+    --identifier="$identifier" \
+    --comment_body="$comment_body_file"
+
+  popd >> /dev/null
+
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    # Move into our cloned repo
+    popd >> /dev/null
+  fi
+}
+
+# Posts a comment from the current pull request.
+# Args:
+#   $1: A unique identifier for this comment.
+delete_comment() {
+  identifier="$1"
+
+  if [ -z "$identifier" ]; then
+    echo "Please pass an identifier as the first argument."
+    exit 1
+  fi
+
+  if [ -z "$GITHUB_API_TOKEN" ]; then
+    echo "No GITHUB_API_TOKEN provided; can't post a comment."
+    exit 1
+  fi
+
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    # Move into our cloned repo
+    pushd github/repo
+  fi
+
+  if [ ! -f scripts/external/github-comment/.git ]; then
+    git submodule update --init --recursive scripts/external/github-comment
+  fi
+
+  pushd scripts/external/github-comment >> /dev/null
+
+  swift run github-comment \
+    --repo=material-components/material-components-ios \
+    --github_token="$GITHUB_API_TOKEN" \
+    --pull_request_number="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" \
+    --identifier="$identifier" \
+    --delete
+
+  popd >> /dev/null
+
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    # Move into our cloned repo
+    popd >> /dev/null
+  fi
+}
+
 # xcode-select's the provided xcode version.
 # Usage example:
 #     select_xcode 9.2.0
@@ -222,36 +313,14 @@ run_bazel_affected() {
     echo "Nothing to build."
     exit 0
   fi
+  
+  comment_identifier="affected-targets"
 
   if [ -z "$TARGET" ]; then
     echo "Nothing to build."
 
     if [ -n "$GITHUB_API_TOKEN" ]; then
-      if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-        # Move into our cloned repo
-        pushd github/repo
-      fi
-
-      if [ ! -f scripts/external/github-comment/.git ]; then
-        git submodule update --init --recursive scripts/external/github-comment
-      fi
-
-      pushd scripts/external/github-comment >> /dev/null
-
-      # No changelog, so delete any existing comment
-      swift run github-comment \
-        --repo=material-components/material-components-ios \
-        --github_token="$GITHUB_API_TOKEN" \
-        --pull_request_number="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" \
-        --identifier=affected-targets \
-        --delete
-
-      popd >> /dev/null
-
-      if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-        # Move into our cloned repo
-        popd >> /dev/null
-      fi
+      delete_comment "$comment_identifier"
     fi
 
     exit 0
@@ -259,11 +328,6 @@ run_bazel_affected() {
     echo "$TARGET"
 
     if [ -n "$GITHUB_API_TOKEN" ]; then
-      if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-        # Move into our cloned repo
-        pushd github/repo
-      fi
-
       comment_tmp_path=$(mktemp -d)
       comment_tmp_file="$comment_tmp_path/comment.tmp"
       echo "bazel detected changes to the following targets:" > "$comment_tmp_file"
@@ -272,25 +336,7 @@ run_bazel_affected() {
       echo "$TARGET" >> "$comment_tmp_file"
       echo '```' >> "$comment_tmp_file"
 
-      if [ ! -f scripts/external/github-comment/.git ]; then
-        git submodule update --init --recursive scripts/external/github-comment
-      fi
-
-      pushd scripts/external/github-comment >> /dev/null
-
-      swift run github-comment \
-        --repo=material-components/material-components-ios \
-        --github_token="$GITHUB_API_TOKEN" \
-        --pull_request_number="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" \
-        --identifier=affected-targets \
-        --comment_body="$comment_tmp_file"
-
-      popd >> /dev/null
-
-      if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-        # Move into our cloned repo
-        popd >> /dev/null
-      fi
+      post_comment "$comment_identifier" "$comment_tmp_file"
     fi
   fi
 

--- a/.kokoro
+++ b/.kokoro
@@ -163,7 +163,6 @@ post_comment() {
   popd >> /dev/null
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-    # Move into our cloned repo
     popd >> /dev/null
   fi
 }
@@ -205,7 +204,6 @@ delete_comment() {
   popd >> /dev/null
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-    # Move into our cloned repo
     popd >> /dev/null
   fi
 }

--- a/.kokoro
+++ b/.kokoro
@@ -223,41 +223,73 @@ run_bazel_affected() {
     exit 0
   fi
 
-  if [ ! -f scripts/external/github-comment/.git ]; then
-    git submodule update --init --recursive scripts/external/github-comment
-  fi
-
-  pushd scripts/external/github-comment >> /dev/null
-
-  comment_tmp_path=$(mktemp -d)
-  comment_tmp_file="$comment_tmp_path/comment.tmp"
-  echo "bazel detected changes to the following targets:" > "$comment_tmp_file"
-  echo "$TARGET" >> "$comment_tmp_file"
-
   if [ -z "$TARGET" ]; then
     echo "Nothing to build."
 
-    # No changelog, so delete any existing comment
-    swift run github-comment \
-      --repo=material-components/material-components-ios \
-      --github_token="$GITHUB_API_TOKEN" \
-      --pull_request_number="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" \
-      --identifier=affected-targets \
-      --delete
+    if [ -n "$GITHUB_API_TOKEN" ]; then
+      if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+        # Move into our cloned repo
+        pushd github/repo
+      fi
+
+      if [ ! -f scripts/external/github-comment/.git ]; then
+        git submodule update --init --recursive scripts/external/github-comment
+      fi
+
+      pushd scripts/external/github-comment >> /dev/null
+
+      # No changelog, so delete any existing comment
+      swift run github-comment \
+        --repo=material-components/material-components-ios \
+        --github_token="$GITHUB_API_TOKEN" \
+        --pull_request_number="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" \
+        --identifier=affected-targets \
+        --delete
+
+      popd >> /dev/null
+
+      if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+        # Move into our cloned repo
+        popd >> /dev/null
+      fi
+    fi
 
     exit 0
   else
     echo "$TARGET"
 
-    swift run github-comment \
-      --repo=material-components/material-components-ios \
-      --github_token="$GITHUB_API_TOKEN" \
-      --pull_request_number="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" \
-      --identifier=affected-targets \
-      --comment_body="$comment_tmp_file"
-  fi
+    if [ -n "$GITHUB_API_TOKEN" ]; then
+      if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+        # Move into our cloned repo
+        pushd github/repo
+      fi
 
-  popd >> /dev/null
+      comment_tmp_path=$(mktemp -d)
+      comment_tmp_file="$comment_tmp_path/comment.tmp"
+      echo "bazel detected changes to the following targets:" > "$comment_tmp_file"
+      echo "$TARGET" >> "$comment_tmp_file"
+
+      if [ ! -f scripts/external/github-comment/.git ]; then
+        git submodule update --init --recursive scripts/external/github-comment
+      fi
+
+      pushd scripts/external/github-comment >> /dev/null
+
+      swift run github-comment \
+        --repo=material-components/material-components-ios \
+        --github_token="$GITHUB_API_TOKEN" \
+        --pull_request_number="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" \
+        --identifier=affected-targets \
+        --comment_body="$comment_tmp_file"
+
+      popd >> /dev/null
+
+      if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+        # Move into our cloned repo
+        popd >> /dev/null
+      fi
+    fi
+  fi
 
   run_bazel
 }

--- a/.kokoro
+++ b/.kokoro
@@ -223,8 +223,42 @@ run_bazel_affected() {
     exit 0
   fi
 
-  echo "$TARGET"
-  
+  if [ ! -f scripts/external/github-comment/.git ]; then
+    git submodule update --init --recursive scripts/external/github-comment
+  fi
+
+  pushd scripts/external/github-comment >> /dev/null
+
+  comment_tmp_path=$(mktemp -d)
+  comment_tmp_file="$comment_tmp_path/comment.tmp"
+  echo "bazel detected changes to the following targets:" > "$comment_tmp_file"
+  echo "$TARGET" >> "$comment_tmp_file"
+
+  if [ -z "$TARGET" ]; then
+    echo "Nothing to build."
+
+    # No changelog, so delete any existing comment
+    swift run github-comment \
+      --repo=material-components/material-components-ios \
+      --github_token="$GITHUB_API_TOKEN" \
+      --pull_request_number="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" \
+      --identifier=affected-targets \
+      --delete
+
+    exit 0
+  else
+    echo "$TARGET"
+
+    swift run github-comment \
+      --repo=material-components/material-components-ios \
+      --github_token="$GITHUB_API_TOKEN" \
+      --pull_request_number="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" \
+      --identifier=affected-targets \
+      --comment_body="$comment_tmp_file"
+  fi
+
+  popd >> /dev/null
+
   run_bazel
 }
 

--- a/.kokoro
+++ b/.kokoro
@@ -267,7 +267,10 @@ run_bazel_affected() {
       comment_tmp_path=$(mktemp -d)
       comment_tmp_file="$comment_tmp_path/comment.tmp"
       echo "bazel detected changes to the following targets:" > "$comment_tmp_file"
+      echo >> "$comment_tmp_file"
+      echo '```' >> "$comment_tmp_file"
       echo "$TARGET" >> "$comment_tmp_file"
+      echo '```' >> "$comment_tmp_file"
 
       if [ ! -f scripts/external/github-comment/.git ]; then
         git submodule update --init --recursive scripts/external/github-comment


### PR DESCRIPTION
This change introduces two new methods to `.kokoro`: `post_comment` and `delete_comment`. These methods may be used to post feedback to the pull request in the form of a GitHub comment.

The apidiff and clang-format toolchains both already use aspects of this method.

In a follow-up PR I will migrate the apidiff job to use these new methods.

These methods are being used as part of the affected bazel jobs in order to post back the targets that will be tested as part of this PR.