### PR TITLE
[Ripple] Add better resizing animation support

### DIFF
--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -17,9 +17,20 @@
 
 #import "MaterialMath.h"
 
-@interface MDCRippleView () <MDCRippleLayerDelegate>
+@interface MDCRippleView () <CALayerDelegate, MDCRippleLayerDelegate>
+
 @property(nonatomic, strong) MDCRippleLayer *activeRippleLayer;
 @property(nonatomic, strong) CAShapeLayer *maskLayer;
+
+@end
+
+@interface MDCRipplePendingAnimation : NSObject <CAAction>
+
+@property(nonatomic, weak) CALayer *animationSourceLayer;
+@property(nonatomic, strong) NSString *keyPath;
+@property(nonatomic, strong) id fromValue;
+@property(nonatomic, strong) id toValue;
+
 @end
 
 static const CGFloat kRippleDefaultAlpha = (CGFloat)0.16;
@@ -55,6 +66,7 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
 
   // Use mask layer when the superview has a shadowPath.
   _maskLayer = [CAShapeLayer layer];
+  _maskLayer.delegate = self;
 }
 
 - (void)layoutSubviews {
@@ -194,4 +206,42 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   }
 }
 
+#pragma mark - CALayerDelegate
+
+- (id<CAAction>)actionForLayer:(CALayer *)layer forKey:(NSString *)event {
+  if ([event isEqualToString:@"path"] || [event isEqualToString:@"shadowPath"]) {
+    // We have to create a pending animation because if we are inside a UIKit animation block we
+    // won't know any properties of the animation block until it is commited.
+    MDCRipplePendingAnimation *pendingAnim = [[MDCRipplePendingAnimation alloc] init];
+    pendingAnim.animationSourceLayer = self.superview.layer;
+    pendingAnim.fromValue = [layer.presentationLayer valueForKey:event];
+    pendingAnim.toValue = nil;
+    pendingAnim.keyPath = event;
+
+    return pendingAnim;
+  }
+  return nil;
+}
+
+@end
+
+@implementation MDCRipplePendingAnimation
+
+- (void)runActionForKey:(NSString *)event object:(id)anObject arguments:(NSDictionary *)dict {
+  if ([anObject isKindOfClass:[CAShapeLayer class]]) {
+    CAShapeLayer *layer = (CAShapeLayer *)anObject;
+
+    // In order to synchronize our animation with UIKit animations we have to fetch the resizing
+    // animation created by UIKit and copy the configuration to our custom animation.
+    CAAnimation *boundsAction = [self.animationSourceLayer animationForKey:@"bounds.size"];
+    if ([boundsAction isKindOfClass:[CABasicAnimation class]]) {
+      CABasicAnimation *animation = (CABasicAnimation *)[boundsAction copy];
+      animation.keyPath = self.keyPath;
+      animation.fromValue = self.fromValue;
+      animation.toValue = self.toValue;
+
+      [layer addAnimation:animation forKey:event];
+    }
+  }
+}
 @end

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -236,13 +236,18 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   // animation created by UIKit and copy the configuration to our custom animation.
   CAShapeLayer *layer = (CAShapeLayer *)anObject;
   CAAnimation *boundsAction = [self.animationSourceLayer animationForKey:@"bounds.size"];
-  if ([boundsAction isKindOfClass:[CABasicAnimation class]]) {
-    CABasicAnimation *animation = (CABasicAnimation *)[boundsAction copy];
-    animation.keyPath = self.keyPath;
-    animation.fromValue = self.fromValue;
-    animation.toValue = self.toValue;
-
-    [layer addAnimation:animation forKey:event];
+  BOOL isBasicAnimation = [boundsAction isKindOfClass:[CABasicAnimation class]];
+  if (!isBasicAnimation) {
+    NSAssert(isBasicAnimation || !boundsAction,
+             @"This animation synchronization does not support a bounds size change that "
+             @"isn't of a CABasicAnimation type.");
+    return;
   }
+  CABasicAnimation *animation = (CABasicAnimation *)[boundsAction copy];
+  animation.keyPath = self.keyPath;
+  animation.fromValue = self.fromValue;
+  animation.toValue = self.toValue;
+
+  [layer addAnimation:animation forKey:event];
 }
 @end

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -228,20 +228,21 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
 @implementation MDCRipplePendingAnimation
 
 - (void)runActionForKey:(NSString *)event object:(id)anObject arguments:(NSDictionary *)dict {
-  if ([anObject isKindOfClass:[CAShapeLayer class]]) {
-    CAShapeLayer *layer = (CAShapeLayer *)anObject;
+  if (![anObject isKindOfClass:[CAShapeLayer class]]) {
+    return;
+  }
 
-    // In order to synchronize our animation with UIKit animations we have to fetch the resizing
-    // animation created by UIKit and copy the configuration to our custom animation.
-    CAAnimation *boundsAction = [self.animationSourceLayer animationForKey:@"bounds.size"];
-    if ([boundsAction isKindOfClass:[CABasicAnimation class]]) {
-      CABasicAnimation *animation = (CABasicAnimation *)[boundsAction copy];
-      animation.keyPath = self.keyPath;
-      animation.fromValue = self.fromValue;
-      animation.toValue = self.toValue;
+  // In order to synchronize our animation with UIKit animations we have to fetch the resizing
+  // animation created by UIKit and copy the configuration to our custom animation.
+  CAShapeLayer *layer = (CAShapeLayer *)anObject;
+  CAAnimation *boundsAction = [self.animationSourceLayer animationForKey:@"bounds.size"];
+  if ([boundsAction isKindOfClass:[CABasicAnimation class]]) {
+    CABasicAnimation *animation = (CABasicAnimation *)[boundsAction copy];
+    animation.keyPath = self.keyPath;
+    animation.fromValue = self.fromValue;
+    animation.toValue = self.toValue;
 
-      [layer addAnimation:animation forKey:event];
-    }
+    [layer addAnimation:animation forKey:event];
   }
 }
 @end

--- a/components/Ripple/src/MDCStatefulRippleView.m
+++ b/components/Ripple/src/MDCStatefulRippleView.m
@@ -171,7 +171,7 @@ static UIColor *RippleSelectedColor(void) {
     // If ripple becomes highlighted we initiate a ripple with animation.
     [self updateRippleColor];
     [self beginRippleTouchDownAtPoint:_lastTouch animated:_didReceiveTouch completion:nil];
-  } else {
+  } else if (!rippleHighlighted) {
     if (!self.allowsSelection && !self.dragged && !_tapWentOutsideOfBounds) {
       // We dissolve the ripple when highlighted is NO, unless we are going into
       // selection or dragging.

--- a/components/Ripple/src/MDCStatefulRippleView.m
+++ b/components/Ripple/src/MDCStatefulRippleView.m
@@ -171,7 +171,7 @@ static UIColor *RippleSelectedColor(void) {
     // If ripple becomes highlighted we initiate a ripple with animation.
     [self updateRippleColor];
     [self beginRippleTouchDownAtPoint:_lastTouch animated:_didReceiveTouch completion:nil];
-  } else if (!rippleHighlighted) {
+  } else {
     if (!self.allowsSelection && !self.dragged && !_tapWentOutsideOfBounds) {
       // We dissolve the ripple when highlighted is NO, unless we are going into
       // selection or dragging.


### PR DESCRIPTION
As part of the effort for: #7268 to integrate Ripple into Chips, there were some improvements that were added into the Ripple component.

1. Chips support resizable chips on tap, which can be animated. To have the Ripple expand correctly based on the new animated bounds of the Chip, we added a synchronization between the animations. This is the same as what Ink currently offers as part of its implementation. This was tested along with PR #7270 to check that the animations were successfully synchronized.

This should land prior to #7270 to make sure that the Ripple integration with Chips has these improvements to ensure a smooth and correct integration.

Using the old Ink | Using Ripple without this improvement | Using Ripple with this improvement
------------ | ------------- | -------------
![inkanimated](https://user-images.githubusercontent.com/4066863/56767133-fa9f6f80-6778-11e9-9ccd-4b0a72140e96.gif) | ![ripplebeforechange](https://user-images.githubusercontent.com/4066863/56767149-00955080-6779-11e9-8242-5acae5bce951.gif) | ![afterchangeripple](https://user-images.githubusercontent.com/4066863/56767164-08ed8b80-6779-11e9-9441-198920a5d903.gif)


