### PR TITLE
[BottomNavigation] Confirm (un)selected ink is same.

### DIFF
--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
@@ -125,6 +125,7 @@ static UIImage *fakeImage(void) {
   // Then
   XCTAssertNotEqualObjects(item1.inkView.inkColor, item1DefaultInkColor);
   XCTAssertNotEqualObjects(item2.inkView.inkColor, item2DefaultInkColor);
+  XCTAssertEqualObjects(item1.inkView.inkColor, item2.inkView.inkColor);
 }
 
 - (void)testBadgeCenterIsCorrectWithoutRTL {


### PR DESCRIPTION
When changing the value of `selectedItemTintColor`, we should confirm that
both selected and unselected items receive the same ink color.

Follow-up for #4937
