### PR TITLE
[NavigationDrawer] Fix issue when setting `trackingScrollView`

### DIFF
--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -77,7 +77,7 @@
   if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
     MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
         (MDCBottomDrawerPresentationController *)self.presentationController;
-    bottomDrawerPresentationController.trackingScrollView = trackingScrollView;
+      bottomDrawerPresentationController.trackingScrollView = trackingScrollView;
   }
   // Rather than have the client manually disable scrolling on the internal scroll view for
   // the drawer to work properly, we can disable it if a trackingScrollView is provided.

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -77,7 +77,7 @@
   if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
     MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
         (MDCBottomDrawerPresentationController *)self.presentationController;
-      bottomDrawerPresentationController.trackingScrollView = trackingScrollView;
+    bottomDrawerPresentationController.trackingScrollView = trackingScrollView;
   }
   // Rather than have the client manually disable scrolling on the internal scroll view for
   // the drawer to work properly, we can disable it if a trackingScrollView is provided.

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -72,15 +72,16 @@
   return UIModalPresentationCustom;
 }
 
-- (UIScrollView *)trackingScrollView {
-  return self.transitionController.trackingScrollView;
-}
-
 - (void)setTrackingScrollView:(UIScrollView *)trackingScrollView {
+  _trackingScrollView = trackingScrollView;
+  if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
+    MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
+        (MDCBottomDrawerPresentationController *)self.presentationController;
+    bottomDrawerPresentationController.trackingScrollView = trackingScrollView;
+  }
   // Rather than have the client manually disable scrolling on the internal scroll view for
   // the drawer to work properly, we can disable it if a trackingScrollView is provided.
   [trackingScrollView setScrollEnabled:NO];
-  self.transitionController.trackingScrollView = trackingScrollView;
 }
 
 - (void)setTopCornersRadius:(CGFloat)radius forDrawerState:(MDCBottomDrawerState)drawerState {

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -505,16 +505,10 @@
   XCTAssertEqual(self.fakeScrollView.scrollEnabled, NO);
 }
 
-- (void)testSetTrackingScrollView {
+- (void)testSetTrackingScrollViewAfterSetScrimColor {
   // Given
-  MDCBottomDrawerPresentationController *drawerPresentationController = nil;
-  if ([self.drawerViewController.presentationController
-          isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
-    drawerPresentationController =
-        (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
-  } else {
-    drawerPresentationController = nil;
-  }
+  MDCBottomDrawerPresentationController *drawerPresentationController =
+      (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
 
   // When
   self.drawerViewController.scrimColor = UIColor.blueColor;

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -506,17 +506,22 @@
 }
 
 - (void)testSetTrackingScrollView {
+  // Given
+  MDCBottomDrawerPresentationController *drawerPresentationController = nil;
+  if ([self.drawerViewController.presentationController
+       isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
+    drawerPresentationController =
+        (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
+  } else {
+    drawerPresentationController = nil;
+  }
+
   // When
   self.drawerViewController.scrimColor = UIColor.blueColor;
   self.drawerViewController.trackingScrollView = self.fakeScrollView;
-  if ([self.drawerViewController.presentationController
-       isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
-    MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
-        (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
 
-    // Then
-    XCTAssertNotNil(bottomDrawerPresentationController.bottomDrawerContainerViewController.trackingScrollView);
-  }
+  // Then
+  XCTAssertNotNil(drawerPresentationController.bottomDrawerContainerViewController.trackingScrollView);
 }
 
 - (void)testBottomDrawerTopInset {

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -505,6 +505,20 @@
   XCTAssertEqual(self.fakeScrollView.scrollEnabled, NO);
 }
 
+- (void)testSetTrackingScrollView {
+  // When
+  self.drawerViewController.scrimColor = UIColor.blueColor;
+  self.drawerViewController.trackingScrollView = self.fakeScrollView;
+  if ([self.drawerViewController.presentationController
+       isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
+    MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
+        (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
+
+    // Then
+    XCTAssertNotNil(bottomDrawerPresentationController.bottomDrawerContainerViewController.trackingScrollView);
+  }
+}
+
 - (void)testBottomDrawerTopInset {
   // Given
   MDCNavigationDrawerFakeHeaderViewController *fakeHeader =

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -511,6 +511,8 @@
       (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
 
   // When
+  // Setting the scrim color before setting the tracking scroll view in some cases used to
+  // not set the trackingScrollView on bottomDrawerContainerViewController.
   self.drawerViewController.scrimColor = UIColor.blueColor;
   self.drawerViewController.trackingScrollView = self.fakeScrollView;
 

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -509,7 +509,7 @@
   // Given
   MDCBottomDrawerPresentationController *drawerPresentationController = nil;
   if ([self.drawerViewController.presentationController
-       isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
+          isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
     drawerPresentationController =
         (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
   } else {
@@ -521,7 +521,8 @@
   self.drawerViewController.trackingScrollView = self.fakeScrollView;
 
   // Then
-  XCTAssertNotNil(drawerPresentationController.bottomDrawerContainerViewController.trackingScrollView);
+  XCTAssertNotNil(
+      drawerPresentationController.bottomDrawerContainerViewController.trackingScrollView);
 }
 
 - (void)testBottomDrawerTopInset {


### PR DESCRIPTION
## Related links
* Related bugs: #5804 #6305 
* Component: [NavigationDrawer](https://github.com/material-components/material-components-ios/tree/develop/components/NavigationDrawer)
## Introduction
While working on #6305 I noticed that in certain cases the NavigationDrawer would not set the `trackingScrollView` correctly in certain cases.
## The problem
There was a race condition that if a user set any one of the properties on the `presentationController` before they set the `trackingScrollView` then the `trackingScrollView` internally would be nil.
## The fix
Set the tracking scroll view on the `presentationController` instead of on the `transitionController`.