### PR TITLE
[AppBar] Add support for MDCAppBarNavigationController delegate to pick a tracking scroll view.

### DIFF
--- a/components/AppBar/src/MDCAppBarNavigationController.h
+++ b/components/AppBar/src/MDCAppBarNavigationController.h
@@ -67,7 +67,8 @@
  controller. If a flexible header is already present in the view controller, this method will not
  be invoked.
  */
-- (nullable UIScrollView *)appBarNavigationController:(nonnull MDCAppBarNavigationController *)navigationController
+- (nullable UIScrollView *)appBarNavigationController:
+                               (nonnull MDCAppBarNavigationController *)navigationController
                   trackingScrollViewForViewController:(nonnull UIViewController *)viewController
                           suggestedTrackingScrollView:(nullable UIScrollView *)scrollView;
 

--- a/components/AppBar/src/MDCAppBarNavigationController.h
+++ b/components/AppBar/src/MDCAppBarNavigationController.h
@@ -41,6 +41,36 @@
        willAddAppBarViewController:(nonnull MDCAppBarViewController *)appBarViewController
            asChildOfViewController:(nonnull UIViewController *)viewController;
 
+/**
+ Asks the receiver to determine the tracking scroll view for a given view controller.
+
+ If this method is not implemented, the app bar navigation controller will extract the first
+ UIScrollView instance in the view controller's view hierarchy using a depth-first view traversal.
+
+ Implement this method when you need to change the default behavior of the tracking scroll view
+ detection. The suggested tracking scroll view will contain the scroll view that would have been
+ used; you can ignore this value.
+
+ Your implementation will likely return the suggested tracking scroll view by default, with custom
+ logic being implemented for specific view controllers that require it.
+
+ @param navigationController The app bar navigation controller instance that owns the view
+ controller.
+ @param viewController The view controller for which the tracking scroll view should be determined.
+ @param scrollView A suggested tracking scroll view. This is the first UIScrollView instance
+ detected by a depth-first view traversal of @c viewController's view hierarchy. This suggestion
+ can be ignored.
+ @return The tracking scroll view to be used for this view controller. If nil is returned then no
+ tracking scroll view will be set.
+
+ @note This method will only be invoked if a new App Bar instance is about to be added to the view
+ controller. If a flexible header is already present in the view controller, this method will not
+ be invoked.
+ */
+- (nullable UIScrollView *)appBarNavigationController:(nonnull MDCAppBarNavigationController *)navigationController
+                  trackingScrollViewForViewController:(nonnull UIViewController *)viewController
+                          suggestedTrackingScrollView:(nullable UIScrollView *)scrollView;
+
 #pragma mark - Will be deprecated
 
 /**

--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -126,8 +126,9 @@
   UIScrollView *trackingScrollView =
       [self findFirstInstanceOfUIScrollViewInView:viewControllerView];
 
-  if ([self.delegate respondsToSelector:
-          @selector(appBarNavigationController:trackingScrollViewForViewController:suggestedTrackingScrollView:)]) {
+  if ([self.delegate respondsToSelector:@selector
+                     (appBarNavigationController:
+                         trackingScrollViewForViewController:suggestedTrackingScrollView:)]) {
     trackingScrollView = [self.delegate appBarNavigationController:self
                                trackingScrollViewForViewController:viewController
                                        suggestedTrackingScrollView:trackingScrollView];

--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -126,6 +126,13 @@
   UIScrollView *trackingScrollView =
       [self findFirstInstanceOfUIScrollViewInView:viewControllerView];
 
+  if ([self.delegate respondsToSelector:
+          @selector(appBarNavigationController:trackingScrollViewForViewController:suggestedTrackingScrollView:)]) {
+    trackingScrollView = [self.delegate appBarNavigationController:self
+                               trackingScrollViewForViewController:viewController
+                                       suggestedTrackingScrollView:trackingScrollView];
+  }
+
   MDCAppBar *appBar = [[MDCAppBar alloc] init];
 
   // Book-keeping so that we can do two things:

--- a/components/AppBar/tests/unit/AppBarNavigationControllerTests.swift
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerTests.swift
@@ -15,7 +15,7 @@
 import XCTest
 import MaterialComponents.MaterialAppBar
 
-private class MockAppBarNavigationControllerDelete:
+private class MockAppBarNavigationControllerDelegate:
     NSObject, MDCAppBarNavigationControllerDelegate {
   var trackingScrollView: UIScrollView?
   func appBarNavigationController(_ navigationController: MDCAppBarNavigationController,
@@ -245,14 +245,14 @@ class AppBarNavigationControllerTests: XCTestCase {
     XCTAssertEqual(appBarViewController.headerView.trackingScrollView, scrollView1)
   }
 
-  func testDeleteCanReturnNilTrackingScrollView() {
+  func testDelegateCanReturnNilTrackingScrollView() {
     // Given
     let viewController = UIViewController()
     let scrollView1 = UIScrollView()
     viewController.view.addSubview(scrollView1)
     let scrollView2 = UIScrollView()
     viewController.view.addSubview(scrollView2)
-    let delegate = MockAppBarNavigationControllerDelete()
+    let delegate = MockAppBarNavigationControllerDelegate()
     navigationController.delegate = delegate
 
     // When
@@ -267,14 +267,14 @@ class AppBarNavigationControllerTests: XCTestCase {
     XCTAssertNil(appBarViewController.headerView.trackingScrollView)
   }
 
-  func testDeleteCanPickDifferentTrackingScrollView() {
+  func testDelegateCanPickDifferentTrackingScrollView() {
     // Given
     let viewController = UIViewController()
     let scrollView1 = UIScrollView()
     viewController.view.addSubview(scrollView1)
     let scrollView2 = UIScrollView()
     viewController.view.addSubview(scrollView2)
-    let delegate = MockAppBarNavigationControllerDelete()
+    let delegate = MockAppBarNavigationControllerDelegate()
     navigationController.delegate = delegate
 
     // When

--- a/components/AppBar/tests/unit/AppBarNavigationControllerTests.swift
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerTests.swift
@@ -15,6 +15,16 @@
 import XCTest
 import MaterialComponents.MaterialAppBar
 
+private class MockAppBarNavigationControllerDelete:
+    NSObject, MDCAppBarNavigationControllerDelegate {
+  var trackingScrollView: UIScrollView?
+  func appBarNavigationController(_ navigationController: MDCAppBarNavigationController,
+                                  trackingScrollViewFor trackingScrollViewForViewController: UIViewController,
+                                  suggestedTrackingScrollView: UIScrollView?) -> UIScrollView? {
+    return trackingScrollView
+  }
+}
+
 class AppBarNavigationControllerTests: XCTestCase {
 
   var navigationController: MDCAppBarNavigationController!
@@ -215,6 +225,67 @@ class AppBarNavigationControllerTests: XCTestCase {
                       + "header view controller for status bar style updates.")
     }
   }
+
+  func testInfersFirstTrackingScrollViewByDefault() {
+    // Given
+    let viewController = UIViewController()
+    let scrollView1 = UIScrollView()
+    viewController.view.addSubview(scrollView1)
+    let scrollView2 = UIScrollView()
+    viewController.view.addSubview(scrollView2)
+
+    // When
+    navigationController.pushViewController(viewController, animated: false)
+
+    // Then
+    guard let appBarViewController = navigationController.appBarViewController(for: viewController) else {
+      XCTFail("No app bar view controller found.")
+      return
+    }
+    XCTAssertEqual(appBarViewController.headerView.trackingScrollView, scrollView1)
+  }
+
+  func testDeleteCanReturnNilTrackingScrollView() {
+    // Given
+    let viewController = UIViewController()
+    let scrollView1 = UIScrollView()
+    viewController.view.addSubview(scrollView1)
+    let scrollView2 = UIScrollView()
+    viewController.view.addSubview(scrollView2)
+    let delegate = MockAppBarNavigationControllerDelete()
+    navigationController.delegate = delegate
+
+    // When
+    delegate.trackingScrollView = nil
+    navigationController.pushViewController(viewController, animated: false)
+
+    // Then
+    guard let appBarViewController = navigationController.appBarViewController(for: viewController) else {
+      XCTFail("No app bar view controller found.")
+      return
+    }
+    XCTAssertNil(appBarViewController.headerView.trackingScrollView)
+  }
+
+  func testDeleteCanPickDifferentTrackingScrollView() {
+    // Given
+    let viewController = UIViewController()
+    let scrollView1 = UIScrollView()
+    viewController.view.addSubview(scrollView1)
+    let scrollView2 = UIScrollView()
+    viewController.view.addSubview(scrollView2)
+    let delegate = MockAppBarNavigationControllerDelete()
+    navigationController.delegate = delegate
+
+    // When
+    delegate.trackingScrollView = scrollView2
+    navigationController.pushViewController(viewController, animated: false)
+
+    // Then
+    guard let appBarViewController = navigationController.appBarViewController(for: viewController) else {
+      XCTFail("No app bar view controller found.")
+      return
+    }
+    XCTAssertEqual(appBarViewController.headerView.trackingScrollView, scrollView2)
+  }
 }
-
-


### PR DESCRIPTION
MDCAppBarNavigationController's tracking scroll view detection uses a depth-first view traversal algorithm to find a tracking scroll view candidate. This logic works most of the time, but there are cases where this algorithm picks up the wrong tracking scroll view. For example, if a horizontally scrollable tab bar has been added to the view controller's view and there is no other scroll view then the tab bar will be picked as the tracking scroll view.

Prior to this change, our recommendation to clients that encountered cases like this was to opt out of the MDCAppBarNavigationController app bar injection logic by creating and managing a custom app bar instance.

After this change, clients will be able to customize the tracking scroll view detection logic. This will reduce the need to opt out of the app bar navigation controller's injection behavior.

This change helps mitigate https://github.com/material-components/material-components-ios/issues/5344

Googlers: this change was instigated by a client integration in [cl/241070130](http://cl/241070130).