### PR TITLE
{kokoro} Detect snapshot tests missing bazel support.

### DIFF
--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -61,8 +61,6 @@ modified_files() {
 
   git diff --name-only "${range}" \
     | grep -E '(\.swift|\.h|\.m)$' \
-    | grep -vE '\/tests\/snapshot\/' \
-    | grep -vE '^components\/private\/Snapshot\/' \
     | sort \
     | uniq
 


### PR DESCRIPTION
Now that bazel builds support snapshot test targets, we should detect and
fail when they are missing from a bazel target.
