### PR TITLE
[PageControl] Adds intrinsic content size to MDCPageControl

### DIFF
--- a/components/PageControl/src/MDCPageControl.m
+++ b/components/PageControl/src/MDCPageControl.m
@@ -207,6 +207,10 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
 
 #pragma mark - UIView(UIViewGeometry)
 
+- (CGSize)intrinsicContentSize {
+  return [MDCPageControl sizeForNumberOfPages:_numberOfPages];
+}
+
 - (CGSize)sizeThatFits:(__unused CGSize)size {
   return [MDCPageControl sizeForNumberOfPages:_numberOfPages];
 }
@@ -471,6 +475,8 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
 #pragma mark - Private
 
 - (void)resetControl {
+  [self invalidateIntrinsicContentSize];
+
   // Clear indicators.
   for (CALayer *layer in [_containerView.layer.sublayers copy]) {
     if (layer != _trackLayer) {

--- a/components/PageControl/tests/unit/PageControlExampleTests.m
+++ b/components/PageControl/tests/unit/PageControlExampleTests.m
@@ -109,7 +109,7 @@
   CGSize intrinsicSize = CGSizeZero;
   CGSize frameSize = CGSizeZero;
 
-  // Test both controls with 1 page.
+  // Test with one page.
   pageControl.numberOfPages = 1;
   [pageControl sizeToFit];
 
@@ -118,7 +118,7 @@
   XCTAssertEqual(frameSize.height, intrinsicSize.height);
   XCTAssertEqual(frameSize.width, intrinsicSize.width);
 
-  // Test both controls with 4 pages.
+  // Test with multiple pages.
   pageControl.numberOfPages = 4;
   [pageControl sizeToFit];
 

--- a/components/PageControl/tests/unit/PageControlExampleTests.m
+++ b/components/PageControl/tests/unit/PageControlExampleTests.m
@@ -126,6 +126,20 @@
   frameSize = pageControl.frame.size;
   XCTAssertEqual(frameSize.height, intrinsicSize.height);
   XCTAssertEqual(frameSize.width, intrinsicSize.width);
+
+  // Test it isn't dependent on sizeToFit being called. Call ordering matters here, relying on the
+  // old frame still being set.
+  pageControl.numberOfPages = 3;
+
+  intrinsicSize = pageControl.intrinsicContentSize;
+  frameSize = pageControl.frame.size;
+  XCTAssertEqual(frameSize.height, intrinsicSize.height);  // Height shouldn't change.
+  XCTAssertNotEqual(frameSize.width, intrinsicSize.width);
+
+  [pageControl sizeToFit];
+  frameSize = pageControl.frame.size;
+  XCTAssertEqual(frameSize.height, intrinsicSize.height);
+  XCTAssertEqual(frameSize.width, intrinsicSize.width);
 }
 
 - (void)testScrollOffsetOutOfBoundsOfNumberOfPages {

--- a/components/PageControl/tests/unit/PageControlExampleTests.m
+++ b/components/PageControl/tests/unit/PageControlExampleTests.m
@@ -102,6 +102,32 @@
   XCTAssertNotEqual(frame.size.width, nativePageControl.frame.size.width);
 }
 
+- (void)testIntrinsicContentSize {
+  // Tests that MDCPageControl's intrinsicContentSize matches its size after `sizeToFit`.
+  MDCPageControl *pageControl = [[MDCPageControl alloc] init];
+
+  CGSize intrinsicSize = CGSizeZero;
+  CGSize frameSize = CGSizeZero;
+
+  // Test both controls with 1 page.
+  pageControl.numberOfPages = 1;
+  [pageControl sizeToFit];
+
+  intrinsicSize = pageControl.intrinsicContentSize;
+  frameSize = pageControl.frame.size;
+  XCTAssertEqual(frameSize.height, intrinsicSize.height);
+  XCTAssertEqual(frameSize.width, intrinsicSize.width);
+
+  // Test both controls with 4 pages.
+  pageControl.numberOfPages = 4;
+  [pageControl sizeToFit];
+
+  intrinsicSize = pageControl.intrinsicContentSize;
+  frameSize = pageControl.frame.size;
+  XCTAssertEqual(frameSize.height, intrinsicSize.height);
+  XCTAssertEqual(frameSize.width, intrinsicSize.width);
+}
+
 - (void)testScrollOffsetOutOfBoundsOfNumberOfPages {
   // Given
   CGRect frame = CGRectMake(0, 0, 100, 100);


### PR DESCRIPTION
Adds `intrinsicContentSize` support to `MDCPageControl`, utilizing the same logic as `sizeThatFits:`.

fixes #7306 
