### PR TITLE
Enable -Wunguarded-availability.

### DIFF
--- a/catalog/MaterialComponentsWarnings.xcconfig
+++ b/catalog/MaterialComponentsWarnings.xcconfig
@@ -15,5 +15,6 @@ MDC_BASIC_WARNINGS = -Wall -Wextra -Werror
 MDC_EXTRA_WARNINGS = -Wcast-align -Wconversion -Watomic-properties -Wmissing-prototypes -Wnewline-eof -Woverlength-strings -Wshadow -Wstrict-selector-match -Wundeclared-selector -Wunreachable-code -Wstrict-prototypes
 MDC_IGNORABLE_WARNINGS = -Wno-error=deprecated -Wno-error=deprecated-implementations
 MDC_DISABLED_WARNINGS = -Wno-partial-availability -Wno-sign-conversion -Wno-unused-parameter
+MDC_AVAILABILITY = -Wunguarded-availability
 
-WARNING_CFLAGS = $(inherited) $(MDC_BASIC_WARNINGS) $(MDC_EXTRA_WARNINGS) $(MDC_IGNORABLE_WARNINGS) $(MDC_DISABLED_WARNINGS)
+WARNING_CFLAGS = $(inherited) $(MDC_BASIC_WARNINGS) $(MDC_EXTRA_WARNINGS) $(MDC_IGNORABLE_WARNINGS) $(MDC_DISABLED_WARNINGS) $(MDC_AVAILABILITY)

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -66,7 +66,7 @@ static NSString *const kMDCBottomNavigationBarOfAnnouncement = @"of";
 @property(nonatomic, strong) UIView *itemsLayoutView;
 @property(nonatomic, strong) NSMutableArray *inkControllers;
 @property(nonatomic) BOOL shouldPretendToBeATabBar;
-@property(nonatomic, strong) UILayoutGuide *barItemsLayoutGuide;
+@property(nonatomic, strong) UILayoutGuide *barItemsLayoutGuide NS_AVAILABLE_IOS(9_0);
 @end
 
 @implementation MDCBottomNavigationBar

--- a/components/BottomNavigation/src/MDCBottomNavigationBarController.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBarController.m
@@ -276,23 +276,27 @@
 }
 
 - (void)loadiOS9PlusConstraints {
-  // Navigation Bar Constraints
-  [self.view.leftAnchor constraintEqualToAnchor:self.navigationBar.leftAnchor].active = YES;
-  [self.view.rightAnchor constraintEqualToAnchor:self.navigationBar.rightAnchor].active = YES;
+  if (@available(iOS 9.0, *)) {
+    // Navigation Bar Constraints
+    [self.view.leftAnchor constraintEqualToAnchor:self.navigationBar.leftAnchor].active = YES;
+    [self.view.rightAnchor constraintEqualToAnchor:self.navigationBar.rightAnchor].active = YES;
+    [self.navigationBar.topAnchor constraintEqualToAnchor:self.content.bottomAnchor].active = YES;
+    [self.navigationBar.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor].active = YES;
+  }
 
-  [self.navigationBar.topAnchor constraintEqualToAnchor:self.content.bottomAnchor].active = YES;
-  [self.navigationBar.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor].active = YES;
   if (@available(iOS 11.0, *)) {
     [self.navigationBar.barItemsBottomAnchor
         constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor]
         .active = YES;
   }
 
-  // Content View Constraints
-  [self.view.leftAnchor constraintEqualToAnchor:self.content.leftAnchor].active = YES;
-  [self.view.rightAnchor constraintEqualToAnchor:self.content.rightAnchor].active = YES;
+  if (@available(iOS 9.0, *)) {
+    // Content View Constraints
+    [self.view.leftAnchor constraintEqualToAnchor:self.content.leftAnchor].active = YES;
+    [self.view.rightAnchor constraintEqualToAnchor:self.content.rightAnchor].active = YES;
 
-  [self.view.topAnchor constraintEqualToAnchor:self.content.topAnchor].active = YES;
+    [self.view.topAnchor constraintEqualToAnchor:self.content.topAnchor].active = YES;
+  }
 }
 
 /**

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
@@ -88,7 +88,7 @@
   self.appBarViewController.headerView.minimumHeight = 56 + 72;
 
   UIFont *font;
-  if ([UIFont respondsToSelector:@selector(monospacedDigitSystemFontOfSize:weight:)]) {
+  if (@available(iOS 9.0, *)) {
     font = [UIFont monospacedDigitSystemFontOfSize:14 weight:UIFontWeightRegular];
   } else {
     font = [UIFont systemFontOfSize:14];

--- a/components/Tabs/examples/supplemental/TabBarTextOnlyExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarTextOnlyExampleSupplemental.m
@@ -51,7 +51,7 @@ static NSString *const kReusableIdentifierItem = @"Cell";
   self.appBarViewController.headerView.maximumHeight = kAppBarMinHeight + kTabBarHeight;
 
   UIFont *font;
-  if ([UIFont respondsToSelector:@selector(monospacedDigitSystemFontOfSize:weight:)]) {
+  if (@available(iOS 9.0, *)) {
     font = [UIFont monospacedDigitSystemFontOfSize:14 weight:UIFontWeightRegular];
   } else {
     font = [UIFont systemFontOfSize:14];

--- a/components/Tabs/tests/unit/MDCTabBarLayoutTests.m
+++ b/components/Tabs/tests/unit/MDCTabBarLayoutTests.m
@@ -98,7 +98,9 @@ static NSArray<UICollectionViewCell *> *SortedCellsFromCollectionView(
       (UICollectionViewFlowLayout *)collectionView.collectionViewLayout;
 
   // When
-  _tabBar.mdf_semanticContentAttribute = UISemanticContentAttributeUnspecified;
+  if (@available(iOS 9.0, *)) {
+    _tabBar.mdf_semanticContentAttribute = UISemanticContentAttributeUnspecified;
+  }
 
   // Then
   CGFloat leftInset = flowLayout.sectionInset.left;

--- a/components/TextFields/examples/TextFieldsTableViewExample.m
+++ b/components/TextFields/examples/TextFieldsTableViewExample.m
@@ -52,15 +52,17 @@ static NSString *const TSTTextFieldTableViewCellIdentifier = @"TSTTextFieldsTabl
   if (@available(iOS 11.0, *)) {
     [self.tableView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor]
         .active = YES;
-  } else {
+  } else if (@available(iOS 9.0, *)) {
     [self.tableView.topAnchor constraintEqualToAnchor:self.topLayoutGuide.bottomAnchor].active =
         YES;
   }
 
-  [self.tableView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor].active = YES;
+  if (@available(iOS 9.0, *)) {
+    [self.tableView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor].active = YES;
 
-  [self.tableView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor].active = YES;
-  [self.tableView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor].active = YES;
+    [self.tableView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor].active = YES;
+    [self.tableView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor].active = YES;
+  }
 
   [self setupDataModel];
 }
@@ -137,12 +139,14 @@ static NSString *const TSTTextFieldTableViewCellIdentifier = @"TSTTextFieldsTabl
     self.textField.translatesAutoresizingMaskIntoConstraints = NO;
     [self addSubview:self.textField];
 
-    [self.textField.topAnchor constraintEqualToAnchor:self.topAnchor].active = YES;
-    [self.textField.bottomAnchor constraintEqualToAnchor:self.bottomAnchor].active = YES;
-    [self.textField.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:8].active =
-        YES;
-    [self.textField.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-8].active =
-        YES;
+    if (@available(iOS 9.0, *)) {
+      [self.textField.topAnchor constraintEqualToAnchor:self.topAnchor].active = YES;
+      [self.textField.bottomAnchor constraintEqualToAnchor:self.bottomAnchor].active = YES;
+      [self.textField.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:8].active =
+          YES;
+      [self.textField.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-8].active =
+          YES;
+    }
 
     _textFieldController = [[MDCTextInputControllerFilled alloc] initWithTextInput:self.textField];
   }

--- a/components/TextFields/examples/TextFieldsTableViewExample.m
+++ b/components/TextFields/examples/TextFieldsTableViewExample.m
@@ -144,8 +144,8 @@ static NSString *const TSTTextFieldTableViewCellIdentifier = @"TSTTextFieldsTabl
       [self.textField.bottomAnchor constraintEqualToAnchor:self.bottomAnchor].active = YES;
       [self.textField.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:8].active =
           YES;
-      [self.textField.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-8].active =
-          YES;
+      [self.textField.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-8]
+          .active = YES;
     }
 
     _textFieldController = [[MDCTextInputControllerFilled alloc] initWithTextInput:self.textField];

--- a/components/Typography/examples/TypographyMaterialStylesViewController.m
+++ b/components/Typography/examples/TypographyMaterialStylesViewController.m
@@ -93,15 +93,17 @@
   UIKIT_EXTERN const CGFloat UIFontWeightBlack NS_AVAILABLE_IOS(8_2);
 */
 
-  NSLog(@"UIFontWeightUltraLight %f", UIFontWeightUltraLight);
-  NSLog(@"UIFontWeightThin %f", UIFontWeightThin);
-  NSLog(@"UIFontWeightLight %f", UIFontWeightLight);
-  NSLog(@"UIFontWeightRegular %f", UIFontWeightRegular);
-  NSLog(@"UIFontWeightMedium %f", UIFontWeightMedium);
-  NSLog(@"UIFontWeightSemibold %f", UIFontWeightSemibold);
-  NSLog(@"UIFontWeightBold %f", UIFontWeightBold);
-  NSLog(@"UIFontWeightHeavy %f", UIFontWeightHeavy);
-  NSLog(@"UIFontWeightBlack %f", UIFontWeightBlack);
+  if (@available(iOS 8.2, *)) {
+    NSLog(@"UIFontWeightUltraLight %f", UIFontWeightUltraLight);
+    NSLog(@"UIFontWeightThin %f", UIFontWeightThin);
+    NSLog(@"UIFontWeightLight %f", UIFontWeightLight);
+    NSLog(@"UIFontWeightRegular %f", UIFontWeightRegular);
+    NSLog(@"UIFontWeightMedium %f", UIFontWeightMedium);
+    NSLog(@"UIFontWeightSemibold %f", UIFontWeightSemibold);
+    NSLog(@"UIFontWeightBold %f", UIFontWeightBold);
+    NSLog(@"UIFontWeightHeavy %f", UIFontWeightHeavy);
+    NSLog(@"UIFontWeightBlack %f", UIFontWeightBlack);
+  }
 
   UIFont *defaultFont = [UIFont mdc_preferredFontForMaterialTextStyle:MDCFontTextStyleBody1];
   NSLog(@"Font Family : %@", defaultFont.familyName);


### PR DESCRIPTION
### Context

By default, Objective-C code will only perform availability checks for iOS APIs introduced from iOS 11 and up. We can enable -Wunguarded-availability to turn on available checks for older SDKs.

Additional context for this behavior comes from [llvm](https://reviews.llvm.org/D34264);

> [This patch](https://reviews.llvm.org/D34264) adds a new warning flag called -Wunguarded-availability-new. If -Wunguarded-availability is off, this warning only warns about uses of APIs that have been introduced in macOS >= 10.13, iOS >= 11, watchOS >= 4 and tvOS >= 11. This warning is on by default. We decided to use this kind of solution as we didn't want to turn on -Wunguarded-availability by default, as we didn't want our users to get warnings about uses of old APIs in their existing projects.

### What's happening in this change

This change turns on -Wunguarded-availability. This has the effect of the compiler performing availability checks for all APIs at or above the current deployment target (iOS 8.0). As such, this PR addresses several instances of code that were not performing availability checks.

Going forward, we will be able to use availability to encode our supported SDKs into the APIs that we provide. For example, we could annotate MDCActivityIndicator with NS_AVAILABLE_IOS(9_0) and all of our code would then have to use runtime checks prior to using this API.

### Caveats

Because -Wunguarded-availability is not enabled by default in Objective-C, our clients will need to proactively enable this flag in order to be warned of any use of APIs that support OS versions < 11.0. We can mitigate this risk in two ways:

1. Clearly announce any changes in our supported OS versions.
2. Encourage clients to enable -Wunguarded-availability.