### PR TITLE
{kokoro} Only upgrade gem/homebrew when needed.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -14,14 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Make sure both Homebrew and RubyGems are up to date
-brew --version
-brew update
-brew --version
-brew doctor
-
-gem update --system --no-document
-
 # Fail on any error
 set -e
 
@@ -34,6 +26,7 @@ fi
 
 source "${scripts_dir}/github_comments.sh"
 source "${scripts_dir}/select_xcode.sh"
+source "${scripts_dir}/package_managers.sh"
 
 # To install homebrew formulas at specific versions we need to point directly
 # to the desired sha in the homebrew formula repository.
@@ -142,7 +135,7 @@ upload_bazel_test_artifacts() {
     done
   }
 
-  brew install rename
+  brew_install rename
 
   # rename all test.log to sponge_log.log and then copy them to the kokoro
   # artifacts directory.
@@ -312,11 +305,11 @@ run_cocoapods() {
     # Move into our cloned repo
     cd github/repo
 
-    gem install xcpretty cocoapods --no-document --quiet
+    gem_install xcpretty cocoapods
     pod --version
 
     # Install git-lfs
-    brew install git-lfs
+    brew_install git-lfs
     git lfs install
     git lfs pull
   fi
@@ -374,9 +367,8 @@ generate_website() {
 
     ./scripts/build_site.sh
 
-    gem install bundler --no-document --quiet
-    brew update
-    brew install yarn --without-node
+    gem_install bundler
+    brew_install yarn --without-node
   fi
 
   cd docsite-generator
@@ -415,7 +407,7 @@ generate_apidiff() {
     cd github/repo
 
     # Install sourcekitten, a dependency of the apidiff tool
-    brew install "$SOURCEKITTEN_FORMULA"
+    brew_install "$SOURCEKITTEN_FORMULA"
 
     sourcekitten version
   fi

--- a/scripts/lib/package_managers.sh
+++ b/scripts/lib/package_managers.sh
@@ -24,7 +24,6 @@ gem_install() {
 }
 
 brew_update() {
-  gem_update
   brew --version
   brew update
   brew --version

--- a/scripts/lib/package_managers.sh
+++ b/scripts/lib/package_managers.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright 2019-present The Material Components for iOS Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+brew_update() {
+  brew --version
+  brew update
+  brew --version
+  brew doctor
+}
+
+brew_install() {
+  brew_update
+  brew install "$@"
+}
+
+gem_update() {
+  gem update --system --no-document --quiet
+}
+
+gem_install() {
+#  gem_update
+  gem install "$@" --no-document --quiet
+}
+

--- a/scripts/lib/package_managers.sh
+++ b/scripts/lib/package_managers.sh
@@ -18,7 +18,7 @@ brew_update() {
   brew --version
   brew update
   brew --version
-  brew doctor
+  brew doctor || true
 }
 
 brew_install() {
@@ -31,7 +31,7 @@ gem_update() {
 }
 
 gem_install() {
-#  gem_update
+  gem_update
   gem install "$@" --no-document --quiet
 }
 

--- a/scripts/lib/package_managers.sh
+++ b/scripts/lib/package_managers.sh
@@ -18,7 +18,6 @@ brew_update() {
   brew --version
   brew update
   brew --version
-  brew doctor || true
 }
 
 brew_install() {

--- a/scripts/lib/package_managers.sh
+++ b/scripts/lib/package_managers.sh
@@ -34,4 +34,3 @@ brew_install() {
   brew install "$@"
 }
 
-

--- a/scripts/lib/package_managers.sh
+++ b/scripts/lib/package_managers.sh
@@ -14,7 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+gem_update() {
+  gem update --system --no-document --quiet
+}
+
+gem_install() {
+  gem_update
+  gem install "$@" --no-document --quiet
+}
+
 brew_update() {
+  gem_update
   brew --version
   brew update
   brew --version
@@ -25,12 +35,4 @@ brew_install() {
   brew install "$@"
 }
 
-gem_update() {
-  gem update --system --no-document --quiet
-}
-
-gem_install() {
-  gem_update
-  gem install "$@" --no-document --quiet
-}
 


### PR DESCRIPTION
Instead of updating both RubyGems and Homebrew at the beginning of the kokoro
script, they should only be updated if they're going to be used for an install
or update command.

Closes #6256
