### PR TITLE
[Cards] Fix elevation values for Highlighted and Selected for Cards in themer.

### DIFF
--- a/components/Cards/src/Theming/MDCCard+MaterialTheming.m
+++ b/components/Cards/src/Theming/MDCCard+MaterialTheming.m
@@ -18,7 +18,7 @@
 #import <MaterialComponents/MaterialCards+ShapeThemer.h>
 
 static const MDCShadowElevation kNormalElevation = 1;
-static const MDCShadowElevation kHighlightedElevation = 4;
+static const MDCShadowElevation kHighlightedElevation = 1;
 static const CGFloat kBorderWidth = 1;
 
 @implementation MDCCard (MaterialTheming)

--- a/components/Cards/src/Theming/MDCCardCollectionCell+MaterialTheming.m
+++ b/components/Cards/src/Theming/MDCCardCollectionCell+MaterialTheming.m
@@ -18,8 +18,8 @@
 #import "MaterialCards+ShapeThemer.h"
 
 static const MDCShadowElevation kNormalElevation = 1;
-static const MDCShadowElevation kHighlightedElevation = 4;
-static const MDCShadowElevation kSelectedElevation = 4;
+static const MDCShadowElevation kHighlightedElevation = 1;
+static const MDCShadowElevation kSelectedElevation = 1;
 static const CGFloat kBorderWidth = 1;
 
 @implementation MDCCardCollectionCell (MaterialTheming)

--- a/components/Cards/tests/unit/Theming/CardsMaterialThemingTests.swift
+++ b/components/Cards/tests/unit/Theming/CardsMaterialThemingTests.swift
@@ -52,7 +52,7 @@ class CardsMaterialThemingTests: XCTestCase {
 
     // Test remaining properties
     XCTAssertEqual(card.shadowElevation(for: .normal), ShadowElevation(rawValue: 1))
-    XCTAssertEqual(card.shadowElevation(for: .highlighted), ShadowElevation(rawValue: 4))
+    XCTAssertEqual(card.shadowElevation(for: .highlighted), ShadowElevation(rawValue: 1))
     XCTAssertTrue(card.isInteractable)
   }
 
@@ -152,8 +152,8 @@ class CardsMaterialThemingTests: XCTestCase {
 
     // Test remaining properties
     XCTAssertEqual(cardCell.shadowElevation(for: .normal), ShadowElevation(rawValue: 1))
-    XCTAssertEqual(cardCell.shadowElevation(for: .highlighted), ShadowElevation(rawValue: 4))
-    XCTAssertEqual(cardCell.shadowElevation(for: .selected), ShadowElevation(rawValue: 4))
+    XCTAssertEqual(cardCell.shadowElevation(for: .highlighted), ShadowElevation(rawValue: 1))
+    XCTAssertEqual(cardCell.shadowElevation(for: .selected), ShadowElevation(rawValue: 1))
     XCTAssertTrue(cardCell.isInteractable)
   }
 


### PR DESCRIPTION
Our current highlighted and selected elevation values for cards and card cells should be 1 point rather than 4.

closes: b/123236251 and b/123434660