### PR TITLE
WIP - [ShadowLayer] Fix initWithLayer: copying by adding sublayers.

### DIFF
--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -120,8 +120,15 @@ static const float kAmbientShadowOpacity = (float)0.08;
       MDCShadowLayer *otherLayer = (MDCShadowLayer *)layer;
       _elevation = otherLayer.elevation;
       _shadowMaskEnabled = otherLayer.isShadowMaskEnabled;
+
       _bottomShadow = [[CAShapeLayer alloc] initWithLayer:otherLayer.bottomShadow];
+      _bottomShadow.delegate = self;
+      [self addSublayer:_bottomShadow];
+
       _topShadow = [[CAShapeLayer alloc] initWithLayer:otherLayer.topShadow];
+      _topShadow.delegate = self;
+      [self addSublayer:_topShadow];
+
       _topShadowMask = [[CAShapeLayer alloc] initWithLayer:otherLayer.topShadowMask];
       _bottomShadowMask = [[CAShapeLayer alloc] initWithLayer:otherLayer.bottomShadowMask];
       [self commonMDCShadowLayerInit];

--- a/components/ShadowLayer/tests/unit/ShadowLayerTests.m
+++ b/components/ShadowLayer/tests/unit/ShadowLayerTests.m
@@ -27,6 +27,18 @@
   // Then
   XCTAssertEqualWithAccuracy(shadowLayer.elevation, 0, 0.0001);
   XCTAssertTrue(shadowLayer.isShadowMaskEnabled);
+  XCTAssertGreaterThan(shadowLayer.sublayers.count, 0);
+}
+
+- (void)testInitWithLayerCopy {
+  // Given
+  MDCShadowLayer *shadowLayer = [[MDCShadowLayer alloc] init];
+  MDCShadowLayer *copyShadowLayer = [[MDCShadowLayer alloc] initWithLayer:shadowLayer];
+
+  // Then
+  XCTAssertEqualWithAccuracy(copyShadowLayer.elevation, shadowLayer.elevation, 0.0001);
+  XCTAssertEqual(copyShadowLayer.isShadowMaskEnabled, shadowLayer.isShadowMaskEnabled);
+  XCTAssertEqual(copyShadowLayer.sublayers.count, shadowLayer.sublayers.count);
 }
 
 @end


### PR DESCRIPTION
Fixes the copy initWithLayer: initializer by adding the copied top and bottom shadow layers as sublayers.

The sublayers would never be added and a shadow would never appear. Also sets the delegate == self as per similar code in commonMDCShadowLayerInit.