### PR TITLE
Update documentation and usages of objc_bundle to apple_bundle_import

### DIFF
--- a/contributing/bazel_kokoro.md
+++ b/contributing/bazel_kokoro.md
@@ -118,21 +118,18 @@ If your component depends on non-source resources, you can add a bundle target t
 with the following additions:
 
 ```
+load("//tools/build_defs/apple:resources.bzl", "apple_bundle_import")
+
 mdc_public_objc_library(
     name = "ComponentName",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
 )
 
-filegroup(
-    name = "BundleFiles",
-    srcs = glob([
+apple_bundle_import(
+    name = "Bundle",
+    bundle_imports = glob([
         "src/ComponentName.bundle/**",
     ]),
-)
-
-objc_bundle(
-    name = "Bundle",
-    bundle_imports = [":BundleFiles"],
 )
 ```
 


### PR DESCRIPTION
Update documentation and usages of objc_bundle to apple_bundle_import because we stopped using the older one.
