### PR TITLE
{kokoro} Fix `bazel uncovered` script failures due to pushd/popd

### DIFF
--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -93,9 +93,7 @@ update_comment() {
 
 # Determines if any of the modified files are not included in a bazel rule.
 check_files_covered() {
-  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-    pushd github/repo >> /dev/null
-  fi
+  update_comment # Deletes any previously-posted comment
 
   files=$(modified_files)
   SAVEIFS=$IFS
@@ -108,9 +106,11 @@ check_files_covered() {
     exit 0
   fi
 
-  # We must upgrade bazel prior to running bazel query because we rely on features in bazel
-  # 0.20.
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    pushd github/repo >> /dev/null
+    
+    # We must upgrade bazel prior to running bazel query because we rely on features in bazel
+    # 0.20.
     bazel version
     use_bazel.sh 0.20.0
     bazel version
@@ -134,16 +134,14 @@ check_files_covered() {
     fi
   done 
   
-  if (( exit_status != 0 )); then
-    missing_targets=$(echo -e "$missing_targets" | sort | uniq)
-    update_comment "$missing_targets"
-  else
-    update_comment # Deletes any previously-posted comment
-  fi 
-
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     popd >> /dev/null
   fi
+
+  if (( exit_status != 0 )); then
+    missing_targets=$(echo -e "$missing_targets" | sort | uniq)
+    update_comment "$missing_targets"
+  fi 
 
   exit $exit_status
 } 

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -88,6 +88,7 @@ update_comment() {
     if [ -n "$GITHUB_API_TOKEN" ]; then
       post_comment "$COMMENT_IDENTIFIER" "$comment_tmp_file"
     fi
+    rm -f "$comment_tmp_file"
   fi
 }
 

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -59,8 +59,7 @@ modified_files() {
   #  commit.
   range="${base_sha}...HEAD"
 
-  git log --name-only --pretty=oneline --full-index "${range}" \
-    | grep -vE '^[0-9a-f]{40} ' \
+  git diff --name-only "${range}" \
     | grep -E '(\.swift|\.h|\.m)$' \
     | grep -vE '\/tests\/snapshot\/' \
     | sort \

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -87,7 +87,6 @@ update_comment() {
     if [ -n "$GITHUB_API_TOKEN" ]; then
       post_comment "$COMMENT_IDENTIFIER" "$comment_tmp_file"
     fi
-    rm -f "$comment_tmp_file"
   fi
 }
 


### PR DESCRIPTION
The `files_missing_bazel_target` script was generating errors when trying to "pop" directories from the stack after posting a comment. This was causing spurious errors in jobs (e.g., [#6118](https://fusion.corp.google.com/runanalysis/info/prod%3AMaterialComponents_iOS%2Fmacos_external%2Fpresubmit_bazel_targets_updated/prod%3AMaterialComponents_iOS%2Fmacos_external%2Fpresubmit_bazel_targets_updated/KOKORO/0ba82f15-aa10-4c62-8269-034794d0b9d5/1545981553724/prod%3AMaterialComponents_iOS%2Fmacos_external%2Fpresubmit_bazel_targets_updated%20Build%20%2385/Targets)).  Refactoring the script should result in correctly-balanced `pushd`/`popd` calls.