### PR TITLE
[Catalog] {Snapshots} Revert to serial execution order.

### DIFF
--- a/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
+++ b/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F56C18D8F10BA69D348E3AD45B3DA353"
+               BlueprintIdentifier = "674FDC5D181285D37A7365BCEF7D6864"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -64,12 +64,10 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES"
-            testExecutionOrdering = "random">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F56C18D8F10BA69D348E3AD45B3DA353"
+               BlueprintIdentifier = "674FDC5D181285D37A7365BCEF7D6864"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">

--- a/catalog/MDCDragons.xcodeproj/xcshareddata/xcschemes/MDCDragons.xcscheme
+++ b/catalog/MDCDragons.xcodeproj/xcshareddata/xcschemes/MDCDragons.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F56C18D8F10BA69D348E3AD45B3DA353"
+               BlueprintIdentifier = "674FDC5D181285D37A7365BCEF7D6864"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -63,12 +63,10 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES"
-            testExecutionOrdering = "random">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F56C18D8F10BA69D348E3AD45B3DA353"
+               BlueprintIdentifier = "674FDC5D181285D37A7365BCEF7D6864"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">


### PR DESCRIPTION
Snapshot tests executed in parallel seemed to have increasing duration
as the tests execute. This may be an environmental issue (it was seen on
kokoro), but in either case we can revert changes to try and avoid the
time-outs seen with parallel execution.
