### PR TITLE
[States] Material State Scheme (Experimental Prototype)

### DIFF
--- a/MaterialComponentsExamples.podspec
+++ b/MaterialComponentsExamples.podspec
@@ -1,6 +1,7 @@
 experimental_sources = [
   'components/*/examples/experimental/supplemental/*.{h,m,swift}',
   'components/*/examples/experimental/*.{h,m,swift}',
+  'components/private/State/src/*.{h,m,swift}'
 ]
 
 experimental_headers = [

--- a/components/private/State/examples/StateSchemeExampleController.swift
+++ b/components/private/State/examples/StateSchemeExampleController.swift
@@ -1,0 +1,95 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+class StateSchemeExampleController: UIViewController {
+
+  let colorScheme = StateExampleColorScheme(withDefaults: .material201804)
+  let stateScheme = StateScheme(withDefaults: .material201804)
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    self.view.backgroundColor = colorScheme.backgroundColor
+
+    experimentWithSchemeAPI()
+  }
+
+  /*
+   The following retrieves the overlay and content colors for the normal state in the on-white theme.
+
+   The console output after running this example is:
+
+   State Example> overlayColorResource for state: [enabled] is: [ nil ]. It should be: [nil]
+
+   State Example> contentColorResource for state: [disabled] is: [palette: grey tint: tint800 opacity: 0.38]
+   State Example> It should be: [MDCPalette.grey.tint800 at 38%]. Is it ? true
+
+   State Example> ContentColorResource for state: [pressed] is: [palette: grey tint: tint900]
+   State Example> It is overriden by the current color scheme and should therefore be: [MDCPalette.grey.tint900]. Is it ? true
+
+   State Example> contentColorResource for state: [enabled] is: [ semantic: onSurface (on-surface) ]
+   State Example> It should be the semantic color: [onSurface]. Is it ? true
+
+   Note: There is no UI for this example.
+
+   */
+  func experimentWithSchemeAPI() {
+
+    let enabled = MDCControlState.normal
+    let disabled = MDCControlState.disabled
+    let pressed = MDCControlState.highlighted
+
+    let overlayResource = stateScheme.overlayColorResource(forState: enabled, forTheme: StateTheme.onWhite)
+    print("State Example> overlayColorResource for state: [\(enabled)] is: [", overlayResource ?? "nil", "]. It should be: [nil]")
+
+    if let disabledResource = stateScheme.contentColorResource(forState: disabled, forTheme: StateTheme.onWhite) {
+      print("State Example> contentColorResource for state: [\(disabled)] is: [\(disabledResource)]")
+      let disabledColor = colorScheme.realColor(colorResource: disabledResource)
+      print("State Example> It should be: [MDCPalette.grey.tint800 at 38%]. Is it ?", disabledColor == MDCPalette.grey.tint800.withAlphaComponent(0.38))
+    } else {
+      print("State Example> Error: disabledResource should not be nil")
+    }
+
+    if let pressedResource = stateScheme.contentColorResource(forState: pressed, forTheme: StateTheme.onWhite) {
+      print("State Example> ContentColorResource for state: [\(pressed)] is: [\(pressedResource)]")
+      let pressedColor = colorScheme.realColor(colorResource: pressedResource)
+      print("State Example> It is overriden by the current color scheme and should therefore be: [MDCPalette.grey.tint900]. Is it ?", pressedColor == MDCPalette.grey.tint900)
+    } else {
+      print("State Example> Error: pressedColor should not be nil")
+    }
+
+    if let contentResource = stateScheme.contentColorResource(forState: enabled, forTheme: StateTheme.onWhite) {
+      print("State Example> contentColorResource for state: [\(enabled)] is: [", contentResource, "]")
+
+      let contentColor = colorScheme.realColor(colorResource: contentResource)
+      print("State Example> It should be the semantic color: [onSurface]. Is it ?", contentColor == colorScheme.onSurfaceColor)
+    } else {
+      print("State Example> Error: contentColor should not be nil")
+    }
+  }
+}
+
+// MARK: Catalog by convention
+
+extension StateSchemeExampleController {
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Alpha: States", "States Prototype"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
+  }
+}

--- a/components/private/State/src/ColorResource.swift
+++ b/components/private/State/src/ColorResource.swift
@@ -1,0 +1,227 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+enum Resource {
+  enum Color {
+    enum Semantic: String {
+      case primary = "primary", onPrimary = "on-primary", surface = "surface",
+           onSurface = "on-surface", overlay = "overlay", error = "error",
+           background = "background", onBackground = "on-background", outline = "outline"
+    }
+    enum Palette: String {
+
+      case grey = "grey", blue = "blue", blueGrey = "bluegrey", indigo = "indigo", purple = "purple",
+      red = "red", orange = "orange", yellow = "yellow"
+
+      enum Tint: String {
+        case tint50 = "50", tint100 = "100", tint200 = "200", tint300 = "300",
+        tint400 = "400", tint500 = "500", tint600 = "600", tint700 = "700",
+        tint800 = "800", tint900 = "900"
+      }
+    }
+  }
+}
+
+/**
+ ColorResource is a dynamic representation of a color-type resource. It supports different formats
+ which represent colors in Material. It is also used in serialzing color, in any of the supported
+ formats, to and from a dictionary.
+
+ ColorResource uses enumerations to remain independent of a specific scheme implementaiton.
+ It is produced by the state schemes, and built to be consumed by themers, which can then pass
+ it to a color scheme to get a UIColor value specific to that color scheme.
+
+ The following color formats are currently supported:
+ * Hex: Strings in format "#999999"
+ * Semantic names: an enum that corresponds to a color in MDCSemanticColorScheme
+ * Palette names: enums of palettes and tints, corresponding to Material Palettes.
+
+ Additionally, it supports 2 color variations, applied to a color, in any format:
+ * Opacity: alpha percentage of the base color
+ * Hue: percentage of darkness or lightness of the base color
+ * [TBD: Emphasis: High, Medium, Low]
+
+ Opacity and Hue are used to generate variations of the base colors. This is needed mainly in
+ expressing states in components. The specific colors that these variations produce can later be
+ overriden by specific color schemes to produce exact colors in case the default opacity/hue
+ doesn't produce a sufficiently accessible color ratio.
+ */
+struct ColorResource: CustomStringConvertible {
+
+  let hexColor: String?
+  let semanticColorName: Resource.Color.Semantic?
+  let palette: Resource.Color.Palette?
+  let tint: Resource.Color.Palette.Tint?
+  let opacity: CGFloat?
+  let darker: CGFloat?
+
+  /// Converting a semantic name to a ColorResource instance
+  init(semanticColorName: Resource.Color.Semantic, opacity: CGFloat? = nil, darker: CGFloat? = nil) {
+    self.semanticColorName = semanticColorName
+    self.opacity = opacity
+    self.darker = darker
+    self.hexColor = nil
+    self.palette = nil
+    self.tint = nil
+  }
+
+  init(palette: Resource.Color.Palette, tint: Resource.Color.Palette.Tint, opacity: CGFloat? = nil, darker: CGFloat? = nil) {
+    self.palette = palette
+    self.tint = tint
+    self.opacity = opacity
+    self.darker = darker
+    self.semanticColorName = nil
+    self.hexColor = nil
+  }
+
+  /// Converting a hex string to a ColorResource instance
+  init?(hex: String, opacity: CGFloat? = nil, darker: CGFloat? = nil) {
+    // Verify the given string is a valid 6-digit hex number
+    if let first = hex.first, first == "#" {
+      guard hex.count == 7, Int(hex.dropFirst(), radix: 16) != nil else { return nil }
+    } else {
+      guard hex.count == 6, Int(hex, radix: 16) != nil else { return nil }
+    }
+    self.hexColor = hex
+    self.opacity = opacity
+    self.darker = darker
+    self.semanticColorName = nil
+    self.palette = nil
+    self.tint = nil
+  }
+
+  /// Converting a UIColor color to a ColorResource instance
+  init(realColor: UIColor, opacity: CGFloat? = nil, darker: CGFloat? = nil) {
+    let (hexColor, alpha) = realColor.toHex()
+    self.hexColor = hexColor
+    self.opacity = opacity ?? alpha // provided opacity supersedes alpha if found in UIColor
+    self.darker = darker
+    self.semanticColorName = nil
+    self.palette = nil
+    self.tint = nil
+  }
+
+  var description: String {
+    var desc = ""
+    if let hex = self.hexColor {
+      desc += " hexColor: \(hex)"
+    }
+    if let semantic = self.semanticColorName {
+      desc += " semantic: \(semantic) (\(semantic.rawValue))"
+    }
+    if let palette = self.palette {
+      desc += " palette: \(palette)"
+    }
+    if let tint = self.tint {
+      desc += " tint: \(tint)"
+    }
+    if let opacity = self.opacity {
+      desc += " opacity: \(opacity)"
+    }
+    if let darker = self.darker {
+      desc += " darker: \(darker)"
+    }
+    return String(desc.dropFirst())
+  }
+}
+
+
+/// Convenience UIColor extensions to serialize UIColors to and from string hex values.
+extension UIColor {
+
+  /// Returning UIColor as a hex string: #FFFFFF. Alpha values are ignored.
+  var hex: String {
+    let colorRef = cgColor.components
+    let r = colorRef?[0] ?? 0
+    let g = colorRef?[1] ?? 0
+    let b = ((colorRef?.count ?? 0) > 2 ? colorRef?[2] : g) ?? 0
+
+    let hexString = String(
+      format: "#%02lX%02lX%02lX",
+      lroundf(Float(r * 255)),
+      lroundf(Float(g * 255)),
+      lroundf(Float(b * 255))
+    )
+
+    return hexString
+  }
+
+  /// Returning UIColor as a tuple with a hex string: #FFFFFF and an alpha value
+  func toHex() -> (String, CGFloat?) {
+    let colorRef = cgColor.components
+    let r = colorRef?[0] ?? 0
+    let g = colorRef?[1] ?? 0
+    let b = ((colorRef?.count ?? 0) > 2 ? colorRef?[2] : g) ?? 0
+    let a = cgColor.alpha
+
+    let hexString = String(
+      format: "#%02lX%02lX%02lX",
+      lroundf(Float(r * 255)),
+      lroundf(Float(g * 255)),
+      lroundf(Float(b * 255))
+    )
+
+    return (hexString, a)
+  }
+
+  /// Initialize a UIColor using a hex string. The initializer fails if the string is invalid.
+  convenience init?(hexString hex: String, a: CGFloat? = 1.0) {
+    var cString:String = hex.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+
+    if (cString.hasPrefix("#")) {
+      cString.remove(at: cString.startIndex)
+    }
+
+    if ((cString.count) != 6) {
+      return nil
+    }
+
+    var rgbValue:UInt32 = 0
+    Scanner(string: cString).scanHexInt32(&rgbValue)
+
+    self.init(
+      red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
+      green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
+      blue: CGFloat(rgbValue & 0x0000FF) / 255.0,
+      alpha: a ?? 1.0
+    )
+  }
+}
+
+/// Convenience UIColor extensions to make UIColor darker or lighter by a given percentage
+extension UIColor {
+
+  func lighter(amount : CGFloat = 0.25) -> UIColor {
+    return hueColor(withBrightness: 1 + amount)
+  }
+
+  func darker(amount : CGFloat = 0.25) -> UIColor {
+    return hueColor(withBrightness: 1 - amount)
+  }
+
+  private func hueColor(withBrightness multiplier: CGFloat) -> UIColor {
+    var hue         : CGFloat = 0
+    var saturation  : CGFloat = 0
+    var brightness  : CGFloat = 0
+    var alpha       : CGFloat = 0
+
+    getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
+    return UIColor( hue: hue,
+                    saturation: saturation,
+                    brightness: brightness * multiplier,
+                    alpha: alpha )
+  }
+}

--- a/components/private/State/src/MDCControlState.swift
+++ b/components/private/State/src/MDCControlState.swift
@@ -1,0 +1,123 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/**
+ MDCControlState represents all Material states, including the special interactive
+ state, which is any state that is not normal, disabled or error.
+ * Eight distinctive states are supported.
+ * Material's enabled and pressed states are renamed as their UIControlState state names (which
+   is normal and highlighted).
+ * We are still experimenting with state combinations. Whther adding names for state combinations
+   (like: selectedHighlighted) is needed, is stil in debate.
+ */
+struct MDCControlState: OptionSet, CustomStringConvertible {
+
+  /// Material names of states
+  var name: String {
+    switch self {
+    case .normal:      return "enabled"
+    case .highlighted: return "pressed"
+    case .selected:    return "selected"
+    case .active:      return "active"
+    case .focused:     return "focused"
+    case .dragged:     return "dragged"
+    case .disabled:    return "disabled"
+    case .error:       return "error"
+
+    case .interactive: return "interactive"
+
+    case .selectedHighlighted: return "selected+pressed"
+    case .selectedFocused:     return "selected+focused"
+    case .selectedDragged:     return "selected+dragged"
+
+    case .activeHighlighted: return "active+pressed"
+    case .activeFocused:     return "active+focused"
+    case .activeDragged:     return "active+dragged"
+
+    default: return "<undefined>"
+    }
+  }
+
+  var description: String {
+    var state = ""
+    if self.contains(.normal) {state += " enabled"}
+    if self.contains(.highlighted) {state += " pressed"}
+    if self.contains(.selected) {state += " selected"}
+    if self.contains(.active) {state += " active"}
+    if self.contains(.focused) {state += " focused"}
+    if self.contains(.dragged) {state += " dragged"}
+    if self.contains(.disabled) {state += " disabled"}
+    if self.contains(.error) {state += " error"}
+    return String(state.dropFirst())
+  }
+
+  /// Converting material states to UIControlStates
+  var controlState: UIControlState? {
+    switch self {
+    case .normal: return .normal
+    case .selected: return .selected
+    case .disabled: return .disabled
+    case .highlighted: return .highlighted
+    case .focused:
+      if #available(iOSApplicationExtension 9.0, *) {
+        return .focused
+      } else {
+        return nil
+      }
+    default: return nil
+    }
+  }
+
+  let rawValue: UInt
+
+  // States enumberations
+  static let normal      = MDCControlState(rawValue: 1 << 0)  // Material: Enabled
+  static let highlighted = MDCControlState(rawValue: 1 << 1)  // Material: Pressed
+  static let selected    = MDCControlState(rawValue: 1 << 2)  // Material: Selected
+  static let active      = MDCControlState(rawValue: 1 << 3)  // Material: Active
+  static let focused     = MDCControlState(rawValue: 1 << 4)  // Material: Focused
+  static let dragged     = MDCControlState(rawValue: 1 << 5)  // Material: Dragged
+  static let disabled    = MDCControlState(rawValue: 1 << 6)  // Material: Disabled
+  static let error       = MDCControlState(rawValue: 1 << 7)  // Material: Error
+
+  // Grouping all interactive material states (all states excluding normal, disabled & error)
+  static let interactive = MDCControlState(rawValue: 1 << 8)
+
+  // "On/Off" state combinations (selected and active are the "On/Off" states).
+  static let selectedHighlighted: MDCControlState = [.selected, .highlighted]
+  static let selectedFocused: MDCControlState = [.selected, .focused]
+  static let selectedDragged: MDCControlState = [.selected, .dragged]
+
+  static let activeHighlighted: MDCControlState = [.active, .highlighted]
+  static let activeFocused: MDCControlState = [.active, .focused]
+  static let activeDragged: MDCControlState = [.active, .dragged]
+
+  // These are used by the state system to determine which theming to apply for requested states.
+  var isSelected: Bool { return self.contains(.selected) }
+  var isActive:   Bool { return self.contains(.active) }
+  var isHighlighted: Bool { return self.contains(.highlighted) }
+  var isFocused:  Bool { return self.contains(.focused) }
+  var isDragged:  Bool { return self.contains(.dragged) }
+
+  // Returns true if self is an interactive state (a member of interactiveSet)
+  var isInteractive: Bool {
+    // TODO: if at least 1 bit in self appears in the interactiveSet - we should return true.
+    //       currently it returns true only if all bits appear in interactiveSet.
+    let interactiveSet: MDCControlState =
+        [.selected, .active, .highlighted, .focused, .dragged]
+    return interactiveSet.contains(self)
+  }
+}

--- a/components/private/State/src/StateExampleColorScheme.swift
+++ b/components/private/State/src/StateExampleColorScheme.swift
@@ -1,0 +1,160 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/**
+ Creating a new StateExampleColorScheming in order to add a couple of colors and
+ the realColor(colorResource:) method, which converts a color resource to an actual UIColor.
+
+ Note: onPrimaryColorVariant and onSurfaceColorVariant are not used in state theming.
+ */
+protocol StateExampleColorScheming: MDCColorScheming {
+  var MDCColorScheme: MDCColorScheming { get }
+
+  var primaryColor: UIColor { get set }
+  var secondaryColor: UIColor { get set }
+  var errorColor: UIColor { get set }
+  var surfaceColor: UIColor { get set }
+  var backgroundColor: UIColor { get set }
+  var onPrimaryColor: UIColor { get set }
+  var onSecondaryColor: UIColor { get set }
+  var onSurfaceColor: UIColor { get set }
+  var onBackgroundColor: UIColor { get set }
+
+  // New semantic color names
+  var overlayColor: UIColor { get set }
+  var outlineColor: UIColor { get set }   // Adding outline for now, to align with GM
+}
+
+/**
+ Creating a new StateExampleColorScheme which (a) defines and uses the overlayColor, (b) creates
+ all the default colors schemes used by the example [TBD], and (c) includes a realColor() function
+ which converts a ColorResource to UIColor.
+ */
+class StateExampleColorScheme: StateExampleColorScheming {
+  let MDCColorScheme: MDCColorScheming
+
+  var primaryColor: UIColor
+  var primaryColorVariant: UIColor // Required to conform to MDCColorScheming protocol. Not used in prototype.
+  var secondaryColor: UIColor
+  var errorColor: UIColor
+  var surfaceColor: UIColor
+  var backgroundColor: UIColor
+  var onPrimaryColor: UIColor
+  var onSecondaryColor: UIColor
+  var onSurfaceColor: UIColor
+  var onBackgroundColor: UIColor
+
+  // New semantic color names
+  var overlayColor: UIColor
+  var outlineColor: UIColor
+
+  init(withDefaults defaults: MDCColorSchemeDefaults) {
+
+    MDCColorScheme = MDCSemanticColorScheme(defaults: .material201804)
+
+    switch defaults {
+
+    case .material201804:
+
+      // State system colors
+      surfaceColor = MDCColorScheme.surfaceColor
+      onSurfaceColor = MDCColorScheme.onSurfaceColor
+
+      backgroundColor = MDCColorScheme.backgroundColor
+      onBackgroundColor = MDCColorScheme.onBackgroundColor
+
+      // Assigning new values. No mapping in MDCColorScheme.
+      overlayColor = MDCPalette.grey.tint800
+      outlineColor = MDCPalette.grey.tint300
+
+      primaryColor = MDCColorScheme.primaryColor
+      onPrimaryColor = MDCColorScheme.onPrimaryColor
+      primaryColorVariant = MDCColorScheme.primaryColorVariant
+
+      errorColor = MDCColorScheme.errorColor
+
+      // Colors not used in state theming
+      secondaryColor = MDCColorScheme.secondaryColor
+      onSecondaryColor = MDCColorScheme.onSecondaryColor
+    }
+  }
+}
+
+extension StateExampleColorScheme {
+  
+  /// Converting a ColorResource to a real color, taken from the current color scheme.
+  func realColor(colorResource: ColorResource) -> UIColor? {
+
+    // Convert the resource to a UIColor, using one of the color formats
+    guard let color: UIColor = {
+      if let hexString = colorResource.hexColor {
+        // Convert a hext string to a UIColor
+        return UIColor(hexString: hexString)
+      } else if let palette = colorResource.palette, let tint = colorResource.tint {
+        // Convert a palette + tint values to a UIColor
+        let palette: MDCPalette = {
+          switch palette {
+          case .grey: return MDCPalette.grey
+          case .blueGrey: return MDCPalette.blueGrey
+          case .indigo: return MDCPalette.indigo
+          case .blue: return MDCPalette.blue
+          case .purple: return MDCPalette.purple
+          case .red: return MDCPalette.red
+          case .orange: return MDCPalette.orange
+          case .yellow: return MDCPalette.yellow
+          }
+        }()
+        switch tint {
+        case .tint50: return palette.tint50
+        case .tint100: return palette.tint100
+        case .tint200: return palette.tint200
+        case .tint300: return palette.tint300
+        case .tint400: return palette.tint400
+        case .tint500: return palette.tint500
+        case .tint600: return palette.tint600
+        case .tint700: return palette.tint700
+        case .tint800: return palette.tint800
+        case .tint900: return palette.tint900
+        }
+      } else if let semanticName = colorResource.semanticColorName {
+        // Convert a semantic name to a UIColor
+        switch semanticName {
+        case .primary: return primaryColor
+        case .onPrimary: return onPrimaryColor
+        case .surface: return surfaceColor
+        case .onSurface: return onSurfaceColor
+        case .background: return backgroundColor
+        case .onBackground: return onBackgroundColor
+        case .outline: return outlineColor
+        case .overlay: return overlayColor
+        case .error: return errorColor
+        }
+      }
+      return nil
+      }() else {
+        return nil
+    }
+    // Add opacity and hue variations
+    if let opacity = colorResource.opacity, opacity < CGFloat(1.0) {
+      return color.withAlphaComponent(opacity)
+    } else if let percent = colorResource.darker {
+      return percent > 0 ? color.darker(amount: percent) : color.lighter(amount: -percent)
+    } else {
+      return color
+    }
+  }
+
+}

--- a/components/private/State/src/StateScheme.swift
+++ b/components/private/State/src/StateScheme.swift
@@ -1,0 +1,407 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+enum StateTheme: String {
+
+  case onWhite, onPrimary
+  case outline, elevated
+
+  // Some themes "inherit" attributes from other themes (only 1 level
+  // of inheritance is supported at this point):
+  var baseTheme: StateTheme? {
+    switch self {
+    case .outline: return .onWhite
+    case .elevated: return .onWhite
+    default: return nil
+    }
+  }
+}
+
+// State dictionary is a list of attributes. An attribute is a list of resources:
+typealias ResourceDictionary = [String:String]
+typealias AttributeDictionary = [String:ResourceDictionary]
+typealias StateDictionary = [String:AttributeDictionary]
+
+/**
+
+ Material State Scheme
+
+ The State Scheme map stores state-related values that determine appearance of states in components
+ for multiple themes. Each theme includes a pre-defined list of attributes that determine its
+ appearance. Currently supported state-related attributes include:
+     overlay color, container color, content color, border color and elevation.
+
+ Each of the 5 attributes includes a single value for each of the states it relates to. Values may
+ be missing if they inherit from "normal"/"enabled" state. If no normal/enabled state value is
+ defined, then these missing values are ignore.
+
+ These single values are stored as ResourceDictionary types, which are converted by getters
+ and returnd as color resources (a ColorResource instances) - for color values, or as
+ ShadowElevation - for elevation values.
+
+ Each attribute is stored as a AttributeDictionary, which is a map of states (string keys) to
+ ResourceDictionaries (values).
+
+ An entire theme (for isntance: the "onWhite" theme) is stored as a StateDictionary, which is a
+ dictionary of these 5 main attribures, each mapped to a AttributeDictionary which describes
+ all its states.
+
+ The dictionary structure is private, and access to it is available through getters and setters
+ which convert the dictionary string data to types used by themers or other schemes.
+
+ Dictionary values used enums to convert between between Strings and real values. See the
+ MDCControlState enumeration for the full list of states; See Resource.Color.Semantic for the
+ list of semantic color names; See Resource.Color.Palette and Resource.Color.Palette.Tint for
+ palette and tint enumberaionts; And StateTheme for the list of themes.
+
+ Each shadowElevation attribute has a getter and a setter, converting ShadowElevation to
+ strings and vice versa.
+
+ Each color attribute has a getter which returns a ColorResource class. When a ColorResource is
+ passed to an instance of MDCSemanticColotScheme, it is converted to a "real" UIColor, based on
+ values from the color scheme (see StateExampleColorScheme.realColor()).
+
+ Additionally, each color attribute has 2 setters, one accepting a palette and another accepting
+ a semantic color name (enum). These setters may be used to override specific state values when
+ required. Setters accepting hex values are not supported at this point and may be added in the
+ future as need arise.
+
+ Implementation notes:
+
+ * State names use material names. The mapping to UIControlState is:
+      "enabled" == "normal"
+      "pressed" == "highlighted".
+
+ * State names also include states that do not exist in UIControlState,
+      like: dragged, active & error.
+
+ * The "Enabled" state (aka: "normal") will act as the default value in UIControls when
+   values for "selected" or "pressed" states are not provided in this map.  This is a default
+   behavior of UIControl, and an active assumption in building this map (meaning, values will not
+   be provided for the "selected" or "pressed" states if they suppose to inherit from the
+   "enabled" state).
+
+ * "Darker" and "ligher" variations are used in MDC for a generic contrast increase of the
+    interactive states. These are overriden with specific values for each color combinations
+    (check overrides in init(withDefaults:)).
+
+   Note that components supporting non-UIControlState states, like dragged, active & error, must
+   adopt this implementation to get correct theming for those states (they must use the "enabled"
+   state, if provided, as a default to the dragged, active & error states, if the latters are
+   not provided).
+ */
+
+class StateScheme {
+
+  // MARK: Private Theme Dictionaries
+
+  private lazy var onWhite: StateDictionary = [
+    "overlay": [
+      "selected": ["semanticColor": "overlay", "opacity": "0.12"],
+      "pressed": ["semanticColor": "overlay", "opacity": "0.10"],
+      "dragged": ["semanticColor": "overlay", "opacity": "0.08"]
+    ],
+    "container": [
+      "enabled": ["semanticColor": "surface"],
+    ],
+    "content": [
+      "enabled": ["semanticColor": "on-surface"],
+      "interactive": ["semanticColor": "on-surface", "darker": "0.2"],  // 20% darker onSurface
+      "disabled": ["palette": "grey", "tint": "800", "opacity": "0.38"],
+      "error": ["semanticColor": "error"],
+    ],
+    "border": [
+      "focused": ["semanticColor": "overlay"],
+    ],
+    "shadowElevation": [
+      "dragged": ["shadowElevation": "3"],
+    ]
+  ]
+
+  private lazy var onPrimary: StateDictionary = [
+    "overlay": [
+      "selected": ["semanticColor": "overlay", "opacity": "0.24"],
+      "pressed": ["semanticColor": "overlay", "opacity": "0.20"],
+      "dragged": ["semanticColor": "overlay", "opacity": "0.16"]
+    ],
+    "container": [
+      "enabled": ["semanticColor": "primary"],
+      "disabled": ["palette": "grey", "tint": "800", "opacity": "0.12"],
+    ],
+    "content": [
+      "enabled": ["semanticColor": "on-primary"],
+      "interactive": ["semanticColor": "on-primary", "darker": "-0.2"],  // 20% lighter onPrimary
+      "disabled": ["palette": "grey", "tint": "800", "opacity": "0.38"],
+      "error": ["semanticColor": "error"],
+    ],
+    "border": [
+      "focused": ["semanticColor": "overlay"],    // is this correct?
+    ],
+    "shadowElevation": [
+      "pressed": ["shadowElevation": "2"],
+      "dragged": ["shadowElevation": "3"],
+    ]
+  ]
+
+  // This "theme" inherits all unspecified propertie from "onWhite"
+  private lazy var outlined: StateDictionary = [
+    "border": [
+      "enabled": ["palette": "grey", "tint": "300"],
+      "interactive": ["semanticColor": "on-surface", "darker": "0.2"],  // 20% darker onSurface
+      "focused": ["semanticColor": "overlay"],
+      "disabled": ["palette": "grey", "tint": "800", "opacity": "0.12"],
+      "error": ["semanticColor": "error"],
+    ],
+  ]
+
+  // This "theme" inherits all unspecified propertie from "onWhite"
+  private var elevated: StateDictionary = [
+    "shadowElevation": [
+      "enabled": ["shadowElevation": "1"],
+      "selected": ["shadowElevation": "1"],
+      "active": ["shadowElevation": "1"],
+      "pressed": ["shadowElevation": "3"],
+      "dragged": ["shadowElevation": "4"],
+    ]
+  ]
+
+  // MARK: Initializers
+
+  init(withDefaults defaults: MDCColorSchemeDefaults) {
+
+    // Overriding the calculated value of interactive states color - for all themes
+    switch defaults {
+    case .material201804:
+      setContentColor(palette: .grey, tint: .tint900, forState: .interactive, forTheme: .onWhite)
+      setBorderColor(palette: .grey, tint: .tint900, forState: .interactive, forTheme: .outline)
+    }
+  }
+
+  // MARK: Attributes setters using UIColor
+
+  // Color setter which accept a palette and tint + opacity for the given theme + state
+  func setOverlayColor(palette: Resource.Color.Palette, tint: Resource.Color.Palette.Tint, opacity: CGFloat? = nil, forState state: MDCControlState, forTheme theme: StateTheme) {
+    let resource = ColorResource(palette: palette, tint: tint, opacity: opacity)
+    setColor(attribute: "overlay", colorResource: resource, forState: state, forTheme: theme)
+  }
+
+  func setContainerColor(palette: Resource.Color.Palette, tint: Resource.Color.Palette.Tint, opacity: CGFloat? = nil, forState state: MDCControlState, forTheme theme: StateTheme) {
+    let resource = ColorResource(palette: palette, tint: tint, opacity: opacity)
+    setColor(attribute: "container", colorResource: resource, forState: state, forTheme: theme)
+  }
+
+  func setContentColor(palette: Resource.Color.Palette, tint: Resource.Color.Palette.Tint, opacity: CGFloat? = nil, forState state: MDCControlState, forTheme theme: StateTheme) {
+    let resource = ColorResource(palette: palette, tint: tint, opacity: opacity)
+    setColor(attribute: "content", colorResource: resource, forState: state, forTheme: theme)
+  }
+
+  func setBorderColor(palette: Resource.Color.Palette, tint: Resource.Color.Palette.Tint, opacity: CGFloat? = nil, forState state: MDCControlState, forTheme theme: StateTheme) {
+    let resource = ColorResource(palette: palette, tint: tint, opacity: opacity)
+    setColor(attribute: "border", colorResource: resource, forState: state, forTheme: theme)
+  }
+
+  // MARK: Attribute setters Using Semantic Color Names
+
+  // Color setter which accept a semantic color name + opacity for the given theme + state
+  func setOverlayColor(semanticColorName: Resource.Color.Semantic, opacity: CGFloat? = nil, forState state: MDCControlState, forTheme theme: StateTheme) {
+    let resource = ColorResource(semanticColorName: semanticColorName, opacity: opacity)
+    setColor(attribute: "overlay", colorResource: resource, forState: state, forTheme: theme)
+  }
+
+  func setContainerColor(semanticColorName: Resource.Color.Semantic, opacity: CGFloat? = nil, forState state: MDCControlState, forTheme theme: StateTheme) {
+    let resource = ColorResource(semanticColorName: semanticColorName, opacity: opacity)
+    setColor(attribute: "container", colorResource: resource, forState: state, forTheme: theme)
+  }
+
+  func setContentColor(semanticColorName: Resource.Color.Semantic, opacity: CGFloat? = nil, forState state: MDCControlState, forTheme theme: StateTheme) {
+    let resource = ColorResource(semanticColorName: semanticColorName, opacity: opacity)
+    setColor(attribute: "content", colorResource: resource, forState: state, forTheme: theme)
+  }
+
+  func setBorderColor(semanticColorName: Resource.Color.Semantic, opacity: CGFloat? = nil, forState state: MDCControlState, forTheme theme: StateTheme) {
+    let resource = ColorResource(semanticColorName: semanticColorName, opacity: opacity)
+    setColor(attribute: "border", colorResource: resource, forState: state, forTheme: theme)
+  }
+
+  // MARK: Color Attributes Getters
+
+  // Overlay color getter, returning a State color, which can be transofrmed to a realColor by a colorScheme
+  func overlayColorResource(forState state: MDCControlState, forTheme theme: StateTheme) -> ColorResource? {
+    return color(attribute: "overlay", forState: state, forTheme: theme)
+  }
+
+  func containerColorResource(forState state: MDCControlState, forTheme theme: StateTheme) -> ColorResource? {
+    return color(attribute: "container", forState: state, forTheme: theme)
+  }
+
+  func contentColorResource(forState state: MDCControlState, forTheme theme: StateTheme) -> ColorResource? {
+    return color(attribute: "content", forState: state, forTheme: theme)
+  }
+
+  func borderColorResource(forState state: MDCControlState, forTheme theme: StateTheme) -> ColorResource? {
+    return color(attribute: "border", forState: state, forTheme: theme)
+  }
+
+  // MARK: shadowElevation Attribute Setters & Getters
+
+  func shadowElevation(forState state: MDCControlState, forTheme theme: StateTheme) -> ShadowElevation? {
+    guard let stateDictionary: StateDictionary = {
+      if let baseTheme = theme.baseTheme {
+        // Themes that inherit from other themes. Assuming a single level of inheritance.
+        return themeDictionary(theme) ?? themeDictionary(baseTheme)
+      } else {
+        // Base themes with no inheritance
+        return themeDictionary(theme)
+      }
+    }() else { return nil }
+    guard let attributeInfo = attribute(named: "shadowElevation", forState: state, dictionary: stateDictionary)
+      else { return nil }
+    if let elevationString = attributeInfo["shadowElevation"],
+      let shadowElevation = Double(elevationString) {
+      return ShadowElevation(rawValue: CGFloat(shadowElevation))
+    }
+    return nil
+  }
+
+  func setShadowElevation(_ elevation: ShadowElevation, forState state: MDCControlState, forTheme theme: StateTheme) {
+    setShadowElevation(String(describing: elevation.rawValue), forState: state, forTheme: theme)
+  }
+
+  // MARK: Private utility methods
+
+  /// Return the StateDictionary of the requested theme
+  private func themeDictionary(_ theme: StateTheme) -> StateDictionary? {
+    switch theme {
+    case .onWhite: return onWhite
+    case .onPrimary: return onPrimary
+    case .outline: return outlined
+    case .elevated: return elevated
+    }
+  }
+
+  /// Returns the ResourceDictionary of the requested attribute name, for the requested state and theme.
+  /// If the given state is an interactive state, and the speicifc state value is
+  /// missing, the interactive state will be returned (if the value exists).
+  private func attribute(named name: String, forState state: MDCControlState, dictionary: StateDictionary) -> ResourceDictionary? {
+    guard let attributeInfo = dictionary[name] else { return nil }
+    if let stateInfo = attributeInfo[state.name] {
+      return stateInfo
+    } else if state.isInteractive, let stateInfo = attributeInfo["interactive"] {
+      return stateInfo
+    }
+    return nil
+  }
+
+  /// Returns the ColorResource of the requested attribute, for the requested state and theme.
+  private func color(attribute attributeName: String, forState state: MDCControlState, forTheme theme: StateTheme) -> ColorResource? {
+    guard let stateDictionary: StateDictionary = {
+      if let baseTheme = theme.baseTheme {
+        // Themes that inherit from other themes. Assuming a single level of inheritance.
+        return themeDictionary(theme) ?? themeDictionary(baseTheme)
+      } else {
+        // Base themes with no inheritance
+        return themeDictionary(theme)
+      }
+    }() else { return nil }
+    guard let attributeInfo = attribute(named: attributeName, forState: state, dictionary: stateDictionary) else { return nil }
+    return ColorResource(dictionary: attributeInfo)
+  }
+
+  /// Updates the ColorResource for the requested attribute, in the requested state and theme.
+  private func setColor(attribute: String, colorResource: ColorResource, forState state: MDCControlState, forTheme theme: StateTheme) {
+    switch theme {
+    case .onWhite:
+      onWhite[attribute]?[state.name] = colorResource.toDictionary()
+    case .onPrimary:
+      onPrimary[attribute]?[state.name] = colorResource.toDictionary()
+    default: return
+    }
+  }
+
+  /// Updates the ShadowElevation for the requested state and theme. (The attribute is always "shadowElevation")
+  private func setShadowElevation(_ elevation: String, forState state: MDCControlState, forTheme theme: StateTheme) {
+    switch theme {
+    case .onWhite:
+      onWhite["shadowElevation"]?[state.name] = ["shadowElevation": elevation]
+    case .onPrimary:
+      onPrimary["shadowElevation"]?[state.name] = ["shadowElevation": elevation]
+    default: return
+    }
+  }
+}
+
+// MARK: ColorResource extension
+
+private extension ColorResource {
+
+  /**
+    Converting a ResourceDictionary to a ColorResource, returning nil if the entry cannot
+    be converted to a ColorResource. The representations of colors are supported:
+    * "semanticColor" is verified against the list of semantic colors in MDCSemanticColorScheming.
+    * "palette" and "tint" are verified againts valid Palette names and tints.
+    * "hex" strings are verified as a valid 6-digit hex values (leading with an optional #).
+   */
+  init?(dictionary: ResourceDictionary) {
+
+    let opacity: CGFloat? = {
+      if let opacityString = dictionary["opacity"], let opacity = Double(opacityString) {
+        return CGFloat(opacity)
+      }
+      return nil
+    }()
+
+    let darker: CGFloat? = {
+      if let darkerString = dictionary["darker"], let darker = Double(darkerString) {
+        return CGFloat(darker)
+      }
+      return nil
+    }()
+
+    if let semanticName = dictionary["semanticColor"] {
+      // Verify semanticName is a valid semantic color
+      guard let semanticColorName = Resource.Color.Semantic(rawValue: semanticName) else { return nil }
+      self.init(semanticColorName: semanticColorName, opacity: opacity, darker: darker)
+    } else if let hexColor = dictionary["hexColor"] {
+      self.init(hex: hexColor, opacity: opacity, darker: darker)
+    } else if let palette = dictionary["palette"], let tint = dictionary["tint"] {
+      guard let palette = Resource.Color.Palette(rawValue: palette),
+        let tint = Resource.Color.Palette.Tint(rawValue: tint) else { return nil }
+      self.init(palette: palette, tint: tint, opacity: opacity, darker: darker)
+    } else {
+      return nil
+    }
+  }
+
+  /// Serializing ColorResource to an ResourceDictionary dictionary
+  func toDictionary() -> ResourceDictionary {
+    var attributeDictionary: ResourceDictionary = [:]
+    if let semanticColorName = self.semanticColorName {
+      attributeDictionary["semanticColor"] = semanticColorName.rawValue
+    } else if let palette = self.palette, let tint = self.tint {
+      attributeDictionary["palette"] = palette.rawValue
+      attributeDictionary["tint"] = tint.rawValue
+    } else if let hexColor = self.hexColor {
+      attributeDictionary["hexColor"] = hexColor
+    }
+    if let opacity = self.opacity {
+      attributeDictionary["opacity"] = String(describing: opacity)
+    }
+    if let darker = self.darker {
+      attributeDictionary["darker"] = String(describing: darker)
+    }
+    return attributeDictionary
+  }
+}


### PR DESCRIPTION
### Material State Scheme

This is an experimental implementation of a State Scheme. Main implementation ideas:

* Storing state related information outside of themers, in a dedicated data source. This will allow sharing state information across components/themers.
* The State Scheme stores its data in a dictionary, which can be serialized and/or shared with external systems (in the future).
* Using a ColorResource class which represents colors and reduces dependency between subsystems (more info below).
* Colors that don't pass contrast ratio can be overridden and customized by clients, who can pick  specific colors that work with their color schemes.  This concept is demonstrated in the StateScheme initializer. 

### Color Resources

The Color Resource class is a concept borrowed from Android's Resources, which are being used heavily in their theming implementation. 

On iOS, we use Color Resources to serialized/de-serialized colors from a dictionary.  They are used independently by the different schemes, reducing cross dependency between them.  

Internally, the State scheme manages all state-related values as strings in a single dictionary and uses Color Resources to return structured and validated color data which can then be converted to an actual UIColor (and to guarantee the success of this conversion).
This allows the state scheme to return abstract information, like a semantic color name, without knowing the specific value, which will be assigned to it later by a specific color scheme.  

### State Map Implementation

The State Scheme's map stores state-related values which determine appearance of states in components.  State appearance is different for "on-primary" and "on white" themes, therefore a separate map is stored for each theme.

Each theme map is made of a pre-defined list of attributes, which determine its appearance in the different states. Currently supported state-related attributes include: `overlay color, container color, content color, border color and elevation.`  Each of the 5 attributes includes one or more values, one for each state. 

The State Scheme map is a private dictionary, with values stored as strings. This is to allow easy archiving or loading from external sources. The scheme exposes public access methods (getters and setters) for each attribute and their different states.  

The State scheme's getters returns color values as ColorResources, which can then be passed to specific color schemes to generate UIColor values from that scheme. In contrast, ShadowElevation getters return ShadowElevation type. 

The State Scheme also defines 2 setters for each color, one accepting Palette colors, and another which accepts a semantic color name. 

### MDCControlState

A MDCControlState enumeration is used to represent all supported Material States. It is also used to convert between Material States and UIControlStates. Components that define their own State enumerations will have to provide a conversion method between this enumeration and their own's (Alternatively, all components should share this single enumeration).

### StateExampleColorScheme

StateExampleColorScheme is a temporary place to add logic without making changes directly in MDCSemanticColorScheme in. We expect the color scheme to have an additional "overlayColor" and possibly an "outlineColor" (which may already exist on some systems).  Additionally, it defines a method that maps ColorResources to "real" UIColors.

### Public API Considerations

A public API that can be used by themers has not yet been determined, and is not included in this PR.  The current example file demonstrates getting a ColorResource from the StateScheme, and passes it to a ColorScheme to get an final UIColor.

We are considering adding a public API to the color scheme which will return a UIColor (hiding the specific implementation of colors as resources from themers and client apps). For instance:

```
In MDCSemanticColorScheme.h:

- (UIColor *)contentColorForState:(MDCControlState)state  forTheme:(StateTheme)theme;
```

This can be achieved by adding a StateScheme property to the color scheme, and initializing it with the same defaults enumeration (to allow for color-scheme specific overrides of states). For example:

```
In MDCSemanticColorScheme.m:

 init(withDefaults defaults: MDCColorSchemeDefaults) {

    MDCColorScheme = MDCSemanticColorScheme(defaults: .material201804)
    MDCStateScheme = MDCStateScheme(defaults: .material201804)
   ...
}
```

### Issue
b/122521260
