### PR TITLE
[Tabs] Fix badge text truncation bug in MDCItemBarCell

### DIFF
--- a/components/Tabs/src/private/MDCItemBarCell+Private.h
+++ b/components/Tabs/src/private/MDCItemBarCell+Private.h
@@ -15,5 +15,7 @@
 #import "MDCItemBarCell.h"
 
 @interface MDCItemBarCell ()
+- (CGSize)badgeLabelSizeWithText:(NSString *)string font:(UIFont *)font;
 @property(nonatomic, strong) UILabel *titleLabel;
+@property(nonatomic, strong, readonly) UILabel *badgeLabel;
 @end

--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -583,8 +583,7 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3;
   _titleLabel.text = [[self class] displayedTitleForTitle:_title style:_style];
 }
 
-- (CGSize)badgeLabelSizeWithText:(NSString *)string
-                            font:(UIFont *)font {
+- (CGSize)badgeLabelSizeWithText:(NSString *)string font:(UIFont *)font {
   if (string.length <= 0) {
     return CGSizeZero;
   }
@@ -592,22 +591,21 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3;
   NSMutableString *longestAllowableBadgeString = [[NSMutableString alloc] init];
   __block NSUInteger composedCharacterIndex = 0;
   [string enumerateSubstringsInRange:NSMakeRange(0, string.length)
-                        options:NSStringEnumerationByComposedCharacterSequences
-                     usingBlock:^(NSString *substring, NSRange substringRange,
-                                  NSRange enclosingRange, BOOL *stop)
-   {
-     [longestAllowableBadgeString appendString:substring];
-     composedCharacterIndex++;
-     if (composedCharacterIndex == kBadgeMaxTextComposedCharacterLength) {
-       *stop = YES;
-     }
-   }];
+                             options:NSStringEnumerationByComposedCharacterSequences
+                          usingBlock:^(NSString *substring, NSRange substringRange,
+                                       NSRange enclosingRange, BOOL *stop) {
+                            [longestAllowableBadgeString appendString:substring];
+                            composedCharacterIndex++;
+                            if (composedCharacterIndex == kBadgeMaxTextComposedCharacterLength) {
+                              *stop = YES;
+                            }
+                          }];
 
   CGRect largestAllowableBadgeRect =
       [[longestAllowableBadgeString copy] boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)
-                                            options:NSStringDrawingUsesLineFragmentOrigin
-                                         attributes:@{NSFontAttributeName : font}
-                                            context:nil];
+                                                       options:NSStringDrawingUsesLineFragmentOrigin
+                                                    attributes:@{NSFontAttributeName : font}
+                                                       context:nil];
   return largestAllowableBadgeRect.size;
 }
 

--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -251,7 +251,7 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3;
   titleBounds.size = titleSize;
 
   // Size badge
-  CGSize badgeSize = [self badgeLabelSizeWithText:_badgeLabel.text];
+  CGSize badgeSize = [self badgeLabelSizeWithText:_badgeLabel.text font:_badgeLabel.font];
   badgeBounds.size = badgeSize;
 
   // Determine badge center
@@ -583,7 +583,8 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3;
   _titleLabel.text = [[self class] displayedTitleForTitle:_title style:_style];
 }
 
-- (CGSize)badgeLabelSizeWithText:(NSString *)string {
+- (CGSize)badgeLabelSizeWithText:(NSString *)string
+                            font:(UIFont *)font {
   if (string.length <= 0) {
     return CGSizeZero;
   }
@@ -605,7 +606,7 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3;
   CGRect largestAllowableBadgeRect =
       [[longestAllowableBadgeString copy] boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)
                                             options:NSStringDrawingUsesLineFragmentOrigin
-                                         attributes:@{NSFontAttributeName : _badgeLabel.font}
+                                         attributes:@{NSFontAttributeName : font}
                                             context:nil];
   return largestAllowableBadgeRect.size;
 }

--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -33,8 +33,9 @@ static const CGFloat kBadgeFontSize = 12;
 /// Padding between top of the cell and the badge.
 static const CGFloat kBadgeTopPadding = 6;
 
-/// Maximum width of a badge. This allows for 3 characters before truncation.
-static const CGFloat kBadgeMaxWidth = 22;
+/// Maximum badge text character length. Badge text longer than this number of characters will
+/// truncate.
+static const NSUInteger kBadgeMaxTextLength = 3;
 
 /// Outer edge padding from spec: https://material.io/go/design-tabs#spec.
 static const UIEdgeInsets kEdgeInsets = {.top = 0, .right = 16, .bottom = 0, .left = 16};
@@ -249,11 +250,17 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3;
   titleCenter.x = CGRectGetMidX(contentBounds);
   titleBounds.size = titleSize;
 
-  // Horizontally align the badge.
-  CGSize badgeSize = [_badgeLabel sizeThatFits:contentBounds.size];
-  badgeSize.width = MIN(kBadgeMaxWidth, badgeSize.width);
+  // Size badge
+  NSString *longestAllowableBadgeString = [_badgeLabel.text substringToIndex:kBadgeMaxTextLength];
+  CGRect largestAllowableBadgeRect =
+      [longestAllowableBadgeString boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)
+                                                options:NSStringDrawingUsesLineFragmentOrigin
+                                             attributes:@{NSFontAttributeName : _badgeLabel.font}
+                                                context:nil];
+  CGSize badgeSize = largestAllowableBadgeRect.size;
   badgeBounds.size = badgeSize;
 
+  // Determine badge center
   if (_style.shouldDisplayBadge) {
     CGFloat badgeOffset = (imageBounds.size.width / 2) + (badgeSize.width / 2);
     if (self.mdf_effectiveUserInterfaceLayoutDirection ==

--- a/components/Tabs/tests/unit/MDCItemBarCellTests.m
+++ b/components/Tabs/tests/unit/MDCItemBarCellTests.m
@@ -82,4 +82,23 @@
   XCTAssertEqualObjects(cell.titleLabel.text, @"A TITLE");
 }
 
+/// Tests that a cell's badge label doesn't increase in size as the badge value gets to be more than
+/// four characters
+- (void)testBadgeLabelTextTruncation {
+  MDCItemBarStyle *style = [[MDCItemBarStyle alloc] init];
+  style.shouldDisplayImage = YES;
+  style.shouldDisplayBadge = YES;
+  style.shouldDisplayTitle = YES;
+
+  MDCItemBarCell *cell = [[MDCItemBarCell alloc] initWithFrame:CGRectZero];
+  [cell applyStyle:style];
+  cell.image = [UIImage imageNamed:@"TabBarDemo_ic_info"];
+  cell.title = @"A title";
+  cell.badgeValue = @"xxxx";
+  CGRect frameWithFourDigitBadgeValue = cell.badgeLabel.frame;
+  cell.badgeValue = @"xxxxx";
+  CGRect frameWithFiveDigitBadgeValue = cell.badgeLabel.frame;
+  XCTAssertEqualWithAccuracy(CGRectGetWidth(frameWithFiveDigitBadgeValue),
+                             CGRectGetWidth(frameWithFourDigitBadgeValue), 0.001);
+}
 @end


### PR DESCRIPTION
This PR fixes a bug where badge text 3 characters long was truncating when it shouldn't have been.

Before:
![simulator screen shot - iphone x - 2019-03-06 at 12 45 17](https://user-images.githubusercontent.com/8020010/53902531-566a3980-400f-11e9-99a0-135df5a20cb0.png)

After:
![simulator screen shot - iphone x - 2019-03-06 at 12 42 51](https://user-images.githubusercontent.com/8020010/53902532-566a3980-400f-11e9-9b28-fe3c62be2834.png)
 
Closes #4587.