### PR TITLE
[Snapshot] Add BUILD file.

### DIFF
--- a/components/private/Snapshot/BUILD
+++ b/components/private/Snapshot/BUILD
@@ -1,0 +1,28 @@
+# Copyright 2019-present The Material Components for iOS Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "//:material_components_ios.bzl",
+    "mdc_objc_library",
+    "mdc_public_objc_library",
+)
+
+licenses(["notice"])  # Apache 2.0
+
+mdc_public_objc_library(
+    name = "Snapshot",
+    deps = [
+        "@ios_snapshot_test_case//:SnapshotTestCase",
+    ],
+)


### PR DESCRIPTION
Creating a BUILD file and public "Snapshot" target for clients to depend on.
The primary use of this target will be in material_components_ios.bzl to
generate snapshot build rules.

Closes #6230