### PR TITLE
[Catalog] Remove the button scheme from the AppTheme.

### DIFF
--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -20,7 +20,6 @@ import MaterialComponentsBeta.MaterialContainerScheme
 
 final class AppTheme {
   let containerScheme: MDCContainerScheme
-  let buttonScheme: MDCButtonScheming
 
   var colorScheme: MDCColorScheming {
     return containerScheme.colorScheme ?? AppTheme.defaultColorScheme
@@ -34,10 +33,6 @@ final class AppTheme {
     self.containerScheme = MDCContainerScheme()
     self.containerScheme.colorScheme = colorScheme as? MDCSemanticColorScheme
     self.containerScheme.typographyScheme = typographyScheme as? MDCTypographyScheme
-    let buttonScheme = MDCButtonScheme()
-    buttonScheme.colorScheme = colorScheme
-    buttonScheme.typographyScheme = typographyScheme
-    self.buttonScheme = buttonScheme
   }
 
   static let defaultTheme: AppTheme = {


### PR DESCRIPTION
This property is no longer necessary now that we're able to theme buttons with the container scheme.

Related to https://github.com/material-components/material-components-ios/issues/6450

This change was extracted from https://github.com/material-components/material-components-ios/pull/6509
