### PR TITLE
Replacing graphic with its voiced representation

### DIFF
--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -17,7 +17,7 @@ is expected to do the following, in order of priority:
 - Do not break Google.
 - Cut a release early in the working calendar week.
 - Land a release at least once every calendar week.
-- ✨Share something new with the team while you're waiting for tests to pass.
+- (Sparkles) Share something new with the team while you're waiting for tests to pass.
 
 If something is stopping the release engineer from achieving any of the above goals, the culprit
 code should be removed immediately from the release.


### PR DESCRIPTION
I wasn't able to understand what the "stars" meant until I turned on VoiceOver. "Sparkles" still doesn't really make sense to me, but that's what VoiceOver reads it as.  I suspect the intention was "optional" or something akin to "extra credit".  Replacing it with the text VoiceOver uses so people with my abilities can understand the meaning.

TESTED=VoiceOver reads it in a nearly identical manner. Users without VoiceOver can understand the intended word.

Fixes #7324 
Follow-up to #7321