### PR TITLE
{kokoro} Add bazel pinning support to High Sierra images

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -220,9 +220,11 @@ run_bazel_affected() {
     # 0.20.
     if [ -n "$KOKORO_BUILD_NUMBER" ]; then
       bazel version
-      sw_vers
-      use_bazel.sh 0.20.0
-      bazel version
+      bazel_minor_version=$(bazel version | grep "Build label" | cut -d'.' -f2)
+      if [ "$bazel_minor_version" -lt "20" ]; then
+        use_bazel.sh 0.20.0
+        bazel version
+      fi
     fi
     
     # Output the affected targets to the logs. This also gives the affected_targets script the

--- a/.kokoro
+++ b/.kokoro
@@ -191,7 +191,7 @@ upload_bazel_test_artifacts() {
 upgrade_kokoro_bazel_if_needed() {
   bazel version
 
-  if [ -f "$KOKORO_GFILE_DIR/use_bazel.sh"]; then
+  if [ -f "$KOKORO_GFILE_DIR/use_bazel.sh" ]; then
     "$KOKORO_GFILE_DIR/use_bazel.sh" 0.20.0
   else
     use_bazel.sh 0.20.0

--- a/.kokoro
+++ b/.kokoro
@@ -191,14 +191,12 @@ upload_bazel_test_artifacts() {
 upgrade_kokoro_bazel_if_needed() {
   bazel version
 
-  # Only update bazel if the version is less than 0.20
-  bazel_version=$(bazel version | grep "Build label" | cut -d' ' -f3)
-  bazel_major_version=$(echo "$bazel_version" | cut -d'.' -f1)
-  bazel_minor_version=$(echo "$bazel_version" | cut -d'.' -f2)
-  if [ "$bazel_major_version" -eq 0 ] && [ "$bazel_minor_version" -lt "20" ]; then
+  if [ -f "$KOKORO_GFILE_DIR/use_bazel.sh"]; then
+    "$KOKORO_GFILE_DIR/use_bazel.sh" 0.20.0
+  else
     use_bazel.sh 0.20.0
-    bazel version
   fi
+  bazel version
 }
 
 run_bazel_affected() {

--- a/.kokoro
+++ b/.kokoro
@@ -220,6 +220,7 @@ run_bazel_affected() {
     # 0.20.
     if [ -n "$KOKORO_BUILD_NUMBER" ]; then
       bazel version
+      sw_vers
       use_bazel.sh 0.20.0
       bazel version
     fi

--- a/.kokoro
+++ b/.kokoro
@@ -192,7 +192,7 @@ upgrade_kokoro_bazel_if_needed() {
   bazel version
 
   if [ -f "$KOKORO_GFILE_DIR/use_bazel.sh" ]; then
-    "$KOKORO_GFILE_DIR/use_bazel.sh" 0.20.0
+    bash "$KOKORO_GFILE_DIR/use_bazel.sh" 0.20.0
   else
     use_bazel.sh 0.20.0
   fi

--- a/.kokoro
+++ b/.kokoro
@@ -187,9 +187,11 @@ upload_bazel_test_artifacts() {
   find -L . -name "sponge_log.xml" -type f | copy_to_artifacts
 }
 
-# Upgrades the machine's current bazel version to at least 0.20.0
+# Upgrades kokoro's current bazel version to at least 0.20.0
 upgrade_kokoro_bazel_if_needed() {
   bazel version
+  # High sierra machines do not presently have a use_bazel.sh tool
+  # They do come pre-installed with bazel 0.21 however, so we don't need to update bazel.
   if [ "$KOKORO_JOB_POOL" != "high-sierra" ]; then
     use_bazel.sh 0.20.0
     bazel version

--- a/.kokoro
+++ b/.kokoro
@@ -220,8 +220,7 @@ run_bazel_affected() {
     # 0.20.
     if [ -n "$KOKORO_BUILD_NUMBER" ]; then
       bazel version
-      bazel_minor_version=$(bazel version | grep "Build label" | cut -d'.' -f2)
-      if [ "$bazel_minor_version" -lt "20" ]; then
+      if [ "$KOKORO_JOB_POOL" != "high-sierra" ]; then
         use_bazel.sh 0.20.0
         bazel version
       fi

--- a/.kokoro
+++ b/.kokoro
@@ -190,9 +190,12 @@ upload_bazel_test_artifacts() {
 # Upgrades kokoro's current bazel version to at least 0.20.0
 upgrade_kokoro_bazel_if_needed() {
   bazel version
-  # High sierra machines do not presently have a use_bazel.sh tool
-  # They do come pre-installed with bazel 0.21 however, so we don't need to update bazel.
-  if [ "$KOKORO_JOB_POOL" != "high-sierra" ]; then
+
+  # Only update bazel if the version is less than 0.20
+  bazel_version=$(bazel version | grep "Build label" | cut -d' ' -f3)
+  bazel_major_version=$(echo "$bazel_version" | cut -d'.' -f1)
+  bazel_minor_version=$(echo "$bazel_version" | cut -d'.' -f2)
+  if [ "$bazel_major_version" -eq 0 ] && [ "$bazel_minor_version" -lt "20" ]; then
     use_bazel.sh 0.20.0
     bazel version
   fi

--- a/.kokoro
+++ b/.kokoro
@@ -187,6 +187,15 @@ upload_bazel_test_artifacts() {
   find -L . -name "sponge_log.xml" -type f | copy_to_artifacts
 }
 
+# Upgrades the machine's current bazel version to at least 0.20.0
+upgrade_kokoro_bazel_if_needed() {
+  bazel version
+  if [ "$KOKORO_JOB_POOL" != "high-sierra" ]; then
+    use_bazel.sh 0.20.0
+    bazel version
+  fi
+}
+
 run_bazel_affected() {
   echo "Checking affected targets..."
   if [ -z "$COMMAND" ]; then
@@ -219,11 +228,7 @@ run_bazel_affected() {
     # We must upgrade bazel prior to running bazel query because we rely on features in bazel
     # 0.20.
     if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-      bazel version
-      if [ "$KOKORO_JOB_POOL" != "high-sierra" ]; then
-        use_bazel.sh 0.20.0
-        bazel version
-      fi
+      upgrade_kokoro_bazel_if_needed
     fi
     
     # Output the affected targets to the logs. This also gives the affected_targets script the
@@ -280,9 +285,7 @@ run_bazel() {
   fi
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-    bazel version
-    use_bazel.sh 0.20.0
-    bazel version
+    upgrade_kokoro_bazel_if_needed
   fi
 
   if [ -n "$VERBOSE_OUTPUT" ]; then


### PR DESCRIPTION
This PR fixes our xcode10.1.0 presubmit jobs.

## Context

Kokoro's High Sierra machines do not yet include a `use_bazel.sh` tool, which our `.kokoro` script uses to pin the bazel version to 0.20.

## The problem

Our kokoro High Sierra jobs are failing because they are unconditionally attempting to run `use_bazel.sh`.

## The fix

We've explicitly added `use_bazel.sh` to our High Sierra images now. The script is placed in a specific location, however, so this PR updates the bazel pinning logic to make use of the script if it's available in that specific location.