### PR TITLE
[Snapshot] Extract TextFields strings for reuse in all Snapshot tests

### DIFF
--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageSnapshotTests.m
@@ -16,7 +16,6 @@
 
 #import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerLeadingImageSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageSnapshotTests.m
@@ -16,7 +16,7 @@
 
 #import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "MDCSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerLeadingImageSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerSnapshotTests.m
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerSnapshotTests.m
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "MDCSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageSnapshotTests.m
@@ -14,7 +14,7 @@
 
 #import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "MDCSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerLeadingImageSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageSnapshotTests.m
@@ -14,7 +14,6 @@
 
 #import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerLeadingImageSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerSnapshotTests.m
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerSnapshotTests.m
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "MDCSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthCharacterCountSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthCharacterCountSnapshotTests.m
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "MDCSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthCharacterCountSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthCharacterCountSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthCharacterCountSnapshotTests.m
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthCharacterCountSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageSnapshotTests.m
@@ -14,7 +14,6 @@
 
 #import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthControllerLeadingImageSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageSnapshotTests.m
@@ -14,7 +14,7 @@
 
 #import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "MDCSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthControllerLeadingImageSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerSnapshotTests.m
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "MDCSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerSnapshotTests.m
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerSnapshotTests.m
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldOutlinedControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerSnapshotTests.m
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "MDCSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldOutlinedControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.m
@@ -16,7 +16,7 @@
 #import <UIKit/UIKit.h>
 
 #import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "MDCSnapshotTestsStrings.h"
 
 @implementation MDCAbstractTextFieldSnapshotTests (I18N)
 
@@ -57,14 +57,14 @@
 }
 
 - (void)changeStringsToArabic {
-  self.shortInputText = MDCTextFieldSnapshotTestsInputShortTextArabic;
-  self.longInputText = MDCTextFieldSnapshotTestsInputLongTextArabic;
-  self.shortPlaceholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextArabic;
-  self.longPlaceholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextArabic;
-  self.shortHelperText = MDCTextFieldSnapshotTestsHelperShortTextArabic;
-  self.longHelperText = MDCTextFieldSnapshotTestsHelperLongTextArabic;
-  self.shortErrorText = MDCTextFieldSnapshotTestsErrorShortTextArabic;
-  self.longErrorText = MDCTextFieldSnapshotTestsErrorLongTextArabic;
+  self.shortInputText = MDCSnapshotTestsInputShortTextArabic;
+  self.longInputText = MDCSnapshotTestsInputLongTextArabic;
+  self.shortPlaceholderText = MDCSnapshotTestsPlaceholderShortTextArabic;
+  self.longPlaceholderText = MDCSnapshotTestsPlaceholderLongTextArabic;
+  self.shortHelperText = MDCSnapshotTestsHelperShortTextArabic;
+  self.longHelperText = MDCSnapshotTestsHelperLongTextArabic;
+  self.shortErrorText = MDCSnapshotTestsErrorShortTextArabic;
+  self.longErrorText = MDCSnapshotTestsErrorLongTextArabic;
 }
 
 - (void)changeLayoutToRTL {

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.m
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "MDCSnapshotTestsStrings.h"
 
 @implementation MDCAbstractTextFieldSnapshotTests
 
@@ -21,14 +21,14 @@
   [super setUp];
 
   // Default to Latin strings
-  self.shortInputText = MDCTextFieldSnapshotTestsInputShortTextLatin;
-  self.longInputText = MDCTextFieldSnapshotTestsInputLongTextLatin;
-  self.shortPlaceholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextLatin;
-  self.longPlaceholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextLatin;
-  self.shortHelperText = MDCTextFieldSnapshotTestsHelperShortTextLatin;
-  self.longHelperText = MDCTextFieldSnapshotTestsHelperLongTextLatin;
-  self.shortErrorText = MDCTextFieldSnapshotTestsErrorShortTextLatin;
-  self.longErrorText = MDCTextFieldSnapshotTestsErrorLongTextLatin;
+  self.shortInputText = MDCSnapshotTestsInputShortTextLatin;
+  self.longInputText = MDCSnapshotTestsInputLongTextLatin;
+  self.shortPlaceholderText = MDCSnapshotTestsPlaceholderShortTextLatin;
+  self.longPlaceholderText = MDCSnapshotTestsPlaceholderLongTextLatin;
+  self.shortHelperText = MDCSnapshotTestsHelperShortTextLatin;
+  self.longHelperText = MDCSnapshotTestsHelperLongTextLatin;
+  self.shortErrorText = MDCSnapshotTestsErrorShortTextLatin;
+  self.longErrorText = MDCSnapshotTestsErrorLongTextLatin;
 }
 
 - (void)tearDown {

--- a/components/private/Snapshot/MDCSnapshotTestsStrings.h
+++ b/components/private/Snapshot/MDCSnapshotTestsStrings.h
@@ -14,30 +14,30 @@
 
 #pragma mark - Latin text
 
-static NSString *const MDCTextFieldSnapshotTestsPlaceholderShortTextLatin = @"P text";
-static NSString *const MDCTextFieldSnapshotTestsPlaceholderLongTextLatin =
+static NSString *const MDCSnapshotTestsPlaceholderShortTextLatin = @"P text";
+static NSString *const MDCSnapshotTestsPlaceholderLongTextLatin =
     @"Placeholder text placeholder text placeholder text placeholder text placeholder text.";
-static NSString *const MDCTextFieldSnapshotTestsHelperShortTextLatin = @"H text";
-static NSString *const MDCTextFieldSnapshotTestsHelperLongTextLatin =
+static NSString *const MDCSnapshotTestsHelperShortTextLatin = @"H text";
+static NSString *const MDCSnapshotTestsHelperLongTextLatin =
     @"Helper text helper text helper text helper text helper text helper text helper text.";
-static NSString *const MDCTextFieldSnapshotTestsErrorShortTextLatin = @"E text";
-static NSString *const MDCTextFieldSnapshotTestsErrorLongTextLatin =
+static NSString *const MDCSnapshotTestsErrorShortTextLatin = @"E text";
+static NSString *const MDCSnapshotTestsErrorLongTextLatin =
     @"Error text error text error text error text error text error text error text error text.";
-static NSString *const MDCTextFieldSnapshotTestsInputShortTextLatin = @"I text";
-static NSString *const MDCTextFieldSnapshotTestsInputLongTextLatin =
+static NSString *const MDCSnapshotTestsInputShortTextLatin = @"I text";
+static NSString *const MDCSnapshotTestsInputLongTextLatin =
     @"Input text input text input text input text input text input text input text input text.";
 
 #pragma mark - Arabic text
 
-static NSString *const MDCTextFieldSnapshotTestsPlaceholderShortTextArabic = @"تلك أي.";
-static NSString *const MDCTextFieldSnapshotTestsPlaceholderLongTextArabic =
+static NSString *const MDCSnapshotTestsPlaceholderShortTextArabic = @"تلك أي.";
+static NSString *const MDCSnapshotTestsPlaceholderLongTextArabic =
     @"بـ أخر جسيمة نتيجة بالرّغم, إذ لهيمنة بالولايات غير, أي ذلك بخطوط ليبين العظمى. في لان.";
-static NSString *const MDCTextFieldSnapshotTestsHelperShortTextArabic = @"العظمى الخطّة.";
-static NSString *const MDCTextFieldSnapshotTestsHelperLongTextArabic =
+static NSString *const MDCSnapshotTestsHelperShortTextArabic = @"العظمى الخطّة.";
+static NSString *const MDCSnapshotTestsHelperLongTextArabic =
     @"أن حلّت أعمال وقد, انه ان قادة سبتمبر حاملات, عدد قد وعلى الأثناء،. ما حتى مكّن.";
-static NSString *const MDCTextFieldSnapshotTestsErrorShortTextArabic = @"على الطرفين.";
-static NSString *const MDCTextFieldSnapshotTestsErrorLongTextArabic =
+static NSString *const MDCSnapshotTestsErrorShortTextArabic = @"على الطرفين.";
+static NSString *const MDCSnapshotTestsErrorLongTextArabic =
     @"أسر وتنامت الإتفاقية بـ, قد منتصف التنازلي عدد. الى و أطراف الصين. علاقة مساعدة تلك ما.";
-static NSString *const MDCTextFieldSnapshotTestsInputShortTextArabic = @"ذلك في.";
-static NSString *const MDCTextFieldSnapshotTestsInputLongTextArabic =
+static NSString *const MDCSnapshotTestsInputShortTextArabic = @"ذلك في.";
+static NSString *const MDCSnapshotTestsInputLongTextArabic =
     @"دول السيطرة استطاعوا ٣٠. مليون وفرنسا أوراقهم انه تم, نفس قد والديون العالمية. دون ما تنفّس.";


### PR DESCRIPTION
### Context
Currently `MDCTextField` snapshot tests use a helper file for different strings. This would be helpful if we could use this for other components snapshot test as well as MDCTextField, as other components will need to test different values in their labels.  This would be helpful if other components can use this and not have to depend on MDCTextFieldSnapshot test but if this file was in a more general folder.
### The problem
Currently we have to redefine string values similar to what `MDCTextField` has or depend on MDCTextField snapshot test to get the values.
### The fix
Move this file to a more general folder and rename the values to not include _TextField_.