### PR TITLE
{WIP} A new [ChipTextField] component in alpha (un-reverted)

### DIFF
--- a/components/ChipTextField/examples/ChipTextFieldExampleViewController.swift
+++ b/components/ChipTextField/examples/ChipTextFieldExampleViewController.swift
@@ -1,0 +1,128 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+class ChipTextFieldExampleViewController: UIViewController {
+
+  let chipTextField = MDCChipTextField()
+  let chipInputController: MDCTextInputControllerOutlined
+  let textField = MDCTextField()
+  let inputController: MDCTextInputControllerOutlined
+  let resignButton = MDCButton()
+
+  override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    chipInputController = MDCTextInputControllerOutlined(textInput: chipTextField)
+    chipInputController.placeholderText = "With Chips"
+    inputController = MDCTextInputControllerOutlined(textInput: textField)
+    inputController.placeholderText = "Regular MDCTextField"
+    super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.view.backgroundColor = UIColor.white
+
+    setupExample()
+  }
+
+  func setupExample() {
+    chipTextField.translatesAutoresizingMaskIntoConstraints = false
+    chipTextField.backgroundColor = .white
+    chipTextField.delegate = self
+
+    // when on, enter responds to auto-correction which is confusing when we're trying to create "chips"
+    chipTextField.autocorrectionType = UITextAutocorrectionType.no
+    view.addSubview(chipTextField)
+
+    // position the textfield somewhere in the screen
+    if #available(iOSApplicationExtension 11.0, *) {
+      let guide = view.safeAreaLayoutGuide
+      chipTextField.leadingAnchor.constraint(equalTo: guide.leadingAnchor, constant: 20.0).isActive = true
+      chipTextField.trailingAnchor.constraint(equalTo: guide.trailingAnchor, constant: -20.0).isActive = true
+      chipTextField.topAnchor.constraint(equalTo: guide.topAnchor, constant: 40.0).isActive = true
+    } else if #available(iOSApplicationExtension 9.0, *) {
+      chipTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20.0).isActive = true
+      chipTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20.0).isActive = true
+      chipTextField.topAnchor.constraint(equalTo: view.topAnchor, constant: 40.0).isActive = true
+    } else {
+      // Fallback on earlier versions
+      print("This example is supported on iOS version 9 or later.")
+    }
+
+    textField.translatesAutoresizingMaskIntoConstraints = false
+    textField.backgroundColor = .white
+    view.addSubview(textField)
+
+    // position the textfield somewhere in the screen
+    if #available(iOSApplicationExtension 11.0, *) {
+      let guide = view.safeAreaLayoutGuide
+      textField.leadingAnchor.constraint(equalTo: guide.leadingAnchor, constant: 20.0).isActive = true
+      textField.trailingAnchor.constraint(equalTo: guide.trailingAnchor, constant: -20.0).isActive = true
+      textField.topAnchor.constraint(equalTo: chipTextField.bottomAnchor, constant: 20.0).isActive = true
+    } else if #available(iOSApplicationExtension 9.0, *) {
+      textField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20.0).isActive = true
+      textField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20.0).isActive = true
+      textField.topAnchor.constraint(equalTo: chipTextField.bottomAnchor, constant: 20.0).isActive = true
+    } else {
+      // Fallback on earlier versions
+      print("This example is supported on iOS version 9 or later.")
+    }
+
+    resignButton.setTitle("Resign", for: .normal)
+    resignButton.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(resignButton)
+
+    resignButton.applyContainedTheme(withScheme: MDCContainerScheme())
+    resignButton.addTarget(self, action: #selector(resignTapped), for: .touchUpInside)
+
+    if #available(iOSApplicationExtension 9.0, *) {
+      resignButton.leadingAnchor.constraint(equalTo: textField.leadingAnchor).isActive = true
+      resignButton.topAnchor.constraint(equalTo: textField.bottomAnchor, constant: 20.0).isActive = true
+    }
+  }
+
+  @objc func resignTapped(_ sender: Any) {
+    chipTextField.resignFirstResponder()
+    textField.resignFirstResponder()
+  }
+}
+
+extension ChipTextFieldExampleViewController: UITextFieldDelegate {
+
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    if let chipTextField = textField as? MDCChipTextField,
+      let chipText = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+      chipText.count > 0 {
+      chipTextField.appendChip(text: chipText)
+      chipTextField.text = ""
+    }
+    return true
+  }
+}
+
+extension ChipTextFieldExampleViewController {
+
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Chip Text Field", "A Chip Text Field"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
+  }
+}

--- a/components/ChipTextField/examples/MDCChipTextField.h
+++ b/components/ChipTextField/examples/MDCChipTextField.h
@@ -1,0 +1,48 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCTextField.h"
+
+/*
+ MDCChipTextField is a sublcass of MDCTextField which is a subclass of UITextField.
+ MDCChipTextField adds chip support to MDCTextField, including adding and removing chips
+    and default layout and scrolling support, as specified by the
+    [Material Guidelines](https://material.io/design/components/chips.html#input-chips).
+*/
+@interface MDCChipTextField : MDCTextField
+
+/*
+ Appends a chip to the end of the text field.
+
+ To add a chip when hitting the enter key, set a UITextFieldDelegate to the MDCChipTextField
+ instance, and listen to the enter key event. Once detected, you can add a chip with the content
+ of the text field. Alternatively, you may present a list of options to select from and later
+ add a chip with the selected text.
+
+ Example:
+
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    if let chipTextField = textField as? MDCChipTextField,
+       let chipText = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+       chipText.count > 0 {
+       chipTextField.appendChip(text: chipText) chipTextField.text = ""
+    }
+    return true
+  }
+
+ @param text The string to display in the chip.
+ */
+- (void)appendChipWithText:(nonnull NSString *)text NS_SWIFT_NAME(appendChip(text:));
+
+@end

--- a/components/ChipTextField/examples/MDCChipTextField.m
+++ b/components/ChipTextField/examples/MDCChipTextField.m
@@ -1,0 +1,229 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCChipTextField.h"
+#import "MaterialChips.h"
+
+@interface MDCChipTextField ()
+
+@property(nonatomic, strong) UIView *chipsView;
+@property(nonatomic) CGFloat insetX;
+@property(nonatomic, strong) NSLayoutConstraint *leadingConstraint;
+@property(nonatomic, strong) NSMutableArray<MDCChipView *> *chips;
+
+@end
+
+@implementation MDCChipTextField
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+  if (self) {
+    _chipsView = [[UIView alloc] initWithFrame:CGRectZero];
+    _chipsView.translatesAutoresizingMaskIntoConstraints = NO;
+    _chipsView.clipsToBounds = YES;
+    self.leftView = _chipsView;
+
+    [self addTarget:self
+                  action:@selector(chipTextFieldTextDidChange)
+        forControlEvents:UIControlEventEditingChanged];
+
+    _chips = [NSMutableArray array];
+  }
+  return self;
+}
+
+- (void)appendChipWithText:(NSString *)text {
+  MDCChipView *chip = [[MDCChipView alloc] init];
+  chip.titleLabel.text = text;
+  chip.translatesAutoresizingMaskIntoConstraints = NO;
+
+  [self.chipsView addSubview:chip];
+
+  // Constraints
+  [self.chipsView addConstraints:@[
+    [NSLayoutConstraint constraintWithItem:self.chipsView
+                                 attribute:NSLayoutAttributeTop
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:chip
+                                 attribute:NSLayoutAttributeTop
+                                multiplier:1.0
+                                  constant:0.0],
+    [NSLayoutConstraint constraintWithItem:self.chipsView
+                                 attribute:NSLayoutAttributeBottom
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:chip
+                                 attribute:NSLayoutAttributeBottom
+                                multiplier:1.0
+                                  constant:0.0]
+  ]];
+
+  MDCChipView *lastChip = [self.chips lastObject];
+  if (lastChip == nil) {
+    self.leadingConstraint = [NSLayoutConstraint constraintWithItem:self.chipsView
+                                                          attribute:NSLayoutAttributeLeading
+                                                          relatedBy:NSLayoutRelationEqual
+                                                             toItem:chip
+                                                          attribute:NSLayoutAttributeLeading
+                                                         multiplier:1.0
+                                                           constant:0];
+    [self.chipsView addConstraint:self.leadingConstraint];
+  } else {
+    [self.chipsView addConstraint:[NSLayoutConstraint constraintWithItem:lastChip
+                                                               attribute:NSLayoutAttributeTrailing
+                                                               relatedBy:NSLayoutRelationEqual
+                                                                  toItem:chip
+                                                               attribute:NSLayoutAttributeLeading
+                                                              multiplier:1.0
+                                                                constant:0]];
+  }
+
+  // recalculate the layout to get a correct chip frame values
+  [self.chipsView layoutIfNeeded];
+  self.insetX = CGRectGetMaxX(chip.frame);
+  [self.chips addObject:chip];
+
+  self.leftViewMode = UITextFieldViewModeAlways;
+}
+
+- (void)chipTextFieldTextDidChange {
+  [self deselectAllChips];
+  [self setupEditingRect];
+}
+
+- (void)setupEditingRect {
+  CGRect textRect = [self textRectForBounds:self.bounds];
+  UITextRange *textRange = [self textRangeFromPosition:self.beginningOfDocument
+                                            toPosition:self.endOfDocument];
+  CGRect inputRect = [self firstRectForRange:textRange];
+
+  CGFloat space = textRect.size.width - inputRect.size.width;
+  if (space < 0 || self.leadingConstraint.constant > 0) {
+    self.insetX += space;
+    self.leadingConstraint.constant -= space;
+  }
+}
+
+#pragma mark - UITextField overrides
+
+- (BOOL)shouldChangeTextInRange:(UITextRange *)range replacementText:(NSString *)text {
+  return [super shouldChangeTextInRange:range replacementText:text];
+}
+
+- (void)deleteBackward {
+  NSInteger cursorPosition = [self offsetFromPosition:self.beginningOfDocument
+                                           toPosition:self.selectedTextRange.start];
+  if (cursorPosition == 0) {
+    [self respondToDeleteBackward];
+  }
+  [super deleteBackward];
+}
+
+- (CGRect)textRectForBounds:(CGRect)bounds {
+  CGRect textRect = [super textRectForBounds:bounds];
+  textRect.origin.x = MAX(self.insetX, textRect.origin.x);
+  return textRect;
+}
+
+- (CGRect)editingRectForBounds:(CGRect)bounds {
+  CGRect editingRect = [super editingRectForBounds:bounds];
+  editingRect.origin.x = MAX(self.insetX, editingRect.origin.x);
+  return editingRect;
+}
+
+- (CGRect)leftViewRectForBounds:(CGRect)bounds {
+  CGRect leftViewRect = [super leftViewRectForBounds:bounds];
+  leftViewRect.size.width = MAX(self.insetX, leftViewRect.size.width);
+  return leftViewRect;
+}
+
+- (CGRect)rightViewRectForBounds:(CGRect)bounds {
+  CGRect viewRect = [super rightViewRectForBounds:bounds];
+  viewRect.size.width = MAX(self.insetX, viewRect.size.width);
+  return viewRect;
+}
+
+#pragma mark - Deletion
+
+- (void)deselectAllChipsExceptChip:(MDCChipView *)chip {
+  for (MDCChipView *otherChip in self.chips) {
+    if (chip != otherChip) {
+      otherChip.selected = NO;
+    }
+  }
+}
+
+- (void)selectLastChip {
+  MDCChipView *lastChip = self.chips.lastObject;
+  [self deselectAllChipsExceptChip:lastChip];
+  lastChip.selected = YES;
+  UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
+                                  [lastChip accessibilityLabel]);
+}
+
+- (void)deselectAllChips {
+  [self deselectAllChipsExceptChip:nil];
+}
+
+- (void)removeChip:(MDCChipView *)chip {
+  [self.chips removeObject:chip];
+  [chip removeFromSuperview];
+
+  MDCChipView *lastChip = [self.chips lastObject];
+  self.insetX = CGRectGetMaxX(lastChip.frame) + 10;
+
+  CGFloat textFieldWidth = CGRectGetWidth([self textRectForBounds:self.bounds]);
+  if (self.leadingConstraint.constant > 0 && textFieldWidth > 0) {
+    self.insetX += textFieldWidth;
+    self.leadingConstraint.constant -= textFieldWidth;
+  }
+
+  [self invalidateIntrinsicContentSize];
+  [self setNeedsLayout];
+
+  if (self.chips.count == 0) {
+    self.leftViewMode = UITextFieldViewModeNever;
+  }
+}
+
+- (void)removeSelectedChips {
+  NSMutableArray *chipsToRemove = [NSMutableArray array];
+  for (MDCChipView *chip in self.chips) {
+    if (chip.isSelected) {
+      [chipsToRemove addObject:chip];
+    }
+  }
+  for (MDCChipView *chip in chipsToRemove) {
+    [self removeChip:chip];
+  }
+}
+
+- (BOOL)isAnyChipSelected {
+  for (MDCChipView *chip in self.chips) {
+    if (chip.isSelected) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
+- (void)respondToDeleteBackward {
+  if ([self isAnyChipSelected]) {
+    [self removeSelectedChips];
+    [self deselectAllChips];
+  } else {
+    [self selectLastChip];
+  }
+}
+
+@end

--- a/components/ChipTextField/examples/UITextFieldWithChipsExample.swift
+++ b/components/ChipTextField/examples/UITextFieldWithChipsExample.swift
@@ -1,0 +1,265 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+class UITextFieldWithChipsExample: UIViewController {
+
+  fileprivate let textField = InsetTextField()
+  private var leftView = UIView()
+  fileprivate var leadingConstraint: NSLayoutConstraint?
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    self.view.backgroundColor = UIColor.white
+
+    setupExample()
+    additionalTextField()
+
+    // this fixes the issue of the cursor becoming half size when the field is empty
+    DispatchQueue.main.async {
+      self.textField.becomeFirstResponder()
+    }
+  }
+
+  private func setupExample() {
+
+    textField.translatesAutoresizingMaskIntoConstraints = false
+    textField.backgroundColor = UIColor.black.withAlphaComponent(0.05)
+    textField.layer.borderWidth = 1.0
+    textField.layer.borderColor = UIColor.black.cgColor
+    textField.textColor = .darkGray
+    textField.text = "With Chips (Hit Enter)"
+
+    // when on, enter responds to auto-correction which is confusing when we're trying to create "chips"
+    textField.autocorrectionType = UITextAutocorrectionType.no
+
+    textField.delegate = self
+
+    textField.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged)
+
+    view.addSubview(textField)
+
+    // position the textfield somewhere in the screen
+    if #available(iOSApplicationExtension 11.0, *) {
+      let guide = view.safeAreaLayoutGuide
+      textField.leadingAnchor.constraint(equalTo: guide.leadingAnchor, constant: 20.0).isActive = true
+      textField.trailingAnchor.constraint(equalTo: guide.trailingAnchor, constant: -20.0).isActive = true
+      textField.topAnchor.constraint(equalTo: guide.topAnchor, constant: 40.0).isActive = true
+    } else if #available(iOSApplicationExtension 9.0, *) {
+      textField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20.0).isActive = true
+      textField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20.0).isActive = true
+      textField.topAnchor.constraint(equalTo: view.topAnchor, constant: 40.0).isActive = true
+    } else {
+      // Fallback on earlier versions
+      print("This example is supported on iOS version 9 or later.")
+    }
+
+    leftView.translatesAutoresizingMaskIntoConstraints = false
+    leftView.backgroundColor = UIColor.yellow.withAlphaComponent(0.5)
+
+    leftView.clipsToBounds = true
+    textField.leftView = leftView
+    textField.leftViewMode = .always
+  }
+
+  private func additionalTextField() {
+    let additionalTextField = PlainTextField()
+    additionalTextField.translatesAutoresizingMaskIntoConstraints = false
+    additionalTextField.backgroundColor = UIColor.black.withAlphaComponent(0.05)
+    additionalTextField.layer.borderWidth = 1.0
+    additionalTextField.layer.borderColor = UIColor.black.cgColor
+    additionalTextField.textColor = .darkGray
+    additionalTextField.text = "Regular UITextfield"
+
+    // when on, enter responds to auto-correction which is confusing when we're trying to create "chips"
+    additionalTextField.autocorrectionType = UITextAutocorrectionType.no
+
+    view.addSubview(additionalTextField)
+
+    // position the textfield somewhere in the screen
+    if #available(iOSApplicationExtension 9.0, *) {
+      additionalTextField.leadingAnchor.constraint(equalTo: textField.leadingAnchor).isActive = true
+      additionalTextField.trailingAnchor.constraint(equalTo: textField.trailingAnchor).isActive = true
+      additionalTextField.topAnchor.constraint(equalTo: textField.topAnchor, constant: 60.0).isActive = true
+    } else {
+      // Fallback on earlier versions
+      print("This example is supported on iOS version 9 or later.")
+    }
+  }
+
+  fileprivate func appendLabel(text: String) {
+
+    let pad: CGFloat = 5.0
+
+    // create label and add to left view
+    let label = newLabel(text: text)
+    let lastLabel = leftView.subviews.last
+    leftView.addSubview(label)
+
+    // add constraints
+    if #available(iOSApplicationExtension 9.0, *) {
+      label.topAnchor.constraint(equalTo: leftView.topAnchor).isActive = true
+      label.bottomAnchor.constraint(equalTo: leftView.bottomAnchor).isActive = true
+      if let lastLabel = lastLabel {
+        label.leadingAnchor.constraint(equalTo: lastLabel.trailingAnchor, constant: pad).isActive = true
+        //label.leadingAnchor.constraint(equalTo: lastLabel.trailingAnchor, constant: pad).isActive = true
+        //lastmax = lastLabel.frame.maxX
+      } else {
+        leadingConstraint = label.leadingAnchor.constraint(equalTo: leftView.leadingAnchor)
+        leadingConstraint?.priority = UILayoutPriorityDefaultLow
+        leadingConstraint?.isActive = true
+      }
+    } else {
+      // Fallback on earlier versions
+      print("This example is supported on iOS version 9 or later.")
+    }
+
+    // adjust text field's inset and width
+    leftView.layoutIfNeeded()
+    textField.insetX = label.frame.maxX
+  }
+
+  private func newLabel(text: String) -> UILabel {
+    // create label and add to left view
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.backgroundColor = UIColor.red.withAlphaComponent(0.4)
+    label.text = " " + text + " "
+    label.textColor = .white
+    label.layer.cornerRadius = 3.0
+    label.layer.masksToBounds = true
+    return label
+  }
+}
+
+// MARK: Example Extensions
+
+extension UITextFieldWithChipsExample: UITextFieldDelegate {
+
+  // listen to "enter" key
+  func textField(_ textField: UITextField,
+                 shouldChangeCharactersIn range: NSRange,
+                 replacementString string: String) -> Bool {
+    if string == "\n" {
+      if let trimmedText = textField.text?.trimmingCharacters(in: .whitespaces),
+        trimmedText.count > 0 {
+        appendLabel(text: trimmedText)
+        textField.text = ""
+      }
+    }
+    return true
+  }
+
+  func setupEditingRect(string: String) {
+
+    let textrect = textField.textRect(forBounds: textField.bounds)
+    let insetTextField = textField as InsetTextField
+    if let textrange = textField.textRange(from: textField.beginningOfDocument, to: textField.endOfDocument) {
+      let firstrect = textField.firstRect(for: textrange)
+
+      // if space is too small for typing, we need to make more room - by moving the split point
+      let textWidth = firstrect.width
+      let fieldWidth = textrect.width
+      let space = fieldWidth - textWidth
+      if space < 0 {
+        insetTextField.insetX += space
+        if let leadingConstraint = leadingConstraint {
+          //leftView.removeConstraint(leadingConstraint)
+          leadingConstraint.constant += space
+        }
+        insetTextField.layoutIfNeeded()
+      }
+
+    }
+  }
+
+  @objc func textFieldDidChange(_ textField: UITextField) {
+    setupEditingRect(string: textField.text ?? "")
+  }
+}
+
+extension UITextFieldWithChipsExample {
+  override var preferredStatusBarStyle: UIStatusBarStyle {
+    return .lightContent
+  }
+}
+
+extension UITextFieldWithChipsExample {
+
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Chip Text Field", "UI Text Fields With Label Chips"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
+  }
+}
+
+// MARK: UITextField Subclass
+
+private class InsetTextField: UITextField {
+
+  // the split point: this is the x position where chips view ends and text begins.
+  // Updating this property moves the split point between chips & text.
+  var insetX: CGFloat = 8.0
+
+  // default padding for the textfield, taking insetX into account for the left position
+  let insetRect = UIEdgeInsets(top: 5.0, left: 8.0, bottom: 5.0, right: 8.0)
+
+  // text bounds
+  override func textRect(forBounds bounds: CGRect) -> CGRect {
+    let superbounds = super.textRect(forBounds: bounds)
+    var newbounds = UIEdgeInsetsInsetRect(superbounds, insetRect)
+    newbounds.origin.x = insetX
+    return newbounds
+  }
+
+  // text bounds while editing
+  override func editingRect(forBounds bounds: CGRect) -> CGRect {
+    let superbounds = super.editingRect(forBounds: bounds)
+    var newbounds = UIEdgeInsetsInsetRect(superbounds, insetRect)
+    newbounds.origin.x = insetX
+    return newbounds
+  }
+
+  // left view bounds
+  override func leftViewRect(forBounds bounds: CGRect) -> CGRect {
+    let superbounds = super.leftViewRect(forBounds: bounds)
+    var newbounds = superbounds
+    newbounds.size.width = insetX
+    return newbounds
+  }
+}
+
+class PlainTextField: UITextField {
+
+  // default padding for the textfield, taking insetX into account for the left position
+  let insetRect = UIEdgeInsets(top: 5.0, left: 8.0, bottom: 5.0, right: 8.0)
+
+  // text bounds
+  override func textRect(forBounds bounds: CGRect) -> CGRect {
+    let superbounds = super.textRect(forBounds: bounds)
+    let newbounds = UIEdgeInsetsInsetRect(superbounds, insetRect)
+    return newbounds
+  }
+
+  // text bounds while editing
+  override func editingRect(forBounds bounds: CGRect) -> CGRect {
+    let superbounds = super.editingRect(forBounds: bounds)
+    let newbounds = UIEdgeInsetsInsetRect(superbounds, insetRect)
+    return newbounds
+  }
+}


### PR DESCRIPTION
Duplicate of: #6623 (Submitted)

Reverting reverted (#6035)
This reverts commit b7ed9ca3ceade89c1b3ca393ba207d3d29c055df.

### Goal

Adding Chips support to Text Fields. 

### Description

MDCChipTextField is a MDCTextField subclass, which is a UITextField subclass.
It supports adding and removing chips, by typing or pressing the delete button.  Enabling scrolling of the Chips and the remaining alignment issues will be resolved in followup PRs. 

MDCChipTextField is added as an Alpha component.

### MDCChipTextField API

```
- (void)appendChipWithText:(nonnull NSString *)text;
```

Note that it is the responsibility of the client to determine when chips are added, and the text they display.  

### Issues

b/118378923: Add support for Chips [Epic]
b/117178827:  [TextFields] Append chips from within TextField
b/117178109: [TextFields] Support deletion of Chips using the keyboard
#4286: [Story] As a user, I want to append a Chip to a Text Field so that I can organize my inputs.

### Followup work

b/117178177: [TextFields] Align Chips to the baseline of the typed text.

### Screenshots

![first chip text](https://user-images.githubusercontent.com/2329102/50109930-0eedc180-0207-11e9-862f-15230d06dd30.png)
![first chip chip](https://user-images.githubusercontent.com/2329102/50109931-0f865800-0207-11e9-97c5-e72e19730e10.png)
![second chip text](https://user-images.githubusercontent.com/2329102/50109932-0f865800-0207-11e9-91e7-615fd914c0a1.png)
![second chip chip](https://user-images.githubusercontent.com/2329102/50109934-0f865800-0207-11e9-96e3-7922b6970740.png)
