### PR TITLE
[Chips] Use umbrella header

### DIFF
--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -23,7 +23,7 @@
 #import "MaterialShadowLayer.h"
 #import "MaterialShapes.h"
 #import "MaterialTypography.h"
-#import "UIApplication+AppExtensions.h"
+#import "MaterialApplication.h"
 
 static const MDCFontTextStyle kTitleTextStyle = MDCFontTextStyleBody2;
 

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -16,6 +16,7 @@
 
 #import <MDFInternationalization/MDFInternationalization.h>
 
+#import "MaterialApplication.h"
 #import "MaterialInk.h"
 #import "MaterialMath.h"
 #import "MaterialRipple.h"
@@ -23,7 +24,6 @@
 #import "MaterialShadowLayer.h"
 #import "MaterialShapes.h"
 #import "MaterialTypography.h"
-#import "MaterialApplication.h"
 
 static const MDCFontTextStyle kTitleTextStyle = MDCFontTextStyleBody2;
 


### PR DESCRIPTION
When using #7394 as a template for other components I noticed chips wasn't using the umbrella header. This change updates the import statement to be the umbrella header instead of the direct header.

Related to #7394 