### PR TITLE
[TextFields] Add underlined Arabic snapshot tests.

### DIFF
--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests.m
@@ -1,0 +1,52 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "MaterialTextFields.h"
+
+@interface MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests
+    : MDCAbstractTextFieldSnapshotTests
+
+@end
+
+@implementation MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests
+
+- (void)setUp {
+  [super setUp];
+
+  // Uncomment below to recreate the golden images for all test methods. Add it to a test method to
+  // update only that golden image.
+  //  self.recordMode = YES;
+
+  self.textField.clearButtonMode = UITextFieldViewModeAlways;
+  [self addLeadingImage];
+
+  MDCTextInputControllerUnderline *controller =
+      [[MDCTextInputControllerUnderline alloc] initWithTextInput:self.textField];
+  controller.floatingEnabled = NO;
+  self.textFieldController = controller;
+
+  [self changeStringsToArabic];
+  if (@available(iOS 9.0, *)) {
+    [self changeLayoutToRTL];
+  } else {
+    NSLog(@"[ERROR] RTL tests can only run on iOS 9 or later.");
+  }
+}
+
+// NOTE: Additional test methods can be found in MDCAbstractTextFieldSnapshotTests.m
+
+@end

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldEmptyDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldEmptyDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9edf262d596880071da4471fc7496981f335490d8dfc396dff20db1857ef265
+size 4274

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldEmptyIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldEmptyIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42247ee2da39ea0df4edbf67564a6642b96b9eb3e6f6920675382413f34c682b
+size 4232

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldEmpty_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldEmpty_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:699941d1180df19abaf2cbbd1441afa3ac6cef6346830a96cc054ae5b4769add
+size 4223

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongErrorTextDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongErrorTextDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f055e5c75204356c5662834ae75bc3b0b4358d0e40b6646487ac68dbe3074037
+size 11755

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongErrorTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongErrorTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27fbc498474f851db7b40668d839654f1e350da913c4ef8356d8a78e9dd9fee9
+size 11729

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongErrorText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongErrorText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7436e721cfbf7cb6d888004371a0dc6a10ef5beabcfb9ac33eeacc2b8073a5e0
+size 11724

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongHelperTextDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongHelperTextDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24bc6956d6c249aea2d32e44a77421da7b608b32577d458cea5b59629a73871b
+size 10219

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongHelperTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongHelperTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68e8c7e7f8e16120a12b1d6fcc595bcf653043befda9def927c76c5c64a5eec3
+size 10201

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongHelperText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongHelperText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df12d0b4586532891d651f3685a7dda868e118e1c4a3c31ab4c2f717b02729e9
+size 10193

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputPlaceholderErrorTextsDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputPlaceholderErrorTextsDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e00ad9ca78e504b130c9991e3e60d7e8cd8033b565addd3781ff7893ba38fb1
+size 18238

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputPlaceholderErrorTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputPlaceholderErrorTextsIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c23114ec0e5c13be99e02162ce1237d89b3069e34be02bd7f70478755f55735
+size 18224

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputPlaceholderErrorTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputPlaceholderErrorTexts_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:452f7ff31aba08094a0af05971d8e4fb19ca46385fcd22574908bfdf101755a5
+size 18219

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputPlaceholderHelperTextsDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputPlaceholderHelperTextsDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9139bf0cd257830a7ef15f3456b1971ec55d71599e09c5fdb6a43ac9dd482963
+size 16720

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputPlaceholderHelperTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputPlaceholderHelperTextsIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85487365f97141f152739384a120f869bf3927a92c080912c10e47f57ab030c0
+size 16705

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputPlaceholderHelperTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputPlaceholderHelperTexts_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9738e7bf1cb3a7472808376020284d12e737a1bfc86c9b4b41f96a7b837a6ac
+size 16699

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputTextDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputTextDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6980833f8991f762f89396dfabf42ba03f93b21b7e62bf4951aff2044167b049
+size 10800

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c20ec582cc63d55f59a06a3fa6488318acfe7953e23cc7d9c5b84ec6c7216c7b
+size 10771

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongInputText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2502fef904034006a80b55e5d39fba1aa92a1d7d4fdc6675aeaa1791e7a546e7
+size 10776

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongPlaceholderTextDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongPlaceholderTextDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a949138876888e9852045ae7fa5246f5a95bcd9b036cee9fb9f36d2803c6073
+size 9287

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongPlaceholderTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongPlaceholderTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1392a3b6946a88f919a4a7a58318b4c7887dad1ded4503723f72b9c2ef34138d
+size 9726

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongPlaceholderText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithLongPlaceholderText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a1383965bc2c98831e37f27d9975e7066a4289afe127f952ac8fbea82497f86
+size 9717

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortErrorTextDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortErrorTextDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ef6bd4806a4c8611833d83b4289be77ce17a6b2268734c2d8a3d2ffc11da0f1
+size 6486

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortErrorTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortErrorTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c73bbfd08245d4d702c9c97710cdafb7e452318b98a4f1751fdbd6a47be0bd2
+size 6449

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortErrorText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortErrorText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b10a6693f5d7ad1610c63b058265fb37053e8df0a6df14c93c1a432ff924f0cf
+size 6444

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortHelperTextDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortHelperTextDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d55d4ebcc3140f9bf82a45ae62125bf9620d015337030247a470f5754b08625
+size 6083

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortHelperTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortHelperTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aca67d7e6fcc83ff31bdac08197528fcb8e3835bff4a526e11cb4b447e4997c1
+size 6066

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortHelperText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortHelperText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25bfd34fb0e3f5870128e2a728c3086397c979f327ea562b2f56597da6c459f8
+size 6053

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputPlaceholderErrorTextsDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputPlaceholderErrorTextsDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9bc4b0daee864ea6e0f245df7775382229dd4df9d4d19e42e2872ecc9d19750
+size 8638

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputPlaceholderErrorTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputPlaceholderErrorTextsIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:474ee390b26312af69c9567d8d7cbac5816466e8c7d47f7504e5d93948dfc3ea
+size 8630

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputPlaceholderErrorTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputPlaceholderErrorTexts_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e4c7e15eea92372d014e467798d8e483800853eaae257f919615aa2a4053c16
+size 8628

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputPlaceholderHelperTextsDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputPlaceholderHelperTextsDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f376c9598a4c7a9ccb2ddeccdf8a912f8a7ca588463705b220b13d219c5123d
+size 8263

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputPlaceholderHelperTextsIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputPlaceholderHelperTextsIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b9196279a29fe30fa962852a40421df501afaffcbc5a80d0d2ad37efeb0108b
+size 8249

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputPlaceholderHelperTexts_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputPlaceholderHelperTexts_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcd69bcffec71149e834ba11947f3bbd72e0935bf5a60b0582f9ceaebdd71c21
+size 8241

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputTextDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputTextDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7ce1a9b39df4f758413b5716ded766ed180e83ac8da8aa03c585a650e584f91
+size 6474

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e90b8180b3b59a2ec03f749036dbc52b150f97de123b216bf44101f898da2a15
+size 6464

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortInputText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:078dcae1b42be69a527aa19c75044bc87f1195c15e69d4f5224e55c79e3903ca
+size 6449

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortPlaceholderTextDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortPlaceholderTextDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc967bbff5b94ea7eb20b1c575f33c998f3e6e05e20a6e15d545568b76d0e91c
+size 5463

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortPlaceholderTextIsEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortPlaceholderTextIsEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a31ece21c8cbf973a9973dadff8046eb5ef3e9848126f9936181d53845ae50f0
+size 5638

--- a/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortPlaceholderText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests/testTextFieldWithShortPlaceholderText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b4348fd1a9a5fe78752d66464ed5f97ebde0e9f6cef292e95fbbdd51a3829b4
+size 5629


### PR DESCRIPTION
Adding Arabic Right-to-Left snapshot tests for the Underline controller style.

Part of #5762
