### PR TITLE
{clang-format-ci} Fix broken presubmit.

### DIFF
--- a/.clang-format-ci
+++ b/.clang-format-ci
@@ -46,6 +46,7 @@ lint_clang_format() {
   git fetch > /dev/null
   TAG=$(git tag --sort=v:refname -l "$CLANG_FORMAT_CI_VERSION" | tail -n1)
   git checkout "$TAG" > /dev/null
+  git submodule update --init --recursive
   echo "Using clang-format-ci $TAG"
   popd
 


### PR DESCRIPTION
The v1.0.0 version of clang-format-ci relies on submodules for the github-comment repo. The develop branch of clang-format-ci does not.

When we clone clang-format-ci it does so at develop, which means our clone submodule initialization does nothing. When we then check out the v1.0.0 release, submodules will not have been initialized and the github-comment repo will not exist, resulting in the error `error: root manifest not found`.

Initializing submodules after checking out the desired tag resolves this issue.

Fixes https://github.com/material-components/material-components-ios/issues/6464