### PR TITLE
[TextFields] Fix Contained example error states.

### DIFF
--- a/components/TextFields/examples/TextFieldOutlinedExample.m
+++ b/components/TextFields/examples/TextFieldOutlinedExample.m
@@ -291,12 +291,63 @@
 - (BOOL)textFieldShouldReturn:(UITextField *)textField {
   [textField resignFirstResponder];
 
-  if (textField == (UITextField *)self.phoneController.textInput &&
-      ![self isValidPhoneNumber:textField.text partially:NO]) {
-    [self.phoneController setErrorText:@"Invalid Phone Number" errorAccessibilityValue:nil];
+  if (textField == (UITextField *)self.nameController.textInput) {
+    if ([textField.text rangeOfCharacterFromSet:[NSCharacterSet decimalDigitCharacterSet]].length &&
+        ![self.nameController.errorText isEqualToString:@"Error: You cannot enter numbers"]) {
+      // The entered text contains numbers and we have not set an error
+      [self.nameController setErrorText:@"You cannot enter numbers" errorAccessibilityValue:nil];
+
+      // Since we are doing manual layout, we need to react to the expansion of the input that will
+      // come from setting an error.
+      [self.view setNeedsLayout];
+    } else if (self.nameController.errorText != nil) {
+      // There should be no error but error text is being shown.
+      [self.nameController setErrorText:nil errorAccessibilityValue:nil];
+
+      // Since we are doing manual layout, we need to react to the contraction of the input that
+      // will come from setting an error.
+      [self.view setNeedsLayout];
+    }
+  } else if (textField == (UITextField *)self.cityController.textInput) {
+    if ([textField.text rangeOfCharacterFromSet:[[NSCharacterSet letterCharacterSet] invertedSet]]
+            .length > 0) {
+      [self.cityController setErrorText:@"Error: City can only contain letters"
+                errorAccessibilityValue:nil];
+    } else {
+      [self.cityController setErrorText:nil errorAccessibilityValue:nil];
+    }
+  } else if (textField == (UITextField *)self.phoneController.textInput) {
+    if (![self isValidPhoneNumber:textField.text partially:NO]) {
+      [self.phoneController setErrorText:@"Invalid Phone Number" errorAccessibilityValue:nil];
+    } else if (self.phoneController.errorText != nil) {
+      [self.phoneController setErrorText:nil errorAccessibilityValue:nil];
+    }
+  } else if (textField == (UITextField *)self.zipController.textInput) {
+    if ([textField.text rangeOfCharacterFromSet:[NSCharacterSet letterCharacterSet]].length > 0) {
+      [self.zipController setErrorText:@"Error: Zip can only contain numbers"
+               errorAccessibilityValue:nil];
+    } else if (textField.text.length > 5) {
+      [self.zipController setErrorText:@"Error: Zip can only contain five digits"
+               errorAccessibilityValue:nil];
+    } else {
+      [self.zipController setErrorText:nil errorAccessibilityValue:nil];
+    }
   }
 
   return NO;
+}
+
+- (BOOL)textFieldShouldClear:(UITextField *)textField {
+  if (textField == (UITextField *)self.nameController.textInput) {
+    [self.nameController setErrorText:nil errorAccessibilityValue:nil];
+  } else if (textField == (UITextField *)self.cityController.textInput) {
+    [self.cityController setErrorText:nil errorAccessibilityValue:nil];
+  } else if (textField == (UITextField *)self.phoneController.textInput) {
+    [self.phoneController setErrorText:nil errorAccessibilityValue:nil];
+  } else if (textField == (UITextField *)self.zipController.textInput) {
+    [self.zipController setErrorText:nil errorAccessibilityValue:nil];
+  }
+  return YES;
 }
 
 - (BOOL)textField:(UITextField *)textField


### PR DESCRIPTION
Fixing the error logic of the Contained Text Fields example. This makes it
easier to debug issues around the error state and UIAccessibility.  Specifically, this clears the error state for some of the text fields that would "hang around" in the following conditions:

1.  The user places the Text Field in an "error state" by entering invalid text.
2.  The user changes the focus from the error-state Text Field to another
3.  The user then either:
    1.  Returns focus to that error-state Text Field and corrects the error and uses the "Return" button to resign first responder on the text field
     2. Presses the Text Field's clear button to remove the offending content.

In both cases, the error state incorrectly "stuck around" even though the content did not warrant that state.

| |Precondition|Result|
|---|---|---|
|Before|![outlined-error-content-before](https://user-images.githubusercontent.com/1753199/56605451-31875100-65d2-11e9-87ef-f0d069fa8114.png)|![outlined-error-cleared-before](https://user-images.githubusercontent.com/1753199/56604064-20891080-65cf-11e9-9348-fbfc9201b765.png)
|After|![outlined-error-content-before](https://user-images.githubusercontent.com/1753199/56605451-31875100-65d2-11e9-87ef-f0d069fa8114.png)|![outlined-error-cleared-after](https://user-images.githubusercontent.com/1753199/56604071-241c9780-65cf-11e9-997e-24bcfa35b13e.png)|

Prework for #7157
