### PR TITLE
[BottomNavigation] Stop excluding VC example.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -141,6 +141,7 @@ fix_bazel_imports() {
     rewrite_catalogs "s/import catalog_by_convention_CatalogByConvention/import CatalogByConvention/"
     rewrite_catalogs "s/import material_internationalization_ios_MDFInternationalization/import MDFInternationalization/"
     rewrite_catalogs "s/import material_text_accessibility_ios_MDFTextAccessibility/import MDFTextAccessibility/"
+    rewrite_examples "s/import components_(.+)_\1Beta \/\/ BetaSplit/import MaterialComponentsBeta.Material\1Beta/"
     rewrite_examples "s/import components_(.+)_\1 \/\/ Beta/import MaterialComponentsBeta.Material\1/"
     rewrite_examples "s/import components_schemes_(.+)_.+ \/\/ Beta/import MaterialComponentsBeta.Material\1Scheme/"
     rewrite_examples "s/import components_schemes_(.+)_.+/import MaterialComponents.Material\1Scheme/"

--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -141,13 +141,13 @@ swift_library(
             "examples/*.swift",
             "examples/supplemental/*.swift",
         ],
-        exclude = ["examples/BottomNavigationBarControllerExampleViewController.swift"],
     ),
     copts = [
         "-swift-version",
         "3",
     ],
     deps = [
+        ":BottomNavigationBeta",
         ":BottomNavigation",
         ":ColorThemer",
         ":ObjcExamples",

--- a/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
+++ b/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-import MaterialComponentsBeta.MDCBottomNavigationBarController
+import MaterialComponentsBeta.MaterialBottomNavigationBeta
 import MaterialComponents.MaterialBottomNavigation_ColorThemer
 import MaterialComponents.MaterialBottomNavigation_TypographyThemer
 


### PR DESCRIPTION
The Bottom Navigation swift examples were excluding the
BottomNavigationController example.

Closes #4160