### PR TITLE
{kokoro} Deflake snapshot tests on kokoro

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -306,6 +306,12 @@ run_bazel() {
     brew_install git-lfs
     git lfs install
     git lfs pull
+
+    # Reset the simulators to prepare for hosted snapshot tests
+    sim_cleaner_tmp=$(mktemp -d)
+    git clone https://github.com/material-foundation/ios-simulator-utils.git "$sim_cleaner_tmp"
+    source "${sim_cleaner_tmp}/scripts/cleanup_simulators.sh"
+    perform_pre_test_cleanup "iPhone"
   fi
 
   bazel $COMMAND $TARGET --xcode_version $xcode_version --ios_minimum_os=8.0 \

--- a/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
+++ b/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0AB2C042ABFBEAC086DC600CF04E7AEE"
+               BlueprintIdentifier = "25495DCFCDCBCF0CCE0EC64D3F2E19BA"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -47,7 +47,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "90AD8DD5E9A01B04B8F90EAD5E4DDC12"
+               BlueprintIdentifier = "18BDFA6090F84FC5BFB2E47E5F312D3B"
                BuildableName = "MaterialComponents-Unit-Tests.xctest"
                BlueprintName = "MaterialComponents-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -57,19 +57,17 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "66CCE84B4769BC018886C9B17F690F61"
+               BlueprintIdentifier = "E5193D9A97F109A741C961A050A72910"
                BuildableName = "MaterialComponentsBeta-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES"
-            testExecutionOrdering = "random">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0AB2C042ABFBEAC086DC600CF04E7AEE"
+               BlueprintIdentifier = "25495DCFCDCBCF0CCE0EC64D3F2E19BA"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">

--- a/catalog/MDCDragons.xcodeproj/xcshareddata/xcschemes/MDCDragons.xcscheme
+++ b/catalog/MDCDragons.xcodeproj/xcshareddata/xcschemes/MDCDragons.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0AB2C042ABFBEAC086DC600CF04E7AEE"
+               BlueprintIdentifier = "25495DCFCDCBCF0CCE0EC64D3F2E19BA"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -46,7 +46,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "90AD8DD5E9A01B04B8F90EAD5E4DDC12"
+               BlueprintIdentifier = "18BDFA6090F84FC5BFB2E47E5F312D3B"
                BuildableName = "MaterialComponents-Unit-Tests.xctest"
                BlueprintName = "MaterialComponents-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -56,19 +56,17 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "66CCE84B4769BC018886C9B17F690F61"
+               BlueprintIdentifier = "E5193D9A97F109A741C961A050A72910"
                BuildableName = "MaterialComponentsBeta-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES"
-            testExecutionOrdering = "random">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0AB2C042ABFBEAC086DC600CF04E7AEE"
+               BlueprintIdentifier = "25495DCFCDCBCF0CCE0EC64D3F2E19BA"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-Tests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">

--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -115,6 +115,9 @@ mdc_snapshot_objc_library(
 
 mdc_snapshot_test(
     name = "snapshot_tests",
+    # Tests have sometimes taken more than 5 minutes to launch the simulator
+    # and execute
+    timeout = "long",
     deps = ["snapshot_test_lib"],
 )
 

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -205,6 +205,8 @@ def mdc_snapshot_test(
       runner = SNAPSHOT_IOS_RUNNER_TARGET,
       test_host = "//components/private/Snapshot/TestHost",
       visibility = visibility,
+      # TODO(https://github.com/material-components/material-components-ios/issues/6335)
+      flaky = 1,
       size = size,
       **kwargs)
 


### PR DESCRIPTION
Snapshot tests were timing-out because of two causes:
1. Simulators were not starting up correctly
2. Text Fields snapshot tests were taking too long.
3. Snapshot tests were sometimes taking longer than 1 second.

The solutions to these problems seem to be:
1. Reset and pre-start simulators before calling bazel
2. Increasing the time-out for text fields snapshot tests
3. Turning off parallel snapshot tests to prevent CPU/resource starvation for tests.

Work-around for #6335