### PR TITLE
{kokoro} Fix affected targets calculation.

### DIFF
--- a/scripts/affected_targets
+++ b/scripts/affected_targets
@@ -43,7 +43,7 @@ fi
 
 # Generates a list of files that were modified within $range.
 modified_files() {
-  git log --name-only --pretty=oneline --full-index "$range" \
+  git diff --name-only "$range" \
     | grep -vE '^[0-9a-f]{40} ' \
     | sort \
     | uniq


### PR DESCRIPTION
The affected_targets script was looking at the entire log of changes within a
branch or history. Instead, it should only look at the differences between
HEAD and the diff base.
