### PR TITLE
[TextFields] Fix example layout.

### DIFF
--- a/components/TextFields/examples/TextFieldCustomFontExample.m
+++ b/components/TextFields/examples/TextFieldCustomFontExample.m
@@ -143,11 +143,12 @@
   self.scrollView = [[UIScrollView alloc] initWithFrame:CGRectZero];
   self.scrollView.translatesAutoresizingMaskIntoConstraints = NO;
   [self.view addSubview:self.scrollView];
-  NSArray *constraints =
-      [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[scrollView]|"
-                                              options:0
-                                              metrics:nil
-                                                views:@{@"scrollView" : self.scrollView}];
+  id<UILayoutSupport> topGuide = self.topLayoutGuide;
+  NSArray *constraints = [NSLayoutConstraint
+      constraintsWithVisualFormat:@"V:|[topGuide]-[scrollView]|"
+                          options:0
+                          metrics:nil
+                            views:@{@"topGuide" : topGuide, @"scrollView" : self.scrollView}];
 
   [NSLayoutConstraint activateConstraints:constraints];
   constraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[scrollView]|"

--- a/components/TextFields/examples/TextFieldOutlinedExample.swift
+++ b/components/TextFields/examples/TextFieldOutlinedExample.swift
@@ -270,10 +270,10 @@ final class TextFieldOutlinedSwiftExample: UIViewController {
     scrollView.translatesAutoresizingMaskIntoConstraints = false
 
     NSLayoutConstraint.activate(NSLayoutConstraint.constraints(
-      withVisualFormat: "V:|[scrollView]|",
+      withVisualFormat: "V:|[topGuide]-[scrollView]|",
       options: [],
       metrics: nil,
-      views: ["scrollView": scrollView]))
+      views: ["scrollView": scrollView, "topGuide": topLayoutGuide]))
     NSLayoutConstraint.activate(NSLayoutConstraint.constraints(withVisualFormat: "H:|[scrollView]|",
                                                                options: [],
                                                                metrics: nil,

--- a/components/TextFields/examples/supplemental/TextFieldKitchenSinkExampleSupplemental.swift
+++ b/components/TextFields/examples/supplemental/TextFieldKitchenSinkExampleSupplemental.swift
@@ -153,10 +153,10 @@ extension TextFieldKitchenSinkSwiftExample {
     scrollView.translatesAutoresizingMaskIntoConstraints = false
 
     NSLayoutConstraint.activate(NSLayoutConstraint.constraints(
-      withVisualFormat: "V:|[scrollView]|",
+      withVisualFormat: "V:|[topGuide]-[scrollView]|",
       options: [],
       metrics: nil,
-      views: ["scrollView": scrollView]))
+      views: ["scrollView": scrollView, "topGuide": topLayoutGuide]))
     NSLayoutConstraint.activate(NSLayoutConstraint.constraints(withVisualFormat: "H:|[scrollView]|",
                                                                options: [],
                                                                metrics: nil,


### PR DESCRIPTION
Fixing more example layouts so that the text fields are visible below the
AppBar.

|Before|After|
|---|---|
|![customfont-before](https://user-images.githubusercontent.com/1753199/56601838-27615480-65ca-11e9-85e0-57452e41293d.png)|![customfont-after](https://user-images.githubusercontent.com/1753199/56601846-2b8d7200-65ca-11e9-9571-db1f408a83ed.png)|
|![kitchensink-before](https://user-images.githubusercontent.com/1753199/56601858-2f20f900-65ca-11e9-9abb-84188cbe36bb.png)|![kitchensink-after](https://user-images.githubusercontent.com/1753199/56601882-3ba55180-65ca-11e9-8bd8-10e5ede0bab2.png)|
|![outlinedswift-before](https://user-images.githubusercontent.com/1753199/56601891-41029c00-65ca-11e9-8306-6aa1caf4b221.png)|![outlinedswift-after](https://user-images.githubusercontent.com/1753199/56601910-4b249a80-65ca-11e9-950e-674fc54caebd.png)|

Preparation for #7157
