### PR TITLE
[TextFields] Add Cyrillic, Hindi, Korean helpers for snapshot tests.

### DIFF
--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h
@@ -18,6 +18,12 @@
 
 - (void)changeStringsToArabic;
 
+- (void)changeStringsToCyrillic;
+
+- (void)changeStringsToHindi;
+
+- (void)changeStringsToKorean;
+
 - (void)changeLayoutToRTL NS_AVAILABLE_IOS(9.0);
 
 @end

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests+I18N.m
@@ -20,6 +20,8 @@
 
 @implementation MDCAbstractTextFieldSnapshotTests (I18N)
 
+#pragma mark - Internal helpers
+
 - (void)MDCForceTextInputRightToLeft:(UIView *)view {
   if ([view conformsToProtocol:@protocol(UITextInput)]) {
     id<UITextInput> textInput = (id<UITextInput>)view;
@@ -56,6 +58,8 @@
   }
 }
 
+#pragma mark - Public API
+
 - (void)changeStringsToArabic {
   self.shortInputText = MDCTextFieldSnapshotTestsInputShortTextArabic;
   self.longInputText = MDCTextFieldSnapshotTestsInputLongTextArabic;
@@ -65,6 +69,39 @@
   self.longHelperText = MDCTextFieldSnapshotTestsHelperLongTextArabic;
   self.shortErrorText = MDCTextFieldSnapshotTestsErrorShortTextArabic;
   self.longErrorText = MDCTextFieldSnapshotTestsErrorLongTextArabic;
+}
+
+- (void)changeStringsToCyrillic {
+  self.shortInputText = MDCTextFieldSnapshotTestsInputShortTextCyrillic;
+  self.longInputText = MDCTextFieldSnapshotTestsInputLongTextCyrillic;
+  self.shortPlaceholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextCyrillic;
+  self.longPlaceholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextCyrillic;
+  self.shortHelperText = MDCTextFieldSnapshotTestsHelperShortTextCyrillic;
+  self.longHelperText = MDCTextFieldSnapshotTestsHelperLongTextCyrillic;
+  self.shortErrorText = MDCTextFieldSnapshotTestsErrorShortTextCyrillic;
+  self.longErrorText = MDCTextFieldSnapshotTestsErrorLongTextCyrillic;
+}
+
+- (void)changeStringsToHindi {
+  self.shortInputText = MDCTextFieldSnapshotTestsInputShortTextHindi;
+  self.longInputText = MDCTextFieldSnapshotTestsInputLongTextHindi;
+  self.shortPlaceholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextHindi;
+  self.longPlaceholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextHindi;
+  self.shortHelperText = MDCTextFieldSnapshotTestsHelperShortTextHindi;
+  self.longHelperText = MDCTextFieldSnapshotTestsHelperLongTextHindi;
+  self.shortErrorText = MDCTextFieldSnapshotTestsErrorShortTextHindi;
+  self.longErrorText = MDCTextFieldSnapshotTestsErrorLongTextHindi;
+}
+
+- (void)changeStringsToKorean {
+  self.shortInputText = MDCTextFieldSnapshotTestsInputShortTextKorean;
+  self.longInputText = MDCTextFieldSnapshotTestsInputLongTextKorean;
+  self.shortPlaceholderText = MDCTextFieldSnapshotTestsPlaceholderShortTextKorean;
+  self.longPlaceholderText = MDCTextFieldSnapshotTestsPlaceholderLongTextKorean;
+  self.shortHelperText = MDCTextFieldSnapshotTestsHelperShortTextKorean;
+  self.longHelperText = MDCTextFieldSnapshotTestsHelperLongTextKorean;
+  self.shortErrorText = MDCTextFieldSnapshotTestsErrorShortTextKorean;
+  self.longErrorText = MDCTextFieldSnapshotTestsErrorLongTextKorean;
 }
 
 - (void)changeLayoutToRTL {

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestsStrings.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestsStrings.h
@@ -46,31 +46,39 @@ static NSString *const MDCTextFieldSnapshotTestsInputLongTextArabic =
 
 static NSString *const MDCTextFieldSnapshotTestsPlaceholderShortTextHindi = @"जाता करेसाथ";
 static NSString *const MDCTextFieldSnapshotTestsPlaceholderLongTextHindi =
-    @"उदेश विभाग शारिरिक पुर्णता पुष्टिकर्ता सुना सुविधा प्राप्त बनाकर अतित संसाध बिन्दुओ स्वतंत्र जोवे जिम्मे तकरीबन स्वतंत्रता कराना चिदंश";
+    @"उदेश विभाग शारिरिक पुर्णता पुष्टिकर्ता सुना सुविधा प्राप्त बनाकर अतित संसाध बिन्दुओ स्वतंत्र जोवे जिम्मे तकरीबन "
+     "स्वतंत्रता कराना चिदंश";
 static NSString *const MDCTextFieldSnapshotTestsHelperShortTextHindi = @"जिवन ध्येय";
 static NSString *const MDCTextFieldSnapshotTestsHelperLongTextHindi =
-    @"कारन असरकारक मुश्किले बाटते भेदनक्षमता सुचनाचलचित्र करती सीमित उनको ध्वनि परिवहन कार्यसिधान्तो वर्णन लचकनहि दिनांक सकती";
+    @"कारन असरकारक मुश्किले बाटते भेदनक्षमता सुचनाचलचित्र करती सीमित उनको ध्वनि परिवहन कार्यसिधान्तो वर्णन "
+     "लचकनहि दिनांक सकती";
 static NSString *const MDCTextFieldSnapshotTestsErrorShortTextHindi = @"बाटते पहोच";
 static NSString *const MDCTextFieldSnapshotTestsErrorLongTextHindi =
-    @"बाजार विभाजन मार्गदर्शन विश्वव्यापि बदले पहेला उनको नयेलिए वर्तमान समजते प्राधिकरन व्याख्यान विकेन्द्रियकरण थातक माध्यम व्यवहार";
+    @"बाजार विभाजन मार्गदर्शन विश्वव्यापि बदले पहेला उनको नयेलिए वर्तमान समजते प्राधिकरन व्याख्यान विकेन्द्रियकरण "
+     "थातक माध्यम व्यवहार";
 static NSString *const MDCTextFieldSnapshotTestsInputShortTextHindi = @"हमारी अतित";
 static NSString *const MDCTextFieldSnapshotTestsInputLongTextHindi =
-    @"हमारि कलइस सारांश परस्पर वास्तविक होसके अधिकांश अर्थपुर्ण विकेन्द्रियकरण पडता करने एसलिये तकनिकल व्याख्या सुचना शीघ्र";
+    @"हमारि कलइस सारांश परस्पर वास्तविक होसके अधिकांश अर्थपुर्ण विकेन्द्रियकरण पडता करने एसलिये तकनिकल व्याख्या "
+     "सुचना शीघ्र";
 
 #pragma mark - Korean text
 
 static NSString *const MDCTextFieldSnapshotTestsPlaceholderShortTextKorean = @"것은 같은.";
 static NSString *const MDCTextFieldSnapshotTestsPlaceholderLongTextKorean =
-    @"미인을 그들의 창공에 어디 교향악이다. 속잎나고. 끝까지 수 못할 이 철환하였는가 구하지 내려온 것이다. 인도하겠다는 인간에.";
+    @"미인을 그들의 창공에 어디 교향악이다. 속잎나고. 끝까지 수 못할 이 철환하였는가 구하지 내려온 "
+     "것이다. 인도하겠다는 인간에.";
 static NSString *const MDCTextFieldSnapshotTestsHelperShortTextKorean = @"때문이다. 보이는.";
 static NSString *const MDCTextFieldSnapshotTestsHelperLongTextKorean =
-    @"꾸며 어디 미인을 같은 새가 봄바람을 힘있다. 이상은 아름다우냐? 이상의 무엇을 내려온 봄바람이다. 얼음 보이는 있으며,";
+    @"꾸며 어디 미인을 같은 새가 봄바람을 힘있다. 이상은 아름다우냐? 이상의 무엇을 내려온 "
+     "봄바람이다. 얼음 보이는 있으며,";
 static NSString *const MDCTextFieldSnapshotTestsErrorShortTextKorean = @"힘차게 얼음.";
 static NSString *const MDCTextFieldSnapshotTestsErrorLongTextKorean =
-    @"아름다우냐?않는 인류의 돋고. 쓸쓸한 천고에 가치를 황금시대다. 하는 수 장식하는 위하여. 없으면 살았으며. 기관과 꽃이.";
+    @"아름다우냐?않는 인류의 돋고. 쓸쓸한 천고에 가치를 황금시대다. 하는 수 장식하는 위하여. "
+     "없으면 살았으며. 기관과 꽃이.";
 static NSString *const MDCTextFieldSnapshotTestsInputShortTextKorean = @"수 끓는.";
 static NSString *const MDCTextFieldSnapshotTestsInputLongTextKorean =
-    @"천자만홍이 품었기 청춘이 끓는 않는 끓는다. 때문이다. 이상은 심장의 품으며. 천고에 무한한 하여도 이것을 것이 같이,";
+    @"천자만홍이 품었기 청춘이 끓는 않는 끓는다. 때문이다. 이상은 심장의 품으며. 천고에 무한한 "
+     "하여도 이것을 것이 같이,";
 
 #pragma mark - Cyrillic text
 

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestsStrings.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestsStrings.h
@@ -41,3 +41,48 @@ static NSString *const MDCTextFieldSnapshotTestsErrorLongTextArabic =
 static NSString *const MDCTextFieldSnapshotTestsInputShortTextArabic = @"ذلك في.";
 static NSString *const MDCTextFieldSnapshotTestsInputLongTextArabic =
     @"دول السيطرة استطاعوا ٣٠. مليون وفرنسا أوراقهم انه تم, نفس قد والديون العالمية. دون ما تنفّس.";
+
+#pragma mark - Hindi text
+
+static NSString *const MDCTextFieldSnapshotTestsPlaceholderShortTextHindi = @"जाता करेसाथ";
+static NSString *const MDCTextFieldSnapshotTestsPlaceholderLongTextHindi =
+    @"उदेश विभाग शारिरिक पुर्णता पुष्टिकर्ता सुना सुविधा प्राप्त बनाकर अतित संसाध बिन्दुओ स्वतंत्र जोवे जिम्मे तकरीबन स्वतंत्रता कराना चिदंश";
+static NSString *const MDCTextFieldSnapshotTestsHelperShortTextHindi = @"जिवन ध्येय";
+static NSString *const MDCTextFieldSnapshotTestsHelperLongTextHindi =
+    @"कारन असरकारक मुश्किले बाटते भेदनक्षमता सुचनाचलचित्र करती सीमित उनको ध्वनि परिवहन कार्यसिधान्तो वर्णन लचकनहि दिनांक सकती";
+static NSString *const MDCTextFieldSnapshotTestsErrorShortTextHindi = @"बाटते पहोच";
+static NSString *const MDCTextFieldSnapshotTestsErrorLongTextHindi =
+    @"बाजार विभाजन मार्गदर्शन विश्वव्यापि बदले पहेला उनको नयेलिए वर्तमान समजते प्राधिकरन व्याख्यान विकेन्द्रियकरण थातक माध्यम व्यवहार";
+static NSString *const MDCTextFieldSnapshotTestsInputShortTextHindi = @"हमारी अतित";
+static NSString *const MDCTextFieldSnapshotTestsInputLongTextHindi =
+    @"हमारि कलइस सारांश परस्पर वास्तविक होसके अधिकांश अर्थपुर्ण विकेन्द्रियकरण पडता करने एसलिये तकनिकल व्याख्या सुचना शीघ्र";
+
+#pragma mark - Korean text
+
+static NSString *const MDCTextFieldSnapshotTestsPlaceholderShortTextKorean = @"것은 같은.";
+static NSString *const MDCTextFieldSnapshotTestsPlaceholderLongTextKorean =
+    @"미인을 그들의 창공에 어디 교향악이다. 속잎나고. 끝까지 수 못할 이 철환하였는가 구하지 내려온 것이다. 인도하겠다는 인간에.";
+static NSString *const MDCTextFieldSnapshotTestsHelperShortTextKorean = @"때문이다. 보이는.";
+static NSString *const MDCTextFieldSnapshotTestsHelperLongTextKorean =
+    @"꾸며 어디 미인을 같은 새가 봄바람을 힘있다. 이상은 아름다우냐? 이상의 무엇을 내려온 봄바람이다. 얼음 보이는 있으며,";
+static NSString *const MDCTextFieldSnapshotTestsErrorShortTextKorean = @"힘차게 얼음.";
+static NSString *const MDCTextFieldSnapshotTestsErrorLongTextKorean =
+    @"아름다우냐?않는 인류의 돋고. 쓸쓸한 천고에 가치를 황금시대다. 하는 수 장식하는 위하여. 없으면 살았으며. 기관과 꽃이.";
+static NSString *const MDCTextFieldSnapshotTestsInputShortTextKorean = @"수 끓는.";
+static NSString *const MDCTextFieldSnapshotTestsInputLongTextKorean =
+    @"천자만홍이 품었기 청춘이 끓는 않는 끓는다. 때문이다. 이상은 심장의 품으며. 천고에 무한한 하여도 이것을 것이 같이,";
+
+#pragma mark - Cyrillic text
+
+static NSString *const MDCTextFieldSnapshotTestsPlaceholderShortTextCyrillic = @"долор сит.";
+static NSString *const MDCTextFieldSnapshotTestsPlaceholderLongTextCyrillic =
+    @"Лорем ипсум долор сит амет, орнатус улламцорпер репрехендунт иус еи, цаусае трацтатос меа.";
+static NSString *const MDCTextFieldSnapshotTestsHelperShortTextCyrillic = @"Сед ет.";
+static NSString *const MDCTextFieldSnapshotTestsHelperLongTextCyrillic =
+    @"Лорем ипсум долор сит амет, агам малорум яуи ут, елитр иудицо апериам еос ут ессе.";
+static NSString *const MDCTextFieldSnapshotTestsErrorShortTextCyrillic = @"Лорем ипсум.";
+static NSString *const MDCTextFieldSnapshotTestsErrorLongTextCyrillic =
+    @"Лорем ипсум долор сит амет, иус но хинц вертерем. Ин вис импетус еяуидем инермис сед.";
+static NSString *const MDCTextFieldSnapshotTestsInputShortTextCyrillic = @"Цум еирмод.";
+static NSString *const MDCTextFieldSnapshotTestsInputLongTextCyrillic =
+    @"Лорем ипсум долор сит амет, ат сит оратио ассентиор цотидиеяуе, нец но аццусам делицата.";


### PR DESCRIPTION
Adding more scripts and helper methods to enable testing across multiple
scripts within text fields.

Part of #5762
