### PR TITLE
[Dialogs] Fix Theming extension for presentation controller.

### DIFF
--- a/components/Dialogs/src/Theming/MDCDialogPresentationController+MaterialTheming.m
+++ b/components/Dialogs/src/Theming/MDCDialogPresentationController+MaterialTheming.m
@@ -25,7 +25,7 @@ static const CGFloat kCornerRadius = 4;
     colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   }
-  self.scrimColor = colorScheme.primaryColor;
+  self.scrimColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.32];
 
   // Other properties
   self.dialogCornerRadius = kCornerRadius;

--- a/components/Dialogs/tests/unit/Theming/DialogsMaterialThemingTests.swift
+++ b/components/Dialogs/tests/unit/Theming/DialogsMaterialThemingTests.swift
@@ -216,8 +216,8 @@ class DialogsMaterialThemingTests: XCTestCase {
     let scheme: MDCContainerScheme = MDCContainerScheme()
 
     // When
-    presentationThemedController.applyTheme(withScheme: scheme)
     alertThemedAlert.applyTheme(withScheme: scheme)
+    presentationThemedController.applyTheme(withScheme: scheme)
 
     // Then
     // Color

--- a/components/Dialogs/tests/unit/Theming/DialogsMaterialThemingTests.swift
+++ b/components/Dialogs/tests/unit/Theming/DialogsMaterialThemingTests.swift
@@ -205,7 +205,7 @@ class DialogsMaterialThemingTests: XCTestCase {
         XCTAssert(false, "alert.mdc_dialogPresentationController should not be nil")
         return
     }
-    
+
     let presentationThemedAlert: MDCAlertController = MDCAlertController(title: "Title",
                                                                          message: "Message")
     guard let presentationThemedController = presentationThemedAlert.mdc_dialogPresentationController
@@ -216,7 +216,7 @@ class DialogsMaterialThemingTests: XCTestCase {
     let scheme: MDCContainerScheme = MDCContainerScheme()
 
     // When
-    presentationThemedAlert.applyTheme(withScheme: scheme)
+    presentationThemedController.applyTheme(withScheme: scheme)
     alertThemedAlert.applyTheme(withScheme: scheme)
 
     // Then

--- a/components/Dialogs/tests/unit/Theming/DialogsMaterialThemingTests.swift
+++ b/components/Dialogs/tests/unit/Theming/DialogsMaterialThemingTests.swift
@@ -200,7 +200,7 @@ class DialogsMaterialThemingTests: XCTestCase {
     // Given
     let alertThemedAlert: MDCAlertController = MDCAlertController(title: "Title",
                                                                   message: "Message")
-    guard let alertThemedController = presentationThemedAlert.mdc_dialogPresentationController
+    guard let alertThemedController = alertThemedAlert.mdc_dialogPresentationController
       else {
         XCTAssert(false, "alert.mdc_dialogPresentationController should not be nil")
         return

--- a/components/Dialogs/tests/unit/Theming/DialogsMaterialThemingTests.swift
+++ b/components/Dialogs/tests/unit/Theming/DialogsMaterialThemingTests.swift
@@ -174,6 +174,7 @@ class DialogsMaterialThemingTests: XCTestCase {
   }
 
   func testMDCDialogPresentationControllerTheming() {
+    // Given
     let alert: MDCAlertController = MDCAlertController(title: "Title", message: "Message")
     guard let presentationController = alert.mdc_dialogPresentationController else {
       XCTAssert(false, "alert.mdc_dialogPresentationController should not be nil")
@@ -182,13 +183,50 @@ class DialogsMaterialThemingTests: XCTestCase {
     let scheme: MDCContainerScheme = MDCContainerScheme()
     let colorScheme = MDCSemanticColorScheme()
 
+    // When
     presentationController.applyTheme(withScheme: scheme)
 
+    // Then
     // Color
-    XCTAssertEqual(presentationController.scrimColor, colorScheme.primaryColor)
+    XCTAssertEqual(presentationController.scrimColor,
+                   colorScheme.onSurfaceColor.withAlphaComponent(0.32))
 
     // Other properties
     XCTAssertEqual(presentationController.dialogCornerRadius, kCornerRadius, accuracy: 0.001)
     XCTAssertEqual(presentationController.dialogElevation, ShadowElevation.dialog)
+  }
+
+  func testMDCDialogPresentationControllerThemingMatchesAlertControllerTheming() {
+    // Given
+    let alertThemedAlert: MDCAlertController = MDCAlertController(title: "Title",
+                                                                  message: "Message")
+    guard let alertThemedController = presentationThemedAlert.mdc_dialogPresentationController
+      else {
+        XCTAssert(false, "alert.mdc_dialogPresentationController should not be nil")
+        return
+    }
+    
+    let presentationThemedAlert: MDCAlertController = MDCAlertController(title: "Title",
+                                                                         message: "Message")
+    guard let presentationThemedController = presentationThemedAlert.mdc_dialogPresentationController
+      else {
+      XCTAssert(false, "alert.mdc_dialogPresentationController should not be nil")
+      return
+    }
+    let scheme: MDCContainerScheme = MDCContainerScheme()
+
+    // When
+    presentationThemedAlert.applyTheme(withScheme: scheme)
+    alertThemedAlert.applyTheme(withScheme: scheme)
+
+    // Then
+    // Color
+    XCTAssertEqual(presentationThemedController.scrimColor, alertThemedController.scrimColor)
+
+    // Other properties
+    XCTAssertEqual(presentationThemedController.dialogCornerRadius,
+                   alertThemedController.dialogCornerRadius, accuracy: 0.001)
+    XCTAssertEqual(presentationThemedController.dialogElevation,
+                   alertThemedController.dialogElevation)
   }
 }


### PR DESCRIPTION
The theming extension for MDCDialogPresentationController used
`primaryColor` instead of `onSurfaceColor` @ 32%.

Added a test to verify that the AlertController and
PresentationController theming extensions result in the same
scrim-related theming values.

|Before|After|
|---|---|
|![present-bug](https://user-images.githubusercontent.com/1753199/51408900-300b4000-1b2e-11e9-854c-4c8c299ebc40.png)|![present-fix](https://user-images.githubusercontent.com/1753199/51408911-3994a800-1b2e-11e9-91c1-e2e50c2019a6.png)|



Closes #6417
