### PR TITLE
[Ink] Reduce flakiness of layer timing test.

### DIFF
--- a/components/Ink/tests/unit/MDCInkLayerTests.m
+++ b/components/Ink/tests/unit/MDCInkLayerTests.m
@@ -93,7 +93,7 @@
   // Given
   CapturingMDCInkLayerSubclass *inkLayer = [[CapturingMDCInkLayerSubclass alloc] init];
   inkLayer.bounds = CGRectMake(0, 0, 10, 10);
-  inkLayer.speed = (CGFloat)0.5;
+  inkLayer.speed = (float)0.0025;
   inkLayer.endAnimationDelay = (CGFloat)0.9;
 
   // When
@@ -113,7 +113,7 @@
   // Given
   CapturingMDCInkLayerSubclass *inkLayer = [[CapturingMDCInkLayerSubclass alloc] init];
   inkLayer.bounds = CGRectMake(0, 0, 10, 10);
-  inkLayer.speed = (CGFloat)0.5;
+  inkLayer.speed = (float)0.0025;
 
   // When
   [inkLayer changeAnimationAtPoint:CGPointMake(5, 5)];


### PR DESCRIPTION
The scaled animation tests were very sensitive to test environment
delays. By reducing the speed of the layer, the tests can be less
sensitive to test-related delays but would still calculate the scaled
effect accurately.