### PR TITLE
[Tabs] Expose inkStyle in MDCTabBar

### DIFF
--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -17,6 +17,7 @@
 #import "MDCTabBarAlignment.h"
 #import "MDCTabBarItemAppearance.h"
 #import "MDCTabBarTextTransform.h"
+#import "MaterialInk.h"
 
 @class MDCTabBarItem;
 @protocol MDCTabBarDelegate;
@@ -92,6 +93,14 @@ IB_DESIGNABLE
 
 /** Ink color for taps on tab bar items. Default: Semi-transparent white. */
 @property(nonatomic, nonnull) UIColor *inkColor UI_APPEARANCE_SELECTOR;
+
+/**
+ Ink style for taps on tab bar items.
+
+ Defaults to MDCInkStyleBounded when UIBarPosition is Top or Any.
+ Defaults to MDCInkStyleUnbounded when UIBarPosition is Bottom.
+*/
+@property(nonatomic, assign) MDCInkStyle inkStyle;
 
 /** Color for the bottom divider. Default: Clear. */
 @property(nonatomic, nonnull) UIColor *bottomDividerColor;

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -18,7 +18,6 @@
 
 #import "MDCTabBarIndicatorTemplate.h"
 #import "MDCTabBarUnderlineIndicatorTemplate.h"
-#import "MaterialInk.h"
 #import "MaterialTypography.h"
 #import "private/MDCItemBar.h"
 #import "private/MDCItemBarAlignment.h"
@@ -124,7 +123,7 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   _selectedTitleColor = _selectedItemTintColor;
   _unselectedTitleColor = _unselectedItemTintColor;
   _inkColor = [UIColor colorWithWhite:1 alpha:(CGFloat)0.7];
-
+  _inkStyle = MDCInkStyleBounded;
   self.clipsToBounds = YES;
   _barPosition = UIBarPositionAny;
   _hasDefaultItemAppearance = YES;
@@ -275,6 +274,14 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 - (void)setInkColor:(UIColor *)inkColor {
   if (_inkColor != inkColor && ![_inkColor isEqual:inkColor]) {
     _inkColor = inkColor;
+
+    [self updateItemBarStyle];
+  }
+}
+
+- (void)setInkStyle:(MDCInkStyle)inkStyle {
+  if (_inkStyle != inkStyle) {
+    _inkStyle = inkStyle;
 
     [self updateItemBarStyle];
   }
@@ -603,6 +610,8 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
 
   if (_barPosition != newPosition) {
     _barPosition = newPosition;
+    self.inkStyle =
+        [MDCTabBar isTopTabsForPosition:_barPosition] ? MDCInkStyleBounded : MDCInkStyleUnbounded;
     [self updatePositionDerivedDefaultValues];
     [self updateItemBarStyle];
   }
@@ -632,6 +641,7 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(MDCTabBarAlignm
   style.selectionIndicatorTemplate = self.selectionIndicatorTemplate;
   style.selectionIndicatorColor = self.tintColor;
   style.inkColor = _inkColor;
+  style.inkStyle = _inkStyle;
   style.displaysUppercaseTitles = self.displaysUppercaseTitles;
 
   style.selectedTitleColor = _selectedTitleColor ?: self.tintColor;

--- a/components/Tabs/tests/unit/MDCTabBarTests.m
+++ b/components/Tabs/tests/unit/MDCTabBarTests.m
@@ -32,6 +32,7 @@
   XCTAssertEqualObjects(tabBar.unselectedItemTintColor, [UIColor colorWithWhite:1
                                                                           alpha:(CGFloat)0.7]);
   XCTAssertEqualObjects(tabBar.inkColor, [UIColor colorWithWhite:1 alpha:(CGFloat)0.7]);
+  XCTAssertEqual(tabBar.inkStyle, MDCInkStyleBounded);
   XCTAssertNil(tabBar.barTintColor);
   XCTAssertTrue(tabBar.clipsToBounds);
   XCTAssertEqual(tabBar.barPosition, UIBarPositionAny);

--- a/components/Tabs/tests/unit/MaterialTabsTests.m
+++ b/components/Tabs/tests/unit/MaterialTabsTests.m
@@ -16,7 +16,7 @@
 
 #import "MaterialTabs.h"
 
-@interface MaterialTabsTests : XCTestCase
+@interface MaterialTabsTests : XCTestCase <MDCTabBarDelegate>
 @end
 
 @implementation MaterialTabsTests {
@@ -24,15 +24,18 @@
   UITabBarItem *_itemA;
   UITabBarItem *_itemB;
   UITabBarItem *_itemC;
+  BOOL _shouldPositionTabBarAtBottom;
 }
 
 - (void)setUp {
   [super setUp];
 
   _tabBar = [[MDCTabBar alloc] init];
+  _tabBar.delegate = nil;
   _itemA = [[UITabBarItem alloc] initWithTitle:@"A" image:nil tag:0];
   _itemB = [[UITabBarItem alloc] initWithTitle:@"B" image:nil tag:0];
   _itemC = [[UITabBarItem alloc] initWithTitle:@"C" image:nil tag:0];
+  _shouldPositionTabBarAtBottom = NO;
 }
 
 - (void)tearDown {
@@ -96,6 +99,30 @@
   XCTAssertEqual(_tabBar.selectedItem, _itemB);
 }
 
+- (void)testInkStyleForBottom {
+  // Given
+  _shouldPositionTabBarAtBottom = YES;
+  _tabBar.delegate = self;
+
+  // Then
+  _tabBar.inkStyle = MDCInkStyleUnbounded;
+}
+
+- (void)testInkStyleForAny {
+  // Given
+  _shouldPositionTabBarAtBottom = NO;
+  _tabBar.delegate = self;
+
+  // Then
+  _tabBar.inkStyle = MDCInkStyleBounded;
+}
+
 // TODO(#5199): Add a snapshot test to prove the tabs render without a window
+
+#pragma mark MDCTabBarDelegate
+
+- (UIBarPosition)positionForBar:(id<UIBarPositioning>)bar {
+  return _shouldPositionTabBarAtBottom ? UIBarPositionBottom : UIBarPositionAny;
+}
 
 @end


### PR DESCRIPTION
This is the MDC code changes for resolving issue: b/73833491

In this PR I am exposing the inkStyle so clients can configure if that ink should be bounded or unbounded depending on their use case.

By default in MDC the inkStyle is unbounded if MDCTabBar is placed on the bottom and bounded otherwise.

QA=Unit tests and testing visually on all the existing examples in dragons.