### PR TITLE
[Catalog] Update AppTheme with container scheme

### DIFF
--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -19,50 +19,21 @@ import MaterialComponents.MaterialTypographyScheme
 import MaterialComponentsBeta.MaterialContainerScheme
 
 final class AppTheme {
-  let containerScheme: MDCContainerScheme
+  let containerScheme: MDCContainerScheming
 
   var colorScheme: MDCColorScheming {
-    return containerScheme.colorScheme ?? AppTheme.defaultColorScheme
+    return containerScheme.colorScheme ?? MDCSemanticColorScheme(defaults: .material201804)
   }
 
   var typographyScheme: MDCTypographyScheming {
-    return containerScheme.typographyScheme ?? AppTheme.defaultTypographyScheme
+    return containerScheme.typographyScheme ?? MDCTypographyScheme(defaults: .material201804)
+  }
+2
+  init(containerScheme: MDCContainerScheming) {
+    self.containerScheme = containerScheme
   }
 
-  init(colorScheme: MDCColorScheming, typographyScheme: MDCTypographyScheming) {
-    self.containerScheme = MDCContainerScheme()
-    self.containerScheme.colorScheme = colorScheme as? MDCSemanticColorScheme
-    self.containerScheme.typographyScheme = typographyScheme as? MDCTypographyScheme
-  }
-
-  static let defaultTheme: AppTheme = {
-    return AppTheme(colorScheme: defaultColorScheme,
-                    typographyScheme: defaultTypographyScheme)
-  }()
-
-  static var defaultColorScheme: MDCSemanticColorScheme = {
-    let colorScheme = MDCSemanticColorScheme()
-    colorScheme.primaryColor =  UIColor(red: CGFloat(0x21) / 255.0,
-                                        green: CGFloat(0x21) / 255.0,
-                                        blue: CGFloat(0x21) / 255.0,
-                                        alpha: 1)
-    colorScheme.primaryColorVariant = .init(white: 0.7, alpha: 1)
-    colorScheme.secondaryColor = UIColor(red: CGFloat(0x00) / 255.0,
-                                         green: CGFloat(0xE6) / 255.0,
-                                         blue: CGFloat(0x76) / 255.0,
-                                         alpha: 1)
-    return colorScheme
-  }()
-
-  static var defaultTypographyScheme: MDCTypographyScheme = {
-    let typographyScheme = MDCTypographyScheme()
-    typographyScheme.headline1 = UIFont.systemFont(ofSize: 20)
-    typographyScheme.headline2 = UIFont.systemFont(ofSize: 18)
-    typographyScheme.headline3 = UIFont.systemFont(ofSize: 15)
-    return typographyScheme
-  }()
-
-  static var globalTheme: AppTheme = defaultTheme {
+  static var globalTheme = AppTheme(containerScheme: DefaultContainerScheme()) {
     didSet {
       NotificationCenter.default.post(name: AppTheme.didChangeGlobalThemeNotificationName,
                                       object: nil,
@@ -72,4 +43,28 @@ final class AppTheme {
 
   static let didChangeGlobalThemeNotificationName =
     Notification.Name("MDCCatalogDidChangeGlobalTheme")
+}
+
+func DefaultContainerScheme() -> MDCContainerScheme {
+  let containerScheme = MDCContainerScheme()
+
+  let colorScheme = MDCSemanticColorScheme()
+  colorScheme.primaryColor =  UIColor(red: CGFloat(0x21) / 255.0,
+                                      green: CGFloat(0x21) / 255.0,
+                                      blue: CGFloat(0x21) / 255.0,
+                                      alpha: 1)
+  colorScheme.primaryColorVariant = .init(white: 0.7, alpha: 1)
+  colorScheme.secondaryColor = UIColor(red: CGFloat(0x00) / 255.0,
+                                       green: CGFloat(0xE6) / 255.0,
+                                       blue: CGFloat(0x76) / 255.0,
+                                       alpha: 1)
+  containerScheme.colorScheme = colorScheme
+
+  let typographyScheme = MDCTypographyScheme()
+  typographyScheme.headline1 = UIFont.systemFont(ofSize: 20)
+  typographyScheme.headline2 = UIFont.systemFont(ofSize: 18)
+  typographyScheme.headline3 = UIFont.systemFont(ofSize: 15)
+  containerScheme.typographyScheme = typographyScheme
+
+  return containerScheme
 }

--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -28,7 +28,7 @@ final class AppTheme {
   var typographyScheme: MDCTypographyScheming {
     return containerScheme.typographyScheme ?? MDCTypographyScheme(defaults: .material201804)
   }
-2
+
   init(containerScheme: MDCContainerScheming) {
     self.containerScheme = containerScheme
   }

--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -16,19 +16,22 @@ import MDFTextAccessibility
 import MaterialComponents.MaterialIcons_ic_check
 import MaterialComponents.MaterialPalettes
 import MaterialComponents.MaterialThemes
+import MaterialComponentsBeta.MaterialContainerScheme
 import UIKit
 
-private func createSchemeWithPalette(_ palette: MDCPalette) -> MDCSemanticColorScheme {
+private func schemeWithPalette(_ palette: MDCPalette) -> MDCContainerScheming {
+  let containerScheme = DefaultContainerScheme()
+
   let scheme = MDCSemanticColorScheme()
   scheme.primaryColor = palette.tint500
   scheme.primaryColorVariant = palette.tint900
   scheme.secondaryColor = scheme.primaryColor
   if let onPrimaryColor = MDFTextAccessibility.textColor(fromChoices: [MDCPalette.grey.tint100,
-                                                                      MDCPalette.grey.tint900,
-                                                                      UIColor.black,
-                                                                      UIColor.white],
-                                                        onBackgroundColor: scheme.primaryColor,
-                                                        options: .preferLighter) {
+                                                                       MDCPalette.grey.tint900,
+                                                                       UIColor.black,
+                                                                       UIColor.white],
+                                                         onBackgroundColor: scheme.primaryColor,
+                                                         options: .preferLighter) {
     scheme.onPrimaryColor = onPrimaryColor
   }
   if let onSecondaryColor = MDFTextAccessibility.textColor(fromChoices: [MDCPalette.grey.tint100,
@@ -39,18 +42,20 @@ private func createSchemeWithPalette(_ palette: MDCPalette) -> MDCSemanticColorS
                                                            options: .preferLighter) {
     scheme.onSecondaryColor = onSecondaryColor
   }
-  return scheme
+  containerScheme.colorScheme = scheme
+
+  return containerScheme
 }
 
 private struct MDCColorThemeCellConfiguration {
   let name: String
   let mainColor: UIColor
-  let colorScheme: () -> MDCColorScheming
+  let scheme: MDCContainerScheming
 
-  init(name: String, mainColor: UIColor, colorScheme: @escaping () -> MDCColorScheming) {
+  init(name: String, mainColor: UIColor, scheme: MDCContainerScheming) {
     self.name = name
     self.mainColor = mainColor
-    self.colorScheme = colorScheme
+    self.scheme = scheme
   }
 }
 
@@ -69,38 +74,26 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
   private let cellReuseIdentifier = "cell"
   private let colorSchemeConfigurations = [
     MDCColorThemeCellConfiguration(name: "Default",
-                                   mainColor: AppTheme.defaultTheme.colorScheme.primaryColor,
-                                   colorScheme: { return AppTheme.defaultTheme.colorScheme }),
+                                   mainColor: AppTheme.globalTheme.colorScheme.primaryColor,
+                                   scheme: DefaultContainerScheme()),
     MDCColorThemeCellConfiguration(name: "Blue",
                                    mainColor: MDCPalette.blue.tint500,
-                                   colorScheme: {
-                                    return createSchemeWithPalette(MDCPalette.blue)
-    }),
+                                   scheme: schemeWithPalette(MDCPalette.blue)),
     MDCColorThemeCellConfiguration(name: "Red",
                                    mainColor: MDCPalette.red.tint500,
-                                   colorScheme: {
-                                    return createSchemeWithPalette(MDCPalette.red)
-    }),
+                                   scheme: schemeWithPalette(MDCPalette.red)),
     MDCColorThemeCellConfiguration(name: "Green",
                                    mainColor: MDCPalette.green.tint500,
-                                   colorScheme: {
-                                    return createSchemeWithPalette(MDCPalette.green)
-    }),
+                                   scheme: schemeWithPalette(MDCPalette.green)),
     MDCColorThemeCellConfiguration(name: "Amber",
                                    mainColor: MDCPalette.amber.tint500,
-                                   colorScheme: {
-                                    return createSchemeWithPalette(MDCPalette.amber)
-    }),
+                                   scheme: schemeWithPalette(MDCPalette.amber)),
     MDCColorThemeCellConfiguration(name: "Pink",
                                    mainColor: MDCPalette.pink.tint500,
-                                   colorScheme: {
-                                    return createSchemeWithPalette(MDCPalette.pink)
-    }),
+                                   scheme: schemeWithPalette(MDCPalette.pink)),
     MDCColorThemeCellConfiguration(name: "Orange",
                                    mainColor: MDCPalette.orange.tint500,
-                                   colorScheme: {
-                                    return createSchemeWithPalette(MDCPalette.orange)
-    })
+                                   scheme: schemeWithPalette(MDCPalette.orange)),
   ]
   private let cellSize : CGFloat = 48.0 // minimum touch target
   private let cellSpacing : CGFloat = 8.0
@@ -212,10 +205,9 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
   }
 
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    let colorScheme = colorSchemeConfigurations[indexPath.item].colorScheme()
     navigationController?.popViewController(animated: true)
-    AppTheme.globalTheme = AppTheme(colorScheme: colorScheme,
-                                    typographyScheme: AppTheme.globalTheme.typographyScheme)
+    let scheme = colorSchemeConfigurations[indexPath.item].scheme
+    AppTheme.globalTheme = AppTheme(containerScheme: scheme)
   }
 
 }


### PR DESCRIPTION
The AppTheme now stores its container scheme as a readonly `MDCContainerScheming` type. As part of this change, the initializer now accepts a container scheme type and the default initialization has been moved out to a separate method. The theming controller has been updated to make use of this new API pattern.

Closes https://github.com/material-components/material-components-ios/issues/6527

Part of https://github.com/material-components/material-components-ios/issues/6450

This PR consists of multiple smaller changes. I will be breaking these changes into smaller PRs.