### PR TITLE
{kokoro} Build everything when using run_bazel

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -346,7 +346,7 @@ run_bazel() {
       perform_pre_test_cleanup "iPhone"
     fi
   fi
-  
+
   bazel $COMMAND $TARGET --xcode_version $xcode_version --ios_minimum_os=8.0 \
     --ios_multi_cpus=i386,x86_64 $extra_args $verbosity_args \
     --test_env="FB_REFERENCE_IMAGE_DIR=$snapshot_dir" \

--- a/.kokoro
+++ b/.kokoro
@@ -291,7 +291,7 @@ run_bazel() {
     COMMAND="test"
   fi
   if [ -z "$TARGET" ]; then
-    TARGET="//components/..."
+    TARGET="//..."
   fi
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
@@ -346,7 +346,7 @@ run_bazel() {
       perform_pre_test_cleanup "iPhone"
     fi
   fi
-
+  
   bazel $COMMAND $TARGET --xcode_version $xcode_version --ios_minimum_os=8.0 \
     --ios_multi_cpus=i386,x86_64 $extra_args $verbosity_args \
     --test_env="FB_REFERENCE_IMAGE_DIR=$snapshot_dir" \

--- a/catalog/BUILD
+++ b/catalog/BUILD
@@ -88,6 +88,7 @@ swift_library(
         "//components/private/Icons/icons/ic_more_horiz",
         "//components/private/Icons/icons/ic_settings",
         "//components/schemes/Color",
+        "//components/schemes/Container",
         "//components/schemes/Typography",
         "@catalog_by_convention//:CatalogByConvention",
         "@material_internationalization_ios//:MDFInternationalization",


### PR DESCRIPTION
If no target is provided, the `-d bazel` (`run_bazel` within `.kokoro`) dependency system only
built (or tested) the components. Instead, it should build the entire
workspace.

Closes #6458
