### PR TITLE
Removing Swift code from ObjC snippet in theming

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -98,7 +98,7 @@ MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
 containerScheme.colorScheme.primaryColor = [UIColor redColor];
 
 // Or assign a customized scheme instance:
-let shapeScheme = MDCShapeScheme()
+MDCShapeScheme *shapeScheme = [[MDCShapeScheme alloc] init];
 containerScheme.shapeScheme = shapeScheme
 ```
 <!--</div>-->


### PR DESCRIPTION
Small improvement to the obj-c code snippet using Swift instead of Objc