### PR TITLE
[CI] updated Jazzy yaml files to include the framework root

### DIFF
--- a/components/ActionSheet/.jazzy.yaml
+++ b/components/ActionSheet/.jazzy.yaml
@@ -3,3 +3,4 @@ module: ActionSheet
 umbrella_header: src/MaterialActionSheet.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/ActivityIndicator/.jazzy.yaml
+++ b/components/ActivityIndicator/.jazzy.yaml
@@ -3,3 +3,4 @@ module: ActivityIndicator
 umbrella_header: src/MaterialActivityIndicator.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/AnimationTiming/.jazzy.yaml
+++ b/components/AnimationTiming/.jazzy.yaml
@@ -3,3 +3,4 @@ module: AnimationTiming
 umbrella_header: src/MaterialAnimationTiming.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/AppBar/.jazzy.yaml
+++ b/components/AppBar/.jazzy.yaml
@@ -3,3 +3,4 @@ module: AppBar
 umbrella_header: src/MaterialAppBar.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Backdrop/.jazzy.yaml
+++ b/components/Backdrop/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Backdrop
 umbrella_header: src/MaterialBackdrop.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Banner/.jazzy.yaml
+++ b/components/Banner/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Banner
 umbrella_header: src/MaterialBanner.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/BottomAppBar/.jazzy.yaml
+++ b/components/BottomAppBar/.jazzy.yaml
@@ -3,3 +3,4 @@ module: BottomAppBar
 umbrella_header: src/MaterialBottomAppBar.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/BottomNavigation/.jazzy.yaml
+++ b/components/BottomNavigation/.jazzy.yaml
@@ -3,3 +3,4 @@ module: BottomNavigation
 umbrella_header: src/MaterialBottomNavigation.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/BottomSheet/.jazzy.yaml
+++ b/components/BottomSheet/.jazzy.yaml
@@ -3,3 +3,4 @@ module: BottomSheet
 umbrella_header: src/MaterialBottomSheet.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/ButtonBar/.jazzy.yaml
+++ b/components/ButtonBar/.jazzy.yaml
@@ -3,3 +3,4 @@ module: ButtonBar
 umbrella_header: src/MaterialButtonBar.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Buttons/.jazzy.yaml
+++ b/components/Buttons/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Buttons
 umbrella_header: src/MaterialButtons.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Cards/.jazzy.yaml
+++ b/components/Cards/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Cards
 umbrella_header: src/MaterialCards.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Checkboxes/.jazzy.yaml
+++ b/components/Checkboxes/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Checkboxes
 umbrella_header: src/MaterialCheckboxes.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Chips/.jazzy.yaml
+++ b/components/Chips/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Chips
 umbrella_header: src/MaterialChips.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/CollectionCells/.jazzy.yaml
+++ b/components/CollectionCells/.jazzy.yaml
@@ -3,3 +3,4 @@ module: CollectionCells
 umbrella_header: src/MaterialCollectionCells.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/CollectionLayoutAttributes/.jazzy.yaml
+++ b/components/CollectionLayoutAttributes/.jazzy.yaml
@@ -3,3 +3,4 @@ module: CollectionLayoutAttributes
 umbrella_header: src/MaterialCollectionLayoutAttributes.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Collections/.jazzy.yaml
+++ b/components/Collections/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Collections
 umbrella_header: src/MaterialCollections.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/DataTables/.jazzy.yaml
+++ b/components/DataTables/.jazzy.yaml
@@ -3,3 +3,4 @@ module: DataTables
 umbrella_header: src/MaterialDataTables.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Dialogs/.jazzy.yaml
+++ b/components/Dialogs/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Dialogs
 umbrella_header: src/MaterialDialogs.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Dividers/.jazzy.yaml
+++ b/components/Dividers/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Dividers
 umbrella_header: src/MaterialDividers.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/FeatureHighlight/.jazzy.yaml
+++ b/components/FeatureHighlight/.jazzy.yaml
@@ -3,3 +3,4 @@ module: FeatureHighlight
 umbrella_header: src/MaterialFeatureHighlight.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/FlexibleHeader/.jazzy.yaml
+++ b/components/FlexibleHeader/.jazzy.yaml
@@ -3,3 +3,4 @@ module: FlexibleHeader
 umbrella_header: src/MaterialFlexibleHeader.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/HeaderStackView/.jazzy.yaml
+++ b/components/HeaderStackView/.jazzy.yaml
@@ -3,3 +3,4 @@ module: HeaderStackView
 umbrella_header: src/MaterialHeaderStackView.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/ImageList/.jazzy.yaml
+++ b/components/ImageList/.jazzy.yaml
@@ -3,3 +3,4 @@ module: ImageList
 umbrella_header: src/MaterialImageList.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Ink/.jazzy.yaml
+++ b/components/Ink/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Ink
 umbrella_header: src/MaterialInk.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/LibraryInfo/.jazzy.yaml
+++ b/components/LibraryInfo/.jazzy.yaml
@@ -3,3 +3,4 @@ module: LibraryInfo
 umbrella_header: src/MaterialLibraryInfo.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/List/.jazzy.yaml
+++ b/components/List/.jazzy.yaml
@@ -3,3 +3,4 @@ module: List
 umbrella_header: src/MaterialList.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/MaskedTransition/.jazzy.yaml
+++ b/components/MaskedTransition/.jazzy.yaml
@@ -3,3 +3,4 @@ module: MaskedTransition
 umbrella_header: src/MaterialMaskedTransition.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Menus/.jazzy.yaml
+++ b/components/Menus/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Menus
 umbrella_header: src/MaterialMenus.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/NavigationBar/.jazzy.yaml
+++ b/components/NavigationBar/.jazzy.yaml
@@ -3,3 +3,4 @@ module: NavigationBar
 umbrella_header: src/MaterialNavigationBar.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/NavigationDrawer/.jazzy.yaml
+++ b/components/NavigationDrawer/.jazzy.yaml
@@ -3,3 +3,4 @@ module: NavigationDrawer
 umbrella_header: src/MaterialNavigationDrawer.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/OverlayWindow/.jazzy.yaml
+++ b/components/OverlayWindow/.jazzy.yaml
@@ -3,3 +3,4 @@ module: OverlayWindow
 umbrella_header: src/MaterialOverlayWindow.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/PageControl/.jazzy.yaml
+++ b/components/PageControl/.jazzy.yaml
@@ -3,3 +3,4 @@ module: PageControl
 umbrella_header: src/MaterialPageControl.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Palettes/.jazzy.yaml
+++ b/components/Palettes/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Palettes
 umbrella_header: src/MaterialPalettes.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/ProgressView/.jazzy.yaml
+++ b/components/ProgressView/.jazzy.yaml
@@ -3,3 +3,4 @@ module: ProgressView
 umbrella_header: src/MaterialProgressView.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/RadioButton/.jazzy.yaml
+++ b/components/RadioButton/.jazzy.yaml
@@ -3,3 +3,4 @@ module: RadioButton
 umbrella_header: src/MaterialRadioButton.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Ripple/.jazzy.yaml
+++ b/components/Ripple/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Ripple
 umbrella_header: src/MaterialRipple.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/ShadowElevations/.jazzy.yaml
+++ b/components/ShadowElevations/.jazzy.yaml
@@ -3,3 +3,4 @@ module: ShadowElevations
 umbrella_header: src/MaterialShadowElevations.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/ShadowLayer/.jazzy.yaml
+++ b/components/ShadowLayer/.jazzy.yaml
@@ -3,3 +3,4 @@ module: ShadowLayer
 umbrella_header: src/MaterialShadowLayer.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/ShapeLibrary/.jazzy.yaml
+++ b/components/ShapeLibrary/.jazzy.yaml
@@ -2,3 +2,4 @@ module: ShapeLibrary
 umbrella_header: src/MaterialShapeLibrary.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Shapes/.jazzy.yaml
+++ b/components/Shapes/.jazzy.yaml
@@ -2,3 +2,4 @@ module: Shapes
 umbrella_header: src/MaterialShapes.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/SideSheet/.jazzy.yaml
+++ b/components/SideSheet/.jazzy.yaml
@@ -3,3 +3,4 @@ module: SideSheet
 umbrella_header: src/MaterialSideSheet.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Slider/.jazzy.yaml
+++ b/components/Slider/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Slider
 umbrella_header: src/MaterialSlider.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Snackbar/.jazzy.yaml
+++ b/components/Snackbar/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Snackbar
 umbrella_header: src/MaterialSnackbar.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Switch/.jazzy.yaml
+++ b/components/Switch/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Switch
 umbrella_header: src/MaterialSwitch.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Tabs/.jazzy.yaml
+++ b/components/Tabs/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Tabs
 umbrella_header: src/MaterialTabs.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/TextFields/.jazzy.yaml
+++ b/components/TextFields/.jazzy.yaml
@@ -3,3 +3,4 @@ module: TextFields
 umbrella_header: src/MaterialTextFields.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Themes/.jazzy.yaml
+++ b/components/Themes/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Themes
 umbrella_header: src/MaterialThemes.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Tooltips/.jazzy.yaml
+++ b/components/Tooltips/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Tooltips
 umbrella_header: src/MaterialTooltips.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/Typography/.jazzy.yaml
+++ b/components/Typography/.jazzy.yaml
@@ -3,3 +3,4 @@ module: Typography
 umbrella_header: src/MaterialTypography.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/docs/.jazzy.yaml
+++ b/components/docs/.jazzy.yaml
@@ -3,3 +3,4 @@ module: docs
 umbrella_header: src/Materialdocs.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/schemes/.jazzy.yaml
+++ b/components/schemes/.jazzy.yaml
@@ -3,3 +3,4 @@ module: schemes
 umbrella_header: src/Materialschemes.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../

--- a/components/schemes/Color/.jazzy.yaml
+++ b/components/schemes/Color/.jazzy.yaml
@@ -2,3 +2,4 @@ module: ColorScheme
 umbrella_header: src/MaterialColorScheme.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../../

--- a/components/schemes/Container/.jazzy.yaml
+++ b/components/schemes/Container/.jazzy.yaml
@@ -2,3 +2,4 @@ module: ContainerScheme
 umbrella_header: src/MaterialContainerScheme.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../../

--- a/components/schemes/Shape/.jazzy.yaml
+++ b/components/schemes/Shape/.jazzy.yaml
@@ -2,3 +2,4 @@ module: ShapeScheme
 umbrella_header: src/MaterialShapeScheme.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../../

--- a/components/schemes/Typography/.jazzy.yaml
+++ b/components/schemes/Typography/.jazzy.yaml
@@ -2,3 +2,4 @@ module: TypographyScheme
 umbrella_header: src/MaterialTypographyScheme.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../../

--- a/scripts/generate_jazzy_yamls.sh
+++ b/scripts/generate_jazzy_yamls.sh
@@ -26,6 +26,7 @@ module: $component
 umbrella_header: src/Material$component.h
 objc: true
 sdk: iphonesimulator
+framework_root: ../
 EOL
 
 done


### PR DESCRIPTION
We have had errors when generating the docs using jazzy specifically around components giving a fatal error around not finding imports when depending on other components. This is because each component for jazzy is isolated and on its own unless we provide the framework root. This caused our website generator to crash each time and fail to generate a new website.

This should resolve this problem.

QA=
Before the fix when running the website generator we got these errors:
```
/material-components-ios/components/BottomAppBar/src/MDCBottomAppBarView.h:17:9: fatal error: 'MaterialButtons.h' file not found
building site
building search index
^C/Library/Ruby/Gems/2.3.0/gems/rouge-3.1.1/lib/rouge/lexer.rb:458:in `load': Interrupt
	from /Library/Ruby/Gems/2.3.0/gems/rouge-3.1.1/lib/rouge/lexer.rb:458:in `load_lexer'
	from /Library/Ruby/Gems/2.3.0/gems/rouge-3.1.1/lib/rouge.rb:50:in `block in <top (required)>'
	from /Library/Ruby/Gems/2.3.0/gems/rouge-3.1.1/lib/rouge.rb:49:in `each'
	from /Library/Ruby/Gems/2.3.0/gems/rouge-3.1.1/lib/rouge.rb:49:in `<top (required)>'
	from /Library/Ruby/Gems/2.3.0/gems/jazzy-0.9.3/lib/jazzy/jazzy_markdown.rb:2:in `require'
	from /Library/Ruby/Gems/2.3.0/gems/jazzy-0.9.3/lib/jazzy/jazzy_markdown.rb:2:in `<top (required)>'
	from /Library/Ruby/Gems/2.3.0/gems/jazzy-0.9.3/lib/jazzy/doc.rb:7:in `require'
	from /Library/Ruby/Gems/2.3.0/gems/jazzy-0.9.3/lib/jazzy/doc.rb:7:in `<top (required)>'
	from /Library/Ruby/Gems/2.3.0/gems/jazzy-0.9.3/lib/jazzy/config.rb:5:in `require'
	from /Library/Ruby/Gems/2.3.0/gems/jazzy-0.9.3/lib/jazzy/config.rb:5:in `<top (required)>'
	from /Library/Ruby/Gems/2.3.0/gems/jazzy-0.9.3/lib/jazzy.rb:1:in `require'
	from /Library/Ruby/Gems/2.3.0/gems/jazzy-0.9.3/lib/jazzy.rb:1:in `<top (required)>'
	from /Library/Ruby/Gems/2.3.0/gems/jazzy-0.9.3/bin/jazzy:13:in `require'
	from /Library/Ruby/Gems/2.3.0/gems/jazzy-0.9.3/bin/jazzy:13:in `<top (required)>'
	from /usr/local/bin/jazzy:22:in `load'
	from /usr/local/bin/jazzy:22:in `<top (required)>'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/cli/exec.rb:74:in `load'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/cli/exec.rb:74:in `kernel_load'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/cli/exec.rb:28:in `run'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/cli.rb:463:in `exec'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/cli.rb:27:in `dispatch'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/cli.rb:18:in `start'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/exe/bundle:30:in `block in <top (required)>'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/exe/bundle:22:in `<top (required)>'
	from /usr/local/bin/bundle:22:in `load'
	from /usr/local/bin/bundle:22:in `<main>'
/material-components-site-generator/scripts/lib/reporter.js:36
      throw e;
      ^

Error: Command failed: bundle exec jazzy         --output "/material-components-site-generator/.stage/ios/catalog/bottomnavigation/api-docs/"         --theme "/material-components-site-generator/ios-api-docs-src/theme"         --head '/components'         --use-safe-filenames
    at checkExecSyncError (child_process.js:601:13)
    at execSync (child_process.js:641:13)
    at JazzyApiGenerator.build (/material-components-site-generator/scripts/lib/jazzy-api-generator.js:34:5)
    at PlatformSite.generateApiDocs (/material-components-site-generator/scripts/lib/platform-site.js:212:17)
    at platformSites.forEach (/material-components-site-generator/scripts/build:86:14)
    at Array.forEach (<anonymous>)
    at reporter.step (/material-components-site-generator/scripts/build:85:21)
    at Reporter.step (/material-components-site-generator/scripts/lib/reporter.js:32:22)
    at Object.<anonymous> (/material-components-site-generator/scripts/build:84:14)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:191:16)
    at bootstrap_node.js:612:3
```
Now we no longer get fatal errors or crash when running the script.