### PR TITLE
[Buttons] Don't make Buttons example launch screen.

### DIFF
--- a/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
+++ b/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
@@ -25,7 +25,6 @@ class ButtonsDynamicTypeViewController: UIViewController {
       "breadcrumbs": ["Buttons", "Buttons (DynamicType)"],
       "primaryDemo": false,
       "presentable": false,
-      "debug": true, 
     ]
   }
 


### PR DESCRIPTION
The Buttons example should not be the first screen of the Dragons App.

Follow-up from #7003
