### PR TITLE
[BottomNavigation] Remove deprecation notice from sizeThatFitsIncludesSafeArea

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -160,8 +160,7 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarAlignment) {
 
  Defaults to @c YES.
  */
-@property(nonatomic, assign) BOOL sizeThatFitsIncludesSafeArea __deprecated_msg(
-    "Safe area should be determined by superviews and added to the bar's bounds.");
+@property(nonatomic, assign) BOOL sizeThatFitsIncludesSafeArea;
 
 /**
  If @c YES, it will truncate titles that don't fit within the bounds available to the item.


### PR DESCRIPTION
This API was introduced in https://github.com/material-components/material-components-ios/pull/6717 but I did not notice that the deprecation warning was still present in the PR once it was merged.

As per our deprecation policy, the API will eventually be marked deprecated once we're ready to begin removing usage of the API.

Until then, we expect clients to intentionally make use of this API to opt in to the new behavior. Doing so should not result in a deprecation warning at this time because we do want clients to make use of it.