### PR TITLE
[AppBar] Update AppBar theming extension docs.

### DIFF
--- a/components/AppBar/docs/theming-extensions.md
+++ b/components/AppBar/docs/theming-extensions.md
@@ -2,8 +2,7 @@
 
 `MDCAppBarViewController` supports Material Theming using a Container Scheme. The code is currently
 in Beta readiness, which means you will need to follow the [instructions for adding the
-MaterialComponentsBeta podspec to your
-project](https://github.com/material-components/material-components-ios/blob/73bdc03c2bd2abd032b0b69f05cd76928361aa37/contributing/beta_components.md#beta-program-for-components).
+MaterialComponentsBeta podspec to your project](https://github.com/material-components/material-components-ios/blob/develop/contributing/beta_components.md).
 There are two variants for Material Theming of an AppBar.  The Surface Variant colors the App Bar
 background to be `surfaceColor` and the Primary Variant colors the App Bar background to be
 `primaryColor`.


### PR DESCRIPTION
This PR is to follow up a comment https://github.com/material-components/material-components-ios/pull/7089#discussion_r274479805 to fix link in AppBar theming extension readme.