### PR TITLE
[MDC release] Publish cocoapods allows warnings

### DIFF
--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -330,7 +330,7 @@ You can now publish the release to GitHub:
 ## Publish to Cocoapods
 
     git checkout stable
-    pod trunk push MaterialComponents.podspec --skip-tests
+    pod trunk push MaterialComponents.podspec --skip-tests --allow-warnings
 
 ## Coordinate with release-blocking clients to finish work
 


### PR DESCRIPTION
Because of a warning in the linter about no swift version specified (https://github.com/material-components/material-components-ios/issues/7318) we need to allow warnings in order to publish the podspec

