### PR TITLE
[BottomDrawer] Fix crash when dividing by 0.

### DIFF
--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -799,6 +799,11 @@ static UIColor *DrawerShadowColor(void) {
 - (CGFloat)transitionPercentageForContentOffset:(CGPoint)contentOffset
                                          offset:(CGFloat)offset
                                        distance:(CGFloat)distance {
+  // If the distance is 0 or negative there is no distance for a transition to occur and therefore
+  // it is set to 1 (100%).
+  if (distance <= 0) {
+    return 1;
+  }
   return 1 - MAX(0, MIN(1, (self.transitionCompleteContentOffset - contentOffset.y - offset) /
                                distance));
 }


### PR DESCRIPTION
In the rare case where the distance is 0 when calculating the transition percentage, there was a crash. This was discovered when calculation code coverage.

As a solution, in this case we don't have any transition occurring as there is no distance for it to transition in, and therefore the transition is already completed from the start and we will return 1 (100%) to notify the caller the transition has already completed.

Resolves #6646 

