### PR TITLE
[FlexibleHeader] FlexibleHeader changes

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -77,7 +77,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 }
 
 @interface MDCFlexibleHeaderView () <MDCStatusBarShifterDelegate,
-                                     MDCFlexibleHeaderSafeAreaDelegate,
+                                     MDCFlexibleHeaderTopSafeAreaDelegate,
                                      MDCFlexibleHeaderMinMaxHeightDelegate>
 
 // The intensity strength of the shadow being displayed under the flexible header. Use this property
@@ -465,7 +465,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   [_topSafeArea safeAreaInsetsDidChange];
 }
 
-#pragma mark MDCFlexibleHeaderSafeAreaDelegate
+#pragma mark MDCFlexibleHeaderTopSafeAreaDelegate
 
 - (void)flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
   [self.minMaxHeight recalculateMinMaxHeight];

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -249,7 +249,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
 - (void)commonMDCFlexibleHeaderViewInit {
   _topSafeArea = [[MDCFlexibleHeaderTopSafeArea alloc] init];
-  _topSafeArea.delegate = self;
+  _topSafeArea.topSafeAreaDelegate = self;
 
   _minMaxHeight = [[MDCFlexibleHeaderMinMaxHeight alloc] initWithTopSafeArea:_topSafeArea];
   _minMaxHeight.delegate = self;

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
@@ -173,7 +173,7 @@
  */
 @protocol MDCFlexibleHeaderSafeAreaDelegate
 - (UIViewController *_Nullable)flexibleHeaderViewControllerTopSafeAreaInsetViewController:
-(nonnull MDCFlexibleHeaderViewController *)flexibleHeaderViewController;
+    (nonnull MDCFlexibleHeaderViewController *)flexibleHeaderViewController;
 @end
 
 /**

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
@@ -16,6 +16,7 @@
 
 @class MDCFlexibleHeaderView;
 @protocol MDCFlexibleHeaderViewLayoutDelegate;
+@protocol MDCFlexibleHeaderSafeAreaDelegate;
 
 /**
  The MDCFlexibleHeaderViewController controller is a simple UIViewController-oriented interface
@@ -41,6 +42,9 @@
 
 /** The layout delegate will be notified of any changes to the flexible header view's frame. */
 @property(nonatomic, weak, nullable) id<MDCFlexibleHeaderViewLayoutDelegate> layoutDelegate;
+
+/** The safe area delegate can be queried for the correct way to calculate safe areas. */
+@property(nonatomic, weak, nullable) id<MDCFlexibleHeaderSafeAreaDelegate> safeAreaDelegate;
 
 #pragma mark - Enabling top layout guide adjustment behavior
 
@@ -161,6 +165,15 @@
  */
 @property(nonatomic) BOOL inferPreferredStatusBarStyle;
 
+@end
+
+/**
+ This delegate makes it possible to customize which ancestor view controller is used when
+ inferTopSafeAreaInsetFromViewController is enabled on MDCFlexibleHeaderViewController.
+ */
+@protocol MDCFlexibleHeaderSafeAreaDelegate
+- (UIViewController *_Nullable)flexibleHeaderViewControllerTopSafeAreaInsetViewController:
+(nonnull MDCFlexibleHeaderViewController *)flexibleHeaderViewController;
 @end
 
 /**

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -583,7 +583,7 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
   }
 
   UIViewController *ancestor =
-  [self.safeAreaDelegate flexibleHeaderViewControllerTopSafeAreaInsetViewController:self];
+      [self.safeAreaDelegate flexibleHeaderViewControllerTopSafeAreaInsetViewController:self];
   if (ancestor == nil) {
     ancestor = [self fhv_rootAncestorOfViewController:parent];
 
@@ -594,7 +594,7 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
       // controller. Doing so would result in the top layout guide being infinitely increased.
       // Let's use the top layout guide view controller's ancestor instead.
       ancestor = [self
-                  fhv_rootAncestorOfViewController:self.topLayoutGuideViewController.parentViewController];
+          fhv_rootAncestorOfViewController:self.topLayoutGuideViewController.parentViewController];
     }
   }
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -582,15 +582,20 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
     return;
   }
 
-  UIViewController *ancestor = [self fhv_rootAncestorOfViewController:parent];
+  UIViewController *ancestor =
+  [self.safeAreaDelegate flexibleHeaderViewControllerTopSafeAreaInsetViewController:self];
+  if (ancestor == nil) {
+    ancestor = [self fhv_rootAncestorOfViewController:parent];
 
-  // Are we attempting to extract the top safe area inset from our top layout guide view controller?
-  if (self.topLayoutGuideAdjustmentEnabled && ancestor == self.topLayoutGuideViewController) {
-    // We can't use the provided ancestor because it's a child of the top layout guide view
-    // controller. Doing so would result in the top layout guide being infinitely increased.
-    // Let's use the top layout guide view controller's ancestor instead.
-    ancestor = [self
-        fhv_rootAncestorOfViewController:self.topLayoutGuideViewController.parentViewController];
+    // Are we attempting to extract the top safe area inset from our top layout guide view
+    // controller?
+    if (self.topLayoutGuideAdjustmentEnabled && ancestor == self.topLayoutGuideViewController) {
+      // We can't use the provided ancestor because it's a child of the top layout guide view
+      // controller. Doing so would result in the top layout guide being infinitely increased.
+      // Let's use the top layout guide view controller's ancestor instead.
+      ancestor = [self
+                  fhv_rootAncestorOfViewController:self.topLayoutGuideViewController.parentViewController];
+    }
   }
 
   // if ancestor == nil at this point, then we're in a bad spot because there's nowhere for us to

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.h
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.h
@@ -72,7 +72,7 @@ __attribute__((objc_subclassing_restricted)) @interface MDCFlexibleHeaderTopSafe
 /**
  The delegate may react to changes in the top safe area inset.
  */
-@property(nonatomic, weak, nullable) id<MDCFlexibleHeaderTopSafeAreaDelegate> delegate;
+@property(nonatomic, weak, nullable) id<MDCFlexibleHeaderTopSafeAreaDelegate> topSafeAreaDelegate;
 
 @end
 

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.h
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.h
@@ -17,7 +17,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-@protocol MDCFlexibleHeaderSafeAreaDelegate;
+@protocol MDCFlexibleHeaderTopSafeAreaDelegate;
 
 /**
  Extracts the top safe area for a given view controller.
@@ -72,7 +72,7 @@ __attribute__((objc_subclassing_restricted)) @interface MDCFlexibleHeaderTopSafe
 /**
  The delegate may react to changes in the top safe area inset.
  */
-@property(nonatomic, weak, nullable) id<MDCFlexibleHeaderSafeAreaDelegate> delegate;
+@property(nonatomic, weak, nullable) id<MDCFlexibleHeaderTopSafeAreaDelegate> delegate;
 
 @end
 
@@ -80,7 +80,7 @@ __attribute__((objc_subclassing_restricted)) @interface MDCFlexibleHeaderTopSafe
  The delegate protocol through which MDCFlexibleHeaderTopSafeArea communicates changes in the top
  safe area inset.
  */
-@protocol MDCFlexibleHeaderSafeAreaDelegate
+@protocol MDCFlexibleHeaderTopSafeAreaDelegate
 @required
 
 /**

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.m
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.m
@@ -70,13 +70,13 @@ static const CGFloat kNonXStatusBarHeight = 20;
     BOOL topSafeAreaInsetLikelyAffectedByStatusBarVisibility =
         self.lastNonZeroTopSafeAreaInset == kNonXStatusBarHeight;
     if (topSafeAreaInsetLikelyAffectedByStatusBarVisibility &&
-        [self.delegate flexibleHeaderSafeAreaIsStatusBarShifted:self]) {
+        [self.topSafeAreaDelegate flexibleHeaderSafeAreaIsStatusBarShifted:self]) {
       return self.lastNonZeroTopSafeAreaInset;
     } else {
       return self.extractedTopSafeAreaInset;
     }
   } else {
-    return [self.delegate flexibleHeaderSafeAreaDeviceTopSafeAreaInset:self];
+    return [self.topSafeAreaDelegate flexibleHeaderSafeAreaDeviceTopSafeAreaInset:self];
   }
 }
 
@@ -85,7 +85,7 @@ static const CGFloat kNonXStatusBarHeight = 20;
     [self extractTopSafeAreaInset];
   } else {
     // The device safe area insets may have changed, so we always fall back to calling the delegate.
-    [self.delegate flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:self];
+    [self.topSafeAreaDelegate flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:self];
   }
 }
 
@@ -98,7 +98,7 @@ static const CGFloat kNonXStatusBarHeight = 20;
   if (_inferTopSafeAreaInsetFromViewController) {
     [self extractTopSafeAreaInset];
   } else {
-    [self.delegate flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:self];
+    [self.topSafeAreaDelegate flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:self];
   }
 }
 
@@ -113,7 +113,7 @@ static const CGFloat kNonXStatusBarHeight = 20;
 
   // No need to inform the delegate if this behavior is diabled.
   if (self.inferTopSafeAreaInsetFromViewController) {
-    [self.delegate flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:self];
+    [self.topSafeAreaDelegate flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:self];
   }
 }
 

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderHeightLegacySafeAreaBehaviorTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderHeightLegacySafeAreaBehaviorTests.m
@@ -40,9 +40,9 @@
 
   // Fake the top safe area behavior so that we can control the top safe area inset.
   _delegate = [[FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate alloc] init];
-  _delegate.forwardingDelegate = _flexibleHeaderView.topSafeArea.delegate;
+  _delegate.forwardingDelegate = _flexibleHeaderView.topSafeArea.topSafeAreaDelegate;
   _delegate.deviceTopSafeAreaInset = 123;
-  _flexibleHeaderView.topSafeArea.delegate = _delegate;
+  _flexibleHeaderView.topSafeArea.topSafeAreaDelegate = _delegate;
 
   [_delegate flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:_flexibleHeaderView.topSafeArea];
 }

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderHeightTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderHeightTests.m
@@ -39,9 +39,9 @@
 
   // Fake the top safe area behavior so that we can control the top safe area inset.
   _delegate = [[FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate alloc] init];
-  _delegate.forwardingDelegate = _flexibleHeaderView.topSafeArea.delegate;
+  _delegate.forwardingDelegate = _flexibleHeaderView.topSafeArea.topSafeAreaDelegate;
   _delegate.deviceTopSafeAreaInset = 123;
-  _flexibleHeaderView.topSafeArea.delegate = _delegate;
+  _flexibleHeaderView.topSafeArea.topSafeAreaDelegate = _delegate;
 
   [_delegate flexibleHeaderSafeAreaTopSafeAreaInsetDidChange:_flexibleHeaderView.topSafeArea];
 }

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderMinMaxHeightIncludesSafeAreaTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderMinMaxHeightIncludesSafeAreaTests.m
@@ -34,7 +34,7 @@
 
   _topSafeArea = [[MDCFlexibleHeaderTopSafeArea alloc] init];
   _delegate = [[FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate alloc] init];
-  _topSafeArea.delegate = _delegate;
+  _topSafeArea.topSafeAreaDelegate = _delegate;
 }
 
 - (void)tearDown {

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderMinMaxHeightTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderMinMaxHeightTests.m
@@ -34,7 +34,7 @@
 
   _topSafeArea = [[MDCFlexibleHeaderTopSafeArea alloc] init];
   _delegate = [[FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate alloc] init];
-  _topSafeArea.delegate = _delegate;
+  _topSafeArea.topSafeAreaDelegate = _delegate;
 }
 
 - (void)tearDown {

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderTopSafeAreaTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderTopSafeAreaTests.m
@@ -49,7 +49,7 @@
   // Given
   const CGFloat deviceTopSafeAreaInset = 123;
   _delegate.deviceTopSafeAreaInset = deviceTopSafeAreaInset;
-  _topSafeArea.delegate = _delegate;
+  _topSafeArea.topSafeAreaDelegate = _delegate;
 
   // Then
   XCTAssertNil(_topSafeArea.topSafeAreaSourceViewController);
@@ -64,7 +64,7 @@
       [[FlexibleHeaderTopSafeAreaTestsFakeViewController alloc] init];
   viewController.topSafeAreaInset = 44;
   _delegate.deviceTopSafeAreaInset = deviceTopSafeAreaInset;
-  _topSafeArea.delegate = _delegate;
+  _topSafeArea.topSafeAreaDelegate = _delegate;
 
   // When
   _topSafeArea.topSafeAreaSourceViewController = viewController;
@@ -77,7 +77,7 @@
 
 - (void)testDidChangeInvokesDelegate {
   // Given
-  _topSafeArea.delegate = _delegate;
+  _topSafeArea.topSafeAreaDelegate = _delegate;
 
   // When
   [_topSafeArea safeAreaInsetsDidChange];
@@ -88,7 +88,7 @@
 
 - (void)testSettingViewControllerDoesNotInvokeDelegate {
   // Given
-  _topSafeArea.delegate = _delegate;
+  _topSafeArea.topSafeAreaDelegate = _delegate;
   FlexibleHeaderTopSafeAreaTestsFakeViewController *viewController =
       [[FlexibleHeaderTopSafeAreaTestsFakeViewController alloc] init];
 
@@ -158,7 +158,7 @@
 - (void)testTopSafeAreaInsetDoesNotChangeWhileStatusBarIsShiftedWithNonNotchSafeAreaSize {
   // Given
   _topSafeArea.inferTopSafeAreaInsetFromViewController = YES;
-  _topSafeArea.delegate = _delegate;
+  _topSafeArea.topSafeAreaDelegate = _delegate;
   FlexibleHeaderTopSafeAreaTestsFakeViewController *viewController =
       [[FlexibleHeaderTopSafeAreaTestsFakeViewController alloc] init];
   viewController.topSafeAreaInset = 20;
@@ -176,7 +176,7 @@
 - (void)testTopSafeAreaInsetDoesChangeWhileStatusBarIsShiftedWithAnyOtherSize {
   // Given
   _topSafeArea.inferTopSafeAreaInsetFromViewController = YES;
-  _topSafeArea.delegate = _delegate;
+  _topSafeArea.topSafeAreaDelegate = _delegate;
   FlexibleHeaderTopSafeAreaTestsFakeViewController *viewController =
       [[FlexibleHeaderTopSafeAreaTestsFakeViewController alloc] init];
   viewController.topSafeAreaInset = 44;

--- a/components/FlexibleHeader/tests/unit/supplemental/FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate.h
+++ b/components/FlexibleHeader/tests/unit/supplemental/FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate.h
@@ -17,9 +17,9 @@
 #import "../../../src/private/MDCFlexibleHeaderTopSafeArea.h"
 
 @interface FlexibleHeaderTopSafeAreaTestsFakeTopSafeAreaDelegate
-    : NSObject <MDCFlexibleHeaderSafeAreaDelegate>
+    : NSObject <MDCFlexibleHeaderTopSafeAreaDelegate>
 @property(nonatomic) BOOL isStatusBarShifted;
 @property(nonatomic) BOOL topSafeAreaInsetDidChangeWasCalled;
 @property(nonatomic) CGFloat deviceTopSafeAreaInset;
-@property(nonatomic, weak) id<MDCFlexibleHeaderSafeAreaDelegate> forwardingDelegate;
+@property(nonatomic, weak) id<MDCFlexibleHeaderTopSafeAreaDelegate> forwardingDelegate;
 @end


### PR DESCRIPTION
Changes shepherded from [cl/234843277](http://cl/234843277). From CL:

Add a configuration to allow safe areas to be calculated based on parent.

Prior to this CL, inferTopSafeAreaInsetFromViewController set to YES assumed
the header was embedded into a VC heirarchy at the top, so the most
ancestor VC is the only one that would know the safe areas.  That's fine
if the header is always at the top of the screen, but breaks when the
header has something above it.

parentIsAncestorForTopSafeAreaInset instead sets the parent's safe area
as the safe area the header should respect.
