### PR TITLE
[BottomNavigation] Deprecate `itemsContentInsets` API

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -128,7 +128,8 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarAlignment) {
  centered. The contents are centered in this rect, but not compressed, so they may still extend
  beyond these bounds. Defaults to {0, 0, 0, 0}. The inset is flipped for RTL.
  */
-@property(nonatomic, assign) UIEdgeInsets itemsContentInsets;
+@property(nonatomic, assign)
+    UIEdgeInsets itemsContentInsets __deprecated_msg("This API will be removed.");
 
 /**
  The margin between the item's icon and title when alignment is either Justified or Centered.


### PR DESCRIPTION
The API is not a parameter in Material Bottom Navigation and has no internal
usage. It behaves unlike `contentEdgeInsets` found on classes like UIButton
and is unintuitive in how it affects item layout.

Part of #6556
