### PR TITLE
[TextFields] Add a Theming extension for MDCTextInputControllerFilled.

### DIFF
--- a/MaterialComponentsBeta.podspec
+++ b/MaterialComponentsBeta.podspec
@@ -227,6 +227,27 @@ Pod::Spec.new do |mdc|
     end
   end
 
+  mdc.subspec "TextFields+Theming" do |extension|
+    extension.ios.deployment_target = '8.0'
+    extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
+    extension.source_files = [
+      "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}",
+      "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
+    ]
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+ColorThemer"
+    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+TypographyThemer"
+    extension.dependency "MaterialComponentsBeta/schemes/Container"
+
+    extension.test_spec 'UnitTests' do |unit_tests|
+      unit_tests.source_files = [
+      "components/#{extension.base_name.split('+')[0]}/tests/unit/#{extension.base_name.split('+')[1]}/*.{h,m,swift}",
+      "components/#{extension.base_name.split('+')[0]}/tests/unit/#{extension.base_name.split('+')[1]}/supplemental/*.{h,m,swift}"
+      ]
+      unit_tests.resources = "components/#{extension.base_name.split('+')[0]}/tests/unit/#{extension.base_name.split('+')[1]}/resources/*"
+    end
+  end
+
   # Ripple
 
   mdc.subspec "Ripple" do |component|

--- a/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
+++ b/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
@@ -587,9 +587,19 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "41997BAA3EE99D8BDC1A3505F441336C"
+               BlueprintIdentifier = "032F1E326A2F5B54A52350BE13F3EC5C"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-SnapshotTests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-SnapshotTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F413A0F53D9A356F61C27680636F29DC"
+               BuildableName = "MaterialComponentsBeta-Unit-TextFields+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponentsBeta-Unit-TextFields+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/catalog/Podfile
+++ b/catalog/Podfile
@@ -69,6 +69,7 @@ target "MDCCatalog" do
     'Chips+Theming/UnitTests',
     'Dialogs+Theming/UnitTests',
     'Ripple/UnitTests',
+    'TextFields+Theming/UnitTests',
     'schemes/Container/UnitTests',
   ]
   pod 'MaterialComponentsSnapshotTests', :path => '../', :testspecs => [

--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -202,6 +202,7 @@ swift_library(
     deps = [
         ":ColorThemer",
         ":TextFields",
+        ":Theming",
         "//components/Palettes",
         "//components/private/Math",
     ],

--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -57,6 +57,16 @@ mdc_public_objc_library(
 )
 
 mdc_extension_objc_library(
+    name = "Theming",
+    deps = [
+        ":ColorThemer",
+        ":TextFields",
+        ":TypographyThemer",
+        "//components/schemes/Container",
+    ],
+)
+
+mdc_extension_objc_library(
     name = "ColorThemer",
     deps = [
         ":TextFields",
@@ -180,7 +190,10 @@ mdc_snapshot_test(
 
 swift_library(
     name = "unit_test_swift_sources",
-    srcs = glob(["tests/unit/*.swift"]),
+    srcs = glob([
+        "tests/unit/*.swift",
+        "tests/unit/Theming/*.swift"
+    ]),
     copts = [
         "-swift-version",
         "3",

--- a/components/TextFields/src/Theming/MDCTextInputControllerFilled+MaterialTheming.h
+++ b/components/TextFields/src/Theming/MDCTextInputControllerFilled+MaterialTheming.h
@@ -1,0 +1,33 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <MaterialComponents/MaterialTextFields.h>
+#import <MaterialComponentsBeta/MaterialContainerScheme.h>
+
+/**
+ This category is used to style MDCTextInputControllerFilled instances to a specific Material style
+ which can be found within the
+ [Material Guidelines](https://material.io/design/components/text-fields.html).
+ */
+@interface MDCTextInputControllerFilled (MaterialTheming)
+
+/**
+ Applies a container scheme to this instance.
+
+ @param scheme A container scheme instance containing any desired customizations to the theming
+ system.
+ */
+- (void)applyThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
+@end

--- a/components/TextFields/src/Theming/MDCTextInputControllerFilled+MaterialTheming.m
+++ b/components/TextFields/src/Theming/MDCTextInputControllerFilled+MaterialTheming.m
@@ -33,8 +33,7 @@
 }
 
 - (void)applyTypographyThemeWithScheme:(nonnull id<MDCTypographyScheming>)typographyScheme {
-  [MDCTextFieldTypographyThemer applyTypographyScheme:typographyScheme
-                                toTextInputController:self];
+  [MDCTextFieldTypographyThemer applyTypographyScheme:typographyScheme toTextInputController:self];
 }
 
 @end

--- a/components/TextFields/src/Theming/MDCTextInputControllerFilled+MaterialTheming.m
+++ b/components/TextFields/src/Theming/MDCTextInputControllerFilled+MaterialTheming.m
@@ -1,0 +1,40 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCTextInputControllerFilled+MaterialTheming.h"
+
+#import <MaterialComponents/MaterialTextFields+ColorThemer.h>
+#import <MaterialComponents/MaterialTextFields+TypographyThemer.h>
+
+@implementation MDCTextInputControllerFilled (MaterialTheming)
+
+- (void)applyThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme {
+  // Color
+  [self applyColorThemeWithScheme:scheme.colorScheme];
+
+  // Typography
+  [self applyTypographyThemeWithScheme:scheme.typographyScheme];
+}
+
+- (void)applyColorThemeWithScheme:(nonnull id<MDCColorScheming>)colorScheme {
+  [MDCFilledTextFieldColorThemer applySemanticColorScheme:colorScheme
+                              toTextInputControllerFilled:self];
+}
+
+- (void)applyTypographyThemeWithScheme:(nonnull id<MDCTypographyScheming>)typographyScheme {
+  [MDCTextFieldTypographyThemer applyTypographyScheme:typographyScheme
+                                toTextInputController:self];
+}
+
+@end

--- a/components/TextFields/src/Theming/MaterialTextFields+Theming.h
+++ b/components/TextFields/src/Theming/MaterialTextFields+Theming.h
@@ -1,0 +1,15 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCTextInputControllerFilled+MaterialTheming.h"

--- a/components/TextFields/tests/unit/Theming/TextFieldsMaterialThemingTests.swift
+++ b/components/TextFields/tests/unit/Theming/TextFieldsMaterialThemingTests.swift
@@ -1,0 +1,76 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+import MaterialComponents.MaterialTextFields
+import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialTypographyScheme
+import MaterialComponentsBeta.MaterialContainerScheme
+import MaterialComponentsBeta.MaterialTextFields_Theming
+
+class TextFieldsMaterialThemingTests: XCTestCase {
+
+  let filledActiveAlpha: CGFloat = 0.87
+  let filledOnSurfaceAlpha: CGFloat = 0.6
+  let filledDisabledAlpha: CGFloat = 0.38
+  let filledSurfaceOverlayAlpha: CGFloat = 0.04
+  let filledIndicatorLineAlpha: CGFloat = 0.42
+  let filledIconAlpha: CGFloat = 0.54
+
+  func testMDCTextInputControllerFilledThemingWithContainerScheme() {
+    // Given
+    let textFieldFilled = MDCTextField()
+    let textFieldControllerFilled = MDCTextInputControllerFilled(textInput: textFieldFilled)
+    let scheme: MDCContainerScheme = MDCContainerScheme()
+
+    // When
+    textFieldControllerFilled.applyTheme(withScheme: scheme)
+
+    // Then
+    // Color
+    XCTAssertEqual(textFieldControllerFilled.borderFillColor,
+                   scheme.colorScheme.onSurfaceColor.withAlphaComponent(filledSurfaceOverlayAlpha))
+    XCTAssertEqual(textFieldControllerFilled.normalColor,
+                   scheme.colorScheme.onSurfaceColor.withAlphaComponent(filledIndicatorLineAlpha))
+    XCTAssertEqual(textFieldControllerFilled.inlinePlaceholderColor,
+                   scheme.colorScheme.onSurfaceColor.withAlphaComponent(filledOnSurfaceAlpha))
+    XCTAssertEqual(textFieldControllerFilled.leadingUnderlineLabelTextColor,
+                   scheme.colorScheme.onSurfaceColor.withAlphaComponent(filledOnSurfaceAlpha))
+    XCTAssertEqual(textFieldControllerFilled.activeColor, scheme.colorScheme.primaryColor)
+    //XCTAssertEqual(textFieldControllerFilled.textInput.textColor,
+    //               scheme.colorScheme.onSurfaceColor.withAlphaComponent(filledActiveAlpha))
+    XCTAssertEqual(textFieldControllerFilled.errorColor, scheme.colorScheme.errorColor)
+    XCTAssertEqual(textFieldControllerFilled.disabledColor,
+                   scheme.colorScheme.onSurfaceColor.withAlphaComponent(filledDisabledAlpha))
+    XCTAssertEqual(textFieldControllerFilled.floatingPlaceholderNormalColor,
+                   scheme.colorScheme.onSurfaceColor.withAlphaComponent(filledOnSurfaceAlpha))
+    XCTAssertEqual(textFieldControllerFilled.floatingPlaceholderActiveColor,
+                   scheme.colorScheme.primaryColor.withAlphaComponent(filledActiveAlpha))
+    XCTAssertEqual(textFieldControllerFilled.textInputClearButtonTintColor,
+                   scheme.colorScheme.onSurfaceColor.withAlphaComponent(filledIconAlpha))
+
+    // Typography
+    XCTAssertEqual(textFieldControllerFilled.inlinePlaceholderFont,
+                   scheme.typographyScheme.subtitle1)
+    XCTAssertEqual(textFieldControllerFilled.leadingUnderlineLabelFont,
+                   scheme.typographyScheme.caption)
+    XCTAssertEqual(textFieldControllerFilled.trailingUnderlineLabelFont,
+                   scheme.typographyScheme.caption)
+    let placeholderScale: CGFloat =
+      scheme.typographyScheme.caption.pointSize / scheme.typographyScheme.subtitle1.pointSize
+    XCTAssertEqual(CGFloat(textFieldControllerFilled.floatingPlaceholderScale.doubleValue),
+                   placeholderScale)
+  }
+}


### PR DESCRIPTION
Includes support for theming MDCTextInputControllerFilled and tests of the behavior.

Part of https://github.com/material-components/material-components-ios/issues/6836