### PR TITLE
[ButtonBar] Expose a rectForItem:inCoordinateSpace: API.

### DIFF
--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
@@ -28,10 +28,10 @@ class ButtonBarTypicalUseSwiftExample: UIViewController {
     return scheme
   }
 
+  lazy var buttonBar = MDCButtonBar()
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    let buttonBar = MDCButtonBar()
     buttonBar.applyPrimaryTheme(withScheme: scheme)
 
     // MDCButtonBar ignores the style of UIBarButtonItem.
@@ -66,8 +66,10 @@ class ButtonBarTypicalUseSwiftExample: UIViewController {
     view.backgroundColor = .white
   }
 
-  @objc func didTapActionButton(_ sender: Any) {
-    print("Did tap action item: \(sender)")
+  @objc func didTapActionButton(_ item: UIBarButtonItem) {
+    let rect = buttonBar.rect(for: item, in: view)
+    print("\(rect)")
+    print("Did tap action item: \(item)")
   }
 
   // MARK: Typical application code (not Material-specific)

--- a/components/ButtonBar/src/MDCButtonBar.h
+++ b/components/ButtonBar/src/MDCButtonBar.h
@@ -99,6 +99,17 @@ IB_DESIGNABLE
 @property(nonatomic, copy, nullable) NSArray<UIBarButtonItem *> *items;
 
 /**
+ Returns the rect of the item's view within the coordinate space of @c view.
+
+ If the provided item is not contained in @c items, then the behavior is undefined.
+
+ @param item The item within @c items whose rect should be computed.
+ @param coordinateSpace The coordinate space the returned rect should be in relation to.
+ */
+- (CGRect)rectForItem:(nonnull UIBarButtonItem *)item
+    inCoordinateSpace:(nonnull id<UICoordinateSpace>)coordinateSpace;
+
+/**
  If greater than zero, will ensure that any UIButton with a title is aligned to the provided
  baseline.
 

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -425,6 +425,13 @@ static NSString *const kEnabledSelector = @"enabled";
   }
 }
 
+- (CGRect)rectForItem:(nonnull UIBarButtonItem *)item
+    inCoordinateSpace:(nonnull id<UICoordinateSpace>)coordinateSpace {
+  NSUInteger itemIndex = [self.items indexOfObject:item];
+  UIView *buttonView = _buttonViews[itemIndex];
+  return [buttonView convertRect:buttonView.bounds toCoordinateSpace:coordinateSpace];
+}
+
 - (void)setUppercasesButtonTitles:(BOOL)uppercasesButtonTitles {
   _uppercasesButtonTitles = uppercasesButtonTitles;
 

--- a/components/ButtonBar/tests/unit/ButtonBarRectForItemTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarRectForItemTests.swift
@@ -41,7 +41,10 @@ class ButtonBarRectForItemTests: XCTestCase {
 
   func testLongTextButtonMatchesExpectedSize() {
     // Given
-    let items = [UIBarButtonItem(title: "Text that is relatively long", style: .plain, target: nil, action: nil)]
+    let items = [UIBarButtonItem(title: "Text that is relatively long",
+                                 style: .plain,
+                                 target: nil,
+                                 action: nil)]
     buttonBar.items = items
     buttonBar.layoutIfNeeded()
 

--- a/components/ButtonBar/tests/unit/ButtonBarRectForItemTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarRectForItemTests.swift
@@ -1,0 +1,105 @@
+// Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import MaterialComponents.MaterialButtonBar
+import MaterialComponents.MaterialButtons
+
+// Tests for Button Bar's rectForItemAtIndex:inCoordinateSpace: API.
+class ButtonBarRectForItemTests: XCTestCase {
+
+  var buttonBar: MDCButtonBar!
+
+  override func setUp() {
+    buttonBar = MDCButtonBar()
+    buttonBar.frame = CGRect(x: 0, y: 0, width: 200, height: 100)
+  }
+
+  func testShortTextButtonMatchesExpectedSize() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    buttonBar.items = items
+    buttonBar.layoutIfNeeded()
+
+    // When
+    let rect = buttonBar.rectForItem(at: 0, in: buttonBar)
+
+    // Then
+    XCTAssertEqual(rect.size, CGSize(width: 60, height: 100))
+  }
+
+  func testLongTextButtonMatchesExpectedSize() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text that is relatively long", style: .plain, target: nil, action: nil)]
+    buttonBar.items = items
+    buttonBar.layoutIfNeeded()
+
+    // When
+    let rect = buttonBar.rectForItem(at: 0, in: buttonBar)
+
+    // Then
+    XCTAssertEqual(rect.size, CGSize(width: 244, height: 100))
+  }
+
+  func testOriginOfEachButtonIncreasesWhenLeading() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil),
+                 UIBarButtonItem(title: "Text 2", style: .plain, target: nil, action: nil)]
+    buttonBar.items = items
+    buttonBar.layoutPosition = .leading
+    buttonBar.layoutIfNeeded()
+
+    // When
+    let origins = (0..<items.count).map { index in
+      buttonBar.rectForItem(at: UInt(index), in: buttonBar).origin
+    }
+
+    // Then
+    XCTAssertEqual(origins, [CGPoint(x: 0, y: 0), CGPoint(x: 60, y: 0)])
+  }
+
+  func testOriginOfEachButtonDecreasesWhenTrailing() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil),
+                 UIBarButtonItem(title: "Text 2", style: .plain, target: nil, action: nil)]
+    buttonBar.items = items
+    buttonBar.layoutPosition = .trailing
+    buttonBar.layoutIfNeeded()
+
+    // When
+    let origins = (0..<items.count).map { index in
+      buttonBar.rectForItem(at: UInt(index), in: buttonBar).origin
+    }
+
+    // Then
+    XCTAssertEqual(origins, [CGPoint(x: 72, y: 0), CGPoint(x: 0, y: 0)])
+  }
+
+  func testRectInParentCoordinateSpaceFactorsInButtonBarOrigin() {
+    // Given
+    let items = [UIBarButtonItem(title: "Text", style: .plain, target: nil, action: nil)]
+    buttonBar.items = items
+    buttonBar.layoutIfNeeded()
+    let containerView = UIView()
+    buttonBar.frame.origin.x += 10
+    buttonBar.frame.origin.y += 20
+    containerView.addSubview(buttonBar)
+
+    // When
+    let rect = buttonBar.rectForItem(at: 0, in: containerView)
+
+    // Then
+    XCTAssertEqual(rect, CGRect(x: 10, y: 20, width: 60, height: 100))
+  }
+}

--- a/components/ButtonBar/tests/unit/ButtonBarRectForItemTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarRectForItemTests.swift
@@ -33,7 +33,7 @@ class ButtonBarRectForItemTests: XCTestCase {
     buttonBar.layoutIfNeeded()
 
     // When
-    let rect = buttonBar.rectForItem(at: 0, in: buttonBar)
+    let rect = buttonBar.rect(for: items[0], in: buttonBar)
 
     // Then
     XCTAssertEqual(rect.size, CGSize(width: 60, height: 100))
@@ -46,7 +46,7 @@ class ButtonBarRectForItemTests: XCTestCase {
     buttonBar.layoutIfNeeded()
 
     // When
-    let rect = buttonBar.rectForItem(at: 0, in: buttonBar)
+    let rect = buttonBar.rect(for: items[0], in: buttonBar)
 
     // Then
     XCTAssertEqual(rect.size, CGSize(width: 244, height: 100))
@@ -61,8 +61,8 @@ class ButtonBarRectForItemTests: XCTestCase {
     buttonBar.layoutIfNeeded()
 
     // When
-    let origins = (0..<items.count).map { index in
-      buttonBar.rectForItem(at: UInt(index), in: buttonBar).origin
+    let origins = items.map { item in
+      buttonBar.rect(for: item, in: buttonBar).origin
     }
 
     // Then
@@ -78,8 +78,8 @@ class ButtonBarRectForItemTests: XCTestCase {
     buttonBar.layoutIfNeeded()
 
     // When
-    let origins = (0..<items.count).map { index in
-      buttonBar.rectForItem(at: UInt(index), in: buttonBar).origin
+    let origins = items.map { item in
+      buttonBar.rect(for: item, in: buttonBar).origin
     }
 
     // Then
@@ -97,7 +97,7 @@ class ButtonBarRectForItemTests: XCTestCase {
     containerView.addSubview(buttonBar)
 
     // When
-    let rect = buttonBar.rectForItem(at: 0, in: containerView)
+    let rect = buttonBar.rect(for: items[0], in: containerView)
 
     // Then
     XCTAssertEqual(rect, CGRect(x: 10, y: 20, width: 60, height: 100))

--- a/components/ButtonBar/tests/unit/ButtonBarRectForItemTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarRectForItemTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2016-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,8 +22,16 @@ class ButtonBarRectForItemTests: XCTestCase {
   var buttonBar: MDCButtonBar!
 
   override func setUp() {
+    super.setUp()
+
     buttonBar = MDCButtonBar()
     buttonBar.frame = CGRect(x: 0, y: 0, width: 200, height: 100)
+  }
+
+  override func tearDown() {
+    buttonBar = nil
+
+    super.tearDown()
   }
 
   func testShortTextButtonMatchesExpectedSize() {


### PR DESCRIPTION
This API will allow clients to present overlay views that point to views in an MDCButtonBar.

Expected usage:

```swift
@objc func didTapButton(_ item: UIBarButtonItem) {
  let rect = buttonBar.rect(for: item, in: view)
  // Present an overlay pointing at `rect`
}
```

Closes https://github.com/material-components/material-components-ios/issues/7248
