### PR TITLE
[Catalog] Theme the primary demo button using theming extensions.

### DIFF
--- a/catalog/BUILD
+++ b/catalog/BUILD
@@ -67,6 +67,7 @@ swift_library(
         "//components/AppBar:TypographyThemer",
         "//components/BottomSheet",
         "//components/Buttons",
+        "//components/Buttons:ButtonThemer",
         "//components/Buttons:Theming",
         "//components/Collections",
         "//components/Dialogs",

--- a/catalog/BUILD
+++ b/catalog/BUILD
@@ -67,7 +67,7 @@ swift_library(
         "//components/AppBar:TypographyThemer",
         "//components/BottomSheet",
         "//components/Buttons",
-        "//components/Buttons:ButtonThemer",
+        "//components/Buttons:Theming",
         "//components/Collections",
         "//components/Dialogs",
         "//components/FlexibleHeader",

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -24,6 +24,7 @@ import MaterialComponents.MaterialButtons_ButtonThemer
 import MaterialComponents.MaterialCollections
 import MaterialComponents.MaterialTypography
 import MaterialComponents.MaterialFlexibleHeader_ColorThemer
+import MaterialComponentsBeta.MaterialButtons_Theming
 
 class NodeViewTableViewDemoCell: UITableViewCell {
 

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -524,8 +524,7 @@ extension MDCNodeListViewController {
       cell?.selectionStyle = .none
       let primaryDemoCell = cell as! NodeViewTableViewPrimaryDemoCell
       let button = primaryDemoCell.containedButton
-      let buttonScheme = AppTheme.globalTheme.buttonScheme
-      MDCContainedButtonThemer.applyScheme(buttonScheme, to:button)
+      button.applyContainedTheme(withScheme: AppTheme.globalTheme.containerScheme)
       button.addTarget(self, action: #selector(primaryDemoButtonClicked), for: .touchUpInside)
     } else {
       cell = tableView.dequeueReusableCell(withIdentifier: "NodeViewTableViewDemoCell")


### PR DESCRIPTION
The only visible change appears to be in the corner radii of the button.

Part of https://github.com/material-components/material-components-ios/issues/6450

This change was extracted from https://github.com/material-components/material-components-ios/pull/6509

| Before | After |
|:-------|:------|
| ![simulator screen shot - iphone xr - 2019-01-29 at 12 34 12](https://user-images.githubusercontent.com/45670/51927754-4c2a9f00-23c2-11e9-8417-21083975c8a1.png) | ![simulator screen shot - iphone xr - 2019-01-29 at 12 32 24](https://user-images.githubusercontent.com/45670/51927740-45039100-23c2-11e9-9f81-773a52e200bf.png) |
