### PR TITLE
[Collections] Clean up interface by removing NS_REQUIRES_SUPER

### DIFF
--- a/components/Collections/src/MDCCollectionViewController.h
+++ b/components/Collections/src/MDCCollectionViewController.h
@@ -49,20 +49,11 @@
  as well as ink during the highlight/unhighlight states.
  */
 
-- (BOOL)collectionView:(nonnull UICollectionView *)collectionView
-    shouldHighlightItemAtIndexPath:(nonnull NSIndexPath *)indexPath NS_REQUIRES_SUPER;
-
 - (void)collectionView:(nonnull UICollectionView *)collectionView
     didHighlightItemAtIndexPath:(nonnull NSIndexPath *)indexPath NS_REQUIRES_SUPER;
 
 - (void)collectionView:(nonnull UICollectionView *)collectionView
     didUnhighlightItemAtIndexPath:(nonnull NSIndexPath *)indexPath NS_REQUIRES_SUPER;
-
-- (BOOL)collectionView:(nonnull UICollectionView *)collectionView
-    shouldSelectItemAtIndexPath:(nonnull NSIndexPath *)indexPath NS_REQUIRES_SUPER;
-
-- (BOOL)collectionView:(nonnull UICollectionView *)collectionView
-    shouldDeselectItemAtIndexPath:(nonnull NSIndexPath *)indexPath NS_REQUIRES_SUPER;
 
 - (void)collectionView:(nonnull UICollectionView *)collectionView
     didSelectItemAtIndexPath:(nonnull NSIndexPath *)indexPath NS_REQUIRES_SUPER;


### PR DESCRIPTION
The delegate calls that return "BOOL" have no reason to *require* subclasses to call them. They set no state in the collection view. Subclasses can certainly call [super] if they want to get the functionality of MDCCollectionViewController, but the NS_REQUIRES_SUPER is too strong a requirement for a lot of subclassing.