### PR TITLE
[FlexibleHeader] Fix incorrect insets during animated transitions

### DIFF
--- a/components/AppBar/examples/AppBarAnimatedGlitchExample.swift
+++ b/components/AppBar/examples/AppBarAnimatedGlitchExample.swift
@@ -119,6 +119,7 @@ class AppBarAnimatedJumpExample: UIViewController {
     #else
     tab.didMove(toParentViewController: self)
     #endif
+    tab.headerView = self.appBarViewController.headerView
 
     tab.view.alpha = 0
     let animateIn = {
@@ -126,8 +127,6 @@ class AppBarAnimatedJumpExample: UIViewController {
     }
 
     let finishMove = {
-      tab.headerView = self.appBarViewController.headerView
-
       self.appBarViewController.headerView.trackingScrollView = tab.tableView
       self.currentTab = tab
     }
@@ -275,5 +274,11 @@ extension SimpleTableViewController: UITableViewDelegate {
 
   func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
     headerView?.trackingScrollDidEndDraggingWillDecelerate(decelerate)
+  }
+
+  func scrollViewDidChangeAdjustedContentInset(_ scrollView: UIScrollView) {
+    if #available(iOS 11.0, *) {
+      headerView?.trackingScrollDidChangeAdjustedContentInset(scrollView)
+    }
   }
 }

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -82,6 +82,17 @@ IB_DESIGNABLE
  */
 - (void)trackingScrollViewDidScroll;
 
+/**
+ Informs the receiver that the tracking scroll view's adjustedContentInset has changed.
+
+ Must be called from the trackingScrollView delegate's
+ UIScrollViewDelegate::scrollViewDidChangeAdjustedContentInset: implementor.
+
+ @note Do not invoke this method if self.observesTrackingScrollViewScrollEvents is YES.
+ */
+- (void)trackingScrollViewDidChangeAdjustedContentInset:(nullable UIScrollView *)trackingScrollView
+    API_AVAILABLE(ios(11.0), tvos(11.0));
+
 #pragma mark Changing the tracking scroll view
 
 /**

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1553,6 +1553,10 @@ static BOOL isRunningiOS10_3OrAbove() {
   [self fhv_contentOffsetDidChange];
 }
 
+- (void)trackingScrollViewDidChangeAdjustedContentInset:(UIScrollView *)trackingScrollView {
+  [self fhv_adjustTrackingScrollViewInsetsForTrackingScrollView:trackingScrollView];
+}
+
 - (void)trackingScrollViewDidEndDraggingWillDecelerate:(BOOL)willDecelerate {
   NSAssert(!self.observesTrackingScrollViewScrollEvents,
            @"Do not manually forward tracking scroll view events when"

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -507,7 +507,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 #pragma mark - MDCFlexibleHeaderMinMaxHeightDelegate
 
 - (void)flexibleHeaderMaximumHeightDidChange:(MDCFlexibleHeaderMinMaxHeight *)safeAreas {
-  [self fhv_adjustTrackingScrollViewInsets];
+  [self fhv_adjustTrackingScrollViewInsetsForTrackingScrollView:_trackingScrollView];
 }
 
 - (void)flexibleHeaderMinMaxHeightDidChange:(MDCFlexibleHeaderMinMaxHeight *)safeAreas {
@@ -516,11 +516,12 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
 #pragma mark - Private (fhv_ prefix)
 
-- (void)fhv_setContentOffset:(CGPoint)contentOffset {
+- (void)fhv_setContentOffset:(CGPoint)contentOffset
+       forTrackingScrollView:(UIScrollView *)trackingScrollView {
   // Avoid excessive writes. This can also cause infinite recursion if we're observing the content
   // offset because of observesTrackingScrollViewScrollEvents.
-  if (!CGPointEqualToPoint(contentOffset, _trackingScrollView.contentOffset)) {
-    _trackingScrollView.contentOffset = contentOffset;
+  if (!CGPointEqualToPoint(contentOffset, trackingScrollView.contentOffset)) {
+    trackingScrollView.contentOffset = contentOffset;
   }
 
   // When we manually set our content offset it's because we're trying to avoid any sort of content
@@ -529,21 +530,22 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   _shiftAccumulatorLastContentOffset = [self fhv_boundedContentOffset];
 }
 
-- (void)fhv_adjustTrackingScrollViewInsets {
-  CGPoint offsetPriorToInsetAdjustment = _trackingScrollView.contentOffset;
-  [self fhv_enforceInsetsForScrollView:_trackingScrollView];
+- (void)fhv_adjustTrackingScrollViewInsetsForTrackingScrollView:(UIScrollView *)trackingScrollView {
+  CGPoint offsetPriorToInsetAdjustment = trackingScrollView.contentOffset;
+  [self fhv_enforceInsetsForScrollView:trackingScrollView];
 
   // Only restore the content offset if UIScrollView didn't decide to update the content offset for
   // us. Notably, it seems to automatically adjust the content offset in the first runloop in which
   // the scroll view's been created, but not in any further runloops.
-  if (CGPointEqualToPoint(offsetPriorToInsetAdjustment, _trackingScrollView.contentOffset)) {
-    CGFloat scrollViewAdjustedContentInsetTop = _trackingScrollView.contentInset.top;
+  if (CGPointEqualToPoint(offsetPriorToInsetAdjustment, trackingScrollView.contentOffset)) {
+    CGFloat scrollViewAdjustedContentInsetTop = trackingScrollView.contentInset.top;
     if (@available(iOS 11.0, *)) {
-      scrollViewAdjustedContentInsetTop = _trackingScrollView.adjustedContentInset.top;
+      scrollViewAdjustedContentInsetTop = trackingScrollView.adjustedContentInset.top;
     }
     offsetPriorToInsetAdjustment.y =
         MAX(offsetPriorToInsetAdjustment.y, -scrollViewAdjustedContentInsetTop);
-    [self fhv_setContentOffset:offsetPriorToInsetAdjustment];
+    [self fhv_setContentOffset:offsetPriorToInsetAdjustment
+         forTrackingScrollView:trackingScrollView];
   }
 }
 
@@ -646,7 +648,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
     // statusBarShifterNeedsStatusBarAppearanceUpdate:
     CGPoint contentOffset = scrollView.contentOffset;
     contentOffset.y -= topInsetAdjustment;
-    [self fhv_setContentOffset:contentOffset];
+    [self fhv_setContentOffset:contentOffset forTrackingScrollView:_trackingScrollView];
   }
 
   _wasStatusBarHidden = statusBarIsHidden;
@@ -1225,7 +1227,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
       // focusing.
       CGPoint offset = self.trackingScrollView.contentOffset;
       offset.y = MAX(offset.y, -self.maximumHeight);
-      [self fhv_setContentOffset:offset];
+      [self fhv_setContentOffset:offset forTrackingScrollView:self.trackingScrollView];
       // Setting the transform on the same run loop as the accessibility scroll can cause additional
       // incorrect scrolling as the scrollview attempts to resolve to a position that will place
       // the header in the center of the scroll. Punting to the next loop prevents this.
@@ -1391,9 +1393,12 @@ static BOOL isRunningiOS10_3OrAbove() {
   _isChangingStatusBarVisibility = YES;
   CGPoint stashedContentOffset = _trackingScrollView.contentOffset;
   [self.delegate flexibleHeaderViewNeedsStatusBarAppearanceUpdate:self];
-  [self fhv_enforceInsetsForScrollView:_trackingScrollView];
+  [self fhv_enforceInsetsForScrollView:self.trackingScrollView];
+  __weak typeof(self) weakSelf = self;
   [UIView performWithoutAnimation:^{
-    [self fhv_setContentOffset:stashedContentOffset];
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    [strongSelf fhv_setContentOffset:stashedContentOffset
+               forTrackingScrollView:strongSelf.trackingScrollView];
   }];
   _isChangingStatusBarVisibility = NO;
 }
@@ -1658,7 +1663,7 @@ static BOOL isRunningiOS10_3OrAbove() {
   CGFloat delta = _trackingScrollView.contentInset.top - previousInsets.top;
   CGPoint contentOffset = _trackingScrollView.contentOffset;
   contentOffset.y -= delta;  // Keeps the scroll view offset from jumping.
-  [self fhv_setContentOffset:contentOffset];
+  [self fhv_setContentOffset:contentOffset forTrackingScrollView:_trackingScrollView];
   _contentInsetsAreChanging = NO;
 }
 


### PR DESCRIPTION
Issue: https://github.com/material-components/material-components-ios/issues/6437

Change:
Allow flexible header to update insets when adjustedContentInset is changed on a tracking view that 
 is currently not being tracked.

Screenshot before change:
![fv3](https://user-images.githubusercontent.com/8836258/53745307-c8eee400-3e6c-11e9-9e9f-23233caea1de.gif)

Screenshot after change:
iPhone7+ (10.3.1)
![fv2](https://user-images.githubusercontent.com/8836258/53744858-dd7eac80-3e6b-11e9-8db8-ee4bdbe849a6.gif)

iPhoneX (12.0)
![fv1](https://user-images.githubusercontent.com/8836258/53744882-ef604f80-3e6b-11e9-967d-23e09fc42c43.gif)
