### PR TITLE
[BottomNavigation] Add examples bazel targets

### DIFF
--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -20,6 +20,7 @@ load(
     "mdc_public_objc_library",
     "mdc_unit_test_suite",
 )
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -73,6 +74,32 @@ mdc_objc_library(
     hdrs = native.glob(["src/private/*.h"]),
     includes = ["src/private"],
     visibility = ["//visibility:private"],
+)
+
+mdc_objc_library(
+    name = "ObjcExamples"
+    srcs = native.glob([
+        "examples/*.m",
+        "examples/*.h",
+        "examples/supplemental/*.m",
+        "examples/supplemental/*.h",
+    ]),
+    deps = [
+        ":BottomNavigation",
+        "//components/Palettes",
+    ],
+)
+
+swift_library(
+    name = "SwiftExamples",
+    srcs = native.glob([
+        "examples/*.swift",
+        "examples/supplemental/*.swift",
+    ]),
+    deps = [
+        ":BottomNavigation",
+        "//components/Palettes",
+    ],
 )
 
 mdc_objc_library(

--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -97,10 +97,13 @@ mdc_objc_library(
 
 swift_library(
     name = "SwiftExamples",
-    srcs = native.glob([
-        "examples/*.swift",
-        "examples/supplemental/*.swift",
-    ]),
+    srcs = native.glob(
+        [
+            "examples/*.swift",
+            "examples/supplemental/*.swift",
+        ],
+        exclude = ["examples/BottomNavigationBarControllerExampleViewController.swift"],
+    ),
     copts = [
         "-swift-version",
         "3",

--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -77,16 +77,21 @@ mdc_objc_library(
 )
 
 mdc_objc_library(
-    name = "ObjcExamples"
+    name = "ObjcExamples",
     srcs = native.glob([
         "examples/*.m",
         "examples/*.h",
         "examples/supplemental/*.m",
         "examples/supplemental/*.h",
     ]),
+    includes = ["examples/supplemental"],
     deps = [
         ":BottomNavigation",
+        ":ColorThemer",
+        ":TypographyThemer",
         "//components/Palettes",
+        "//components/schemes/Color",
+        "//components/schemes/Typography",
     ],
 )
 
@@ -96,8 +101,17 @@ swift_library(
         "examples/*.swift",
         "examples/supplemental/*.swift",
     ]),
+    copts = [
+        "-swift-version",
+        "3",
+    ],
     deps = [
         ":BottomNavigation",
+        ":ColorThemer",
+        ":ObjcExamples",
+        ":TypographyThemer",
+        "//components/AppBar",
+        "//components/Buttons",
         "//components/Palettes",
     ],
 )


### PR DESCRIPTION
Adding Objective-C and Swift examples targets for the bazel build
system.

Closes #6159 

Excludes `BottomNavigationBarControllerExampleViewController.swift` due to Issue #6160.