### PR TITLE
[FlexibleHeader] Fix for FlexibleHeader on iPad in split screen

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -111,8 +111,7 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 - (void)commonMDCFlexibleHeaderViewControllerInit {
   _inferPreferredStatusBarStyle = YES;
 
-  MDCFlexibleHeaderView *headerView =
-      [[MDCFlexibleHeaderView alloc] initWithFrame:[UIScreen mainScreen].bounds];
+   MDCFlexibleHeaderView *headerView = [[MDCFlexibleHeaderView alloc] initWithFrame:CGRectZero];
   headerView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
   headerView.delegate = self;
   _headerView = headerView;
@@ -136,6 +135,9 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
   if (shouldDisableAutomaticInsetting) {
     parent.automaticallyAdjustsScrollViewInsets = NO;
   }
+
+  // Size the header based on the parent view controller
+  _headerView.frame = parent.view.bounds;
 }
 
 - (void)didMoveToParentViewController:(UIViewController *)parent {

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -111,7 +111,7 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 - (void)commonMDCFlexibleHeaderViewControllerInit {
   _inferPreferredStatusBarStyle = YES;
 
-   MDCFlexibleHeaderView *headerView = [[MDCFlexibleHeaderView alloc] initWithFrame:CGRectZero];
+  MDCFlexibleHeaderView *headerView = [[MDCFlexibleHeaderView alloc] initWithFrame:CGRectZero];
   headerView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
   headerView.delegate = self;
   _headerView = headerView;


### PR DESCRIPTION
MDCFlexibleHeaderViewController had assumed that width was always equal to the screen width. In iPad split screen, this causes the header to be too wide.

cl/169740658
b/65638103

Tested=cl/242860945

**_Note:_** This is a copy of #6790.
