### PR TITLE
[Dragons] Added missing imports to the dragons target

### DIFF
--- a/catalog/MDCDragons/MDCDragonsController.swift
+++ b/catalog/MDCDragons/MDCDragonsController.swift
@@ -16,7 +16,10 @@
 
 import CatalogByConvention
 
+import MaterialComponents.MaterialAppBar
 import MaterialComponents.MaterialFlexibleHeader
+import MaterialComponents.MaterialIcons_ic_chevron_right
+import MaterialComponents.MaterialKeyboardWatcher
 import MaterialComponents.MaterialLibraryInfo
 import MaterialComponents.MaterialShadowElevations
 import MaterialComponents.MaterialShadowLayer


### PR DESCRIPTION
Added missing imports to the dragons target

Related bug: #5526