### PR TITLE
[TextFields] Fix examples layout

### DIFF
--- a/components/TextFields/examples/MultilineTextFieldLegacyExample.m
+++ b/components/TextFields/examples/MultilineTextFieldLegacyExample.m
@@ -109,19 +109,22 @@
   self.textFieldControllerFullWidth.characterCountMax = 140;
   self.textFieldControllerFullWidth.placeholderText = @"Full Width Controller";
 
+  id<UILayoutSupport> topGuide = self.topLayoutGuide;
   [NSLayoutConstraint
-      activateConstraints:
-          [NSLayoutConstraint
-              constraintsWithVisualFormat:@"V:[unstyled]-[area]-[floating]-[charMax]-[fullWidth]"
-                                  options:0
-                                  metrics:nil
-                                    views:@{
-                                      @"unstyled" : multilineTextFieldUnstyled,
-                                      @"area" : multilineTextFieldUnstyledArea,
-                                      @"charMax" : multilineTextFieldCharMaxDefault,
-                                      @"floating" : multilineTextFieldFloating,
-                                      @"fullWidth" : multilineTextFieldCharMaxFullWidth
-                                    }]];
+      activateConstraints:[NSLayoutConstraint
+                              constraintsWithVisualFormat:
+                                  @"V:[topGuide]-[unstyled]-[area]-[floating]-[charMax]-[fullWidth]"
+                                                  options:0
+                                                  metrics:nil
+                                                    views:@{
+                                                      @"topGuide" : topGuide,
+                                                      @"unstyled" : multilineTextFieldUnstyled,
+                                                      @"area" : multilineTextFieldUnstyledArea,
+                                                      @"charMax" : multilineTextFieldCharMaxDefault,
+                                                      @"floating" : multilineTextFieldFloating,
+                                                      @"fullWidth" :
+                                                          multilineTextFieldCharMaxFullWidth
+                                                    }]];
   [NSLayoutConstraint
       activateConstraints:[NSLayoutConstraint
                               constraintsWithVisualFormat:@"H:|-[unstyled]-|"

--- a/components/TextFields/examples/TextFieldControllerStylesExample.m
+++ b/components/TextFields/examples/TextFieldControllerStylesExample.m
@@ -100,13 +100,15 @@
 
   [self.textFieldControllerFilled mdc_setAdjustsFontForContentSizeCategory:YES];
 
+  id<UILayoutSupport> topGuide = self.topLayoutGuide;
   [NSLayoutConstraint
       activateConstraints:[NSLayoutConstraint
-                              constraintsWithVisualFormat:@"V:[charMax]-[floating]"
+                              constraintsWithVisualFormat:@"V:[topGuide]-[charMax]-[floating]"
                                                   options:NSLayoutFormatAlignAllLeading |
                                                           NSLayoutFormatAlignAllTrailing
                                                   metrics:nil
                                                     views:@{
+                                                      @"topGuide" : topGuide,
                                                       @"charMax" : textFieldOutlined,
                                                       @"floating" : textFieldFilled
                                                     }]];

--- a/components/TextFields/examples/TextFieldOutlinedExample.m
+++ b/components/TextFields/examples/TextFieldOutlinedExample.m
@@ -176,7 +176,9 @@
   self.messageController.placeholderText = @"Message";
   [self styleTextInputController:self.messageController];
 
+  id<UILayoutSupport> topGuide = self.topLayoutGuide;
   NSDictionary *views = @{
+    @"topGuide" : topGuide,
     @"name" : textFieldName,
     @"address" : textFieldAddress,
     @"city" : textFieldCity,
@@ -187,14 +189,14 @@
     @"message" : textFieldMessage
   };
   NSMutableArray<NSLayoutConstraint *> *constraints = [NSMutableArray
-      arrayWithArray:
-          [NSLayoutConstraint
-              constraintsWithVisualFormat:@"V:[name]-[address]-[city]-[stateZip]-[phone]-[message]"
+      arrayWithArray:[NSLayoutConstraint
+                         constraintsWithVisualFormat:
+                             @"V:[topGuide]-[name]-[address]-[city]-[stateZip]-[phone]-[message]"
 
-                                  options:NSLayoutFormatAlignAllLeading |
-                                          NSLayoutFormatAlignAllTrailing
-                                  metrics:nil
-                                    views:views]];
+                                             options:NSLayoutFormatAlignAllLeading |
+                                                     NSLayoutFormatAlignAllTrailing
+                                             metrics:nil
+                                               views:views]];
   [constraints addObject:[NSLayoutConstraint constraintWithItem:textFieldName
                                                       attribute:NSLayoutAttributeLeading
                                                       relatedBy:NSLayoutRelationEqual


### PR DESCRIPTION
Fixing the examples layout so the content doesn't overlap the App Bar.

|Before|After|
|---|---|
|![legacy-multi-before](https://user-images.githubusercontent.com/1753199/56600236-3ba35280-65c6-11e9-9276-52acb5cde63b.png)|![legacy-multi-after](https://user-images.githubusercontent.com/1753199/56600242-3f36d980-65c6-11e9-8faf-bc5255bf3bdb.png)|
|![outlined-before](https://user-images.githubusercontent.com/1753199/56600248-42ca6080-65c6-11e9-911f-2cd9828dfb62.png)|![outlined-after](https://user-images.githubusercontent.com/1753199/56600262-49f16e80-65c6-11e9-9775-95d452fec723.png)|
|![controller-styles-before](https://user-images.githubusercontent.com/1753199/56600269-4e1d8c00-65c6-11e9-9359-8e98f0e1cbc1.png)|![controller-styles-after](https://user-images.githubusercontent.com/1753199/56600290-57a6f400-65c6-11e9-9d8f-8f9ac2c243be.png)|

Preparation for #7157