### PR TITLE
[ActionSheet] Flash scroll indicators when view appears.

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -186,6 +186,12 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   return MDCCeil(preferredHeight);
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+  [super viewDidAppear:animated];
+
+  [self.tableView flashScrollIndicators];
+}
+
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];
 

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -189,7 +189,7 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
 - (void)viewDidAppear:(BOOL)animated {
   [super viewDidAppear:animated];
 
-  [self.tableView flashScrollIndicators];
+  [self.transitionController.trackingScrollView flashScrollIndicators];
 }
 
 - (void)viewWillAppear:(BOOL)animated {


### PR DESCRIPTION
## Related Links
**Component:** [ActionSheet](https://github.com/material-components/material-components-ios/tree/develop/components/ActionSheet)
**Apple API** [`flashScrollIndicators`](https://developer.apple.com/documentation/uikit/uiscrollview/1619435-flashscrollindicators?language=objc)
**Bug**: https://github.com/material-components/material-components-ios/issues/6845

## Introduction
MDCActionSheet does not indicate to users that there is scrollable content if the content is taller than half of the screen. For instance, if there is 100 options on certain devices an MDCActionSheet would open up half way which would be right where a cell ends. This leads to users not being able to identify that there is scrollable content.

## Q/A
This was manually tested on a simulator.

## Screenshots
| Before | After |
| --- | --- |
|![Simulator Screen Shot - iPhone XR - 2019-04-05 at 11 38 25](https://user-images.githubusercontent.com/7131294/55639463-78ceae80-5797-11e9-8ca5-b48062f57000.png)|![Simulator Screen Shot - iPhone XR - 2019-04-05 at 11 36 53](https://user-images.githubusercontent.com/7131294/55639475-7cfacc00-5797-11e9-944d-2b1c23c04b2f.png)|



**_Note:_** These screenshots were taken right after presenting the _Thirty Options_ example within the Swift example.
