### PR TITLE
[Ripple] Remove the notion of state and its implementation from the ripple touch controller

### DIFF
--- a/components/Ripple/examples/RippleTypicalUseExample.m
+++ b/components/Ripple/examples/RippleTypicalUseExample.m
@@ -45,7 +45,6 @@
     MDCRippleTouchController *rippleTouchController =
         [[MDCRippleTouchController alloc] initWithView:view];
     rippleTouchController.delegate = self;
-    rippleTouchController.allowsSelection = YES;
     [_rippleTouchControllers addObject:rippleTouchController];
   }
   [containerView addSubview:self.surfaces];

--- a/components/Ripple/src/MDCRippleTouchController.h
+++ b/components/Ripple/src/MDCRippleTouchController.h
@@ -19,18 +19,6 @@
 @protocol MDCRippleTouchControllerDelegate;
 
 /**
- Provides the current state of the ripple. The ripple is either in its normal state, or in the
- selected state where the ripple remains spread on the view.
-
- - MDCRippleStateNormal: The ripple is in its normal state.
- - MDCRippleStateSelected: The ripple is in the selected state.
- */
-typedef NS_ENUM(NSInteger, MDCRippleState) {
-  MDCRippleStateNormal = 0,
-  MDCRippleStateSelected,
-};
-
-/**
  The MDCRippleTouchController is a convenience controller that adds all the needed touch tracking
  and logic to provide the correct ripple effect based on the user interacting with the view the
  ripple is added to.
@@ -48,53 +36,15 @@ typedef NS_ENUM(NSInteger, MDCRippleState) {
  */
 @property(nonatomic, strong, readonly, nonnull) MDCRippleView *rippleView;
 
-/** Delegate to extend the behavior of the touch control. */
-
 /**
  A delegate to extend the behavior of the touch controller.
  */
 @property(nonatomic, weak, nullable) id<MDCRippleTouchControllerDelegate> delegate;
 
-/** Gesture recognizer used to bind touch events to ripple. */
-
 /**
  The gesture recognizer used to bind the touch events to the ripple.
  */
 @property(nonatomic, strong, readonly, nonnull) UILongPressGestureRecognizer *gestureRecognizer;
-
-/**
- The selection gesture recognizer used to bind the touch events related to selection to the ripple.
- */
-@property(nonatomic, strong, readonly, nullable)
-    UILongPressGestureRecognizer *selectionGestureRecognizer;
-
-/**
- This BOOL tells the touch controller to allow selection and all the logic and visuals
- that come with it, for this ripple.
-
- Defaults to NO.
- */
-@property(nonatomic) BOOL allowsSelection;
-
-/**
- This BOOL is set to YES if the ripple is currently selected, or NO otherwise.
- It only has significance if selectionMode is activated.
-
- Defaults to NO.
- */
-@property(nonatomic, getter=isSelected) BOOL selected;
-
-/**
- This BOOL is set to YES if the ripple is currently in the selection mode, or NO otherwise.
-
- Defaults to NO.
- */
-@property(nonatomic) BOOL selectionMode;
-
-/**
- The current state of the ripple.
- */
-@property(nonatomic, readonly) MDCRippleState state;
 
 /**
  Unavailable, please use `initWithView` instead.
@@ -108,38 +58,6 @@ typedef NS_ENUM(NSInteger, MDCRippleState) {
  ripple is added as a subview to.
  */
 - (nonnull instancetype)initWithView:(nonnull UIView *)view NS_DESIGNATED_INITIALIZER;
-
-/**
- Sets the color of the ripple for state.
-
- @param rippleColor The ripple color to set the ripple to.
- @param state The state of the ripple in which to set the ripple color.
- */
-- (void)setRippleColor:(nullable UIColor *)rippleColor forState:(MDCRippleState)state;
-
-/**
- Gets the ripple color for the given state.
-
- @param state The ripple's state.
- @return the color of the ripple for state.
- */
-- (nullable UIColor *)rippleColorForState:(MDCRippleState)state;
-
-/**
- Sets the alpha of the ripple for state.
-
- @param rippleAlpha The ripple alpha to set the ripple to.
- @param state The state of the ripple in which to set the ripple alpha.
- */
-- (void)setRippleAlpha:(CGFloat)rippleAlpha forState:(MDCRippleState)state;
-
-/**
- Gets the ripple alpha for the given state.
-
- @param state The ripple's state.
- @return the alpha of the ripple for state.
- */
-- (CGFloat)rippleAlphaForState:(MDCRippleState)state;
 
 @end
 

--- a/components/Ripple/src/MDCRippleTouchController.m
+++ b/components/Ripple/src/MDCRippleTouchController.m
@@ -16,8 +16,6 @@
 
 @implementation MDCRippleTouchController {
   BOOL _tapWentOutsideOfBounds;
-  NSMutableDictionary<NSNumber *, UIColor *> *_rippleColors;
-  NSMutableDictionary<NSNumber *, NSNumber *> *_rippleAlphas;
 }
 
 - (instancetype)initWithView:(UIView *)view {
@@ -36,24 +34,6 @@
 
     _rippleView = [[MDCRippleView alloc] initWithFrame:view.bounds];
     [_view addSubview:_rippleView];
-    _tapWentOutsideOfBounds = NO;
-
-    if (_rippleColors == nil) {
-      _rippleColors = [NSMutableDictionary dictionary];
-      _rippleColors[@(MDCRippleStateNormal)] = [UIColor blackColor];
-      _rippleColors[@(MDCRippleStateSelected)] = [UIColor colorWithRed:(CGFloat)0.384
-                                                                 green:0
-                                                                  blue:(CGFloat)0.933
-                                                                 alpha:1];
-    }
-
-    if (_rippleAlphas == nil) {
-      _rippleAlphas = [NSMutableDictionary dictionary];
-      _rippleAlphas[@(MDCRippleStateNormal)] = @(0.16);
-      _rippleAlphas[@(MDCRippleStateSelected)] = @(0.08);
-    }
-
-    _selectionMode = NO;
   }
   return self;
 }
@@ -61,90 +41,6 @@
 - (void)dealloc {
   [_view removeGestureRecognizer:_gestureRecognizer];
   _gestureRecognizer.delegate = nil;
-  [_view removeGestureRecognizer:_selectionGestureRecognizer];
-  _selectionGestureRecognizer.delegate = nil;
-}
-
-- (UIColor *)rippleColorForState:(MDCRippleState)state {
-  UIColor *rippleColor = _rippleColors[@(state)];
-  if (state != MDCRippleStateNormal && rippleColor == nil) {
-    rippleColor = _rippleColors[@(MDCRippleStateNormal)];
-  }
-  return rippleColor;
-}
-
-- (void)updateRippleColor {
-  UIColor *rippleColor = [self rippleColorForState:self.state];
-  [self.rippleView setRippleColor:rippleColor];
-}
-
-- (void)updateActiveRippleColor {
-  UIColor *rippleColor = [self constructedColorByState];
-  [self.rippleView setActiveRippleColor:rippleColor];
-}
-
-- (void)setRippleColor:(UIColor *)rippleColor forState:(MDCRippleState)state {
-  _rippleColors[@(state)] = rippleColor;
-
-  [self updateRippleColor];
-}
-
-- (CGFloat)rippleAlphaForState:(MDCRippleState)state {
-  NSNumber *rippleAlpha = _rippleAlphas[@(state)];
-  if (state != MDCRippleStateNormal && rippleAlpha == nil) {
-    rippleAlpha = _rippleAlphas[@(MDCRippleStateNormal)];
-  }
-  return (CGFloat)rippleAlpha.doubleValue;
-}
-
-- (void)setRippleAlpha:(CGFloat)rippleAlpha forState:(MDCRippleState)state {
-  _rippleAlphas[@(state)] = @(rippleAlpha);
-}
-
-- (UIColor *)constructedColorByState {
-  UIColor *rippleColor = [self rippleColorForState:self.state];
-  return [rippleColor colorWithAlphaComponent:[self rippleAlphaForState:self.state]];
-}
-
-- (void)setState:(MDCRippleState)state {
-  _state = state;
-  [self updateActiveRippleColor];
-}
-
-- (void)setAllowsSelection:(BOOL)allowsSelection {
-  _allowsSelection = allowsSelection;
-
-  if (allowsSelection) {
-    _selectionGestureRecognizer = [[UILongPressGestureRecognizer alloc]
-        initWithTarget:self
-                action:@selector(handleRippleSelectionGesture:)];
-    _selectionGestureRecognizer.minimumPressDuration = (CGFloat)0.5;
-    _selectionGestureRecognizer.delegate = self;
-    _selectionGestureRecognizer.cancelsTouchesInView = NO;
-    _selectionGestureRecognizer.delaysTouchesEnded = NO;
-    [_view addGestureRecognizer:_selectionGestureRecognizer];
-  } else {
-    [_view removeGestureRecognizer:_selectionGestureRecognizer];
-    _selectionGestureRecognizer.delegate = nil;
-  }
-}
-
-- (void)setSelected:(BOOL)selected {
-  _selected = selected;
-  [self setState:selected ? MDCRippleStateSelected : MDCRippleStateNormal];
-}
-
-- (void)setSelectionMode:(BOOL)selectionMode {
-  _selectionMode = selectionMode;
-  UIColor *rippleColor =
-      [self rippleColorForState:selectionMode ? MDCRippleStateSelected : MDCRippleStateNormal];
-  rippleColor =
-      [rippleColor colorWithAlphaComponent:[self rippleAlphaForState:MDCRippleStateNormal]];
-  [self.rippleView setRippleColor:rippleColor];
-}
-
-- (void)cancelRippleTouchProcessing {
-  [self.rippleView cancelAllRipplesAnimated:YES];
 }
 
 - (void)handleRippleGesture:(UILongPressGestureRecognizer *)recognizer {
@@ -152,17 +48,9 @@
 
   switch (recognizer.state) {
     case UIGestureRecognizerStateBegan: {
-      _tapWentOutsideOfBounds = NO;
       [self.rippleView beginRippleTouchDownAtPoint:touchLocation
                                           animated:YES
-                                        completion:^{
-                                          if (self.selectionMode) {
-                                            self.selected = !self.selected;
-                                            if (!self.selected) {
-                                              [self.rippleView cancelAllRipplesAnimated:YES];
-                                            }
-                                          }
-                                        }];
+                                        completion:nil];
       if ([_delegate respondsToSelector:@selector(rippleTouchController:
                                                    didProcessRippleView:atTouchLocation:)]) {
         [_delegate rippleTouchController:self
@@ -185,40 +73,11 @@
       break;
     }
     case UIGestureRecognizerStateEnded:
-      if (!_selectionMode) {
-        [self.rippleView beginRippleTouchUpAnimated:YES completion:nil];
-      }
+      [self.rippleView beginRippleTouchUpAnimated:YES completion:nil];
       break;
     case UIGestureRecognizerStateCancelled:
     case UIGestureRecognizerStateFailed:
       [self.rippleView cancelAllRipplesAnimated:YES];
-      break;
-  }
-}
-
-- (void)handleRippleSelectionGesture:(UILongPressGestureRecognizer *)recognizer {
-  switch (recognizer.state) {
-    case UIGestureRecognizerStateBegan: {
-      [self setSelectionMode:!_selectionMode];
-      if (self.selectionMode) {
-        self.selected = YES;
-      } else {
-        if (!self.selected) {
-          [self.rippleView cancelAllRipplesAnimated:YES];
-        }
-      }
-      break;
-    }
-    case UIGestureRecognizerStatePossible:  // Ignored
-      break;
-    case UIGestureRecognizerStateChanged: {
-      break;
-    }
-    case UIGestureRecognizerStateCancelled:
-      break;
-    case UIGestureRecognizerStateEnded:
-      break;
-    case UIGestureRecognizerStateFailed:
       break;
   }
 }

--- a/components/Ripple/src/MDCRippleTouchController.m
+++ b/components/Ripple/src/MDCRippleTouchController.m
@@ -48,9 +48,7 @@
 
   switch (recognizer.state) {
     case UIGestureRecognizerStateBegan: {
-      [self.rippleView beginRippleTouchDownAtPoint:touchLocation
-                                          animated:YES
-                                        completion:nil];
+      [self.rippleView beginRippleTouchDownAtPoint:touchLocation animated:YES completion:nil];
       if ([_delegate respondsToSelector:@selector(rippleTouchController:
                                                    didProcessRippleView:atTouchLocation:)]) {
         [_delegate rippleTouchController:self


### PR DESCRIPTION
For our Ink successor Ripple, which is currently a Beta component, we want to initially clean the implementation so it doesn't consist any notion of state and be equivalent to our Ink component in terms of API and feature set. Further additions will be reviewed and discussed as follow ups with the team.