### PR TITLE
{kokoro} Set ownership for Ruby Gems

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -18,6 +18,11 @@
 set -e
 COCOAPODS_VERSION="1.6.0"
 
+# Fix permissions issue with Ruby Gems (b/128326105)
+if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+  sudo chown -Rh $(whoami) /Library/Ruby/Gems
+fi
+
 if [ -n "$KOKORO_BUILD_NUMBER" ]; then
   repo_dir='github/repo'
 else


### PR DESCRIPTION
According to feedback from the kokoro team in b/128326105, we should
assign ownership to specific directories before running our kokoro jobs.
The ownership change is considered expected behavior and previous
ownership values are considered a defect (but convenient for clients).
