### PR TITLE
[BottomNavigation] Extract common Snapshot consts.

### DIFF
--- a/components/BottomNavigation/tests/snapshot/MDCBottomNavigationBarBlurEffectSnapshotTests.m
+++ b/components/BottomNavigation/tests/snapshot/MDCBottomNavigationBarBlurEffectSnapshotTests.m
@@ -23,17 +23,8 @@
 #import "MaterialInk.h"
 #import "MaterialSnapshot.h"
 #import "supplemental/MDCBottomNavigationSnapshotTestMutableTraitCollection.h"
+#import "supplemental/MDCBottomNavigationSnapshotTestUtilities.h"
 #import "supplemental/MDCFakeBottomNavigationBar.h"
-
-static const CGFloat kWidthTypical = 360;
-static const CGFloat kHeightTypical = 56;
-static NSString *const kLongTitleLatin =
-    @"123456789012345678901234567890123456789012345678901234567890";
-static NSString *const kLongTitleArabic =
-    @"دول السيطرة استطاعوا ٣٠. مليون وفرنسا أوراقهم انه تم, نفس قد والديون العالمية. دون ما تنفّس.";
-static NSString *const kShortTitleArabic = @"ما تنفّس.";
-static NSString *const kBadgeTitleLatin = @"888+";
-static NSString *const kBadgeTitleArabic = @"أورا";
 
 @interface MDCBottomNavigationBarBlurEffectSnapshotTests : MDCSnapshotTestCase
 @property(nonatomic, strong) MDCFakeBottomNavigationBar *navigationBar;
@@ -66,7 +57,7 @@ static NSString *const kBadgeTitleArabic = @"أورا";
               image:[UIImage mdc_testImageOfSize:imageSize
                                        withStyle:MDCSnapshotTestImageStyleCheckerboard]
                 tag:2];
-  self.tabItem2.badgeValue = kBadgeTitleLatin;
+  self.tabItem2.badgeValue = MDCBottomNavigationTestBadgeTitleLatin;
   self.tabItem3 = [[UITabBarItem alloc]
       initWithTitle:@"Item 3"
               image:[UIImage mdc_testImageOfSize:imageSize
@@ -114,14 +105,18 @@ static NSString *const kBadgeTitleArabic = @"أورا";
       view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
     }
   }
-  self.navigationBar.items[1].badgeValue = kBadgeTitleArabic;
+  self.navigationBar.items[1].badgeValue = MDCBottomNavigationTestBadgeTitleArabic;
 }
 
 - (UIView *)superviewForVisualBlurEffectWithNavigationBar:(MDCBottomNavigationBar *)navigationBar {
   UIView *barSuperview =
-      [[UIView alloc] initWithFrame:CGRectMake(0, 0, kWidthTypical, kHeightTypical * 2)];
+      [[UIView alloc] initWithFrame:CGRectMake(0, 0, MDCBottomNavigationBarTestWidthTypical,
+                                               MDCBottomNavigationBarTestHeightTypical * 2)];
   UIColor *patternColor = [UIColor
-      colorWithPatternImage:[UIImage mdc_testImageOfSize:CGSizeMake(kWidthTypical, kWidthTypical)]];
+      colorWithPatternImage:[UIImage
+                                mdc_testImageOfSize:CGSizeMake(
+                                                        MDCBottomNavigationBarTestWidthTypical,
+                                                        MDCBottomNavigationBarTestWidthTypical)]];
   barSuperview.backgroundColor = patternColor;
   [barSuperview addSubview:navigationBar];
   return barSuperview;
@@ -130,7 +125,9 @@ static NSString *const kBadgeTitleArabic = @"أورا";
 - (void)configureNavigationBarForVisualBlurEffectTest:(MDCBottomNavigationBar *)navigationBar {
   navigationBar.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
   navigationBar.selectedItem = self.tabItem2;
-  navigationBar.frame = CGRectMake(0, kHeightTypical, kWidthTypical, kHeightTypical);
+  navigationBar.frame =
+      CGRectMake(0, MDCBottomNavigationBarTestHeightTypical, MDCBottomNavigationBarTestWidthTypical,
+                 MDCBottomNavigationBarTestHeightTypical);
   [self performInkTouchOnBar:navigationBar item:self.tabItem2];
 }
 
@@ -203,7 +200,8 @@ static NSString *const kBadgeTitleArabic = @"أورا";
     self.navigationBar.selectedItem = self.tabItem2;
 
     UIView *superView =
-        [[UIView alloc] initWithFrame:CGRectMake(0, 0, kWidthTypical, kHeightTypical * 2)];
+        [[UIView alloc] initWithFrame:CGRectMake(0, 0, MDCBottomNavigationBarTestWidthTypical,
+                                                 MDCBottomNavigationBarTestHeightTypical * 2)];
     [superView addSubview:self.navigationBar];
     self.navigationBar.translatesAutoresizingMaskIntoConstraints = NO;
     [superView.bottomAnchor constraintEqualToAnchor:self.navigationBar.bottomAnchor].active = YES;
@@ -238,7 +236,8 @@ static NSString *const kBadgeTitleArabic = @"أورا";
     self.navigationBar.selectedItem = self.tabItem2;
 
     UIView *superView =
-        [[UIView alloc] initWithFrame:CGRectMake(0, 0, kWidthTypical, kHeightTypical * 2)];
+        [[UIView alloc] initWithFrame:CGRectMake(0, 0, MDCBottomNavigationBarTestWidthTypical,
+                                                 MDCBottomNavigationBarTestHeightTypical * 2)];
     [superView addSubview:self.navigationBar];
     self.navigationBar.translatesAutoresizingMaskIntoConstraints = NO;
     [superView.bottomAnchor constraintEqualToAnchor:self.navigationBar.bottomAnchor].active = YES;

--- a/components/BottomNavigation/tests/snapshot/MDCBottomNavigationBarSnapshotTests.m
+++ b/components/BottomNavigation/tests/snapshot/MDCBottomNavigationBarSnapshotTests.m
@@ -23,22 +23,13 @@
 #import "MaterialInk.h"
 #import "MaterialSnapshot.h"
 #import "supplemental/MDCBottomNavigationSnapshotTestMutableTraitCollection.h"
+#import "supplemental/MDCBottomNavigationSnapshotTestUtilities.h"
 #import "supplemental/MDCFakeBottomNavigationBar.h"
 
 static const CGFloat kWidthWide = 1600;
-static const CGFloat kWidthiPad = 1024;
-static const CGFloat kWidthTypical = 360;
 static const CGFloat kWidthNarrow = 240;
 static const CGFloat kHeightTall = 120;
-static const CGFloat kHeightTypical = 56;
 static const CGFloat kHeightShort = 48;
-static NSString *const kLongTitleLatin =
-    @"123456789012345678901234567890123456789012345678901234567890";
-static NSString *const kLongTitleArabic =
-    @"دول السيطرة استطاعوا ٣٠. مليون وفرنسا أوراقهم انه تم, نفس قد والديون العالمية. دون ما تنفّس.";
-static NSString *const kShortTitleArabic = @"ما تنفّس.";
-static NSString *const kBadgeTitleLatin = @"888+";
-static NSString *const kBadgeTitleArabic = @"أورا";
 
 @interface MDCBottomNavigationBarSnapshotTests : MDCSnapshotTestCase
 @property(nonatomic, strong) MDCFakeBottomNavigationBar *navigationBar;
@@ -71,7 +62,7 @@ static NSString *const kBadgeTitleArabic = @"أورا";
               image:[UIImage mdc_testImageOfSize:imageSize
                                        withStyle:MDCSnapshotTestImageStyleCheckerboard]
                 tag:2];
-  self.tabItem2.badgeValue = kBadgeTitleLatin;
+  self.tabItem2.badgeValue = MDCBottomNavigationTestBadgeTitleLatin;
   self.tabItem3 = [[UITabBarItem alloc]
       initWithTitle:@"Item 3"
               image:[UIImage mdc_testImageOfSize:imageSize
@@ -137,9 +128,9 @@ static NSString *const kBadgeTitleArabic = @"أورا";
     }
   }
   if (self.navigationBar.items.count >= 2U) {
-    self.navigationBar.items[1].badgeValue = kBadgeTitleArabic;
+    self.navigationBar.items[1].badgeValue = MDCBottomNavigationTestBadgeTitleArabic;
   } else {
-    self.navigationBar.items.firstObject.badgeValue = kBadgeTitleArabic;
+    self.navigationBar.items.firstObject.badgeValue = MDCBottomNavigationTestBadgeTitleArabic;
   }
 }
 
@@ -161,7 +152,7 @@ static NSString *const kBadgeTitleArabic = @"أورا";
   self.navigationBar.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
   self.navigationBar.selectedItem = self.tabItem2;
   self.navigationBar.frame = CGRectMake(0, 0, kWidthNarrow, kHeightShort);
-  [self changeToRTLAndArabicWithTitle:kShortTitleArabic];
+  [self changeToRTLAndArabicWithTitle:MDCBottomNavigationTestShortTitleArabic];
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
   // Then
@@ -184,7 +175,7 @@ static NSString *const kBadgeTitleArabic = @"أورا";
   self.navigationBar.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
   self.navigationBar.selectedItem = self.tabItem2;
   self.navigationBar.frame = CGRectMake(0, 0, kWidthWide, kHeightTall);
-  [self changeToRTLAndArabicWithTitle:kShortTitleArabic];
+  [self changeToRTLAndArabicWithTitle:MDCBottomNavigationTestShortTitleArabic];
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
   // Then
@@ -226,7 +217,7 @@ static NSString *const kBadgeTitleArabic = @"أورا";
   CGSize fitSize = [self.navigationBar sizeThatFits:CGSizeMake(kWidthWide, kHeightTall)];
   self.navigationBar.frame = CGRectMake(0, 0, fitSize.width, fitSize.height);
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
-  [self changeToRTLAndArabicWithTitle:kShortTitleArabic];
+  [self changeToRTLAndArabicWithTitle:MDCBottomNavigationTestShortTitleArabic];
 
   // When
   self.tabItem1.titlePositionAdjustment = UIOffsetMake(20, -20);
@@ -269,7 +260,7 @@ static NSString *const kBadgeTitleArabic = @"أورا";
   CGSize fitSize = [self.navigationBar sizeThatFits:CGSizeMake(kWidthWide, kHeightTall)];
   self.navigationBar.frame = CGRectMake(0, 0, fitSize.width, fitSize.height);
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
-  [self changeToRTLAndArabicWithTitle:kShortTitleArabic];
+  [self changeToRTLAndArabicWithTitle:MDCBottomNavigationTestShortTitleArabic];
 
   // When
   self.tabItem1.titlePositionAdjustment = UIOffsetMake(20, -20);
@@ -296,7 +287,8 @@ static NSString *const kBadgeTitleArabic = @"أورا";
   self.navigationBar.items = @[ self.tabItem1, self.tabItem2, self.tabItem3 ];
   self.navigationBar.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
   self.navigationBar.selectedItem = self.tabItem2;
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthTypical,
+                                        MDCBottomNavigationBarTestHeightTypical);
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem2];
 
   // Then
@@ -329,7 +321,8 @@ static NSString *const kBadgeTitleArabic = @"أورا";
   self.navigationBar.items = @[ self.tabItem1, self.tabItem2, self.tabItem3 ];
   self.navigationBar.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
   self.navigationBar.selectedItem = self.tabItem2;
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthTypical,
+                                        MDCBottomNavigationBarTestHeightTypical);
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem2];
 
   // Then
@@ -344,8 +337,9 @@ static NSString *const kBadgeTitleArabic = @"أورا";
                     withAlignment:MDCBottomNavigationBarAlignmentJustified
                   titleVisibility:MDCBottomNavigationBarTitleVisibilityAlways
                   traitCollection:nil
-                        allTitles:kLongTitleLatin];
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthiPad, kHeightTypical);
+                        allTitles:MDCBottomNavigationTestLongTitleLatin];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthiPad,
+                                        MDCBottomNavigationBarTestHeightTypical);
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
   self.navigationBar.selectedItemTintColor = UIColor.orangeColor;
   self.navigationBar.unselectedItemTintColor = UIColor.blackColor;
@@ -365,8 +359,9 @@ static NSString *const kBadgeTitleArabic = @"أورا";
                     withAlignment:MDCBottomNavigationBarAlignmentJustified
                   titleVisibility:MDCBottomNavigationBarTitleVisibilityAlways
                   traitCollection:nil
-                        allTitles:kLongTitleLatin];
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthiPad, kHeightTypical);
+                        allTitles:MDCBottomNavigationTestLongTitleLatin];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthiPad,
+                                        MDCBottomNavigationBarTestHeightTypical);
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
   self.navigationBar.selectedItemTintColor = UIColor.orangeColor;
   self.navigationBar.unselectedItemTintColor = UIColor.blackColor;
@@ -386,8 +381,9 @@ static NSString *const kBadgeTitleArabic = @"أورا";
                     withAlignment:MDCBottomNavigationBarAlignmentJustified
                   titleVisibility:MDCBottomNavigationBarTitleVisibilityAlways
                   traitCollection:nil
-                        allTitles:kLongTitleLatin];
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthiPad, kHeightTypical);
+                        allTitles:MDCBottomNavigationTestLongTitleLatin];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthiPad,
+                                        MDCBottomNavigationBarTestHeightTypical);
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
   self.navigationBar.selectedItemTintColor = UIColor.orangeColor;
   self.navigationBar.unselectedItemTintColor = UIColor.blackColor;
@@ -407,8 +403,9 @@ static NSString *const kBadgeTitleArabic = @"أورا";
                     withAlignment:MDCBottomNavigationBarAlignmentJustified
                   titleVisibility:MDCBottomNavigationBarTitleVisibilityAlways
                   traitCollection:nil
-                        allTitles:kLongTitleLatin];
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthiPad, kHeightTypical);
+                        allTitles:MDCBottomNavigationTestLongTitleLatin];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthiPad,
+                                        MDCBottomNavigationBarTestHeightTypical);
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
   self.navigationBar.selectedItemTintColor = UIColor.orangeColor;
   self.navigationBar.unselectedItemTintColor = UIColor.blackColor;

--- a/components/BottomNavigation/tests/snapshot/MDCBottomNavigationBarTitleLayoutSnapshotTests.m
+++ b/components/BottomNavigation/tests/snapshot/MDCBottomNavigationBarTitleLayoutSnapshotTests.m
@@ -23,18 +23,8 @@
 #import "MaterialInk.h"
 #import "MaterialSnapshot.h"
 #import "supplemental/MDCBottomNavigationSnapshotTestMutableTraitCollection.h"
+#import "supplemental/MDCBottomNavigationSnapshotTestUtilities.h"
 #import "supplemental/MDCFakeBottomNavigationBar.h"
-
-static const CGFloat kWidthiPad = 1024;
-static const CGFloat kWidthTypical = 360;
-static const CGFloat kHeightTypical = 56;
-static NSString *const kLongTitleLatin =
-    @"123456789012345678901234567890123456789012345678901234567890";
-static NSString *const kLongTitleArabic =
-    @"دول السيطرة استطاعوا ٣٠. مليون وفرنسا أوراقهم انه تم, نفس قد والديون العالمية. دون ما تنفّس.";
-static NSString *const kShortTitleArabic = @"ما تنفّس.";
-static NSString *const kBadgeTitleLatin = @"888+";
-static NSString *const kBadgeTitleArabic = @"أورا";
 
 @interface MDCBottomNavigationBarTitleLayoutSnapshotTests : MDCSnapshotTestCase
 @property(nonatomic, strong) MDCFakeBottomNavigationBar *navigationBar;
@@ -67,7 +57,7 @@ static NSString *const kBadgeTitleArabic = @"أورا";
               image:[UIImage mdc_testImageOfSize:imageSize
                                        withStyle:MDCSnapshotTestImageStyleCheckerboard]
                 tag:2];
-  self.tabItem2.badgeValue = kBadgeTitleLatin;
+  self.tabItem2.badgeValue = MDCBottomNavigationTestBadgeTitleLatin;
   self.tabItem3 = [[UITabBarItem alloc]
       initWithTitle:@"Item 3"
               image:[UIImage mdc_testImageOfSize:imageSize
@@ -132,7 +122,7 @@ static NSString *const kBadgeTitleArabic = @"أورا";
       view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
     }
   }
-  self.navigationBar.items[1].badgeValue = kBadgeTitleArabic;
+  self.navigationBar.items[1].badgeValue = MDCBottomNavigationTestBadgeTitleArabic;
 }
 
 #pragma mark - Title length tests
@@ -143,8 +133,9 @@ static NSString *const kBadgeTitleArabic = @"أورا";
                     withAlignment:MDCBottomNavigationBarAlignmentJustified
                   titleVisibility:MDCBottomNavigationBarTitleVisibilityAlways
                   traitCollection:nil
-                        allTitles:kLongTitleLatin];
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthiPad, kHeightTypical);
+                        allTitles:MDCBottomNavigationTestLongTitleLatin];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthiPad,
+                                        MDCBottomNavigationBarTestHeightTypical);
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
   // Then
@@ -157,8 +148,9 @@ static NSString *const kBadgeTitleArabic = @"أورا";
                     withAlignment:MDCBottomNavigationBarAlignmentJustified
                   titleVisibility:MDCBottomNavigationBarTitleVisibilityAlways
                   traitCollection:nil
-                        allTitles:kLongTitleLatin];
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthiPad, kHeightTypical);
+                        allTitles:MDCBottomNavigationTestLongTitleLatin];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthiPad,
+                                        MDCBottomNavigationBarTestHeightTypical);
   self.navigationBar.truncatesLongTitles = NO;
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
@@ -172,9 +164,10 @@ static NSString *const kBadgeTitleArabic = @"أورا";
                     withAlignment:MDCBottomNavigationBarAlignmentJustified
                   titleVisibility:MDCBottomNavigationBarTitleVisibilityAlways
                   traitCollection:nil
-                        allTitles:kLongTitleLatin];
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthiPad, kHeightTypical);
-  [self changeToRTLAndArabicWithTitle:kLongTitleArabic];
+                        allTitles:MDCBottomNavigationTestLongTitleLatin];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthiPad,
+                                        MDCBottomNavigationBarTestHeightTypical);
+  [self changeToRTLAndArabicWithTitle:MDCBottomNavigationTestLongTitleArabic];
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
   // Then
@@ -187,9 +180,10 @@ static NSString *const kBadgeTitleArabic = @"أورا";
                     withAlignment:MDCBottomNavigationBarAlignmentJustified
                   titleVisibility:MDCBottomNavigationBarTitleVisibilityAlways
                   traitCollection:nil
-                        allTitles:kLongTitleLatin];
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthiPad, kHeightTypical);
-  [self changeToRTLAndArabicWithTitle:kLongTitleArabic];
+                        allTitles:MDCBottomNavigationTestLongTitleLatin];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthiPad,
+                                        MDCBottomNavigationBarTestHeightTypical);
+  [self changeToRTLAndArabicWithTitle:MDCBottomNavigationTestLongTitleArabic];
   self.navigationBar.truncatesLongTitles = NO;
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
@@ -208,8 +202,9 @@ static NSString *const kBadgeTitleArabic = @"أورا";
                     withAlignment:MDCBottomNavigationBarAlignmentJustifiedAdjacentTitles
                   titleVisibility:MDCBottomNavigationBarTitleVisibilityAlways
                   traitCollection:traitCollection
-                        allTitles:kLongTitleLatin];
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthiPad, kHeightTypical);
+                        allTitles:MDCBottomNavigationTestLongTitleLatin];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthiPad,
+                                        MDCBottomNavigationBarTestHeightTypical);
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
   // Then
@@ -227,8 +222,9 @@ static NSString *const kBadgeTitleArabic = @"أورا";
                     withAlignment:MDCBottomNavigationBarAlignmentJustifiedAdjacentTitles
                   titleVisibility:MDCBottomNavigationBarTitleVisibilityAlways
                   traitCollection:traitCollection
-                        allTitles:kLongTitleLatin];
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthiPad, kHeightTypical);
+                        allTitles:MDCBottomNavigationTestLongTitleLatin];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthiPad,
+                                        MDCBottomNavigationBarTestHeightTypical);
   self.navigationBar.truncatesLongTitles = NO;
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
@@ -247,9 +243,10 @@ static NSString *const kBadgeTitleArabic = @"أورا";
                     withAlignment:MDCBottomNavigationBarAlignmentJustifiedAdjacentTitles
                   titleVisibility:MDCBottomNavigationBarTitleVisibilityAlways
                   traitCollection:traitCollection
-                        allTitles:kLongTitleLatin];
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthiPad, kHeightTypical);
-  [self changeToRTLAndArabicWithTitle:kLongTitleArabic];
+                        allTitles:MDCBottomNavigationTestLongTitleLatin];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthiPad,
+                                        MDCBottomNavigationBarTestHeightTypical);
+  [self changeToRTLAndArabicWithTitle:MDCBottomNavigationTestLongTitleArabic];
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
   // Then
@@ -267,9 +264,10 @@ static NSString *const kBadgeTitleArabic = @"أورا";
                     withAlignment:MDCBottomNavigationBarAlignmentJustifiedAdjacentTitles
                   titleVisibility:MDCBottomNavigationBarTitleVisibilityAlways
                   traitCollection:traitCollection
-                        allTitles:kLongTitleLatin];
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthiPad, kHeightTypical);
-  [self changeToRTLAndArabicWithTitle:kLongTitleArabic];
+                        allTitles:MDCBottomNavigationTestLongTitleLatin];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthiPad,
+                                        MDCBottomNavigationBarTestHeightTypical);
+  [self changeToRTLAndArabicWithTitle:MDCBottomNavigationTestLongTitleArabic];
   self.navigationBar.truncatesLongTitles = NO;
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
@@ -283,8 +281,9 @@ static NSString *const kBadgeTitleArabic = @"أورا";
                     withAlignment:MDCBottomNavigationBarAlignmentCentered
                   titleVisibility:MDCBottomNavigationBarTitleVisibilityAlways
                   traitCollection:nil
-                        allTitles:kLongTitleLatin];
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthiPad, kHeightTypical);
+                        allTitles:MDCBottomNavigationTestLongTitleLatin];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthiPad,
+                                        MDCBottomNavigationBarTestHeightTypical);
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
   // Then
@@ -297,8 +296,9 @@ static NSString *const kBadgeTitleArabic = @"أورا";
                     withAlignment:MDCBottomNavigationBarAlignmentCentered
                   titleVisibility:MDCBottomNavigationBarTitleVisibilityAlways
                   traitCollection:nil
-                        allTitles:kLongTitleLatin];
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthiPad, kHeightTypical);
+                        allTitles:MDCBottomNavigationTestLongTitleLatin];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthiPad,
+                                        MDCBottomNavigationBarTestHeightTypical);
   self.navigationBar.truncatesLongTitles = NO;
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
@@ -312,9 +312,10 @@ static NSString *const kBadgeTitleArabic = @"أورا";
                     withAlignment:MDCBottomNavigationBarAlignmentCentered
                   titleVisibility:MDCBottomNavigationBarTitleVisibilityAlways
                   traitCollection:nil
-                        allTitles:kLongTitleLatin];
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthiPad, kHeightTypical);
-  [self changeToRTLAndArabicWithTitle:kLongTitleArabic];
+                        allTitles:MDCBottomNavigationTestLongTitleLatin];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthiPad,
+                                        MDCBottomNavigationBarTestHeightTypical);
+  [self changeToRTLAndArabicWithTitle:MDCBottomNavigationTestLongTitleArabic];
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
   // Then
@@ -327,9 +328,10 @@ static NSString *const kBadgeTitleArabic = @"أورا";
                     withAlignment:MDCBottomNavigationBarAlignmentCentered
                   titleVisibility:MDCBottomNavigationBarTitleVisibilityAlways
                   traitCollection:nil
-                        allTitles:kLongTitleLatin];
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthiPad, kHeightTypical);
-  [self changeToRTLAndArabicWithTitle:kLongTitleArabic];
+                        allTitles:MDCBottomNavigationTestLongTitleLatin];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthiPad,
+                                        MDCBottomNavigationBarTestHeightTypical);
+  [self changeToRTLAndArabicWithTitle:MDCBottomNavigationTestLongTitleArabic];
   self.navigationBar.truncatesLongTitles = NO;
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
@@ -344,7 +346,8 @@ static NSString *const kBadgeTitleArabic = @"أورا";
   self.navigationBar.items = @[ self.tabItem1, self.tabItem2, self.tabItem3 ];
   self.navigationBar.titleVisibility = MDCBottomNavigationBarTitleVisibilitySelected;
   self.navigationBar.selectedItem = self.tabItem2;
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthTypical,
+                                        MDCBottomNavigationBarTestHeightTypical);
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
   // Then
@@ -356,8 +359,9 @@ static NSString *const kBadgeTitleArabic = @"أورا";
   self.navigationBar.items = @[ self.tabItem1, self.tabItem2, self.tabItem3 ];
   self.navigationBar.titleVisibility = MDCBottomNavigationBarTitleVisibilitySelected;
   self.navigationBar.selectedItem = self.tabItem2;
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
-  [self changeToRTLAndArabicWithTitle:kShortTitleArabic];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthTypical,
+                                        MDCBottomNavigationBarTestHeightTypical);
+  [self changeToRTLAndArabicWithTitle:MDCBottomNavigationTestShortTitleArabic];
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
   // Then
@@ -369,7 +373,8 @@ static NSString *const kBadgeTitleArabic = @"أورا";
   self.navigationBar.items = @[ self.tabItem1, self.tabItem2, self.tabItem3 ];
   self.navigationBar.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
   self.navigationBar.selectedItem = self.tabItem2;
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthTypical,
+                                        MDCBottomNavigationBarTestHeightTypical);
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
   // Then
@@ -381,8 +386,9 @@ static NSString *const kBadgeTitleArabic = @"أورا";
   self.navigationBar.items = @[ self.tabItem1, self.tabItem2, self.tabItem3 ];
   self.navigationBar.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
   self.navigationBar.selectedItem = self.tabItem2;
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
-  [self changeToRTLAndArabicWithTitle:kShortTitleArabic];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthTypical,
+                                        MDCBottomNavigationBarTestHeightTypical);
+  [self changeToRTLAndArabicWithTitle:MDCBottomNavigationTestShortTitleArabic];
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
   // Then
@@ -394,7 +400,8 @@ static NSString *const kBadgeTitleArabic = @"أورا";
   self.navigationBar.items = @[ self.tabItem1, self.tabItem2, self.tabItem3 ];
   self.navigationBar.titleVisibility = MDCBottomNavigationBarTitleVisibilityNever;
   self.navigationBar.selectedItem = self.tabItem2;
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthTypical,
+                                        MDCBottomNavigationBarTestHeightTypical);
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
   // Then
@@ -406,8 +413,9 @@ static NSString *const kBadgeTitleArabic = @"أورا";
   self.navigationBar.items = @[ self.tabItem1, self.tabItem2, self.tabItem3 ];
   self.navigationBar.titleVisibility = MDCBottomNavigationBarTitleVisibilityNever;
   self.navigationBar.selectedItem = self.tabItem2;
-  self.navigationBar.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
-  [self changeToRTLAndArabicWithTitle:kShortTitleArabic];
+  self.navigationBar.frame = CGRectMake(0, 0, MDCBottomNavigationBarTestWidthTypical,
+                                        MDCBottomNavigationBarTestHeightTypical);
+  [self changeToRTLAndArabicWithTitle:MDCBottomNavigationTestShortTitleArabic];
   [self performInkTouchOnBar:self.navigationBar item:self.tabItem1];
 
   // Then

--- a/components/BottomNavigation/tests/snapshot/MDCBottomNavigationItemViewSnapshotTests.m
+++ b/components/BottomNavigation/tests/snapshot/MDCBottomNavigationItemViewSnapshotTests.m
@@ -16,38 +16,36 @@
 
 #import "../../src/private/MDCBottomNavigationItemView.h"
 #import "MaterialBottomNavigation.h"
+#import "supplemental/MDCBottomNavigationSnapshotTestUtilities.h"
 
-static NSString *const kLongTitleLatin =
-    @"123456789012345678901234567890123456789012345678901234567890";
 static NSString *const kBadgeTitleEmpty = @"";
 static NSString *const kBadgeTitleSingleLatin = @"8";
 static NSString *const kBadgeTitleMaxLatin = @"888+";
-static NSString *const kLongTitleArabic =
-    @"دول السيطرة استطاعوا ٣٠. مليون وفرنسا أوراقهم انه تم, نفس قد والديون العالمية. دون ما تنفّس.";
 static NSString *const kBadgeTitleSingleArabic = @"أ";
 static NSString *const kBadgeTitleMaxArabic = @"أورا";
+
 /** The shortest acceptable height for correct layout. */
-static const CGFloat kHeightShort = 48;
+static const CGFloat kItemViewHeightShort = 48;
 
 /** Typical height for correct layout. */
-static const CGFloat kHeightTypical = 56;
+static const CGFloat kItemViewHeightTypical = 56;
 
 /** A height too tall for correct layout. */
-static const CGFloat kHeightTall = 120;
+static const CGFloat kItemViewHeightTall = 120;
 
 /** A width too narrow for correct layout */
-static const CGFloat kWidthNarrrow = 40;  // 64 - 12 points on leading/trailing edge
+static const CGFloat kItemViewWidthNarrrow = 40;  // 64 - 12 points on leading/trailing edge
 
 /** The minimum acceptable width for correct layout */
-static const CGFloat kWidthMinimum = 56;  // 80 - 12 points on leading/trailing edge
+static const CGFloat kItemViewWidthMinimum = 56;  // 80 - 12 points on leading/trailing edge
 
 /** The suggested width for correct layout */
-static const CGFloat kWidthTypical = 96;  // 120 - 12 points on leading/trailing edge
+static const CGFloat kItemViewWidthTypical = 96;  // 120 - 12 points on leading/trailing edge
 
 /** The maximum acceptable width for correct layout */
-static const CGFloat kWidthMaximum = 144;  // 168 - 12 points on leading/trailing edge
+static const CGFloat kItemViewWidthMaximum = 144;  // 168 - 12 points on leading/trailing edge
 
-static const CGFloat kContentHorizontalMargin = 12;
+static const CGFloat kItemViewContentHorizontalMargin = 12;
 
 @interface MDCBottomNavigationItemViewSnapshotTests : MDCSnapshotTestCase
 @property(nonatomic, strong) MDCBottomNavigationItemView *itemView;
@@ -65,8 +63,8 @@ static const CGFloat kContentHorizontalMargin = 12;
   self.itemView = [[MDCBottomNavigationItemView alloc] init];
   self.itemView.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
   self.itemView.image = [UIImage mdc_testImageOfSize:CGSizeMake(24, 24)];
-  self.itemView.title = kLongTitleLatin;
-  self.itemView.contentHorizontalMargin = kContentHorizontalMargin;
+  self.itemView.title = MDCBottomNavigationTestLongTitleLatin;
+  self.itemView.contentHorizontalMargin = kItemViewContentHorizontalMargin;
   self.itemView.backgroundColor = UIColor.whiteColor;
   self.itemView.badgeValue = kBadgeTitleEmpty;
 }
@@ -80,7 +78,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   if (@available(iOS 9.0, *)) {
     self.itemView.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
   }
-  self.itemView.title = kLongTitleArabic;
+  self.itemView.title = MDCBottomNavigationTestLongTitleArabic;
   self.itemView.badgeValue = badgeValue;
 }
 
@@ -89,7 +87,7 @@ static const CGFloat kContentHorizontalMargin = 12;
 - (void)testNarrowWidthTypicalHeightLongTitleEmptyBadgeStackedLTR {
   // When
   self.itemView.titleBelowIcon = YES;
-  self.itemView.frame = CGRectMake(0, 0, kWidthNarrrow, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthNarrrow, kItemViewHeightTypical);
 
   [self generateAndVerifySnapshot];
 }
@@ -98,7 +96,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   [self changeToRTLAndArabicWithBadgeValue:kBadgeTitleEmpty];
   self.itemView.titleBelowIcon = YES;
-  self.itemView.frame = CGRectMake(0, 0, kWidthNarrrow, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthNarrrow, kItemViewHeightTypical);
 
   [self generateAndVerifySnapshot];
 }
@@ -106,7 +104,7 @@ static const CGFloat kContentHorizontalMargin = 12;
 - (void)testNarrowWidthTypicalHeightLongTitleSingleBadgeAdjacentLTR {
   // When
   self.itemView.titleBelowIcon = NO;
-  self.itemView.frame = CGRectMake(0, 0, kWidthNarrrow, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthNarrrow, kItemViewHeightTypical);
   self.itemView.badgeValue = kBadgeTitleSingleLatin;
 
   [self generateAndVerifySnapshot];
@@ -116,7 +114,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   [self changeToRTLAndArabicWithBadgeValue:kBadgeTitleSingleArabic];
   self.itemView.titleBelowIcon = NO;
-  self.itemView.frame = CGRectMake(0, 0, kWidthNarrrow, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthNarrrow, kItemViewHeightTypical);
 
   [self generateAndVerifySnapshot];
 }
@@ -125,7 +123,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   self.itemView.titleBelowIcon = YES;
   self.itemView.badgeValue = kBadgeTitleMaxLatin;
-  self.itemView.frame = CGRectMake(0, 0, kWidthMinimum, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthMinimum, kItemViewHeightTypical);
 
   [self generateAndVerifySnapshot];
 }
@@ -134,7 +132,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   [self changeToRTLAndArabicWithBadgeValue:kBadgeTitleMaxArabic];
   self.itemView.titleBelowIcon = YES;
-  self.itemView.frame = CGRectMake(0, 0, kWidthMinimum, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthMinimum, kItemViewHeightTypical);
 
   [self generateAndVerifySnapshot];
 }
@@ -142,7 +140,7 @@ static const CGFloat kContentHorizontalMargin = 12;
 - (void)testMinimumWidthTypicalHeightLongTitleEmptyBadgeAdjacentLTR {
   // When
   self.itemView.titleBelowIcon = NO;
-  self.itemView.frame = CGRectMake(0, 0, kWidthMinimum, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthMinimum, kItemViewHeightTypical);
 
   [self generateAndVerifySnapshot];
 }
@@ -151,7 +149,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   [self changeToRTLAndArabicWithBadgeValue:kBadgeTitleEmpty];
   self.itemView.titleBelowIcon = NO;
-  self.itemView.frame = CGRectMake(0, 0, kWidthMinimum, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthMinimum, kItemViewHeightTypical);
 
   [self generateAndVerifySnapshot];
 }
@@ -160,7 +158,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   self.itemView.titleBelowIcon = YES;
   self.itemView.badgeValue = kBadgeTitleSingleLatin;
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightTypical);
 
   [self generateAndVerifySnapshot];
 }
@@ -169,7 +167,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   [self changeToRTLAndArabicWithBadgeValue:kBadgeTitleSingleArabic];
   self.itemView.titleBelowIcon = YES;
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightTypical);
 
   [self generateAndVerifySnapshot];
 }
@@ -178,7 +176,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   self.itemView.titleBelowIcon = NO;
   self.itemView.badgeValue = kBadgeTitleMaxLatin;
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightTypical);
 
   [self generateAndVerifySnapshot];
 }
@@ -187,7 +185,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   [self changeToRTLAndArabicWithBadgeValue:kBadgeTitleMaxArabic];
   self.itemView.titleBelowIcon = NO;
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightTypical);
 
   [self generateAndVerifySnapshot];
 }
@@ -195,7 +193,7 @@ static const CGFloat kContentHorizontalMargin = 12;
 - (void)testMaximumWidthTypicalHeightLongTitleEmptyBadgeStackedLTR {
   // When
   self.itemView.titleBelowIcon = YES;
-  self.itemView.frame = CGRectMake(0, 0, kWidthMaximum, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthMaximum, kItemViewHeightTypical);
 
   [self generateAndVerifySnapshot];
 }
@@ -204,7 +202,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   [self changeToRTLAndArabicWithBadgeValue:kBadgeTitleEmpty];
   self.itemView.titleBelowIcon = YES;
-  self.itemView.frame = CGRectMake(0, 0, kWidthMaximum, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthMaximum, kItemViewHeightTypical);
 
   [self generateAndVerifySnapshot];
 }
@@ -213,7 +211,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   self.itemView.titleBelowIcon = NO;
   self.itemView.badgeValue = kBadgeTitleSingleLatin;
-  self.itemView.frame = CGRectMake(0, 0, kWidthMaximum, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthMaximum, kItemViewHeightTypical);
 
   [self generateAndVerifySnapshot];
 }
@@ -222,7 +220,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   [self changeToRTLAndArabicWithBadgeValue:kBadgeTitleSingleArabic];
   self.itemView.titleBelowIcon = NO;
-  self.itemView.frame = CGRectMake(0, 0, kWidthMaximum, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthMaximum, kItemViewHeightTypical);
 
   [self generateAndVerifySnapshot];
 }
@@ -232,7 +230,7 @@ static const CGFloat kContentHorizontalMargin = 12;
 - (void)testTypicalWidthShortHeightLongTitleEmptyBadgeStackedLTR {
   // When
   self.itemView.titleBelowIcon = YES;
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightShort);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightShort);
 
   [self generateAndVerifySnapshot];
 }
@@ -241,7 +239,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   [self changeToRTLAndArabicWithBadgeValue:kBadgeTitleEmpty];
   self.itemView.titleBelowIcon = YES;
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightShort);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightShort);
 
   [self generateAndVerifySnapshot];
 }
@@ -250,7 +248,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   self.itemView.titleBelowIcon = NO;
   self.itemView.badgeValue = kBadgeTitleSingleLatin;
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightShort);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightShort);
 
   [self generateAndVerifySnapshot];
 }
@@ -259,7 +257,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   [self changeToRTLAndArabicWithBadgeValue:kBadgeTitleSingleArabic];
   self.itemView.titleBelowIcon = NO;
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightShort);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightShort);
 
   [self generateAndVerifySnapshot];
 }
@@ -268,7 +266,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   self.itemView.titleBelowIcon = YES;
   self.itemView.badgeValue = kBadgeTitleMaxLatin;
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightTall);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightTall);
 
   [self generateAndVerifySnapshot];
 }
@@ -277,7 +275,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   [self changeToRTLAndArabicWithBadgeValue:kBadgeTitleMaxArabic];
   self.itemView.titleBelowIcon = YES;
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightTall);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightTall);
 
   [self generateAndVerifySnapshot];
 }
@@ -285,7 +283,7 @@ static const CGFloat kContentHorizontalMargin = 12;
 - (void)testTypicalWidthTallHeightLongTitleEmptyBadgeAdjacentLTR {
   // When
   self.itemView.titleBelowIcon = NO;
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightTall);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightTall);
 
   [self generateAndVerifySnapshot];
 }
@@ -294,7 +292,7 @@ static const CGFloat kContentHorizontalMargin = 12;
   // When
   [self changeToRTLAndArabicWithBadgeValue:kBadgeTitleEmpty];
   self.itemView.titleBelowIcon = NO;
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightTall);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightTall);
 
   [self generateAndVerifySnapshot];
 }
@@ -303,7 +301,7 @@ static const CGFloat kContentHorizontalMargin = 12;
 
 - (void)testChangeUnselectedImageWhenNotSelectedWithSelectedImage {
   // Given
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightTypical);
   self.itemView.selected = NO;
   self.itemView.selectedImage = [[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)
                                                     withStyle:MDCSnapshotTestImageStyleEllipses]
@@ -321,7 +319,7 @@ static const CGFloat kContentHorizontalMargin = 12;
 
 - (void)testChangeUnselectedImageWhenNotSelectedWithoutSelectedImage {
   // Given
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightTypical);
   self.itemView.selected = NO;
   self.itemView.selectedImage = nil;
   self.itemView.selectedItemTintColor = UIColor.orangeColor;
@@ -338,7 +336,7 @@ static const CGFloat kContentHorizontalMargin = 12;
 
 - (void)testChangeUnselectedImageWhenSelectedWithSelectedImage {
   // Given
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightTypical);
   self.itemView.selected = YES;
   self.itemView.selectedImage = [[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)
                                                     withStyle:MDCSnapshotTestImageStyleEllipses]
@@ -357,7 +355,7 @@ static const CGFloat kContentHorizontalMargin = 12;
 
 - (void)testChangeUnselectedImageWhenSelectedWithoutSelectedImage {
   // Given
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightTypical);
   self.itemView.selected = YES;
   self.itemView.selectedImage = nil;
   self.itemView.selectedItemTintColor = UIColor.orangeColor;
@@ -374,7 +372,7 @@ static const CGFloat kContentHorizontalMargin = 12;
 
 - (void)testChangeSelectedImageWhenNotSelected {
   // Given
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightTypical);
   self.itemView.selected = NO;
   self.itemView.selectedItemTintColor = UIColor.orangeColor;
   self.itemView.unselectedItemTintColor = UIColor.blackColor;
@@ -390,7 +388,7 @@ static const CGFloat kContentHorizontalMargin = 12;
 
 - (void)testChangeSelectedImageWhenSelected {
   // Given
-  self.itemView.frame = CGRectMake(0, 0, kWidthTypical, kHeightTypical);
+  self.itemView.frame = CGRectMake(0, 0, kItemViewWidthTypical, kItemViewHeightTypical);
   self.itemView.selected = YES;
   self.itemView.selectedItemTintColor = UIColor.orangeColor;
   self.itemView.unselectedItemTintColor = UIColor.blackColor;

--- a/components/BottomNavigation/tests/snapshot/supplemental/MDCBottomNavigationSnapshotTestUtilities.h
+++ b/components/BottomNavigation/tests/snapshot/supplemental/MDCBottomNavigationSnapshotTestUtilities.h
@@ -1,0 +1,39 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** Width of an MDCBottomNavigationBar on an iPad. */
+static const CGFloat MDCBottomNavigationBarTestWidthiPad = 1024;
+
+/** Typical width for an MDCBottomNavigationBar. */
+static const CGFloat MDCBottomNavigationBarTestWidthTypical = 360;
+
+/** Typical height for an MDCBottomNavigationBar. */
+static const CGFloat MDCBottomNavigationBarTestHeightTypical = 56;
+
+/** An Arabic-character title that could reasonably fit in a Bottom Navigation item. */
+static NSString *const MDCBottomNavigationTestShortTitleArabic = @"ما تنفّس.";
+
+/** A Latin-character title that could reasonably fit in a Bottom Navigation item. */
+static NSString *const MDCBottomNavigationTestBadgeTitleLatin = @"888+";
+
+/** A Latin-character title too long to fit in a Bottom Navigation item. */
+static NSString *const MDCBottomNavigationTestLongTitleLatin =
+    @"123456789012345678901234567890123456789012345678901234567890";
+
+/** An Arabic-character title too long to fit in a Bottom Navigation item. */
+static NSString *const MDCBottomNavigationTestLongTitleArabic =
+    @"دول السيطرة استطاعوا ٣٠. مليون وفرنسا أوراقهم انه تم, نفس قد والديون العالمية. دون ما تنفّس.";
+
+/** An Arabic-character title that could reasonably fit in a Bottom Navigation item. */
+static NSString *const MDCBottomNavigationTestBadgeTitleArabic = @"أورا";


### PR DESCRIPTION
Pulling out reusable constants for Snapshot tests into a dedicated file.
This reduces boilerplate code needed in each of the test classes.

Closes #6844
