### PR TITLE
{Cocoapods} Automatically find snapshot targets.

### DIFF
--- a/MaterialComponentsSnapshotTests.podspec
+++ b/MaterialComponentsSnapshotTests.podspec
@@ -44,18 +44,11 @@ module SnapshotPodspecHelper
   end
 
   def self.components
-    return [
-      Component.new("BottomAppBar"),
-      Component.new("BottomNavigation"),
-      Component.new("Buttons"),
-      Component.new("ButtonBar"),
-      Component.new("Cards"),
-      Component.new("Chips"),
-      Component.new("Dialogs"),
-      Component.new("Ripple"),
-      Component.new("Slider"),
-      Component.new("TextFields"),
-    ]
+    components_with_snapshots = []
+    Dir["components/**/tests/snapshot"].each do |dir|
+      components_with_snapshots << Component.new(dir.split('/')[-3])
+      end
+    return components_with_snapshots
   end
 end
 

--- a/MaterialComponentsSnapshotTests.podspec
+++ b/MaterialComponentsSnapshotTests.podspec
@@ -44,11 +44,9 @@ module SnapshotPodspecHelper
   end
 
   def self.components
-    components_with_snapshots = []
-    Dir["components/**/tests/snapshot"].each do |dir|
-      components_with_snapshots << Component.new(dir.split('/')[-3])
-      end
-    return components_with_snapshots
+    return Dir["components/**/tests/snapshot"].map { |dir|
+      dir = Component.new(dir.split(File::SEPARATOR)[-3])
+    }
   end
 end
 


### PR DESCRIPTION
Instead of having to update snapshot targets manually, the podspec could
search for components with a "tests/snapshot" subdirectory and use that
to generate subspecs.
