### PR TITLE
[TextFields] Minor clean-up/refactor of text fields snapshot tests.

### DIFF
--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageSnapshotTests.m
@@ -20,11 +20,9 @@
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerLeadingImageSnapshotTests : MDCAbstractTextFieldSnapshotTests
-@property(nonatomic, strong) MDCTextInputControllerFilled *textFieldController;
 @end
 
 @implementation MDCTextFieldFilledControllerLeadingImageSnapshotTests
-@dynamic textFieldController;
 
 - (void)setUp {
   [super setUp];
@@ -37,9 +35,10 @@
 
   [self addLeadingImage];
 
-  self.textFieldController =
+  MDCTextInputControllerFilled *controller =
       [[MDCTextInputControllerFilled alloc] initWithTextInput:self.textField];
-  self.textFieldController.floatingEnabled = NO;
+  controller.floatingEnabled = NO;
+  self.textFieldController = controller;
 }
 
 // NOTE: Additional test methods can be found in MDCAbstractTextFieldSnapshotTests.m

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerSnapshotTests.m
@@ -17,11 +17,9 @@
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests
-@property(nonatomic, strong) MDCTextInputControllerFilled *textFieldController;
 @end
 
 @implementation MDCTextFieldFilledControllerSnapshotTests
-@dynamic textFieldController;
 
 - (void)setUp {
   [super setUp];
@@ -32,9 +30,10 @@
 
   self.textField.clearButtonMode = UITextFieldViewModeAlways;
 
-  self.textFieldController =
+  MDCTextInputControllerFilled *controller =
       [[MDCTextInputControllerFilled alloc] initWithTextInput:self.textField];
-  self.textFieldController.floatingEnabled = NO;
+  controller.floatingEnabled = NO;
+  self.textFieldController = controller;
 }
 
 // NOTE: Additional test methods can be found in MDCAbstractTextFieldSnapshotTests.m

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests.m
@@ -19,11 +19,9 @@
 
 @interface MDCTextFieldFilledFloatingControllerBaselineSnapshotTests
     : MDCAbstractTextFieldSnapshotTests
-@property(nonatomic, strong) MDCTextInputControllerFilled *textFieldController;
 @end
 
 @implementation MDCTextFieldFilledFloatingControllerBaselineSnapshotTests
-@dynamic textFieldController;
 
 - (void)setUp {
   [super setUp];
@@ -34,9 +32,10 @@
 
   self.textField.clearButtonMode = UITextFieldViewModeAlways;
 
-  self.textFieldController =
+  MDCTextInputControllerFilled *controller =
       [[MDCTextInputControllerFilled alloc] initWithTextInput:self.textField];
-  self.textFieldController.floatingEnabled = YES;
+  controller.floatingEnabled = YES;
+  self.textFieldController = controller;
 
   MDCSemanticColorScheme *colorScheme =
       [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageSnapshotTests.m
@@ -23,7 +23,6 @@
 @end
 
 @implementation MDCTextFieldFilledFloatingControllerLeadingImageSnapshotTests
-@dynamic textFieldController;
 
 - (void)setUp {
   [super setUp];

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerSnapshotTests.m
@@ -17,11 +17,9 @@
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests
-@property(nonatomic, strong) MDCTextInputControllerFilled *textFieldController;
 @end
 
 @implementation MDCTextFieldFilledFloatingControllerSnapshotTests
-@dynamic textFieldController;
 
 - (void)setUp {
   [super setUp];
@@ -32,9 +30,10 @@
 
   self.textField.clearButtonMode = UITextFieldViewModeAlways;
 
-  self.textFieldController =
+  MDCTextInputControllerFilled *controller =
       [[MDCTextInputControllerFilled alloc] initWithTextInput:self.textField];
-  self.textFieldController.floatingEnabled = YES;
+  controller.floatingEnabled = YES;
+  self.textFieldController = controller;
 }
 
 // NOTE: Additional test methods can be found in MDCAbstractTextFieldSnapshotTests.m

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageSnapshotTests.m
@@ -34,7 +34,6 @@
 
   [self addLeadingImage];
 
-  self.textField.clearButtonMode = UITextFieldViewModeAlways;
   self.textFieldController =
       [[MDCTextInputControllerFullWidth alloc] initWithTextInput:self.textField];
 }


### PR DESCRIPTION
The filled text fields snapshot tests were redeclaring the
`textFieldController` property of a new type, forcing it to be marked
`@dynamic`. Instead, it's cleaner to just configure the custom properties on
the controller as an automatic variable before the assignment to the
superclass property.

Also removing a duplicate `clearButtonMode` assignment from the FullWidth
snapshot.

Part of #5762
