### PR TITLE
[BottomNavigation] Suppress deprecation warning.

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -424,7 +424,10 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
     itemView.accessibilityLabel = item.accessibilityLabel;
     itemView.accessibilityHint = item.accessibilityHint;
     itemView.isAccessibilityElement = item.isAccessibilityElement;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     itemView.contentInsets = self.itemsContentInsets;
+#pragma clang diagnostic pop
     itemView.contentVerticalMargin = self.itemsContentVerticalMargin;
     itemView.contentHorizontalMargin = self.itemsContentHorizontalMargin;
     MDCInkTouchController *controller = [[MDCInkTouchController alloc] initWithView:itemView];


### PR DESCRIPTION
`itemsContentInsets` is deprecated and planned for removal. Pod lint is
complaining about the internal use of the deprecated API.

Part of #6556
