### PR TITLE
[NavigationBar] Refactor tests 

### DIFF
--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -42,6 +42,13 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   [super tearDown];
 }
 
+- (void)setUpNavBarWithTitleViewLayoutBehavior:
+    (MDCNavigationBarTitleViewLayoutBehavior)layoutBahavior {
+  self.navBar.frame = CGRectMake(0, 0, 300, 25);
+  self.navBar.titleView = [[UIView alloc] init];
+  self.navBar.titleViewLayoutBehavior = layoutBahavior;
+}
+
 - (void)testSettingTextAlignmentToCenterMustCenterTheTitleLabel {
   // Given
   self.navBar.frame = CGRectMake(0, 0, 300, 25);
@@ -96,9 +103,7 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
 
 - (void)testTitleViewIsCenteredWithNoButtonsAndFillBehavior {
   // Given
-  self.navBar.frame = CGRectMake(0, 0, 300, 25);
-  self.navBar.titleView = [[UIView alloc] init];
-  self.navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorFill;
+  [self setUpNavBarWithTitleViewLayoutBehavior:MDCNavigationBarTitleViewLayoutBehaviorFill];
 
   // When
   [self.navBar layoutIfNeeded];
@@ -110,9 +115,7 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
 
 - (void)testTitleViewShiftedRightWithLeadingButtonsAndFillBehavior {
   // Given
-  self.navBar.frame = CGRectMake(0, 0, 300, 25);
-  self.navBar.titleView = [[UIView alloc] init];
-  self.navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorFill;
+  [self setUpNavBarWithTitleViewLayoutBehavior:MDCNavigationBarTitleViewLayoutBehaviorFill];
   self.navBar.leadingBarButtonItems =
       @[ [[UIBarButtonItem alloc] initWithTitle:@"Button"
                                           style:UIBarButtonItemStylePlain
@@ -128,9 +131,7 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
 
 - (void)testTitleViewShiftedLeftWithTrailingButtonsAndFillBehavior {
   // Given
-  self.navBar.frame = CGRectMake(0, 0, 300, 25);
-  self.navBar.titleView = [[UIView alloc] init];
-  self.navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorFill;
+  [self setUpNavBarWithTitleViewLayoutBehavior:MDCNavigationBarTitleViewLayoutBehaviorFill];
   self.navBar.trailingBarButtonItems =
       @[ [[UIBarButtonItem alloc] initWithTitle:@"Button"
                                           style:UIBarButtonItemStylePlain
@@ -146,9 +147,7 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
 
 - (void)testTitleViewCenteredWithLeadingButtonsAndCenterBehavior {
   // Given
-  self.navBar.frame = CGRectMake(0, 0, 300, 25);
-  self.navBar.titleView = [[UIView alloc] init];
-  self.navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorCenter;
+  [self setUpNavBarWithTitleViewLayoutBehavior:MDCNavigationBarTitleViewLayoutBehaviorCenter];
   self.navBar.leadingBarButtonItems =
       @[ [[UIBarButtonItem alloc] initWithTitle:@"Button"
                                           style:UIBarButtonItemStylePlain
@@ -165,9 +164,7 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
 
 - (void)testTitleViewCenteredWithTrailingButtonsAndCenterBehavior {
   // Given
-  self.navBar.frame = CGRectMake(0, 0, 300, 25);
-  self.navBar.titleView = [[UIView alloc] init];
-  self.navBar.titleViewLayoutBehavior = MDCNavigationBarTitleViewLayoutBehaviorCenter;
+  [self setUpNavBarWithTitleViewLayoutBehavior:MDCNavigationBarTitleViewLayoutBehaviorCenter];
   self.navBar.trailingBarButtonItems =
       @[ [[UIBarButtonItem alloc] initWithTitle:@"Button"
                                           style:UIBarButtonItemStylePlain


### PR DESCRIPTION
### Context
In working on #6118  I noticed some of the test had the same setup in the _Given_ section.  This duplication of code reduces the readability of the code and the test added in #6118 will also use this function to further reduce the duplication of _Given_ in the tests.
### The problem
Some of the test had the same _Given_.
### The fix
Move the duplicate code to it's own function to improve readability and make it so test later can be simpler.
### Related bug
This was noticed when working on #6133 