### PR TITLE
[private] Include snapshot tests in examples in Podspec

### DIFF
--- a/MaterialComponentsSnapshotTests.podspec
+++ b/MaterialComponentsSnapshotTests.podspec
@@ -61,6 +61,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'MaterialComponents'
   s.dependency 'MaterialComponentsBeta'
+  s.dependency 'MaterialComponentsExamples'
 
   # Top level sources are required. Without them, unit test targets do not show up in Xcode.
   # However, no top level sources can import iOSSnapshotTestCase, otherwise the app will crash on

--- a/MaterialComponentsSnapshotTests.podspec
+++ b/MaterialComponentsSnapshotTests.podspec
@@ -12,9 +12,10 @@ module SnapshotPodspecHelper
 
     def default_source_files
       if @name.present?
-        source_files = Dir["components/#{@name}/**/tests/snapshot/*.{h,m,swift}"]
-        supplemental_files = Dir["components/#{@name}/**/tests/snapshot/supplemental/*.{h,m,swift}"]
-        return source_files + supplemental_files
+        source_files = Dir["components/#{@name}/tests/snapshot/*.{h,m,swift}"]
+        supplemental_files = Dir["components/#{@name}/tests/snapshot/supplemental/*.{h,m,swift}"]
+        example_files = Dir["components/#{@name}/examples/tests/snapshot/supplemental/*.{h,m,swift}"]
+        return source_files + supplemental_files + example_files
       end
       return []
     end

--- a/MaterialComponentsSnapshotTests.podspec
+++ b/MaterialComponentsSnapshotTests.podspec
@@ -14,7 +14,7 @@ module SnapshotPodspecHelper
       if @name.present?
         source_files = Dir["components/#{@name}/tests/snapshot/*.{h,m,swift}"]
         supplemental_files = Dir["components/#{@name}/tests/snapshot/supplemental/*.{h,m,swift}"]
-        example_files = Dir["components/#{@name}/examples/tests/snapshot/supplemental/*.{h,m,swift}"]
+        example_files = Dir["components/#{@name}/examples/tests/snapshot/*.{h,m,swift}"]
         return source_files + supplemental_files + example_files
       end
       return []

--- a/MaterialComponentsSnapshotTests.podspec
+++ b/MaterialComponentsSnapshotTests.podspec
@@ -12,10 +12,9 @@ module SnapshotPodspecHelper
 
     def default_source_files
       if @name.present?
-        return [
-          "components/#{@name}/tests/snapshot/*.{h,m,swift}",
-          "components/#{@name}/tests/snapshot/supplemental/*.{h,m,swift}",
-        ]
+        source_files = Dir["components/#{@name}/**/tests/snapshot/*.{h,m,swift}"]
+        supplemental_files = Dir["components/#{@name}/**/tests/snapshot/supplemental/*.{h,m,swift}"]
+        return source_files + supplemental_files
       end
       return []
     end
@@ -45,7 +44,7 @@ module SnapshotPodspecHelper
 
   def self.components
     return Dir["components/**/tests/snapshot"].map { |dir|
-      dir = Component.new(dir.split(File::SEPARATOR)[-3])
+      dir = Component.new(dir.split(File::SEPARATOR)[1])
     }
   end
 end

--- a/components/private/Snapshot/BUILD
+++ b/components/private/Snapshot/BUILD
@@ -17,6 +17,7 @@ load(
     "mdc_objc_library",
     "mdc_public_objc_library",
 )
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -28,10 +29,20 @@ mdc_objc_library(
     ]),
 )
 
+swift_library(
+    name = "SnapshotSwiftLib",
+    srcs = glob(["src/*.swift"]),
+    copts = [
+        "-swift-version",
+        "3",
+    ],
+)
+
 mdc_public_objc_library(
     name = "Snapshot",
     deps = [
         "@ios_snapshot_test_case//:SnapshotTestCase",
         ":SnapshotSourceDummies",
+        ":SnapshotSwiftLib",
     ],
 )

--- a/components/private/Snapshot/src/MDCSnapshotDummy.swift
+++ b/components/private/Snapshot/src/MDCSnapshotDummy.swift
@@ -1,0 +1,13 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.


### PR DESCRIPTION
Part of work to unblock #6840.

We don't support adding tests under examples directory right now. But adding snapshot tests for Alpha components (Banner, TextField, ChipTextField..) is good for development, and making those tests live under examples is reasonable. 

- Added example tests into test spec source files.
- Added a dummy file into test spec to make sure swift runtime are linked correctly when XCode compiles.