### PR TITLE
[Snapshot] Add test host for snapshot tests.

### DIFF
--- a/components/private/Snapshot/TestHost/BUILD
+++ b/components/private/Snapshot/TestHost/BUILD
@@ -11,13 +11,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-load("//:material_components_ios.bzl", "mdc_public_objc_library")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
+load("//:material_components_ios.bzl", "mdc_objc_library")
 
 licenses(["notice"])  # Apache 2.0
 
-mdc_public_objc_library(
-    name = "TestHost",
+mdc_objc_library(
+    name = "test_host_lib",
+    srcs = native.glob([
+        "src/*.m",
+    ]),
+    hdrs = native.glob([
+        "src/*.h",
+    ]),
+    enable_modules = 1,
 )
 
-exports_files(["TestHost-Info.plist"])
+ios_application(
+    name = "TestHost",
+    infoplists = ["TestHost-Info.plist"],
+    families = ["iphone"],
+    bundle_id = "io.material.ios.snapshot",
+    testonly = 1,
+    deps = [":test_host_lib"],
+    visibility = ["//components:__subpackages__"],
+    minimum_os_version = "10.0.0"
+)
+

--- a/components/private/Snapshot/TestHost/BUILD
+++ b/components/private/Snapshot/TestHost/BUILD
@@ -1,0 +1,27 @@
+# Copyright 2019-present The Material Components for iOS Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "//:material_components_ios.bzl",
+    "mdc_public_objc_library",
+)
+
+licenses(["notice"])  # Apache 2.0
+
+mdc_public_objc_library(
+    name = "TestHost",
+)
+
+exports_files(["TestHost-Info.plist"])
+

--- a/components/private/Snapshot/TestHost/BUILD
+++ b/components/private/Snapshot/TestHost/BUILD
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load(
-    "//:material_components_ios.bzl",
-    "mdc_public_objc_library",
-)
+load("//:material_components_ios.bzl", "mdc_public_objc_library")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -24,4 +21,3 @@ mdc_public_objc_library(
 )
 
 exports_files(["TestHost-Info.plist"])
-

--- a/components/private/Snapshot/TestHost/TestHost-Info.plist
+++ b/components/private/Snapshot/TestHost/TestHost-Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+</dict>
+</plist>

--- a/components/private/Snapshot/TestHost/src/TestHostMinimalDelegate.h
+++ b/components/private/Snapshot/TestHost/src/TestHostMinimalDelegate.h
@@ -1,0 +1,18 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+#import <UIKit/UIKit.h>
+
+// No-op delegate sufficient to satisfy UIApplicationMain.
+@interface TestHostMinimalDelegate : UIResponder <UIApplicationDelegate>
+@end

--- a/components/private/Snapshot/TestHost/src/TestHostMinimalDelegate.m
+++ b/components/private/Snapshot/TestHost/src/TestHostMinimalDelegate.m
@@ -1,0 +1,17 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+#import "TestHostMinimalDelegate.h"
+
+@implementation TestHostMinimalDelegate
+@end

--- a/components/private/Snapshot/TestHost/src/main.m
+++ b/components/private/Snapshot/TestHost/src/main.m
@@ -15,6 +15,6 @@
 
 int main(int argc, char *argv[]) {
   @autoreleasepool {
-    return UIApplicationMain( argc, argv, nil, NSStringFromClass([TestHostMinimalDelegate class]));
+    return UIApplicationMain(argc, argv, nil, NSStringFromClass([TestHostMinimalDelegate class]));
   }
 }

--- a/components/private/Snapshot/TestHost/src/main.m
+++ b/components/private/Snapshot/TestHost/src/main.m
@@ -1,0 +1,20 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+#import "TestHostMinimalDelegate.h"
+
+int main(int argc, char *argv[]) {
+  @autoreleasepool {
+    return UIApplicationMain( argc, argv, nil, NSStringFromClass([TestHostMinimalDelegate class]));
+  }
+}


### PR DESCRIPTION
Snapshot test targets built with bazel will require a test host. Rather
than compiling/launching the entire catalog, a simple test host can be
used. The test host has no actual functionality other than to respond to
UIApplicationDelegate.

Part of #6287
