### PR TITLE
{kokoro} Run snapshots "exclusively"

### DIFF
--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -196,6 +196,7 @@ def mdc_snapshot_test(
     minimum_os_version = SNAPSHOT_IOS_MINIMUM_OS,
     visibility = ["//visibility:private"],
     size = "medium",
+    tags = ["exclusive"],
     **kwargs):
   """Declare an MDC ios_unit_test for snapshot tests."""
   ios_unit_test(
@@ -203,6 +204,7 @@ def mdc_snapshot_test(
       deps = deps,
       minimum_os_version = minimum_os_version,
       runner = SNAPSHOT_IOS_RUNNER_TARGET,
+      tags = tags,
       test_host = "//components/private/Snapshot/TestHost",
       visibility = visibility,
       # TODO(https://github.com/material-components/material-components-ios/issues/6335)


### PR DESCRIPTION
Execute snapshot tests when no other tests are running.

Snapshot tests are being flakier than expected, usually due to Simulator
startup difficulties. They're already marked "flaky" so they
get attempted 3 times by default.

Attempting to improve #6335
