### PR TITLE
[Ink] Add animation delegate callbacks for MDCLegacyInkLayer

### DIFF
--- a/components/Ink/src/MDCInkView.m
+++ b/components/Ink/src/MDCInkView.m
@@ -27,7 +27,7 @@
 
 @end
 
-@interface MDCInkView () <CALayerDelegate, MDCInkLayerDelegate>
+@interface MDCInkView () <CALayerDelegate, MDCInkLayerDelegate, MDCLegacyInkLayerDelegate>
 
 @property(nonatomic, strong) CAShapeLayer *maskLayer;
 @property(nonatomic, copy) MDCInkCompletionBlock startInkRippleCompletionBlock;
@@ -74,6 +74,8 @@
   // Use mask layer when the superview has a shadowPath.
   _maskLayer = [CAShapeLayer layer];
   _maskLayer.delegate = self;
+
+  self.inkLayer.animationDelegate = self;
 }
 
 - (void)layoutSubviews {
@@ -259,6 +261,20 @@
     [view addSubview:foundInkView];
   }
   return foundInkView;
+}
+
+#pragma mark - MDCLegacyInkLayerDelegate
+
+- (void)legacyInkLayerAnimationDidStart:(MDCLegacyInkLayer *)inkLayer {
+  if ([self.animationDelegate respondsToSelector:@selector(inkAnimationDidStart:)]) {
+    [self.animationDelegate inkAnimationDidStart:self];
+  }
+}
+
+- (void)legacyInkLayerAnimationDidEnd:(MDCLegacyInkLayer *)inkLayer {
+  if ([self.animationDelegate respondsToSelector:@selector(inkAnimationDidEnd:)]) {
+    [self.animationDelegate inkAnimationDidEnd:self];
+  }
 }
 
 #pragma mark - MDCInkLayerDelegate

--- a/components/Ink/src/private/MDCLegacyInkLayer+Private.h
+++ b/components/Ink/src/private/MDCLegacyInkLayer+Private.h
@@ -16,29 +16,43 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol MDCLegacyInkLayerRippleDelegate <MDCLegacyInkLayerDelegate>
-@optional
-- (void)animationDidStart:(nullable CAAnimation *)anim;
+@class MDCLegacyInkLayerRipple;
 
+@protocol MDCLegacyInkLayerRippleDelegate <MDCLegacyInkLayerDelegate>
+
+/// Called if MDCLegacyInkLayerRipple did start animating.
+- (void)animationDidStart:(MDCLegacyInkLayerRipple *)layerRipple;
+
+/// Called for every MDCLegacyInkLayerRipple if an animation did end.
 - (void)animationDidStop:(nullable CAAnimation *)anim
-              shapeLayer:(nullable CAShapeLayer *)shapeLayer
+              shapeLayer:(nullable CAShapeLayer *)layerRipple
                 finished:(BOOL)finished;
+
 @end
 
 @interface MDCLegacyInkLayer () <MDCLegacyInkLayerRippleDelegate>
+
+/// A Boolean value indicating whether animations of this layer are in progress.
 @property(nonatomic, assign, getter=isAnimating) BOOL animating;
+
+/// Enter any ink applied to the layer. Currently only exposed for testing.
 - (void)enterAllInks;
+
 @end
 
 @interface MDCLegacyInkLayerRipple : CAShapeLayer
 @end
 
 @interface MDCLegacyInkLayerForegroundRipple : MDCLegacyInkLayerRipple
+
 - (void)exit:(BOOL)animated;
+
 @end
 
 @interface MDCLegacyInkLayerBackgroundRipple : MDCLegacyInkLayerRipple
+
 - (void)exit:(BOOL)animated;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/components/Ink/src/private/MDCLegacyInkLayer+Private.h
+++ b/components/Ink/src/private/MDCLegacyInkLayer+Private.h
@@ -14,17 +14,20 @@
 
 #import "MDCLegacyInkLayer.h"
 
-@protocol MDCLegacyInkLayerRippleDelegate <NSObject>
+NS_ASSUME_NONNULL_BEGIN
 
+@protocol MDCLegacyInkLayerRippleDelegate <MDCLegacyInkLayerDelegate>
 @optional
+- (void)animationDidStart:(nullable CAAnimation *)anim;
 
-- (void)animationDidStop:(CAAnimation *)anim
-              shapeLayer:(CAShapeLayer *)shapeLayer
+- (void)animationDidStop:(nullable CAAnimation *)anim
+              shapeLayer:(nullable CAShapeLayer *)shapeLayer
                 finished:(BOOL)finished;
-
 @end
 
 @interface MDCLegacyInkLayer () <MDCLegacyInkLayerRippleDelegate>
+@property(nonatomic, assign, getter=isAnimating) BOOL animating;
+- (void)enterAllInks;
 @end
 
 @interface MDCLegacyInkLayerRipple : CAShapeLayer
@@ -37,3 +40,5 @@
 @interface MDCLegacyInkLayerBackgroundRipple : MDCLegacyInkLayerRipple
 - (void)exit:(BOOL)animated;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/components/Ink/src/private/MDCLegacyInkLayer.h
+++ b/components/Ink/src/private/MDCLegacyInkLayer.h
@@ -15,6 +15,8 @@
 #import <QuartzCore/QuartzCore.h>
 #import <UIKit/UIKit.h>
 
+@protocol MDCLegacyInkLayerDelegate;
+
 /**
  A Core Animation layer that draws and animates the ink effect.
 
@@ -26,6 +28,12 @@
  3. On touch up, the ink ripple will lose energy, opacity will start to decrease.
  */
 @interface MDCLegacyInkLayer : CALayer
+
+/**
+ Ink layer animation delegate. Clients set this delegate to receive updates when ink layer
+ animations start and end.
+ */
+@property(nonatomic, weak, nullable) id<MDCLegacyInkLayerDelegate> animationDelegate;
 
 /** Clips the ripple to the bounds of the layer. */
 @property(nonatomic, assign, getter=isBounded) BOOL bounded;
@@ -96,5 +104,29 @@
  @param completionBlock Block called after the completion of the evaporation.
  */
 - (void)evaporateToPoint:(CGPoint)point completion:(void (^_Nullable)(void))completionBlock;
+
+@end
+
+/**
+ Delegate protocol for the MDCLegacyInkLayer. Clients may implement this protocol to receive updates
+ when ink layer animations start and end.
+ */
+@protocol MDCLegacyInkLayerDelegate <NSObject>
+
+@optional
+
+/**
+ Called when the ink ripple animation begins.
+
+ @param inkLayer The MDCLegacyInkLayer that starts animating.
+ */
+- (void)legacyInkLayerAnimationDidStart:(nonnull MDCLegacyInkLayer *)inkLayer;
+
+/**
+ Called when the ink ripple animation ends.
+
+ @param inkLayer The MDCLegacyInkLayer that ends animating.
+ */
+- (void)legacyInkLayerAnimationDidEnd:(nonnull MDCLegacyInkLayer *)inkLayer;
 
 @end

--- a/components/Ink/src/private/MDCLegacyInkLayer.m
+++ b/components/Ink/src/private/MDCLegacyInkLayer.m
@@ -17,7 +17,8 @@
 
 #import <UIKit/UIKit.h>
 
-static inline CGPoint MDCLegacyInkLayerInterpolatePoint(CGPoint start, CGPoint end,
+static inline CGPoint MDCLegacyInkLayerInterpolatePoint(CGPoint start,
+                                                        CGPoint end,
                                                         CGFloat offsetPercent) {
   CGPoint centerOffsetPoint = CGPointMake(start.x + (end.x - start.x) * offsetPercent,
                                           start.y + (end.y - start.y) * offsetPercent);
@@ -618,8 +619,7 @@ static NSString *const kInkLayerBackgroundOpacityAnim = @"backgroundOpacityAnim"
 
 #pragma mark - MDCLegacyRippleInkLayerDelegate
 
-- (void)animationDidStart:(MDCLegacyInkLayerRipple *)layerRipple
-{
+- (void)animationDidStart:(MDCLegacyInkLayerRipple *)layerRipple {
   if (!self.isAnimating) {
     self.animating = YES;
 

--- a/components/Ink/tests/unit/MDCLegacyInkLayerTests.m
+++ b/components/Ink/tests/unit/MDCLegacyInkLayerTests.m
@@ -272,20 +272,19 @@
 
   // When
   self.legacyInkLayerAnimationDidStartExpectation =
-  [self expectationWithDescription:@"Legacy Ink Layer animation did start"];
+      [self expectationWithDescription:@"Legacy Ink Layer animation did start"];
   [self.inkLayer enterAllInks];
   [self waitForExpectationsWithTimeout:5 handler:nil];
 
   XCTAssertTrue(self.inkLayer.isAnimating,
-                 @"After legacy ink animation did end callback there should be no animation.");
+                @"After legacy ink animation did end callback there should be no animation.");
   XCTAssertEqual(self.legacyInkLayerAnimationDidStartCount, 1U,
                  @"The legacy ink animation did start callback should only be called once");
 
   // When
   self.legacyInkLayerAnimationDidEndExpectation =
-  [self expectationWithDescription:@"Legacy Ink Layer animation did end"];
+      [self expectationWithDescription:@"Legacy Ink Layer animation did end"];
   [self.inkLayer resetAllInk:NO];
-  
 
   // Then
   [self waitForExpectationsWithTimeout:5 handler:nil];


### PR DESCRIPTION
Add animation delegate callbacks for MDCLegacyInkLayer

We would like to observer the start and stop animations of an MDCInkTouchController by setting the animationDelegate of the MDCInkTouchController's MDCInkView. If [MDCInkView usesLegacyInkRipple] == YES the MDCLegacyInkLayer does not call any animation callbacks right now.