### PR TITLE
[Cards] The image tint color for the Card Cell should be themed to primaryColor

### DIFF
--- a/components/Cards/src/ColorThemer/MDCCardsColorThemer.m
+++ b/components/Cards/src/ColorThemer/MDCCardsColorThemer.m
@@ -26,6 +26,7 @@ static const CGFloat kStrokeVariantBorderOpacity = (CGFloat)0.37;
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                       toCardCell:(nonnull MDCCardCollectionCell *)cardCell {
   cardCell.backgroundColor = colorScheme.surfaceColor;
+  [cardCell setImageTintColor:colorScheme.primaryColor forState:MDCCardCellStateNormal];
 }
 
 + (void)applyOutlinedVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme


### PR DESCRIPTION
The selected icon of the MDCCardCollectionCell should be set in our themers to primaryColor as defined by material guidelines.

closes: b/123439095