### PR TITLE
[Catalog] {Xcode} Execute snapshot tests in parallel on Xcode 10

### DIFF
--- a/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
+++ b/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9926820AE994504EC996875C055C2135"
+               BlueprintIdentifier = "F56C18D8F10BA69D348E3AD45B3DA353"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -47,7 +47,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9BDB8B8616CA4B2FED889BF1D1C2AFB1"
+               BlueprintIdentifier = "C18CA295A45D4143CFF8F6628A723B01"
                BuildableName = "MaterialComponents-Unit-Tests.xctest"
                BlueprintName = "MaterialComponents-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -57,17 +57,19 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3171F7594A536C448D38F6611EB2A7B7"
+               BlueprintIdentifier = "8F88287BD86476EC237E2DFD2A15D7F0"
                BuildableName = "MaterialComponentsBeta-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9926820AE994504EC996875C055C2135"
+               BlueprintIdentifier = "F56C18D8F10BA69D348E3AD45B3DA353"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">

--- a/catalog/MDCDragons.xcodeproj/xcshareddata/xcschemes/MDCDragons.xcscheme
+++ b/catalog/MDCDragons.xcodeproj/xcshareddata/xcschemes/MDCDragons.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9926820AE994504EC996875C055C2135"
+               BlueprintIdentifier = "F56C18D8F10BA69D348E3AD45B3DA353"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -46,7 +46,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9BDB8B8616CA4B2FED889BF1D1C2AFB1"
+               BlueprintIdentifier = "C18CA295A45D4143CFF8F6628A723B01"
                BuildableName = "MaterialComponents-Unit-Tests.xctest"
                BlueprintName = "MaterialComponents-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -56,17 +56,19 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3171F7594A536C448D38F6611EB2A7B7"
+               BlueprintIdentifier = "8F88287BD86476EC237E2DFD2A15D7F0"
                BuildableName = "MaterialComponentsBeta-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9926820AE994504EC996875C055C2135"
+               BlueprintIdentifier = "F56C18D8F10BA69D348E3AD45B3DA353"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">


### PR DESCRIPTION
Running the tests in parallel is showing around a 60% reduction in
execution time for snapshot tests. On my laptop, total execution time
dropped from ~70 seconds to ~26 seconds. Local testing with Xcode 9.4.1 indicates that these settings don't improve times on Xcode 9.4.1 but also cause no obvious or immediate problems.

## Local build logs
|Serial Tests|Parallel Tests|
|---|---|
|<img width="958" alt="snapshot-serial" src="https://user-images.githubusercontent.com/1753199/50531449-0e430e00-0ad8-11e9-9b14-f43b4e3d6ed2.png">|<img width="967" alt="snapshot-parallel" src="https://user-images.githubusercontent.com/1753199/50531451-14d18580-0ad8-11e9-85f1-7dea0e5df07f.png">|
