### PR TITLE
[Buttons] Fix broken link within documentation

### DIFF
--- a/components/Buttons/docs/theming.md
+++ b/components/Buttons/docs/theming.md
@@ -2,7 +2,7 @@
 
 You can theme an MDCButton to match one of the Material Design button styles using button theming
 extensions. The content below assumes that you have read the article on
-[Theming](../../docs/theming.md).
+[Theming](../../../docs/theming.md).
 
 ### How to theme an MDCButton
 


### PR DESCRIPTION
The link within the buttons _theming extension_ documentation was broken, this resulted in a 404 error. The doc link was off by 1 directory, this changes updates the link to go up one level.

Related to https://github.com/material-components/material-components-ios/issues/6592