### PR TITLE
{kokoro} Fix develop

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -16,6 +16,7 @@
 
 # Fail on any error
 set -e
+KOKORO_VERSION="1.5.3"
 
 if [ -n "$KOKORO_BUILD_NUMBER" ]; then
   repo_dir='github/repo'
@@ -386,7 +387,9 @@ run_cocoapods() {
     # Move into our cloned repo
     cd github/repo
 
-    gem_install xcpretty cocoapods
+    gem_install xcpretty 
+    # TODO(https://github.com/material-components/material-components-ios/issues/6356 ): Move to 1.6
+    gem install cocoapods -v "$KOKORO_VERSION"
     pod --version
 
     # Install git-lfs

--- a/.kokoro
+++ b/.kokoro
@@ -16,7 +16,7 @@
 
 # Fail on any error
 set -e
-KOKORO_VERSION="1.5.3"
+COCOAPODS_VERSION="1.5.3"
 
 if [ -n "$KOKORO_BUILD_NUMBER" ]; then
   repo_dir='github/repo'
@@ -389,7 +389,7 @@ run_cocoapods() {
 
     gem_install xcpretty 
     # TODO(https://github.com/material-components/material-components-ios/issues/6356 ): Move to 1.6
-    gem install cocoapods -v "$KOKORO_VERSION"
+    gem install cocoapods -v "$COCOAPODS_VERSION"
     pod --version
 
     # Install git-lfs

--- a/components/BottomSheet/tests/unit/BottomSheetShapeThemerTests.swift
+++ b/components/BottomSheet/tests/unit/BottomSheetShapeThemerTests.swift
@@ -15,6 +15,7 @@
 import XCTest
 import MaterialComponents.MaterialBottomSheet
 import MaterialComponents.MaterialBottomSheet_ShapeThemer
+import MaterialComponents.MaterialShapeLibrary
 
 class BottomSheetShapeThemerTests: XCTestCase {
 

--- a/components/Cards/tests/unit/MDCCardShapeThemerTests.swift
+++ b/components/Cards/tests/unit/MDCCardShapeThemerTests.swift
@@ -15,6 +15,7 @@
 import XCTest
 import MaterialComponents.MaterialCards
 import MaterialComponents.MaterialCards_ShapeThemer
+import MaterialComponents.MaterialShapeLibrary
 
 class CardShapeThemerTests: XCTestCase {
 

--- a/components/Cards/tests/unit/Theming/CardsMaterialThemingTests.swift
+++ b/components/Cards/tests/unit/Theming/CardsMaterialThemingTests.swift
@@ -16,6 +16,7 @@ import XCTest
 
 import MaterialComponents.MaterialCards
 import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialShapeLibrary
 import MaterialComponents.MaterialShapeScheme
 import MaterialComponentsBeta.MaterialCards_Theming
 import MaterialComponentsBeta.MaterialContainerScheme


### PR DESCRIPTION
Fixes the `develop` branch by:
* Pinning kokoro to CocoaPods 1.5.3
* Restoring missing imports causing bazel builds to fail.

Closes #6574
Related to #6356