### PR TITLE
[Dialogs] Add DialogPresentationControllerDelegate

### DIFF
--- a/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
@@ -15,6 +15,7 @@
 #import "DialogsRoundedCornerExampleViewController.h"
 #import "MaterialButtons.h"
 #import "MaterialDialogs+Theming.h"
+#import "MaterialDialogs.h"
 
 @interface DialogsRoundedCornerSimpleController : UIViewController
 

--- a/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
@@ -59,7 +59,7 @@
 
 @end
 
-@interface DialogsRoundedCornerExampleViewController ()
+@interface DialogsRoundedCornerExampleViewController () <MDCDialogPresentationControllerDelegate>
 
 @property(nonatomic, strong) MDCFlatButton *presentButton;
 @property(nonatomic, strong) MDCDialogTransitionController *transitionController;
@@ -111,9 +111,15 @@
 
   // ensure shadow/tracking layer matches the dialog's corner radius
   MDCDialogPresentationController *controller = viewController.mdc_dialogPresentationController;
+  controller.dialogPresentationControllerDelegate = self;
   [controller applyThemeWithScheme:self.containerScheme];
 
   [self presentViewController:viewController animated:YES completion:nil];
+}
+
+- (void)dialogPresentationControllerDidDismissDialog:
+    (MDCDialogPresentationController *)dialogPresentationController {
+  NSLog(@"You just dismissed a dialog with rounded corners");
 }
 
 #pragma mark - CatalogByConvention

--- a/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
@@ -118,7 +118,7 @@
   [self presentViewController:viewController animated:YES completion:nil];
 }
 
-- (void)dialogPresentationControllerDidDismissDialog:
+- (void)dialogPresentationControllerDidDismiss:
     (MDCDialogPresentationController *)dialogPresentationController {
   NSLog(@"You just dismissed a dialog with rounded corners");
 }

--- a/components/Dialogs/src/MDCDialogPresentationController.h
+++ b/components/Dialogs/src/MDCDialogPresentationController.h
@@ -25,7 +25,7 @@
 @protocol MDCDialogPresentationControllerDelegate <NSObject>
 @optional
 - (void)dialogPresentationControllerDidDismissDialog:
-    (MDCDialogPresentationController *)dialogPresentationController;
+    (MDCDialogPresentationController *_Nonnull)dialogPresentationController;
 @end
 
 /**
@@ -50,7 +50,7 @@
 /**
  An object conforming to MDCDialogPresentationControllerDelegate.
  */
-@property(nonatomic, weak) id<MDCDialogPresentationControllerDelegate>
+@property(nonatomic, weak, nullable) id<MDCDialogPresentationControllerDelegate>
     dialogPresentationControllerDelegate;
 
 /**

--- a/components/Dialogs/src/MDCDialogPresentationController.h
+++ b/components/Dialogs/src/MDCDialogPresentationController.h
@@ -29,7 +29,7 @@
  MDCDialogPresentationController dismissals.
  */
 - (void)dialogPresentationControllerDidDismiss:
-    (MDCDialogPresentationController *_Nonnull)dialogPresentationController;
+    (nonnull MDCDialogPresentationController *)dialogPresentationController;
 @end
 
 /**

--- a/components/Dialogs/src/MDCDialogPresentationController.h
+++ b/components/Dialogs/src/MDCDialogPresentationController.h
@@ -16,6 +16,18 @@
 
 #import "MaterialShadowElevations.h"
 
+@class MDCDialogPresentationController;
+
+/**
+ Similar to UIPopoverPresentationControllerDelegate, MDCDialogPresentationControllerDelegate lets
+ you customize the behavior of a popover-based presentation.
+ */
+@protocol MDCDialogPresentationControllerDelegate <NSObject>
+@optional
+- (void)dialogPresentationControllerDidDismissDialog:
+    (MDCDialogPresentationController *)dialogPresentationController;
+@end
+
 /**
  MDCDialogPresentationController will present a modal ViewController as a dialog according to the
  Material spec.
@@ -34,6 +46,12 @@
  presentedView's frame.
  */
 @interface MDCDialogPresentationController : UIPresentationController
+
+/**
+ An object conforming to MDCDialogPresentationControllerDelegate.
+ */
+@property(nonatomic, weak) id<MDCDialogPresentationControllerDelegate>
+    dialogPresentationControllerDelegate;
 
 /**
  Should a tap on the dimmed background view dismiss the presented controller.

--- a/components/Dialogs/src/MDCDialogPresentationController.h
+++ b/components/Dialogs/src/MDCDialogPresentationController.h
@@ -19,12 +19,16 @@
 @class MDCDialogPresentationController;
 
 /**
- Similar to UIPopoverPresentationControllerDelegate, MDCDialogPresentationControllerDelegate lets
- you customize the behavior of a popover-based presentation.
+ MDCDialogPresentationControllerDelegate provides a method that allows a delegate of an
+ MDCDialogPresentationController to respond to its dismissals.
  */
 @protocol MDCDialogPresentationControllerDelegate <NSObject>
-@optional
-- (void)dialogPresentationControllerDidDismissDialog:
+
+/**
+ This method allows a delegate conforming to MDCDialogPresentationControllerDelegate to respond to
+ MDCDialogPresentationController dismissals.
+ */
+- (void)dialogPresentationControllerDidDismiss:
     (MDCDialogPresentationController *_Nonnull)dialogPresentationController;
 @end
 
@@ -48,7 +52,9 @@
 @interface MDCDialogPresentationController : UIPresentationController
 
 /**
- An object conforming to MDCDialogPresentationControllerDelegate.
+ An object conforming to MDCDialogPresentationControllerDelegate. When non-nil, the
+ MDCDialogPresentationController will call the appropriate MDCDialogPresentationControllerDelegate
+ methods on this object.
  */
 @property(nonatomic, weak, nullable) id<MDCDialogPresentationControllerDelegate>
     dialogPresentationControllerDelegate;

--- a/components/Dialogs/src/MDCDialogPresentationController.h
+++ b/components/Dialogs/src/MDCDialogPresentationController.h
@@ -23,7 +23,7 @@
  MDCDialogPresentationController to respond to its dismissals.
  */
 @protocol MDCDialogPresentationControllerDelegate <NSObject>
-
+@optional
 /**
  This method allows a delegate conforming to MDCDialogPresentationControllerDelegate to respond to
  MDCDialogPresentationController dismissals.

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -301,16 +301,11 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
 
 - (void)dismiss:(UIGestureRecognizer *)gesture {
   if (gesture.state == UIGestureRecognizerStateRecognized) {
-    __weak __typeof(self) weakSelf = self;
     [self.presentingViewController
         dismissViewControllerAnimated:YES
                            completion:^{
-                             if ([weakSelf.dialogPresentationControllerDelegate
-                                     respondsToSelector:@selector
-                                     (dialogPresentationControllerDidDismissDialog:)]) {
-                               [weakSelf.dialogPresentationControllerDelegate
-                                   dialogPresentationControllerDidDismissDialog:weakSelf];
-                             }
+                             [self.dialogPresentationControllerDelegate
+                                 dialogPresentationControllerDidDismiss:self];
                            }];
   }
 }

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -301,7 +301,17 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
 
 - (void)dismiss:(UIGestureRecognizer *)gesture {
   if (gesture.state == UIGestureRecognizerStateRecognized) {
-    [self.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
+    __weak __typeof(self) weakSelf = self;
+    [self.presentingViewController
+        dismissViewControllerAnimated:YES
+                           completion:^{
+                             if ([weakSelf.dialogPresentationControllerDelegate
+                                     respondsToSelector:@selector
+                                     (dialogPresentationControllerDidDismissDialog:)]) {
+                               [weakSelf.dialogPresentationControllerDelegate
+                                   dialogPresentationControllerDidDismissDialog:weakSelf];
+                             }
+                           }];
   }
 }
 

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -304,8 +304,12 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
     [self.presentingViewController
         dismissViewControllerAnimated:YES
                            completion:^{
-                             [self.dialogPresentationControllerDelegate
-                                 dialogPresentationControllerDidDismiss:self];
+                             if ([self.dialogPresentationControllerDelegate
+                                     respondsToSelector:@selector
+                                     (dialogPresentationControllerDidDismiss:)]) {
+                               [self.dialogPresentationControllerDelegate
+                                   dialogPresentationControllerDidDismiss:self];
+                             }
                            }];
   }
 }


### PR DESCRIPTION
This PR adds a protocol called `MDCDialogPresentationControllerDelegate `, based on `UIPopoverPresentationControllerDelegate`.
Closes #1455.