### PR TITLE
[Catalog] Add @objc annotations to our containerScheme instances in Swift

### DIFF
--- a/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
+++ b/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
@@ -23,7 +23,7 @@ import MaterialComponents.MaterialActionSheet_Theming
 
 class ActionSheetSwiftExampleViewController: UIViewController {
 
-  var containerScheme: MDCContainerScheming = MDCContainerScheme()
+  @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
   
   let tableView = UITableView()
   enum ActionSheetExampleType {

--- a/components/Cards/examples/CardExampleViewController.swift
+++ b/components/Cards/examples/CardExampleViewController.swift
@@ -23,7 +23,7 @@ class CardExampleViewController: UIViewController {
   @IBOutlet weak var card: MDCCard!
   @IBOutlet weak var button: MDCButton!
 
-  var containerScheme: MDCContainerScheming
+  @objc var containerScheme: MDCContainerScheming
 
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     containerScheme = MDCContainerScheme()

--- a/components/Cards/examples/EditReorderCollectionViewController.swift
+++ b/components/Cards/examples/EditReorderCollectionViewController.swift
@@ -31,7 +31,7 @@ class EditReorderCollectionViewController: UIViewController,
                                         collectionViewLayout: UICollectionViewFlowLayout())
   var toggle = ToggleMode.edit
 
-  var containerScheme: MDCContainerScheming
+  @objc var containerScheme: MDCContainerScheming
 
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     containerScheme = MDCContainerScheme()

--- a/components/Cards/examples/EditReorderShapedCollectionViewController.swift
+++ b/components/Cards/examples/EditReorderShapedCollectionViewController.swift
@@ -41,7 +41,7 @@ class EditReorderShapedCollectionViewController: UIViewController,
   UICollectionViewDataSource,
   UICollectionViewDelegateFlowLayout {
 
-  var containerScheme: MDCContainerScheming
+  @objc var containerScheme: MDCContainerScheming
 
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     containerScheme = MDCContainerScheme()

--- a/components/Dialogs/examples/DialogsAlertComparisonExample.swift
+++ b/components/Dialogs/examples/DialogsAlertComparisonExample.swift
@@ -29,7 +29,7 @@ class DialogsAlertComparisonExample: UIViewController {
   private let materialButton = MDCButton()
   private let themedButton = MDCButton()
   private let uikitButton = MDCButton()
-  var containerScheme: MDCContainerScheming = MDCContainerScheme()
+  @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
 
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/components/Dialogs/examples/DialogsAlertCustomizationExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsAlertCustomizationExampleViewController.swift
@@ -27,7 +27,7 @@ import MaterialComponents.MaterialPalettes
 
 class DialogsAlertCustomizationExampleViewController: MDCCollectionViewController {
 
-  var containerScheme: MDCContainerScheming = MDCContainerScheme()
+  @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
 
   let kReusableIdentifierItem = "customCell"
 

--- a/components/Dialogs/examples/DialogsCustomShadowExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsCustomShadowExampleViewController.swift
@@ -63,7 +63,7 @@ class DialogsCustomShadowExampleViewController: UIViewController {
 
   let textButton = MDCButton()
   let transitionController = MDCDialogTransitionController()
-  var containerScheme: MDCContainerScheming = MDCContainerScheme()
+  @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
 
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/components/Dialogs/examples/DialogsLongAlertExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsLongAlertExampleViewController.swift
@@ -23,7 +23,7 @@ import MaterialComponentsBeta.MaterialDialogs_Theming
 class DialogsLongAlertExampleViewController: UIViewController {
 
   let textButton = MDCButton()
-  var containerScheme: MDCContainerScheming = MDCContainerScheme()
+  @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
 
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/components/Ripple/examples/CardCellsWithRippleExample.swift
+++ b/components/Ripple/examples/CardCellsWithRippleExample.swift
@@ -32,7 +32,7 @@ class CardCellsWithRippleExample: UIViewController,
                                         collectionViewLayout: UICollectionViewFlowLayout())
   var toggle = ToggleMode.edit
 
-  var containerScheme: MDCContainerScheming
+  @objc var containerScheme: MDCContainerScheming
 
   var colorScheme: MDCColorScheming {
     return containerScheme.colorScheme

--- a/components/Ripple/examples/CardWithRippleExample.swift
+++ b/components/Ripple/examples/CardWithRippleExample.swift
@@ -22,7 +22,7 @@ class CardWithRippleExample: UIViewController {
   var card = MDCCard()
   var button = MDCButton()
 
-  var containerScheme: MDCContainerScheming
+  @objc var containerScheme: MDCContainerScheming
 
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     card.enableRippleBehavior = true


### PR DESCRIPTION
We need to add @objc annotations to the containerScheme instances in our Swift examples, because we moved to Swift 4.2, the respondsToSelector won't find the `setContainerScheme:` setter otherwise.