### PR TITLE
[Tabs] Add willDisplayItem/didEndDisplayingItem methods to MDCTabBar.

### DIFF
--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -176,7 +176,7 @@ IB_DESIGNABLE
 
 /**
  Sets the color of the title for the specified state.
- 
+
  If the @c MDCTabBarItemState value is not set, then defaults to a default value. Therefore,
  at a minimum, you should set the value for MDCTabBarItemStateNormal.
  */
@@ -242,5 +242,23 @@ IB_DESIGNABLE
  changes to the tab bar's selected item.
  */
 - (void)tabBar:(nonnull MDCTabBar *)tabBar didSelectItem:(nonnull UITabBarItem *)item;
+
+/**
+ Called when the specified UITabBarItem is about to be displayed. Delegates can use this method
+ to detect when an item is going to appear on screen, as opposed to monitoring the view itself to
+ see when it becomes visible.
+ */
+- (void)tabBar:(nonnull MDCTabBar *)tabBar
+    willDisplayItem:(nonnull UITabBarItem *)item
+            atIndex:(NSInteger)index;
+
+/**
+ Called when the specified UITabBarItem is no longer displayed. Delegates can use this method
+ to detect when an item is removed from the screen, as opposed to monitoring the view itself to
+ see when it disappears.
+ */
+- (void)tabBar:(nonnull MDCTabBar *)tabBar
+    didEndDisplayingItem:(nonnull UITabBarItem *)item
+                 atIndex:(NSInteger)index;
 
 @end

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -417,6 +417,24 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   return shouldSelect;
 }
 
+- (void)itemBar:(nonnull MDCItemBar *)itemBar
+    willDisplayItem:(nonnull UITabBarItem *)item
+            atIndex:(NSInteger)index {
+  id<MDCTabBarDelegate> delegate = self.delegate;
+  if ([delegate respondsToSelector:@selector(tabBar:willDisplayItem:atIndex:)]) {
+    [delegate tabBar:self willDisplayItem:item atIndex:index];
+  }
+}
+
+- (void)itemBar:(nonnull MDCItemBar *)itemBar
+    didEndDisplayingItem:(nonnull UITabBarItem *)item
+                 atIndex:(NSInteger)index {
+  id<MDCTabBarDelegate> delegate = self.delegate;
+  if ([delegate respondsToSelector:@selector(tabBar:didEndDisplayingItem:atIndex:)]) {
+    [delegate tabBar:self didEndDisplayingItem:item atIndex:index];
+  }
+}
+
 #pragma mark - UIView
 
 - (void)tintColorDidChange {

--- a/components/Tabs/src/private/MDCItemBar.h
+++ b/components/Tabs/src/private/MDCItemBar.h
@@ -80,6 +80,7 @@
  selection changes.
  */
 @protocol MDCItemBarDelegate <NSObject>
+
 /**
  Called before the selected item changes by user action. This method is not called for programmatic
  changes to the bar's selected item. Return YES to allow the selection.
@@ -91,6 +92,24 @@
  changes to the bar's selected item.
  */
 - (void)itemBar:(nonnull MDCItemBar *)itemBar didSelectItem:(nonnull UITabBarItem *)item;
+
+/**
+ Called when the specified UITabBarItem is about to be displayed. Delegates can use this method
+ to detect when an item is going to appear on screen, as opposed to monitoring the view itself to
+ see when it becomes visible.
+ */
+- (void)itemBar:(nonnull MDCItemBar *)itemBar
+    willDisplayItem:(nonnull UITabBarItem *)item
+            atIndex:(NSInteger)index;
+
+/**
+ Called when the specified UITabBarItem is no longer displayed. Delegates can use this method
+ to detect when an item is removed from the screen, as opposed to monitoring the view itself to
+ see when it disappears.
+ */
+- (void)itemBar:(nonnull MDCItemBar *)itemBar
+    didEndDisplayingItem:(nonnull UITabBarItem *)item
+                 atIndex:(NSInteger)index;
 
 @end
 

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -379,6 +379,30 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   }
 }
 
+- (void)collectionView:(UICollectionView *)collectionView
+       willDisplayCell:(UICollectionViewCell *)cell
+    forItemAtIndexPath:(NSIndexPath *)indexPath {
+  // Notify the delegate of the tab bar item that will be displayed.
+  id<MDCItemBarDelegate> delegate = self.delegate;
+  if ([delegate respondsToSelector:@selector(itemBar:willDisplayItem:atIndex:)]) {
+    UITabBarItem *itemBarItem = [self itemAtIndexPath:indexPath];
+    NSInteger index = indexPath.item;
+    [delegate itemBar:self willDisplayItem:itemBarItem atIndex:index];
+  }
+}
+
+- (void)collectionView:(UICollectionView *)collectionView
+  didEndDisplayingCell:(UICollectionViewCell *)cell
+    forItemAtIndexPath:(NSIndexPath *)indexPath {
+  // Notify the delegate of the tab bar item which will no longer be displayed.
+  id<MDCItemBarDelegate> delegate = self.delegate;
+  if ([delegate respondsToSelector:@selector(itemBar:didEndDisplayingItem:atIndex:)]) {
+    UITabBarItem *itemBarItem = [self itemAtIndexPath:indexPath];
+    NSInteger index = indexPath.item;
+    [delegate itemBar:self didEndDisplayingItem:itemBarItem atIndex:index];
+  }
+}
+
 #pragma mark - UICollectionViewDataSource
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView


### PR DESCRIPTION
This is useful for notifying the users of when near UITabBarItems will
be (or did stop being) displayed. Users can then take actions such as
logging impressions of new tabs.
