### PR TITLE
[Shapes] Use MaterialShapeLibraryNew

### DIFF
--- a/components/BottomSheet/tests/unit/BottomSheetShapeThemerTests.swift
+++ b/components/BottomSheet/tests/unit/BottomSheetShapeThemerTests.swift
@@ -15,7 +15,7 @@
 import XCTest
 import MaterialComponents.MaterialBottomSheet
 import MaterialComponents.MaterialBottomSheet_ShapeThemer
-import MaterialComponents.MaterialShapeLibrary
+import MaterialComponents.MaterialShapeLibraryNew
 
 class BottomSheetShapeThemerTests: XCTestCase {
 

--- a/components/Buttons/tests/unit/Theming/ButtonsThemingTest.swift
+++ b/components/Buttons/tests/unit/Theming/ButtonsThemingTest.swift
@@ -18,7 +18,7 @@ import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialShadowElevations
 import MaterialComponents.MaterialShapeScheme
-import MaterialComponents.MaterialShapeLibrary
+import MaterialComponents.MaterialShapeLibraryNew
 import MaterialComponents.MaterialTypographyScheme
 import MaterialComponentsBeta.MaterialButtons_Theming
 import MaterialComponentsBeta.MaterialContainerScheme

--- a/components/Cards/examples/EditReorderShapedCollectionViewController.swift
+++ b/components/Cards/examples/EditReorderShapedCollectionViewController.swift
@@ -15,7 +15,7 @@
 import UIKit
 
 import MaterialComponents.MaterialCards
-import MaterialComponents.MaterialShapeLibrary
+import MaterialComponents.MaterialShapeLibraryNew
 import MaterialComponentsBeta.MaterialContainerScheme
 
 class ShapedCardCollectionCell: MDCCardCollectionCell {

--- a/components/Cards/examples/ShapedCardViewController.swift
+++ b/components/Cards/examples/ShapedCardViewController.swift
@@ -15,7 +15,7 @@
 import UIKit
 
 import MaterialComponents.MaterialCards
-import MaterialComponents.MaterialShapeLibrary
+import MaterialComponents.MaterialShapeLibraryNew
 
 @available(iOS 9.0, *)
 class CardView: MDCCard {

--- a/components/Cards/tests/unit/MDCCardShapeThemerTests.swift
+++ b/components/Cards/tests/unit/MDCCardShapeThemerTests.swift
@@ -15,7 +15,7 @@
 import XCTest
 import MaterialComponents.MaterialCards
 import MaterialComponents.MaterialCards_ShapeThemer
-import MaterialComponents.MaterialShapeLibrary
+import MaterialComponents.MaterialShapeLibraryNew
 
 class CardShapeThemerTests: XCTestCase {
 

--- a/components/Cards/tests/unit/Theming/CardsMaterialThemingTests.swift
+++ b/components/Cards/tests/unit/Theming/CardsMaterialThemingTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 import MaterialComponents.MaterialCards
 import MaterialComponents.MaterialColorScheme
-import MaterialComponents.MaterialShapeLibrary
+import MaterialComponents.MaterialShapeLibraryNew
 import MaterialComponents.MaterialShapeScheme
 import MaterialComponentsBeta.MaterialCards_Theming
 import MaterialComponentsBeta.MaterialContainerScheme

--- a/components/Chips/tests/unit/Theming/ChipsMaterialThemingTests.swift
+++ b/components/Chips/tests/unit/Theming/ChipsMaterialThemingTests.swift
@@ -17,7 +17,7 @@ import XCTest
 import MaterialComponents.MaterialChips
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialShapeScheme
-import MaterialComponents.MaterialShapeLibrary
+import MaterialComponents.MaterialShapeLibraryNew
 import MaterialComponents.MaterialTypographyScheme
 import MaterialComponentsBeta.MaterialChips_Theming
 import MaterialComponentsBeta.MaterialContainerScheme

--- a/components/ShadowLayer/examples/ShapesShadows.swift
+++ b/components/ShadowLayer/examples/ShapesShadows.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import UIKit
-import MaterialComponents.MaterialShapeLibrary
+import MaterialComponents.MaterialShapeLibraryNew
 import MaterialComponents.MaterialShapes
 
 class ShapesShadows: UIView {


### PR DESCRIPTION
Cocoapods failed on continuous after https://github.com/material-components/material-components-ios/pull/6580. This PR addresses some validation errors I saw when I dug a little deeper.

Closes #6524.