### PR TITLE
[Dialogs] Deprecate Themers and AlertScheme.

### DIFF
--- a/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.h
+++ b/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.h
@@ -20,7 +20,7 @@
 /**
  The Material Design color system's themer for instances of MDCAlertController.
  */
-@interface MDCAlertColorThemer : NSObject
+__deprecated_msg("Please use MaterialDialogs+Theming.") @interface MDCAlertColorThemer : NSObject
 
 /**
  Applies a color scheme's properties to an MDCAlertController.

--- a/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
+++ b/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
@@ -18,7 +18,10 @@
 #import "MaterialButtons+ColorThemer.h"
 #import "MaterialButtons.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation MDCAlertColorThemer
+#pragma clang diagnostic pop
 
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                toAlertController:(nonnull MDCAlertController *)alertController {

--- a/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.h
+++ b/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.h
@@ -17,7 +17,8 @@
 #import "MDCAlertScheme.h"
 #import "MaterialDialogs.h"
 
-@interface MDCAlertControllerThemer : NSObject
+__deprecated_msg("Please use MaterialDialogs+Theming.") @interface MDCAlertControllerThemer :
+    NSObject
 
 /**
  Applies a component scheme's properties to an MDCAlertController.
@@ -25,7 +26,9 @@
  @param alertScheme The component scheme to apply to the alert dialog instance.
  @param alertController An alert dialog instance to which the component scheme should be applied.
  */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (void)applyScheme:(nonnull id<MDCAlertScheming>)alertScheme
     toAlertController:(nonnull MDCAlertController *)alertController;
-
+#pragma clang diagnostic pop
 @end

--- a/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.h
+++ b/components/Dialogs/src/DialogThemer/MDCAlertControllerThemer.h
@@ -17,8 +17,8 @@
 #import "MDCAlertScheme.h"
 #import "MaterialDialogs.h"
 
-__deprecated_msg("Please use MaterialDialogs+Theming.") @interface MDCAlertControllerThemer :
-    NSObject
+__deprecated_msg("Please use MaterialDialogs+Theming.") @interface MDCAlertControllerThemer
+    : NSObject
 
 /**
  Applies a component scheme's properties to an MDCAlertController.

--- a/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
+++ b/components/Dialogs/src/DialogThemer/MDCAlertScheme.h
@@ -20,7 +20,7 @@
 #import "MaterialTypographyScheme.h"
 
 /** Defines a readonly immutable interface for component style data to be applied by a themer. */
-@protocol MDCAlertScheming
+__deprecated_msg("Please use MDCContainerScheming") @protocol MDCAlertScheming
 
 /** The color scheme to apply to Dialog. */
 @property(nonnull, readonly, nonatomic) id<MDCColorScheming> colorScheme;
@@ -41,7 +41,8 @@
 
 /**  A simple implementation of @c MDCAlertScheming that provides default color,
  typography and shape schemes, from which customizations can be made. */
-@interface MDCAlertScheme : NSObject <MDCAlertScheming>
+__deprecated_msg("Please use MDCContainerScheme") @interface MDCAlertScheme
+    : NSObject<MDCAlertScheming>
 
 /** The color scheme to apply to Dialog. */
 @property(nonnull, readwrite, nonatomic) id<MDCColorScheming> colorScheme;

--- a/components/Dialogs/src/DialogThemer/MDCAlertScheme.m
+++ b/components/Dialogs/src/DialogThemer/MDCAlertScheme.m
@@ -16,7 +16,10 @@
 
 static const CGFloat kCornerRadius = 4;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation MDCAlertScheme
+#pragma clang diagnostic pop
 
 - (instancetype)init {
   self = [super init];

--- a/components/Dialogs/src/Theming/MDCAlertController+MaterialTheming.m
+++ b/components/Dialogs/src/Theming/MDCAlertController+MaterialTheming.m
@@ -29,7 +29,10 @@ static const CGFloat kCornerRadius = 4;
     colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [MDCAlertColorThemer applySemanticColorScheme:colorScheme toAlertController:self];
+#pragma clang diagnostic pop
 
   // Typography
   id<MDCTypographyScheming> typographyScheme = scheme.typographyScheme;
@@ -37,7 +40,10 @@ static const CGFloat kCornerRadius = 4;
     typographyScheme =
         [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
   }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [MDCAlertTypographyThemer applyTypographyScheme:typographyScheme toAlertController:self];
+#pragma clang diagnostic pop
 
   // Other properties
   self.cornerRadius = kCornerRadius;

--- a/components/Dialogs/src/Theming/MDCAlertController+MaterialTheming.m
+++ b/components/Dialogs/src/Theming/MDCAlertController+MaterialTheming.m
@@ -31,6 +31,8 @@ static const CGFloat kCornerRadius = 4;
   }
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  // TODO(https://github.com/material-components/material-components-ios/issues/6566 ): Inline the
+  // theming code
   [MDCAlertColorThemer applySemanticColorScheme:colorScheme toAlertController:self];
 #pragma clang diagnostic pop
 
@@ -42,6 +44,8 @@ static const CGFloat kCornerRadius = 4;
   }
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  // TODO(https://github.com/material-components/material-components-ios/issues/6566 ): Inline the
+  // theming code
   [MDCAlertTypographyThemer applyTypographyScheme:typographyScheme toAlertController:self];
 #pragma clang diagnostic pop
 

--- a/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.h
+++ b/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.h
@@ -20,8 +20,8 @@
 /**
  The Material Design typography system's themer for instances of MDCAlertController.
  */
-__deprecated_msg("Please use MaterialDialogs+Theming.") @interface MDCAlertTypographyThemer :
-    NSObject
+__deprecated_msg("Please use MaterialDialogs+Theming.") @interface MDCAlertTypographyThemer
+    : NSObject
 
 /**
  Applies a typography scheme's properties to an MDCAlertController.

--- a/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.h
+++ b/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.h
@@ -20,7 +20,8 @@
 /**
  The Material Design typography system's themer for instances of MDCAlertController.
  */
-@interface MDCAlertTypographyThemer : NSObject
+__deprecated_msg("Please use MaterialDialogs+Theming.") @interface MDCAlertTypographyThemer :
+    NSObject
 
 /**
  Applies a typography scheme's properties to an MDCAlertController.

--- a/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.m
+++ b/components/Dialogs/src/TypographyThemer/MDCAlertTypographyThemer.m
@@ -18,7 +18,10 @@
 #import "MaterialButtons+TypographyThemer.h"
 #import "MaterialTypography.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation MDCAlertTypographyThemer
+#pragma clang diagnostic pop
 
 + (void)applyTypographyScheme:(nonnull id<MDCTypographyScheming>)typographyScheme
             toAlertController:(nonnull MDCAlertController *)alertController {


### PR DESCRIPTION
Theming extensions and Container Schemes are now in Beta. In an upcoming
release, the Themers and AlertScheme will be deprecated for Dialogs.
Clients should prefer to use theming extensions instead. Please see the
Dialogs README.md for details on how to use theming extensions.

Part of #6566
