### PR TITLE
[Beta] Point main pod to github/develop

### DIFF
--- a/contributing/beta_components.md
+++ b/contributing/beta_components.md
@@ -14,7 +14,11 @@ any other.
 From the point of view of the public, Beta components are not made available as part of our
 published pod. External clients that wish to use an Beta component in their Podfile will need to
 manually specify the MaterialComponentsBeta target and our repo.
+
+Because the Beta components are pointing to the `HEAD` of the `develop` branch, you need to also update your MaterialComponents pod to point to `develop` as well.
+
 ```
+   pod 'MaterialComponents', :git => 'https://github.com/material-components/material-components-ios.git', :branch => 'develop'
    pod 'MaterialComponentsBeta', :git => 'https://github.com/material-components/material-components-ios.git'
 ```
 When the component graduates to "Ready" clients will need to change their specs to point at the main pod.


### PR DESCRIPTION
Our Beta instructions failed to have clients point the `MaterialComponents` pod target at the `develop` branch of our Git repository.  This often results in a mismatch in code found in `develop` (for Beta) and `stable` (for the released versions).

Addresses issues seen in #6949 