### PR TITLE
[BottomNavigation] Restore examples titles.

### DIFF
--- a/components/BottomNavigation/examples/BottomNavigationNilBadges.swift
+++ b/components/BottomNavigation/examples/BottomNavigationNilBadges.swift
@@ -24,6 +24,7 @@ class BottomNavigationNilBadges : UIViewController {
 
   init() {
     super.init(nibName: nil, bundle: nil)
+    self.title = "Bottom Navigation (Swift)"  
   }
 
   @available(*, unavailable)

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -32,6 +32,7 @@
 - (id)init {
   self = [super init];
   if (self) {
+    self.title = @"Bottom Navigation";
     _colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     _typographyScheme = [[MDCTypographyScheme alloc] init];


### PR DESCRIPTION
Examples titles were incorrectly removed in #6718.  Restoring those
titles. These mistakes weren't found because the original PR only
checked the Dragons app and not the Catalog.

Fixes #6867
