### PR TITLE
[Ripple] Adds additional API of adding the Ripple to a view and its position in the view hierarchy.

### DIFF
--- a/MDCRippleTouchControllerTests.m
+++ b/MDCRippleTouchControllerTests.m
@@ -1,0 +1,80 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MDCRippleLayer.h"
+#import "MaterialRipple.h"
+
+//@interface FakeMDCRippleViewAnimationDelegate : NSObject <MDCRippleViewDelegate>
+//@property(nonatomic, strong) MDCRippleView *rippleView;
+//@property(nonatomic, assign) BOOL rippleTouchDownDidBegin;
+//@property(nonatomic, assign) BOOL rippleTouchDownDidEnd;
+//@property(nonatomic, assign) BOOL rippleTouchUpDidBegin;
+//@property(nonatomic, assign) BOOL rippleTouchUpDidEnd;
+//
+//@end
+
+#pragma mark - Tests
+
+@interface MDCRippleTouchControllerTests : XCTestCase
+
+@end
+
+@implementation MDCRippleTouchControllerTests
+
+- (void)testInit {
+  // Given
+  MDCRippleTouchController *touchController = [[MDCRippleTouchController alloc] init];
+
+  // Then
+  XCTAssertNil(touchController.view);
+  XCTAssertNotNil(touchController.rippleView);
+  XCTAssertTrue(touchController.shouldProcessRippleWithScrollViewGestures);
+  XCTAssertNotNil(touchController.gestureRecognizer);
+}
+
+- (void)testInitWithView {
+  // Given
+  UIView *parentView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+  MDCRippleTouchController *touchController =
+      [[MDCRippleTouchController alloc] initWithView:parentView];
+
+  // Then
+  XCTAssertEqualObjects(parentView, touchController.view);
+  XCTAssertNotNil(touchController.rippleView);
+  XCTAssertEqualObjects(touchController.rippleView.superview, parentView);
+  XCTAssertTrue(touchController.shouldProcessRippleWithScrollViewGestures);
+  XCTAssertNotNil(touchController.gestureRecognizer);
+  XCTAssertTrue(CGRectEqualToRect(touchController.rippleView.frame, parentView.bounds));
+}
+
+- (void)testAddRippleToView {
+  // Given
+  UIView *parentView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+  MDCRippleTouchController *touchController = [[MDCRippleTouchController alloc] init];
+
+  // When
+  [touchController addRippleToView:parentView];
+
+  // Then
+  XCTAssertEqualObjects(parentView, touchController.view);
+  XCTAssertNotNil(touchController.rippleView);
+  XCTAssertEqualObjects(touchController.rippleView.superview, parentView);
+  XCTAssertTrue(touchController.shouldProcessRippleWithScrollViewGestures);
+  XCTAssertNotNil(touchController.gestureRecognizer);
+  XCTAssertTrue(CGRectEqualToRect(touchController.rippleView.frame, parentView.bounds));
+}
+
+@end

--- a/components/Ripple/src/MDCRippleTouchController.h
+++ b/components/Ripple/src/MDCRippleTouchController.h
@@ -128,7 +128,7 @@
               atTouchLocation:(CGPoint)location;
 
 /**
- Inserts the ripple view into the given view.
+ Provides an opportunity to add the rippleView anywhere in the given view's hierarchy.
 
  If this method is not implemented, the ripple view is added as a subview of the given view provided
  in the controller's `addRippleToView:` method or convenience initializer `initWithView:`.

--- a/components/Ripple/src/MDCRippleTouchController.h
+++ b/components/Ripple/src/MDCRippleTouchController.h
@@ -56,31 +56,23 @@
 @property(nonatomic, assign) BOOL shouldProcessRippleWithScrollViewGestures;
 
 /**
- Initializes the controller.
-
- @param view The view that responds to the touch events for the ripple, and the view which the
- ripple is added as a subview to.
- */
-
-/**
  Initializes the controller and adds the initialized ripple view as a subview of the provided view.
 
  Note: When using this initializer, calling `addRippleToView:` isn't needed.
 
- @param view The view that responds to the touch events for the ripple, and the view which the
- ripple is added as a subview to.
- @return a MDCRippleTouchController instance.
+ @param view The view that responds to the touch events for the ripple. The ripple
+ is added to it as a subview.
+ @return an MDCRippleTouchController instance.
  */
 - (nonnull instancetype)initWithView:(nonnull UIView *)view;
 
 /**
  Initializes the controller.
 
- Note: To effectively use the controller a call to `addRippleToView` is needed to provide a view
- that will respond to the touch events for the ripple, and to which the ripple is added as a
- subview to.
+ Note: To effectively use the controller a call to `addRippleToView:` is needed to provide a view
+ that responds to the touch events for the ripple. The ripple is added to the view as a subview.
 
- @return a MDCRippleTouchController instance.
+ @return an MDCRippleTouchController instance.
  */
 - (nonnull instancetype)init;
 
@@ -91,8 +83,8 @@
  Note: This needs to be called if using the `init` initialized rather than the `initWithView:`
  initializer.
 
- @param view The view that responds to the touch events for the ripple, and the view which the
- ripple is added as a subview to.
+ @param view The view that responds to the touch events for the ripple. The ripple
+ is added to it as a subview.
  */
 - (void)addRippleToView:(nonnull UIView *)view;
 
@@ -147,7 +139,7 @@
  @param view The view to add the ripple view to.
  */
 - (void)rippleTouchController:(nonnull MDCRippleTouchController *)rippleTouchController
-             insertRippleView:(nonnull UIView *)rippleView
+             insertRippleView:(nonnull MDCRippleView *)rippleView
                      intoView:(nonnull UIView *)view;
 
 @end

--- a/components/Ripple/src/MDCRippleTouchController.h
+++ b/components/Ripple/src/MDCRippleTouchController.h
@@ -56,17 +56,47 @@
 @property(nonatomic, assign) BOOL shouldProcessRippleWithScrollViewGestures;
 
 /**
- Unavailable, please use `initWithView` instead.
- */
-- (nonnull instancetype)init NS_UNAVAILABLE;
-
-/**
  Initializes the controller.
 
  @param view The view that responds to the touch events for the ripple, and the view which the
  ripple is added as a subview to.
  */
-- (nonnull instancetype)initWithView:(nonnull UIView *)view NS_DESIGNATED_INITIALIZER;
+
+/**
+ Initializes the controller and adds the initialized ripple view as a subview of the provided view.
+
+ Note: When using this initializer, calling `addRippleToView:` isn't needed.
+
+ @param view The view that responds to the touch events for the ripple, and the view which the
+ ripple is added as a subview to.
+ @return a MDCRippleTouchController instance.
+ */
+- (nonnull instancetype)initWithView:(nonnull UIView *)view;
+
+
+/**
+ Initializes the controller.
+
+ Note: To effectively use the controller a call to `addRippleToView` is needed to provide a view
+ that will respond to the touch events for the ripple, and to which the ripple is added as a
+ subview to.
+
+ @return a MDCRippleTouchController instance.
+ */
+- (nonnull instancetype)init;
+
+
+/**
+ Adds the ripple view as a subview to the provided view, and adds the ripple's gesture recognizer
+ to it.
+
+ Note: This needs to be called if using the `init` initialized rather than the `initWithView:`
+ initializer.
+
+ @param view The view that responds to the touch events for the ripple, and the view which the
+ ripple is added as a subview to.
+ */
+- (void)addRippleToView:(nonnull UIView *)view;
 
 @end
 
@@ -106,5 +136,20 @@
 - (void)rippleTouchController:(nonnull MDCRippleTouchController *)rippleTouchController
          didProcessRippleView:(nonnull MDCRippleView *)rippleView
               atTouchLocation:(CGPoint)location;
+
+/**
+ Inserts the ripple view into the given view.
+
+ If this method is not implemented, the ripple view is added as a subview of the given view provided
+ in the controller's `addRippleToView:` method or convenience initializer `initWithView:`.
+ Delegates can choose to insert the ripple view anywhere in the view hierarchy.
+
+ @param rippleTouchController The ripple touch controller.
+ @param rippleView The ripple view.
+ @param view The view to add the ripple view to.
+ */
+- (void)rippleTouchController:(nonnull MDCRippleTouchController *)rippleTouchController
+             insertRippleView:(nonnull UIView *)rippleView
+                     intoView:(nonnull UIView *)view;
 
 @end

--- a/components/Ripple/src/MDCRippleTouchController.h
+++ b/components/Ripple/src/MDCRippleTouchController.h
@@ -73,7 +73,6 @@
  */
 - (nonnull instancetype)initWithView:(nonnull UIView *)view;
 
-
 /**
  Initializes the controller.
 
@@ -84,7 +83,6 @@
  @return a MDCRippleTouchController instance.
  */
 - (nonnull instancetype)init;
-
 
 /**
  Adds the ripple view as a subview to the provided view, and adds the ripple's gesture recognizer

--- a/components/Ripple/src/MDCRippleTouchController.h
+++ b/components/Ripple/src/MDCRippleTouchController.h
@@ -136,7 +136,7 @@
 
  @param rippleTouchController The ripple touch controller.
  @param rippleView The ripple view.
- @param view The view to add the ripple view to.
+ @param view The requested superview of the ripple view.
  */
 - (void)rippleTouchController:(nonnull MDCRippleTouchController *)rippleTouchController
              insertRippleView:(nonnull MDCRippleView *)rippleView

--- a/components/Ripple/src/MDCRippleTouchController.m
+++ b/components/Ripple/src/MDCRippleTouchController.m
@@ -19,6 +19,15 @@
 }
 
 - (instancetype)initWithView:(UIView *)view {
+  self = [self init];
+  if (self) {
+    [self addRippleToView:view];
+  }
+  return self;
+}
+
+- (instancetype)init
+{
   self = [super init];
   if (self) {
     _gestureRecognizer =
@@ -30,13 +39,24 @@
     _gestureRecognizer.delaysTouchesEnded = NO;
 
     _shouldProcessRippleWithScrollViewGestures = YES;
-    _view = view;
-    [_view addGestureRecognizer:_gestureRecognizer];
-
-    _rippleView = [[MDCRippleView alloc] initWithFrame:view.bounds];
-    [_view addSubview:_rippleView];
+    _rippleView = [[MDCRippleView alloc] init];
   }
   return self;
+}
+
+- (void)addRippleToView:(UIView *)view {
+  if (_view) {
+    return;
+  }
+  _view = view;
+  [_view addGestureRecognizer:_gestureRecognizer];
+  _rippleView.frame = view.bounds;
+
+  if ([_delegate respondsToSelector:@selector(rippleTouchController:insertRippleView:intoView:)]) {
+    [_delegate rippleTouchController:self insertRippleView:_rippleView intoView:_view];
+  } else {
+    [_view addSubview:_rippleView];
+  }
 }
 
 - (void)dealloc {

--- a/components/Ripple/src/MDCRippleTouchController.m
+++ b/components/Ripple/src/MDCRippleTouchController.m
@@ -48,6 +48,7 @@
 }
 
 - (void)configureRippleWithView:(UIView *)view {
+  [_view removeGestureRecognizer:_gestureRecognizer];
   _view = view;
   [_view addGestureRecognizer:_gestureRecognizer];
   _rippleView.frame = view.bounds;

--- a/components/Ripple/src/MDCRippleTouchController.m
+++ b/components/Ripple/src/MDCRippleTouchController.m
@@ -21,7 +21,7 @@
 - (instancetype)initWithView:(UIView *)view {
   self = [self init];
   if (self) {
-    [self addRippleToView:view];
+    [self configureRippleWithView:view];
   }
   return self;
 }
@@ -44,9 +44,10 @@
 }
 
 - (void)addRippleToView:(UIView *)view {
-  if (_view) {
-    return;
-  }
+  [self configureRippleWithView:view];
+}
+
+- (void)configureRippleWithView:(UIView *)view {
   _view = view;
   [_view addGestureRecognizer:_gestureRecognizer];
   _rippleView.frame = view.bounds;

--- a/components/Ripple/src/MDCRippleTouchController.m
+++ b/components/Ripple/src/MDCRippleTouchController.m
@@ -26,8 +26,7 @@
   return self;
 }
 
-- (instancetype)init
-{
+- (instancetype)init {
   self = [super init];
   if (self) {
     _gestureRecognizer =

--- a/components/Ripple/tests/unit/MDCRippleTouchControllerTests.m
+++ b/components/Ripple/tests/unit/MDCRippleTouchControllerTests.m
@@ -14,17 +14,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "MDCRippleLayer.h"
 #import "MaterialRipple.h"
-
-//@interface FakeMDCRippleViewAnimationDelegate : NSObject <MDCRippleViewDelegate>
-//@property(nonatomic, strong) MDCRippleView *rippleView;
-//@property(nonatomic, assign) BOOL rippleTouchDownDidBegin;
-//@property(nonatomic, assign) BOOL rippleTouchDownDidEnd;
-//@property(nonatomic, assign) BOOL rippleTouchUpDidBegin;
-//@property(nonatomic, assign) BOOL rippleTouchUpDidEnd;
-//
-//@end
 
 #pragma mark - Tests
 

--- a/components/Ripple/tests/unit/MDCRippleTouchControllerTests.m
+++ b/components/Ripple/tests/unit/MDCRippleTouchControllerTests.m
@@ -35,7 +35,7 @@
 }
 
 - (void)testInitWithView {
-  // When
+  // Given
   UIView *parentView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
   MDCRippleTouchController *touchController =
       [[MDCRippleTouchController alloc] initWithView:parentView];

--- a/components/Ripple/tests/unit/MDCRippleTouchControllerTests.m
+++ b/components/Ripple/tests/unit/MDCRippleTouchControllerTests.m
@@ -16,8 +16,7 @@
 
 #import "MaterialRipple.h"
 
-#pragma mark - Tests
-
+/** Unit tests for MDCRippleTouchController. */
 @interface MDCRippleTouchControllerTests : XCTestCase
 
 @end
@@ -25,7 +24,7 @@
 @implementation MDCRippleTouchControllerTests
 
 - (void)testInit {
-  // Given
+  // When
   MDCRippleTouchController *touchController = [[MDCRippleTouchController alloc] init];
 
   // Then
@@ -36,7 +35,7 @@
 }
 
 - (void)testInitWithView {
-  // Given
+  // When
   UIView *parentView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
   MDCRippleTouchController *touchController =
       [[MDCRippleTouchController alloc] initWithView:parentView];
@@ -47,7 +46,10 @@
   XCTAssertEqualObjects(touchController.rippleView.superview, parentView);
   XCTAssertTrue(touchController.shouldProcessRippleWithScrollViewGestures);
   XCTAssertNotNil(touchController.gestureRecognizer);
-  XCTAssertTrue(CGRectEqualToRect(touchController.rippleView.frame, parentView.bounds));
+  XCTAssertTrue(CGRectEqualToRect(touchController.rippleView.frame, parentView.bounds),
+                @"(%@) is not equal to (%@)",
+                NSStringFromCGRect(touchController.rippleView.frame),
+                NSStringFromCGRect(parentView.bounds));
 }
 
 - (void)testAddRippleToView {
@@ -64,7 +66,10 @@
   XCTAssertEqualObjects(touchController.rippleView.superview, parentView);
   XCTAssertTrue(touchController.shouldProcessRippleWithScrollViewGestures);
   XCTAssertNotNil(touchController.gestureRecognizer);
-  XCTAssertTrue(CGRectEqualToRect(touchController.rippleView.frame, parentView.bounds));
+  XCTAssertTrue(CGRectEqualToRect(touchController.rippleView.frame, parentView.bounds),
+                @"(%@) is not equal to (%@)",
+                NSStringFromCGRect(touchController.rippleView.frame),
+                NSStringFromCGRect(parentView.bounds));
 }
 
 @end

--- a/components/Ripple/tests/unit/MDCRippleTouchControllerTests.m
+++ b/components/Ripple/tests/unit/MDCRippleTouchControllerTests.m
@@ -47,8 +47,7 @@
   XCTAssertTrue(touchController.shouldProcessRippleWithScrollViewGestures);
   XCTAssertNotNil(touchController.gestureRecognizer);
   XCTAssertTrue(CGRectEqualToRect(touchController.rippleView.frame, parentView.bounds),
-                @"(%@) is not equal to (%@)",
-                NSStringFromCGRect(touchController.rippleView.frame),
+                @"(%@) is not equal to (%@)", NSStringFromCGRect(touchController.rippleView.frame),
                 NSStringFromCGRect(parentView.bounds));
 }
 
@@ -67,8 +66,7 @@
   XCTAssertTrue(touchController.shouldProcessRippleWithScrollViewGestures);
   XCTAssertNotNil(touchController.gestureRecognizer);
   XCTAssertTrue(CGRectEqualToRect(touchController.rippleView.frame, parentView.bounds),
-                @"(%@) is not equal to (%@)",
-                NSStringFromCGRect(touchController.rippleView.frame),
+                @"(%@) is not equal to (%@)", NSStringFromCGRect(touchController.rippleView.frame),
                 NSStringFromCGRect(parentView.bounds));
 }
 


### PR DESCRIPTION
Add support of adding Ripple anywhere in the view hierarchy using the rippleTouchController's delegate and added an initializer that doesn't add the ripple as a subview straight away.

This PR provides these changes to the RippleTouchController class:
1. Adds a `init` initializer and turns `initWithView` to a convenience initializer. This allows users to add the view that owns the tap gesture and have the ripple as its subview to be added at a later time.
2. Provided a new method to the RippleTouchControllerDelegate that is optional and if conformed to allows users to decide where in the view hierarchy the ripple view should be added.

Both changes above allow the MDCRippleTouchController to better support the API of the MDCInkTouchController when migration comes. Also this change won't break existing clients who already use the RippleTouchController.

Unit tests provided for the added API.

Closes b/128908674