### PR TITLE
[Buttons] Update titleFont:forState: API

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -729,13 +729,27 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 #pragma mark - Title Font
 
 - (nullable UIFont *)titleFontForState:(UIControlState)state {
-  return _fonts[@(state)];
+  // If the `.highlighted` flag is set, turn off the `.disabled` flag
+  if ((state & UIControlStateHighlighted) == UIControlStateHighlighted) {
+    state = state & ~UIControlStateDisabled;
+  }
+  return _fonts[@(state)] ?: _fonts(UIControlStateNormal);
 }
 
 - (void)setTitleFont:(nullable UIFont *)font forState:(UIControlState)state {
-  _fonts[@(state)] = font;
+  UIControlState storageState = state;
+  // If the `.highlighted` flag is set, turn off the `.disabled` flag
+  if ((state & UIControlStateHighlighted) == UIControlStateHighlighted) {
+    storageState = state & ~UIControlStateDisabled;
+  }
 
-  [self updateTitleFont];
+  // Only update the backing dictionary if:
+  // 1. The `state` argument is the same as the "storage" state, OR
+  // 2. There is already a value in the "storage" state.
+  if (storageState == state || _backgroundColors[@(storageState)] != nil) {
+    _backgroundColors[@(storageState)] = backgroundColor;
+    [self updateTitleFont];
+  }
 }
 
 #pragma mark - Private methods

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -733,7 +733,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   if ((state & UIControlStateHighlighted) == UIControlStateHighlighted) {
     state = state & ~UIControlStateDisabled;
   }
-  return _fonts[@(state)] ?: _fonts(UIControlStateNormal);
+  return _fonts[@(state)] ?: _fonts[@(UIControlStateNormal)];
 }
 
 - (void)setTitleFont:(nullable UIFont *)font forState:(UIControlState)state {
@@ -746,8 +746,8 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   // Only update the backing dictionary if:
   // 1. The `state` argument is the same as the "storage" state, OR
   // 2. There is already a value in the "storage" state.
-  if (storageState == state || _backgroundColors[@(storageState)] != nil) {
-    _backgroundColors[@(storageState)] = backgroundColor;
+  if (storageState == state || _fonts[@(storageState)] != nil) {
+    _fonts[@(storageState)] = font;
     [self updateTitleFont];
   }
 }

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -494,6 +494,34 @@ static NSString *controlStateDescription(UIControlState controlState) {
   }
 }
 
+#pragma mark - titleFont:forState:
+
+- (void)testTitleFontForState {
+  for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
+    // Given
+    UIFont *randomFont = [UIFont systemFontOfSize:arc4random_uniform(100)];
+
+    // When
+    [self.button setTitleFont:randomFont forState:controlState];
+
+    // Then
+    XCTAssertEqualObjects([self.button titleFontForState:controlState], randomFont);
+  }
+}
+
+- (void)testTitleFontForStateFallbackBehavior {
+  // Given
+  UIFont *fakeFont = [UIFont systemFontOfSize:25];
+  // When
+  [self.button setTitleFont:fakeFont forState:UIControlStateNormal];
+
+  // Then
+  for (NSUInteger controlState = 0; controlState < kNumUIControlStates; ++controlState) {
+    XCTAssertEqualObjects([self.button titleFontForState:controlState], fakeFont);
+  }
+}
+
+
 #pragma mark - shadowColor:forState:
 
 - (void)testRemovedShadowColorForState {

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -521,7 +521,6 @@ static NSString *controlStateDescription(UIControlState controlState) {
   }
 }
 
-
 #pragma mark - shadowColor:forState:
 
 - (void)testRemovedShadowColorForState {


### PR DESCRIPTION
## Motivation
As outlined in #5919 many of our `forState:` APIs don't match what `UIButton` is doing. This addresses that problem for our `titleFont` API. This updates the fallback behavior. Additionally this will help facilitate #7388.

## Test
In other test similar to this one we update a `UIButton` with a `UIColor` to make sure the colors match for a given state in given conditions, since `UIButton` doesn't have any `forState` APIs that set a font we can't test this as easily. Also this follows the same pattern outlined in the other PRs to address this issue.