### PR TITLE
{kokoro} Exclude "snapshot" tests from bazel coverage.

### DIFF
--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -62,7 +62,7 @@ modified_files() {
   git log --name-only --pretty=oneline --full-index "${range}" \
     | grep -vE '^[0-9a-f]{40} ' \
     | grep -E '(\.swift|\.h|\.m)$' \
-    | grep -E '\/tests\/snapshot\/'
+    | grep -vE '\/tests\/snapshot\/'
     | sort \
     | uniq
 

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -62,7 +62,7 @@ modified_files() {
   git log --name-only --pretty=oneline --full-index "${range}" \
     | grep -vE '^[0-9a-f]{40} ' \
     | grep -E '(\.swift|\.h|\.m)$' \
-    | grep -vE '\/tests\/snapshot\/'
+    | grep -vE '\/tests\/snapshot\/' \
     | sort \
     | uniq
 

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -62,6 +62,7 @@ modified_files() {
   git log --name-only --pretty=oneline --full-index "${range}" \
     | grep -vE '^[0-9a-f]{40} ' \
     | grep -E '(\.swift|\.h|\.m)$' \
+    | grep -E '\/tests\/snapshot\/'
     | sort \
     | uniq
 


### PR DESCRIPTION
Since our snapshot tests cannot currently execute in bazel, we should exclude
them from coverage calculations for bazel targets.
