### PR TITLE
[Snackbar] Allow the delegate to override accessibilityViewIsModal

### DIFF
--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -222,7 +222,7 @@
     BOOL mdc_adjustsFontForContentSizeCategory;
 
 /**
- If enabled, accessibilityViewIsModal will be enabled for all non-transient snackbar views.
+ If enabled, accessibilityViewIsModal will be enabled for all snackbar views.
 
  Default is set to NO.
  */

--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -241,7 +241,7 @@ typedef NS_ENUM(NSInteger, MDCSnackBarManagerAccessibilityViewMode) {
     BOOL mdc_adjustsFontForContentSizeCategory;
 
 /**
- The MDCSnackBarManagerAccessibilityViewMode of the snackbar manager.
+ The MDCSnackBarManagerAccessibilityViewMode of this snackbar manager.
 
  Default is MDCSnackBarManagerAccessibilityViewIsModalNever.
  */

--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -20,28 +20,6 @@
 @protocol MDCSnackbarSuspensionToken;
 
 /**
- Different operating modes for the snackbar manager to set the boolean value of
- accessibilityViewIsModal for snackbar views.
-
- Default value is MDCSnackBarManagerAccessibilityViewIsModalNever.
- */
-typedef NS_ENUM(NSInteger, MDCSnackBarManagerAccessibilityViewMode) {
-  /**
-   The accessibilityViewIsModal boolean value will be NO for all snackbar views.
-   */
-  MDCSnackBarManagerAccessibilityViewIsModalNever,
-  /**
-   The accessibilityViewIsModal boolean value will be YES for all non-transient snackbar views with
-   actions, and NO for all transient snackbar views.
-   */
-  MDCSnackBarManagerAccessibilityViewNonTransientIsModal,
-  /**
-   The accessibilityViewIsModal boolean value will be YES for all snackbar views.
-   */
-  MDCSnackBarManagerAccessibilityViewIsModal,
-};
-
-/**
  Delegate protocol for the MDCSnackbarManager.
  */
 @protocol MDCSnackbarManagerDelegate <NSObject>
@@ -243,11 +221,13 @@ typedef NS_ENUM(NSInteger, MDCSnackBarManagerAccessibilityViewMode) {
     BOOL mdc_adjustsFontForContentSizeCategory;
 
 /**
- The MDCSnackBarManagerAccessibilityViewMode of this snackbar manager.
+ If enabled, accessibilityViewIsModal will be enabled for all non-transient snackbar views by default.
+ If accessibilityViewIsModal needs to be set for specific snackbar views, MDCSnackbarManagerDelegate
+ can be used to access snackbar view and set the accessibilityViewIsModal value.
 
- Default is MDCSnackBarManagerAccessibilityViewIsModalNever.
+ Default is set to NO.
  */
-@property(nonatomic, assign) MDCSnackBarManagerAccessibilityViewMode accessibilityViewIsModalMode;
+@property(nonatomic, assign) BOOL shouldEnableAccessibilityViewIsModal;
 
 /**
  The delegate for MDCSnackbarManager through which it may inform of snackbar presentation updates.

--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -20,7 +20,8 @@
 @protocol MDCSnackbarSuspensionToken;
 
 /**
- Different operating modes for the snackbar manager to set the boolean value of accessibilityViewIsModal for snackbar views.
+ Different operating modes for the snackbar manager to set the boolean value of
+ accessibilityViewIsModal for snackbar views.
 
  Default value is MDCSnackBarManagerAccessibilityViewIsModalNever.
  */
@@ -30,7 +31,8 @@ typedef NS_ENUM(NSInteger, MDCSnackBarManagerAccessibilityViewMode) {
    */
   MDCSnackBarManagerAccessibilityViewIsModalNever,
   /**
-   The accessibilityViewIsModal boolean value will be YES for all non-transient snackbar views with actions, and NO for all transient snackbar views.
+   The accessibilityViewIsModal boolean value will be YES for all non-transient snackbar views with
+   actions, and NO for all transient snackbar views.
    */
   MDCSnackBarManagerAccessibilityViewNonTransientIsModal,
   /**

--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -221,9 +221,10 @@
     BOOL mdc_adjustsFontForContentSizeCategory;
 
 /**
- If enabled, accessibilityViewIsModal will be enabled for all non-transient snackbar views by default.
- If accessibilityViewIsModal needs to be set for specific snackbar views, MDCSnackbarManagerDelegate
- can be used to access snackbar view and set the accessibilityViewIsModal value.
+ If enabled, accessibilityViewIsModal will be enabled for all non-transient snackbar views by
+ default. If accessibilityViewIsModal needs to be set for specific snackbar views,
+ MDCSnackbarManagerDelegate can be used to access snackbar view and set the accessibilityViewIsModal
+ value.
 
  Default is set to NO.
  */

--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -19,6 +19,25 @@
 @class MDCSnackbarMessageView;
 @protocol MDCSnackbarSuspensionToken;
 
+/**
+ Different operating modes for the snackbar manager to set the boolean value of accessibilityViewIsModal for snackbar views.
+
+ Default value is MDCSnackBarManagerAccessibilityViewIsModalNever.
+ */
+typedef NS_ENUM(NSInteger, MDCSnackBarManagerAccessibilityViewMode) {
+  /**
+   The accessibilityViewIsModal boolean value will be NO for all snackbar views.
+   */
+  MDCSnackBarManagerAccessibilityViewIsModalNever,
+  /**
+   The accessibilityViewIsModal boolean value will be YES for all non-transient snackbar views with actions, and NO for all transient snackbar views.
+   */
+  MDCSnackBarManagerAccessibilityViewNonTransientIsModal,
+  /**
+   The accessibilityViewIsModal boolean value will be YES for all snackbar views.
+   */
+  MDCSnackBarManagerAccessibilityViewIsModal,
+};
 
 /**
  Delegate protocol for the MDCSnackbarManager.
@@ -222,11 +241,11 @@
     BOOL mdc_adjustsFontForContentSizeCategory;
 
 /**
- If enabled, accessibilityViewIsModal will be enabled for all snackbar views.
+ The MDCSnackBarManagerAccessibilityViewMode of the snackbar manager.
 
- Default is set to NO.
+ Default is MDCSnackBarManagerAccessibilityViewIsModalNever.
  */
-@property(nonatomic, assign) BOOL shouldEnableAccessibilityViewIsModal;
+@property(nonatomic, assign) MDCSnackBarManagerAccessibilityViewMode accessibilityViewIsModalMode;
 
 /**
  The delegate for MDCSnackbarManager through which it may inform of snackbar presentation updates.

--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -223,8 +223,8 @@
 /**
  If enabled, accessibilityViewIsModal will be enabled for all non-transient snackbar views by
  default. If accessibilityViewIsModal needs to be set for specific snackbar views,
- MDCSnackbarManagerDelegate can be used to access snackbar view and set the accessibilityViewIsModal
- value.
+ -willPresentSnackbarWithMessageView: in MDCSnackbarManagerDelegate can be used to access
+ snackbar view and set the accessibilityViewIsModal value.
 
  Default is set to NO.
  */

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -228,7 +228,8 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
   snackbarView = [[viewClass alloc] initWithMessage:message
                                      dismissHandler:dismissHandler
                                     snackbarManager:self.manager];
-  snackbarView.accessibilityViewIsModal = self.manager.shouldEnableAccessibilityViewIsModal && ![self isSnackbarTransient:snackbarView];
+  snackbarView.accessibilityViewIsModal =
+      self.manager.shouldEnableAccessibilityViewIsModal && ![self isSnackbarTransient:snackbarView];
   [self.delegate willPresentSnackbarWithMessageView:snackbarView];
   self.currentSnackbar = snackbarView;
   self.overlayView.accessibilityViewIsModal = snackbarView.accessibilityViewIsModal;
@@ -243,7 +244,8 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
               animated:YES
             completion:^{
               MDCSnackbarManagerInternal *strongSelf = weakSelf;
-              if (!snackbarView.accessibilityViewIsModal && [strongSelf isSnackbarTransient:snackbarView]) {
+              if (!snackbarView.accessibilityViewIsModal &&
+                  [strongSelf isSnackbarTransient:snackbarView]) {
                 snackbarView.accessibilityElementsHidden = YES;
                 UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
                                                 message.voiceNotificationText);

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -242,7 +242,8 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
       showSnackbarView:snackbarView
               animated:YES
             completion:^{
-              if (!snackbarView.accessibilityViewIsModal && [self isSnackbarTransient:snackbarView]) {
+              if (!snackbarView.accessibilityViewIsModal &&
+                  [self isSnackbarTransient:snackbarView]) {
                 snackbarView.accessibilityElementsHidden = YES;
                 UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
                                                 message.voiceNotificationText);

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -245,7 +245,7 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
               if (snackbarView.accessibilityViewIsModal ||
                   ![self isSnackbarTransient:snackbarView]) {
                 UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification,
-                                                  snackbarView);
+                                                snackbarView);
               } else {
                 snackbarView.accessibilityElementsHidden = YES;
                 UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -237,9 +237,9 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
       break;
     case MDCSnackBarManagerAccessibilityViewNonTransientIsModal:
       if ([self isSnackbarTransient:snackbarView]) {
-          accessibilityViewIsModal = NO;
+        accessibilityViewIsModal = NO;
       } else {
-          accessibilityViewIsModal = YES;
+        accessibilityViewIsModal = YES;
       }
       break;
     case MDCSnackBarManagerAccessibilityViewIsModalNever:
@@ -258,8 +258,7 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
               animated:YES
             completion:^{
               MDCSnackbarManagerInternal *strongSelf = weakSelf;
-              if (!accessibilityViewIsModal &&
-                  [strongSelf isSnackbarTransient:snackbarView]) {
+              if (!accessibilityViewIsModal && [strongSelf isSnackbarTransient:snackbarView]) {
                 snackbarView.accessibilityElementsHidden = YES;
                 UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
                                                 message.voiceNotificationText);
@@ -304,30 +303,29 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
                 }];
 
   __weak MDCSnackbarManagerInternal *weakSelf = self;
-  [self.overlayView
-      dismissSnackbarViewAnimated:YES
-                       completion:^{
-                         MDCSnackbarManagerInternal *strongSelf = weakSelf;
-                         strongSelf.overlayView.hidden = YES;
-                         [strongSelf deactivateOverlay:strongSelf.overlayView];
+  [self.overlayView dismissSnackbarViewAnimated:YES
+                                     completion:^{
+                                       MDCSnackbarManagerInternal *strongSelf = weakSelf;
+                                       strongSelf.overlayView.hidden = YES;
+                                       [strongSelf deactivateOverlay:strongSelf.overlayView];
 
-                         // If the snackbarView was transient and accessibilityViewIsModal
-                         // is NO, the Snackbar was just announced (layout was not
-                         // reported as changed) so there is no need to post a layout
-                         // change here.
-                         if (strongSelf.overlayView.accessibilityViewIsModal ||
-                             ![strongSelf isSnackbarTransient:snackbarView]) {
-                           UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification,
-                                                           nil);
-                         }
+                                       // If the snackbarView was transient and
+                                       // accessibilityViewIsModal is NO, the Snackbar was just
+                                       // announced (layout was not reported as changed) so there is
+                                       // no need to post a layout change here.
+                                       if (strongSelf.overlayView.accessibilityViewIsModal ||
+                                           ![strongSelf isSnackbarTransient:snackbarView]) {
+                                         UIAccessibilityPostNotification(
+                                             UIAccessibilityLayoutChangedNotification, nil);
+                                       }
 
-                         strongSelf.currentSnackbar = nil;
+                                       strongSelf.currentSnackbar = nil;
 
-                         // Now that the snackbarView is offscreen, we can allow more
-                         // messages to be shown.
-                         strongSelf.showingMessage = NO;
-                         [strongSelf showNextMessageIfNecessaryMainThread];
-                       }];
+                                       // Now that the snackbarView is offscreen, we can allow more
+                                       // messages to be shown.
+                                       strongSelf.showingMessage = NO;
+                                       [strongSelf showNextMessageIfNecessaryMainThread];
+                                     }];
 }
 
 #pragma mark - Helper methods

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -242,14 +242,14 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
       showSnackbarView:snackbarView
               animated:YES
             completion:^{
-              if (!snackbarView.accessibilityViewIsModal &&
-                  [self isSnackbarTransient:snackbarView]) {
+              if (snackbarView.accessibilityViewIsModal ||
+                  ![self isSnackbarTransient:snackbarView]) {
+                UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification,
+                                                  snackbarView);
+              } else {
                 snackbarView.accessibilityElementsHidden = YES;
                 UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
                                                 message.voiceNotificationText);
-              } else {
-                UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification,
-                                                snackbarView);
               }
 
               if ([self isSnackbarTransient:snackbarView]) {

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -228,25 +228,10 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
   snackbarView = [[viewClass alloc] initWithMessage:message
                                      dismissHandler:dismissHandler
                                     snackbarManager:self.manager];
+  snackbarView.accessibilityViewIsModal = self.manager.shouldEnableAccessibilityViewIsModal && ![self isSnackbarTransient:snackbarView];
   [self.delegate willPresentSnackbarWithMessageView:snackbarView];
   self.currentSnackbar = snackbarView;
-  BOOL accessibilityViewIsModal;
-  switch (self.manager.accessibilityViewIsModalMode) {
-    case MDCSnackBarManagerAccessibilityViewIsModal:
-      accessibilityViewIsModal = YES;
-      break;
-    case MDCSnackBarManagerAccessibilityViewNonTransientIsModal:
-      if ([self isSnackbarTransient:snackbarView]) {
-        accessibilityViewIsModal = NO;
-      } else {
-        accessibilityViewIsModal = YES;
-      }
-      break;
-    case MDCSnackBarManagerAccessibilityViewIsModalNever:
-      accessibilityViewIsModal = NO;
-      break;
-  }
-  self.overlayView.accessibilityViewIsModal = accessibilityViewIsModal;
+  self.overlayView.accessibilityViewIsModal = snackbarView.accessibilityViewIsModal;
   self.overlayView.hidden = NO;
   [self activateOverlay:self.overlayView];
 
@@ -258,7 +243,7 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
               animated:YES
             completion:^{
               MDCSnackbarManagerInternal *strongSelf = weakSelf;
-              if (!accessibilityViewIsModal && [strongSelf isSnackbarTransient:snackbarView]) {
+              if (!snackbarView.accessibilityViewIsModal && [strongSelf isSnackbarTransient:snackbarView]) {
                 snackbarView.accessibilityElementsHidden = YES;
                 UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
                                                 message.voiceNotificationText);

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -238,14 +238,11 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
 
   // Once the Snackbar has finished animating on screen, start the automatic dismiss timeout, but
   // only if the user isn't running VoiceOver.
-  __weak MDCSnackbarManagerInternal *weakSelf = self;
   [self.overlayView
       showSnackbarView:snackbarView
               animated:YES
             completion:^{
-              MDCSnackbarManagerInternal *strongSelf = weakSelf;
-              if (!snackbarView.accessibilityViewIsModal &&
-                  [strongSelf isSnackbarTransient:snackbarView]) {
+              if (!snackbarView.accessibilityViewIsModal && [self isSnackbarTransient:snackbarView]) {
                 snackbarView.accessibilityElementsHidden = YES;
                 UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
                                                 message.voiceNotificationText);
@@ -254,7 +251,7 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
                                                 snackbarView);
               }
 
-              if ([strongSelf isSnackbarTransient:snackbarView]) {
+              if ([self isSnackbarTransient:snackbarView]) {
                 __weak MDCSnackbarMessageView *weakSnackbarView = snackbarView;
                 dispatch_time_t popTime =
                     dispatch_time(DISPATCH_TIME_NOW, (int64_t)(message.duration * NSEC_PER_SEC));
@@ -289,29 +286,27 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
                   [message executeCompletionHandlerWithUserInteraction:userPrompted completion:nil];
                 }];
 
-  __weak MDCSnackbarManagerInternal *weakSelf = self;
   [self.overlayView dismissSnackbarViewAnimated:YES
                                      completion:^{
-                                       MDCSnackbarManagerInternal *strongSelf = weakSelf;
-                                       strongSelf.overlayView.hidden = YES;
-                                       [strongSelf deactivateOverlay:strongSelf.overlayView];
+                                       self.overlayView.hidden = YES;
+                                       [self deactivateOverlay:self.overlayView];
 
                                        // If the snackbarView was transient and
                                        // accessibilityViewIsModal is NO, the Snackbar was just
                                        // announced (layout was not reported as changed) so there is
                                        // no need to post a layout change here.
-                                       if (strongSelf.overlayView.accessibilityViewIsModal ||
-                                           ![strongSelf isSnackbarTransient:snackbarView]) {
+                                       if (self.overlayView.accessibilityViewIsModal ||
+                                           ![self isSnackbarTransient:snackbarView]) {
                                          UIAccessibilityPostNotification(
                                              UIAccessibilityLayoutChangedNotification, nil);
                                        }
 
-                                       strongSelf.currentSnackbar = nil;
+                                       self.currentSnackbar = nil;
 
                                        // Now that the snackbarView is offscreen, we can allow more
                                        // messages to be shown.
-                                       strongSelf.showingMessage = NO;
-                                       [strongSelf showNextMessageIfNecessaryMainThread];
+                                       self.showingMessage = NO;
+                                       [self showNextMessageIfNecessaryMainThread];
                                      }];
 }
 

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -123,49 +123,12 @@
                         self.message.accessibilityHint);
 }
 
-- (void)testSnackbarSetAccessibiltyViewIsModalAppliedWithActions {
+- (void)testSnackbarAccessibiltyViewIsModalByDefaultWithActions {
   // Given
   self.manager.internalManager.isVoiceOverRunningOverride = YES;
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   action.title = @"Tap Me";
   self.message.action = action;
-  self.manager.shouldEnableAccessibilityViewIsModal = YES;
-
-  // When
-  [self.manager showMessage:self.message];
-  XCTestExpectation *expectation = [self expectationWithDescription:@"completed"];
-  dispatch_async(dispatch_get_main_queue(), ^{
-    [expectation fulfill];
-  });
-  [self waitForExpectationsWithTimeout:3 handler:nil];
-
-  // Then
-  XCTAssertTrue(self.manager.internalManager.overlayView.accessibilityViewIsModal);
-}
-
-- (void)testSnackbarAccessibiltyViewIsModalAppliedWithNoActions {
-  // Given
-  self.manager.shouldEnableAccessibilityViewIsModal = YES;
-
-  // When
-  [self.manager showMessage:self.message];
-  XCTestExpectation *expectation = [self expectationWithDescription:@"completed"];
-  dispatch_async(dispatch_get_main_queue(), ^{
-    [expectation fulfill];
-  });
-  [self waitForExpectationsWithTimeout:3 handler:nil];
-
-  // Then
-  XCTAssertTrue(self.manager.internalManager.overlayView.accessibilityViewIsModal);
-}
-
-- (void)testSnackbarSetAccessibiltyViewIsModalShouldBeNoForActionSnacbarsWhenManagerIsNo {
-  // Given
-  self.manager.internalManager.isVoiceOverRunningOverride = YES;
-  MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
-  action.title = @"Tap Me";
-  self.message.action = action;
-  self.manager.shouldEnableAccessibilityViewIsModal = NO;
 
   // When
   [self.manager showMessage:self.message];
@@ -179,9 +142,9 @@
   XCTAssertFalse(self.manager.internalManager.overlayView.accessibilityViewIsModal);
 }
 
-- (void)testSnackbarAccessibiltyViewIsModalShouldBeNoByDefault {
+- (void)testSnackbarAccessibiltyViewIsModalByDefaultWithNoActions {
   // Given
-  self.manager.shouldEnableAccessibilityViewIsModal = NO;
+  self.manager.internalManager.isVoiceOverRunningOverride = YES;
 
   // When
   [self.manager showMessage:self.message];
@@ -193,6 +156,80 @@
 
   // Then
   XCTAssertFalse(self.manager.internalManager.overlayView.accessibilityViewIsModal);
+}
+
+- (void)testSnackbarAccessibiltyViewNonTransientIsModalModeWithActions {
+  // Given
+  self.manager.internalManager.isVoiceOverRunningOverride = YES;
+  MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
+  action.title = @"Tap Me";
+  self.message.action = action;
+  self.manager.accessibilityViewIsModalMode = MDCSnackBarManagerAccessibilityViewNonTransientIsModal;
+
+  // When
+  [self.manager showMessage:self.message];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completed"];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [expectation fulfill];
+  });
+  [self waitForExpectationsWithTimeout:3 handler:nil];
+
+  // Then
+  XCTAssertTrue(self.manager.internalManager.overlayView.accessibilityViewIsModal);
+}
+
+- (void)testSnackbarAccessibiltyViewNonTransientIsModalModeWithNoActions {
+  // Given
+  self.manager.internalManager.isVoiceOverRunningOverride = YES;
+  self.manager.accessibilityViewIsModalMode = MDCSnackBarManagerAccessibilityViewNonTransientIsModal;
+
+  // When
+  [self.manager showMessage:self.message];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completed"];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [expectation fulfill];
+  });
+  [self waitForExpectationsWithTimeout:3 handler:nil];
+
+  // Then
+  XCTAssertFalse(self.manager.internalManager.overlayView.accessibilityViewIsModal);
+}
+
+- (void)testSnackbarAccessibiltyViewIsModalModeWithActions {
+  // Given
+  self.manager.internalManager.isVoiceOverRunningOverride = YES;
+  MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
+  action.title = @"Tap Me";
+  self.message.action = action;
+  self.manager.accessibilityViewIsModalMode = MDCSnackBarManagerAccessibilityViewIsModal;
+
+  // When
+  [self.manager showMessage:self.message];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completed"];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [expectation fulfill];
+  });
+  [self waitForExpectationsWithTimeout:3 handler:nil];
+
+  // Then
+  XCTAssertTrue(self.manager.internalManager.overlayView.accessibilityViewIsModal);
+}
+
+- (void)testSnackbarAccessibiltyViewIsModalModeWithNoActions {
+  // Given
+  self.manager.internalManager.isVoiceOverRunningOverride = YES;
+  self.manager.accessibilityViewIsModalMode = MDCSnackBarManagerAccessibilityViewIsModal;
+
+  // When
+  [self.manager showMessage:self.message];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completed"];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [expectation fulfill];
+  });
+  [self waitForExpectationsWithTimeout:3 handler:nil];
+
+  // Then
+  XCTAssertTrue(self.manager.internalManager.overlayView.accessibilityViewIsModal);
 }
 
 @end

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -158,14 +158,13 @@
   XCTAssertFalse(self.manager.internalManager.overlayView.accessibilityViewIsModal);
 }
 
-- (void)testSnackbarAccessibiltyViewNonTransientIsModalModeWithActions {
+- (void)testSnackbarAccessibiltyViewIsModalYesWithActions {
   // Given
   self.manager.internalManager.isVoiceOverRunningOverride = YES;
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   action.title = @"Tap Me";
   self.message.action = action;
-  self.manager.accessibilityViewIsModalMode =
-      MDCSnackBarManagerAccessibilityViewNonTransientIsModal;
+  self.manager.shouldEnableAccessibilityViewIsModal = YES;
 
   // When
   [self.manager showMessage:self.message];
@@ -179,11 +178,10 @@
   XCTAssertTrue(self.manager.internalManager.overlayView.accessibilityViewIsModal);
 }
 
-- (void)testSnackbarAccessibiltyViewNonTransientIsModalModeWithNoActions {
+- (void)testSnackbarAccessibiltyViewIsModalYesWithNoActions {
   // Given
   self.manager.internalManager.isVoiceOverRunningOverride = YES;
-  self.manager.accessibilityViewIsModalMode =
-      MDCSnackBarManagerAccessibilityViewNonTransientIsModal;
+  self.manager.shouldEnableAccessibilityViewIsModal = YES;
 
   // When
   [self.manager showMessage:self.message];
@@ -197,13 +195,14 @@
   XCTAssertFalse(self.manager.internalManager.overlayView.accessibilityViewIsModal);
 }
 
-- (void)testSnackbarAccessibiltyViewIsModalModeWithActions {
+- (void)testSnackbarAccessibiltyViewIsModalWithSnackbarViewOverwriteWithActions {
   // Given
+  self.delegate.shouldSetSnackbarViewAccessibilityViewIsModal = YES;
   self.manager.internalManager.isVoiceOverRunningOverride = YES;
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   action.title = @"Tap Me";
   self.message.action = action;
-  self.manager.accessibilityViewIsModalMode = MDCSnackBarManagerAccessibilityViewIsModal;
+  self.message.accessibilityViewIsModal = YES;
 
   // When
   [self.manager showMessage:self.message];
@@ -217,10 +216,11 @@
   XCTAssertTrue(self.manager.internalManager.overlayView.accessibilityViewIsModal);
 }
 
-- (void)testSnackbarAccessibiltyViewIsModalModeWithNoActions {
+- (void)testSnackbarAccessibiltyViewIsModalWithSnackbarViewOverwriteWithNoActions {
   // Given
+  self.delegate.shouldSetSnackbarViewAccessibilityViewIsModal = YES;
   self.manager.internalManager.isVoiceOverRunningOverride = YES;
-  self.manager.accessibilityViewIsModalMode = MDCSnackBarManagerAccessibilityViewIsModal;
+  self.message.accessibilityViewIsModal = YES;
 
   // When
   [self.manager showMessage:self.message];

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -123,7 +123,7 @@
                         self.message.accessibilityHint);
 }
 
-- (void)testSnackbarSetAccessibiltyViewIsModalForActionSnacbars {
+- (void)testSnackbarSetAccessibiltyViewIsModalAppliedWithActions {
   // Given
   self.manager.internalManager.isVoiceOverRunningOverride = YES;
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
@@ -143,7 +143,7 @@
   XCTAssertTrue(self.manager.internalManager.overlayView.accessibilityViewIsModal);
 }
 
-- (void)testSnackbarAccessibiltyViewIsModalShouldBeNoWithNoActions {
+- (void)testSnackbarAccessibiltyViewIsModalAppliedWithNoActions {
   // Given
   self.manager.shouldEnableAccessibilityViewIsModal = YES;
 
@@ -156,7 +156,7 @@
   [self waitForExpectationsWithTimeout:3 handler:nil];
 
   // Then
-  XCTAssertFalse(self.manager.internalManager.overlayView.accessibilityViewIsModal);
+  XCTAssertTrue(self.manager.internalManager.overlayView.accessibilityViewIsModal);
 }
 
 - (void)testSnackbarSetAccessibiltyViewIsModalShouldBeNoForActionSnacbarsWhenManagerIsNo {

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -123,7 +123,7 @@
                         self.message.accessibilityHint);
 }
 
-- (void)testSnackbarAccessibiltyViewIsModalByDefaultToNoWithActions {
+- (void)testSnackbarAccessibiltyViewIsModalDefaultsToNoWithActions {
   // Given
   self.manager.internalManager.isVoiceOverRunningOverride = YES;
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
@@ -142,7 +142,7 @@
   XCTAssertFalse(self.manager.internalManager.overlayView.accessibilityViewIsModal);
 }
 
-- (void)testSnackbarAccessibiltyViewIsModalByDefaultToNoWithNoActions {
+- (void)testSnackbarAccessibiltyViewIsModalDefaultsToNoWithNoActions {
   // Given
   self.manager.internalManager.isVoiceOverRunningOverride = YES;
 
@@ -158,7 +158,7 @@
   XCTAssertFalse(self.manager.internalManager.overlayView.accessibilityViewIsModal);
 }
 
-- (void)testSnackbarAccessibiltyViewIsModalYesWithActions {
+- (void)testWhenSnackbarAccessibiltyViewIsModalIsYesWithActions {
   // Given
   self.manager.internalManager.isVoiceOverRunningOverride = YES;
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
@@ -178,7 +178,7 @@
   XCTAssertTrue(self.manager.internalManager.overlayView.accessibilityViewIsModal);
 }
 
-- (void)testSnackbarAccessibiltyViewIsModalYesWithActionsAndWithoutVoiceOver {
+- (void)testWhenSnackbarAccessibiltyViewIsModalIsYesWithActionsAndWithoutVoiceOver {
   // Given
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   action.title = @"Tap Me";
@@ -197,7 +197,7 @@
   XCTAssertFalse(self.manager.internalManager.overlayView.accessibilityViewIsModal);
 }
 
-- (void)testSnackbarAccessibiltyViewIsModalYesWithNoActions {
+- (void)testWhenSnackbarAccessibiltyViewIsModalIsYesWhenWithNoActions {
   // Given
   self.manager.internalManager.isVoiceOverRunningOverride = YES;
   self.manager.shouldEnableAccessibilityViewIsModal = YES;
@@ -221,7 +221,6 @@
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   action.title = @"Tap Me";
   self.message.action = action;
-  self.message.accessibilityViewIsModal = YES;
 
   // When
   [self.manager showMessage:self.message];
@@ -239,7 +238,6 @@
   // Given
   self.delegate.shouldSetSnackbarViewAccessibilityViewIsModal = YES;
   self.manager.internalManager.isVoiceOverRunningOverride = YES;
-  self.message.accessibilityViewIsModal = YES;
 
   // When
   [self.manager showMessage:self.message];

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -164,7 +164,8 @@
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
   action.title = @"Tap Me";
   self.message.action = action;
-  self.manager.accessibilityViewIsModalMode = MDCSnackBarManagerAccessibilityViewNonTransientIsModal;
+  self.manager.accessibilityViewIsModalMode =
+      MDCSnackBarManagerAccessibilityViewNonTransientIsModal;
 
   // When
   [self.manager showMessage:self.message];
@@ -181,7 +182,8 @@
 - (void)testSnackbarAccessibiltyViewNonTransientIsModalModeWithNoActions {
   // Given
   self.manager.internalManager.isVoiceOverRunningOverride = YES;
-  self.manager.accessibilityViewIsModalMode = MDCSnackBarManagerAccessibilityViewNonTransientIsModal;
+  self.manager.accessibilityViewIsModalMode =
+      MDCSnackBarManagerAccessibilityViewNonTransientIsModal;
 
   // When
   [self.manager showMessage:self.message];

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -123,7 +123,7 @@
                         self.message.accessibilityHint);
 }
 
-- (void)testSnackbarAccessibiltyViewIsModalByDefaultWithActions {
+- (void)testSnackbarAccessibiltyViewIsModalByDefaultToNoWithActions {
   // Given
   self.manager.internalManager.isVoiceOverRunningOverride = YES;
   MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
@@ -142,7 +142,7 @@
   XCTAssertFalse(self.manager.internalManager.overlayView.accessibilityViewIsModal);
 }
 
-- (void)testSnackbarAccessibiltyViewIsModalByDefaultWithNoActions {
+- (void)testSnackbarAccessibiltyViewIsModalByDefaultToNoWithNoActions {
   // Given
   self.manager.internalManager.isVoiceOverRunningOverride = YES;
 
@@ -176,6 +176,25 @@
 
   // Then
   XCTAssertTrue(self.manager.internalManager.overlayView.accessibilityViewIsModal);
+}
+
+- (void)testSnackbarAccessibiltyViewIsModalYesWithActionsAndWithoutVoiceOver {
+  // Given
+  MDCSnackbarMessageAction *action = [[MDCSnackbarMessageAction alloc] init];
+  action.title = @"Tap Me";
+  self.message.action = action;
+  self.manager.shouldEnableAccessibilityViewIsModal = YES;
+
+  // When
+  [self.manager showMessage:self.message];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completed"];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [expectation fulfill];
+  });
+  [self waitForExpectationsWithTimeout:3 handler:nil];
+
+  // Then
+  XCTAssertFalse(self.manager.internalManager.overlayView.accessibilityViewIsModal);
 }
 
 - (void)testSnackbarAccessibiltyViewIsModalYesWithNoActions {

--- a/components/Snackbar/tests/unit/supplemental/MDCFakeMDCSnackbarManagerDelegate.h
+++ b/components/Snackbar/tests/unit/supplemental/MDCFakeMDCSnackbarManagerDelegate.h
@@ -19,6 +19,7 @@
 @interface FakeMDCSnackbarManagerDelegate : NSObject <MDCSnackbarManagerDelegate>
 
 @property(nonatomic, strong) MDCSnackbarMessageView *presentedView;
+@property(nonatomic, assign) BOOL shouldSetSnackbarViewAccessibilityViewIsModal;
 
 - (void)willPresentSnackbarWithMessageView:(MDCSnackbarMessageView *)messageView;
 

--- a/components/Snackbar/tests/unit/supplemental/MDCFakeMDCSnackbarManagerDelegate.m
+++ b/components/Snackbar/tests/unit/supplemental/MDCFakeMDCSnackbarManagerDelegate.m
@@ -18,6 +18,9 @@
 
 - (void)willPresentSnackbarWithMessageView:(MDCSnackbarMessageView *)messageView {
   self.presentedView = messageView;
+  if (self.shouldSetSnackbarViewAccessibilityViewIsModal) {
+    messageView.accessibilityViewIsModal = YES;
+  }
 }
 
 @end


### PR DESCRIPTION
Enabling client's ability to overwrite the accessibilityViewIsModal in snackbar view by the delegate method.

closes #5879