### PR TITLE
[Shape] Add NSCopying to MDCShapeScheme

### DIFF
--- a/components/schemes/Shape/src/MDCShapeScheme.h
+++ b/components/schemes/Shape/src/MDCShapeScheme.h
@@ -23,7 +23,7 @@
  There are no optional properties and all shapes must be provided,
  supporting more reliable shape theming.
  */
-@protocol MDCShapeScheming
+@protocol MDCShapeScheming <NSCopying>
 
 /**
  The shape defining small sized components.

--- a/components/schemes/Shape/src/MDCShapeScheme.m
+++ b/components/schemes/Shape/src/MDCShapeScheme.m
@@ -37,4 +37,31 @@
   return self;
 }
 
+- (nonnull id)copyWithZone:(nullable NSZone *)zone {
+  MDCShapeScheme *copy =
+      [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  copy.smallComponentShape = self.smallComponentShape;
+  copy.mediumComponentShape = self.mediumComponentShape;
+  copy.largeComponentShape = self.largeComponentShape;
+  return copy;
+}
+
+- (BOOL)isEqual:(id)other {
+  if (other == self) {
+    return YES;
+  }
+
+  if (!other || ![[other class] isEqual:[self class]]) {
+    return NO;
+  }
+
+  MDCShapeScheme *otherShapeScheme = (MDCShapeScheme *)other;
+  return [self.smallComponentShape isEqual:otherShapeScheme.smallComponentShape] && [self.mediumComponentShape isEqual:otherShapeScheme.mediumComponentShape] && [self.largeComponentShape isEqual:otherShapeScheme.largeComponentShape];
+}
+
+- (NSUInteger)hash {
+  return (self.smallComponentShape.hash ^ self.mediumComponentShape.hash ^
+          self.largeComponentShape.hash);
+}
+
 @end

--- a/components/schemes/Shape/src/MDCShapeScheme.m
+++ b/components/schemes/Shape/src/MDCShapeScheme.m
@@ -46,24 +46,4 @@
   return copy;
 }
 
-- (BOOL)isEqual:(id)other {
-  if (other == self) {
-    return YES;
-  }
-
-  if (!other || ![[other class] isEqual:[self class]]) {
-    return NO;
-  }
-
-  MDCShapeScheme *otherShapeScheme = (MDCShapeScheme *)other;
-  return [self.smallComponentShape isEqual:otherShapeScheme.smallComponentShape] &&
-         [self.mediumComponentShape isEqual:otherShapeScheme.mediumComponentShape] &&
-         [self.largeComponentShape isEqual:otherShapeScheme.largeComponentShape];
-}
-
-- (NSUInteger)hash {
-  return (self.smallComponentShape.hash ^ self.mediumComponentShape.hash ^
-          self.largeComponentShape.hash);
-}
-
 @end

--- a/components/schemes/Shape/src/MDCShapeScheme.m
+++ b/components/schemes/Shape/src/MDCShapeScheme.m
@@ -56,7 +56,9 @@
   }
 
   MDCShapeScheme *otherShapeScheme = (MDCShapeScheme *)other;
-  return [self.smallComponentShape isEqual:otherShapeScheme.smallComponentShape] && [self.mediumComponentShape isEqual:otherShapeScheme.mediumComponentShape] && [self.largeComponentShape isEqual:otherShapeScheme.largeComponentShape];
+  return [self.smallComponentShape isEqual:otherShapeScheme.smallComponentShape] &&
+         [self.mediumComponentShape isEqual:otherShapeScheme.mediumComponentShape] &&
+         [self.largeComponentShape isEqual:otherShapeScheme.largeComponentShape];
 }
 
 - (NSUInteger)hash {

--- a/components/schemes/Shape/tests/unit/MDCShapeSchemeTests.m
+++ b/components/schemes/Shape/tests/unit/MDCShapeSchemeTests.m
@@ -96,35 +96,6 @@
 
   // Then
   XCTAssertNotEqual(shapeScheme, copiedShapeScheme);
-  XCTAssertEqualObjects(shapeScheme, copiedShapeScheme);
-  XCTAssertEqualObjects(shapeScheme.smallComponentShape, copiedShapeScheme.smallComponentShape);
-  XCTAssertEqualObjects(shapeScheme.mediumComponentShape, copiedShapeScheme.mediumComponentShape);
-  XCTAssertEqualObjects(shapeScheme.largeComponentShape, copiedShapeScheme.largeComponentShape);
-}
-
-- (void)testCopyShapeSchemeWithCustomValues {
-  // Given
-  MDCShapeScheme *shapeScheme =
-      [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
-  MDCShapeCategory *smallComponentShape =
-      [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyCut andSize:20];
-  shapeScheme.smallComponentShape = smallComponentShape;
-  MDCShapeCategory *mediumComponentShape =
-      [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyRounded andSize:40];
-  shapeScheme.mediumComponentShape = mediumComponentShape;
-  MDCShapeCategory *largeComponentShape =
-      [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyRounded andSize:60];
-  shapeScheme.largeComponentShape = largeComponentShape;
-
-  // When
-  MDCShapeScheme *copiedShapeScheme = [shapeScheme copy];
-
-  // Then
-  XCTAssertNotEqual(shapeScheme, copiedShapeScheme);
-  XCTAssertEqualObjects(shapeScheme, copiedShapeScheme);
-  XCTAssertEqualObjects(copiedShapeScheme.smallComponentShape, smallComponentShape);
-  XCTAssertEqualObjects(copiedShapeScheme.mediumComponentShape, mediumComponentShape);
-  XCTAssertEqualObjects(copiedShapeScheme.largeComponentShape, largeComponentShape);
 }
 
 @end

--- a/components/schemes/Shape/tests/unit/MDCShapeSchemeTests.m
+++ b/components/schemes/Shape/tests/unit/MDCShapeSchemeTests.m
@@ -85,4 +85,46 @@
   XCTAssertEqualObjects(cat.bottomRightCorner, copiedCat.bottomRightCorner);
   XCTAssertEqualObjects(cat.bottomLeftCorner, copiedCat.bottomLeftCorner);
 }
+
+- (void)testCopyShapeScheme {
+  // Given
+  MDCShapeScheme *shapeScheme =
+      [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+
+  // When
+  MDCShapeScheme *copiedShapeScheme = [shapeScheme copy];
+
+  // Then
+  XCTAssertNotEqual(shapeScheme, copiedShapeScheme);
+  XCTAssertEqualObjects(shapeScheme, copiedShapeScheme);
+  XCTAssertEqualObjects(shapeScheme.smallComponentShape, copiedShapeScheme.smallComponentShape);
+  XCTAssertEqualObjects(shapeScheme.mediumComponentShape, copiedShapeScheme.mediumComponentShape);
+  XCTAssertEqualObjects(shapeScheme.largeComponentShape, copiedShapeScheme.largeComponentShape);
+}
+
+- (void)testCopyShapeSchemeWithCustomValues {
+  // Given
+  MDCShapeScheme *shapeScheme =
+      [[MDCShapeScheme alloc] initWithDefaults:MDCShapeSchemeDefaultsMaterial201809];
+  MDCShapeCategory *smallComponentShape =
+      [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyCut andSize:20];
+  shapeScheme.smallComponentShape = smallComponentShape;
+  MDCShapeCategory *mediumComponentShape =
+      [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyRounded andSize:40];
+  shapeScheme.mediumComponentShape = mediumComponentShape;
+  MDCShapeCategory *largeComponentShape =
+      [[MDCShapeCategory alloc] initCornersWithFamily:MDCShapeCornerFamilyRounded andSize:60];
+  shapeScheme.largeComponentShape = largeComponentShape;
+
+  // When
+  MDCShapeScheme *copiedShapeScheme = [shapeScheme copy];
+
+  // Then
+  XCTAssertNotEqual(shapeScheme, copiedShapeScheme);
+  XCTAssertEqualObjects(shapeScheme, copiedShapeScheme);
+  XCTAssertEqualObjects(copiedShapeScheme.smallComponentShape, smallComponentShape);
+  XCTAssertEqualObjects(copiedShapeScheme.mediumComponentShape, mediumComponentShape);
+  XCTAssertEqualObjects(copiedShapeScheme.largeComponentShape, largeComponentShape);
+}
+
 @end


### PR DESCRIPTION
## Related links
* Original PR: #5929 
* Original bug: #5880 
* Scheme: [`MDCShapeScheme`](https://github.com/material-components/material-components-ios/tree/develop/components/schemes/Shape)

## Introduction
This was originally done in #5929 but that was closed. This change adds `copy` to `MDCShapeScheme`. The original PR added this to `MDCShapeScheme` this is a proposal to add it to the protocol `MDCShapeScheming` so if a client implements `MDCShapeScheming` or `MDCContainerScheming` they can then `copy` it.

## The problem
NSCopy was never added to MDCShapeScheme and we may need to copy a shape scheme within a container scheme.

## The fix
Add `NSCopying` to `MDCShapeScheming`.

## Additional notes
I have attached everyone to review so this can be where we discuss this proposal.

