### PR TITLE
[TextFields] Fix snapshot test imports.

### DIFF
--- a/components/TextFields/tests/snapshot/MDCAbstractTextFieldSnapshotTestsTests.m
+++ b/components/TextFields/tests/snapshot/MDCAbstractTextFieldSnapshotTestsTests.m
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #import <XCTest/XCTest.h>
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 
 @interface MDCAbstractTextFieldSnapshotTests (Testing)
 - (BOOL)shouldTestExecute;

--- a/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountArabicSnapshotTests.m
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
-#import "SnapshotFakeMDCMultilineTextField.h"
+#import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaOutlinedControllerBaselineCharacterCountArabicSnapshotTests
     : MDCAbstractTextFieldSnapshotTests <MDCTextFieldSnapshotTestCaseHooking>

--- a/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountArabicSnapshotTests.m
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaOutlinedControllerBaselineCharacterCountArabicSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountCyrillicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountCyrillicSnapshotTests.m
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaOutlinedControllerBaselineCharacterCountCyrillicSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountCyrillicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountCyrillicSnapshotTests.m
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
-#import "SnapshotFakeMDCMultilineTextField.h"
+#import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaOutlinedControllerBaselineCharacterCountCyrillicSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountHindiSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountHindiSnapshotTests.m
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaOutlinedControllerBaselineCharacterCountHindiSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountHindiSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountHindiSnapshotTests.m
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
-#import "SnapshotFakeMDCMultilineTextField.h"
+#import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaOutlinedControllerBaselineCharacterCountHindiSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountKoreanSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountKoreanSnapshotTests.m
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
-#import "SnapshotFakeMDCMultilineTextField.h"
+#import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaOutlinedControllerBaselineCharacterCountKoreanSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountKoreanSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountKoreanSnapshotTests.m
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaOutlinedControllerBaselineCharacterCountKoreanSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountSnapshotTests.m
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
-#import "SnapshotFakeMDCMultilineTextField.h"
+#import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaOutlinedControllerBaselineCharacterCountSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerBaselineCharacterCountSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaOutlinedControllerBaselineCharacterCountSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
-#import "SnapshotFakeMDCMultilineTextField.h"
+#import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaOutlinedControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests
 @end

--- a/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaOutlinedControllerSnapshotTests.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaOutlinedControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountArabicSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
-#import "SnapshotFakeMDCMultilineTextField.h"
+#import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaUnderlinedControllerCharacterCountArabicSnapshotTests
     : MDCAbstractTextFieldSnapshotTests <MDCTextFieldSnapshotTestCaseHooking>

--- a/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountArabicSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 #import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaUnderlinedControllerCharacterCountArabicSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountCyrillicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountCyrillicSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 #import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaUnderlinedControllerCharacterCountCyrillicSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountCyrillicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountCyrillicSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
-#import "SnapshotFakeMDCMultilineTextField.h"
+#import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaUnderlinedControllerCharacterCountCyrillicSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountHindiSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountHindiSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 #import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaUnderlinedControllerCharacterCountHindiSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountHindiSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountHindiSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
-#import "SnapshotFakeMDCMultilineTextField.h"
+#import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaUnderlinedControllerCharacterCountHindiSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountKoreanSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountKoreanSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
-#import "SnapshotFakeMDCMultilineTextField.h"
+#import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaUnderlinedControllerCharacterCountKoreanSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountKoreanSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountKoreanSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 #import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaUnderlinedControllerCharacterCountKoreanSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountSnapshotTests.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaUnderlinedControllerCharacterCountSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextAreaUnderlinedControllerCharacterCountSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
-#import "SnapshotFakeMDCMultilineTextField.h"
+#import "supplemental/SnapshotFakeMDCMultilineTextField.h"
 
 @interface MDCTextAreaUnderlinedControllerCharacterCountSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageArabicSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerLeadingImageArabicSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageArabicSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerLeadingImageArabicSnapshotTests
     : MDCAbstractTextFieldSnapshotTests <MDCTextFieldSnapshotTestCaseHooking>

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageCyrillicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageCyrillicSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerLeadingImageCyrillicSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageCyrillicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageCyrillicSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerLeadingImageCyrillicSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageHindiSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageHindiSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerLeadingImageHindiSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageHindiSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageHindiSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerLeadingImageHindiSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageKoreanSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageKoreanSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerLeadingImageKoreanSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageKoreanSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageKoreanSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerLeadingImageKoreanSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageSnapshotTests.m
@@ -14,9 +14,9 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCTextFieldSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerLeadingImageSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerLeadingImageSnapshotTests.m
@@ -14,10 +14,10 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "supplemental/MDCTextFieldSnapshotTestsStrings.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerLeadingImageSnapshotTests : MDCAbstractTextFieldSnapshotTests
 @end

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerSnapshotTests.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCTextFieldSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledControllerSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "supplemental/MDCTextFieldSnapshotTestsStrings.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests
 @end

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerBaselineSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 
 @interface MDCTextFieldFilledFloatingControllerBaselineSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageArabicSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerLeadingImageArabicSnapshotTests
     : MDCAbstractTextFieldSnapshotTests <MDCTextFieldSnapshotTestCaseHooking>

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageArabicSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerLeadingImageArabicSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageCyrillicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageCyrillicSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerLeadingImageCyrillicSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageCyrillicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageCyrillicSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerLeadingImageCyrillicSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageHindiSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageHindiSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerLeadingImageHindiSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageHindiSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageHindiSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerLeadingImageHindiSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageKoreanSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageKoreanSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerLeadingImageKoreanSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageKoreanSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageKoreanSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerLeadingImageKoreanSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "supplemental/MDCTextFieldSnapshotTestsStrings.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerLeadingImageSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerLeadingImageSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCTextFieldSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerLeadingImageSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerSnapshotTests.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCTextFieldSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFilledFloatingControllerSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "supplemental/MDCTextFieldSnapshotTestsStrings.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFilledFloatingControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests
 @end

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthCharacterCountSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthCharacterCountSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "supplemental/MDCTextFieldSnapshotTestsStrings.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthCharacterCountSnapshotTests : MDCAbstractTextFieldSnapshotTests
 @end

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthCharacterCountSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthCharacterCountSnapshotTests.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCTextFieldSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthCharacterCountSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageArabicSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthControllerLeadingImageArabicSnapshotTests
     : MDCAbstractTextFieldSnapshotTests <MDCTextFieldSnapshotTestCaseHooking>

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageArabicSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthControllerLeadingImageArabicSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageCyrillicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageCyrillicSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthControllerLeadingImageCyrillicSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageCyrillicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageCyrillicSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthControllerLeadingImageCyrillicSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageHindiSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageHindiSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthControllerLeadingImageHindiSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageHindiSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageHindiSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthControllerLeadingImageHindiSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageKoreanSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageKoreanSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthControllerLeadingImageKoreanSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageKoreanSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageKoreanSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthControllerLeadingImageKoreanSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCTextFieldSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthControllerLeadingImageSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerLeadingImageSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "supplemental/MDCTextFieldSnapshotTestsStrings.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthControllerLeadingImageSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerSnapshotTests.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCTextFieldSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldFullWidthControllerSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "supplemental/MDCTextFieldSnapshotTestsStrings.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldFullWidthControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests
 @end

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests.m
@@ -14,9 +14,10 @@
 
 #import <XCTest/XCTest.h>
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
+#import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 
 /**
  Snapshot tests for MDCTextInputControllerOutlined with:

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineCharacterCountSnapshotTests.m
@@ -14,7 +14,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageArabicSnapshotTests.m
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 
 @interface MDCTextFieldOutlinedControllerBaselineLeadingImageArabicSnapshotTests
     : MDCAbstractTextFieldSnapshotTests <MDCTextFieldSnapshotTestCaseHooking>

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageArabicSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageCyrillicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageCyrillicSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageCyrillicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageCyrillicSnapshotTests.m
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 
 @interface MDCTextFieldOutlinedControllerBaselineLeadingImageCyrillicSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageHindiSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageHindiSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageHindiSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageHindiSnapshotTests.m
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 
 @interface MDCTextFieldOutlinedControllerBaselineLeadingImageHindiSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageKoreanSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageKoreanSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageKoreanSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageKoreanSnapshotTests.m
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 
 @interface MDCTextFieldOutlinedControllerBaselineLeadingImageKoreanSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageSnapshotTests.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineLeadingImageSnapshotTests.m
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 
 @interface MDCTextFieldOutlinedControllerBaselineLeadingImageSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerBaselineSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields+ColorThemer.h"
 #import "MaterialTextFields+TypographyThemer.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 
 @interface MDCTextFieldOutlinedControllerBaselineSnapshotTests : MDCAbstractTextFieldSnapshotTests
 @end

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "supplemental/MDCTextFieldSnapshotTestsStrings.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldOutlinedControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests
 @end

--- a/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldOutlinedControllerSnapshotTests.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests.h"
-#import "MDCTextFieldSnapshotTestsStrings.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCTextFieldSnapshotTestsStrings.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldOutlinedControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerCharacterCountSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerCharacterCountSnapshotTests.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedControllerCharacterCountSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerCharacterCountSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerCharacterCountSnapshotTests.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 
 @interface MDCTextFieldUnderlinedControllerCharacterCountSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedControllerLeadingImageArabicSnapshotTests
     : MDCAbstractTextFieldSnapshotTests <MDCTextFieldSnapshotTestCaseHooking>

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageCyrillicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageCyrillicSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedControllerLeadingImageCyrillicSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageCyrillicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageCyrillicSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedControllerLeadingImageCyrillicSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageHindiSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageHindiSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedControllerLeadingImageHindiSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageHindiSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageHindiSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedControllerLeadingImageHindiSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageKoreanSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageKoreanSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedControllerLeadingImageKoreanSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageKoreanSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageKoreanSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedControllerLeadingImageKoreanSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedControllerLeadingImageSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerLeadingImageSnapshotTests.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedControllerLeadingImageSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerSnapshotTests.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 
 @interface MDCTextFieldUnderlinedControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests
 @end

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedControllerSnapshotTests.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageArabicSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedFloatingControllerLeadingImageArabicSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageArabicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageArabicSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedFloatingControllerLeadingImageArabicSnapshotTests
     : MDCAbstractTextFieldSnapshotTests <MDCTextFieldSnapshotTestCaseHooking>

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageCyrillicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageCyrillicSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedFloatingControllerLeadingImageCyrillicSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageCyrillicSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageCyrillicSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedFloatingControllerLeadingImageCyrillicSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageHindiSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageHindiSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedFloatingControllerLeadingImageHindiSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageHindiSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageHindiSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedFloatingControllerLeadingImageHindiSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageKoreanSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageKoreanSnapshotTests.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedFloatingControllerLeadingImageKoreanSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageKoreanSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageKoreanSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+I18N.h"
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+I18N.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedFloatingControllerLeadingImageKoreanSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageSnapshotTests.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedFloatingControllerLeadingImageSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerLeadingImageSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialTextFields.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests+LeadingImage.h"
 #import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
-#import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedFloatingControllerLeadingImageSnapshotTests
     : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerSnapshotTests.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCAbstractTextFieldSnapshotTests.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
 
 @interface MDCTextFieldUnderlinedFloatingControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests

--- a/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCTextFieldUnderlinedFloatingControllerSnapshotTests.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 #import "MaterialTextFields.h"
+#import "supplemental/MDCAbstractTextFieldSnapshotTests.h"
 
 @interface MDCTextFieldUnderlinedFloatingControllerSnapshotTests : MDCAbstractTextFieldSnapshotTests
 

--- a/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCAbstractTextFieldSnapshotTests.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <Foundation/Foundation.h>
+
 #import "MDCTextFieldSnapshotTestCase.h"
 #import "MaterialTextFields.h"
 

--- a/components/TextFields/tests/snapshot/supplemental/MDCSnapshotFakeTextInput.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCSnapshotFakeTextInput.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 #import "MaterialTextFields.h"
 

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.h
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
 #import "MaterialSnapshot.h"

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestCase.m
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <CoreGraphics/CoreGraphics.h>
+#import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
 #import "MDCTextFieldSnapshotTestCase.h"

--- a/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestsStrings.h
+++ b/components/TextFields/tests/snapshot/supplemental/MDCTextFieldSnapshotTestsStrings.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <Foundation/Foundation.h>
+
 #pragma mark - Latin text
 
 static NSString *const MDCTextFieldSnapshotTestsPlaceholderShortTextLatin = @"P text";

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.h
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.h
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <UIKit/UIKit.h>
-
 #import "MDCSnapshotFakeTextInput.h"
 #import "MaterialTextFields.h"
 

--- a/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.m
+++ b/components/TextFields/tests/snapshot/supplemental/SnapshotFakeMDCTextField.m
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#import <UIKit/UIKit.h>
 
 #import "SnapshotFakeMDCTextField.h"
 #import <MDFInternationalization/MDFInternationalization.h>


### PR DESCRIPTION
In order to prepare snapshot tests to compile using bazel, all of the
import statements need to be fixed to use the correct paths.

Part of #6287