### PR TITLE
[BottomAppBar] Add examples to BUILD file

### DIFF
--- a/components/BottomAppBar/BUILD
+++ b/components/BottomAppBar/BUILD
@@ -79,7 +79,7 @@ mdc_examples_swift_library(
         ":BottomAppBar",
         ":ColorThemer",
         "//components/AppBar",
-        "//components/Button:ButtonThemer",
+        "//components/Buttons:ButtonThemer",
         "//components/Buttons",
         "//components/schemes/Color",
         "//components/schemes/Typography",

--- a/components/BottomAppBar/BUILD
+++ b/components/BottomAppBar/BUILD
@@ -15,6 +15,8 @@
 
 load(
     "//:material_components_ios.bzl",
+    "mdc_examples_objc_library",
+    "mdc_examples_swift_library",
     "mdc_extension_objc_library",
     "mdc_objc_library",
     "mdc_public_objc_library",
@@ -52,6 +54,35 @@ mdc_extension_objc_library(
         ":BottomAppBar",
         "//components/Themes",
         "//components/schemes/Color",
+    ],
+)
+
+mdc_examples_objc_library(
+    name = "ObjcExamples",
+    deps = [
+        ":BottomAppBar",
+        ":ColorThemer",
+        "//components/AppBar",
+        "//components/AppBar:ColorThemer",
+        "//components/AppBar:TypographyThemer",
+        "//components/Buttons",
+        "//components/Buttons:Theming",
+        "//components/schemes/Color",
+        "//components/schemes/Container",
+        "//components/schemes/Typography",
+    ],
+)
+
+mdc_examples_swift_library(
+    name = "SwiftExamples",
+    deps = [
+        ":BottomAppBar",
+        ":ColorThemer",
+        "//components/AppBar",
+        "//components/Button:ButtonThemer",
+        "//components/Buttons",
+        "//components/schemes/Color",
+        "//components/schemes/Typography",
     ],
 )
 

--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.m
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.m
@@ -17,6 +17,7 @@
 #import "MaterialBottomAppBar+ColorThemer.h"
 #import "MaterialBottomAppBar.h"
 #import "MaterialButtons+Theming.h"
+#import "MaterialContainerScheme.h"
 
 #import "supplemental/BottomAppBarTypicalUseSupplemental.h"
 

--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
@@ -18,6 +18,9 @@ import UIKit
 import MaterialComponents.MaterialAppBar
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialBottomAppBar_ColorThemer
+import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialTypographyScheme
 import MaterialComponents.MaterialButtons_ButtonThemer
 
 class BottomAppBarTypicalUseSwiftExample: UIViewController {


### PR DESCRIPTION
This change is the part of the move to add all examples to `BUILD` files, this additionally adds the missing imports in the examples.
Closes #6223 