### PR TITLE
[ActionSheet] Fix issue where rotation caused bug

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -236,6 +236,10 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   self.mdc_bottomSheetPresentationController.dismissOnBackgroundTap = dismissOnBackgroundTap;
 }
 
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+  return self.presentingViewController.supportedInterfaceOrientations;
+}
+
 /* Disable setter. Always use internal transition controller */
 - (void)setTransitioningDelegate:
     (__unused id<UIViewControllerTransitioningDelegate>)transitioningDelegate {


### PR DESCRIPTION
## Context
MDCActionSheet should only support the `UIInterfaceOrientationMask` that its presenting viewController supports. When these two things conflict this can result in unexpected behavior within applications.

Closes #7285

## Testing
This was tested manually, no test were added as MDCActionSheet is presented and within a test environment the `supportedInterfaceOrientations` always results in the same behavior. I will purse a follow up that has a _fake_ of a presenting view controller and a _fake_ of MDCActionSheet.