### PR TITLE
[Dialogs] Use test Typography scheme

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -771,6 +771,7 @@ Pod::Spec.new do |mdc|
       ]
       unit_tests.resources = "components/#{component.base_name}/tests/unit/resources/*"
       unit_tests.dependency "MaterialComponents/Dialogs+DialogThemer"
+      unit_tests.dependency "MaterialComponentsTestingSupport/schemes/Typography"
     end
   end
 

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -158,6 +158,7 @@ mdc_objc_library(
 
 swift_library(
     name = "unit_test_swift_sources",
+    testonly = 1,
     srcs = glob([
         "tests/unit/*.swift",
         "tests/unit/Theming/*.swift",
@@ -171,6 +172,7 @@ swift_library(
         ":DialogThemer",
         ":Theming",
         "//components/Buttons:Theming",
+        "//components/schemes/Typography:TestingSupport",
     ],
 )
 

--- a/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
+++ b/components/Dialogs/tests/unit/MDCAlertControllerAlertThemerTests.swift
@@ -17,6 +17,7 @@ import XCTest
 import MaterialComponents.MaterialShadowElevations
 import MaterialComponents.MaterialDialogs
 import MaterialComponents.MaterialDialogs_DialogThemer
+import MaterialComponentsTestingSupport.MaterialTypographyScheme_TestingSupport
 
 class MDCAlertControllerAlertThemerTests: XCTestCase {
 
@@ -31,7 +32,7 @@ class MDCAlertControllerAlertThemerTests: XCTestCase {
 
     alertScheme = MDCAlertScheme()
     alertScheme.colorScheme = MDCSemanticColorScheme()
-    alertScheme.typographyScheme = MDCTypographyScheme()
+    alertScheme.typographyScheme = MDCTypographyScheme.withVaryingFontSize()
 
     alert = MDCAlertController(title: "Title", message: "Message")
   }
@@ -41,14 +42,6 @@ class MDCAlertControllerAlertThemerTests: XCTestCase {
     alert = nil
 
     super.tearDown()
-  }
-
-
-  func testDefaultAlertScheme() {
-    XCTAssertEqual(alertScheme.colorScheme.primaryColor, MDCSemanticColorScheme().primaryColor)
-    XCTAssertEqual(alertScheme.typographyScheme.body1, MDCTypographyScheme().body1)
-    XCTAssertEqual(alertScheme.cornerRadius, defaultCornerRadius)
-    XCTAssertEqual(alertScheme.elevation, defaultElevation)
   }
 
   func testApplyingAlertSchemeWithCustomColor() {
@@ -103,9 +96,7 @@ class MDCAlertControllerAlertThemerTests: XCTestCase {
 
   func testApplyingAlertSchemeWithCustomTypography() {
     // Given
-    let typographyScheme = MDCTypographyScheme()
-    let testFont = UIFont.boldSystemFont(ofSize: 55.0)
-    typographyScheme.headline6 = testFont
+    let typographyScheme = MDCTypographyScheme.withVaryingFontSize()
     alertScheme.typographyScheme = typographyScheme
 
     // When
@@ -115,7 +106,6 @@ class MDCAlertControllerAlertThemerTests: XCTestCase {
     XCTAssertEqual(alertScheme.typographyScheme.headline6, typographyScheme.headline6)
     XCTAssertEqual(alertView.titleFont, alertScheme.typographyScheme.headline6)
     XCTAssertNotEqual(alertView.titleFont, MDCTypographyScheme().headline6)
-    XCTAssertEqual(alertView.titleFont, testFont)
   }
 
   func testApplyingAlertSchemeWithCustomShape() {


### PR DESCRIPTION
Using a test-specific Typography scheme to simplify custom scheme
creation. Removes a unit test that was testing the unit test setUp
method.
