### PR TITLE
[Dialogs] Update examples to use theming extensions

### DIFF
--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -108,6 +108,8 @@ mdc_examples_objc_library(
         ":Theming",
         "//components/Buttons:ButtonThemer",
         "//components/Collections",
+        "//components/schemes/Color",
+        "//components/schemes/Container",
     ],
 )
 
@@ -118,6 +120,7 @@ mdc_examples_swift_library(
         ":Dialogs",
         ":Theming",
         "//components/Collections",
+        "//components/schemes/Color",
         "//components/schemes/Container",
     ],
 )

--- a/components/Dialogs/examples/DialogsAlertComparisonExample.swift
+++ b/components/Dialogs/examples/DialogsAlertComparisonExample.swift
@@ -29,13 +29,13 @@ class DialogsAlertComparisonExample: UIViewController {
   private let materialButton = MDCButton()
   private let themedButton = MDCButton()
   private let uikitButton = MDCButton()
-  var containerScheme = MDCContainerScheme()
+  var containerScheme: MDCContainerScheming = MDCContainerScheme()
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor =
-        containerScheme.colorScheme?.backgroundColor ?? MDCSemanticColorScheme().backgroundColor
+    view.backgroundColor = containerScheme.colorScheme?.backgroundColor ??
+        MDCSemanticColorScheme(defaults: .material201804).backgroundColor
 
     materialButton.translatesAutoresizingMaskIntoConstraints = false
     materialButton.setTitle("Material Alert", for: .normal)

--- a/components/Dialogs/examples/DialogsAlertComparisonExample.swift
+++ b/components/Dialogs/examples/DialogsAlertComparisonExample.swift
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
+import UIKit
+
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialDialogs
-import MaterialComponents.MaterialDialogs_DialogThemer
 import MaterialComponents.MaterialTypographyScheme
+import MaterialComponentsBeta.MaterialButtons_Theming
 import MaterialComponentsBeta.MaterialContainerScheme
 import MaterialComponentsBeta.MaterialDialogs_Theming
 
@@ -25,20 +26,23 @@ import MaterialComponentsBeta.MaterialDialogs_Theming
 /// Controller.
 class DialogsAlertComparisonExample: UIViewController {
 
-  private let materialButton = MDCFlatButton()
-  private let themedButton = MDCFlatButton()
-  private let uikitButton = MDCFlatButton()
+  private let materialButton = MDCButton()
+  private let themedButton = MDCButton()
+  private let uikitButton = MDCButton()
+  var containerScheme = MDCContainerScheme()
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor = UIColor.white
+    view.backgroundColor =
+        containerScheme.colorScheme?.backgroundColor ?? MDCSemanticColorScheme().backgroundColor
 
     materialButton.translatesAutoresizingMaskIntoConstraints = false
     materialButton.setTitle("Material Alert", for: .normal)
     materialButton.setTitleColor(UIColor(white: 0.1, alpha:1), for: .normal)
     materialButton.sizeToFit()
     materialButton.addTarget(self, action: #selector(tapMaterial), for: .touchUpInside)
+    materialButton.applyTextTheme(withScheme: containerScheme)
     self.view.addSubview(materialButton)
 
     NSLayoutConstraint.activate([
@@ -63,6 +67,7 @@ class DialogsAlertComparisonExample: UIViewController {
     themedButton.setTitleColor(UIColor(white: 0.1, alpha:1), for: .normal)
     themedButton.sizeToFit()
     themedButton.addTarget(self, action: #selector(tapThemed), for: .touchUpInside)
+    themedButton.applyTextTheme(withScheme: containerScheme)
     self.view.addSubview(themedButton)
 
     NSLayoutConstraint.activate([
@@ -87,6 +92,7 @@ class DialogsAlertComparisonExample: UIViewController {
       uikitButton.setTitleColor(UIColor(white: 0.1, alpha:1), for: .normal)
       uikitButton.sizeToFit()
       uikitButton.addTarget(self, action: #selector(tapUIKit), for: .touchUpInside)
+      uikitButton.applyTextTheme(withScheme: containerScheme)
       self.view.addSubview(uikitButton)
 
       NSLayoutConstraint.activate([
@@ -114,8 +120,7 @@ class DialogsAlertComparisonExample: UIViewController {
 
   @objc func tapThemed(_ sender: Any) {
     let alertController = createMDCAlertController()
-    let scheme = MDCContainerScheme()
-    alertController.applyTheme(withScheme: scheme)
+    alertController.applyTheme(withScheme: containerScheme)
     self.present(alertController, animated: true, completion: nil)
   }
 

--- a/components/Dialogs/examples/DialogsAlertCustomizationExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsAlertCustomizationExampleViewController.swift
@@ -28,6 +28,7 @@ import MaterialComponents.MaterialPalettes
 class DialogsAlertCustomizationExampleViewController: MDCCollectionViewController {
 
   var containerScheme: MDCContainerScheme = MDCContainerScheme()
+  var colorScheme = MDCSemanticColorScheme()
 
   let kReusableIdentifierItem = "customCell"
 

--- a/components/Dialogs/examples/DialogsAlertCustomizationExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsAlertCustomizationExampleViewController.swift
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
+import UIKit
+
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialCollections
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialDialogs
-import MaterialComponents.MaterialDialogs_DialogThemer
 import MaterialComponents.MaterialPalettes
 import MaterialComponents.MaterialTypographyScheme
 import MaterialComponentsBeta.MaterialButtons_Theming
@@ -40,7 +40,8 @@ class DialogsAlertCustomizationExampleViewController: MDCCollectionViewControlle
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor = UIColor.white
+    view.backgroundColor =
+        containerScheme.colorScheme?.backgroundColor ?? MDCSemanticColorScheme().backgroundColor
 
     loadCollectionView(menu: [
       "Centered Title",
@@ -214,8 +215,6 @@ class DialogsAlertCustomizationExampleViewController: MDCCollectionViewControlle
     alert.addAction(MDCAlertAction(title:"Medium", emphasis: .medium, handler: handler))
     alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
 
-    let containerScheme = MDCContainerScheme()
-    let colorScheme = MDCSemanticColorScheme()
     colorScheme.primaryColor = .blue
     containerScheme.colorScheme = colorScheme
     alert.applyTheme(withScheme: containerScheme)

--- a/components/Dialogs/examples/DialogsAlertCustomizationExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsAlertCustomizationExampleViewController.swift
@@ -27,8 +27,7 @@ import MaterialComponents.MaterialPalettes
 
 class DialogsAlertCustomizationExampleViewController: MDCCollectionViewController {
 
-  var containerScheme: MDCContainerScheme = MDCContainerScheme()
-  var colorScheme = MDCSemanticColorScheme()
+  var containerScheme: MDCContainerScheming = MDCContainerScheme()
 
   let kReusableIdentifierItem = "customCell"
 
@@ -41,8 +40,8 @@ class DialogsAlertCustomizationExampleViewController: MDCCollectionViewControlle
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor =
-        containerScheme.colorScheme?.backgroundColor ?? MDCSemanticColorScheme().backgroundColor
+    view.backgroundColor = containerScheme.colorScheme?.backgroundColor ??
+        MDCSemanticColorScheme(defaults: .material201804).backgroundColor
 
     loadCollectionView(menu: [
       "Centered Title",
@@ -216,9 +215,12 @@ class DialogsAlertCustomizationExampleViewController: MDCCollectionViewControlle
     alert.addAction(MDCAlertAction(title:"Medium", emphasis: .medium, handler: handler))
     alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
 
-    colorScheme.primaryColor = .blue
-    containerScheme.colorScheme = colorScheme
-    alert.applyTheme(withScheme: containerScheme)
+    let container: MDCContainerScheme =
+        containerScheme as? MDCContainerScheme ?? MDCContainerScheme()
+    let containerCopy: MDCContainerScheme = container.copy() as! MDCContainerScheme
+    containerCopy.colorScheme =
+        containerCopy.colorScheme ?? MDCSemanticColorScheme(defaults: .material201804)
+    alert.applyTheme(withScheme: containerCopy)
     return alert
   }
 

--- a/components/Dialogs/examples/DialogsAlertCustomizationExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsAlertCustomizationExampleViewController.swift
@@ -215,12 +215,9 @@ class DialogsAlertCustomizationExampleViewController: MDCCollectionViewControlle
     alert.addAction(MDCAlertAction(title:"Medium", emphasis: .medium, handler: handler))
     alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
 
-    let container: MDCContainerScheme =
-        containerScheme as? MDCContainerScheme ?? MDCContainerScheme()
-    let containerCopy: MDCContainerScheme = container.copy() as! MDCContainerScheme
-    containerCopy.colorScheme =
-        containerCopy.colorScheme ?? MDCSemanticColorScheme(defaults: .material201804)
-    alert.applyTheme(withScheme: containerCopy)
+    alert.applyTheme(withScheme: containerScheme)
+    alert.button(for: alert.actions.first!)?.setBackgroundColor(.blue, for: .normal)
+
     return alert
   }
 

--- a/components/Dialogs/examples/DialogsAlertCustomizationExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsAlertCustomizationExampleViewController.swift
@@ -215,6 +215,10 @@ class DialogsAlertCustomizationExampleViewController: MDCCollectionViewControlle
     alert.addAction(MDCAlertAction(title:"Medium", emphasis: .medium, handler: handler))
     alert.addAction(MDCAlertAction(title:"Low", emphasis: .low, handler: handler))
 
+    let containerScheme = MDCContainerScheme()
+    let colorScheme = MDCSemanticColorScheme()
+    colorScheme.primaryColor = .blue
+    containerScheme.colorScheme = colorScheme
     alert.applyTheme(withScheme: containerScheme)
     alert.button(for: alert.actions.first!)?.setBackgroundColor(.blue, for: .normal)
 

--- a/components/Dialogs/examples/DialogsAlertExampleViewController.m
+++ b/components/Dialogs/examples/DialogsAlertExampleViewController.m
@@ -26,7 +26,7 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
 @interface DialogsAlertExampleViewController : MDCCollectionViewController
 @property(nonatomic, strong, nullable) NSArray *modes;
-@property(nonatomic, strong, nonnull) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong, nonnull) id<MDCContainerScheming> containerScheme;
 @end
 
 @interface DialogsAlertExampleViewController (Supplemental)

--- a/components/Dialogs/examples/DialogsAlertExampleViewController.m
+++ b/components/Dialogs/examples/DialogsAlertExampleViewController.m
@@ -61,8 +61,7 @@ static NSString *const kReusableIdentifierItem = @"cell";
 }
 
 - (void)themeAlertController:(MDCAlertController *)alertController {
-  MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-  [alertController applyThemeWithScheme:scheme];
+  [alertController applyThemeWithScheme:self.containerScheme];
 }
 
 - (IBAction)didTapShowLongAlert {

--- a/components/Dialogs/examples/DialogsAlertExampleViewController.m
+++ b/components/Dialogs/examples/DialogsAlertExampleViewController.m
@@ -35,10 +35,20 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
 @implementation DialogsAlertExampleViewController
 
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+    scheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    _containerScheme = scheme;
+  }
+  return self;
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.containerScheme = [[MDCContainerScheme alloc] init];
   [self loadCollectionView:@[
     @"Show Long Alert", @"Alert (Dynamic Type enabled)", @"Overpopulated Alert"
   ]];

--- a/components/Dialogs/examples/DialogsCustomShadowExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsCustomShadowExampleViewController.swift
@@ -103,6 +103,7 @@ class DialogsCustomShadowExampleViewController: UIViewController {
     // presentation controller.
     if let presentationController = presentedController.mdc_dialogPresentationController {
       presentationController.applyTheme(withScheme: containerScheme)
+      presentationController.dialogCornerRadius = presentedController.view.layer.cornerRadius
     }
   }
 

--- a/components/Dialogs/examples/DialogsCustomShadowExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsCustomShadowExampleViewController.swift
@@ -12,15 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
+import UIKit
+
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialDialogs
+import MaterialComponentsBeta.MaterialButtons_Theming
+import MaterialComponentsBeta.MDCContainerScheme
+import MaterialComponentsBeta.MaterialDialogs_Theming
 
 class CustomShadowViewController: UIViewController {
 
   let bodyLabel = UILabel()
-
-  let dismissButton = MDCFlatButton()
 
   override func viewDidLoad() {
 
@@ -54,30 +56,33 @@ class CustomShadowViewController: UIViewController {
 
 class DialogsCustomShadowExampleViewController: UIViewController {
 
-  let flatButton = MDCFlatButton()
+  let textButton = MDCButton()
   let transitionController = MDCDialogTransitionController()
+  var containerScheme = MDCContainerScheme()
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor = UIColor.white
+    view.backgroundColor =
+        containerScheme.colorScheme?.backgroundColor ?? MDCSemanticColorScheme().backgroundColor
 
-    flatButton.setTitle("PRESENT ALERT", for: UIControlState())
-    flatButton.setTitleColor(UIColor(white: 0.1, alpha:1), for: UIControlState())
-    flatButton.sizeToFit()
-    flatButton.translatesAutoresizingMaskIntoConstraints = false
-    flatButton.addTarget(self, action: #selector(tap), for: .touchUpInside)
-    self.view.addSubview(flatButton)
+    textButton.setTitle("PRESENT ALERT", for: UIControlState())
+    textButton.setTitleColor(UIColor(white: 0.1, alpha:1), for: UIControlState())
+    textButton.sizeToFit()
+    textButton.translatesAutoresizingMaskIntoConstraints = false
+    textButton.addTarget(self, action: #selector(tap), for: .touchUpInside)
+    textButton.applyTextTheme(withScheme: containerScheme)
+    self.view.addSubview(textButton)
 
     NSLayoutConstraint.activate([
-      NSLayoutConstraint(item:flatButton,
+      NSLayoutConstraint(item:textButton,
                        attribute:.centerX,
                        relatedBy:.equal,
                        toItem:self.view,
                        attribute:.centerX,
                        multiplier:1.0,
                        constant: 0.0),
-      NSLayoutConstraint(item:flatButton,
+      NSLayoutConstraint(item:textButton,
                        attribute:.centerY,
                        relatedBy:.equal,
                        toItem:self.view,
@@ -97,7 +102,7 @@ class DialogsCustomShadowExampleViewController: UIViewController {
     // We set the corner radius to adjust the shadow that is implemented via the trackingView in the
     // presentation controller.
     if let presentationController = presentedController.mdc_dialogPresentationController {
-      presentationController.dialogCornerRadius = presentedController.view.layer.cornerRadius
+      presentationController.applyTheme(withScheme: containerScheme)
     }
   }
 

--- a/components/Dialogs/examples/DialogsCustomShadowExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsCustomShadowExampleViewController.swift
@@ -58,13 +58,13 @@ class DialogsCustomShadowExampleViewController: UIViewController {
 
   let textButton = MDCButton()
   let transitionController = MDCDialogTransitionController()
-  var containerScheme = MDCContainerScheme()
+  var containerScheme: MDCContainerScheming = MDCContainerScheme()
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor =
-        containerScheme.colorScheme?.backgroundColor ?? MDCSemanticColorScheme().backgroundColor
+    view.backgroundColor = containerScheme.colorScheme?.backgroundColor ??
+        MDCSemanticColorScheme(defaults: .material201804).backgroundColor
 
     textButton.setTitle("PRESENT ALERT", for: UIControlState())
     textButton.setTitleColor(UIColor(white: 0.1, alpha:1), for: UIControlState())

--- a/components/Dialogs/examples/DialogsCustomShadowExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsCustomShadowExampleViewController.swift
@@ -17,7 +17,7 @@ import UIKit
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialDialogs
 import MaterialComponentsBeta.MaterialButtons_Theming
-import MaterialComponentsBeta.MDCContainerScheme
+import MaterialComponentsBeta.MaterialContainerScheme
 import MaterialComponentsBeta.MaterialDialogs_Theming
 
 class CustomShadowViewController: UIViewController {

--- a/components/Dialogs/examples/DialogsDismissingExampleViewController.m
+++ b/components/Dialogs/examples/DialogsDismissingExampleViewController.m
@@ -15,6 +15,8 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialApplication.h"
+#import "MaterialButtons.h"
+#import "MaterialButtons+Theming.h"
 #import "MaterialCollections.h"
 #import "MaterialColorScheme.h"
 #import "MaterialDialogs+Theming.h"
@@ -176,7 +178,9 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
 @interface ProgrammaticViewController ()
 
-@property(nonatomic, strong) MDCFlatButton *dismissButton;
+@property(nonatomic, strong) MDCButton *dismissButton;
+
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 
 @end
 
@@ -187,17 +191,18 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
   self.view.backgroundColor = [UIColor whiteColor];
 
-  _dismissButton = [[MDCFlatButton alloc] init];
-  [_dismissButton setTitle:@"Dismiss" forState:UIControlStateNormal];
-  [_dismissButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
-  _dismissButton.autoresizingMask =
+  self.dismissButton = [[MDCFlatButton alloc] init];
+  [self.dismissButton setTitle:@"Dismiss" forState:UIControlStateNormal];
+  [self.dismissButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
+  self.dismissButton.autoresizingMask =
       UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |
       UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin;
-  [_dismissButton addTarget:self
+  [self.dismissButton addTarget:self
                      action:@selector(dismiss:)
            forControlEvents:UIControlEventTouchUpInside];
+  [self.dismissButton applyTextThemeWithScheme:self.containerScheme];
 
-  [self.view addSubview:_dismissButton];
+  [self.view addSubview:self.dismissButton];
 }
 
 - (void)viewWillLayoutSubviews {
@@ -221,7 +226,9 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
 @interface OpenURLViewController ()
 
-@property(nonatomic, strong) MDCFlatButton *dismissButton;
+@property(nonatomic, strong) MDCButton *dismissButton;
+
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 
 @end
 
@@ -232,17 +239,17 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
   self.view.backgroundColor = [UIColor whiteColor];
 
-  _dismissButton = [[MDCFlatButton alloc] init];
-  [_dismissButton setTitle:@"material.io" forState:UIControlStateNormal];
-  [_dismissButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
-  _dismissButton.autoresizingMask =
+  self.dismissButton = [[MDCFlatButton alloc] init];
+  [self.dismissButton setTitle:@"material.io" forState:UIControlStateNormal];
+  [self.dismissButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
+  self.dismissButton.autoresizingMask =
       UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |
       UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin;
-  [_dismissButton addTarget:self
+  [self.dismissButton addTarget:self
                      action:@selector(dismiss:)
            forControlEvents:UIControlEventTouchUpInside];
-
-  [self.view addSubview:_dismissButton];
+  [self.dismissButton applyTextThemeWithScheme:self.containerScheme];
+  [self.view addSubview:self.dismissButton];
 }
 
 - (void)viewWillLayoutSubviews {

--- a/components/Dialogs/examples/DialogsDismissingExampleViewController.m
+++ b/components/Dialogs/examples/DialogsDismissingExampleViewController.m
@@ -27,7 +27,7 @@
 #pragma mark - DialogsDismissingExampleViewController Interfaces
 
 @interface DialogsDismissingExampleViewController : MDCCollectionViewController
-@property(nonatomic, strong, nullable) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong, nullable) id<MDCContainerScheming> containerScheme;
 @property(nonatomic, strong, nullable) NSArray *modes;
 @property(nonatomic, strong) MDCDialogTransitionController *transitionController;
 @end
@@ -46,19 +46,16 @@
 
 @implementation DialogsDismissingExampleViewController
 
-- (id)init {
-  self = [super init];
-  if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
-    self.containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-  }
-  return self;
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
+
+  if (self.containerScheme == nil) {
+    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+    scheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    self.containerScheme = scheme;
+  }
+
   [self loadCollectionView:@[
     @"Dismissable Programmatic", @"Dismissable Storyboard", @"Non-dismissable Programmatic",
     @"Open URL"
@@ -126,8 +123,7 @@
       [storyboard instantiateViewControllerWithIdentifier:identifier];
   viewController.modalPresentationStyle = UIModalPresentationCustom;
   viewController.transitioningDelegate = self.transitionController;
-  viewController.colorScheme = self.containerScheme.colorScheme;
-  viewController.typographyScheme = self.containerScheme.typographyScheme;
+  viewController.containerScheme = self.containerScheme;
   [self presentViewController:viewController animated:YES completion:NULL];
 }
 

--- a/components/Dialogs/examples/DialogsDismissingExampleViewController.m
+++ b/components/Dialogs/examples/DialogsDismissingExampleViewController.m
@@ -51,7 +51,7 @@
   if (self) {
     MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
     scheme.colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     _containerScheme = scheme;
   }
   return self;

--- a/components/Dialogs/examples/DialogsDismissingExampleViewController.m
+++ b/components/Dialogs/examples/DialogsDismissingExampleViewController.m
@@ -180,7 +180,7 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
 @property(nonatomic, strong) MDCButton *dismissButton;
 
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 
 @end
 
@@ -189,9 +189,16 @@ static NSString *const kReusableIdentifierItem = @"cell";
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.view.backgroundColor = [UIColor whiteColor];
+  id<MDCColorScheming> colorScheme;
+  if (self.containerScheme.colorScheme != nil) {
+    colorScheme = self.containerScheme.colorScheme;
+  } else {
+    colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+  self.view.backgroundColor = colorScheme.backgroundColor;
 
-  self.dismissButton = [[MDCFlatButton alloc] init];
+  self.dismissButton = [[MDCButton alloc] init];
   [self.dismissButton setTitle:@"Dismiss" forState:UIControlStateNormal];
   [self.dismissButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
   self.dismissButton.autoresizingMask =
@@ -228,7 +235,7 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
 @property(nonatomic, strong) MDCButton *dismissButton;
 
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 
 @end
 
@@ -237,9 +244,16 @@ static NSString *const kReusableIdentifierItem = @"cell";
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.view.backgroundColor = [UIColor whiteColor];
+  id<MDCColorScheming> colorScheme;
+  if (self.containerScheme.colorScheme != nil) {
+    colorScheme = self.containerScheme.colorScheme;
+  } else {
+    colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+  self.view.backgroundColor = colorScheme.backgroundColor;
 
-  self.dismissButton = [[MDCFlatButton alloc] init];
+  self.dismissButton = [[MDCButton alloc] init];
   [self.dismissButton setTitle:@"material.io" forState:UIControlStateNormal];
   [self.dismissButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
   self.dismissButton.autoresizingMask =

--- a/components/Dialogs/examples/DialogsDismissingExampleViewController.m
+++ b/components/Dialogs/examples/DialogsDismissingExampleViewController.m
@@ -189,7 +189,9 @@ static NSString *const kReusableIdentifierItem = @"cell";
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  id<MDCColorScheming> colorScheme = self.containerScheme.colorScheme ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  id<MDCColorScheming> colorScheme =
+      self.containerScheme.colorScheme
+          ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   self.view.backgroundColor = colorScheme.backgroundColor;
 
   self.dismissButton = [[MDCButton alloc] init];
@@ -238,7 +240,9 @@ static NSString *const kReusableIdentifierItem = @"cell";
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  id<MDCColorScheming> colorScheme = self.containerScheme.colorScheme ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  id<MDCColorScheming> colorScheme =
+      self.containerScheme.colorScheme
+          ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   self.view.backgroundColor = colorScheme.backgroundColor;
 
   self.dismissButton = [[MDCButton alloc] init];

--- a/components/Dialogs/examples/DialogsDismissingExampleViewController.m
+++ b/components/Dialogs/examples/DialogsDismissingExampleViewController.m
@@ -189,13 +189,7 @@ static NSString *const kReusableIdentifierItem = @"cell";
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  id<MDCColorScheming> colorScheme;
-  if (self.containerScheme.colorScheme != nil) {
-    colorScheme = self.containerScheme.colorScheme;
-  } else {
-    colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  }
+  id<MDCColorScheming> colorScheme = self.containerScheme.colorScheme ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   self.view.backgroundColor = colorScheme.backgroundColor;
 
   self.dismissButton = [[MDCButton alloc] init];
@@ -244,13 +238,7 @@ static NSString *const kReusableIdentifierItem = @"cell";
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  id<MDCColorScheming> colorScheme;
-  if (self.containerScheme.colorScheme != nil) {
-    colorScheme = self.containerScheme.colorScheme;
-  } else {
-    colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  }
+  id<MDCColorScheming> colorScheme = self.containerScheme.colorScheme ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   self.view.backgroundColor = colorScheme.backgroundColor;
 
   self.dismissButton = [[MDCButton alloc] init];

--- a/components/Dialogs/examples/DialogsDismissingExampleViewController.m
+++ b/components/Dialogs/examples/DialogsDismissingExampleViewController.m
@@ -15,8 +15,8 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialApplication.h"
-#import "MaterialButtons.h"
 #import "MaterialButtons+Theming.h"
+#import "MaterialButtons.h"
 #import "MaterialCollections.h"
 #import "MaterialColorScheme.h"
 #import "MaterialDialogs+Theming.h"
@@ -201,8 +201,8 @@ static NSString *const kReusableIdentifierItem = @"cell";
       UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |
       UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin;
   [self.dismissButton addTarget:self
-                     action:@selector(dismiss:)
-           forControlEvents:UIControlEventTouchUpInside];
+                         action:@selector(dismiss:)
+               forControlEvents:UIControlEventTouchUpInside];
   [self.dismissButton applyTextThemeWithScheme:self.containerScheme];
 
   [self.view addSubview:self.dismissButton];
@@ -256,8 +256,8 @@ static NSString *const kReusableIdentifierItem = @"cell";
       UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |
       UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin;
   [self.dismissButton addTarget:self
-                     action:@selector(dismiss:)
-           forControlEvents:UIControlEventTouchUpInside];
+                         action:@selector(dismiss:)
+               forControlEvents:UIControlEventTouchUpInside];
   [self.dismissButton applyTextThemeWithScheme:self.containerScheme];
   [self.view addSubview:self.dismissButton];
 }

--- a/components/Dialogs/examples/DialogsDismissingExampleViewController.m
+++ b/components/Dialogs/examples/DialogsDismissingExampleViewController.m
@@ -46,15 +46,19 @@
 
 @implementation DialogsDismissingExampleViewController
 
-- (void)viewDidLoad {
-  [super viewDidLoad];
-
-  if (self.containerScheme == nil) {
+- (instancetype)init {
+  self = [super init];
+  if (self) {
     MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
     scheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.containerScheme = scheme;
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    _containerScheme = scheme;
   }
+  return self;
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
 
   [self loadCollectionView:@[
     @"Dismissable Programmatic", @"Dismissable Storyboard", @"Non-dismissable Programmatic",

--- a/components/Dialogs/examples/DialogsLongAlertExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertExampleViewController.swift
@@ -23,17 +23,13 @@ import MaterialComponentsBeta.MaterialDialogs_Theming
 class DialogsLongAlertExampleViewController: UIViewController {
 
   let textButton = MDCButton()
-  lazy var containerScheme: MDCContainerScheme = {
-    let scheme = MDCContainerScheme()
-    scheme.colorScheme = MDCSemanticColorScheme(defaults: .material201804)
-    scheme.typographyScheme = MDCTypographyScheme(defaults: .material201804)
-    return scheme
-  }()
+  var containerScheme: MDCContainerScheming = MDCContainerScheme()
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor = containerScheme.colorScheme?.backgroundColor
+    view.backgroundColor = containerScheme.colorScheme?.backgroundColor ??
+        MDCSemanticColorScheme(defaults: .material201804).backgroundColor
 
     textButton.setTitle("PRESENT ALERT", for: UIControlState())
     textButton.setTitleColor(UIColor(white: 0.1, alpha:1), for: UIControlState())

--- a/components/Dialogs/examples/DialogsLongAlertExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertExampleViewController.swift
@@ -25,8 +25,8 @@ class DialogsLongAlertExampleViewController: UIViewController {
   let textButton = MDCButton()
   lazy var containerScheme: MDCContainerScheme = {
     let scheme = MDCContainerScheme()
-    scheme.colorScheme = MDCSemanticColorScheme()
-    scheme.typographyScheme = MDCTypographyScheme()
+    scheme.colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    scheme.typographyScheme = MDCTypographyScheme(defaults: .material201804)
     return scheme
   }()
 

--- a/components/Dialogs/examples/DialogsLongAlertExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertExampleViewController.swift
@@ -12,35 +12,46 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
+import UIKit
+
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialDialogs
+import MaterialComponentsBeta.MaterialButtons_Theming
+import MaterialComponentsBeta.MaterialContainerScheme
+import MaterialComponentsBeta.MaterialDialogs_Theming
 
 class DialogsLongAlertExampleViewController: UIViewController {
 
-  let flatButton = MDCFlatButton()
+  let textButton = MDCButton()
+  lazy var containerScheme: MDCContainerScheme = {
+    let scheme = MDCContainerScheme()
+    scheme.colorScheme = MDCSemanticColorScheme()
+    scheme.typographyScheme = MDCTypographyScheme()
+    return scheme
+  }()
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor = UIColor.white
+    view.backgroundColor = containerScheme.colorScheme?.backgroundColor
 
-    flatButton.setTitle("PRESENT ALERT", for: UIControlState())
-    flatButton.setTitleColor(UIColor(white: 0.1, alpha:1), for: UIControlState())
-    flatButton.sizeToFit()
-    flatButton.translatesAutoresizingMaskIntoConstraints = false
-    flatButton.addTarget(self, action: #selector(tap), for: .touchUpInside)
-    self.view.addSubview(flatButton)
+    textButton.setTitle("PRESENT ALERT", for: UIControlState())
+    textButton.setTitleColor(UIColor(white: 0.1, alpha:1), for: UIControlState())
+    textButton.sizeToFit()
+    textButton.translatesAutoresizingMaskIntoConstraints = false
+    textButton.addTarget(self, action: #selector(tap), for: .touchUpInside)
+    textButton.applyTextTheme(withScheme: containerScheme)
+    self.view.addSubview(textButton)
 
     NSLayoutConstraint.activate([
-      NSLayoutConstraint(item:flatButton,
+      NSLayoutConstraint(item:textButton,
                        attribute:.centerX,
                        relatedBy:.equal,
                        toItem:self.view,
                        attribute:.centerX,
                        multiplier:1.0,
                        constant: 0.0),
-      NSLayoutConstraint(item:flatButton,
+      NSLayoutConstraint(item:textButton,
                        attribute:.centerY,
                        relatedBy:.equal,
                        toItem:self.view,
@@ -68,7 +79,7 @@ class DialogsLongAlertExampleViewController: UIViewController {
     let action = MDCAlertAction(title:"OK") { (_) in print("OK") }
 
     materialAlertController.addAction(action)
-
+    materialAlertController.applyTheme(withScheme: containerScheme)
     self.present(materialAlertController, animated: true, completion: nil)
   }
 }

--- a/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
@@ -85,7 +85,7 @@
   if (self) {
     MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
     scheme.colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     _containerScheme = scheme;
   }
   return self;

--- a/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
@@ -31,7 +31,9 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  id<MDCColorScheming> colorScheme = self.containerScheme.colorScheme ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  id<MDCColorScheming> colorScheme =
+      self.containerScheme.colorScheme
+          ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   self.view.backgroundColor = colorScheme.backgroundColor;
 
   self.dismissButton = [[MDCButton alloc] initWithFrame:CGRectZero];
@@ -92,7 +94,9 @@
   // A presented view controller will set this object as its transitioning delegate.
   self.transitionController = [[MDCDialogTransitionController alloc] init];
 
-  id<MDCColorScheming> colorScheme = self.containerScheme.colorScheme ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  id<MDCColorScheming> colorScheme =
+      self.containerScheme.colorScheme
+          ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   self.view.backgroundColor = colorScheme.backgroundColor;
 
   self.presentButton = [[MDCButton alloc] initWithFrame:CGRectZero];

--- a/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
@@ -31,13 +31,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  id<MDCColorScheming> colorScheme;
-  if (self.containerScheme.colorScheme != nil) {
-    colorScheme = self.containerScheme.colorScheme;
-  } else {
-    colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  }
+  id<MDCColorScheming> colorScheme = self.containerScheme.colorScheme ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   self.view.backgroundColor = colorScheme.backgroundColor;
 
   self.dismissButton = [[MDCButton alloc] initWithFrame:CGRectZero];
@@ -98,13 +92,7 @@
   // A presented view controller will set this object as its transitioning delegate.
   self.transitionController = [[MDCDialogTransitionController alloc] init];
 
-  id<MDCColorScheming> colorScheme;
-  if (self.containerScheme.colorScheme != nil) {
-    colorScheme = self.containerScheme.colorScheme;
-  } else {
-    colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  }
+  id<MDCColorScheming> colorScheme = self.containerScheme.colorScheme ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   self.view.backgroundColor = colorScheme.backgroundColor;
 
   self.presentButton = [[MDCButton alloc] initWithFrame:CGRectZero];

--- a/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
@@ -80,9 +80,19 @@
 
 @implementation DialogsRoundedCornerExampleViewController
 
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+    scheme.colorScheme =
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    _containerScheme = scheme;
+  }
+  return self;
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
-  self.containerScheme = [[MDCContainerScheme alloc] init];
 
   // We must create and store a strong reference to the transitionController.
   // A presented view controller will set this object as its transitioning delegate.

--- a/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
@@ -14,11 +14,15 @@
 
 #import "DialogsRoundedCornerExampleViewController.h"
 #import "MaterialButtons.h"
+#import "MaterialButtons+Theming.h"
+#import "MaterialDialogs.h"
 #import "MaterialDialogs+Theming.h"
 
 @interface DialogsRoundedCornerSimpleController : UIViewController
 
-@property(nonatomic, strong) MDCFlatButton *dismissButton;
+@property(nonatomic, strong) MDCButton *dismissButton;
+
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 
 @end
 
@@ -29,17 +33,17 @@
 
   self.view.backgroundColor = [UIColor whiteColor];
 
-  _dismissButton = [[MDCFlatButton alloc] initWithFrame:CGRectZero];
-  [_dismissButton setTitle:@"Dismiss" forState:UIControlStateNormal];
-  [_dismissButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
-  _dismissButton.autoresizingMask =
+  self.dismissButton = [[MDCFlatButton alloc] initWithFrame:CGRectZero];
+  [self.dismissButton setTitle:@"Dismiss" forState:UIControlStateNormal];
+  [self.dismissButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
+  self.dismissButton.autoresizingMask =
       UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |
       UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin;
-  [_dismissButton addTarget:self
+  [self.dismissButton addTarget:self
                      action:@selector(dismiss:)
            forControlEvents:UIControlEventTouchUpInside];
-
-  [self.view addSubview:_dismissButton];
+  [self.dismissButton applyTextThemeWithScheme:self.containerScheme];
+  [self.view addSubview:self.dismissButton];
 }
 
 - (void)viewWillLayoutSubviews {
@@ -61,7 +65,7 @@
 
 @interface DialogsRoundedCornerExampleViewController ()
 
-@property(nonatomic, strong) MDCFlatButton *presentButton;
+@property(nonatomic, strong) MDCButton *presentButton;
 @property(nonatomic, strong) MDCDialogTransitionController *transitionController;
 @property(nonatomic, strong) MDCContainerScheme *containerScheme;
 
@@ -79,17 +83,17 @@
 
   self.view.backgroundColor = [UIColor whiteColor];
 
-  _presentButton = [[MDCFlatButton alloc] initWithFrame:CGRectZero];
-  [_presentButton setTitle:@"Present" forState:UIControlStateNormal];
-  [_presentButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
-  _presentButton.autoresizingMask =
+  self.presentButton = [[MDCFlatButton alloc] initWithFrame:CGRectZero];
+  [self.presentButton setTitle:@"Present" forState:UIControlStateNormal];
+  [self.presentButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
+  self.presentButton.autoresizingMask =
       UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |
       UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin;
-  [_presentButton addTarget:self
+  [self.presentButton addTarget:self
                      action:@selector(didTapPresent:)
            forControlEvents:UIControlEventTouchUpInside];
-
-  [self.view addSubview:_presentButton];
+  [self.presentButton applyTextThemeWithScheme:self.containerScheme];
+  [self.view addSubview:self.presentButton];
 }
 
 - (void)viewWillLayoutSubviews {

--- a/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
@@ -22,7 +22,7 @@
 
 @property(nonatomic, strong) MDCButton *dismissButton;
 
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 
 @end
 
@@ -31,9 +31,16 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.view.backgroundColor = [UIColor whiteColor];
+  id<MDCColorScheming> colorScheme;
+  if (self.containerScheme.colorScheme != nil) {
+    colorScheme = self.containerScheme.colorScheme;
+  } else {
+    colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+  self.view.backgroundColor = colorScheme.backgroundColor;
 
-  self.dismissButton = [[MDCFlatButton alloc] initWithFrame:CGRectZero];
+  self.dismissButton = [[MDCButton alloc] initWithFrame:CGRectZero];
   [self.dismissButton setTitle:@"Dismiss" forState:UIControlStateNormal];
   [self.dismissButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
   self.dismissButton.autoresizingMask =
@@ -67,7 +74,7 @@
 
 @property(nonatomic, strong) MDCButton *presentButton;
 @property(nonatomic, strong) MDCDialogTransitionController *transitionController;
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 
 @end
 
@@ -81,9 +88,16 @@
   // A presented view controller will set this object as its transitioning delegate.
   self.transitionController = [[MDCDialogTransitionController alloc] init];
 
-  self.view.backgroundColor = [UIColor whiteColor];
+  id<MDCColorScheming> colorScheme;
+  if (self.containerScheme.colorScheme != nil) {
+    colorScheme = self.containerScheme.colorScheme;
+  } else {
+    colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+  self.view.backgroundColor = colorScheme.backgroundColor;
 
-  self.presentButton = [[MDCFlatButton alloc] initWithFrame:CGRectZero];
+  self.presentButton = [[MDCButton alloc] initWithFrame:CGRectZero];
   [self.presentButton setTitle:@"Present" forState:UIControlStateNormal];
   [self.presentButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
   self.presentButton.autoresizingMask =

--- a/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #import "DialogsRoundedCornerExampleViewController.h"
-#import "MaterialButtons.h"
 #import "MaterialButtons+Theming.h"
-#import "MaterialDialogs.h"
+#import "MaterialButtons.h"
 #import "MaterialDialogs+Theming.h"
+#import "MaterialDialogs.h"
 
 @interface DialogsRoundedCornerSimpleController : UIViewController
 
@@ -47,8 +47,8 @@
       UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |
       UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin;
   [self.dismissButton addTarget:self
-                     action:@selector(dismiss:)
-           forControlEvents:UIControlEventTouchUpInside];
+                         action:@selector(dismiss:)
+               forControlEvents:UIControlEventTouchUpInside];
   [self.dismissButton applyTextThemeWithScheme:self.containerScheme];
   [self.view addSubview:self.dismissButton];
 }
@@ -104,8 +104,8 @@
       UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |
       UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin;
   [self.presentButton addTarget:self
-                     action:@selector(didTapPresent:)
-           forControlEvents:UIControlEventTouchUpInside];
+                         action:@selector(didTapPresent:)
+               forControlEvents:UIControlEventTouchUpInside];
   [self.presentButton applyTextThemeWithScheme:self.containerScheme];
   [self.view addSubview:self.presentButton];
 }

--- a/components/Dialogs/examples/DialogsTypicalUseExampleViewController.m
+++ b/components/Dialogs/examples/DialogsTypicalUseExampleViewController.m
@@ -25,24 +25,28 @@
 
 @interface DialogsTypicalUseExampleViewController : UIViewController
 @property(nonatomic, strong, nullable) MDCContainerScheme *containerScheme;
-@property(nonatomic, strong, nullable) MDCSemanticColorScheme *colorScheme;
 @property(nonatomic, strong, nullable) NSArray *modes;
 @property(nonatomic, strong, nullable) MDCButton *button;
 @end
 
 @implementation DialogsTypicalUseExampleViewController
 
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _containerScheme = [[MDCContainerScheme alloc] init];
+    _containerScheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    _containerScheme.typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+  }
+  return self;
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  if (!self.containerScheme) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
-  }
-  if (!self.colorScheme) {
-    self.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  }
-  self.view.backgroundColor = self.colorScheme.backgroundColor;
+  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
 
   MDCButton *dismissButton = [[MDCButton alloc] initWithFrame:CGRectZero];
   self.button = dismissButton;

--- a/components/Dialogs/examples/DialogsTypicalUseExampleViewController.m
+++ b/components/Dialogs/examples/DialogsTypicalUseExampleViewController.m
@@ -31,22 +31,18 @@
 
 @implementation DialogsTypicalUseExampleViewController
 
-- (instancetype)init {
-  self = [super init];
-  if (self) {
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  if (self.containerScheme == nil) {
     MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
     scheme.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     scheme.typographyScheme =
         [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
-    _containerScheme = scheme;
+    self.containerScheme = scheme;
   }
-  return self;
-}
-
-- (void)viewDidLoad {
-  [super viewDidLoad];
-
+  
   self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
 
   MDCButton *dismissButton = [[MDCButton alloc] initWithFrame:CGRectZero];

--- a/components/Dialogs/examples/DialogsTypicalUseExampleViewController.m
+++ b/components/Dialogs/examples/DialogsTypicalUseExampleViewController.m
@@ -36,7 +36,7 @@
   if (self) {
     MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
     scheme.colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     _containerScheme = scheme;
   }
   return self;
@@ -50,7 +50,7 @@
     colorScheme = self.containerScheme.colorScheme;
   } else {
     colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   }
   self.view.backgroundColor = colorScheme.backgroundColor;
 

--- a/components/Dialogs/examples/DialogsTypicalUseExampleViewController.m
+++ b/components/Dialogs/examples/DialogsTypicalUseExampleViewController.m
@@ -24,7 +24,7 @@
 #pragma mark - DialogsTypicalUseExampleViewController
 
 @interface DialogsTypicalUseExampleViewController : UIViewController
-@property(nonatomic, strong, nullable) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong, nullable) id<MDCContainerScheming> containerScheme;
 @property(nonatomic, strong, nullable) NSArray *modes;
 @property(nonatomic, strong, nullable) MDCButton *button;
 @end
@@ -34,11 +34,12 @@
 - (instancetype)init {
   self = [super init];
   if (self) {
-    _containerScheme = [[MDCContainerScheme alloc] init];
-    _containerScheme.colorScheme =
+    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+    scheme.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    _containerScheme.typographyScheme =
+    scheme.typographyScheme =
         [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+    _containerScheme = scheme;
   }
   return self;
 }

--- a/components/Dialogs/examples/DialogsTypicalUseExampleViewController.m
+++ b/components/Dialogs/examples/DialogsTypicalUseExampleViewController.m
@@ -31,19 +31,28 @@
 
 @implementation DialogsTypicalUseExampleViewController
 
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+    scheme.colorScheme =
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    _containerScheme = scheme;
+  }
+  return self;
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  if (self.containerScheme == nil) {
-    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-    scheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    scheme.typographyScheme =
-        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
-    self.containerScheme = scheme;
+  id<MDCColorScheming> colorScheme;
+  if (self.containerScheme.colorScheme != nil) {
+    colorScheme = self.containerScheme.colorScheme;
+  } else {
+    colorScheme =
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   }
-  
-  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
+  self.view.backgroundColor = colorScheme.backgroundColor;
 
   MDCButton *dismissButton = [[MDCButton alloc] initWithFrame:CGRectZero];
   self.button = dismissButton;

--- a/components/Dialogs/examples/DialogsTypicalUseExampleViewController.m
+++ b/components/Dialogs/examples/DialogsTypicalUseExampleViewController.m
@@ -45,13 +45,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  id<MDCColorScheming> colorScheme;
-  if (self.containerScheme.colorScheme != nil) {
-    colorScheme = self.containerScheme.colorScheme;
-  } else {
-    colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  }
+  id<MDCColorScheming> colorScheme = self.containerScheme.colorScheme ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   self.view.backgroundColor = colorScheme.backgroundColor;
 
   MDCButton *dismissButton = [[MDCButton alloc] initWithFrame:CGRectZero];

--- a/components/Dialogs/examples/DialogsTypicalUseExampleViewController.m
+++ b/components/Dialogs/examples/DialogsTypicalUseExampleViewController.m
@@ -45,7 +45,9 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  id<MDCColorScheming> colorScheme = self.containerScheme.colorScheme ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  id<MDCColorScheming> colorScheme =
+      self.containerScheme.colorScheme
+          ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   self.view.backgroundColor = colorScheme.backgroundColor;
 
   MDCButton *dismissButton = [[MDCButton alloc] initWithFrame:CGRectZero];

--- a/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerExampleViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerExampleViewController.m
@@ -156,7 +156,7 @@
 
 @property(nonatomic, strong) MDCButton *presentButton;
 
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 
 @end
 
@@ -166,9 +166,16 @@
   [super viewDidLoad];
 
   // Create a way to present a view controller.
-  self.view.backgroundColor = [UIColor whiteColor];
+  id<MDCColorScheming> colorScheme;
+  if (self.containerScheme.colorScheme != nil) {
+    colorScheme = self.containerScheme.colorScheme;
+  } else {
+    colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+  self.view.backgroundColor = colorScheme.backgroundColor;
 
-  self.presentButton = [[MDCFlatButton alloc] init];
+  self.presentButton = [[MDCButton alloc] init];
   [self.presentButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
   [self.presentButton setBackgroundColor:[UIColor darkGrayColor] forState:UIControlStateNormal];
   [self.presentButton setTitle:@"Present View Controller" forState:UIControlStateNormal];

--- a/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerExampleViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerExampleViewController.m
@@ -185,7 +185,9 @@
   [super viewDidLoad];
 
   // Create a way to present a view controller.
-  id<MDCColorScheming> colorScheme = self.containerScheme.colorScheme ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  id<MDCColorScheming> colorScheme =
+      self.containerScheme.colorScheme
+          ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   self.view.backgroundColor = colorScheme.backgroundColor;
 
   self.presentButton = [[MDCButton alloc] init];

--- a/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerExampleViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerExampleViewController.m
@@ -18,16 +18,18 @@
  */
 
 #import "DialogDismissalOverPresentedControllerExampleViewController.h"
+
 #import "MaterialButtons.h"
+#import "MaterialButtons+Theming.h"
+#import "MaterialContainerScheme.h"
 #import "MaterialDialogs.h"
+#import "MaterialDialogs+Theming.h"
 
 #pragma mark - Helper View Controller
 
 @interface PresentedViewControllerWithDialog : UIViewController
 
-@property(nonatomic, strong) MDCFlatButton *dialogButton;
-
-@property(nonatomic, strong) MDCFlatButton *dismissButton;
+@property(nonatomic, strong) MDCButton *dialogButton;
 
 @property(nonatomic, strong) UILabel *topLeftLabel;
 
@@ -37,6 +39,8 @@
 
 @property(nonatomic, strong) UILabel *bottomRightLabel;
 
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+
 @end
 
 @implementation PresentedViewControllerWithDialog
@@ -44,6 +48,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
+  self.containerScheme = [[MDCContainerScheme alloc] init];
   self.navigationItem.title = @"Presented View Controller";
 
   // Make a layout that displays content in the corners.
@@ -104,15 +109,16 @@
   [NSLayoutConstraint activateConstraints:constraints];
 
   // Add a button to show the dialog from this presented view controller.
-  _dialogButton = [[MDCFlatButton alloc] init];
-  [_dialogButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
-  [_dialogButton setBackgroundColor:[UIColor darkGrayColor] forState:UIControlStateNormal];
-  [_dialogButton setTitle:@"Show Dialog" forState:UIControlStateNormal];
-  _dialogButton.translatesAutoresizingMaskIntoConstraints = NO;
-  [_dialogButton addTarget:self
-                    action:@selector(showDialog:)
-          forControlEvents:UIControlEventTouchUpInside];
-  [self.view addSubview:_dialogButton];
+  self.dialogButton = [[MDCButton alloc] init];
+  [self.dialogButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+  [self.dialogButton setBackgroundColor:[UIColor darkGrayColor] forState:UIControlStateNormal];
+  [self.dialogButton setTitle:@"Show Dialog" forState:UIControlStateNormal];
+  self.dialogButton.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.dialogButton addTarget:self
+                        action:@selector(showDialog:)
+              forControlEvents:UIControlEventTouchUpInside];
+  [self.dialogButton applyTextThemeWithScheme:self.containerScheme];
+  [self.view addSubview:self.dialogButton];
 
   [[NSLayoutConstraint constraintWithItem:_dialogButton
                                 attribute:NSLayoutAttributeCenterX
@@ -138,6 +144,7 @@
                                                     " remain unchanged and all four sections should"
                                                     " continue to be fully visible."];
   [dialog addAction:[MDCAlertAction actionWithTitle:@"Dismiss Me" handler:nil]];
+  [dialog applyThemeWithScheme:self.containerScheme];
   [self presentViewController:dialog animated:YES completion:nil];
 }
 
@@ -147,7 +154,9 @@
 
 @interface DialogDismissalOverPresentedControllerExampleViewController ()
 
-@property(nonatomic, strong) MDCFlatButton *presentButton;
+@property(nonatomic, strong) MDCButton *presentButton;
+
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 
 @end
 
@@ -159,15 +168,16 @@
   // Create a way to present a view controller.
   self.view.backgroundColor = [UIColor whiteColor];
 
-  _presentButton = [[MDCFlatButton alloc] init];
-  [_presentButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
-  [_presentButton setBackgroundColor:[UIColor darkGrayColor] forState:UIControlStateNormal];
-  [_presentButton setTitle:@"Present View Controller" forState:UIControlStateNormal];
-  _presentButton.translatesAutoresizingMaskIntoConstraints = NO;
-  [_presentButton addTarget:self
+  self.presentButton = [[MDCFlatButton alloc] init];
+  [self.presentButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+  [self.presentButton setBackgroundColor:[UIColor darkGrayColor] forState:UIControlStateNormal];
+  [self.presentButton setTitle:@"Present View Controller" forState:UIControlStateNormal];
+  self.presentButton.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.presentButton addTarget:self
                      action:@selector(presentController:)
            forControlEvents:UIControlEventTouchUpInside];
-  [self.view addSubview:_presentButton];
+  [self.presentButton applyTextThemeWithScheme:self.containerScheme];
+  [self.view addSubview:self.presentButton];
 
   [[NSLayoutConstraint constraintWithItem:_presentButton
                                 attribute:NSLayoutAttributeCenterX

--- a/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerExampleViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerExampleViewController.m
@@ -39,7 +39,7 @@
 
 @property(nonatomic, strong) UILabel *bottomRightLabel;
 
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 
 @end
 

--- a/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerExampleViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerExampleViewController.m
@@ -50,7 +50,7 @@
   if (self) {
     MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
     scheme.colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     _containerScheme = scheme;
   }
   return self;
@@ -175,7 +175,7 @@
   if (self) {
     MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
     scheme.colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     _containerScheme = scheme;
   }
   return self;

--- a/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerExampleViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerExampleViewController.m
@@ -45,10 +45,20 @@
 
 @implementation PresentedViewControllerWithDialog
 
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+    scheme.colorScheme =
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    _containerScheme = scheme;
+  }
+  return self;
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.containerScheme = [[MDCContainerScheme alloc] init];
   self.navigationItem.title = @"Presented View Controller";
 
   // Make a layout that displays content in the corners.
@@ -110,8 +120,6 @@
 
   // Add a button to show the dialog from this presented view controller.
   self.dialogButton = [[MDCButton alloc] init];
-  [self.dialogButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
-  [self.dialogButton setBackgroundColor:[UIColor darkGrayColor] forState:UIControlStateNormal];
   [self.dialogButton setTitle:@"Show Dialog" forState:UIControlStateNormal];
   self.dialogButton.translatesAutoresizingMaskIntoConstraints = NO;
   [self.dialogButton addTarget:self
@@ -161,6 +169,17 @@
 @end
 
 @implementation DialogDismissalOverPresentedControllerExampleViewController
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+    scheme.colorScheme =
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    _containerScheme = scheme;
+  }
+  return self;
+}
 
 - (void)viewDidLoad {
   [super viewDidLoad];

--- a/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerExampleViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerExampleViewController.m
@@ -185,13 +185,7 @@
   [super viewDidLoad];
 
   // Create a way to present a view controller.
-  id<MDCColorScheming> colorScheme;
-  if (self.containerScheme.colorScheme != nil) {
-    colorScheme = self.containerScheme.colorScheme;
-  } else {
-    colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  }
+  id<MDCColorScheming> colorScheme = self.containerScheme.colorScheme ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   self.view.backgroundColor = colorScheme.backgroundColor;
 
   self.presentButton = [[MDCButton alloc] init];

--- a/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerExampleViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogDismissalOverPresentedControllerExampleViewController.m
@@ -19,11 +19,11 @@
 
 #import "DialogDismissalOverPresentedControllerExampleViewController.h"
 
-#import "MaterialButtons.h"
 #import "MaterialButtons+Theming.h"
+#import "MaterialButtons.h"
 #import "MaterialContainerScheme.h"
-#import "MaterialDialogs.h"
 #import "MaterialDialogs+Theming.h"
+#import "MaterialDialogs.h"
 
 #pragma mark - Helper View Controller
 
@@ -181,8 +181,8 @@
   [self.presentButton setTitle:@"Present View Controller" forState:UIControlStateNormal];
   self.presentButton.translatesAutoresizingMaskIntoConstraints = NO;
   [self.presentButton addTarget:self
-                     action:@selector(presentController:)
-           forControlEvents:UIControlEventTouchUpInside];
+                         action:@selector(presentController:)
+               forControlEvents:UIControlEventTouchUpInside];
   [self.presentButton applyTextThemeWithScheme:self.containerScheme];
   [self.view addSubview:self.presentButton];
 

--- a/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeExampleViewController.h
+++ b/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeExampleViewController.h
@@ -17,14 +17,16 @@
  instructions. It is not necessary to import this file to use Material Components for iOS.
  */
 
-#import "MaterialColorScheme.h"
-#import "MaterialTypographyScheme.h"
-
 #import <UIKit/UIKit.h>
+
+#import "MaterialColorScheme.h"
+#import "MaterialContainerScheme.h"
+#import "MaterialTypographyScheme.h"
 
 @interface DialogWithPreferredContentSizeExampleViewController : UIViewController
 
 @property(nonatomic, strong, nullable) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong, nullable) MDCContainerScheme *containerScheme;
 @property(nonatomic, strong, nullable) MDCTypographyScheme *typographyScheme;
 
 @end

--- a/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeExampleViewController.h
+++ b/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeExampleViewController.h
@@ -25,8 +25,6 @@
 
 @interface DialogWithPreferredContentSizeExampleViewController : UIViewController
 
-@property(nonatomic, strong, nullable) MDCSemanticColorScheme *colorScheme;
 @property(nonatomic, strong, nullable) MDCContainerScheme *containerScheme;
-@property(nonatomic, strong, nullable) MDCTypographyScheme *typographyScheme;
 
 @end

--- a/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeExampleViewController.h
+++ b/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeExampleViewController.h
@@ -19,12 +19,10 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialColorScheme.h"
 #import "MaterialContainerScheme.h"
-#import "MaterialTypographyScheme.h"
 
 @interface DialogWithPreferredContentSizeExampleViewController : UIViewController
 
-@property(nonatomic, strong, nullable) MDCContainerScheme *containerScheme;
+@property(nonatomic, strong, nullable) id<MDCContainerScheming> containerScheme;
 
 @end

--- a/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeExampleViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeExampleViewController.m
@@ -19,8 +19,8 @@
 
 #import "DialogWithPreferredContentSizeExampleViewController.h"
 
-#import "MaterialButtons.h"
 #import "MaterialButtons+Theming.h"
+#import "MaterialButtons.h"
 #import "MaterialColorScheme.h"
 #import "MaterialTypographyScheme.h"
 

--- a/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeExampleViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeExampleViewController.m
@@ -28,10 +28,22 @@
 
 @implementation DialogWithPreferredContentSizeExampleViewController
 
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _containerScheme = [[MDCContainerScheme alloc] init];
+    _containerScheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    _containerScheme.typographyScheme =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+  }
+  return self;
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  [button applyContainedThemeWithScheme:self.containerScheme];
+  [self.button applyContainedThemeWithScheme:self.containerScheme];
 }
 
 - (IBAction)buttonPushed:(id)sender {

--- a/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeExampleViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeExampleViewController.m
@@ -19,8 +19,8 @@
 
 #import "DialogWithPreferredContentSizeExampleViewController.h"
 
-#import "MaterialButtons+ButtonThemer.h"
 #import "MaterialButtons.h"
+#import "MaterialButtons+Theming.h"
 
 @interface DialogWithPreferredContentSizeExampleViewController ()
 @property(nonatomic, strong) IBOutlet MDCButton *button;
@@ -31,10 +31,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  MDCButtonScheme *scheme = [[MDCButtonScheme alloc] init];
-  scheme.colorScheme = self.colorScheme;
-  scheme.typographyScheme = self.typographyScheme;
-  [MDCContainedButtonThemer applyScheme:scheme toButton:self.button];
+  [button applyContainedThemeWithScheme:self.containerScheme];
 }
 
 - (IBAction)buttonPushed:(id)sender {

--- a/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeExampleViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeExampleViewController.m
@@ -21,6 +21,8 @@
 
 #import "MaterialButtons.h"
 #import "MaterialButtons+Theming.h"
+#import "MaterialColorScheme.h"
+#import "MaterialTypographyScheme.h"
 
 @interface DialogWithPreferredContentSizeExampleViewController ()
 @property(nonatomic, strong) IBOutlet MDCButton *button;
@@ -31,11 +33,12 @@
 - (instancetype)init {
   self = [super init];
   if (self) {
-    _containerScheme = [[MDCContainerScheme alloc] init];
-    _containerScheme.colorScheme =
+    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
+    scheme.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    _containerScheme.typographyScheme =
+    scheme.typographyScheme =
         [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+    _containerScheme = scheme;
   }
   return self;
 }

--- a/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeExampleViewController.m
+++ b/components/Dialogs/examples/supplemental/DialogWithPreferredContentSizeExampleViewController.m
@@ -30,21 +30,12 @@
 
 @implementation DialogWithPreferredContentSizeExampleViewController
 
-- (instancetype)init {
-  self = [super init];
-  if (self) {
-    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-    scheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    scheme.typographyScheme =
-        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
-    _containerScheme = scheme;
-  }
-  return self;
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
+
+  if (self.containerScheme == nil) {
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+  }
 
   [self.button applyContainedThemeWithScheme:self.containerScheme];
 }


### PR DESCRIPTION
## Related links
* Bug: #6438 
* Component: [Dialogs](https://github.com/material-components/material-components-ios/tree/develop/components/Dialogs)
## Introduction
As we move to theming extensions all components that have a theming extension should use that within it's examples. Currently MDCAlertController has a theming extension and should use it in all examples. Additionally all components within the examples that have a theming extension should use it.
## The problem
Within MDCAlertController examples some components are using the old _Themers_.
## The fix
For all components being used in MDCAlertController examples use a theming extension if available.
## Additional notes
This also cleans up some ivar usage and import statements.