### PR TITLE
[Catalog] Update catalog cell's theming implementation.

### DIFF
--- a/catalog/MDCCatalog/MDCCatalogCollectionViewCell.swift
+++ b/catalog/MDCCatalog/MDCCatalogCollectionViewCell.swift
@@ -23,26 +23,38 @@ class MDCCatalogCollectionViewCell: UICollectionViewCell {
     static let padding: CGFloat = 16
   }
 
-  private lazy var label: UILabel = {
-    let label = UILabel()
-    label.textColor = AppTheme.defaultTheme.colorScheme.primaryColor
-    label.font = MDCTypography.buttonFont()
-
-    return label
-  }()
+  private let label: UILabel
   private lazy var tile = MDCCatalogTileView(frame: CGRect.zero)
 
+  deinit {
+    NotificationCenter.default.removeObserver(self,
+                                              name: AppTheme.didChangeGlobalThemeNotificationName,
+                                              object: nil)
+  }
+
   override init(frame: CGRect) {
+    label = UILabel()
+
     super.init(frame: frame)
     contentView.addSubview(label)
     contentView.clipsToBounds = true
     contentView.addSubview(tile)
     self.isAccessibilityElement = true
     self.accessibilityTraits |= UIAccessibilityTraitButton
+
+    updateTheme()
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(self.themeDidChange),
+      name: AppTheme.didChangeGlobalThemeNotificationName,
+      object: nil)
   }
 
   @available(*, unavailable)
   required init(coder: NSCoder) {
+    label = UILabel()
+
     super.init(coder: coder)!
   }
 
@@ -70,6 +82,15 @@ class MDCCatalogCollectionViewCell: UICollectionViewCell {
   override func prepareForReuse() {
     super.prepareForReuse()
     label.text = ""
+  }
+
+  func updateTheme() {
+    label.font = AppTheme.globalTheme.typographyScheme.button
+    label.textColor = AppTheme.globalTheme.colorScheme.primaryColor
+  }
+
+  func themeDidChange(notification: NSNotification) {
+    updateTheme()
   }
 
   func populateView(_ componentName: String) {

--- a/catalog/MDCCatalog/MDCCatalogCollectionViewCell.swift
+++ b/catalog/MDCCatalog/MDCCatalogCollectionViewCell.swift
@@ -86,7 +86,7 @@ class MDCCatalogCollectionViewCell: UICollectionViewCell {
 
   func updateTheme() {
     label.font = AppTheme.globalTheme.typographyScheme.button
-    label.textColor = AppTheme.globalTheme.colorScheme.primaryColor
+    label.textColor = AppTheme.globalTheme.colorScheme.onBackgroundColor
   }
 
   func themeDidChange(notification: NSNotification) {

--- a/catalog/MDCCatalog/MDCCatalogCollectionViewCell.swift
+++ b/catalog/MDCCatalog/MDCCatalogCollectionViewCell.swift
@@ -23,7 +23,7 @@ class MDCCatalogCollectionViewCell: UICollectionViewCell {
     static let padding: CGFloat = 16
   }
 
-  private let label: UILabel
+  private let label = UILabel()
   private lazy var tile = MDCCatalogTileView(frame: CGRect.zero)
 
   deinit {
@@ -33,8 +33,6 @@ class MDCCatalogCollectionViewCell: UICollectionViewCell {
   }
 
   override init(frame: CGRect) {
-    label = UILabel()
-
     super.init(frame: frame)
     contentView.addSubview(label)
     contentView.clipsToBounds = true
@@ -53,8 +51,6 @@ class MDCCatalogCollectionViewCell: UICollectionViewCell {
 
   @available(*, unavailable)
   required init(coder: NSCoder) {
-    label = UILabel()
-
     super.init(coder: coder)!
   }
 


### PR DESCRIPTION
Ensures that the cell responds to theming changes and that it themes itself with the latest theme, rather than the default.

Note that none of our themes customize the onBackgroundColor, so this change won't result in any visible effects.

Part of https://github.com/material-components/material-components-ios/issues/6450

Extracted from https://github.com/material-components/material-components-ios/pull/6509

| Before | After |
|:-------|:--------|
| ![simulator screen shot - iphone xr - 2019-01-29 at 12 52 57](https://user-images.githubusercontent.com/45670/51928841-d2e07b80-23c4-11e9-8c13-e49638b720dc.png) | ![simulator screen shot - iphone xr - 2019-01-29 at 12 54 31](https://user-images.githubusercontent.com/45670/51928938-0ae7be80-23c5-11e9-9c57-d262fb560a5e.png) |
