### PR TITLE
[BottomSheet] Add API to flashScrollIndicators

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetController.h
+++ b/components/BottomSheet/src/MDCBottomSheetController.h
@@ -51,7 +51,7 @@
 
  @note Defaults to @c NO.
  */
-@property(nonatomic, assign) BOOL showScrollIndicatorsByDefault;
+@property(nonatomic, assign) BOOL shouldFlashScrollIndicatorsOnAppearance;
 
 /**
  When set to false, the bottom sheet controller can't be dismissed by tapping outside of sheet area.

--- a/components/BottomSheet/src/MDCBottomSheetController.h
+++ b/components/BottomSheet/src/MDCBottomSheetController.h
@@ -46,6 +46,14 @@
 @property(nonatomic, weak, nullable) UIScrollView *trackingScrollView;
 
 /**
+ This property determines if @c showFlashIndicators is called by default when @c
+ MDCBottomSheetController calls @c viewDidAppear.
+
+ @note Defaults to @c NO.
+ */
+@property(nonatomic, assign) BOOL showScrollIndicatorsByDefault;
+
+/**
  When set to false, the bottom sheet controller can't be dismissed by tapping outside of sheet area.
  */
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -73,6 +73,14 @@
   [self.contentViewController.view layoutIfNeeded];
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+  [super viewDidAppear:animated];
+
+  if (self.showScrollIndicatorsByDefault && self.trackingScrollView) {
+    [self.trackingScrollView flashScrollIndicators];
+  }
+}
+
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
   return self.contentViewController.supportedInterfaceOrientations;
 }

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -76,7 +76,7 @@
 - (void)viewDidAppear:(BOOL)animated {
   [super viewDidAppear:animated];
 
-  if (self.showScrollIndicatorsByDefault && self.trackingScrollView) {
+  if (self.shouldFlashScrollIndicatorsOnAppearance) {
     [self.trackingScrollView flashScrollIndicators];
   }
 }

--- a/components/BottomSheet/tests/unit/BottomSheetTests.m
+++ b/components/BottomSheet/tests/unit/BottomSheetTests.m
@@ -30,7 +30,7 @@
   MDCBottomSheetController *bottomSheet = [[MDCBottomSheetController alloc] init];
 
   // Then
-  XCTAssertFalse(bottomSheet.showScrollIndicatorsByDefault);
+  XCTAssertFalse(bottomSheet.shouldFlashScrollIndicatorsOnAppearance);
 }
 
 - (void)testSetShowScrollIndicatorsResultsInCorrectValue {
@@ -38,10 +38,10 @@
   MDCBottomSheetController *bottomSheet = [[MDCBottomSheetController alloc] init];
 
   // When
-  bottomSheet.showScrollIndicatorsByDefault = YES;
+  bottomSheet.shouldFlashScrollIndicatorsOnAppearance = YES;
 
   // Then
-  XCTAssertTrue(bottomSheet.showScrollIndicatorsByDefault);
+  XCTAssertTrue(bottomSheet.shouldFlashScrollIndicatorsOnAppearance);
 }
 
 @end

--- a/components/BottomSheet/tests/unit/BottomSheetTests.m
+++ b/components/BottomSheet/tests/unit/BottomSheetTests.m
@@ -25,4 +25,23 @@
   XCTAssertTrue(YES);
 }
 
+- (void)testBottomSheetDefaults {
+  // Given
+  MDCBottomSheetController *bottomSheet = [[MDCBottomSheetController alloc] init];
+
+  // Then
+  XCTAssertFalse(bottomSheet.showScrollIndicatorsByDefault);
+}
+
+- (void)testSetShowScrollIndicatorsResultsInCorrectValue {
+  // Given
+  MDCBottomSheetController *bottomSheet = [[MDCBottomSheetController alloc] init];
+
+  // When
+  bottomSheet.showScrollIndicatorsByDefault = YES;
+
+  // Then
+  XCTAssertTrue(bottomSheet.showScrollIndicatorsByDefault);
+}
+
 @end


### PR DESCRIPTION
## The problem
Currently `MDCBottomSheet` does not indicate to users that there is scrollable content by default. If a client is using this component and want to inform their users that the content is scrollable they currently have no way to do that.

## The fix
Add a behavioral flag for when clients want to `flashScrollIndicators` so that clients can opt into this behavior if they need it. This is recommended by Apple when:

> [You should call this method whenever you bring the scroll view to front.](https://developer.apple.com/documentation/uikit/uiscrollview/1619435-flashscrollindicators?language=objc).

## Alternatives considered
Calling `flashScrollIndicators` by default.

## Videos
| Before | After | 
| - | - |
|![before](https://user-images.githubusercontent.com/7131294/55986827-36f9a880-5c6e-11e9-86e0-f9fe7df936db.gif)|![after](https://user-images.githubusercontent.com/7131294/55986838-3bbe5c80-5c6e-11e9-8909-e518524a7b7b.gif)|

