### PR TITLE
[Tabs] Fix constraint crash in example.

### DIFF
--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
@@ -234,8 +234,8 @@
   [self.starPage addSubview:starView];
   [starView sizeToFit];
 
-  CGFloat x = centered ? 1 : (arc4random_uniform(199) + 1) / 100;  // 0 < x <=2
-  CGFloat y = centered ? 1 : (arc4random_uniform(199) + 1) / 100;  // 0 < y <=2
+  CGFloat x = centered ? 1 : (CGFloat)((arc4random_uniform(199) + 1) / 100.0);  // 0 < x <=2
+  CGFloat y = centered ? 1 : (CGFloat)((arc4random_uniform(199) + 1) / 100.0);  // 0 < y <=2
 
   [NSLayoutConstraint constraintWithItem:starView
                                attribute:NSLayoutAttributeCenterX


### PR DESCRIPTION
When adding a Star, the example would crash because one of the two
x/y values would nearly always be 0. This was caused by converting a
double into an integer in an earlier PR.

Closes #7009