### PR TITLE
[Tabs] Move the clipsToBounds behavior from MDCTabBar to MDCItemBar

### DIFF
--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -125,7 +125,6 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   _unselectedTitleColor = _unselectedItemTintColor;
   _inkColor = [UIColor colorWithWhite:1 alpha:(CGFloat)0.7];
 
-  self.clipsToBounds = YES;
   _barPosition = UIBarPositionAny;
   _hasDefaultItemAppearance = YES;
   _hasDefaultAlignment = YES;

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -99,6 +99,7 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 }
 
 - (void)commonItemBarInit {
+  self.clipsToBounds=YES;
   _alignment = MDCItemBarAlignmentLeading;
   _style = [[MDCItemBarStyle alloc] init];
   _items = @[];

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -99,7 +99,7 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 }
 
 - (void)commonItemBarInit {
-  self.clipsToBounds=YES;
+  self.clipsToBounds = YES;
   _alignment = MDCItemBarAlignmentLeading;
   _style = [[MDCItemBarStyle alloc] init];
   _items = @[];


### PR DESCRIPTION
The primary benefit here is that it allows the user to add a shadow to the CALayer of MDCTabBar without it getting clipped to bounds. (Where as setting `.clipsToBounds=NO` on MDCTabBar then the underlying itemBar/collectionView will extend outside of the bounds of the parent.)

By moving this clipsToBounds up a layer, it allows both of these behaviors to work.

For example:

- Adding a shadow to tabs: https://i.imgur.com/2CY15ip.png

- Tabs extending out of bounds if attempting to set MDCTabBar clipsToBounds=NO as it exists today: https://i.imgur.com/YYfkIMq.png
- Tabs fixed when setting MDCTabBar clipsToBounds=NO with this change: https://i.imgur.com/7QJhFBx.png
