### PR TITLE
[Chips] Add fallback behavior for M2 Dynamic Type.

### DIFF
--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -144,14 +144,14 @@
     BOOL mdc_adjustsFontForContentSizeCategory UI_APPEARANCE_SELECTOR;
 
 /**
- Enable legacy font scaling curves for Dynamic Type.
+ Enable font scaling curves fallback behavior for Dynamic Type.
 
- Legacy font scaling uses the older [UIFont mdc_fontSizedForMaterialTextStyle:scaledForDynamicType:
- category instead of the MDCFontScaler API.
+ Scale font by calling the older [UIFont mdc_fontSizedForMaterialTextStyle:scaledForDynamicType:]
+ category method when the font is not associated with a scaling curve.
 
  Default value is YES.
  */
-@property(nonatomic, readwrite, setter=mdc_setLegacyFontScaling:) BOOL mdc_legacyFontScaling;
+@property(nonatomic, assign) BOOL fontScalingShouldFallback;
 
 /**
  The minimum dimensions of the Chip. A non-positive value for either height or width is equivalent

--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -155,12 +155,16 @@
     BOOL mdc_legacyFontScaling __deprecated;
 
 /**
- Enable font scaling curves fallback behavior for Dynamic Type.
+ Affects the fallback behavior for when a scaled font is not provided.
 
- Scale font by calling the older [UIFont mdc_fontSizedForMaterialTextStyle:scaledForDynamicType:]
- category method when the font is not associated with a scaling curve.
+ If enabled, the font size will adjust even if a scaled font has not been provided for
+ a given UIFont property on this component.
 
- Default value is YES.
+ If disabled, the font size will only be adjusted if a scaled font has been provided.
+ This behavior most closely matches UIKit's.
+
+ Default value is YES, but this flag will eventually default to NO and then be deprecated
+ and deleted.
  */
 @property(nonatomic, assign) BOOL adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
 

--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -162,7 +162,7 @@
 
  Default value is YES.
  */
-@property(nonatomic, assign) BOOL fontScalingShouldFallback;
+@property(nonatomic, assign) BOOL adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
 
 /**
  The minimum dimensions of the Chip. A non-positive value for either height or width is equivalent

--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -144,6 +144,17 @@
     BOOL mdc_adjustsFontForContentSizeCategory UI_APPEARANCE_SELECTOR;
 
 /**
+ Enable legacy font scaling curves for Dynamic Type.
+
+ Legacy font scaling uses the older [UIFont mdc_fontSizedForMaterialTextStyle:scaledForDynamicType:
+ category instead of the MDCFontScaler API.
+
+ Default value is YES.
+ */
+@property(nonatomic, readwrite, setter=mdc_setLegacyFontScaling:)
+    BOOL mdc_legacyFontScaling __deprecated;
+
+/**
  Enable font scaling curves fallback behavior for Dynamic Type.
 
  Scale font by calling the older [UIFont mdc_fontSizedForMaterialTextStyle:scaledForDynamicType:]

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -135,6 +135,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 - (void)commonMDCChipViewInit {
   _minimumSize = kMDCChipMinimumSizeDefault;
   self.isAccessibilityElement = YES;
+  _mdc_legacyFontScaling = YES;
   _fontScalingShouldFallback = YES;
 }
 
@@ -510,7 +511,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 
   // If we are automatically adjusting for Dynamic Type resize the font based on the text style
   if (self.mdc_adjustsFontForContentSizeCategory) {
-    if (titleFont.mdc_scalingCurve) {
+    if (titleFont.mdc_scalingCurve && !self.mdc_legacyFontScaling) {
       UIContentSizeCategory sizeCategory = UIContentSizeCategoryLarge;
       if (@available(iOS 10.0, *)) {
         sizeCategory = self.traitCollection.preferredContentSizeCategory;

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -135,7 +135,6 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 - (void)commonMDCChipViewInit {
   _minimumSize = kMDCChipMinimumSizeDefault;
   self.isAccessibilityElement = YES;
-  _mdc_legacyFontScaling = YES;
   _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
 }
 
@@ -299,6 +298,14 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
   }
 
   [self updateTitleFont];
+}
+
+- (void)mdc_setLegacyFontScaling:(BOOL)legacyScaling {
+  _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = legacyScaling;
+}
+
+- (BOOL)mdc_legacyFontScaling {
+  return _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
 }
 
 - (void)contentSizeCategoryDidChange:(__unused NSNotification *)notification {

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -135,7 +135,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 - (void)commonMDCChipViewInit {
   _minimumSize = kMDCChipMinimumSizeDefault;
   self.isAccessibilityElement = YES;
-  _mdc_legacyFontScaling = YES;
+  _fontScalingShouldFallback = YES;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
@@ -510,7 +510,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 
   // If we are automatically adjusting for Dynamic Type resize the font based on the text style
   if (self.mdc_adjustsFontForContentSizeCategory) {
-    if (titleFont.mdc_scalingCurve && !self.mdc_legacyFontScaling) {
+    if (titleFont.mdc_scalingCurve) {
       UIContentSizeCategory sizeCategory = UIContentSizeCategoryLarge;
       if (@available(iOS 10.0, *)) {
         sizeCategory = self.traitCollection.preferredContentSizeCategory;
@@ -518,7 +518,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
         sizeCategory = [UIApplication mdc_safeSharedApplication].preferredContentSizeCategory;
       }
       titleFont = [titleFont mdc_scaledFontForSizeCategory:sizeCategory];
-    } else {
+    } else if (self.fontScalingShouldFallback) {
       titleFont =
           [titleFont mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
                                   scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -136,7 +136,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
   _minimumSize = kMDCChipMinimumSizeDefault;
   self.isAccessibilityElement = YES;
   _mdc_legacyFontScaling = YES;
-  _fontScalingShouldFallback = YES;
+  _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
@@ -519,7 +519,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
         sizeCategory = [UIApplication mdc_safeSharedApplication].preferredContentSizeCategory;
       }
       titleFont = [titleFont mdc_scaledFontForSizeCategory:sizeCategory];
-    } else if (self.fontScalingShouldFallback) {
+    } else if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
       titleFont =
           [titleFont mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
                                   scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -416,7 +416,7 @@ static inline UIImage *TestImage(CGSize size) {
     // Given
     MDCChipsTestsFakeChipView *chipView = [[MDCChipsTestsFakeChipView alloc] init];
     chipView.mdc_adjustsFontForContentSizeCategory = YES;
-    chipView.mdc_legacyFontScaling = NO;
+    chipView.fontScalingShouldFallback = NO;
     UIFont *titleFont = [UIFont systemFontOfSize:14.0 weight:UIFontWeightMedium];
     MDCFontScaler *fontScaler = [[MDCFontScaler alloc] initForMaterialTextStyle:MDCTextStyleBody2];
     titleFont = [fontScaler scaledFontWithFont:titleFont];

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -440,4 +440,12 @@ static inline UIImage *TestImage(CGSize size) {
   }
 }
 
+- (void)testChipViewAdjustsFontForContentSizeCategoryWhenScaledFontIsUnavailableDefaultValue {
+  // Given
+  MDCChipView *chipView = [[MDCChipView alloc] init];
+
+  // Then
+  XCTAssertTrue(chipView.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable);
+}
+
 @end

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -416,7 +416,7 @@ static inline UIImage *TestImage(CGSize size) {
     // Given
     MDCChipsTestsFakeChipView *chipView = [[MDCChipsTestsFakeChipView alloc] init];
     chipView.mdc_adjustsFontForContentSizeCategory = YES;
-    chipView.fontScalingShouldFallback = NO;
+    chipView.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
     UIFont *titleFont = [UIFont systemFontOfSize:14.0 weight:UIFontWeightMedium];
     MDCFontScaler *fontScaler = [[MDCFontScaler alloc] initForMaterialTextStyle:MDCTextStyleBody2];
     titleFont = [fontScaler scaledFontWithFont:titleFont];


### PR DESCRIPTION
mdc_legacyFontScaling shouldn't serve as the flag for migration from legacy behavior. It has been deprecated. adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable is added in this PR as a new API to support dynamic type fallback behavior when a scaling curve is not associated with a font.

