### PR TITLE
[Kokoro] [Test] [Do not merge] Tweak "cocoapods-podspec" job

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -387,8 +387,7 @@ run_cocoapods() {
     select_xcode "$XCODE_VERSION"
 
     # Move into our cloned repo
-    # cd github/repo
-    repo_dir
+    cd github/repo
     echo "moved to repo_dir"
 
     gem_install xcpretty 

--- a/.kokoro
+++ b/.kokoro
@@ -388,8 +388,8 @@ run_cocoapods() {
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     echo "no kokoro build number"
-    move_derived_data_to_tmp
-    # delete_all_derived_data
+    # move_derived_data_to_tmp
+    delete_all_derived_data
   fi
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
@@ -418,22 +418,23 @@ run_cocoapods() {
       bash scripts/test_all catalog/MDCCatalog.xcworkspace:MDCCatalog
     fi
   elif [ "$DEPENDENCY_SYSTEM" = "cocoapods-podspec" ]; then
-    cd catalog
-    echo "in catalog:"
-    ls
-    rm -rf Pods
-    echo "prep_all..."
-    bash ../scripts/prep_all
-    echo "still in catalog:"
-    ls
+    # cd catalog
+    # echo "in catalog:"
+    # ls
+    # rm -rf Pods
+    # echo "prep_all..."
+    # bash ../scripts/prep_all
+    # echo "still in catalog:"
+    # ls
     # cd ..
 
     # pod cache clean --all
     # cd catalog
-    echo "running pod repo update..."
-    pod install
-    echo "linting..."
-    pod lib lint ../MaterialComponents.podspec --skip-tests --fail-fast --verbose
+    # echo "running pod repo update..."
+    # pod install
+    # echo "linting..."
+    # pod lib lint ../MaterialComponents.podspec --skip-tests --fail-fast --verbose
+    pod lib lint MaterialComponents.podspec --skip-tests --fail-fast --verbose
   fi
 
   if [ -n "$CODECOV_TOKEN" ]; then

--- a/.kokoro
+++ b/.kokoro
@@ -409,11 +409,8 @@ run_cocoapods() {
       bash scripts/test_all catalog/MDCCatalog.xcworkspace:MDCCatalog
     fi
   elif [ "$DEPENDENCY_SYSTEM" = "cocoapods-podspec" ]; then
+    cd catalog && rm -rf Pods && cd ..
     pod cache clean --all
-    echo "running ls:"
-    ls
-    echo "running pwd:"
-    pwd
     bash scripts/prep_all
     pod lib lint MaterialComponents.podspec --skip-tests --fail-fast --verbose
   fi

--- a/.kokoro
+++ b/.kokoro
@@ -378,15 +378,18 @@ run_bazel() {
 run_cocoapods() {
   echo "Running cocoapods builds..."
 
-  # if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+    echo "no kokoro build number"
     # move_derived_data_to_tmp
-  # fi
+  fi
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     select_xcode "$XCODE_VERSION"
 
     # Move into our cloned repo
-    cd github/repo
+    # cd github/repo
+    repo_dir
+    echo "moved to repo_dir"
 
     gem_install xcpretty 
     gem install cocoapods -v "$COCOAPODS_VERSION"
@@ -408,6 +411,11 @@ run_cocoapods() {
     fi
   elif [ "$DEPENDENCY_SYSTEM" = "cocoapods-podspec" ]; then
     pod cache clean --all
+    echo "running ls:"
+    ls
+    echo "running pwd:"
+    pwd
+    bash scripts/prep_all
     pod lib lint MaterialComponents.podspec --skip-tests --fail-fast --verbose
   fi
 

--- a/.kokoro
+++ b/.kokoro
@@ -170,9 +170,18 @@ move_derived_data_to_tmp() {
   targetDir="${HOME}/Library/Developer/Xcode/DerivedData"
   if [[ -d "$targetDir" ]]; then
     mv "$targetDir" /tmpfs/
-    ln -sf /tmpfs/DerivedData "$targetDir"
+    # ln -sf /tmpfs/DerivedData "$targetDir"
+    ln -sf /tmpfs/DerivedData "${HOME}/Library/Developer/Xcode/"
   fi
 }
+
+# delete_all_derived_data() {
+#   targetDir="${HOME}/Library/Developer/Xcode/DerivedData"
+#   if [[ -d "$targetDir" ]]; then
+#     rm -rf "$targetDir"
+#     rm -rf /tmpfs/DerivedData
+#   fi
+# }
 
 # Uploads all of the bazel test artifacts to Kokoro's artifacts storage.
 upload_bazel_test_artifacts() {
@@ -380,7 +389,7 @@ run_cocoapods() {
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     echo "no kokoro build number"
-    # move_derived_data_to_tmp
+    move_derived_data_to_tmp
   fi
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
@@ -390,7 +399,8 @@ run_cocoapods() {
     cd github/repo
 
     gem_install xcpretty 
-    gem install cocoapods -v "$COCOAPODS_VERSION"
+    gem_install install cocoapods -v "$COCOAPODS_VERSION"
+    echo "installed cocoapods version:"
     pod --version
 
     # Install git-lfs
@@ -408,10 +418,17 @@ run_cocoapods() {
       bash scripts/test_all catalog/MDCCatalog.xcworkspace:MDCCatalog
     fi
   elif [ "$DEPENDENCY_SYSTEM" = "cocoapods-podspec" ]; then
-    cd catalog && rm -rf Pods && cd ..
-    pod cache clean --all
-    bash scripts/prep_all
     cd catalog
+    echo "in catalog:"
+    ls
+    rm -rf Pods
+    rm Podfile.lock
+    echo "still in catalog:"
+    ls
+    # cd ..
+    pod cache clean --all
+    # bash scripts/prep_all
+    # cd catalog
     echo "linting..."
     pod lib lint ../MaterialComponents.podspec --skip-tests --fail-fast --verbose
   fi

--- a/.kokoro
+++ b/.kokoro
@@ -175,13 +175,13 @@ move_derived_data_to_tmp() {
   fi
 }
 
-# delete_all_derived_data() {
-#   targetDir="${HOME}/Library/Developer/Xcode/DerivedData"
-#   if [[ -d "$targetDir" ]]; then
-#     rm -rf "$targetDir"
-#     rm -rf /tmpfs/DerivedData
-#   fi
-# }
+delete_all_derived_data() {
+  targetDir="${HOME}/Library/Developer/Xcode/DerivedData"
+  if [[ -d "$targetDir" ]]; then
+    rm -rf "$targetDir"
+    rm -rf /tmpfs/DerivedData
+  fi
+}
 
 # Uploads all of the bazel test artifacts to Kokoro's artifacts storage.
 upload_bazel_test_artifacts() {
@@ -389,7 +389,8 @@ run_cocoapods() {
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     echo "no kokoro build number"
-    move_derived_data_to_tmp
+    # move_derived_data_to_tmp
+    delete_all_derived_data
   fi
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
@@ -426,13 +427,12 @@ run_cocoapods() {
     bash ../scripts/prep_all
     echo "still in catalog:"
     ls
-    rm Podfile.lock
     # cd ..
 
     # pod cache clean --all
     # cd catalog
     echo "running pod repo update..."
-    pod repo update
+    pod install
     echo "linting..."
     pod lib lint ../MaterialComponents.podspec --skip-tests --fail-fast --verbose
   fi

--- a/.kokoro
+++ b/.kokoro
@@ -170,7 +170,6 @@ move_derived_data_to_tmp() {
   targetDir="${HOME}/Library/Developer/Xcode/DerivedData"
   if [[ -d "$targetDir" ]]; then
     mv "$targetDir" /tmpfs/
-    # ln -sf /tmpfs/DerivedData "$targetDir"
     ln -sf /tmpfs/DerivedData "${HOME}/Library/Developer/Xcode/"
   fi
 }
@@ -389,8 +388,8 @@ run_cocoapods() {
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     echo "no kokoro build number"
-    # move_derived_data_to_tmp
-    delete_all_derived_data
+    move_derived_data_to_tmp
+    # delete_all_derived_data
   fi
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then

--- a/.kokoro
+++ b/.kokoro
@@ -423,7 +423,7 @@ run_cocoapods() {
     ls
     rm -rf Pods
     echo "prep_all..."
-    bash scripts/prep_all
+    bash ../scripts/prep_all
     echo "still in catalog:"
     ls
     rm Podfile.lock

--- a/.kokoro
+++ b/.kokoro
@@ -378,9 +378,9 @@ run_bazel() {
 run_cocoapods() {
   echo "Running cocoapods builds..."
 
-  if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+  # if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     # move_derived_data_to_tmp
-  fi
+  # fi
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
     select_xcode "$XCODE_VERSION"

--- a/.kokoro
+++ b/.kokoro
@@ -422,12 +422,13 @@ run_cocoapods() {
     echo "in catalog:"
     ls
     rm -rf Pods
-    rm Podfile.lock
+    echo "prep_all..."
+    bash scripts/prep_all
     echo "still in catalog:"
     ls
+    rm Podfile.lock
     # cd ..
     pod cache clean --all
-    # bash scripts/prep_all
     # cd catalog
     echo "linting..."
     pod lib lint ../MaterialComponents.podspec --skip-tests --fail-fast --verbose

--- a/.kokoro
+++ b/.kokoro
@@ -388,7 +388,6 @@ run_cocoapods() {
 
     # Move into our cloned repo
     cd github/repo
-    echo "moved to repo_dir"
 
     gem_install xcpretty 
     gem install cocoapods -v "$COCOAPODS_VERSION"
@@ -412,7 +411,9 @@ run_cocoapods() {
     cd catalog && rm -rf Pods && cd ..
     pod cache clean --all
     bash scripts/prep_all
-    pod lib lint MaterialComponents.podspec --skip-tests --fail-fast --verbose
+    cd catalog
+    echo "linting..."
+    pod lib lint ../MaterialComponents.podspec --skip-tests --fail-fast --verbose
   fi
 
   if [ -n "$CODECOV_TOKEN" ]; then

--- a/.kokoro
+++ b/.kokoro
@@ -408,7 +408,7 @@ run_cocoapods() {
     fi
   elif [ "$DEPENDENCY_SYSTEM" = "cocoapods-podspec" ]; then
     pod cache clean --all
-    pod lib lint MaterialComponents.podspec --skip-tests --fail-fast
+    pod lib lint MaterialComponents.podspec --skip-tests --fail-fast --verbose
   fi
 
   if [ -n "$CODECOV_TOKEN" ]; then

--- a/.kokoro
+++ b/.kokoro
@@ -389,7 +389,6 @@ run_cocoapods() {
     cd github/repo
 
     gem_install xcpretty 
-    # TODO(https://github.com/material-components/material-components-ios/issues/6356 ): Move to 1.6
     gem install cocoapods -v "$COCOAPODS_VERSION"
     pod --version
 
@@ -408,7 +407,8 @@ run_cocoapods() {
       bash scripts/test_all catalog/MDCCatalog.xcworkspace:MDCCatalog
     fi
   elif [ "$DEPENDENCY_SYSTEM" = "cocoapods-podspec" ]; then
-    pod lib lint MaterialComponents.podspec --skip-tests
+    pod cache clean --all
+    pod lib lint MaterialComponents.podspec --skip-tests --fail-fast
   fi
 
   if [ -n "$CODECOV_TOKEN" ]; then

--- a/.kokoro
+++ b/.kokoro
@@ -428,8 +428,11 @@ run_cocoapods() {
     ls
     rm Podfile.lock
     # cd ..
-    pod cache clean --all
+
+    # pod cache clean --all
     # cd catalog
+    echo "running pod repo update..."
+    pod repo update
     echo "linting..."
     pod lib lint ../MaterialComponents.podspec --skip-tests --fail-fast --verbose
   fi

--- a/.kokoro
+++ b/.kokoro
@@ -379,7 +379,7 @@ run_cocoapods() {
   echo "Running cocoapods builds..."
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then
-    move_derived_data_to_tmp
+    # move_derived_data_to_tmp
   fi
 
   if [ -n "$KOKORO_BUILD_NUMBER" ]; then

--- a/.kokoro
+++ b/.kokoro
@@ -399,7 +399,7 @@ run_cocoapods() {
     cd github/repo
 
     gem_install xcpretty 
-    gem_install install cocoapods -v "$COCOAPODS_VERSION"
+    gem install cocoapods -v "$COCOAPODS_VERSION"
     echo "installed cocoapods version:"
     pod --version
 


### PR DESCRIPTION
The "cocoapods-podspec" job has failed during the last few releases.

The ticket (#6678) suggests that it might be due to the Podfile.lock being placed somewhere where it cannot be found later. I could be wrong, but I don't think that's why. The logs only mention the Podfile.lock not being found in a "note," as you can see here:
> -- ERROR | [MaterialComponents/ActionSheet, MaterialComponents/ActivityIndicator, MaterialComponents/ActivityIndicator+ColorThemer, and more...] xcodebuild: Returned an unsuccessful exit code. You can use `--verbose` for more information.
> -- NOTE  | [MaterialComponents/ActionSheet, MaterialComponents/ActivityIndicator, MaterialComponents/ActivityIndicator+ColorThemer, and more...] xcodebuild:  error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.

The "error" part looks like it has more to do with subspecs failing validation. Since it isn't failing locally for anyone, it's possible that this relates to caching. I have anecdotal evidence to support this. Once, a month or two ago, during a time where I was switching between Cocoapods 1.5 and 1.6 a lot, I was seeing validation failures in Dialogs that nobody else saw. It wasn't an issue in CI, and it wasn't failing locally for anyone else. It was just my machine. I ran `pod cache clean --all` and the issue was resolved. I figure it's worth trying here.

The "fail fast" argument is just so we can see the first thing to go wrong in greater detail. Right now we're getting a truncated list of failed subspecs, but no insight into what's problematic about those subspecs. This might tell us.  

EDIT: I actually do think it is a matter of the Podfile.lock not being found, or something like that.