### PR TITLE
[TextFields] Invalidate caret timers in snapshot tests.

### DIFF
--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
@@ -25,7 +25,19 @@
   self.textField = [[SnapshotFakeMDCTextField alloc] init];
 }
 
+- (void)removeAllSubviewsFromSuperviews:(UIView *)view {
+  NSArray *subviews = [view.subviews copy];
+  for (UIView *subview in subviews) {
+    [self removeAllSubviewsFromSuperviews:subview];
+  }
+  [view removeFromSuperview];
+}
+
 - (void)tearDown {
+  // This is required to invalidate any pending UITextField caret blink timers.
+  // Calling `removeFromSuperview` on `self.textField` is insufficient.
+  // See https://github.com/material-components/material-components-ios/issues/6181
+  [self removeAllSubviewsFromSuperviews:self.textField];
   self.textField = nil;
 
   [super tearDown];


### PR DESCRIPTION
Text fields snapshot tests were taking longer and longer to execute. The root
cause was "caret blink" timers added to the main run loop for every text field
that was set to `isEditing = YES`. It is sufficient to remove all subviews of
the text field from their superviews to invalidate the timer. The actual
culprit appears to be a private subview of class `UITextSelectionView`, but
since accessing it would be more fragile than this solution, it's best to just
destroy the view hierarchy.

## Execution time with this change

```
	 Executed 6 tests, with 0 failures (0 unexpected) in 0.200 (0.202) seconds
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.132 (0.137) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.206 (2.220) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.935 (1.950) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.097 (2.111) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.969 (1.983) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.903 (1.918) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.811 (1.825) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.269 (2.284) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.953 (1.967) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.383 (2.398) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.062 (2.076) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.953 (1.967) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.110 (2.124) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.723 (1.737) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.144 (2.158) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.051 (2.065) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.757 (1.771) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.729 (1.743) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.858 (1.872) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.258 (2.272) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.884 (1.898) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.292 (2.306) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.205 (2.219) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.928 (1.942) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.903 (1.917) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.692 (1.706) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.040 (2.054) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.729 (1.744) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.094 (2.108) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.936 (1.951) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.769 (1.783) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 1.772 (1.786) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.369 (2.383) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.944 (2.958) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.449 (2.463) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.882 (2.896) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.858 (2.872) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.567 (2.581) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.518 (2.532) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.669 (2.683) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.128 (2.142) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.479 (2.494) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.105 (2.119) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.518 (2.532) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.502 (2.516) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.171 (2.185) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.149 (2.163) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.730 (2.744) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.361 (2.375) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.758 (2.773) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.718 (2.732) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.424 (2.439) seconds
	 Executed 39 tests, with 0 failures (0 unexpected) in 2.382 (2.396) seconds
	 Executed 2046 tests, with 0 failures (0 unexpected) in 114.427 (115.196) seconds
	 Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
	 Executed 2046 tests, with 0 failures (0 unexpected) in 114.427 (115.203) seconds
```

Closes #6181 