### PR TITLE
[FlexibleHeader] Fix incorrect insets during animated transitions

### DIFF
--- a/components/AppBar/examples/AppBarAnimatedGlitchExample.swift
+++ b/components/AppBar/examples/AppBarAnimatedGlitchExample.swift
@@ -119,6 +119,7 @@ class AppBarAnimatedJumpExample: UIViewController {
     #else
     tab.didMove(toParentViewController: self)
     #endif
+    tab.headerView = self.appBarViewController.headerView
 
     tab.view.alpha = 0
     let animateIn = {
@@ -126,8 +127,6 @@ class AppBarAnimatedJumpExample: UIViewController {
     }
 
     let finishMove = {
-      tab.headerView = self.appBarViewController.headerView
-
       self.appBarViewController.headerView.trackingScrollView = tab.tableView
       self.currentTab = tab
     }
@@ -275,5 +274,11 @@ extension SimpleTableViewController: UITableViewDelegate {
 
   func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
     headerView?.trackingScrollDidEndDraggingWillDecelerate(decelerate)
+  }
+
+  func scrollViewDidChangeAdjustedContentInset(_ scrollView: UIScrollView) {
+    if #available(iOS 11.0, *) {
+      headerView?.trackingScrollDidChangeAdjustedContentInset(scrollView)
+    }
   }
 }

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -82,6 +82,17 @@ IB_DESIGNABLE
  */
 - (void)trackingScrollViewDidScroll;
 
+/**
+ Informs the receiver that the tracking scroll view's adjustedContentInset has changed.
+
+ Must be called from the trackingScrollView delegate's
+ UIScrollViewDelegate::scrollViewDidChangeAdjustedContentInset: implementor.
+
+ @note Do not invoke this method if self.observesTrackingScrollViewScrollEvents is YES.
+ */
+- (void)trackingScrollViewDidChangeAdjustedContentInset:(nullable UIScrollView *)trackingScrollView
+    API_AVAILABLE(ios(11.0), tvos(11.0));
+
 #pragma mark Changing the tracking scroll view
 
 /**

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1550,6 +1550,10 @@ static BOOL isRunningiOS10_3OrAbove() {
   [self fhv_contentOffsetDidChange];
 }
 
+- (void)trackingScrollViewDidChangeAdjustedContentInset:(UIScrollView *)trackingScrollView {
+  [self fhv_adjustTrackingScrollViewInsetsForTrackingScrollView:trackingScrollView];
+}
+
 - (void)trackingScrollViewDidEndDraggingWillDecelerate:(BOOL)willDecelerate {
   NSAssert(!self.observesTrackingScrollViewScrollEvents,
            @"Do not manually forward tracking scroll view events when"


### PR DESCRIPTION
Closes issue: https://github.com/material-components/material-components-ios/issues/6437

Change:
Allow flexible header to update insets when adjustedContentInset is changed on a tracking view that 
 is currently not being tracked.

Screenshot before change:
![fv3](https://user-images.githubusercontent.com/8836258/53745307-c8eee400-3e6c-11e9-9e9f-23233caea1de.gif)

Screenshot after change:
iPhone7+ (10.3.1)
![fv2](https://user-images.githubusercontent.com/8836258/53744858-dd7eac80-3e6b-11e9-8db8-ee4bdbe849a6.gif)

iPhoneX (12.0)
![fv1](https://user-images.githubusercontent.com/8836258/53744882-ef604f80-3e6b-11e9-967d-23e09fc42c43.gif)
