### PR TITLE
[Buttons] [Ripple] fix button to update ripple states correctly

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -321,9 +321,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   }
   [super touchesBegan:touches withEvent:event];
 
-  if (self.enableRippleBehavior) {
-    self.rippleView.rippleHighlighted = YES;
-  } else {
+  if (!self.enableRippleBehavior) {
     [self handleBeginTouches:touches];
   }
 }
@@ -343,9 +341,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   }
   [super touchesEnded:touches withEvent:event];
 
-  if (self.enableRippleBehavior) {
-    self.rippleView.rippleHighlighted = NO;
-  } else {
+  if (!self.enableRippleBehavior) {
     CGPoint location = [self locationFromTouches:touches];
     [_inkView startTouchEndedAnimationAtPoint:location completion:nil];
   }
@@ -358,9 +354,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   }
   [super touchesCancelled:touches withEvent:event];
 
-  if (self.enableRippleBehavior) {
-    self.rippleView.rippleHighlighted = NO;
-  } else {
+  if (!self.enableRippleBehavior) {
     [self evaporateInkToPoint:[self locationFromTouches:touches]];
   }
 }
@@ -379,12 +373,14 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (void)setHighlighted:(BOOL)highlighted {
   [super setHighlighted:highlighted];
+
   self.rippleView.rippleHighlighted = highlighted;
   [self updateAfterStateChange:NO];
 }
 
 - (void)setSelected:(BOOL)selected {
   [super setSelected:selected];
+
   self.rippleView.selected = selected;
   [self updateAfterStateChange:NO];
 }

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -379,13 +379,13 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 - (void)setHighlighted:(BOOL)highlighted {
   [super setHighlighted:highlighted];
-
+  self.rippleView.rippleHighlighted = highlighted;
   [self updateAfterStateChange:NO];
 }
 
 - (void)setSelected:(BOOL)selected {
   [super setSelected:selected];
-
+  self.rippleView.selected = selected;
   [self updateAfterStateChange:NO];
 }
 

--- a/components/Buttons/tests/unit/ButtonRippleTests.m
+++ b/components/Buttons/tests/unit/ButtonRippleTests.m
@@ -127,39 +127,48 @@
 
 #pragma mark - Touch tests
 
-- (void)testTouchesBeganSetsRippleHighlightedToYES {
+- (void)testSettingHighlightedUpdatesRippleTheming {
   // Given
   self.button.enableRippleBehavior = YES;
 
   // When
-  [self.button touchesBegan:[NSSet setWithObject:[[UITouch alloc] init]] withEvent:nil];
+  self.button.highlighted = YES;
 
   // Then
   XCTAssertTrue(self.button.rippleView.isRippleHighlighted);
-}
 
-- (void)testTouchesCancelledSetsRippleHighlightedToNO {
-  // Given
-  self.button.enableRippleBehavior = YES;
-  self.button.rippleView.rippleHighlighted = YES;
-
-  // When
-  [self.button touchesCancelled:[NSSet setWithObject:[[UITouch alloc] init]] withEvent:nil];
+  // And When
+  self.button.highlighted = NO;
 
   // Then
   XCTAssertFalse(self.button.rippleView.isRippleHighlighted);
 }
 
-- (void)testTouchesEndedSetsRippleHighlightedToNO {
+- (void)testSettingSelectedWhenNotAllowedDoesntUpdateRippleTheming {
   // Given
   self.button.enableRippleBehavior = YES;
-  self.button.rippleView.rippleHighlighted = YES;
 
   // When
-  [self.button touchesEnded:[NSSet setWithObject:[[UITouch alloc] init]] withEvent:nil];
+  self.button.selected = YES;
 
   // Then
-  XCTAssertFalse(self.button.rippleView.isRippleHighlighted);
+  XCTAssertFalse(self.button.rippleView.isSelected);
+}
+
+- (void)testSettingSelectedUpdatesRippleTheming {
+  // Given
+  self.button.enableRippleBehavior = YES;
+  self.button.rippleView.allowsSelection = YES;
+  self.button.selected = YES;
+
+  // Then
+  XCTAssertTrue(self.button.rippleView.isSelected);
+
+  // And When
+  self.button.selected = NO;
+
+  // Then
+  XCTAssertFalse(self.button.rippleView.isSelected);
 }
 
 @end


### PR DESCRIPTION
### Description
Buttons do not change the ripple state correctly when their selected or highlighted states are updated programmatically. To fix this issue, we're updating the RippleViews's highlighted and selected states to match the button's highlighted and selected states.

Steps to reproduce the highlighted state issued:
1. set: button.isHighlighted = true 
Expected: button is highlighted (background is light blue)
Outcome: button is not highlighted (background is white)

Steps to reproduce the selected state issued:
1. set: button.isSelected = true 
Expected: button is selected (background is light blue)
Outcome: button is not selected (background is white)

Before: 
![image](https://user-images.githubusercontent.com/2329102/57167435-c60c6300-6dcb-11e9-8e54-3aa96b0f8eb8.png)

After:
![image](https://user-images.githubusercontent.com/2329102/57167455-dd4b5080-6dcb-11e9-864e-cd4d960df464.png)

### Issue
b/128908676
Issue: https://github.com/material-components/material-components-ios/issues/7342