### PR TITLE
[ActionSheet] Make examples use container scheme

### DIFF
--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -15,6 +15,8 @@
 
 load(
     "//:material_components_ios.bzl",
+    "mdc_examples_objc_library",
+    "mdc_examples_swift_library",
     "mdc_extension_objc_library",
     "mdc_objc_library",
     "mdc_public_objc_library",
@@ -82,32 +84,29 @@ mdc_objc_library(
     includes = ["src/private"],
 )
 
-mdc_objc_library(
+mdc_examples_objc_library(
     name = "ObjcExamples",
-    srcs = glob([
-        "examples/*.m",
-        "examples/*.h",
-        "examples/supplemental/*.m",
-        "examples/supplemental/*.h",
-    ]),
     deps = [
         ":ActionSheet",
         ":Theming",
-        "//components/Buttons:ButtonThemer",
+        "//components/Buttons",
+        "//components/Buttons:Theming",
         "//components/schemes/Color",
+        "//components/schemes/Container",
         "//components/schemes/Typography",
     ],
 )
 
-swift_library(
+mdc_examples_swift_library(
     name = "SwiftExamples",
-    srcs = glob([
-        "examples/*.swift",
-        "examples/supplemental/*.swift",
-    ]),
     deps = [
         ":ActionSheet",
         ":Theming",
+        "//components/Buttons",
+        "//components/Buttons:Theming",
+        "//components/schemes/Color",
+        "//components/schemes/Container",
+        "//components/schemes/Typography",
     ],
 )
 

--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -102,8 +102,6 @@ mdc_examples_swift_library(
     deps = [
         ":ActionSheet",
         ":Theming",
-        "//components/Buttons",
-        "//components/Buttons:Theming",
         "//components/schemes/Color",
         "//components/schemes/Container",
         "//components/schemes/Typography",

--- a/components/ActionSheet/examples/ActionSheetComparisonExampleViewController.h
+++ b/components/ActionSheet/examples/ActionSheetComparisonExampleViewController.h
@@ -14,12 +14,6 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialColorScheme.h"
-#import "MaterialTypographyScheme.h"
-
 @interface ActionSheetComparisonExampleViewController : UIViewController
-
-@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
-@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
 
 @end

--- a/components/ActionSheet/examples/ActionSheetComparisonExampleViewController.m
+++ b/components/ActionSheet/examples/ActionSheetComparisonExampleViewController.m
@@ -37,6 +37,8 @@
   if (self) {
     self.title = @"Action Sheet";
     _containerScheme = [[MDCContainerScheme alloc] init];
+    _containerScheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     _showMaterialButton = [[MDCButton alloc] init];
     _showUIKitButton = [[MDCButton alloc] init];
   }
@@ -45,16 +47,6 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-
-  if (self.containerScheme.colorScheme == nil) {
-    self.containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  }
-
-  if (self.containerScheme.typographyScheme == nil) {
-    self.containerScheme.typographyScheme =
-        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
-  }
 
   self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
   [self.showMaterialButton setTitle:@"Show Material Action sheet" forState:UIControlStateNormal];

--- a/components/ActionSheet/examples/ActionSheetComparisonExampleViewController.m
+++ b/components/ActionSheet/examples/ActionSheetComparisonExampleViewController.m
@@ -18,7 +18,9 @@
 #import "MaterialActionSheet.h"
 #import "MaterialButtons+Theming.h"
 #import "MaterialButtons.h"
+#import "MaterialColorScheme.h"
 #import "MaterialContainerScheme.h"
+#import "MaterialTypographyScheme.h"
 
 @interface ActionSheetComparisonExampleViewController ()
 
@@ -34,8 +36,6 @@
   self = [super init];
   if (self) {
     self.title = @"Action Sheet";
-    _colorScheme = [[MDCSemanticColorScheme alloc] init];
-    _typographyScheme = [[MDCTypographyScheme alloc] init];
     _containerScheme = [[MDCContainerScheme alloc] init];
     _showMaterialButton = [[MDCButton alloc] init];
     _showUIKitButton = [[MDCButton alloc] init];
@@ -47,11 +47,13 @@
   [super viewDidLoad];
 
   if (self.containerScheme.colorScheme == nil) {
-    self.containerScheme.colorScheme = self.colorScheme;
+    self.containerScheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   }
 
   if (self.containerScheme.typographyScheme == nil) {
-    self.containerScheme.typographyScheme = self.typographyScheme;
+    self.containerScheme.typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
   }
 
   self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;

--- a/components/ActionSheet/examples/ActionSheetComparisonExampleViewController.m
+++ b/components/ActionSheet/examples/ActionSheetComparisonExampleViewController.m
@@ -26,7 +26,7 @@
 
 @property(nonatomic, strong) MDCButton *showMaterialButton;
 @property(nonatomic, strong) MDCButton *showUIKitButton;
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 
 @end
 
@@ -36,9 +36,10 @@
   self = [super init];
   if (self) {
     self.title = @"Action Sheet";
-    _containerScheme = [[MDCContainerScheme alloc] init];
-    _containerScheme.colorScheme =
+    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+    scheme.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    _containerScheme = scheme;
     _showMaterialButton = [[MDCButton alloc] init];
     _showUIKitButton = [[MDCButton alloc] init];
   }
@@ -48,7 +49,15 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
+  id<MDCColorScheming> colorScheme;
+  if (self.containerScheme.colorScheme != nil) {
+    colorScheme = self.containerScheme.colorScheme;
+  } else {
+    colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+
+  self.view.backgroundColor = colorScheme.backgroundColor;
   [self.showMaterialButton setTitle:@"Show Material Action sheet" forState:UIControlStateNormal];
   [self.showMaterialButton sizeToFit];
   [self.showUIKitButton setTitle:@"Show UIKit Action sheet" forState:UIControlStateNormal];

--- a/components/ActionSheet/examples/ActionSheetComparisonExampleViewController.m
+++ b/components/ActionSheet/examples/ActionSheetComparisonExampleViewController.m
@@ -16,8 +16,9 @@
 
 #import "MaterialActionSheet+Theming.h"
 #import "MaterialActionSheet.h"
-#import "MaterialButtons+ButtonThemer.h"
+#import "MaterialButtons+Theming.h"
 #import "MaterialButtons.h"
+#import "MaterialContainerScheme.h"
 
 @interface ActionSheetComparisonExampleViewController ()
 
@@ -27,9 +28,7 @@
 
 @end
 
-@implementation ActionSheetComparisonExampleViewController {
-  MDCButtonScheme *_buttonScheme;
-}
+@implementation ActionSheetComparisonExampleViewController
 
 - (instancetype)init {
   self = [super init];
@@ -37,51 +36,48 @@
     self.title = @"Action Sheet";
     _colorScheme = [[MDCSemanticColorScheme alloc] init];
     _typographyScheme = [[MDCTypographyScheme alloc] init];
+    _containerScheme = [[MDCContainerScheme alloc] init];
     _showMaterialButton = [[MDCButton alloc] init];
     _showUIKitButton = [[MDCButton alloc] init];
-    _buttonScheme = [[MDCButtonScheme alloc] init];
   }
   return self;
-}
-
-- (MDCContainerScheme *)containerScheme {
-  if (!_containerScheme) {
-    _containerScheme = [[MDCContainerScheme alloc] init];
-  }
-  _containerScheme.colorScheme = self.colorScheme;
-  _containerScheme.typographyScheme = self.typographyScheme;
-  return _containerScheme;
 }
 
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.view.backgroundColor = _colorScheme.backgroundColor;
-  [_showMaterialButton setTitle:@"Show Material Action sheet" forState:UIControlStateNormal];
-  [_showMaterialButton sizeToFit];
-  [_showUIKitButton setTitle:@"Show UIKit Action sheet" forState:UIControlStateNormal];
-  [_showUIKitButton sizeToFit];
-  _buttonScheme.colorScheme = _colorScheme;
-  _buttonScheme.typographyScheme = _typographyScheme;
-  [MDCContainedButtonThemer applyScheme:_buttonScheme toButton:_showMaterialButton];
-  [_showMaterialButton addTarget:self
+  if (self.containerScheme.colorScheme == nil) {
+    self.containerScheme.colorScheme = self.colorScheme;
+  }
+
+  if (self.containerScheme.typographyScheme == nil) {
+    self.containerScheme.typographyScheme = self.typographyScheme;
+  }
+
+  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
+  [self.showMaterialButton setTitle:@"Show Material Action sheet" forState:UIControlStateNormal];
+  [self.showMaterialButton sizeToFit];
+  [self.showUIKitButton setTitle:@"Show UIKit Action sheet" forState:UIControlStateNormal];
+  [self.showUIKitButton sizeToFit];
+  [self.showMaterialButton applyContainedThemeWithScheme:self.containerScheme];
+  [self.showMaterialButton addTarget:self
                           action:@selector(showMaterialActionSheet)
                 forControlEvents:UIControlEventTouchUpInside];
-  [self.view addSubview:_showMaterialButton];
-  [MDCContainedButtonThemer applyScheme:_buttonScheme toButton:_showUIKitButton];
-  [_showUIKitButton addTarget:self
+  [self.view addSubview:self.showMaterialButton];
+  [self.showUIKitButton applyContainedThemeWithScheme:self.containerScheme];
+  [self.showUIKitButton addTarget:self
                        action:@selector(showUIKitActionSheet)
              forControlEvents:UIControlEventTouchUpInside];
-  [self.view addSubview:_showUIKitButton];
+  [self.view addSubview:self.showUIKitButton];
 }
 
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
 
-  _showMaterialButton.center = CGPointMake(self.view.center.x, self.view.center.y - 80);
-  CGPoint UIKitCenter = _showMaterialButton.center;
-  UIKitCenter.y += CGRectGetHeight(_showMaterialButton.frame) * 2;
-  _showUIKitButton.center = UIKitCenter;
+  self.showMaterialButton.center = CGPointMake(self.view.center.x, self.view.center.y - 80);
+  CGPoint UIKitCenter = self.showMaterialButton.center;
+  UIKitCenter.y += CGRectGetHeight(self.showMaterialButton.frame) * 2;
+  self.showUIKitButton.center = UIKitCenter;
 }
 
 - (void)showMaterialActionSheet {

--- a/components/ActionSheet/examples/ActionSheetComparisonExampleViewController.m
+++ b/components/ActionSheet/examples/ActionSheetComparisonExampleViewController.m
@@ -64,13 +64,13 @@
   [self.showUIKitButton sizeToFit];
   [self.showMaterialButton applyContainedThemeWithScheme:self.containerScheme];
   [self.showMaterialButton addTarget:self
-                          action:@selector(showMaterialActionSheet)
-                forControlEvents:UIControlEventTouchUpInside];
+                              action:@selector(showMaterialActionSheet)
+                    forControlEvents:UIControlEventTouchUpInside];
   [self.view addSubview:self.showMaterialButton];
   [self.showUIKitButton applyContainedThemeWithScheme:self.containerScheme];
   [self.showUIKitButton addTarget:self
-                       action:@selector(showUIKitActionSheet)
-             forControlEvents:UIControlEventTouchUpInside];
+                           action:@selector(showUIKitActionSheet)
+                 forControlEvents:UIControlEventTouchUpInside];
   [self.view addSubview:self.showUIKitButton];
 }
 

--- a/components/ActionSheet/examples/ActionSheetComparisonExampleViewController.m
+++ b/components/ActionSheet/examples/ActionSheetComparisonExampleViewController.m
@@ -36,10 +36,7 @@
   self = [super init];
   if (self) {
     self.title = @"Action Sheet";
-    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-    scheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    _containerScheme = scheme;
+    _containerScheme = [[MDCContainerScheme alloc] init];
     _showMaterialButton = [[MDCButton alloc] init];
     _showUIKitButton = [[MDCButton alloc] init];
   }

--- a/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
+++ b/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
@@ -23,8 +23,6 @@ import MaterialComponentsBeta.MaterialContainerScheme
 
 class ActionSheetSwiftExampleViewController: UIViewController {
 
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
   var containerScheme = MDCContainerScheme()
   
   let tableView = UITableView()
@@ -55,7 +53,8 @@ class ActionSheetSwiftExampleViewController: UIViewController {
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
     
-    view.backgroundColor = colorScheme.backgroundColor
+    view.backgroundColor = containerScheme.colorScheme?.backgroundColor ??
+        MDCSemanticColorScheme(defaults: .material201804).backgroundColor
     tableView.frame = view.frame
     tableView.frame.origin.y = 0.0
     view.addSubview(tableView)

--- a/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
+++ b/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
@@ -22,12 +22,8 @@ class ActionSheetSwiftExampleViewController: UIViewController {
 
   var colorScheme = MDCSemanticColorScheme()
   var typographyScheme = MDCTypographyScheme()
-  var containerScheme: MDCContainerScheming {
-    let scheme = MDCContainerScheme()
-    scheme.colorScheme = colorScheme
-    scheme.typographyScheme = typographyScheme
-    return scheme
-  }
+  var containerScheme = MDCContainerScheming()
+  
   let tableView = UITableView()
   enum ActionSheetExampleType {
     case typical, title, message, noIcons, titleAndMessage, dynamicType, delayed, thirtyOptions

--- a/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
+++ b/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
@@ -23,7 +23,21 @@ import MaterialComponentsBeta.MaterialContainerScheme
 
 class ActionSheetSwiftExampleViewController: UIViewController {
 
-  var containerScheme = MDCContainerScheme()
+  var containerScheme: MDCContainerScheming
+
+  init() {
+    let scheme = MDCContainerScheme()
+    scheme.colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    containerScheme = scheme
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    let scheme = MDCContainerScheme()
+    scheme.colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    containerScheme = scheme
+    super.init(coder: aDecoder)
+  }
   
   let tableView = UITableView()
   enum ActionSheetExampleType {

--- a/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
+++ b/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
@@ -13,16 +13,19 @@
 // limitations under the License.
 
 import UIKit
-import MaterialComponentsBeta.MaterialActionSheet
-import MaterialComponentsBeta.MaterialActionSheet_Theming
+
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialTypographyScheme
+
+import MaterialComponentsBeta.MaterialActionSheet
+import MaterialComponentsBeta.MaterialActionSheet_Theming
+import MaterialComponentsBeta.MaterialContainerScheme
 
 class ActionSheetSwiftExampleViewController: UIViewController {
 
   var colorScheme = MDCSemanticColorScheme()
   var typographyScheme = MDCTypographyScheme()
-  var containerScheme = MDCContainerScheming()
+  var containerScheme = MDCContainerScheme()
   
   let tableView = UITableView()
   enum ActionSheetExampleType {

--- a/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
+++ b/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
@@ -23,21 +23,7 @@ import MaterialComponentsBeta.MaterialContainerScheme
 
 class ActionSheetSwiftExampleViewController: UIViewController {
 
-  var containerScheme: MDCContainerScheming
-
-  init() {
-    let scheme = MDCContainerScheme()
-    scheme.colorScheme = MDCSemanticColorScheme(defaults: .material201804)
-    containerScheme = scheme
-    super.init(nibName: nil, bundle: nil)
-  }
-
-  required init?(coder aDecoder: NSCoder) {
-    let scheme = MDCContainerScheme()
-    scheme.colorScheme = MDCSemanticColorScheme(defaults: .material201804)
-    containerScheme = scheme
-    super.init(coder: aDecoder)
-  }
+  var containerScheme: MDCContainerScheming = MDCContainerScheme()
   
   let tableView = UITableView()
   enum ActionSheetExampleType {

--- a/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.h
+++ b/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.h
@@ -14,7 +14,6 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialActionSheet.h"
 #import "MaterialColorScheme.h"
 #import "MaterialTypographyScheme.h"
 

--- a/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.h
+++ b/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.h
@@ -14,12 +14,6 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialColorScheme.h"
-#import "MaterialTypographyScheme.h"
-
 @interface ActionSheetTypicalUseExampleViewController : UIViewController
-
-@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
-@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
 
 @end

--- a/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.m
+++ b/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.m
@@ -14,9 +14,11 @@
 
 #import "ActionSheetTypicalUseExampleViewController.h"
 
+#import "MaterialActionSheet.h"
 #import "MaterialActionSheet+Theming.h"
-#import "MaterialButtons+ButtonThemer.h"
+#import "MaterialButtons+Theming.h"
 #import "MaterialButtons.h"
+#import "MaterialContainerScheme.h"
 
 @interface ActionSheetTypicalUseExampleViewController ()
 
@@ -25,9 +27,7 @@
 
 @end
 
-@implementation ActionSheetTypicalUseExampleViewController {
-  MDCButtonScheme *_buttonScheme;
-}
+@implementation ActionSheetTypicalUseExampleViewController
 
 - (instancetype)init {
   self = [super init];
@@ -36,40 +36,37 @@
     _colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     _typographyScheme = [[MDCTypographyScheme alloc] init];
+    _containerScheme = [[MDCContainerScheme alloc] init];
     _showButton = [[MDCButton alloc] init];
-    _buttonScheme = [[MDCButtonScheme alloc] init];
   }
   return self;
-}
-
-- (MDCContainerScheme *)containerScheme {
-  if (!_containerScheme) {
-    _containerScheme = [[MDCContainerScheme alloc] init];
-  }
-  _containerScheme.colorScheme = self.colorScheme;
-  _containerScheme.typographyScheme = self.typographyScheme;
-  return _containerScheme;
 }
 
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.view.backgroundColor = _colorScheme.backgroundColor;
-  [_showButton setTitle:@"Show action sheet" forState:UIControlStateNormal];
-  [_showButton sizeToFit];
-  _buttonScheme.colorScheme = _colorScheme;
-  _buttonScheme.typographyScheme = _typographyScheme;
-  [MDCContainedButtonThemer applyScheme:_buttonScheme toButton:_showButton];
-  [_showButton addTarget:self
+  if (self.containerScheme.colorScheme == nil) {
+    self.containerScheme.colorScheme = self.colorScheme;
+  }
+
+  if (self.containerScheme.typographyScheme == nil) {
+    self.containerScheme.typographyScheme = self.typographyScheme;
+  }
+
+  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
+  [self.showButton setTitle:@"Show action sheet" forState:UIControlStateNormal];
+  [self.showButton sizeToFit];
+  [self.showButton applyContainedThemeWithScheme:self.containerScheme];
+  [self.showButton addTarget:self
                   action:@selector(showActionSheet)
         forControlEvents:UIControlEventTouchUpInside];
-  [self.view addSubview:_showButton];
+  [self.view addSubview:self.showButton];
 }
 
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
 
-  _showButton.center = CGPointMake(self.view.center.x, self.view.center.y - 80);
+  self.showButton.center = CGPointMake(self.view.center.x, self.view.center.y - 80);
 }
 
 - (void)showActionSheet {

--- a/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.m
+++ b/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.m
@@ -25,7 +25,7 @@
 @interface ActionSheetTypicalUseExampleViewController ()
 
 @property(nonatomic, strong) MDCButton *showButton;
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 
 @end
 
@@ -35,9 +35,10 @@
   self = [super init];
   if (self) {
     self.title = @"Action Sheet";
-    _containerScheme = [[MDCContainerScheme alloc] init];
-    _containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];;
+    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+    scheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    _containerScheme = scheme;
     _showButton = [[MDCButton alloc] init];
   }
   return self;
@@ -46,7 +47,15 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
+  id<MDCColorScheming> colorScheme;
+  if (self.containerScheme.colorScheme != nil) {
+    colorScheme = self.containerScheme.colorScheme;
+  } else {
+    colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+
+  self.view.backgroundColor = colorScheme.backgroundColor;
   [self.showButton setTitle:@"Show action sheet" forState:UIControlStateNormal];
   [self.showButton sizeToFit];
   [self.showButton applyContainedThemeWithScheme:self.containerScheme];

--- a/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.m
+++ b/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.m
@@ -14,8 +14,8 @@
 
 #import "ActionSheetTypicalUseExampleViewController.h"
 
-#import "MaterialActionSheet.h"
 #import "MaterialActionSheet+Theming.h"
+#import "MaterialActionSheet.h"
 #import "MaterialButtons+Theming.h"
 #import "MaterialButtons.h"
 #import "MaterialColorScheme.h"
@@ -60,8 +60,8 @@
   [self.showButton sizeToFit];
   [self.showButton applyContainedThemeWithScheme:self.containerScheme];
   [self.showButton addTarget:self
-                  action:@selector(showActionSheet)
-        forControlEvents:UIControlEventTouchUpInside];
+                      action:@selector(showActionSheet)
+            forControlEvents:UIControlEventTouchUpInside];
   [self.view addSubview:self.showButton];
 }
 

--- a/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.m
+++ b/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.m
@@ -35,10 +35,7 @@
   self = [super init];
   if (self) {
     self.title = @"Action Sheet";
-    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-    scheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    _containerScheme = scheme;
+    _containerScheme = [[MDCContainerScheme alloc] init];
     _showButton = [[MDCButton alloc] init];
   }
   return self;

--- a/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.m
+++ b/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.m
@@ -18,7 +18,9 @@
 #import "MaterialActionSheet+Theming.h"
 #import "MaterialButtons+Theming.h"
 #import "MaterialButtons.h"
+#import "MaterialColorScheme.h"
 #import "MaterialContainerScheme.h"
+#import "MaterialTypographyScheme.h"
 
 @interface ActionSheetTypicalUseExampleViewController ()
 
@@ -33,9 +35,6 @@
   self = [super init];
   if (self) {
     self.title = @"Action Sheet";
-    _colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    _typographyScheme = [[MDCTypographyScheme alloc] init];
     _containerScheme = [[MDCContainerScheme alloc] init];
     _showButton = [[MDCButton alloc] init];
   }
@@ -46,11 +45,13 @@
   [super viewDidLoad];
 
   if (self.containerScheme.colorScheme == nil) {
-    self.containerScheme.colorScheme = self.colorScheme;
+    self.containerScheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];;
   }
 
   if (self.containerScheme.typographyScheme == nil) {
-    self.containerScheme.typographyScheme = self.typographyScheme;
+    self.containerScheme.typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
   }
 
   self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;

--- a/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.m
+++ b/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.m
@@ -36,6 +36,8 @@
   if (self) {
     self.title = @"Action Sheet";
     _containerScheme = [[MDCContainerScheme alloc] init];
+    _containerScheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];;
     _showButton = [[MDCButton alloc] init];
   }
   return self;
@@ -43,16 +45,6 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-
-  if (self.containerScheme.colorScheme == nil) {
-    self.containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];;
-  }
-
-  if (self.containerScheme.typographyScheme == nil) {
-    self.containerScheme.typographyScheme =
-        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
-  }
 
   self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
   [self.showButton setTitle:@"Show action sheet" forState:UIControlStateNormal];

--- a/components/Dialogs/examples/DialogsAlertExampleViewController.m
+++ b/components/Dialogs/examples/DialogsAlertExampleViewController.m
@@ -26,7 +26,7 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
 @interface DialogsAlertExampleViewController : MDCCollectionViewController
 @property(nonatomic, strong, nullable) NSArray *modes;
-@property(nonatomic, strong, nonnull) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong, nonnull) id<MDCContainerScheming> containerScheme;
 @end
 
 @interface DialogsAlertExampleViewController (Supplemental)
@@ -35,10 +35,20 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
 @implementation DialogsAlertExampleViewController
 
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+    scheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    _containerScheme = scheme;
+  }
+  return self;
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.containerScheme = [[MDCContainerScheme alloc] init];
   [self loadCollectionView:@[
     @"Show Long Alert", @"Alert (Dynamic Type enabled)", @"Overpopulated Alert"
   ]];
@@ -61,8 +71,7 @@ static NSString *const kReusableIdentifierItem = @"cell";
 }
 
 - (void)themeAlertController:(MDCAlertController *)alertController {
-  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-  [alertController applyThemeWithScheme:scheme];
+  [alertController applyThemeWithScheme:self.containerScheme];
 }
 
 - (IBAction)didTapShowLongAlert {

--- a/components/Dialogs/examples/DialogsAlertExampleViewController.m
+++ b/components/Dialogs/examples/DialogsAlertExampleViewController.m
@@ -26,7 +26,7 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
 @interface DialogsAlertExampleViewController : MDCCollectionViewController
 @property(nonatomic, strong, nullable) NSArray *modes;
-@property(nonatomic, strong, nonnull) id<MDCContainerScheming> containerScheme;
+@property(nonatomic, strong, nonnull) MDCContainerScheme *containerScheme;
 @end
 
 @interface DialogsAlertExampleViewController (Supplemental)
@@ -35,20 +35,10 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
 @implementation DialogsAlertExampleViewController
 
-- (instancetype)init {
-  self = [super init];
-  if (self) {
-    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-    scheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    _containerScheme = scheme;
-  }
-  return self;
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
+  self.containerScheme = [[MDCContainerScheme alloc] init];
   [self loadCollectionView:@[
     @"Show Long Alert", @"Alert (Dynamic Type enabled)", @"Overpopulated Alert"
   ]];
@@ -71,7 +61,8 @@ static NSString *const kReusableIdentifierItem = @"cell";
 }
 
 - (void)themeAlertController:(MDCAlertController *)alertController {
-  [alertController applyThemeWithScheme:self.containerScheme];
+  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+  [alertController applyThemeWithScheme:scheme];
 }
 
 - (IBAction)didTapShowLongAlert {


### PR DESCRIPTION
## Related links
* Bug: #6442 
* Component: [ActionSheet](https://github.com/material-components/material-components-ios/tree/develop/components/ActionSheet)
## Introduction
As we move to theming extensions all components that have a theming extension should use that within it's examples. Currently MDCActionSheet has a theming extension and is using it in the examples but the examples we also using the old button _Themers_ instead of the theming extensions.
## The problem
Within MDCActionSheet examples some buttons are using the old _Themers_.
## The fix
For all components being used in MDCActionSheet examples use a theming extension if available.
## Additional notes
This also cleans up some ivar usage.