### PR TITLE
Update build environment for Xcode and CocoaPods

### DIFF
--- a/docs/build-env/README.md
+++ b/docs/build-env/README.md
@@ -37,8 +37,8 @@ errors to allow the normal deprecation process to work:
 
 ### Xcode
 
-The core team tests against **Xcode 9.0, Xcode 9.2, Xcode 9.4, and Swift 3.2**. 
-Swift 4 support is added whenever possible and will be the standard when Xcode 8 support is dropped in 2018.
+The core team tests against **Xcode 10.0 and Swift 3.2**. 
+Swift 4 support is added whenever possible and will be the standard when Xcode 8 support is dropped.
 
 ### iOS
 
@@ -46,7 +46,7 @@ Our components currently support **iOS 8.0 and up**.
 
 ### CocoaPods
 
-We are using CocoaPods 1.5.0.
+We are using CocoaPods 1.6.1.
 
 ### Ruby
 


### PR DESCRIPTION
We are currently stuck on Xcode 10.0 (possibly 10.1) and use CocoaPods 1.6.1. We no longer support CocoaPods 1.5.x, nor do we regularly use Xcode 9.x except for presubmit testing.

Fixes #7143
