### PR TITLE
[scripts] Fix the generate_readme script's jazzy symbol generation.

### DIFF
--- a/scripts/generate_readme
+++ b/scripts/generate_readme
@@ -139,7 +139,18 @@ cat "$TMP_EXPANDED_README_PATH" | while read -r line; do
 
     pushd "$COMPONENT_PATH" >> /dev/null
     echo "Generating jazzy docs for API links..."
-    jazzy . --output apidocs
+
+    # Note: Setting `--framework-root=.` makes it so that jazzy can't resolve any symbols outside
+    # of the given component. This is intentional; we only want the symbols for this particular
+    # component to appear in the generated README. The unfortunate side effect of this is that
+    # jazzy generates erroneous "fatal error" statements for imports that live outside of the
+    # component.
+    echo
+    echo "Note: \"fatal error: 'SomeHeader.h' file not found\" errors are ok so long as they are"
+    echo "headers that are not within this component directory."
+    echo
+
+    jazzy . --output apidocs --framework-root=.
     extract_apis_of_type "Classes" "Class" >> "$TMP_README_PATH"
     extract_apis_of_type "Protocols" "Protocol" >> "$TMP_README_PATH"
     extract_apis_of_type "Enums" "Enumeration" >> "$TMP_README_PATH"


### PR DESCRIPTION
Context is described in the associated issue.

The fix here is to force jazzy to only look at a given component when resolving headers. This means the generate_readme script will generate some import errors, so I've added a notice to the script indicating that these errors are likely ok.

Closes https://github.com/material-components/material-components-ios/issues/7195