### PR TITLE
[BottomAppBar] Fix FAB location when RTL changes.

### DIFF
--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -50,7 +50,6 @@ static const int kMDCButtonAnimationDuration = 200;
 @property(nonatomic, strong) MDCBottomAppBarCutView *cutView;
 @property(nonatomic, strong) MDCBottomAppBarLayer *bottomBarLayer;
 @property(nonatomic, strong) MDCNavigationBar *navBar;
-@property(nonatomic, assign) UIUserInterfaceLayoutDirection layoutDirection;
 
 @end
 
@@ -80,7 +79,6 @@ static const int kMDCButtonAnimationDuration = 200;
 
   self.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin |
                            UIViewAutoresizingFlexibleRightMargin);
-  self.layoutDirection = self.mdf_effectiveUserInterfaceLayoutDirection;
 
   [self addFloatingButton];
   [self addBottomBarLayer];
@@ -129,7 +127,8 @@ static const int kMDCButtonAnimationDuration = 200;
   floatingButtonPoint.y = MAX(0, navigationBarTopEdgeYOffset - self.floatingButtonVerticalOffset);
   switch (self.floatingButtonPosition) {
     case MDCBottomAppBarFloatingButtonPositionLeading: {
-      if (self.layoutDirection == UIUserInterfaceLayoutDirectionLeftToRight) {
+      if (self.mdf_effectiveUserInterfaceLayoutDirection ==
+          UIUserInterfaceLayoutDirectionLeftToRight) {
         floatingButtonPoint.x = kMDCBottomAppBarFloatingButtonPositionX;
       } else {
         floatingButtonPoint.x = appBarWidth - kMDCBottomAppBarFloatingButtonPositionX;
@@ -141,7 +140,8 @@ static const int kMDCButtonAnimationDuration = 200;
       break;
     }
     case MDCBottomAppBarFloatingButtonPositionTrailing: {
-      if (self.layoutDirection == UIUserInterfaceLayoutDirectionLeftToRight) {
+      if (self.mdf_effectiveUserInterfaceLayoutDirection ==
+          UIUserInterfaceLayoutDirectionLeftToRight) {
         floatingButtonPoint.x = appBarWidth - kMDCBottomAppBarFloatingButtonPositionX;
       } else {
         floatingButtonPoint.x = kMDCBottomAppBarFloatingButtonPositionX;


### PR DESCRIPTION
If the `semanticContentAttribute` for an MDCBottomAppBarView changes
during its lifetime, it won't correctly reposition the FAB. Instead of
checking the interface layout orientation once during initialization, it
should check every time it needs to perform layout.

|Before|After|
|---|---|
|<img width="380" alt="testfloatingbuttontrailingrtl_11_2-develop" src="https://user-images.githubusercontent.com/1753199/52929433-6812c800-3312-11e9-8505-07933e1ee077.png">|<img width="380" alt="testfloatingbuttontrailingrtl_11_2 2x" src="https://user-images.githubusercontent.com/1753199/52929438-6ba64f00-3312-11e9-805f-edc2e68cf1a5.png">|

    
Fixes #6642