### PR TITLE
{Scripts} Create a script to detect changed files not in a bazel rule

### DIFF
--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -30,7 +30,7 @@ modified_files() {
   fi
 
   # `base_sha` is the merge base of `target_branch` and the current HEAD.
-  base_sha=$(git merge-base "$target_branch" HEAD)
+  base_sha=$(git merge-base "${target_branch}" HEAD)
 
   # `TARGET` is then all bazel targets affected by changes in the commit range between `base_sha`
   # and `HEAD`.  By default, that becomes all changes between the `develop` branch and the latest
@@ -82,7 +82,7 @@ check_files_covered() {
   fi
 
   if (( exit_status != 0 )); then
-    echo  -e "The following files are not in any BUILD targets:\n\n$missing_targets" | sort | uniq
+    echo  -e "The following files are not in any BUILD targets:\n\n${missing_targets}" | sort | uniq
     exit $exit_status
   fi 
 } 

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -21,8 +21,6 @@ echo "Bazel target detection v${script_version}"
 
 # Generates a list of files that were modified since the target branch 
 modified_files() {
-  echo "Entered 'modified_files'"
-
   # Move to our cloned repository
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     pushd github/repo >> /dev/null
@@ -36,19 +34,13 @@ modified_files() {
     target_branch=develop
   fi
 
-  echo "Target branch: ${target_branch}"
-
   # `base_sha` is the merge base of `target_branch` and the current HEAD.
-  echo "git merge-base ${target_branch} HEAD"
   base_sha=$(git merge-base "${target_branch}" HEAD)
-
-  echo "Base SHA: ${base_sha}"
 
   # `TARGET` is then all bazel targets affected by changes in the commit range between `base_sha`
   # and `HEAD`.  By default, that becomes all changes between the `develop` branch and the latest
   #  commit.
   range="${base_sha}...HEAD"
-
   
   git log --name-only --pretty=oneline --full-index "${range}" \
     | grep -vE '^[0-9a-f]{40} ' \
@@ -63,8 +55,6 @@ modified_files() {
 
 # Determines if any of the modified files are not included in a bazel rule.
 check_files_covered() {
-  echo "Enter 'check_files_covered'"
-
   files=$(modified_files)
   if [ -z "$files" ]; then
     echo "No source files were modified"
@@ -91,7 +81,6 @@ check_files_covered() {
     fi
   done 
   
-
   if (( exit_status != 0 )); then
     echo  -e "The following files are not in any BUILD targets:\n\n${missing_targets}" | sort | uniq
     exit $exit_status

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -15,12 +15,19 @@
 # limitations under the License.
 #
 # Finds all newly-added files that are missing BUILD targets
-script_version=0.0.1
+script_version=0.0.2
 
 echo "Bazel target detection v${script_version}"
 
 # Generates a list of files that were modified since the target branch 
 modified_files() {
+  # Move to our cloned repository
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    pushd github/repo >> /dev/null
+  fi
+
+  pwd
+
   # `target_branch` is either the Pull Request destination branch (where it will be merged) or if
   # none can be determined, defaults to `develop`.
   if [ -n "$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH" ]; then
@@ -29,8 +36,12 @@ modified_files() {
     target_branch=develop
   fi
 
+  echo "Target branch: ${target_branch}"
+
   # `base_sha` is the merge base of `target_branch` and the current HEAD.
   base_sha=$(git merge-base "${target_branch}" HEAD)
+
+  echo "Base SHA: ${base_sha}"
 
   # `TARGET` is then all bazel targets affected by changes in the commit range between `base_sha`
   # and `HEAD`.  By default, that becomes all changes between the `develop` branch and the latest
@@ -38,20 +49,19 @@ modified_files() {
   range="${base_sha}...HEAD"
 
   
-  git log --name-only --pretty=oneline --full-index "$range" \
+  git log --name-only --pretty=oneline --full-index "${range}" \
     | grep -vE '^[0-9a-f]{40} ' \
     | grep -E '(\.swift|\.h|\.m)' \
     | sort \
     | uniq
+
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    popd >> /dev/null
+  fi
 }
 
 # Determines if any of the modified files are not included in a bazel rule.
 check_files_covered() {
-  # Move to our cloned repository
-  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-    pushd github/repo >> /dev/null
-  fi
-
   files=$(modified_files)
   if [ -z "$files" ]; then
     exit 0
@@ -77,9 +87,6 @@ check_files_covered() {
     fi
   done 
   
-  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-    popd >> /dev/null
-  fi
 
   if (( exit_status != 0 )); then
     echo  -e "The following files are not in any BUILD targets:\n\n${missing_targets}" | sort | uniq

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -15,9 +15,7 @@
 # limitations under the License.
 #
 # Finds all newly-added files that are missing BUILD targets
-script_version=0.0.8
-
-set -x -e
+script_version=0.0.9
 
 echo "Bazel target detection v${script_version}"
 
@@ -29,10 +27,6 @@ modified_files() {
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     pushd github/repo >> /dev/null
   fi
-
-  pwd
-  git fetch
-  git branch -a
 
   # `target_branch` is either the Pull Request destination branch (where it will be merged) or if
   # none can be determined, defaults to `develop`.

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -15,12 +15,14 @@
 # limitations under the License.
 #
 # Finds all newly-added files that are missing BUILD targets
-script_version=0.0.2
+script_version=0.0.3
 
 echo "Bazel target detection v${script_version}"
 
 # Generates a list of files that were modified since the target branch 
 modified_files() {
+  echo "Entered 'modified_files'"
+
   # Move to our cloned repository
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     pushd github/repo >> /dev/null
@@ -39,6 +41,7 @@ modified_files() {
   echo "Target branch: ${target_branch}"
 
   # `base_sha` is the merge base of `target_branch` and the current HEAD.
+  git merge-base "${target_branch}" HEAD
   base_sha=$(git merge-base "${target_branch}" HEAD)
 
   echo "Base SHA: ${base_sha}"
@@ -83,7 +86,7 @@ check_files_covered() {
     fi
     ((current_index++))
     if (( current_index%10==1 )); then
-      (>&2 echo "$current_index / $num_files" )
+      echo "$current_index / $num_files" 
     fi
   done 
   

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 # Finds all newly-added files that are missing BUILD targets
-script_version=0.0.9
+script_version=0.0.10
 
 echo "Bazel target detection v${script_version}"
 
@@ -44,7 +44,7 @@ modified_files() {
   
   git log --name-only --pretty=oneline --full-index "${range}" \
     | grep -vE '^[0-9a-f]{40} ' \
-    | grep -E '(\.swift|\.h|\.m)' \
+    | grep -E '(\.swift|\.h|\.m)$' \
     | sort \
     | uniq
 
@@ -56,6 +56,11 @@ modified_files() {
 # Determines if any of the modified files are not included in a bazel rule.
 check_files_covered() {
   files=$(modified_files)
+  SAVEIFS=$IFS
+  IFS=$'\n'
+  files=($files)
+  IFS=$SAVEIFS
+
   if [ -z "$files" ]; then
     echo "No source files were modified"
     exit 0
@@ -76,13 +81,13 @@ check_files_covered() {
       exit_status=1
     fi
     ((current_index++))
-    if (( current_index%10==1 )); then
-      echo "$current_index / $num_files" 
+    if (( current_index % 25==0 )); then
+      echo "Processing file $current_index / $num_files" 
     fi
   done 
   
   if (( exit_status != 0 )); then
-    echo  -e "The following files are not in any BUILD targets:\n\n${missing_targets}" | sort | uniq
+    echo  -e "[FAILURE] The following files are not in any BUILD targets:\n\n${missing_targets}" | sort | uniq
     exit $exit_status
   fi 
 } 

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -15,9 +15,10 @@
 # limitations under the License.
 #
 # Finds all newly-added files that are missing BUILD targets
-VERSION=0.0.1
+script_version=0.0.1
 
-echo "Bazel target detection v$VERSION"
+echo "Bazel target detection v${script_version}"
+
 # Generates a list of files that were modified since the target branch 
 modified_files() {
   # `target_branch` is either the Pull Request destination branch (where it will be merged) or if
@@ -44,30 +45,31 @@ modified_files() {
     | uniq
 }
 
+# Determines if any of the modified files are not included in a bazel rule.
 check_files_covered() {
   # Move to our cloned repository
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     pushd github/repo >> /dev/null
   fi
 
-  all_files=$(modified_files)
-  if [ -z "$all_files" ]; then
+  files=$(modified_files)
+  if [ -z "$files" ]; then
     exit 0
   fi
-  num_files="${#all_files[@]}"
+  num_files="${#files[@]}"
   current_index=0
-  for file_path in "${all_files[@]}"; do
+  for file in "${files[@]}"; do
     # allrdeps is part of Sky Query, which can only be accessed when universe_scope and order_output
     # are provided. See the following docs for more details:
     # https://docs.bazel.build/versions/master/query.html#sky-query
     targets=$(bazel query \
       --universe_scope=//... \
       --order_output=no \
-      "kind(rule, allrdeps('$file_path'))" \
+      "kind(rule, allrdeps('$file'))" \
       2>/dev/null ) 
     if [ -z "$targets" ]; then
-      MISSING_TARGETS="${MISSING_TARGETS}${file_path}\n"
-      EXIT_STATUS=1
+      missing_targets="${missing_targets}${file}\n"
+      exit_status=1
     fi
     ((current_index++))
     if (( current_index%10==1 )); then
@@ -79,9 +81,9 @@ check_files_covered() {
     popd >> /dev/null
   fi
 
-  if (( EXIT_STATUS != 0 )); then
-    echo  -e "The following files are not in any BUILD targets:\n\n$MISSING_TARGETS" | sort | uniq
-    exit $EXIT_STATUS
+  if (( exit_status != 0 )); then
+    echo  -e "The following files are not in any BUILD targets:\n\n$missing_targets" | sort | uniq
+    exit $exit_status
   fi 
 } 
 

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -15,7 +15,9 @@
 # limitations under the License.
 #
 # Finds all newly-added files that are missing BUILD targets
-script_version=0.0.4
+script_version=0.0.5
+
+set -x -e
 
 echo "Bazel target detection v${script_version}"
 
@@ -29,6 +31,7 @@ modified_files() {
   fi
 
   pwd
+  git fetch
 
   # `target_branch` is either the Pull Request destination branch (where it will be merged) or if
   # none can be determined, defaults to `develop`.

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Finds all files that are missing BUILD targets
+
+# SEARCH_PATHS should be the set of paths to search for uncovered files
+SEARCH_PATHS="$1"
+
+[[ -z "$SEARCH_PATHS" ]] && SEARCH_PATHS="components"
+
+EXIT_STATUS=0
+MISSING_TARGETS=""
+
+while read LINE; do 
+  label=$(bazel query \'$LINE\' 2>/dev/null); 
+  if [ -z $label ]; then
+    MISSING_TARGETS="$MISSING_TARGETS""$LINE""\n";
+    EXIT_STATUS=1;
+  fi 
+  bazel query "attr('srcs', $label, ${label//:*/}:*) union attr('hdrs', $label, ${label//:*/}:*)" 2>/dev/null >/dev/null; 
+done <<< "$(find "$SEARCH_PATHS" -type f \( -name "*.swift" -or -name "*.h" -or -name "*.m" \))"
+
+echo -e "$MISSING_TARGETS" | sort -u
+
+exit $EXIT_STATUS

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -43,6 +43,9 @@ modified_files() {
 }
 
 check_files_covered() {
+  # Move to our cloned repository
+  cd github/repo
+
   all_files=$(modified_files)
   if [ -z "$all_files" ]; then
     exit 0

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 # Finds all newly-added files that are missing BUILD targets
-script_version=0.0.6
+script_version=0.0.7
 
 set -x -e
 
@@ -32,6 +32,7 @@ modified_files() {
 
   pwd
   git fetch
+  git branch -a
 
   # `target_branch` is either the Pull Request destination branch (where it will be merged) or if
   # none can be determined, defaults to `develop`.

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -15,7 +15,9 @@
 # limitations under the License.
 #
 # Finds all newly-added files that are missing BUILD targets
+VERSION=0.0.1
 
+echo "Bazel target detection v$VERSION"
 # Generates a list of files that were modified since the target branch 
 modified_files() {
   # `target_branch` is either the Pull Request destination branch (where it will be merged) or if
@@ -44,7 +46,9 @@ modified_files() {
 
 check_files_covered() {
   # Move to our cloned repository
-  cd github/repo
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    pushd github/repo >> /dev/null
+  fi
 
   all_files=$(modified_files)
   if [ -z "$all_files" ]; then
@@ -70,6 +74,11 @@ check_files_covered() {
       (>&2 echo "$current_index / $num_files" )
     fi
   done 
+  
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    popd >> /dev/null
+  fi
+
   if (( EXIT_STATUS != 0 )); then
     echo  -e "The following files are not in any BUILD targets:\n\n$MISSING_TARGETS" | sort | uniq
     exit $EXIT_STATUS

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 # Finds all newly-added files that are missing BUILD targets
-script_version=0.0.5
+script_version=0.0.6
 
 set -x -e
 
@@ -44,7 +44,7 @@ modified_files() {
   echo "Target branch: ${target_branch}"
 
   # `base_sha` is the merge base of `target_branch` and the current HEAD.
-  echo "git merge-base '${target_branch}' HEAD"
+  echo "git merge-base ${target_branch} HEAD"
   base_sha=$(git merge-base "${target_branch}" HEAD)
 
   echo "Base SHA: ${base_sha}"

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -14,25 +14,64 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Finds all files that are missing BUILD targets
+# Finds all newly-added files that are missing BUILD targets
 
-# SEARCH_PATHS should be the set of paths to search for uncovered files
-SEARCH_PATHS="$1"
+# Generates a list of files that were modified since the target branch 
+modified_files() {
+  # `target_branch` is either the Pull Request destination branch (where it will be merged) or if
+  # none can be determined, defaults to `develop`.
+  if [ -n "$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH" ]; then
+    target_branch="$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH"
+  else
+    target_branch=develop
+  fi
 
-[[ -z "$SEARCH_PATHS" ]] && SEARCH_PATHS="components"
+  # `base_sha` is the merge base of `target_branch` and the current HEAD.
+  base_sha=$(git merge-base "$target_branch" HEAD)
 
-EXIT_STATUS=0
-MISSING_TARGETS=""
+  # `TARGET` is then all bazel targets affected by changes in the commit range between `base_sha`
+  # and `HEAD`.  By default, that becomes all changes between the `develop` branch and the latest
+  #  commit.
+  range="${base_sha}...HEAD"
 
-while read LINE; do 
-  label=$(bazel query \'$LINE\' 2>/dev/null); 
-  if [ -z $label ]; then
-    MISSING_TARGETS="$MISSING_TARGETS""$LINE""\n";
-    EXIT_STATUS=1;
+  
+  git log --name-only --pretty=oneline --full-index "$range" \
+    | grep -vE '^[0-9a-f]{40} ' \
+    | grep -E '(\.swift|\.h|\.m)' \
+    | sort \
+    | uniq
+}
+
+check_files_covered() {
+  all_files=$(modified_files)
+  if [ -z "$all_files" ]; then
+    exit 0
+  fi
+  num_files="${#all_files[@]}"
+  current_index=0
+  for file_path in "${all_files[@]}"; do
+    # allrdeps is part of Sky Query, which can only be accessed when universe_scope and order_output
+    # are provided. See the following docs for more details:
+    # https://docs.bazel.build/versions/master/query.html#sky-query
+    targets=$(bazel query \
+      --universe_scope=//... \
+      --order_output=no \
+      "kind(rule, allrdeps('$file_path'))" \
+      2>/dev/null ) 
+    if [ -z "$targets" ]; then
+      MISSING_TARGETS="${MISSING_TARGETS}${file_path}\n"
+      EXIT_STATUS=1
+    fi
+    ((current_index++))
+    if (( current_index%10==1 )); then
+      (>&2 echo "$current_index / $num_files" )
+    fi
+  done 
+  if (( EXIT_STATUS != 0 )); then
+    echo  -e "The following files are not in any BUILD targets:\n\n$MISSING_TARGETS" | sort | uniq
+    exit $EXIT_STATUS
   fi 
-  bazel query "attr('srcs', $label, ${label//:*/}:*) union attr('hdrs', $label, ${label//:*/}:*)" 2>/dev/null >/dev/null; 
-done <<< "$(find "$SEARCH_PATHS" -type f \( -name "*.swift" -or -name "*.h" -or -name "*.m" \))"
+} 
 
-echo -e "$MISSING_TARGETS" | sort -u
+check_files_covered
 
-exit $EXIT_STATUS

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 # Finds all newly-added files that are missing BUILD targets
-script_version=0.0.7
+script_version=0.0.8
 
 set -x -e
 
@@ -37,7 +37,7 @@ modified_files() {
   # `target_branch` is either the Pull Request destination branch (where it will be merged) or if
   # none can be determined, defaults to `develop`.
   if [ -n "$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH" ]; then
-    target_branch="$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH"
+    target_branch="origin/${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH}"
   else
     target_branch=develop
   fi

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 # Finds all newly-added files that are missing BUILD targets
-script_version=0.0.3
+script_version=0.0.4
 
 echo "Bazel target detection v${script_version}"
 
@@ -41,7 +41,7 @@ modified_files() {
   echo "Target branch: ${target_branch}"
 
   # `base_sha` is the merge base of `target_branch` and the current HEAD.
-  git merge-base "${target_branch}" HEAD
+  echo "git merge-base '${target_branch}' HEAD"
   base_sha=$(git merge-base "${target_branch}" HEAD)
 
   echo "Base SHA: ${base_sha}"
@@ -65,8 +65,11 @@ modified_files() {
 
 # Determines if any of the modified files are not included in a bazel rule.
 check_files_covered() {
+  echo "Enter 'check_files_covered'"
+
   files=$(modified_files)
   if [ -z "$files" ]; then
+    echo "No source files were modified"
     exit 0
   fi
   num_files="${#files[@]}"

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -15,9 +15,6 @@
 # limitations under the License.
 #
 # Finds all newly-added files that are missing BUILD targets
-script_version=0.0.10
-
-echo "Bazel target detection v${script_version}"
 
 # Generates a list of files that were modified since the target branch 
 modified_files() {
@@ -68,13 +65,8 @@ check_files_covered() {
   num_files="${#files[@]}"
   current_index=0
   for file in "${files[@]}"; do
-    # allrdeps is part of Sky Query, which can only be accessed when universe_scope and order_output
-    # are provided. See the following docs for more details:
-    # https://docs.bazel.build/versions/master/query.html#sky-query
     targets=$(bazel query \
-      --universe_scope=//... \
-      --order_output=no \
-      "kind(rule, allrdeps('$file'))" \
+      "kind(rule, deps('$file'))" \
       2>/dev/null ) 
     if [ -z "$targets" ]; then
       missing_targets="${missing_targets}${file}\n"


### PR DESCRIPTION
In order to prevent us from having example code that cannot be compiled internally, we should detect any PRs that might have new code not covered by a bazel rule. Being included by a bazel rule will provide greater chance for the source to be compiled and perhaps even tested.

Supports #2641
Supports #5370