### PR TITLE
[Ripple] Remove setting frame based on superview

### DIFF
--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -71,8 +71,8 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
 
 - (void)layoutSubviews {
   [super layoutSubviews];
+
   [self updateRippleStyle];
-  self.frame = CGRectStandardize(self.superview.bounds);
 }
 
 - (void)layoutSublayersOfLayer:(CALayer *)layer {

--- a/components/Ripple/tests/unit/MDCRippleViewTests.m
+++ b/components/Ripple/tests/unit/MDCRippleViewTests.m
@@ -166,4 +166,34 @@
   XCTAssertEqualObjects(rippleView.rippleColor, [UIColor blueColor]);
 }
 
+- (void)testFrameIsSizeOfSuperViewByDefault {
+  // Given
+  CGRect fakeFrame = CGRectMake(0, 0, 200, 200);
+  UIView *fakeView = [[UIView alloc] init];
+  MDCRippleView *rippleView = [[MDCRippleView alloc] init];
+  [fakeView addSubview:rippleView];
+
+  // When
+  fakeView.bounds = fakeFrame;
+
+  // Then
+  XCTAssertTrue(CGRectEqualToRect(fakeFrame, rippleView.frame), @"%@ not equal to %@", NSStringFromCGRect(fakeFrame), NSStringFromCGRect(rippleView.frame));
+}
+
+- (void)testFrameRespondsToCustomization {
+  // Given
+  CGRect fakeViewFrame = CGRectMake(0, 0, 200, 200);
+  CGRect fakeRippleFrame = CGRectMake(0, 0, 50, 50);
+  UIView *fakeView = [[UIView alloc] init];
+  MDCRippleView *rippleView = [[MDCRippleView alloc] init];
+  [fakeView addSubview:rippleView];
+
+  // When
+  fakeView.bounds = fakeViewFrame;
+  rippleView.frame = fakeRippleFrame;
+
+  // Then
+  XCTAssertTrue(CGRectEqualToRect(fakeRippleFrame, rippleView.frame), @"%@ not equal to %@", NSStringFromCGRect(fakeRippleFrame), NSStringFromCGRect(rippleView.frame));
+}
+
 @end

--- a/components/Ripple/tests/unit/MDCRippleViewTests.m
+++ b/components/Ripple/tests/unit/MDCRippleViewTests.m
@@ -177,7 +177,8 @@
   fakeView.bounds = fakeFrame;
 
   // Then
-  XCTAssertTrue(CGRectEqualToRect(fakeFrame, rippleView.frame), @"%@ not equal to %@", NSStringFromCGRect(fakeFrame), NSStringFromCGRect(rippleView.frame));
+  XCTAssertTrue(CGRectEqualToRect(fakeFrame, rippleView.frame), @"%@ not equal to %@",
+                NSStringFromCGRect(fakeFrame), NSStringFromCGRect(rippleView.frame));
 }
 
 - (void)testFrameRespondsToCustomization {
@@ -193,7 +194,8 @@
   rippleView.frame = fakeRippleFrame;
 
   // Then
-  XCTAssertTrue(CGRectEqualToRect(fakeRippleFrame, rippleView.frame), @"%@ not equal to %@", NSStringFromCGRect(fakeRippleFrame), NSStringFromCGRect(rippleView.frame));
+  XCTAssertTrue(CGRectEqualToRect(fakeRippleFrame, rippleView.frame), @"%@ not equal to %@",
+                NSStringFromCGRect(fakeRippleFrame), NSStringFromCGRect(rippleView.frame));
 }
 
 @end


### PR DESCRIPTION
In order for [`MDCRipple`](https://github.com/material-components/material-components-ios/tree/develop/components/Ripple/src) to support customizable ripple size the superview needs to be able to adjust the ripple view's frame. By setting the frame to the superview's frame it overrides whatever the superview sets within its `layoutSubviews` method. This removes that override to allow for a more customizable ripple.

Closes #7329 