### PR TITLE
[Dialogs] Fix presented corner radius in custom view controllers

### DIFF
--- a/components/Dialogs/examples/DialogsAlertExampleViewController.m
+++ b/components/Dialogs/examples/DialogsAlertExampleViewController.m
@@ -127,36 +127,6 @@ static NSString *const kReusableIdentifierItem = @"cell";
   [self presentViewController:materialAlertController animated:YES completion:NULL];
 }
 
-- (IBAction)didTapNondismissingAlert {
-  NSString *titleString = @"This alert requires an action.";
-  NSString *messageString = @"You can't dismiss it by tapping the background. You must choose "
-                             "one of the actions available.";
-
-  MDCAlertController *materialAlertController =
-      [MDCAlertController alertControllerWithTitle:titleString message:messageString];
-  [self themeAlertController:materialAlertController];
-
-  MDCAlertAction *agreeAction = [MDCAlertAction actionWithTitle:@"AGREE"
-                                                        handler:^(MDCAlertAction *action) {
-                                                          NSLog(@"%@", @"AGREE pressed");
-                                                        }];
-  [materialAlertController addAction:agreeAction];
-
-  MDCAlertAction *disagreeAaction = [MDCAlertAction actionWithTitle:@"DISAGREE"
-                                                            handler:^(MDCAlertAction *action) {
-                                                              NSLog(@"%@", @"DISAGREE pressed");
-                                                            }];
-  [materialAlertController addAction:disagreeAaction];
-
-  // This code accesses the presentation controller and turns off dismiss on background tap.
-  MDCDialogPresentationController *presentationController =
-      materialAlertController.mdc_dialogPresentationController;
-  [presentationController applyThemeWithScheme:self.containerScheme];
-  presentationController.dismissOnBackgroundTap = NO;
-
-  [self presentViewController:materialAlertController animated:YES completion:NULL];
-}
-
 - (IBAction)didTapDynamicAlert {
   // The following strings are extra verbose to better demonstrate the dynamic handling of an alert.
   NSString *titleString = @"This alert supports Dynamic Type font sizing.";

--- a/components/Dialogs/examples/DialogsCustomShadowExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsCustomShadowExampleViewController.swift
@@ -28,7 +28,13 @@ class CustomShadowViewController: UIViewController {
 
     super.viewDidLoad()
     view.backgroundColor = UIColor.white
-    view.layer.cornerRadius = 32.0
+
+    // This demonstrates how to manually set the corner raidus, while ensuring that
+    // the presentation controller's corner radius matches, so it renders the shadow correctly.
+    // Note that setting the corner radius in viewDidLoad is not recommended, since it
+    // may be overriden if callers apply a theme using a thmeing extension.
+    self.view.layer.cornerRadius = 32.0
+    self.mdc_dialogPresentationController?.dialogCornerRadius = 32.0
 
     bodyLabel.text =
       "This presented view has a corner radius so we've set the corner radius on the presentation controller."
@@ -98,13 +104,6 @@ class DialogsCustomShadowExampleViewController: UIViewController {
     presentedController.transitioningDelegate = self.transitionController;
 
     self.present(presentedController, animated: true, completion: nil)
-
-    // We set the corner radius to adjust the shadow that is implemented via the trackingView in the
-    // presentation controller.
-    if let presentationController = presentedController.mdc_dialogPresentationController {
-      presentationController.applyTheme(withScheme: containerScheme)
-      presentationController.dialogCornerRadius = presentedController.view.layer.cornerRadius
-    }
   }
 
   // MARK: Catalog by convention

--- a/components/Dialogs/examples/DialogsCustomShadowExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsCustomShadowExampleViewController.swift
@@ -29,12 +29,11 @@ class CustomShadowViewController: UIViewController {
     super.viewDidLoad()
     view.backgroundColor = UIColor.white
 
-    // This demonstrates how to manually set the corner raidus, while ensuring that
-    // the presentation controller's corner radius matches, so it renders the shadow correctly.
+    // Setting the corner radius of the view's layer will propagate to the shadow
+    // layer when the view is presented by MDCDailogPresentationController.
     // Note that setting the corner radius in viewDidLoad is not recommended, since it
-    // may be overriden if callers apply a theme using a thmeing extension.
+    // will be overriden if callers apply a themer to the MDCDailogPresentationController instance.
     self.view.layer.cornerRadius = 32.0
-    self.mdc_dialogPresentationController?.dialogCornerRadius = 32.0
 
     bodyLabel.text =
       "This presented view has a corner radius so we've set the corner radius on the presentation controller."
@@ -100,9 +99,15 @@ class DialogsCustomShadowExampleViewController: UIViewController {
 
   @objc func tap(_ sender: Any) {
     let presentedController = CustomShadowViewController(nibName: nil, bundle: nil)
+
+    // Using a MDCDialogTransitionController as the transition delegate also sets
+    // MDCDailogPresentationController as the presentation controller.
+    // Make sure to store a strong reference to the transitionController.
     presentedController.modalPresentationStyle = .custom;
     presentedController.transitioningDelegate = self.transitionController;
 
+    // Note this example demonstrate direct manipulation of cornerRadius on the
+    //  view's layer so we're intentionally not calling the presentation controller's themer.
     self.present(presentedController, animated: true, completion: nil)
   }
 

--- a/components/Dialogs/examples/DialogsDismissingExampleViewController.m
+++ b/components/Dialogs/examples/DialogsDismissingExampleViewController.m
@@ -89,6 +89,8 @@
   viewController.modalPresentationStyle = UIModalPresentationCustom;
   viewController.transitioningDelegate = self.transitionController;
 
+  // Apply a presentation theme to the custom view controller
+  [viewController.mdc_dialogPresentationController applyThemeWithScheme:self.containerScheme];
   [self presentViewController:viewController animated:YES completion:NULL];
 }
 
@@ -98,14 +100,11 @@
   viewController.modalPresentationStyle = UIModalPresentationCustom;
   viewController.transitioningDelegate = self.transitionController;
 
-  [self presentViewController:viewController animated:YES completion:NULL];
-
   MDCDialogPresentationController *presentationController =
       viewController.mdc_dialogPresentationController;
+  presentationController.dismissOnBackgroundTap = NO;
   [presentationController applyThemeWithScheme:self.containerScheme];
-  if (presentationController) {
-    presentationController.dismissOnBackgroundTap = NO;
-  }
+  [self presentViewController:viewController animated:YES completion:NULL];
 }
 
 - (IBAction)didTapOpenURL {
@@ -113,6 +112,7 @@
   viewController.modalPresentationStyle = UIModalPresentationCustom;
   viewController.transitioningDelegate = self.transitionController;
 
+  [viewController.mdc_dialogPresentationController applyThemeWithScheme:self.containerScheme];
   [self presentViewController:viewController animated:YES completion:NULL];
 }
 
@@ -128,6 +128,8 @@
   viewController.modalPresentationStyle = UIModalPresentationCustom;
   viewController.transitioningDelegate = self.transitionController;
   viewController.containerScheme = self.containerScheme;
+
+  [viewController.mdc_dialogPresentationController applyThemeWithScheme:self.containerScheme];
   [self presentViewController:viewController animated:YES completion:NULL];
 }
 

--- a/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
@@ -127,29 +127,29 @@ static const CGFloat kCornerRadiusUnthemed = 12;
                                  relatedBy:NSLayoutRelationEqual
                                     toItem:presentButton
                                  attribute:NSLayoutAttributeCenterX
-                                multiplier:1.0
-                                  constant:0.0],
+                                multiplier:1
+                                  constant:0],
     [NSLayoutConstraint constraintWithItem:self.view
                                  attribute:NSLayoutAttributeCenterY
                                  relatedBy:NSLayoutRelationEqual
                                     toItem:presentButton
                                  attribute:NSLayoutAttributeCenterY
-                                multiplier:1.1
-                                  constant:0.0],
+                                multiplier:(CGFloat)1.1
+                                  constant:0],
     [NSLayoutConstraint constraintWithItem:self.view
                                  attribute:NSLayoutAttributeCenterX
                                  relatedBy:NSLayoutRelationEqual
                                     toItem:unthemedButton
                                  attribute:NSLayoutAttributeCenterX
-                                multiplier:1.0
-                                  constant:0.0],
+                                multiplier:1
+                                  constant:0],
     [NSLayoutConstraint constraintWithItem:self.view
                                  attribute:NSLayoutAttributeCenterY
                                  relatedBy:NSLayoutRelationEqual
                                     toItem:unthemedButton
                                  attribute:NSLayoutAttributeCenterY
-                                multiplier:0.9
-                                  constant:0.0],
+                                multiplier:(CGFloat)0.9
+                                  constant:0],
   ]];
 
   self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;

--- a/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
@@ -126,13 +126,17 @@
   viewController.modalPresentationStyle = UIModalPresentationCustom;
   viewController.transitioningDelegate = self.transitionController;
 
-  // sets the dialog's corner radius
-  viewController.view.layer.cornerRadius = 24;
-
-  // ensure shadow/tracking layer matches the dialog's corner radius
   MDCDialogPresentationController *controller = viewController.mdc_dialogPresentationController;
   controller.dialogPresentationControllerDelegate = self;
+
+  // Apply a presentation theme, which, among other things, sets the corner radius
   [controller applyThemeWithScheme:self.containerScheme];
+
+  // Manually override the dialog's corner radius that was set when we applied a presentation theme
+  // Ensure both the presented view and the presentation controller corner
+  // radius mathcnes, so the presented shadow is rendered correctly.
+  viewController.view.layer.cornerRadius = 24.0;
+  controller.dialogCornerRadius = 24.0;
 
   [self presentViewController:viewController animated:YES completion:nil];
 }

--- a/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
@@ -123,20 +123,23 @@
   DialogsRoundedCornerSimpleController *viewController =
       [[DialogsRoundedCornerSimpleController alloc] initWithNibName:nil bundle:nil];
 
+  // Make sure to store a strong reference to the transitionController.
   viewController.modalPresentationStyle = UIModalPresentationCustom;
   viewController.transitioningDelegate = self.transitionController;
 
   MDCDialogPresentationController *controller = viewController.mdc_dialogPresentationController;
   controller.dialogPresentationControllerDelegate = self;
 
-  // Apply a presentation theme, which, among other things, sets the corner radius
+  // Apply a presentation theme, which, among other things, sets the dialog's corner radius to 4.
   [controller applyThemeWithScheme:self.containerScheme];
 
-  // Manually override the dialog's corner radius that was set when we applied a presentation theme
-  // Ensure both the presented view and the presentation controller corner
-  // radius mathcnes, so the presented shadow is rendered correctly.
+  // To override the corner radius set by the themer, update the presentation controller's radius.
+  // The following line will override the value set by the themer, setting 10.0 as the final value:
+  viewController.mdc_dialogPresentationController.dialogCornerRadius = 10.0;
+
+  // Once dialogCornerRadius property is set, manually setting the view's cornerRadius is ignored.
+  // Hence, the following value will be ignored (corner radius is still 10.0):
   viewController.view.layer.cornerRadius = 24.0;
-  controller.dialogCornerRadius = 24.0;
 
   [self presentViewController:viewController animated:YES completion:nil];
 }

--- a/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
@@ -178,9 +178,9 @@ static const CGFloat kCornerRadiusUnthemed = 12;
   // The following line will override the value set by the themer, setting 6.0 as the final value:
   viewController.mdc_dialogPresentationController.dialogCornerRadius = kCornerRadiusThemed;
 
-  // Do not set the corner radius directly on the view while using the presentation
-  // controller themer. This next line is ignored bcasue applyThemeWithScheme: takes precedence:
-  viewController.view.layer.cornerRadius = 24.0;
+  // Do not set the corner radius directly on the view if applying a presentation controller
+  // themer. This next line is ignored bcasue applyThemeWithScheme: takes precedence:
+  viewController.view.layer.cornerRadius = 24.0;  // AVOID!
 
   [self presentViewController:viewController animated:YES completion:nil];
 }
@@ -196,7 +196,7 @@ static const CGFloat kCornerRadiusUnthemed = 12;
   viewController.containerScheme = self.containerScheme;
 
   // Setting the presented dialog's corner radius on an un-themed dialog is ok:
-  viewController.view.layer.cornerRadius = kCornerRadiusUnthemed;
+  viewController.view.layer.cornerRadius = kCornerRadiusUnthemed;  // OK!
 
   [self presentViewController:viewController animated:YES completion:nil];
 }

--- a/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
+++ b/components/Dialogs/examples/DialogsRoundedCornerExampleViewController.m
@@ -18,11 +18,14 @@
 #import "MaterialDialogs+Theming.h"
 #import "MaterialDialogs.h"
 
+static const CGFloat kCornerRadiusThemed = 3;
+static const CGFloat kCornerRadiusUnthemed = 12;
+
 @interface DialogsRoundedCornerSimpleController : UIViewController
 
 @property(nonatomic, strong) MDCButton *dismissButton;
 
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 
 @end
 
@@ -31,10 +34,14 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  id<MDCColorScheming> colorScheme =
-      self.containerScheme.colorScheme
-          ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  self.view.backgroundColor = colorScheme.backgroundColor;
+  if (self.containerScheme == nil) {
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+  }
+
+  if (self.containerScheme.colorScheme == nil) {
+    self.containerScheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
 
   self.dismissButton = [[MDCButton alloc] initWithFrame:CGRectZero];
   [self.dismissButton setTitle:@"Dismiss" forState:UIControlStateNormal];
@@ -45,8 +52,10 @@
   [self.dismissButton addTarget:self
                          action:@selector(dismiss:)
                forControlEvents:UIControlEventTouchUpInside];
-  [self.dismissButton applyTextThemeWithScheme:self.containerScheme];
   [self.view addSubview:self.dismissButton];
+
+  [self.dismissButton applyTextThemeWithScheme:self.containerScheme];
+  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
 }
 
 - (void)viewWillLayoutSubviews {
@@ -68,64 +77,96 @@
 
 @interface DialogsRoundedCornerExampleViewController () <MDCDialogPresentationControllerDelegate>
 
-@property(nonatomic, strong) MDCButton *presentButton;
 @property(nonatomic, strong) MDCDialogTransitionController *transitionController;
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 
 @end
 
 @implementation DialogsRoundedCornerExampleViewController
 
-- (instancetype)init {
-  self = [super init];
-  if (self) {
-    MDCContainerScheme *scheme = [[MDCContainerScheme alloc] init];
-    scheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    _containerScheme = scheme;
-  }
-  return self;
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
+
+  if (self.containerScheme == nil) {
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+  }
+
+  if (self.containerScheme.colorScheme == nil) {
+    self.containerScheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  }
 
   // We must create and store a strong reference to the transitionController.
   // A presented view controller will set this object as its transitioning delegate.
   self.transitionController = [[MDCDialogTransitionController alloc] init];
 
-  id<MDCColorScheming> colorScheme =
-      self.containerScheme.colorScheme
-          ?: [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  self.view.backgroundColor = colorScheme.backgroundColor;
+  MDCButton *presentButton = [[MDCButton alloc] initWithFrame:CGRectZero];
+  [presentButton setTitle:[NSString stringWithFormat:@"Themed -- override radius to: %.1f",
+                                                     kCornerRadiusThemed]
+                 forState:UIControlStateNormal];
+  [presentButton addTarget:self
+                    action:@selector(didTapPresentThemed:)
+          forControlEvents:UIControlEventTouchUpInside];
+  [self.view addSubview:presentButton];
 
-  self.presentButton = [[MDCButton alloc] initWithFrame:CGRectZero];
-  [self.presentButton setTitle:@"Present" forState:UIControlStateNormal];
-  [self.presentButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
-  self.presentButton.autoresizingMask =
-      UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin |
-      UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin;
-  [self.presentButton addTarget:self
-                         action:@selector(didTapPresent:)
-               forControlEvents:UIControlEventTouchUpInside];
-  [self.presentButton applyTextThemeWithScheme:self.containerScheme];
-  [self.view addSubview:self.presentButton];
+  MDCButton *unthemedButton = [[MDCButton alloc] initWithFrame:CGRectZero];
+  [unthemedButton setTitle:[NSString stringWithFormat:@"Un-Themed -- override radius to: %.1f",
+                                                      kCornerRadiusUnthemed]
+                  forState:UIControlStateNormal];
+  [unthemedButton addTarget:self
+                     action:@selector(didTapPresentDefault:)
+           forControlEvents:UIControlEventTouchUpInside];
+  [self.view addSubview:unthemedButton];
+
+  presentButton.translatesAutoresizingMaskIntoConstraints = NO;
+  unthemedButton.translatesAutoresizingMaskIntoConstraints = NO;
+
+  [self.view addConstraints:@[
+    [NSLayoutConstraint constraintWithItem:self.view
+                                 attribute:NSLayoutAttributeCenterX
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:presentButton
+                                 attribute:NSLayoutAttributeCenterX
+                                multiplier:1.0
+                                  constant:0.0],
+    [NSLayoutConstraint constraintWithItem:self.view
+                                 attribute:NSLayoutAttributeCenterY
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:presentButton
+                                 attribute:NSLayoutAttributeCenterY
+                                multiplier:1.1
+                                  constant:0.0],
+    [NSLayoutConstraint constraintWithItem:self.view
+                                 attribute:NSLayoutAttributeCenterX
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:unthemedButton
+                                 attribute:NSLayoutAttributeCenterX
+                                multiplier:1.0
+                                  constant:0.0],
+    [NSLayoutConstraint constraintWithItem:self.view
+                                 attribute:NSLayoutAttributeCenterY
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:unthemedButton
+                                 attribute:NSLayoutAttributeCenterY
+                                multiplier:0.9
+                                  constant:0.0],
+  ]];
+
+  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
+  [presentButton applyTextThemeWithScheme:self.containerScheme];
+  [unthemedButton applyTextThemeWithScheme:self.containerScheme];
 }
 
-- (void)viewWillLayoutSubviews {
-  [super viewWillLayoutSubviews];
-  [_presentButton sizeToFit];
-  _presentButton.center =
-      CGPointMake(CGRectGetMidX(self.view.bounds), CGRectGetMidY(self.view.bounds));
-}
-
-- (IBAction)didTapPresent:(id)sender {
+// Theming the presentation controller, and manually overriding
+// the default corner radius set by the themer,
+- (IBAction)didTapPresentThemed:(id)sender {
   DialogsRoundedCornerSimpleController *viewController =
       [[DialogsRoundedCornerSimpleController alloc] initWithNibName:nil bundle:nil];
 
   // Make sure to store a strong reference to the transitionController.
   viewController.modalPresentationStyle = UIModalPresentationCustom;
   viewController.transitioningDelegate = self.transitionController;
+  viewController.containerScheme = self.containerScheme;
 
   MDCDialogPresentationController *controller = viewController.mdc_dialogPresentationController;
   controller.dialogPresentationControllerDelegate = self;
@@ -134,12 +175,28 @@
   [controller applyThemeWithScheme:self.containerScheme];
 
   // To override the corner radius set by the themer, update the presentation controller's radius.
-  // The following line will override the value set by the themer, setting 10.0 as the final value:
-  viewController.mdc_dialogPresentationController.dialogCornerRadius = 10.0;
+  // The following line will override the value set by the themer, setting 6.0 as the final value:
+  viewController.mdc_dialogPresentationController.dialogCornerRadius = kCornerRadiusThemed;
 
-  // Once dialogCornerRadius property is set, manually setting the view's cornerRadius is ignored.
-  // Hence, the following value will be ignored (corner radius is still 10.0):
+  // Do not set the corner radius directly on the view while using the presentation
+  // controller themer. This next line is ignored bcasue applyThemeWithScheme: takes precedence:
   viewController.view.layer.cornerRadius = 24.0;
+
+  [self presentViewController:viewController animated:YES completion:nil];
+}
+
+// NOT theming the presentation controller, while manually setting the corner radius
+- (IBAction)didTapPresentDefault:(id)sender {
+  DialogsRoundedCornerSimpleController *viewController =
+      [[DialogsRoundedCornerSimpleController alloc] initWithNibName:nil bundle:nil];
+
+  // Make sure to store a strong reference to the transitionController.
+  viewController.modalPresentationStyle = UIModalPresentationCustom;
+  viewController.transitioningDelegate = self.transitionController;
+  viewController.containerScheme = self.containerScheme;
+
+  // Setting the presented dialog's corner radius on an un-themed dialog is ok:
+  viewController.view.layer.cornerRadius = kCornerRadiusUnthemed;
 
   [self presentViewController:viewController animated:YES completion:nil];
 }

--- a/components/Dialogs/examples/DialogsThemedPresentationExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsThemedPresentationExampleViewController.swift
@@ -213,12 +213,7 @@ class DialogsThemedPresentationExampleViewController: UIViewController {
     customDialogController.modalPresentationStyle = .custom;
     customDialogController.transitioningDelegate = self.transitionController;
 
-    if let presentationController = customDialogController.mdc_dialogPresentationController {
-      presentationController.applyTheme(withScheme: containerScheme)
-      // TODO: remove setting the cornerRadius of custom dialog view here.
-      // Github link: https://github.com/material-components/material-components-ios/issues/6622
-      customDialogController.view.layer.cornerRadius = presentationController.dialogCornerRadius;
-    }
+    customDialogController.mdc_dialogPresentationController?.applyTheme(withScheme: containerScheme)
     present(customDialogController, animated: true, completion: nil)
   }
 }

--- a/components/Dialogs/src/MDCDialogPresentationController.h
+++ b/components/Dialogs/src/MDCDialogPresentationController.h
@@ -16,8 +16,6 @@
 
 #import "MaterialShadowElevations.h"
 
-extern CGFloat const MDCUsePresentedViewCornerRadius;
-
 @class MDCDialogPresentationController;
 
 /**
@@ -71,22 +69,22 @@ extern CGFloat const MDCUsePresentedViewCornerRadius;
 /**
  Customize the corner radius of the shadow to match the presented view's corner radius.
 
- By default (when the value is MDCUsePresentedViewCornerRadius), the dialogCornerRadius is ignored,
- and the presented view will be presented with it original corner radius value that is assigned
- by the client. The presentation controller will ensure in that case to match its shadow
- shape to the corner radius of the presented view.
+ By default, the corner radius of the presented shadow is adjusted to match the corner radius of the
+ view being presented.  This behavior is achieved without making any changes to dialogCornerRadius.
+ Once a value is set on dialogCornerRadius, that value will be used to determine the radius of both
+ the presetned view and the shadow. That means that any further changes to the presented view's
+ corner radius (yourViewController.view.layer.cornerRadius) will be ignored once dialogCornerRadius
+ is set.
 
- Modifying dialogCornerRadius to a positive value, will present the presented view with this
- positive value, overriding previous corner radius values that may have been previously
- set by the client. The presentation controller will ensure in that case to match both the
- presetned view's and the shadow's corner radius to the value assigned in dialogCornerRadius.
+ In either cases, the presentation controller ensures that the shadow layer's corner radius matches
+ the presented view's.
 
  Material themers use dialogCornerRadius for setting the corner radius, therefore, when applying
  a themer to your custom UIViewController, any value you assign to your view's corner radius
-(through view.layer.cornerRadius) will be ignored. In that case, if you wish to further
- customize the corner radius of the presented view, set dialogCornerRadius instead.
+ will be ignored. If you wish to override the corner radius after a themer is called, make sure
+ to set it to dialogCornerRadius, and not to the presented view's corner radius.
 
- Defaults to: MDCUsePresentedViewCornerRadius (-1.0).
+ Defaults to: The presented view's corner radius.
  */
 @property(nonatomic, assign) CGFloat dialogCornerRadius;
 

--- a/components/Dialogs/src/MDCDialogPresentationController.h
+++ b/components/Dialogs/src/MDCDialogPresentationController.h
@@ -68,10 +68,19 @@
 
 /**
  Customize the corner radius of the shadow to match the presented view's corner radius.
- If the presented view corner radius and dialogCornerRadius are different, the rendered shadow will
- not match.
 
- Defaults to 0.0.
+ The default value (-1) will use the presented view's corner radius as the corner radius of the
+ shadow. Setting any value to myPresentedViewConteroller.view.layer.cornerRadius will be used
+ as the shadow's corner radius.
+
+ Changing the dialogCornerRadius will work in the opposite way. When a view controller is pesented,
+ it's view's corner radius will be adjusted to match this value.
+
+ Applying a themer on a custom dialog or on an alert (MDCAlertController) will adjust the
+ dialogCornerRadius value, and will override any value manually set for the
+ presented view controller.
+
+ Defaults to -1.0.
  */
 @property(nonatomic, assign) CGFloat dialogCornerRadius;
 

--- a/components/Dialogs/src/MDCDialogPresentationController.h
+++ b/components/Dialogs/src/MDCDialogPresentationController.h
@@ -16,7 +16,7 @@
 
 #import "MaterialShadowElevations.h"
 
-extern CGFloat const kPresentedViewCorenerRadius;
+extern CGFloat const MDCUsePresentedViewCornerRadius;
 
 @class MDCDialogPresentationController;
 
@@ -71,7 +71,7 @@ extern CGFloat const kPresentedViewCorenerRadius;
 /**
  Customize the corner radius of the shadow to match the presented view's corner radius.
 
- By default (when the value is kPresentedViewCorenerRadius), the dialogCornerRadius is ignored,
+ By default (when the value is MDCUsePresentedViewCornerRadius), the dialogCornerRadius is ignored,
  and the presented view will be presented with it original corner radius value that is assigned
  by the client. The presentation controller will ensure in that case to match its shadow
  shape to the corner radius of the presented view.
@@ -86,7 +86,7 @@ extern CGFloat const kPresentedViewCorenerRadius;
 (through view.layer.cornerRadius) will be ignored. In that case, if you wish to further
  customize the corner radius of the presented view, set dialogCornerRadius instead.
 
- Defaults to: kPresentedViewCorenerRadius (-1.0).
+ Defaults to: MDCUsePresentedViewCornerRadius (-1.0).
  */
 @property(nonatomic, assign) CGFloat dialogCornerRadius;
 

--- a/components/Dialogs/src/MDCDialogPresentationController.h
+++ b/components/Dialogs/src/MDCDialogPresentationController.h
@@ -16,6 +16,8 @@
 
 #import "MaterialShadowElevations.h"
 
+extern CGFloat const kPresentedViewCorenerRadius;
+
 @class MDCDialogPresentationController;
 
 /**
@@ -69,18 +71,22 @@
 /**
  Customize the corner radius of the shadow to match the presented view's corner radius.
 
- The default value (-1) will use the presented view's corner radius as the corner radius of the
- shadow. Setting any value to myPresentedViewConteroller.view.layer.cornerRadius will be used
- as the shadow's corner radius.
+ By default (when the value is kPresentedViewCorenerRadius), the dialogCornerRadius is ignored,
+ and the presented view will be presented with it original corner radius value that is assigned
+ by the client. The presentation controller will ensure in that case to match its shadow
+ shape to the corner radius of the presented view.
 
- Changing the dialogCornerRadius will work in the opposite way. When a view controller is pesented,
- it's view's corner radius will be adjusted to match this value.
+ Modifying dialogCornerRadius to a positive value, will present the presented view with this
+ positive value, overriding previous corner radius values that may have been previously
+ set by the client. The presentation controller will ensure in that case to match both the
+ presetned view's and the shadow's corner radius to the value assigned in dialogCornerRadius.
 
- Applying a themer on a custom dialog or on an alert (MDCAlertController) will adjust the
- dialogCornerRadius value, and will override any value manually set for the
- presented view controller.
+ Material themers use dialogCornerRadius for setting the corner radius, therefore, when applying
+ a themer to your custom UIViewController, any value you assign to your view's corner radius
+(through view.layer.cornerRadius) will be ignored. In that case, if you wish to further
+ customize the corner radius of the presented view, set dialogCornerRadius instead.
 
- Defaults to -1.0.
+ Defaults to: kPresentedViewCorenerRadius (-1.0).
  */
 @property(nonatomic, assign) CGFloat dialogCornerRadius;
 

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -18,6 +18,7 @@
 #import "MaterialShadowLayer.h"
 #import "private/MDCDialogShadowedView.h"
 
+CGFloat const kPresentedViewCorenerRadius = -1.0;
 static CGFloat MDCDialogMinimumWidth = 280;
 // TODO: Spec indicates 40 side margins and 280 minimum width.
 // That is incompatible with a 320 wide device.
@@ -72,7 +73,7 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
   self = [super initWithPresentedViewController:presentedViewController
                        presentingViewController:presentingViewController];
   if (self) {
-    _dialogCornerRadius = -1.0;
+    _dialogCornerRadius = kPresentedViewCorenerRadius;
     _dimmingView = [[UIView alloc] initWithFrame:CGRectZero];
     _dimmingView.backgroundColor = [UIColor colorWithWhite:0 alpha:(CGFloat)0.32];
     _dimmingView.alpha = 0;
@@ -138,7 +139,7 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
   // https://material.io/guidelines/motion/choreography.html#choreography-creation
 
   // Ensure corner radius matches between the tracking view and the view being presented
-  if (self.dialogCornerRadius < 0) {
+  if (self.dialogCornerRadius <= kPresentedViewCorenerRadius) {
     // If dialogCornerRadius is not set, use the presented view's cornerRadius for the shadow layer.
     _trackingView.layer.cornerRadius = self.presentedView.layer.cornerRadius;
   } else {
@@ -147,7 +148,7 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
     _trackingView.layer.cornerRadius = self.dialogCornerRadius;
     // Note: For MDCAlertController, this assumes that the "view" property points to the same
     // instance as the "alertView" property. Therefore, we are safe to not set its cornerRadius
-    // property (its ".cornerRadius", rather then its ".view.layer.cornerRadius")
+    // property (its ".cornerRadius", rather then its "presentedView.layer.cornerRadius")
     self.presentedView.layer.cornerRadius = self.dialogCornerRadius;
   }
 

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -140,7 +140,7 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
   // Ensure corner radius matches between the tracking view and the view being presented
   if (self.dialogCornerRadius < 0) {
     // If dialogCornerRadius is not set, use the presented view's cornerRadius for the shadow layer.
-    _trackingView.layer.cornerRadius = self.presentedViewController.view.layer.cornerRadius;
+    _trackingView.layer.cornerRadius = self.presentedView.layer.cornerRadius;
   } else {
     // If dialogCornerRadius is set, use its value for the shadow layer as well as the presented
     // view layer, overriding any direct assignments to the presented view's cornerRadius.
@@ -148,7 +148,7 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
     // Note: For MDCAlertController, this assumes that the "view" property points to the same
     // instance as the "alertView" property. Therefore, we are safe to not set its cornerRadius
     // property (its ".cornerRadius", rather then its ".view.layer.cornerRadius")
-    self.presentedViewController.view.layer.cornerRadius = self.dialogCornerRadius;
+    self.presentedView.layer.cornerRadius = self.dialogCornerRadius;
   }
 
   // Set the dimming view to the container's bounds and fully transparent.

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -51,16 +51,6 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
   return _dismissGestureRecognizer.enabled;
 }
 
-// presentedViewCornerRadius wraps the cornerRadius property of our tracking view to avoid
-// duplication.
-- (void)setDialogCornerRadius:(CGFloat)cornerRadius {
-  _trackingView.layer.cornerRadius = cornerRadius;
-}
-
-- (CGFloat)dialogCornerRadius {
-  return _trackingView.layer.cornerRadius;
-}
-
 - (void)setScrimColor:(UIColor *)scrimColor {
   self.dimmingView.backgroundColor = scrimColor;
 }
@@ -82,6 +72,7 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
   self = [super initWithPresentedViewController:presentedViewController
                        presentingViewController:presentingViewController];
   if (self) {
+    _dialogCornerRadius = -1.0;
     _dimmingView = [[UIView alloc] initWithFrame:CGRectZero];
     _dimmingView.backgroundColor = [UIColor colorWithWhite:0 alpha:(CGFloat)0.32];
     _dimmingView.alpha = 0;
@@ -145,6 +136,20 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
   // TODO: Follow the Material spec description of Autonomous surface creation for both
   // presentation and dismissal of the dialog.
   // https://material.io/guidelines/motion/choreography.html#choreography-creation
+
+  // Ensure corner radius matches between the tracking view and the view being presented
+  if (self.dialogCornerRadius < 0) {
+    // If dialogCornerRadius is not set, use the presented view's cornerRadius for the shadow layer.
+    _trackingView.layer.cornerRadius = self.presentedViewController.view.layer.cornerRadius;
+  } else {
+    // If dialogCornerRadius is set, use its value for the shadow layer as well as the presented
+    // view layer, overriding any direct assignments to the presented view's cornerRadius.
+    _trackingView.layer.cornerRadius = self.dialogCornerRadius;
+    // Note: For MDCAlertController, this assumes that the "view" property points to the same
+    // instance as the "alertView" property. Therefore, we are safe to not set its cornerRadius
+    // property (its ".cornerRadius", rather then its ".view.layer.cornerRadius")
+    self.presentedViewController.view.layer.cornerRadius = self.dialogCornerRadius;
+  }
 
   // Set the dimming view to the container's bounds and fully transparent.
   self.dimmingView.frame = self.containerView.bounds;

--- a/components/Dialogs/src/Theming/MDCDialogPresentationController+MaterialTheming.h
+++ b/components/Dialogs/src/Theming/MDCDialogPresentationController+MaterialTheming.h
@@ -16,17 +16,31 @@
 #import "MaterialContainerScheme.h"
 
 /**
- This category is used to style MDCDialogPresentationController instances to a specific Material
- style which can be found within the [Material
- Guidelines](https://material.io/design/components/dialogs.html).
+ An MDCDialogPresentationController theming extension used in theming
+ presentation attributes of custom UIViewControllers according to the
+ [Material Guidelines](https://material.io/design/components/dialogs.html).
  */
 @interface MDCDialogPresentationController (MaterialTheming)
 
 /**
- Applies a container scheme to this instance.
+ Applying material theming to the presentation attributes of a MDCDialogPresentationController,
+ when it is used in a custom UIViewController presentation. Themeable presentation attributes
+ may inclue scrim color corner raidus or shadow elevation.
 
- @param scheme A container scheme instance containing any desired customizations to the theming
- system.
+ @note Make sure to call this method *after* a transition delegate has been
+       assigned to a Material transition controller instance (MDCDialogTransitionController).
+       Calling this method before the transition delegate is assigned may
+       lead to undesired effects and is not supported.
+
+ @example:
+
+ myViewController.modalPresentationStyle = UIModalPresentationCustom;
+ // Note: make sure to store a strong reference to the transitionController instance
+ myViewController.transitioningDelegate = self.transitionController;
+ [myViewController.mdc_dialogPresentationController applyThemeWithScheme:self.containerScheme];
+ [self presentViewController:myViewController animated:YES completion:nil];
+
+ @param scheme The container scheme whose values are used in theming the presentation attributes
  */
 - (void)applyThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
 

--- a/components/Dialogs/src/Theming/MDCDialogPresentationController+MaterialTheming.m
+++ b/components/Dialogs/src/Theming/MDCDialogPresentationController+MaterialTheming.m
@@ -27,8 +27,15 @@ static const CGFloat kCornerRadius = 4;
   }
   self.scrimColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.32];
 
-  // Other properties
-  self.dialogCornerRadius = kCornerRadius;
+  // Corner Radius
+  if ([self.presentedViewController isKindOfClass:[MDCAlertController class]]) {
+    ((MDCAlertController *)self.presentedViewController).cornerRadius = kCornerRadius;
+  } else {
+    self.presentedViewController.view.layer.cornerRadius = kCornerRadius;
+    self.dialogCornerRadius = kCornerRadius;
+  }
+
+  // Elevation
   self.dialogElevation = MDCShadowElevationDialog;
 }
 

--- a/components/Dialogs/src/Theming/MDCDialogPresentationController+MaterialTheming.m
+++ b/components/Dialogs/src/Theming/MDCDialogPresentationController+MaterialTheming.m
@@ -28,12 +28,7 @@ static const CGFloat kCornerRadius = 4;
   self.scrimColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.32];
 
   // Corner Radius
-  if ([self.presentedViewController isKindOfClass:[MDCAlertController class]]) {
-    ((MDCAlertController *)self.presentedViewController).cornerRadius = kCornerRadius;
-  } else {
-    self.presentedViewController.view.layer.cornerRadius = kCornerRadius;
-    self.dialogCornerRadius = kCornerRadius;
-  }
+  self.dialogCornerRadius = kCornerRadius;
 
   // Elevation
   self.dialogElevation = MDCShadowElevationDialog;

--- a/components/Dialogs/tests/unit/Theming/DialogsMaterialThemingTests.swift
+++ b/components/Dialogs/tests/unit/Theming/DialogsMaterialThemingTests.swift
@@ -193,8 +193,6 @@ class DialogsMaterialThemingTests: XCTestCase {
 
     // Corner Radius
     XCTAssertEqual(presentationController.dialogCornerRadius, kCornerRadius, accuracy: 0.001)
-    XCTAssertEqual(alert.view.layer.cornerRadius, kCornerRadius, accuracy: 0.001)
-    XCTAssertEqual(alert.cornerRadius, kCornerRadius, accuracy: 0.001)
 
     // Elevation
     XCTAssertEqual(presentationController.dialogElevation, ShadowElevation.dialog)
@@ -207,6 +205,8 @@ class DialogsMaterialThemingTests: XCTestCase {
     dialog.modalPresentationStyle = .custom
     dialog.transitioningDelegate = transitionController
 
+    // The presentation controller is the object under test. It should be defined correctly
+    // once an MDC transition delegate is assigned. We first verify is exists before testing it:
     guard let presentationController = dialog.mdc_dialogPresentationController else {
       XCTAssert(false, "alert.mdc_dialogPresentationController should not be nil")
       return
@@ -218,15 +218,17 @@ class DialogsMaterialThemingTests: XCTestCase {
     presentationController.applyTheme(withScheme: scheme)
 
     // Then
-    // Color
+    // Presentation
+    XCTAssertEqual(dialog.presentationController, presentationController)
+
+    // Presentation Color
     XCTAssertEqual(presentationController.scrimColor,
                    colorScheme.onSurfaceColor.withAlphaComponent(0.32))
 
-    // Corner Radius
+    // Presentation Corner Radius
     XCTAssertEqual(presentationController.dialogCornerRadius, kCornerRadius, accuracy: 0.001)
-    XCTAssertEqual(dialog.view.layer.cornerRadius, kCornerRadius, accuracy: 0.001)
 
-    // Elevation
+    // Presentation Elevation
     XCTAssertEqual(presentationController.dialogElevation, ShadowElevation.dialog)
   }
 

--- a/components/Dialogs/tests/unit/Theming/DialogsMaterialThemingTests.swift
+++ b/components/Dialogs/tests/unit/Theming/DialogsMaterialThemingTests.swift
@@ -41,7 +41,7 @@ class DialogsMaterialThemingTests: XCTestCase {
     alert.addAction(action2)
     let action3: MDCAlertAction = MDCAlertAction(title: "", emphasis: .high)
     alert.addAction(action3)
-
+    
     alert.applyTheme(withScheme: scheme)
 
     // Color
@@ -191,8 +191,42 @@ class DialogsMaterialThemingTests: XCTestCase {
     XCTAssertEqual(presentationController.scrimColor,
                    colorScheme.onSurfaceColor.withAlphaComponent(0.32))
 
-    // Other properties
+    // Corner Radius
     XCTAssertEqual(presentationController.dialogCornerRadius, kCornerRadius, accuracy: 0.001)
+    XCTAssertEqual(alert.view.layer.cornerRadius, kCornerRadius, accuracy: 0.001)
+    XCTAssertEqual(alert.cornerRadius, kCornerRadius, accuracy: 0.001)
+
+    // Elevation
+    XCTAssertEqual(presentationController.dialogElevation, ShadowElevation.dialog)
+  }
+
+  func testMDCDialogPresentationControllerThemingWithCustomViewController() {
+    // Given
+    let dialog: UIViewController = UIViewController(nibName: nil, bundle: nil)
+    let transitionController = MDCDialogTransitionController()
+    dialog.modalPresentationStyle = .custom
+    dialog.transitioningDelegate = transitionController
+
+    guard let presentationController = dialog.mdc_dialogPresentationController else {
+      XCTAssert(false, "alert.mdc_dialogPresentationController should not be nil")
+      return
+    }
+    let scheme: MDCContainerScheme = MDCContainerScheme()
+    let colorScheme = MDCSemanticColorScheme()
+
+    // When
+    presentationController.applyTheme(withScheme: scheme)
+
+    // Then
+    // Color
+    XCTAssertEqual(presentationController.scrimColor,
+                   colorScheme.onSurfaceColor.withAlphaComponent(0.32))
+
+    // Corner Radius
+    XCTAssertEqual(presentationController.dialogCornerRadius, kCornerRadius, accuracy: 0.001)
+    XCTAssertEqual(dialog.view.layer.cornerRadius, kCornerRadius, accuracy: 0.001)
+
+    // Elevation
     XCTAssertEqual(presentationController.dialogElevation, ShadowElevation.dialog)
   }
 


### PR DESCRIPTION
### Background

MDCDailogPresentationController renders the shadow layer of a presented view controller.  Its theming extension themes all presentation aspects, but it cannot ensure that the corner radius of the presentation controller matches the corner radius of the view it presents.

I've been experimenting with 3 different solutions to this problem, eventually deciding the last one is the optimal.  Feedback welcome!

### Solution A [REJECTED]

Apply a presentation theme directly to the custom view controller. Unlike MDCDailogPresentationController extension, a UIViewController extension has access to both the presented view and the presentation controller, and can ensure the corner radius is set on both.

**Rejected because**: Adding a theming extension to a UIKit class is less optimal.

### Solution B [REJECTED]

Going back to a MDCDailogPresentationController theming extension.
This solution sets the corner radius of the presentedViewController in MDCDialogPresentationController theming extension (thanks @wenyuzhang666 and @ianegordon  for your helpful input).

My concern with this approach is that by accessing the view property of the presentedViewController we may trigger "viewDidLoad" inside the themer.

**Rejected because**: Its a little brittle. It is not clear what effect view.layer.cornerRadius has over mdc_presentationController.dialogCornerRadius.

**Implementation in commit**: "Fix presented corner radius in custom view controllers"

### Solution C [ACCEPTED]

Changing the way MDCDailogPresentationController's dialogCornerRadius is used to determine corner radius.  This solution uses it to conditionally set the corner radius for both its shadow layer and the presented view layer.

We ensure internally that these 2 match by setting the corner radius on both - dynamically when the presentation animation begins (in MDCDailogPresentationController). 

Which corner radius "wins" is determined by the following logic:

dialogCornerRadius is configured by default to be disabled (it has a default value of -1), which allows the presented view's cornerRadius to take precedence and be used for the shadow layer.

When dialogCornerRadius has a non-negative value, typically when set by a themer, it becomes the preferred value that's applied to both the shadow layer and the presented view layer.

**Accepted because**:
* The corner radius of the shadow layer is guaranteed to always match the view's without any additional steps (as long as neither of them is changed again after the end of the run loop after the view is presented).
* Default UIKit behavior is preserved when a themer is not called: setting view.layer.cornerRadius alone will result in correct radius for both shadow and presented view.
* The themer can override the corner radius by setting dialogCornerRadius alone, and it will result in correct radius for both shadow and presented view.

Note: Accessing the presentedViewController.view property did not seem to be a problem. The view seems to be always be loaded by the time [MDCDailogPresentationController presentationTransitionWillBegin] is called.

**Implementation in commit**: "Changing purpose of dialogCornerRadius to fix the presented corner-radius issue" (or final diff of this PR).

### Before and After

Note: this Before & After view works for all 3 solutions.

Before (Incorrect shadow shape with a custom corner radius value of 24):

![dialogbefore](https://user-images.githubusercontent.com/2329102/53240646-45174980-366d-11e9-893e-528378c5aade.png)

After (Correct shadow shape with a custom corner radius value of 24):

![dialogafter](https://user-images.githubusercontent.com/2329102/53240651-49dbfd80-366d-11e9-8811-d51660fe40d0.png)

### Issues

#6622
b/124469770
Followup issue: b/126934531