### PR TITLE
[NavigationDrawer] Expose the a11y identifier so it can be reached for testing purposes.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -1169,7 +1169,7 @@ Pod::Spec.new do |mdc|
       "components/#{component.base_name}/src/*.{h,m}",
       "components/#{component.base_name}/src/private/*.{h,m}"
     ]
-    component.exclude_files = "components/#{component.base_name}/src/private/MDCBottomDrawerContainerViewController+Test.h"
+    component.exclude_files = "components/#{component.base_name}/src/private/MDCBottomDrawerContainerViewController+Testing.h"
 
     component.dependency "MaterialComponents/Palettes"
     component.dependency "MaterialComponents/ShadowLayer"
@@ -1180,7 +1180,7 @@ Pod::Spec.new do |mdc|
       unit_tests.source_files = [
         "components/#{component.base_name}/tests/unit/*.{h,m,swift}",
         "components/#{component.base_name}/tests/unit/supplemental/*.{h,m,swift}",
-        "components/#{component.base_name}/src/private/MDCBottomDrawerContainerViewController+Test.h"
+        "components/#{component.base_name}/src/private/MDCBottomDrawerContainerViewController+Testing.h"
       ]
       unit_tests.dependency "MaterialComponents/NavigationDrawer+ColorThemer"
     end

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -1169,6 +1169,7 @@ Pod::Spec.new do |mdc|
       "components/#{component.base_name}/src/*.{h,m}",
       "components/#{component.base_name}/src/private/*.{h,m}"
     ]
+    component.exclude_files = "components/#{component.base_name}/src/private/MDCBottomDrawerContainerViewController+Test.h"
 
     component.dependency "MaterialComponents/Palettes"
     component.dependency "MaterialComponents/ShadowLayer"
@@ -1178,7 +1179,8 @@ Pod::Spec.new do |mdc|
     component.test_spec 'UnitTests' do |unit_tests|
       unit_tests.source_files = [
         "components/#{component.base_name}/tests/unit/*.{h,m,swift}",
-        "components/#{component.base_name}/tests/unit/supplemental/*.{h,m,swift}"
+        "components/#{component.base_name}/tests/unit/supplemental/*.{h,m,swift}",
+        "components/#{component.base_name}/src/private/MDCBottomDrawerContainerViewController+Test.h"
       ]
       unit_tests.dependency "MaterialComponents/NavigationDrawer+ColorThemer"
     end

--- a/components/NavigationDrawer/BUILD
+++ b/components/NavigationDrawer/BUILD
@@ -54,6 +54,15 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
+mdc_objc_library(
+    name = "TestingHeader",
+    testonly = 1,
+    hdrs = native.glob(["src/private/MDCBottomDrawerContainerViewController+Test.h"]),
+    includes = ["src/private/MDCBottomDrawerContainerViewController+Test.h"],
+    visibility = ["//visibility:public"],
+    deps = [":NavigationDrawer"],
+)
+
 mdc_examples_swift_library(
     name = "SwiftExamples",
     deps = [

--- a/components/NavigationDrawer/BUILD
+++ b/components/NavigationDrawer/BUILD
@@ -57,8 +57,8 @@ mdc_objc_library(
 mdc_objc_library(
     name = "TestingHeader",
     testonly = 1,
-    hdrs = native.glob(["src/private/MDCBottomDrawerContainerViewController+Test.h"]),
-    includes = ["src/private/MDCBottomDrawerContainerViewController+Test.h"],
+    hdrs = native.glob(["src/private/MDCBottomDrawerContainerViewController+Testing.h"]),
+    includes = ["src/private/MDCBottomDrawerContainerViewController+Testing.h"],
     visibility = ["//visibility:public"],
     deps = [":NavigationDrawer"],
 )

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -17,7 +17,7 @@ import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialBottomAppBar_ColorThemer
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialNavigationDrawer
-import MaterialComponents.
+//import MaterialComponents.MDCNavigationDrawerContainerViewController_Testing
 import MaterialComponents.MaterialNavigationDrawer_ColorThemer
 
 class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewControllerDelegate {

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -17,7 +17,6 @@ import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialBottomAppBar_ColorThemer
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialNavigationDrawer
-//import MaterialComponents.MDCNavigationDrawerContainerViewController_Testing
 import MaterialComponents.MaterialNavigationDrawer_ColorThemer
 
 class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewControllerDelegate {

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -17,6 +17,7 @@ import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialBottomAppBar_ColorThemer
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialNavigationDrawer
+import MaterialComponents.
 import MaterialComponents.MaterialNavigationDrawer_ColorThemer
 
 class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewControllerDelegate {

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController+Testing.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController+Testing.h
@@ -1,0 +1,23 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCBottomDrawerContainerViewController.h"
+
+/**
+ Exposes parts of MDCBottomDrawerContainerViewController for testing.
+ */
+@interface MDCBottomDrawerContainerViewController (Testing)
+
+NSString *_Nonnull const kMDCBottomDrawerScrollViewAccessibilityIdentifier;
+

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController+Testing.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController+Testing.h
@@ -14,11 +14,10 @@
 
 #import "MDCBottomDrawerContainerViewController.h"
 
+extern NSString *_Nonnull const kMDCBottomDrawerScrollViewAccessibilityIdentifier;
+
 /**
  Exposes parts of MDCBottomDrawerContainerViewController for testing.
  */
 @interface MDCBottomDrawerContainerViewController (Testing)
-
-extern NSString *_Nonnull const kMDCBottomDrawerScrollViewAccessibilityIdentifier;
-
 @end

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController+Testing.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController+Testing.h
@@ -19,5 +19,6 @@
  */
 @interface MDCBottomDrawerContainerViewController (Testing)
 
-NSString *_Nonnull const kMDCBottomDrawerScrollViewAccessibilityIdentifier;
+extern NSString *_Nonnull const kMDCBottomDrawerScrollViewAccessibilityIdentifier;
 
+@end

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -35,7 +35,7 @@ static const CGFloat kEpsilon = (CGFloat)0.001;
 static const CGFloat kScrollViewBufferForPerformance = 20;
 static const CGFloat kDragVelocityThresholdForHidingDrawer = -2;
 static NSString *const kContentOffsetKeyPath = @"contentOffset";
-static NSString *const kScrollviewAccessibilityIdentifier = @"kMDCBottomDrawerScrollviewA11yID";
+NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier = @"kMDCBottomDrawerScrollViewAccessibilityIdentifier";
 
 static UIColor *DrawerShadowColor(void) {
   return [[UIColor blackColor] colorWithAlphaComponent:(CGFloat)0.2];
@@ -431,7 +431,7 @@ static UIColor *DrawerShadowColor(void) {
     [self.contentViewController didMoveToParentViewController:self];
   }
 
-  self.scrollView.accessibilityIdentifier = kScrollviewAccessibilityIdentifier;
+  self.scrollView.accessibilityIdentifier = kMDCBottomDrawerScrollViewAccessibilityIdentifier;
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -35,7 +35,8 @@ static const CGFloat kEpsilon = (CGFloat)0.001;
 static const CGFloat kScrollViewBufferForPerformance = 20;
 static const CGFloat kDragVelocityThresholdForHidingDrawer = -2;
 static NSString *const kContentOffsetKeyPath = @"contentOffset";
-NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier = @"kMDCBottomDrawerScrollViewAccessibilityIdentifier";
+NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
+    @"kMDCBottomDrawerScrollViewAccessibilityIdentifier";
 
 static UIColor *DrawerShadowColor(void) {
   return [[UIColor blackColor] colorWithAlphaComponent:(CGFloat)0.2];


### PR DESCRIPTION
Expose the a11y identifier so it can be reached for testing purposes.

Clients have asked for this to fully test the component in Earl Grey.