### PR TITLE
[TextFields] Add API for Filled/Outlined/Base textfield classes

### DIFF
--- a/components/TextFields/src/MDCBaseTextField.h
+++ b/components/TextFields/src/MDCBaseTextField.h
@@ -14,13 +14,13 @@
 
 #import <UIKit/UIKit.h>
 
-/** This type is used to configure the behavior of an MDCInputTextField's label. */
-typedef NS_ENUM(NSInteger, MDCInputTextFieldLabelBehavior) {
+/** This type is used to configure the behavior of an MDCBaseTextField's label. */
+typedef NS_ENUM(NSInteger, MDCBaseTextFieldLabelBehavior) {
   /** Indicates that the text field label animates to a position above the text when editing begins.
    */
-  MDCInputTextFieldLabelBehaviorFloats,
+  MDCBaseTextFieldLabelBehaviorFloats,
   /** Indicates that the text field label disappears when editing begins. */
-  MDCInputTextFieldLabelBehaviorDisappears,
+  MDCBaseTextFieldLabelBehaviorDisappears,
 };
 
 /**
@@ -36,7 +36,7 @@ typedef NS_ENUM(NSInteger, MDCInputTextFieldLabelBehavior) {
  Caution: While not explicitly forbidden by the compiler, subclassing this class is highly
  discouraged and not supported. Please consider alternatives.
  */
-@interface MDCInputTextField : UITextField
+@interface MDCBaseTextField : UITextField
 
 /**
  The @c label is a label that occupies the area the text usually occupies when there is no
@@ -48,9 +48,9 @@ typedef NS_ENUM(NSInteger, MDCInputTextFieldLabelBehavior) {
 /**
  This property determines the behavior of the textfield's label during editing.
 
- @note The default is MDCInputTextFieldLabelBehaviorFloats.
+ @note The default is MDCBaseTextFieldLabelBehaviorFloats.
  */
-@property(nonatomic, assign) MDCInputTextFieldLabelBehavior labelBehavior;
+@property(nonatomic, assign) MDCBaseTextFieldLabelBehavior labelBehavior;
 
 /**
  The @c leadingAssistiveLabel is a label below the text on the leading edge of the view. It can be

--- a/components/TextFields/src/MDCFilledTextField.h
+++ b/components/TextFields/src/MDCFilledTextField.h
@@ -22,21 +22,33 @@
 @interface MDCFilledTextField : MDCInputTextField
 
 /**
- Sets the filled background color for a given state.
-
- @param filledBackgroundColor the filled background color.
- @param state the state.
+ The filled background color when the text field is enabled and not editing.
  */
-- (void)setFilledBackgroundColor:(UIColor *)filledBackgroundColor
-                        forState:(MDCContainedInputViewState)state;
+@property (strong, nonatomic) UIColor *filledBackgroundColorNormal;
 
 /**
- Sets the underline color for a given state.
-
- @param underlineColor the underline color.
- @param state the state.
+ The filled background color when the text field is enabled and editing.
  */
-- (void)setUnderlineColor:(UIColor *)underlineColor
-                 forState:(MDCContainedInputViewState)state;
+@property (strong, nonatomic) UIColor *filledBackgroundColorEditing;
+
+/**
+ The filled background color when the text field is disabled.
+ */
+@property (strong, nonatomic) UIColor *filledBackgroundColorDisabled;
+
+/**
+ The underline color when the text field is enabled and not editing.
+ */
+@property (strong, nonatomic) UIColor *underlineColorNormal;
+
+/**
+ The underline color when the text field is enabled and editing.
+ */
+@property (strong, nonatomic) UIColor *underlineColorEditing;
+
+/**
+ The underline color when the text field is disabled.
+ */
+@property (strong, nonatomic) UIColor *underlineColorDisabled;
 
 @end

--- a/components/TextFields/src/MDCFilledTextField.h
+++ b/components/TextFields/src/MDCFilledTextField.h
@@ -24,31 +24,21 @@
 /**
  The filled background color when the text field is enabled and not editing.
  */
-@property(strong, nonatomic) UIColor *filledBackgroundColorNormal;
-
-/**
- The filled background color when the text field is enabled and editing.
- */
-@property(strong, nonatomic) UIColor *filledBackgroundColorEditing;
-
-/**
- The filled background color when the text field is disabled.
- */
-@property(strong, nonatomic) UIColor *filledBackgroundColorDisabled;
+@property(strong, nonatomic, nonnull) UIColor *filledBackgroundColor;
 
 /**
  The underline color when the text field is enabled and not editing.
  */
-@property(strong, nonatomic) UIColor *underlineColorNormal;
+@property(strong, nonatomic, nonnull) UIColor *underlineColorNormal;
 
 /**
  The underline color when the text field is enabled and editing.
  */
-@property(strong, nonatomic) UIColor *underlineColorEditing;
+@property(strong, nonatomic, nonnull) UIColor *underlineColorEditing;
 
 /**
  The underline color when the text field is disabled.
  */
-@property(strong, nonatomic) UIColor *underlineColorDisabled;
+@property(strong, nonatomic, nonnull) UIColor *underlineColorDisabled;
 
 @end

--- a/components/TextFields/src/MDCFilledTextField.h
+++ b/components/TextFields/src/MDCFilledTextField.h
@@ -19,7 +19,7 @@
 /**
  An implementation of a Material filled text field.
  */
-@interface MDCFilledTextField : MDCInputTextField
+__attribute__((objc_subclassing_restricted)) @interface MDCFilledTextField : MDCInputTextField
 
 /**
  Sets the filled background color for a given state.
@@ -29,13 +29,13 @@
  UIControlStateDisabled, and UIControlStateEditing, which is a custom MDC
  UIControlState value.
  */
-- (void)setFilledBackgroundColor:(UIColor *)filledBackgroundColor forState:(UIControlState)state;
+- (void)setFilledBackgroundColor:(nonnull UIColor *)filledBackgroundColor forState:(UIControlState)state;
 /**
  Returns the filled background color for a given state.
 
  @param state The UIControlState.
  */
-- (UIColor *)filledBackgroundColorForState:(UIControlState)state;
+- (nonnull UIColor *)filledBackgroundColorForState:(UIControlState)state;
 
 /**
  Sets the underline color for a given state.
@@ -45,13 +45,13 @@
  UIControlStateDisabled, and UIControlStateEditing, which is a custom MDC
  UIControlState value.
  */
-- (void)setUnderlineColor:(UIColor *)underlineColor forState:(UIControlState)state;
+- (void)setUnderlineColor:(nonnull UIColor *)underlineColor forState:(UIControlState)state;
 
 /**
  Returns the underline color for a given state.
 
  @param state The UIControlState.
  */
-- (UIColor *)underlineColorForState:(UIControlState)state;
+- (nonnull UIColor *)underlineColorForState:(UIControlState)state;
 
 @end

--- a/components/TextFields/src/MDCFilledTextField.h
+++ b/components/TextFields/src/MDCFilledTextField.h
@@ -1,0 +1,42 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+#import "MDCInputTextField.h"
+
+/**
+ An implementation of a Material filled text field.
+ */
+@interface MDCFilledTextField : MDCInputTextField
+
+/**
+ Sets the filled background color for a given state.
+
+ @param filledBackgroundColor the filled background color.
+ @param state the state.
+ */
+- (void)setFilledBackgroundColor:(UIColor *)filledBackgroundColor
+                        forState:(MDCContainedInputViewState)state;
+
+/**
+ Sets the underline color for a given state.
+
+ @param underlineColor the underline color.
+ @param state the state.
+ */
+- (void)setUnderlineColor:(UIColor *)underlineColor
+                 forState:(MDCContainedInputViewState)state;
+
+@end

--- a/components/TextFields/src/MDCFilledTextField.h
+++ b/components/TextFields/src/MDCFilledTextField.h
@@ -24,31 +24,31 @@
 /**
  The filled background color when the text field is enabled and not editing.
  */
-@property (strong, nonatomic) UIColor *filledBackgroundColorNormal;
+@property(strong, nonatomic) UIColor *filledBackgroundColorNormal;
 
 /**
  The filled background color when the text field is enabled and editing.
  */
-@property (strong, nonatomic) UIColor *filledBackgroundColorEditing;
+@property(strong, nonatomic) UIColor *filledBackgroundColorEditing;
 
 /**
  The filled background color when the text field is disabled.
  */
-@property (strong, nonatomic) UIColor *filledBackgroundColorDisabled;
+@property(strong, nonatomic) UIColor *filledBackgroundColorDisabled;
 
 /**
  The underline color when the text field is enabled and not editing.
  */
-@property (strong, nonatomic) UIColor *underlineColorNormal;
+@property(strong, nonatomic) UIColor *underlineColorNormal;
 
 /**
  The underline color when the text field is enabled and editing.
  */
-@property (strong, nonatomic) UIColor *underlineColorEditing;
+@property(strong, nonatomic) UIColor *underlineColorEditing;
 
 /**
  The underline color when the text field is disabled.
  */
-@property (strong, nonatomic) UIColor *underlineColorDisabled;
+@property(strong, nonatomic) UIColor *underlineColorDisabled;
 
 @end

--- a/components/TextFields/src/MDCFilledTextField.h
+++ b/components/TextFields/src/MDCFilledTextField.h
@@ -22,23 +22,36 @@
 @interface MDCFilledTextField : MDCInputTextField
 
 /**
- The filled background color when the text field is enabled and not editing.
+ Sets the filled background color for a given state.
+
+ @param filledBackgroundColor The UIColor for the given state.
+ @param state The UIControlState. The accepted values are UIControlStateNormal,
+ UIControlStateDisabled, and UIControlStateEditing, which is a custom MDC
+ UIControlState value.
  */
-@property(strong, nonatomic, nonnull) UIColor *filledBackgroundColor;
+- (void)setFilledBackgroundColor:(UIColor *)filledBackgroundColor forState:(UIControlState)state;
+/**
+ Returns the filled background color for a given state.
+
+ @param state The UIControlState.
+ */
+- (UIColor *)filledBackgroundColorForState:(UIControlState)state;
 
 /**
- The underline color when the text field is enabled and not editing.
+ Sets the underline color for a given state.
+
+ @param underlineColor The UIColor for the given state.
+ @param state The UIControlState. The accepted values are UIControlStateNormal,
+ UIControlStateDisabled, and UIControlStateEditing, which is a custom MDC
+ UIControlState value.
  */
-@property(strong, nonatomic, nonnull) UIColor *underlineColorNormal;
+- (void)setUnderlineColor:(UIColor *)underlineColor forState:(UIControlState)state;
 
 /**
- The underline color when the text field is enabled and editing.
- */
-@property(strong, nonatomic, nonnull) UIColor *underlineColorEditing;
+ Returns the underline color for a given state.
 
-/**
- The underline color when the text field is disabled.
+ @param state The UIControlState.
  */
-@property(strong, nonatomic, nonnull) UIColor *underlineColorDisabled;
+- (UIColor *)underlineColorForState:(UIControlState)state;
 
 @end

--- a/components/TextFields/src/MDCFilledTextField.h
+++ b/components/TextFields/src/MDCFilledTextField.h
@@ -29,7 +29,8 @@ __attribute__((objc_subclassing_restricted)) @interface MDCFilledTextField : MDC
  UIControlStateDisabled, and UIControlStateEditing, which is a custom MDC
  UIControlState value.
  */
-- (void)setFilledBackgroundColor:(nonnull UIColor *)filledBackgroundColor forState:(UIControlState)state;
+- (void)setFilledBackgroundColor:(nonnull UIColor *)filledBackgroundColor
+                        forState:(UIControlState)state;
 /**
  Returns the filled background color for a given state.
 

--- a/components/TextFields/src/MDCFilledTextField.h
+++ b/components/TextFields/src/MDCFilledTextField.h
@@ -36,7 +36,6 @@
  @param underlineColor the underline color.
  @param state the state.
  */
-- (void)setUnderlineColor:(UIColor *)underlineColor
-                 forState:(MDCContainedInputViewState)state;
+- (void)setUnderlineColor:(UIColor *)underlineColor forState:(MDCContainedInputViewState)state;
 
 @end

--- a/components/TextFields/src/MDCFilledTextField.h
+++ b/components/TextFields/src/MDCFilledTextField.h
@@ -14,12 +14,12 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MDCInputTextField.h"
+#import "MDCBaseTextField.h"
 
 /**
  An implementation of a Material filled text field.
  */
-__attribute__((objc_subclassing_restricted)) @interface MDCFilledTextField : MDCInputTextField
+__attribute__((objc_subclassing_restricted)) @interface MDCFilledTextField : MDCBaseTextField
 
 /**
  Sets the filled background color for a given state.

--- a/components/TextFields/src/MDCInputTextField.h
+++ b/components/TextFields/src/MDCInputTextField.h
@@ -1,0 +1,163 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+/**
+ A set of Contained Input View states outlined in the Material guidelines. These states overlap with
+ and extend UIControlState.
+ */
+typedef NS_OPTIONS(NSInteger, MDCContainedInputViewState) {
+  /**
+   The default state of the contained input view.
+   */
+  MDCContainedInputViewStateNormal = 1 << 0,
+  /**
+   The state the view is in during normal editing.
+   */
+  MDCContainedInputViewStateFocused = 1 << 1,
+  /**
+   This state most closely resembles the @c selected UIControlState.
+   */
+  MDCContainedInputViewStateActivated = 1 << 2,
+  /**
+   The error state.
+   */
+  MDCContainedInputViewStateErrored = 1 << 3,
+  /**
+   The disabled state.
+   */
+  MDCContainedInputViewStateDisabled = 1 << 4,
+};
+
+/**
+ A UITextField subclass that attempts to do the following:
+
+ - Earnestly interpret and actualize the Material guidelines for text fields, which can be found
+ here: https://material.io/design/components/text-fields.html#outlined-text-field
+
+ - Feel intuitive for someone used to the conventions of iOS development and UIKit controls.
+
+ - Enable easy set up and reliable and predictable behavior.
+
+ */
+@interface MDCInputTextField : UITextField
+
+/**
+ The @c floatingLabel is a label that occupies the area the text usually occupies when there is no
+ text and that floats above the text once there is text. It is distinct from the placeholder.
+ */
+@property(strong, nonatomic, readonly, nonnull) UILabel *floatingLabel;
+
+/**
+ When set to YES, the floating label floats when the view becomes the first responder. When
+ set to NO it disappears.
+
+ @note The default is YES.
+ */
+@property(nonatomic, assign) BOOL canFloatingLabelFloat;
+
+/**
+ The @c leadingUnderlineLabel is a label below the text on the leading edge of the view. It can be
+ used to display helper or error text.
+ */
+@property(strong, nonatomic, readonly, nonnull) UILabel *leadingUnderlineLabel;
+
+/**
+ The @c trailingUnderlineLabel is a label below the text on the trailing edge of the view. It can be
+ used to display helper or error text.
+ */
+@property(strong, nonatomic, readonly, nonnull) UILabel *trailingUnderlineLabel;
+
+/**
+ This is essentially an RTL-aware wrapper around UITextField's leftView/rightView class.
+ */
+@property(strong, nonatomic, nullable) UIView *leadingView;
+
+/**
+ This is essentially an RTL-aware wrapper around UITextField's leftView/rightView class.
+ */
+@property(strong, nonatomic, nullable) UIView *trailingView;
+
+/**
+ This is essentially an RTL-aware wrapper around UITextField's leftViewMode/rightViewMode class.
+ */
+@property(nonatomic, assign) UITextFieldViewMode leadingViewMode;
+
+/**
+ This is essentially an RTL-aware wrapper around UITextField's leftViewMode/rightViewMode class.
+ */
+@property(nonatomic, assign) UITextFieldViewMode trailingViewMode;
+
+/**
+ This property toggles the error state (similar to @c isHighlighted, @c isEnabled, @c isSelected,
+ etc.) that is part of a general interpretation of the states outlined in the Material guidelines
+ for Text Fields. See the @c MDCContainedInputViewState enum for more information.
+ */
+@property(nonatomic, assign) BOOL isErrored;
+
+/**
+ This property toggles the activated state (similar to @c isHighlighted, @c isEnabled, @c
+ isSelected, etc.) that is part of a general interpretation of the states outlined in the Material
+ guidelines for Text Fields. See the @c MDCContainedInputViewState enum for more information.
+ */
+@property(nonatomic, assign) BOOL isActivated;
+
+/**
+ Indicates whether the text field should automatically update its font when the device’s
+ UIContentSizeCategory is changed.
+
+ This property is modeled after the adjustsFontForContentSizeCategory property in the
+ UIContentSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
+
+ Defaults value is NO.
+ */
+@property(nonatomic, setter=mdc_setAdjustsFontForContentSizeCategory:)
+    BOOL mdc_adjustsFontForContentSizeCategory;
+
+/**
+ Sets the text color for a given state.
+
+ @param textColor the text color.
+ @param state the state.
+ */
+- (void)setTextColor:(UIColor *)textColor forState:(MDCContainedInputViewState)state;
+
+/**
+ Sets the underline label color for a given state.
+
+ @param underlineLabelColor the underline label color.
+ @param state the state.
+ */
+- (void)setUnderlineLabelColor:(UIColor *)underlineLabelColor
+                      forState:(MDCContainedInputViewState)state;
+
+/**
+ Sets the floating label color for a given state.
+
+ @param floatingLabelColor the floating label color.
+ @param state the state.
+ */
+- (void)setFloatingLabelColor:(UIColor *)floatingLabelColor
+                     forState:(MDCContainedInputViewState)state;
+
+/**
+ Sets the placeholder color for a given state.
+
+ @param placeholderColor the placeholder color.
+ @param state the state.
+ */
+- (void)setPlaceholderColor:(UIColor *)placeholderColor forState:(MDCContainedInputViewState)state;
+
+@end

--- a/components/TextFields/src/MDCInputTextField.h
+++ b/components/TextFields/src/MDCInputTextField.h
@@ -88,31 +88,31 @@
 /**
  The floating label color when the text field is enabled and not editing.
  */
-@property (strong, nonatomic) UIColor *floatingLabelColorNormal;
+@property(strong, nonatomic) UIColor *floatingLabelColorNormal;
 
 /**
  The floating label color when the text field is enabled and editing.
  */
-@property (strong, nonatomic) UIColor *floatingLabelColorEditing;
+@property(strong, nonatomic) UIColor *floatingLabelColorEditing;
 
 /**
  The floating label color when the text field is disabled.
  */
-@property (strong, nonatomic) UIColor *floatingLabelColorDisabled;
+@property(strong, nonatomic) UIColor *floatingLabelColorDisabled;
 
 /**
  The text color when the text field is enabled and not editing.
  */
-@property (strong, nonatomic) UIColor *textColorNormal;
+@property(strong, nonatomic) UIColor *textColorNormal;
 
 /**
  The text color when the text field is enabled and editing.
  */
-@property (strong, nonatomic) UIColor *textColorEditing;
+@property(strong, nonatomic) UIColor *textColorEditing;
 
 /**
  The text color when the text field is disabled.
  */
-@property (strong, nonatomic) UIColor *textColorDisabled;
+@property(strong, nonatomic) UIColor *textColorDisabled;
 
 @end

--- a/components/TextFields/src/MDCInputTextField.h
+++ b/components/TextFields/src/MDCInputTextField.h
@@ -88,31 +88,31 @@
 /**
  The floating label color when the text field is enabled and not editing.
  */
-@property(strong, nonatomic) UIColor *floatingLabelColorNormal;
+@property(strong, nonatomic, nonnull) UIColor *floatingLabelColorNormal;
 
 /**
  The floating label color when the text field is enabled and editing.
  */
-@property(strong, nonatomic) UIColor *floatingLabelColorEditing;
+@property(strong, nonatomic, nonnull) UIColor *floatingLabelColorEditing;
 
 /**
  The floating label color when the text field is disabled.
  */
-@property(strong, nonatomic) UIColor *floatingLabelColorDisabled;
+@property(strong, nonatomic, nonnull) UIColor *floatingLabelColorDisabled;
 
 /**
  The text color when the text field is enabled and not editing.
  */
-@property(strong, nonatomic) UIColor *textColorNormal;
+@property(strong, nonatomic, nonnull) UIColor *textColorNormal;
 
 /**
  The text color when the text field is enabled and editing.
  */
-@property(strong, nonatomic) UIColor *textColorEditing;
+@property(strong, nonatomic, nonnull) UIColor *textColorEditing;
 
 /**
  The text color when the text field is disabled.
  */
-@property(strong, nonatomic) UIColor *textColorDisabled;
+@property(strong, nonatomic, nonnull) UIColor *textColorDisabled;
 
 @end

--- a/components/TextFields/src/MDCInputTextField.h
+++ b/components/TextFields/src/MDCInputTextField.h
@@ -81,22 +81,22 @@ typedef NS_OPTIONS(NSInteger, MDCContainedInputViewState) {
 @property(strong, nonatomic, readonly, nonnull) UILabel *trailingUnderlineLabel;
 
 /**
- This is essentially an RTL-aware wrapper around UITextField's leftView/rightView class.
+ This is essentially an RTL-aware wrapper around UITextField's leftView/rightView property.
  */
 @property(strong, nonatomic, nullable) UIView *leadingView;
 
 /**
- This is essentially an RTL-aware wrapper around UITextField's leftView/rightView class.
+ This is essentially an RTL-aware wrapper around UITextField's leftView/rightView property.
  */
 @property(strong, nonatomic, nullable) UIView *trailingView;
 
 /**
- This is essentially an RTL-aware wrapper around UITextField's leftViewMode/rightViewMode class.
+ This is essentially an RTL-aware wrapper around UITextField's leftViewMode/rightViewMode property.
  */
 @property(nonatomic, assign) UITextFieldViewMode leadingViewMode;
 
 /**
- This is essentially an RTL-aware wrapper around UITextField's leftViewMode/rightViewMode class.
+ This is essentially an RTL-aware wrapper around UITextField's leftViewMode/rightViewMode property.
  */
 @property(nonatomic, assign) UITextFieldViewMode trailingViewMode;
 

--- a/components/TextFields/src/MDCInputTextField.h
+++ b/components/TextFields/src/MDCInputTextField.h
@@ -14,6 +14,14 @@
 
 #import <UIKit/UIKit.h>
 
+/** This type is used to configure the behavior of an MDCInputTextField's label. */
+typedef NS_ENUM(NSInteger, MDCInputTextFieldLabelBehavior) {
+  /** Indicates that the text field label animates to a position above the text when editing begins. */
+  MDCInputTextFieldLabelBehaviorFloats,
+  /** Indicates that the text field label disappears when editing begins. */
+  MDCInputTextFieldLabelBehaviorDisappears,
+};
+
 /**
  A UITextField subclass that attempts to do the following:
 
@@ -24,34 +32,34 @@
 
  - Enable easy set up and reliable and predictable behavior.
 
+ Caution: While not explicitly forbidden by the compiler, subclassing this class is highly discouraged and not supported. Please consider alternatives.
  */
 @interface MDCInputTextField : UITextField
 
 /**
- The @c floatingLabel is a label that occupies the area the text usually occupies when there is no
- text and that floats above the text once there is text. It is distinct from the placeholder.
+ The @c label is a label that occupies the area the text usually occupies when there is no
+ text. It is distinct from the placeholder in that it can move above the text area or disappear to reveal the placeholder when editing begins.
  */
-@property(strong, nonatomic, readonly, nonnull) UILabel *floatingLabel;
+@property(strong, nonatomic, readonly, nonnull) UILabel *label;
 
 /**
- When set to YES, the floating label floats when the view becomes the first responder. When
- set to NO it disappears.
+ This property determines the behavior of the textfield's label during editing.
 
- @note The default is YES.
+ @note The default is MDCInputTextFieldLabelBehaviorFloats.
  */
-@property(nonatomic, assign) BOOL canFloatingLabelFloat;
+@property(nonatomic, assign) MDCInputTextFieldLabelBehavior labelBehavior;
 
 /**
- The @c leadingUnderlineLabel is a label below the text on the leading edge of the view. It can be
+ The @c leadingAssistiveLabel is a label below the text on the leading edge of the view. It can be
  used to display helper or error text.
  */
-@property(strong, nonatomic, readonly, nonnull) UILabel *leadingUnderlineLabel;
+@property(strong, nonatomic, readonly, nonnull) UILabel *leadingAssistiveLabel;
 
 /**
- The @c trailingUnderlineLabel is a label below the text on the trailing edge of the view. It can be
+ The @c trailingAssistiveLabel is a label below the text on the trailing edge of the view. It can be
  used to display helper or error text.
  */
-@property(strong, nonatomic, readonly, nonnull) UILabel *trailingUnderlineLabel;
+@property(strong, nonatomic, readonly, nonnull) UILabel *trailingAssistiveLabel;
 
 /**
  This is essentially an RTL-aware wrapper around UITextField's leftView/rightView property.
@@ -86,20 +94,20 @@
     BOOL mdc_adjustsFontForContentSizeCategory;
 
 /**
- Sets the floating label color for a given state.
+ Sets the label color for a given state.
 
- @param floatingLabelColor The UIColor for the given state.
+ @param labelColor The UIColor for the given state.
  @param state The UIControlState. The accepted values are UIControlStateNormal,
  UIControlStateDisabled, and UIControlStateEditing, which is a custom MDC
  UIControlState value.
  */
-- (void)setFLoatingLabelColor:(UIColor *)floatingLabelColor forState:(UIControlState)state;
+- (void)setLabelColor:(nonnull UIColor *)labelColor forState:(UIControlState)state;
 /**
- Returns the floating label color for a given state.
+ Returns the label color for a given state.
 
  @param state The UIControlState.
  */
-- (UIColor *)floatingLabelColorForState:(UIControlState)state;
+- (nonnull UIColor *)labelColorForState:(UIControlState)state;
 
 /**
  Sets the text color for a given state.
@@ -109,12 +117,12 @@
  UIControlStateDisabled, and UIControlStateEditing, which is a custom MDC
  UIControlState value.
  */
-- (void)setTextColor:(UIColor *)textColor forState:(UIControlState)state;
+- (void)setTextColor:(nonnull UIColor *)textColor forState:(UIControlState)state;
 /**
  Returns the text color for a given state.
 
  @param state The UIControlState.
  */
-- (UIColor *)textColorForState:(UIControlState)state;
+- (nonnull UIColor *)textColorForState:(UIControlState)state;
 
 @end

--- a/components/TextFields/src/MDCInputTextField.h
+++ b/components/TextFields/src/MDCInputTextField.h
@@ -15,33 +15,6 @@
 #import <UIKit/UIKit.h>
 
 /**
- A set of Contained Input View states outlined in the Material guidelines. These states overlap with
- and extend UIControlState.
- */
-typedef NS_OPTIONS(NSInteger, MDCContainedInputViewState) {
-  /**
-   The default state of the contained input view.
-   */
-  MDCContainedInputViewStateNormal = 1 << 0,
-  /**
-   The state the view is in during normal editing.
-   */
-  MDCContainedInputViewStateFocused = 1 << 1,
-  /**
-   This state most closely resembles the @c selected UIControlState.
-   */
-  MDCContainedInputViewStateActivated = 1 << 2,
-  /**
-   The error state.
-   */
-  MDCContainedInputViewStateErrored = 1 << 3,
-  /**
-   The disabled state.
-   */
-  MDCContainedInputViewStateDisabled = 1 << 4,
-};
-
-/**
  A UITextField subclass that attempts to do the following:
 
  - Earnestly interpret and actualize the Material guidelines for text fields, which can be found
@@ -101,20 +74,6 @@ typedef NS_OPTIONS(NSInteger, MDCContainedInputViewState) {
 @property(nonatomic, assign) UITextFieldViewMode trailingViewMode;
 
 /**
- This property toggles the error state (similar to @c isHighlighted, @c isEnabled, @c isSelected,
- etc.) that is part of a general interpretation of the states outlined in the Material guidelines
- for Text Fields. See the @c MDCContainedInputViewState enum for more information.
- */
-@property(nonatomic, assign) BOOL isErrored;
-
-/**
- This property toggles the activated state (similar to @c isHighlighted, @c isEnabled, @c
- isSelected, etc.) that is part of a general interpretation of the states outlined in the Material
- guidelines for Text Fields. See the @c MDCContainedInputViewState enum for more information.
- */
-@property(nonatomic, assign) BOOL isActivated;
-
-/**
  Indicates whether the text field should automatically update its font when the device’s
  UIContentSizeCategory is changed.
 
@@ -127,37 +86,33 @@ typedef NS_OPTIONS(NSInteger, MDCContainedInputViewState) {
     BOOL mdc_adjustsFontForContentSizeCategory;
 
 /**
- Sets the text color for a given state.
-
- @param textColor the text color.
- @param state the state.
+ The floating label color when the text field is enabled and not editing.
  */
-- (void)setTextColor:(UIColor *)textColor forState:(MDCContainedInputViewState)state;
+@property (strong, nonatomic) UIColor *floatingLabelColorNormal;
 
 /**
- Sets the underline label color for a given state.
-
- @param underlineLabelColor the underline label color.
- @param state the state.
+ The floating label color when the text field is enabled and editing.
  */
-- (void)setUnderlineLabelColor:(UIColor *)underlineLabelColor
-                      forState:(MDCContainedInputViewState)state;
+@property (strong, nonatomic) UIColor *floatingLabelColorEditing;
 
 /**
- Sets the floating label color for a given state.
-
- @param floatingLabelColor the floating label color.
- @param state the state.
+ The floating label color when the text field is disabled.
  */
-- (void)setFloatingLabelColor:(UIColor *)floatingLabelColor
-                     forState:(MDCContainedInputViewState)state;
+@property (strong, nonatomic) UIColor *floatingLabelColorDisabled;
 
 /**
- Sets the placeholder color for a given state.
-
- @param placeholderColor the placeholder color.
- @param state the state.
+ The text color when the text field is enabled and not editing.
  */
-- (void)setPlaceholderColor:(UIColor *)placeholderColor forState:(MDCContainedInputViewState)state;
+@property (strong, nonatomic) UIColor *textColorNormal;
+
+/**
+ The text color when the text field is enabled and editing.
+ */
+@property (strong, nonatomic) UIColor *textColorEditing;
+
+/**
+ The text color when the text field is disabled.
+ */
+@property (strong, nonatomic) UIColor *textColorDisabled;
 
 @end

--- a/components/TextFields/src/MDCInputTextField.h
+++ b/components/TextFields/src/MDCInputTextField.h
@@ -86,33 +86,35 @@
     BOOL mdc_adjustsFontForContentSizeCategory;
 
 /**
- The floating label color when the text field is enabled and not editing.
+ Sets the floating label color for a given state.
+
+ @param floatingLabelColor The UIColor for the given state.
+ @param state The UIControlState. The accepted values are UIControlStateNormal,
+ UIControlStateDisabled, and UIControlStateEditing, which is a custom MDC
+ UIControlState value.
  */
-@property(strong, nonatomic, nonnull) UIColor *floatingLabelColorNormal;
+- (void)setFLoatingLabelColor:(UIColor *)floatingLabelColor forState:(UIControlState)state;
+/**
+ Returns the floating label color for a given state.
+
+ @param state The UIControlState.
+ */
+- (UIColor *)floatingLabelColorForState:(UIControlState)state;
 
 /**
- The floating label color when the text field is enabled and editing.
- */
-@property(strong, nonatomic, nonnull) UIColor *floatingLabelColorEditing;
+ Sets the text color for a given state.
 
-/**
- The floating label color when the text field is disabled.
+ @param textColor The UIColor for the given state.
+ @param state The UIControlState. The accepted values are UIControlStateNormal,
+ UIControlStateDisabled, and UIControlStateEditing, which is a custom MDC
+ UIControlState value.
  */
-@property(strong, nonatomic, nonnull) UIColor *floatingLabelColorDisabled;
+- (void)setTextColor:(UIColor *)textColor forState:(UIControlState)state;
+/**
+ Returns the text color for a given state.
 
-/**
- The text color when the text field is enabled and not editing.
+ @param state The UIControlState.
  */
-@property(strong, nonatomic, nonnull) UIColor *textColorNormal;
-
-/**
- The text color when the text field is enabled and editing.
- */
-@property(strong, nonatomic, nonnull) UIColor *textColorEditing;
-
-/**
- The text color when the text field is disabled.
- */
-@property(strong, nonatomic, nonnull) UIColor *textColorDisabled;
+- (UIColor *)textColorForState:(UIControlState)state;
 
 @end

--- a/components/TextFields/src/MDCInputTextField.h
+++ b/components/TextFields/src/MDCInputTextField.h
@@ -16,7 +16,8 @@
 
 /** This type is used to configure the behavior of an MDCInputTextField's label. */
 typedef NS_ENUM(NSInteger, MDCInputTextFieldLabelBehavior) {
-  /** Indicates that the text field label animates to a position above the text when editing begins. */
+  /** Indicates that the text field label animates to a position above the text when editing begins.
+   */
   MDCInputTextFieldLabelBehaviorFloats,
   /** Indicates that the text field label disappears when editing begins. */
   MDCInputTextFieldLabelBehaviorDisappears,
@@ -32,13 +33,15 @@ typedef NS_ENUM(NSInteger, MDCInputTextFieldLabelBehavior) {
 
  - Enable easy set up and reliable and predictable behavior.
 
- Caution: While not explicitly forbidden by the compiler, subclassing this class is highly discouraged and not supported. Please consider alternatives.
+ Caution: While not explicitly forbidden by the compiler, subclassing this class is highly
+ discouraged and not supported. Please consider alternatives.
  */
 @interface MDCInputTextField : UITextField
 
 /**
  The @c label is a label that occupies the area the text usually occupies when there is no
- text. It is distinct from the placeholder in that it can move above the text area or disappear to reveal the placeholder when editing begins.
+ text. It is distinct from the placeholder in that it can move above the text area or disappear to
+ reveal the placeholder when editing begins.
  */
 @property(strong, nonatomic, readonly, nonnull) UILabel *label;
 

--- a/components/TextFields/src/MDCOutlinedTextField.h
+++ b/components/TextFields/src/MDCOutlinedTextField.h
@@ -14,12 +14,12 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MDCInputTextField.h"
+#import "MDCBaseTextField.h"
 
 /**
  An implementation of a Material outlined text field.
  */
-__attribute__((objc_subclassing_restricted)) @interface MDCOutlinedTextField : MDCInputTextField
+__attribute__((objc_subclassing_restricted)) @interface MDCOutlinedTextField : MDCBaseTextField
 
 /**
  Sets the outline color for a given state.

--- a/components/TextFields/src/MDCOutlinedTextField.h
+++ b/components/TextFields/src/MDCOutlinedTextField.h
@@ -19,7 +19,7 @@
 /**
  An implementation of a Material outlined text field.
  */
-@interface MDCOutlinedTextField : MDCInputTextField
+__attribute__((objc_subclassing_restricted)) @interface MDCOutlinedTextField : MDCInputTextField
 
 /**
  Sets the outline color for a given state.
@@ -29,12 +29,12 @@
  UIControlStateDisabled, and UIControlStateEditing, which is a custom MDC
  UIControlState value.
  */
-- (void)setOutlineColor:(UIColor *)outlineColor forState:(UIControlState)state;
+- (void)setOutlineColor:(nonnull UIColor *)outlineColor forState:(UIControlState)state;
 /**
  Returns the outline color for a given state.
 
  @param state The UIControlState.
  */
-- (UIColor *)outlineColorForState:(UIControlState)state;
+- (nonnull UIColor *)outlineColorForState:(UIControlState)state;
 
 @end

--- a/components/TextFields/src/MDCOutlinedTextField.h
+++ b/components/TextFields/src/MDCOutlinedTextField.h
@@ -1,0 +1,26 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+#import "MDCInputTextField.h"
+
+/**
+ An implementation of a Material outlined text field.
+ */
+@interface MDCOutlinedTextField : MDCInputTextField
+
+- (void)setOutlineColor:(UIColor *)outlineColor forState:(MDCContainedInputViewState)state;
+
+@end

--- a/components/TextFields/src/MDCOutlinedTextField.h
+++ b/components/TextFields/src/MDCOutlinedTextField.h
@@ -24,16 +24,16 @@
 /**
  The outline color when the text field is enabled and not editing.
  */
-@property(strong, nonatomic) UIColor *outlineColorNormal;
+@property(strong, nonatomic, nonnull) UIColor *outlineColorNormal;
 
 /**
  The outline color when the text field is enabled and editing.
  */
-@property(strong, nonatomic) UIColor *outlineColorEditing;
+@property(strong, nonatomic, nonnull) UIColor *outlineColorEditing;
 
 /**
  The outline color when the text field is disabled.
  */
-@property(strong, nonatomic) UIColor *outlineColorDisabled;
+@property(strong, nonatomic, nonnull) UIColor *outlineColorDisabled;
 
 @end

--- a/components/TextFields/src/MDCOutlinedTextField.h
+++ b/components/TextFields/src/MDCOutlinedTextField.h
@@ -21,6 +21,19 @@
  */
 @interface MDCOutlinedTextField : MDCInputTextField
 
-- (void)setOutlineColor:(UIColor *)outlineColor forState:(MDCContainedInputViewState)state;
+/**
+ The outline color when the text field is enabled and not editing.
+ */
+@property (strong, nonatomic) UIColor *outlineColorNormal;
+
+/**
+ The outline color when the text field is enabled and editing.
+ */
+@property (strong, nonatomic) UIColor *outlineColorEditing;
+
+/**
+ The outline color when the text field is disabled.
+ */
+@property (strong, nonatomic) UIColor *outlineColorDisabled;
 
 @end

--- a/components/TextFields/src/MDCOutlinedTextField.h
+++ b/components/TextFields/src/MDCOutlinedTextField.h
@@ -24,16 +24,16 @@
 /**
  The outline color when the text field is enabled and not editing.
  */
-@property (strong, nonatomic) UIColor *outlineColorNormal;
+@property(strong, nonatomic) UIColor *outlineColorNormal;
 
 /**
  The outline color when the text field is enabled and editing.
  */
-@property (strong, nonatomic) UIColor *outlineColorEditing;
+@property(strong, nonatomic) UIColor *outlineColorEditing;
 
 /**
  The outline color when the text field is disabled.
  */
-@property (strong, nonatomic) UIColor *outlineColorDisabled;
+@property(strong, nonatomic) UIColor *outlineColorDisabled;
 
 @end

--- a/components/TextFields/src/MDCOutlinedTextField.h
+++ b/components/TextFields/src/MDCOutlinedTextField.h
@@ -22,18 +22,19 @@
 @interface MDCOutlinedTextField : MDCInputTextField
 
 /**
- The outline color when the text field is enabled and not editing.
- */
-@property(strong, nonatomic, nonnull) UIColor *outlineColorNormal;
+ Sets the outline color for a given state.
 
-/**
- The outline color when the text field is enabled and editing.
+ @param outlineColor The UIColor for the given state.
+ @param state The UIControlState. The accepted values are UIControlStateNormal,
+ UIControlStateDisabled, and UIControlStateEditing, which is a custom MDC
+ UIControlState value.
  */
-@property(strong, nonatomic, nonnull) UIColor *outlineColorEditing;
+- (void)setOutlineColor:(UIColor *)outlineColor forState:(UIControlState)state;
+/**
+ Returns the outline color for a given state.
 
-/**
- The outline color when the text field is disabled.
+ @param state The UIControlState.
  */
-@property(strong, nonatomic, nonnull) UIColor *outlineColorDisabled;
+- (UIColor *)outlineColorForState:(UIControlState)state;
 
 @end


### PR DESCRIPTION
This PR shows the proposed APIs for MDCInputTextField, MDCFilledTextField, and MDCOutlinedTextField.

A few things to keep in mind:
- There has been some discussion about whether or not the filled and outlined text fields should inherit from a base text field class. My view is that because the only things that differentiate them are their positioning delegates ([filled](https://github.com/material-components/material-components-ios/blob/develop/components/TextFields/examples/experimental/supplemental/MDCFilledTextField.m#L58) and [outlined](https://github.com/material-components/material-components-ios/blob/develop/components/TextFields/examples/experimental/supplemental/MDCOutlinedTextField.m#L58)) and their styles ([filled](https://github.com/material-components/material-components-ios/blob/develop/components/TextFields/examples/experimental/supplemental/MDCContainerStylerFilled.h#L25) and [outlined](https://github.com/material-components/material-components-ios/blob/develop/components/TextFields/examples/experimental/supplemental/MDCContainerStylerOutlined.h#L23)) it makes sense for their substantial shared behavior to live in a superclass. Some downsides to having this be the case are as follows:
  - Clients would be able to subclass this base text field class as well.
  - There is a chance that over time the two subclasses will try to override behavior from the superclass and we will feel a kind of "inheritance burden."
- MDCContainedInputView and many of the things associated with it are private after https://github.com/material-components/material-components-ios/pull/7144, but the need to expose a type representing the Material/text field states still exists, because clients will need to be able to call methods like `-setOutlineColor:forState:` with these new concrete classes. For that reason, this PR exposes MDCContainedInputViewState. The problem is that this type may need to go away once our team arrives at a solution for how the State subsystem should be handled generally. In that sense, this API review is kind of blocked on the State work.

Closes #7147.