### PR TITLE
[NavigationDrawer] Remove unneeded dependency on MDCBottomDrawerContainerViewController

### DIFF
--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController+Testing.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController+Testing.h
@@ -12,12 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCBottomDrawerContainerViewController.h"
-
 extern NSString *_Nonnull const kMDCBottomDrawerScrollViewAccessibilityIdentifier;
-
-/**
- Exposes parts of MDCBottomDrawerContainerViewController for testing.
- */
-@interface MDCBottomDrawerContainerViewController (Testing)
-@end


### PR DESCRIPTION
When exposing `kMDCBottomDrawerScrollViewAccessibilityIdentifier` to clients for testing purposes, which is the a11y identifier for the internal scrollview of the navigation drawer, we don't actually need to depend on MDCBottomDrawerContainerViewController. By depending on it, we will need to expose this private file to the client but that is actually not needed.

Because the BUILD target for this testing header doesn't actually include the private/ files this caused an error. Removing this unneeded dependency fixes the error and also provides the needed extern string to the client.

closes: #7137 