### PR TITLE
[FeatureHighlight] Add examples to BUILD file

### DIFF
--- a/components/FeatureHighlight/BUILD
+++ b/components/FeatureHighlight/BUILD
@@ -98,7 +98,7 @@ mdc_examples_objc_library(
         ":FeatureHighlight",
         ":FeatureHightlightAccessibilityMutator",
         "//components/Buttons",
-        "//components/Buttons+Theming",
+        "//components/Buttons:Theming",
         "//components/Buttons:ButtonThemer",
         "//components/Collections",
         "//components/Palettes",

--- a/components/FeatureHighlight/BUILD
+++ b/components/FeatureHighlight/BUILD
@@ -96,7 +96,7 @@ mdc_examples_objc_library(
         ":ColorThemer",
         ":TypographyThemer",
         ":FeatureHighlight",
-        ":FeatureHightlightAccessibilityMutator",
+        ":FeatureHighlightAccessibilityMutator",
         "//components/Buttons",
         "//components/Buttons:Theming",
         "//components/Buttons:ButtonThemer",

--- a/components/FeatureHighlight/BUILD
+++ b/components/FeatureHighlight/BUILD
@@ -15,6 +15,8 @@
 
 load(
     "//:material_components_ios.bzl",
+    "mdc_examples_objc_library",
+    "mdc_examples_swift_library",
     "mdc_extension_objc_library",
     "mdc_objc_library",
     "mdc_public_objc_library",
@@ -86,6 +88,39 @@ mdc_objc_library(
     hdrs = native.glob(["src/private/*.h"]),
     includes = ["src/private"],
     visibility = ["//visibility:private"],
+)
+
+mdc_examples_objc_library(
+    name = "ObjcExamples",
+    deps = [
+        ":ColorThemer",
+        ":TypographyThemer",
+        ":FeatureHighlight",
+        ":FeatureHightlightAccessibilityMutator",
+        "//components/Buttons",
+        "//components/Buttons+Theming",
+        "//components/Buttons:ButtonThemer",
+        "//components/Collections",
+        "//components/Palettes",
+        "//components/private/Math",
+        "//components/schemes/Color",
+        "//components/schemes/Container",
+        "//components/schemes/Typography",
+        "//components/Typography",
+    ],
+)
+
+mdc_examples_swift_library(
+    name = "SwiftExamples",
+    deps = [
+        ":FeatureHighlight",
+        ":ColorThemer",
+        ":TypographyThemer",
+        "//components/Buttons",
+        "//components/Buttons:ButtonThemer",
+        "//components/schemes/Color",
+        "//components/schemes/Typography",
+    ],
 )
 
 mdc_objc_library(

--- a/components/FeatureHighlight/BUILD
+++ b/components/FeatureHighlight/BUILD
@@ -94,27 +94,27 @@ mdc_examples_objc_library(
     name = "ObjcExamples",
     deps = [
         ":ColorThemer",
-        ":TypographyThemer",
         ":FeatureHighlight",
         ":FeatureHighlightAccessibilityMutator",
+        ":TypographyThemer",
         "//components/Buttons",
-        "//components/Buttons:Theming",
         "//components/Buttons:ButtonThemer",
+        "//components/Buttons:Theming",
         "//components/Collections",
         "//components/Palettes",
+        "//components/Typography",
         "//components/private/Math",
         "//components/schemes/Color",
         "//components/schemes/Container",
         "//components/schemes/Typography",
-        "//components/Typography",
     ],
 )
 
 mdc_examples_swift_library(
     name = "SwiftExamples",
     deps = [
-        ":FeatureHighlight",
         ":ColorThemer",
+        ":FeatureHighlight",
         ":TypographyThemer",
         "//components/Buttons",
         "//components/Buttons:ButtonThemer",

--- a/components/FeatureHighlight/examples/FeatureHightlightTypicalUseViewController.swift
+++ b/components/FeatureHighlight/examples/FeatureHightlightTypicalUseViewController.swift
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import MaterialComponents.MaterialButtons_ButtonThemer
+import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialFeatureHighlight
 import MaterialComponents.MaterialFeatureHighlight_ColorThemer
 import MaterialComponents.MaterialFeatureHighlight_TypographyThemer
-import MaterialComponents.MaterialButtons_ButtonThemer
+import MaterialComponents.MaterialTypographyScheme
 
 /// Example to show how to use a feature highlight
 class FeatureHighlightSwiftViewController: UIViewController {


### PR DESCRIPTION
This change is the part of the move to add all examples to `BUILD` files, this additionally adds the missing imports in the `.swift` example.
Closes #6213 

