### PR TITLE
[Docs] Point first internal step at Requirements

### DIFF
--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -122,7 +122,7 @@ exception to our normal squash-and-merge procedure.
 
 ### Start internal testing
 
-You can now start the internal release testing process documented at [go/mdc-releasing](http://go/mdc-releasing#import-the-release-candidate).
+You can now start the internal release testing process documented at [go/mdc-releasing](http://go/mdc-releasing#requirements).
 
 ### Resolve any failures
 


### PR DESCRIPTION
The first internal steps require some one-time set-up (in the future possibly repeated set-up) and shouldn't be skipped. Pointing the link to the Requirements section so those can be seen and attended to by the release engineer.
