### PR TITLE
[ActionSheet] Promote to Ready

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -52,6 +52,27 @@ Pod::Spec.new do |mdc|
   #  end
   #
 
+  # ActionSheet
+
+  mdc.subspec "ActionSheet" do |component|
+    component.ios.deployment_target = '8.0'
+    component.public_header_files = "components/#{component.base_name}/src/*.h"
+    component.source_files = [
+      "components/#{component.base_name}/src/*.{h,m}",
+      "components/#{component.base_name}/src/private/*.{h,m}"
+    ]
+
+    component.dependency "MaterialComponents/BottomSheet"
+    component.dependency "MaterialComponents/Ink"
+    component.dependency "MaterialComponents/Typography"
+
+    component.test_spec 'UnitTests' do |unit_tests|
+      unit_tests.source_files = [
+        "components/#{component.base_name}/tests/unit/*.{h,m,swift}"
+      ]
+    end
+  end
+
   # ActivityIndicator
 
   mdc.subspec "ActivityIndicator" do |component|

--- a/MaterialComponentsBeta.podspec
+++ b/MaterialComponentsBeta.podspec
@@ -15,27 +15,11 @@ Pod::Spec.new do |mdc|
 
   # ActionSheet
 
-  mdc.subspec "ActionSheet" do |component|
-    component.ios.deployment_target = '8.0'
-    component.public_header_files = "components/#{component.base_name}/src/*.h"
-    component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
-
-    component.dependency "MaterialComponents/BottomSheet"
-    component.dependency "MaterialComponents/Ink"
-    component.dependency "MaterialComponents/Typography"
-
-    component.test_spec 'UnitTests' do |unit_tests|
-      unit_tests.source_files = "components/#{component.base_name}/tests/unit/*.{h,m,swift}"
-      unit_tests.dependency "MaterialComponentsBeta/#{component.base_name}+Theming"
-      unit_tests.dependency "MaterialComponentsBeta/#{component.base_name}+#{component.base_name}Themer"
-    end
-  end
-
   mdc.subspec "ActionSheet+ActionSheetThemer" do |extension|
     extension.ios.deployment_target = '8.0'
     extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
     extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
-    extension.dependency "MaterialComponentsBeta/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponentsBeta/ActionSheet+ColorThemer"
     extension.dependency "MaterialComponentsBeta/ActionSheet+TypographyThemer"
   end
@@ -44,7 +28,7 @@ Pod::Spec.new do |mdc|
     extension.ios.deployment_target = '8.0'
     extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
     extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
-    extension.dependency "MaterialComponentsBeta/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Color"
   end
 
@@ -52,7 +36,7 @@ Pod::Spec.new do |mdc|
     extension.ios.deployment_target = '8.0'
     extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
     extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
-    extension.dependency "MaterialComponentsBeta/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponentsBeta/#{extension.base_name.split('+')[0]}+ColorThemer"
     extension.dependency "MaterialComponentsBeta/#{extension.base_name.split('+')[0]}+TypographyThemer"
     extension.dependency "MaterialComponentsBeta/schemes/Container"
@@ -62,7 +46,7 @@ Pod::Spec.new do |mdc|
     extension.ios.deployment_target = '8.0'
     extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
     extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
-    extension.dependency "MaterialComponentsBeta/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Typography"
   end
 

--- a/catalog/Podfile
+++ b/catalog/Podfile
@@ -9,6 +9,7 @@ target "MDCCatalog" do
   project 'MDCCatalog.xcodeproj'
   pod 'MaterialComponentsExamples', :path => '../'
   pod 'MaterialComponents', :path => '../', :testspecs => [
+    'ActionSheet/UnitTests',
     'ActivityIndicator/UnitTests',
     'AnimationTiming/UnitTests',
     'AppBar/UnitTests',
@@ -57,7 +58,6 @@ target "MDCCatalog" do
     'Typography/UnitTests',
   ]
   pod 'MaterialComponentsBeta', :path => '../', :testspecs => [
-    'ActionSheet/UnitTests',
     'BottomNavigation/UnitTests',
     'ButtonBar+Theming/UnitTests',
     'Buttons+Theming/UnitTests',

--- a/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
+++ b/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
@@ -17,7 +17,7 @@ import UIKit
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialTypographyScheme
 
-import MaterialComponentsBeta.MaterialActionSheet
+import MaterialComponents.MaterialActionSheet
 import MaterialComponentsBeta.MaterialActionSheet_Theming
 import MaterialComponentsBeta.MaterialContainerScheme
 

--- a/components/ActionSheet/tests/unit/ActionSheetTest.swift
+++ b/components/ActionSheet/tests/unit/ActionSheetTest.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import XCTest
-import MaterialComponentsBeta.MaterialActionSheet
+import MaterialComponents.MaterialActionSheet
 import MaterialComponentsBeta.MaterialActionSheet_ColorThemer
 
 class ActionSheetTest: XCTestCase {


### PR DESCRIPTION
## Related links
* Component: [ActionSheet](https://github.com/material-components/material-components-ios/tree/develop/components/ActionSheet)
* Component readiness: [beta-components](https://github.com/material-components/material-components-ios/blob/develop/contributing/beta_components.md)

## Introduction
MDCActionSheet has been in the beta program [since last August](https://github.com/material-components/material-components-ios/pull/4830). I don't foresee any major API changes. 

## Motivation
This will allow clients to use MDCActionSheet through CocoaPods instead of having to clone our repo.

## Proposed solution
Update the Podspec to reflect the `MDCActionSheet` component as a _Ready_ component.
