### PR TITLE
[Catalog] {WIP} Allow users to set individual color properties from within the app

### DIFF
--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -152,6 +152,7 @@ class MDCThemePickerViewController: UIViewController, UITableViewDelegate, UITab
 
   private func showDialog(for propertyIndex: Int) {
     print("Change \(properties[propertyIndex])")
+    present(ColorSchemeDialog(nibName: nil, bundle: nil), animated: true, completion: nil)
   }
 
 }
@@ -230,5 +231,26 @@ class SchemeCell : UITableViewCell {
 }
 
 class ColorSchemeDialog : UIViewController {
-  
+
+  lazy var alertView: MDCAlertControllerView = {
+    self.view as? MDCAlertControllerView
+  }()
+  override var view: UIView! = MDCAlertControllerView(frame: .zero)
+
+  override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    super.init(nibName: nil, bundle: nil)
+    self.transitionCoordinator = MDCDialogTransitionController()
+    super.transitioningDelegate = self.transitionCoordinator
+    super.modalPresentationStyle = .custom
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    self.alertView.backgroundColor = .blue
+  }
 }

--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -303,10 +303,6 @@ class ColorSchemeDialog : UIViewController {
 
 fileprivate class MDCDialogThemePickerView: UIView {
 
-  private enum Slider {
-    case red, green, blue
-  }
-
   private let redLeadingButton = MDCButton(frame: .zero)
   private let redSlider = MDCSlider(frame: .zero)
   private let redTrailingButton = MDCButton(frame: .zero)

--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -17,6 +17,7 @@ import MaterialComponents.MaterialIcons_ic_check
 import MaterialComponents.MaterialPalettes
 import MaterialComponents.MaterialThemes
 import MaterialComponentsBeta.MaterialContainerScheme
+import MaterialComponents.MaterialList
 import UIKit
 
 private func schemeWithPalette(_ palette: MDCPalette) -> MDCContainerScheming {
@@ -59,29 +60,32 @@ private struct MDCColorThemeCellConfiguration {
   }
 }
 
-class MDCThemePickerViewController: UIViewController {
+class MDCThemePickerViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
 
   let titleColor = AppTheme.globalTheme.colorScheme.onSurfaceColor.withAlphaComponent(0.5)
   let titleFont = AppTheme.globalTheme.typographyScheme.button
 
-  let properties: [String] = ["primaryColor", "primaryColorVariant", "secondaryColor", "errorColor", "surfaceColor", "backgroundColor", "onPrimaryColor", "onSecondaryColor", "onSurfaceColor", "onBackgroundColor"]
-  /**
-  @property(nonnull, readwrite, copy, nonatomic) UIColor *primaryColor;
-  @property(nonnull, readwrite, copy, nonatomic) UIColor *primaryColorVariant;
-  @property(nonnull, readwrite, copy, nonatomic) UIColor *secondaryColor;
-  @property(nonnull, readwrite, copy, nonatomic) UIColor *errorColor;
-  @property(nonnull, readwrite, copy, nonatomic) UIColor *surfaceColor;
-  @property(nonnull, readwrite, copy, nonatomic) UIColor *backgroundColor;
-  @property(nonnull, readwrite, copy, nonatomic) UIColor *onPrimaryColor;
-  @property(nonnull, readwrite, copy, nonatomic) UIColor *onSecondaryColor;
-  @property(nonnull, readwrite, copy, nonatomic) UIColor *onSurfaceColor;
-  @property(nonnull, readwrite, copy, nonatomic) UIColor *onBackgroundColor;
- */
+  private let tableView = UITableView()
+
+  private let cellReuseIdentifier = "cell"
+  private let cellHeight: CGFloat = 48 // Minimum touch target
+
+  private let properties: [String] = [
+    "primaryColor",
+    "primaryColorVariant",
+    "secondaryColor",
+    "errorColor",
+    "surfaceColor",
+    "backgroundColor",
+    "onPrimaryColor",
+    "onSecondaryColor",
+    "onSurfaceColor",
+    "onBackgroundColor",
+    ]
 
 
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-
   }
 
   @available(*, unavailable)
@@ -92,183 +96,139 @@ class MDCThemePickerViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
+    title = "Material Color scheme picker"
 
+    view.backgroundColor = AppTheme.globalTheme.colorScheme.backgroundColor
+    tableView.register(SchemeCell.self, forCellReuseIdentifier: cellReuseIdentifier)
+    tableView.translatesAutoresizingMaskIntoConstraints = false
+    tableView.dataSource = self
+    tableView.delegate = self
+    tableView.separatorColor = .clear
+    view.addSubview(tableView)
+  }
 
+  override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+
+    positionTableView()
+  }
+
+  func positionTableView() {
+    var originX = view.bounds.origin.x
+    var width = view.bounds.size.width
+    var height = view.bounds.size.height
+    if #available(iOS 11.0, *) {
+      originX += view.safeAreaInsets.left;
+      width -= (view.safeAreaInsets.left + view.safeAreaInsets.right);
+      height -= (view.safeAreaInsets.top + view.safeAreaInsets.bottom);
+    }
+    let frame = CGRect(x: originX, y: view.bounds.origin.y, width: width, height: height)
+    tableView.frame = frame
+  }
+
+  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return properties.count
+  }
+
+  func numberOfSections(in tableView: UITableView) -> Int {
+    return 1
+  }
+
+  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    let cell: SchemeCell =
+      tableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier) as? SchemeCell ??
+        SchemeCell(frame: .zero)
+    cell.title = properties[indexPath.row]
+    return cell
+  }
+
+  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    showDialog(for: indexPath.row)
+  }
+
+  func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    return cellHeight
+  }
+
+  private func showDialog(for propertyIndex: Int) {
+    print("Change \(properties[propertyIndex])")
   }
 
 }
 
-class PaletteCell : UICollectionViewCell {
-  let imageView = UIImageView()
+class SchemeCell : UITableViewCell {
 
-  override init(frame: CGRect) {
-    super.init(frame: frame)
-
-    imageView.image = MDCIcons.imageFor_ic_check()?.withRenderingMode(.alwaysTemplate)
-    imageView.tintColor = .white
-    imageView.contentMode = .center
-    self.contentView.addSubview(imageView)
+  public var title: String {
+    willSet {
+      set(title: newValue)
+    }
   }
 
-  override func layoutSubviews() {
-    imageView.frame = self.contentView.frame
+  private let label = UILabel()
+
+  lazy var leadingConstraint = NSLayoutConstraint(item: self.label,
+                                             attribute: .leading,
+                                             relatedBy: .equal,
+                                             toItem: self.contentView,
+                                             attribute: .leading,
+                                             multiplier: 1,
+                                             constant: 16)
+
+  lazy var trailingContraint = NSLayoutConstraint(item: self.label,
+                                                  attribute: .trailing,
+                                                  relatedBy: .equal,
+                                                  toItem: self.contentView,
+                                                  attribute: .trailing,
+                                                  multiplier: 1,
+                                                  constant: -16)
+
+  lazy var topContraint = NSLayoutConstraint(item: self.label,
+                                             attribute: .top,
+                                             relatedBy: .equal,
+                                             toItem: self.contentView,
+                                             attribute: .top,
+                                             multiplier: 1,
+                                             constant: 0)
+
+  lazy var bottomContraint = NSLayoutConstraint(item: self.label,
+                                             attribute: .bottom,
+                                             relatedBy: .equal,
+                                             toItem: self.contentView,
+                                             attribute: .bottom,
+                                             multiplier: 1,
+                                             constant: 0)
+
+
+  override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+    title = ""
+    super.init(style: .default, reuseIdentifier: reuseIdentifier)
+
+    self.accessibilityHint = "Changes the catalog color scheme."
+    self.accessibilityLabel = title
+    self.contentView.addSubview(label)
+    self.label.translatesAutoresizingMaskIntoConstraints = false
   }
 
+  @available(*, unavailable)
   required init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+
+    leadingConstraint.isActive = true
+    trailingContraint.isActive = true
+    topContraint.isActive = true
+    bottomContraint.isActive = true
+  }
+
+  private func set(title newTitle: String) {
+    label.text = newTitle
+    self.accessibilityLabel = newTitle
+  }
 }
 
-/**
- private let cellReuseIdentifier = "cell"
- private let colorSchemeConfigurations = [
- MDCColorThemeCellConfiguration(name: "Default",
- mainColor: AppTheme.defaultTheme.colorScheme.primaryColor,
- colorScheme: { return AppTheme.defaultTheme.colorScheme }),
- MDCColorThemeCellConfiguration(name: "Blue",
- mainColor: MDCPalette.blue.tint500,
- colorScheme: {
- return createSchemeWithPalette(MDCPalette.blue)
- }),
- MDCColorThemeCellConfiguration(name: "Red",
- mainColor: MDCPalette.red.tint500,
- colorScheme: {
- return createSchemeWithPalette(MDCPalette.red)
- }),
- MDCColorThemeCellConfiguration(name: "Green",
- mainColor: MDCPalette.green.tint500,
- colorScheme: {
- return createSchemeWithPalette(MDCPalette.green)
- }),
- MDCColorThemeCellConfiguration(name: "Amber",
- mainColor: MDCPalette.amber.tint500,
- colorScheme: {
- return createSchemeWithPalette(MDCPalette.amber)
- }),
- MDCColorThemeCellConfiguration(name: "Pink",
- mainColor: MDCPalette.pink.tint500,
- colorScheme: {
- return createSchemeWithPalette(MDCPalette.pink)
- }),
- MDCColorThemeCellConfiguration(name: "Orange",
- mainColor: MDCPalette.orange.tint500,
- colorScheme: {
- return createSchemeWithPalette(MDCPalette.orange)
- })
- ]
- private let cellSize : CGFloat = 48.0 // minimum touch target
- private let cellSpacing : CGFloat = 8.0
-
- override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
- super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-
- }
-
- required init?(coder aDecoder: NSCoder) {
- fatalError("init(coder:) has not been implemented")
- }
-
- override func viewDidLoad() {
- super.viewDidLoad()
-
- title = "Material Palette-based themes"
- view.backgroundColor = .white
- setUpCollectionView()
- }
-
- override func viewDidLayoutSubviews() {
- super.viewDidLayoutSubviews()
-
- positionCollectionView()
- }
-
- func setUpCollectionView() {
- palettesCollectionView.register(PaletteCell.self,
- forCellWithReuseIdentifier: cellReuseIdentifier)
- palettesCollectionView.translatesAutoresizingMaskIntoConstraints = false
- palettesCollectionView.delegate = self
- palettesCollectionView.dataSource = self
- palettesCollectionView.backgroundColor = .white
- view.addSubview(palettesCollectionView)
- }
-
- func positionCollectionView() {
- var originX = view.bounds.origin.x
- var width = view.bounds.size.width
- var height = view.bounds.size.height
- if #available(iOS 11.0, *) {
- originX += view.safeAreaInsets.left;
- width -= (view.safeAreaInsets.left + view.safeAreaInsets.right);
- height -= (view.safeAreaInsets.top + view.safeAreaInsets.bottom);
- }
- let frame = CGRect(x: originX, y: view.bounds.origin.y, width: width, height: height)
- palettesCollectionView.frame = frame
- palettesCollectionView.collectionViewLayout.invalidateLayout()
- }
-
- func collectionView(_ collectionView: UICollectionView,
- cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
- let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellReuseIdentifier,
- for: indexPath) as! PaletteCell
- cell.contentView.backgroundColor = colorSchemeConfigurations[indexPath.item].mainColor
- cell.contentView.layer.cornerRadius = cellSize / 2
- cell.contentView.layer.borderWidth = 1
- cell.contentView.layer.borderColor =
- AppTheme.globalTheme.colorScheme.onSurfaceColor.withAlphaComponent(0.05).cgColor
- if AppTheme.globalTheme.colorScheme.primaryColor
- == colorSchemeConfigurations[indexPath.item].mainColor {
- cell.imageView.isHidden = false
- cell.isSelected = true
- } else {
- cell.imageView.isHidden = true
- cell.isSelected = false
- }
- cell.isAccessibilityElement = true
- cell.accessibilityLabel = colorSchemeConfigurations[indexPath.row].name
- cell.accessibilityHint = "Changes the catalog color theme."
- return cell
- }
-
- func collectionView(_ collectionView: UICollectionView,
- layout collectionViewLayout: UICollectionViewLayout,
- sizeForItemAt indexPath: IndexPath) -> CGSize {
- return CGSize(width: cellSize, height: cellSize)
- }
-
- func collectionView(_ collectionView: UICollectionView,
- layout collectionViewLayout: UICollectionViewLayout,
- insetForSectionAt section: Int) -> UIEdgeInsets {
- return UIEdgeInsets(top: cellSpacing,
- left: cellSpacing,
- bottom: cellSpacing,
- right: cellSpacing)
- }
-
- func collectionView(_ collectionView: UICollectionView,
- layout collectionViewLayout: UICollectionViewLayout,
- minimumLineSpacingForSectionAt section: Int) -> CGFloat {
- return cellSpacing
- }
-
- func collectionView(_ collectionView: UICollectionView,
- layout collectionViewLayout: UICollectionViewLayout,
- minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
- return cellSpacing
- }
-
- func numberOfSections(in collectionView: UICollectionView) -> Int {
- return 1
- }
-
- func collectionView(_ collectionView: UICollectionView,
- numberOfItemsInSection section: Int) -> Int {
- return colorSchemeConfigurations.count
- }
-
- func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
- let colorScheme = colorSchemeConfigurations[indexPath.item].colorScheme()
- navigationController?.popViewController(animated: true)
- AppTheme.globalTheme = AppTheme(colorScheme: colorScheme,
- typographyScheme: AppTheme.globalTheme.typographyScheme)
- }
- */
+class ColorSchemeDialog : UIViewController {
+  
+}

--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -59,50 +59,32 @@ private struct MDCColorThemeCellConfiguration {
   }
 }
 
-class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource,
-  UICollectionViewDelegateFlowLayout {
-
-  let palettesCollectionView = UICollectionView(frame: .zero,
-                                                collectionViewLayout: UICollectionViewFlowLayout())
-
-  private var collectionViewLayout: UICollectionViewFlowLayout {
-    return palettesCollectionView.collectionViewLayout as! UICollectionViewFlowLayout
-  }
+class MDCThemePickerViewController: UIViewController {
 
   let titleColor = AppTheme.globalTheme.colorScheme.onSurfaceColor.withAlphaComponent(0.5)
   let titleFont = AppTheme.globalTheme.typographyScheme.button
-  private let cellReuseIdentifier = "cell"
-  private let colorSchemeConfigurations = [
-    MDCColorThemeCellConfiguration(name: "Default",
-                                   mainColor: AppTheme.globalTheme.colorScheme.primaryColor,
-                                   scheme: DefaultContainerScheme()),
-    MDCColorThemeCellConfiguration(name: "Blue",
-                                   mainColor: MDCPalette.blue.tint500,
-                                   scheme: schemeWithPalette(MDCPalette.blue)),
-    MDCColorThemeCellConfiguration(name: "Red",
-                                   mainColor: MDCPalette.red.tint500,
-                                   scheme: schemeWithPalette(MDCPalette.red)),
-    MDCColorThemeCellConfiguration(name: "Green",
-                                   mainColor: MDCPalette.green.tint500,
-                                   scheme: schemeWithPalette(MDCPalette.green)),
-    MDCColorThemeCellConfiguration(name: "Amber",
-                                   mainColor: MDCPalette.amber.tint500,
-                                   scheme: schemeWithPalette(MDCPalette.amber)),
-    MDCColorThemeCellConfiguration(name: "Pink",
-                                   mainColor: MDCPalette.pink.tint500,
-                                   scheme: schemeWithPalette(MDCPalette.pink)),
-    MDCColorThemeCellConfiguration(name: "Orange",
-                                   mainColor: MDCPalette.orange.tint500,
-                                   scheme: schemeWithPalette(MDCPalette.orange)),
-  ]
-  private let cellSize : CGFloat = 48.0 // minimum touch target
-  private let cellSpacing : CGFloat = 8.0
+
+  let properties: [String] = ["primaryColor", "primaryColorVariant", "secondaryColor", "errorColor", "surfaceColor", "backgroundColor", "onPrimaryColor", "onSecondaryColor", "onSurfaceColor", "onBackgroundColor"]
+  /**
+  @property(nonnull, readwrite, copy, nonatomic) UIColor *primaryColor;
+  @property(nonnull, readwrite, copy, nonatomic) UIColor *primaryColorVariant;
+  @property(nonnull, readwrite, copy, nonatomic) UIColor *secondaryColor;
+  @property(nonnull, readwrite, copy, nonatomic) UIColor *errorColor;
+  @property(nonnull, readwrite, copy, nonatomic) UIColor *surfaceColor;
+  @property(nonnull, readwrite, copy, nonatomic) UIColor *backgroundColor;
+  @property(nonnull, readwrite, copy, nonatomic) UIColor *onPrimaryColor;
+  @property(nonnull, readwrite, copy, nonatomic) UIColor *onSecondaryColor;
+  @property(nonnull, readwrite, copy, nonatomic) UIColor *onSurfaceColor;
+  @property(nonnull, readwrite, copy, nonatomic) UIColor *onBackgroundColor;
+ */
+
 
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 
   }
 
+  @available(*, unavailable)
   required init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
@@ -110,104 +92,8 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    title = "Material Palette-based themes"
-    view.backgroundColor = .white
-    setUpCollectionView()
-  }
 
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
 
-    positionCollectionView()
-  }
-
-  func setUpCollectionView() {
-    palettesCollectionView.register(PaletteCell.self,
-                                    forCellWithReuseIdentifier: cellReuseIdentifier)
-    palettesCollectionView.translatesAutoresizingMaskIntoConstraints = false
-    palettesCollectionView.delegate = self
-    palettesCollectionView.dataSource = self
-    palettesCollectionView.backgroundColor = .white
-    view.addSubview(palettesCollectionView)
-  }
-
-  func positionCollectionView() {
-    var originX = view.bounds.origin.x
-    var width = view.bounds.size.width
-    var height = view.bounds.size.height
-    if #available(iOS 11.0, *) {
-      originX += view.safeAreaInsets.left;
-      width -= (view.safeAreaInsets.left + view.safeAreaInsets.right);
-      height -= (view.safeAreaInsets.top + view.safeAreaInsets.bottom);
-    }
-    let frame = CGRect(x: originX, y: view.bounds.origin.y, width: width, height: height)
-    palettesCollectionView.frame = frame
-    palettesCollectionView.collectionViewLayout.invalidateLayout()
-  }
-
-  func collectionView(_ collectionView: UICollectionView,
-                      cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellReuseIdentifier,
-                                                  for: indexPath) as! PaletteCell
-    cell.contentView.backgroundColor = colorSchemeConfigurations[indexPath.item].mainColor
-    cell.contentView.layer.cornerRadius = cellSize / 2
-    cell.contentView.layer.borderWidth = 1
-    cell.contentView.layer.borderColor =
-      AppTheme.globalTheme.colorScheme.onSurfaceColor.withAlphaComponent(0.05).cgColor
-    if AppTheme.globalTheme.colorScheme.primaryColor
-      == colorSchemeConfigurations[indexPath.item].mainColor {
-      cell.imageView.isHidden = false
-      cell.isSelected = true
-    } else {
-      cell.imageView.isHidden = true
-      cell.isSelected = false
-    }
-    cell.isAccessibilityElement = true
-    cell.accessibilityLabel = colorSchemeConfigurations[indexPath.row].name
-    cell.accessibilityHint = "Changes the catalog color theme."
-    return cell
-  }
-
-  func collectionView(_ collectionView: UICollectionView,
-                      layout collectionViewLayout: UICollectionViewLayout,
-                      sizeForItemAt indexPath: IndexPath) -> CGSize {
-    return CGSize(width: cellSize, height: cellSize)
-  }
-
-  func collectionView(_ collectionView: UICollectionView,
-                      layout collectionViewLayout: UICollectionViewLayout,
-                      insetForSectionAt section: Int) -> UIEdgeInsets {
-    return UIEdgeInsets(top: cellSpacing,
-                        left: cellSpacing,
-                        bottom: cellSpacing,
-                        right: cellSpacing)
-  }
-
-  func collectionView(_ collectionView: UICollectionView,
-                      layout collectionViewLayout: UICollectionViewLayout,
-                      minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-    return cellSpacing
-  }
-
-  func collectionView(_ collectionView: UICollectionView,
-                      layout collectionViewLayout: UICollectionViewLayout,
-                      minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
-    return cellSpacing
-  }
-
-  func numberOfSections(in collectionView: UICollectionView) -> Int {
-    return 1
-  }
-
-  func collectionView(_ collectionView: UICollectionView,
-                      numberOfItemsInSection section: Int) -> Int {
-    return colorSchemeConfigurations.count
-  }
-
-  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    navigationController?.popViewController(animated: true)
-    let scheme = colorSchemeConfigurations[indexPath.item].scheme
-    AppTheme.globalTheme = AppTheme(containerScheme: scheme)
   }
 
 }
@@ -232,3 +118,157 @@ class PaletteCell : UICollectionViewCell {
     fatalError("init(coder:) has not been implemented")
   }
 }
+
+/**
+ private let cellReuseIdentifier = "cell"
+ private let colorSchemeConfigurations = [
+ MDCColorThemeCellConfiguration(name: "Default",
+ mainColor: AppTheme.defaultTheme.colorScheme.primaryColor,
+ colorScheme: { return AppTheme.defaultTheme.colorScheme }),
+ MDCColorThemeCellConfiguration(name: "Blue",
+ mainColor: MDCPalette.blue.tint500,
+ colorScheme: {
+ return createSchemeWithPalette(MDCPalette.blue)
+ }),
+ MDCColorThemeCellConfiguration(name: "Red",
+ mainColor: MDCPalette.red.tint500,
+ colorScheme: {
+ return createSchemeWithPalette(MDCPalette.red)
+ }),
+ MDCColorThemeCellConfiguration(name: "Green",
+ mainColor: MDCPalette.green.tint500,
+ colorScheme: {
+ return createSchemeWithPalette(MDCPalette.green)
+ }),
+ MDCColorThemeCellConfiguration(name: "Amber",
+ mainColor: MDCPalette.amber.tint500,
+ colorScheme: {
+ return createSchemeWithPalette(MDCPalette.amber)
+ }),
+ MDCColorThemeCellConfiguration(name: "Pink",
+ mainColor: MDCPalette.pink.tint500,
+ colorScheme: {
+ return createSchemeWithPalette(MDCPalette.pink)
+ }),
+ MDCColorThemeCellConfiguration(name: "Orange",
+ mainColor: MDCPalette.orange.tint500,
+ colorScheme: {
+ return createSchemeWithPalette(MDCPalette.orange)
+ })
+ ]
+ private let cellSize : CGFloat = 48.0 // minimum touch target
+ private let cellSpacing : CGFloat = 8.0
+
+ override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+ super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+
+ }
+
+ required init?(coder aDecoder: NSCoder) {
+ fatalError("init(coder:) has not been implemented")
+ }
+
+ override func viewDidLoad() {
+ super.viewDidLoad()
+
+ title = "Material Palette-based themes"
+ view.backgroundColor = .white
+ setUpCollectionView()
+ }
+
+ override func viewDidLayoutSubviews() {
+ super.viewDidLayoutSubviews()
+
+ positionCollectionView()
+ }
+
+ func setUpCollectionView() {
+ palettesCollectionView.register(PaletteCell.self,
+ forCellWithReuseIdentifier: cellReuseIdentifier)
+ palettesCollectionView.translatesAutoresizingMaskIntoConstraints = false
+ palettesCollectionView.delegate = self
+ palettesCollectionView.dataSource = self
+ palettesCollectionView.backgroundColor = .white
+ view.addSubview(palettesCollectionView)
+ }
+
+ func positionCollectionView() {
+ var originX = view.bounds.origin.x
+ var width = view.bounds.size.width
+ var height = view.bounds.size.height
+ if #available(iOS 11.0, *) {
+ originX += view.safeAreaInsets.left;
+ width -= (view.safeAreaInsets.left + view.safeAreaInsets.right);
+ height -= (view.safeAreaInsets.top + view.safeAreaInsets.bottom);
+ }
+ let frame = CGRect(x: originX, y: view.bounds.origin.y, width: width, height: height)
+ palettesCollectionView.frame = frame
+ palettesCollectionView.collectionViewLayout.invalidateLayout()
+ }
+
+ func collectionView(_ collectionView: UICollectionView,
+ cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+ let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellReuseIdentifier,
+ for: indexPath) as! PaletteCell
+ cell.contentView.backgroundColor = colorSchemeConfigurations[indexPath.item].mainColor
+ cell.contentView.layer.cornerRadius = cellSize / 2
+ cell.contentView.layer.borderWidth = 1
+ cell.contentView.layer.borderColor =
+ AppTheme.globalTheme.colorScheme.onSurfaceColor.withAlphaComponent(0.05).cgColor
+ if AppTheme.globalTheme.colorScheme.primaryColor
+ == colorSchemeConfigurations[indexPath.item].mainColor {
+ cell.imageView.isHidden = false
+ cell.isSelected = true
+ } else {
+ cell.imageView.isHidden = true
+ cell.isSelected = false
+ }
+ cell.isAccessibilityElement = true
+ cell.accessibilityLabel = colorSchemeConfigurations[indexPath.row].name
+ cell.accessibilityHint = "Changes the catalog color theme."
+ return cell
+ }
+
+ func collectionView(_ collectionView: UICollectionView,
+ layout collectionViewLayout: UICollectionViewLayout,
+ sizeForItemAt indexPath: IndexPath) -> CGSize {
+ return CGSize(width: cellSize, height: cellSize)
+ }
+
+ func collectionView(_ collectionView: UICollectionView,
+ layout collectionViewLayout: UICollectionViewLayout,
+ insetForSectionAt section: Int) -> UIEdgeInsets {
+ return UIEdgeInsets(top: cellSpacing,
+ left: cellSpacing,
+ bottom: cellSpacing,
+ right: cellSpacing)
+ }
+
+ func collectionView(_ collectionView: UICollectionView,
+ layout collectionViewLayout: UICollectionViewLayout,
+ minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+ return cellSpacing
+ }
+
+ func collectionView(_ collectionView: UICollectionView,
+ layout collectionViewLayout: UICollectionViewLayout,
+ minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+ return cellSpacing
+ }
+
+ func numberOfSections(in collectionView: UICollectionView) -> Int {
+ return 1
+ }
+
+ func collectionView(_ collectionView: UICollectionView,
+ numberOfItemsInSection section: Int) -> Int {
+ return colorSchemeConfigurations.count
+ }
+
+ func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+ let colorScheme = colorSchemeConfigurations[indexPath.item].colorScheme()
+ navigationController?.popViewController(animated: true)
+ AppTheme.globalTheme = AppTheme(colorScheme: colorScheme,
+ typographyScheme: AppTheme.globalTheme.typographyScheme)
+ }
+ */

--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -321,10 +321,38 @@ class ColorSchemeDialog : UIViewController {
     AppTheme.globalTheme = AppTheme.init(containerScheme: scheme)
   }
 
+  /**
+   "onBackgroundColor",
+ */
+
   private func update(colorScheme: MDCSemanticColorScheme,
                       property: String,
-                      with color: UIColor) -> MDCSemanticColorScheme {
-    return MDCSemanticColorScheme(defaults: .material201804)
+                      with newColor: UIColor) -> MDCSemanticColorScheme {
+    switch property {
+    case "primaryColor":
+      colorScheme.primaryColor = newColor
+    case "primaryColorVariant":
+      colorScheme.primaryColorVariant = newColor
+    case "secondaryColor":
+      colorScheme.secondaryColor = newColor
+    case "errorColor":
+      colorScheme.errorColor = newColor
+    case "surfaceColor":
+      colorScheme.surfaceColor = newColor
+    case "backgroundColor":
+      colorScheme.backgroundColor = newColor
+    case "onPrimaryColor":
+      colorScheme.onPrimaryColor = newColor
+    case "onSecondaryColor":
+      colorScheme.onSecondaryColor = newColor
+    case "onSurfaceColor":
+      colorScheme.onSurfaceColor = newColor
+    case "onBackgroundColor":
+      colorScheme.onBackgroundColor = newColor
+    default:
+      break
+    }
+    return colorScheme
   }
 }
 

--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -296,8 +296,35 @@ class ColorSchemeDialog : UIViewController {
   }
 
   @objc private func submit() {
-    
-    self.dismiss(animated: true, completion: nil)
+    defer {
+      self.dismiss(animated: true, completion: nil)
+    }
+    // Get current color scheme
+    guard let semanticColor =
+      AppTheme.globalTheme.containerScheme.colorScheme as? MDCSemanticColorScheme else {
+      return
+    }
+
+    guard let color = alertView.color else { return }
+
+    // Update value
+    let updatedColorScheme = update(colorScheme: semanticColor, property: property, with: color)
+    // Set color scheme on container scheme
+    let scheme = MDCContainerScheme()
+    scheme.typographyScheme =
+      AppTheme.globalTheme.containerScheme.typographyScheme as? MDCTypographyScheme
+        ?? MDCTypographyScheme(defaults: .material201804)
+    scheme.shapeScheme = AppTheme.globalTheme.containerScheme.shapeScheme as? MDCShapeScheme
+      ?? MDCShapeScheme()
+    scheme.colorScheme = updatedColorScheme
+    // Update global theme
+    AppTheme.globalTheme = AppTheme.init(containerScheme: scheme)
+  }
+
+  private func update(colorScheme: MDCSemanticColorScheme,
+                      property: String,
+                      with color: UIColor) -> MDCSemanticColorScheme {
+    return MDCSemanticColorScheme(defaults: .material201804)
   }
 }
 


### PR DESCRIPTION
## Related links
* Bugs: No bug

## Introduction
We currently allow users to set a primary color and generate a theme based off that within the catalog app. A primary color can be paired with multiple secondaryColors, surfaceColors, etc. This change allows us to set all properties on an individual basis. This will allow designers to play around with different colors and see what they can achieve with MDC-components. Additionally we previously only allowed users to pick a primary color based on a handful of colors this now allows users to set any color value. I got the design for this dialog from [here](https://material.io/design/components/sliders.html#usage)

## The problem
Our catalog doesn't allow setting all color properties

## The fix
Add a mechanism to allow users to set all properties on an individual basis.

## Why WIP?
This is a quick prototype by no means have I cleaned up the code.

## Videos
| Before | After | 
| - | - |
|![before](https://user-images.githubusercontent.com/7131294/52138127-4af3af00-261a-11e9-8fc5-4e2b1cbfc4c9.gif)|![after](https://user-images.githubusercontent.com/7131294/52138147-58a93480-261a-11e9-9be5-ab90364ec5b1.gif)|
