### PR TITLE
[Docs] Make "Share something" clearly optional

### DIFF
--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -17,7 +17,7 @@ is expected to do the following, in order of priority:
 - Do not break Google.
 - Cut a release early in the working calendar week.
 - Land a release at least once every calendar week.
-- ✨Share something new with the team while you're waiting for tests to pass.
+- (Optional) Share something new with the team while you're waiting for tests to pass.
 
 If something is stopping the release engineer from achieving any of the above goals, the culprit
 code should be removed immediately from the release.


### PR DESCRIPTION
The emoji in the releasing documentation wasn't clear on its meaning/purpose. Particularly for people who don't know how to read emojis, the meaning is lost.  Changing it to "optional" to make it clearer that it's a nice thing to do but not strictly required for releasing.

Fixes #7324
Follow-up to #7321