### PR TITLE
[testing] {kokoro} Add snapshot testing rule.

### DIFF
--- a/components/testing/runners/BUILD
+++ b/components/testing/runners/BUILD
@@ -15,6 +15,13 @@ ios_test_runner(
 )
 
 ios_test_runner(
+    name = "IPHONE_7_IN_11_2",
+    device_type = "iPhone 7",
+    os_version = "11.2",
+    visibility = ["//visibility:public"],
+)
+
+ios_test_runner(
     name = "IPHONE_7_PLUS_IN_10_3",
     device_type = "iPhone 7 Plus",
     os_version = "10.3",

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -2,11 +2,7 @@
 
 load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
 load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
-load("@build_bazel_rules_apple//apple:ios.bzl", 
-    "ios_application",
-    "ios_unit_test",
-    "ios_unit_test_suite"
-)
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test", "ios_unit_test_suite")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 IOS_MINIMUM_OS = "8.0"

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -2,10 +2,15 @@
 
 load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
 load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test_suite")
+load("@build_bazel_rules_apple//apple:ios.bzl", 
+    "ios_application",
+    "ios_unit_test",
+    "ios_unit_test_suite"
+)
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 IOS_MINIMUM_OS = "8.0"
+SNAPSHOT_IOS_MINIMUM_OS = "10.0"
 
 DEFAULT_IOS_RUNNER_TARGETS = [
     "//components/testing/runners:IPHONE_5_IN_8_1",
@@ -13,6 +18,8 @@ DEFAULT_IOS_RUNNER_TARGETS = [
     "//components/testing/runners:IPHONE_7_PLUS_IN_10_3",
     "//components/testing/runners:IPHONE_X_IN_11_0",
 ]
+
+SNAPSHOT_IOS_RUNNER_TARGET = "//components/testing/runners:IPHONE_7_IN_11_2"
 
 def mdc_objc_library(
     name,
@@ -162,6 +169,24 @@ def mdc_examples_swift_library(
           "examples/*.swift",
           "examples/supplemental/*.swift",
       ]),
+      **kwargs)
+
+def mdc_snapshot_test(
+    name,
+    deps = [],
+    minimum_os_version = SNAPSHOT_IOS_MINIMUM_OS,
+    visibility = ["//visibility:private"],
+    size = "medium",
+    **kwargs):
+  """Declare an MDC ios_unit_test for snapshot tests."""
+  ios_unit_test(
+      name = name,
+      deps = deps,
+      minimum_os_version = minimum_os_version,
+      runner = SNAPSHOT_IOS_RUNNER_TARGET,
+      test_host = "//components/private/Snapshot/TestHost",
+      visibility = visibility,
+      size = size,
       **kwargs)
 
 def mdc_unit_test_suite(


### PR DESCRIPTION
Creates a new snapshot testing rule that can depend on the tests and
component under test and uses the components/private/Snapshot/TestHost
as the test_host.

Part of #6287
