### PR TITLE
[Dialogs] Remove internal usage of Themers.

### DIFF
--- a/components/Dialogs/src/Theming/MDCAlertController+MaterialTheming.m
+++ b/components/Dialogs/src/Theming/MDCAlertController+MaterialTheming.m
@@ -24,30 +24,10 @@ static const CGFloat kCornerRadius = 4;
 
 - (void)applyThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme {
   // Color
-  id<MDCColorScheming> colorScheme = scheme.colorScheme;
-  if (!colorScheme) {
-    colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  }
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  // TODO(https://github.com/material-components/material-components-ios/issues/6566 ): Inline the
-  // theming code
-  [MDCAlertColorThemer applySemanticColorScheme:colorScheme toAlertController:self];
-#pragma clang diagnostic pop
+  [self applyColorThemeWithScheme:scheme.colorScheme];
 
   // Typography
-  id<MDCTypographyScheming> typographyScheme = scheme.typographyScheme;
-  if (!typographyScheme) {
-    typographyScheme =
-        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
-  }
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  // TODO(https://github.com/material-components/material-components-ios/issues/6566 ): Inline the
-  // theming code
-  [MDCAlertTypographyThemer applyTypographyScheme:typographyScheme toAlertController:self];
-#pragma clang diagnostic pop
+  [self applyTypographyThemeWithScheme:scheme.typographyScheme];
 
   // Other properties
   self.cornerRadius = kCornerRadius;
@@ -70,6 +50,28 @@ static const CGFloat kCornerRadius = 4;
         break;
     }
   }
+}
+
+- (void)applyTypographyThemeWithScheme:(id<MDCTypographyScheming>)typographyScheme {
+  if (!typographyScheme) {
+    typographyScheme =
+    [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+  }
+  self.titleFont = typographyScheme.headline6;
+  self.messageFont = typographyScheme.body1;
+}
+
+- (void)applyColorThemeWithScheme:(id<MDCColorScheming>)colorScheme {
+  if (!colorScheme) {
+    colorScheme =
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+
+  self.titleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
+  self.messageColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+  self.titleIconTintColor = colorScheme.primaryColor;
+  self.scrimColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.32];
+  self.backgroundColor = colorScheme.surfaceColor;
 }
 
 @end

--- a/components/Dialogs/src/Theming/MDCAlertController+MaterialTheming.m
+++ b/components/Dialogs/src/Theming/MDCAlertController+MaterialTheming.m
@@ -55,7 +55,7 @@ static const CGFloat kCornerRadius = 4;
 - (void)applyTypographyThemeWithScheme:(id<MDCTypographyScheming>)typographyScheme {
   if (!typographyScheme) {
     typographyScheme =
-    [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
   }
   self.titleFont = typographyScheme.headline6;
   self.messageFont = typographyScheme.body1;
@@ -64,7 +64,7 @@ static const CGFloat kCornerRadius = 4;
 - (void)applyColorThemeWithScheme:(id<MDCColorScheming>)colorScheme {
   if (!colorScheme) {
     colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   }
 
   self.titleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];


### PR DESCRIPTION
Dialogs Theming Extensions should not use the Themers since they are
deprecated and expected to be deleted. Instead, the appropriate themer
code can be inlined and independently applied.

Part of #6565