### PR TITLE
{Tests} Fix font comparison in Objective-C.

### DIFF
--- a/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
@@ -148,7 +148,7 @@
   XCTAssertNotEqual(cells.count, 0U);
   for (MDCActionSheetItemTableViewCell *cell in cells) {
     // Then
-    XCTAssertEqual(cell.actionLabel.font, actionFont);
+    XCTAssertEqualObjects(cell.actionLabel.font, actionFont);
   }
 }
 

--- a/components/ActionSheet/tests/unit/MDCActionSheetTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTest.m
@@ -384,7 +384,7 @@ static const CGFloat kSafeAreaAmount = 20;
   self.actionSheet.titleFont = titleFont;
 
   // Then
-  XCTAssertEqual(self.actionSheet.header.titleLabel.font, titleFont);
+  XCTAssertEqualObjects(self.actionSheet.header.titleLabel.font, titleFont);
 }
 
 - (void)testSetMessageFont {
@@ -395,7 +395,7 @@ static const CGFloat kSafeAreaAmount = 20;
   self.actionSheet.messageFont = messageFont;
 
   // Then
-  XCTAssertEqual(self.actionSheet.header.messageLabel.font, messageFont);
+  XCTAssertEqualObjects(self.actionSheet.header.messageLabel.font, messageFont);
 }
 
 @end

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -84,7 +84,7 @@
 
   // Then
   for (MDCBottomNavigationItemView *item in self.bottomNavBar.itemViews) {
-    XCTAssertEqual(item.itemTitleFont, self.bottomNavBar.itemTitleFont);
+    XCTAssertEqualObjects(item.itemTitleFont, self.bottomNavBar.itemTitleFont);
   }
 }
 
@@ -99,7 +99,7 @@
 
   // Then
   for (MDCBottomNavigationItemView *item in self.bottomNavBar.itemViews) {
-    XCTAssertEqual(item.itemTitleFont, self.bottomNavBar.itemTitleFont);
+    XCTAssertEqualObjects(item.itemTitleFont, self.bottomNavBar.itemTitleFont);
   }
 }
 

--- a/components/BottomNavigation/tests/unit/BottomNavigationTypographyThemerTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTypographyThemerTests.m
@@ -33,7 +33,7 @@
   [MDCBottomNavigationBarTypographyThemer applyTypographyScheme:typographyScheme
                                           toBottomNavigationBar:bottomBar];
 
-  XCTAssertEqual(bottomBar.itemTitleFont, typographyScheme.caption);
+  XCTAssertEqualObjects(bottomBar.itemTitleFont, typographyScheme.caption);
 }
 
 @end

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -74,10 +74,10 @@
 
   // Then
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
-  XCTAssertEqual(view.titleLabel.font, testFont);
-  XCTAssertEqual(view.messageLabel.font, testFont);
+  XCTAssertEqualObjects(view.titleLabel.font, testFont);
+  XCTAssertEqualObjects(view.messageLabel.font, testFont);
   for (UIButton *button in view.actionManager.buttonsInActionOrder) {
-    XCTAssertEqual(button.titleLabel.font, testFont);
+    XCTAssertEqualObjects(button.titleLabel.font, testFont);
   }
 }
 

--- a/components/Dialogs/tests/unit/MDCAlertControllerTypographyThemerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTypographyThemerTests.m
@@ -32,10 +32,10 @@
   [MDCAlertTypographyThemer applyTypographyScheme:typographyScheme toAlertController:alert];
 
   MDCAlertControllerView *view = (MDCAlertControllerView *)alert.view;
-  XCTAssertEqual(view.titleLabel.font, typographyScheme.headline6);
-  XCTAssertEqual(view.messageLabel.font, typographyScheme.body1);
+  XCTAssertEqualObjects(view.titleLabel.font, typographyScheme.headline6);
+  XCTAssertEqualObjects(view.messageLabel.font, typographyScheme.body1);
   for (UIButton *button in view.actionManager.buttonsInActionOrder) {
-    XCTAssertEqual(button.titleLabel.font, typographyScheme.button);
+    XCTAssertEqualObjects(button.titleLabel.font, typographyScheme.button);
   }
 }
 

--- a/components/Snackbar/tests/unit/MDCSnackbarManagerInstanceTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarManagerInstanceTests.m
@@ -105,11 +105,11 @@
 
   // Then
   XCTAssertEqual(manager.alignment, MDCSnackbarManager.alignment);
-  XCTAssertEqual(manager.buttonFont, MDCSnackbarManager.buttonFont);
+  XCTAssertEqualObjects(manager.buttonFont, MDCSnackbarManager.buttonFont);
   XCTAssertEqual(manager.delegate, MDCSnackbarManager.delegate);
   XCTAssertEqual(manager.mdc_adjustsFontForContentSizeCategory,
                  MDCSnackbarManager.mdc_adjustsFontForContentSizeCategory);
-  XCTAssertEqual(manager.messageFont, MDCSnackbarManager.messageFont);
+  XCTAssertEqualObjects(manager.messageFont, MDCSnackbarManager.messageFont);
   XCTAssertEqual(manager.messageTextColor, MDCSnackbarManager.messageTextColor);
   XCTAssertEqual(manager.shouldApplyStyleChangesToVisibleSnackbars,
                  MDCSnackbarManager.shouldApplyStyleChangesToVisibleSnackbars);


### PR DESCRIPTION
Several unit tests were using identity comparison operations
(`XCTAssertEqual`) instead of equality comparison (`XCTAssertEqualObjects`).
Because UIFont supports `NSCopying`, assigning a UIFont to a `copy` property
can result in a copied object.

Unit tests seemed to flake sometimes, most recently in a Pull Request for
Dynamic Type (#6733).

QA=Unit tests pass
