### PR TITLE
[Docs] Fix links within documenation

### DIFF
--- a/components/ActionSheet/README.md
+++ b/components/ActionSheet/README.md
@@ -40,7 +40,7 @@ the screen and displays actions a user can take.
   - [Theming](#theming)
   - [How to theme an MDCActionSheet](#how-to-theme-an-mdcactionsheet)
   - [Color Theming (To be deleted)](#color-theming-to-be-deleted)
-  - [Typography Theming - to be deleted](#typography-theming---to-be-deleted)
+  - [Typography Theming (To be deleted)](#typography-theming-to-be-deleted)
 - [Accessibility](#accessibility)
   - [Set `-isScrimAccessibilityElement`](#set-`-isscrimaccessibilityelement`)
   - [Set `-scrimAccessibilityLabel`](#set-`-scrimaccessibilitylabel`)
@@ -268,7 +268,7 @@ MDCActionSheetController *actionSheet = [[MDCActionSheetController alloc] init];
 
 <!-- Extracted from docs/typography-theming.md -->
 
-### Typography Theming - to be deleted
+### Typography Theming (To be deleted)
 
 You can theme an Action Sheet with your app's typography scheme using the TypographyThemer extension.
 

--- a/components/ActionSheet/README.md
+++ b/components/ActionSheet/README.md
@@ -39,8 +39,8 @@ the screen and displays actions a user can take.
 - [Extensions](#extensions)
   - [Theming](#theming)
   - [How to theme an MDCActionSheet](#how-to-theme-an-mdcactionsheet)
-  - [Color Theming (To be deleted)](#color-theming-(to-be-deleted))
-  - [Typography Theming (To be deleted)](#typography-theming-(to-be-deleted))
+  - [Color Theming - to be deleted](#color-theming-to-be-deleted)
+  - [Typography Theming - to be deleted](#typography-theming-to-be-deleted)
 - [Accessibility](#accessibility)
   - [Set `-isScrimAccessibilityElement`](#set-`-isscrimaccessibilityelement`)
   - [Set `-scrimAccessibilityLabel`](#set-`-scrimaccessibilitylabel`)
@@ -226,7 +226,7 @@ actionSheet.applyTheme(withScheme: containerScheme)
 
 <!-- Extracted from docs/color-theming.md -->
 
-### Color Theming (To be deleted)
+### Color Theming - to be deleted
 
 You can theme an Action Sheet with your app's color scheme using the ColorThemer extension.
 
@@ -268,7 +268,7 @@ MDCActionSheetController *actionSheet = [[MDCActionSheetController alloc] init];
 
 <!-- Extracted from docs/typography-theming.md -->
 
-### Typography Theming (To be deleted)
+### Typography Theming - to be deleted
 
 You can theme an Action Sheet with your app's typography scheme using the TypographyThemer extension.
 

--- a/components/ActionSheet/README.md
+++ b/components/ActionSheet/README.md
@@ -39,8 +39,8 @@ the screen and displays actions a user can take.
 - [Extensions](#extensions)
   - [Theming](#theming)
   - [How to theme an MDCActionSheet](#how-to-theme-an-mdcactionsheet)
-  - [Color Theming - to be deleted](#color-theming-to-be-deleted)
-  - [Typography Theming - to be deleted](#typography-theming-to-be-deleted)
+  - [Color Theming (To be deleted)](#color-theming-to-be-deleted)
+  - [Typography Theming - to be deleted](#typography-theming---to-be-deleted)
 - [Accessibility](#accessibility)
   - [Set `-isScrimAccessibilityElement`](#set-`-isscrimaccessibilityelement`)
   - [Set `-scrimAccessibilityLabel`](#set-`-scrimaccessibilitylabel`)
@@ -226,7 +226,7 @@ actionSheet.applyTheme(withScheme: containerScheme)
 
 <!-- Extracted from docs/color-theming.md -->
 
-### Color Theming - to be deleted
+### Color Theming (To be deleted)
 
 You can theme an Action Sheet with your app's color scheme using the ColorThemer extension.
 

--- a/components/ActionSheet/README.md
+++ b/components/ActionSheet/README.md
@@ -40,7 +40,6 @@ the screen and displays actions a user can take.
   - [Theming](#theming)
   - [How to theme an MDCActionSheet](#how-to-theme-an-mdcactionsheet)
 - [Accessibility](#accessibility)
-- [Accessibility](#accessibility)
   - [Set `-isScrimAccessibilityElement`](#set-`-isscrimaccessibilityelement`)
   - [Set `-scrimAccessibilityLabel`](#set-`-scrimaccessibilitylabel`)
   - [Set `-scrimAccessibilityHint`](#set-`-scrimaccessibilityhint`)
@@ -226,8 +225,6 @@ actionSheet.applyTheme(withScheme: containerScheme)
 
 
 
-
-## Accessibility
 
 <!-- Extracted from docs/accessibility.md -->
 

--- a/components/ActionSheet/README.md
+++ b/components/ActionSheet/README.md
@@ -39,13 +39,15 @@ the screen and displays actions a user can take.
 - [Extensions](#extensions)
   - [Theming](#theming)
   - [How to theme an MDCActionSheet](#how-to-theme-an-mdcactionsheet)
-  - [Color Theming (To be deleted)](#color-theming-to-be-deleted)
-  - [Typography Theming (To be deleted)](#typography-theming-to-be-deleted)
+- [Accessibility](#accessibility)
 - [Accessibility](#accessibility)
   - [Set `-isScrimAccessibilityElement`](#set-`-isscrimaccessibilityelement`)
   - [Set `-scrimAccessibilityLabel`](#set-`-scrimaccessibilitylabel`)
   - [Set `-scrimAccessibilityHint`](#set-`-scrimaccessibilityhint`)
   - [Set `-scrimAccessibilityTraits`](#set-`-scrimaccessibilitytraits`)
+- [Unsupported](#unsupported)
+  - [Color Theming](#color-theming)
+  - [Typography Theming](#typography-theming)
 
 - - -
 
@@ -224,90 +226,8 @@ actionSheet.applyTheme(withScheme: containerScheme)
 
 
 
-<!-- Extracted from docs/color-theming.md -->
 
-### Color Theming (To be deleted)
-
-You can theme an Action Sheet with your app's color scheme using the ColorThemer extension.
-
-You must first add the Color Themer extension to your project:
-
-```bash
-pod `MaterialComponentsBeta/ActionSheet+ColorThemer`
-```
-
-<!--<div class="material-code-render" markdown="1">-->
-#### Swift
-```swift
-// Step 1: Import the ColorThemer extension
-import MaterialComponentsBeta.MaterialActionSheet_ColorThemer
-
-// Step 2: Create or get a color scheme
-let colorScheme = MDCSemanticColorScheme()
-
-// Step 3: Apply the color scheme to your component
-let actionSheet = MDCActionSheetController()
-MDCActionSheetColorThemer.applySemanticColorScheme(colorScheme, to: actionSheet)
-```
-
-#### Objective-C
-
-```objc
-// Step 1: Import the ColorThemer extension
-#import "MaterialActionSheet+ColorThemer.h"
-
-// Step 2: Create or get a color scheme
-id<MDCColorScheming> colorScheme = [[MDCSematnicColorScheme alloc] init];
-
-// Step 3: Apply the color scheme to your component
-MDCActionSheetController *actionSheet = [[MDCActionSheetController alloc] init];
-[MDCActionSheetColorThemer applySemanticColorScheme:self.colorScheme
-                            toActionSheetController:actionSheet];
-```
-<!--</div>-->
-
-<!-- Extracted from docs/typography-theming.md -->
-
-### Typography Theming (To be deleted)
-
-You can theme an Action Sheet with your app's typography scheme using the TypographyThemer extension.
-
-You must first add the Typography Themer extension to your project:
-
-```bash
-pod `MaterialComponentsBeta/ActionSheet+TypographyThemer`
-```
-
-<!--<div class="material-code-render" markdown="1">-->
-#### Swift
-```swift
-// Step 1: Import the ColorThemer extension
-import MaterialComponentsBeta.MaterialActionSheet_TypographyThemer
-
-// Step 2: Create or get a color scheme
-let typographyScheme = MDCTypographyScheme()
-
-// Step 3: Apply the color scheme to your component
-let actionSheet = MDCActionSheetController()
-MDCActionSheetTypographyThemer.applyTypographyScheme(typographyScheme, to: actionSheet)
-```
-
-#### Objective-C
-
-```objc
-// Step 1: Import the ColorThemer extension
-#import "MaterialActionSheet+TypographyThemer.h"
-
-// Step 2: Create or get a color scheme
-id<MDCTypographyScheming> typographyScheme = [[MDCTypographyScheme alloc] init];
-
-// Step 3: Apply the color scheme to your component
-MDCActionSheetController *actionSheet = [[MDCActionSheetController alloc] init];
-[MDCActionSheetTypographyThemer applyTypographyScheme:self.typographyScheme
-                              toActionSheetController:actionSheet];
-```
-<!--</div>-->
-
+## Accessibility
 
 <!-- Extracted from docs/accessibility.md -->
 
@@ -386,6 +306,93 @@ actionSheet.transitionController.scrimAccessibilityTraits = UIAccessibilityTrait
 ```objc
 MDCActionSheetController *actionSheet = [MDCActionSheetController alloc] init];
 actionSheet.scrimAccessibilityTraits = UIAccessibilityTraitButton;
+```
+<!--</div>-->
+
+
+## Unsupported
+
+<!-- Extracted from docs/color-theming.md -->
+
+### Color Theming
+
+You can theme an Action Sheet with your app's color scheme using the ColorThemer extension.
+
+You must first add the Color Themer extension to your project:
+
+```bash
+pod `MaterialComponentsBeta/ActionSheet+ColorThemer`
+```
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+// Step 1: Import the ColorThemer extension
+import MaterialComponentsBeta.MaterialActionSheet_ColorThemer
+
+// Step 2: Create or get a color scheme
+let colorScheme = MDCSemanticColorScheme()
+
+// Step 3: Apply the color scheme to your component
+let actionSheet = MDCActionSheetController()
+MDCActionSheetColorThemer.applySemanticColorScheme(colorScheme, to: actionSheet)
+```
+
+#### Objective-C
+
+```objc
+// Step 1: Import the ColorThemer extension
+#import "MaterialActionSheet+ColorThemer.h"
+
+// Step 2: Create or get a color scheme
+id<MDCColorScheming> colorScheme = [[MDCSematnicColorScheme alloc] init];
+
+// Step 3: Apply the color scheme to your component
+MDCActionSheetController *actionSheet = [[MDCActionSheetController alloc] init];
+[MDCActionSheetColorThemer applySemanticColorScheme:self.colorScheme
+                            toActionSheetController:actionSheet];
+```
+<!--</div>-->
+
+<!-- Extracted from docs/typography-theming.md -->
+
+### Typography Theming
+
+You can theme an Action Sheet with your app's typography scheme using the TypographyThemer extension.
+
+You must first add the Typography Themer extension to your project:
+
+```bash
+pod `MaterialComponentsBeta/ActionSheet+TypographyThemer`
+```
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+// Step 1: Import the ColorThemer extension
+import MaterialComponentsBeta.MaterialActionSheet_TypographyThemer
+
+// Step 2: Create or get a color scheme
+let typographyScheme = MDCTypographyScheme()
+
+// Step 3: Apply the color scheme to your component
+let actionSheet = MDCActionSheetController()
+MDCActionSheetTypographyThemer.applyTypographyScheme(typographyScheme, to: actionSheet)
+```
+
+#### Objective-C
+
+```objc
+// Step 1: Import the ColorThemer extension
+#import "MaterialActionSheet+TypographyThemer.h"
+
+// Step 2: Create or get a color scheme
+id<MDCTypographyScheming> typographyScheme = [[MDCTypographyScheme alloc] init];
+
+// Step 3: Apply the color scheme to your component
+MDCActionSheetController *actionSheet = [[MDCActionSheetController alloc] init];
+[MDCActionSheetTypographyThemer applyTypographyScheme:self.typographyScheme
+                              toActionSheetController:actionSheet];
 ```
 <!--</div>-->
 

--- a/components/ActionSheet/README.md
+++ b/components/ActionSheet/README.md
@@ -38,7 +38,6 @@ the screen and displays actions a user can take.
 - [MDCActionSheetController vs. UIAlertControllerStyleActionSheet](#mdcactionsheetcontroller-vs.-uialertcontrollerstyleactionsheet)
 - [Extensions](#extensions)
   - [Theming](#theming)
-  - [How to theme an MDCActionSheet](#how-to-theme-an-mdcactionsheet)
 - [Accessibility](#accessibility)
   - [Set `-isScrimAccessibilityElement`](#set-`-isscrimaccessibilityelement`)
   - [Set `-scrimAccessibilityLabel`](#set-`-scrimaccessibilitylabel`)
@@ -174,15 +173,7 @@ Material UIAlertController please see the `MDCAlertController` class.
 
 You can theme an MDCActionSheet to match the Material Design style by using a theming extension. The content below assumes you have read the article on [Theming](../../docs/theming.md).
 
-### How to theme an MDCActionSheet
-
-First, add the pod extension to your project.
-
-```bash
-pod `MaterialComponents/ActionSheet+Theming`
-```
-
-Then, create an action sheet and import the theming extension header for Action Sheets.
+First, create an action sheet and import the theming extension header for Action Sheets.
 
 <!--<div class="material-code-render" markdown="1">-->
 #### Swift

--- a/components/ActionSheet/docs/README.md
+++ b/components/ActionSheet/docs/README.md
@@ -57,8 +57,6 @@ Material UIAlertController please see the `MDCAlertController` class.
 
 - [Theming](theming.md)
 
-## Accessibility
-
 - [Accessibility](accessibility.md)
 
 ## Unsupported

--- a/components/ActionSheet/docs/README.md
+++ b/components/ActionSheet/docs/README.md
@@ -56,7 +56,12 @@ Material UIAlertController please see the `MDCAlertController` class.
 ## Extensions
 
 - [Theming](theming.md)
-- [Color Theming](color-theming.md)
-- [Typography Theming](typography-theming.md)
+
+## Accessibility
 
 - [Accessibility](accessibility.md)
+
+## Unsupported
+
+- [Color Theming](color-theming.md)
+- [Typography Theming](typography-theming.md)

--- a/components/ActionSheet/docs/color-theming.md
+++ b/components/ActionSheet/docs/color-theming.md
@@ -1,4 +1,4 @@
-### Color Theming (To be deleted)
+### Color Theming
 
 You can theme an Action Sheet with your app's color scheme using the ColorThemer extension.
 

--- a/components/ActionSheet/docs/color-theming.md
+++ b/components/ActionSheet/docs/color-theming.md
@@ -1,4 +1,4 @@
-### Color Theming - to be deleted
+### Color Theming (To be deleted)
 
 You can theme an Action Sheet with your app's color scheme using the ColorThemer extension.
 

--- a/components/ActionSheet/docs/color-theming.md
+++ b/components/ActionSheet/docs/color-theming.md
@@ -1,4 +1,4 @@
-### Color Theming (To be deleted)
+### Color Theming - to be deleted
 
 You can theme an Action Sheet with your app's color scheme using the ColorThemer extension.
 

--- a/components/ActionSheet/docs/theming.md
+++ b/components/ActionSheet/docs/theming.md
@@ -2,15 +2,7 @@
 
 You can theme an MDCActionSheet to match the Material Design style by using a theming extension. The content below assumes you have read the article on [Theming](../../../docs/theming.md).
 
-### How to theme an MDCActionSheet
-
-First, add the pod extension to your project.
-
-```bash
-pod `MaterialComponents/ActionSheet+Theming`
-```
-
-Then, create an action sheet and import the theming extension header for Action Sheets.
+First, create an action sheet and import the theming extension header for Action Sheets.
 
 <!--<div class="material-code-render" markdown="1">-->
 #### Swift

--- a/components/ActionSheet/docs/typography-theming.md
+++ b/components/ActionSheet/docs/typography-theming.md
@@ -1,4 +1,4 @@
-### Typography Theming (To be deleted)
+### Typography Theming
 
 You can theme an Action Sheet with your app's typography scheme using the TypographyThemer extension.
 

--- a/components/ActionSheet/docs/typography-theming.md
+++ b/components/ActionSheet/docs/typography-theming.md
@@ -1,4 +1,4 @@
-### Typography Theming (To be deleted)
+### Typography Theming - to be deleted
 
 You can theme an Action Sheet with your app's typography scheme using the TypographyThemer extension.
 

--- a/components/ActionSheet/docs/typography-theming.md
+++ b/components/ActionSheet/docs/typography-theming.md
@@ -1,4 +1,4 @@
-### Typography Theming - to be deleted
+### Typography Theming (To be deleted)
 
 You can theme an Action Sheet with your app's typography scheme using the TypographyThemer extension.
 

--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -61,8 +61,8 @@ The Material Design top app bar displays information and actions relating to the
   - [Enabling inferred top safe area insets](#enabling-inferred-top-safe-area-insets)
 - [Extensions](#extensions)
   - [Theming](#theming)
-  - [Color Theming (To be deleted)](#color-theming-(to-be-deleted))
-  - [Typography Theming (To be deleted)](#typography-theming-(to-be-deleted))
+  - [Color Theming - to be deleted](#color-theming-to-be-deleted)
+  - [Typography Theming - to be deleted](#typography-theming-to-be-deleted)
 - [Accessibility](#accessibility)
   - [MDCAppBar Accessibility](#mdcappbar-accessibility)
 - [Migration guides](#migration-guides)
@@ -688,7 +688,7 @@ MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
 
 <!-- Extracted from docs/color-theming.md -->
 
-### Color Theming (To be deleted)
+### Color Theming - to be deleted
 
 You can theme an app bar with your app's color scheme using the ColorThemer extension.
 
@@ -728,7 +728,7 @@ id<MDCColorScheming> colorScheme = [[MDCSemanticColorScheme alloc] initWithDefau
 
 <!-- Extracted from docs/typography-theming.md -->
 
-### Typography Theming (To be deleted)
+### Typography Theming - to be deleted
 
 You can theme an app bar with your app's typography scheme using the TypographyThemer extension.
 

--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -61,12 +61,13 @@ The Material Design top app bar displays information and actions relating to the
   - [Enabling inferred top safe area insets](#enabling-inferred-top-safe-area-insets)
 - [Extensions](#extensions)
   - [Theming](#theming)
-  - [Color Theming (To be deleted)](#color-theming-to-be-deleted)
-  - [Typography Theming (To be deleted)](#typography-theming-to-be-deleted)
 - [Accessibility](#accessibility)
   - [MDCAppBar Accessibility](#mdcappbar-accessibility)
 - [Migration guides](#migration-guides)
   - [Migration guide: MDCAppBar to MDCAppBarViewController](#migration-guide-mdcappbar-to-mdcappbarviewcontroller)
+- [Unsupported](#unsupported)
+  - [Color Theming](#color-theming)
+  - [Typography Theming](#typography-theming)
 
 - - -
 
@@ -686,87 +687,6 @@ MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
 
 <!--</div>-->
 
-<!-- Extracted from docs/color-theming.md -->
-
-### Color Theming (To be deleted)
-
-You can theme an app bar with your app's color scheme using the ColorThemer extension.
-
-You must first add the Color Themer extension to your project:
-
-```bash
-pod 'MaterialComponents/AppBar+ColorThemer'
-```
-
-<!--<div class="material-code-render" markdown="1">-->
-#### Swift
-```swift
-// Step 1: Import the ColorThemer extension
-import MaterialComponents.MaterialAppBar_ColorThemer
-
-// Step 2: Create or get a color scheme
-let colorScheme = MDCSemanticColorScheme()
-
-// Step 3: Apply the color scheme to your component
-MDCAppBarColorThemer.applySemanticColorScheme(colorScheme, to: component)
-```
-
-#### Objective-C
-
-```objc
-// Step 1: Import the ColorThemer extension
-#import "MaterialAppBar+ColorThemer.h"
-
-// Step 2: Create or get a color scheme
-id<MDCColorScheming> colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-
-// Step 3: Apply the color scheme to your component
-[MDCAppBarColorThemer applySemanticColorScheme:colorScheme
-                                      toAppBar:component];
-```
-<!--</div>-->
-
-<!-- Extracted from docs/typography-theming.md -->
-
-### Typography Theming (To be deleted)
-
-You can theme an app bar with your app's typography scheme using the TypographyThemer extension.
-
-You must first add the Typography Themer extension to your project:
-
-```bash
-pod 'MaterialComponents/AppBar+TypographyThemer'
-```
-
-<!--<div class="material-code-render" markdown="1">-->
-#### Swift
-```swift
-// Step 1: Import the TypographyThemer extension
-import MaterialComponents.MaterialAppBar_TypographyThemer
-
-// Step 2: Create or get a typography scheme
-let typographyScheme = MDCTypographyScheme()
-
-// Step 3: Apply the typography scheme to your component
-MDCAppBarTypographyThemer.applyTypographyScheme(typographyScheme, to: component)
-```
-
-#### Objective-C
-
-```objc
-// Step 1: Import the TypographyThemer extension
-#import "MaterialAppBar+TypographyThemer.h"
-
-// Step 2: Create or get a typography scheme
-id<MDCTypographyScheming> typographyScheme = [[MDCTypographyScheme alloc] init];
-
-// Step 3: Apply the typography scheme to your component
-[MDCAppBarTypographyThemer applyTypographyScheme:colorScheme
-                                        toAppBar:component];
-```
-<!--</div>-->
-
-
 
 ## Accessibility
 
@@ -864,4 +784,87 @@ any references of `appBar.headerViewController` with `appBarViewController`.
 #### Example migrations
 
 - [MDCCatalog examples](https://github.com/material-components/material-components-ios/commit/50e1fd091d8d08426f390c124bf6310c54174d8c)
+
+
+## Unsupported
+
+<!-- Extracted from docs/color-theming.md -->
+
+### Color Theming
+
+You can theme an app bar with your app's color scheme using the ColorThemer extension.
+
+You must first add the Color Themer extension to your project:
+
+```bash
+pod 'MaterialComponents/AppBar+ColorThemer'
+```
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+// Step 1: Import the ColorThemer extension
+import MaterialComponents.MaterialAppBar_ColorThemer
+
+// Step 2: Create or get a color scheme
+let colorScheme = MDCSemanticColorScheme()
+
+// Step 3: Apply the color scheme to your component
+MDCAppBarColorThemer.applySemanticColorScheme(colorScheme, to: component)
+```
+
+#### Objective-C
+
+```objc
+// Step 1: Import the ColorThemer extension
+#import "MaterialAppBar+ColorThemer.h"
+
+// Step 2: Create or get a color scheme
+id<MDCColorScheming> colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+
+// Step 3: Apply the color scheme to your component
+[MDCAppBarColorThemer applySemanticColorScheme:colorScheme
+                                      toAppBar:component];
+```
+<!--</div>-->
+
+<!-- Extracted from docs/typography-theming.md -->
+
+### Typography Theming
+
+You can theme an app bar with your app's typography scheme using the TypographyThemer extension.
+
+You must first add the Typography Themer extension to your project:
+
+```bash
+pod 'MaterialComponents/AppBar+TypographyThemer'
+```
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+// Step 1: Import the TypographyThemer extension
+import MaterialComponents.MaterialAppBar_TypographyThemer
+
+// Step 2: Create or get a typography scheme
+let typographyScheme = MDCTypographyScheme()
+
+// Step 3: Apply the typography scheme to your component
+MDCAppBarTypographyThemer.applyTypographyScheme(typographyScheme, to: component)
+```
+
+#### Objective-C
+
+```objc
+// Step 1: Import the TypographyThemer extension
+#import "MaterialAppBar+TypographyThemer.h"
+
+// Step 2: Create or get a typography scheme
+id<MDCTypographyScheming> typographyScheme = [[MDCTypographyScheme alloc] init];
+
+// Step 3: Apply the typography scheme to your component
+[MDCAppBarTypographyThemer applyTypographyScheme:colorScheme
+                                        toAppBar:component];
+```
+<!--</div>-->
 

--- a/components/AppBar/README.md
+++ b/components/AppBar/README.md
@@ -61,8 +61,8 @@ The Material Design top app bar displays information and actions relating to the
   - [Enabling inferred top safe area insets](#enabling-inferred-top-safe-area-insets)
 - [Extensions](#extensions)
   - [Theming](#theming)
-  - [Color Theming - to be deleted](#color-theming-to-be-deleted)
-  - [Typography Theming - to be deleted](#typography-theming-to-be-deleted)
+  - [Color Theming (To be deleted)](#color-theming-to-be-deleted)
+  - [Typography Theming (To be deleted)](#typography-theming-to-be-deleted)
 - [Accessibility](#accessibility)
   - [MDCAppBar Accessibility](#mdcappbar-accessibility)
 - [Migration guides](#migration-guides)
@@ -688,7 +688,7 @@ MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
 
 <!-- Extracted from docs/color-theming.md -->
 
-### Color Theming - to be deleted
+### Color Theming (To be deleted)
 
 You can theme an app bar with your app's color scheme using the ColorThemer extension.
 
@@ -728,7 +728,7 @@ id<MDCColorScheming> colorScheme = [[MDCSemanticColorScheme alloc] initWithDefau
 
 <!-- Extracted from docs/typography-theming.md -->
 
-### Typography Theming - to be deleted
+### Typography Theming (To be deleted)
 
 You can theme an app bar with your app's typography scheme using the TypographyThemer extension.
 

--- a/components/AppBar/docs/README.md
+++ b/components/AppBar/docs/README.md
@@ -70,9 +70,6 @@ See the [FlexibleHeader](../../FlexibleHeader) documentation for additional usag
 ## Extensions
 
 - [Theming](theming.md)
-- [Color Theming](color-theming.md)
-- [Typography Theming](typography-theming.md)
-
 
 ## Accessibility
 
@@ -81,3 +78,8 @@ See the [FlexibleHeader](../../FlexibleHeader) documentation for additional usag
 ## Migration guides
 
 - [Migration guide: MDCAppBar to MDCAppBarViewController](migration-guide-appbar-appbarviewcontroller.md)
+
+## Unsupported
+
+- [Color Theming](color-theming.md)
+- [Typography Theming](typography-theming.md)

--- a/components/AppBar/docs/color-theming.md
+++ b/components/AppBar/docs/color-theming.md
@@ -1,4 +1,4 @@
-### Color Theming (To be deleted)
+### Color Theming
 
 You can theme an app bar with your app's color scheme using the ColorThemer extension.
 

--- a/components/AppBar/docs/color-theming.md
+++ b/components/AppBar/docs/color-theming.md
@@ -1,4 +1,4 @@
-### Color Theming (To be deleted)
+### Color Theming - to be deleted
 
 You can theme an app bar with your app's color scheme using the ColorThemer extension.
 

--- a/components/AppBar/docs/color-theming.md
+++ b/components/AppBar/docs/color-theming.md
@@ -1,4 +1,4 @@
-### Color Theming - to be deleted
+### Color Theming (To be deleted)
 
 You can theme an app bar with your app's color scheme using the ColorThemer extension.
 

--- a/components/AppBar/docs/typography-theming.md
+++ b/components/AppBar/docs/typography-theming.md
@@ -1,4 +1,4 @@
-### Typography Theming (To be deleted)
+### Typography Theming
 
 You can theme an app bar with your app's typography scheme using the TypographyThemer extension.
 

--- a/components/AppBar/docs/typography-theming.md
+++ b/components/AppBar/docs/typography-theming.md
@@ -1,4 +1,4 @@
-### Typography Theming (To be deleted)
+### Typography Theming - to be deleted
 
 You can theme an app bar with your app's typography scheme using the TypographyThemer extension.
 

--- a/components/AppBar/docs/typography-theming.md
+++ b/components/AppBar/docs/typography-theming.md
@@ -1,4 +1,4 @@
-### Typography Theming - to be deleted
+### Typography Theming (To be deleted)
 
 You can theme an app bar with your app's typography scheme using the TypographyThemer extension.
 


### PR DESCRIPTION
This change fixes the broken links in `MDCActionSheet` and `MDCAppBar` components. This also moves the _Themer_ documentation to an "unsupported" section.