### PR TITLE
[Tabs] Do not truncate badge text on MDCItemBarCell

### DIFF
--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -33,10 +33,6 @@ static const CGFloat kBadgeFontSize = 12;
 /// Padding between top of the cell and the badge.
 static const CGFloat kBadgeTopPadding = 6;
 
-/// Maximum badge text character length. Badge text longer than this number of characters will
-/// truncate.
-static const NSUInteger kBadgeMaxTextComposedCharacterLength = 4;
-
 /// Outer edge padding from spec: https://material.io/go/design-tabs#spec.
 static const UIEdgeInsets kEdgeInsets = {.top = 0, .right = 16, .bottom = 0, .left = 16};
 
@@ -588,24 +584,11 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3;
     return CGSizeZero;
   }
 
-  NSMutableString *longestAllowableBadgeString = [[NSMutableString alloc] init];
-  __block NSUInteger composedCharacterIndex = 0;
-  [string enumerateSubstringsInRange:NSMakeRange(0, string.length)
-                             options:NSStringEnumerationByComposedCharacterSequences
-                          usingBlock:^(NSString *substring, NSRange substringRange,
-                                       NSRange enclosingRange, BOOL *stop) {
-                            [longestAllowableBadgeString appendString:substring];
-                            composedCharacterIndex++;
-                            if (composedCharacterIndex == kBadgeMaxTextComposedCharacterLength) {
-                              *stop = YES;
-                            }
-                          }];
-
   CGRect largestAllowableBadgeRect =
-      [[longestAllowableBadgeString copy] boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)
-                                                       options:NSStringDrawingUsesLineFragmentOrigin
-                                                    attributes:@{NSFontAttributeName : font}
-                                                       context:nil];
+      [string boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)
+                           options:NSStringDrawingUsesLineFragmentOrigin
+                        attributes:@{NSFontAttributeName : font}
+                           context:nil];
   return largestAllowableBadgeRect.size;
 }
 

--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -584,12 +584,10 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3;
     return CGSizeZero;
   }
 
-  CGRect largestAllowableBadgeRect =
-      [string boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)
-                           options:NSStringDrawingUsesLineFragmentOrigin
-                        attributes:@{NSFontAttributeName : font}
-                           context:nil];
-  return largestAllowableBadgeRect.size;
+  return [string boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)
+                              options:NSStringDrawingUsesLineFragmentOrigin
+                           attributes:@{NSFontAttributeName : font}
+                              context:nil].size;
 }
 
 @end

--- a/components/Tabs/src/private/MDCItemBarCell.m
+++ b/components/Tabs/src/private/MDCItemBarCell.m
@@ -587,7 +587,8 @@ static const NSTimeInterval kSelectionAnimationDuration = 0.3;
   return [string boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)
                               options:NSStringDrawingUsesLineFragmentOrigin
                            attributes:@{NSFontAttributeName : font}
-                              context:nil].size;
+                              context:nil]
+      .size;
 }
 
 @end


### PR DESCRIPTION
Following https://github.com/material-components/material-components-ios/pull/6786 @romoore said that Tabs shouldn't limit badge text. This PR makes it so that badge text does not truncate. Here is a screenshot:

![Simulator Screen Shot - iPhone X - 2019-03-15 at 17 02 01](https://user-images.githubusercontent.com/8020010/54462042-c5007300-4744-11e9-8645-ad59fe217672.png)

Closes #6915.