### PR TITLE
[TextFields] Increase snapshot test timeout.

### DIFF
--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -115,6 +115,9 @@ mdc_snapshot_objc_library(
 
 mdc_snapshot_test(
     name = "snapshot_tests",
+    # Tests have sometimes taken more than 5 minutes to launch the simulator
+    # and execute
+    timeout = "long",
     deps = ["snapshot_test_lib"],
 )
 


### PR DESCRIPTION
Since they appear to be taking more than 5 minutes (including simulator
start-up) we can increase the timeout a bit and get them to complete
rather than failing entirely.

