### PR TITLE
[NavigationDrawer] Removed beta references in NavigationDrawer

### DIFF
--- a/components/NavigationDrawer/README.md
+++ b/components/NavigationDrawer/README.md
@@ -48,8 +48,6 @@ Navigation drawers are recommended for:
 
 ## Overview
 
-Navigation Drawer is currently a [beta component](https://github.com/material-components/material-components-ios/blob/develop/contributing/beta_components.md). Therefore, clients that wish to use Navigation Drawer in their app will need to manually clone the repo and add the code to their project.
-
 Navigation Drawer currently provides the [Bottom Drawer](https://developer.apple.com/documentation/uikit/uiaccessibilityelement/1619577-accessibilitylabel) presentation style.
 
 The Navigation Drawer is architected by implementing a custom `UIPresentationController` and a `UIViewControllerTransitioningDelegate` named `MDCBottomDrawerPresentationController` and `MDCBottomDrawerTransitionController` respectively.
@@ -70,8 +68,6 @@ Lastly, your headerViewController conforms to the `MDCBottomDrawerHeader` protoc
 
 ## Installation
 
-**This component is a [beta component](https://github.com/material-components/material-components-ios/blob/develop/contributing/beta_components.md) and therefore doesn't support installation via CocoaPods. To install this component you will need to manually clone the repo and add the code to your project. This is intended.**
-
 ### Importing
 
 To import the component:
@@ -79,7 +75,7 @@ To import the component:
 <!--<div class="material-code-render" markdown="1">-->
 #### Swift
 ```swift
-import MaterialComponentsBeta.MaterialNavigationDrawer
+import MaterialComponents.MaterialNavigationDrawer
 ```
 
 #### Objective-C

--- a/components/NavigationDrawer/docs/README.md
+++ b/components/NavigationDrawer/docs/README.md
@@ -17,8 +17,6 @@ Navigation drawers are recommended for:
 
 ## Overview
 
-Navigation Drawer is currently a [beta component](https://github.com/material-components/material-components-ios/blob/develop/contributing/beta_components.md). Therefore, clients that wish to use Navigation Drawer in their app will need to manually clone the repo and add the code to their project.
-
 Navigation Drawer currently provides the [Bottom Drawer](https://developer.apple.com/documentation/uikit/uiaccessibilityelement/1619577-accessibilitylabel) presentation style.
 
 The Navigation Drawer is architected by implementing a custom `UIPresentationController` and a `UIViewControllerTransitioningDelegate` named `MDCBottomDrawerPresentationController` and `MDCBottomDrawerTransitionController` respectively.
@@ -38,8 +36,6 @@ Lastly, your headerViewController conforms to the `MDCBottomDrawerHeader` protoc
 `MDCBottomDrawerViewController` is a `UIViewController` that allows you to provide your drawer content via the `contentViewController` and your desired header (optional) through the `headerViewController` property.
 
 ## Installation
-
-*This component is a [beta component](https://github.com/material-components/material-components-ios/blob/develop/contributing/beta_components.md) and therefore doesn't support installation via CocoaPods. This is intended.*
 
 - [Typical installation](../../../docs/component-installation.md)
 


### PR DESCRIPTION
In this PR I remove all the "beta" mentioning in our NavigationDrawer as it has been promote to "ready" and no longer in "beta".

Resolves #6681 . 