### PR TITLE
[BottomNavigation] Removes code handling pre-iOS 9 constraints from the controller

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBarController.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBarController.m
@@ -374,83 +374,11 @@ static CGAffineTransform MDCLargeItemViewAnimationTransitionTransform() {
   self.content.translatesAutoresizingMaskIntoConstraints = NO;
   self.navigationBar.translatesAutoresizingMaskIntoConstraints = NO;
 
-  if (@available(iOS 9.0, *)) {
-    [self loadiOS9PlusConstraints];
-  } else {
-    [self loadPreiOS9Constraints];
-  }
-}
-
-- (void)loadPreiOS9Constraints {
   // Navigation Bar Constraints
-  NSArray<NSLayoutConstraint *> *navigationBarConstraints = @[
-    [NSLayoutConstraint constraintWithItem:self.navigationBar
-                                 attribute:NSLayoutAttributeLeading
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:self.view
-                                 attribute:NSLayoutAttributeLeading
-                                multiplier:1
-                                  constant:0],
-    [NSLayoutConstraint constraintWithItem:self.navigationBar
-                                 attribute:NSLayoutAttributeTrailing
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:self.view
-                                 attribute:NSLayoutAttributeTrailing
-                                multiplier:1
-                                  constant:0],
-    [NSLayoutConstraint constraintWithItem:self.navigationBar
-                                 attribute:NSLayoutAttributeBottom
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:self.view
-                                 attribute:NSLayoutAttributeBottom
-                                multiplier:1
-                                  constant:0],
-    [NSLayoutConstraint constraintWithItem:self.navigationBar
-                                 attribute:NSLayoutAttributeTop
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:self.content
-                                 attribute:NSLayoutAttributeBottom
-                                multiplier:1
-                                  constant:0]
-  ];
-
-  // Content View Constraints
-  NSArray<NSLayoutConstraint *> *contentConstraints = @[
-    [NSLayoutConstraint constraintWithItem:self.content
-                                 attribute:NSLayoutAttributeLeading
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:self.view
-                                 attribute:NSLayoutAttributeLeading
-                                multiplier:1
-                                  constant:0],
-    [NSLayoutConstraint constraintWithItem:self.content
-                                 attribute:NSLayoutAttributeTrailing
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:self.view
-                                 attribute:NSLayoutAttributeTrailing
-                                multiplier:1
-                                  constant:0],
-    [NSLayoutConstraint constraintWithItem:self.content
-                                 attribute:NSLayoutAttributeTop
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:self.view
-                                 attribute:NSLayoutAttributeTop
-                                multiplier:1
-                                  constant:0]
-  ];
-
-  [NSLayoutConstraint activateConstraints:navigationBarConstraints];
-  [NSLayoutConstraint activateConstraints:contentConstraints];
-}
-
-- (void)loadiOS9PlusConstraints {
-  if (@available(iOS 9.0, *)) {
-    // Navigation Bar Constraints
-    [self.view.leftAnchor constraintEqualToAnchor:self.navigationBar.leftAnchor].active = YES;
-    [self.view.rightAnchor constraintEqualToAnchor:self.navigationBar.rightAnchor].active = YES;
-    [self.navigationBar.topAnchor constraintEqualToAnchor:self.content.bottomAnchor].active = YES;
-    [self.navigationBar.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor].active = YES;
-  }
+  [self.view.leftAnchor constraintEqualToAnchor:self.navigationBar.leftAnchor].active = YES;
+  [self.view.rightAnchor constraintEqualToAnchor:self.navigationBar.rightAnchor].active = YES;
+  [self.navigationBar.topAnchor constraintEqualToAnchor:self.content.bottomAnchor].active = YES;
+  [self.navigationBar.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor].active = YES;
 
   if (@available(iOS 11.0, *)) {
     [self.navigationBar.barItemsBottomAnchor
@@ -458,13 +386,11 @@ static CGAffineTransform MDCLargeItemViewAnimationTransitionTransform() {
         .active = YES;
   }
 
-  if (@available(iOS 9.0, *)) {
-    // Content View Constraints
-    [self.view.leftAnchor constraintEqualToAnchor:self.content.leftAnchor].active = YES;
-    [self.view.rightAnchor constraintEqualToAnchor:self.content.rightAnchor].active = YES;
+  // Content View Constraints
+  [self.view.leftAnchor constraintEqualToAnchor:self.content.leftAnchor].active = YES;
+  [self.view.rightAnchor constraintEqualToAnchor:self.content.rightAnchor].active = YES;
 
-    [self.view.topAnchor constraintEqualToAnchor:self.content.topAnchor].active = YES;
-  }
+  [self.view.topAnchor constraintEqualToAnchor:self.content.topAnchor].active = YES;
 }
 
 /**
@@ -472,45 +398,10 @@ static CGAffineTransform MDCLargeItemViewAnimationTransitionTransform() {
  */
 - (void)addConstraintsForContentView:(UIView *)view {
   view.translatesAutoresizingMaskIntoConstraints = NO;
-  if (@available(iOS 9.0, *)) {
-    [view.leadingAnchor constraintEqualToAnchor:self.content.leadingAnchor].active = YES;
-    [view.trailingAnchor constraintEqualToAnchor:self.content.trailingAnchor].active = YES;
-    [view.topAnchor constraintEqualToAnchor:self.content.topAnchor].active = YES;
-    [view.bottomAnchor constraintEqualToAnchor:self.content.bottomAnchor].active = YES;
-  } else {
-    [NSLayoutConstraint constraintWithItem:self.content
-                                 attribute:NSLayoutAttributeLeading
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:view
-                                 attribute:NSLayoutAttributeLeading
-                                multiplier:1
-                                  constant:0]
-        .active = YES;
-    [NSLayoutConstraint constraintWithItem:self.content
-                                 attribute:NSLayoutAttributeTrailing
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:view
-                                 attribute:NSLayoutAttributeTrailing
-                                multiplier:1
-                                  constant:0]
-        .active = YES;
-    [NSLayoutConstraint constraintWithItem:self.content
-                                 attribute:NSLayoutAttributeTop
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:view
-                                 attribute:NSLayoutAttributeTop
-                                multiplier:1
-                                  constant:0]
-        .active = YES;
-    [NSLayoutConstraint constraintWithItem:self.content
-                                 attribute:NSLayoutAttributeBottom
-                                 relatedBy:NSLayoutRelationEqual
-                                    toItem:view
-                                 attribute:NSLayoutAttributeBottom
-                                multiplier:1
-                                  constant:0]
-        .active = YES;
-  }
+  [view.leadingAnchor constraintEqualToAnchor:self.content.leadingAnchor].active = YES;
+  [view.trailingAnchor constraintEqualToAnchor:self.content.trailingAnchor].active = YES;
+  [view.topAnchor constraintEqualToAnchor:self.content.topAnchor].active = YES;
+  [view.bottomAnchor constraintEqualToAnchor:self.content.bottomAnchor].active = YES;
 }
 
 /** Maps an array of view controllers to their corrisponding tab bar items **/


### PR DESCRIPTION
After the upgrade of the minimum supported iOS version to iOS 9, the code handling the constraints for pre-iOS 9 are no longer needed.  Removal reduces the size of this class considerably.