### PR TITLE
{kokoro} Exclude `Snapshot` component from coverage.

### DIFF
--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -62,6 +62,7 @@ modified_files() {
   git diff --name-only "${range}" \
     | grep -E '(\.swift|\.h|\.m)$' \
     | grep -vE '\/tests\/snapshot\/' \
+    | grep -vE '^components\/private\/Snapshot\/' \
     | sort \
     | uniq
 


### PR DESCRIPTION
Since all of the `Snapshot` code is so far completely unbuildable on bazel
(because of the dependency on the snapshot library), changes to it should be
excluded from the bazel coverage job.