### PR TITLE
[Action Sheet Docs]: Fixing handler error and adding missing parenthesis

### DIFF
--- a/components/ActionSheet/README.md
+++ b/components/ActionSheet/README.md
@@ -110,10 +110,10 @@ let actionSheet = MDCActionSheetController(title: "Action Sheet",
                                            message: "Secondary line text")
 let actionOne = MDCActionSheetAction(title: "Home", 
                                      image: UIImage(named: "Home"), 
-                                     handler: { print("Home action" })
+                                     handler: { (action) in print("\(action.title) action")})
 let actionTwo = MDCActionSheetAction(title: "Email", 
                                      image: UIImage(named: "Email"), 
-                                     handler: { print("Email action" })
+                                     handler: { (action) in print("\(action.title) action")})
 actionSheet.addAction(actionOne)
 actionSheet.addAction(actionTwo)
 


### PR DESCRIPTION
The code example for an action sheet was missing a closing parenthesis for the print statement in the handler. The handler also gives this error in its current state:

Cannot convert value of type '() -> ()' to expected argument type 'MDCActionSheetHandler?' (aka 'Optional<(MDCActionSheetAction) -> ()>')

The handler method has been updated to include "(action) in" to conform properly.

This helps those who may copy and paste the example to then modify.