### PR TITLE
[BottomNavigation] Badge size grows with value

### DIFF
--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemBadge.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemBadge.m
@@ -92,28 +92,14 @@ static const CGFloat kMinDiameter = 9;
   // Calculate the badge and label heights
   CGSize labelSize = [self.badgeValueLabel sizeThatFits:size];
   CGFloat badgeHeight = labelSize.height + kBadgeYPadding;
-  if (badgeHeight > size.height) {
-    badgeHeight = size.height;
-    labelSize = CGSizeMake(labelSize.width, badgeHeight - kBadgeYPadding);
-  }
   CGFloat contentXPadding = [self badgeXPaddingForRadius:badgeHeight / 2];
   CGFloat badgeWidth = labelSize.width + contentXPadding;
-  if (badgeWidth > size.width) {
-    badgeWidth = size.width;
-    labelSize = CGSizeMake(badgeWidth - contentXPadding, labelSize.height);
-  }
   badgeWidth = MAX(kMinDiameter, badgeWidth);
   badgeHeight = MAX(kMinDiameter, badgeHeight);
   if (badgeWidth < badgeHeight) {
     badgeWidth = badgeHeight;
   }
   return CGSizeMake(badgeWidth, badgeHeight);
-}
-
-- (void)sizeToFit {
-  CGSize fitSize = [self sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)];
-  CGRect newBounds = CGRectMake(0, 0, fitSize.width, fitSize.height);
-  self.bounds = newBounds;
 }
 
 - (void)setBadgeValue:(NSString *)badgeValue {

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -406,6 +406,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
   } else {
     self.badge.hidden = NO;
   }
+  [self setNeedsLayout];
 }
 
 - (void)setImage:(UIImage *)image {


### PR DESCRIPTION
When the badge value grows to a larger string than the initial value,
the badge view will now correctly have its bounds updated.

|Before|After|
|---|---|
|![bn-badge-grow-before](https://user-images.githubusercontent.com/1753199/52574523-80eb1d00-2dea-11e9-842c-4a7fd0a56b89.gif)|![bn-badge-grow-after](https://user-images.githubusercontent.com/1753199/52574532-847ea400-2dea-11e9-97ea-14c7d1c1b815.gif)|

