### PR TITLE
[TextFields] Quash -Wsign-compare triggers

### DIFF
--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -1495,7 +1495,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
           [NSString stringWithFormat:@"%lu characters remaining",
                                      charactersForTextInput > self.characterCountMax
                                          ? 0U
-                                         : (unsigned long)(MAX(0, self.characterCountMax -
+                                         : (unsigned long)(MAX(0U, self.characterCountMax -
                                                                       charactersForTextInput))];
     }
 

--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -1496,7 +1496,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
                                      charactersForTextInput > self.characterCountMax
                                          ? 0U
                                          : (unsigned long)(MAX(0U, self.characterCountMax -
-                                                                      charactersForTextInput))];
+                                                                       charactersForTextInput))];
     }
 
     // Simply sending a layout change notification does not seem to


### PR DESCRIPTION
Corrects an implicit cast of a signed literal to its unsigned value. Although in this case there are no possible negative consequences, some static analyzers detect is as a potential problem.

Extracted from [cl/246520183](http://cl/246520183).

Closes #7359