### PR TITLE
[Chips] Update chips examples to use container schemes

### DIFF
--- a/components/Chips/examples/ChipsActionExampleViewController.m
+++ b/components/Chips/examples/ChipsActionExampleViewController.m
@@ -27,21 +27,14 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.colorScheme =
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    self.containerScheme.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.shapeScheme = [[MDCShapeScheme alloc] init];
-    self.typographyScheme =
+    self.containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+    self.containerScheme.typographyScheme =
         [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
   }
   return self;
-}
-
-- (MDCContainerScheme *)containerScheme {
-  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-  scheme.colorScheme = self.colorScheme;
-  scheme.shapeScheme = self.shapeScheme;
-  scheme.typographyScheme = self.typographyScheme;
-  return scheme;
 }
 
 - (void)loadView {
@@ -78,6 +71,7 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+  [_sizingChip applyThemeWithScheme:self.containerScheme];
 
   _isOutlined = NO;
   self.navigationItem.rightBarButtonItem =

--- a/components/Chips/examples/ChipsActionExampleViewController.m
+++ b/components/Chips/examples/ChipsActionExampleViewController.m
@@ -124,17 +124,9 @@
 
   // Apply Theming
   if (_isOutlined) {
-    if (self.containerScheming.colorScheme) {
-      [chipView applyOutlinedThemeWithScheme:self.containerScheming];
-    } else {
-      [chipView applyOutlinedThemeWithScheme:self.defaultContainerScheme];
-    }
+    [chipView applyOutlinedThemeWithScheme:self.containerScheming];
   } else {
-    if (self.containerScheming.colorScheme) {
-      [chipView applyThemeWithScheme:self.containerScheming];
-    } else {
-      [chipView applyThemeWithScheme:self.defaultContainerScheme];
-    }
+    [chipView applyThemeWithScheme:self.containerScheming];
   }
 
   return cell;

--- a/components/Chips/examples/ChipsActionExampleViewController.m
+++ b/components/Chips/examples/ChipsActionExampleViewController.m
@@ -27,18 +27,13 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheming = [self defaultContainerScheme];
+    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+    scheme.colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    scheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    scheme.shapeScheme = [[MDCShapeScheme alloc] init];
+    self.containerScheme = scheme;
   }
   return self;
-}
-
-- (MDCContainerScheme *)defaultContainerScheme {
-  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-  containerScheme.colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-  return containerScheme;
 }
 
 - (void)loadView {
@@ -75,11 +70,7 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  if (self.containerScheming.colorScheme) {
-    [_sizingChip applyThemeWithScheme:self.containerScheming];
-  } else {
-    [_sizingChip applyThemeWithScheme:self.defaultContainerScheme];
-  }
+  [_sizingChip applyThemeWithScheme:self.containerScheme];
 
   _isOutlined = NO;
   self.navigationItem.rightBarButtonItem =
@@ -124,9 +115,9 @@
 
   // Apply Theming
   if (_isOutlined) {
-    [chipView applyOutlinedThemeWithScheme:self.containerScheming];
+    [chipView applyOutlinedThemeWithScheme:self.containerScheme];
   } else {
-    [chipView applyThemeWithScheme:self.containerScheming];
+    [chipView applyThemeWithScheme:self.containerScheme];
   }
 
   return cell;

--- a/components/Chips/examples/ChipsActionExampleViewController.m
+++ b/components/Chips/examples/ChipsActionExampleViewController.m
@@ -28,7 +28,8 @@
   self = [super init];
   if (self) {
     MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-    scheme.colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    scheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     scheme.typographyScheme = [[MDCTypographyScheme alloc] init];
     scheme.shapeScheme = [[MDCShapeScheme alloc] init];
     self.containerScheme = scheme;

--- a/components/Chips/examples/ChipsActionExampleViewController.m
+++ b/components/Chips/examples/ChipsActionExampleViewController.m
@@ -27,14 +27,18 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
-    self.containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-    self.containerScheme.typographyScheme =
-        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+    self.containerScheming = [self defaultContainerScheme];
   }
   return self;
+}
+
+- (MDCContainerScheme *)defaultContainerScheme {
+  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+  containerScheme.colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+  return containerScheme;
 }
 
 - (void)loadView {
@@ -71,7 +75,11 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  [_sizingChip applyThemeWithScheme:self.containerScheme];
+  if (self.containerScheming.colorScheme) {
+    [_sizingChip applyThemeWithScheme:self.containerScheming];
+  } else {
+    [_sizingChip applyThemeWithScheme:self.defaultContainerScheme];
+  }
 
   _isOutlined = NO;
   self.navigationItem.rightBarButtonItem =
@@ -116,9 +124,17 @@
 
   // Apply Theming
   if (_isOutlined) {
-    [chipView applyOutlinedThemeWithScheme:[self containerScheme]];
+    if (self.containerScheming.colorScheme) {
+      [chipView applyOutlinedThemeWithScheme:self.containerScheming];
+    } else {
+      [chipView applyOutlinedThemeWithScheme:self.defaultContainerScheme];
+    }
   } else {
-    [chipView applyThemeWithScheme:[self containerScheme]];
+    if (self.containerScheming.colorScheme) {
+      [chipView applyThemeWithScheme:self.containerScheming];
+    } else {
+      [chipView applyThemeWithScheme:self.defaultContainerScheme];
+    }
   }
 
   return cell;

--- a/components/Chips/examples/ChipsActionExampleViewController.m
+++ b/components/Chips/examples/ChipsActionExampleViewController.m
@@ -27,12 +27,7 @@
 - (id)init {
   self = [super init];
   if (self) {
-    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-    scheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    scheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-    scheme.shapeScheme = [[MDCShapeScheme alloc] init];
-    self.containerScheme = scheme;
+    self.containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }

--- a/components/Chips/examples/ChipsChoiceExampleViewController.m
+++ b/components/Chips/examples/ChipsChoiceExampleViewController.m
@@ -28,18 +28,12 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.colorScheme =
+    _containerScheme = [[MDCContainerScheme alloc] init];
+    _containerScheme.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.shapeScheme = [[MDCShapeScheme alloc] init];
+    _containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
   }
   return self;
-}
-
-- (MDCContainerScheme *)containerScheme {
-  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-  scheme.colorScheme = self.colorScheme;
-  scheme.shapeScheme = self.shapeScheme;
-  return scheme;
 }
 
 - (void)loadView {
@@ -75,6 +69,7 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+  [self.sizingChip applyThemeWithScheme:self.containerScheme];
 
   self.outlined = NO;
   self.navigationItem.rightBarButtonItem =

--- a/components/Chips/examples/ChipsChoiceExampleViewController.m
+++ b/components/Chips/examples/ChipsChoiceExampleViewController.m
@@ -125,17 +125,9 @@
   cell.userInteractionEnabled = indexPath.row != 2;
 
   if (self.isOutlined) {
-    if (self.containerScheming.colorScheme) {
-      [chipView applyOutlinedThemeWithScheme:self.containerScheming];
-    } else {
-      [chipView applyOutlinedThemeWithScheme:self.defaultContainerScheme];
-    }
+    [chipView applyOutlinedThemeWithScheme:self.containerScheming];
   } else {
-    if (self.containerScheming.colorScheme) {
-      [chipView applyThemeWithScheme:self.containerScheming];
-    } else {
-      [chipView applyThemeWithScheme:self.defaultContainerScheme];
-    }
+    [chipView applyThemeWithScheme:self.containerScheming];
   }
 
   return cell;

--- a/components/Chips/examples/ChipsChoiceExampleViewController.m
+++ b/components/Chips/examples/ChipsChoiceExampleViewController.m
@@ -28,18 +28,13 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheming = [self defaultContainerScheme];
+    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+    scheme.colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    scheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    scheme.shapeScheme = [[MDCShapeScheme alloc] init];
+    self.containerScheme = scheme;
   }
   return self;
-}
-
-- (MDCContainerScheme *)defaultContainerScheme {
-  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-  containerScheme.colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-  return containerScheme;
 }
 
 - (void)loadView {
@@ -75,11 +70,7 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  if (self.containerScheming.colorScheme) {
-    [self.sizingChip applyThemeWithScheme:self.containerScheming];
-  } else {
-    [self.sizingChip applyThemeWithScheme:self.defaultContainerScheme];
-  }
+  [self.sizingChip applyThemeWithScheme:self.containerScheme];
 
   self.outlined = NO;
   self.navigationItem.rightBarButtonItem =
@@ -125,9 +116,9 @@
   cell.userInteractionEnabled = indexPath.row != 2;
 
   if (self.isOutlined) {
-    [chipView applyOutlinedThemeWithScheme:self.containerScheming];
+    [chipView applyOutlinedThemeWithScheme:self.containerScheme];
   } else {
-    [chipView applyThemeWithScheme:self.containerScheming];
+    [chipView applyThemeWithScheme:self.containerScheme];
   }
 
   return cell;

--- a/components/Chips/examples/ChipsChoiceExampleViewController.m
+++ b/components/Chips/examples/ChipsChoiceExampleViewController.m
@@ -29,7 +29,8 @@
   self = [super init];
   if (self) {
     MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-    scheme.colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    scheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     scheme.typographyScheme = [[MDCTypographyScheme alloc] init];
     scheme.shapeScheme = [[MDCShapeScheme alloc] init];
     self.containerScheme = scheme;

--- a/components/Chips/examples/ChipsChoiceExampleViewController.m
+++ b/components/Chips/examples/ChipsChoiceExampleViewController.m
@@ -28,12 +28,18 @@
 - (id)init {
   self = [super init];
   if (self) {
-    _containerScheme = [[MDCContainerScheme alloc] init];
-    _containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    _containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+    self.containerScheming = [self defaultContainerScheme];
   }
   return self;
+}
+
+- (MDCContainerScheme *)defaultContainerScheme {
+  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+  containerScheme.colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+  return containerScheme;
 }
 
 - (void)loadView {
@@ -69,7 +75,11 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  [self.sizingChip applyThemeWithScheme:self.containerScheme];
+  if (self.containerScheming.colorScheme) {
+    [self.sizingChip applyThemeWithScheme:self.containerScheming];
+  } else {
+    [self.sizingChip applyThemeWithScheme:self.defaultContainerScheme];
+  }
 
   self.outlined = NO;
   self.navigationItem.rightBarButtonItem =
@@ -115,9 +125,17 @@
   cell.userInteractionEnabled = indexPath.row != 2;
 
   if (self.isOutlined) {
-    [chipView applyOutlinedThemeWithScheme:[self containerScheme]];
+    if (self.containerScheming.colorScheme) {
+      [chipView applyOutlinedThemeWithScheme:self.containerScheming];
+    } else {
+      [chipView applyOutlinedThemeWithScheme:self.defaultContainerScheme];
+    }
   } else {
-    [chipView applyThemeWithScheme:[self containerScheme]];
+    if (self.containerScheming.colorScheme) {
+      [chipView applyThemeWithScheme:self.containerScheming];
+    } else {
+      [chipView applyThemeWithScheme:self.defaultContainerScheme];
+    }
   }
 
   return cell;

--- a/components/Chips/examples/ChipsChoiceExampleViewController.m
+++ b/components/Chips/examples/ChipsChoiceExampleViewController.m
@@ -28,12 +28,8 @@
 - (id)init {
   self = [super init];
   if (self) {
-    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-    scheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    scheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-    scheme.shapeScheme = [[MDCShapeScheme alloc] init];
-    self.containerScheme = scheme;
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    ;
   }
   return self;
 }

--- a/components/Chips/examples/ChipsChoiceExampleViewController.m
+++ b/components/Chips/examples/ChipsChoiceExampleViewController.m
@@ -29,7 +29,6 @@
   self = [super init];
   if (self) {
     self.containerScheme = [[MDCContainerScheme alloc] init];
-    ;
   }
   return self;
 }

--- a/components/Chips/examples/ChipsCollectionExampleViewController.m
+++ b/components/Chips/examples/ChipsCollectionExampleViewController.m
@@ -14,6 +14,7 @@
 
 #import "supplemental/ChipsExamplesSupplemental.h"
 
+#import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
 
 @implementation ChipsCollectionExampleViewController
@@ -26,6 +27,10 @@
   self = [super initWithCollectionViewLayout:layout];
   if (self) {
     self.editing = YES;
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    self.containerScheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    self.containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
   }
   return self;
 }
@@ -50,6 +55,7 @@
   MDCChipCollectionViewCell *cell =
       [collectionView dequeueReusableCellWithReuseIdentifier:@"Cell" forIndexPath:indexPath];
   cell.chipView.titleLabel.text = self.titles[indexPath.row];
+  [cell.chipView applyThemeWithScheme:self.containerScheme];
   return cell;
 }
 

--- a/components/Chips/examples/ChipsCollectionExampleViewController.m
+++ b/components/Chips/examples/ChipsCollectionExampleViewController.m
@@ -28,7 +28,8 @@
   if (self) {
     self.editing = YES;
     MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-    scheme.colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    scheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     scheme.typographyScheme = [[MDCTypographyScheme alloc] init];
     scheme.shapeScheme = [[MDCShapeScheme alloc] init];
     self.containerScheme = scheme;

--- a/components/Chips/examples/ChipsCollectionExampleViewController.m
+++ b/components/Chips/examples/ChipsCollectionExampleViewController.m
@@ -61,11 +61,7 @@
   MDCChipCollectionViewCell *cell =
       [collectionView dequeueReusableCellWithReuseIdentifier:@"Cell" forIndexPath:indexPath];
   cell.chipView.titleLabel.text = self.titles[indexPath.row];
-  if (self.containerScheming.colorScheme) {
-    [cell.chipView applyThemeWithScheme:self.containerScheming];
-  } else {
-    [cell.chipView applyThemeWithScheme:self.defaultContainerScheme];
-  }
+  [cell.chipView applyThemeWithScheme:self.containerScheming];
   return cell;
 }
 

--- a/components/Chips/examples/ChipsCollectionExampleViewController.m
+++ b/components/Chips/examples/ChipsCollectionExampleViewController.m
@@ -27,18 +27,13 @@
   self = [super initWithCollectionViewLayout:layout];
   if (self) {
     self.editing = YES;
-    self.containerScheming = [self defaultContainerScheme];
+    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+    scheme.colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    scheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    scheme.shapeScheme = [[MDCShapeScheme alloc] init];
+    self.containerScheme = scheme;
   }
   return self;
-}
-
-- (MDCContainerScheme *)defaultContainerScheme {
-  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-  containerScheme.colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-  return containerScheme;
 }
 
 - (void)viewDidLoad {
@@ -61,7 +56,7 @@
   MDCChipCollectionViewCell *cell =
       [collectionView dequeueReusableCellWithReuseIdentifier:@"Cell" forIndexPath:indexPath];
   cell.chipView.titleLabel.text = self.titles[indexPath.row];
-  [cell.chipView applyThemeWithScheme:self.containerScheming];
+  [cell.chipView applyThemeWithScheme:self.containerScheme];
   return cell;
 }
 

--- a/components/Chips/examples/ChipsCollectionExampleViewController.m
+++ b/components/Chips/examples/ChipsCollectionExampleViewController.m
@@ -27,12 +27,18 @@
   self = [super initWithCollectionViewLayout:layout];
   if (self) {
     self.editing = YES;
-    self.containerScheme = [[MDCContainerScheme alloc] init];
-    self.containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.containerScheming = [self defaultContainerScheme];
   }
   return self;
+}
+
+- (MDCContainerScheme *)defaultContainerScheme {
+  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+  containerScheme.colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+  return containerScheme;
 }
 
 - (void)viewDidLoad {
@@ -55,7 +61,11 @@
   MDCChipCollectionViewCell *cell =
       [collectionView dequeueReusableCellWithReuseIdentifier:@"Cell" forIndexPath:indexPath];
   cell.chipView.titleLabel.text = self.titles[indexPath.row];
-  [cell.chipView applyThemeWithScheme:self.containerScheme];
+  if (self.containerScheming.colorScheme) {
+    [cell.chipView applyThemeWithScheme:self.containerScheming];
+  } else {
+    [cell.chipView applyThemeWithScheme:self.defaultContainerScheme];
+  }
   return cell;
 }
 

--- a/components/Chips/examples/ChipsCollectionExampleViewController.m
+++ b/components/Chips/examples/ChipsCollectionExampleViewController.m
@@ -27,12 +27,8 @@
   self = [super initWithCollectionViewLayout:layout];
   if (self) {
     self.editing = YES;
-    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-    scheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    scheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-    scheme.shapeScheme = [[MDCShapeScheme alloc] init];
-    self.containerScheme = scheme;
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    ;
   }
   return self;
 }

--- a/components/Chips/examples/ChipsCollectionExampleViewController.m
+++ b/components/Chips/examples/ChipsCollectionExampleViewController.m
@@ -28,7 +28,6 @@
   if (self) {
     self.editing = YES;
     self.containerScheme = [[MDCContainerScheme alloc] init];
-    ;
   }
   return self;
 }

--- a/components/Chips/examples/ChipsCustomizedExampleViewController.m
+++ b/components/Chips/examples/ChipsCustomizedExampleViewController.m
@@ -85,11 +85,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  if (self.containerScheming.colorScheme) {
-    [_sizingChip applyThemeWithScheme:self.containerScheming];
-  } else {
-    [_sizingChip applyThemeWithScheme:self.defaultContainerScheme];
-  }
+  [_sizingChip applyThemeWithScheme:self.containerScheming];
 }
 
 - (void)viewWillLayoutSubviews {
@@ -113,11 +109,7 @@
   cell.chipView.titleLabel.text = self.titles[indexPath.row];
   cell.chipView.selectedImageView.image = [self doneImage];
   cell.alwaysAnimateResize = YES;
-  if (self.containerScheming.colorScheme) {
-    [cell.chipView applyThemeWithScheme:self.containerScheming];
-  } else {
-    [cell.chipView applyThemeWithScheme:self.defaultContainerScheme];
-  }
+  [cell.chipView applyThemeWithScheme:self.containerScheming];
   return cell;
 }
 

--- a/components/Chips/examples/ChipsCustomizedExampleViewController.m
+++ b/components/Chips/examples/ChipsCustomizedExampleViewController.m
@@ -14,6 +14,7 @@
 
 #import "supplemental/ChipsExamplesSupplemental.h"
 
+#import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
 
 @implementation ChipsCustomizedExampleViewController {
@@ -64,6 +65,16 @@
   [self.view addSubview:_collectionView];
 }
 
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  self.containerScheme = [[MDCContainerScheme alloc] init];
+  self.containerScheme.colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  self.containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+  [_sizingChip applyThemeWithScheme:self.containerScheme];
+}
+
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
 
@@ -85,7 +96,7 @@
   cell.chipView.titleLabel.text = self.titles[indexPath.row];
   cell.chipView.selectedImageView.image = [self doneImage];
   cell.alwaysAnimateResize = YES;
-
+  [cell.chipView applyThemeWithScheme:self.containerScheme];
   return cell;
 }
 

--- a/components/Chips/examples/ChipsCustomizedExampleViewController.m
+++ b/components/Chips/examples/ChipsCustomizedExampleViewController.m
@@ -25,12 +25,18 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
-    self.containerScheme.colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.containerScheming = [self defaultContainerScheme];
   }
   return self;
+}
+
+- (MDCContainerScheme *)defaultContainerScheme {
+  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+  containerScheme.colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+  return containerScheme;
 }
 
 + (void)configureChip:(MDCChipView *)chip {
@@ -79,7 +85,11 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  [_sizingChip applyThemeWithScheme:self.containerScheme];
+  if (self.containerScheming.colorScheme) {
+    [_sizingChip applyThemeWithScheme:self.containerScheming];
+  } else {
+    [_sizingChip applyThemeWithScheme:self.defaultContainerScheme];
+  }
 }
 
 - (void)viewWillLayoutSubviews {
@@ -103,7 +113,11 @@
   cell.chipView.titleLabel.text = self.titles[indexPath.row];
   cell.chipView.selectedImageView.image = [self doneImage];
   cell.alwaysAnimateResize = YES;
-  [cell.chipView applyThemeWithScheme:self.containerScheme];
+  if (self.containerScheming.colorScheme) {
+    [cell.chipView applyThemeWithScheme:self.containerScheming];
+  } else {
+    [cell.chipView applyThemeWithScheme:self.defaultContainerScheme];
+  }
   return cell;
 }
 

--- a/components/Chips/examples/ChipsCustomizedExampleViewController.m
+++ b/components/Chips/examples/ChipsCustomizedExampleViewController.m
@@ -22,6 +22,17 @@
   MDCChipView *_sizingChip;
 }
 
+- (id)init {
+  self = [super init];
+  if (self) {
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    self.containerScheme.colorScheme =
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    self.containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+  }
+  return self;
+}
+
 + (void)configureChip:(MDCChipView *)chip {
   UIFont *customTitleFont = [UIFont fontWithName:@"ChalkDuster" size:14];
   chip.titleFont = customTitleFont;
@@ -68,10 +79,6 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.containerScheme = [[MDCContainerScheme alloc] init];
-  self.containerScheme.colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  self.containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
   [_sizingChip applyThemeWithScheme:self.containerScheme];
 }
 

--- a/components/Chips/examples/ChipsCustomizedExampleViewController.m
+++ b/components/Chips/examples/ChipsCustomizedExampleViewController.m
@@ -25,18 +25,13 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheming = [self defaultContainerScheme];
+    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+    scheme.colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    scheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    scheme.shapeScheme = [[MDCShapeScheme alloc] init];
+    self.containerScheme = scheme;
   }
   return self;
-}
-
-- (MDCContainerScheme *)defaultContainerScheme {
-  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-  containerScheme.colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-  return containerScheme;
 }
 
 + (void)configureChip:(MDCChipView *)chip {
@@ -85,7 +80,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  [_sizingChip applyThemeWithScheme:self.containerScheming];
+  [_sizingChip applyThemeWithScheme:self.containerScheme];
 }
 
 - (void)viewWillLayoutSubviews {
@@ -109,7 +104,7 @@
   cell.chipView.titleLabel.text = self.titles[indexPath.row];
   cell.chipView.selectedImageView.image = [self doneImage];
   cell.alwaysAnimateResize = YES;
-  [cell.chipView applyThemeWithScheme:self.containerScheming];
+  [cell.chipView applyThemeWithScheme:self.containerScheme];
   return cell;
 }
 

--- a/components/Chips/examples/ChipsCustomizedExampleViewController.m
+++ b/components/Chips/examples/ChipsCustomizedExampleViewController.m
@@ -26,7 +26,8 @@
   self = [super init];
   if (self) {
     MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-    scheme.colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    scheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     scheme.typographyScheme = [[MDCTypographyScheme alloc] init];
     scheme.shapeScheme = [[MDCShapeScheme alloc] init];
     self.containerScheme = scheme;

--- a/components/Chips/examples/ChipsCustomizedExampleViewController.m
+++ b/components/Chips/examples/ChipsCustomizedExampleViewController.m
@@ -25,12 +25,8 @@
 - (id)init {
   self = [super init];
   if (self) {
-    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-    scheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    scheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-    scheme.shapeScheme = [[MDCShapeScheme alloc] init];
-    self.containerScheme = scheme;
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    ;
   }
   return self;
 }

--- a/components/Chips/examples/ChipsCustomizedExampleViewController.m
+++ b/components/Chips/examples/ChipsCustomizedExampleViewController.m
@@ -26,7 +26,6 @@
   self = [super init];
   if (self) {
     self.containerScheme = [[MDCContainerScheme alloc] init];
-    ;
   }
   return self;
 }

--- a/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
+++ b/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
@@ -20,18 +20,8 @@ import MaterialComponentsBeta.MaterialChips_Theming
 import MaterialComponentsBeta.MaterialContainerScheme
 
 class ChipsFieldDeleteEnabledViewController : UIViewController, MDCChipFieldDelegate {
-  var colorScheme = MDCSemanticColorScheme()
-  var shapeScheme = MDCShapeScheme()
-  var typographyScheme = MDCTypographyScheme()
+  var containerScheme = MDCContainerScheme()
   var chipField = MDCChipField()
-
-  var scheme: MDCContainerScheming {
-    let scheme = MDCContainerScheme()
-    scheme.colorScheme = colorScheme
-    scheme.shapeScheme = shapeScheme
-    scheme.typographyScheme = typographyScheme
-    return scheme
-  }
 
   init() {
     super.init(nibName: nil, bundle: nil)
@@ -45,11 +35,14 @@ class ChipsFieldDeleteEnabledViewController : UIViewController, MDCChipFieldDele
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor = colorScheme.backgroundColor
+    containerScheme.colorScheme = MDCSemanticColorScheme()
+    containerScheme.shapeScheme = MDCShapeScheme()
+    containerScheme.typographyScheme = MDCTypographyScheme()
+    view.backgroundColor = containerScheme.colorScheme!.backgroundColor
     chipField.frame = .zero
     chipField.delegate = self
     chipField.textField.placeholderLabel.text = "This is a chip field."
-    chipField.backgroundColor = colorScheme.surfaceColor
+    chipField.backgroundColor = containerScheme.colorScheme!.surfaceColor
     chipField.showChipsDeleteButton = true
     view.addSubview(chipField)
   }
@@ -70,7 +63,7 @@ class ChipsFieldDeleteEnabledViewController : UIViewController, MDCChipFieldDele
   }
 
   func chipField(_ chipField: MDCChipField, didAddChip chip: MDCChipView) {
-    chip.applyTheme(withScheme: scheme)
+    chip.applyTheme(withScheme: containerScheme)
     chip.sizeToFit()
     let chipVerticalInset = min(0, chip.bounds.height - 48 / 2)
     chip.hitAreaInsets = UIEdgeInsetsMake(chipVerticalInset, 0, chipVerticalInset, 0)

--- a/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
+++ b/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
@@ -25,24 +25,37 @@ class ChipsFieldDeleteEnabledViewController : UIViewController, MDCChipFieldDele
 
   init() {
     super.init(nibName: nil, bundle: nil)
+    commonInit()
   }
 
   @available(*, unavailable)
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
+    commonInit()
+  }
+
+  func commonInit() {
+    setUpContainerScheme()
+  }
+
+  func setUpContainerScheme() {
+    containerScheme.colorScheme = MDCSemanticColorScheme()
+    containerScheme.shapeScheme = MDCShapeScheme()
+    containerScheme.typographyScheme = MDCTypographyScheme()
   }
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    containerScheme.colorScheme = MDCSemanticColorScheme()
-    containerScheme.shapeScheme = MDCShapeScheme()
-    containerScheme.typographyScheme = MDCTypographyScheme()
-    view.backgroundColor = containerScheme.colorScheme!.backgroundColor
+    view.backgroundColor =
+      containerScheme.colorScheme?.backgroundColor ??
+      MDCSemanticColorScheme().backgroundColor
     chipField.frame = .zero
     chipField.delegate = self
     chipField.textField.placeholderLabel.text = "This is a chip field."
-    chipField.backgroundColor = containerScheme.colorScheme!.surfaceColor
+    chipField.backgroundColor =
+      containerScheme.colorScheme?.surfaceColor ??
+      MDCSemanticColorScheme().surfaceColor
     chipField.showChipsDeleteButton = true
     view.addSubview(chipField)
   }

--- a/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
+++ b/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
@@ -72,11 +72,7 @@ class ChipsFieldDeleteEnabledViewController : UIViewController, MDCChipFieldDele
   }
 
   func chipField(_ chipField: MDCChipField, didAddChip chip: MDCChipView) {
-    if let _ = containerScheming.colorScheme {
-      chip.applyTheme(withScheme: containerScheming)
-    } else {
-      chip.applyTheme(withScheme: ChipsFieldDeleteEnabledViewController.defaultContainerScheme)
-    }
+    chip.applyTheme(withScheme: containerScheming)
     chip.sizeToFit()
     let chipVerticalInset = min(0, chip.bounds.height - 48 / 2)
     chip.hitAreaInsets = UIEdgeInsetsMake(chipVerticalInset, 0, chipVerticalInset, 0)

--- a/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
+++ b/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
@@ -24,20 +24,16 @@ class ChipsFieldDeleteEnabledViewController : UIViewController, MDCChipFieldDele
   var chipField = MDCChipField()
 
   init() {
-    containerScheming = ChipsFieldDeleteEnabledViewController.defaultContainerScheme
+    let scheme = MDCContainerScheme()
+    scheme.colorScheme = MDCSemanticColorScheme()
+    scheme.shapeScheme = MDCShapeScheme()
+    scheme.typographyScheme = MDCTypographyScheme()
+    containerScheming = scheme
     super.init(nibName: nil, bundle: nil)
   }
 
   required init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) is not implemented")
-  }
-
-  static var defaultContainerScheme: MDCContainerScheme {
-    let containerScheme = MDCContainerScheme()
-    containerScheme.colorScheme = MDCSemanticColorScheme()
-    containerScheme.shapeScheme = MDCShapeScheme()
-    containerScheme.typographyScheme = MDCTypographyScheme()
-    return containerScheme
   }
 
   override func viewDidLoad() {

--- a/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
+++ b/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
@@ -20,41 +20,37 @@ import MaterialComponentsBeta.MaterialChips_Theming
 import MaterialComponentsBeta.MaterialContainerScheme
 
 class ChipsFieldDeleteEnabledViewController : UIViewController, MDCChipFieldDelegate {
-  var containerScheme = MDCContainerScheme()
+  var containerScheming: MDCContainerScheming
   var chipField = MDCChipField()
 
   init() {
+    containerScheming = ChipsFieldDeleteEnabledViewController.defaultContainerScheme
     super.init(nibName: nil, bundle: nil)
-    commonInit()
   }
 
-  @available(*, unavailable)
   required init?(coder aDecoder: NSCoder) {
-    super.init(coder: aDecoder)
-    commonInit()
+    fatalError("init(coder:) is not implemented")
   }
 
-  func commonInit() {
-    setUpContainerScheme()
-  }
-
-  func setUpContainerScheme() {
+  static var defaultContainerScheme: MDCContainerScheme {
+    let containerScheme = MDCContainerScheme()
     containerScheme.colorScheme = MDCSemanticColorScheme()
     containerScheme.shapeScheme = MDCShapeScheme()
     containerScheme.typographyScheme = MDCTypographyScheme()
+    return containerScheme
   }
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
     view.backgroundColor =
-      containerScheme.colorScheme?.backgroundColor ??
+      containerScheming.colorScheme?.backgroundColor ??
       MDCSemanticColorScheme().backgroundColor
     chipField.frame = .zero
     chipField.delegate = self
     chipField.textField.placeholderLabel.text = "This is a chip field."
     chipField.backgroundColor =
-      containerScheme.colorScheme?.surfaceColor ??
+      containerScheming.colorScheme?.surfaceColor ??
       MDCSemanticColorScheme().surfaceColor
     chipField.showChipsDeleteButton = true
     view.addSubview(chipField)
@@ -76,7 +72,11 @@ class ChipsFieldDeleteEnabledViewController : UIViewController, MDCChipFieldDele
   }
 
   func chipField(_ chipField: MDCChipField, didAddChip chip: MDCChipView) {
-    chip.applyTheme(withScheme: containerScheme)
+    if let _ = containerScheming.colorScheme {
+      chip.applyTheme(withScheme: containerScheming)
+    } else {
+      chip.applyTheme(withScheme: ChipsFieldDeleteEnabledViewController.defaultContainerScheme)
+    }
     chip.sizeToFit()
     let chipVerticalInset = min(0, chip.bounds.height - 48 / 2)
     chip.hitAreaInsets = UIEdgeInsetsMake(chipVerticalInset, 0, chipVerticalInset, 0)

--- a/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
+++ b/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
@@ -24,11 +24,7 @@ class ChipsFieldDeleteEnabledViewController : UIViewController, MDCChipFieldDele
   var chipField = MDCChipField()
 
   init() {
-    let scheme = MDCContainerScheme()
-    scheme.colorScheme = MDCSemanticColorScheme()
-    scheme.shapeScheme = MDCShapeScheme()
-    scheme.typographyScheme = MDCTypographyScheme()
-    containerScheming = scheme
+    containerScheming = MDCContainerScheme()
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/components/Chips/examples/ChipsFilterExampleViewController.m
+++ b/components/Chips/examples/ChipsFilterExampleViewController.m
@@ -30,7 +30,7 @@
   if (self) {
     MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
     containerScheme.colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
     containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
     self.containerScheme = containerScheme;

--- a/components/Chips/examples/ChipsFilterExampleViewController.m
+++ b/components/Chips/examples/ChipsFilterExampleViewController.m
@@ -28,18 +28,14 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheming = [self defaultContainerScheme];
+    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+    containerScheme.colorScheme =
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+    containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.containerScheme = containerScheme;
   }
   return self;
-}
-
-- (MDCContainerScheme *)defaultContainerScheme {
-  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-  containerScheme.colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-  return containerScheme;
 }
 
 - (void)loadView {
@@ -121,20 +117,22 @@
   chipView.titleLabel.text = self.titles[indexPath.row];
   chipView.selectedImageView.image =
       [[self doneImage] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-  if (self.containerScheming.colorScheme) {
+  if (self.containerScheme.colorScheme) {
     chipView.selectedImageView.tintColor =
-        [self.containerScheming.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.54];
+        [self.containerScheme.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.54];
   } else {
-    chipView.selectedImageView.tintColor = [self.defaultContainerScheme.colorScheme.onSurfaceColor
-        colorWithAlphaComponent:(CGFloat)0.54];
+    MDCSemanticColorScheme *colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    chipView.selectedImageView.tintColor =
+        [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.54];
   }
   chipView.selected = [_selectedIndecies containsObject:indexPath];
   cell.alwaysAnimateResize = [self shouldAnimateResize];
 
   if (_isOutlined) {
-    [chipView applyOutlinedThemeWithScheme:self.containerScheming];
+    [chipView applyOutlinedThemeWithScheme:self.containerScheme];
   } else {
-    [chipView applyThemeWithScheme:self.containerScheming];
+    [chipView applyThemeWithScheme:self.containerScheme];
   }
 
   return cell;

--- a/components/Chips/examples/ChipsFilterExampleViewController.m
+++ b/components/Chips/examples/ChipsFilterExampleViewController.m
@@ -28,21 +28,14 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.colorScheme =
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    self.containerScheme.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.shapeScheme = [[MDCShapeScheme alloc] init];
-    self.typographyScheme =
+    self.containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+    self.containerScheme.typographyScheme =
         [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
   }
   return self;
-}
-
-- (MDCContainerScheme *)containerScheme {
-  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-  scheme.colorScheme = self.colorScheme;
-  scheme.shapeScheme = self.shapeScheme;
-  scheme.typographyScheme = self.typographyScheme;
-  return scheme;
 }
 
 - (void)loadView {
@@ -125,7 +118,7 @@
   chipView.selectedImageView.image =
       [[self doneImage] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   chipView.selectedImageView.tintColor =
-      [_colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.54];
+      [self.containerScheme.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.54];
   chipView.selected = [_selectedIndecies containsObject:indexPath];
   cell.alwaysAnimateResize = [self shouldAnimateResize];
 

--- a/components/Chips/examples/ChipsFilterExampleViewController.m
+++ b/components/Chips/examples/ChipsFilterExampleViewController.m
@@ -132,17 +132,9 @@
   cell.alwaysAnimateResize = [self shouldAnimateResize];
 
   if (_isOutlined) {
-    if (self.containerScheming.colorScheme) {
-      [chipView applyOutlinedThemeWithScheme:self.containerScheming];
-    } else {
-      [chipView applyOutlinedThemeWithScheme:self.defaultContainerScheme];
-    }
+    [chipView applyOutlinedThemeWithScheme:self.containerScheming];
   } else {
-    if (self.containerScheming.colorScheme) {
-      [chipView applyThemeWithScheme:self.containerScheming];
-    } else {
-      [chipView applyThemeWithScheme:self.defaultContainerScheme];
-    }
+    [chipView applyThemeWithScheme:self.containerScheming];
   }
 
   return cell;

--- a/components/Chips/examples/ChipsFilterExampleViewController.m
+++ b/components/Chips/examples/ChipsFilterExampleViewController.m
@@ -28,14 +28,18 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
-    self.containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-    self.containerScheme.typographyScheme =
-        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+    self.containerScheming = [self defaultContainerScheme];
   }
   return self;
+}
+
+- (MDCContainerScheme *)defaultContainerScheme {
+  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+  containerScheme.colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+  return containerScheme;
 }
 
 - (void)loadView {
@@ -117,15 +121,28 @@
   chipView.titleLabel.text = self.titles[indexPath.row];
   chipView.selectedImageView.image =
       [[self doneImage] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-  chipView.selectedImageView.tintColor =
-      [self.containerScheme.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.54];
+  if (self.containerScheming.colorScheme) {
+    chipView.selectedImageView.tintColor =
+        [self.containerScheming.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.54];
+  } else {
+    chipView.selectedImageView.tintColor = [self.defaultContainerScheme.colorScheme.onSurfaceColor
+        colorWithAlphaComponent:(CGFloat)0.54];
+  }
   chipView.selected = [_selectedIndecies containsObject:indexPath];
   cell.alwaysAnimateResize = [self shouldAnimateResize];
 
   if (_isOutlined) {
-    [chipView applyOutlinedThemeWithScheme:[self containerScheme]];
+    if (self.containerScheming.colorScheme) {
+      [chipView applyOutlinedThemeWithScheme:self.containerScheming];
+    } else {
+      [chipView applyOutlinedThemeWithScheme:self.defaultContainerScheme];
+    }
   } else {
-    [chipView applyThemeWithScheme:[self containerScheme]];
+    if (self.containerScheming.colorScheme) {
+      [chipView applyThemeWithScheme:self.containerScheming];
+    } else {
+      [chipView applyThemeWithScheme:self.defaultContainerScheme];
+    }
   }
 
   return cell;

--- a/components/Chips/examples/ChipsFilterExampleViewController.m
+++ b/components/Chips/examples/ChipsFilterExampleViewController.m
@@ -29,7 +29,6 @@
   self = [super init];
   if (self) {
     self.containerScheme = [[MDCContainerScheme alloc] init];
-    ;
   }
   return self;
 }

--- a/components/Chips/examples/ChipsFilterExampleViewController.m
+++ b/components/Chips/examples/ChipsFilterExampleViewController.m
@@ -28,12 +28,8 @@
 - (id)init {
   self = [super init];
   if (self) {
-    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-    containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-    containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-    self.containerScheme = containerScheme;
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    ;
   }
   return self;
 }

--- a/components/Chips/examples/ChipsInputExampleViewController.m
+++ b/components/Chips/examples/ChipsInputExampleViewController.m
@@ -81,17 +81,9 @@
 - (void)chipField:(MDCChipField *)chipField didAddChip:(MDCChipView *)chip {
   // Every other chip is stroked
   if (chipField.chips.count % 2) {
-    if (self.containerScheming.colorScheme) {
-      [chip applyOutlinedThemeWithScheme:self.containerScheming];
-    } else {
-      [chip applyOutlinedThemeWithScheme:self.defaultContainerScheme];
-    }
+    [chip applyOutlinedThemeWithScheme:self.containerScheming];
   } else {
-    if (self.containerScheming.colorScheme) {
-      [chip applyThemeWithScheme:self.containerScheming];
-    } else {
-      [chip applyThemeWithScheme:self.defaultContainerScheme];
-    }
+    [chip applyThemeWithScheme:self.containerScheming];
   }
   [chip sizeToFit];
   CGFloat chipVerticalInset = MIN(0, (CGRectGetHeight(chip.bounds) - 48) / 2);

--- a/components/Chips/examples/ChipsInputExampleViewController.m
+++ b/components/Chips/examples/ChipsInputExampleViewController.m
@@ -29,36 +29,34 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheming = [self defaultContainerScheme];
+    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+    containerScheme.colorScheme =
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+    containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.containerScheme = containerScheme;
   }
   return self;
-}
-
-- (MDCContainerScheme *)defaultContainerScheme {
-  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-  containerScheme.colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-  return containerScheme;
 }
 
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  if (self.containerScheming.colorScheme) {
-    self.view.backgroundColor = self.containerScheming.colorScheme.backgroundColor;
+  if (self.containerScheme.colorScheme) {
+    self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
   } else {
-    self.view.backgroundColor = self.defaultContainerScheme.colorScheme.backgroundColor;
+    MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    self.view.backgroundColor = colorScheme.backgroundColor;
   }
 
   _chipField = [[MDCChipField alloc] initWithFrame:CGRectZero];
   _chipField.delegate = self;
   _chipField.textField.placeholderLabel.text = @"This is a chip field.";
-  if (self.containerScheming.colorScheme) {
-    _chipField.backgroundColor = self.containerScheming.colorScheme.surfaceColor;
+  if (self.containerScheme.colorScheme) {
+    _chipField.backgroundColor = self.containerScheme.colorScheme.surfaceColor;
   } else {
-    _chipField.backgroundColor = self.defaultContainerScheme.colorScheme.surfaceColor;
+    MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    _chipField.backgroundColor = colorScheme.surfaceColor;
   }
   [self.view addSubview:_chipField];
 }
@@ -81,9 +79,9 @@
 - (void)chipField:(MDCChipField *)chipField didAddChip:(MDCChipView *)chip {
   // Every other chip is stroked
   if (chipField.chips.count % 2) {
-    [chip applyOutlinedThemeWithScheme:self.containerScheming];
+    [chip applyOutlinedThemeWithScheme:self.containerScheme];
   } else {
-    [chip applyThemeWithScheme:self.containerScheming];
+    [chip applyThemeWithScheme:self.containerScheme];
   }
   [chip sizeToFit];
   CGFloat chipVerticalInset = MIN(0, (CGRectGetHeight(chip.bounds) - 48) / 2);

--- a/components/Chips/examples/ChipsInputExampleViewController.m
+++ b/components/Chips/examples/ChipsInputExampleViewController.m
@@ -29,31 +29,24 @@
 - (id)init {
   self = [super init];
   if (self) {
-    _colorScheme =
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    self.containerScheme.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    _typographyScheme = [[MDCTypographyScheme alloc] init];
-    _shapeScheme = [[MDCShapeScheme alloc] init];
+    self.containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
   }
   return self;
-}
-
-- (MDCContainerScheme *)containerScheme {
-  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-  scheme.colorScheme = self.colorScheme;
-  scheme.shapeScheme = self.shapeScheme;
-  scheme.typographyScheme = self.typographyScheme;
-  return scheme;
 }
 
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.view.backgroundColor = self.colorScheme.backgroundColor;
+  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
 
   _chipField = [[MDCChipField alloc] initWithFrame:CGRectZero];
   _chipField.delegate = self;
   _chipField.textField.placeholderLabel.text = @"This is a chip field.";
-  _chipField.backgroundColor = self.colorScheme.surfaceColor;
+  _chipField.backgroundColor = self.containerScheme.colorScheme.surfaceColor;
   [self.view addSubview:_chipField];
 }
 

--- a/components/Chips/examples/ChipsInputExampleViewController.m
+++ b/components/Chips/examples/ChipsInputExampleViewController.m
@@ -29,24 +29,37 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
-    self.containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-    self.containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+    self.containerScheming = [self defaultContainerScheme];
   }
   return self;
+}
+
+- (MDCContainerScheme *)defaultContainerScheme {
+  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+  containerScheme.colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+  return containerScheme;
 }
 
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
+  if (self.containerScheming.colorScheme) {
+    self.view.backgroundColor = self.containerScheming.colorScheme.backgroundColor;
+  } else {
+    self.view.backgroundColor = self.defaultContainerScheme.colorScheme.backgroundColor;
+  }
 
   _chipField = [[MDCChipField alloc] initWithFrame:CGRectZero];
   _chipField.delegate = self;
   _chipField.textField.placeholderLabel.text = @"This is a chip field.";
-  _chipField.backgroundColor = self.containerScheme.colorScheme.surfaceColor;
+  if (self.containerScheming.colorScheme) {
+    _chipField.backgroundColor = self.containerScheming.colorScheme.surfaceColor;
+  } else {
+    _chipField.backgroundColor = self.defaultContainerScheme.colorScheme.surfaceColor;
+  }
   [self.view addSubview:_chipField];
 }
 
@@ -68,9 +81,17 @@
 - (void)chipField:(MDCChipField *)chipField didAddChip:(MDCChipView *)chip {
   // Every other chip is stroked
   if (chipField.chips.count % 2) {
-    [chip applyOutlinedThemeWithScheme:[self containerScheme]];
+    if (self.containerScheming.colorScheme) {
+      [chip applyOutlinedThemeWithScheme:self.containerScheming];
+    } else {
+      [chip applyOutlinedThemeWithScheme:self.defaultContainerScheme];
+    }
   } else {
-    [chip applyThemeWithScheme:[self containerScheme]];
+    if (self.containerScheming.colorScheme) {
+      [chip applyThemeWithScheme:self.containerScheming];
+    } else {
+      [chip applyThemeWithScheme:self.defaultContainerScheme];
+    }
   }
   [chip sizeToFit];
   CGFloat chipVerticalInset = MIN(0, (CGRectGetHeight(chip.bounds) - 48) / 2);

--- a/components/Chips/examples/ChipsInputExampleViewController.m
+++ b/components/Chips/examples/ChipsInputExampleViewController.m
@@ -31,7 +31,7 @@
   if (self) {
     MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
     containerScheme.colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
     containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
     self.containerScheme = containerScheme;
@@ -45,7 +45,8 @@
   if (self.containerScheme.colorScheme) {
     self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
   } else {
-    MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    MDCSemanticColorScheme *colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     self.view.backgroundColor = colorScheme.backgroundColor;
   }
 
@@ -55,7 +56,8 @@
   if (self.containerScheme.colorScheme) {
     _chipField.backgroundColor = self.containerScheme.colorScheme.surfaceColor;
   } else {
-    MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    MDCSemanticColorScheme *colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     _chipField.backgroundColor = colorScheme.surfaceColor;
   }
   [self.view addSubview:_chipField];

--- a/components/Chips/examples/ChipsInputExampleViewController.m
+++ b/components/Chips/examples/ChipsInputExampleViewController.m
@@ -29,12 +29,8 @@
 - (id)init {
   self = [super init];
   if (self) {
-    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-    containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-    containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-    self.containerScheme = containerScheme;
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    ;
   }
   return self;
 }

--- a/components/Chips/examples/ChipsInputExampleViewController.m
+++ b/components/Chips/examples/ChipsInputExampleViewController.m
@@ -30,7 +30,6 @@
   self = [super init];
   if (self) {
     self.containerScheme = [[MDCContainerScheme alloc] init];
-    ;
   }
   return self;
 }

--- a/components/Chips/examples/ChipsShapingExampleViewController.m
+++ b/components/Chips/examples/ChipsShapingExampleViewController.m
@@ -32,13 +32,18 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
-    self.containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-    self.containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.containerScheming = [self defaultContainerScheme];
   }
   return self;
+}
+
+- (MDCContainerScheme *)defaultContainerScheme {
+  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+  containerScheme.colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+  return containerScheme;
 }
 
 - (void)viewDidLoad {
@@ -56,10 +61,11 @@
   _chipView.accessoryPadding = UIEdgeInsetsMake(0, 0, 0, 10);
   CGSize chipSize = [_chipView sizeThatFits:self.view.bounds.size];
   _chipView.frame = CGRectMake(20, 20, chipSize.width + 20, chipSize.height + 20);
-  if (!self.containerScheme.colorScheme) {
-    self.containerScheme.colorScheme = [[MDCSemanticColorScheme alloc] init];
+  if (self.containerScheming.colorScheme) {
+    [_chipView applyThemeWithScheme:self.containerScheming];
+  } else {
+    [_chipView applyThemeWithScheme:self.defaultContainerScheme];
   }
-  [_chipView applyThemeWithScheme:self.containerScheme];
   _chipView.shapeGenerator = _rectangleShapeGenerator;
   [self.view addSubview:_chipView];
 
@@ -70,8 +76,13 @@
   [_cornerSlider addTarget:self
                     action:@selector(cornerSliderChanged:)
           forControlEvents:UIControlEventValueChanged];
-  [MDCSliderColorThemer applySemanticColorScheme:self.containerScheme.colorScheme
-                                        toSlider:_cornerSlider];
+  if (self.containerScheming.colorScheme) {
+    [MDCSliderColorThemer applySemanticColorScheme:self.containerScheming.colorScheme
+                                          toSlider:_cornerSlider];
+  } else {
+    [MDCSliderColorThemer applySemanticColorScheme:[self defaultContainerScheme].colorScheme
+                                          toSlider:_cornerSlider];
+  }
   [self.view addSubview:_cornerSlider];
 
   _cornerStyleControl = [[UISegmentedControl alloc] initWithItems:@[ @"Rounded", @"Cut", @"None" ]];

--- a/components/Chips/examples/ChipsShapingExampleViewController.m
+++ b/components/Chips/examples/ChipsShapingExampleViewController.m
@@ -56,6 +56,9 @@
   _chipView.accessoryPadding = UIEdgeInsetsMake(0, 0, 0, 10);
   CGSize chipSize = [_chipView sizeThatFits:self.view.bounds.size];
   _chipView.frame = CGRectMake(20, 20, chipSize.width + 20, chipSize.height + 20);
+  if (!self.containerScheme.colorScheme) {
+    self.containerScheme.colorScheme = [[MDCSemanticColorScheme alloc] init];
+  }
   [_chipView applyThemeWithScheme:self.containerScheme];
   _chipView.shapeGenerator = _rectangleShapeGenerator;
   [self.view addSubview:_chipView];

--- a/components/Chips/examples/ChipsShapingExampleViewController.m
+++ b/components/Chips/examples/ChipsShapingExampleViewController.m
@@ -34,7 +34,7 @@
   if (self) {
     MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
     containerScheme.colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
     containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
     self.containerScheme = containerScheme;
@@ -74,8 +74,7 @@
   } else {
     MDCSemanticColorScheme *colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    [MDCSliderColorThemer applySemanticColorScheme:colorScheme
-                                          toSlider:_cornerSlider];
+    [MDCSliderColorThemer applySemanticColorScheme:colorScheme toSlider:_cornerSlider];
   }
   [self.view addSubview:_cornerSlider];
 

--- a/components/Chips/examples/ChipsShapingExampleViewController.m
+++ b/components/Chips/examples/ChipsShapingExampleViewController.m
@@ -22,12 +22,6 @@
 #import "MaterialSlider+ColorThemer.h"
 #import "MaterialSlider.h"
 
-@interface ChipsShapingExampleViewController ()
-@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
-@property(nonatomic, strong) MDCShapeScheme *shapeScheme;
-@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
-@end
-
 @implementation ChipsShapingExampleViewController {
   MDCChipView *_chipView;
   MDCSlider *_cornerSlider;
@@ -38,20 +32,13 @@
 - (id)init {
   self = [super init];
   if (self) {
-    _colorScheme =
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    self.containerScheme.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    _shapeScheme = [[MDCShapeScheme alloc] init];
-    _typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+    self.containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
   }
   return self;
-}
-
-- (MDCContainerScheme *)containerScheme {
-  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-  scheme.colorScheme = self.colorScheme;
-  scheme.shapeScheme = self.shapeScheme;
-  scheme.typographyScheme = self.typographyScheme;
-  return scheme;
 }
 
 - (void)viewDidLoad {
@@ -69,7 +56,7 @@
   _chipView.accessoryPadding = UIEdgeInsetsMake(0, 0, 0, 10);
   CGSize chipSize = [_chipView sizeThatFits:self.view.bounds.size];
   _chipView.frame = CGRectMake(20, 20, chipSize.width + 20, chipSize.height + 20);
-  [_chipView applyThemeWithScheme:[self containerScheme]];
+  [_chipView applyThemeWithScheme:self.containerScheme];
   _chipView.shapeGenerator = _rectangleShapeGenerator;
   [self.view addSubview:_chipView];
 
@@ -80,7 +67,8 @@
   [_cornerSlider addTarget:self
                     action:@selector(cornerSliderChanged:)
           forControlEvents:UIControlEventValueChanged];
-  [MDCSliderColorThemer applySemanticColorScheme:_colorScheme toSlider:_cornerSlider];
+  [MDCSliderColorThemer applySemanticColorScheme:self.containerScheme.colorScheme
+                                        toSlider:_cornerSlider];
   [self.view addSubview:_cornerSlider];
 
   _cornerStyleControl = [[UISegmentedControl alloc] initWithItems:@[ @"Rounded", @"Cut", @"None" ]];

--- a/components/Chips/examples/ChipsShapingExampleViewController.m
+++ b/components/Chips/examples/ChipsShapingExampleViewController.m
@@ -32,18 +32,14 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheming = [self defaultContainerScheme];
+    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+    containerScheme.colorScheme =
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+    containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.containerScheme = containerScheme;
   }
   return self;
-}
-
-- (MDCContainerScheme *)defaultContainerScheme {
-  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-  containerScheme.colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-  return containerScheme;
 }
 
 - (void)viewDidLoad {
@@ -61,7 +57,7 @@
   _chipView.accessoryPadding = UIEdgeInsetsMake(0, 0, 0, 10);
   CGSize chipSize = [_chipView sizeThatFits:self.view.bounds.size];
   _chipView.frame = CGRectMake(20, 20, chipSize.width + 20, chipSize.height + 20);
-  [_chipView applyThemeWithScheme:self.containerScheming];
+  [_chipView applyThemeWithScheme:self.containerScheme];
   _chipView.shapeGenerator = _rectangleShapeGenerator;
   [self.view addSubview:_chipView];
 
@@ -72,11 +68,13 @@
   [_cornerSlider addTarget:self
                     action:@selector(cornerSliderChanged:)
           forControlEvents:UIControlEventValueChanged];
-  if (self.containerScheming.colorScheme) {
-    [MDCSliderColorThemer applySemanticColorScheme:self.containerScheming.colorScheme
+  if (self.containerScheme.colorScheme) {
+    [MDCSliderColorThemer applySemanticColorScheme:self.containerScheme.colorScheme
                                           toSlider:_cornerSlider];
   } else {
-    [MDCSliderColorThemer applySemanticColorScheme:[self defaultContainerScheme].colorScheme
+    MDCSemanticColorScheme *colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    [MDCSliderColorThemer applySemanticColorScheme:colorScheme
                                           toSlider:_cornerSlider];
   }
   [self.view addSubview:_cornerSlider];

--- a/components/Chips/examples/ChipsShapingExampleViewController.m
+++ b/components/Chips/examples/ChipsShapingExampleViewController.m
@@ -61,11 +61,7 @@
   _chipView.accessoryPadding = UIEdgeInsetsMake(0, 0, 0, 10);
   CGSize chipSize = [_chipView sizeThatFits:self.view.bounds.size];
   _chipView.frame = CGRectMake(20, 20, chipSize.width + 20, chipSize.height + 20);
-  if (self.containerScheming.colorScheme) {
-    [_chipView applyThemeWithScheme:self.containerScheming];
-  } else {
-    [_chipView applyThemeWithScheme:self.defaultContainerScheme];
-  }
+  [_chipView applyThemeWithScheme:self.containerScheming];
   _chipView.shapeGenerator = _rectangleShapeGenerator;
   [self.view addSubview:_chipView];
 

--- a/components/Chips/examples/ChipsShapingExampleViewController.m
+++ b/components/Chips/examples/ChipsShapingExampleViewController.m
@@ -33,7 +33,6 @@
   self = [super init];
   if (self) {
     self.containerScheme = [[MDCContainerScheme alloc] init];
-    ;
   }
   return self;
 }

--- a/components/Chips/examples/ChipsShapingExampleViewController.m
+++ b/components/Chips/examples/ChipsShapingExampleViewController.m
@@ -32,12 +32,8 @@
 - (id)init {
   self = [super init];
   if (self) {
-    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-    containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-    containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-    self.containerScheme = containerScheme;
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    ;
   }
   return self;
 }

--- a/components/Chips/examples/ChipsSizingExampleViewController.m
+++ b/components/Chips/examples/ChipsSizingExampleViewController.m
@@ -30,7 +30,7 @@
   if (self) {
     MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
     containerScheme.colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
     containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
     self.containerScheme = containerScheme;

--- a/components/Chips/examples/ChipsSizingExampleViewController.m
+++ b/components/Chips/examples/ChipsSizingExampleViewController.m
@@ -28,13 +28,18 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
-    self.containerScheme.colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-    self.containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.containerScheming = [self defaultContainerScheme];
   }
   return self;
+}
+
+- (MDCContainerScheme *)defaultContainerScheme {
+  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+  containerScheme.colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+  return containerScheme;
 }
 
 - (void)viewDidLoad {
@@ -46,7 +51,11 @@
   _chipView.titleLabel.text = @"Material";
   _chipView.imageView.image = [self faceImage];
   _chipView.accessoryView = [self deleteButton];
-  [_chipView applyThemeWithScheme:self.containerScheme];
+  if (self.containerScheming.colorScheme) {
+    [_chipView applyThemeWithScheme:self.containerScheming];
+  } else {
+    [_chipView applyThemeWithScheme:self.defaultContainerScheme];
+  }
   [self.view addSubview:_chipView];
 
   CGSize chipSize = [_chipView sizeThatFits:self.view.bounds.size];

--- a/components/Chips/examples/ChipsSizingExampleViewController.m
+++ b/components/Chips/examples/ChipsSizingExampleViewController.m
@@ -28,18 +28,14 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheming = [self defaultContainerScheme];
+    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+    containerScheme.colorScheme =
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+    containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.containerScheme = containerScheme;
   }
   return self;
-}
-
-- (MDCContainerScheme *)defaultContainerScheme {
-  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-  containerScheme.colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-  return containerScheme;
 }
 
 - (void)viewDidLoad {
@@ -51,7 +47,7 @@
   _chipView.titleLabel.text = @"Material";
   _chipView.imageView.image = [self faceImage];
   _chipView.accessoryView = [self deleteButton];
-  [_chipView applyThemeWithScheme:self.containerScheming];
+  [_chipView applyThemeWithScheme:self.containerScheme];
   [self.view addSubview:_chipView];
 
   CGSize chipSize = [_chipView sizeThatFits:self.view.bounds.size];

--- a/components/Chips/examples/ChipsSizingExampleViewController.m
+++ b/components/Chips/examples/ChipsSizingExampleViewController.m
@@ -51,11 +51,7 @@
   _chipView.titleLabel.text = @"Material";
   _chipView.imageView.image = [self faceImage];
   _chipView.accessoryView = [self deleteButton];
-  if (self.containerScheming.colorScheme) {
-    [_chipView applyThemeWithScheme:self.containerScheming];
-  } else {
-    [_chipView applyThemeWithScheme:self.defaultContainerScheme];
-  }
+  [_chipView applyThemeWithScheme:self.containerScheming];
   [self.view addSubview:_chipView];
 
   CGSize chipSize = [_chipView sizeThatFits:self.view.bounds.size];

--- a/components/Chips/examples/ChipsSizingExampleViewController.m
+++ b/components/Chips/examples/ChipsSizingExampleViewController.m
@@ -14,6 +14,7 @@
 
 #import "supplemental/ChipsExamplesSupplemental.h"
 
+#import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
 #import "MaterialSlider.h"
 
@@ -29,10 +30,17 @@
 
   self.view.backgroundColor = [UIColor whiteColor];
 
+  self.containerScheme = [[MDCContainerScheme alloc] init];
+  self.containerScheme.colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  self.containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+  self.containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+
   _chipView = [[MDCChipView alloc] init];
   _chipView.titleLabel.text = @"Material";
   _chipView.imageView.image = [self faceImage];
   _chipView.accessoryView = [self deleteButton];
+  [_chipView applyThemeWithScheme:self.containerScheme];
   [self.view addSubview:_chipView];
 
   CGSize chipSize = [_chipView sizeThatFits:self.view.bounds.size];

--- a/components/Chips/examples/ChipsSizingExampleViewController.m
+++ b/components/Chips/examples/ChipsSizingExampleViewController.m
@@ -25,16 +25,22 @@
   UISegmentedControl *_horizontalAlignmentControl;
 }
 
+- (id)init {
+  self = [super init];
+  if (self) {
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    self.containerScheme.colorScheme =
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    self.containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+    self.containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+  }
+  return self;
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
 
   self.view.backgroundColor = [UIColor whiteColor];
-
-  self.containerScheme = [[MDCContainerScheme alloc] init];
-  self.containerScheme.colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  self.containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-  self.containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
 
   _chipView = [[MDCChipView alloc] init];
   _chipView.titleLabel.text = @"Material";

--- a/components/Chips/examples/ChipsSizingExampleViewController.m
+++ b/components/Chips/examples/ChipsSizingExampleViewController.m
@@ -29,7 +29,6 @@
   self = [super init];
   if (self) {
     self.containerScheme = [[MDCContainerScheme alloc] init];
-    ;
   }
   return self;
 }

--- a/components/Chips/examples/ChipsSizingExampleViewController.m
+++ b/components/Chips/examples/ChipsSizingExampleViewController.m
@@ -28,12 +28,8 @@
 - (id)init {
   self = [super init];
   if (self) {
-    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-    containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-    containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-    self.containerScheme = containerScheme;
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    ;
   }
   return self;
 }

--- a/components/Chips/examples/ChipsTypicalUseViewController.m
+++ b/components/Chips/examples/ChipsTypicalUseViewController.m
@@ -29,11 +29,18 @@
   if (self) {
     _sizingChip = [[MDCChipView alloc] init];
     _sizingChip.mdc_adjustsFontForContentSizeCategory = YES;
-    _containerScheme = [[MDCContainerScheme alloc] init];
-    _containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-    _containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.containerScheming = [self defaultContainerScheme];
   }
   return self;
+}
+
+- (MDCContainerScheme *)defaultContainerScheme {
+  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+  containerScheme.colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+  return containerScheme;
 }
 
 - (void)dealloc {
@@ -45,7 +52,11 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  [_sizingChip applyThemeWithScheme:self.containerScheme];
+  if (self.containerScheming.colorScheme) {
+    [_sizingChip applyThemeWithScheme:self.containerScheming];
+  } else {
+    [_sizingChip applyThemeWithScheme:self.defaultContainerScheme];
+  }
 
   if (@available(iOS 11.0, *)) {
     self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
@@ -112,7 +123,11 @@
 
   ChipModel *model = self.model[indexPath.row];
   [model apply:cell.chipView];
-  [cell.chipView applyThemeWithScheme:self.containerScheme];
+  if (self.containerScheming.colorScheme) {
+    [cell.chipView applyThemeWithScheme:self.containerScheming];
+  } else {
+    [cell.chipView applyThemeWithScheme:self.defaultContainerScheme];
+  }
   return cell;
 }
 

--- a/components/Chips/examples/ChipsTypicalUseViewController.m
+++ b/components/Chips/examples/ChipsTypicalUseViewController.m
@@ -52,11 +52,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  if (self.containerScheming.colorScheme) {
-    [_sizingChip applyThemeWithScheme:self.containerScheming];
-  } else {
-    [_sizingChip applyThemeWithScheme:self.defaultContainerScheme];
-  }
+  [_sizingChip applyThemeWithScheme:self.containerScheming];
 
   if (@available(iOS 11.0, *)) {
     self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
@@ -123,11 +119,7 @@
 
   ChipModel *model = self.model[indexPath.row];
   [model apply:cell.chipView];
-  if (self.containerScheming.colorScheme) {
-    [cell.chipView applyThemeWithScheme:self.containerScheming];
-  } else {
-    [cell.chipView applyThemeWithScheme:self.defaultContainerScheme];
-  }
+  [cell.chipView applyThemeWithScheme:self.containerScheming];
   return cell;
 }
 

--- a/components/Chips/examples/ChipsTypicalUseViewController.m
+++ b/components/Chips/examples/ChipsTypicalUseViewController.m
@@ -29,18 +29,14 @@
   if (self) {
     _sizingChip = [[MDCChipView alloc] init];
     _sizingChip.mdc_adjustsFontForContentSizeCategory = YES;
-    self.containerScheme = [self defaultContainerScheme];
+    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+    containerScheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+    containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.containerScheme = containerScheme;
   }
   return self;
-}
-
-- (MDCContainerScheme *)defaultContainerScheme {
-  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-  containerScheme.colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-  containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-  return containerScheme;
 }
 
 - (void)dealloc {

--- a/components/Chips/examples/ChipsTypicalUseViewController.m
+++ b/components/Chips/examples/ChipsTypicalUseViewController.m
@@ -29,7 +29,7 @@
   if (self) {
     _sizingChip = [[MDCChipView alloc] init];
     _sizingChip.mdc_adjustsFontForContentSizeCategory = YES;
-    self.containerScheming = [self defaultContainerScheme];
+    self.containerScheme = [self defaultContainerScheme];
   }
   return self;
 }
@@ -52,7 +52,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  [_sizingChip applyThemeWithScheme:self.containerScheming];
+  [_sizingChip applyThemeWithScheme:self.containerScheme];
 
   if (@available(iOS 11.0, *)) {
     self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
@@ -119,7 +119,7 @@
 
   ChipModel *model = self.model[indexPath.row];
   [model apply:cell.chipView];
-  [cell.chipView applyThemeWithScheme:self.containerScheming];
+  [cell.chipView applyThemeWithScheme:self.containerScheme];
   return cell;
 }
 

--- a/components/Chips/examples/ChipsTypicalUseViewController.m
+++ b/components/Chips/examples/ChipsTypicalUseViewController.m
@@ -14,8 +14,7 @@
 
 #import "supplemental/ChipsExamplesSupplemental.h"
 
-#import "MaterialChips+ShapeThemer.h"
-#import "MaterialChips+TypographyThemer.h"
+#import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
 
 @implementation ChipsTypicalUseViewController {
@@ -30,8 +29,9 @@
   if (self) {
     _sizingChip = [[MDCChipView alloc] init];
     _sizingChip.mdc_adjustsFontForContentSizeCategory = YES;
-    self.shapeScheme = [[MDCShapeScheme alloc] init];
-    self.typographyScheme = [[MDCTypographyScheme alloc] init];
+    _containerScheme = [[MDCContainerScheme alloc] init];
+    _containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
+    _containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
   }
   return self;
 }
@@ -45,8 +45,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  [MDCChipViewTypographyThemer applyTypographyScheme:self.typographyScheme toChipView:_sizingChip];
-  [MDCChipViewShapeThemer applyShapeScheme:self.shapeScheme toChipView:_sizingChip];
+  [_sizingChip applyThemeWithScheme:self.containerScheme];
 
   if (@available(iOS 11.0, *)) {
     self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
@@ -113,10 +112,7 @@
 
   ChipModel *model = self.model[indexPath.row];
   [model apply:cell.chipView];
-  [MDCChipViewTypographyThemer applyTypographyScheme:self.typographyScheme
-                                          toChipView:cell.chipView];
-  [MDCChipViewShapeThemer applyShapeScheme:self.shapeScheme toChipView:cell.chipView];
-
+  [cell.chipView applyThemeWithScheme:self.containerScheme];
   return cell;
 }
 

--- a/components/Chips/examples/ChipsTypicalUseViewController.m
+++ b/components/Chips/examples/ChipsTypicalUseViewController.m
@@ -29,12 +29,8 @@
   if (self) {
     _sizingChip = [[MDCChipView alloc] init];
     _sizingChip.mdc_adjustsFontForContentSizeCategory = YES;
-    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-    containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    containerScheme.shapeScheme = [[MDCShapeScheme alloc] init];
-    containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-    self.containerScheme = containerScheme;
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+    ;
   }
   return self;
 }

--- a/components/Chips/examples/ChipsTypicalUseViewController.m
+++ b/components/Chips/examples/ChipsTypicalUseViewController.m
@@ -30,7 +30,6 @@
     _sizingChip = [[MDCChipView alloc] init];
     _sizingChip.mdc_adjustsFontForContentSizeCategory = YES;
     self.containerScheme = [[MDCContainerScheme alloc] init];
-    ;
   }
   return self;
 }

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
@@ -25,26 +25,26 @@
     : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
 @property(nonatomic, strong) UICollectionView *collectionView;
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
 
 @interface ChipsActionExampleViewController
     : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
 @property(nonatomic, strong) UICollectionView *collectionView;
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
 
 @interface ChipsCollectionExampleViewController
     : ExampleChipCollectionViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
 
 @interface ChipsCustomizedExampleViewController
     : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
 
 @interface ChipsCustomizedExampleViewController (Supplemental)
@@ -54,7 +54,7 @@
 @interface ChipsFilterExampleViewController
     : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
 
 @interface ChipsFilterAnimatedExampleViewController
@@ -66,11 +66,11 @@
 @end
 
 @interface ChipsInputExampleViewController : UIViewController
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
 
 @interface ChipsSizingExampleViewController : UIViewController
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
 
 @interface ChipsSizingExampleViewController (Supplemental)
@@ -83,7 +83,7 @@
                                            UICollectionViewDataSource,
                                            UICollectionViewDelegateFlowLayout>
 @property(nonatomic, strong) NSArray<ChipModel *> *model;
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
 
 @interface ChipsTypicalUseViewController (Supplemental)
@@ -91,7 +91,7 @@
 @end
 
 @interface ChipsShapingExampleViewController : UIViewController
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
 
 @interface ChipsShapingExampleViewController (Supplemental)

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
@@ -25,26 +25,26 @@
     : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
 @property(nonatomic, strong) UICollectionView *collectionView;
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
 @end
 
 @interface ChipsActionExampleViewController
     : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
 @property(nonatomic, strong) UICollectionView *collectionView;
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
 @end
 
 @interface ChipsCollectionExampleViewController
     : ExampleChipCollectionViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
 @end
 
 @interface ChipsCustomizedExampleViewController
     : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
 @end
 
 @interface ChipsCustomizedExampleViewController (Supplemental)
@@ -54,7 +54,7 @@
 @interface ChipsFilterExampleViewController
     : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
 @end
 
 @interface ChipsFilterAnimatedExampleViewController
@@ -66,11 +66,11 @@
 @end
 
 @interface ChipsInputExampleViewController : UIViewController
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
 @end
 
 @interface ChipsSizingExampleViewController : UIViewController
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
 @end
 
 @interface ChipsSizingExampleViewController (Supplemental)
@@ -83,7 +83,7 @@
                                            UICollectionViewDataSource,
                                            UICollectionViewDelegateFlowLayout>
 @property(nonatomic, strong) NSArray<ChipModel *> *model;
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
 @end
 
 @interface ChipsTypicalUseViewController (Supplemental)
@@ -91,7 +91,7 @@
 @end
 
 @interface ChipsShapingExampleViewController : UIViewController
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheming;
 @end
 
 @interface ChipsShapingExampleViewController (Supplemental)

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 #import <UIKit/UIKit.h>
-#import "MaterialColorScheme.h"
-#import "MaterialShapeScheme.h"
-#import "MaterialTypographyScheme.h"
+#import "MaterialContainerScheme.h"
 
 @class MDCChipView;
 @class ChipModel;
@@ -27,27 +25,26 @@
     : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
 @property(nonatomic, strong) UICollectionView *collectionView;
-@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
-@property(nonatomic, strong) MDCShapeScheme *shapeScheme;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 @end
 
 @interface ChipsActionExampleViewController
     : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
 @property(nonatomic, strong) UICollectionView *collectionView;
-@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
-@property(nonatomic, strong) MDCShapeScheme *shapeScheme;
-@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 @end
 
 @interface ChipsCollectionExampleViewController
     : ExampleChipCollectionViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 @end
 
 @interface ChipsCustomizedExampleViewController
     : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 @end
 
 @interface ChipsCustomizedExampleViewController (Supplemental)
@@ -57,9 +54,7 @@
 @interface ChipsFilterExampleViewController
     : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
-@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
-@property(nonatomic, strong) MDCShapeScheme *shapeScheme;
-@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 @end
 
 @interface ChipsFilterAnimatedExampleViewController
@@ -71,12 +66,11 @@
 @end
 
 @interface ChipsInputExampleViewController : UIViewController
-@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
-@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
-@property(nonatomic, strong) MDCShapeScheme *shapeScheme;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 @end
 
 @interface ChipsSizingExampleViewController : UIViewController
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 @end
 
 @interface ChipsSizingExampleViewController (Supplemental)
@@ -89,8 +83,7 @@
                                            UICollectionViewDataSource,
                                            UICollectionViewDelegateFlowLayout>
 @property(nonatomic, strong) NSArray<ChipModel *> *model;
-@property(nonatomic, strong) MDCShapeScheme *shapeScheme;
-@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 @end
 
 @interface ChipsTypicalUseViewController (Supplemental)
@@ -98,6 +91,7 @@
 @end
 
 @interface ChipsShapingExampleViewController : UIViewController
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 @end
 
 @interface ChipsShapingExampleViewController (Supplemental)


### PR DESCRIPTION
This PR adds a container scheme property to the chips examples that didn't have them.
It also uses the theming extension to theme chips that weren't already being themed with it.

Closes #6439.
