### PR TITLE
[States] New Color Resource class for the State System

### DIFF
--- a/MaterialComponentsExamples.podspec
+++ b/MaterialComponentsExamples.podspec
@@ -1,11 +1,13 @@
 experimental_sources = [
   'components/*/examples/experimental/supplemental/*.{h,m,swift}',
   'components/*/examples/experimental/*.{h,m,swift}',
+  'components/schemes/*/examples/src/*.{h,m,swift}',
 ]
 
 experimental_headers = [
   'components/*/examples/experimental/supplemental/*.h',
   'components/*/examples/experimental/*.h',
+  'components/schemes/*/examples/src/*.h',
 ]
 
 experimental_resources = [

--- a/components/schemes/State/examples/src/MDCColorResource.h
+++ b/components/schemes/State/examples/src/MDCColorResource.h
@@ -1,0 +1,157 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+// Note: Make sure to update [semanticResourceFromName:] when changing or adding values
+typedef NS_ENUM(NSInteger, MDCColorResourceSemantic) {
+  MDCColorResourceSemanticNone,
+  MDCColorResourceSemanticPrimary,
+  MDCColorResourceSemanticOnPrimary,
+  MDCColorResourceSemanticSurface,
+  MDCColorResourceSemanticOnSurface,
+  MDCColorResourceSemanticOverlay,
+  MDCColorResourceSemanticBackground,
+  MDCColorResourceSemanticOnBackground,
+  MDCColorResourceSemanticOutline,
+  MDCColorResourceSemanticError,
+};
+
+// Note: Make sure to update [paletteResourceFromName:] when changing or adding values
+typedef NS_ENUM(NSInteger, MDCColorResourcePalette) {
+  MDCColorResourcePaletteNone,
+  MDCColorResourcePaletteGrey,
+  MDCColorResourcePaletteBlue,
+  MDCColorResourcePaletteBlueGrey,
+  MDCColorResourcePaletteIndigo,
+  MDCColorResourcePalettePurple,
+  MDCColorResourcePaletteRed,
+  MDCColorResourcePaletteOrange,
+  MDCColorResourcePaletteYellow,
+};
+
+// Note: Make sure to update [paletteTintResourceFromName:] when changing or adding values
+typedef NS_ENUM(NSInteger, MDCColorResourcePaletteTint) {
+  MDCColorResourcePaletteTintNone,
+  MDCColorResourcePaletteTint50,
+  MDCColorResourcePaletteTint100,
+  MDCColorResourcePaletteTint200,
+  MDCColorResourcePaletteTint300,
+  MDCColorResourcePaletteTint400,
+  MDCColorResourcePaletteTint500,
+  MDCColorResourcePaletteTint600,
+  MDCColorResourcePaletteTint700,
+  MDCColorResourcePaletteTint800,
+  MDCColorResourcePaletteTint900,
+};
+
+static const CGFloat MDCColorResourceDefaultOpacity = 1.0;
+static const CGFloat MDCColorResourceDefaultDim = 1.0;
+
+/**
+ MDCColorResource is a dynamic representation of color resources. It supports different
+ formats of colors used in Material Theming. It is also used in serializing colors (in any of
+ its supported formats) to and from a dictionary.
+
+ ColorResource uses enumerations which allows it to be independent of specific color formats.
+ StateScheme getters return ColorResource, which can be later converted by themers to an actual
+ UIColor. Themers who pass a ColorResource to a color scheme, get an actual UIColor that is based
+ on colors from those color schemes.
+
+ The following color formats are currently supported:
+ * Hex: Strings in format "#999999"
+ * Semantic names: an MDCColorResourceSemantic enum that corresponds to an
+                   MDCSemanticColorScheme color
+ * Palette names: MDCColorResourcePalette and MDCColorResourcePaletteTint enumerations,
+                  corresponding to MDCPalettes and tints.
+
+ Additionally, MDCColorResource supports 2 color variations, applied to a color, in any format:
+ * Opacity: alpha percentage of the base color
+ * Dim: percentage of darkness (values between 0 & 1.0) or lightness (values between -1.0 and 0)
+        of the base color. Examples: 0.25 means 25% darker color. -0.15 is 15% lighter color.
+ * [TBD: Emphasis: High, Medium, Low]
+
+ Note:
+ Opacity and Dim are used to generate variations of the base color. This is needed
+ mainly for expressing state colors when the makeup of colors in a colorScheme is
+ unknown (as is in MDC).  These variations may fit many color schemes, but it can
+ also be overridden if needed, especially in cases in which the color scheme does
+ not produce a sufficiently accessible contrast ratio.
+ */
+
+@interface MDCColorResource : NSObject
+
+@property(nonatomic, strong, readonly, nullable) NSString *hexColor;
+@property(nonatomic, assign, readonly) MDCColorResourceSemantic semantic;
+@property(nonatomic, assign, readonly) MDCColorResourcePalette palette;
+@property(nonatomic, assign, readonly) MDCColorResourcePaletteTint tint;
+@property(nonatomic, assign, readonly) CGFloat opacity;
+@property(nonatomic, assign, readonly) CGFloat dim;
+
+/// Initializes a color resource representing a semantic color
+- (nonnull instancetype)initWithSemanticResource:(MDCColorResourceSemantic)semanticResource;
+
+/// Initializes a color resource representing a semantic color, with given opacity or dim
+- (nonnull instancetype)initWithSemanticResource:(MDCColorResourceSemantic)semanticResource
+                                         opacity:(CGFloat)opacity
+                                             dim:(CGFloat)dim;
+
+/// Initializes a color resource representing a palette+tint color
+- (nonnull instancetype)initWithPaletteResource:(MDCColorResourcePalette)palette
+                                           tint:(MDCColorResourcePaletteTint)tint;
+
+/// Initializes a color resource representing a palette+tint color, with given opacity or dim
+- (nonnull instancetype)initWithPaletteResource:(MDCColorResourcePalette)palette
+                                           tint:(MDCColorResourcePaletteTint)tint
+                                        opacity:(CGFloat)opacity
+                                            dim:(CGFloat)dim;
+
+/// Initializes a color resource representing a hex color
+- (nonnull instancetype)initWithHexString:(NSString *)hex;
+
+/// Initializes a color resource representing a hex color, with given opacity or dim
+- (nonnull instancetype)initWithHexString:(NSString *)hex opacity:(CGFloat)opacity dim:(CGFloat)dim;
+
+/// returns the "name" of the semantic enumeration as a string value
+- (nullable NSString *)semanticNameFromResource:(MDCColorResourceSemantic)semantic;
+
+/// returns the "name" of the palette enumeration as a string value
+- (nullable NSString *)paletteNameFromResource:(MDCColorResourcePalette)palette;
+
+/// returns the "name" of the palette-tint enumeration as a string value
+- (nullable NSString *)paletteTintNameFromResource:(MDCColorResourcePaletteTint)tint;
+
+/**
+ Converts the given string to a MDCColorResourceSemantic enumeration. Returns
+ MDCColorResourceSemanticNone if the string doesn't match any enumeration value
+ @param semanticName Expecting a hyphenated all lowercase semantic name, like "on-primary".
+                           (names should match colors from the MDCColorScheming protocol)
+ */
+- (MDCColorResourceSemantic)semanticResourceFromName:(NSString *)semanticName;
+
+/**
+ Converts the given string to a MDCColorResourcePalette enumeration. Returns
+ MDCColorResourcePaletteNone if the string doesn't match any enumeration value
+ @param paletteName Expecting an all lowercase short palette name, like: "blue".
+ */
+- (MDCColorResourcePalette)paletteResourceFromName:(NSString *)paletteName;
+
+/**
+ Converts the given string to a MDCColorResourcePaletteTint enumeration. Returns
+ MDCColorResourcePaletteTintNone if the string doesn't match any enumeration value
+ @param tintName Expecting a valid digit-only tint number, like: "100" for tint100.
+ */
+- (MDCColorResourcePaletteTint)paletteTintResourceFromName:(NSString *)tintName;
+
+@end

--- a/components/schemes/State/examples/src/MDCColorResource.m
+++ b/components/schemes/State/examples/src/MDCColorResource.m
@@ -1,0 +1,319 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCColorResource.h"
+
+@interface MDCColorResource ()
+
+@property(nonatomic, strong, readwrite, nullable) NSString *hex;
+@property(nonatomic, assign, readwrite) MDCColorResourceSemantic semantic;
+@property(nonatomic, assign, readwrite) MDCColorResourcePalette palette;
+@property(nonatomic, assign, readwrite) MDCColorResourcePaletteTint tint;
+@property(nonatomic, assign, readwrite) CGFloat opacity;
+@property(nonatomic, assign, readwrite) CGFloat dim;
+
+@end
+
+@implementation MDCColorResource
+
+- (nonnull instancetype)initWithSemanticResource:(MDCColorResourceSemantic)semanticResource {
+  return [self initWithSemanticResource:semanticResource
+                                opacity:MDCColorResourceDefaultOpacity
+                                    dim:MDCColorResourceDefaultDim];
+}
+
+- (nonnull instancetype)initWithSemanticResource:(MDCColorResourceSemantic)semanticResource
+                                         opacity:(CGFloat)opacity
+                                             dim:(CGFloat)dim {
+  self = [super init];
+  if (self) {
+    self.semantic = semanticResource;
+    self.opacity = opacity;
+    self.dim = dim;
+
+    self.palette = MDCColorResourcePaletteNone;
+    self.tint = MDCColorResourcePaletteTintNone;
+    self.hex = nil;
+  }
+  return self;
+}
+
+- (nonnull instancetype)initWithPaletteResource:(MDCColorResourcePalette)palette
+                                           tint:(MDCColorResourcePaletteTint)tint {
+  return [self initWithPaletteResource:palette
+                                  tint:tint
+                               opacity:MDCColorResourceDefaultOpacity
+                                   dim:MDCColorResourceDefaultDim];
+}
+
+- (nonnull instancetype)initWithPaletteResource:(MDCColorResourcePalette)palette
+                                           tint:(MDCColorResourcePaletteTint)tint
+                                        opacity:(CGFloat)opacity
+                                            dim:(CGFloat)dim {
+  self = [super init];
+  if (self) {
+    self.palette = palette;
+    self.tint = tint;
+    self.opacity = opacity;
+    self.dim = dim;
+
+    self.semantic = MDCColorResourceSemanticNone;
+    self.hex = nil;
+  }
+  return self;
+}
+
+- (nonnull instancetype)initWithHexString:(NSString *)hex {
+  return [self initWithHexString:hex
+                         opacity:MDCColorResourceDefaultOpacity
+                             dim:MDCColorResourceDefaultDim];
+}
+
+// Expecting hex string with format: #999999
+- (nonnull instancetype)initWithHexString:(NSString *)hex
+                                  opacity:(CGFloat)opacity
+                                      dim:(CGFloat)dim {
+  if (hex.length != 7) {
+    return nil;  // Invalid hex string
+  }
+  // Extract the last 6 charachters
+  unsigned int hexval;
+  NSString *hexString = [hex substringFromIndex:1];
+  NSScanner *scanner = [NSScanner scannerWithString:hexString];
+  [scanner scanHexInt:&hexval];
+  if (hexval == 0) {
+    return nil;  // Invalid hex string
+  }
+  self = [super init];
+  if (self) {
+    self.hex = [NSString stringWithFormat:@"#%@", hexString];
+    self.opacity = opacity;
+    self.dim = dim;
+
+    self.palette = MDCColorResourcePaletteNone;
+    self.tint = MDCColorResourcePaletteTintNone;
+    self.semantic = MDCColorResourceSemanticNone;
+  }
+  return self;
+}
+
+- (NSString *)description {
+  return [NSString
+      stringWithFormat:@"semantic: %@ | palette: %@, tint: %@, hex: %@, opacity: %.2f, dim: %.2f",
+                       [self semanticNameFromResource:self.semantic],
+                       [self paletteNameFromResource:self.palette],
+                       [self paletteTintNameFromResource:self.tint], self.hex, self.opacity,
+                       self.dim];
+}
+
+- (nullable NSString *)semanticNameFromResource:(MDCColorResourceSemantic)semantic {
+  switch (semantic) {
+    case MDCColorResourceSemanticPrimary:
+      return @"primary";
+      break;
+    case MDCColorResourceSemanticOnPrimary:
+      return @"on-primary";
+      break;
+    case MDCColorResourceSemanticSurface:
+      return @"surface";
+      break;
+    case MDCColorResourceSemanticOnSurface:
+      return @"on-surface";
+      break;
+    case MDCColorResourceSemanticOverlay:
+      return @"overlay";
+      break;
+    case MDCColorResourceSemanticBackground:
+      return @"background";
+      break;
+    case MDCColorResourceSemanticOnBackground:
+      return @"on-background";
+      break;
+    case MDCColorResourceSemanticOutline:
+      return @"outline";
+      break;
+    case MDCColorResourceSemanticError:
+      return @"error";
+      break;
+    case MDCColorResourceSemanticNone:
+      return nil;
+      break;
+  }
+}
+
+- (nullable NSString *)paletteNameFromResource:(MDCColorResourcePalette)palette {
+  switch (palette) {
+    case MDCColorResourcePaletteGrey:
+      return @"grey";
+      break;
+    case MDCColorResourcePaletteBlueGrey:
+      return @"bluegrey";
+      break;
+    case MDCColorResourcePaletteBlue:
+      return @"blue";
+      break;
+    case MDCColorResourcePaletteIndigo:
+      return @"indigo";
+      break;
+    case MDCColorResourcePalettePurple:
+      return @"purple";
+      break;
+    case MDCColorResourcePaletteRed:
+      return @"red";
+      break;
+    case MDCColorResourcePaletteOrange:
+      return @"orange";
+      break;
+    case MDCColorResourcePaletteYellow:
+      return @"yellow";
+      break;
+    case MDCColorResourcePaletteNone:
+      return nil;
+      break;
+  }
+}
+
+- (nullable NSString *)paletteTintNameFromResource:(MDCColorResourcePaletteTint)tint {
+  switch (tint) {
+    case MDCColorResourcePaletteTint50:
+      return @"50";
+      break;
+    case MDCColorResourcePaletteTint100:
+      return @"100";
+      break;
+    case MDCColorResourcePaletteTint200:
+      return @"200";
+      break;
+    case MDCColorResourcePaletteTint300:
+      return @"300";
+      break;
+    case MDCColorResourcePaletteTint400:
+      return @"400";
+      break;
+    case MDCColorResourcePaletteTint500:
+      return @"500";
+      break;
+    case MDCColorResourcePaletteTint600:
+      return @"600";
+      break;
+    case MDCColorResourcePaletteTint700:
+      return @"700";
+      break;
+    case MDCColorResourcePaletteTint800:
+      return @"800";
+      break;
+    case MDCColorResourcePaletteTint900:
+      return @"900";
+      break;
+    case MDCColorResourcePaletteTintNone:
+      return nil;
+      break;
+  }
+}
+
+- (MDCColorResourceSemantic)semanticResourceFromName:(NSString *)semanticName {
+  if ([semanticName isEqualToString:@"primary"]) {
+    return MDCColorResourceSemanticPrimary;
+  }
+  if ([semanticName isEqualToString:@"on-primary"]) {
+    return MDCColorResourceSemanticOnPrimary;
+  }
+  if ([semanticName isEqualToString:@"surface"]) {
+    return MDCColorResourceSemanticSurface;
+  }
+  if ([semanticName isEqualToString:@"on-surface"]) {
+    return MDCColorResourceSemanticOnSurface;
+  }
+  if ([semanticName isEqualToString:@"overlay"]) {
+    return MDCColorResourceSemanticOverlay;
+  }
+  if ([semanticName isEqualToString:@"background"]) {
+    return MDCColorResourceSemanticBackground;
+  }
+  if ([semanticName isEqualToString:@"on-background"]) {
+    return MDCColorResourceSemanticOnBackground;
+  }
+  if ([semanticName isEqualToString:@"outline"]) {
+    return MDCColorResourceSemanticOutline;
+  }
+  if ([semanticName isEqualToString:@"error"]) {
+    return MDCColorResourceSemanticError;
+  }
+  return MDCColorResourceSemanticNone;
+}
+
+- (MDCColorResourcePalette)paletteResourceFromName:(NSString *)paletteName {
+  if ([paletteName isEqualToString:@"grey"]) {
+    return MDCColorResourcePaletteGrey;
+  }
+  if ([paletteName isEqualToString:@"blue"]) {
+    return MDCColorResourcePaletteBlue;
+  }
+  if ([paletteName isEqualToString:@"bluegrey"]) {
+    return MDCColorResourcePaletteBlueGrey;
+  }
+  if ([paletteName isEqualToString:@"indigo"]) {
+    return MDCColorResourcePaletteIndigo;
+  }
+  if ([paletteName isEqualToString:@"purple"]) {
+    return MDCColorResourcePalettePurple;
+  }
+  if ([paletteName isEqualToString:@"red"]) {
+    return MDCColorResourcePaletteRed;
+  }
+  if ([paletteName isEqualToString:@"orange"]) {
+    return MDCColorResourcePaletteOrange;
+  }
+  if ([paletteName isEqualToString:@"yellow"]) {
+    return MDCColorResourcePaletteYellow;
+  }
+  return MDCColorResourcePaletteNone;
+}
+
+- (MDCColorResourcePaletteTint)paletteTintResourceFromName:(NSString *)tintName {
+  if ([tintName isEqualToString:@"50"]) {
+    return MDCColorResourcePaletteTint50;
+  }
+  if ([tintName isEqualToString:@"100"]) {
+    return MDCColorResourcePaletteTint100;
+  }
+  if ([tintName isEqualToString:@"200"]) {
+    return MDCColorResourcePaletteTint200;
+  }
+  if ([tintName isEqualToString:@"300"]) {
+    return MDCColorResourcePaletteTint300;
+  }
+  if ([tintName isEqualToString:@"400"]) {
+    return MDCColorResourcePaletteTint400;
+  }
+  if ([tintName isEqualToString:@"500"]) {
+    return MDCColorResourcePaletteTint500;
+  }
+  if ([tintName isEqualToString:@"600"]) {
+    return MDCColorResourcePaletteTint600;
+  }
+  if ([tintName isEqualToString:@"700"]) {
+    return MDCColorResourcePaletteTint700;
+  }
+  if ([tintName isEqualToString:@"800"]) {
+    return MDCColorResourcePaletteTint800;
+  }
+  if ([tintName isEqualToString:@"900"]) {
+    return MDCColorResourcePaletteTint900;
+  }
+
+  return MDCColorResourcePaletteTintNone;
+}
+
+@end


### PR DESCRIPTION
### Material State Scheme

This is an experimental implementation of a State System. 

This PR adds the ColorResource class (#4), which is one part of the following complete list of a State Scheme implementation (See PR: #6585 for a complete implementation).

1. Storing state related information outside of themers, in a dedicated data source (StateScheme). This will allow sharing state information across components/themers.
2. Storing state data in a dictionary, which can be serialized and/or shared with external systems (in the future).  The StateScheme exposes getters and setters to access the private state information that is in this dictionary.
3. Using a ColorResource class to represent colors in the State Scheme (more about this below).
4. Colors that don't pass contrast ratio can be overridden and customized by clients, who can pick  specific colors that work with their color schemes.  This concept is demonstrated in the StateScheme initializer. 

### Color Resources

The Color Resource class is a concept borrowed from Android's Resources, which are being used heavily in its theming implementation. In this implementation, Color Resources represent colors in different formats, including Material formats (semantic or palette colors) or platform formats (expressed as hex values).

The StateScheme, which manages all state-related data in a single (private) dictionary, uses ColorResources in its getters and setters to expose its private state-color information. ColorResources are useful for string data serialization. Colors, stored as strings in a dictionary are converted to a structured and validated color format that can be reliably converted to a concrete UIColor. The StateScheme's ColorResources based API allows independence of a specific Color Scheme implementation. Clients (mostly themers) can then use the ColorResources, together with a specific color scheme, to get a concrete UIColor that can be used to theme components.

### Issue

b/123929971: [b/123929971](b/123929971)
b/122521260: [b/122521260](b/122521260)

Complete Prototype: #6585
Experimental Prototype: #6548