### PR TITLE
[Buttons] Update examples to use theming extensions

### DIFF
--- a/components/Buttons/BUILD
+++ b/components/Buttons/BUILD
@@ -110,12 +110,8 @@ mdc_objc_library(
 mdc_examples_objc_library(
     name = "ObjcExamples",
     deps = [
-        ":ButtonThemer",
         ":Buttons",
-        ":ColorThemer",
-        ":ShapeThemer",
         ":Theming",
-        ":TypographyThemer",
         "//components/Typography",
         "//components/private/Math",
         "//components/private/ShapeLibrary",
@@ -130,12 +126,8 @@ mdc_examples_objc_library(
 mdc_examples_swift_library(
     name = "SwiftExamples",
     deps = [
-        ":ButtonThemer",
         ":Buttons",
-        ":ColorThemer",
-        ":ShapeThemer",
         ":Theming",
-        ":TypographyThemer",
         "//components/Typography",
         "//components/schemes/Color",
         "//components/schemes/Container",

--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -24,6 +24,7 @@
 @property(weak, nonatomic) IBOutlet MDCButton *containedButton;
 @property(weak, nonatomic) IBOutlet MDCFloatingButton *floatingActionButton;
 @property(weak, nonatomic) IBOutlet UISwitch *inkBoundingSwitch;
+@property(strong, nonatomic) MDCContainerScheme *containerScheme;
 @end
 
 @implementation ButtonsContentEdgeInsetsExample
@@ -54,17 +55,6 @@
                                            inMode:MDCFloatingButtonModeNormal];
 
   [self updateInkStyle:self.inkBoundingSwitch.isOn ? MDCInkStyleBounded : MDCInkStyleUnbounded];
-}
-
-- (MDCContainerScheme *)containerScheme {
-  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-  scheme.colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  scheme.shapeScheme =
-      [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
-  scheme.typographyScheme =
-      [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
-  return scheme;
 }
 
 - (void)updateInkStyle:(MDCInkStyle)inkStyle {

--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -42,6 +42,14 @@
 
 #pragma mark - UIViewController
 
+- (id)init {
+  self = [super init];
+  if (self) {
+    _containerScheme = [[MDCContainerScheme alloc] init];
+  }
+  return self;
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
 

--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -14,7 +14,6 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialButtons+ButtonThemer.h"
 #import "MaterialButtons+Theming.h"
 #import "MaterialButtons.h"
 #import "MaterialContainerScheme.h"

--- a/components/Buttons/examples/ButtonsCustomFontViewController.swift
+++ b/components/Buttons/examples/ButtonsCustomFontViewController.swift
@@ -34,15 +34,14 @@ class ButtonsCustomFontViewController: UIViewController {
     super.viewDidLoad()
 
     // Define our design data
-    let buttonScheme = MDCButtonScheme()
     if let customFont = UIFont(name:"Zapfino", size:14.0) {
       let typographyScheme = MDCTypographyScheme()
       typographyScheme.button = customFont
-      buttonScheme.typographyScheme = typographyScheme
     }
 
     // Apply our design data using the Material themers
-    view.backgroundColor = buttonScheme.colorScheme.backgroundColor
+    view.backgroundColor =
+        containerScheme.colorScheme?.backgroundColor ?? MDCSemanticColorScheme().backgroundColor
 
     let flatButtonStatic = MDCButton()
     flatButtonStatic.applyContainedTheme(withScheme: containerScheme)

--- a/components/Buttons/examples/ButtonsCustomFontViewController.swift
+++ b/components/Buttons/examples/ButtonsCustomFontViewController.swift
@@ -15,9 +15,12 @@
 import UIKit
 
 import MaterialComponents.MaterialButtons
-import MaterialComponents.MaterialButtons_ButtonThemer
+import MaterialComponentsBeta.MaterialButtons_Theming
+import MaterialComponentsBeta.MaterialContainerScheme
 
 class ButtonsCustomFontViewController: UIViewController {
+
+  var containerScheme = MDCContainerScheme()
 
   class func catalogMetadata() -> [String: Any] {
     return [
@@ -42,7 +45,7 @@ class ButtonsCustomFontViewController: UIViewController {
     view.backgroundColor = buttonScheme.colorScheme.backgroundColor
 
     let flatButtonStatic = MDCButton()
-    MDCContainedButtonThemer.applyScheme(buttonScheme, to: flatButtonStatic)
+    flatButtonStatic.applyContainedTheme(withScheme: containerScheme)
     flatButtonStatic.setTitle("Static", for: UIControlState())
     flatButtonStatic.sizeToFit()
     flatButtonStatic.translatesAutoresizingMaskIntoConstraints = false
@@ -50,7 +53,7 @@ class ButtonsCustomFontViewController: UIViewController {
     view.addSubview(flatButtonStatic)
 
     let flatButtonDynamic = MDCButton()
-    MDCContainedButtonThemer.applyScheme(buttonScheme, to: flatButtonDynamic)
+    flatButtonDynamic.applyContainedTheme(withScheme: containerScheme)
     flatButtonDynamic.setTitle("Dynamic", for: UIControlState())
     flatButtonDynamic.sizeToFit()
     flatButtonDynamic.translatesAutoresizingMaskIntoConstraints = false

--- a/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
+++ b/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
@@ -15,6 +15,8 @@
 import UIKit
 
 import MaterialComponents.MaterialButtons
+import MaterialComponentsBeta.MaterialButtons_Theming
+import MaterialComponentsBeta.MaterialContainerScheme
 
 class ButtonsDynamicTypeViewController: UIViewController {
 
@@ -26,6 +28,8 @@ class ButtonsDynamicTypeViewController: UIViewController {
     ]
   }
 
+  var containerScheme = MDCContainerScheme()
+
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -33,7 +37,8 @@ class ButtonsDynamicTypeViewController: UIViewController {
     let titleColor = UIColor.white
     let backgroundColor = UIColor(white: 0.1, alpha: 1.0)
 
-    let flatButtonStatic = MDCRaisedButton()
+    let flatButtonStatic = MDCButton()
+    flatButtonStatic.applyContainedTheme(withScheme: containerScheme)
     flatButtonStatic.setTitleColor(titleColor, for: .normal)
     flatButtonStatic.setBackgroundColor(backgroundColor, for: .normal)
     flatButtonStatic.setTitle("Static", for: UIControlState())
@@ -42,7 +47,8 @@ class ButtonsDynamicTypeViewController: UIViewController {
     flatButtonStatic.addTarget(self, action: #selector(tap), for: .touchUpInside)
     view.addSubview(flatButtonStatic)
 
-    let flatButtonDynamic = MDCRaisedButton()
+    let flatButtonDynamic = MDCButton()
+    flatButtonDynamic.applyContainedTheme(withScheme: containerScheme)
     flatButtonDynamic.setTitleColor(titleColor, for: .normal)
     flatButtonDynamic.setBackgroundColor(backgroundColor, for: .normal)
     flatButtonDynamic.setTitle("Dynamic", for: UIControlState())

--- a/components/Buttons/examples/ButtonsShapesExampleViewController.m
+++ b/components/Buttons/examples/ButtonsShapesExampleViewController.m
@@ -60,10 +60,6 @@
   self.view.backgroundColor = [UIColor colorWithWhite:(CGFloat)0.9 alpha:1];
   UIColor *titleColor = [UIColor whiteColor];
 
-  MDCButtonScheme *buttonScheme = [[MDCButtonScheme alloc] init];
-  buttonScheme.colorScheme = self.colorScheme;
-  buttonScheme.typographyScheme = self.typographyScheme;
-
   // Raised button
 
   MDCButton *containedButton = [[MDCButton alloc] init];
@@ -123,8 +119,7 @@
 
   MDCButton *strokedButton = [self buildCustomStrokedButton];
   [strokedButton setTitle:@"Button" forState:UIControlStateNormal];
-  [MDCButtonTypographyThemer applyTypographyScheme:self.typographyScheme toButton:strokedButton];
-  [MDCButtonColorThemer applySemanticColorScheme:self.colorScheme toButton:strokedButton];
+  [strokedButton applyOutlinedThemeWithScheme:self.containerScheme];
 
   MDCSlantedRectShapeGenerator *strokedShapeGenerator = [[MDCSlantedRectShapeGenerator alloc] init];
   strokedShapeGenerator.slant = 10;
@@ -140,9 +135,7 @@
 
   MDCButton *disabledStrokedButton = [self buildCustomStrokedButton];
   [disabledStrokedButton setTitle:@"Button" forState:UIControlStateNormal];
-  [MDCButtonTypographyThemer applyTypographyScheme:self.typographyScheme
-                                          toButton:disabledStrokedButton];
-  [MDCButtonColorThemer applySemanticColorScheme:self.colorScheme toButton:disabledStrokedButton];
+  [disabledStrokedButton applyOutlinedThemeWithScheme:self.containerScheme];
 
   MDCRectangleShapeGenerator *disabledStrokedShapeGenerator =
       [[MDCRectangleShapeGenerator alloc] init];

--- a/components/Buttons/examples/ButtonsShapesExampleViewController.m
+++ b/components/Buttons/examples/ButtonsShapesExampleViewController.m
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MaterialButtons+ButtonThemer.h"
-#import "MaterialButtons+ColorThemer.h"
 #import "MaterialButtons+Theming.h"
-#import "MaterialButtons+TypographyThemer.h"
 #import "MaterialButtons.h"
 #import "MaterialContainerScheme.h"
 #import "MaterialShapeLibrary.h"

--- a/components/Buttons/examples/ButtonsShapesExampleViewController.m
+++ b/components/Buttons/examples/ButtonsShapesExampleViewController.m
@@ -43,7 +43,7 @@
   return self;
 }
 
-- (MDCButton *)buildCustomStrokedButton {
+- (MDCButton *)buildCustomOutlinedButton {
   MDCButton *button = [[MDCButton alloc] init];
   [button setBorderWidth:1.0 forState:UIControlStateNormal];
   [button setBorderColor:[UIColor colorWithWhite:(CGFloat)0.1 alpha:1]
@@ -112,50 +112,50 @@
        forControlEvents:UIControlEventTouchUpInside];
   [self.view addSubview:flatButton];
 
-  // Custom stroked button
+  // Custom outlined button
 
-  MDCButton *strokedButton = [self buildCustomStrokedButton];
-  [strokedButton setTitle:@"Button" forState:UIControlStateNormal];
-  [strokedButton applyOutlinedThemeWithScheme:self.containerScheme];
+  MDCButton *outlinedButton = [self buildCustomOutlinedButton];
+  [outlinedButton setTitle:@"Button" forState:UIControlStateNormal];
+  [outlinedButton applyOutlinedThemeWithScheme:self.containerScheme];
 
-  MDCSlantedRectShapeGenerator *strokedShapeGenerator = [[MDCSlantedRectShapeGenerator alloc] init];
-  strokedShapeGenerator.slant = 10;
-  strokedButton.shapeGenerator = strokedShapeGenerator;
+  MDCSlantedRectShapeGenerator *outlinedShapeGenerator = [[MDCSlantedRectShapeGenerator alloc] init];
+  outlinedShapeGenerator.slant = 10;
+  outlinedButton.shapeGenerator = outlinedShapeGenerator;
 
-  [strokedButton sizeToFit];
-  [strokedButton addTarget:self
+  [outlinedButton sizeToFit];
+  [outlinedButton addTarget:self
                     action:@selector(didTap:)
           forControlEvents:UIControlEventTouchUpInside];
-  [self.view addSubview:strokedButton];
+  [self.view addSubview:outlinedButton];
 
-  // Disabled custom stroked button
+  // Disabled custom outlined button
 
-  MDCButton *disabledStrokedButton = [self buildCustomStrokedButton];
-  [disabledStrokedButton setTitle:@"Button" forState:UIControlStateNormal];
-  [disabledStrokedButton applyOutlinedThemeWithScheme:self.containerScheme];
+  MDCButton *disabledOutlinedButton = [self buildCustomOutlinedButton];
+  [disabledOutlinedButton setTitle:@"Button" forState:UIControlStateNormal];
+  [disabledOutlinedButton applyOutlinedThemeWithScheme:self.containerScheme];
 
-  MDCRectangleShapeGenerator *disabledStrokedShapeGenerator =
+  MDCRectangleShapeGenerator *disabledOutlinedShapeGenerator =
       [[MDCRectangleShapeGenerator alloc] init];
-  [disabledStrokedShapeGenerator
+  [disabledOutlinedShapeGenerator
       setTopEdge:[[MDCTriangleEdgeTreatment alloc] initWithSize:5 style:MDCTriangleEdgeStyleCut]];
-  [disabledStrokedShapeGenerator setTopLeftCorner:[[MDCCutCornerTreatment alloc] initWithCut:10]];
-  [disabledStrokedShapeGenerator
+  [disabledOutlinedShapeGenerator setTopLeftCorner:[[MDCCutCornerTreatment alloc] initWithCut:10]];
+  [disabledOutlinedShapeGenerator
       setTopRightCorner:[[MDCCurvedCornerTreatment alloc] initWithSize:CGSizeMake(5, 20)]];
-  [disabledStrokedShapeGenerator
+  [disabledOutlinedShapeGenerator
       setBottomEdge:[[MDCTriangleEdgeTreatment alloc] initWithSize:5
                                                              style:MDCTriangleEdgeStyleHandle]];
-  [disabledStrokedShapeGenerator
+  [disabledOutlinedShapeGenerator
       setBottomRightCorner:[[MDCCutCornerTreatment alloc] initWithCut:5]];
-  [disabledStrokedShapeGenerator
+  [disabledOutlinedShapeGenerator
       setBottomLeftCorner:[[MDCCurvedCornerTreatment alloc] initWithSize:CGSizeMake(10, 5)]];
-  disabledStrokedButton.shapeGenerator = disabledStrokedShapeGenerator;
+  disabledOutlinedButton.shapeGenerator = disabledOutlinedShapeGenerator;
 
-  [disabledStrokedButton sizeToFit];
-  [disabledStrokedButton addTarget:self
+  [disabledOutlinedButton sizeToFit];
+  [disabledOutlinedButton addTarget:self
                             action:@selector(didTap:)
                   forControlEvents:UIControlEventTouchUpInside];
-  [disabledStrokedButton setEnabled:NO];
-  [self.view addSubview:disabledStrokedButton];
+  [disabledOutlinedButton setEnabled:NO];
+  [self.view addSubview:disabledOutlinedButton];
 
   // Floating action button
 
@@ -178,7 +178,7 @@
   [self.view addSubview:self.floatingButton];
 
   self.buttons = @[
-    containedButton, disabledContainedButton, flatButton, strokedButton, disabledStrokedButton,
+    containedButton, disabledContainedButton, flatButton, outlinedButton, disabledOutlinedButton,
     self.floatingButton
   ];
 
@@ -189,13 +189,13 @@
   UILabel *raisedButtonLabel = [self addLabelWithText:@"Contained: Cut Corners"];
   UILabel *disabledRaisedButtonLabel = [self addLabelWithText:@"Disabled Contained: Curved Cut"];
   UILabel *flatButtonLabel = [self addLabelWithText:@"Flat: Oval Ink"];
-  UILabel *strokedButtonLabel = [self addLabelWithText:@"Stroked: Triangular"];
-  UILabel *disabledStrokedButtonLabel = [self addLabelWithText:@"Stroked Disabled: Freeform"];
+  UILabel *outlinedButtonLabel = [self addLabelWithText:@"Outlined: Triangular"];
+  UILabel *disabledOutlinedButtonLabel = [self addLabelWithText:@"Outlined Disabled: Freeform"];
   UILabel *floatingDiamondLabel = [self addLabelWithText:@"Floating Action: Diamond"];
 
   self.labels = @[
-    raisedButtonLabel, disabledRaisedButtonLabel, flatButtonLabel, strokedButtonLabel,
-    disabledStrokedButtonLabel, floatingDiamondLabel
+    raisedButtonLabel, disabledRaisedButtonLabel, flatButtonLabel, outlinedButtonLabel,
+    disabledOutlinedButtonLabel, floatingDiamondLabel
   ];
 }
 

--- a/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
+++ b/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
@@ -15,7 +15,7 @@
 import Foundation
 import UIKit
 
-import MaterialComponents.MaterialButtons_ButtonThemer
+import MaterialComponents.MaterialButtons
 import MaterialComponentsBeta.MaterialButtons_Theming
 import MaterialComponentsBeta.MaterialContainerScheme
 

--- a/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
+++ b/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
@@ -23,6 +23,8 @@ class ButtonsSimpleExampleSwiftViewController: UIViewController {
 
   let floatingButtonPlusDimension = CGFloat(24)
   let kMinimumAccessibleButtonSize = CGSize(width: 64, height: 48)
+
+  var containerScheme = MDCContainerScheme()
   
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -30,10 +32,9 @@ class ButtonsSimpleExampleSwiftViewController: UIViewController {
     view.backgroundColor = UIColor(white: 0.9, alpha: 1.0)
     //let titleColor = UIColor.white
     let backgroundColor = UIColor(white: 0.1, alpha: 1.0)
-    let buttonScheme = MDCButtonScheme()
     
     let containedButton = MDCButton()
-    MDCContainedButtonThemer.applyScheme(buttonScheme, to: containedButton)
+    containedButton.applyContainedTheme(withScheme: containerScheme)
     containedButton.setTitle("Tap Me Too", for: UIControlState())
     containedButton.sizeToFit()
     let containedButtonVerticalInset =

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -20,11 +20,13 @@ import MaterialComponents.MaterialButtons_ButtonThemer
 class ButtonsSwiftAndStoryboardController: UIViewController {
 
   let containedButton = MDCButton()
-  let flatButton = MDCFlatButton()
+  let flatButton = MDCButton()
   let floatingButton = MDCFloatingButton()
 
+  var containerScheme = MDCContainerScheme()
+
   @IBOutlet weak var storyboardContained: MDCButton!
-  @IBOutlet weak var storyboardFlat: MDCFlatButton!
+  @IBOutlet weak var storyboardFlat: MDCButton!
   @IBOutlet weak var storyboardFloating: MDCFloatingButton!
 
   private lazy var containerView: UIView = {
@@ -85,6 +87,9 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
       ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton)
     storyboardFloating.layer.addSublayer(storyboardPlusShapeLayer)
 
+    storyboardContained.applyContainedTheme(withScheme: containerScheme)
+    storyboardFlat.applyTextTheme(withScheme: containerScheme)
+
     addButtonConstraints()
   }
 
@@ -132,16 +137,14 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
   private func buttonSetup() {
     let backgroundColor = UIColor(white: 0.1, alpha: 1.0)
 
-    let buttonScheme = MDCButtonScheme()
-    MDCContainedButtonThemer.applyScheme(buttonScheme, to: containedButton)
-    MDCContainedButtonThemer.applyScheme(buttonScheme, to: storyboardContained)
-
+    containedButton.applyContainedTheme(withScheme: containerScheme)
     containedButton.setTitle("Programmatic", for: .normal)
     containedButton.sizeToFit()
     containedButton.translatesAutoresizingMaskIntoConstraints = false
     containedButton.addTarget(self, action: #selector(tap), for: .touchUpInside)
     innerContainerView.addSubview(containedButton)
 
+    flatButton.applyTextTheme(withScheme: containerScheme)
     flatButton.setTitleColor(.gray, for: .normal)
     flatButton.setTitle("Programmatic", for: .normal)
     flatButton.sizeToFit()

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -15,7 +15,9 @@
 import Foundation
 import UIKit
 
-import MaterialComponents.MaterialButtons_ButtonThemer
+import MaterialComponents.MaterialButtons
+import MaterialComponentsBeta.MaterialButtons_Theming
+import MaterialComponentsBeta.MaterialContainerScheme
 
 class ButtonsSwiftAndStoryboardController: UIViewController {
 

--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -47,23 +47,10 @@ const CGSize kMinimumAccessibleButtonSize = {64.0, 48.0};
   return self;
 }
 
-- (MDCContainerScheme *)containerScheme {
-  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-  scheme.colorScheme = self.colorScheme;
-  scheme.shapeScheme = self.shapeScheme;
-  scheme.typographyScheme = self.typographyScheme;
-  return scheme;
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
   self.view.backgroundColor = [UIColor whiteColor];
-
-  MDCButtonScheme *buttonScheme = [[MDCButtonScheme alloc] init];
-  buttonScheme.colorScheme = self.colorScheme;
-  buttonScheme.shapeScheme = self.shapeScheme;
-  buttonScheme.typographyScheme = self.typographyScheme;
 
   // Contained button
 

--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import "MaterialButtons.h"
+#import "MaterialButtons+Theming.h"
 #import "MaterialContainerScheme.h"
 #import "MaterialTypography.h"
 

--- a/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
+++ b/components/Buttons/examples/ButtonsTypicalUseExampleViewController.m
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MaterialButtons+ButtonThemer.h"
-#import "MaterialButtons+ColorThemer.h"
-#import "MaterialButtons+Theming.h"
-#import "MaterialButtons+TypographyThemer.h"
 #import "MaterialButtons.h"
 #import "MaterialContainerScheme.h"
 #import "MaterialTypography.h"

--- a/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
+++ b/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
@@ -15,12 +15,16 @@
 import UIKit
 
 import MaterialComponents.MaterialButtons
+import MaterialComponentsBeta.MaterialButtons_Theming
+import MaterialComponentsBeta.MaterialContainerScheme
 
 class FloatingButtonExampleSwiftViewController: UIViewController {
 
   let miniFloatingButton = MDCFloatingButton(frame: .zero, shape: .mini)
   let defaultFloatingButton = MDCFloatingButton()
   let largeIconFloatingButton = MDCFloatingButton()
+
+  var containerScheme = MDCContainerScheme()
 
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
+++ b/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
@@ -40,11 +40,13 @@ class FloatingButtonExampleSwiftViewController: UIViewController {
     miniFloatingButton.setMinimumSize(CGSize(width: 96, height: 40), for: .mini, in: .expanded)
     miniFloatingButton.setImage(plusImage, for: .normal)
     miniFloatingButton.accessibilityLabel = "Create"
+    miniFloatingButton.applySecondaryTheme(withScheme: containerScheme)
 
     defaultFloatingButton.sizeToFit()
     defaultFloatingButton.translatesAutoresizingMaskIntoConstraints = false
     defaultFloatingButton.setImage(plusImage, for: .normal)
     defaultFloatingButton.accessibilityLabel = "Create"
+    defaultFloatingButton.applySecondaryTheme(withScheme: containerScheme)
 
     largeIconFloatingButton.sizeToFit()
     largeIconFloatingButton.translatesAutoresizingMaskIntoConstraints = false
@@ -52,6 +54,7 @@ class FloatingButtonExampleSwiftViewController: UIViewController {
     largeIconFloatingButton.accessibilityLabel = "Create"
     largeIconFloatingButton.setContentEdgeInsets(UIEdgeInsetsMake(-6, -6, -6, 0), for: .default,
                                                  in: .expanded)
+    largeIconFloatingButton.applySecondaryTheme(withScheme: containerScheme)
 
     let label = UILabel()
     label.translatesAutoresizingMaskIntoConstraints = false

--- a/components/Buttons/examples/FloatingButtonExampleViewController.m
+++ b/components/Buttons/examples/FloatingButtonExampleViewController.m
@@ -14,8 +14,6 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialButtons+ColorThemer.h"
-#import "MaterialButtons+ShapeThemer.h"
 #import "MaterialButtons.h"
 #import <MaterialComponentsBeta/MaterialButtons+Theming.h>
 

--- a/components/Buttons/examples/FloatingButtonExampleViewController.m
+++ b/components/Buttons/examples/FloatingButtonExampleViewController.m
@@ -17,6 +17,7 @@
 #import "MaterialButtons+ColorThemer.h"
 #import "MaterialButtons+ShapeThemer.h"
 #import "MaterialButtons.h"
+#import <MaterialComponentsBeta/MaterialButtons+Theming.h>
 
 NSString *kButtonLabel = @"Create";
 NSString *kMiniButtonLabel = @"Add";
@@ -26,8 +27,7 @@ NSString *kMiniButtonLabel = @"Add";
 @property(nonatomic, strong) MDCFloatingButton *miniFloatingButton;
 @property(nonatomic, strong) MDCFloatingButton *defaultFloatingButton;
 @property(nonatomic, strong) MDCFloatingButton *largeIconFloatingButton;
-@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
-@property(nonatomic, strong) MDCShapeScheme *shapeScheme;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 @end
 
 @implementation FloatingButtonExampleViewController
@@ -35,9 +35,8 @@ NSString *kMiniButtonLabel = @"Add";
 - (id)init {
   self = [super init];
   if (self) {
-    self.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.shapeScheme = [[MDCShapeScheme alloc] init];
+    _containerScheme = [[MDCContainerScheme alloc] init];
+    _containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
   }
   return self;
 }
@@ -65,18 +64,13 @@ NSString *kMiniButtonLabel = @"Add";
   [self.miniFloatingButton setMinimumSize:CGSizeMake(96, 40)
                                  forShape:MDCFloatingButtonShapeMini
                                    inMode:MDCFloatingButtonModeExpanded];
-  [MDCFloatingButtonColorThemer applySemanticColorScheme:self.colorScheme
-                                                toButton:self.miniFloatingButton];
-  [MDCFloatingButtonShapeThemer applyShapeScheme:self.shapeScheme toButton:self.miniFloatingButton];
+  [self.miniFloatingButton applySecondaryThemeWithScheme:self.containerScheme];
 
   self.defaultFloatingButton = [[MDCFloatingButton alloc] init];
   self.defaultFloatingButton.translatesAutoresizingMaskIntoConstraints = NO;
   [self.defaultFloatingButton setImage:plusImage forState:UIControlStateNormal];
   self.defaultFloatingButton.accessibilityLabel = kButtonLabel;
-  [MDCFloatingButtonColorThemer applySemanticColorScheme:self.colorScheme
-                                                toButton:self.defaultFloatingButton];
-  [MDCFloatingButtonShapeThemer applyShapeScheme:self.shapeScheme
-                                        toButton:self.defaultFloatingButton];
+  [self.defaultFloatingButton applySecondaryThemeWithScheme:self.containerScheme];
 
   self.largeIconFloatingButton = [[MDCFloatingButton alloc] init];
   self.largeIconFloatingButton.translatesAutoresizingMaskIntoConstraints = NO;
@@ -85,10 +79,7 @@ NSString *kMiniButtonLabel = @"Add";
   [self.largeIconFloatingButton setContentEdgeInsets:UIEdgeInsetsMake(-6, -6, -6, 0)
                                             forShape:MDCFloatingButtonShapeDefault
                                               inMode:MDCFloatingButtonModeExpanded];
-  [MDCFloatingButtonColorThemer applySemanticColorScheme:self.colorScheme
-                                                toButton:self.largeIconFloatingButton];
-  [MDCFloatingButtonShapeThemer applyShapeScheme:self.shapeScheme
-                                        toButton:self.largeIconFloatingButton];
+  [self.largeIconFloatingButton applySecondaryThemeWithScheme:self.containerScheme];
 
   [self.view addSubview:self.iPadLabel];
   [self.view addSubview:self.miniFloatingButton];

--- a/components/Buttons/examples/FloatingButtonExampleViewController.m
+++ b/components/Buttons/examples/FloatingButtonExampleViewController.m
@@ -15,7 +15,7 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialButtons.h"
-#import <MaterialComponentsBeta/MaterialButtons+Theming.h>
+#import "MaterialButtons+Theming.h"
 
 NSString *kButtonLabel = @"Create";
 NSString *kMiniButtonLabel = @"Add";


### PR DESCRIPTION
## Related links
* Related bug: #6441 
* Theming extensions: [Buttons+Theming](https://github.com/material-components/material-components-ios/tree/develop/components/Buttons/src/Theming)
## Introduction
The team is pivoting to using theming extensions so our examples should reflect the current best practices when using our APIs. 
## The problem
We are using _Themers_ in some instances and some instances used a work around for the container scheme. In #6458 we added a Catalog wide container scheme.
## The fix
Remove _Themers_ for _Theming extensions_ and remove the workarounds for not having a catalog wide container scheme.