### PR TITLE
[TextFields] Add pre-verification hook for snapshot tests.

### DIFF
--- a/components/TextFields/tests/snapshot/MDCAbstractTextFieldSnapshotTestsTests.m
+++ b/components/TextFields/tests/snapshot/MDCAbstractTextFieldSnapshotTestsTests.m
@@ -86,8 +86,8 @@
  A test fake implementation of MDCAbstractTextFieldSnapshotTests that conforms to the
  @c MDCTextFieldSnapshotTestCaseHooking protocol.
  */
-@interface MDCAbstractTextFieldSnapshotTestsHookingFake : MDCAbstractTextFieldSnapshotTestsFake
-    <MDCTextFieldSnapshotTestCaseHooking>
+@interface MDCAbstractTextFieldSnapshotTestsHookingFake
+    : MDCAbstractTextFieldSnapshotTestsFake <MDCTextFieldSnapshotTestCaseHooking>
 @property(nonatomic, assign) BOOL beforeGenerateSnapshotAndVerifyCalled;
 @end
 

--- a/components/TextFields/tests/snapshot/MDCAbstractTextFieldSnapshotTestsTests.m
+++ b/components/TextFields/tests/snapshot/MDCAbstractTextFieldSnapshotTestsTests.m
@@ -1,0 +1,558 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+#import "MDCAbstractTextFieldSnapshotTests.h"
+
+@interface MDCAbstractTextFieldSnapshotTests (Testing)
+- (BOOL)shouldTestExecute;
+- (void)testTextFieldEmpty;
+- (void)testTextFieldEmptyIsEditing;
+- (void)testTextFieldEmptyDisabled;
+- (void)testTextFieldWithShortPlaceholderText;
+- (void)testTextFieldWithShortPlaceholderTextIsEditing;
+- (void)testTextFieldWithShortPlaceholderTextDisabled;
+- (void)testTextFieldWithLongPlaceholderText;
+- (void)testTextFieldWithLongPlaceholderTextIsEditing;
+- (void)testTextFieldWithLongPlaceholderTextDisabled;
+- (void)testTextFieldWithShortHelperText;
+- (void)testTextFieldWithShortHelperTextIsEditing;
+- (void)testTextFieldWithShortHelperTextDisabled;
+- (void)testTextFieldWithLongHelperText;
+- (void)testTextFieldWithLongHelperTextIsEditing;
+- (void)testTextFieldWithLongHelperTextDisabled;
+- (void)testTextFieldWithShortErrorText;
+- (void)testTextFieldWithShortErrorTextIsEditing;
+- (void)testTextFieldWithShortErrorTextDisabled;
+- (void)testTextFieldWithLongErrorText;
+- (void)testTextFieldWithLongErrorTextIsEditing;
+- (void)testTextFieldWithLongErrorTextDisabled;
+- (void)testTextFieldWithShortInputText;
+- (void)testTextFieldWithShortInputTextIsEditing;
+- (void)testTextFieldWithShortInputTextDisabled;
+- (void)testTextFieldWithLongInputText;
+- (void)testTextFieldWithLongInputTextIsEditing;
+- (void)testTextFieldWithLongInputTextDisabled;
+- (void)testTextFieldWithShortInputPlaceholderHelperTexts;
+- (void)testTextFieldWithShortInputPlaceholderHelperTextsIsEditing;
+- (void)testTextFieldWithShortInputPlaceholderHelperTextsDisabled;
+- (void)testTextFieldWithLongInputPlaceholderHelperTexts;
+- (void)testTextFieldWithLongInputPlaceholderHelperTextsIsEditing;
+- (void)testTextFieldWithLongInputPlaceholderHelperTextsDisabled;
+- (void)testTextFieldWithShortInputPlaceholderErrorTexts;
+- (void)testTextFieldWithShortInputPlaceholderErrorTextsIsEditing;
+- (void)testTextFieldWithShortInputPlaceholderErrorTextsDisabled;
+- (void)testTextFieldWithLongInputPlaceholderErrorTexts;
+- (void)testTextFieldWithLongInputPlaceholderErrorTextsIsEditing;
+- (void)testTextFieldWithLongInputPlaceholderErrorTextsDisabled;
+@end
+
+/**
+ A test fake implementation of MDCAbstractTextFieldSnapshotTests that does not conform to the
+ @c MDCTextFieldSnapshotTestCaseHooking protocol.
+ */
+@interface MDCAbstractTextFieldSnapshotTestsFake : MDCAbstractTextFieldSnapshotTests
+@property(nonatomic, assign) BOOL generateSnapshotAndVerifyCalled;
+@end
+
+@implementation MDCAbstractTextFieldSnapshotTestsFake
+
+- (BOOL)shouldTestExecute {
+  return YES;
+}
+
+- (void)beforeGenerateSnapshotAndVerify {
+  XCTAssertTrue(NO, @"This method should not be called.");
+}
+
+- (void)generateSnapshotAndVerify {
+  self.generateSnapshotAndVerifyCalled = YES;
+}
+
+@end
+
+/**
+ A test fake implementation of MDCAbstractTextFieldSnapshotTests that conforms to the
+ @c MDCTextFieldSnapshotTestCaseHooking protocol.
+ */
+@interface MDCAbstractTextFieldSnapshotTestsHookingFake : MDCAbstractTextFieldSnapshotTestsFake
+    <MDCTextFieldSnapshotTestCaseHooking>
+@property(nonatomic, assign) BOOL beforeGenerateSnapshotAndVerifyCalled;
+@end
+
+@implementation MDCAbstractTextFieldSnapshotTestsHookingFake
+
+- (void)beforeGenerateSnapshotAndVerify {
+  self.beforeGenerateSnapshotAndVerifyCalled = YES;
+}
+
+@end
+
+@interface MDCAbstractTextFieldSnapshotTestsTests : XCTestCase
+@property(nonatomic, strong) MDCAbstractTextFieldSnapshotTestsFake *fakeTest;
+@property(nonatomic, strong) MDCAbstractTextFieldSnapshotTestsHookingFake *hookingFakeTest;
+@end
+
+/**
+ A set of tests to ensure that @c MDCAbstractTextFieldSnapshotTests invoke the expected set of hooks
+ when they are implemented by a subclass.
+ */
+@implementation MDCAbstractTextFieldSnapshotTestsTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.fakeTest = [[MDCAbstractTextFieldSnapshotTestsFake alloc] init];
+  self.hookingFakeTest = [[MDCAbstractTextFieldSnapshotTestsHookingFake alloc] init];
+}
+
+- (void)tearDown {
+  self.hookingFakeTest = nil;
+  self.fakeTest = nil;
+
+  [super tearDown];
+}
+
+#pragma mark - Tests
+
+- (void)testTestTextFieldEmpty {
+  // When
+  [self.fakeTest testTextFieldEmpty];
+  [self.hookingFakeTest testTextFieldEmpty];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldEmptyIsEditing {
+  // When
+  [self.fakeTest testTextFieldEmptyIsEditing];
+  [self.hookingFakeTest testTextFieldEmptyIsEditing];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldEmptyDisabled {
+  // When
+  [self.fakeTest testTextFieldEmptyDisabled];
+  [self.hookingFakeTest testTextFieldEmptyDisabled];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortPlaceholderText {
+  // When
+  [self.fakeTest testTextFieldWithShortPlaceholderText];
+  [self.hookingFakeTest testTextFieldWithShortPlaceholderText];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortPlaceholderTextIsEditing {
+  // When
+  [self.fakeTest testTextFieldWithShortPlaceholderTextIsEditing];
+  [self.hookingFakeTest testTextFieldWithShortPlaceholderTextIsEditing];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortPlaceholderTextDisabled {
+  // When
+  [self.fakeTest testTextFieldWithShortPlaceholderTextDisabled];
+  [self.hookingFakeTest testTextFieldWithShortPlaceholderTextDisabled];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongPlaceholderText {
+  // When
+  [self.fakeTest testTextFieldWithLongPlaceholderText];
+  [self.hookingFakeTest testTextFieldWithLongPlaceholderText];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongPlaceholderTextIsEditing {
+  // When
+  [self.fakeTest testTextFieldWithLongPlaceholderTextIsEditing];
+  [self.hookingFakeTest testTextFieldWithLongPlaceholderTextIsEditing];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongPlaceholderTextDisabled {
+  // When
+  [self.fakeTest testTextFieldWithLongPlaceholderTextDisabled];
+  [self.hookingFakeTest testTextFieldWithLongPlaceholderTextDisabled];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortHelperText {
+  // When
+  [self.fakeTest testTextFieldWithShortHelperText];
+  [self.hookingFakeTest testTextFieldWithShortHelperText];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortHelperTextIsEditing {
+  // When
+  [self.fakeTest testTextFieldWithShortHelperTextIsEditing];
+  [self.hookingFakeTest testTextFieldWithShortHelperTextIsEditing];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortHelperTextDisabled {
+  // When
+  [self.fakeTest testTextFieldWithShortHelperTextDisabled];
+  [self.hookingFakeTest testTextFieldWithShortHelperTextDisabled];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongHelperText {
+  // When
+  [self.fakeTest testTextFieldWithLongHelperText];
+  [self.hookingFakeTest testTextFieldWithLongHelperText];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongHelperTextIsEditing {
+  // When
+  [self.fakeTest testTextFieldWithLongHelperTextIsEditing];
+  [self.hookingFakeTest testTextFieldWithLongHelperTextIsEditing];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongHelperTextDisabled {
+  // When
+  [self.fakeTest testTextFieldWithLongHelperTextDisabled];
+  [self.hookingFakeTest testTextFieldWithLongHelperTextDisabled];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortErrorText {
+  // When
+  [self.fakeTest testTextFieldWithShortErrorText];
+  [self.hookingFakeTest testTextFieldWithShortErrorText];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortErrorTextIsEditing {
+  // When
+  [self.fakeTest testTextFieldWithShortErrorTextIsEditing];
+  [self.hookingFakeTest testTextFieldWithShortErrorTextIsEditing];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortErrorTextDisabled {
+  // When
+  [self.fakeTest testTextFieldWithShortErrorTextDisabled];
+  [self.hookingFakeTest testTextFieldWithShortErrorTextDisabled];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongErrorText {
+  // When
+  [self.fakeTest testTextFieldWithLongErrorText];
+  [self.hookingFakeTest testTextFieldWithLongErrorText];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongErrorTextIsEditing {
+  // When
+  [self.fakeTest testTextFieldWithLongErrorTextIsEditing];
+  [self.hookingFakeTest testTextFieldWithLongErrorTextIsEditing];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongErrorTextDisabled {
+  // When
+  [self.fakeTest testTextFieldWithLongErrorTextDisabled];
+  [self.hookingFakeTest testTextFieldWithLongErrorTextDisabled];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortInputText {
+  // When
+  [self.fakeTest testTextFieldWithShortInputText];
+  [self.hookingFakeTest testTextFieldWithShortInputText];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortInputTextIsEditing {
+  // When
+  [self.fakeTest testTextFieldWithShortInputTextIsEditing];
+  [self.hookingFakeTest testTextFieldWithShortInputTextIsEditing];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortInputTextDisabled {
+  // When
+  [self.fakeTest testTextFieldWithShortInputTextDisabled];
+  [self.hookingFakeTest testTextFieldWithShortInputTextDisabled];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongInputText {
+  // When
+  [self.fakeTest testTextFieldWithLongInputText];
+  [self.hookingFakeTest testTextFieldWithLongInputText];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongInputTextIsEditing {
+  // When
+  [self.fakeTest testTextFieldWithLongInputTextIsEditing];
+  [self.hookingFakeTest testTextFieldWithLongInputTextIsEditing];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongInputTextDisabled {
+  // When
+  [self.fakeTest testTextFieldWithLongInputTextDisabled];
+  [self.hookingFakeTest testTextFieldWithLongInputTextDisabled];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortInputPlaceholderHelperTexts {
+  // When
+  [self.fakeTest testTextFieldWithShortInputPlaceholderHelperTexts];
+  [self.hookingFakeTest testTextFieldWithShortInputPlaceholderHelperTexts];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortInputPlaceholderHelperTextsIsEditing {
+  // When
+  [self.fakeTest testTextFieldWithShortInputPlaceholderHelperTextsIsEditing];
+  [self.hookingFakeTest testTextFieldWithShortInputPlaceholderHelperTextsIsEditing];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortInputPlaceholderHelperTextsDisabled {
+  // When
+  [self.fakeTest testTextFieldWithShortInputPlaceholderHelperTextsDisabled];
+  [self.hookingFakeTest testTextFieldWithShortInputPlaceholderHelperTextsDisabled];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongInputPlaceholderHelperTexts {
+  // When
+  [self.fakeTest testTextFieldWithLongInputPlaceholderHelperTexts];
+  [self.hookingFakeTest testTextFieldWithLongInputPlaceholderHelperTexts];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongInputPlaceholderHelperTextsIsEditing {
+  // When
+  [self.fakeTest testTextFieldWithLongInputPlaceholderHelperTextsIsEditing];
+  [self.hookingFakeTest testTextFieldWithLongInputPlaceholderHelperTextsIsEditing];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongInputPlaceholderHelperTextsDisabled {
+  // When
+  [self.fakeTest testTextFieldWithLongInputPlaceholderHelperTextsDisabled];
+  [self.hookingFakeTest testTextFieldWithLongInputPlaceholderHelperTextsDisabled];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortInputPlaceholderErrorTexts {
+  // When
+  [self.fakeTest testTextFieldWithShortInputPlaceholderErrorTexts];
+  [self.hookingFakeTest testTextFieldWithShortInputPlaceholderErrorTexts];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortInputPlaceholderErrorTextsIsEditing {
+  // When
+  [self.fakeTest testTextFieldWithShortInputPlaceholderErrorTextsIsEditing];
+  [self.hookingFakeTest testTextFieldWithShortInputPlaceholderErrorTextsIsEditing];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithShortInputPlaceholderErrorTextsDisabled {
+  // When
+  [self.fakeTest testTextFieldWithShortInputPlaceholderErrorTextsDisabled];
+  [self.hookingFakeTest testTextFieldWithShortInputPlaceholderErrorTextsDisabled];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongInputPlaceholderErrorTexts {
+  // When
+  [self.fakeTest testTextFieldWithLongInputPlaceholderErrorTexts];
+  [self.hookingFakeTest testTextFieldWithLongInputPlaceholderErrorTexts];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongInputPlaceholderErrorTextsIsEditing {
+  // When
+  [self.fakeTest testTextFieldWithLongInputPlaceholderErrorTextsIsEditing];
+  [self.hookingFakeTest testTextFieldWithLongInputPlaceholderErrorTextsIsEditing];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+- (void)testTestTextFieldWithLongInputPlaceholderErrorTextsDisabled {
+  // When
+  [self.fakeTest testTextFieldWithLongInputPlaceholderErrorTextsDisabled];
+  [self.hookingFakeTest testTextFieldWithLongInputPlaceholderErrorTextsDisabled];
+
+  // Then
+  XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+}
+
+@end

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.h
@@ -15,6 +15,30 @@
 #import "MDCTextFieldSnapshotTestCase.h"
 #import "MaterialTextFields.h"
 
+/**
+ Defines several methods that allow subclasses to define "hook" methods that execute after different
+ portions of the test lifecycle.
+
+ In general, the test method lifecycle is:
+
+ -   Call @c setUp
+ -   Assign strings to the relevant properties.
+ -   Call @c beforeGenerateSnapshotAndVerify
+ -   Call @c generateSnapshotAndVerify
+ -   Call @c tearDown
+ */
+@protocol MDCTextFieldSnapshotTestCaseHooking
+
+@optional
+
+/**
+ Hook for test classes to execute any additional code desired before `generateSnapshotAndVerify` is
+ called.
+ */
+- (void)beforeGenerateSnapshotAndVerify;
+
+@end
+
 @interface MDCAbstractTextFieldSnapshotTests : MDCTextFieldSnapshotTestCase
 
 /**

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.m
@@ -52,12 +52,25 @@
   return YES;
 }
 
+- (void)invokeBeforeGenerateSnapshotAndVerify {
+  if ([self conformsToProtocol:@protocol(MDCTextFieldSnapshotTestCaseHooking)]) {
+    if ([self respondsToSelector:@selector(beforeGenerateSnapshotAndVerify)]) {
+      id<MDCTextFieldSnapshotTestCaseHooking> selfAsHooking =
+          (id<MDCTextFieldSnapshotTestCaseHooking>)self;
+      [selfAsHooking beforeGenerateSnapshotAndVerify];
+    }
+  }
+}
+
 #pragma mark - Tests
 
 - (void)testTextFieldEmpty {
   if (![self shouldTestExecute]) {
     return;
   }
+
+  // When
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -70,6 +83,7 @@
 
   // When
   [self.textField MDCtest_setIsEditing:YES];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -81,6 +95,7 @@
   }
 
   self.textField.enabled = NO;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -95,6 +110,7 @@
 
   // When
   self.textFieldController.placeholderText = self.shortPlaceholderText;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -108,6 +124,7 @@
   // When
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   [self.textField MDCtest_setIsEditing:YES];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -121,6 +138,7 @@
   // When
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   self.textField.enabled = NO;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -133,6 +151,7 @@
 
   // When
   self.textFieldController.placeholderText = self.longPlaceholderText;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -146,6 +165,7 @@
   // When
   self.textFieldController.placeholderText = self.longPlaceholderText;
   [self.textField MDCtest_setIsEditing:YES];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -159,6 +179,7 @@
   // When
   self.textFieldController.placeholderText = self.longPlaceholderText;
   self.textField.enabled = NO;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -171,6 +192,7 @@
 
   // When
   self.textFieldController.helperText = self.shortHelperText;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -184,6 +206,7 @@
   // When
   self.textFieldController.helperText = self.shortHelperText;
   [self.textField MDCtest_setIsEditing:YES];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -197,6 +220,7 @@
   // When
   self.textFieldController.helperText = self.shortHelperText;
   self.textField.enabled = NO;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -209,6 +233,7 @@
 
   // When
   self.textFieldController.helperText = self.longHelperText;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -222,6 +247,7 @@
   // When
   self.textFieldController.helperText = self.longHelperText;
   [self.textField MDCtest_setIsEditing:YES];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -235,6 +261,7 @@
   // When
   self.textFieldController.helperText = self.longHelperText;
   self.textField.enabled = NO;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -248,6 +275,7 @@
   // When
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -262,6 +290,7 @@
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
   [self.textField MDCtest_setIsEditing:YES];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -276,6 +305,7 @@
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
   self.textField.enabled = NO;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -289,6 +319,7 @@
   // When
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -303,6 +334,7 @@
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
   [self.textField MDCtest_setIsEditing:YES];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -317,6 +349,7 @@
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
   self.textField.enabled = NO;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -329,6 +362,7 @@
 
   // When
   self.textField.text = self.shortInputText;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -342,6 +376,7 @@
   // When
   self.textField.text = self.shortInputText;
   [self.textField MDCtest_setIsEditing:YES];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -355,6 +390,7 @@
   // When
   self.textField.text = self.shortInputText;
   self.textField.enabled = NO;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -367,6 +403,7 @@
 
   // When
   self.textField.text = self.longInputText;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -380,6 +417,7 @@
   // When
   self.textField.text = self.longInputText;
   [self.textField MDCtest_setIsEditing:YES];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -393,6 +431,7 @@
   // When
   self.textField.text = self.longInputText;
   self.textField.enabled = NO;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -409,6 +448,7 @@
   self.textField.text = self.shortInputText;
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   self.textFieldController.helperText = self.shortHelperText;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -424,6 +464,7 @@
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   self.textFieldController.helperText = self.shortHelperText;
   [self.textField MDCtest_setIsEditing:YES];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -439,6 +480,7 @@
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   self.textFieldController.helperText = self.shortHelperText;
   self.textField.enabled = NO;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -453,6 +495,7 @@
   self.textField.text = self.longInputText;
   self.textFieldController.placeholderText = self.longPlaceholderText;
   self.textFieldController.helperText = self.longHelperText;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -468,6 +511,7 @@
   self.textFieldController.placeholderText = self.longPlaceholderText;
   self.textFieldController.helperText = self.longHelperText;
   [self.textField MDCtest_setIsEditing:YES];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -483,6 +527,7 @@
   self.textFieldController.placeholderText = self.longPlaceholderText;
   self.textFieldController.helperText = self.longHelperText;
   self.textField.enabled = NO;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -498,6 +543,7 @@
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -514,6 +560,7 @@
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
   [self.textField MDCtest_setIsEditing:YES];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -530,6 +577,7 @@
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
   self.textField.enabled = NO;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -545,6 +593,7 @@
   self.textFieldController.placeholderText = self.longPlaceholderText;
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -561,6 +610,7 @@
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
   [self.textField MDCtest_setIsEditing:YES];
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -577,6 +627,7 @@
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
   self.textField.enabled = NO;
+  [self invokeBeforeGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];


### PR DESCRIPTION
Adds a new pre-verification hook for test classes to implement if they need to
perform any additional configuration or customization before the snapshot is
generated. For example, RTL tests need to be able to change the base writing
direction of any `input` text after it's set but before the snapshot image is
captured.

Part of #5762
Prework for #6122