### PR TITLE
[FlexibleHeader] Fix voice over layout bug.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1226,7 +1226,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
       // a lesser offset than this to pull the flexible header into the center of the scrollview on
       // focusing.
       CGPoint offset = self.trackingScrollView.contentOffset;
-      offset.y = MAX(offset.y, -self.maximumHeight);
+      offset.y = MAX(offset.y, -self.minMaxHeight.maximumHeightWithTopSafeArea);
       [self fhv_setContentOffset:offset forTrackingScrollView:self.trackingScrollView];
       // Setting the transform on the same run loop as the accessibility scroll can cause additional
       // incorrect scrolling as the scrollview attempts to resolve to a position that will place


### PR DESCRIPTION
Fix a bug when voice over is enabled, it wasn't taking in the height + safe area when calculating the top offset. This was causing the bar to overlap with the rest of the scroll view.

This was exported from [cl/245477140](http://cl/245477140).

Original author: @djjliang

Closes https://github.com/material-components/material-components-ios/issues/7320

### Repro steps

1. Enable VoiceOver
2. Open MDCCatalog.
3. Open the App Bar examples.
4. Open the primary App Bar example.

| Before | After |
|:-------|:------|
| ![IMG_1600](https://user-images.githubusercontent.com/45670/57042528-90e9fe80-6c6d-11e9-842b-0870f939c6de.png) | ![IMG_1601](https://user-images.githubusercontent.com/45670/57042535-96474900-6c6d-11e9-92ef-c23a25003d27.png) |

After this change, the content will be initially scrolled to the top as expected, rather than partially scrolled down.