### PR TITLE
[.kokoro] Upgrade bazel prior to checking dependencies.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -307,7 +307,7 @@ run_bazel_affected() {
     
     # Output the affected targets to the logs. This also gives the affected_targets script the
     # opportunity to fail.
-    scripts/affected_targets $bazel_kind $base_sha...HEAD)
+    scripts/affected_targets "$bazel_kind" "$base_sha...HEAD"
 
     # `TARGET` is then all bazel targets affected by changes in the commit range between `base_sha`
     # and `HEAD`.  By default, that becomes all changes between the `develop` branch and the latest

--- a/.kokoro
+++ b/.kokoro
@@ -304,6 +304,10 @@ run_bazel_affected() {
       use_bazel.sh 0.20.0
       bazel version
     fi
+    
+    # Output the affected targets to the logs. This also gives the affected_targets script the
+    # opportunity to fail.
+    scripts/affected_targets $bazel_kind $base_sha...HEAD)
 
     # `TARGET` is then all bazel targets affected by changes in the commit range between `base_sha`
     # and `HEAD`.  By default, that becomes all changes between the `develop` branch and the latest
@@ -331,8 +335,6 @@ run_bazel_affected() {
 
     exit 0
   else
-    echo "$TARGET"
-
     if [ -n "$GITHUB_API_TOKEN" ]; then
       comment_tmp_path=$(mktemp -d)
       comment_tmp_file="$comment_tmp_path/comment.tmp"

--- a/.kokoro
+++ b/.kokoro
@@ -297,6 +297,14 @@ run_bazel_affected() {
     # `base_sha` is the merge base of `target_branch` and the current HEAD.
     base_sha=$(git merge-base "$target_branch" HEAD)
 
+    # We must upgrade bazel prior to running bazel query because we rely on features in bazel
+    # 0.20.
+    if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+      bazel version
+      use_bazel.sh 0.20.0
+      bazel version
+    fi
+
     # `TARGET` is then all bazel targets affected by changes in the commit range between `base_sha`
     # and `HEAD`.  By default, that becomes all changes between the `develop` branch and the latest
     #  commit.


### PR DESCRIPTION
The scripts/affected_targets script was not returning the expected targets on kokoro, but it was doing so locally. It was failing on kokoro because the default bazel install on kokoro is 0.11, but we rely on 0.20 in order to be able to run bazel query.

This change upgrades the bazel version to 0.20 prior to checking the affected targets.

I tested the failure by adding the following command to https://github.com/material-components/material-components-ios/pull/6101

```
bazel query --universe_scope=//... --order_output=no "kind(test, allrdeps('components/Buttons/src/private/MDCButton+Subclassing.h'))"
```

Which generated the following error output:

```
ERROR: error loading package 'components/PageControl': Extension file not found. Unable to load package for '@bazel_tools//tools/build_defs/cc:action_names.bzl': BUILD file not found on package path
```