### PR TITLE
[ColorScheme] Add test schemes.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -98,6 +98,7 @@ Pod::Spec.new do |mdc|
       ]
       unit_tests.resources = "components/#{component.base_name}/tests/unit/resources/*"
       unit_tests.dependency "MaterialComponents/ActivityIndicator+ColorThemer"
+      unit_tests.dependency "MaterialComponentsTestingSupport/schemes/Color"
     end
   end
 
@@ -221,6 +222,7 @@ Pod::Spec.new do |mdc|
       ]
       unit_tests.resources = "components/#{component.base_name}/tests/unit/resources/*"
       unit_tests.dependency "MaterialComponents/BottomAppBar+ColorThemer"
+      unit_tests.dependency "MaterialComponentsTestingSupport/schemes/Color"
     end
   end
 

--- a/MaterialComponentsTestingSupport.podspec
+++ b/MaterialComponentsTestingSupport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MaterialComponentsTestingSupport"
-  s.version      = "77.0.0"
+  s.version      = "78.0.0"
   s.authors      = "The Material Components authors."
   s.summary      = "This spec provides support files and utilities for testing."
   s.homepage     = "https://github.com/material-components/material-components-ios"
@@ -10,6 +10,13 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.subspec "schemes" do |scheme|
+    scheme.subspec "Color" do |component|
+      component.ios.deployment_target = '8.0'
+      component.public_header_files = "components/schemes/#{component.base_name}/tests/support/*.h"
+      component.source_files = "components/schemes/#{component.base_name}/tests/support/*.{h,m,swift}"
+      component.dependency "MaterialComponents/schemes/Color"
+    end
+    
     scheme.subspec "Typography" do |component|
       component.ios.deployment_target = '8.0'
       component.public_header_files = "components/schemes/#{component.base_name}/tests/support/*.h"

--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -63,6 +63,7 @@ mdc_extension_objc_library(
 
 swift_library(
     name = "unit_test_swift_sources",
+    testonly = 1,
     srcs = glob(["tests/unit/*.swift"]),
     copts = [
         "-swift-version",
@@ -72,6 +73,7 @@ swift_library(
     deps = [
         ":ActivityIndicator",
         ":ColorThemer",
+        "//components/schemes/Color:TestingSupport",
     ],
 )
 

--- a/components/ActivityIndicator/tests/unit/ActivityIndicatorColorThemerTests.swift
+++ b/components/ActivityIndicator/tests/unit/ActivityIndicatorColorThemerTests.swift
@@ -15,14 +15,14 @@
 import XCTest
 import MaterialComponents.MaterialActivityIndicator
 import MaterialComponents.MaterialActivityIndicator_ColorThemer
+import MaterialComponentsTestingSupport.MaterialColorScheme_TestingSupport
 
 class ActivityIndicatorColorThemerTests: XCTestCase {
 
   func testColorThemerChangesTheBackgroundColor() {
     // Given
-    let colorScheme = MDCSemanticColorScheme()
+    let colorScheme = MDCSemanticColorScheme.withVaryingOpacity()
     let activityIndicator = MDCActivityIndicator()
-    colorScheme.primaryColor = .red
     activityIndicator.cycleColors = [ .white ]
 
     // When

--- a/components/BottomAppBar/BUILD
+++ b/components/BottomAppBar/BUILD
@@ -106,6 +106,7 @@ mdc_objc_library(
         ":ColorThemer",
         ":private",
         "//components/NavigationBar",
+        "//components/schemes/Color:TestingSupport",
     ],
 )
 

--- a/components/BottomAppBar/tests/unit/BottomAppBarColorThemerTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarColorThemerTests.m
@@ -16,8 +16,8 @@
 
 #import "MaterialBottomAppBar+ColorThemer.h"
 #import "MaterialBottomAppBar.h"
-#import "MaterialThemes.h"
 #import "MaterialColorScheme+TestingSupport.h"
+#import "MaterialThemes.h"
 
 @interface BottomAppBarColorThemerTests : XCTestCase
 @property(nonatomic, strong) MDCBottomAppBarView *bottomAppBar;

--- a/components/BottomAppBar/tests/unit/BottomAppBarColorThemerTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarColorThemerTests.m
@@ -17,6 +17,7 @@
 #import "MaterialBottomAppBar+ColorThemer.h"
 #import "MaterialBottomAppBar.h"
 #import "MaterialThemes.h"
+#import "MaterialColorScheme+TestingSupport.h"
 
 @interface BottomAppBarColorThemerTests : XCTestCase
 @property(nonatomic, strong) MDCBottomAppBarView *bottomAppBar;
@@ -49,11 +50,7 @@
 - (void)testSurfaceVariantColorThemer {
   // Given
   MDCSemanticColorScheme *colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  colorScheme.primaryColor = UIColor.orangeColor;
-  colorScheme.onPrimaryColor = UIColor.cyanColor;
-  colorScheme.surfaceColor = UIColor.blueColor;
-  colorScheme.onSurfaceColor = UIColor.purpleColor;
+      [MDCSemanticColorScheme semanticColorSchemeWithVaryingOpacity];
 
   // When
   [MDCBottomAppBarColorThemer applySurfaceVariantWithSemanticColorScheme:colorScheme

--- a/components/schemes/Color/BUILD
+++ b/components/schemes/Color/BUILD
@@ -27,6 +27,18 @@ mdc_public_objc_library(
     name = "Color",
 )
 
+mdc_objc_library(
+    name = "TestingSupport",
+    testonly = 1,
+    srcs = glob(["tests/support/*.m"]),
+    hdrs = glob(["tests/support/*.h"]),
+    includes = ["tests/support"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":Color",
+    ],
+)
+
 package_group(
     name = "test_targets",
     packages = [

--- a/components/schemes/Color/tests/support/MDCSemanticColorScheme+TestValues.h
+++ b/components/schemes/Color/tests/support/MDCSemanticColorScheme+TestValues.h
@@ -1,0 +1,33 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <MaterialComponents/MaterialColorScheme.h>
+
+/**
+ Color schemes intended for use in unit or snapshot tests.
+ */
+@interface MDCSemanticColorScheme (TestValues)
+
+/**
+ An @c MDCSemanticColorScheme where the colors vary in opacity. Not a good choice for snapshot
+ testing.
+ */
++ (nonnull instancetype)semanticColorSchemeWithVaryingOpacity;
+
+/**
+ An @c MDCSemanticColorScheme where the colors have very high contrast. Useful in snapshot testing.
+ */
++ (nonnull instancetype)semanticColorSchemeWithHighContrast;
+
+@end

--- a/components/schemes/Color/tests/support/MDCSemanticColorScheme+TestValues.m
+++ b/components/schemes/Color/tests/support/MDCSemanticColorScheme+TestValues.m
@@ -1,0 +1,55 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCSemanticColorScheme+TestValues.h"
+
+@implementation MDCSemanticColorScheme (TestValues)
+
++ (instancetype)semanticColorSchemeWithHighContrast {
+  MDCSemanticColorScheme *colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  colorScheme.primaryColor = UIColor.redColor;
+  colorScheme.primaryColorVariant = [UIColor colorWithRed:1
+                                                    green:(CGFloat)0.2
+                                                     blue:(CGFloat)0.2
+                                                    alpha:1];
+  colorScheme.secondaryColor = UIColor.cyanColor;
+  colorScheme.errorColor = [UIColor colorWithRed:1 green:(CGFloat).5 blue:0 alpha:1];
+  colorScheme.surfaceColor = [UIColor colorWithWhite:(CGFloat)0.9 alpha:1];
+  colorScheme.backgroundColor = UIColor.blackColor;
+  colorScheme.onPrimaryColor = [UIColor colorWithWhite:(CGFloat)0.1 alpha:1];
+  colorScheme.onSecondaryColor = [UIColor colorWithWhite:0 alpha:1];
+  colorScheme.onSurfaceColor = UIColor.blackColor;
+  colorScheme.onBackgroundColor = UIColor.whiteColor;
+
+  return colorScheme;
+}
+
++ (instancetype)semanticColorSchemeWithVaryingOpacity {
+  MDCSemanticColorScheme *colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  colorScheme.primaryColor = [UIColor colorWithWhite:1 alpha:(CGFloat)0.05];
+  colorScheme.primaryColorVariant = [UIColor colorWithWhite:1 alpha:(CGFloat)0.1];
+  colorScheme.secondaryColor = [UIColor colorWithWhite:1 alpha:(CGFloat)0.15];
+  colorScheme.errorColor = [UIColor colorWithWhite:1 alpha:(CGFloat)0.2];
+  colorScheme.surfaceColor = [UIColor colorWithWhite:1 alpha:(CGFloat)0.25];
+  colorScheme.backgroundColor = [UIColor colorWithWhite:1 alpha:(CGFloat)0.3];
+  colorScheme.onPrimaryColor = [UIColor colorWithWhite:1 alpha:(CGFloat)0.35];
+  colorScheme.onSecondaryColor = [UIColor colorWithWhite:1 alpha:(CGFloat)0.4];
+  colorScheme.onSurfaceColor = [UIColor colorWithWhite:1 alpha:(CGFloat)0.45];
+  colorScheme.onBackgroundColor = [UIColor colorWithWhite:1 alpha:(CGFloat)0.5];
+  return colorScheme;
+}
+
+@end

--- a/components/schemes/Color/tests/support/MaterialColorScheme+TestingSupport.h
+++ b/components/schemes/Color/tests/support/MaterialColorScheme+TestingSupport.h
@@ -1,0 +1,15 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCSemanticColorScheme+TestValues.h"


### PR DESCRIPTION
Adding test schemes useful for unit/snapshot tests where the baseline
scheme is insufficient (for example to verify bindings).
