### PR TITLE
[BottomNavigation] Prevents the client from setting the navigation items directly when using the bottom navigation bar controller.

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBarController.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBarController.m
@@ -183,7 +183,6 @@ static void *const kObservationContext = (void *)&kObservationContext;
   // Verify tab bar items correspond with the view controllers tab bar items.
   if (items.count != self.viewControllers.count) {
     [[self unauthorizedItemsChangedException] raise];
-    return;
   }
 
   // Verify each new and the view controller's tab bar items are equal.
@@ -192,7 +191,6 @@ static void *const kObservationContext = (void *)&kObservationContext;
     UITabBarItem *newTabBarItem = [items objectAtIndex:i];
     if (![viewControllerTabBarItem isEqual:newTabBarItem]) {
       [[self unauthorizedItemsChangedException] raise];
-      return;
     }
   }
 }

--- a/components/BottomNavigation/src/MDCBottomNavigationBarController.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBarController.m
@@ -181,10 +181,8 @@ static void *const kObservationContext = (void *)&kObservationContext;
 
 - (void)didUpdateNavigationBarItemsWithNewValue:(NSArray *)items {
   // Verify tab bar items correspond with the view controllers tab bar items.
-  BOOL isItemViewControllerCountEqual = items.count == self.viewControllers.count;
-  NSAssert(isItemViewControllerCountEqual, [self navigationBarItemsChangedExceptionDescription]);
-  if (!isItemViewControllerCountEqual) {
-    NSLog(@"%@", [self navigationBarItemsChangedExceptionDescription]);
+  if (items.count != self.viewControllers.count) {
+    [[self unauthorizedItemsChangedException] raise];
     return;
   }
 
@@ -192,10 +190,8 @@ static void *const kObservationContext = (void *)&kObservationContext;
   for (NSUInteger i = 0; i < self.viewControllers.count; i++) {
     UITabBarItem *viewControllerTabBarItem = [self.viewControllers objectAtIndex:i].tabBarItem;
     UITabBarItem *newTabBarItem = [items objectAtIndex:i];
-    BOOL tabBarItemsEqual = [viewControllerTabBarItem isEqual:newTabBarItem];
-    NSAssert(tabBarItemsEqual, [self navigationBarItemsChangedExceptionDescription]);
-    if (!tabBarItemsEqual) {
-      NSLog(@"%@", [self navigationBarItemsChangedExceptionDescription]);
+    if (![viewControllerTabBarItem isEqual:newTabBarItem]) {
+      [[self unauthorizedItemsChangedException] raise];
       return;
     }
   }
@@ -414,14 +410,16 @@ static void *const kObservationContext = (void *)&kObservationContext;
 }
 
 /**
- * Returns a string for an exception description when the navigation bar's items are set outside of
- * this class.
+ * Returns an exception for when the navigation bar's items are changed from outside of this class.
  */
-- (NSString *)navigationBarItemsChangedExceptionDescription {
-  return [NSString
+- (NSException *)unauthorizedItemsChangedException {
+  NSString *reason = [NSString
       stringWithFormat:
           @"Attempting to set %@'s navigation bar items.  Please instead use setViewControllers:",
           NSStringFromClass([self class])];
+  return [NSException exceptionWithName:NSInternalInconsistencyException
+                                 reason:reason
+                               userInfo:nil];
 }
 
 @end

--- a/components/BottomNavigation/src/MDCBottomNavigationBarController.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBarController.m
@@ -34,22 +34,18 @@ static void *const kObservationContext = (void *)&kObservationContext;
     _viewControllers = @[];
     _selectedIndex = NSNotFound;
 
-#ifdef DEBUG
     [_navigationBar addObserver:self
                      forKeyPath:NSStringFromSelector(@selector(items))
                         options:NSKeyValueObservingOptionNew
                         context:kObservationContext];
-#endif
   }
 
   return self;
 }
 
-#ifdef DEBUG
 - (void)dealloc {
   [_navigationBar removeObserver:self forKeyPath:NSStringFromSelector(@selector(items))];
 }
-#endif
 
 - (void)viewDidLoad {
   [super viewDidLoad];
@@ -185,14 +181,23 @@ static void *const kObservationContext = (void *)&kObservationContext;
 
 - (void)didUpdateNavigationBarItemsWithNewValue:(NSArray *)items {
   // Verify tab bar items correspond with the view controllers tab bar items.
-  NSAssert(items.count == self.viewControllers.count,
-           [self navigationBarItemsChangedExceptionDescription]);
+  BOOL isItemViewControllerCountEqual = items.count == self.viewControllers.count;
+  NSAssert(isItemViewControllerCountEqual, [self navigationBarItemsChangedExceptionDescription]);
+  if (!isItemViewControllerCountEqual) {
+    NSLog(@"%@", [self navigationBarItemsChangedExceptionDescription]);
+    return;
+  }
 
+  // Verify each new and the view controller's tab bar items are equal.
   for (NSUInteger i = 0; i < self.viewControllers.count; i++) {
     UITabBarItem *viewControllerTabBarItem = [self.viewControllers objectAtIndex:i].tabBarItem;
     UITabBarItem *newTabBarItem = [items objectAtIndex:i];
-    NSAssert([viewControllerTabBarItem isEqual:newTabBarItem],
-             [self navigationBarItemsChangedExceptionDescription]);
+    BOOL tabBarItemsEqual = [viewControllerTabBarItem isEqual:newTabBarItem];
+    NSAssert(tabBarItemsEqual, [self navigationBarItemsChangedExceptionDescription]);
+    if (!tabBarItemsEqual) {
+      NSLog(@"%@", [self navigationBarItemsChangedExceptionDescription]);
+      return;
+    }
   }
 }
 

--- a/components/BottomNavigation/src/MDCBottomNavigationBarController.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBarController.m
@@ -14,6 +14,9 @@
 
 #import "MDCBottomNavigationBarController.h"
 
+// A context for Key Value Observing
+static void *const kObservationContext = (void *)&kObservationContext;
+
 @interface MDCBottomNavigationBarController ()
 
 /** The view that hosts the content for the selected view controller **/
@@ -30,10 +33,23 @@
     _content = [[UIView alloc] init];
     _viewControllers = @[];
     _selectedIndex = NSNotFound;
+
+#ifdef DEBUG
+    [_navigationBar addObserver:self
+                     forKeyPath:NSStringFromSelector(@selector(items))
+                        options:NSKeyValueObservingOptionNew
+                        context:kObservationContext];
+#endif
   }
 
   return self;
 }
+
+#ifdef DEBUG
+- (void)dealloc {
+  [_navigationBar removeObserver:self forKeyPath:NSStringFromSelector(@selector(items))];
+}
+#endif
 
 - (void)viewDidLoad {
   [super viewDidLoad];
@@ -94,8 +110,8 @@
 - (void)setViewControllers:(NSArray<UIViewController *> *)viewControllers {
   [self deselectCurrentItem];
   NSArray *viewControllersCopy = [viewControllers copy];
-  self.navigationBar.items = [self tabBarItemsForViewControllers:viewControllersCopy];
   _viewControllers = viewControllersCopy;
+  self.navigationBar.items = [self tabBarItemsForViewControllers:viewControllersCopy];
 
   self.selectedViewController = viewControllersCopy.firstObject;
 }
@@ -146,6 +162,38 @@
   }
 
   return YES;
+}
+
+#pragma mark - Key Value Observation Methods
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary<NSKeyValueChangeKey, id> *)change
+                       context:(void *)context {
+  if (context != kObservationContext) {
+    [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+    return;
+  }
+
+  id newValue = [change objectForKey:NSKeyValueChangeNewKey];
+  if (object == self.navigationBar &&
+      [keyPath isEqualToString:NSStringFromSelector(@selector(items))] &&
+      [newValue isKindOfClass:[NSArray class]]) {
+    [self didUpdateNavigationBarItemsWithNewValue:(NSArray *)newValue];
+  }
+}
+
+- (void)didUpdateNavigationBarItemsWithNewValue:(NSArray *)items {
+  // Verify tab bar items correspond with the view controllers tab bar items.
+  NSAssert(items.count == self.viewControllers.count,
+           [self navigationBarItemsChangedExceptionDescription]);
+
+  for (NSUInteger i = 0; i < self.viewControllers.count; i++) {
+    UITabBarItem *viewControllerTabBarItem = [self.viewControllers objectAtIndex:i].tabBarItem;
+    UITabBarItem *newTabBarItem = [items objectAtIndex:i];
+    NSAssert([viewControllerTabBarItem isEqual:newTabBarItem],
+             [self navigationBarItemsChangedExceptionDescription]);
+  }
 }
 
 #pragma mark - Private Methods
@@ -358,6 +406,17 @@
   }
 
   return tabBarItems;
+}
+
+/**
+ * Returns a string for an exception description when the navigation bar's items are set outside of
+ * this class.
+ */
+- (NSString *)navigationBarItemsChangedExceptionDescription {
+  return [NSString
+      stringWithFormat:
+          @"Attempting to set %@'s navigation bar items.  Please instead use setViewControllers:",
+          NSStringFromClass([self class])];
 }
 
 @end

--- a/components/BottomNavigation/tests/unit/MDCBottomNavigationBarControllerTests.m
+++ b/components/BottomNavigation/tests/unit/MDCBottomNavigationBarControllerTests.m
@@ -243,6 +243,31 @@ static CGFloat const kDefaultExpectationTimeout = 15;
   [self waitForExpectationsWithTimeout:kDefaultExpectationTimeout handler:nil];
 }
 
+- (void)testShouldNotSetNavigationBarItemsWithNoExistingViewControllers {
+  // Given
+  NSArray<UITabBarItem *> *tabBarItems = @[
+    [[UITabBarItem alloc] initWithTitle:@"Tab 1" image:nil tag:0],
+    [[UITabBarItem alloc] initWithTitle:@"Tab 2" image:nil tag:1]
+  ];
+
+  // When/Then
+  XCTAssertThrowsSpecificNamed(self.bottomNavigationBarController.navigationBar.items = tabBarItems,
+                               NSException, NSInternalInconsistencyException);
+}
+
+- (void)testShouldNotSetNavigationBarItemsWithExistingViewControllers {
+  // Given
+  NSArray<UITabBarItem *> *tabBarItems = @[
+    [[UITabBarItem alloc] initWithTitle:@"Tab 1" image:nil tag:0],
+    [[UITabBarItem alloc] initWithTitle:@"Tab 2" image:nil tag:1]
+  ];
+  self.bottomNavigationBarController.viewControllers = [self createArrayOfTwoFakeViewControllers];
+
+  // When/Then
+  XCTAssertThrowsSpecificNamed(self.bottomNavigationBarController.navigationBar.items = tabBarItems,
+                               NSException, NSInternalInconsistencyException);
+}
+
 #pragma mark - MDCBottomNavigationBarControllerDelegate Methods
 
 - (void)bottomNavigationBarController:


### PR DESCRIPTION
Observes the navigation bar's items property and if at anytime the new items do not equal the view controllers' tab bar items an exception will be thrown.

Closes #6785