### PR TITLE
[Ripple] Remove manipulation of clipping for the ripple's superview

### DIFF
--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -82,12 +82,9 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
     if (self.superview.layer.shadowPath) {
       self.maskLayer.path = self.superview.layer.shadowPath;
       self.layer.mask = _maskLayer;
-    } else {
-      self.superview.clipsToBounds = YES;
     }
   } else {
     self.layer.mask = nil;
-    self.superview.clipsToBounds = NO;
   }
 }
 

--- a/components/Ripple/src/private/MDCRippleLayer.m
+++ b/components/Ripple/src/private/MDCRippleLayer.m
@@ -164,6 +164,8 @@ static NSString *const kRippleLayerScaleString = @"transform.scale";
   fadeOutAnim.beginTime = [self convertTime:_rippleTouchDownStartTime + delay fromLayer:nil];
   fadeOutAnim.timingFunction =
       [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
+  fadeOutAnim.fillMode = kCAFillModeForwards;
+  fadeOutAnim.removedOnCompletion = NO;
   [CATransaction setCompletionBlock:^{
     if (completion) {
       completion();


### PR DESCRIPTION
Our MDCRippleView during its layout stage checks if its superview has a shadowPath and if so masks the RippleView to that path, which is correct.

However, when there isn't a shaowPath it clips the superview to bounds. There are two problems with this:
1. There can still be a shadow if the shadowPath is nil, and therefore will hide the shadow.
2. The ripple view should refrain from manipulating views outside its jurisdiction, and the user should change the clipping of bounds appropriately if needed.

The fix is to remove the manipulation of the clipping to bounds from MDCRippleView.

Resolves #6979