### PR TITLE
[AppBar] Refactor AppBar example table views

### DIFF
--- a/components/AppBar/examples/AppBarAnimatedGlitchExample.swift
+++ b/components/AppBar/examples/AppBarAnimatedGlitchExample.swift
@@ -31,11 +31,11 @@ class AppBarAnimatedJumpExample: UIViewController {
   var typographyScheme = MDCTypographyScheme()
 
   fileprivate let tabs = [
-    SimpleTableViewController(title: "First"),
-    SimpleTableViewController(title: "Second"),
-    SimpleTableViewController(title: "Third"),
+    SimpleComposedTableViewController(title: "First"),
+    SimpleComposedTableViewController(title: "Second"),
+    SimpleComposedTableViewController(title: "Third"),
   ]
-  private var currentTab: SimpleTableViewController? = nil
+  private var currentTab: SimpleComposedTableViewController? = nil
 
   lazy var tabBar: MDCTabBar = {
     let tabBar = MDCTabBar()
@@ -82,7 +82,7 @@ class AppBarAnimatedJumpExample: UIViewController {
     switchToTab(tabs[0], animated: false)
   }
 
-  fileprivate func switchToTab(_ tab: SimpleTableViewController, animated: Bool = true) {
+  fileprivate func switchToTab(_ tab: SimpleComposedTableViewController, animated: Bool = true) {
 
     appBarViewController.headerView.trackingScrollWillChange(toScroll: tab.tableView)
 
@@ -204,81 +204,3 @@ extension AppBarAnimatedJumpExample {
   }
 }
 
-fileprivate class SimpleTableViewController: UIViewController {
-
-  init(title: String) {
-    super.init(nibName: nil, bundle: nil)
-    self.title = title
-  }
-
-  required init?(coder aDecoder: NSCoder) {
-    fatalError("NSCoding unsupported")
-  }
-
-  var tableView = UITableView(frame: CGRect(), style: .plain)
-
-  var headerView: MDCFlexibleHeaderView?
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-
-    self.view.addSubview(tableView)
-    self.tableView.frame = self.view.bounds
-
-    tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
-    tableView.delegate = self
-    tableView.dataSource = self
-
-    view.isOpaque = false
-    view.backgroundColor = .white
-  }
-}
-
-extension SimpleTableViewController: UITableViewDataSource {
-
-  func numberOfSections(in tableView: UITableView) -> Int {
-    return 1
-  }
-
-  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return 100
-  }
-}
-
-extension SimpleTableViewController: UITableViewDelegate {
-
-  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
-    let titleString = title ?? ""
-    cell.textLabel?.text = "\(titleString): Row \(indexPath.item)"
-    return cell
-  }
-
-  func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    headerView?.trackingScrollDidScroll()
-  }
-
-  func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-    headerView?.trackingScrollDidEndDecelerating()
-  }
-
-  func scrollViewWillEndDragging(
-    _ scrollView: UIScrollView,
-    withVelocity velocity: CGPoint,
-    targetContentOffset: UnsafeMutablePointer<CGPoint>
-  ) {
-    headerView?.trackingScrollWillEndDragging(
-      withVelocity: velocity,
-      targetContentOffset: targetContentOffset)
-  }
-
-  func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-    headerView?.trackingScrollDidEndDraggingWillDecelerate(decelerate)
-  }
-
-  func scrollViewDidChangeAdjustedContentInset(_ scrollView: UIScrollView) {
-    if #available(iOS 11.0, *) {
-      headerView?.trackingScrollDidChangeAdjustedContentInset(scrollView)
-    }
-  }
-}

--- a/components/AppBar/examples/AppBarGlitchExample.swift
+++ b/components/AppBar/examples/AppBarGlitchExample.swift
@@ -30,9 +30,9 @@ class AppBarJumpExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()
   var typographyScheme = MDCTypographyScheme()
 
-  fileprivate let firstTab = SimpleTableViewController()
-  fileprivate let secondTab = SimpleTableViewController()
-  private var currentTab: SimpleTableViewController? = nil
+  fileprivate let firstTab = SimpleComposedTableViewController()
+  fileprivate let secondTab = SimpleComposedTableViewController()
+  private var currentTab: SimpleComposedTableViewController? = nil
 
   lazy var tabBar: MDCTabBar = {
     let tabBar = MDCTabBar()
@@ -78,7 +78,7 @@ class AppBarJumpExample: UIViewController {
     switchToTab(firstTab)
   }
 
-  fileprivate func switchToTab(_ tab: SimpleTableViewController) {
+  fileprivate func switchToTab(_ tab: SimpleComposedTableViewController) {
 
     appBarViewController.headerView.trackingScrollWillChange(toScroll: tab.tableView)
 
@@ -169,57 +169,3 @@ extension AppBarJumpExample {
   }
 }
 
-fileprivate class SimpleTableViewController: UIViewController {
-
-  var tableView = UITableView(frame: CGRect(), style: .plain)
-
-  var headerView: MDCFlexibleHeaderView?
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-
-    self.view.addSubview(tableView)
-    self.tableView.frame = self.view.bounds
-
-    tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
-    tableView.delegate = self
-    tableView.dataSource = self
-  }
-}
-
-extension SimpleTableViewController: UITableViewDataSource {
-
-  func numberOfSections(in tableView: UITableView) -> Int {
-    return 1
-  }
-
-  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return 100
-  }
-}
-
-extension SimpleTableViewController: UITableViewDelegate {
-
-  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
-    let titleString = title ?? ""
-    cell.textLabel?.text = "\(titleString): Row \(indexPath.item)"
-    return cell
-  }
-
-  func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    headerView?.trackingScrollDidScroll()
-  }
-
-  func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-    headerView?.trackingScrollDidEndDecelerating()
-  }
-
-  func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-    headerView?.trackingScrollWillEndDragging(withVelocity: velocity, targetContentOffset: targetContentOffset)
-  }
-
-  func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-    headerView?.trackingScrollDidEndDraggingWillDecelerate(decelerate)
-  }
-}

--- a/components/AppBar/examples/AppBarManualTabsExample.swift
+++ b/components/AppBar/examples/AppBarManualTabsExample.swift
@@ -34,9 +34,9 @@ class AppBarManualTabsExample: UIViewController {
   var colorScheme = MDCSemanticColorScheme()
   var typographyScheme = MDCTypographyScheme()
 
-  fileprivate let firstTab = SimpleTableViewController()
-  fileprivate let secondTab = SimpleTableViewController()
-  private var currentTab: SimpleTableViewController? = nil
+  fileprivate let firstTab = SimpleInheritedTableViewController()
+  fileprivate let secondTab = SimpleInheritedTableViewController()
+  private var currentTab: SimpleInheritedTableViewController? = nil
 
   lazy var tabBar: MDCTabBar = {
     let tabBar = MDCTabBar()
@@ -82,7 +82,7 @@ class AppBarManualTabsExample: UIViewController {
     switchToTab(firstTab)
   }
 
-  fileprivate func switchToTab(_ tab: SimpleTableViewController) {
+  fileprivate func switchToTab(_ tab: SimpleInheritedTableViewController) {
     appBarViewController.headerView.trackingScrollWillChange(toScroll: tab.tableView)
 
     if let currentTab = currentTab {
@@ -170,49 +170,5 @@ extension AppBarManualTabsExample {
 
   func catalogShouldHideNavigation() -> Bool {
     return true
-  }
-}
-
-private class SimpleTableViewController: UITableViewController {
-
-  var headerView: MDCFlexibleHeaderView?
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-
-    tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
-    tableView.delegate = self
-    tableView.dataSource = self
-  }
-
-  override func numberOfSections(in tableView: UITableView) -> Int {
-    return 1
-  }
-
-  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return 100
-  }
-
-  override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
-    let titleString = title ?? ""
-    cell.textLabel?.text = "\(titleString): Row \(indexPath.item)"
-    return cell
-  }
-
-  override func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    headerView?.trackingScrollDidScroll()
-  }
-
-  override func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-    headerView?.trackingScrollDidEndDecelerating()
-  }
-
-  override func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-    headerView?.trackingScrollWillEndDragging(withVelocity: velocity, targetContentOffset: targetContentOffset)
-  }
-
-  override func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-    headerView?.trackingScrollDidEndDraggingWillDecelerate(decelerate)
   }
 }

--- a/components/AppBar/examples/supplemental/SimpleComposedTableViewController.swift
+++ b/components/AppBar/examples/supplemental/SimpleComposedTableViewController.swift
@@ -1,0 +1,83 @@
+/// A simple table view controller which is manually composed.
+///
+/// This view controller is meaningfully *not* a subclass of UITableViewController and its view is
+/// not a UIScrollView subclass. This avoids logic which might attempt to be smart by detecting
+/// these cases.
+class SimpleComposedTableViewController: UIViewController {
+
+  init(title: String? = nil) {
+    super.init(nibName: nil, bundle: nil)
+    self.title = title
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("NSCoding unsupported")
+  }
+
+  var tableView = UITableView(frame: CGRect(), style: .plain)
+
+  var headerView: MDCFlexibleHeaderView?
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    self.view.addSubview(tableView)
+    self.tableView.frame = self.view.bounds
+
+    tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
+    tableView.delegate = self
+    tableView.dataSource = self
+
+    view.isOpaque = false
+    view.backgroundColor = .white
+  }
+}
+
+extension SimpleComposedTableViewController: UITableViewDataSource {
+
+  func numberOfSections(in tableView: UITableView) -> Int {
+    return 1
+  }
+
+  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return 100
+  }
+}
+
+extension SimpleComposedTableViewController: UITableViewDelegate {
+
+  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
+    let titleString = title ?? ""
+    cell.textLabel?.text = "\(titleString): Row \(indexPath.item)"
+    return cell
+  }
+
+  func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    headerView?.trackingScrollDidScroll()
+  }
+
+  func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+    headerView?.trackingScrollDidEndDecelerating()
+  }
+
+  func scrollViewWillEndDragging(
+    _ scrollView: UIScrollView,
+    withVelocity velocity: CGPoint,
+    targetContentOffset: UnsafeMutablePointer<CGPoint>
+  ) {
+    headerView?.trackingScrollWillEndDragging(
+      withVelocity: velocity,
+      targetContentOffset: targetContentOffset)
+  }
+
+  func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+    headerView?.trackingScrollDidEndDraggingWillDecelerate(decelerate)
+  }
+
+  func scrollViewDidChangeAdjustedContentInset(_ scrollView: UIScrollView) {
+    if #available(iOS 11.0, *) {
+      headerView?.trackingScrollDidChangeAdjustedContentInset(scrollView)
+    }
+  }
+}

--- a/components/AppBar/examples/supplemental/SimpleComposedTableViewController.swift
+++ b/components/AppBar/examples/supplemental/SimpleComposedTableViewController.swift
@@ -1,3 +1,20 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+import MaterialComponents.MaterialFlexibleHeader
+
 /// A simple table view controller which is manually composed.
 ///
 /// This view controller is meaningfully *not* a subclass of UITableViewController and its view is

--- a/components/AppBar/examples/supplemental/SimpleInheritedTableViewController.swift
+++ b/components/AppBar/examples/supplemental/SimpleInheritedTableViewController.swift
@@ -1,3 +1,20 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+import MaterialComponents.MaterialFlexibleHeader
+
 /// A table view controller which inherits directly from UITableViewController.
 ///
 /// This intentionally sets things up such that its view is a subclass of UIScrollView, which is

--- a/components/AppBar/examples/supplemental/SimpleInheritedTableViewController.swift
+++ b/components/AppBar/examples/supplemental/SimpleInheritedTableViewController.swift
@@ -1,0 +1,68 @@
+/// A table view controller which inherits directly from UITableViewController.
+///
+/// This intentionally sets things up such that its view is a subclass of UIScrollView, which is
+/// handled specially by some components.
+class SimpleInheritedTableViewController: UITableViewController {
+
+  init(title: String? = nil) {
+    super.init(nibName: nil, bundle: nil)
+    self.title = title
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("NSCoding unsupported")
+  }
+
+  var headerView: MDCFlexibleHeaderView?
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
+    tableView.delegate = self
+    tableView.dataSource = self
+  }
+
+  override func numberOfSections(in tableView: UITableView) -> Int {
+    return 1
+  }
+
+  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return 100
+  }
+
+  override func tableView(
+    _ tableView: UITableView,
+    cellForRowAt indexPath: IndexPath
+  ) -> UITableViewCell {
+    let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
+    let titleString = title ?? ""
+    cell.textLabel?.text = "\(titleString): Row \(indexPath.item)"
+    return cell
+  }
+
+  override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    headerView?.trackingScrollDidScroll()
+  }
+
+  override func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+    headerView?.trackingScrollDidEndDecelerating()
+  }
+
+  override func scrollViewWillEndDragging(
+    _ scrollView: UIScrollView,
+    withVelocity velocity: CGPoint,
+    targetContentOffset: UnsafeMutablePointer<CGPoint>
+  ) {
+    headerView?.trackingScrollWillEndDragging(
+      withVelocity: velocity,
+      targetContentOffset: targetContentOffset)
+  }
+
+  override func scrollViewDidEndDragging(
+    _ scrollView: UIScrollView,
+    willDecelerate decelerate: Bool
+  ) {
+    headerView?.trackingScrollDidEndDraggingWillDecelerate(decelerate)
+  }
+}


### PR DESCRIPTION
This refactors the "simple" example table view controllers used in a bunch of these examples into two types: a "composed" one which creates its own table view and an "inherited" one which subclasses UITableViewController. They behave differently, so this makes that explicit and also reduces some code duplication.