### PR TITLE
[NavigationBar] Fix bug where titleView would disappear.

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -563,9 +563,6 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
 }
 
 - (void)setTitleView:(UIView *)titleView {
-  if (self.titleView == titleView) {
-    return;
-  }
   // Ignore sandbag KVO events
   if ([_observedNavigationItem.titleView isKindOfClass:[MDCNavigationBarSandbagView class]]) {
     return;
@@ -580,8 +577,10 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
     _observedNavigationItem.titleView = nil;
   }
 
-  [self.titleView removeFromSuperview];
-  _titleView = titleView;
+  if (self.titleView != titleView) {
+    [self.titleView removeFromSuperview];
+    _titleView = titleView;
+  }
 
   if (_titleView != nil) {
     [self addSubview:_titleView];

--- a/components/NavigationBar/tests/unit/NavigationBarTitleViewTests.swift
+++ b/components/NavigationBar/tests/unit/NavigationBarTitleViewTests.swift
@@ -58,7 +58,7 @@ class NavigationBarTitleViewTests: XCTestCase {
   }
 
   // Designed to keep https://github.com/material-components/material-components-ios/issues/7207
-  // from regressing. Currently fails.
+  // from regressing.
   func testTitleViewAssignmentThenRemovalFromViewHierarchyThenReassignmentAddsItAsASubview() {
     // Given
     let navigationBar = MDCNavigationBar()
@@ -121,7 +121,7 @@ class NavigationBarTitleViewTests: XCTestCase {
   }
 
   // Designed to keep https://github.com/material-components/material-components-ios/issues/7207
-  // from regressing. Currently fails.
+  // from regressing.
   func testNavigationItemTitleViewAssignmentWithReassignmentThenTheftKeepsTitleViewAsSubview() {
     // Given
     let navigationBar = MDCNavigationBar()

--- a/components/NavigationBar/tests/unit/NavigationBarTitleViewTests.swift
+++ b/components/NavigationBar/tests/unit/NavigationBarTitleViewTests.swift
@@ -59,19 +59,19 @@ class NavigationBarTitleViewTests: XCTestCase {
 
   // Designed to keep https://github.com/material-components/material-components-ios/issues/7207
   // from regressing. Currently fails.
-//  func testTitleViewAssignmentThenRemovalFromViewHierarchyThenReassignmentAddsItAsASubview() {
-//    // Given
-//    let navigationBar = MDCNavigationBar()
-//    let titleView = UIView()
-//
-//    // When
-//    navigationBar.titleView = titleView
-//    titleView.removeFromSuperview()
-//    navigationBar.titleView = titleView
-//
-//    // Then
-//    XCTAssertEqual(titleView.superview, navigationBar)
-//  }
+  func testTitleViewAssignmentThenRemovalFromViewHierarchyThenReassignmentAddsItAsASubview() {
+    // Given
+    let navigationBar = MDCNavigationBar()
+    let titleView = UIView()
+
+    // When
+    navigationBar.titleView = titleView
+    titleView.removeFromSuperview()
+    navigationBar.titleView = titleView
+
+    // Then
+    XCTAssertEqual(titleView.superview, navigationBar)
+  }
 
   // MARK: Assignment view UINavigationItem
 
@@ -122,21 +122,21 @@ class NavigationBarTitleViewTests: XCTestCase {
 
   // Designed to keep https://github.com/material-components/material-components-ios/issues/7207
   // from regressing. Currently fails.
-//  func testNavigationItemTitleViewAssignmentWithReassignmentThenTheftKeepsTitleViewAsSubview() {
-//    // Given
-//    let navigationBar = MDCNavigationBar()
-//    let titleView = UIView()
-//    let navigationItem = UINavigationItem()
-//    let simulatedThiefView = UIView()
-//
-//    // When
-//    navigationItem.titleView = titleView
-//    navigationBar.observe(navigationItem)
-//    navigationItem.titleView = titleView
-//    simulatedThiefView.addSubview(navigationItem.titleView!)
-//
-//    // Then
-//    XCTAssertEqual(navigationItem.titleView?.superview, simulatedThiefView)
-//    XCTAssertEqual(titleView.superview, navigationBar)
-//  }
+  func testNavigationItemTitleViewAssignmentWithReassignmentThenTheftKeepsTitleViewAsSubview() {
+    // Given
+    let navigationBar = MDCNavigationBar()
+    let titleView = UIView()
+    let navigationItem = UINavigationItem()
+    let simulatedThiefView = UIView()
+
+    // When
+    navigationItem.titleView = titleView
+    navigationBar.observe(navigationItem)
+    navigationItem.titleView = titleView
+    simulatedThiefView.addSubview(navigationItem.titleView!)
+
+    // Then
+    XCTAssertEqual(navigationItem.titleView?.superview, simulatedThiefView)
+    XCTAssertEqual(titleView.superview, navigationBar)
+  }
 }


### PR DESCRIPTION
Closes https://github.com/material-components/material-components-ios/issues/7207

Context
-------

UINavigationBar will attempt to steal a navigationItem's titleView property for its own use, even if the navigation bar is not visible. Our own MDCNavigationBar also wants to show the titleView instance but we can't stop UINavigationBar from stealing the titleView.

To protect against this behavior, MDCNavigationBar implements a "sandbag swap" of the titleView when it's assigned. UINavigationBar ends up stealing the sandbag away, while our MDCNavigationBar keeps an internal reference to the desired titleView.

Before this fix
---------------

The sandbag view would be swapped the first time titleView is assigned. If the same titleView was assigned to the navigationItem again, however, we would not swap it with a sandbag. The result is that navigationItem.titleView would be pointing at the actual view (not the sandbag) when UINavigationBar comes around to steal the titleView. The result is that the titleView would disappear from MDCNavigationBar.

After this fix
--------------

We now assign the sandbag view on every assignment, regardless of whether the view is the same or not.

I wrote a test to simulate the theft behavior of UINavigationBar. I verified that the test failed before this patch and that it passes after this patch. I also verified the original bug with the internal client's code and example.