### PR TITLE
[Snapshot] Fix CGFloat cast.

### DIFF
--- a/components/private/Snapshot/src/UIView+MDCSnapshot.m
+++ b/components/private/Snapshot/src/UIView+MDCSnapshot.m
@@ -24,7 +24,7 @@
   UIView *backgroundView = [[UIView alloc]
       initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.bounds) + insets.left + insets.right,
                                CGRectGetHeight(self.bounds) + insets.top + insets.bottom)];
-  backgroundView.backgroundColor = [UIColor colorWithWhite:0.8 alpha:1];
+  backgroundView.backgroundColor = [UIColor colorWithWhite:(CGFloat)0.8 alpha:1];
   [backgroundView addSubview:self];
 
   CGRect frame = self.frame;


### PR DESCRIPTION
One CGFloat value was being passed as a double. This causes build errors
with bazel which is more strict than Xcode.

Prework for #6287
