### PR TITLE
[Snackbar] Make initialization threadsafe.

### DIFF
--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -126,7 +126,6 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
     _manager = manager;
     _pendingMessages = [[NSMutableArray alloc] init];
     _suspensionTokens = [NSMutableDictionary dictionary];
-    _overlayView = [[MDCSnackbarOverlayView alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
   }
   return self;
 }
@@ -267,6 +266,16 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
                 });
               }
             }];
+}
+
+- (MDCSnackbarOverlayView *)overlayView {
+  // Ensure that this method is called on the main thread.
+  NSAssert([NSThread isMainThread], @"Method is not called on main thread.");
+
+  if (!_overlayView) {
+    _overlayView = [[MDCSnackbarOverlayView alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+  }
+  return _overlayView;
 }
 
 - (void)hideSnackbarViewReally:(MDCSnackbarMessageView *)snackbarView

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -269,10 +269,10 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
 }
 
 - (MDCSnackbarOverlayView *)overlayView {
-  // Ensure that this method is called on the main thread.
-  NSAssert([NSThread isMainThread], @"Method is not called on main thread.");
-
   if (!_overlayView) {
+    // Only initialize on the main thread.
+    NSAssert([NSThread isMainThread], @"Method is not called on main thread.");
+
     _overlayView = [[MDCSnackbarOverlayView alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
   }
   return _overlayView;

--- a/components/Snackbar/tests/unit/SnackbarManagerTests.m
+++ b/components/Snackbar/tests/unit/SnackbarManagerTests.m
@@ -76,7 +76,7 @@
   });
 
   // Then
-  [self waitForExpectations:@[expect] timeout:3];
+  [self waitForExpectations:@[ expect ] timeout:3];
 }
 
 @end

--- a/components/Snackbar/tests/unit/SnackbarManagerTests.m
+++ b/components/Snackbar/tests/unit/SnackbarManagerTests.m
@@ -67,7 +67,9 @@
 }
 
 - (void)testInstanceCreatedInBackgroundThread {
+  // Given
   XCTestExpectation *expect = [self expectationWithDescription:@""];
+
   // When
   dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
     MDCSnackbarManager *manager = [[MDCSnackbarManager alloc] init];

--- a/components/Snackbar/tests/unit/SnackbarManagerTests.m
+++ b/components/Snackbar/tests/unit/SnackbarManagerTests.m
@@ -66,4 +66,17 @@
   [self waitForExpectationsWithTimeout:3.0 handler:nil];
 }
 
+- (void)testInstanceCreatedInBackgroundThread {
+  XCTestExpectation *expect = [self expectationWithDescription:@""];
+  // When
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+    MDCSnackbarManager *manager = [[MDCSnackbarManager alloc] init];
+    (void)manager;
+    [expect fulfill];
+  });
+
+  // Then
+  [self waitForExpectations:@[expect] timeout:3];
+}
+
 @end


### PR DESCRIPTION
Initializing a SnackbarManager should be safe on any thread. Delaying
UIView initialization can make it thread safe and no longer crash.

QA=Tested in iOS 7/iOS 11.2 simulator in Dragons.

Closes #6759