### PR TITLE
[BottomSheet] Ensure custom scrim color is used in `MDCBottomSheetPre…

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -90,7 +90,8 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   UIView *containerView = [self containerView];
 
   _dimmingView = [[UIView alloc] initWithFrame:self.containerView.bounds];
-  _dimmingView.backgroundColor = [UIColor colorWithWhite:0 alpha:(CGFloat)0.4];
+  _dimmingView.backgroundColor =
+      _scrimColor ? _scrimColor : [UIColor colorWithWhite:0 alpha:(CGFloat)0.4];
   _dimmingView.translatesAutoresizingMaskIntoConstraints = NO;
   _dimmingView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;


### PR DESCRIPTION
…sentationController`.

Originally, the recently introduced `scrimColor` property was not affecting the actual scrim color in `MDCBottomSheetPresentationController`. This change adds a check to see if `scrimColor` property has been set, and if so, assigns it to `dimmingView`’s `backgroundColor`.

Closes #6162.