### PR TITLE
[Docs] Make bazel installer explicit

### DIFF
--- a/contributing/bazel_kokoro.md
+++ b/contributing/bazel_kokoro.md
@@ -10,7 +10,7 @@ script is the `.kokoro` script in the root of the repo.
 
 ## Running kokoro presubmits locally
 
-First, ensure that you have [installed bazel](https://docs.bazel.build/versions/master/install-os-x.html)
+First, ensure that you have [installed bazel 0.20](https://docs.bazel.build/versions/master/install-os-x.html#install-with-installer-mac-os-x) using the binary installer (not Homebrew)
 and at least one version of Xcode.
 
 Run the following command from the root of your MDC-iOS repo to run the presubmits:


### PR DESCRIPTION
Brew is not a good option for bazel installs since it doesn't allow downgrading versions. We only support 0.20 at the moment, so clients should use the specific installer script for 0.20.

