### PR TITLE
Add @obj annotations to get Swift examples to show up in Dragons

### DIFF
--- a/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
+++ b/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
@@ -98,7 +98,7 @@ class ActionSheetSwiftExampleViewController: UIViewController {
 // MARK: Catalog by Convensions
 extension ActionSheetSwiftExampleViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Action Sheet", "Action Sheet (Swift)"],
       "primaryDemo": false,

--- a/components/ActivityIndicator/examples/ActivityIndicatorSwiftExampleViewController.swift
+++ b/components/ActivityIndicator/examples/ActivityIndicatorSwiftExampleViewController.swift
@@ -84,7 +84,7 @@ extension ActivityIndicatorSwiftExampleViewController : MDCActivityIndicatorDele
    }
 
   // MARK: Catalog by convention
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Activity Indicator", "Activity Indicator (Swift)"],
       "primaryDemo": false,

--- a/components/AnimationTiming/examples/AnimationTimingSwiftExampleViewController.swift
+++ b/components/AnimationTiming/examples/AnimationTimingSwiftExampleViewController.swift
@@ -175,7 +175,7 @@ extension AnimationTimingSwiftExampleViewController {
       scrollView.addSubview(materialSharpView)
    }
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Animation Timing", "Animation Timing (Swift)"],
       "primaryDemo": false,

--- a/components/AppBar/examples/AppBarAnimatedGlitchExample.swift
+++ b/components/AppBar/examples/AppBarAnimatedGlitchExample.swift
@@ -183,7 +183,7 @@ extension AppBarAnimatedJumpExample: MDCTabBarDelegate {
 
 extension AppBarAnimatedJumpExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["App Bar", "Manual Tabs Jump (Animated)"],
       "primaryDemo": false,

--- a/components/AppBar/examples/AppBarGlitchExample.swift
+++ b/components/AppBar/examples/AppBarGlitchExample.swift
@@ -148,7 +148,7 @@ extension AppBarJumpExample: MDCTabBarDelegate {
 
 extension AppBarJumpExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["App Bar", "Manual Tabs Jump"],
       "primaryDemo": false,

--- a/components/AppBar/examples/AppBarImageryExample.swift
+++ b/components/AppBar/examples/AppBarImageryExample.swift
@@ -96,7 +96,7 @@ class AppBarImagerySwiftExample: UITableViewController {
 // MARK: Catalog by convention
 extension AppBarImagerySwiftExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["App Bar", "Imagery (Swift)"],
       "primaryDemo": false,

--- a/components/AppBar/examples/AppBarInheritedAnimatedJumpExample.swift
+++ b/components/AppBar/examples/AppBarInheritedAnimatedJumpExample.swift
@@ -183,7 +183,7 @@ extension AppBarInheritedAnimatedJumpExample: MDCTabBarDelegate {
 
 extension AppBarInheritedAnimatedJumpExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["App Bar", "Manual Tabs Jump (Animated, UITableViewController)"],
       "primaryDemo": false,

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
@@ -71,7 +71,7 @@ class AppBarInterfaceBuilderSwiftExample: UIViewController, UIScrollViewDelegate
 // MARK: Catalog by convention
 extension AppBarInterfaceBuilderSwiftExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["App Bar", "Interface Builder (Swift)"],
       "primaryDemo": false,

--- a/components/AppBar/examples/AppBarManualTabsExample.swift
+++ b/components/AppBar/examples/AppBarManualTabsExample.swift
@@ -152,7 +152,7 @@ extension AppBarManualTabsExample: MDCTabBarDelegate {
 
 extension AppBarManualTabsExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["App Bar", "Manual tabs"],
       "primaryDemo": false,

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -152,7 +152,7 @@ class AppBarModalPresentationSwiftExample: UITableViewController {
 // MARK: Catalog by convention
 extension AppBarModalPresentationSwiftExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["App Bar", "Modal Presentation (Swift)"],
       "primaryDemo": false,

--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -88,7 +88,7 @@ class AppBarTypicalUseSwiftExample: UITableViewController {
 // MARK: Catalog by convention
 extension AppBarTypicalUseSwiftExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["App Bar", "App Bar (Swift)"],
       "primaryDemo": false,

--- a/components/AppBar/examples/AppBarWithUITableViewController.swift
+++ b/components/AppBar/examples/AppBarWithUITableViewController.swift
@@ -106,7 +106,7 @@ class AppBarWithUITableViewController: UITableViewController {
 
 extension AppBarWithUITableViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["App Bar", "AppBar+UITableViewController"],
       "primaryDemo": false,

--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
@@ -140,7 +140,7 @@ class BottomAppBarTypicalUseSwiftExample: UIViewController {
 // MARK: Catalog by convention
 extension BottomAppBarTypicalUseSwiftExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Bottom App Bar", "Bottom App Bar (Swift)"],
       "primaryDemo": false,

--- a/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
+++ b/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
@@ -52,7 +52,7 @@ class BottomNavigationControllerExampleViewController: MDCBottomNavigationBarCon
     viewControllers = [ viewController1, viewController2, viewController3 ]
   }
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Bottom Navigation", "Bottom Navigation Controller"],
       "presentable": false

--- a/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
@@ -124,7 +124,7 @@ class BottomNavigationExplicitlySetColorExample: UIViewController {
 // MARK: Catalog by convention
 extension BottomNavigationExplicitlySetColorExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Bottom Navigation", "Bottom Navigation Set Color (Swift)"],
       "primaryDemo": false,

--- a/components/BottomNavigation/examples/BottomNavigationNilBadges.swift
+++ b/components/BottomNavigation/examples/BottomNavigationNilBadges.swift
@@ -97,7 +97,7 @@ class BottomNavigationNilBadges : UIViewController {
 // MARK: Catalog by convention
 extension BottomNavigationNilBadges {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Bottom Navigation", "Badge Value Test"],
       "primaryDemo": false,

--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -124,7 +124,7 @@ class BottomNavigationResetExample: UIViewController {
 // MARK: Catalog by convention
 extension BottomNavigationResetExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Bottom Navigation", "Bottom Navigation Reorder (Swift)"],
       "primaryDemo": false,

--- a/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
@@ -72,7 +72,7 @@ class BottomNavigationSelectedIconExample: UIViewController {
 // MARK: - Catalog by Conventions
 extension BottomNavigationSelectedIconExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Bottom Navigation", "Bottom Navigation Selected"],
       "primaryDemo": false,

--- a/components/BottomNavigation/examples/BottomNavigationTitleVisibilityChangeExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTitleVisibilityChangeExample.swift
@@ -115,7 +115,7 @@ class BottomNavigationTitleVisibilityChangeExample: UIViewController, MDCBottomN
 // MARK: Catalog by convention
 extension BottomNavigationTitleVisibilityChangeExample {
   
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Bottom Navigation", "Bottom Navigation Title Visibility (Swift)"],
       "primaryDemo": false,

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
@@ -70,7 +70,7 @@ class BottomNavigationTypicalUseSwiftExample: UIViewController {
 // MARK: Catalog by convention
 extension BottomNavigationTypicalUseSwiftExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Bottom Navigation", "Bottom Navigation (Swift)"],
       "primaryDemo": false,

--- a/components/BottomSheet/examples/BottomSheetTableViewExample.swift
+++ b/components/BottomSheet/examples/BottomSheetTableViewExample.swift
@@ -109,7 +109,7 @@ private class BottomSheetTableViewMenu: UITableViewController {
 // MARK: Catalog by convention
 extension BottomSheetTableViewExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Bottom Sheet", "Table View Menu"],
       "primaryDemo": false,

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
@@ -85,7 +85,7 @@ class ButtonBarTypicalUseSwiftExample: UIViewController {
 // MARK: Catalog by convention
 extension ButtonBarTypicalUseSwiftExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Button Bar", "Button Bar (Swift)"],
       "primaryDemo": false,

--- a/components/Buttons/examples/ButtonsCustomFontViewController.swift
+++ b/components/Buttons/examples/ButtonsCustomFontViewController.swift
@@ -22,7 +22,7 @@ class ButtonsCustomFontViewController: UIViewController {
 
   var containerScheme = MDCContainerScheme()
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Buttons", "Buttons (Custom Font)"],
       "primaryDemo": false,

--- a/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
+++ b/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
@@ -20,7 +20,7 @@ import MaterialComponentsBeta.MaterialContainerScheme
 
 class ButtonsDynamicTypeViewController: UIViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Buttons", "Buttons (DynamicType)"],
       "primaryDemo": false,

--- a/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
+++ b/components/Buttons/examples/ButtonsSimpleExampleSwiftViewController.swift
@@ -120,7 +120,7 @@ class ButtonsSimpleExampleSwiftViewController: UIViewController {
 
 extension ButtonsSimpleExampleSwiftViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Buttons", "Buttons (Swift)"],
       "primaryDemo": false,

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -207,7 +207,7 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
 
 extension ButtonsSwiftAndStoryboardController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Buttons", "Buttons (Swift and Storyboard)"],
       "primaryDemo": false,

--- a/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
+++ b/components/Buttons/examples/FloatingButtonExampleSwiftViewController.swift
@@ -116,7 +116,7 @@ class FloatingButtonExampleSwiftViewController: UIViewController {
 
 extension FloatingButtonExampleSwiftViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Buttons", "Floating Action Button (Swift)"],
       "primaryDemo": false,

--- a/components/Cards/examples/CardExampleViewController.swift
+++ b/components/Cards/examples/CardExampleViewController.swift
@@ -62,7 +62,7 @@ class CardExampleViewController: UIViewController {
 
 extension CardExampleViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Cards", "Card (Swift)"],
       "description": "Cards contain content and actions about a single subject.",

--- a/components/Cards/examples/EditReorderCollectionViewController.swift
+++ b/components/Cards/examples/EditReorderCollectionViewController.swift
@@ -246,7 +246,7 @@ class EditReorderCollectionViewController: UIViewController,
 
 extension EditReorderCollectionViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Cards", "Edit/Reorder"],
       "primaryDemo": false,

--- a/components/Cards/examples/EditReorderShapedCollectionViewController.swift
+++ b/components/Cards/examples/EditReorderShapedCollectionViewController.swift
@@ -211,7 +211,7 @@ class EditReorderShapedCollectionViewController: UIViewController,
 
 extension EditReorderShapedCollectionViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Cards", "Shaped Edit/Reorder"],
       "primaryDemo": false,

--- a/components/Cards/examples/ShapedCardViewController.swift
+++ b/components/Cards/examples/ShapedCardViewController.swift
@@ -213,7 +213,7 @@ class ShapedCardViewController: UIViewController {
 @available(iOS 9.0, *)
 extension ShapedCardViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Cards", "Shaped Card"],
       "primaryDemo": false,

--- a/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
+++ b/components/Chips/examples/ChipsFieldDeleteEnabledViewController.swift
@@ -68,7 +68,7 @@ class ChipsFieldDeleteEnabledViewController : UIViewController, MDCChipFieldDele
 }
 // MARK - Catalog by Convention
 extension ChipsFieldDeleteEnabledViewController {
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs" : ["Chips", "Chips Input Delete Enabled (Swift)"],
       "primaryDemo" : false,

--- a/components/Collections/examples/CollectionsSimpleSwiftDemo.swift
+++ b/components/Collections/examples/CollectionsSimpleSwiftDemo.swift
@@ -54,7 +54,7 @@ class CollectionsSimpleSwiftDemo: MDCCollectionViewController {
 // MARK: Catalog by convention
 extension CollectionsSimpleSwiftDemo {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": [ "Collections", "Simple Swift Demo"],
       "primaryDemo": false,

--- a/components/Dialogs/examples/DialogsAlertComparisonExample.swift
+++ b/components/Dialogs/examples/DialogsAlertComparisonExample.swift
@@ -192,7 +192,7 @@ class DialogsAlertComparisonExample: UIViewController {
 // MARK: Catalog by convention
 extension DialogsAlertComparisonExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Dialogs", "Alert Comparison"],
       "primaryDemo": false,

--- a/components/Dialogs/examples/DialogsAlertCustomizationExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsAlertCustomizationExampleViewController.swift
@@ -337,7 +337,7 @@ private extension MDCButton {
 // MARK: Catalog by convention
 extension DialogsAlertCustomizationExampleViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Dialogs", "Alert Customization"],
       "primaryDemo": false,

--- a/components/Dialogs/examples/DialogsCustomShadowExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsCustomShadowExampleViewController.swift
@@ -112,7 +112,7 @@ class DialogsCustomShadowExampleViewController: UIViewController {
 
   // MARK: Catalog by convention
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Dialogs", "View with Corner Radius"],
       "primaryDemo": false,

--- a/components/Dialogs/examples/DialogsLongAlertExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertExampleViewController.swift
@@ -82,7 +82,7 @@ class DialogsLongAlertExampleViewController: UIViewController {
 // MARK: Catalog by convention
 extension DialogsLongAlertExampleViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Dialogs", "Swift Alert Demo"],
       "primaryDemo": false,

--- a/components/Dialogs/examples/DialogsThemedPresentationExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsThemedPresentationExampleViewController.swift
@@ -219,7 +219,7 @@ class DialogsThemedPresentationExampleViewController: UIViewController {
 
 extension DialogsThemedPresentationExampleViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Dialogs", "Dialog Presentation Controller Theming"],
       "primaryDemo": false,

--- a/components/Dialogs/examples/DialogsWithEmphasisButtonExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsWithEmphasisButtonExampleViewController.swift
@@ -74,7 +74,7 @@ class DialogsWithEmphasisButtonExampleViewController: UIViewController {
 
 extension DialogsWithEmphasisButtonExampleViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Dialogs", "Dialog with Themed Emphasis Buttons"],
       "primaryDemo": false,

--- a/components/FeatureHighlight/examples/FeatureHightlightTypicalUseViewController.swift
+++ b/components/FeatureHighlight/examples/FeatureHightlightTypicalUseViewController.swift
@@ -70,7 +70,7 @@ class FeatureHighlightSwiftViewController: UIViewController {
 
 extension FeatureHighlightSwiftViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Feature Highlight", "Feature Highlight (Swift)"],
       "primaryDemo": false,

--- a/components/List/examples/BaseCellExample.swift
+++ b/components/List/examples/BaseCellExample.swift
@@ -117,7 +117,7 @@ extension BaseCellExample: UICollectionViewDataSource {
 // MARK: Catalog By Convention
 extension BaseCellExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["List Items", "MDCBaseCell Example (Swift)"],
       "description": "MDCBaseCell Example (Swift)",

--- a/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
+++ b/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
@@ -245,7 +245,7 @@ private class ModalViewController: UIViewController {
 
 extension MaskedTransitionTypicalUseSwiftExample {
   // MARK: - CatalogByConvention
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs" : [ "Masked Transition", "Masked Transition (Swift)" ],
       "description" : "Examples of how the Floating Action Button can transition to other "

--- a/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.swift
+++ b/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.swift
@@ -23,7 +23,7 @@ import MaterialComponents.MaterialNavigationBar
 extension NavigationBarTypicalUseSwiftExample {
 
   // (CatalogByConvention)
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Navigation Bar", "Navigation Bar (Swift)"],
       "primaryDemo": false,

--- a/components/NavigationDrawer/examples/BottomDrawerExpandFullscreenExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerExpandFullscreenExample.swift
@@ -124,7 +124,7 @@ class ExpandFullscreenContentViewController: UITableViewController {
 
 extension BottomDrawerExpandFullscreenExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Navigation Drawer", "Expand to Fullscreen Example"],
       "description": "Navigation Drawer",

--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -145,7 +145,7 @@ class DrawerContentTableViewController: UITableViewController {
 
 extension BottomDrawerInfiniteScrollingExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Navigation Drawer", "Bottom Drawer Infinite Scrolling"],
       "description": "Navigation Drawer",

--- a/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
@@ -74,7 +74,7 @@ class BottomDrawerNoHeaderExample: UIViewController {
 
 extension BottomDrawerNoHeaderExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Navigation Drawer", "Bottom Drawer No Header"],
       "primaryDemo": false,

--- a/components/NavigationDrawer/examples/BottomDrawerWithChangingContentSize.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithChangingContentSize.swift
@@ -153,7 +153,7 @@ UICollectionViewDelegate, UICollectionViewDataSource {
 
 extension BottomDrawerWithChangingContentSizeExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Navigation Drawer", "Bottom Drawer Changing Content Size"],
       "primaryDemo": false,

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderLessContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderLessContentExample.swift
@@ -25,7 +25,7 @@ class BottomDrawerWithHeaderLessContentExample: BottomDrawerWithHeaderExample {
     super.presentNavigationDrawer()
   }
 
-  override class func catalogMetadata() -> [String: Any] {
+  @objc override class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Navigation Drawer", "Bottom Drawer Less Content"],
       "primaryDemo": false,

--- a/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
@@ -131,7 +131,7 @@ class DrawerContentWithScrollViewController: UIViewController,
 
 extension BottomDrawerWithScrollableContentExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Navigation Drawer", "Bottom Drawer Scrollable Content"],
       "primaryDemo": false,

--- a/components/PageControl/examples/PageControlTypicalUseExample.swift
+++ b/components/PageControl/examples/PageControlTypicalUseExample.swift
@@ -119,7 +119,7 @@ class PageControlSwiftExampleViewController: UIViewController, UIScrollViewDeleg
 
   // MARK: - CatalogByConvention
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Page Control", "Swift example"],
       "primaryDemo": false,

--- a/components/Palettes/examples/PalettesExpandedExample.swift
+++ b/components/Palettes/examples/PalettesExpandedExample.swift
@@ -44,7 +44,7 @@ class PalettesGeneratedExampleViewController: PalettesExampleViewController {
 // MARK: - Catalog by convention
 extension PalettesGeneratedExampleViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Palettes", "Generated Palettes"],
       "primaryDemo": false,

--- a/components/Palettes/examples/PalettesStandardExample.swift
+++ b/components/Palettes/examples/PalettesStandardExample.swift
@@ -44,7 +44,7 @@ class PalettesStandardExampleViewController: PalettesExampleViewController {
 // MARK: - Catalog by convention
 extension PalettesStandardExampleViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Palettes", "Standard Palettes"],
       "description": "The Palettes component provides sets of reference colors that work "

--- a/components/Ripple/examples/CardCellsWithRippleExample.swift
+++ b/components/Ripple/examples/CardCellsWithRippleExample.swift
@@ -217,7 +217,7 @@ class CardCellsWithRippleExample: UIViewController,
 
 extension CardCellsWithRippleExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Ripple", "Card Cell with Ripple"],
       "primaryDemo": false,

--- a/components/Ripple/examples/CardWithRippleExample.swift
+++ b/components/Ripple/examples/CardWithRippleExample.swift
@@ -77,7 +77,7 @@ class CardWithRippleExample: UIViewController {
 
 extension CardWithRippleExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Ripple", "Card with Ripple"],
       "primaryDemo": false,

--- a/components/Ripple/examples/StatefulRippleExample.swift
+++ b/components/Ripple/examples/StatefulRippleExample.swift
@@ -115,7 +115,7 @@ class StatefulRippleExample : UIViewController {
 
 extension StatefulRippleExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Ripple", "Stateful Ripple"],
       "primaryDemo": false,

--- a/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.swift
+++ b/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.swift
@@ -86,7 +86,7 @@ class ShadowElevationsTypicalUseExample: UIViewController {
 // MARK: Catalog by convention
 extension ShadowElevationsTypicalUseExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Shadow", "Shadow Elevations (Swift)"],
       "primaryDemo": false,

--- a/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
+++ b/components/ShadowLayer/examples/ShadowDragSquareExampleViewController.swift
@@ -70,7 +70,7 @@ class ShadowDragSquareExampleViewController: UIViewController {
 
   // MARK: - CatalogByConvention
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": [ "Shadow", "Shadow Layer"],
       "description": "Shadow Layer implements the Material Design specifications for "

--- a/components/ShadowLayer/examples/ShapesShadows.swift
+++ b/components/ShadowLayer/examples/ShapesShadows.swift
@@ -69,7 +69,7 @@ extension ShapesShadowsController {
   
   // MARK: Catalog by convention
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Shadow", "Shape & Shadow"],
       "primaryDemo": false,

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
@@ -250,7 +250,7 @@ extension TabBarIconSwiftExample {
 // MARK: - Catalog by convention
 extension TabBarIconSwiftExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Tab Bar", "Tabs with Icons (Swift)"],
       "primaryDemo": false,

--- a/components/Tabs/examples/supplemental/TabBarIndicatorTemplateExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIndicatorTemplateExampleSupplemental.swift
@@ -121,7 +121,7 @@ extension TabBarIndicatorTemplateExample {
 // MARK: - Catalog by convention
 extension TabBarIndicatorTemplateExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Tab Bar", "Custom Selection Indicator"],
       "primaryDemo": false,

--- a/components/TextFields/examples/TextFieldFilledExample.swift
+++ b/components/TextFields/examples/TextFieldFilledExample.swift
@@ -435,7 +435,7 @@ extension TextFieldFilledSwiftExample {
 
 extension TextFieldFilledSwiftExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Text Field", "Filled Text Fields"],
       "primaryDemo": false,

--- a/components/TextFields/examples/TextFieldLegacyExample.swift
+++ b/components/TextFields/examples/TextFieldLegacyExample.swift
@@ -393,7 +393,7 @@ extension TextFieldLegacySwiftExample {
 
 extension TextFieldLegacySwiftExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Text Field", "[Legacy] Typical Use"],
       "primaryDemo": false,

--- a/components/TextFields/examples/TextFieldManualLayoutLegacyExample.swift
+++ b/components/TextFields/examples/TextFieldManualLayoutLegacyExample.swift
@@ -338,7 +338,7 @@ extension TextFieldManualLayoutLegacySwiftExample {
 // MARK: - CatalogByConvention
 extension TextFieldManualLayoutLegacySwiftExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Text Field", "[Legacy] Manual Layout (Swift)"],
       "primaryDemo": false,

--- a/components/TextFields/examples/TextFieldOutlinedExample.swift
+++ b/components/TextFields/examples/TextFieldOutlinedExample.swift
@@ -410,7 +410,7 @@ extension TextFieldOutlinedSwiftExample {
 
 extension TextFieldOutlinedSwiftExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Text Field", "Outlined Fields & Text Areas"],
       "primaryDemo": false,

--- a/components/TextFields/examples/TextFieldSemanticColorThemer.swift
+++ b/components/TextFields/examples/TextFieldSemanticColorThemer.swift
@@ -211,7 +211,7 @@ extension TextFieldSemanticColorThemer {
 
 extension TextFieldSemanticColorThemer {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Text Field", "Theming Text Fields"],
       "primaryDemo": false,

--- a/components/TextFields/examples/TextFieldUnderlineExample.swift
+++ b/components/TextFields/examples/TextFieldUnderlineExample.swift
@@ -414,7 +414,7 @@ extension TextFieldUnderlineSwiftExample {
 
 extension TextFieldUnderlineSwiftExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Text Field", "Underline Style"],
       "description": "Text fields let users enter and edit text.",

--- a/components/TextFields/examples/experimental/InputTextFieldStoryboardExampleViewController.swift
+++ b/components/TextFields/examples/experimental/InputTextFieldStoryboardExampleViewController.swift
@@ -95,7 +95,7 @@ extension SimpleTextFieldStoryboardExampleViewController {
 // MARK: - CatalogByConvention
 
 extension SimpleTextFieldStoryboardExampleViewController {
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Text Field", "Input Text Field (Storyboard)"],
       "description": "Text fields let users enter and edit text.",

--- a/components/TextFields/examples/supplemental/TextFieldKitchenSinkExampleSupplemental.swift
+++ b/components/TextFields/examples/supplemental/TextFieldKitchenSinkExampleSupplemental.swift
@@ -476,7 +476,7 @@ extension TextFieldKitchenSinkSwiftExample {
 
 extension TextFieldKitchenSinkSwiftExample {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Text Field", "Kitchen Sink"],
       "primaryDemo": false,

--- a/components/Typography/examples/TypographyFontListExample.swift
+++ b/components/Typography/examples/TypographyFontListExample.swift
@@ -145,7 +145,7 @@ class TypographyFontListExampleViewController: UITableViewController {
 // MARK: - CatalogByConvention
 extension TypographyFontListExampleViewController {
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["Typography and Fonts", "Typography"],
       "description": "The Typography component provides methods for displaying text using the "

--- a/components/private/Dragons/examples/ZShadow.swift
+++ b/components/private/Dragons/examples/ZShadow.swift
@@ -98,7 +98,7 @@ extension ZShadowViewController {
   
   // MARK: Catalog by convention
 
-  class func catalogMetadata() -> [String: Any] {
+  @objc class func catalogMetadata() -> [String: Any] {
     return [
       "breadcrumbs": ["ZShadow"],
       "primaryDemo": false,


### PR DESCRIPTION
This is follow up for #7166. 

I'm doing ~two~ one thing in this PR:
- Adding `@objc` annotations to Swift `catalogMetadata()` methods, because the Swift 4 compiler no longer attempts to infer what methods should be visible to Objective-C. As a result of this change, no Swift examples were showing up in Dragons after #7166. See this article: https://useyourloaf.com/blog/objc-warnings-upgrading-to-swift-4/ for additional context.
- ~Moving MDCChipTextField from its own component directory to the TextFields experimental directory, where MDCInputTextField and InputChipView live. This is due to the fact that it was not covered by bazel in its previous location. I just ignored the "bazel affected" error for #7166, and didn't want to ignore it for this PR.~