### PR TITLE
[Dialogs] Fix broken link to beta documentation.

### DIFF
--- a/components/Dialogs/README.md
+++ b/components/Dialogs/README.md
@@ -197,7 +197,7 @@ You can theme an MDCDialog to match the Material Design Dialog using your app's 
 extension.
 
 You must first add the Dialog theming extension to your project, by following the standard 
-[beta component](docs/../../contributing/beta_components.md) steps.
+[beta component](docs/../../../contributing/beta_components.md) steps.
 
 You can then import the theming extension and create an `MDCContainerScheme` instance. A container scheme 
 defines the design parameters that you can use to theme your dialogs.
@@ -269,86 +269,6 @@ MDCAlertScheme *alertScheme = [[MDCAlertScheme alloc] init];
 
 // Step 3: Apply the alert scheme to your component using the desired alert style
 [MDCAlertControllerThemer applyScheme:alertScheme toAlertController:alertController];
-```
-<!--</div>-->
-
-<!-- Extracted from docs/color-theming.md -->
-
-### Color Theming
-
-You can theme a dialog with your app's color scheme using the ColorThemer extension.
-
-You must first add the Color Themer extension to your project:
-
-```bash
-pod 'MaterialComponents/Dialogs+ColorThemer'
-```
-
-<!--<div class="material-code-render" markdown="1">-->
-#### Swift
-```swift
-// Step 1: Import the ColorThemer extension
-import MaterialComponents.MaterialDialogs_ColorThemer
-
-// Step 2: Create or get a color scheme
-let colorScheme = MDCSemanticColorScheme()
-
-// Step 3: Apply the color scheme to your component
-MDCAlertColorThemer.applySemanticColorScheme(colorScheme, to: component)
-```
-
-#### Objective-C
-
-```objc
-// Step 1: Import the ColorThemer extension
-#import "MaterialDialogs+ColorThemer.h"
-
-// Step 2: Create or get a color scheme
-id<MDCColorScheming> colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-
-// Step 3: Apply the color scheme to your component
-[MDCAlertColorThemer applySemanticColorScheme:colorScheme
-     toAlertController:component];
-```
-<!--</div>-->
-
-<!-- Extracted from docs/typography-theming.md -->
-
-### Typography Theming
-
-You can theme a dialog with your app's typography scheme using the TypographyThemer extension.
-
-You must first add the Typography Themer extension to your project:
-
-```bash
-pod 'MaterialComponents/Dialogs+TypographyThemer'
-```
-
-<!--<div class="material-code-render" markdown="1">-->
-#### Swift
-```swift
-// Step 1: Import the TypographyThemer extension
-import MaterialComponents.MaterialDialogs_TypographyThemer
-
-// Step 2: Create or get a typography scheme
-let typographyScheme = MDCTypographyScheme()
-
-// Step 3: Apply the typography scheme to your component
-MDCAlertTypographyThemer.applyTypographyScheme(typographyScheme, to: component)
-```
-
-#### Objective-C
-
-```objc
-// Step 1: Import the TypographyThemer extension
-#import "MaterialDialogs+TypographyThemer.h"
-
-// Step 2: Create or get a typography scheme
-id<MDCTypographyScheming> typographyScheme = [[MDCTypographyScheme alloc] init];
-
-// Step 3: Apply the typography scheme to your component
-[MDCAlertTypographyThemer applyTypographyScheme:colorScheme
-     toAlertController:component];
 ```
 <!--</div>-->
 

--- a/components/Dialogs/docs/theming.md
+++ b/components/Dialogs/docs/theming.md
@@ -4,7 +4,7 @@ You can theme an MDCDialog to match the Material Design Dialog using your app's 
 extension.
 
 You must first add the Dialog theming extension to your project, by following the standard 
-[beta component](../../../contributing/beta_components.md) steps.
+[beta component](../../../../contributing/beta_components.md) steps.
 
 You can then import the theming extension and create an `MDCContainerScheme` instance. A container scheme 
 defines the design parameters that you can use to theme your dialogs.


### PR DESCRIPTION
Fixes the following error in the website job:

```
Error:
Broken link docs/../../contributing/beta_components.md in /Volumes/BuildData/tmpfs/src/github/repo/docsite-generator/.stage/ios/catalog/dialogs/index.md
```

The readme was regenerated by running `./scripts/generate_readme Dialogs`