### PR TITLE
[Ripple] Make rippleRadius a property

### DIFF
--- a/components/Ripple/src/private/MDCRippleLayer.h
+++ b/components/Ripple/src/private/MDCRippleLayer.h
@@ -48,7 +48,7 @@ typedef void (^MDCRippleCompletionBlock)(void);
 /**
  The radius the ripple expands to when activated.
  */
-@property(nonatomic, assign) CGFloat rippleRadius;
+@property(nonatomic, assign) CGFloat maxRippleRadius;
 
 /**
  Starts the ripple at the given point.

--- a/components/Ripple/src/private/MDCRippleLayer.h
+++ b/components/Ripple/src/private/MDCRippleLayer.h
@@ -46,6 +46,11 @@ typedef void (^MDCRippleCompletionBlock)(void);
 @property(nonatomic, assign) CFTimeInterval rippleTouchDownStartTime;
 
 /**
+ The radius the ripple expands to when activated.
+ */
+@property(nonatomic, assign) CGFloat rippleRadius;
+
+/**
  Starts the ripple at the given point.
 
  @param point The point to start the ripple animation.

--- a/components/Ripple/src/private/MDCRippleLayer.h
+++ b/components/Ripple/src/private/MDCRippleLayer.h
@@ -47,8 +47,11 @@ typedef void (^MDCRippleCompletionBlock)(void);
 
 /**
  The radius the ripple expands to when activated.
+
+ @note This only impacts new ripples, if a ripple is already being animated this property will have
+ no impact.
  */
-@property(nonatomic, assign) CGFloat maxRippleRadius;
+@property(nonatomic, assign) CGFloat maximumRadius;
 
 /**
  Starts the ripple at the given point.

--- a/components/Ripple/src/private/MDCRippleLayer.m
+++ b/components/Ripple/src/private/MDCRippleLayer.m
@@ -43,7 +43,7 @@ static CGFloat GetDefaultRippleRadius(CGRect rect) {
 
 - (void)setPathFromRadii {
   CGFloat radius =
-      self.maxRippleRadius > 0 ? self.maxRippleRadius : GetDefaultRippleRadius(self.bounds);
+      self.maximumRadius > 0 ? self.maximumRadius : GetDefaultRippleRadius(self.bounds);
   CGRect ovalRect = CGRectMake(CGRectGetMidX(self.bounds) - radius,
                                CGRectGetMidY(self.bounds) - radius, radius * 2, radius * 2);
   UIBezierPath *circlePath = [UIBezierPath bezierPathWithOvalInRect:ovalRect];

--- a/components/Ripple/src/private/MDCRippleLayer.m
+++ b/components/Ripple/src/private/MDCRippleLayer.m
@@ -43,9 +43,9 @@ static NSString *const kRippleLayerScaleString = @"transform.scale";
 }
 
 - (void)setPathFromRadii {
-  CGRect ovalRect =
-      CGRectMake(CGRectGetMidX(self.bounds) - self.rippleRadius,
-                 CGRectGetMidY(self.bounds) - self.rippleRadius, self.rippleRadius * 2, self.rippleRadius * 2);
+  CGRect ovalRect = CGRectMake(CGRectGetMidX(self.bounds) - self.rippleRadius,
+                               CGRectGetMidY(self.bounds) - self.rippleRadius,
+                               self.rippleRadius * 2, self.rippleRadius * 2);
   UIBezierPath *circlePath = [UIBezierPath bezierPathWithOvalInRect:ovalRect];
   self.path = circlePath.CGPath;
 }

--- a/components/Ripple/src/private/MDCRippleLayer.m
+++ b/components/Ripple/src/private/MDCRippleLayer.m
@@ -32,7 +32,10 @@ static NSString *const kRippleLayerScaleString = @"transform.scale";
 
 - (void)setNeedsLayout {
   [super setNeedsLayout];
-  [self setRadiiWithRect:self.bounds];
+
+  if (self.rippleRadius <= 0) {
+    [self setRadiiWithRect:self.bounds];
+  }
   [self setPathFromRadii];
   self.position = CGPointMake(CGRectGetMidX(self.bounds), CGRectGetMidY(self.bounds));
 }

--- a/components/Ripple/src/private/MDCRippleLayer.m
+++ b/components/Ripple/src/private/MDCRippleLayer.m
@@ -32,12 +32,6 @@ static CGFloat GetDefaultRippleRadius(CGRect rect) {
   return (CGFloat)(MDCHypot(CGRectGetMidX(rect), CGRectGetMidY(rect)) + kExpandRippleBeyondSurface);
 }
 
-@interface MDCRippleLayer ()
-
-- (void)setPathFromRadii;
-
-@end
-
 @implementation MDCRippleLayer
 
 - (void)setNeedsLayout {

--- a/components/Ripple/src/private/MDCRippleLayer.m
+++ b/components/Ripple/src/private/MDCRippleLayer.m
@@ -55,11 +55,6 @@ static CGFloat DefaultRippleRadius(CGRect rect) {
   self.path = circlePath.CGPath;
 }
 
-- (void)setRippleRadius:(CGFloat)rippleRadius {
-  _rippleRadius = rippleRadius;
-  [self setPathFromRadii];
-}
-
 - (void)startRippleAtPoint:(CGPoint)point
                   animated:(BOOL)animated
                 completion:(MDCRippleCompletionBlock)completion {

--- a/components/Ripple/src/private/MDCRippleLayer.m
+++ b/components/Ripple/src/private/MDCRippleLayer.m
@@ -28,27 +28,24 @@ static NSString *const kRippleLayerOpacityString = @"opacity";
 static NSString *const kRippleLayerPositionString = @"position";
 static NSString *const kRippleLayerScaleString = @"transform.scale";
 
+static CGFloat DefaultRippleRadius(CGRect rect) {
+  return (CGFloat)(MDCHypot(CGRectGetMidX(rect), CGRectGetMidY(rect)) + kExpandRippleBeyondSurface);
+}
+
 @implementation MDCRippleLayer
 
 - (void)setNeedsLayout {
   [super setNeedsLayout];
 
-  if (self.rippleRadius <= 0) {
-    [self setRadiiWithRect:self.bounds];
-  }
   [self setPathFromRadii];
   self.position = CGPointMake(CGRectGetMidX(self.bounds), CGRectGetMidY(self.bounds));
 }
 
-- (void)setRadiiWithRect:(CGRect)rect {
-  self.rippleRadius =
-      (CGFloat)(MDCHypot(CGRectGetMidX(rect), CGRectGetMidY(rect)) + kExpandRippleBeyondSurface);
-}
-
 - (void)setPathFromRadii {
-  CGRect ovalRect = CGRectMake(CGRectGetMidX(self.bounds) - self.rippleRadius,
-                               CGRectGetMidY(self.bounds) - self.rippleRadius,
-                               self.rippleRadius * 2, self.rippleRadius * 2);
+  CGFloat radius = self.rippleRadius > 0 ? self.rippleRadius : DefaultRippleRadius(self.bounds);
+  CGRect ovalRect = CGRectMake(CGRectGetMidX(self.bounds) - radius,
+                               CGRectGetMidY(self.bounds) - radius,
+                               radius * 2, radius * 2);
   UIBezierPath *circlePath = [UIBezierPath bezierPathWithOvalInRect:ovalRect];
   self.path = circlePath.CGPath;
 }

--- a/components/Ripple/src/private/MDCRippleLayer.m
+++ b/components/Ripple/src/private/MDCRippleLayer.m
@@ -48,7 +48,8 @@ static CGFloat GetDefaultRippleRadius(CGRect rect) {
 }
 
 - (void)setPathFromRadii {
-  CGFloat radius = self.maxRippleRadius > 0 ? self.maxRippleRadius : GetDefaultRippleRadius(self.bounds);
+  CGFloat radius =
+      self.maxRippleRadius > 0 ? self.maxRippleRadius : GetDefaultRippleRadius(self.bounds);
   CGRect ovalRect = CGRectMake(CGRectGetMidX(self.bounds) - radius,
                                CGRectGetMidY(self.bounds) - radius, radius * 2, radius * 2);
   UIBezierPath *circlePath = [UIBezierPath bezierPathWithOvalInRect:ovalRect];

--- a/components/Ripple/src/private/MDCRippleLayer.m
+++ b/components/Ripple/src/private/MDCRippleLayer.m
@@ -44,8 +44,7 @@ static CGFloat DefaultRippleRadius(CGRect rect) {
 - (void)setPathFromRadii {
   CGFloat radius = self.rippleRadius > 0 ? self.rippleRadius : DefaultRippleRadius(self.bounds);
   CGRect ovalRect = CGRectMake(CGRectGetMidX(self.bounds) - radius,
-                               CGRectGetMidY(self.bounds) - radius,
-                               radius * 2, radius * 2);
+                               CGRectGetMidY(self.bounds) - radius, radius * 2, radius * 2);
   UIBezierPath *circlePath = [UIBezierPath bezierPathWithOvalInRect:ovalRect];
   self.path = circlePath.CGPath;
 }

--- a/components/Ripple/src/private/MDCRippleLayer.m
+++ b/components/Ripple/src/private/MDCRippleLayer.m
@@ -32,6 +32,12 @@ static CGFloat DefaultRippleRadius(CGRect rect) {
   return (CGFloat)(MDCHypot(CGRectGetMidX(rect), CGRectGetMidY(rect)) + kExpandRippleBeyondSurface);
 }
 
+@interface MDCRippleLayer ()
+
+- (void)setPathFromRadii;
+
+@end
+
 @implementation MDCRippleLayer
 
 - (void)setNeedsLayout {
@@ -47,6 +53,11 @@ static CGFloat DefaultRippleRadius(CGRect rect) {
                                CGRectGetMidY(self.bounds) - radius, radius * 2, radius * 2);
   UIBezierPath *circlePath = [UIBezierPath bezierPathWithOvalInRect:ovalRect];
   self.path = circlePath.CGPath;
+}
+
+- (void)setRippleRadius:(CGFloat)rippleRadius {
+  _rippleRadius = rippleRadius;
+  [self setPathFromRadii];
 }
 
 - (void)startRippleAtPoint:(CGPoint)point

--- a/components/Ripple/src/private/MDCRippleLayer.m
+++ b/components/Ripple/src/private/MDCRippleLayer.m
@@ -28,7 +28,7 @@ static NSString *const kRippleLayerOpacityString = @"opacity";
 static NSString *const kRippleLayerPositionString = @"position";
 static NSString *const kRippleLayerScaleString = @"transform.scale";
 
-static CGFloat DefaultRippleRadius(CGRect rect) {
+static CGFloat GetDefaultRippleRadius(CGRect rect) {
   return (CGFloat)(MDCHypot(CGRectGetMidX(rect), CGRectGetMidY(rect)) + kExpandRippleBeyondSurface);
 }
 
@@ -48,7 +48,7 @@ static CGFloat DefaultRippleRadius(CGRect rect) {
 }
 
 - (void)setPathFromRadii {
-  CGFloat radius = self.rippleRadius > 0 ? self.rippleRadius : DefaultRippleRadius(self.bounds);
+  CGFloat radius = self.maxRippleRadius > 0 ? self.maxRippleRadius : GetDefaultRippleRadius(self.bounds);
   CGRect ovalRect = CGRectMake(CGRectGetMidX(self.bounds) - radius,
                                CGRectGetMidY(self.bounds) - radius, radius * 2, radius * 2);
   UIBezierPath *circlePath = [UIBezierPath bezierPathWithOvalInRect:ovalRect];

--- a/components/Ripple/src/private/MDCRippleLayer.m
+++ b/components/Ripple/src/private/MDCRippleLayer.m
@@ -28,9 +28,7 @@ static NSString *const kRippleLayerOpacityString = @"opacity";
 static NSString *const kRippleLayerPositionString = @"position";
 static NSString *const kRippleLayerScaleString = @"transform.scale";
 
-@implementation MDCRippleLayer {
-  CGFloat _rippleRadius;
-}
+@implementation MDCRippleLayer
 
 - (void)setNeedsLayout {
   [super setNeedsLayout];
@@ -40,14 +38,14 @@ static NSString *const kRippleLayerScaleString = @"transform.scale";
 }
 
 - (void)setRadiiWithRect:(CGRect)rect {
-  _rippleRadius =
+  self.rippleRadius =
       (CGFloat)(MDCHypot(CGRectGetMidX(rect), CGRectGetMidY(rect)) + kExpandRippleBeyondSurface);
 }
 
 - (void)setPathFromRadii {
   CGRect ovalRect =
-      CGRectMake(CGRectGetMidX(self.bounds) - _rippleRadius,
-                 CGRectGetMidY(self.bounds) - _rippleRadius, _rippleRadius * 2, _rippleRadius * 2);
+      CGRectMake(CGRectGetMidX(self.bounds) - self.rippleRadius,
+                 CGRectGetMidY(self.bounds) - self.rippleRadius, self.rippleRadius * 2, self.rippleRadius * 2);
   UIBezierPath *circlePath = [UIBezierPath bezierPathWithOvalInRect:ovalRect];
   self.path = circlePath.CGPath;
 }

--- a/components/Ripple/tests/unit/MDCRippleLayerTests.m
+++ b/components/Ripple/tests/unit/MDCRippleLayerTests.m
@@ -82,7 +82,7 @@
 
   // Then
   XCTAssertNil(rippleLayer.delegate);
-  XCTAssertEqual(rippleLayer.rippleRadius, 0);
+  XCTAssertEqual(rippleLayer.maxRippleRadius, 0);
   XCTAssertFalse(rippleLayer.isStartAnimationActive);
   XCTAssertEqualWithAccuracy(rippleLayer.rippleTouchDownStartTime, 0, 0.0001);
 }
@@ -280,10 +280,10 @@
   CGFloat fakeRadius = 25;
 
   // When
-  rippleLayer.rippleRadius = fakeRadius;
+  rippleLayer.maxRippleRadius = fakeRadius;
 
   // Then
-  XCTAssertEqual(rippleLayer.rippleRadius, fakeRadius);
+  XCTAssertEqual(rippleLayer.maxRippleRadius, fakeRadius);
 }
 
 @end

--- a/components/Ripple/tests/unit/MDCRippleLayerTests.m
+++ b/components/Ripple/tests/unit/MDCRippleLayerTests.m
@@ -42,7 +42,7 @@
 
 - (void)setPathFromRadii {
   [super setPathFromRadii];
-  
+
   self.fakePathFromRadii = YES;
 }
 

--- a/components/Ripple/tests/unit/MDCRippleLayerTests.m
+++ b/components/Ripple/tests/unit/MDCRippleLayerTests.m
@@ -76,6 +76,7 @@
 
   // Then
   XCTAssertNil(rippleLayer.delegate);
+  XCTAssertEqual(rippleLayer.rippleRadius, 0);
   XCTAssertFalse(rippleLayer.isStartAnimationActive);
   XCTAssertEqualWithAccuracy(rippleLayer.rippleTouchDownStartTime, 0, 0.0001);
 }
@@ -266,4 +267,30 @@
                         basicAnimation.timingFunction);
   XCTAssertEqualWithAccuracy(basicAnimation.duration, (CGFloat)0.075, 0.0001);
 }
+
+- (void)testRippleRadiusAfterSetNeedsLayout {
+  // Given
+  CGRect fakeBounds = CGRectMake(0, 0, 18, 24);
+  MDCRippleLayer *rippleLayer = [[MDCRippleLayer alloc] init];
+  rippleLayer.bounds = fakeBounds;
+
+  // When
+  [rippleLayer setNeedsLayout];
+
+  // Then
+  XCTAssertEqual(rippleLayer.rippleRadius, 25);
+}
+
+- (void)testRippleRadiusSetToCustomValue {
+  // Given
+  MDCRippleLayer *rippleLayer = [[MDCRippleLayer alloc] init];
+  CGFloat fakeRadius = 25;
+
+  // When
+  rippleLayer.rippleRadius = fakeRadius;
+
+  // Then
+  XCTAssertEqual(rippleLayer.rippleRadius, fakeRadius);
+}
+
 @end

--- a/components/Ripple/tests/unit/MDCRippleLayerTests.m
+++ b/components/Ripple/tests/unit/MDCRippleLayerTests.m
@@ -16,12 +16,6 @@
 
 #import "MDCRippleLayer.h"
 
-@interface MDCRippleLayer (Testing)
-
-- (void)setPathFromRadii;
-
-@end
-
 #pragma mark - Fake classes
 
 @interface FakeMDCRippleLayer : MDCRippleLayer

--- a/components/Ripple/tests/unit/MDCRippleLayerTests.m
+++ b/components/Ripple/tests/unit/MDCRippleLayerTests.m
@@ -16,13 +16,21 @@
 
 #import "MDCRippleLayer.h"
 
-#pragma mark - Fake classes
+@interface MDCRippleLayer (Testing)
 
-@interface CapturingAnimationsMDCRippleLayer : MDCRippleLayer
-@property(nonatomic, strong) NSMutableArray *addedAnimations;
+- (void)setPathFromRadii;
+
 @end
 
-@implementation CapturingAnimationsMDCRippleLayer
+#pragma mark - Fake classes
+
+@interface FakeMDCRippleLayer : MDCRippleLayer
+@property(nonatomic, strong) NSMutableArray *addedAnimations;
+@property(nonatomic, assign) BOOL fakePathFromRadii;
+- (void)setPathFromRadii;
+@end
+
+@implementation FakeMDCRippleLayer
 
 - (void)addAnimation:(CAAnimation *)anim forKey:(NSString *)key {
   if (!self.addedAnimations) {
@@ -30,6 +38,12 @@
   }
   [self.addedAnimations addObject:anim];
   [super addAnimation:anim forKey:key];
+}
+
+- (void)setPathFromRadii {
+  [super setPathFromRadii];
+  
+  self.fakePathFromRadii = YES;
 }
 
 @end
@@ -154,7 +168,7 @@
 
 - (void)testAnimationTimingInSpeedScaledLayer {
   // Given
-  CapturingAnimationsMDCRippleLayer *rippleLayer = [[CapturingAnimationsMDCRippleLayer alloc] init];
+  FakeMDCRippleLayer *rippleLayer = [[FakeMDCRippleLayer alloc] init];
   rippleLayer.bounds = CGRectMake(0, 0, 10, 10);
   rippleLayer.speed = (float)0.1;
   CGFloat expectedRippleFadeoutDelay = (CGFloat)0.150;
@@ -176,7 +190,7 @@
 
 - (void)testStartRippleAnimationCorrectness {
   // Given
-  CapturingAnimationsMDCRippleLayer *rippleLayer = [[CapturingAnimationsMDCRippleLayer alloc] init];
+  FakeMDCRippleLayer *rippleLayer = [[FakeMDCRippleLayer alloc] init];
   CGPoint point = CGPointMake(10, 10);
 
   // When
@@ -213,7 +227,7 @@
 
 - (void)testEndRippleAnimationCorrectness {
   // Given
-  CapturingAnimationsMDCRippleLayer *rippleLayer = [[CapturingAnimationsMDCRippleLayer alloc] init];
+  FakeMDCRippleLayer *rippleLayer = [[FakeMDCRippleLayer alloc] init];
 
   // When
   [rippleLayer endRippleAnimated:YES completion:nil];
@@ -232,7 +246,7 @@
 
 - (void)testFadeInRippleAnimationCorrectness {
   // Given
-  CapturingAnimationsMDCRippleLayer *rippleLayer = [[CapturingAnimationsMDCRippleLayer alloc] init];
+  FakeMDCRippleLayer *rippleLayer = [[FakeMDCRippleLayer alloc] init];
 
   // When
   [rippleLayer fadeInRippleAnimated:YES completion:nil];
@@ -251,7 +265,7 @@
 
 - (void)testFadeOutRippleAnimationCorrectness {
   // Given
-  CapturingAnimationsMDCRippleLayer *rippleLayer = [[CapturingAnimationsMDCRippleLayer alloc] init];
+  FakeMDCRippleLayer *rippleLayer = [[FakeMDCRippleLayer alloc] init];
 
   // When
   [rippleLayer fadeOutRippleAnimated:YES completion:nil];
@@ -270,7 +284,7 @@
 
 - (void)testRippleRadiusSetToCustomValue {
   // Given
-  MDCRippleLayer *rippleLayer = [[MDCRippleLayer alloc] init];
+  FakeMDCRippleLayer *rippleLayer = [[FakeMDCRippleLayer alloc] init];
   CGFloat fakeRadius = 25;
 
   // When
@@ -278,6 +292,7 @@
 
   // Then
   XCTAssertEqual(rippleLayer.rippleRadius, fakeRadius);
+  XCTAssertEqual(rippleLayer.fakePathFromRadii, YES);
 }
 
 @end

--- a/components/Ripple/tests/unit/MDCRippleLayerTests.m
+++ b/components/Ripple/tests/unit/MDCRippleLayerTests.m
@@ -26,8 +26,6 @@
 
 @interface FakeMDCRippleLayer : MDCRippleLayer
 @property(nonatomic, strong) NSMutableArray *addedAnimations;
-@property(nonatomic, assign) BOOL fakePathFromRadii;
-- (void)setPathFromRadii;
 @end
 
 @implementation FakeMDCRippleLayer
@@ -38,12 +36,6 @@
   }
   [self.addedAnimations addObject:anim];
   [super addAnimation:anim forKey:key];
-}
-
-- (void)setPathFromRadii {
-  [super setPathFromRadii];
-
-  self.fakePathFromRadii = YES;
 }
 
 @end
@@ -292,7 +284,6 @@
 
   // Then
   XCTAssertEqual(rippleLayer.rippleRadius, fakeRadius);
-  XCTAssertEqual(rippleLayer.fakePathFromRadii, YES);
 }
 
 @end

--- a/components/Ripple/tests/unit/MDCRippleLayerTests.m
+++ b/components/Ripple/tests/unit/MDCRippleLayerTests.m
@@ -268,19 +268,6 @@
   XCTAssertEqualWithAccuracy(basicAnimation.duration, (CGFloat)0.075, 0.0001);
 }
 
-- (void)testRippleRadiusAfterSetNeedsLayout {
-  // Given
-  CGRect fakeBounds = CGRectMake(0, 0, 18, 24);
-  MDCRippleLayer *rippleLayer = [[MDCRippleLayer alloc] init];
-  rippleLayer.bounds = fakeBounds;
-
-  // When
-  [rippleLayer setNeedsLayout];
-
-  // Then
-  XCTAssertEqual(rippleLayer.rippleRadius, 25);
-}
-
 - (void)testRippleRadiusSetToCustomValue {
   // Given
   MDCRippleLayer *rippleLayer = [[MDCRippleLayer alloc] init];

--- a/components/Ripple/tests/unit/MDCRippleLayerTests.m
+++ b/components/Ripple/tests/unit/MDCRippleLayerTests.m
@@ -76,7 +76,7 @@
 
   // Then
   XCTAssertNil(rippleLayer.delegate);
-  XCTAssertEqual(rippleLayer.maxRippleRadius, 0);
+  XCTAssertEqual(rippleLayer.maximumRadius, 0);
   XCTAssertFalse(rippleLayer.isStartAnimationActive);
   XCTAssertEqualWithAccuracy(rippleLayer.rippleTouchDownStartTime, 0, 0.0001);
 }
@@ -268,16 +268,17 @@
   XCTAssertEqualWithAccuracy(basicAnimation.duration, (CGFloat)0.075, 0.0001);
 }
 
+/** Test that setting @c maximumRadius correctly sets the property on @c MDCRippleLayer. */
 - (void)testRippleRadiusSetToCustomValue {
   // Given
-  FakeMDCRippleLayer *rippleLayer = [[FakeMDCRippleLayer alloc] init];
+  MDCRippleLayer *rippleLayer = [[MDCRippleLayer alloc] init];
   CGFloat fakeRadius = 25;
 
   // When
-  rippleLayer.maxRippleRadius = fakeRadius;
+  rippleLayer.maximumRadius = fakeRadius;
 
   // Then
-  XCTAssertEqual(rippleLayer.maxRippleRadius, fakeRadius);
+  XCTAssertEqual(rippleLayer.maximumRadius, fakeRadius);
 }
 
 @end


### PR DESCRIPTION
This change modifies the rippleRadius _ivar_ to make it a _property_. This exposes it in the private header of the `MDCRippleLayer.h` so that later if we need to modify the rippleRadius to support min/max values we can. This change also allows us to test this property.