### PR TITLE
[Chips] Update chips examples to use theming extension

### DIFF
--- a/components/Chips/examples/ChipsActionExampleViewController.m
+++ b/components/Chips/examples/ChipsActionExampleViewController.m
@@ -14,8 +14,9 @@
 
 #import "ChipsExamplesSupplemental.h"
 
+#import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
-#import "MaterialChips+ChipThemer.h"
+#import "MaterialContainerScheme.h"
 
 @implementation ChipsActionExampleViewController {
   UICollectionView *_collectionView;
@@ -31,6 +32,13 @@
     self.shapeScheme = [[MDCShapeScheme alloc] init];
   }
   return self;
+}
+
+- (MDCContainerScheme *)containerScheme {
+  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+  scheme.colorScheme = self.colorScheme;
+  scheme.shapeScheme = self.shapeScheme;
+  return scheme;
 }
 
 - (void)loadView {
@@ -111,15 +119,11 @@
   // Customize Chip
   chipView.titleLabel.text = self.titles[indexPath.row];
 
-  MDCChipViewScheme *scheme = [[MDCChipViewScheme alloc] init];
-  scheme.colorScheme = self.colorScheme;
-  scheme.shapeScheme = self.shapeScheme;
-
   // Apply Theming
   if (_isOutlined) {
-    [MDCChipViewThemer applyOutlinedVariantWithScheme:scheme toChipView:chipView];
+    [chipView applyOutlinedThemeWithScheme:[self containerScheme]];
   } else {
-    [MDCChipViewThemer applyScheme:scheme toChipView:chipView];
+    [chipView applyThemeWithScheme:[self containerScheme]];
   }
 
   return cell;

--- a/components/Chips/examples/ChipsActionExampleViewController.m
+++ b/components/Chips/examples/ChipsActionExampleViewController.m
@@ -30,6 +30,8 @@
     self.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     self.shapeScheme = [[MDCShapeScheme alloc] init];
+    self.typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
   }
   return self;
 }
@@ -38,6 +40,7 @@
   MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
   scheme.colorScheme = self.colorScheme;
   scheme.shapeScheme = self.shapeScheme;
+  scheme.typographyScheme = self.typographyScheme;
   return scheme;
 }
 

--- a/components/Chips/examples/ChipsChoiceExampleViewController.m
+++ b/components/Chips/examples/ChipsChoiceExampleViewController.m
@@ -14,8 +14,9 @@
 
 #import "ChipsExamplesSupplemental.h"
 
+#import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
-#import "MaterialChips+ChipThemer.h"
+#import "MaterialContainerScheme.h"
 
 @interface ChipsChoiceExampleViewController ()
 @property(nonatomic, strong) MDCChipView *sizingChip;
@@ -32,6 +33,13 @@
     self.shapeScheme = [[MDCShapeScheme alloc] init];
   }
   return self;
+}
+
+- (MDCContainerScheme *)containerScheme {
+  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+  scheme.colorScheme = self.colorScheme;
+  scheme.shapeScheme = self.shapeScheme;
+  return scheme;
 }
 
 - (void)loadView {
@@ -112,14 +120,10 @@
   chipView.enabled = indexPath.row != 2;
   cell.userInteractionEnabled = indexPath.row != 2;
 
-  MDCChipViewScheme *scheme = [[MDCChipViewScheme alloc] init];
-  scheme.colorScheme = self.colorScheme;
-  scheme.shapeScheme = self.shapeScheme;
-
   if (self.isOutlined) {
-    [MDCChipViewThemer applyOutlinedVariantWithScheme:scheme toChipView:chipView];
+    [chipView applyOutlinedThemeWithScheme:[self containerScheme]];
   } else {
-    [MDCChipViewThemer applyScheme:scheme toChipView:chipView];
+    [chipView applyThemeWithScheme:[self containerScheme]];
   }
 
   return cell;

--- a/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
+++ b/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
@@ -21,12 +21,14 @@ import MaterialComponentsBeta.MaterialContainerScheme
 
 class ChipsFieldDeleteEnabledViewController : UIViewController, MDCChipFieldDelegate {
   var colorScheme = MDCSemanticColorScheme()
+  var shapeScheme = MDCShapeScheme()
   var typographyScheme = MDCTypographyScheme()
   var chipField = MDCChipField()
 
   var scheme: MDCContainerScheming {
     let scheme = MDCContainerScheme()
     scheme.colorScheme = colorScheme
+    scheme.shapeScheme = shapeScheme
     scheme.typographyScheme = typographyScheme
     return scheme
   }

--- a/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
+++ b/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
@@ -15,13 +15,21 @@
 import UIKit
 
 import MaterialComponents.MaterialChips
-import MaterialComponents.MaterialChips_ChipThemer
 import MaterialComponents.MaterialTextFields
+import MaterialComponentsBeta.MaterialChips_Theming
+import MaterialComponentsBeta.MaterialContainerScheme
 
 class ChipsFieldDeleteEnabledViewController : UIViewController, MDCChipFieldDelegate {
   var colorScheme = MDCSemanticColorScheme()
   var typographyScheme = MDCTypographyScheme()
   var chipField = MDCChipField()
+
+  var scheme: MDCContainerScheming {
+    let scheme = MDCContainerScheme()
+    scheme.colorScheme = colorScheme
+    scheme.typographyScheme = typographyScheme
+    return scheme
+  }
 
   init() {
     super.init(nibName: nil, bundle: nil)
@@ -60,10 +68,7 @@ class ChipsFieldDeleteEnabledViewController : UIViewController, MDCChipFieldDele
   }
 
   func chipField(_ chipField: MDCChipField, didAddChip chip: MDCChipView) {
-    let scheme = MDCChipViewScheme()
-    scheme.colorScheme = colorScheme
-    scheme.typographyScheme = typographyScheme
-    MDCChipViewThemer.applyScheme(scheme, to: chip)
+    chip.applyTheme(withScheme: scheme)
     chip.sizeToFit()
     let chipVerticalInset = min(0, chip.bounds.height - 48 / 2)
     chip.hitAreaInsets = UIEdgeInsetsMake(chipVerticalInset, 0, chipVerticalInset, 0)

--- a/components/Chips/examples/ChipsFilterExampleViewController.m
+++ b/components/Chips/examples/ChipsFilterExampleViewController.m
@@ -31,6 +31,8 @@
     self.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     self.shapeScheme = [[MDCShapeScheme alloc] init];
+    self.typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
   }
   return self;
 }
@@ -39,6 +41,7 @@
   MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
   scheme.colorScheme = self.colorScheme;
   scheme.shapeScheme = self.shapeScheme;
+  scheme.typographyScheme = self.typographyScheme;
   return scheme;
 }
 

--- a/components/Chips/examples/ChipsFilterExampleViewController.m
+++ b/components/Chips/examples/ChipsFilterExampleViewController.m
@@ -14,8 +14,9 @@
 
 #import "ChipsExamplesSupplemental.h"
 
+#import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
-#import "MaterialChips+ChipThemer.h"
+#import "MaterialContainerScheme.h"
 
 @implementation ChipsFilterExampleViewController {
   UICollectionView *_collectionView;
@@ -32,6 +33,13 @@
     self.shapeScheme = [[MDCShapeScheme alloc] init];
   }
   return self;
+}
+
+- (MDCContainerScheme *)containerScheme {
+  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+  scheme.colorScheme = self.colorScheme;
+  scheme.shapeScheme = self.shapeScheme;
+  return scheme;
 }
 
 - (void)loadView {
@@ -117,15 +125,11 @@
       [_colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.54];
   chipView.selected = [_selectedIndecies containsObject:indexPath];
   cell.alwaysAnimateResize = [self shouldAnimateResize];
- 
-  MDCChipViewScheme *scheme = [[MDCChipViewScheme alloc] init];
-  scheme.colorScheme = self.colorScheme;
-  scheme.shapeScheme = self.shapeScheme;
 
   if (_isOutlined) {
-    [MDCChipViewThemer applyOutlinedVariantWithScheme:scheme toChipView:chipView];
+    [chipView applyOutlinedThemeWithScheme:[self containerScheme]];
   } else {
-    [MDCChipViewThemer applyScheme:scheme toChipView:chipView];
+    [chipView applyThemeWithScheme:[self containerScheme]];
   }
 
   return cell;

--- a/components/Chips/examples/ChipsInputExampleViewController.m
+++ b/components/Chips/examples/ChipsInputExampleViewController.m
@@ -14,9 +14,10 @@
 
 #import "ChipsExamplesSupplemental.h"
 
+#import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
+#import "MaterialContainerScheme.h"
 #import "MaterialTextFields.h"
-#import "MaterialChips+ChipThemer.h"
 
 @interface ChipsInputExampleViewController () <MDCChipFieldDelegate>
 @end
@@ -34,6 +35,14 @@
     _shapeScheme = [[MDCShapeScheme alloc] init];
   }
   return self;
+}
+
+- (MDCContainerScheme *)containerScheme {
+  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+  scheme.colorScheme = self.colorScheme;
+  scheme.shapeScheme = self.shapeScheme;
+  scheme.typographyScheme = self.typographyScheme;
+  return scheme;
 }
 
 - (void)viewDidLoad {
@@ -64,16 +73,11 @@
 }
 
 - (void)chipField:(MDCChipField *)chipField didAddChip:(MDCChipView *)chip {
-  MDCChipViewScheme *scheme = [[MDCChipViewScheme alloc] init];
-  scheme.colorScheme = self.colorScheme;
-  scheme.typographyScheme = self.typographyScheme;
-  scheme.shapeScheme = self.shapeScheme;
-
   // Every other chip is stroked
   if (chipField.chips.count%2) {
-    [MDCChipViewThemer applyOutlinedVariantWithScheme:scheme toChipView:chip];
+    [chip applyOutlinedThemeWithScheme:[self containerScheme]];
   } else {
-    [MDCChipViewThemer applyScheme:scheme toChipView:chip];
+    [chip applyThemeWithScheme:[self containerScheme]];
   }
   [chip sizeToFit];
   CGFloat chipVerticalInset = MIN(0, (CGRectGetHeight(chip.bounds) - 48) / 2);

--- a/components/Chips/examples/ChipsShapingExampleViewController.m
+++ b/components/Chips/examples/ChipsShapingExampleViewController.m
@@ -17,10 +17,10 @@
 #import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
 #import "MaterialContainerScheme.h"
-#import "MaterialSlider.h"
-#import "MaterialSlider+ColorThemer.h"
-#import "MaterialShapes.h"
 #import "MaterialShapeLibrary.h"
+#import "MaterialShapes.h"
+#import "MaterialSlider+ColorThemer.h"
+#import "MaterialSlider.h"
 
 @interface ChipsShapingExampleViewController()
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;

--- a/components/Chips/examples/ChipsShapingExampleViewController.m
+++ b/components/Chips/examples/ChipsShapingExampleViewController.m
@@ -24,6 +24,7 @@
 
 @interface ChipsShapingExampleViewController()
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong) MDCShapeScheme *shapeScheme;
 @property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
 @end
 
@@ -39,6 +40,7 @@
   if (self) {
     _colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    _shapeScheme = [[MDCShapeScheme alloc] init];
     _typographyScheme = [[MDCTypographyScheme alloc] init];
   }
   return self;
@@ -47,6 +49,7 @@
 - (MDCContainerScheme *)containerScheme {
   MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
   scheme.colorScheme = self.colorScheme;
+  scheme.shapeScheme = self.shapeScheme;
   scheme.typographyScheme = self.typographyScheme;
   return scheme;
 }

--- a/components/Chips/examples/ChipsShapingExampleViewController.m
+++ b/components/Chips/examples/ChipsShapingExampleViewController.m
@@ -14,8 +14,9 @@
 
 #import "ChipsExamplesSupplemental.h"
 
+#import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
-#import "MaterialChips+ChipThemer.h"
+#import "MaterialContainerScheme.h"
 #import "MaterialSlider.h"
 #import "MaterialSlider+ColorThemer.h"
 #import "MaterialShapes.h"
@@ -43,6 +44,13 @@
   return self;
 }
 
+- (MDCContainerScheme *)containerScheme {
+  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+  scheme.colorScheme = self.colorScheme;
+  scheme.typographyScheme = self.typographyScheme;
+  return scheme;
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -58,12 +66,8 @@
   _chipView.accessoryPadding = UIEdgeInsetsMake(0, 0, 0, 10);
   CGSize chipSize = [_chipView sizeThatFits:self.view.bounds.size];
   _chipView.frame = CGRectMake(20, 20, chipSize.width + 20, chipSize.height + 20);
+  [_chipView applyThemeWithScheme:[self containerScheme]];
   _chipView.shapeGenerator = _rectangleShapeGenerator;
-
-  MDCChipViewScheme *chipScheme = [[MDCChipViewScheme alloc] init];
-  chipScheme.colorScheme = _colorScheme;
-  chipScheme.typographyScheme = _typographyScheme;
-  [MDCChipViewThemer applyScheme:chipScheme toChipView:_chipView];
   [self.view addSubview:_chipView];
 
   _cornerSlider = [[MDCSlider alloc] initWithFrame:CGRectZero];

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
@@ -37,6 +37,7 @@
 @property(nonatomic, strong) UICollectionView *collectionView;
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
 @property(nonatomic, strong) MDCShapeScheme *shapeScheme;
+@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
 @end
 
 @interface ChipsCollectionExampleViewController : ExampleChipCollectionViewController
@@ -59,6 +60,7 @@
 @property(nonatomic, strong) NSArray<NSString *> *titles;
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
 @property(nonatomic, strong) MDCShapeScheme *shapeScheme;
+@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
 @end
 
 @interface ChipsFilterAnimatedExampleViewController : ChipsFilterExampleViewController

--- a/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
+++ b/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.m
@@ -31,8 +31,8 @@
 #import "MaterialCards+ShapeThemer.h"
 #import "MaterialCards+Theming.h"
 #import "MaterialCards.h"
-#import "MaterialChips+ChipThemer.h"
 #import "MaterialChips+ShapeThemer.h"
+#import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
 #import "MaterialColorScheme.h"
 #import "MaterialContainerScheme.h"
@@ -124,18 +124,13 @@
   self.floatingButton.translatesAutoresizingMaskIntoConstraints = NO;
   [self.componentContentView addSubview:self.floatingButton];
 
-  MDCChipViewScheme *chipViewScheme = [[MDCChipViewScheme alloc] init];
-  chipViewScheme.colorScheme = self.colorScheme;
-  chipViewScheme.shapeScheme = self.shapeScheme;
-  chipViewScheme.typographyScheme = self.typographyScheme;
-
   self.chipView = [[MDCChipView alloc] init];
   self.chipView.titleLabel.text = @"Material";
   self.chipView.imageView.image = [self faceImage];
   self.chipView.accessoryView = [self deleteButton];
   self.chipView.minimumSize = CGSizeMake(140, 33);
   self.chipView.translatesAutoresizingMaskIntoConstraints = NO;
-  [MDCChipViewThemer applyScheme:chipViewScheme toChipView:self.chipView];
+  [self.chipView applyThemeWithScheme:self.containerScheme];
   [self.componentContentView addSubview:self.chipView];
 
   self.card = [[MDCCard alloc] init];


### PR DESCRIPTION
### Context
As the team pivots to using theming within extensions we continue this work with Chips.

### The problem
We currently do not utilize the theming extension for chips examples

### The fix
* This change updates all the chips examples to use the new chips theming extension.
* Additionally, this updates the shape example to use the new chips theming extension.

### Bug
Closes #6083 
