### PR TITLE
[List] Fix copyright dates for Theming files.

### DIFF
--- a/components/List/src/Theming/MDCBaseCell+MaterialTheming.h
+++ b/components/List/src/Theming/MDCBaseCell+MaterialTheming.h
@@ -1,4 +1,4 @@
-// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/components/List/src/Theming/MDCBaseCell+MaterialTheming.m
+++ b/components/List/src/Theming/MDCBaseCell+MaterialTheming.m
@@ -1,4 +1,4 @@
-// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/components/List/src/Theming/MDCSelfSizingStereoCell+MaterialTheming.h
+++ b/components/List/src/Theming/MDCSelfSizingStereoCell+MaterialTheming.h
@@ -1,4 +1,4 @@
-// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/components/List/src/Theming/MDCSelfSizingStereoCell+MaterialTheming.m
+++ b/components/List/src/Theming/MDCSelfSizingStereoCell+MaterialTheming.m
@@ -1,4 +1,4 @@
-// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/components/List/src/Theming/MaterialList+Theming.h
+++ b/components/List/src/Theming/MaterialList+Theming.h
@@ -1,4 +1,4 @@
-// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/components/List/tests/unit/Theming/ListMaterialThemingTests.swift
+++ b/components/List/tests/unit/Theming/ListMaterialThemingTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
PR #7397 was authored in 2019 (as the commit history on GitHub shows),
but the copyright dates reflect 2018. This is incorrect and they should
be updated to be accurate.

Follow-up to #7397
