### PR TITLE
[BottomNavigation] Add sizeThatFits: to Item View

### DIFF
--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -22,6 +22,9 @@
 #import "MaterialBottomNavigationStrings_table.h"
 #import "MaterialMath.h"
 
+// A number large enough to be larger than any reasonable screen dimension but small enough that
+// CGFloat doesn't lose precision.
+static const CGFloat kMaxSizeDimension = 1000000;
 static const CGFloat MDCBottomNavigationItemViewInkOpacity = (CGFloat)0.150;
 static const CGFloat MDCBottomNavigationItemViewTitleFontSize = 12;
 static const CGFloat kMDCBottomNavigationItemViewBadgeYOffset = 4;
@@ -151,6 +154,52 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
     _button.accessibilityValue = self.accessibilityValue;
     [self addSubview:_button];
   }
+}
+
+- (CGSize)sizeThatFits:(__unused CGSize)size {
+  if (self.titleBelowIcon) {
+    return [self sizeThatFitsForVerticalLayout];
+  } else {
+    return [self sizeThatFitsForHorizontalLayout];
+  }
+}
+
+- (CGSize)sizeThatFitsForVerticalLayout {
+  BOOL titleHidden =
+      self.titleVisibility == MDCBottomNavigationBarTitleVisibilityNever ||
+      (self.titleVisibility == MDCBottomNavigationBarTitleVisibilitySelected && !self.selected);
+  CGSize maxSize = CGSizeMake(kMaxSizeDimension, kMaxSizeDimension);
+  CGSize iconSize = [self.iconImageView sizeThatFits:maxSize];
+  CGRect iconFrame = CGRectMake(0, 0, iconSize.width, iconSize.height);
+  CGSize badgeSize = [self.badge sizeThatFits:maxSize];
+  CGPoint badgeCenter = [self badgeCenterFromIconFrame:iconFrame isRTL:NO];
+  CGRect badgeFrame =
+      CGRectMake(badgeCenter.x - badgeSize.width / 2, badgeCenter.y - badgeSize.height / 2,
+                 badgeSize.width, badgeSize.height);
+  CGRect labelFrame = CGRectZero;
+  if (!titleHidden) {
+    CGSize labelSize = [self.label sizeThatFits:maxSize];
+    labelFrame = CGRectMake(CGRectGetMidX(iconFrame) - labelSize.width / 2,
+                            CGRectGetMaxY(iconFrame) + self.contentVerticalMargin, labelSize.width,
+                            labelSize.height);
+  }
+  return CGRectStandardize(CGRectUnion(labelFrame, CGRectUnion(iconFrame, badgeFrame))).size;
+}
+
+- (CGSize)sizeThatFitsForHorizontalLayout {
+  CGSize maxSize = CGSizeMake(kMaxSizeDimension, kMaxSizeDimension);
+  CGSize iconSize = [self.iconImageView sizeThatFits:maxSize];
+  CGRect iconFrame = CGRectMake(0, 0, iconSize.width, iconSize.height);
+  CGSize badgeSize = [self.badge sizeThatFits:maxSize];
+  CGPoint badgeCenter = [self badgeCenterFromIconFrame:iconFrame isRTL:NO];
+  CGRect badgeFrame =
+      CGRectMake(badgeCenter.x - badgeSize.width / 2, badgeCenter.y - badgeSize.height / 2,
+                 badgeSize.width, badgeSize.height);
+  CGSize labelSize = [self.label sizeThatFits:maxSize];
+  CGRect labelFrame = CGRectMake(CGRectGetMaxX(iconFrame) + self.contentHorizontalMargin,
+                                 CGRectGetMidY(iconFrame) - labelSize.height / 2, labelSize.width,
+                                 labelSize.height);
+  return CGRectStandardize(CGRectUnion(labelFrame, CGRectUnion(iconFrame, badgeFrame))).size;
 }
 
 - (void)layoutSubviews {

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
@@ -181,4 +181,88 @@ static UIImage *fakeImage(void) {
   XCTAssertEqualWithAccuracy(badgePoint.y, expectedCenter.y, 0.001);
 }
 
+- (void)testSizeThatFitsSmallSize {
+  // Given
+  MDCBottomNavigationItemView *itemView =
+      [[MDCBottomNavigationItemView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+  itemView.image = fakeImage();
+  itemView.title = @"A very long title that takes much space to fit.";
+  itemView.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+  itemView.titleBelowIcon = YES;
+  CGSize desiredSize = CGSizeMake(24, 8);
+
+  // When
+  CGSize fitSize = [itemView sizeThatFits:desiredSize];
+
+  // Then
+  XCTAssertGreaterThanOrEqual(fitSize.width, desiredSize.width);
+  XCTAssertGreaterThanOrEqual(fitSize.height, desiredSize.height);
+}
+
+- (void)testSizeThatFitsLargerThanTooSmallBounds {
+  // Given
+  CGRect originalFrame = CGRectMake(0, 0, 1, 3);
+  MDCBottomNavigationItemView *itemView =
+      [[MDCBottomNavigationItemView alloc] initWithFrame:originalFrame];
+  itemView.title = @"A very long title that takes much space to fit.";
+  itemView.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+  itemView.titleBelowIcon = YES;
+
+  // When
+  CGSize fitSize = [itemView sizeThatFits:CGSizeMake(10000, 10000)];
+
+  // Then
+  XCTAssertGreaterThan(fitSize.width, originalFrame.size.width);
+  XCTAssertGreaterThan(fitSize.height, originalFrame.size.height);
+}
+
+- (void)testSizeThatFitsSmallerThanTooLargeBounds {
+  // Given
+  CGRect originalFrame = CGRectMake(0, 0, 1202, 1301);
+  MDCBottomNavigationItemView *itemView =
+      [[MDCBottomNavigationItemView alloc] initWithFrame:originalFrame];
+  itemView.title = @"1";
+  itemView.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+  itemView.titleBelowIcon = YES;
+
+  // When
+  CGSize fitSize = [itemView sizeThatFits:CGSizeMake(10000, 10000)];
+
+  // Then
+  XCTAssertLessThan(fitSize.width, originalFrame.size.width);
+  XCTAssertLessThan(fitSize.height, originalFrame.size.height);
+}
+
+- (void)testSizeThatFitWithCGSizeZero {
+  // Given
+  MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];
+  itemView.title = @"Favorites";
+  itemView.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+
+  // When
+  CGSize fitSize = [itemView sizeThatFits:CGSizeZero];
+
+  // Then
+  XCTAssertGreaterThan(fitSize.width, 0);
+  XCTAssertGreaterThan(fitSize.height, 0);
+}
+
+- (void)testSizeThatFitsMatchesSizeToFitUnbounded {
+  // Given
+  MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];
+  itemView.title = @"Favorites";
+  itemView.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+  CGSize fitSize = [itemView sizeThatFits:CGSizeMake(10000, 10000)];
+
+  // When
+  [itemView sizeToFit];
+
+  // Then
+  CGRect fitBounds = CGRectStandardize(itemView.bounds);
+  XCTAssertFalse(CGRectEqualToRect(fitBounds, CGRectZero),
+                 @"sizeToFit should never set a CGRectZero bounds when content is present.");
+  XCTAssertEqualWithAccuracy(fitBounds.size.width, fitSize.width, 0.001);
+  XCTAssertEqualWithAccuracy(fitBounds.size.height, fitSize.height, 0.001);
+}
+
 @end

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
@@ -182,6 +182,7 @@ static UIImage *fakeImage(void) {
 }
 
 #pragma mark - sizeThatFits
+
 - (void)testSizeThatFitsSmallSizeStackedLayout {
   // Given
   MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];

--- a/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationItemViewTests.m
@@ -181,10 +181,10 @@ static UIImage *fakeImage(void) {
   XCTAssertEqualWithAccuracy(badgePoint.y, expectedCenter.y, 0.001);
 }
 
-- (void)testSizeThatFitsSmallSize {
+#pragma mark - sizeThatFits
+- (void)testSizeThatFitsSmallSizeStackedLayout {
   // Given
-  MDCBottomNavigationItemView *itemView =
-      [[MDCBottomNavigationItemView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+  MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];
   itemView.image = fakeImage();
   itemView.title = @"A very long title that takes much space to fit.";
   itemView.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
@@ -199,7 +199,24 @@ static UIImage *fakeImage(void) {
   XCTAssertGreaterThanOrEqual(fitSize.height, desiredSize.height);
 }
 
-- (void)testSizeThatFitsLargerThanTooSmallBounds {
+- (void)testSizeThatFitsSmallSizeAdjacentLayout {
+  // Given
+  MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];
+  itemView.image = fakeImage();
+  itemView.title = @"A very long title that takes much space to fit.";
+  itemView.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+  itemView.titleBelowIcon = NO;
+  CGSize desiredSize = CGSizeMake(24, 8);
+
+  // When
+  CGSize fitSize = [itemView sizeThatFits:desiredSize];
+
+  // Then
+  XCTAssertGreaterThanOrEqual(fitSize.width, desiredSize.width);
+  XCTAssertGreaterThanOrEqual(fitSize.height, desiredSize.height);
+}
+
+- (void)testSizeThatFitsLargerThanTooSmallBoundsStackedLayout {
   // Given
   CGRect originalFrame = CGRectMake(0, 0, 1, 3);
   MDCBottomNavigationItemView *itemView =
@@ -216,7 +233,24 @@ static UIImage *fakeImage(void) {
   XCTAssertGreaterThan(fitSize.height, originalFrame.size.height);
 }
 
-- (void)testSizeThatFitsSmallerThanTooLargeBounds {
+- (void)testSizeThatFitsLargerThanTooSmallBoundsAdjacentLayout {
+  // Given
+  CGRect originalFrame = CGRectMake(0, 0, 1, 3);
+  MDCBottomNavigationItemView *itemView =
+      [[MDCBottomNavigationItemView alloc] initWithFrame:originalFrame];
+  itemView.title = @"A very long title that takes much space to fit.";
+  itemView.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+  itemView.titleBelowIcon = NO;
+
+  // When
+  CGSize fitSize = [itemView sizeThatFits:CGSizeMake(10000, 10000)];
+
+  // Then
+  XCTAssertGreaterThan(fitSize.width, originalFrame.size.width);
+  XCTAssertGreaterThan(fitSize.height, originalFrame.size.height);
+}
+
+- (void)testSizeThatFitsSmallerThanTooLargeBoundsStackedLayout {
   // Given
   CGRect originalFrame = CGRectMake(0, 0, 1202, 1301);
   MDCBottomNavigationItemView *itemView =
@@ -233,11 +267,29 @@ static UIImage *fakeImage(void) {
   XCTAssertLessThan(fitSize.height, originalFrame.size.height);
 }
 
-- (void)testSizeThatFitWithCGSizeZero {
+- (void)testSizeThatFitsSmallerThanTooLargeBoundsAdjacentLayout {
+  // Given
+  CGRect originalFrame = CGRectMake(0, 0, 1202, 1301);
+  MDCBottomNavigationItemView *itemView =
+      [[MDCBottomNavigationItemView alloc] initWithFrame:originalFrame];
+  itemView.title = @"1";
+  itemView.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+  itemView.titleBelowIcon = NO;
+
+  // When
+  CGSize fitSize = [itemView sizeThatFits:CGSizeMake(10000, 10000)];
+
+  // Then
+  XCTAssertLessThan(fitSize.width, originalFrame.size.width);
+  XCTAssertLessThan(fitSize.height, originalFrame.size.height);
+}
+
+- (void)testSizeThatFitWithCGSizeZeroStackedLayout {
   // Given
   MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];
   itemView.title = @"Favorites";
   itemView.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+  itemView.titleBelowIcon = YES;
 
   // When
   CGSize fitSize = [itemView sizeThatFits:CGSizeZero];
@@ -247,11 +299,46 @@ static UIImage *fakeImage(void) {
   XCTAssertGreaterThan(fitSize.height, 0);
 }
 
-- (void)testSizeThatFitsMatchesSizeToFitUnbounded {
+- (void)testSizeThatFitWithCGSizeZeroAdjacentLayout {
   // Given
   MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];
   itemView.title = @"Favorites";
   itemView.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+  itemView.titleBelowIcon = NO;
+
+  // When
+  CGSize fitSize = [itemView sizeThatFits:CGSizeZero];
+
+  // Then
+  XCTAssertGreaterThan(fitSize.width, 0);
+  XCTAssertGreaterThan(fitSize.height, 0);
+}
+
+- (void)testSizeThatFitsMatchesSizeToFitUnboundedStackedLayout {
+  // Given
+  MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];
+  itemView.title = @"Favorites";
+  itemView.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+  itemView.titleBelowIcon = YES;
+  CGSize fitSize = [itemView sizeThatFits:CGSizeMake(10000, 10000)];
+
+  // When
+  [itemView sizeToFit];
+
+  // Then
+  CGRect fitBounds = CGRectStandardize(itemView.bounds);
+  XCTAssertFalse(CGRectEqualToRect(fitBounds, CGRectZero),
+                 @"sizeToFit should never set a CGRectZero bounds when content is present.");
+  XCTAssertEqualWithAccuracy(fitBounds.size.width, fitSize.width, 0.001);
+  XCTAssertEqualWithAccuracy(fitBounds.size.height, fitSize.height, 0.001);
+}
+
+- (void)testSizeThatFitsMatchesSizeToFitUnboundedAdjacentLayout {
+  // Given
+  MDCBottomNavigationItemView *itemView = [[MDCBottomNavigationItemView alloc] init];
+  itemView.title = @"Favorites";
+  itemView.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
+  itemView.titleBelowIcon = NO;
   CGSize fitSize = [itemView sizeThatFits:CGSizeMake(10000, 10000)];
 
   // When


### PR DESCRIPTION
The MDCBottomNavigationItemView did not implement sizeThatFits: and so it was
not possible for the MDCBottomNavigationBar to interrogate the view for its
appropriate size during layout.

Part of #6520
