### PR TITLE
[States] New States Scheme classes in Alpha

### DIFF
--- a/MaterialComponentsExamples.podspec
+++ b/MaterialComponentsExamples.podspec
@@ -1,17 +1,18 @@
 experimental_sources = [
   'components/*/examples/experimental/supplemental/*.{h,m,swift}',
   'components/*/examples/experimental/*.{h,m,swift}',
+  'components/schemes/*/examples/src/*.{h,m,swift}',
 ]
 
 experimental_headers = [
   'components/*/examples/experimental/supplemental/*.h',
   'components/*/examples/experimental/*.h',
+  'components/schemes/*/examples/src/*.h',
 ]
 
 experimental_resources = [
   'components/*/examples/experimental/resources/*'
 ]
-
 
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsExamples"

--- a/components/schemes/State/examples/StateSchemeExampleController.h
+++ b/components/schemes/State/examples/StateSchemeExampleController.h
@@ -1,0 +1,20 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+#import "MaterialStates.h"
+
+@interface StateSchemeExampleController : UIViewController
+
+@end

--- a/components/schemes/State/examples/StateSchemeExampleController.h
+++ b/components/schemes/State/examples/StateSchemeExampleController.h
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #import <UIKit/UIKit.h>
-#import "MaterialStates.h"
 
 @interface StateSchemeExampleController : UIViewController
 

--- a/components/schemes/State/examples/StateSchemeExampleController.m
+++ b/components/schemes/State/examples/StateSchemeExampleController.m
@@ -1,0 +1,148 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "StateSchemeExampleController.h"
+#import "MaterialPalettes.h"
+#import "MaterialStates.h"
+
+@interface StateSchemeExampleController ()
+
+@property(nullable, strong, nonatomic) MDCStateExampleColorScheme *exampleColorScheme;
+@property(nullable, strong, nonatomic) MDCStateScheme *stateScheme;
+
+@end
+
+@implementation StateSchemeExampleController
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  // Note: State and Color schemes should be initialized with the same defaults, to ensure
+  //       State overrides match the colors in the color scheme.
+  if (self.exampleColorScheme == nil) {
+    self.exampleColorScheme =
+        [[MDCStateExampleColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+  if (self.stateScheme == nil) {
+    self.stateScheme =
+        [[MDCStateScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
+
+  self.view.backgroundColor = self.exampleColorScheme.backgroundColor;
+
+  // Note: There is no UI for this example.
+  [self runStateSchemeExperiment];
+}
+
+/**
+ The following retrieves various state colors for the OnWhite theme.
+
+ The console output after running this experiment example is:
+
+ State Example> onWhiteNormalOverlayColor should be: [null]. Is it? [YES]
+ State Example> onWhiteSelectedOverlayColor should be: [overlay-12%]. Is it? [YES]
+ State Example> overlay for state: [NORMAL] is: [(null)]. It should be: [null]
+ State Example> overlay for state: [PRESSED] is:
+                [semantic: overlay | palette: --, tint: --, hex: --, opacity: 0.10, dim: 1.00].
+                It should be: [overlay]
+ State Example> content for state: [DISABLED] is:
+                [semantic: -- | palette: grey, tint: 800, hex: --, opacity: 0.38, dim: 1.00]
+                It should be: [Palette.grey.tint800 at 38%]. Is it? [YES]
+ State Example> content for state: [PRESSED] is:
+                [semantic: on-surface | palette: --, tint: --, hex: --, opacity: 1.00, dim: 0.20].
+                It should be: [on-surface 20% dim]
+ State Example> overriding the content color for the PRESSED state to: Primary Color
+ State Example> modified content for state: [PRESSED] is:
+                [semantic: primary | palette: --, tint: --, hex: --, opacity: 0.60, dim: 1.00].
+                It should be: [PrimaryColor 60%]
+
+*/
+- (void)runStateSchemeExperiment {
+  UIColor *onWhiteNormalOverlayColor =
+      [[self.stateScheme overlayColorResourceForState:MDCControlStateNormal
+                                                theme:MDCStateSchemeThemeOnWhite]
+          colorWithColorScheme:self.exampleColorScheme];
+  NSLog(@"State Example> onWhiteNormalOverlayColor should be: [null]. Is it? [%@]",
+        onWhiteNormalOverlayColor == nil ? @"YES" : @"NO");
+
+  UIColor *onWhiteSelectedOverlayColor =
+      [[self.stateScheme overlayColorResourceForState:MDCControlStateSelected
+                                                theme:MDCStateSchemeThemeOnWhite]
+          colorWithColorScheme:self.exampleColorScheme];
+
+  NSLog(@"State Example> onWhiteSelectedOverlayColor should be: [overlay-12%%]. Is it? [%@]",
+        [onWhiteSelectedOverlayColor
+            isEqual:[self.exampleColorScheme.overlayColor colorWithAlphaComponent:0.12]]
+            ? @"YES"
+            : @"NO");
+
+  MDCColorResource *normalOverlay =
+      [self.stateScheme overlayColorResourceForState:MDCControlStateNormal
+                                               theme:MDCStateSchemeThemeOnWhite];
+  NSLog(@"State Example> overlay for state: [NORMAL] is: [%@]. It should be: [null]",
+        normalOverlay);
+
+  MDCColorResource *pressedOverlay =
+      [self.stateScheme overlayColorResourceForState:MDCControlStateHighlighted
+                                               theme:MDCStateSchemeThemeOnWhite];
+  NSLog(@"State Example> overlay for state: [PRESSED] is: [%@]. It should be: [overlay]",
+        pressedOverlay);
+
+  MDCColorResource *disabledContent =
+      [self.stateScheme contentColorResourceForState:MDCControlStateDisabled
+                                               theme:MDCStateSchemeThemeOnWhite];
+  NSLog(@"State Example> content for state: [DISABLED] is: [%@]", disabledContent);
+  if (disabledContent != nil) {
+    UIColor *disabledColor = [disabledContent colorWithColorScheme:self.exampleColorScheme];
+    UIColor *intendedDisabledColor = [MDCPalette.greyPalette.tint800 colorWithAlphaComponent:0.38];
+    NSLog(@"State Example> It should be: [Palette.grey.tint800 at 38%%]. Is it? [%@]",
+          [disabledColor isEqual:intendedDisabledColor] ? @"YES" : @"NO");
+  }
+
+  MDCColorResource *pressedContent =
+      [self.stateScheme contentColorResourceForState:MDCControlStateHighlighted
+                                               theme:MDCStateSchemeThemeOnWhite];
+  NSLog(
+      @"State Example> content for state: [PRESSED] is: [%@]. It should be: [on-surface 20%% dim]",
+      pressedContent);
+
+  // override the content color for the pressed state
+  [self.stateScheme setContentColorWithSemanticColor:MDCColorResourceSemanticPrimary
+                                             opacity:0.6
+                                            forState:MDCControlStateInteractive
+                                             inTheme:MDCStateSchemeThemeOnWhite];
+  NSLog(@"State Example> overriding the content color for the PRESSED state to: Primary Color");
+  MDCColorResource *newPressedContent =
+      [self.stateScheme contentColorResourceForState:MDCControlStateHighlighted
+                                               theme:MDCStateSchemeThemeOnWhite];
+  NSLog(@"State Example> modified content for state: [PRESSED] is: [%@].", newPressedContent);
+  NSLog(@"It should be: [PrimaryColor 60%%]");
+}
+
+@end
+
+// MARK: Catalog by Convention
+
+@implementation StateSchemeExampleController (CatalogByConvention)
+
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs" : @[ @"Alpha: States", @"States Prototype" ],
+    @"description" : @"Prototype of States Theming.",
+    @"primaryDemo" : @NO,
+    @"presentable" : @NO,
+  };
+}
+
+@end

--- a/components/schemes/State/examples/StateSchemeExampleController.m
+++ b/components/schemes/State/examples/StateSchemeExampleController.m
@@ -138,7 +138,7 @@
 
 + (NSDictionary *)catalogMetadata {
   return @{
-    @"breadcrumbs" : @[ @"Alpha: States", @"States Prototype" ],
+    @"breadcrumbs" : @[ @"Schemes", @"States Prototype (Alpha)" ],
     @"description" : @"Prototype of States Theming.",
     @"primaryDemo" : @NO,
     @"presentable" : @NO,

--- a/components/schemes/State/examples/src/MDCColorResource+ColorScheming.h
+++ b/components/schemes/State/examples/src/MDCColorResource+ColorScheming.h
@@ -1,0 +1,34 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCColorResource.h"
+#import "MDCStateExampleColorScheme.h"
+#import "MaterialColorScheme.h"
+
+@interface MDCColorResource (ColorScheming)
+
+/**
+ Converts a color resource to a UIColor instance, using the given color scheme if
+ the resouce represents a semantic color.
+
+ Note: While in alpha, MDCColorResource uses MDCStateExampleColorScheme in order to
+       support additional colors used in alpha. Once these colors migrate to Beta, this
+       API will reference the MDCColorScheming protocol instead:
+
+ - (UIColor *)colorWithColorScheme:(id<MDCColorScheming>)colorScheme;
+
+ */
+- (UIColor *)colorWithColorScheme:(MDCStateExampleColorScheme *)colorScheme;
+
+@end

--- a/components/schemes/State/examples/src/MDCColorResource+ColorScheming.m
+++ b/components/schemes/State/examples/src/MDCColorResource+ColorScheming.m
@@ -1,0 +1,211 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCColorResource+ColorScheming.h"
+#import "MaterialPalettes.h"
+
+/// Convenience UIColor extension methods
+@interface UIColor (Private)
+
+/// Initialize a UIColor from a hex string
+- (nullable instancetype)initWithHexString:(NSString *)hexString;
+
+/// Initialize a UIColor from a hex string and an alpha value
+- (nullable instancetype)initWithHexString:(NSString *)hexString alpha:(CGFloat)alpha;
+
+/// Returns a darker color by given amount
+- (nonnull UIColor *)darker:(CGFloat)amount;
+
+/// Returns a lighter color by given amount
+- (nonnull UIColor *)lighter:(CGFloat)amount;
+
+@end
+
+@implementation MDCColorResource (ColorScheming)
+
+/// Converting a ColorResource to a UIColor, based on the current color scheme.
+- (UIColor *)colorWithColorScheme:(MDCStateExampleColorScheme *)colorScheme {
+  UIColor *color = nil;
+
+  if (self.hexColor != nil) {
+    // Convert a hext string to a UIColor
+    color = [[UIColor alloc] initWithHexString:self.hexColor];
+
+  } else if (self.palette != MDCColorResourcePaletteNone &&
+             self.tint != MDCColorResourcePaletteTintNone) {
+    MDCPalette *palette = nil;
+
+    // Convert a palette & a tint to a UIColor
+    switch (self.palette) {
+      case MDCColorResourcePaletteGrey:
+        palette = MDCPalette.greyPalette;
+        break;
+      case MDCColorResourcePaletteBlueGrey:
+        palette = MDCPalette.blueGreyPalette;
+        break;
+      case MDCColorResourcePaletteIndigo:
+        palette = MDCPalette.indigoPalette;
+        break;
+      case MDCColorResourcePaletteBlue:
+        palette = MDCPalette.bluePalette;
+        break;
+      case MDCColorResourcePalettePurple:
+        palette = MDCPalette.purplePalette;
+        break;
+      case MDCColorResourcePaletteRed:
+        palette = MDCPalette.redPalette;
+        break;
+      case MDCColorResourcePaletteOrange:
+        palette = MDCPalette.orangePalette;
+        break;
+      case MDCColorResourcePaletteYellow:
+        palette = MDCPalette.yellowPalette;
+        break;
+      case MDCColorResourcePaletteNone:
+        return nil;
+    }
+    switch (self.tint) {
+      case MDCColorResourcePaletteTint50:
+        color = palette.tint50;
+        break;
+      case MDCColorResourcePaletteTint100:
+        color = palette.tint100;
+        break;
+      case MDCColorResourcePaletteTint200:
+        color = palette.tint200;
+        break;
+      case MDCColorResourcePaletteTint300:
+        color = palette.tint300;
+        break;
+      case MDCColorResourcePaletteTint400:
+        color = palette.tint400;
+        break;
+      case MDCColorResourcePaletteTint500:
+        color = palette.tint500;
+        break;
+      case MDCColorResourcePaletteTint600:
+        color = palette.tint600;
+        break;
+      case MDCColorResourcePaletteTint700:
+        color = palette.tint700;
+        break;
+      case MDCColorResourcePaletteTint800:
+        color = palette.tint800;
+        break;
+      case MDCColorResourcePaletteTint900:
+        color = palette.tint900;
+        break;
+      case MDCColorResourcePaletteTintNone:
+        return nil;
+    }
+  } else if (self.semantic != MDCColorResourceSemanticNone) {
+    // Convert a semantic name to a UIColor
+    switch (self.semantic) {
+      case MDCColorResourceSemanticPrimary:
+        color = colorScheme.primaryColor;
+        break;
+      case MDCColorResourceSemanticOnPrimary:
+        color = colorScheme.onPrimaryColor;
+        break;
+      case MDCColorResourceSemanticSurface:
+        color = colorScheme.surfaceColor;
+        break;
+      case MDCColorResourceSemanticOnSurface:
+        color = colorScheme.onSurfaceColor;
+        break;
+      case MDCColorResourceSemanticBackground:
+        color = colorScheme.backgroundColor;
+        break;
+      case MDCColorResourceSemanticOnBackground:
+        color = colorScheme.onBackgroundColor;
+        break;
+      case MDCColorResourceSemanticOverlay:
+        color = colorScheme.overlayColor;
+        break;
+      case MDCColorResourceSemanticOutline:
+        color = colorScheme.outlineColor;
+        break;
+      case MDCColorResourceSemanticError:
+        color = colorScheme.errorColor;
+        break;
+      case MDCColorResourceSemanticNone:
+        return nil;
+    }
+  }
+
+  // Add opacity and dim variations
+  if (self.opacity < 1.0) {
+    return [color colorWithAlphaComponent:self.opacity];
+  } else if (self.dim < 1.0 && self.dim >= 0.0) {
+    return [color darker:self.dim];
+  } else if (self.dim > -1.0 && self.dim < 0.0) {
+    return [color lighter:-self.dim];
+  } else {
+    return color;
+  }
+}
+@end
+
+#pragma mark - UIColor helper methods
+
+@implementation UIColor (Private)
+
+/// Initialize a UIColor from a hex string
+- (nullable instancetype)initWithHexString:(NSString *)hexString {
+  return [self initWithHexString:hexString alpha:1.0];
+}
+
+/// Initialize a UIColor from a hex string and an alpha value
+- (nullable instancetype)initWithHexString:(NSString *)hexString alpha:(CGFloat)alpha {
+  NSString *cString =
+      [[hexString stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet]
+          uppercaseString];
+
+  if ([cString hasPrefix:@"#"]) {
+    cString = [cString substringFromIndex:1];
+  }
+
+  if (cString.length != 6) {
+    return nil;
+  }
+
+  UInt32 rgbValue = 0;
+  [[[NSScanner alloc] initWithString:cString] scanHexInt:&rgbValue];
+  return [self initWithRed:((rgbValue & 0xFF0000) >> 16) / 255.0
+                     green:((rgbValue & 0x00FF00) >> 8) / 255.0
+                      blue:(rgbValue & 0x0000FF) / 255.0
+                     alpha:alpha];
+}
+
+/// Returns a darker color by given amount
+- (nonnull UIColor *)darker:(CGFloat)amount {
+  return [self colorWithHue:1 - amount];
+}
+
+/// Returns a lighter color by given amount
+- (nonnull UIColor *)lighter:(CGFloat)amount {
+  return [self colorWithHue:1 + amount];
+}
+
+/// Returns a darker color if amount is positive, or a lighter color if amount is negative
+- (nonnull UIColor *)colorWithHue:(CGFloat)multiplier {
+  CGFloat hue = 0, saturation = 0, brightness = 0, alpha = 0;
+  [self getHue:&hue saturation:&saturation brightness:&brightness alpha:&alpha];
+  return [[UIColor alloc] initWithHue:hue
+                           saturation:saturation
+                           brightness:brightness * multiplier
+                                alpha:alpha];
+}
+
+@end

--- a/components/schemes/State/examples/src/MDCColorResource.h
+++ b/components/schemes/State/examples/src/MDCColorResource.h
@@ -1,0 +1,159 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+// Note: Make sure to update [semanticResourceFromName:] when changing or adding values
+typedef NS_ENUM(NSInteger, MDCColorResourceSemantic) {
+  MDCColorResourceSemanticNone,
+  MDCColorResourceSemanticPrimary,
+  MDCColorResourceSemanticOnPrimary,
+  MDCColorResourceSemanticSurface,
+  MDCColorResourceSemanticOnSurface,
+  MDCColorResourceSemanticOverlay,
+  MDCColorResourceSemanticBackground,
+  MDCColorResourceSemanticOnBackground,
+  MDCColorResourceSemanticOutline,
+  MDCColorResourceSemanticError,
+  // TODO: verify all semantic colors are represented
+};
+
+// Note: Make sure to update [paletteResourceFromName:] when changing or adding values
+typedef NS_ENUM(NSInteger, MDCColorResourcePalette) {
+  MDCColorResourcePaletteNone,
+  MDCColorResourcePaletteGrey,
+  MDCColorResourcePaletteBlue,
+  MDCColorResourcePaletteBlueGrey,
+  MDCColorResourcePaletteIndigo,
+  MDCColorResourcePalettePurple,
+  MDCColorResourcePaletteRed,
+  MDCColorResourcePaletteOrange,
+  MDCColorResourcePaletteYellow,
+  // TODO: verify all palettes are represented
+};
+
+// Note: Make sure to update [paletteTintResourceFromName:] when changing or adding values
+typedef NS_ENUM(NSInteger, MDCColorResourcePaletteTint) {
+  MDCColorResourcePaletteTintNone,
+  MDCColorResourcePaletteTint50,
+  MDCColorResourcePaletteTint100,
+  MDCColorResourcePaletteTint200,
+  MDCColorResourcePaletteTint300,
+  MDCColorResourcePaletteTint400,
+  MDCColorResourcePaletteTint500,
+  MDCColorResourcePaletteTint600,
+  MDCColorResourcePaletteTint700,
+  MDCColorResourcePaletteTint800,
+  MDCColorResourcePaletteTint900,
+};
+
+static const CGFloat MDCColorResourceDefaultOpacity = 1.0;
+static const CGFloat MDCColorResourceDefaultDim = 1.0;
+
+/**
+ MDCColorResource is a dynamic representation of color resources. It supports different
+ formats of colors used in Material Theming. It is also used in serializing colors (in any of
+ its supported formats) to and from a dictionary.
+
+ ColorResource uses enumerations which allows it to be independent of specific color formats.
+ StateScheme getters return ColorResource, which can be later converted by themers to an actual
+ UIColor. Themers who pass a ColorResource to a color scheme, get an actual UIColor that is based
+ on colors from those color schemes.
+
+ The following color formats are currently supported:
+ * Hex: Strings in format "#999999"
+ * Semantic names: an MDCColorResourceSemantic enum that corresponds to an
+                   MDCSemanticColorScheme color
+ * Palette names: MDCColorResourcePalette and MDCColorResourcePaletteTint enumerations,
+                  corresponding to MDCPalettes and tints.
+
+ Additionally, MDCColorResource supports 2 color variations, applied to a color, in any format:
+ * Opacity: alpha percentage of the base color
+ * Dim: percentage of darkness (values between 0 & 1.0) or lightness (values between -1.0 and 0)
+        of the base color. Examples: 0.25 means 25% darker color. -0.15 is 15% lighter color.
+ * [TBD: Emphasis: High, Medium, Low]
+
+ Note:
+ Opacity and Dim are used to generate variations of the base color. This is needed
+ mainly for expressing state colors when the makeup of colors in a colorScheme is
+ unknown (as is in MDC).  These variations may fit many color schemes, but it can
+ also be overridden if needed, especially in cases in which the color scheme does
+ not produce a sufficiently accessible contrast ratio.
+ */
+
+@interface MDCColorResource : NSObject
+
+@property(nonatomic, strong, readonly, nullable) NSString *hexColor;
+@property(nonatomic, assign, readonly) MDCColorResourceSemantic semantic;
+@property(nonatomic, assign, readonly) MDCColorResourcePalette palette;
+@property(nonatomic, assign, readonly) MDCColorResourcePaletteTint tint;
+@property(nonatomic, assign, readonly) CGFloat opacity;
+@property(nonatomic, assign, readonly) CGFloat dim;
+
+/// Initializes a color resource representing a semantic color
+- (nonnull instancetype)initWithSemanticResource:(MDCColorResourceSemantic)semanticResource;
+
+/// Initializes a color resource representing a semantic color, with given opacity or dim
+- (nonnull instancetype)initWithSemanticResource:(MDCColorResourceSemantic)semanticResource
+                                         opacity:(CGFloat)opacity
+                                             dim:(CGFloat)dim;
+
+/// Initializes a color resource representing a palette+tint color
+- (nonnull instancetype)initWithPaletteResource:(MDCColorResourcePalette)palette
+                                           tint:(MDCColorResourcePaletteTint)tint;
+
+/// Initializes a color resource representing a palette+tint color, with given opacity or dim
+- (nonnull instancetype)initWithPaletteResource:(MDCColorResourcePalette)palette
+                                           tint:(MDCColorResourcePaletteTint)tint
+                                        opacity:(CGFloat)opacity
+                                            dim:(CGFloat)dim;
+
+/// Initializes a color resource representing a hex color
+- (nonnull instancetype)initWithHexString:(NSString *)hex;
+
+/// Initializes a color resource representing a hex color, with given opacity or dim
+- (nonnull instancetype)initWithHexString:(NSString *)hex opacity:(CGFloat)opacity dim:(CGFloat)dim;
+
+/// returns the "name" of the semantic enumeration as a string value
+- (nullable NSString *)semanticNameFromResource:(MDCColorResourceSemantic)semantic;
+
+/// returns the "name" of the palette enumeration as a string value
+- (nullable NSString *)paletteNameFromResource:(MDCColorResourcePalette)palette;
+
+/// returns the "name" of the palette-tint enumeration as a string value
+- (nullable NSString *)paletteTintNameFromResource:(MDCColorResourcePaletteTint)tint;
+
+/**
+ Converts the given string to a MDCColorResourceSemantic enumeration. Returns
+ MDCColorResourceSemanticNone if the string doesn't match any enumeration value
+ @param semanticName Expecting a hyphenated all lowercase semantic name, like "on-primary".
+                           (names should match colors from the MDCColorScheming protocol)
+ */
+- (MDCColorResourceSemantic)semanticResourceFromName:(NSString *)semanticName;
+
+/**
+ Converts the given string to a MDCColorResourcePalette enumeration. Returns
+ MDCColorResourcePaletteNone if the string doesn't match any enumeration value
+ @param paletteName Expecting an all lowercase short palette name, like: "blue".
+ */
+- (MDCColorResourcePalette)paletteResourceFromName:(NSString *)paletteName;
+
+/**
+ Converts the given string to a MDCColorResourcePaletteTint enumeration. Returns
+ MDCColorResourcePaletteTintNone if the string doesn't match any enumeration value
+ @param tintName Expecting a valid digit-only tint number, like: "100" for tint100.
+ */
+- (MDCColorResourcePaletteTint)paletteTintResourceFromName:(NSString *)tintName;
+
+@end

--- a/components/schemes/State/examples/src/MDCColorResource.m
+++ b/components/schemes/State/examples/src/MDCColorResource.m
@@ -1,0 +1,323 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCColorResource.h"
+#import "MDCControlState.h"
+
+@interface MDCColorResource ()
+
+/**
+ [TBD]
+ */
+@property(nonatomic, strong, readwrite, nullable) NSString *hex;
+@property(nonatomic, assign, readwrite) MDCColorResourceSemantic semantic;
+@property(nonatomic, assign, readwrite) MDCColorResourcePalette palette;
+@property(nonatomic, assign, readwrite) MDCColorResourcePaletteTint tint;
+@property(nonatomic, assign, readwrite) CGFloat opacity;
+@property(nonatomic, assign, readwrite) CGFloat dim;
+
+@end
+
+@implementation MDCColorResource
+
+- (nonnull instancetype)initWithSemanticResource:(MDCColorResourceSemantic)semanticResource {
+  return [self initWithSemanticResource:semanticResource
+                                opacity:MDCColorResourceDefaultOpacity
+                                    dim:MDCColorResourceDefaultDim];
+}
+
+- (nonnull instancetype)initWithSemanticResource:(MDCColorResourceSemantic)semanticResource
+                                         opacity:(CGFloat)opacity
+                                             dim:(CGFloat)dim {
+  self = [super init];
+  if (self) {
+    self.semantic = semanticResource;
+    self.opacity = opacity;
+    self.dim = dim;
+
+    self.palette = MDCColorResourcePaletteNone;
+    self.tint = MDCColorResourcePaletteTintNone;
+    self.hex = nil;
+  }
+  return self;
+}
+
+- (nonnull instancetype)initWithPaletteResource:(MDCColorResourcePalette)palette
+                                           tint:(MDCColorResourcePaletteTint)tint {
+  return [self initWithPaletteResource:palette
+                                  tint:tint
+                               opacity:MDCColorResourceDefaultOpacity
+                                   dim:MDCColorResourceDefaultDim];
+}
+
+- (nonnull instancetype)initWithPaletteResource:(MDCColorResourcePalette)palette
+                                           tint:(MDCColorResourcePaletteTint)tint
+                                        opacity:(CGFloat)opacity
+                                            dim:(CGFloat)dim {
+  self = [super init];
+  if (self) {
+    self.palette = palette;
+    self.tint = tint;
+    self.opacity = opacity;
+    self.dim = dim;
+
+    self.semantic = MDCColorResourceSemanticNone;
+    self.hex = nil;
+  }
+  return self;
+}
+
+- (nonnull instancetype)initWithHexString:(NSString *)hex {
+  return [self initWithHexString:hex
+                         opacity:MDCColorResourceDefaultOpacity
+                             dim:MDCColorResourceDefaultDim];
+}
+
+// Expecting hex string with format: #999999
+- (nonnull instancetype)initWithHexString:(NSString *)hex
+                                  opacity:(CGFloat)opacity
+                                      dim:(CGFloat)dim {
+  if (hex.length != 7) {
+    return nil;  // Invalid hex string
+  }
+  // Extract the last 6 charachters
+  unsigned int hexval;
+  NSString *hexString = [hex substringFromIndex:1];
+  NSScanner *scanner = [NSScanner scannerWithString:hexString];
+  [scanner scanHexInt:&hexval];
+  if (hexval == 0) {
+    return nil;  // Invalid hex string
+  }
+  self = [super init];
+  if (self) {
+    self.hex = [NSString stringWithFormat:@"#%@", hexString];
+    self.opacity = opacity;
+    self.dim = dim;
+
+    self.palette = MDCColorResourcePaletteNone;
+    self.tint = MDCColorResourcePaletteTintNone;
+    self.semantic = MDCColorResourceSemanticNone;
+  }
+  return self;
+}
+
+- (NSString *)description {
+  return [NSString
+      stringWithFormat:@"semantic: %@ | palette: %@, tint: %@, hex: %@, opacity: %.2f, dim: %.2f",
+                       [self semanticNameFromResource:self.semantic],
+                       [self paletteNameFromResource:self.palette],
+                       [self paletteTintNameFromResource:self.tint], self.hex, self.opacity,
+                       self.dim];
+}
+
+- (nullable NSString *)semanticNameFromResource:(MDCColorResourceSemantic)semantic {
+  switch (semantic) {
+    case MDCColorResourceSemanticPrimary:
+      return @"primary";
+      break;
+    case MDCColorResourceSemanticOnPrimary:
+      return @"on-primary";
+      break;
+    case MDCColorResourceSemanticSurface:
+      return @"surface";
+      break;
+    case MDCColorResourceSemanticOnSurface:
+      return @"on-surface";
+      break;
+    case MDCColorResourceSemanticOverlay:
+      return @"overlay";
+      break;
+    case MDCColorResourceSemanticBackground:
+      return @"background";
+      break;
+    case MDCColorResourceSemanticOnBackground:
+      return @"on-background";
+      break;
+    case MDCColorResourceSemanticOutline:
+      return @"outline";
+      break;
+    case MDCColorResourceSemanticError:
+      return @"error";
+      break;
+    case MDCColorResourceSemanticNone:
+      return nil;
+      break;
+  }
+}
+
+- (nullable NSString *)paletteNameFromResource:(MDCColorResourcePalette)palette {
+  switch (palette) {
+    case MDCColorResourcePaletteGrey:
+      return @"grey";
+      break;
+    case MDCColorResourcePaletteBlueGrey:
+      return @"bluegrey";
+      break;
+    case MDCColorResourcePaletteBlue:
+      return @"blue";
+      break;
+    case MDCColorResourcePaletteIndigo:
+      return @"indigo";
+      break;
+    case MDCColorResourcePalettePurple:
+      return @"purple";
+      break;
+    case MDCColorResourcePaletteRed:
+      return @"red";
+      break;
+    case MDCColorResourcePaletteOrange:
+      return @"orange";
+      break;
+    case MDCColorResourcePaletteYellow:
+      return @"yellow";
+      break;
+    case MDCColorResourcePaletteNone:
+      return nil;
+      break;
+  }
+}
+
+- (nullable NSString *)paletteTintNameFromResource:(MDCColorResourcePaletteTint)tint {
+  switch (tint) {
+    case MDCColorResourcePaletteTint50:
+      return @"50";
+      break;
+    case MDCColorResourcePaletteTint100:
+      return @"100";
+      break;
+    case MDCColorResourcePaletteTint200:
+      return @"200";
+      break;
+    case MDCColorResourcePaletteTint300:
+      return @"300";
+      break;
+    case MDCColorResourcePaletteTint400:
+      return @"400";
+      break;
+    case MDCColorResourcePaletteTint500:
+      return @"500";
+      break;
+    case MDCColorResourcePaletteTint600:
+      return @"600";
+      break;
+    case MDCColorResourcePaletteTint700:
+      return @"700";
+      break;
+    case MDCColorResourcePaletteTint800:
+      return @"800";
+      break;
+    case MDCColorResourcePaletteTint900:
+      return @"900";
+      break;
+    case MDCColorResourcePaletteTintNone:
+      return nil;
+      break;
+  }
+}
+
+- (MDCColorResourceSemantic)semanticResourceFromName:(NSString *)semanticName {
+  if ([semanticName isEqualToString:@"primary"]) {
+    return MDCColorResourceSemanticPrimary;
+  }
+  if ([semanticName isEqualToString:@"on-primary"]) {
+    return MDCColorResourceSemanticOnPrimary;
+  }
+  if ([semanticName isEqualToString:@"surface"]) {
+    return MDCColorResourceSemanticSurface;
+  }
+  if ([semanticName isEqualToString:@"on-surface"]) {
+    return MDCColorResourceSemanticOnSurface;
+  }
+  if ([semanticName isEqualToString:@"overlay"]) {
+    return MDCColorResourceSemanticOverlay;
+  }
+  if ([semanticName isEqualToString:@"background"]) {
+    return MDCColorResourceSemanticBackground;
+  }
+  if ([semanticName isEqualToString:@"on-background"]) {
+    return MDCColorResourceSemanticOnBackground;
+  }
+  if ([semanticName isEqualToString:@"outline"]) {
+    return MDCColorResourceSemanticOutline;
+  }
+  if ([semanticName isEqualToString:@"error"]) {
+    return MDCColorResourceSemanticError;
+  }
+  return MDCColorResourceSemanticNone;
+}
+
+- (MDCColorResourcePalette)paletteResourceFromName:(NSString *)paletteName {
+  if ([paletteName isEqualToString:@"grey"]) {
+    return MDCColorResourcePaletteGrey;
+  }
+  if ([paletteName isEqualToString:@"blue"]) {
+    return MDCColorResourcePaletteBlue;
+  }
+  if ([paletteName isEqualToString:@"bluegrey"]) {
+    return MDCColorResourcePaletteBlueGrey;
+  }
+  if ([paletteName isEqualToString:@"indigo"]) {
+    return MDCColorResourcePaletteIndigo;
+  }
+  if ([paletteName isEqualToString:@"purple"]) {
+    return MDCColorResourcePalettePurple;
+  }
+  if ([paletteName isEqualToString:@"red"]) {
+    return MDCColorResourcePaletteRed;
+  }
+  if ([paletteName isEqualToString:@"orange"]) {
+    return MDCColorResourcePaletteOrange;
+  }
+  if ([paletteName isEqualToString:@"yellow"]) {
+    return MDCColorResourcePaletteYellow;
+  }
+  return MDCColorResourcePaletteNone;
+}
+
+- (MDCColorResourcePaletteTint)paletteTintResourceFromName:(NSString *)tintName {
+  if ([tintName isEqualToString:@"50"]) {
+    return MDCColorResourcePaletteTint50;
+  }
+  if ([tintName isEqualToString:@"100"]) {
+    return MDCColorResourcePaletteTint100;
+  }
+  if ([tintName isEqualToString:@"200"]) {
+    return MDCColorResourcePaletteTint200;
+  }
+  if ([tintName isEqualToString:@"300"]) {
+    return MDCColorResourcePaletteTint300;
+  }
+  if ([tintName isEqualToString:@"400"]) {
+    return MDCColorResourcePaletteTint400;
+  }
+  if ([tintName isEqualToString:@"500"]) {
+    return MDCColorResourcePaletteTint500;
+  }
+  if ([tintName isEqualToString:@"600"]) {
+    return MDCColorResourcePaletteTint600;
+  }
+  if ([tintName isEqualToString:@"700"]) {
+    return MDCColorResourcePaletteTint700;
+  }
+  if ([tintName isEqualToString:@"800"]) {
+    return MDCColorResourcePaletteTint800;
+  }
+  if ([tintName isEqualToString:@"900"]) {
+    return MDCColorResourcePaletteTint900;
+  }
+
+  return MDCColorResourcePaletteTintNone;
+}
+
+@end

--- a/components/schemes/State/examples/src/MDCControlState.h
+++ b/components/schemes/State/examples/src/MDCControlState.h
@@ -1,0 +1,40 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ Themable Material States
+
+MDCControlState represents all Material states.
+ UIControlState names are preferred when UIKit names are different than Material names.
+
+ * Eight distinctive states are enumerated.
+ * Additional "interactive" state is added to allow collective-theming of interactive states
+   (interactive states include all states except for normal, disabled and error).
+ */
+typedef NS_OPTIONS(NSUInteger, MDCControlState) {
+  MDCControlStateNormal = 0,            // Material: Enabled
+  MDCControlStateHighlighted = 1 << 0,  // Material: Pressed
+  MDCControlStateSelected = 1 << 1,     // Material: Selected
+  MDCControlStateActive = 1 << 2,       // Material: Active
+  MDCControlStateFocused = 1 << 3,      // Material: Focused
+  MDCControlStateDragged = 1 << 4,      // Material: Dragged
+  MDCControlStateDisabled = 1 << 5,     // Material: Disabled
+  MDCControlStateError = 1 << 6,        // Material: Error
+
+  MDCControlStateInteractive = 1 << 7  // Pressed or Selected or Active or Focused or Dragged
+  //  TODO: Change interactive value to a mask:
+  //  MDCControlStateInteractive =  MDCControlStateHighlighted | MDCControlStateSelected |
+  //                                MDCControlStateActive | MDCControlStateFocused |
+  //                                MDCControlStateDragged;
+};

--- a/components/schemes/State/examples/src/MDCStateExampleColorScheme.h
+++ b/components/schemes/State/examples/src/MDCStateExampleColorScheme.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <Foundation/Foundation.h>
-//#import "MDCColorResource.h"
+#import <UIKit/UIKit.h>
 #import "MaterialColorScheme.h"
 
 /**

--- a/components/schemes/State/examples/src/MDCStateExampleColorScheme.h
+++ b/components/schemes/State/examples/src/MDCStateExampleColorScheme.h
@@ -1,0 +1,55 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+//#import "MDCColorResource.h"
+#import "MaterialColorScheme.h"
+
+/**
+ Creating a new MDCStateExampleColorScheme to add a couple of semantic colors to the
+ StateScheme example.
+
+ Note: onPrimaryColorVariant and onSurfaceColorVariant are not used in state theming.
+ */
+@interface MDCStateExampleColorScheme : NSObject <MDCColorScheming, NSCopying>
+
+@property(nonnull, readwrite, copy, nonatomic) MDCSemanticColorScheme *MDCColorScheme;
+
+// Redeclare protocol properties as readwrite (overriding the protocol's readonly attribute)
+@property(nonnull, readwrite, copy, nonatomic) UIColor *primaryColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *primaryColorVariant;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *secondaryColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *errorColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *surfaceColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *backgroundColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *onPrimaryColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *onSecondaryColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *onSurfaceColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *onBackgroundColor;
+
+// Additional semantic names used by the state example
+@property(nonnull, readwrite, copy, nonatomic) UIColor *overlayColor;
+@property(nonnull, readwrite, copy, nonatomic) UIColor *outlineColor;
+
+/**
+ Initializes the color scheme with the latest material defaults.
+ */
+- (nonnull instancetype)init;
+
+/**
+ Initializes the color scheme with the colors associated with the given defaults.
+ */
+- (nonnull instancetype)initWithDefaults:(MDCColorSchemeDefaults)defaults;
+
+@end

--- a/components/schemes/State/examples/src/MDCStateExampleColorScheme.m
+++ b/components/schemes/State/examples/src/MDCStateExampleColorScheme.m
@@ -57,6 +57,7 @@
 
 - (id)copyWithZone:(NSZone *)zone {
   MDCStateExampleColorScheme *copy = [[MDCStateExampleColorScheme alloc] init];
+  copy.MDCColorScheme = self.MDCColorScheme;
   copy.primaryColor = self.primaryColor;
   copy.primaryColorVariant = self.primaryColorVariant;
   copy.secondaryColor = self.secondaryColor;

--- a/components/schemes/State/examples/src/MDCStateExampleColorScheme.m
+++ b/components/schemes/State/examples/src/MDCStateExampleColorScheme.m
@@ -1,0 +1,77 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCStateExampleColorScheme.h"
+#import "MaterialPalettes.h"
+
+#pragma mark - MDCStateExampleColorScheme
+
+@implementation MDCStateExampleColorScheme
+
+- (instancetype)init {
+  return [self initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+}
+
+- (instancetype)initWithDefaults:(MDCColorSchemeDefaults)defaults {
+  self = [super init];
+  if (self) {
+    switch (defaults) {
+      case MDCColorSchemeDefaultsMaterial201804:
+
+        self.MDCColorScheme =
+            [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+
+        _primaryColor = self.MDCColorScheme.primaryColor;
+        _primaryColorVariant = self.MDCColorScheme.primaryColorVariant;
+        _secondaryColor = self.MDCColorScheme.secondaryColor;
+        _errorColor = self.MDCColorScheme.errorColor;
+        _surfaceColor = self.MDCColorScheme.surfaceColor;
+        _backgroundColor = self.MDCColorScheme.backgroundColor;
+        _onPrimaryColor = self.MDCColorScheme.onPrimaryColor;
+        _onSecondaryColor = self.MDCColorScheme.onSecondaryColor;
+        _onSurfaceColor = self.MDCColorScheme.onSurfaceColor;
+        _onBackgroundColor = self.MDCColorScheme.onBackgroundColor;
+
+        // Setting the Example's colors
+        _overlayColor = MDCPalette.greyPalette.tint800;
+        _outlineColor = MDCPalette.greyPalette.tint300;
+
+        break;
+    }
+  }
+  return self;
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone {
+  MDCStateExampleColorScheme *copy = [[MDCStateExampleColorScheme alloc] init];
+  copy.primaryColor = self.primaryColor;
+  copy.primaryColorVariant = self.primaryColorVariant;
+  copy.secondaryColor = self.secondaryColor;
+  copy.surfaceColor = self.surfaceColor;
+  copy.backgroundColor = self.backgroundColor;
+  copy.errorColor = self.errorColor;
+  copy.onPrimaryColor = self.onPrimaryColor;
+  copy.onSecondaryColor = self.onSecondaryColor;
+  copy.onSurfaceColor = self.onSurfaceColor;
+  copy.onBackgroundColor = self.onBackgroundColor;
+
+  copy.overlayColor = self.overlayColor;
+  copy.outlineColor = self.outlineColor;
+
+  return copy;
+}
+
+@end

--- a/components/schemes/State/examples/src/MDCStateScheme.h
+++ b/components/schemes/State/examples/src/MDCStateScheme.h
@@ -1,0 +1,164 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import "MDCColorResource.h"
+#import "MDCControlState.h"
+#import "MaterialColorScheme.h"
+
+/**
+  MDCStateSchemeTheme lists the themes of the StateScheme. Each
+  theme has its own set of state-related information.
+  Themers typically use a single theme to theme all states of components.
+  For instnace, a text and hairline button themers will use the "OnWhite" theme for
+  all state information. A contained button themer will use the "OnPrimary" theme.
+
+  Note that some themes, like outline and elevated may not have state information
+  for all attributes, and will inherit attributes they don't have from a  base
+  theme (either OnWhite and OnPrimary).
+*/
+typedef NS_ENUM(NSInteger, MDCStateSchemeTheme) {
+  MDCStateSchemeThemeNone,
+  MDCStateSchemeThemeOnWhite,    // base theme
+  MDCStateSchemeThemeOnPrimary,  // base theme
+  MDCStateSchemeThemeOutlined,   // inherits from: onWhite
+  MDCStateSchemeThemeElevated    // inherits from: onWhite
+};
+
+/**
+
+ Material State Scheme
+
+ The State Scheme map stores state-related values that determine appearance of states in components.
+ The map supports multiple themes, like OnWhite or OnPrimary. Each theme includes a pre-defined list
+ of attributes that determine its appearance. Currently supported state-related attributes include:
+ overlay color, container color, content color, border color and elevation.
+
+ Each of the 5 attributes includes a single value for each of the states it relates to. Values may
+ be missing if they inherit from "normal"/"enabled" state. If no normal/enabled state value is
+ defined, then these missing values are ignored.
+
+ These single values are stored internally as ResourceDictionary types, which are converted by
+ getters and returnd as a ColorResource instances - for color values, or as ShadowElevation type -
+ for elevation values.
+
+ The actual attributes are stored as AttributeDictionary types, which is a mapping of states
+ (keys) to ResourceDictionaries (values).
+
+ An entire theme (for isntance: the "onWhite" theme) is stored as a StateDictionary, which is a
+ dictionary of these 5 main attribures, each mapped to a AttributeDictionary which describes
+ all its states.
+
+ The dictionary structure is private, and access to it is available through getters and setters
+ which convert the dictionary string data to types used by themers or other schemes.
+
+ Dictionary values use enums to convert between the archived format (NSString) and the "real"/actual
+ values. The enumerations include: the MDCControlState enumeration lists states;
+ MDCColorResourceSemantic lists semantic color names; MDCColorResourcePalette and
+ MDCColorResourcePaletteTint list palettes and tints; MDCStateSchemeTheme lists all themes.
+
+ Each shadowElevation attribute has a getter and a setter, converting ShadowElevation to
+ strings and vice versa.
+
+ Each color attribute has a getter which returns a MDCColorResource class. MDCSemanticColotScheme's
+ realColorWithResource: converts a color resource to an actual color taken from the color
+ scheme.
+
+ Attributes also have setters. Setters are used to override specific state values as needed, for
+ instance, when a contrast ratio is too low for some color schemes. Overrides for Material's default
+ color scheme are updated in the StateScheme's initializer.
+
+ Each color attribute has 2 setters, one accepting a palette color (enum) and another accepting
+ a semantic color name (enum). These setters may be used to override specific state values when
+ required. Setters accepting hex values are not supported at this point and may be added in the
+ future as need arise.
+
+ Implementation notes:
+
+ * State names use material names. The mapping to UIControlState is:
+   "enabled" == "normal"
+   "pressed" == "highlighted".
+   All other state names are the same for both Material theming and UIControl.
+
+ * State names also include states that do not exist in UIControlState,
+   like: dragged, active & error.
+
+ * The "Enabled" state (aka: "normal") acts as the default value in UIControls when values for
+   other states, like "selected" or "pressed", are not provided in this map.  This is a default
+   behavior of UIControl, and an active assumption in building this map (meaning, values will not
+   be provided for states if they meant to be inherit from the "enabled/nomral" state).
+
+   Note that components supporting non-UIControlState states, like Dragged, Active or Error, must
+   adopt this implementation to get correct theming for those states (they must use the "enabled"
+   state, if provided, as a default to the dragged, active & error states, if the latters are
+   not provided).
+
+ * "Darker" and "ligher" variations are used in MDC for a generic contrast increase of the
+   interactive states. These are overriden with specific values for each color combinations
+   (check overrides in init(withDefaults:)).
+
+ */
+
+@interface MDCStateScheme : NSObject
+
+/**
+ Initializes the state scheme with override specific to the given default color scheme.
+ */
+- (nonnull instancetype)initWithDefaults:(MDCColorSchemeDefaults)defaults;
+
+#pragma mark - getters
+
+/// Returns a Color Resource representing an overlay color, for the given state & theme
+- (MDCColorResource *)overlayColorResourceForState:(MDCControlState)state
+                                             theme:(MDCStateSchemeTheme)theme;
+
+/// Returns a Color Resource representing a container color, for the given state & theme
+- (MDCColorResource *)containerColorResourceForState:(MDCControlState)state
+                                               theme:(MDCStateSchemeTheme)theme;
+
+/// Returns a Color Resource representing a content color, for the given state & theme
+- (MDCColorResource *)contentColorResourceForState:(MDCControlState)state
+                                             theme:(MDCStateSchemeTheme)theme;
+
+/// Returns a Color Resource representing a border color, for the given state & theme
+- (MDCColorResource *)borderColorResourceForState:(MDCControlState)state
+                                            theme:(MDCStateSchemeTheme)theme;
+
+#pragma mark - setters by semantic name
+
+/// An overlay color setter, accepting a semantic color, for the given state & theme
+- (void)setOverlayColorWithSemanticColor:(MDCColorResourceSemantic)semanticName
+                                 opacity:(CGFloat)opacity
+                                forState:(MDCControlState)state
+                                 inTheme:(MDCStateSchemeTheme)theme;
+
+/// A container color setter, accepting a semantic color, for the given state & theme
+- (void)setContainerColorWithSemanticColor:(MDCColorResourceSemantic)semanticName
+                                   opacity:(CGFloat)opacity
+                                  forState:(MDCControlState)state
+                                   inTheme:(MDCStateSchemeTheme)theme;
+
+/// A content color setter, accepting a semantic color, for the given state & theme
+- (void)setContentColorWithSemanticColor:(MDCColorResourceSemantic)semanticName
+                                 opacity:(CGFloat)opacity
+                                forState:(MDCControlState)state
+                                 inTheme:(MDCStateSchemeTheme)theme;
+
+/// A border color setter, accepting a semantic color, for the given state & theme
+- (void)setBorderColorWithSemanticColor:(MDCColorResourceSemantic)semanticName
+                                opacity:(CGFloat)opacity
+                               forState:(MDCControlState)state
+                                inTheme:(MDCStateSchemeTheme)theme;
+
+@end

--- a/components/schemes/State/examples/src/MDCStateScheme.h
+++ b/components/schemes/State/examples/src/MDCStateScheme.h
@@ -27,11 +27,11 @@
   Note that some themes, like outline and elevated may not have state information
   for all attributes, and will inherit attributes they don't have from a  base
   theme (either OnWhite and OnPrimary).
+  Note: Theme inheritence is calculated in [self baseThemeDictionary:]
 */
 typedef NS_ENUM(NSInteger, MDCStateSchemeTheme) {
-  MDCStateSchemeThemeNone,
-  MDCStateSchemeThemeOnWhite,    // base theme
-  MDCStateSchemeThemeOnPrimary,  // base theme
+  MDCStateSchemeThemeOnWhite,    // full theme
+  MDCStateSchemeThemeOnPrimary,  // full theme
   MDCStateSchemeThemeOutlined,   // inherits from: onWhite
   MDCStateSchemeThemeElevated    // inherits from: onWhite
 };

--- a/components/schemes/State/examples/src/MDCStateScheme.m
+++ b/components/schemes/State/examples/src/MDCStateScheme.m
@@ -246,8 +246,6 @@ typedef NSDictionary<NSString *, MDCAttributeMutableDictionary *> MDCStateMutabl
       return self.outlined;
     case MDCStateSchemeThemeElevated:
       return self.elevated;
-    case MDCStateSchemeThemeNone:
-      return nil;
   }
 }
 

--- a/components/schemes/State/examples/src/MDCStateScheme.m
+++ b/components/schemes/State/examples/src/MDCStateScheme.m
@@ -1,0 +1,450 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCStateScheme.h"
+#import "MaterialStates.h"
+
+typedef NSDictionary<NSString *, NSString *> MDCResourceDictionary;
+typedef NSDictionary<NSString *, MDCResourceDictionary *> MDCAttributeDictionary;
+typedef NSDictionary<NSString *, MDCAttributeDictionary *> MDCStateDictionary;
+typedef NSMutableDictionary<NSString *, MDCResourceDictionary *> MDCAttributeMutableDictionary;
+typedef NSDictionary<NSString *, MDCAttributeMutableDictionary *> MDCStateMutableDictionary;
+
+@interface MDCColorResource (Private)
+
+/**
+ A private extension of MDCColorResource which converts a dictionary (of type ResourceDictionary)
+ to an MDCColorResource instance, returning nil if the entry cannot be converted.
+ ResourceDictionaries with the following color formats are supported:
+ * "semanticColor" is verified against the list of semantic colors in MDCSemanticColorScheming.
+ * "palette" and "tint" are verified againts valid Palette names and tints.
+ * "hex" strings are verified as a valid 6-digit hex values (leading with an optional #).
+ */
+- (nonnull instancetype)initWithResourceDictionary:(MDCResourceDictionary *)dictionary;
+- (MDCResourceDictionary *)toDictionary;
+
+@end
+
+@interface MDCStateScheme ()
+@property(nonatomic, strong, nonnull) MDCStateMutableDictionary *onWhite;
+@property(nonatomic, strong, nonnull) MDCStateMutableDictionary *onPrimary;
+@property(nonatomic, strong, nonnull) MDCStateMutableDictionary *outlined;
+@property(nonatomic, strong, nonnull) MDCStateMutableDictionary *elevated;
+
+@end
+
+@implementation MDCStateScheme
+
+- (nonnull instancetype)init {
+  self = [super init];
+  if (self) {
+    [self initializeStateDictionaries];
+  }
+  return self;
+}
+
+- (void)initializeStateDictionaries {
+  self.onWhite = [NSMutableDictionary dictionaryWithDictionary:@{
+    @"overlay" : [NSMutableDictionary dictionaryWithDictionary:@{
+      @"selected" : [NSMutableDictionary
+          dictionaryWithDictionary:@{@"semanticColor" : @"overlay", @"opacity" : @"0.12"}],
+      @"pressed" : [NSMutableDictionary
+          dictionaryWithDictionary:@{@"semanticColor" : @"overlay", @"opacity" : @"0.10"}],
+      @"dragged" : [NSMutableDictionary
+          dictionaryWithDictionary:@{@"semanticColor" : @"overlay", @"opacity" : @"0.08"}],
+    }],
+    @"container" : [NSMutableDictionary dictionaryWithDictionary:@{
+      @"enabled" : [NSMutableDictionary dictionaryWithDictionary:@{@"semanticColor" : @"surface"}],
+    }],
+    @"content" : [NSMutableDictionary dictionaryWithDictionary:@{
+      @"enabled" :
+          [NSMutableDictionary dictionaryWithDictionary:@{@"semanticColor" : @"on-surface"}],
+      @"interactive" : [NSMutableDictionary
+          dictionaryWithDictionary:@{@"semanticColor" : @"on-surface", @"dim" : @"0.2"}],
+      @"disabled" : [NSMutableDictionary
+          dictionaryWithDictionary:@{@"palette" : @"grey", @"tint" : @"800", @"opacity" : @"0.38"}],
+      @"error" : [NSMutableDictionary dictionaryWithDictionary:@{@"semanticColor" : @"error"}],
+    }],
+    @"border" : [NSMutableDictionary dictionaryWithDictionary:@{
+      @"focused" : [NSMutableDictionary dictionaryWithDictionary:@{@"semanticColor" : @"overlay"}],
+    }],
+    @"shadowElevation" : [NSMutableDictionary dictionaryWithDictionary:@{
+      @"dragged" : [NSMutableDictionary dictionaryWithDictionary:@{@"shadowElevation" : @"3"}],
+    }]
+  }];
+
+  self.onPrimary = [NSMutableDictionary dictionaryWithDictionary:@{
+    @"overlay" : [NSMutableDictionary dictionaryWithDictionary:@{
+      @"selected" : [NSMutableDictionary
+          dictionaryWithDictionary:@{@"semanticColor" : @"overlay", @"opacity" : @"0.24"}],
+      @"pressed" : [NSMutableDictionary
+          dictionaryWithDictionary:@{@"semanticColor" : @"overlay", @"opacity" : @"0.20"}],
+      @"dragged" : [NSMutableDictionary
+          dictionaryWithDictionary:@{@"semanticColor" : @"overlay", @"opacity" : @"0.16"}],
+    }],
+    @"container" : [NSMutableDictionary dictionaryWithDictionary:@{
+      @"enabled" : [NSMutableDictionary dictionaryWithDictionary:@{@"semanticColor" : @"primary"}],
+      @"disabled" : [NSMutableDictionary
+          dictionaryWithDictionary:@{@"palette" : @"grey", @"tint" : @"800", @"opacity" : @"0.12"}],
+    }],
+    @"content" : [NSMutableDictionary dictionaryWithDictionary:@{
+      @"enabled" :
+          [NSMutableDictionary dictionaryWithDictionary:@{@"semanticColor" : @"on-primary"}],
+      @"interactive" : [NSMutableDictionary dictionaryWithDictionary:@{
+        @"semanticColor" : @"on-primary",
+        @"dim" : @"-0.2"
+      }],  // 20% lighter onPrimary
+      @"disabled" : [NSMutableDictionary
+          dictionaryWithDictionary:@{@"palette" : @"grey", @"tint" : @"800", @"opacity" : @"0.38"}],
+      @"error" : [NSMutableDictionary dictionaryWithDictionary:@{@"semanticColor" : @"error"}],
+    }],
+    @"border" : [NSMutableDictionary dictionaryWithDictionary:@{
+      @"focused" : [NSMutableDictionary
+          dictionaryWithDictionary:@{@"semanticColor" : @"overlay"}],  // is this correct?
+    }],
+    @"shadowElevation" : [NSMutableDictionary dictionaryWithDictionary:@{
+      @"pressed" : [NSMutableDictionary dictionaryWithDictionary:@{@"shadowElevation" : @"2"}],
+      @"dragged" : [NSMutableDictionary dictionaryWithDictionary:@{@"shadowElevation" : @"3"}],
+    }]
+  }];
+
+  // The outlined theme inherits all unlisted attributes from "onWhite" (see baseThemeDictionary:)
+  // Attributes are inherited in their entirety. If an attribute is listed in the child theme, all
+  // its states are taken from the child theme, and all parent states are ignored for those
+  // attributes. Attributes that are not listed in the child theme, will be taken from the parent.
+  self.outlined = [NSMutableDictionary dictionaryWithDictionary:@{
+    @"border" : [NSMutableDictionary dictionaryWithDictionary:@{
+      @"enabled" :
+          [NSMutableDictionary dictionaryWithDictionary:@{@"palette" : @"grey", @"tint" : @"300"}],
+      @"interactive" : [NSMutableDictionary
+          dictionaryWithDictionary:@{@"semanticColor" : @"on-surface", @"dim" : @"0.2"}],
+      @"focused" : [NSMutableDictionary dictionaryWithDictionary:@{@"semanticColor" : @"overlay"}],
+      @"disabled" : [NSMutableDictionary
+          dictionaryWithDictionary:@{@"palette" : @"grey", @"tint" : @"800", @"opacity" : @"0.12"}],
+      @"error" : [NSMutableDictionary dictionaryWithDictionary:@{@"semanticColor" : @"error"}],
+    }]
+  }];
+
+  // The elevated theme inherits all unspecified propertie from "onWhite" (see
+  // baseThemeDictionary:)
+  self.elevated = [NSMutableDictionary dictionaryWithDictionary:@{
+    @"shadowElevation" : [NSMutableDictionary dictionaryWithDictionary:@{
+      @"enabled" : [NSMutableDictionary dictionaryWithDictionary:@{@"shadowElevation" : @"1"}],
+      @"selected" : [NSMutableDictionary dictionaryWithDictionary:@{@"shadowElevation" : @"1"}],
+      @"active" : [NSMutableDictionary dictionaryWithDictionary:@{@"shadowElevation" : @"1"}],
+      @"pressed" : [NSMutableDictionary dictionaryWithDictionary:@{@"shadowElevation" : @"3"}],
+      @"dragged" : [NSMutableDictionary dictionaryWithDictionary:@{@"shadowElevation" : @"4"}],
+    }]
+  }];
+}
+
+- (nonnull instancetype)initWithDefaults:(MDCColorSchemeDefaults)defaults {
+  // First initialize the state dictionary
+  self = [self init];
+  if (self) {
+    // Override specific values as needed
+    switch (defaults) {
+      case MDCColorSchemeDefaultsMaterial201804:
+        // TODO: Add overrides for MDCColorSchemeDefaultsMaterial201804:
+        //[self setContentColor:...];
+        //[self setBorderColor:...];
+        break;
+    }
+  }
+  return self;
+}
+
+#pragma mark - Color Attributes Getters
+
+- (MDCColorResource *)overlayColorResourceForState:(MDCControlState)state
+                                             theme:(MDCStateSchemeTheme)theme {
+  return [self colorForAttributeNamed:@"overlay" state:state theme:theme];
+}
+
+- (MDCColorResource *)containerColorResourceForState:(MDCControlState)state
+                                               theme:(MDCStateSchemeTheme)theme {
+  return [self colorForAttributeNamed:@"container" state:state theme:theme];
+}
+
+- (MDCColorResource *)contentColorResourceForState:(MDCControlState)state
+                                             theme:(MDCStateSchemeTheme)theme {
+  return [self colorForAttributeNamed:@"content" state:state theme:theme];
+}
+
+- (MDCColorResource *)borderColorResourceForState:(MDCControlState)state
+                                            theme:(MDCStateSchemeTheme)theme {
+  return [self colorForAttributeNamed:@"border" state:state theme:theme];
+}
+
+#pragma mark - Color Setters By Semantic Name
+
+- (void)setOverlayColorWithSemanticColor:(MDCColorResourceSemantic)semanticName
+                                 opacity:(CGFloat)opacity
+                                forState:(MDCControlState)state
+                                 inTheme:(MDCStateSchemeTheme)theme {
+  MDCColorResource *resource =
+      [[MDCColorResource alloc] initWithSemanticResource:semanticName
+                                                 opacity:opacity
+                                                     dim:MDCColorResourceDefaultDim];
+  [self setColorResource:resource forAttribute:@"overlay" state:state theme:theme];
+}
+
+- (void)setContainerColorWithSemanticColor:(MDCColorResourceSemantic)semanticName
+                                   opacity:(CGFloat)opacity
+                                  forState:(MDCControlState)state
+                                   inTheme:(MDCStateSchemeTheme)theme {
+  MDCColorResource *resource =
+      [[MDCColorResource alloc] initWithSemanticResource:semanticName
+                                                 opacity:opacity
+                                                     dim:MDCColorResourceDefaultDim];
+  [self setColorResource:resource forAttribute:@"container" state:state theme:theme];
+}
+
+- (void)setContentColorWithSemanticColor:(MDCColorResourceSemantic)semanticName
+                                 opacity:(CGFloat)opacity
+                                forState:(MDCControlState)state
+                                 inTheme:(MDCStateSchemeTheme)theme {
+  MDCColorResource *resource =
+      [[MDCColorResource alloc] initWithSemanticResource:semanticName
+                                                 opacity:opacity
+                                                     dim:MDCColorResourceDefaultDim];
+  [self setColorResource:resource forAttribute:@"content" state:state theme:theme];
+}
+
+- (void)setBorderColorWithSemanticColor:(MDCColorResourceSemantic)semanticName
+                                opacity:(CGFloat)opacity
+                               forState:(MDCControlState)state
+                                inTheme:(MDCStateSchemeTheme)theme {
+  MDCColorResource *resource =
+      [[MDCColorResource alloc] initWithSemanticResource:semanticName
+                                                 opacity:opacity
+                                                     dim:MDCColorResourceDefaultDim];
+  [self setColorResource:resource forAttribute:@"border" state:state theme:theme];
+}
+
+#pragma mark - private helpers
+
+/// Return the StateDictionary of the requested theme
+- (nullable MDCStateDictionary *)themeDictionary:(MDCStateSchemeTheme)theme {
+  switch (theme) {
+    case MDCStateSchemeThemeOnWhite:
+      return self.onWhite;
+    case MDCStateSchemeThemeOnPrimary:
+      return self.onPrimary;
+    case MDCStateSchemeThemeOutlined:
+      return self.outlined;
+    case MDCStateSchemeThemeElevated:
+      return self.elevated;
+    case MDCStateSchemeThemeNone:
+      return nil;
+  }
+}
+
+/// Returns the "parent" theme a theme inherits from. Top level themes, like onWhite and onPrimary
+/// return nil since they do not inherit from other themes.
+- (nullable MDCStateDictionary *)baseThemeDictionary:(MDCStateSchemeTheme)theme {
+  switch (theme) {
+    case MDCStateSchemeThemeOutlined:
+      return self.onWhite;
+    case MDCStateSchemeThemeElevated:
+      return self.onWhite;
+    default:
+      return nil;
+  }
+}
+
+/// Returns the ResourceDictionary of the requested attribute, for the requested state and theme.
+/// If the given state is an interactive state, and the speicifc state value is
+/// missing, the interactive state will be returned (if the value exists).
+/// Will return nil if the requested info is not found in the dictionary
+- (nullable MDCResourceDictionary *)attributeNamed:(NSString *)name
+                                             state:(MDCControlState)state
+                                        dictionary:(MDCStateDictionary *)dictionary {
+  MDCAttributeDictionary *attributeInfo = dictionary[name];
+  if (attributeInfo == nil) {
+    return nil;
+  }
+
+  NSString *stateName = [self controlStateName:state];
+  if (attributeInfo[stateName] != nil) {
+    // Quering the state info by the name of the requested state
+    return attributeInfo[stateName];
+  } else if ([self controlStateIsInteractive:state]) {
+    // fallback for "interactive" states if the value for the requested name is nil.
+    return attributeInfo[@"interactive"];
+  }
+  // TODO: for non ui-controlState states, like dragged, error, active, etc - verify if
+  //       we need to return the "enabled" state here, or is this the responsibility of
+  //       the components?
+  return nil;
+}
+
+/// Returns the ColorResource of the requested attribute, for the requested state and theme.
+- (nullable MDCColorResource *)colorForAttributeNamed:(NSString *)name
+                                                state:(MDCControlState)state
+                                                theme:(MDCStateSchemeTheme)theme {
+  // Get parent (base) and main dictionaries of the requested theme.
+  MDCStateDictionary *baseThemeDictionary = [self baseThemeDictionary:theme];
+  MDCStateDictionary *themeDictionary = [self themeDictionary:theme];
+
+  // Get the attribute from the main dictionary
+  MDCResourceDictionary *attribute = [self attributeNamed:name
+                                                    state:state
+                                               dictionary:themeDictionary];
+
+  // If the attribute is not found in the main dictionary, get it from the parent (if exists).
+  if (attribute == nil && baseThemeDictionary != nil) {
+    attribute = [self attributeNamed:name state:state dictionary:baseThemeDictionary];
+  }
+
+  // If we found the attribute in either dictionary - return it as an MDCColorResource
+  if (attribute != nil) {
+    return [[MDCColorResource alloc] initWithResourceDictionary:attribute];
+  }
+
+  // The requested attribute was not found
+  return nil;
+}
+
+/// Updates the ColorResource for the requested attribute, in the requested state and theme.
+- (void)setColorResource:(MDCColorResource *)resource
+            forAttribute:(NSString *)attributeName
+                   state:(MDCControlState)state
+                   theme:(MDCStateSchemeTheme)theme {
+  NSString *stateName = [self controlStateName:state];
+
+  switch (theme) {
+    case MDCStateSchemeThemeOnWhite:
+      if (self.onWhite[attributeName] != nil) {
+        self.onWhite[attributeName][stateName] = [resource toDictionary];
+      }
+      break;
+
+    case MDCStateSchemeThemeOnPrimary:
+      if (self.onPrimary[attributeName] != nil) {
+        self.onPrimary[attributeName][stateName] = [resource toDictionary];
+      }
+      break;
+
+    default:
+      break;
+  }
+}
+
+- (bool)controlStateIsInteractive:(MDCControlState)controlState {
+  return (controlState & MDCControlStateHighlighted) != 0 ||
+         (controlState & MDCControlStateSelected) != 0 ||
+         (controlState & MDCControlStateActive) != 0 ||
+         (controlState & MDCControlStateFocused) != 0 ||
+         (controlState & MDCControlStateDragged) != 0;
+}
+
+- (NSString *)controlStateName:(MDCControlState)controlState {
+  switch (controlState) {
+    case MDCControlStateNormal:
+      return @"normal";
+      break;
+    case MDCControlStateHighlighted:
+      return @"pressed";
+      break;
+    case MDCControlStateSelected:
+      return @"selected";
+      break;
+    case MDCControlStateActive:
+      return @"active";
+      break;
+    case MDCControlStateFocused:
+      return @"focused";
+      break;
+    case MDCControlStateDragged:
+      return @"dragged";
+      break;
+    case MDCControlStateDisabled:
+      return @"disabled";
+      break;
+    case MDCControlStateError:
+      return @"error";
+      break;
+    case MDCControlStateInteractive:
+      return @"interactive";
+      break;
+  }
+}
+
+@end
+
+@implementation MDCColorResource (Private)
+
+/// Converting a scheme dictionary to an MDCColorResource instance
+- (nonnull instancetype)initWithResourceDictionary:(MDCResourceDictionary *)dictionary {
+  CGFloat opacity = MDCColorResourceDefaultOpacity;
+  if (dictionary[@"opacity"].length > 0) {
+    // value is converted to float, and truncated to no more than 2 percision digits
+    float floatValue = [dictionary[@"opacity"] floatValue];
+    opacity = round(floatValue * 100.0) / 100.0;
+  }
+
+  CGFloat dim = MDCColorResourceDefaultDim;
+  if (dictionary[@"dim"].length > 0) {
+    dim = [dictionary[@"dim"] floatValue];
+  }
+
+  NSString *semanticName = dictionary[@"semanticColor"];
+  if (semanticName.length > 0) {
+    MDCColorResourceSemantic semantic = [self semanticResourceFromName:semanticName];
+    if (semantic == MDCColorResourceSemanticNone) {
+      return nil;  // provided semantic name is invalid.
+    }
+    return [self initWithSemanticResource:semantic opacity:opacity dim:dim];
+  }
+
+  NSString *paletteName = dictionary[@"palette"];
+  NSString *tintName = dictionary[@"tint"];
+  if (paletteName.length || tintName.length) {
+    MDCColorResourcePalette palette = [self paletteResourceFromName:paletteName];
+    MDCColorResourcePaletteTint tint = [self paletteTintResourceFromName:tintName];
+    if (palette == MDCColorResourcePaletteNone || tint == MDCColorResourcePaletteTintNone) {
+      return nil;  // provided palette and/or tint are invalid
+    }
+
+    return [self initWithPaletteResource:palette tint:tint opacity:opacity dim:dim];
+  }
+
+  NSString *hexColor = dictionary[@"hexColor"];
+  if (!hexColor.length) {
+    return [self initWithHexString:hexColor opacity:opacity dim:dim];
+  }
+
+  return nil;
+}
+
+/// Converting a  MDCColorResource to a MDCResourceDictionary dictionary
+- (MDCResourceDictionary *)toDictionary {
+  NSMutableDictionary<NSString *, NSString *> *dictionary = [[NSMutableDictionary alloc] init];
+  dictionary[@"semanticColor"] = [self semanticNameFromResource:self.semantic];
+  dictionary[@"palette"] = [self paletteNameFromResource:self.palette];
+  dictionary[@"tint"] = [self paletteTintNameFromResource:self.tint];
+  if (self.hexColor != nil) {
+    dictionary[@"hexColor"] = self.hexColor;
+  }
+  if (self.opacity != MDCColorResourceDefaultOpacity) {
+    dictionary[@"opacity"] = [NSString stringWithFormat:@"%f", self.opacity];
+  }
+  if (self.dim != MDCColorResourceDefaultDim) {
+    dictionary[@"dim"] = [NSString stringWithFormat:@"%f", self.dim];
+  }
+  return dictionary;
+}
+
+@end

--- a/components/schemes/State/examples/src/MaterialStates.h
+++ b/components/schemes/State/examples/src/MaterialStates.h
@@ -1,0 +1,19 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCColorResource+ColorScheming.h"
+#import "MDCColorResource.h"
+#import "MDCControlState.h"
+#import "MDCStateExampleColorScheme.h"
+#import "MDCStateScheme.h"


### PR DESCRIPTION
### Material State Scheme

This is an experimental implementation of a State System. Main implementation ideas:

* Storing state related information outside of themers, in a dedicated data source (StateScheme). This will allow sharing state information across components/themers.
* Storing state data in a dictionary, which can be serialized and/or shared with external systems (in the future).  The StateScheme exposes getters and setters to access the private state information that is in this dictionary.
* Using a ColorResource class to represent colors in the State Scheme (more about this below).
* Colors that don't pass contrast ratio can be overridden and customized by clients, who can pick  specific colors that work with their color schemes.  This concept is demonstrated in the StateScheme initializer. 

### Color Resources

The Color Resource class is a concept borrowed from Android's Resources, which are being used heavily in its theming implementation. In this implementation, Color Resources represent colors in different formats, including Material formats (semantic or palette colors) or platform formats (expressed as hex values).

The StateScheme, which manages all state-related data in a single (private) dictionary, uses ColorResources in its getters and setters to expose its private state-color information. ColorResources are useful for string data serialization. Colors, stored as strings in a dictionary are converted to a structured and validated color format that can be reliably converted to a concrete UIColor. The StateScheme's ColorResources based API allows independence of a specific Color Scheme implementation. Clients (mostly themers) can then use the ColorResources, together with a specific color scheme, to get a concrete UIColor that can be used to theme components.

### State Map Implementation

The State Scheme's map stores state-related values which determine appearance of states in components.  State appearance is different for "on-primary" and "on white" themes, therefore a separate map is used to store each "theme" in the StateScheme.

Each theme map is made of a pre-defined list of attributes, which determine its appearance in the different states. Currently supported state-related attributes include: `overlay color, container color, content color, border color and elevation.`  Each of the 5 attributes includes multiple state values, one value for each state (only for relevant states). 

The State Scheme map is a private dictionary, with values stored as strings. This is to allow easy archiving or loading from external sources. The scheme exposes public access methods (getters and setters) for each attribute and their different states.  

The State scheme's getters return colors as ColorResources and elevation as ShadowElevations. 

The State Scheme defines a ShadowElevation setter for the state-elevation property, and 2 color setters for each of the 4 color properties: one accepting Palette colors, and another which accepts a semantic color name. 

### MDCControlState

A MDCControlState enumeration is used to represent all supported Material States. It is also used to convert between Material States and UIControlStates. Components that define their own State enumerations will have to provide a conversion method between this enumeration and their own's (Alternatively, all components should share this single enumeration).

Additionally, components must use the enabled/normal state theming information of a property, if it exists, as a default value for all states for which no specific theming info exists for that property. This is especially important in non UIControlStates, like Dragged, Active or Error (or Focused), since UIControls do that by default for states they support.

### StateExampleColorScheme

StateExampleColorScheme is used to add 2 semantic colors that are not yet in MDCColorScheming.  Beta or Final versions of StateScheme and ColorResource will use MDCColorScheming or MDCSemanticColorScheming in their implementations.
The "overlayColor" is a new color added to improve accessibility and get better contrast ratio in states. The "outlineColor" already exists in GM.

### Container Scheme

The Container Scheme API can ensure that a StateScheme is instantiated to match a specific ColorScheme. This is needed because StateScheme overrides are specific to colors used in a ColorScheme.

The current implementation of StateScheme overrides is in the StateScheme initializer, which is based on the same defaults enumeration that is used by MDCSemanticColorScheme. Passing the same default value to both schemes will ensure matching overrides.  An example of a Container Scheme implementation:

```
self.colorScheme = MDCSemanticColorScheme(defaults: .material201804)
self.stateScheme = MDCStateScheme(defaults: .material201804)
```

The Container Scheme API will be available in a follow up PR. 

### A Simplified API

In the current implementation, 2 API calls are used to get a UIColor value for a given state & theme:
```
UIColor *onWhiteSelectedOverlayColor = 
     [[self.stateScheme overlayColorResourceForState:MDCControlStateSelected 
                theme:MDCStateSchemeThemeOnWhite] 
        colorWithColorScheme:self.exampleColorScheme];
```

Other options exist for a one-step API, which gets a UIColor directly for a given state/theme:

**Option 1:**

```
UIColor *onWhiteSelectedOverlayColor = 
     [self.stateScheme overlayColorResourceForState:MDCControlStateSelected 
             theme:MDCStateSchemeThemeOnWhite
             withColorScheme:self.exampleColorScheme];
```

**Option 2:**

Adding StateScheme as a property of the ColorScheme (and making it, plus ShadowElevation (by proxy) a dependency of ColorScheme) provides the simplest API:

```
[self.colorScheme overlayColorResourceForState:MDCControlStateSelected 
         theme:MDCStateSchemeThemeOnWhite];
```

**Option 3:**

Adding the API to the Container Scheme. 

```
[self.containerScheme overlayColorResourceForState:MDCControlStateSelected 
         theme:MDCStateSchemeThemeOnWhite];
```

**Our recommendation:** 

Option 0 (implemented solution).

### Issue

b/122521260: [b/122521260](b/122521260)

Experimental Prototype: #6548