### PR TITLE
[TextFields] Drop RTL assert to a log message.

### DIFF
--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageArabicSnapshotTests.m
@@ -52,7 +52,7 @@
   if (@available(iOS 9.0, *)) {
     [self changeLayoutToRTL];
   } else {
-    XCTAssertTrue(NO, @"RTL tests can only run on iOS 9 or later.");
+    NSLog(@"[ERROR] RTL tests can only run on iOS 9 or later.");
   }
 }
 


### PR DESCRIPTION
Although we won't be supporting iOS 9 much longer, and almost never for
snapshot tests, the entire test should not fail on iOS 8. Instead, it can just
render incorrectly - at least some value will still come from the broken test.

Part of #5762