### PR TITLE
{kokoro} Update Homebrew and RubyGems at the start

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -14,22 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Fail on any error.
-#set -e
-
-echo "Contents of /usr/local/Homebrew/Library/Homebrew/config.rb"
-echo "=========="
-cat /usr/local/Homebrew/Library/Homebrew/config.rb
-echo "=========="
-
 brew --version
-brew prune
-brew doctor
 brew outdated
 brew update
+brew --version
 brew doctor
 
 gem update --system
+
+# Fail on any error
+set -e
 
 if [ -n "$KOKORO_BUILD_NUMBER" ]; then
   # Import source methods for managing GitHub comments

--- a/.kokoro
+++ b/.kokoro
@@ -17,6 +17,11 @@
 # Fail on any error.
 set -e
 
+echo "Contents of /usr/local/Homebrew/Library/Homebrew/config.rb"
+echo "=========="
+cat /usr/local/Homebrew/Library/Homebrew/config.rb
+echo "=========="
+
 gem update --system
 
 if [ -n "$KOKORO_BUILD_NUMBER" ]; then

--- a/.kokoro
+++ b/.kokoro
@@ -15,12 +15,16 @@
 # limitations under the License.
 
 # Fail on any error.
-set -e
+#set -e
 
 echo "Contents of /usr/local/Homebrew/Library/Homebrew/config.rb"
 echo "=========="
 cat /usr/local/Homebrew/Library/Homebrew/config.rb
 echo "=========="
+
+cd /usr/local/bin
+git reset --hard HEAD
+brew doctor
 
 gem update --system
 

--- a/.kokoro
+++ b/.kokoro
@@ -17,6 +17,8 @@
 # Fail on any error.
 set -e
 
+gem update --system
+
 if [ -n "$KOKORO_BUILD_NUMBER" ]; then
   # Import source methods for managing GitHub comments
   scripts_dir='github/repo/scripts/lib'
@@ -366,7 +368,6 @@ generate_website() {
 
     ./scripts/build_site.sh
 
-    gem update --system
     gem install bundler --no-document --quiet
     brew update
     brew install yarn --without-node

--- a/.kokoro
+++ b/.kokoro
@@ -25,6 +25,9 @@ echo "=========="
 brew --version
 brew prune
 brew doctor
+brew outdated
+brew update
+brew doctor
 
 gem update --system
 

--- a/.kokoro
+++ b/.kokoro
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Make sure both Homebrew and RubyGems are up to date
 brew --version
-brew outdated
 brew update
 brew --version
 brew doctor
 
-gem update --system
+gem update --system --no-document
 
 # Fail on any error
 set -e

--- a/.kokoro
+++ b/.kokoro
@@ -22,8 +22,8 @@ echo "=========="
 cat /usr/local/Homebrew/Library/Homebrew/config.rb
 echo "=========="
 
-cd /usr/local/bin
-git reset --hard HEAD
+brew --version
+brew prune
 brew doctor
 
 gem update --system


### PR DESCRIPTION
This morning kokoro started generating job failures as a result of a parsing error in Homebrew's `config.rb`. For now, updating both RubyGems and Homebrew will get the jobs passing again (and the tooling installed) and unblocks the team.

```
/usr/local/Homebrew/Library/Homebrew/config.rb:39:in `initialize': no implicit conversion of nil into String (TypeError)

[ID: 4050959] Build finished after 230 secs, exit value: 1
```

Work-around for #6256