### PR TITLE
[WIP] [ChipTextField] Use MDCChipTextFieldScrollView to replace leftView functionality for flexibility and extensibility

### DIFF
--- a/components/ChipTextField/examples/ChipTextFieldExampleViewController.swift
+++ b/components/ChipTextField/examples/ChipTextFieldExampleViewController.swift
@@ -1,0 +1,128 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+class ChipTextFieldExampleViewController: UIViewController {
+
+  let chipTextField = MDCChipTextField()
+  let chipInputController: MDCTextInputControllerOutlined
+  let textField = MDCTextField()
+  let inputController: MDCTextInputControllerOutlined
+  let resignButton = MDCButton()
+
+  override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    chipInputController = MDCTextInputControllerOutlined(textInput: chipTextField)
+    chipInputController.placeholderText = "With Chips"
+    inputController = MDCTextInputControllerOutlined(textInput: textField)
+    inputController.placeholderText = "Regular MDCTextField"
+    super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.view.backgroundColor = UIColor.white
+
+    setupExample()
+  }
+
+  func setupExample() {
+    chipTextField.translatesAutoresizingMaskIntoConstraints = false
+    chipTextField.backgroundColor = .white
+    chipTextField.delegate = self
+
+    // when on, enter responds to auto-correction which is confusing when we're trying to create "chips"
+    chipTextField.autocorrectionType = UITextAutocorrectionType.no
+    view.addSubview(chipTextField)
+
+    // position the textfield somewhere in the screen
+    if #available(iOSApplicationExtension 11.0, *) {
+      let guide = view.safeAreaLayoutGuide
+      chipTextField.leadingAnchor.constraint(equalTo: guide.leadingAnchor, constant: 20.0).isActive = true
+      chipTextField.trailingAnchor.constraint(equalTo: guide.trailingAnchor, constant: -20.0).isActive = true
+      chipTextField.topAnchor.constraint(equalTo: guide.topAnchor, constant: 40.0).isActive = true
+    } else if #available(iOSApplicationExtension 9.0, *) {
+      chipTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20.0).isActive = true
+      chipTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20.0).isActive = true
+      chipTextField.topAnchor.constraint(equalTo: view.topAnchor, constant: 40.0).isActive = true
+    } else {
+      // Fallback on earlier versions
+      print("This example is supported on iOS version 9 or later.")
+    }
+
+    textField.translatesAutoresizingMaskIntoConstraints = false
+    textField.backgroundColor = .white
+    view.addSubview(textField)
+
+    // position the textfield somewhere in the screen
+    if #available(iOSApplicationExtension 11.0, *) {
+      let guide = view.safeAreaLayoutGuide
+      textField.leadingAnchor.constraint(equalTo: guide.leadingAnchor, constant: 20.0).isActive = true
+      textField.trailingAnchor.constraint(equalTo: guide.trailingAnchor, constant: -20.0).isActive = true
+      textField.topAnchor.constraint(equalTo: chipTextField.bottomAnchor, constant: 20.0).isActive = true
+    } else if #available(iOSApplicationExtension 9.0, *) {
+      textField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20.0).isActive = true
+      textField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20.0).isActive = true
+      textField.topAnchor.constraint(equalTo: chipTextField.bottomAnchor, constant: 20.0).isActive = true
+    } else {
+      // Fallback on earlier versions
+      print("This example is supported on iOS version 9 or later.")
+    }
+
+    resignButton.setTitle("Resign", for: .normal)
+    resignButton.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(resignButton)
+
+    resignButton.applyContainedTheme(withScheme: MDCContainerScheme())
+    resignButton.addTarget(self, action: #selector(resignTapped), for: .touchUpInside)
+
+    if #available(iOSApplicationExtension 9.0, *) {
+      resignButton.leadingAnchor.constraint(equalTo: textField.leadingAnchor).isActive = true
+      resignButton.topAnchor.constraint(equalTo: textField.bottomAnchor, constant: 20.0).isActive = true
+    }
+  }
+
+  @objc func resignTapped(_ sender: Any) {
+    chipTextField.resignFirstResponder()
+    textField.resignFirstResponder()
+  }
+}
+
+extension ChipTextFieldExampleViewController: UITextFieldDelegate {
+
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    if let chipTextField = textField as? MDCChipTextField,
+      let chipText = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+      chipText.count > 0 {
+      chipTextField.appendChip(text: chipText)
+      chipTextField.text = ""
+    }
+    return true
+  }
+}
+
+extension ChipTextFieldExampleViewController {
+
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Chip Text Field", "A Chip Text Field"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
+  }
+}

--- a/components/ChipTextField/examples/MDCChipTextField.h
+++ b/components/ChipTextField/examples/MDCChipTextField.h
@@ -1,0 +1,48 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCTextField.h"
+
+/*
+ MDCChipTextField is a sublcass of MDCTextField which is a subclass of UITextField.
+ MDCChipTextField adds chip support to MDCTextField, including adding and removing chips
+    and default layout and scrolling support, as specified by the
+    [Material Guidelines](https://material.io/design/components/chips.html#input-chips).
+*/
+@interface MDCChipTextField : MDCTextField
+
+/*
+ Appends a chip to the end of the text field.
+
+ To add a chip when hitting the enter key, set a UITextFieldDelegate to the MDCChipTextField
+ instance, and listen to the enter key event. Once detected, you can add a chip with the content
+ of the text field. Alternatively, you may present a list of options to select from and later
+ add a chip with the selected text.
+
+ Example:
+
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    if let chipTextField = textField as? MDCChipTextField,
+       let chipText = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+       chipText.count > 0 {
+       chipTextField.appendChip(text: chipText) chipTextField.text = ""
+    }
+    return true
+  }
+
+ @param text The string to display in the chip.
+ */
+- (void)appendChipWithText:(nonnull NSString *)text NS_SWIFT_NAME(appendChip(text:));
+
+@end

--- a/components/ChipTextField/examples/MDCChipTextField.m
+++ b/components/ChipTextField/examples/MDCChipTextField.m
@@ -1,0 +1,229 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCChipTextField.h"
+#import "MaterialChips.h"
+
+@interface MDCChipTextField ()
+
+@property(nonatomic, strong) UIView *chipsView;
+@property(nonatomic) CGFloat insetX;
+@property(nonatomic, strong) NSLayoutConstraint *leadingConstraint;
+@property(nonatomic, strong) NSMutableArray<MDCChipView *> *chips;
+
+@end
+
+@implementation MDCChipTextField
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+  if (self) {
+    _chipsView = [[UIView alloc] initWithFrame:CGRectZero];
+    _chipsView.translatesAutoresizingMaskIntoConstraints = NO;
+    _chipsView.clipsToBounds = YES;
+    self.leftView = _chipsView;
+
+    [self addTarget:self
+                  action:@selector(chipTextFieldTextDidChange)
+        forControlEvents:UIControlEventEditingChanged];
+
+    _chips = [NSMutableArray array];
+  }
+  return self;
+}
+
+- (void)appendChipWithText:(NSString *)text {
+  MDCChipView *chip = [[MDCChipView alloc] init];
+  chip.titleLabel.text = text;
+  chip.translatesAutoresizingMaskIntoConstraints = NO;
+
+  [self.chipsView addSubview:chip];
+
+  // Constraints
+  [self.chipsView addConstraints:@[
+    [NSLayoutConstraint constraintWithItem:self.chipsView
+                                 attribute:NSLayoutAttributeTop
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:chip
+                                 attribute:NSLayoutAttributeTop
+                                multiplier:1.0
+                                  constant:0.0],
+    [NSLayoutConstraint constraintWithItem:self.chipsView
+                                 attribute:NSLayoutAttributeBottom
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:chip
+                                 attribute:NSLayoutAttributeBottom
+                                multiplier:1.0
+                                  constant:0.0]
+  ]];
+
+  MDCChipView *lastChip = [self.chips lastObject];
+  if (lastChip == nil) {
+    self.leadingConstraint = [NSLayoutConstraint constraintWithItem:self.chipsView
+                                                          attribute:NSLayoutAttributeLeading
+                                                          relatedBy:NSLayoutRelationEqual
+                                                             toItem:chip
+                                                          attribute:NSLayoutAttributeLeading
+                                                         multiplier:1.0
+                                                           constant:0];
+    [self.chipsView addConstraint:self.leadingConstraint];
+  } else {
+    [self.chipsView addConstraint:[NSLayoutConstraint constraintWithItem:lastChip
+                                                               attribute:NSLayoutAttributeTrailing
+                                                               relatedBy:NSLayoutRelationEqual
+                                                                  toItem:chip
+                                                               attribute:NSLayoutAttributeLeading
+                                                              multiplier:1.0
+                                                                constant:0]];
+  }
+
+  // recalculate the layout to get a correct chip frame values
+  [self.chipsView layoutIfNeeded];
+  self.insetX = CGRectGetMaxX(chip.frame);
+  [self.chips addObject:chip];
+
+  self.leftViewMode = UITextFieldViewModeAlways;
+}
+
+- (void)chipTextFieldTextDidChange {
+  [self deselectAllChips];
+  [self setupEditingRect];
+}
+
+- (void)setupEditingRect {
+  CGRect textRect = [self textRectForBounds:self.bounds];
+  UITextRange *textRange = [self textRangeFromPosition:self.beginningOfDocument
+                                            toPosition:self.endOfDocument];
+  CGRect inputRect = [self firstRectForRange:textRange];
+
+  CGFloat space = textRect.size.width - inputRect.size.width;
+  if (space < 0 || self.leadingConstraint.constant > 0) {
+    self.insetX += space;
+    self.leadingConstraint.constant -= space;
+  }
+}
+
+#pragma mark - UITextField overrides
+
+- (BOOL)shouldChangeTextInRange:(UITextRange *)range replacementText:(NSString *)text {
+  return [super shouldChangeTextInRange:range replacementText:text];
+}
+
+- (void)deleteBackward {
+  NSInteger cursorPosition = [self offsetFromPosition:self.beginningOfDocument
+                                           toPosition:self.selectedTextRange.start];
+  if (cursorPosition == 0) {
+    [self respondToDeleteBackward];
+  }
+  [super deleteBackward];
+}
+
+- (CGRect)textRectForBounds:(CGRect)bounds {
+  CGRect textRect = [super textRectForBounds:bounds];
+  textRect.origin.x = MAX(self.insetX, textRect.origin.x);
+  return textRect;
+}
+
+- (CGRect)editingRectForBounds:(CGRect)bounds {
+  CGRect editingRect = [super editingRectForBounds:bounds];
+  editingRect.origin.x = MAX(self.insetX, editingRect.origin.x);
+  return editingRect;
+}
+
+- (CGRect)leftViewRectForBounds:(CGRect)bounds {
+  CGRect leftViewRect = [super leftViewRectForBounds:bounds];
+  leftViewRect.size.width = MAX(self.insetX, leftViewRect.size.width);
+  return leftViewRect;
+}
+
+- (CGRect)rightViewRectForBounds:(CGRect)bounds {
+  CGRect viewRect = [super rightViewRectForBounds:bounds];
+  viewRect.size.width = MAX(self.insetX, viewRect.size.width);
+  return viewRect;
+}
+
+#pragma mark - Deletion
+
+- (void)deselectAllChipsExceptChip:(MDCChipView *)chip {
+  for (MDCChipView *otherChip in self.chips) {
+    if (chip != otherChip) {
+      otherChip.selected = NO;
+    }
+  }
+}
+
+- (void)selectLastChip {
+  MDCChipView *lastChip = self.chips.lastObject;
+  [self deselectAllChipsExceptChip:lastChip];
+  lastChip.selected = YES;
+  UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
+                                  [lastChip accessibilityLabel]);
+}
+
+- (void)deselectAllChips {
+  [self deselectAllChipsExceptChip:nil];
+}
+
+- (void)removeChip:(MDCChipView *)chip {
+  [self.chips removeObject:chip];
+  [chip removeFromSuperview];
+
+  MDCChipView *lastChip = [self.chips lastObject];
+  self.insetX = CGRectGetMaxX(lastChip.frame) + 10;
+
+  CGFloat textFieldWidth = CGRectGetWidth([self textRectForBounds:self.bounds]);
+  if (self.leadingConstraint.constant > 0 && textFieldWidth > 0) {
+    self.insetX += textFieldWidth;
+    self.leadingConstraint.constant -= textFieldWidth;
+  }
+
+  [self invalidateIntrinsicContentSize];
+  [self setNeedsLayout];
+
+  if (self.chips.count == 0) {
+    self.leftViewMode = UITextFieldViewModeNever;
+  }
+}
+
+- (void)removeSelectedChips {
+  NSMutableArray *chipsToRemove = [NSMutableArray array];
+  for (MDCChipView *chip in self.chips) {
+    if (chip.isSelected) {
+      [chipsToRemove addObject:chip];
+    }
+  }
+  for (MDCChipView *chip in chipsToRemove) {
+    [self removeChip:chip];
+  }
+}
+
+- (BOOL)isAnyChipSelected {
+  for (MDCChipView *chip in self.chips) {
+    if (chip.isSelected) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
+- (void)respondToDeleteBackward {
+  if ([self isAnyChipSelected]) {
+    [self removeSelectedChips];
+    [self deselectAllChips];
+  } else {
+    [self selectLastChip];
+  }
+}
+
+@end

--- a/components/ChipTextField/examples/MDCChipTextField.m
+++ b/components/ChipTextField/examples/MDCChipTextField.m
@@ -13,14 +13,22 @@
 // limitations under the License.
 
 #import "MDCChipTextField.h"
+
+#import "MDCChipTextFieldScrollView.h"
 #import "MaterialChips.h"
 
-@interface MDCChipTextField ()
+static CGFloat const kChipsSpacing = 0.0f;
+static CGFloat const kTextToEnterPlaceholderLength = 16.0f;
 
-@property(nonatomic, strong) UIView *chipsView;
-@property(nonatomic) CGFloat insetX;
-@property(nonatomic, strong) NSLayoutConstraint *leadingConstraint;
-@property(nonatomic, strong) NSMutableArray<MDCChipView *> *chips;
+@interface MDCChipTextField () <MDCChipTextFieldScrollViewDataSource>
+
+@property(nonatomic, strong) MDCChipTextFieldScrollView *chipsContainerView;
+
+@property(nonatomic, readwrite, weak) NSLayoutConstraint *chipContainerViewConstraintLeading;
+@property(nonatomic, readwrite, weak) NSLayoutConstraint *chipContainerViewConstraintTrailing;
+@property(nonatomic) CGFloat chipContainerViewConstraintTrailingConstant;
+// Chip view models
+@property(nonatomic, strong) NSMutableArray<MDCChipView *> *chipViews;
 
 @end
 
@@ -29,72 +37,90 @@
 - (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];
   if (self) {
-    _chipsView = [[UIView alloc] initWithFrame:CGRectZero];
-    _chipsView.translatesAutoresizingMaskIntoConstraints = NO;
-    _chipsView.clipsToBounds = YES;
-    self.leftView = _chipsView;
+    _chipViews = [[NSMutableArray alloc] init];
+    _chipContainerViewConstraintTrailingConstant = 0.0f;
+    [self setupChipsContainerView];
 
     [self addTarget:self
                   action:@selector(chipTextFieldTextDidChange)
         forControlEvents:UIControlEventEditingChanged];
 
-    _chips = [NSMutableArray array];
+    [self addTextFieldObservers];
   }
   return self;
 }
 
+- (void)addTextFieldObservers {
+  [[NSNotificationCenter defaultCenter]
+      addObserver:self
+         selector:@selector(textFieldDidEndEditingWithNotification:)
+             name:UITextFieldTextDidEndEditingNotification
+           object:self];
+  [[NSNotificationCenter defaultCenter]
+      addObserver:self
+         selector:@selector(textFieldDidBeginEditingWithNotification:)
+             name:UITextFieldTextDidBeginEditingNotification
+           object:self];
+}
+
+- (void)setupChipsContainerView {
+  MDCChipTextFieldScrollView *chipsContainerView =
+      [[MDCChipTextFieldScrollView alloc] initWithFrame:CGRectZero];
+  chipsContainerView.translatesAutoresizingMaskIntoConstraints = NO;
+  chipsContainerView.chipSpacing = kChipsSpacing;
+  chipsContainerView.dataSource = self;
+  self.chipsContainerView = chipsContainerView;
+  [self addSubview:chipsContainerView];
+
+  NSLayoutConstraint *chipContainerViewConstraintTop =
+      [NSLayoutConstraint constraintWithItem:self.chipsContainerView
+                                   attribute:NSLayoutAttributeTop
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:self
+                                   attribute:NSLayoutAttributeTop
+                                  multiplier:1
+                                    constant:0];
+  NSLayoutConstraint *chipContainerViewConstraintBottom =
+      [NSLayoutConstraint constraintWithItem:self.chipsContainerView
+                                   attribute:NSLayoutAttributeBottom
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:self
+                                   attribute:NSLayoutAttributeBottom
+                                  multiplier:1
+                                    constant:0];
+  [NSLayoutConstraint
+      activateConstraints:@[ chipContainerViewConstraintTop, chipContainerViewConstraintBottom ]];
+  [self updateChipViewLeadingConstraints];
+  [self updateChipViewTrailingConstraints];
+}
+
 - (void)appendChipWithText:(NSString *)text {
-  MDCChipView *chip = [[MDCChipView alloc] init];
-  chip.titleLabel.text = text;
-  chip.translatesAutoresizingMaskIntoConstraints = NO;
+  MDCChipView *chipView = [[MDCChipView alloc] init];
+  chipView.titleLabel.text = text;
+  chipView.translatesAutoresizingMaskIntoConstraints = NO;
 
-  [self.chipsView addSubview:chip];
-
-  // Constraints
-  [self.chipsView addConstraints:@[
-    [NSLayoutConstraint constraintWithItem:self.chipsView
-                                 attribute:NSLayoutAttributeTop
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:chip
-                                 attribute:NSLayoutAttributeTop
-                                multiplier:1.0
-                                  constant:0.0],
-    [NSLayoutConstraint constraintWithItem:self.chipsView
-                                 attribute:NSLayoutAttributeBottom
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:chip
-                                 attribute:NSLayoutAttributeBottom
-                                multiplier:1.0
-                                  constant:0.0]
-  ]];
-
-  MDCChipView *lastChip = [self.chips lastObject];
-  if (lastChip == nil) {
-    self.leadingConstraint = [NSLayoutConstraint constraintWithItem:self.chipsView
-                                                          attribute:NSLayoutAttributeLeading
-                                                          relatedBy:NSLayoutRelationEqual
-                                                             toItem:chip
-                                                          attribute:NSLayoutAttributeLeading
-                                                         multiplier:1.0
-                                                           constant:0];
-    [self.chipsView addConstraint:self.leadingConstraint];
-  } else {
-    [self.chipsView addConstraint:[NSLayoutConstraint constraintWithItem:lastChip
-                                                               attribute:NSLayoutAttributeTrailing
-                                                               relatedBy:NSLayoutRelationEqual
-                                                                  toItem:chip
-                                                               attribute:NSLayoutAttributeLeading
-                                                              multiplier:1.0
-                                                                constant:0]];
-  }
+  [self.chipsContainerView appendChipView:chipView];
 
   // recalculate the layout to get a correct chip frame values
-  [self.chipsView layoutIfNeeded];
-  self.insetX = CGRectGetMaxX(chip.frame);
-  [self.chips addObject:chip];
+  [self.chipsContainerView layoutIfNeeded];
+  [self.chipViews addObject:chipView];
 
-  self.leftViewMode = UITextFieldViewModeAlways;
+  [self clearChipsContainerOffsetWithConstant:kTextToEnterPlaceholderLength];
 }
+
+// TODO: the constant here reflects the margin, places calling this method need to be refactored.
+// Ideally no constant needs to be passed into this method for the function to work.
+- (void)clearChipsContainerOffsetWithConstant:(CGFloat)constant {
+  self.chipContainerViewConstraintTrailingConstant = -constant;
+  [self invalidateIntrinsicContentSize];
+  [self setNeedsLayout];
+  [self layoutIfNeeded];
+  [self.chipsContainerView setNeedsLayout];
+  [self.chipsContainerView layoutIfNeeded];
+  [self.chipsContainerView scrollToRight];
+}
+
+#pragma mark - Text Editing Handler
 
 - (void)chipTextFieldTextDidChange {
   [self deselectAllChips];
@@ -102,22 +128,133 @@
 }
 
 - (void)setupEditingRect {
-  CGRect textRect = [self textRectForBounds:self.bounds];
+  if (CGRectGetWidth(self.chipsContainerView.frame) <= 0) {
+    return;
+  }
+
   UITextRange *textRange = [self textRangeFromPosition:self.beginningOfDocument
                                             toPosition:self.endOfDocument];
   CGRect inputRect = [self firstRectForRange:textRange];
+  CGFloat inputRectLength = inputRect.size.width;
 
-  CGFloat space = textRect.size.width - inputRect.size.width;
-  if (space < 0 || self.leadingConstraint.constant > 0) {
-    self.insetX += space;
-    self.leadingConstraint.constant -= space;
-  }
+  self.chipContainerViewConstraintTrailingConstant =
+      -(inputRectLength + kTextToEnterPlaceholderLength);
+  [self setNeedsUpdateConstraints];
+  [self setNeedsLayout];
+  [self layoutIfNeeded];
+  [self.chipsContainerView setNeedsLayout];
+  [self.chipsContainerView layoutIfNeeded];
+  [self.chipsContainerView scrollToRight];
 }
 
-#pragma mark - UITextField overrides
+#pragma mark - Constraints
 
-- (BOOL)shouldChangeTextInRange:(UITextRange *)range replacementText:(NSString *)text {
-  return [super shouldChangeTextInRange:range replacementText:text];
+- (void)updateConstraints {
+  // TODO: This is not optimized for performance, but due to how MDCTextInputController works, we
+  // need to update constraints here using the latest textInsets values.
+  self.chipContainerViewConstraintLeading.constant = self.textInsets.left;
+  self.chipContainerViewConstraintTrailing.constant =
+      self.chipContainerViewConstraintTrailingConstant;
+
+  [super updateConstraints];
+}
+
+- (void)updateChipViewLeadingConstraints {
+  self.chipContainerViewConstraintLeading.active = NO;
+
+  NSLayoutConstraint *chipContainerViewConstraintLeading = nil;
+  if (self.leftView) {
+    chipContainerViewConstraintLeading =
+        [NSLayoutConstraint constraintWithItem:self.chipsContainerView
+                                     attribute:NSLayoutAttributeLeading
+                                     relatedBy:NSLayoutRelationEqual
+                                        toItem:self.leftView
+                                     attribute:NSLayoutAttributeTrailing
+                                    multiplier:1
+                                      constant:self.textInsets.left];
+  } else {
+    chipContainerViewConstraintLeading =
+        [NSLayoutConstraint constraintWithItem:self.chipsContainerView
+                                     attribute:NSLayoutAttributeLeading
+                                     relatedBy:NSLayoutRelationEqual
+                                        toItem:self
+                                     attribute:NSLayoutAttributeLeading
+                                    multiplier:1
+                                      constant:self.textInsets.left];
+  }
+  chipContainerViewConstraintLeading.active = YES;
+
+  self.chipContainerViewConstraintLeading = chipContainerViewConstraintLeading;
+}
+
+- (void)updateChipViewTrailingConstraints {
+  self.chipContainerViewConstraintTrailing.active = NO;
+
+  NSLayoutConstraint *chipContainerViewConstraintTrailing = nil;
+  if (self.rightView) {
+    chipContainerViewConstraintTrailing =
+        [NSLayoutConstraint constraintWithItem:self.chipsContainerView
+                                     attribute:NSLayoutAttributeTrailing
+                                     relatedBy:NSLayoutRelationLessThanOrEqual
+                                        toItem:self.rightView
+                                     attribute:NSLayoutAttributeLeading
+                                    multiplier:1
+                                      constant:self.chipContainerViewConstraintTrailingConstant];
+  } else {
+    chipContainerViewConstraintTrailing =
+        [NSLayoutConstraint constraintWithItem:self.chipsContainerView
+                                     attribute:NSLayoutAttributeTrailing
+                                     relatedBy:NSLayoutRelationLessThanOrEqual
+                                        toItem:self.clearButton
+                                     attribute:NSLayoutAttributeLeading
+                                    multiplier:1
+                                      constant:self.chipContainerViewConstraintTrailingConstant];
+  }
+  chipContainerViewConstraintTrailing.active = YES;
+
+  self.chipContainerViewConstraintTrailing = chipContainerViewConstraintTrailing;
+}
+
+#pragma mark - overrides
+
+- (void)setLeftViewMode:(UITextFieldViewMode)leftViewMode {
+  [super setLeftViewMode:leftViewMode];
+
+  [self updateChipViewLeadingConstraints];
+  [self setNeedsUpdateConstraints];
+}
+
+- (void)setLeftView:(UIView *)leftView {
+  [super setLeftView:leftView];
+
+  [self updateChipViewLeadingConstraints];
+  [self setNeedsUpdateConstraints];
+}
+
+- (void)setRightViewMode:(UITextFieldViewMode)rightViewMode {
+  [super setRightViewMode:rightViewMode];
+
+  [self updateChipViewTrailingConstraints];
+  [self setNeedsUpdateConstraints];
+}
+
+- (void)setRightView:(UIView *)rightView {
+  [super setRightView:rightView];
+
+  [self updateChipViewTrailingConstraints];
+  [self setNeedsUpdateConstraints];
+}
+
+- (CGRect)textRectForBounds:(CGRect)bounds {
+  CGRect textRect = [super textRectForBounds:bounds];
+  textRect.origin.x = CGRectGetMaxX(self.chipsContainerView.frame);
+  textRect.size.width = MAX(0, textRect.size.width - CGRectGetWidth(self.chipsContainerView.frame));
+  return textRect;
+}
+
+- (CGRect)editingRectForBounds:(CGRect)bounds {
+  CGRect editingRect = [super editingRectForBounds:bounds];
+  return editingRect;
 }
 
 - (void)deleteBackward {
@@ -129,34 +266,22 @@
   [super deleteBackward];
 }
 
-- (CGRect)textRectForBounds:(CGRect)bounds {
-  CGRect textRect = [super textRectForBounds:bounds];
-  textRect.origin.x = MAX(self.insetX, textRect.origin.x);
-  return textRect;
+- (BOOL)hasTextContent {
+  return self.text.length > 0 || self.chipViews.count > 0;
 }
 
-- (CGRect)editingRectForBounds:(CGRect)bounds {
-  CGRect editingRect = [super editingRectForBounds:bounds];
-  editingRect.origin.x = MAX(self.insetX, editingRect.origin.x);
-  return editingRect;
-}
-
-- (CGRect)leftViewRectForBounds:(CGRect)bounds {
-  CGRect leftViewRect = [super leftViewRectForBounds:bounds];
-  leftViewRect.size.width = MAX(self.insetX, leftViewRect.size.width);
-  return leftViewRect;
-}
-
-- (CGRect)rightViewRectForBounds:(CGRect)bounds {
-  CGRect viewRect = [super rightViewRectForBounds:bounds];
-  viewRect.size.width = MAX(self.insetX, viewRect.size.width);
-  return viewRect;
+- (void)clearText {
+  self.text = @"";
+  for (NSInteger index = self.chipViews.count - 1; index >= 0; --index) {
+    MDCChipView *chipView = self.chipViews[index];
+    [self removeChip:chipView];
+  }
 }
 
 #pragma mark - Deletion
 
 - (void)deselectAllChipsExceptChip:(MDCChipView *)chip {
-  for (MDCChipView *otherChip in self.chips) {
+  for (MDCChipView *otherChip in self.chipViews) {
     if (chip != otherChip) {
       otherChip.selected = NO;
     }
@@ -164,7 +289,7 @@
 }
 
 - (void)selectLastChip {
-  MDCChipView *lastChip = self.chips.lastObject;
+  MDCChipView *lastChip = self.chipViews.lastObject;
   [self deselectAllChipsExceptChip:lastChip];
   lastChip.selected = YES;
   UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
@@ -176,29 +301,17 @@
 }
 
 - (void)removeChip:(MDCChipView *)chip {
-  [self.chips removeObject:chip];
-  [chip removeFromSuperview];
-
-  MDCChipView *lastChip = [self.chips lastObject];
-  self.insetX = CGRectGetMaxX(lastChip.frame) + 10;
-
-  CGFloat textFieldWidth = CGRectGetWidth([self textRectForBounds:self.bounds]);
-  if (self.leadingConstraint.constant > 0 && textFieldWidth > 0) {
-    self.insetX += textFieldWidth;
-    self.leadingConstraint.constant -= textFieldWidth;
-  }
+  [self.chipViews removeObject:chip];
+  [self.chipsContainerView removeChipView:chip];
+  [self clearChipsContainerOffsetWithConstant:kTextToEnterPlaceholderLength];
 
   [self invalidateIntrinsicContentSize];
   [self setNeedsLayout];
-
-  if (self.chips.count == 0) {
-    self.leftViewMode = UITextFieldViewModeNever;
-  }
 }
 
 - (void)removeSelectedChips {
   NSMutableArray *chipsToRemove = [NSMutableArray array];
-  for (MDCChipView *chip in self.chips) {
+  for (MDCChipView *chip in self.chipViews) {
     if (chip.isSelected) {
       [chipsToRemove addObject:chip];
     }
@@ -209,7 +322,7 @@
 }
 
 - (BOOL)isAnyChipSelected {
-  for (MDCChipView *chip in self.chips) {
+  for (MDCChipView *chip in self.chipViews) {
     if (chip.isSelected) {
       return YES;
     }
@@ -224,6 +337,26 @@
   } else {
     [self selectLastChip];
   }
+}
+#pragma mark Notification Listener Methods
+
+- (void)textFieldDidBeginEditingWithNotification:(NSNotification *)notification {
+  [self setupEditingRect];
+}
+
+- (void)textFieldDidEndEditingWithNotification:(NSNotification *)notification {
+  [self clearChipsContainerOffsetWithConstant:0.0f];
+  [self.chipsContainerView scrollToLeft];
+}
+
+#pragma mark - MDCChipTextFieldScrollViewDataSource
+
+- (NSInteger)numberOfChipsInScrollView:(MDCChipTextFieldScrollView *)scrollView {
+  return self.chipViews.count;
+}
+
+- (MDCChipView *)scrollView:(MDCChipTextFieldScrollView *)scrollView chipForIndex:(NSInteger)index {
+  return self.chipViews[index];
 }
 
 @end

--- a/components/ChipTextField/examples/MDCChipTextFieldScrollView.h
+++ b/components/ChipTextField/examples/MDCChipTextFieldScrollView.h
@@ -1,0 +1,52 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+#import "MaterialChips.h"
+
+@class MDCChipTextFieldScrollView;
+
+@protocol MDCChipTextFieldScrollViewDelegate <NSObject, UIScrollViewDelegate>
+
+// TODO: delegate methods to handle touch event
+
+@end
+
+@protocol MDCChipTextFieldScrollViewDataSource <NSObject>
+
+- (NSInteger)numberOfChipsInScrollView:(nonnull MDCChipTextFieldScrollView *)scrollView;
+- (nullable MDCChipView *)scrollView:(nonnull MDCChipTextFieldScrollView *)scrollView
+                        chipForIndex:(NSInteger)index;
+
+@end
+
+@interface MDCChipTextFieldScrollView : UIScrollView
+
+@property(nonatomic, weak, nullable) id<MDCChipTextFieldScrollViewDelegate> delegate;
+@property(nonatomic, weak, nullable) id<MDCChipTextFieldScrollViewDataSource> dataSource;
+
+/**
+ The spacing between chips in this scroll view.
+ */
+@property(nonatomic) CGFloat chipSpacing;
+
+- (void)scrollToLeft;
+- (void)scrollToRight;
+
+// TODO: remove these methods if we decide to go with data source. Needs revisit.
+- (void)appendChipView:(nonnull MDCChipView *)chipView;
+- (void)removeChipView:(nonnull MDCChipView *)chipView;
+
+@end

--- a/components/ChipTextField/examples/MDCChipTextFieldScrollView.m
+++ b/components/ChipTextField/examples/MDCChipTextFieldScrollView.m
@@ -1,0 +1,221 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCChipTextFieldScrollView.h"
+
+@interface MDCChipTextFieldScrollView ()
+
+@property(nonatomic, readwrite, strong) UIView *contentView;
+
+@property(nonatomic, readwrite, weak) NSLayoutConstraint *trailingConstraint;
+
+@end
+
+@implementation MDCChipTextFieldScrollView
+@synthesize delegate = _delegate;
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  if ((self = [super initWithFrame:frame])) {
+    [self commonInit];
+  }
+  return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+  if ((self = [super initWithCoder:aDecoder])) {
+    [self commonInit];
+  }
+  return self;
+}
+
+- (void)commonInit {
+  // set up content view
+  UIView *contentView = [[UIView alloc] initWithFrame:self.frame];
+  contentView.translatesAutoresizingMaskIntoConstraints = NO;
+  [self addSubview:contentView];
+  self.contentView = contentView;
+
+  NSLayoutConstraint *contentConstraintTop =
+      [NSLayoutConstraint constraintWithItem:contentView
+                                   attribute:NSLayoutAttributeTop
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:self
+                                   attribute:NSLayoutAttributeTop
+                                  multiplier:1
+                                    constant:0];
+  NSLayoutConstraint *contentConstraintBottom =
+      [NSLayoutConstraint constraintWithItem:contentView
+                                   attribute:NSLayoutAttributeBottom
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:self
+                                   attribute:NSLayoutAttributeBottom
+                                  multiplier:1
+                                    constant:0];
+  NSLayoutConstraint *contentConstraintLeading =
+      [NSLayoutConstraint constraintWithItem:contentView
+                                   attribute:NSLayoutAttributeLeading
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:self
+                                   attribute:NSLayoutAttributeLeading
+                                  multiplier:1
+                                    constant:0];
+  NSLayoutConstraint *contentConstraintTrailing =
+      [NSLayoutConstraint constraintWithItem:contentView
+                                   attribute:NSLayoutAttributeTrailing
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:self
+                                   attribute:NSLayoutAttributeTrailing
+                                  multiplier:1
+                                    constant:0];
+  contentConstraintTrailing.priority = UILayoutPriorityDefaultLow;
+  NSLayoutConstraint *contentConstraintHeight =
+      [NSLayoutConstraint constraintWithItem:contentView
+                                   attribute:NSLayoutAttributeHeight
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:self
+                                   attribute:NSLayoutAttributeHeight
+                                  multiplier:1
+                                    constant:0];
+  NSLayoutConstraint *contentConstraintWidth =
+      [NSLayoutConstraint constraintWithItem:contentView
+                                   attribute:NSLayoutAttributeWidth
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:self
+                                   attribute:NSLayoutAttributeWidth
+                                  multiplier:1
+                                    constant:0];
+  contentConstraintWidth.priority = UILayoutPriorityDefaultLow;
+  [NSLayoutConstraint activateConstraints:@[
+    contentConstraintTop, contentConstraintBottom, contentConstraintLeading,
+    contentConstraintTrailing, contentConstraintHeight, contentConstraintWidth
+  ]];
+
+  NSLayoutConstraint *contentToChipTrailingConstraint =
+      [NSLayoutConstraint constraintWithItem:contentView
+                                   attribute:NSLayoutAttributeTrailing
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:contentView
+                                   attribute:NSLayoutAttributeLeading
+                                  multiplier:1
+                                    constant:0];
+  contentToChipTrailingConstraint.active = YES;
+  self.trailingConstraint = contentToChipTrailingConstraint;
+
+  // Set fixed values for this scroll view.
+  [self setShowsVerticalScrollIndicator:NO];
+  [self setShowsHorizontalScrollIndicator:NO];
+  self.bounces = NO;
+  self.scrollEnabled = NO;
+}
+
+- (void)appendChipView:(MDCChipView *)chipView {
+  self.trailingConstraint.active = NO;
+  [self.contentView addSubview:chipView];
+  NSLayoutConstraint *chipViewConstraintTop =
+      [NSLayoutConstraint constraintWithItem:self.contentView
+                                   attribute:NSLayoutAttributeTop
+                                   relatedBy:NSLayoutRelationLessThanOrEqual
+                                      toItem:chipView
+                                   attribute:NSLayoutAttributeTop
+                                  multiplier:1
+                                    constant:0];
+  NSLayoutConstraint *chipViewConstraintBottom =
+      [NSLayoutConstraint constraintWithItem:self.contentView
+                                   attribute:NSLayoutAttributeBottom
+                                   relatedBy:NSLayoutRelationGreaterThanOrEqual
+                                      toItem:chipView
+                                   attribute:NSLayoutAttributeBottom
+                                  multiplier:1
+                                    constant:0];
+  NSLayoutConstraint *chipViewConstraintCenterY =
+      [NSLayoutConstraint constraintWithItem:self.contentView
+                                   attribute:NSLayoutAttributeCenterY
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:chipView
+                                   attribute:NSLayoutAttributeCenterY
+                                  multiplier:1
+                                    constant:0];
+
+  NSLayoutConstraint *chipViewConstraintLeading = nil;
+  NSInteger numberOfChips = [self.dataSource numberOfChipsInScrollView:self];
+  // The left most chip is always done before all other chips are added right now,
+  // we should remove the assumption when moving to Beta
+  if (numberOfChips == 0) {
+    chipViewConstraintLeading = [NSLayoutConstraint constraintWithItem:self.contentView
+                                                             attribute:NSLayoutAttributeLeading
+                                                             relatedBy:NSLayoutRelationEqual
+                                                                toItem:chipView
+                                                             attribute:NSLayoutAttributeLeading
+                                                            multiplier:1
+                                                              constant:0];
+  } else {
+    MDCChipView *lastChipView = [self.dataSource scrollView:self chipForIndex:numberOfChips - 1];
+    chipViewConstraintLeading = [NSLayoutConstraint constraintWithItem:chipView
+                                                             attribute:NSLayoutAttributeLeading
+                                                             relatedBy:NSLayoutRelationEqual
+                                                                toItem:lastChipView
+                                                             attribute:NSLayoutAttributeTrailing
+                                                            multiplier:1
+                                                              constant:self.chipSpacing];
+  }
+  NSLayoutConstraint *chipViewConstraintTrailing =
+      [NSLayoutConstraint constraintWithItem:self.contentView
+                                   attribute:NSLayoutAttributeTrailing
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:chipView
+                                   attribute:NSLayoutAttributeTrailing
+                                  multiplier:1
+                                    constant:0];
+  [NSLayoutConstraint activateConstraints:@[
+    chipViewConstraintTop, chipViewConstraintBottom, chipViewConstraintCenterY,
+    chipViewConstraintLeading, chipViewConstraintTrailing
+  ]];
+  self.trailingConstraint = chipViewConstraintTrailing;
+}
+
+- (void)removeChipView:(MDCChipView *)chipView {
+  [chipView removeFromSuperview];
+
+  NSInteger numberOfChips = [self.dataSource numberOfChipsInScrollView:self];
+  if (numberOfChips > 0) {
+    MDCChipView *lastChipView = [self.dataSource scrollView:self chipForIndex:numberOfChips - 1];
+    NSLayoutConstraint *chipViewConstraintTrailing =
+        [NSLayoutConstraint constraintWithItem:self.contentView
+                                     attribute:NSLayoutAttributeTrailing
+                                     relatedBy:NSLayoutRelationEqual
+                                        toItem:lastChipView
+                                     attribute:NSLayoutAttributeTrailing
+                                    multiplier:1
+                                      constant:0];
+    chipViewConstraintTrailing.active = YES;
+    self.trailingConstraint = chipViewConstraintTrailing;
+  }
+}
+
+- (void)scrollToLeft {
+  self.contentOffset = CGPointMake(0.0f, self.contentOffset.y);
+}
+
+- (void)scrollToRight {
+  self.contentOffset =
+      CGPointMake(self.contentSize.width - self.bounds.size.width, self.contentOffset.y);
+}
+
+- (void)layoutSubviews {
+  [super layoutSubviews];
+
+  self.contentSize = self.contentView.frame.size;
+}
+
+@end

--- a/components/ChipTextField/examples/UITextFieldWithChipsExample.swift
+++ b/components/ChipTextField/examples/UITextFieldWithChipsExample.swift
@@ -1,0 +1,265 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+class UITextFieldWithChipsExample: UIViewController {
+
+  fileprivate let textField = InsetTextField()
+  private var leftView = UIView()
+  fileprivate var leadingConstraint: NSLayoutConstraint?
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    self.view.backgroundColor = UIColor.white
+
+    setupExample()
+    additionalTextField()
+
+    // this fixes the issue of the cursor becoming half size when the field is empty
+    DispatchQueue.main.async {
+      self.textField.becomeFirstResponder()
+    }
+  }
+
+  private func setupExample() {
+
+    textField.translatesAutoresizingMaskIntoConstraints = false
+    textField.backgroundColor = UIColor.black.withAlphaComponent(0.05)
+    textField.layer.borderWidth = 1.0
+    textField.layer.borderColor = UIColor.black.cgColor
+    textField.textColor = .darkGray
+    textField.text = "With Chips (Hit Enter)"
+
+    // when on, enter responds to auto-correction which is confusing when we're trying to create "chips"
+    textField.autocorrectionType = UITextAutocorrectionType.no
+
+    textField.delegate = self
+
+    textField.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged)
+
+    view.addSubview(textField)
+
+    // position the textfield somewhere in the screen
+    if #available(iOSApplicationExtension 11.0, *) {
+      let guide = view.safeAreaLayoutGuide
+      textField.leadingAnchor.constraint(equalTo: guide.leadingAnchor, constant: 20.0).isActive = true
+      textField.trailingAnchor.constraint(equalTo: guide.trailingAnchor, constant: -20.0).isActive = true
+      textField.topAnchor.constraint(equalTo: guide.topAnchor, constant: 40.0).isActive = true
+    } else if #available(iOSApplicationExtension 9.0, *) {
+      textField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20.0).isActive = true
+      textField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20.0).isActive = true
+      textField.topAnchor.constraint(equalTo: view.topAnchor, constant: 40.0).isActive = true
+    } else {
+      // Fallback on earlier versions
+      print("This example is supported on iOS version 9 or later.")
+    }
+
+    leftView.translatesAutoresizingMaskIntoConstraints = false
+    leftView.backgroundColor = UIColor.yellow.withAlphaComponent(0.5)
+
+    leftView.clipsToBounds = true
+    textField.leftView = leftView
+    textField.leftViewMode = .always
+  }
+
+  private func additionalTextField() {
+    let additionalTextField = PlainTextField()
+    additionalTextField.translatesAutoresizingMaskIntoConstraints = false
+    additionalTextField.backgroundColor = UIColor.black.withAlphaComponent(0.05)
+    additionalTextField.layer.borderWidth = 1.0
+    additionalTextField.layer.borderColor = UIColor.black.cgColor
+    additionalTextField.textColor = .darkGray
+    additionalTextField.text = "Regular UITextfield"
+
+    // when on, enter responds to auto-correction which is confusing when we're trying to create "chips"
+    additionalTextField.autocorrectionType = UITextAutocorrectionType.no
+
+    view.addSubview(additionalTextField)
+
+    // position the textfield somewhere in the screen
+    if #available(iOSApplicationExtension 9.0, *) {
+      additionalTextField.leadingAnchor.constraint(equalTo: textField.leadingAnchor).isActive = true
+      additionalTextField.trailingAnchor.constraint(equalTo: textField.trailingAnchor).isActive = true
+      additionalTextField.topAnchor.constraint(equalTo: textField.topAnchor, constant: 60.0).isActive = true
+    } else {
+      // Fallback on earlier versions
+      print("This example is supported on iOS version 9 or later.")
+    }
+  }
+
+  fileprivate func appendLabel(text: String) {
+
+    let pad: CGFloat = 5.0
+
+    // create label and add to left view
+    let label = newLabel(text: text)
+    let lastLabel = leftView.subviews.last
+    leftView.addSubview(label)
+
+    // add constraints
+    if #available(iOSApplicationExtension 9.0, *) {
+      label.topAnchor.constraint(equalTo: leftView.topAnchor).isActive = true
+      label.bottomAnchor.constraint(equalTo: leftView.bottomAnchor).isActive = true
+      if let lastLabel = lastLabel {
+        label.leadingAnchor.constraint(equalTo: lastLabel.trailingAnchor, constant: pad).isActive = true
+        //label.leadingAnchor.constraint(equalTo: lastLabel.trailingAnchor, constant: pad).isActive = true
+        //lastmax = lastLabel.frame.maxX
+      } else {
+        leadingConstraint = label.leadingAnchor.constraint(equalTo: leftView.leadingAnchor)
+        leadingConstraint?.priority = UILayoutPriorityDefaultLow
+        leadingConstraint?.isActive = true
+      }
+    } else {
+      // Fallback on earlier versions
+      print("This example is supported on iOS version 9 or later.")
+    }
+
+    // adjust text field's inset and width
+    leftView.layoutIfNeeded()
+    textField.insetX = label.frame.maxX
+  }
+
+  private func newLabel(text: String) -> UILabel {
+    // create label and add to left view
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.backgroundColor = UIColor.red.withAlphaComponent(0.4)
+    label.text = " " + text + " "
+    label.textColor = .white
+    label.layer.cornerRadius = 3.0
+    label.layer.masksToBounds = true
+    return label
+  }
+}
+
+// MARK: Example Extensions
+
+extension UITextFieldWithChipsExample: UITextFieldDelegate {
+
+  // listen to "enter" key
+  func textField(_ textField: UITextField,
+                 shouldChangeCharactersIn range: NSRange,
+                 replacementString string: String) -> Bool {
+    if string == "\n" {
+      if let trimmedText = textField.text?.trimmingCharacters(in: .whitespaces),
+        trimmedText.count > 0 {
+        appendLabel(text: trimmedText)
+        textField.text = ""
+      }
+    }
+    return true
+  }
+
+  func setupEditingRect(string: String) {
+
+    let textrect = textField.textRect(forBounds: textField.bounds)
+    let insetTextField = textField as InsetTextField
+    if let textrange = textField.textRange(from: textField.beginningOfDocument, to: textField.endOfDocument) {
+      let firstrect = textField.firstRect(for: textrange)
+
+      // if space is too small for typing, we need to make more room - by moving the split point
+      let textWidth = firstrect.width
+      let fieldWidth = textrect.width
+      let space = fieldWidth - textWidth
+      if space < 0 {
+        insetTextField.insetX += space
+        if let leadingConstraint = leadingConstraint {
+          //leftView.removeConstraint(leadingConstraint)
+          leadingConstraint.constant += space
+        }
+        insetTextField.layoutIfNeeded()
+      }
+
+    }
+  }
+
+  @objc func textFieldDidChange(_ textField: UITextField) {
+    setupEditingRect(string: textField.text ?? "")
+  }
+}
+
+extension UITextFieldWithChipsExample {
+  override var preferredStatusBarStyle: UIStatusBarStyle {
+    return .lightContent
+  }
+}
+
+extension UITextFieldWithChipsExample {
+
+  class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Chip Text Field", "UI Text Fields With Label Chips"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
+  }
+}
+
+// MARK: UITextField Subclass
+
+private class InsetTextField: UITextField {
+
+  // the split point: this is the x position where chips view ends and text begins.
+  // Updating this property moves the split point between chips & text.
+  var insetX: CGFloat = 8.0
+
+  // default padding for the textfield, taking insetX into account for the left position
+  let insetRect = UIEdgeInsets(top: 5.0, left: 8.0, bottom: 5.0, right: 8.0)
+
+  // text bounds
+  override func textRect(forBounds bounds: CGRect) -> CGRect {
+    let superbounds = super.textRect(forBounds: bounds)
+    var newbounds = UIEdgeInsetsInsetRect(superbounds, insetRect)
+    newbounds.origin.x = insetX
+    return newbounds
+  }
+
+  // text bounds while editing
+  override func editingRect(forBounds bounds: CGRect) -> CGRect {
+    let superbounds = super.editingRect(forBounds: bounds)
+    var newbounds = UIEdgeInsetsInsetRect(superbounds, insetRect)
+    newbounds.origin.x = insetX
+    return newbounds
+  }
+
+  // left view bounds
+  override func leftViewRect(forBounds bounds: CGRect) -> CGRect {
+    let superbounds = super.leftViewRect(forBounds: bounds)
+    var newbounds = superbounds
+    newbounds.size.width = insetX
+    return newbounds
+  }
+}
+
+class PlainTextField: UITextField {
+
+  // default padding for the textfield, taking insetX into account for the left position
+  let insetRect = UIEdgeInsets(top: 5.0, left: 8.0, bottom: 5.0, right: 8.0)
+
+  // text bounds
+  override func textRect(forBounds bounds: CGRect) -> CGRect {
+    let superbounds = super.textRect(forBounds: bounds)
+    let newbounds = UIEdgeInsetsInsetRect(superbounds, insetRect)
+    return newbounds
+  }
+
+  // text bounds while editing
+  override func editingRect(forBounds bounds: CGRect) -> CGRect {
+    let superbounds = super.editingRect(forBounds: bounds)
+    let newbounds = UIEdgeInsetsInsetRect(superbounds, insetRect)
+    return newbounds
+  }
+}

--- a/components/TextFields/src/MDCMultilineTextField.m
+++ b/components/TextFields/src/MDCMultilineTextField.m
@@ -711,6 +711,14 @@
   return self.fundament.underline;
 }
 
+- (BOOL)hasTextContent {
+  return self.text.length > 0;
+}
+
+- (void)clearText {
+  self.text = nil;
+}
+
 #pragma mark - UITextView Notification Observation
 
 - (void)textViewDidBeginEditing:(__unused NSNotification *)note {

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -389,6 +389,14 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1;
   return _fundament.underline;
 }
 
+- (BOOL)hasTextContent {
+  return self.text.length > 0;
+}
+
+- (void)clearText {
+  self.text = nil;
+}
+
 #pragma mark - UITextField Property Overrides
 
 #if defined(__IPHONE_10_0) && (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_10_0)
@@ -539,7 +547,7 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1;
     clearButtonWidth += 2 * MDCTextInputClearButtonImageBuiltInPadding;
 
     // Clear buttons are only shown if there is entered text or programatically set text to clear.
-    if (self.text.length > 0) {
+    if (self.hasTextContent) {
       switch (self.clearButtonMode) {
         case UITextFieldViewModeAlways:
         case UITextFieldViewModeUnlessEditing:
@@ -583,7 +591,7 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1;
   if (self.rightView.superview) {
     editingRect.size.width += MDCTextInputEditingRectRightViewPaddingCorrection;
   } else {
-    if (self.text.length > 0) {
+    if (self.hasTextContent) {
       CGFloat clearButtonWidth = CGRectGetWidth(self.clearButton.bounds);
 
       // The width is adjusted by the padding twice: once for the right side, once for left.

--- a/components/TextFields/src/MDCTextInput.h
+++ b/components/TextFields/src/MDCTextInput.h
@@ -201,6 +201,12 @@ typedef NS_ENUM(NSUInteger, MDCTextInputTextInsetsMode) {
 /** The underline view */
 @property(nonatomic, nullable, strong, readonly) MDCTextInputUnderlineView *underline;
 
+/** A boolean value that indicates whether the text input contains content **/
+@property(nonatomic, assign, readonly) BOOL hasTextContent;
+
+/** Clear the text content in the text input **/
+- (void)clearText;
+
 @end
 
 /**

--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -598,7 +598,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 - (void)forceUpdatePlaceholderY {
   BOOL isDirectionToUp = NO;
   if (self.floatingEnabled) {
-    isDirectionToUp = self.textInput.text.length >= 1 || self.textInput.isEditing;
+    isDirectionToUp = self.textInput.hasTextContent || self.textInput.isEditing;
   }
 
   [CATransaction begin];
@@ -1159,7 +1159,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
     return;
   }
   _textInput.placeholder = [placeholderText copy];
-  if (self.isFloatingEnabled && _textInput.text.length > 0) {
+  if (self.isFloatingEnabled && _textInput.hasTextContent) {
     [self updatePlaceholderAnimationConstraints:YES];
   }
 }
@@ -1432,7 +1432,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 }
 
 - (void)textInputDidUpdateConstraints {
-  if (self.isFloatingEnabled && _textInput.text.length > 0) {
+  if (self.isFloatingEnabled && _textInput.hasTextContent > 0) {
     [self updatePlaceholderAnimationConstraints:YES];
   }
 }
@@ -1449,7 +1449,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
   [self updateLayout];
 
-  if (self.isFloatingEnabled && self.textInput.text.length == 0) {
+  if (self.isFloatingEnabled && !self.textInput.hasTextContent) {
     [self movePlaceholderToUp:YES];
   }
   [CATransaction commit];
@@ -1510,7 +1510,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
   [self updateLayout];
 
-  if (self.isFloatingEnabled && self.textInput.text.length == 0) {
+  if (self.isFloatingEnabled && !self.textInput.hasTextContent) {
     [self movePlaceholderToUp:NO];
   }
   [CATransaction commit];

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -95,6 +95,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 @synthesize textColor = _textColor;
 @synthesize trailingUnderlineLabel = _trailingUnderlineLabel;
 @synthesize underline = _underline;
+@synthesize hasTextContent = _hasTextContent;
 @synthesize textInsetsMode = _textInsetsMode;
 
 - (instancetype)init {
@@ -417,6 +418,10 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   [self.textInput sendSubviewToBack:_underline];
 }
 
+- (void)clearText {
+  self.text = nil;
+}
+
 #pragma mark - Border implementation
 
 - (void)setupBorder {
@@ -555,7 +560,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 
 - (CGFloat)clearButtonAlpha {
   CGFloat clearButtonAlpha = 0;
-  if (self.text.length > 0) {
+  if (self.textInput.hasTextContent) {
     switch (self.clearButtonMode) {
       case UITextFieldViewModeAlways:
         clearButtonAlpha = 1;
@@ -616,7 +621,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
     }
   }
 
-  self.text = nil;
+  [self.textInput clearText];
   if (self.textInput.isFirstResponder) {
     if ([self.textInput isKindOfClass:[MDCMultilineTextField class]]) {
       MDCMultilineTextField *textField = (MDCMultilineTextField *)self.textInput;
@@ -894,7 +899,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 }
 
 - (void)updatePlaceholderAlpha {
-  CGFloat opacity = (self.hidesPlaceholderOnInput && self.textInput.text.length > 0) ? 0 : 1;
+  CGFloat opacity = (self.hidesPlaceholderOnInput && self.textInput.hasTextContent) ? 0 : 1;
   self.placeholderLabel.alpha = opacity;
 }
 


### PR DESCRIPTION
This PR is reverting: #6167 which was reverted in a release because of presubmit issue.


This PR is dependent on https://github.com/material-components/material-components-ios/pull/6035. And there is no new API change on MDCChipTextField class level.

This PR is meant to solve the problem mentioned in https://github.com/material-components/material-components-ios/pull/6035 -> "Enabling scrolling of the Chips and the remaining alignment issues will be resolved in followup PRs." 
The issues it solves:
(1) Alignment (a way to adjust it also)
(2) clear button
(3) the coupling issue with apple's leftView in the original PR.

Some remaining problem with the original issues (Will be updated in the TODO in the code too):
(1) The chip removal indentation doesn't work well (Solvable by adding an additional constraint).
(2) The scrolling behavior of Chips was not added (Shouldn't be hard to add on this base - 1 day workload, but needs confirmation from design, it's probably not a feature we want to support right now)
(3) Fix a hack number added on https://github.com/material-components/material-components-ios/pull/6167/files#diff-6c02a09694ee9585406c9dc9da7621efR117.
(4) A known bug where the space between text and clear button is uncertain when the chip is very long, it should be automatically resolved after solving (3).
(5) RTL is not the purpose of this PR. It will be included in https://github.com/material-components/material-components-ios/pull/6035
(6) Screenshot Testing is not the purpose of this PR, but it will be very helpful. Something to work on after solving (1) and (3).

Screenshots:
![simulator screen shot - iphone xs - 2019-01-02 at 11 30 50](https://user-images.githubusercontent.com/8836258/50601363-f249be80-0e81-11e9-8afc-515322a22e52.png)
![simulator screen shot - iphone xs - 2019-01-02 at 11 30 54](https://user-images.githubusercontent.com/8836258/50601366-f4138200-0e81-11e9-9869-27d70871a957.png)
![simulator screen shot - iphone xs - 2019-01-02 at 11 30 57](https://user-images.githubusercontent.com/8836258/50601370-f544af00-0e81-11e9-88f1-7da072b1d5b9.png)
