### PR TITLE
{bazel} Add ios-snapshot-test-case remote repository.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -88,3 +88,9 @@ git_repository(
     remote = "https://github.com/material-motion/motion-transitioning-objc.git",
     tag = "v6.0.0",
 )
+
+git_repository(
+    name = "ios_snapshot_test_case",
+    remote = "https://github.com/material-foundation/ios-snapshot-test-case",
+    commit = "21e2d45c7e9c7208ee61788380521b4044b96ec1",
+)


### PR DESCRIPTION
Adding this repository allows targets to depend on the ios-snapshot-test-case
library. This is a step in getting snapshot tests running in bazel.

Part of #6287