### PR TITLE
[Catalog] Bump the version number in plist of Catalog and Dragons to 75.0.1

### DIFF
--- a/catalog/MDCCatalog/Info.plist
+++ b/catalog/MDCCatalog/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>75.0.1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIAppFonts</key>

--- a/catalog/MDCDragons/Info.plist
+++ b/catalog/MDCDragons/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>75.0.1</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>75.0.1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
The CFBundleVersion was not updated. Based on my current understanding of release script, it basically does a global grep replace. So updating the version number in corresponding plist should ensure future updates. 
