### PR TITLE
[FlexibleHeader] Fix for FlexibleHeader on iPad in split screen

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -112,7 +112,7 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
   _inferPreferredStatusBarStyle = YES;
 
   MDCFlexibleHeaderView *headerView =
-      [[MDCFlexibleHeaderView alloc] initWithFrame:[UIScreen mainScreen].bounds];
+      [[MDCFlexibleHeaderView alloc] initWithFrame:CGRectZero];
   headerView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
   headerView.delegate = self;
   _headerView = headerView;
@@ -136,6 +136,9 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
   if (shouldDisableAutomaticInsetting) {
     parent.automaticallyAdjustsScrollViewInsets = NO;
   }
+
+  //Size the header based on the parent view controller
+  _headerView.frame = parent.view.bounds;
 }
 
 - (void)didMoveToParentViewController:(UIViewController *)parent {

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -111,8 +111,7 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 - (void)commonMDCFlexibleHeaderViewControllerInit {
   _inferPreferredStatusBarStyle = YES;
 
-  MDCFlexibleHeaderView *headerView =
-      [[MDCFlexibleHeaderView alloc] initWithFrame:CGRectZero];
+  MDCFlexibleHeaderView *headerView = [[MDCFlexibleHeaderView alloc] initWithFrame:CGRectZero];
   headerView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
   headerView.delegate = self;
   _headerView = headerView;
@@ -137,7 +136,7 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
     parent.automaticallyAdjustsScrollViewInsets = NO;
   }
 
-  //Size the header based on the parent view controller
+  // Size the header based on the parent view controller
   _headerView.frame = parent.view.bounds;
 }
 


### PR DESCRIPTION
MDCFlexibleHeaderViewController had assumed that width was always equal to the screen width. In iPad split screen, this causes the header to be too wide.

cl/169740658
b/65638103
