### PR TITLE
[TextFields] Fixed issue: Placeholder label gets stuck in expanded state when switching between controls 

### DIFF
--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -581,6 +581,8 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 // itself. That means these constraints need go away. So, we can use the existence of them as a
 // way to check if the placeholder is floating up. See isplaceholderUp.
 - (void)cleanupPlaceholderAnimationConstraints {
+  // We need to clear only deactivated constraints and to prevent the clearing of active
+  // constraints.
   if (self.placeholderAnimationConstraintLeading.active &&
       self.placeholderAnimationConstraintTop.active &&
       self.placeholderAnimationConstraintTrailing.active) {

--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -581,6 +581,9 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 // itself. That means these constraints need go away. So, we can use the existence of them as a
 // way to check if the placeholder is floating up. See isplaceholderUp.
 - (void)cleanupPlaceholderAnimationConstraints {
+  if (self.placeholderAnimationConstraintLeading.active && self.placeholderAnimationConstraintTop.active && self.placeholderAnimationConstraintTrailing.active) {
+    return;
+  }
   self.placeholderAnimationConstraints = nil;
   self.placeholderAnimationConstraintLeading = nil;
   self.placeholderAnimationConstraintTop = nil;

--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -581,7 +581,9 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 // itself. That means these constraints need go away. So, we can use the existence of them as a
 // way to check if the placeholder is floating up. See isplaceholderUp.
 - (void)cleanupPlaceholderAnimationConstraints {
-  if (self.placeholderAnimationConstraintLeading.active && self.placeholderAnimationConstraintTop.active && self.placeholderAnimationConstraintTrailing.active) {
+  if (self.placeholderAnimationConstraintLeading.active &&
+      self.placeholderAnimationConstraintTop.active &&
+      self.placeholderAnimationConstraintTrailing.active) {
     return;
   }
   self.placeholderAnimationConstraints = nil;

--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -581,9 +581,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 // itself. That means these constraints need go away. So, we can use the existence of them as a
 // way to check if the placeholder is floating up. See isplaceholderUp.
 - (void)cleanupPlaceholderAnimationConstraints {
-  if (self.placeholderAnimationConstraintLeading.active &&
-      self.placeholderAnimationConstraintTop.active &&
-      self.placeholderAnimationConstraintTrailing.active) {
+  if (self.placeholderAnimationConstraintLeading.active && self.placeholderAnimationConstraintTop.active && self.placeholderAnimationConstraintTrailing.active) {
     return;
   }
   self.placeholderAnimationConstraints = nil;


### PR DESCRIPTION
## Steps to reproduce
Sometimes if the user taps or tabs quickly between multiple Text Fields on the same view, the floating placeholder remains stuck in the floating ("up") position.

## Expected Behavior
The order of operations when placeholder is animated down: 
1. Deactivating constraints
2. Animating down 
3. Clearing constraints.

The order of operations when placeholder is animated up:
1. Activating constraints 
2. Animating up.

## Actual Behavior
1. Deactivating constraints
2. Start animating down
3. Tap
4. Activating constraints
5. Start animating up
6. Clearing constraints.

So in the  "up" state, the placeholder ends up without constraints. As a result we see this bug.

## Screen capture of the behavior

|Before|After|
|---|---|
|![beforefix](https://user-images.githubusercontent.com/1753199/51116652-b8f64480-17d9-11e9-8c21-916e21cd8551.gif)|![afterfix](https://user-images.githubusercontent.com/1753199/51116674-c8758d80-17d9-11e9-8999-3979c24ef32d.gif)|

Fixes #3679
