### PR TITLE
[Ripple] [States] Moving touch handling ownership away from the ripple view

### DIFF
--- a/components/Ripple/examples/StatefulRippleExample.swift
+++ b/components/Ripple/examples/StatefulRippleExample.swift
@@ -45,18 +45,21 @@ class RippleView : UIView {
   }
 
   override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+    statefulRippleView.touchesBegan(touches, with: event)
     super.touchesBegan(touches, with: event)
+
     statefulRippleView.isRippleHighlighted = true
   }
 
   override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
-    statefulRippleView.superviewTouchMoved(touches.first, event: event)
+    statefulRippleView.touchesMoved(touches, with: event)
     super.touchesMoved(touches, with: event)
   }
 
   override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-    statefulRippleView.superviewTouchEnded()
+    statefulRippleView.touchesEnded(touches, with: event)
     super.touchesEnded(touches, with: event)
+
     statefulRippleView.isRippleHighlighted = false
     if (!didLongPress) {
       statefulRippleView.isSelected = !statefulRippleView.isSelected
@@ -65,8 +68,9 @@ class RippleView : UIView {
   }
 
   override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
-    statefulRippleView.superviewTouchCancelled()
+    statefulRippleView.touchesCancelled(touches, with: event)
     super.touchesCancelled(touches, with: event)
+
     statefulRippleView.isRippleHighlighted = false
   }
 

--- a/components/Ripple/examples/StatefulRippleExample.swift
+++ b/components/Ripple/examples/StatefulRippleExample.swift
@@ -49,7 +49,13 @@ class RippleView : UIView {
     statefulRippleView.isRippleHighlighted = true
   }
 
+  override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+    statefulRippleView.superviewTouchMoved(touches.first, event: event)
+    super.touchesMoved(touches, with: event)
+  }
+
   override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+    statefulRippleView.superviewTouchEnded()
     super.touchesEnded(touches, with: event)
     statefulRippleView.isRippleHighlighted = false
     if (!didLongPress) {
@@ -59,6 +65,7 @@ class RippleView : UIView {
   }
 
   override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+    statefulRippleView.superviewTouchCancelled()
     super.touchesCancelled(touches, with: event)
     statefulRippleView.isRippleHighlighted = false
   }

--- a/components/Ripple/src/MDCStatefulRippleView.h
+++ b/components/Ripple/src/MDCStatefulRippleView.h
@@ -101,4 +101,54 @@ __attribute__((objc_subclassing_restricted)) @interface MDCStatefulRippleView : 
  */
 - (nullable UIColor *)rippleColorForState:(MDCRippleState)state;
 
+/**
+ The next three methods are important to get the correct behavior and functionality
+ for the stateful ripple.
+ The methods need to be invoked in the corresponding `touchesMoved`, `touchesEnded`,
+ and `touchesCancelled` in the superview of this view.
+ More detailed information can be found in each specific method below.
+ */
+#pragma mark - Superview Touch Handling
+
+/**
+ The stateful ripple view should fade in an out as a held touch goes in and out of the view.
+ To identify that a touch is held and then moved we need to have the superview pass the touch to
+ this class so the ripple can react appropriately.
+
+ This class needs to be invoked in the `touchesMoved:withEvent` of its superview BEFORE super is
+ called. It needs to be called before `[super touchesMoved:withEvent]` because otherwise
+ `setHighlighted` will be triggered prior to knowing if the touch is outside the bounds or not
+ and won't be able to act accordingly.
+
+ Note: This class can also be invoked in `continueTrackingWithTouch:withEvent:` of a UIControl.
+
+ @param touch The corresponding touch when it is moved, as provided by `touchesMoved`.
+ @param event The event for the touch, as provided by `touchesMoved`.
+ */
+- (void)superviewTouchMoved:(UITouch *)touch event:(UIEvent *)event;
+
+/**
+ The stateful ripple view needs to identify an end of a touch for two reasons:
+ 1. To know the touch has ended so if `setHighlighted` isn't triggered by a touch, it shouldn't
+    animate the ripple.
+ 2. To dissolve the existing ripple if the touch is let go outside the hit target of the superview.
+
+ This class needs to be invoked in the `touchesEnded:withEvent:` of its superview.
+
+ Note: This class can also be invoked in `endTrackingWithTouch:withEvent` of a UIControl.
+ */
+- (void)superviewTouchEnded;
+
+/**
+ The stateful ripple view needs to identify a cancellation of a touch for two reason:
+ 1. To know the touch has ended so if `setHighlighted` isn't triggered by a touch, it shouldn't
+    animate the ripple.
+ 2. To dissolve the existing ripple if the touch gets cancelled.
+
+ This class needs to be invoked in the `touchesCancelled:withEvent:` of its superview.
+
+ Note: This class can also be invoked in `cancelTrackingWithEvent:` of a UIControl.
+ */
+- (void)superviewTouchCancelled;
+
 @end

--- a/components/Ripple/src/MDCStatefulRippleView.h
+++ b/components/Ripple/src/MDCStatefulRippleView.h
@@ -118,7 +118,7 @@ __attribute__((objc_subclassing_restricted)) @interface MDCStatefulRippleView : 
  @param touches The touches, as provided by the superview's `touchesBegan:withEvent:`.
  @param event The event, as provided by the superview's `touchesBegan:withEvent:`.
  */
-- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event;
+- (void)touchesBegan:(nullable NSSet<UITouch *> *)touches withEvent:(nullable UIEvent *)event;
 
 /**
  The stateful ripple view should fade in an out as a held touch goes in and out of the view.
@@ -132,7 +132,7 @@ __attribute__((objc_subclassing_restricted)) @interface MDCStatefulRippleView : 
  @param touches The touches, as provided by the superview's `touchesMoved:withEvent:`.
  @param event The event, as provided by the superview's `touchesMoved:withEvent:`.
  */
-- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event;
+- (void)touchesMoved:(nullable NSSet<UITouch *> *)touches withEvent:(nullable UIEvent *)event;
 
 /**
  The stateful ripple view needs to identify an end of a touch for two reasons:
@@ -146,7 +146,7 @@ __attribute__((objc_subclassing_restricted)) @interface MDCStatefulRippleView : 
  @param touches The touches, as provided by the superview's `touchesEnded:withEvent:`.
  @param event The event, as provided by the superview's `touchesEnded:withEvent:`.
  */
-- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event;
+- (void)touchesEnded:(nullable NSSet<UITouch *> *)touches withEvent:(nullable UIEvent *)event;
 
 /**
  The stateful ripple view needs to identify a cancellation of a touch for two reason:
@@ -160,6 +160,6 @@ __attribute__((objc_subclassing_restricted)) @interface MDCStatefulRippleView : 
  @param touches The touches, as provided by the superview's `touchesCancelled:withEvent:`.
  @param event The event, as provided by the superview's `touchesCancelled:withEvent:`.
  */
-- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event;
+- (void)touchesCancelled:(nullable NSSet<UITouch *> *)touches withEvent:(nullable UIEvent *)event;
 
 @end

--- a/components/Ripple/src/MDCStatefulRippleView.h
+++ b/components/Ripple/src/MDCStatefulRippleView.h
@@ -104,28 +104,35 @@ __attribute__((objc_subclassing_restricted)) @interface MDCStatefulRippleView : 
 /**
  The next three methods are important to get the correct behavior and functionality
  for the stateful ripple.
- The methods need to be invoked in the corresponding `touchesMoved`, `touchesEnded`,
- and `touchesCancelled` in the superview of this view.
- More detailed information can be found in each specific method below.
+ The methods need to be invoked in the corresponding `touchesBegan`, `touchesMoved`,
+ `touchesEnded`, and `touchesCancelled` in the superview of this view.
+ More detailed information can be found for each method below.
  */
 #pragma mark - Superview Touch Handling
 
 /**
+ The stateful ripple view should receive the initial touch so it knows where to initiate the
+ ripple effect from. It also lets the ripple view's `setHighlighted` know if it has been triggered
+ due to a touch.
+
+ @param touches The touches, as provided by the superview's `touchesBegan:withEvent:`.
+ @param event The event, as provided by the superview's `touchesBegan:withEvent:`.
+ */
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event;
+
+/**
  The stateful ripple view should fade in an out as a held touch goes in and out of the view.
  To identify that a touch is held and then moved we need to have the superview pass the touch to
- this class so the ripple can react appropriately.
+ the ripple so it can react appropriately.
 
- This class needs to be invoked in the `touchesMoved:withEvent` of its superview BEFORE super is
- called. It needs to be called before `[super touchesMoved:withEvent]` because otherwise
- `setHighlighted` will be triggered prior to knowing if the touch is outside the bounds or not
- and won't be able to act accordingly.
+ This class needs to be invoked in the `touchesMoved:withEvent:` of its superview before super is
+ called. This is because otherwise `setHighlighted` will be triggered prior to knowing if the
+ touch is outside the bounds or not and won't be able to act accordingly.
 
- Note: This class can also be invoked in `continueTrackingWithTouch:withEvent:` of a UIControl.
-
- @param touch The corresponding touch when it is moved, as provided by `touchesMoved`.
- @param event The event for the touch, as provided by `touchesMoved`.
+ @param touches The touches, as provided by the superview's `touchesMoved:withEvent:`.
+ @param event The event, as provided by the superview's `touchesMoved:withEvent:`.
  */
-- (void)superviewTouchMoved:(UITouch *)touch event:(UIEvent *)event;
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event;
 
 /**
  The stateful ripple view needs to identify an end of a touch for two reasons:
@@ -133,11 +140,13 @@ __attribute__((objc_subclassing_restricted)) @interface MDCStatefulRippleView : 
     animate the ripple.
  2. To dissolve the existing ripple if the touch is let go outside the hit target of the superview.
 
- This class needs to be invoked in the `touchesEnded:withEvent:` of its superview.
+ This class needs to be invoked in the `touchesEnded:withEvent:` of its superview before super is
+ called.
 
- Note: This class can also be invoked in `endTrackingWithTouch:withEvent` of a UIControl.
+ @param touches The touches, as provided by the superview's `touchesEnded:withEvent:`.
+ @param event The event, as provided by the superview's `touchesEnded:withEvent:`.
  */
-- (void)superviewTouchEnded;
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event;
 
 /**
  The stateful ripple view needs to identify a cancellation of a touch for two reason:
@@ -145,10 +154,12 @@ __attribute__((objc_subclassing_restricted)) @interface MDCStatefulRippleView : 
     animate the ripple.
  2. To dissolve the existing ripple if the touch gets cancelled.
 
- This class needs to be invoked in the `touchesCancelled:withEvent:` of its superview.
+ This class needs to be invoked in the `touchesCancelled:withEvent:` of its superview before super
+ is called.
 
- Note: This class can also be invoked in `cancelTrackingWithEvent:` of a UIControl.
+ @param touches The touches, as provided by the superview's `touchesCancelled:withEvent:`.
+ @param event The event, as provided by the superview's `touchesCancelled:withEvent:`.
  */
-- (void)superviewTouchCancelled;
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event;
 
 @end

--- a/components/Ripple/src/MDCStatefulRippleView.m
+++ b/components/Ripple/src/MDCStatefulRippleView.m
@@ -71,7 +71,6 @@ static UIColor *RippleSelectedColor(void) {
     _rippleColors[@(MDCRippleStateSelected | MDCRippleStateDragged)] =
         [selectionColor colorWithAlphaComponent:kDefaultRippleDraggedAlpha];
   }
-  self.userInteractionEnabled = YES;
 }
 
 - (UIColor *)rippleColorForState:(MDCRippleState)state {
@@ -204,36 +203,33 @@ static UIColor *RippleSelectedColor(void) {
   }
 }
 
-- (BOOL)pointInsideSuperview:(CGPoint)point withEvent:(UIEvent *)event {
-  CGPoint superviewPoint = [self convertPoint:point toView:self.superview];
-  return [self.superview pointInside:superviewPoint withEvent:event];
-}
-
-- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
-  if ([self pointInsideSuperview:point withEvent:event]) {
-    // Once we find that the tap is inside the hit are insets of the encapsulating view (super view
-    // of the ripple view), we would want to capture the touch from where to initiate the ripple,
-    // and also initialize the values to indicate there was a touch, and the held tap's location
-    // to fade the ripple in and out if the help tap goes inside or outside the hit area.
-    _lastTouch = point;
-    if (!_didReceiveTouch) {
-      _didReceiveTouch = YES;
-      _tapWentInsideOfBounds = NO;
-      _tapWentOutsideOfBounds = NO;
-    }
-  }
-  // We will always return NO because we don't want the ripple view to capture and take the touches
-  // from other views. We are just looking to track the initial touch using pointInside.
-  return NO;
-}
-
 #pragma mark - Superview Touch Handling
 
-- (void)superviewTouchMoved:(UITouch *)touch event:(UIEvent *)event {
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+  UITouch *touch = touches.anyObject;
+  CGPoint point = [touch locationInView:self];
+  // Once we find that the tap is inside the hit area insets of the encapsulating view (superview
+  // of the ripple view), we would want to capture the touch from where to initiate the ripple,
+  // and also initialize the values to indicate there was a touch, and the held tap's location
+  // to fade the ripple in and out if the help tap goes inside or outside the hit area.
+  _lastTouch = point;
+  if (!_didReceiveTouch) {
+    _didReceiveTouch = YES;
+    _tapWentInsideOfBounds = NO;
+    _tapWentOutsideOfBounds = NO;
+  }
+}
+
+- (BOOL)pointInsideSuperview:(CGPoint)point withEvent:(UIEvent *)event {
+  return [self.superview pointInside:point withEvent:event];
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
   // When the touch is held and moved outside and inside the bounds of the surface,
   // the ripple should gracefully fade out and in accordingly.
-  CGPoint location = [touch locationInView:self];
-  BOOL pointContainedInSuperview = [self pointInsideSuperview:location withEvent:event];
+  UITouch *touch = touches.anyObject;
+  CGPoint point = [touch locationInView:self];
+  BOOL pointContainedInSuperview = [self pointInsideSuperview:point withEvent:event];
   if (pointContainedInSuperview && _tapWentOutsideOfBounds) {
     _tapWentInsideOfBounds = YES;
     _tapWentOutsideOfBounds = NO;
@@ -244,15 +240,16 @@ static UIColor *RippleSelectedColor(void) {
   }
 }
 
-- (void)superviewTouchEnded {
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
   _didReceiveTouch = NO;
   if (_tapWentOutsideOfBounds) {
     [self beginRippleTouchUpAnimated:NO completion:nil];
   }
 }
 
-- (void)superviewTouchCancelled {
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
   _didReceiveTouch = NO;
   [self beginRippleTouchUpAnimated:YES completion:nil];
 }
+
 @end


### PR DESCRIPTION
In some cases because the Ripple handles touches to figure out when the touch is moved in and out of bounds, or if it is cancelled or ended, it will consume the touch and not allow the superview or other subviews receive the touch.

Therefore, I have moved away from the approach of having the stateful ripple view receive any ownership of the touch by setting pointInside for it to always be NO. However, to be able to have stateful ripple follow material guidelines, I have put new guidance to views adding the ripple view as a subview to pass on the standard touches to the ripple view to have it work as intended.

Documentation in our GitHub on how to integrate it correctly will be added as a follow up. Documentation in the header has been fully fleshed out and added in this PR.

The example for stateful ripple incorporates these updates and works as intended.