### PR TITLE
[FlexibleHeader] Allow touch events in header to pass through

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -398,9 +398,9 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
   UIView *hitView = [super hitTest:point withEvent:event];
 
-  // Forwards taps to the scroll view.
-  if (hitView == self || (_contentView != nil && hitView == _contentView)
-      || [_forwardingViews containsObject:hitView]) {
+  if (hitView == self || (_contentView != nil && hitView == _contentView)) {
+    hitView = nil;
+  } else if ([_forwardingViews containsObject:hitView]) {
     hitView = _trackingScrollView;
   }
 


### PR DESCRIPTION
Make `MDCFlexibleHeaderView` and it's `contentView` pass touch event to higher hierarchy.

This allows translucent header to overlay interactive view.

## example view hierachy
where header is between two interactive view
- View
  - Carousel
  - Header (pass through)
    - contentView (pass through)
    - userHeaderView (hitTest overriden)
  - Card

possible breaking change of #3032