### PR TITLE
[BottomSheet] Additional API providing callbacks for sheet offset and current state changes.

### DIFF
--- a/components/BottomSheet/examples/BottomSheetTypicalUseExample.m
+++ b/components/BottomSheet/examples/BottomSheetTypicalUseExample.m
@@ -65,12 +65,12 @@
 
 - (void)bottomSheetControllerDidChangeYOffset:(MDCBottomSheetController *)controller
                                       yOffset:(CGFloat)yOffset {
-  NSLog(@"bototm sheet Y offset: %f", yOffset);
+  NSLog(@"bottom sheet Y offset changed: %f", yOffset);
 }
 
 - (void)bottomSheetControllerStateChanged:(MDCBottomSheetController *)controller
                                     state:(MDCSheetState)state {
-  NSLog(@"state change: %lu", (unsigned long)state);
+  NSLog(@"bottom sheet state changed to: %lu", (unsigned long)state);
 }
 
 @end

--- a/components/BottomSheet/examples/BottomSheetTypicalUseExample.m
+++ b/components/BottomSheet/examples/BottomSheetTypicalUseExample.m
@@ -63,9 +63,9 @@
   [self presentViewController:bottomSheet animated:YES completion:nil];
 }
 
-- (void)bottomSheetControllerDidChangeScrollOffset:(MDCBottomSheetController *)controller
-                                      scrollOffset:(CGFloat)scrollOffset {
-  NSLog(@"scroll offset: %f", scrollOffset);
+- (void)bottomSheetControllerDidChangeYOffset:(MDCBottomSheetController *)controller
+                                      yOffset:(CGFloat)yOffset {
+  NSLog(@"bototm sheet Y offset: %f", yOffset);
 }
 
 - (void)bottomSheetControllerStateChanged:(MDCBottomSheetController *)controller

--- a/components/BottomSheet/examples/BottomSheetTypicalUseExample.m
+++ b/components/BottomSheet/examples/BottomSheetTypicalUseExample.m
@@ -22,7 +22,7 @@
 #import "supplemental/BottomSheetDummyCollectionViewController.h"
 #import "supplemental/BottomSheetSupplemental.h"
 
-@interface BottomSheetTypicalUseExample ()
+@interface BottomSheetTypicalUseExample () <MDCBottomSheetControllerDelegate>
 @property(nonatomic, strong) MDCShapeScheme *shapeScheme;
 @end
 
@@ -59,7 +59,18 @@
   bottomSheet.isScrimAccessibilityElement = YES;
   bottomSheet.scrimAccessibilityLabel = @"Close";
   bottomSheet.trackingScrollView = viewController.collectionView;
+  bottomSheet.delegate = self;
   [self presentViewController:bottomSheet animated:YES completion:nil];
+}
+
+- (void)bottomSheetControllerDidChangeScrollOffset:(MDCBottomSheetController *)controller
+                                      scrollOffset:(CGFloat)scrollOffset {
+  NSLog(@"scroll offset: %f", scrollOffset);
+}
+
+- (void)bottomSheetControllerStateChanged:(MDCBottomSheetController *)controller
+                                    state:(MDCSheetState)state {
+  NSLog(@"state change: %lu", (unsigned long)state);
 }
 
 @end

--- a/components/BottomSheet/src/MDCBottomSheetController.h
+++ b/components/BottomSheet/src/MDCBottomSheetController.h
@@ -153,7 +153,21 @@
  */
 - (void)bottomSheetControllerDidDismissBottomSheet:(nonnull MDCBottomSheetController *)controller;
 
+/**
+ Called when the state of the bottom sheet changes.
+
+ Note: See what states the sheet can transition to by looking at MDCSheetState.
+
+ @param controller The MDCBottomSheetController that its state changed.
+ @param state The state the sheet changed to.
+ */
 - (void)bottomSheetControllerStateChanged:(nonnull MDCBottomSheetController *)controller state:(MDCSheetState)state;
 
-- (void)bottomSheetControllerDidChangeScrollOffset:(nonnull MDCBottomSheetController *)controller scrollOffset:(CGFloat)scrollOffset;
+/**
+ Called when the Y offset of the sheet's changes in relation to the top of the screen.
+
+ @param controller The MDCBottomSheetController that its Y offset changed.
+ @param yOffset The Y offset the bottom sheet changed to.
+ */
+- (void)bottomSheetControllerDidChangeYOffset:(nonnull MDCBottomSheetController *)controller yOffset:(CGFloat)yOffset;
 @end

--- a/components/BottomSheet/src/MDCBottomSheetController.h
+++ b/components/BottomSheet/src/MDCBottomSheetController.h
@@ -142,7 +142,7 @@
  Delegate for MDCBottomSheetController.
  */
 @protocol MDCBottomSheetControllerDelegate <NSObject>
-
+@optional
 /**
  Called when the user taps the dimmed background or swipes the bottom sheet off to dismiss the
  bottom sheet. Also called with accessibility escape "two finger Z" gestures.
@@ -153,4 +153,7 @@
  */
 - (void)bottomSheetControllerDidDismissBottomSheet:(nonnull MDCBottomSheetController *)controller;
 
+- (void)bottomSheetControllerStateChanged:(nonnull MDCBottomSheetController *)controller state:(MDCSheetState)state;
+
+- (void)bottomSheetControllerDidChangeScrollOffset:(nonnull MDCBottomSheetController *)controller scrollOffset:(CGFloat)scrollOffset;
 @end

--- a/components/BottomSheet/src/MDCBottomSheetController.h
+++ b/components/BottomSheet/src/MDCBottomSheetController.h
@@ -161,7 +161,8 @@
  @param controller The MDCBottomSheetController that its state changed.
  @param state The state the sheet changed to.
  */
-- (void)bottomSheetControllerStateChanged:(nonnull MDCBottomSheetController *)controller state:(MDCSheetState)state;
+- (void)bottomSheetControllerStateChanged:(nonnull MDCBottomSheetController *)controller
+                                    state:(MDCSheetState)state;
 
 /**
  Called when the Y offset of the sheet's changes in relation to the top of the screen.
@@ -169,5 +170,6 @@
  @param controller The MDCBottomSheetController that its Y offset changed.
  @param yOffset The Y offset the bottom sheet changed to.
  */
-- (void)bottomSheetControllerDidChangeYOffset:(nonnull MDCBottomSheetController *)controller yOffset:(CGFloat)yOffset;
+- (void)bottomSheetControllerDidChangeYOffset:(nonnull MDCBottomSheetController *)controller
+                                      yOffset:(CGFloat)yOffset;
 @end

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -144,8 +144,8 @@
 
 - (void)bottomSheetDidChangeYOffset:(nonnull MDCBottomSheetPresentationController *)bottomSheet
                             yOffset:(CGFloat)yOffset {
-  if ([self.delegate
-          respondsToSelector:@selector(bottomSheetControllerDidChangeYOffset:yOffset:)]) {
+  if ([self.delegate respondsToSelector:@selector(bottomSheetControllerDidChangeYOffset:
+                                                                                yOffset:)]) {
     [self.delegate bottomSheetControllerDidChangeYOffset:self yOffset:yOffset];
   }
 }

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -137,6 +137,17 @@
                         sheetState:(MDCSheetState)sheetState {
   _state = sheetState;
   [self updateShapeGenerator];
+  if ([self.delegate respondsToSelector:@selector(bottomSheetControllerStateChanged:state:)]) {
+    [self.delegate bottomSheetControllerStateChanged:self state:sheetState];
+  }
+}
+
+- (void)bottomSheetDidChangeScrollOffset:(nonnull MDCBottomSheetPresentationController *)bottomSheet
+                            scrollOffset:(CGFloat)scrollOffset {
+  if ([self.delegate
+          respondsToSelector:@selector(bottomSheetControllerDidChangeScrollOffset:scrollOffset:)]) {
+    [self.delegate bottomSheetControllerDidChangeScrollOffset:self scrollOffset:scrollOffset];
+  }
 }
 
 - (id<MDCShapeGenerating>)shapeGeneratorForState:(MDCSheetState)state {
@@ -227,7 +238,9 @@
 - (void)bottomSheetPresentationControllerDidDismissBottomSheet:
     (nonnull __unused MDCBottomSheetPresentationController *)bottomSheet {
 #pragma clang diagnostic pop
-  [self.delegate bottomSheetControllerDidDismissBottomSheet:self];
+  if ([self.delegate respondsToSelector:@selector(bottomSheetControllerDidDismissBottomSheet:)]) {
+    [self.delegate bottomSheetControllerDidDismissBottomSheet:self];
+  }
 }
 
 @end

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -142,11 +142,11 @@
   }
 }
 
-- (void)bottomSheetDidChangeScrollOffset:(nonnull MDCBottomSheetPresentationController *)bottomSheet
-                            scrollOffset:(CGFloat)scrollOffset {
+- (void)bottomSheetDidChangeYOffset:(nonnull MDCBottomSheetPresentationController *)bottomSheet
+                            yOffset:(CGFloat)yOffset {
   if ([self.delegate
-          respondsToSelector:@selector(bottomSheetControllerDidChangeScrollOffset:scrollOffset:)]) {
-    [self.delegate bottomSheetControllerDidChangeScrollOffset:self scrollOffset:scrollOffset];
+          respondsToSelector:@selector(bottomSheetControllerDidChangeYOffset:yOffset:)]) {
+    [self.delegate bottomSheetControllerDidChangeYOffset:self yOffset:yOffset];
   }
 }
 

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -42,9 +42,24 @@
 - (void)bottomSheetPresentationControllerDidDismissBottomSheet:
     (nonnull MDCBottomSheetPresentationController *)bottomSheet;
 
+/**
+ Called when the state of the bottom sheet changes.
+
+ Note: See what states the sheet can transition to by looking at MDCSheetState.
+
+ @param bottomSheet The MDCBottomSheetPresentationController that its state changed.
+ @param sheetState The state the sheet changed to.
+ */
 - (void)bottomSheetWillChangeState:(nonnull MDCBottomSheetPresentationController *)bottomSheet
                         sheetState:(MDCSheetState)sheetState;
 
+
+/**
+ Called when the Y offset of the sheet's changes in relation to the top of the screen.
+
+ @param bottomSheet The MDCBottomSheetPresentationController that its Y offset changed.
+ @param yOffset The Y offset the bottom sheet changed to.
+ */
 - (void)bottomSheetDidChangeYOffset:(nonnull MDCBottomSheetPresentationController *)bottomSheet
                         yOffset:(CGFloat)yOffset;
 @end

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -45,8 +45,8 @@
 - (void)bottomSheetWillChangeState:(nonnull MDCBottomSheetPresentationController *)bottomSheet
                         sheetState:(MDCSheetState)sheetState;
 
-- (void)bottomSheetDidChangeScrollOffset:(nonnull MDCBottomSheetPresentationController *)bottomSheet
-                        scrollOffset:(CGFloat)scrollOffset;
+- (void)bottomSheetDidChangeYOffset:(nonnull MDCBottomSheetPresentationController *)bottomSheet
+                        yOffset:(CGFloat)yOffset;
 @end
 
 /**

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -53,7 +53,6 @@
 - (void)bottomSheetWillChangeState:(nonnull MDCBottomSheetPresentationController *)bottomSheet
                         sheetState:(MDCSheetState)sheetState;
 
-
 /**
  Called when the Y offset of the sheet's changes in relation to the top of the screen.
 
@@ -61,7 +60,7 @@
  @param yOffset The Y offset the bottom sheet changed to.
  */
 - (void)bottomSheetDidChangeYOffset:(nonnull MDCBottomSheetPresentationController *)bottomSheet
-                        yOffset:(CGFloat)yOffset;
+                            yOffset:(CGFloat)yOffset;
 @end
 
 /**

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -44,6 +44,9 @@
 
 - (void)bottomSheetWillChangeState:(nonnull MDCBottomSheetPresentationController *)bottomSheet
                         sheetState:(MDCSheetState)sheetState;
+
+- (void)bottomSheetDidChangeScrollOffset:(nonnull MDCBottomSheetPresentationController *)bottomSheet
+                        scrollOffset:(CGFloat)scrollOffset;
 @end
 
 /**

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -294,4 +294,12 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   }
 }
 
+- (void)sheetContainerViewDidChangeScrollOffset:(nonnull MDCSheetContainerView *)containerView
+                                   scrollOffset:(CGFloat)scrollOffset {
+  id<MDCBottomSheetPresentationControllerDelegate> strongDelegate = self.delegate;
+  if ([strongDelegate respondsToSelector:@selector(bottomSheetDidChangeScrollOffset:scrollOffset:)]) {
+    [strongDelegate bottomSheetDidChangeScrollOffset:self scrollOffset:scrollOffset];
+  }
+}
+
 @end

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -294,11 +294,11 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   }
 }
 
-- (void)sheetContainerViewDidChangeScrollOffset:(nonnull MDCSheetContainerView *)containerView
-                                   scrollOffset:(CGFloat)scrollOffset {
+- (void)sheetContainerViewDidChangeYOffset:(nonnull MDCSheetContainerView *)containerView
+                                   yOffset:(CGFloat)yOffset {
   id<MDCBottomSheetPresentationControllerDelegate> strongDelegate = self.delegate;
-  if ([strongDelegate respondsToSelector:@selector(bottomSheetDidChangeScrollOffset:scrollOffset:)]) {
-    [strongDelegate bottomSheetDidChangeScrollOffset:self scrollOffset:scrollOffset];
+  if ([strongDelegate respondsToSelector:@selector(bottomSheetDidChangeYOffset:yOffset:)]) {
+    [strongDelegate bottomSheetDidChangeYOffset:self yOffset:yOffset];
   }
 }
 

--- a/components/BottomSheet/src/private/MDCDraggableView.h
+++ b/components/BottomSheet/src/private/MDCDraggableView.h
@@ -79,4 +79,6 @@
  */
 - (void)draggableView:(nonnull MDCDraggableView *)view draggingEndedWithVelocity:(CGPoint)velocity;
 
+- (void)draggableView:(nonnull MDCDraggableView *)view didPanToOffset:(CGFloat)offset;
+
 @end

--- a/components/BottomSheet/src/private/MDCDraggableView.m
+++ b/components/BottomSheet/src/private/MDCDraggableView.m
@@ -70,7 +70,7 @@ static void CancelGestureRecognizer(UIGestureRecognizer *gesture) {
   }
   if (recognizer.state == UIGestureRecognizerStateBegan ||
       recognizer.state == UIGestureRecognizerStateChanged) {
-    [self.delegate draggableView:self didPanToOffset:self.frame.origin.y];
+    [self.delegate draggableView:self didPanToOffset:CGRectGetMinY(self.frame)];
   }
 }
 

--- a/components/BottomSheet/src/private/MDCDraggableView.m
+++ b/components/BottomSheet/src/private/MDCDraggableView.m
@@ -68,6 +68,10 @@ static void CancelGestureRecognizer(UIGestureRecognizer *gesture) {
   } else if (recognizer.state == UIGestureRecognizerStateEnded) {
     [self.delegate draggableView:self draggingEndedWithVelocity:velocity];
   }
+  if (recognizer.state == UIGestureRecognizerStateBegan ||
+      recognizer.state == UIGestureRecognizerStateChanged) {
+    [self.delegate draggableView:self didPanToOffset:self.frame.origin.y];
+  }
 }
 
 #pragma mark - UIGestureRecognizerDelegate

--- a/components/BottomSheet/src/private/MDCSheetContainerView.h
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.h
@@ -38,6 +38,6 @@
 - (void)sheetContainerViewWillChangeState:(nonnull MDCSheetContainerView *)containerView
                                sheetState:(MDCSheetState)sheetState;
 - (void)sheetContainerViewDidChangeYOffset:(nonnull MDCSheetContainerView *)containerView
-                               yOffset:(CGFloat)yOffset;
+                                   yOffset:(CGFloat)yOffset;
 
 @end

--- a/components/BottomSheet/src/private/MDCSheetContainerView.h
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.h
@@ -37,7 +37,7 @@
 - (void)sheetContainerViewDidHide:(nonnull MDCSheetContainerView *)containerView;
 - (void)sheetContainerViewWillChangeState:(nonnull MDCSheetContainerView *)containerView
                                sheetState:(MDCSheetState)sheetState;
-- (void)sheetContainerViewDidChangeScrollOffset:(nonnull MDCSheetContainerView *)containerView
-                               scrollOffset:(CGFloat)scrollOffset;
+- (void)sheetContainerViewDidChangeYOffset:(nonnull MDCSheetContainerView *)containerView
+                               yOffset:(CGFloat)yOffset;
 
 @end

--- a/components/BottomSheet/src/private/MDCSheetContainerView.h
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.h
@@ -37,5 +37,7 @@
 - (void)sheetContainerViewDidHide:(nonnull MDCSheetContainerView *)containerView;
 - (void)sheetContainerViewWillChangeState:(nonnull MDCSheetContainerView *)containerView
                                sheetState:(MDCSheetState)sheetState;
+- (void)sheetContainerViewDidChangeScrollOffset:(nonnull MDCSheetContainerView *)containerView
+                               scrollOffset:(CGFloat)scrollOffset;
 
 @end

--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -302,7 +302,7 @@ static const CGFloat kSheetBounceBuffer = 150;
       targetPoint = CGPointMake(midX, bottomY);
       break;
   }
-  [self.delegate sheetContainerViewDidChangeScrollOffset:self scrollOffset:targetPoint.y];
+  [self.delegate sheetContainerViewDidChangeYOffset:self yOffset:targetPoint.y];
   return targetPoint;
 }
 
@@ -386,7 +386,7 @@ static const CGFloat kSheetBounceBuffer = 150;
 }
 
 - (void)draggableView:(nonnull MDCDraggableView *)view didPanToOffset:(CGFloat)offset {
-  [self.delegate sheetContainerViewDidChangeScrollOffset:self scrollOffset:offset];
+  [self.delegate sheetContainerViewDidChangeYOffset:self yOffset:offset];
 }
 
 - (void)setSheetState:(MDCSheetState)sheetState {

--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -290,14 +290,20 @@ static const CGFloat kSheetBounceBuffer = 150;
   CGFloat midX = CGRectGetMidX(bounds);
   CGFloat bottomY = CGRectGetMaxY(bounds) - keyboardOffset;
 
+  CGPoint targetPoint;
   switch (self.sheetState) {
     case MDCSheetStatePreferred:
-      return CGPointMake(midX, bottomY - [self truncatedPreferredSheetHeight]);
+      targetPoint = CGPointMake(midX, bottomY - [self truncatedPreferredSheetHeight]);
+      break;
     case MDCSheetStateExtended:
-      return CGPointMake(midX, bottomY - [self maximumSheetHeight]);
+      targetPoint = CGPointMake(midX, bottomY - [self maximumSheetHeight]);
+      break;
     case MDCSheetStateClosed:
-      return CGPointMake(midX, bottomY);
+      targetPoint = CGPointMake(midX, bottomY);
+      break;
   }
+  [self.delegate sheetContainerViewDidChangeScrollOffset:self scrollOffset:targetPoint.y];
+  return targetPoint;
 }
 
 - (void)sheetBehaviorDidUpdate {
@@ -377,6 +383,10 @@ static const CGFloat kSheetBounceBuffer = 150;
 - (void)draggableViewBeganDragging:(__unused MDCDraggableView *)view {
   [self.animator removeAllBehaviors];
   self.isDragging = YES;
+}
+
+- (void)draggableView:(nonnull MDCDraggableView *)view didPanToOffset:(CGFloat)offset {
+  [self.delegate sheetContainerViewDidChangeScrollOffset:self scrollOffset:offset];
 }
 
 - (void)setSheetState:(MDCSheetState)sheetState {

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
@@ -20,6 +20,31 @@
 #import "../../src/private/MDCDraggableView.h"
 #import "../../src/private/MDCSheetContainerView.h"
 
+@interface MDCBottomSheetDelegateTest
+: UIViewController <MDCBottomSheetPresentationControllerDelegate>
+@property(nonatomic, assign) BOOL delegateWasCalled;
+@end
+
+@implementation MDCBottomSheetDelegateTest
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _delegateWasCalled = NO;
+  }
+  return self;
+}
+
+- (void)bottomSheetDidChangeYOffset:(MDCBottomSheetPresentationController *)bottomSheet yOffset:(CGFloat)yOffset {
+  _delegateWasCalled = YES;
+}
+
+- (void)bottomSheetWillChangeState:(MDCBottomSheetPresentationController *)bottomSheet sheetState:(MDCSheetState)sheetState {
+  _delegateWasCalled = YES;
+}
+
+@end
+
 // Exposing internal methods for unit testing
 @interface MDCBottomSheetPresentationController (Testing)
 @property(nonatomic, strong) MDCSheetContainerView *sheetView;
@@ -28,6 +53,9 @@
 
 @interface MDCSheetContainerView (Testing)
 @property(nonatomic) MDCDraggableView *sheet;
+@property(nonatomic) MDCSheetState sheetState;
+- (CGPoint)targetPoint;
+- (void)draggableView:(MDCDraggableView *)view didPanToOffset:(CGFloat)offset;
 @end
 
 /**
@@ -60,6 +88,7 @@
 @interface MDCBottomSheetPresentationControllerPreferredSheetHeightTests : XCTestCase
 @property(nonatomic, strong) FakeSheetView *sheetView;
 @property(nonatomic, strong) MDCBottomSheetPresentationController *presentationController;
+@property(nonatomic, strong, nullable) MDCBottomSheetDelegateTest *delegateTest;
 @end
 
 @implementation MDCBottomSheetPresentationControllerPreferredSheetHeightTests
@@ -82,12 +111,14 @@
       initWithPresentedViewController:stubPresentedViewController
              presentingViewController:stubPresentingViewController];
   self.presentationController.sheetView = self.sheetView;
+  self.delegateTest = [[MDCBottomSheetDelegateTest alloc] init];
 }
 
 - (void)tearDown {
   self.presentationController.sheetView = nil;
   self.presentationController = nil;
   self.sheetView = nil;
+  self.delegateTest = nil;
 
   [super tearDown];
 }
@@ -256,5 +287,42 @@
   CGRect scrollViewFrame = CGRectStandardize(fakeSheet.sheet.frame);
   XCTAssertEqualWithAccuracy(scrollViewFrame.size.height, scrollViewHeight, 0.001);
 }
+
+- (void)testSheetStateChangeCallback {
+  // Given
+  self.presentationController.delegate = self.delegateTest;
+  self.presentationController.sheetView.delegate = (id<MDCSheetContainerViewDelegate>)self.presentationController;
+
+  // When
+  self.sheetView.sheetState = MDCSheetStateExtended;
+
+  // Then
+  XCTAssertEqual(self.delegateTest.delegateWasCalled, YES);
+}
+
+- (void)testSheetYOffsetChangeCallbackFromTargetPoint {
+  // Given
+  self.presentationController.delegate = self.delegateTest;
+  self.presentationController.sheetView.delegate = (id<MDCSheetContainerViewDelegate>)self.presentationController;
+
+  // When
+  [self.sheetView targetPoint];
+
+  // Then
+  XCTAssertEqual(self.delegateTest.delegateWasCalled, YES);
+}
+
+- (void)testSheetYOffsetChangeCallbackFromDidPanToOffset {
+  // Given
+  self.presentationController.delegate = self.delegateTest;
+  self.presentationController.sheetView.delegate = (id<MDCSheetContainerViewDelegate>)self.presentationController;
+
+  // When
+  [self.sheetView draggableView:self.sheetView.sheet didPanToOffset:10];
+
+  // Then
+  XCTAssertEqual(self.delegateTest.delegateWasCalled, YES);
+}
+
 
 @end

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerPreferredSheetHeightTests.m
@@ -21,7 +21,7 @@
 #import "../../src/private/MDCSheetContainerView.h"
 
 @interface MDCBottomSheetDelegateTest
-: UIViewController <MDCBottomSheetPresentationControllerDelegate>
+    : UIViewController <MDCBottomSheetPresentationControllerDelegate>
 @property(nonatomic, assign) BOOL delegateWasCalled;
 @end
 
@@ -35,11 +35,13 @@
   return self;
 }
 
-- (void)bottomSheetDidChangeYOffset:(MDCBottomSheetPresentationController *)bottomSheet yOffset:(CGFloat)yOffset {
+- (void)bottomSheetDidChangeYOffset:(MDCBottomSheetPresentationController *)bottomSheet
+                            yOffset:(CGFloat)yOffset {
   _delegateWasCalled = YES;
 }
 
-- (void)bottomSheetWillChangeState:(MDCBottomSheetPresentationController *)bottomSheet sheetState:(MDCSheetState)sheetState {
+- (void)bottomSheetWillChangeState:(MDCBottomSheetPresentationController *)bottomSheet
+                        sheetState:(MDCSheetState)sheetState {
   _delegateWasCalled = YES;
 }
 
@@ -291,7 +293,8 @@
 - (void)testSheetStateChangeCallback {
   // Given
   self.presentationController.delegate = self.delegateTest;
-  self.presentationController.sheetView.delegate = (id<MDCSheetContainerViewDelegate>)self.presentationController;
+  self.presentationController.sheetView.delegate =
+      (id<MDCSheetContainerViewDelegate>)self.presentationController;
 
   // When
   self.sheetView.sheetState = MDCSheetStateExtended;
@@ -303,7 +306,8 @@
 - (void)testSheetYOffsetChangeCallbackFromTargetPoint {
   // Given
   self.presentationController.delegate = self.delegateTest;
-  self.presentationController.sheetView.delegate = (id<MDCSheetContainerViewDelegate>)self.presentationController;
+  self.presentationController.sheetView.delegate =
+      (id<MDCSheetContainerViewDelegate>)self.presentationController;
 
   // When
   [self.sheetView targetPoint];
@@ -315,7 +319,8 @@
 - (void)testSheetYOffsetChangeCallbackFromDidPanToOffset {
   // Given
   self.presentationController.delegate = self.delegateTest;
-  self.presentationController.sheetView.delegate = (id<MDCSheetContainerViewDelegate>)self.presentationController;
+  self.presentationController.sheetView.delegate =
+      (id<MDCSheetContainerViewDelegate>)self.presentationController;
 
   // When
   [self.sheetView draggableView:self.sheetView.sheet didPanToOffset:10];
@@ -323,6 +328,5 @@
   // Then
   XCTAssertEqual(self.delegateTest.delegateWasCalled, YES);
 }
-
 
 @end


### PR DESCRIPTION
Additional API to the MDCBottomSheetControllerDelegate delegate, allowing clients to conform to the delegate and get callbacks for:
1. The offset of the sheet changes in respect to the top of the screen in points.
2. The state of the sheet changes to one of the possible states of type MDCSheetState.

This has been tested on examples to check for correctness of values and that the methods are called appropriately once the controller conforms to the protocol.

Additional unit tests have been written to test that the added delegate methods are rightly called when the value changes and a callback needs to be made.

Resolves: #7227 
