### PR TITLE
[Buttons] Remove dependency on TypographyThemer in theming extension. 

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -397,7 +397,6 @@ Pod::Spec.new do |mdc|
       unit_tests.resources = "components/#{component.base_name}/tests/unit/resources/*"
       unit_tests.dependency "MaterialComponents/Buttons+ShapeThemer"
       unit_tests.dependency "MaterialComponents/Buttons+ColorThemer"
-      unit_tests.dependency "MaterialComponents/Buttons+TypographyThemer"
       unit_tests.dependency "MaterialComponents/Buttons+TitleColorAccessibilityMutator"
       unit_tests.dependency "MaterialComponents/Buttons+ButtonThemer"
     end

--- a/components/Buttons/BUILD
+++ b/components/Buttons/BUILD
@@ -55,7 +55,6 @@ mdc_extension_objc_library(
         ":Buttons",
         ":ColorThemer",
         ":ShapeThemer",
-        ":TypographyThemer",
         "//components/ShadowElevations",
         "//components/schemes/Container",
     ],

--- a/components/Buttons/src/Theming/MDCButton+MaterialTheming.m
+++ b/components/Buttons/src/Theming/MDCButton+MaterialTheming.m
@@ -157,7 +157,7 @@
 
 - (void)resetTitleForAllStates {
   NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
-  UIControlStateHighlighted | UIControlStateDisabled;
+                                 UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
     [self setTitleFont:nil forState:state];
   }

--- a/components/Buttons/src/Theming/MDCButton+MaterialTheming.m
+++ b/components/Buttons/src/Theming/MDCButton+MaterialTheming.m
@@ -55,7 +55,7 @@
 }
 
 - (void)applyContainedThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {
-  [self resetTitleForAllStates];
+  [self resetTitleFontForAllStates];
   [self setTitleFont:typographyScheme.button forState:UIControlStateNormal];
 }
 
@@ -100,7 +100,7 @@
 }
 
 - (void)applyOutlinedThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {
-  [self resetTitleForAllStates];
+  [self resetTitleFontForAllStates];
   [self setTitleFont:typographyScheme.button forState:UIControlStateNormal];
 }
 
@@ -145,7 +145,7 @@
 }
 
 - (void)applyTextThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {
-  [self resetTitleForAllStates];
+  [self resetTitleFontForAllStates];
   [self setTitleFont:typographyScheme.button forState:UIControlStateNormal];
 }
 
@@ -155,7 +155,7 @@
 
 #pragma mark - General helpers
 
-- (void)resetTitleForAllStates {
+- (void)resetTitleFontForAllStates {
   NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
                                  UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {

--- a/components/Buttons/src/Theming/MDCButton+MaterialTheming.m
+++ b/components/Buttons/src/Theming/MDCButton+MaterialTheming.m
@@ -16,7 +16,6 @@
 
 #import <MaterialComponents/MaterialButtons+ColorThemer.h>
 #import <MaterialComponents/MaterialButtons+ShapeThemer.h>
-#import <MaterialComponents/MaterialButtons+TypographyThemer.h>
 #import <MaterialComponents/MaterialShadowElevations.h>
 
 @implementation MDCButton (MaterialTheming)
@@ -56,7 +55,8 @@
 }
 
 - (void)applyContainedThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {
-  [MDCButtonTypographyThemer applyTypographyScheme:typographyScheme toButton:self];
+  [self resetTitleForAllStates];
+  [self setTitleFont:typographyScheme.button forState:UIControlStateNormal];
 }
 
 - (void)applyContainedThemeWithShapeScheme:(id<MDCShapeScheming>)shapeScheme {
@@ -100,7 +100,8 @@
 }
 
 - (void)applyOutlinedThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {
-  [MDCButtonTypographyThemer applyTypographyScheme:typographyScheme toButton:self];
+  [self resetTitleForAllStates];
+  [self setTitleFont:typographyScheme.button forState:UIControlStateNormal];
 }
 
 - (void)applyOutlinedThemeWithShapeScheme:(id<MDCShapeScheming>)shapeScheme {
@@ -144,11 +145,22 @@
 }
 
 - (void)applyTextThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {
-  [MDCButtonTypographyThemer applyTypographyScheme:typographyScheme toButton:self];
+  [self resetTitleForAllStates];
+  [self setTitleFont:typographyScheme.button forState:UIControlStateNormal];
 }
 
 - (void)applyTextThemeWithShapeScheme:(id<MDCShapeScheming>)shapeScheme {
   [MDCButtonShapeThemer applyShapeScheme:shapeScheme toButton:self];
+}
+
+#pragma mark - General helpers
+
+- (void)resetTitleForAllStates {
+  NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
+  UIControlStateHighlighted | UIControlStateDisabled;
+  for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    [self setTitleFont:nil forState:state];
+  }
 }
 
 @end

--- a/components/Buttons/src/Theming/MDCFloatingButton+MaterialTheming.m
+++ b/components/Buttons/src/Theming/MDCFloatingButton+MaterialTheming.m
@@ -16,7 +16,6 @@
 
 #import <MaterialComponents/MaterialButtons+ColorThemer.h>
 #import <MaterialComponents/MaterialButtons+ShapeThemer.h>
-#import <MaterialComponents/MaterialButtons+TypographyThemer.h>
 
 @implementation MDCFloatingButton (MaterialTheming)
 
@@ -55,7 +54,18 @@
 }
 
 - (void)applySecondaryThemeWithTypographyScheme:(id<MDCTypographyScheming>)scheme {
-  [MDCButtonTypographyThemer applyTypographyScheme:scheme toButton:self];
+  [self resetTitleForAllStates];
+  [self setTitleFont:scheme.button forState:UIControlStateNormal];
+}
+
+#pragma mark - General helpers
+
+- (void)resetTitleForAllStates {
+  NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
+  UIControlStateHighlighted | UIControlStateDisabled;
+  for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    [self setTitleFont:nil forState:state];
+  }
 }
 
 @end

--- a/components/Buttons/src/Theming/MDCFloatingButton+MaterialTheming.m
+++ b/components/Buttons/src/Theming/MDCFloatingButton+MaterialTheming.m
@@ -55,7 +55,7 @@
 
 - (void)applySecondaryThemeWithTypographyScheme:(id<MDCTypographyScheming>)scheme {
   NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
-  UIControlStateHighlighted | UIControlStateDisabled;
+                                 UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
     [self setTitleFont:nil forState:state];
   }

--- a/components/Buttons/src/Theming/MDCFloatingButton+MaterialTheming.m
+++ b/components/Buttons/src/Theming/MDCFloatingButton+MaterialTheming.m
@@ -62,7 +62,7 @@
 
 - (void)resetTitleForAllStates {
   NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
-  UIControlStateHighlighted | UIControlStateDisabled;
+                                 UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
     [self setTitleFont:nil forState:state];
   }

--- a/components/Buttons/src/Theming/MDCFloatingButton+MaterialTheming.m
+++ b/components/Buttons/src/Theming/MDCFloatingButton+MaterialTheming.m
@@ -54,18 +54,12 @@
 }
 
 - (void)applySecondaryThemeWithTypographyScheme:(id<MDCTypographyScheming>)scheme {
-  [self resetTitleForAllStates];
-  [self setTitleFont:scheme.button forState:UIControlStateNormal];
-}
-
-#pragma mark - General helpers
-
-- (void)resetTitleForAllStates {
   NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
-                                 UIControlStateHighlighted | UIControlStateDisabled;
+  UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
     [self setTitleFont:nil forState:state];
   }
+  [self setTitleFont:scheme.button forState:UIControlStateNormal];
 }
 
 @end


### PR DESCRIPTION
In order for us to add dynamic type to our theming extension we need to be setting the font directly in the theming extension. We cannot pass the scheme to the themer object because that would require us updating the themer object that we plan to deprecate. This removes that dependency to allow us to set the font directly in the theming extension and gets the Material iOS team off the themer object. This is in greater service to #7388.

Closes #7393