### PR TITLE
[scripts] Fix relative link rewriting for local files.

### DIFF
--- a/components/ActionSheet/README.md
+++ b/components/ActionSheet/README.md
@@ -53,7 +53,7 @@ the screen and displays actions a user can take.
 
 `MDCActionSheetController` is a material design implementation of UIAlertControllerStyleActionSheet.
 
-Action Sheet is currently a [beta component](docs/../../contributing/beta_components.md). Therefore, clients that
+Action Sheet is currently a [beta component](../../contributing/beta_components.md). Therefore, clients that
 wish to use Action Sheet in their app will need to manually clone the repo and add the code to their project. 
 
 
@@ -171,7 +171,7 @@ Material UIAlertController please see the `MDCAlertController` class.
 
 ### Theming
 
-You can theme an MDCActionSheet to match the Material Design style by using a theming extension. The content below assumes you have read the article on [Theming](docs/../../docs/theming.md).
+You can theme an MDCActionSheet to match the Material Design style by using a theming extension. The content below assumes you have read the article on [Theming](../../docs/theming.md).
 
 ### How to theme an MDCActionSheet
 

--- a/components/Buttons/README.md
+++ b/components/Buttons/README.md
@@ -229,7 +229,7 @@ to "custom" in order for the button's highlight states to work as expected.
 
 You can theme an MDCButton to match one of the Material Design button styles using button theming
 extensions. The content below assumes that you have read the article on
-[Theming](docs/../docs/theming.md).
+[Theming](../../docs/theming.md).
 
 ### How to theme an MDCButton
 

--- a/components/Dialogs/README.md
+++ b/components/Dialogs/README.md
@@ -199,7 +199,7 @@ You can theme an MDCDialog to match the Material Design Dialog using your app's 
 extension.
 
 You must first add the Dialog theming extension to your project, by following the standard 
-[beta component](docs/../../../contributing/beta_components.md) steps.
+[beta component](../../../contributing/beta_components.md) steps.
 
 You can then import the theming extension and create an `MDCContainerScheme` instance. A container scheme 
 defines the design parameters that you can use to theme your dialogs.

--- a/components/TextFields/README.md
+++ b/components/TextFields/README.md
@@ -296,7 +296,7 @@ self.textFieldControllerDefaultCharMax.floatingEnabled = NO;
 You can theme an MDCTextField using the TextField theming extension.
 
 To use the theming extension, first add it to your project by following the
-[steps to use beta components](docs/../../../contributing/beta_components.md).
+[steps to use beta components](../../../contributing/beta_components.md).
 
 Then import the theming extension and create an `MDCContainerScheme` instance. A container scheme
 defines schemes for subsystems like Color and Typography.

--- a/scripts/generate_readme
+++ b/scripts/generate_readme
@@ -204,7 +204,7 @@ echo "Rewriting paths..."
 # Rewrite relative paths
 perl -pi -e "s|\(\.\./|(|g" "$TMP_README_PATH"
 perl -pi -e "s|href=\"\.\./|href=\"|g" "$TMP_README_PATH"
-perl -pi -e "s|\[(.+)\]\((.+)\.md\)|[\1](docs/\2.md)|g" "$TMP_README_PATH"
+perl -pi -e "s|\[(.+)\]\((\w+)\.md\)|[\1](docs/\2.md)|g" "$TMP_README_PATH"
 
 # Rewrite asset paths
 perl -pi -e "s|src=\"assets|src=\"docs/assets|g" "$TMP_README_PATH"


### PR DESCRIPTION
Context is in the associated issue.

This affects the perl expression that prepends `docs/` to urls. Before this change, this perl expression was affecting too many types of urls, causing some urls to become invalid. After this change, the perl expression will only affect urls that link to the same directory.

The perl expression now only modifies urls that link to a sibling markdown file composed of `\w` characters (e.g. `theming.md`). This is not perfect, but it addresses our needs for now. If/when we encounter other types of local urls we can address them separately.

For now, this change fixes the incorrect behavior described in the associated bug.

As part of this change, the readme generator was ran on all components.

Closes https://github.com/material-components/material-components-ios/issues/7203

Related to https://github.com/material-components/material-components-ios/issues/6592