### PR TITLE
[NavigationDrawer] Explain use of AppBar elevation

### DIFF
--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -551,6 +551,7 @@ static UIColor *DrawerShadowColor(void) {
   }
 
   self.headerShadowLayer = [[MDCShadowLayer alloc] init];
+  // The header acts as an AppBar, so it keeps the same elevation value.
   self.headerShadowLayer.elevation = MDCShadowElevationAppBar;
   self.headerShadowLayer.shadowColor = DrawerShadowColor().CGColor;
   [self.headerViewController.view.layer addSublayer:self.headerShadowLayer];


### PR DESCRIPTION
The Bottom Navigation Drawer's header acts as an AppBar, so it should have the same elevation. If AppBars change elevation in the future, so should the Bottom Drawer's header.

Follow-up to #7396