### PR TITLE
[NavigationDrawer] Prevent crash when passing nil completion block for a nullable method parameter.

### DIFF
--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -389,9 +389,7 @@ static UIColor *DrawerShadowColor(void) {
       animations:^{
         [self setupLayout];
       }
-      completion:^(BOOL completed) {
-        completion(completed);
-      }];
+      completion:completion];
 }
 
 #pragma mark UIViewController

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -386,10 +386,10 @@ static UIColor *DrawerShadowColor(void) {
   _shouldPresentAtFullscreen = YES;
   [self cacheLayoutCalculations];
   [UIView animateWithDuration:duration
-      animations:^{
-        [self setupLayout];
-      }
-      completion:completion];
+                   animations:^{
+                     [self setupLayout];
+                   }
+                   completion:completion];
 }
 
 #pragma mark UIViewController


### PR DESCRIPTION
The `expandToFullscreenWithDuration:completion:` method signature declares a nullable completion param. MDCBottomDrawerContainerViewController will always execute the completion block, resulting in an exception when `completion == nil`. The solution is to pass the block directly when calling `[UIView animateWithDuration:completion:]`, which won't try to execute the block when it is nil.