### PR TITLE
[BottomNavigation] Fix import in VC.

### DIFF
--- a/components/BottomNavigation/src/beta/MDCBottomNavigationBarController.h
+++ b/components/BottomNavigation/src/beta/MDCBottomNavigationBarController.h
@@ -14,7 +14,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialBottomNavigation.h"
+#import <MaterialComponents/MaterialBottomNavigation.h>
 
 @protocol MDCBottomNavigationBarControllerDelegate;
 


### PR DESCRIPTION
The MDCBottomNavigationController failed to import MaterialBottomNavigation
correctly. It was using "traditional" header file imports but we should now be
using "framework-style" imports.

Fixes breakage introduced in #6311