### PR TITLE
[Catalog] Add constant for selector

### DIFF
--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -25,6 +25,8 @@ import MaterialComponents.MaterialIcons_ic_more_horiz
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, MDCAppBarNavigationControllerDelegate {
 
+  private static let performPostLaunchSelector = "performPostLaunchSelector"
+
   var window: UIWindow?
 
   let navigationController = MDCAppBarNavigationController()
@@ -57,8 +59,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MDCAppBarNavigationContro
       name: AppTheme.didChangeGlobalThemeNotificationName,
       object: nil)
 
-    if self.responds(to: Selector(("performPostLaunchAction"))) {
-      self.perform(Selector(("performPostLaunchAction")))
+    if self.responds(to: Selector((AppDelegate.performPostLaunchSelector))) {
+      self.perform(Selector((AppDelegate.performPostLaunchSelector)))
     }
 
     return true


### PR DESCRIPTION
## Related links
* Original PR: #6445 
* Related Bug: #5522 
## Introduction
In working on #6445 I missed this but wanted to make those change in before the release. This is a follow up to that PR to address some feedback. The reviewer and I agreed to address the feedback in a follow up as to not delay the release.
## The problem
We have two of the same string that are defined independently of each other but should always match. This could lead to problems if they become out of sync.
## The fix
Define these two strings in a constant so they stay in sync.