### PR TITLE
[BottomAppBar] hide swift example from Catalog.

### DIFF
--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
@@ -150,7 +150,7 @@ extension BottomAppBarTypicalUseSwiftExample {
     return [
       "breadcrumbs": ["Bottom App Bar", "Bottom App Bar (Swift)"],
       "primaryDemo": false,
-      "presentable": true,
+      "presentable": false,
     ]
   }
 


### PR DESCRIPTION
This flag with accidentally turned on. Turning it off now.