### PR TITLE
[NavigationDrawer] Fix up 'contentReachesFullScreen' linker warnings.

### DIFF
--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -793,6 +793,11 @@ static UIColor *DrawerShadowColor(void) {
   return NSNotFound;
 }
 
+- (BOOL)contentReachesFullscreen {
+  return [self shouldPresentFullScreen] ? YES
+                                        : self.contentHeightSurplus >= self.contentHeaderTopInset;
+}
+
 @end
 
 #pragma mark - MDCBottomDrawerContainerViewController + Layout Values
@@ -801,11 +806,6 @@ static UIColor *DrawerShadowColor(void) {
 
 - (CGRect)presentingViewBounds {
   return CGRectStandardize(self.originalPresentingViewController.view.bounds);
-}
-
-- (BOOL)contentReachesFullscreen {
-  return [self shouldPresentFullScreen] ? YES
-                                        : self.contentHeightSurplus >= self.contentHeaderTopInset;
 }
 
 - (BOOL)contentScrollsToReveal {

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -301,6 +301,11 @@ static UIColor *DrawerShadowColor(void) {
   return [self isAccessibilityMode] || [self isMobileLandscape] || _shouldPresentAtFullscreen;
 }
 
+- (BOOL)contentReachesFullscreen {
+  return [self shouldPresentFullScreen] ? YES
+                                        : self.contentHeightSurplus >= self.contentHeaderTopInset;
+}
+
 /**
  The drawer height factor defines how much percentage of the screen space the drawer will take up
  when displayed. The expected range is 0 - 1 (0% - 100%).
@@ -791,11 +796,6 @@ static UIColor *DrawerShadowColor(void) {
   }
 
   return NSNotFound;
-}
-
-- (BOOL)contentReachesFullscreen {
-  return [self shouldPresentFullScreen] ? YES
-                                        : self.contentHeightSurplus >= self.contentHeaderTopInset;
 }
 
 @end


### PR DESCRIPTION
Should fix #6058 by moving definition of 'contentReachesFullScreen' into the actual implementation which corresponds to the interface it is declared in.
