### PR TITLE
[ActionSheet] Conform to UIContentSizeCategoryAdjusting.

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -38,7 +38,8 @@
  in a sheet from the bottom.
 
  */
-__attribute__((objc_subclassing_restricted)) @interface MDCActionSheetController : UIViewController <UIContentSizeCategoryAdjusting>
+__attribute__((objc_subclassing_restricted)) @interface MDCActionSheetController
+    : UIViewController<UIContentSizeCategoryAdjusting>
 
 /**
  Designated initializer to create and return a view controller for displaying an alert to the user.

--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -38,7 +38,7 @@
  in a sheet from the bottom.
 
  */
-__attribute__((objc_subclassing_restricted)) @interface MDCActionSheetController : UIViewController
+__attribute__((objc_subclassing_restricted)) @interface MDCActionSheetController : UIViewController <UIContentSizeCategoryAdjusting>
 
 /**
  Designated initializer to create and return a view controller for displaying an alert to the user.
@@ -112,20 +112,6 @@ __attribute__((objc_subclassing_restricted)) @interface MDCActionSheetController
 @property(nonatomic, nullable, copy) NSString *message;
 
 /**
- Indicates whether the button should automatically update its font when the device’s
- UIContentSizeCategory is changed.
-
- This property is modeled after the adjustsFontForContentSizeCategory property in the
- UIContentSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
-
- If set to YES, this button will base its text font on MDCFontTextStyleButton.
-
- Defaults value is NO.
- */
-@property(nonatomic, setter=mdc_setAdjustsFontForContentSizeCategory:)
-    BOOL mdc_adjustsFontForContentSizeCategory;
-
-/**
   The font applied to the title of the action sheet controller.
  */
 @property(nonatomic, nonnull, strong) UIFont *titleFont;
@@ -188,6 +174,22 @@ __attribute__((objc_subclassing_restricted)) @interface MDCActionSheetController
     (nullable id<UIViewControllerTransitioningDelegate>)transitioningDelegate NS_UNAVAILABLE;
 
 - (void)setModalPresentationStyle:(UIModalPresentationStyle)modalPresentationStyle NS_UNAVAILABLE;
+
+#pragma mark - To be deprecated
+
+/**
+ Indicates whether the button should automatically update its font when the device’s
+ UIContentSizeCategory is changed.
+
+ This property is modeled after the adjustsFontForContentSizeCategory property in the
+ UIContentSizeCategoryAdjusting protocol added by Apple in iOS 10.0.
+
+ If set to YES, this button will base its text font on MDCFontTextStyleButton.
+
+ Defaults value is NO.
+ */
+@property(nonatomic, setter=mdc_setAdjustsFontForContentSizeCategory:)
+    BOOL mdc_adjustsFontForContentSizeCategory;
 
 @end
 

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -71,7 +71,7 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   NSMutableArray<MDCActionSheetAction *> *_actions;
 }
 
-@synthesize mdc_adjustsFontForContentSizeCategory = _mdc_adjustsFontForContentSizeCategory;
+@synthesize adjustsFontForContentSizeCategory = _adjustsFontForContentSizeCategory;
 
 + (instancetype)actionSheetControllerWithTitle:(NSString *)title message:(NSString *)message {
   return [[MDCActionSheetController alloc] initWithTitle:title message:message];
@@ -355,11 +355,14 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
 
 #pragma mark - Dynamic Type
 
-- (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {
-  _mdc_adjustsFontForContentSizeCategory = adjusts;
-  self.header.mdc_adjustsFontForContentSizeCategory = adjusts;
+- (void)setAdjustsFontForContentSizeCategory:(BOOL)adjustsFontForContentSizeCategory {
+  _adjustsFontForContentSizeCategory = adjustsFontForContentSizeCategory;
+
+  self.header.adjustsFontForContentSizeCategory = adjustsFontForContentSizeCategory;
+
   [self updateFontsForDynamicType];
-  if (_mdc_adjustsFontForContentSizeCategory) {
+
+  if (adjustsFontForContentSizeCategory) {
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(updateFontsForDynamicType)
                                                  name:UIContentSizeCategoryDidChangeNotification
@@ -414,6 +417,16 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
 - (void)setInkColor:(UIColor *)inkColor {
   _inkColor = inkColor;
   [self.tableView reloadData];
+}
+
+#pragma mark - To be deprecated
+
+- (BOOL)mdc_adjustsFontForContentSizeCategory {
+  return self.adjustsFontForContentSizeCategory;
+}
+
+- (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjustsFontForContentSizeCategory {
+  self.adjustsFontForContentSizeCategory = adjustsFontForContentSizeCategory;
 }
 
 @end

--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.h
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.h
@@ -14,7 +14,7 @@
 
 #import <UIKit/UIKit.h>
 
-@interface MDCActionSheetHeaderView : UIView
+@interface MDCActionSheetHeaderView : UIView <UIContentSizeCategoryAdjusting>
 
 - (nonnull instancetype)initWithFrame:(CGRect)frame;
 
@@ -24,9 +24,6 @@
 @property(nonatomic, nullable, copy) NSString *title;
 
 @property(nonatomic, nullable, copy) NSString *message;
-
-@property(nonatomic, setter=mdc_setAdjustsFontForContentSizeCategory:)
-    BOOL mdc_adjustsFontForContentSizeCategory;
 
 @property(nonatomic, strong, nonnull) UIFont *titleFont;
 

--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
@@ -33,7 +33,7 @@ static const CGFloat kMiddlePadding = 8;
 
 @implementation MDCActionSheetHeaderView
 
-@synthesize mdc_adjustsFontForContentSizeCategory = _mdc_adjustsFontForContentSizeCategory;
+@synthesize adjustsFontForContentSizeCategory = _adjustsFontForContentSizeCategory;
 
 - (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];
@@ -154,10 +154,10 @@ static const CGFloat kMiddlePadding = 8;
 - (void)updateTitleFont {
   UIFont *titleFont =
       self.titleFont ?: [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleSubheadline];
-  if (self.mdc_adjustsFontForContentSizeCategory) {
+  if (self.adjustsFontForContentSizeCategory) {
     self.titleLabel.font =
         [titleFont mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleSubheadline
-                                scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+                                scaledForDynamicType:self.adjustsFontForContentSizeCategory];
   } else {
     self.titleLabel.font = titleFont;
   }
@@ -167,10 +167,10 @@ static const CGFloat kMiddlePadding = 8;
 - (void)updateMessageFont {
   UIFont *messageFont =
       self.messageFont ?: [UIFont mdc_standardFontForMaterialTextStyle:MDCFontTextStyleBody1];
-  if (self.mdc_adjustsFontForContentSizeCategory) {
+  if (self.adjustsFontForContentSizeCategory) {
     self.messageLabel.font =
         [messageFont mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleBody1
-                                  scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+                                  scaledForDynamicType:self.adjustsFontForContentSizeCategory];
   } else {
     self.messageLabel.font = messageFont;
   }
@@ -178,9 +178,10 @@ static const CGFloat kMiddlePadding = 8;
   [self setNeedsLayout];
 }
 
-- (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {
-  _mdc_adjustsFontForContentSizeCategory = adjusts;
-  if (_mdc_adjustsFontForContentSizeCategory) {
+- (void)setAdjustsFontForContentSizeCategory:(BOOL)adjustsFontForContentSizeCategory {
+  _adjustsFontForContentSizeCategory = adjustsFontForContentSizeCategory;
+
+  if (adjustsFontForContentSizeCategory) {
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(updateFonts)
                                                  name:UIContentSizeCategoryDidChangeNotification


### PR DESCRIPTION
This is part of a general effort to align our support for Dynamic Type with UIKit's APIs.

`MDCActionSheetController` now conforms to `UIContentSizeCategoryAdjusting`. This adds a `adjustsFontForContentSizeCategory` property to the class, replacing the need for `mdc_adjustsFontForContentSizeCategory`.
