### PR TITLE
[Buttons] Add fallback for `borderWidthForState:`

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -628,6 +628,10 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 #pragma mark - Border Width
 
 - (CGFloat)borderWidthForState:(UIControlState)state {
+  // If the `.highlighted` flag is set, turn off the `.disabled` flag
+  if ((state & UIControlStateHighlighted) == UIControlStateHighlighted) {
+    state = state & ~UIControlStateDisabled;
+  }
   NSNumber *borderWidth = _borderWidths[@(state)];
   if (borderWidth != nil) {
     return (CGFloat)borderWidth.doubleValue;
@@ -636,9 +640,17 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 }
 
 - (void)setBorderWidth:(CGFloat)borderWidth forState:(UIControlState)state {
-  _borderWidths[@(state)] = @(borderWidth);
-
-  [self updateBorderWidth];
+  UIControlState storageState = state;
+  if ((state & UIControlStateHighlighted) == UIControlStateHighlighted) {
+    storageState = state & ~UIControlStateDisabled;
+  }
+  // Only update the backing dictionary if:
+  // 1. The `state` argument is the same as the "storage" state, OR
+  // 2. There is already a value in the "storage" state.
+  if (storageState == state || _backgroundColors[@(storageState)] != nil) {
+    _borderWidths[@(state)] = @(borderWidth);
+    [self updateBorderWidth];
+  }
 }
 
 - (void)updateBorderWidth {

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -632,7 +632,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   if (borderWidth != nil) {
     return (CGFloat)borderWidth.doubleValue;
   }
-  return 0;
+  return (CGFloat)[_borderWidths[@(UIControlStateNormal)] doubleValue];
 }
 
 - (void)setBorderWidth:(CGFloat)borderWidth forState:(UIControlState)state {

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -265,6 +265,16 @@ static NSString *controlStateDescription(UIControlState controlState) {
   XCTAssertEqual([button elevationForState:UIControlStateNormal], 0);
 }
 
+- (void)testDefaultBorderWidth {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+
+  // Then
+  for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
+    XCTAssertEqualWithAccuracy([button borderWidthForState:controlState], 0, 0.001);
+  }
+}
+
 - (void)testBorderWidthForStateWithDifferentValues {
   // Given
   MDCButton *button = [[MDCButton alloc] init];

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -270,7 +270,7 @@ static NSString *controlStateDescription(UIControlState controlState) {
   MDCButton *button = [[MDCButton alloc] init];
 
   // Then
-  for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
+  for (NSUInteger controlState = 0; controlState <= kNumUIControlStates; ++controlState) {
     XCTAssertEqualWithAccuracy([button borderWidthForState:controlState], 0, 0.001);
   }
 }
@@ -279,7 +279,7 @@ static NSString *controlStateDescription(UIControlState controlState) {
   // Given
   MDCButton *button = [[MDCButton alloc] init];
 
-  for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
+  for (NSUInteger controlState = 0; controlState <= kNumUIControlStates; ++controlState) {
     CGFloat width = (CGFloat)controlState;
 
     // When
@@ -289,6 +289,10 @@ static NSString *controlStateDescription(UIControlState controlState) {
     if (controlState == (UIControlStateHighlighted | UIControlStateDisabled)) {
       XCTAssertEqualWithAccuracy([button borderWidthForState:controlState],
                                  [button borderWidthForState:UIControlStateHighlighted], 0.001);
+    } else if (controlState ==
+               (UIControlStateHighlighted | UIControlStateDisabled | UIControlStateSelected)) {
+      XCTAssertNotEqualWithAccuracy([button borderWidthForState:controlState],
+                                    [button borderWidthForState:UIControlStateNormal], 0.001);
     } else {
       XCTAssertEqualWithAccuracy([button borderWidthForState:controlState], width, 0.001);
     }
@@ -304,7 +308,7 @@ static NSString *controlStateDescription(UIControlState controlState) {
   [button setBorderWidth:fakeBorderWidth forState:UIControlStateNormal];
 
   // Then
-  for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
+  for (NSUInteger controlState = 0; controlState <= kNumUIControlStates; ++controlState) {
     XCTAssertEqualWithAccuracy([button borderWidthForState:controlState], fakeBorderWidth, 0.001);
   }
 }

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -286,7 +286,12 @@ static NSString *controlStateDescription(UIControlState controlState) {
     [button setBorderWidth:width forState:controlState];
 
     // Then
-    XCTAssertEqualWithAccuracy([button borderWidthForState:controlState], width, 0.001);
+    if (controlState == (UIControlStateHighlighted | UIControlStateDisabled)) {
+      XCTAssertEqualWithAccuracy([button borderWidthForState:controlState],
+                                 [button borderWidthForState:UIControlStateHighlighted], 0.001);
+    } else {
+      XCTAssertEqualWithAccuracy([button borderWidthForState:controlState], width, 0.001);
+    }
   }
 }
 

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -265,6 +265,35 @@ static NSString *controlStateDescription(UIControlState controlState) {
   XCTAssertEqual([button elevationForState:UIControlStateNormal], 0);
 }
 
+- (void)testBorderWidthForStateWithDifferentValues {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+
+  for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
+    CGFloat width = (CGFloat)controlState;
+
+    // When
+    [button setBorderWidth:width forState:controlState];
+
+    // Then
+    XCTAssertEqualWithAccuracy([button borderWidthForState:controlState], width, 0.001);
+  }
+}
+
+- (void)testBorderWidthFallbackBehavior {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+  CGFloat fakeBorderWidth = 99;
+
+  // When
+  [button setBorderWidth:fakeBorderWidth forState:UIControlStateNormal];
+
+  // Then
+  for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
+    XCTAssertEqualWithAccuracy([button borderWidthForState:controlState], fakeBorderWidth, 0.001);
+  }
+}
+
 - (void)testBackgroundColorForState {
   // Given
   MDCButton *button = [[MDCButton alloc] init];


### PR DESCRIPTION
## Related links
* Component: [MDCButton](https://github.com/material-components/material-components-ios/tree/develop/components/Buttons/src)
* Bug: [Buttons] Unset `borderWidthForState:` reverts to 0, not .normal width value #3408
* API: [`borderWidthForState`](https://github.com/material-components/material-components-ios/blob/dfd657d694ad5a8612406815376f253310d9bfae/components/Buttons/src/MDCButton.h#L240)
* Related Apple docs: [`UIControlState`](https://developer.apple.com/documentation/uikit/uicontrol/state)
* Guidelines: [Material Outlined Button](https://material.io/design/components/buttons.html#outlined-button)
## Introduction

Currently we have an API `borderWidthForState:` on `MDCButton` that returns the borderWidth for a given `UIControlState` will return the _borderWidth_. This is used to render a border around the button as shown in the link above.

## The problem

If a client sets the _borderWidth_ for `UIControlStateNormal` then that value will be rendered in all states but the API for any state other than `UIControlStateNormal` will return 0. We want our API to match the rendering behavior.

## The fix

If a client sets a value for `UIControlStateNormal` then return that value if there is no value for the given `UIControlState` they have _asked_ for when calling `borderWidthForState:`.

## Testing

- [x] Default behavior if a client hasn't set any values
- [x] Behavior if a client only sets `UIControlStateNormal`
- [x] Behavior if a client sets every control state to be a unique value

## Screenshots
|    | No border for both states | 2pt border same for both states | 2pt border for `.normal` 4pt border for `.highlighted` |
| --- | --- | --- | --- |
| `.normal` |![simulator screen shot - iphone xs max - 2019-01-18 at 09 49 14](https://user-images.githubusercontent.com/7131294/51393833-b01daf80-1b06-11e9-9850-c5933d8e0181.png)|![simulator screen shot - iphone xs max - 2019-01-18 at 09 48 38](https://user-images.githubusercontent.com/7131294/51393848-b875ea80-1b06-11e9-9a9d-6e5d8e36e92d.png)|![simulator screen shot - iphone xs max - 2019-01-18 at 09 49 47](https://user-images.githubusercontent.com/7131294/51393873-c592d980-1b06-11e9-93ba-5dd18ed3afd8.png)|
| `.highlighted` | ![simulator screen shot - iphone xs max - 2019-01-18 at 09 49 16](https://user-images.githubusercontent.com/7131294/51393892-d8a5a980-1b06-11e9-870f-a10853b775de.png)|![simulator screen shot - iphone xs max - 2019-01-18 at 09 48 39](https://user-images.githubusercontent.com/7131294/51393905-e22f1180-1b06-11e9-88b8-a13e55a3eff5.png)|![simulator screen shot - iphone xs max - 2019-01-18 at 09 49 50](https://user-images.githubusercontent.com/7131294/51393910-e65b2f00-1b06-11e9-848f-90288a5bf368.png)|








_Note:_ This is an API change not a rendering change
