### PR TITLE
[Buttons] Fix `accessibilityTraits` in init.

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -153,7 +153,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   _borderWidths = [NSMutableDictionary dictionary];
   _fonts = [NSMutableDictionary dictionary];
   _accessibilityTraitsIncludesButton = YES;
-  [super setAccessibilityTraits:[super accessibilityTraits] | UIAccessibilityTraitButton];
 
   if (!_backgroundColors) {
     // _backgroundColors may have already been initialized by setting the backgroundColor setter.

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -1086,11 +1086,17 @@ static NSString *controlStateDescription(UIControlState controlState) {
 }
 
 - (void)testAccessibilityTraitsDefaultIncludesButtonExplicitlyFalse {
+  // Given
+  UIButton *referenceButton = [[UIButton alloc] init];
+  [referenceButton setTitle:@"title" forState:UIControlStateNormal];
+
   // When
   self.button.accessibilityTraitsIncludesButton = NO;
 
   // Then
-  XCTAssertEqual(self.button.accessibilityTraits, UIAccessibilityTraitButton);
+  // UIButton does not return `.button` in unit tests, but will in a simulator. The best this test
+  // can do is confirm the behavior matches UIButton.
+  XCTAssertEqual(self.button.accessibilityTraits, referenceButton.accessibilityTraits);
 }
 
 - (void)testSetAccessibilityTraitsIncludesButtonByDefault {


### PR DESCRIPTION
In #6766, MDCButton was updated to allow removing the `.button`
accessibility trait value. The implementation had a bug, however, and
assigned a value to the superclass' value for `accessibilityTraits` in
initialization. This apparently causes UIButton to stop updating its
value for `accessibilityTraits` and it will only return the assigned
value.

This behavior cannot be detected in unit tests, and so the test coverage
was insufficient. Manual testing with the Accessibility Inspector in a
simulator demonstrates the bug and that this change results in a fix
while retaining the ability to set the traits value explicitly if
desired.

Fixes #6944
Follow-up to #6766
