### PR TITLE
[NavigationDrawer] Add a11y identifier for the nav drawer scrollview

### DIFF
--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -35,6 +35,7 @@ static const CGFloat kEpsilon = (CGFloat)0.001;
 static const CGFloat kScrollViewBufferForPerformance = 20;
 static const CGFloat kDragVelocityThresholdForHidingDrawer = -2;
 static NSString *const kContentOffsetKeyPath = @"contentOffset";
+static NSString *const kScrollviewAccessibilityIdentifier = @"kMDCBottomDrawerScrollviewA11yID";
 
 static UIColor *DrawerShadowColor(void) {
   return [[UIColor blackColor] colorWithAlphaComponent:(CGFloat)0.2];
@@ -429,6 +430,8 @@ static UIColor *DrawerShadowColor(void) {
     [self.scrollView addSubview:self.contentViewController.view];
     [self.contentViewController didMoveToParentViewController:self];
   }
+
+  self.scrollView.accessibilityIdentifier = kScrollviewAccessibilityIdentifier;
 }
 
 - (void)viewWillAppear:(BOOL)animated {


### PR DESCRIPTION
Clients have requested access to the internal scrollview for EarlGrey testing by providing an accessibility identifier to the scrollview.