### PR TITLE
[TextFields] Add TextField examples to BUILD file

### DIFF
--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -82,8 +82,8 @@ mdc_extension_objc_library(
 mdc_examples_objc_library(
     name = "ObjcExamples",
     deps = [
-        ":TextFields"
         ":ColorThemer",
+        ":TextFields",
         ":TypographyThemer",
     ],
 )
@@ -108,12 +108,12 @@ mdc_objc_library(
 
 mdc_snapshot_objc_library(
     name = "snapshot_test_lib",
+    asset_catalogs = [
+        "tests/snapshot/resources/TextFieldsSnapshotTests.xcassets/ic_done.imageset",
+        "tests/snapshot/resources/TextFieldsSnapshotTests.xcassets/ic_search.imageset",
+    ],
     sdk_frameworks = [
         "CoreGraphics",
-    ],
-    asset_catalogs = [
-      "tests/snapshot/resources/TextFieldsSnapshotTests.xcassets/ic_done.imageset",
-      "tests/snapshot/resources/TextFieldsSnapshotTests.xcassets/ic_search.imageset",
     ],
     deps = [
         ":ColorThemer",

--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -14,6 +14,7 @@
 
 load(
     "//:material_components_ios.bzl",
+    "mdc_examples_objc_library",
     "mdc_extension_objc_library",
     "mdc_objc_library",
     "mdc_public_objc_library",
@@ -75,6 +76,15 @@ mdc_extension_objc_library(
     deps = [
         ":TextFields",
         "//components/schemes/Typography",
+    ],
+)
+
+mdc_examples_objc_library(
+    name = "ObjcExamples",
+    deps = [
+        ":TextFields"
+        ":ColorThemer",
+        ":TypographyThemer",
     ],
 )
 


### PR DESCRIPTION
This PR adds the **MDCTextField** examples to the BUILD file. I didn't add SimpleTextField stuff to the BUILD file because it's going to change when we add `MaterialComponentsAlpha` in the coming weeks.
Closes #6236.