### PR TITLE
[Buttons] backgroundColorForState: should fall-back to .normal.

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -546,7 +546,8 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   if ((state & UIControlStateHighlighted) == UIControlStateHighlighted) {
     state = state & ~UIControlStateDisabled;
   }
-  return _backgroundColors[@(state)];
+
+  return _backgroundColors[@(state)] ?: _backgroundColors[@(UIControlStateNormal)];
 }
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor forState:(UIControlState)state {
@@ -666,22 +667,15 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 #pragma mark - Private methods
 
-- (UIColor *)currentBackgroundColor {
-  UIColor *color = _backgroundColors[@(self.state)];
-  if (color) {
-    return color;
-  }
-  return [self backgroundColorForState:UIControlStateNormal];
-}
-
 /**
  The background color that a user would see for this button. If self.backgroundColor is not
  transparent, then returns that. Otherwise, returns self.underlyingColorHint.
  @note If self.underlyingColorHint is not set, then this method will return nil.
  */
 - (UIColor *)effectiveBackgroundColor {
-  if (![self isTransparentColor:self.currentBackgroundColor]) {
-    return self.currentBackgroundColor;
+  UIColor *backgroundColor = [self backgroundColorForState:self.state];
+  if (![self isTransparentColor:backgroundColor]) {
+    return backgroundColor;
   } else {
     return self.underlyingColorHint;
   }
@@ -758,7 +752,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 - (void)updateBackgroundColor {
   // When shapeGenerator is unset then self.layer.shapedBackgroundColor sets the layer's
   // backgroundColor. Whereas when shapeGenerator is set the sublayer's fillColor is set.
-  self.layer.shapedBackgroundColor = self.currentBackgroundColor;
+  self.layer.shapedBackgroundColor = [self backgroundColorForState:self.state];
   [self updateDisabledTitleColor];
 }
 

--- a/components/Buttons/tests/unit/ButtonThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonThemerTests.m
@@ -70,7 +70,7 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   XCTAssertEqualObjects([button backgroundColorForState:UIControlStateNormal],
                         [UIColor clearColor]);
   XCTAssertEqualObjects([button backgroundColorForState:UIControlStateDisabled],
-                        nil);
+                        [button backgroundColorForState:UIControlStateNormal]);
   XCTAssertEqualObjects([button titleColorForState:UIControlStateNormal],
                         scheme.colorScheme.primaryColor);
   XCTAssertEqualWithAccuracy(button.disabledAlpha, 1, kEpsilonAccuracy);

--- a/components/Buttons/tests/unit/ButtonTitleColorAccessibilityMutatorTests.m
+++ b/components/Buttons/tests/unit/ButtonTitleColorAccessibilityMutatorTests.m
@@ -92,7 +92,8 @@ static NSString *controlStateDescription(UIControlState controlState);
 - (void)testMutateUsesUnderlyingColorIfButtonBackgroundColorIsTransparent {
   for (UIColor *color in testColors()) {
     for (NSUInteger controlState = 0; controlState <= kNumUIControlStates; ++controlState) {
-      if ((controlState & kUIControlStateDisabledHighlighted) == kUIControlStateDisabledHighlighted) {
+      if ((controlState & kUIControlStateDisabledHighlighted) ==
+          kUIControlStateDisabledHighlighted) {
         // Skip since it's tested with either .highlighted or (.highlighted | .selected)
         continue;
       }

--- a/components/Buttons/tests/unit/ButtonTitleColorAccessibilityMutatorTests.m
+++ b/components/Buttons/tests/unit/ButtonTitleColorAccessibilityMutatorTests.m
@@ -39,14 +39,14 @@ static NSString *controlStateDescription(UIControlState controlState);
 
 - (void)testMutateChangesTextColor {
   for (UIColor *color in testColors()) {
-    for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
+    for (NSUInteger controlState = 0; controlState <= kNumUIControlStates; ++controlState) {
       // Given
       MDCButton *button = [[MDCButton alloc] init];
       // Making the background color the same as the title color.
       [button setBackgroundColor:color forState:(UIControlState)controlState];
       [button setTitleColor:color forState:(UIControlState)controlState];
       UIControlState disabledHighlighed = UIControlStateHighlighted | UIControlStateDisabled;
-      if (controlState == disabledHighlighed) {
+      if ((controlState & disabledHighlighed) == disabledHighlighed) {
         // Skip disabled highlighted state because UIButton ignores setTitleColor:forState: when
         // passed that state. See `UIButton strangeness` in ButtonTests.m
         continue;
@@ -65,7 +65,7 @@ static NSString *controlStateDescription(UIControlState controlState);
 - (void)testMutateKeepsAccessibleTextColor {
   NSDictionary* colors = @{ [UIColor redColor]: [UIColor blackColor]};
   for (UIColor *color in colors) {
-    for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
+    for (NSUInteger controlState = 0; controlState <= kNumUIControlStates; ++controlState) {
       if (controlState & kUIControlStateDisabledHighlighted) {
         // We skip the Disabled Highlighted state because UIButton setter ignores it.
         // see: testTitleColorForStateDisabledHighlight
@@ -91,7 +91,11 @@ static NSString *controlStateDescription(UIControlState controlState);
 
 - (void)testMutateUsesUnderlyingColorIfButtonBackgroundColorIsTransparent {
   for (UIColor *color in testColors()) {
-    for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
+    for (NSUInteger controlState = 0; controlState <= kNumUIControlStates; ++controlState) {
+      if ((controlState & kUIControlStateDisabledHighlighted) == kUIControlStateDisabledHighlighted) {
+        // Skip since it's tested with either .highlighted or (.highlighted | .selected)
+        continue;
+      }
       // Given
       MDCButton *button = [[MDCButton alloc] init];
       button.underlyingColorHint = color;

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -37,17 +37,12 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   // Then
   XCTAssertEqualWithAccuracy(button.disabledAlpha, 1, kEpsilonAccuracy);
   XCTAssertEqualObjects([button backgroundColorForState:UIControlStateNormal], UIColor.clearColor);
-  XCTAssertEqualObjects([button backgroundColorForState:UIControlStateDisabled],
-                        UIColor.clearColor);
   XCTAssertEqualObjects([button titleColorForState:UIControlStateNormal], colorScheme.primaryColor);
   XCTAssertEqualObjects([button titleColorForState:UIControlStateDisabled],
                         [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.38]);
   NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
       UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
-    if (state == UIControlStateDisabled) {
-      continue;  // This state is manually checked above.
-    }
     XCTAssertEqualObjects([button backgroundColorForState:state],
                           [button backgroundColorForState:UIControlStateNormal]);
     XCTAssertEqualObjects([button titleColorForState:state], colorScheme.primaryColor, @"state:%lu",

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -37,12 +37,17 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   // Then
   XCTAssertEqualWithAccuracy(button.disabledAlpha, 1, kEpsilonAccuracy);
   XCTAssertEqualObjects([button backgroundColorForState:UIControlStateNormal], UIColor.clearColor);
+  XCTAssertEqualObjects([button backgroundColorForState:UIControlStateDisabled],
+                        [button backgroundColorForState:UIControlStateNormal]);
   XCTAssertEqualObjects([button titleColorForState:UIControlStateNormal], colorScheme.primaryColor);
   XCTAssertEqualObjects([button titleColorForState:UIControlStateDisabled],
                         [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.38]);
   NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
       UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    if (state == UIControlStateDisabled) {
+      continue;  // This state is manually checked above.
+    }
     XCTAssertEqualObjects([button backgroundColorForState:state],
                           [button backgroundColorForState:UIControlStateNormal]);
     XCTAssertEqualObjects([button titleColorForState:state], colorScheme.primaryColor, @"state:%lu",

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -45,10 +45,11 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
       UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
-    if ((state == UIControlStateNormal)||(state == UIControlStateDisabled))  {
-      continue; // These two states are manually checked above.
+    if (state == UIControlStateDisabled)  {
+      continue; // This state is manually checked above.
     }
-    XCTAssertNil([button backgroundColorForState:state], @"state:%lu", (unsigned long)state);
+    XCTAssertEqualObjects([button backgroundColorForState:state],
+                          [button backgroundColorForState:UIControlStateNormal]);
     XCTAssertEqualObjects([button titleColorForState:state], colorScheme.primaryColor, @"state:%lu",
                           (unsigned long)state);
   }
@@ -76,10 +77,11 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
       UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
-    if ((state == UIControlStateNormal)||(state == UIControlStateDisabled))  {
-      continue; // These two states are manually checked above.
+    if (state == UIControlStateDisabled)  {
+      continue; // This state is manually checked above.
     }
-    XCTAssertNil([button backgroundColorForState:state], @"state:%lu", (unsigned long)state);
+    XCTAssertEqualObjects([button backgroundColorForState:state],
+                          [button backgroundColorForState:UIControlStateNormal]);
     XCTAssertEqualObjects([button titleColorForState:state], colorScheme.onPrimaryColor,
                           @"state:%lu", (unsigned long)state);
   }
@@ -234,17 +236,10 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   NSUInteger maximumStateValue =
       UIControlStateSelected | UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
-    // TODO(https://github.com/material-components/material-components-ios/issues/3411 ):
-    //   MDCButton does not return the correct value for `backgroundColorForState:`
-    if (state == UIControlStateNormal) {
       XCTAssertEqualObjects([button backgroundColorForState:state], colorScheme.secondaryColor,
                             @"Background color (%@) is not equal to (%@) for state (%lu).",
                             [button backgroundColorForState:state], colorScheme.secondaryColor,
                             (unsigned long)state);
-    } else {
-      XCTAssertEqual([button backgroundColorForState:state], nil);
-    }
-
     XCTAssertEqualObjects([button imageTintColorForState:state], colorScheme.onSecondaryColor,
                           @"Image tint color (%@) is not equal to (%@) for state (%lu).",
                           [button imageTintColorForState:state], colorScheme.onSecondaryColor,

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -46,7 +46,7 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
       UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
     if (state == UIControlStateDisabled)  {
-      continue; // This state is manually checked above.
+      continue;  // This state is manually checked above.
     }
     XCTAssertEqualObjects([button backgroundColorForState:state],
                           [button backgroundColorForState:UIControlStateNormal]);
@@ -78,7 +78,7 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
       UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
     if (state == UIControlStateDisabled)  {
-      continue; // This state is manually checked above.
+      continue;  // This state is manually checked above.
     }
     XCTAssertEqualObjects([button backgroundColorForState:state],
                           [button backgroundColorForState:UIControlStateNormal]);

--- a/components/Buttons/tests/unit/ButtonsColorThemerTests.m
+++ b/components/Buttons/tests/unit/ButtonsColorThemerTests.m
@@ -45,7 +45,7 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
       UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
-    if (state == UIControlStateDisabled)  {
+    if (state == UIControlStateDisabled) {
       continue;  // This state is manually checked above.
     }
     XCTAssertEqualObjects([button backgroundColorForState:state],
@@ -77,7 +77,7 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
       UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
-    if (state == UIControlStateDisabled)  {
+    if (state == UIControlStateDisabled) {
       continue;  // This state is manually checked above.
     }
     XCTAssertEqualObjects([button backgroundColorForState:state],

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -281,9 +281,7 @@ static NSString *controlStateDescription(UIControlState controlState) {
   }
 }
 
-// TODO(https://github.com/material-components/material-components-ios/issues/3411 ): Enable this
-//   test when the behavior in MDCButton is fixed.
-- (void)_disabled_testBackgroundColorForStateFallbackBehavior {
+- (void)testBackgroundColorForStateFallbackBehavior {
   // Given
   MDCButton *button = [[MDCButton alloc] init];
 


### PR DESCRIPTION
The rendered (displayed) behavior of background colors in MDCButton is as
expected - when only the `.normal` state is configured, the button keeps that
background at all times.

This is an API-breaking change but does not affect the visual presentation of MDCButton.

Closes #3411
