### PR TITLE
[Buttons] Allow setting `accessibilityTraits`.

### DIFF
--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -132,6 +132,13 @@
 @property(nullable, nonatomic, strong) id<MDCShapeGenerating> shapeGenerator;
 
 /**
+ If true, @c accessiblityTraits will always include @c UIAccessibilityTraitButton.
+
+ @note Defaults to true.
+ */
+@property(nonatomic, assign) BOOL accessibilityTraitsIncludesButton;
+
+/**
  A color used as the button's @c backgroundColor for @c state.
 
  @param state The state.

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -152,6 +152,8 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   _imageTintColors = [NSMutableDictionary dictionary];
   _borderWidths = [NSMutableDictionary dictionary];
   _fonts = [NSMutableDictionary dictionary];
+  _accessibilityTraitsIncludesButton = YES;
+  [super setAccessibilityTraits:[super accessibilityTraits] | UIAccessibilityTraitButton];
 
   if (!_backgroundColors) {
     // _backgroundColors may have already been initialized by setting the backgroundColor setter.
@@ -482,7 +484,10 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 }
 
 - (UIAccessibilityTraits)accessibilityTraits {
-  return [super accessibilityTraits] | UIAccessibilityTraitButton;
+  if (self.accessibilityTraitsIncludesButton) {
+    return [super accessibilityTraits] | UIAccessibilityTraitButton;
+  }
+  return [super accessibilityTraits];
 }
 
 #pragma mark - Ink

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -1089,20 +1089,20 @@ static NSString *controlStateDescription(UIControlState controlState) {
 - (void)testSetAccessibilityTraitsExcludesButtonExplicitly {
   // When
   self.button.accessibilityTraitsIncludesButton = NO;
-  self.button.accessibilityTraits = UIAccessibilityTraitTabBar;
+  self.button.accessibilityTraits = UIAccessibilityTraitAllowsDirectInteraction;
 
   // Then
-  XCTAssertEqual(self.button.accessibilityTraits, UIAccessibilityTraitTabBar);
+  XCTAssertEqual(self.button.accessibilityTraits, UIAccessibilityTraitAllowsDirectInteraction);
 }
 
 - (void)testSetAccessibilityTraitsIncludesButtonExplicitly {
   // When
   self.button.accessibilityTraitsIncludesButton = YES;
-  self.button.accessibilityTraits = UIAccessibilityTraitTabBar;
+  self.button.accessibilityTraits = UIAccessibilityTraitAllowsDirectInteraction;
 
   // Then
   XCTAssertEqual(self.button.accessibilityTraits,
-                 UIAccessibilityTraitTabBar | UIAccessibilityTraitButton);
+                 UIAccessibilityTraitAllowsDirectInteraction | UIAccessibilityTraitButton);
 }
 
 @end

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -1077,6 +1077,22 @@ static NSString *controlStateDescription(UIControlState controlState) {
   XCTAssertEqual(self.button.accessibilityTraits, UIAccessibilityTraitButton);
 }
 
+- (void)testAccessibilityTraitsDefaultIncludesButtonExplicitlyTrue {
+  // When
+  self.button.accessibilityTraitsIncludesButton = YES;
+
+  // Then
+  XCTAssertEqual(self.button.accessibilityTraits, UIAccessibilityTraitButton);
+}
+
+- (void)testAccessibilityTraitsDefaultIncludesButtonExplicitlyFalse {
+  // When
+  self.button.accessibilityTraitsIncludesButton = NO;
+
+  // Then
+  XCTAssertEqual(self.button.accessibilityTraits, UIAccessibilityTraitButton);
+}
+
 - (void)testSetAccessibilityTraitsIncludesButtonByDefault {
   // When
   self.button.accessibilityTraits = UIAccessibilityTraitLink;

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -1070,4 +1070,39 @@ static NSString *controlStateDescription(UIControlState controlState) {
                 NSStringFromCGRect(expectedFrame), NSStringFromCGRect(self.button.frame));
 }
 
+#pragma mark - UIAccessibility
+
+- (void)testAccessibilityTraitsDefault {
+  // Then
+  XCTAssertEqual(self.button.accessibilityTraits, UIAccessibilityTraitButton);
+}
+
+- (void)testSetAccessibilityTraitsIncludesButtonByDefault {
+  // When
+  self.button.accessibilityTraits = UIAccessibilityTraitLink;
+
+  // Then
+  XCTAssertEqual(self.button.accessibilityTraits,
+                 UIAccessibilityTraitLink | UIAccessibilityTraitButton);
+}
+
+- (void)testSetAccessibilityTraitsExcludesButtonExplicitly {
+  // When
+  self.button.accessibilityTraitsIncludesButton = NO;
+  self.button.accessibilityTraits = UIAccessibilityTraitTabBar;
+
+  // Then
+  XCTAssertEqual(self.button.accessibilityTraits, UIAccessibilityTraitTabBar);
+}
+
+- (void)testSetAccessibilityTraitsIncludesButtonExplicitly {
+  // When
+  self.button.accessibilityTraitsIncludesButton = YES;
+  self.button.accessibilityTraits = UIAccessibilityTraitTabBar;
+
+  // Then
+  XCTAssertEqual(self.button.accessibilityTraits,
+                 UIAccessibilityTraitTabBar | UIAccessibilityTraitButton);
+}
+
 @end


### PR DESCRIPTION
Clients should be able to customize the value of `accessibilityTraits`.
However, to migrate any clients currently relying on the old behavior (always
including `.button`) we need a new flag to manage the behavior.

QA=Unit tests!

Part of #6763
Necessitates #6765
