### PR TITLE
[Dialogs] Move the private property declaration to the header

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.h
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.h
@@ -25,6 +25,7 @@
 @property(nonatomic, nullable, strong) UIImageView *titleIconImageView;
 
 @property(nonatomic, nullable, weak) MDCAlertActionManager *actionManager;
+
 /** The scroll view that holds both the @c titleLabel and @c messageLabel. */
 @property(nonatomic, nonnull, strong) UIScrollView *contentScrollView;
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.h
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.h
@@ -25,6 +25,11 @@
 @property(nonatomic, nullable, strong) UIImageView *titleIconImageView;
 
 @property(nonatomic, nullable, weak) MDCAlertActionManager *actionManager;
+/** The scroll view that holds both the @c titleLabel and @c messageLabel. */
+@property(nonatomic, nonnull, strong) UIScrollView *contentScrollView;
+
+/** The scroll view that holds all of the buttons created for each action. */
+@property(nonatomic, nonnull, strong) UIScrollView *actionsScrollView;
 
 - (void)addActionButton:(nonnull MDCButton *)button;
 + (void)styleAsTextButton:(nonnull MDCButton *)button;

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -43,9 +43,6 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
 
 @interface MDCAlertControllerView ()
 
-@property(nonatomic, nonnull, strong) UIScrollView *contentScrollView;
-@property(nonatomic, nonnull, strong) UIScrollView *actionsScrollView;
-
 @property(nonatomic, getter=isVerticalActionsLayout) BOOL verticalActionsLayout;
 
 @end


### PR DESCRIPTION
## Motivation
In order to make changes to _Dialogs_ based on the content we need to be able to access UIScrollViews that hold all of the content.

## Detailed changes
Move the property declaration from the `.m` file to the `.h` file within the `private/` directory of Dialogs.

Related to #7405 