### PR TITLE
[FlexibleHeader] Clarify the docs for preferredStatusBarStyle.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
@@ -146,7 +146,7 @@
 
 /**
  The status bar style that should be used for this view controller.
- 
+
  If the header view controller has been added as aa child view controller then you will need to
  assign the header view controller to the parent's childViewControllerForStatusBarStyle property
  in order for preferredStatusBarStyle to have any effect.

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
@@ -146,6 +146,9 @@
 
 /**
  The status bar style that should be used for this view controller.
+
+ See inferPreferredStatusBarStyle for more details about how this property's setter and getter
+ should be interpreted.
  */
 @property(nonatomic) UIStatusBarStyle preferredStatusBarStyle;
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
@@ -146,6 +146,10 @@
 
 /**
  The status bar style that should be used for this view controller.
+ 
+ If the header view controller has been added as aa child view controller then you will need to
+ assign the header view controller to the parent's childViewControllerForStatusBarStyle property
+ in order for preferredStatusBarStyle to have any effect.
 
  See inferPreferredStatusBarStyle for more details about how this property's setter and getter
  should be interpreted.

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
@@ -147,7 +147,7 @@
 /**
  The status bar style that should be used for this view controller.
 
- If the header view controller has been added as aa child view controller then you will need to
+ If the header view controller has been added as a child view controller then you will need to
  assign the header view controller to the parent's childViewControllerForStatusBarStyle property
  in order for preferredStatusBarStyle to have any effect.
 


### PR DESCRIPTION
Based on an internal interaction with a client in [b/132915687](http://b/132915687), the documentation for preferredStatusBarStyle did not clearly indicate how it is intended to be used. The client was expecting that setting this property alone should have an effect on the status bar style.

This PR clarifies that the `preferredStatusBarStyle` property is a suggestion that is configured by `inferPreferredStatusBarStyle ` and that often needs to be connected to UIKit's `preferredStatusBarStyle` APIs via `childViewControllerForStatusBarStyle`.

Closes https://github.com/material-components/material-components-ios/issues/7418