### PR TITLE
[Scripts] bazel coverage ignores deletions.

### DIFF
--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -63,11 +63,11 @@ modified_files() {
   git diff --name-status "${range}" \
     | grep -v -E '^D'  \
     | grep -E '(\.swift|\.h|\.m)$' \
-    | sort \
-    | uniq \
     | while read LINE; do \
         echo "$LINE" | sed -nE 's/.*[[:blank:]]+([[:alnum:]_\-\.\/+]+)$/\1/p';  \
-      done 
+      done \
+    | sort \
+    | uniq
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     popd >> /dev/null

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -59,7 +59,6 @@ modified_files() {
   #  commit.
   range="${base_sha}...HEAD"
 
-
   git diff --name-status "${range}" \
     | grep -v -E '^D'  \
     | grep -E '(\.swift|\.h|\.m)$' \

--- a/scripts/files_missing_bazel_target
+++ b/scripts/files_missing_bazel_target
@@ -59,10 +59,15 @@ modified_files() {
   #  commit.
   range="${base_sha}...HEAD"
 
-  git diff --name-only "${range}" \
+
+  git diff --name-status "${range}" \
+    | grep -v -E '^D'  \
     | grep -E '(\.swift|\.h|\.m)$' \
     | sort \
-    | uniq
+    | uniq \
+    | while read LINE; do \
+        echo "$LINE" | sed -nE 's/.*[[:blank:]]+([[:alnum:]_\-\.\/+]+)$/\1/p';  \
+      done 
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     popd >> /dev/null


### PR DESCRIPTION
When looking at which files are included in bazel targets and which are
not, we should exclude any files that were deleted. If not, any PR that
deletes a file could potentially produce a false positive and get
blocked from submission.

Closes #6428