### PR TITLE
[ActivityIndicator] Enforce the minimum supported OS to 9.0.

### DIFF
--- a/components/ActivityIndicator/examples/ActivityIndicatorSwiftExampleViewController.swift
+++ b/components/ActivityIndicator/examples/ActivityIndicatorSwiftExampleViewController.swift
@@ -15,6 +15,7 @@
 import UIKit
 import MaterialComponents.MaterialActivityIndicator
 
+@available(iOS 9.0, *)
 class ActivityIndicatorSwiftExampleViewController: UIViewController {
 
    struct MDCPalette {
@@ -78,6 +79,7 @@ class ActivityIndicatorSwiftExampleViewController: UIViewController {
    }
 }
 
+@available(iOS 9.0, *)
 extension ActivityIndicatorSwiftExampleViewController : MDCActivityIndicatorDelegate {
    func activityIndicatorAnimationDidFinish(_ activityIndicator: MDCActivityIndicator) {
       return

--- a/components/ActivityIndicator/src/ColorThemer/MDCActivityIndicatorColorThemer.h
+++ b/components/ActivityIndicator/src/ColorThemer/MDCActivityIndicatorColorThemer.h
@@ -20,6 +20,7 @@
 /**
  The Material Design color system's themer for instances of MDCActivityIndicator.
  */
+NS_AVAILABLE_IOS(9_0)
 @interface MDCActivityIndicatorColorThemer : NSObject
 
 /**
@@ -33,6 +34,7 @@
 
 @end
 
+NS_AVAILABLE_IOS(9_0)
 @interface MDCActivityIndicatorColorThemer (ToBeDeprecated)
 
 /**

--- a/components/ActivityIndicator/src/MDCActivityIndicator.h
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.h
@@ -43,6 +43,7 @@ typedef NS_ENUM(NSInteger, MDCActivityIndicatorMode) {
  See https://material.io/go/design-progress-indicators
  */
 IB_DESIGNABLE
+NS_AVAILABLE_IOS(9_0)
 @interface MDCActivityIndicator : UIView
 
 /**
@@ -143,6 +144,7 @@ IB_DESIGNABLE
 /**
  Delegate protocol for the MDCActivityIndicator.
  */
+NS_AVAILABLE_IOS(9_0)
 @protocol MDCActivityIndicatorDelegate <NSObject>
 
 @optional

--- a/components/ActivityIndicator/tests/unit/ActivityIndicatorColorThemerTests.swift
+++ b/components/ActivityIndicator/tests/unit/ActivityIndicatorColorThemerTests.swift
@@ -16,6 +16,7 @@ import XCTest
 import MaterialComponents.MaterialActivityIndicator
 import MaterialComponents.MaterialActivityIndicator_ColorThemer
 
+@available(iOS 9.0, *)
 class ActivityIndicatorColorThemerTests: XCTestCase {
 
   func testColorThemerChangesTheBackgroundColor() {

--- a/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.swift
+++ b/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.swift
@@ -15,6 +15,7 @@
 import XCTest
 import MaterialComponents.MaterialActivityIndicator
 
+@available(iOS 9.0, *)
 class ActivityIndicatorTests: XCTestCase {
 
   func testCycleColorDefaultValue() {


### PR DESCRIPTION
This is a proof-of-concept of how we can manage the supported OS versions for our APIs.