### PR TITLE
[Catalog] Add @objc annotations to our color and typography scheme instances in Swift 

### DIFF
--- a/components/AppBar/examples/AppBarAnimatedGlitchExample.swift
+++ b/components/AppBar/examples/AppBarAnimatedGlitchExample.swift
@@ -27,8 +27,8 @@ import MaterialComponents.MaterialTypographyScheme
 class AppBarAnimatedJumpExample: UIViewController {
 
   lazy var appBarViewController: MDCAppBarViewController = self.makeAppBar()
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var typographyScheme = MDCTypographyScheme()
 
   fileprivate let tabs = [
     SimpleComposedTableViewController(title: "First"),

--- a/components/AppBar/examples/AppBarGlitchExample.swift
+++ b/components/AppBar/examples/AppBarGlitchExample.swift
@@ -27,8 +27,8 @@ import MaterialComponents.MaterialFlexibleHeader_CanAlwaysExpandToMaximumHeight
 class AppBarJumpExample: UIViewController {
 
   lazy var appBarViewController: MDCAppBarViewController = self.makeAppBar()
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var typographyScheme = MDCTypographyScheme()
 
   fileprivate let firstTab = SimpleComposedTableViewController()
   fileprivate let secondTab = SimpleComposedTableViewController()

--- a/components/AppBar/examples/AppBarImageryExample.swift
+++ b/components/AppBar/examples/AppBarImageryExample.swift
@@ -18,7 +18,7 @@ import MaterialComponents.MaterialAppBar_ColorThemer
 
 class AppBarImagerySwiftExample: UITableViewController {
   let appBarViewController = MDCAppBarViewController()
-  var colorScheme = MDCSemanticColorScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
 
   deinit {
     // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.

--- a/components/AppBar/examples/AppBarInheritedAnimatedJumpExample.swift
+++ b/components/AppBar/examples/AppBarInheritedAnimatedJumpExample.swift
@@ -27,8 +27,8 @@ import MaterialComponents.MaterialTypographyScheme
 class AppBarInheritedAnimatedJumpExample: UIViewController {
 
   lazy var appBarViewController: MDCAppBarViewController = self.makeAppBar()
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var typographyScheme = MDCTypographyScheme()
 
   fileprivate let tabs = [
     SimpleInheritedTableViewController(title: "First"),

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
@@ -19,7 +19,7 @@ import MaterialComponents.MaterialAppBar_ColorThemer
 class AppBarInterfaceBuilderSwiftExample: UIViewController, UIScrollViewDelegate {
   @IBOutlet weak var scrollView: UIScrollView!
   let appBarViewController = MDCAppBarViewController()
-  var colorScheme = MDCSemanticColorScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
 
   deinit {
     // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.

--- a/components/AppBar/examples/AppBarManualTabsExample.swift
+++ b/components/AppBar/examples/AppBarManualTabsExample.swift
@@ -31,8 +31,8 @@ import MaterialComponents.MaterialFlexibleHeader_CanAlwaysExpandToMaximumHeight
 class AppBarManualTabsExample: UIViewController {
 
   lazy var appBarViewController: MDCAppBarViewController = self.makeAppBar()
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var typographyScheme = MDCTypographyScheme()
 
   fileprivate let firstTab = SimpleInheritedTableViewController()
   fileprivate let secondTab = SimpleInheritedTableViewController()

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -19,7 +19,7 @@ import MaterialComponents.MaterialAppBar_ColorThemer
 class AppBarModalPresentationSwiftExamplePresented: UITableViewController {
 
   let appBarViewController = MDCAppBarViewController()
-  var colorScheme = MDCSemanticColorScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
 
   deinit {
     // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
@@ -100,7 +100,7 @@ class AppBarModalPresentationSwiftExamplePresented: UITableViewController {
 class AppBarModalPresentationSwiftExample: UITableViewController {
 
   let appBarViewController = MDCAppBarViewController()
-  var colorScheme = MDCSemanticColorScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
 
   init() {
     super.init(nibName: nil, bundle: nil)

--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -21,8 +21,8 @@ class AppBarTypicalUseSwiftExample: UITableViewController {
 
   // Step 1: Create and initialize an App Bar.
   let appBarViewController = MDCAppBarViewController()
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var typographyScheme = MDCTypographyScheme()
 
   deinit {
     // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.

--- a/components/AppBar/examples/AppBarWithUITableViewController.swift
+++ b/components/AppBar/examples/AppBarWithUITableViewController.swift
@@ -26,7 +26,7 @@ class AppBarWithUITableViewController: UITableViewController {
 
   let appBarViewController = MDCAppBarViewController()
   var numberOfRows = 50
-  var colorScheme = MDCSemanticColorScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
 
   deinit {
     // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.

--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
@@ -27,8 +27,8 @@ class BottomAppBarTypicalUseSwiftExample: UIViewController {
 
   let appBarViewController = MDCAppBarViewController()
   let bottomBarView = MDCBottomAppBarView()
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var typographyScheme = MDCTypographyScheme()
 
   init() {
     super.init(nibName: nil, bundle: nil)

--- a/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
+++ b/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
@@ -20,13 +20,13 @@ import MaterialComponents.MaterialBottomNavigation_TypographyThemer
 
 class BottomNavigationControllerExampleViewController: MDCBottomNavigationBarController {
 
-  public var colorScheme: MDCColorScheming  = MDCSemanticColorScheme() {
+  @objc public var colorScheme: MDCColorScheming  = MDCSemanticColorScheme() {
     didSet {
       apply(colorScheme: colorScheme)
     }
   }
 
-  public var typographyScheme: MDCTypographyScheming = MDCTypographyScheme() {
+  @objc public var typographyScheme: MDCTypographyScheming = MDCTypographyScheme() {
     didSet {
       apply(typographyScheme: typographyScheme)
     }

--- a/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
@@ -19,7 +19,7 @@ import MaterialComponents.MaterialBottomNavigation_ColorThemer
 
 class BottomNavigationExplicitlySetColorExample: UIViewController {
 
-  var colorScheme = MDCSemanticColorScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
 
   let bottomNavBar = MDCBottomNavigationBar()
 

--- a/components/BottomNavigation/examples/BottomNavigationNilBadges.swift
+++ b/components/BottomNavigation/examples/BottomNavigationNilBadges.swift
@@ -17,7 +17,7 @@ import MaterialComponents.MaterialBottomNavigation_ColorThemer
 
 class BottomNavigationNilBadges : UIViewController {
 
-  var colorScheme = MDCSemanticColorScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
 
   // Create a bottom navigation bar to add to a view.
   let bottomNavBar = MDCBottomNavigationBar()

--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -22,8 +22,8 @@ import MaterialComponents.MaterialTypographyScheme
 /// Example to showcase a reorder of the tabs from an user action
 class BottomNavigationResetExample: UIViewController {
 
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var typographyScheme = MDCTypographyScheme()
 
   let bottomNavBar = MDCBottomNavigationBar()
 

--- a/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
@@ -18,8 +18,8 @@ import MaterialComponents.MaterialTypographyScheme
 
 // Example to show different icons for selected and unselected states
 class BottomNavigationSelectedIconExample: UIViewController {
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var typographyScheme = MDCTypographyScheme()
 
   let bottomNavBar = MDCBottomNavigationBar()
 

--- a/components/BottomNavigation/examples/BottomNavigationTitleVisibilityChangeExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTitleVisibilityChangeExample.swift
@@ -18,7 +18,7 @@ import MaterialComponents.MaterialColorScheme
 
 class BottomNavigationTitleVisibilityChangeExample: UIViewController, MDCBottomNavigationBarDelegate {
   
-  var colorScheme = MDCSemanticColorScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
   let instructionLabel = UILabel()
   
   // Create a bottom navigation bar to add to a view.

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
@@ -18,7 +18,7 @@ import MaterialComponents.MaterialColorScheme
 
 class BottomNavigationTypicalUseSwiftExample: UIViewController {
 
-  var colorScheme = MDCSemanticColorScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
 
   // Create a bottom navigation bar to add to a view.
   let bottomNavBar = MDCBottomNavigationBar()

--- a/components/BottomSheet/examples/BottomSheetTableViewExample.swift
+++ b/components/BottomSheet/examples/BottomSheetTableViewExample.swift
@@ -18,8 +18,8 @@ import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialButtons_ButtonThemer
 
 class BottomSheetTableViewExample: UIViewController {
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var typographyScheme = MDCTypographyScheme()
 
   init() {
     super.init(nibName: nil, bundle: nil)

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
@@ -18,8 +18,8 @@ import MaterialComponents.MaterialContainerScheme
 import MaterialComponentsBeta.MaterialButtonBar_Theming
 
 class ButtonBarTypicalUseSwiftExample: UIViewController {
-  var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
-  var typographyScheme = MDCTypographyScheme(defaults: .material201804)
+  @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+  @objc var typographyScheme = MDCTypographyScheme(defaults: .material201804)
 
   var scheme: MDCContainerScheming {
     let scheme = MDCContainerScheme()

--- a/components/FeatureHighlight/examples/FeatureHightlightTypicalUseViewController.swift
+++ b/components/FeatureHighlight/examples/FeatureHightlightTypicalUseViewController.swift
@@ -25,8 +25,8 @@ class FeatureHighlightSwiftViewController: UIViewController {
 
   let showButton = MDCButton()
   let featureButton = MDCButton()
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var typographyScheme = MDCTypographyScheme()
   let buttonScheme = MDCButtonScheme()
 
   override func viewDidLoad() {

--- a/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
+++ b/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
@@ -27,8 +27,8 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
     let useSafeAreaInsets: Bool
   }
   var targets: [TargetInfo] = []
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var typographyScheme = MDCTypographyScheme()
   let rightFAB = MDCFloatingButton()
   let leftFAB = MDCFloatingButton()
 

--- a/components/NavigationBar/examples/NavigationBarTypicalUseExample.swift
+++ b/components/NavigationBar/examples/NavigationBarTypicalUseExample.swift
@@ -19,7 +19,7 @@ import MaterialComponents.MaterialPalettes
 open class NavigationBarTypicalUseSwiftExample: UIViewController {
 
   var navBar = MDCNavigationBar()
-  var colorScheme = MDCSemanticColorScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
   var exampleView = ExampleInstructionsViewNavigationBarTypicalUseSwift()
 
   override open func viewDidLoad() {

--- a/components/NavigationDrawer/examples/BottomDrawerExpandFullscreenExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerExpandFullscreenExample.swift
@@ -20,7 +20,7 @@ import MaterialComponents.MaterialNavigationDrawer
 import MaterialComponents.MaterialNavigationDrawer_ColorThemer
 
 class BottomDrawerExpandFullscreenExample: UIViewController {
-  var colorScheme = MDCSemanticColorScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
   let bottomAppBar = MDCBottomAppBarView()
 
   let headerViewController = DrawerHeaderViewController()
@@ -75,7 +75,7 @@ class BottomDrawerExpandFullscreenExample: UIViewController {
 }
 
 class ExpandFullscreenContentViewController: UITableViewController {
-  var colorScheme: MDCSemanticColorScheme!
+  @objc var colorScheme: MDCSemanticColorScheme!
   weak var drawerVC: MDCBottomDrawerViewController!
 
   init() {

--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -20,7 +20,7 @@ import MaterialComponents.MaterialNavigationDrawer
 import MaterialComponents.MaterialNavigationDrawer_ColorThemer
 
 class BottomDrawerInfiniteScrollingExample: UIViewController {
-  var colorScheme = MDCSemanticColorScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
   let bottomAppBar = MDCBottomAppBarView()
 
   let headerViewController = DrawerHeaderViewController()
@@ -78,7 +78,7 @@ class BottomDrawerInfiniteScrollingExample: UIViewController {
 }
 
 class DrawerContentTableViewController: UITableViewController {
-  var colorScheme: MDCSemanticColorScheme!
+  @objc var colorScheme: MDCSemanticColorScheme!
   weak var drawerVC: MDCBottomDrawerViewController!
 
   override var preferredContentSize: CGSize {

--- a/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
@@ -19,7 +19,7 @@ import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialNavigationDrawer
 
 class BottomDrawerNoHeaderExample: UIViewController {
-  var colorScheme = MDCSemanticColorScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
   let bottomAppBar = MDCBottomAppBarView()
   
   let contentViewController = DrawerContentViewController()

--- a/components/NavigationDrawer/examples/BottomDrawerWithChangingContentSize.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithChangingContentSize.swift
@@ -20,7 +20,7 @@ import MaterialComponents.MaterialNavigationDrawer
 import MaterialComponents.MaterialNavigationDrawer_ColorThemer
 
 class BottomDrawerWithChangingContentSizeExample: UIViewController {
-  var colorScheme = MDCSemanticColorScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
   let bottomAppBar = MDCBottomAppBarView()
 
   let headerViewController = DrawerHeaderViewController()
@@ -78,7 +78,7 @@ class BottomDrawerWithChangingContentSizeExample: UIViewController {
 
 class DrawerChangingContentSizeViewController: UIViewController,
 UICollectionViewDelegate, UICollectionViewDataSource {
-  var colorScheme: MDCSemanticColorScheme!
+  @objc var colorScheme: MDCSemanticColorScheme!
   let numberOfRowsShort : Int = 2
   let numberOfRowsLong : Int = 12
   var longList = false

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -21,7 +21,7 @@ import MaterialComponents.MaterialNavigationDrawer_ColorThemer
 
 class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewControllerDelegate {
 
-  var colorScheme = MDCSemanticColorScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
   let bottomAppBar = MDCBottomAppBarView()
 
   let headerViewController = DrawerHeaderViewController()

--- a/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
@@ -20,7 +20,7 @@ import MaterialComponents.MaterialNavigationDrawer
 import MaterialComponents.MaterialNavigationDrawer_ColorThemer
 
 class BottomDrawerWithScrollableContentExample: UIViewController {
-  var colorScheme = MDCSemanticColorScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
   let bottomAppBar = MDCBottomAppBarView()
 
   let headerViewController = DrawerHeaderViewController()
@@ -76,7 +76,7 @@ class BottomDrawerWithScrollableContentExample: UIViewController {
 
 class DrawerContentWithScrollViewController: UIViewController,
     UICollectionViewDelegate, UICollectionViewDataSource {
-  var colorScheme: MDCSemanticColorScheme!
+  @objc var colorScheme: MDCSemanticColorScheme!
 
   let collectionView: UICollectionView
   let layout = UICollectionViewFlowLayout()

--- a/components/Ripple/examples/CardCellsWithRippleExample.swift
+++ b/components/Ripple/examples/CardCellsWithRippleExample.swift
@@ -34,11 +34,11 @@ class CardCellsWithRippleExample: UIViewController,
 
   @objc var containerScheme: MDCContainerScheming
 
-  var colorScheme: MDCColorScheming {
+  @objc var colorScheme: MDCColorScheming {
     return containerScheme.colorScheme
   }
 
-  var typographyScheme: MDCTypographyScheming {
+  @objc var typographyScheme: MDCTypographyScheming {
     return containerScheme.typographyScheme
   }
 

--- a/components/Tabs/examples/TabBarIconExample.swift
+++ b/components/Tabs/examples/TabBarIconExample.swift
@@ -38,8 +38,8 @@ class TabBarIconSwiftExample: UIViewController {
   lazy var appBarViewController: MDCAppBarViewController = self.setupAppBar()
   lazy var scrollView: UIScrollView = self.setupScrollView()
   lazy var starPage: UIView = self.setupStarPage()
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var typographyScheme = MDCTypographyScheme()
 
   lazy var tabBar: MDCTabBar = {
     let tabBar = MDCTabBar()

--- a/components/Tabs/examples/TabBarIndicatorTemplateExample.swift
+++ b/components/Tabs/examples/TabBarIndicatorTemplateExample.swift
@@ -50,8 +50,8 @@ class TabBarIndicatorTemplateExample: UIViewController {
   lazy var alignmentButton: MDCButton = self.makeAlignmentButton()
   lazy var appearanceButton: MDCButton = self.makeAppearanceButton()
   lazy var appBarViewController: MDCAppBarViewController = self.makeAppBar()
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var typographyScheme = MDCTypographyScheme()
 
   lazy var tabBar: MDCTabBar = {
     let tabBar = MDCTabBar()

--- a/components/TextFields/examples/TextFieldFilledExample.swift
+++ b/components/TextFields/examples/TextFieldFilledExample.swift
@@ -20,8 +20,8 @@ import MaterialComponents.MaterialTextFields_TypographyThemer
 final class TextFieldFilledSwiftExample: UIViewController {
 
   let scrollView = UIScrollView()
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var typographyScheme = MDCTypographyScheme()
 
   let name: MDCTextField = {
     let name = MDCTextField()

--- a/components/TextFields/examples/TextFieldOutlinedExample.swift
+++ b/components/TextFields/examples/TextFieldOutlinedExample.swift
@@ -20,8 +20,8 @@ import MaterialComponents.MaterialTextFields_TypographyThemer
 final class TextFieldOutlinedSwiftExample: UIViewController {
 
   let scrollView = UIScrollView()
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var typographyScheme = MDCTypographyScheme()
 
   let name: MDCTextField = {
     let name = MDCTextField()

--- a/components/TextFields/examples/TextFieldSemanticColorThemer.swift
+++ b/components/TextFields/examples/TextFieldSemanticColorThemer.swift
@@ -19,8 +19,8 @@ import MaterialComponents.MaterialTextFields_TypographyThemer
 
 final class TextFieldSemanticColorThemer: UIViewController {
 
-  var colorScheme = MDCSemanticColorScheme()
-  var typographyScheme = MDCTypographyScheme()
+  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var typographyScheme = MDCTypographyScheme()
 
   let textfieldStandard: MDCTextField = {
     let textfield = MDCTextField()


### PR DESCRIPTION
We need to add @objc annotations to colorScheme and typographyScheme instances in our Swift examples, because we moved to Swift 4.2, the respondsToSelector won't find `setColorScheme:` and `setTypographyScheme:` setters otherwise.