### PR TITLE
[MDC Typography] Add a category of MDCFontScaler to facilitate mutation.

### DIFF
--- a/components/Typography/src/MDCFontScaler+Mutating.h
+++ b/components/Typography/src/MDCFontScaler+Mutating.h
@@ -1,0 +1,24 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+#import "MDCFontScaler.h"
+
+@interface MDCFontScaler (Mutating)
+
+@property(nonatomic, readwrite) NSDictionary<UIContentSizeCategory, NSNumber *> *scalingCurve;
+@property(nonatomic, readwrite) MDCTextStyle textStyle;
+
+@end

--- a/components/Typography/src/MDCFontScaler.m
+++ b/components/Typography/src/MDCFontScaler.m
@@ -34,10 +34,14 @@ MDCTextStyle const MDCTextStyleButton = @"MDC.TextStyle.Button";
 MDCTextStyle const MDCTextStyleCaption = @"MDC.TextStyle.Caption";
 MDCTextStyle const MDCTextStyleOverline = @"MDC.TextStyle.Overline";
 
-@implementation MDCFontScaler {
-  NSDictionary<UIContentSizeCategory, NSNumber *> *_scalingCurve;
-  MDCTextStyle _textStyle;
-}
+@interface MDCFontScaler ()
+
+@property(nonatomic, readwrite) NSDictionary<UIContentSizeCategory, NSNumber *> *scalingCurve;
+@property(nonatomic, readwrite) MDCTextStyle textStyle;
+
+@end
+
+@implementation MDCFontScaler
 
 + (instancetype)scalerForMaterialTextStyle:(MDCTextStyle)textStyle {
   return [[MDCFontScaler alloc] initForMaterialTextStyle:textStyle];

--- a/components/Typography/tests/unit/MaterialScalableFontTests.m
+++ b/components/Typography/tests/unit/MaterialScalableFontTests.m
@@ -14,6 +14,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import "MDCFontScaler+Mutating.h"
 #import "MaterialTypography.h"
 
 #import "MaterialMath.h"
@@ -262,6 +263,32 @@
     // Then
     XCTAssert([defaultFont mdc_isSimplyEqual:largeFont]);
   }
+}
+
+- (void)testMutatingFontScaler {
+  // Given
+  MDCTextStyle textStyle = MDCTextStyleBody1;
+  MDCFontScaler *fontScaler = [[MDCFontScaler alloc] initForMaterialTextStyle:textStyle];
+
+  // When
+  UIFont *font = [UIFont systemFontOfSize:10.0];
+  UIFont *scalableFont = [fontScaler scaledFontWithFont:font];
+  UIFont *originalMediumFont =
+      [scalableFont mdc_scaledFontForSizeCategory:UIContentSizeCategoryMedium];
+
+  NSDictionary<UIContentSizeCategory, NSNumber *> *originalScalingCurve = fontScaler.scalingCurve;
+  NSNumber *originalFontSizeNumberForMedium = originalScalingCurve[UIContentSizeCategoryMedium];
+  NSMutableDictionary<UIContentSizeCategory, NSNumber *> *adjustedScalingCurve =
+      [originalScalingCurve mutableCopy];
+  NSNumber *adjustedFontSizeNumberForMedium = @([originalFontSizeNumberForMedium integerValue] + 1);
+  adjustedScalingCurve[UIContentSizeCategoryMedium] = adjustedFontSizeNumberForMedium;
+  fontScaler.scalingCurve = [adjustedScalingCurve copy];
+  scalableFont = [fontScaler scaledFontWithFont:font];
+  UIFont *adjustedMediumFont =
+      [scalableFont mdc_scaledFontForSizeCategory:UIContentSizeCategoryMedium];
+
+  // Then
+  XCTAssert(originalMediumFont.pointSize < adjustedMediumFont.pointSize);
 }
 
 // TODO: #6937 Identify why testValueScaling works locally but not on Kokoro


### PR DESCRIPTION
closes #7312

The current MDCFontScaler implementation stops clients to add/modify custom curves.

This PR added `MDCFontScaler+Mutating` category to expose essential properties. 

It would help clients to modify the existing curves or adding more curves into a font scaler. It also helps clients if they want to subclass the MDCFontScaler to build their logic for factory class method.