### PR TITLE
[Catalog] Remove AppTheme notification keys.

### DIFF
--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -67,10 +67,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MDCAppBarNavigationContro
   }
 
   func themeDidChange(notification: NSNotification) {
-    guard let colorScheme = notification.userInfo?[AppTheme.globalThemeNotificationColorSchemeKey]
-      as? MDCColorScheming else {
-        return
-    }
+    let colorScheme = AppTheme.globalTheme.colorScheme
     for viewController in navigationController.childViewControllers {
       guard let appBar = navigationController.appBar(for: viewController) else {
         continue

--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -71,15 +71,10 @@ final class AppTheme {
     didSet {
       NotificationCenter.default.post(name: AppTheme.didChangeGlobalThemeNotificationName,
                                       object: nil,
-                                      userInfo:
-        [AppTheme.globalThemeNotificationColorSchemeKey: AppTheme.globalTheme.colorScheme,
-         AppTheme.globalThemeNotificationTypographySchemeKey: AppTheme.globalTheme.typographyScheme]
-      )
+                                      userInfo: nil)
     }
   }
 
   static let didChangeGlobalThemeNotificationName =
     Notification.Name("MDCCatalogDidChangeGlobalTheme")
-  static let globalThemeNotificationColorSchemeKey = "colorScheme"
-  static let globalThemeNotificationTypographySchemeKey = "typographyScheme"
 }

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -116,10 +116,7 @@ class MDCCatalogComponentsController: UICollectionViewController, MDCInkTouchCon
   }
 
   func themeDidChange(notification: NSNotification) {
-    guard let colorScheme = notification.userInfo?[AppTheme.globalThemeNotificationColorSchemeKey]
-          as? MDCColorScheming else {
-      return
-    }
+    let colorScheme = AppTheme.globalTheme.colorScheme
     MDCFlexibleHeaderColorThemer.applySemanticColorScheme(colorScheme,
                                                           to: headerViewController.headerView)
     setNeedsStatusBarAppearanceUpdate()

--- a/catalog/MDCCatalog/MDCCatalogTileView.swift
+++ b/catalog/MDCCatalog/MDCCatalogTileView.swift
@@ -55,9 +55,6 @@ class MDCCatalogTileView: UIView {
   }
 
   func themeDidChange(notification: NSNotification) {
-    guard notification.userInfo?[AppTheme.globalThemeNotificationColorSchemeKey] != nil else {
-        return
-    }
     imageCache.removeAllObjects()
   }
 


### PR DESCRIPTION
Prior to this change, the AppTheme was sending its color and typography scheme along with the "theme did change" notification.

After this change, the AppTheme no longer sends the schemes along with the notification. Examples now pull the schemes from AppTheme.globalTheme rather than from the notification.

The intent of this change is to align the example code on a single pattern of theme extraction (`AppTheme.globalTheme`) and to reduce the complexity of the "theme did change" notification. There was no clear value in providing the schemes along with the notification.

This change has no visible changes.

Part of https://github.com/material-components/material-components-ios/issues/6450

Extracted from https://github.com/material-components/material-components-ios/pull/6509