### PR TITLE
[NavigationBar] Remove duplicate test helper.

### DIFF
--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -291,13 +291,6 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   }
 }
 
-- (void)setUpNavBarWithTitleViewLayoutBehavior:
-    (MDCNavigationBarTitleViewLayoutBehavior)layoutBahavior {
-  self.navBar.frame = CGRectMake(0, 0, 300, 25);
-  self.navBar.titleView = [[UIView alloc] init];
-  self.navBar.titleViewLayoutBehavior = layoutBahavior;
-}
-
 - (void)testTitleFontProperty {
   // Given
   self.navBar.title = @"this is a Title";


### PR DESCRIPTION
A bad merge resulted in a duplicated test helper method. Continuous builds are
failing.

Follow-up to #6136
