### PR TITLE
[Ripple] Added a fix for the ripple sometimes blinking when ending animation

### DIFF
--- a/components/Ripple/src/private/MDCRippleLayer.m
+++ b/components/Ripple/src/private/MDCRippleLayer.m
@@ -164,6 +164,8 @@ static NSString *const kRippleLayerScaleString = @"transform.scale";
   fadeOutAnim.beginTime = [self convertTime:_rippleTouchDownStartTime + delay fromLayer:nil];
   fadeOutAnim.timingFunction =
       [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
+  fadeOutAnim.fillMode = kCAFillModeForwards;
+  fadeOutAnim.removedOnCompletion = NO;
   [CATransaction setCompletionBlock:^{
     if (completion) {
       completion();


### PR DESCRIPTION
I had noticed while working with the Ripple that only on certain devices (not on any simulator i encountered) there is a minimal blink when the Ripple animation is ending, and only when the tap is released immediately and not held.

This is because sometimes there is a gap between the completion and the removal of the ink layer, and the animation ending where the fillMode is reversed and then the opacity goes back to 1. If that gap is too long the blinking will occur. The fix allows us to have the opacity stay at 0 after the animation block is complete, and thereafter the layer will be removed.

This happens on our iPad Mini 4 running iOS 10.3.2. This wasn't reproducible on any simulator.

QA: Ran all the Ripple examples and tests on 3 team devices to make sure the fix works well.