### PR TITLE
{.kokoro} Pin the website job's node version to v8.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -426,6 +426,13 @@ generate_website() {
 
     gem_install bundler
     brew_install yarn --without-node
+    
+    # The above installations update node to v10, but the docsite generator
+    # relies on v8.
+    brew unlink node
+    brew install node@8
+    # Required because node@8 is keg-only, meaning it isn't linked automatically.
+    brew link --force --overwrite node@8
   fi
 
   cd docsite-generator


### PR DESCRIPTION
The docsite-generator relies on node v8 to build and validate the website. Node has since released multiple major versions that have introduced incompatibilities with the docsite-generator. There are two ways to address this:

1. Update docsite-generator to support the latest node.
2. Pin the node version to the last docsite-generator-supported version of node.

Given that docsite-generator is in maintenance mode and unlikely to be updated, this PR implements option 2 in order to fix our website job.

Fixes https://github.com/material-components/material-components-ios/issues/6444