### PR TITLE
[Shapes] ShadowPath nullified when shapeGenerator is nil

### DIFF
--- a/components/Shapes/src/MDCShapedShadowLayer.m
+++ b/components/Shapes/src/MDCShapedShadowLayer.m
@@ -62,8 +62,10 @@
 - (void)layoutSublayers {
   // We have to set the path before calling [super layoutSublayers] because we need the shadowPath
   // to be correctly set before MDCShadowLayer performs layoutSublayers.
-  CGRect standardizedBounds = CGRectStandardize(self.bounds);
-  self.path = [self.shapeGenerator pathForSize:standardizedBounds.size];
+  if (self.shapeGenerator) {
+    CGRect standardizedBounds = CGRectStandardize(self.bounds);
+    self.path = [self.shapeGenerator pathForSize:standardizedBounds.size];
+  }
 
   [super layoutSublayers];
 


### PR DESCRIPTION
Our `MDCShapedShadowLayer` in `layoutSublayers` sets the path based on the shape generator's `pathForSize` method. This in turn sets the `shadowPath` of the CALayer. However, if `shapeGenerator` is nil, the `shadowPath` will become nil as well, nullifying any set up of `shadowPath` that has been set prior by the client.

This fixes this issue and most likely resolves an internal issue.