### PR TITLE
[BottomNavigation] Make Controller available on iOS 8.

### DIFF
--- a/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
+++ b/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
@@ -18,7 +18,6 @@ import MaterialComponentsBeta.MaterialBottomNavigationBeta
 import MaterialComponents.MaterialBottomNavigation_ColorThemer
 import MaterialComponents.MaterialBottomNavigation_TypographyThemer
 
-@available(iOS 9.0, *)
 class BottomNavigationControllerExampleViewController: MDCBottomNavigationBarController {
 
   public var colorScheme: MDCColorScheming  = MDCSemanticColorScheme() {
@@ -34,13 +33,6 @@ class BottomNavigationControllerExampleViewController: MDCBottomNavigationBarCon
   }
 
   override func viewDidLoad() {
-    guard #available(iOS 9, *) else {
-      // The catalog circumvents the controller's guards to ensure that it is only used if
-      // iOS 9+ is available. This is a work around to ensure that the catalog does not crash.
-      // Remove when MDC is upgraded to iOS 9 as a minimum deployment target.
-      return
-    }
-
     super.viewDidLoad()
 
     let viewController1 = UIViewController()
@@ -60,7 +52,7 @@ class BottomNavigationControllerExampleViewController: MDCBottomNavigationBarCon
 
   class func catalogMetadata() -> [String: Any] {
     return [
-      "breadcrumbs": ["Bottom Navigation", "Bottom Navigation Controller (iOS 9+)"],
+      "breadcrumbs": ["Bottom Navigation", "Bottom Navigation Controller"],
       "presentable": false
     ]
   }
@@ -68,7 +60,6 @@ class BottomNavigationControllerExampleViewController: MDCBottomNavigationBarCon
 
 // MARK: Private Functions
 
-@available(iOS 9.0, *)
 extension BottomNavigationControllerExampleViewController {
   fileprivate func apply(colorScheme: MDCColorScheming) {
     MDCBottomNavigationBarColorThemer.applySemanticColorScheme(colorScheme, toBottomNavigation: self.navigationBar)

--- a/components/BottomNavigation/src/MDCBottomNavigationBarController.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBarController.h
@@ -23,9 +23,7 @@
  * between primary destination in an app.  It ties a list of view controllers to the bottom
  * navigation bar and will display the corresponding view controller in the content view when an
  * in the navigation bar is selected.
- * Available iOS 9.0+
  */
-NS_CLASS_AVAILABLE_IOS(9_0)
 @interface MDCBottomNavigationBarController : UIViewController <MDCBottomNavigationBarDelegate>
 
 /**

--- a/components/BottomNavigation/src/MDCBottomNavigationBarController.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBarController.m
@@ -219,6 +219,86 @@
   self.content.translatesAutoresizingMaskIntoConstraints = NO;
   self.navigationBar.translatesAutoresizingMaskIntoConstraints = NO;
 
+  if (@available(iOS 9.0, *)) {
+    [self loadiOS9PlusConstraints];
+  } else {
+    [self loadPreiOS9Constraints];
+  }
+}
+
+- (void)loadPreiOS9Constraints {
+  // Navigation Bar Constraints
+  self.navigationBarHeightConstraint =
+      [NSLayoutConstraint constraintWithItem:self.navigationBar
+                                   attribute:NSLayoutAttributeHeight
+                                   relatedBy:NSLayoutRelationEqual
+                                      toItem:nil
+                                   attribute:NSLayoutAttributeNotAnAttribute
+                                  multiplier:1
+                                    constant:[self calculateNavigationBarHeight]];
+
+  NSArray<NSLayoutConstraint *> *navigationBarConstraints = @[
+    [NSLayoutConstraint constraintWithItem:self.navigationBar
+                                 attribute:NSLayoutAttributeLeading
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:self.view
+                                 attribute:NSLayoutAttributeLeading
+                                multiplier:1
+                                  constant:0],
+    [NSLayoutConstraint constraintWithItem:self.navigationBar
+                                 attribute:NSLayoutAttributeTrailing
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:self.view
+                                 attribute:NSLayoutAttributeTrailing
+                                multiplier:1
+                                  constant:0],
+    [NSLayoutConstraint constraintWithItem:self.navigationBar
+                                 attribute:NSLayoutAttributeBottom
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:self.view
+                                 attribute:NSLayoutAttributeBottom
+                                multiplier:1
+                                  constant:0],
+    [NSLayoutConstraint constraintWithItem:self.navigationBar
+                                 attribute:NSLayoutAttributeTop
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:self.content
+                                 attribute:NSLayoutAttributeBottom
+                                multiplier:1
+                                  constant:0]
+  ];
+
+  // Content View Constraints
+  NSArray<NSLayoutConstraint *> *contentConstraints = @[
+    [NSLayoutConstraint constraintWithItem:self.content
+                                 attribute:NSLayoutAttributeLeading
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:self.view
+                                 attribute:NSLayoutAttributeLeading
+                                multiplier:1
+                                  constant:0],
+    [NSLayoutConstraint constraintWithItem:self.content
+                                 attribute:NSLayoutAttributeTrailing
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:self.view
+                                 attribute:NSLayoutAttributeTrailing
+                                multiplier:1
+                                  constant:0],
+    [NSLayoutConstraint constraintWithItem:self.content
+                                 attribute:NSLayoutAttributeTop
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:self.view
+                                 attribute:NSLayoutAttributeTop
+                                multiplier:1
+                                  constant:0]
+  ];
+
+  [NSLayoutConstraint activateConstraints:navigationBarConstraints];
+  [NSLayoutConstraint activateConstraints:contentConstraints];
+  self.navigationBarHeightConstraint.active = YES;
+}
+
+- (void)loadiOS9PlusConstraints {
   // Navigation Bar Constraints
   [self.view.leftAnchor constraintEqualToAnchor:self.navigationBar.leftAnchor].active = YES;
   [self.view.rightAnchor constraintEqualToAnchor:self.navigationBar.rightAnchor].active = YES;
@@ -242,10 +322,45 @@
  */
 - (void)addConstraintsForContentView:(UIView *)view {
   view.translatesAutoresizingMaskIntoConstraints = NO;
-  [view.leadingAnchor constraintEqualToAnchor:self.content.leadingAnchor].active = YES;
-  [view.trailingAnchor constraintEqualToAnchor:self.content.trailingAnchor].active = YES;
-  [view.topAnchor constraintEqualToAnchor:self.content.topAnchor].active = YES;
-  [view.bottomAnchor constraintEqualToAnchor:self.content.bottomAnchor].active = YES;
+  if (@available(iOS 9.0, *)) {
+    [view.leadingAnchor constraintEqualToAnchor:self.content.leadingAnchor].active = YES;
+    [view.trailingAnchor constraintEqualToAnchor:self.content.trailingAnchor].active = YES;
+    [view.topAnchor constraintEqualToAnchor:self.content.topAnchor].active = YES;
+    [view.bottomAnchor constraintEqualToAnchor:self.content.bottomAnchor].active = YES;
+  } else {
+    [NSLayoutConstraint constraintWithItem:self.content
+                                 attribute:NSLayoutAttributeLeading
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:view
+                                 attribute:NSLayoutAttributeLeading
+                                multiplier:1
+                                  constant:0]
+        .active = YES;
+    [NSLayoutConstraint constraintWithItem:self.content
+                                 attribute:NSLayoutAttributeTrailing
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:view
+                                 attribute:NSLayoutAttributeTrailing
+                                multiplier:1
+                                  constant:0]
+        .active = YES;
+    [NSLayoutConstraint constraintWithItem:self.content
+                                 attribute:NSLayoutAttributeTop
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:view
+                                 attribute:NSLayoutAttributeTop
+                                multiplier:1
+                                  constant:0]
+        .active = YES;
+    [NSLayoutConstraint constraintWithItem:self.content
+                                 attribute:NSLayoutAttributeBottom
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:view
+                                 attribute:NSLayoutAttributeBottom
+                                multiplier:1
+                                  constant:0]
+        .active = YES;
+  }
 }
 
 /** Returns the desired height of the navigation bar. **/


### PR DESCRIPTION
Adds constraints safe for use on iOS 8. This removes the availability
checks previously set on the MDCBottomNavigationBarController class that
may have been causing CocoaPods lint errors.

Related to #6608
