### PR TITLE
[Catalog] Re-enable parallel snapshot tests.

### DIFF
--- a/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
+++ b/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "674FDC5D181285D37A7365BCEF7D6864"
+               BlueprintIdentifier = "0AB2C042ABFBEAC086DC600CF04E7AEE"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -47,7 +47,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C18CA295A45D4143CFF8F6628A723B01"
+               BlueprintIdentifier = "90AD8DD5E9A01B04B8F90EAD5E4DDC12"
                BuildableName = "MaterialComponents-Unit-Tests.xctest"
                BlueprintName = "MaterialComponents-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -57,17 +57,19 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8F88287BD86476EC237E2DFD2A15D7F0"
+               BlueprintIdentifier = "66CCE84B4769BC018886C9B17F690F61"
                BuildableName = "MaterialComponentsBeta-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "674FDC5D181285D37A7365BCEF7D6864"
+               BlueprintIdentifier = "0AB2C042ABFBEAC086DC600CF04E7AEE"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">

--- a/catalog/MDCDragons.xcodeproj/xcshareddata/xcschemes/MDCDragons.xcscheme
+++ b/catalog/MDCDragons.xcodeproj/xcshareddata/xcschemes/MDCDragons.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "674FDC5D181285D37A7365BCEF7D6864"
+               BlueprintIdentifier = "0AB2C042ABFBEAC086DC600CF04E7AEE"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -46,7 +46,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C18CA295A45D4143CFF8F6628A723B01"
+               BlueprintIdentifier = "90AD8DD5E9A01B04B8F90EAD5E4DDC12"
                BuildableName = "MaterialComponents-Unit-Tests.xctest"
                BlueprintName = "MaterialComponents-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -56,17 +56,19 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8F88287BD86476EC237E2DFD2A15D7F0"
+               BlueprintIdentifier = "66CCE84B4769BC018886C9B17F690F61"
                BuildableName = "MaterialComponentsBeta-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "674FDC5D181285D37A7365BCEF7D6864"
+               BlueprintIdentifier = "0AB2C042ABFBEAC086DC600CF04E7AEE"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">


### PR DESCRIPTION
The root cause of snapshot test slow downs was not parallel tests, but an
underlying issue with text fields and the main run loop (#6181). With that
issue resolved, we can re-enable parallel execution of snapshot tests to cut
down the wall time required for the tests.

Part of #5762