### PR TITLE
[TextFields] Rename hook test method.

### DIFF
--- a/components/TextFields/tests/snapshot/MDCAbstractTextFieldSnapshotTestsTests.m
+++ b/components/TextFields/tests/snapshot/MDCAbstractTextFieldSnapshotTestsTests.m
@@ -72,7 +72,7 @@
   return YES;
 }
 
-- (void)beforeGenerateSnapshotAndVerify {
+- (void)willGenerateSnapshotAndVerify {
   XCTAssertTrue(NO, @"This method should not be called.");
 }
 
@@ -88,13 +88,13 @@
  */
 @interface MDCAbstractTextFieldSnapshotTestsHookingFake
     : MDCAbstractTextFieldSnapshotTestsFake <MDCTextFieldSnapshotTestCaseHooking>
-@property(nonatomic, assign) BOOL beforeGenerateSnapshotAndVerifyCalled;
+@property(nonatomic, assign) BOOL willGenerateSnapshotAndVerifyCalled;
 @end
 
 @implementation MDCAbstractTextFieldSnapshotTestsHookingFake
 
-- (void)beforeGenerateSnapshotAndVerify {
-  self.beforeGenerateSnapshotAndVerifyCalled = YES;
+- (void)willGenerateSnapshotAndVerify {
+  self.willGenerateSnapshotAndVerifyCalled = YES;
 }
 
 @end
@@ -134,7 +134,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldEmptyIsEditing {
@@ -145,7 +145,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldEmptyDisabled {
@@ -156,7 +156,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortPlaceholderText {
@@ -167,7 +167,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortPlaceholderTextIsEditing {
@@ -178,7 +178,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortPlaceholderTextDisabled {
@@ -189,7 +189,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongPlaceholderText {
@@ -200,7 +200,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongPlaceholderTextIsEditing {
@@ -211,7 +211,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongPlaceholderTextDisabled {
@@ -222,7 +222,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortHelperText {
@@ -233,7 +233,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortHelperTextIsEditing {
@@ -244,7 +244,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortHelperTextDisabled {
@@ -255,7 +255,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongHelperText {
@@ -266,7 +266,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongHelperTextIsEditing {
@@ -277,7 +277,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongHelperTextDisabled {
@@ -288,7 +288,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortErrorText {
@@ -299,7 +299,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortErrorTextIsEditing {
@@ -310,7 +310,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortErrorTextDisabled {
@@ -321,7 +321,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongErrorText {
@@ -332,7 +332,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongErrorTextIsEditing {
@@ -343,7 +343,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongErrorTextDisabled {
@@ -354,7 +354,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortInputText {
@@ -365,7 +365,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortInputTextIsEditing {
@@ -376,7 +376,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortInputTextDisabled {
@@ -387,7 +387,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongInputText {
@@ -398,7 +398,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongInputTextIsEditing {
@@ -409,7 +409,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongInputTextDisabled {
@@ -420,7 +420,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortInputPlaceholderHelperTexts {
@@ -431,7 +431,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortInputPlaceholderHelperTextsIsEditing {
@@ -442,7 +442,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortInputPlaceholderHelperTextsDisabled {
@@ -453,7 +453,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongInputPlaceholderHelperTexts {
@@ -464,7 +464,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongInputPlaceholderHelperTextsIsEditing {
@@ -475,7 +475,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongInputPlaceholderHelperTextsDisabled {
@@ -486,7 +486,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortInputPlaceholderErrorTexts {
@@ -497,7 +497,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortInputPlaceholderErrorTextsIsEditing {
@@ -508,7 +508,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithShortInputPlaceholderErrorTextsDisabled {
@@ -519,7 +519,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongInputPlaceholderErrorTexts {
@@ -530,7 +530,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongInputPlaceholderErrorTextsIsEditing {
@@ -541,7 +541,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 - (void)testTestTextFieldWithLongInputPlaceholderErrorTextsDisabled {
@@ -552,7 +552,7 @@
   // Then
   XCTAssertTrue(self.fakeTest.generateSnapshotAndVerifyCalled);
   XCTAssertTrue(self.hookingFakeTest.generateSnapshotAndVerifyCalled);
-  XCTAssertTrue(self.hookingFakeTest.beforeGenerateSnapshotAndVerifyCalled);
+  XCTAssertTrue(self.hookingFakeTest.willGenerateSnapshotAndVerifyCalled);
 }
 
 @end

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageArabicSnapshotTests.m
@@ -42,7 +42,7 @@
   [self changeStringsToArabic];
 }
 
-- (void)beforeGenerateSnapshotAndVerify {
+- (void)willGenerateSnapshotAndVerify {
   if (@available(iOS 9.0, *)) {
     [self changeLayoutToRTL];
   } else {

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageArabicSnapshotTests.m
@@ -43,7 +43,7 @@
   [self changeStringsToArabic];
 }
 
-- (void)beforeGenerateSnapshotAndVerify {
+- (void)willGenerateSnapshotAndVerify {
   if (@available(iOS 9.0, *)) {
     [self changeLayoutToRTL];
   } else {

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageArabicSnapshotTests.m
@@ -40,7 +40,7 @@
   [self changeStringsToArabic];
 }
 
-- (void)beforeGenerateSnapshotAndVerify {
+- (void)willGenerateSnapshotAndVerify {
   if (@available(iOS 9.0, *)) {
     [self changeLayoutToRTL];
   } else {

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageArabicSnapshotTests.m
@@ -51,7 +51,7 @@
   [self changeStringsToArabic];
 }
 
-- (void)beforeGenerateSnapshotAndVerify {
+- (void)willGenerateSnapshotAndVerify {
   if (@available(iOS 9.0, *)) {
     [self changeLayoutToRTL];
   } else {

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedTextAreaControllerBaselineCharacterCountArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedTextAreaControllerBaselineCharacterCountArabicSnapshotTests.m
@@ -53,7 +53,7 @@
   [self changeStringsToArabic];
 }
 
-- (void)beforeGenerateSnapshotAndVerify {
+- (void)willGenerateSnapshotAndVerify {
   if (@available(iOS 9.0, *)) {
     [self changeLayoutToRTL];
   } else {

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests.m
@@ -42,7 +42,7 @@
   [self changeStringsToArabic];
 }
 
-- (void)beforeGenerateSnapshotAndVerify {
+- (void)willGenerateSnapshotAndVerify {
   if (@available(iOS 9.0, *)) {
     [self changeLayoutToRTL];
   } else {

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageArabicSnapshotTests.m
@@ -42,7 +42,7 @@
   [self changeStringsToArabic];
 }
 
-- (void)beforeGenerateSnapshotAndVerify {
+- (void)willGenerateSnapshotAndVerify {
   if (@available(iOS 9.0, *)) {
     [self changeLayoutToRTL];
   } else {

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.h
@@ -23,7 +23,7 @@
 
  -   Call @c setUp
  -   Assign strings to the relevant properties.
- -   Call @c beforeGenerateSnapshotAndVerify
+ -   Call @c willGenerateSnapshotAndVerify
  -   Call @c generateSnapshotAndVerify
  -   Call @c tearDown
  */
@@ -35,7 +35,7 @@
  Hook for test classes to execute any additional code desired before `generateSnapshotAndVerify` is
  called.
  */
-- (void)beforeGenerateSnapshotAndVerify;
+- (void)willGenerateSnapshotAndVerify;
 
 @end
 

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.m
@@ -52,12 +52,12 @@
   return YES;
 }
 
-- (void)invokeBeforeGenerateSnapshotAndVerify {
+- (void)invokewillGenerateSnapshotAndVerify {
   if ([self conformsToProtocol:@protocol(MDCTextFieldSnapshotTestCaseHooking)]) {
-    if ([self respondsToSelector:@selector(beforeGenerateSnapshotAndVerify)]) {
+    if ([self respondsToSelector:@selector(willGenerateSnapshotAndVerify)]) {
       id<MDCTextFieldSnapshotTestCaseHooking> selfAsHooking =
           (id<MDCTextFieldSnapshotTestCaseHooking>)self;
-      [selfAsHooking beforeGenerateSnapshotAndVerify];
+      [selfAsHooking willGenerateSnapshotAndVerify];
     }
   }
 }
@@ -70,7 +70,7 @@
   }
 
   // When
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -83,7 +83,7 @@
 
   // When
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -95,7 +95,7 @@
   }
 
   self.textField.enabled = NO;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -110,7 +110,7 @@
 
   // When
   self.textFieldController.placeholderText = self.shortPlaceholderText;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -124,7 +124,7 @@
   // When
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -138,7 +138,7 @@
   // When
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   self.textField.enabled = NO;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -151,7 +151,7 @@
 
   // When
   self.textFieldController.placeholderText = self.longPlaceholderText;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -165,7 +165,7 @@
   // When
   self.textFieldController.placeholderText = self.longPlaceholderText;
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -179,7 +179,7 @@
   // When
   self.textFieldController.placeholderText = self.longPlaceholderText;
   self.textField.enabled = NO;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -192,7 +192,7 @@
 
   // When
   self.textFieldController.helperText = self.shortHelperText;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -206,7 +206,7 @@
   // When
   self.textFieldController.helperText = self.shortHelperText;
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -220,7 +220,7 @@
   // When
   self.textFieldController.helperText = self.shortHelperText;
   self.textField.enabled = NO;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -233,7 +233,7 @@
 
   // When
   self.textFieldController.helperText = self.longHelperText;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -247,7 +247,7 @@
   // When
   self.textFieldController.helperText = self.longHelperText;
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -261,7 +261,7 @@
   // When
   self.textFieldController.helperText = self.longHelperText;
   self.textField.enabled = NO;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -275,7 +275,7 @@
   // When
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -290,7 +290,7 @@
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -305,7 +305,7 @@
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
   self.textField.enabled = NO;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -319,7 +319,7 @@
   // When
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -334,7 +334,7 @@
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -349,7 +349,7 @@
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
   self.textField.enabled = NO;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -362,7 +362,7 @@
 
   // When
   self.textField.text = self.shortInputText;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -376,7 +376,7 @@
   // When
   self.textField.text = self.shortInputText;
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -390,7 +390,7 @@
   // When
   self.textField.text = self.shortInputText;
   self.textField.enabled = NO;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -403,7 +403,7 @@
 
   // When
   self.textField.text = self.longInputText;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -417,7 +417,7 @@
   // When
   self.textField.text = self.longInputText;
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -431,7 +431,7 @@
   // When
   self.textField.text = self.longInputText;
   self.textField.enabled = NO;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -448,7 +448,7 @@
   self.textField.text = self.shortInputText;
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   self.textFieldController.helperText = self.shortHelperText;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -464,7 +464,7 @@
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   self.textFieldController.helperText = self.shortHelperText;
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -480,7 +480,7 @@
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   self.textFieldController.helperText = self.shortHelperText;
   self.textField.enabled = NO;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -495,7 +495,7 @@
   self.textField.text = self.longInputText;
   self.textFieldController.placeholderText = self.longPlaceholderText;
   self.textFieldController.helperText = self.longHelperText;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -511,7 +511,7 @@
   self.textFieldController.placeholderText = self.longPlaceholderText;
   self.textFieldController.helperText = self.longHelperText;
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -527,7 +527,7 @@
   self.textFieldController.placeholderText = self.longPlaceholderText;
   self.textFieldController.helperText = self.longHelperText;
   self.textField.enabled = NO;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -543,7 +543,7 @@
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -560,7 +560,7 @@
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -577,7 +577,7 @@
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
   self.textField.enabled = NO;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -593,7 +593,7 @@
   self.textFieldController.placeholderText = self.longPlaceholderText;
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -610,7 +610,7 @@
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -627,7 +627,7 @@
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
   self.textField.enabled = NO;
-  [self invokeBeforeGenerateSnapshotAndVerify];
+  [self invokewillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.m
@@ -52,7 +52,7 @@
   return YES;
 }
 
-- (void)invokewillGenerateSnapshotAndVerify {
+- (void)invokeWillGenerateSnapshotAndVerify {
   if ([self conformsToProtocol:@protocol(MDCTextFieldSnapshotTestCaseHooking)]) {
     if ([self respondsToSelector:@selector(willGenerateSnapshotAndVerify)]) {
       id<MDCTextFieldSnapshotTestCaseHooking> selfAsHooking =
@@ -70,7 +70,7 @@
   }
 
   // When
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -83,7 +83,7 @@
 
   // When
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -95,7 +95,7 @@
   }
 
   self.textField.enabled = NO;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -110,7 +110,7 @@
 
   // When
   self.textFieldController.placeholderText = self.shortPlaceholderText;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -124,7 +124,7 @@
   // When
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -138,7 +138,7 @@
   // When
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   self.textField.enabled = NO;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -151,7 +151,7 @@
 
   // When
   self.textFieldController.placeholderText = self.longPlaceholderText;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -165,7 +165,7 @@
   // When
   self.textFieldController.placeholderText = self.longPlaceholderText;
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -179,7 +179,7 @@
   // When
   self.textFieldController.placeholderText = self.longPlaceholderText;
   self.textField.enabled = NO;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -192,7 +192,7 @@
 
   // When
   self.textFieldController.helperText = self.shortHelperText;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -206,7 +206,7 @@
   // When
   self.textFieldController.helperText = self.shortHelperText;
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -220,7 +220,7 @@
   // When
   self.textFieldController.helperText = self.shortHelperText;
   self.textField.enabled = NO;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -233,7 +233,7 @@
 
   // When
   self.textFieldController.helperText = self.longHelperText;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -247,7 +247,7 @@
   // When
   self.textFieldController.helperText = self.longHelperText;
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -261,7 +261,7 @@
   // When
   self.textFieldController.helperText = self.longHelperText;
   self.textField.enabled = NO;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -275,7 +275,7 @@
   // When
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -290,7 +290,7 @@
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -305,7 +305,7 @@
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
   self.textField.enabled = NO;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -319,7 +319,7 @@
   // When
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -334,7 +334,7 @@
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -349,7 +349,7 @@
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
   self.textField.enabled = NO;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -362,7 +362,7 @@
 
   // When
   self.textField.text = self.shortInputText;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -376,7 +376,7 @@
   // When
   self.textField.text = self.shortInputText;
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -390,7 +390,7 @@
   // When
   self.textField.text = self.shortInputText;
   self.textField.enabled = NO;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -403,7 +403,7 @@
 
   // When
   self.textField.text = self.longInputText;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -417,7 +417,7 @@
   // When
   self.textField.text = self.longInputText;
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -431,7 +431,7 @@
   // When
   self.textField.text = self.longInputText;
   self.textField.enabled = NO;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -448,7 +448,7 @@
   self.textField.text = self.shortInputText;
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   self.textFieldController.helperText = self.shortHelperText;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -464,7 +464,7 @@
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   self.textFieldController.helperText = self.shortHelperText;
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -480,7 +480,7 @@
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   self.textFieldController.helperText = self.shortHelperText;
   self.textField.enabled = NO;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -495,7 +495,7 @@
   self.textField.text = self.longInputText;
   self.textFieldController.placeholderText = self.longPlaceholderText;
   self.textFieldController.helperText = self.longHelperText;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -511,7 +511,7 @@
   self.textFieldController.placeholderText = self.longPlaceholderText;
   self.textFieldController.helperText = self.longHelperText;
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -527,7 +527,7 @@
   self.textFieldController.placeholderText = self.longPlaceholderText;
   self.textFieldController.helperText = self.longHelperText;
   self.textField.enabled = NO;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -543,7 +543,7 @@
   self.textFieldController.placeholderText = self.shortPlaceholderText;
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -560,7 +560,7 @@
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -577,7 +577,7 @@
   [self.textFieldController setErrorText:self.shortErrorText
                  errorAccessibilityValue:self.shortErrorText];
   self.textField.enabled = NO;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -593,7 +593,7 @@
   self.textFieldController.placeholderText = self.longPlaceholderText;
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -610,7 +610,7 @@
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
   [self.textField MDCtest_setIsEditing:YES];
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];
@@ -627,7 +627,7 @@
   [self.textFieldController setErrorText:self.longErrorText
                  errorAccessibilityValue:self.longErrorText];
   self.textField.enabled = NO;
-  [self invokewillGenerateSnapshotAndVerify];
+  [self invokeWillGenerateSnapshotAndVerify];
 
   // Then
   [self generateSnapshotAndVerify];


### PR DESCRIPTION
The testing hook method that fires just before generating snapshots and
verifying them against the golden images should follow UIKit naming
conventions. The new method is named `-willGenerateSnapshotAndVerify`.
