### PR TITLE
[Chips] Add snapshot tests to Chips

### DIFF
--- a/MaterialComponentsSnapshotTests.podspec
+++ b/MaterialComponentsSnapshotTests.podspec
@@ -25,6 +25,18 @@ Pod::Spec.new do |s|
     end
   end
 
+  s.subspec "Chips" do |component|
+    component.ios.deployment_target = '8.0'
+    component.test_spec 'tests' do |tests|
+      tests.test_spec 'snapshot' do |snapshot_tests|
+        snapshot_tests.requires_app_host = true
+        snapshot_tests.source_files = "components/#{component.base_name}/tests/snapshot/*.{h,m,swift}", "components/#{component.base_name}/tests/snapshot/supplemental/*.{h,m,swift}"
+        snapshot_tests.resources = "components/#{component.base_name}/tests/snapshot/resources/*"
+        snapshot_tests.dependency "MaterialComponentsSnapshotTests/private/Snapshot"
+      end
+    end
+  end
+
  s.subspec "TextFields" do |component|
     component.ios.deployment_target = '8.0'
     component.test_spec 'tests' do |tests|

--- a/catalog/Podfile
+++ b/catalog/Podfile
@@ -59,6 +59,7 @@ target "MDCCatalog" do
   ]
   pod 'MaterialComponentsSnapshotTests', :path => '../', :testspecs => [
     'Cards/tests/snapshot',
+    'Chips/tests/snapshot',
     'TextFields/tests/snapshot',
   ]
   pod 'CatalogByConvention', "~> 2.5"

--- a/components/Chips/tests/snapshot/MDCChipViewSnapshotTests.m
+++ b/components/Chips/tests/snapshot/MDCChipViewSnapshotTests.m
@@ -1,0 +1,62 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialChips+Theming.h"
+#import "MaterialChips.h"
+#import "MaterialSnapshot.h"
+
+@interface MDCChipViewSnapshotTests : MDCSnapshotTestCase
+
+@property(nonatomic, strong) MDCChipView *chip;
+
+@end
+
+@implementation MDCChipViewSnapshotTests
+
+- (void)setUp {
+  [super setUp];
+
+  // Uncomment below to recreate all the goldens (or add the following line to the specific
+  // test you wish to recreate the golden for).
+    self.recordMode = YES;
+
+  self.chip = [[MDCChipView alloc] init];
+  self.chip.titleLabel.text = @"A Chip";
+}
+
+- (void)tearDown {
+  self.chip = nil;
+
+  [super tearDown];
+}
+
+#pragma mark - Helpers
+
+- (void)generateSnapshotAndVerifyForView:(UIView *)view {
+  CGSize aSize = [view sizeThatFits:CGSizeMake(300, INFINITY)];
+  view.bounds = CGRectMake(0, 0, aSize.width, aSize.height);
+  [view layoutIfNeeded];
+
+  UIView *snapshotView = [view mdc_addToBackgroundView];
+  [self snapshotVerifyView:snapshotView];
+}
+
+#pragma mark - Tests
+
+- (void)testDefaultChip {
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chip];
+}
+
+@end

--- a/components/Chips/tests/snapshot/MDCChipViewSnapshotTests.m
+++ b/components/Chips/tests/snapshot/MDCChipViewSnapshotTests.m
@@ -18,6 +18,7 @@
 
 @interface MDCChipViewSnapshotTests : MDCSnapshotTestCase
 
+@property(nonatomic, strong) MDCContainerScheme *scheme;
 @property(nonatomic, strong) MDCChipView *chip;
 
 @end
@@ -29,10 +30,11 @@
 
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
-    self.recordMode = YES;
+  //  self.recordMode = YES;
 
   self.chip = [[MDCChipView alloc] init];
   self.chip.titleLabel.text = @"A Chip";
+  self.scheme = [[MDCContainerScheme alloc] init];
 }
 
 - (void)tearDown {
@@ -55,6 +57,22 @@
 #pragma mark - Tests
 
 - (void)testDefaultChip {
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chip];
+}
+
+- (void)testBaselineThemedChip {
+  // When
+  [self.chip applyThemeWithScheme:self.scheme];
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chip];
+}
+
+- (void)testOutlinedThemedChip {
+  // When
+  [self.chip applyOutlinedThemeWithScheme:self.scheme];
+
   // Then
   [self generateSnapshotAndVerifyForView:self.chip];
 }

--- a/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testBaselineThemedChip_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testBaselineThemedChip_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6440bdf1a6a60161ec41f489d0ed630e12b0950a9e06d50d70815ed1f556cee3
+size 3353

--- a/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChip_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChip_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bbe4a3ed3eee79f834167938def690fadd1a9d0bf536a423f60f0c769defc32
+size 3334

--- a/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testOutlinedThemedChip_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testOutlinedThemedChip_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1cde9b39b84300903d6ce2ca4bcc30fdde14cec6b1d96f9276d2f32af520824a
+size 3924


### PR DESCRIPTION
This change adds snapshot tests to chips for unthemed and the 2 themed variants we have. This initial set of tests only sets the text.

Subsequent PRs will add tests that configure with leading and trailing images.

Part of #6090 