### PR TITLE
{Releasing} Exempt `.gitattributes` from merges.  

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Do not add git-lfs attributes to this files. It causes problems with Cocoapods.
 # snapshot_test_goldens/**/*.png filter=lfs diff=lfs merge=lfs -text
+.gitattributes merge=gitattributes


### PR DESCRIPTION
We have two different versions of `.gitattributes` in the `develop` and
`stable` branches. To avoid conflicts (or accidental merges) between the two
branches, we define a custom merge strategy just for that file.  During weekly
releases (or hotfixes), just after cloning the repository, the release
engineer should run this command:

```bash
git config merge.gitattributes.driver true
```

Follow-up to #5956